### PR TITLE
Fix discrepancy between git.openwrt.org and github by importing the missing commit for ncurses

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -127,6 +127,7 @@ define Build/InstallDev
 	for lib in ncurses panel menu form; do \
 		ln -s lib$$$${lib}w.so $(1)/usr/lib/lib$$$${lib}.so; \
 	done
+	$(TARGET_CROSS)ar rc $(1)/usr/lib/libtinfo.a
 	$(INSTALL_DIR) $(2)/bin
 	$(CP) $(PKG_INSTALL_DIR)/usr/bin/ncursesw5-config $(2)/bin/
 	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' -e 's/$$$$INCS //g' \


### PR DESCRIPTION
The transition from git.openwrt.org to Github is partially flawed, as one commit of May 11th that is present in git.openwrt.org has not been imported to Github although the subsequent commits have been imported. This issue is also discussed at #50 

Discrepancy between git.openwrt.org and Github sources for ncurses can be easily noticed here:
https://github.com/openwrt/openwrt/commits/master/package/libs/ncurses
http://git.openwrt.org/?p=openwrt.git;a=history;f=package/libs/ncurses;hb=HEAD

Difference is also visible in `git log` output:

```
Github:
3907a8c kernel: remove linux 4.3 config
88d875f Revert "ncurses: package the tinfo library separately"

git.openwrt.org:
2016-05-11  luka    kernel: remove linux 4.3 config
2016-05-11  nbd ncurses: install a dummy libtinfo.a for packages that...
2016-05-11  nbd Revert "ncurses: package the tinfo library separately"
```

One commit for ncurses is missing from Github:
`ncurses: install a dummy libtinfo.a for packages that try to link it`
http://git.openwrt.org/?p=openwrt.git;a=commit;h=f06425ef611085a791bcd0399c9b1e1a27525eca  
The missing commit breaks htop at the Openwrt buildbot:  http://buildbot.openwrt.org:8010/broken_packages/ar71xx/htop/compile.txt

Manually replicating the missing commit fixes at least htop package's compilation. Probably something else gets fixed, too.

Fix the issue by importing the missing commit from git.openwrt.org
