### PR TITLE
Reverting git commit a194e83f16b05240184f58b709152fb840cf00f7

### DIFF
--- a/target/linux/brcm2708/bcm2708/profiles/RaspberryPi.mk
+++ b/target/linux/brcm2708/bcm2708/profiles/RaspberryPi.mk
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/RaspberryPi
+  NAME:=Raspberry Pi Models B/B+/CM
+endef
+define Profile/RaspberryPi/Description
+  Raspberry Pi Models B/B+/CM
+endef
+$(eval $(call Profile,RaspberryPi))

--- a/target/linux/brcm2708/bcm2709/profiles/RaspberryPi2.mk
+++ b/target/linux/brcm2708/bcm2709/profiles/RaspberryPi2.mk
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2015 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/RaspberryPi_2
+  NAME:=Raspberry Pi 2 Model B
+endef
+define Profile/RaspberryPi_2/Description
+  Raspberry Pi 2 Model B
+endef
+$(eval $(call Profile,RaspberryPi_2))

--- a/target/linux/brcm2708/bcm2710/profiles/RaspberryPi3.mk
+++ b/target/linux/brcm2708/bcm2710/profiles/RaspberryPi3.mk
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/RaspberryPi_3
+  NAME:=Raspberry Pi 3 Model B
+  PACKAGES:=brcmfmac43430-firmware-sdio kmod-brcmfmac wpad-mini
+endef
+define Profile/RaspberryPi_3/Description
+  Raspberry Pi 3 Model B
+endef
+$(eval $(call Profile,RaspberryPi_3))

--- a/target/linux/brcm2708/image/Makefile
+++ b/target/linux/brcm2708/image/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2012-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -42,39 +42,45 @@ define Build/sdcard-img
 	$(if $(CONFIG_TARGET_IMAGES_GZIP),gzip -9n -c $@ > $(BIN_DIR)/$(notdir $@).gz)
 endef
 
-### Devices ###
+### Device macros ###
 define Device/Default
   FILESYSTEMS := ext4
+  PROFILES = Default $$(DEVICE_PROFILE)
   KERNEL := kernel-bin | kernel-img
   IMAGES := sdcard.img
   IMAGE/sdcard.img := boot-img | sdcard-img
+  DEVICE_PROFILE :=
   DEVICE_DTS :=
 endef
-DEVICE_VARS += DEVICE_DTS
+DEVICE_VARS += DEVICE_PROFILE DEVICE_DTS
 
-define Device/rpi
-  DEVICE_TITLE := Raspberry Pi B/B+/CM/Zero
-  DEVICE_DTS := bcm2708-rpi-b bcm2708-rpi-b-plus bcm2708-rpi-cm
+# $(1) = profile
+# $(2) = image name
+# $(3) = dts
+define bcm27xx
+  define Device/$(2)
+    DEVICE_PROFILE := $(1)
+    DEVICE_DTS := $(3)
+  endef
+  TARGET_DEVICES += $(2)
 endef
+
+### BCM2708/BCM2835 ###
 ifeq ($(SUBTARGET),bcm2708)
-  TARGET_DEVICES += rpi
+  # Raspberry Pi Models B/B+/CM
+  $(eval $(call bcm27xx,RaspberryPi,rpi,bcm2708-rpi-b bcm2708-rpi-b-plus bcm2708-rpi-cm))
 endif
 
-define Device/rpi-2
-  DEVICE_TITLE := Raspberry Pi 2 B
-  DEVICE_DTS := bcm2709-rpi-2-b
-endef
+### BCM2709/BCM2836 ###
 ifeq ($(SUBTARGET),bcm2709)
-  TARGET_DEVICES += rpi-2
+  # Raspberry Pi 2 Model B
+  $(eval $(call bcm27xx,RaspberryPi_2,rpi-2,bcm2709-rpi-2-b))
 endif
 
-define Device/rpi-3
-  DEVICE_TITLE := Raspberry Pi 3 B
-  DEVICE_DTS := bcm2710-rpi-3-b
-  DEVICE_PACKAGES := brcmfmac43430-firmware-sdio kmod-brcmfmac wpad-mini
-endef
+### BCM2710/BCM2837 ###
 ifeq ($(SUBTARGET),bcm2710)
-  TARGET_DEVICES += rpi-3
+  # Raspberry Pi 3 Model B
+  $(eval $(call bcm27xx,RaspberryPi_3,rpi-3,bcm2710-rpi-3-b))
 endif
 
 $(eval $(call BuildImage))


### PR DESCRIPTION
The commit a194e83f16b05240184f58b709152fb840cf00f7 converted brcm2708 targets
to new build system (LEDE). However, this change is not in sync with OpenWrt build
system. Therefore no image is generated for Raspberry Pi boards.

This commit reintroduces the profile files for Raspberry Pi, Raspberry Pi 2 and
Raspberry Pi 3 and reverts the changes in target/linux/brcm2708/image/Makefile.

Signed-off-by: Devaraj Ranganna devaraj.ranganna@arm.com
