### PR TITLE
sysupgrade: fix regular expression

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -103,7 +103,7 @@ EOF
 
 add_uci_conffiles() {
 	local file="$1"
-	( find $(sed -ne '/^[[:space:]]*$/d; /^#/d; p' \
+	( find $(sed -ne '/^[[:space:]]*\($\|#\)/d; p' \
 		/etc/sysupgrade.conf /lib/upgrade/keep.d/* 2>/dev/null) \
 		-type f -o -type l 2>/dev/null;
 	  opkg list-changed-conffiles ) | sort -u > "$file"


### PR DESCRIPTION
Previous regular expression in sed allowed comment strings that starts with
space.

```
$ cat sysupgrade.conf

 # /etc/openvpn/
/etc/config
/etc/profile
/etc/firewall.user
/etc/TC_hfsc.sh
/etc/hotplug.d/iface/30-trafficc
/etc/init.d/trafficc
/root
/etc/crontabs/root
$ sed -ne '/^[[:space:]]*$/d; /^#/d; p' sysupgrade.conf
 # /etc/openvpn/
/etc/config
/etc/profile
/etc/firewall.user
/etc/TC_hfsc.sh
/etc/hotplug.d/iface/30-trafficc
/etc/init.d/trafficc
/root
/etc/crontabs/root
```

This patch fixes that problem

```
$ sed -ne '/^[[:space:]]*\($\|#\)/d; p' sysupgrade.conf
/etc/config
/etc/profile
/etc/firewall.user
/etc/TC_hfsc.sh
/etc/hotplug.d/iface/30-trafficc
/etc/init.d/trafficc
/root
/etc/crontabs/root
```
