### PR TITLE
Patch mac80211 to give correct skb sizes for 4addr wds frames - fixes…

### DIFF
--- a/package/kernel/mac80211/patches/343-mac80211-fix-4addr-frame-size.patch
+++ b/package/kernel/mac80211/patches/343-mac80211-fix-4addr-frame-size.patch
@@ -1,0 +1,11 @@
+--- a/net/wireless/util.c
++++ b/net/wireless/util.c
+@@ -509,7 +509,7 @@ static int __ieee80211_data_to_8023(stru
+ 		 * replace EtherType */
+ 		hdrlen += ETH_ALEN + 2;
+ 	else
+-		tmp.h_proto = htons(skb->len);
++		tmp.h_proto = htons(skb->len-hdrlen);
+ 
+ 	pskb_pull(skb, hdrlen);
+ 


### PR DESCRIPTION
… stp on wds bridges

net/wireless/util.c at line 512 sets length for the skb, then promptly removes 80211 header data, leaving length incorrect, which is caught by llc processing later, preventing stp frames from being processed.

This corrects the h_proto value so frames will be processed with stp information over wds 4addr type bridges.
