### PR TITLE
Enable nand for mt7621

### DIFF
--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=mt7621
 BOARDNAME:=MT7621 based boards
-FEATURES+=usb rtc
+FEATURES+=usb nand rtc
 CPU_TYPE:=1004kc
 CPU_SUBTYPE:=dsp
 


### PR DESCRIPTION
Ubiquiti ERX is an mt7621 based nand device, so enable nand packages for mt7621 boards

Signed-off-by: Nikolay Martynov mar.kolya@gmail.com
