### PR TITLE
openssl: update to 1.0.2j

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.0.2
-PKG_BUGFIX:=h
+PKG_BUGFIX:=j
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -22,7 +22,7 @@ PKG_SOURCE_URL:=http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/ \
 	ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source \
 	ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/
-PKG_MD5SUM:=9392e65072ce4b614c1392eefc1f23d0
+PKG_MD5SUM:=96322138f0b69e61b7212bc53d5e912b
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/140-makefile-dirs.patch
+++ b/package/libs/openssl/patches/140-makefile-dirs.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -136,7 +136,7 @@ FIPSCANLIB=
+@@ -137,7 +137,7 @@ FIPSCANLIB=
  
  BASEADDR=
  

--- a/package/libs/openssl/patches/150-no_engines.patch
+++ b/package/libs/openssl/patches/150-no_engines.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -2109,6 +2109,11 @@ EOF
+@@ -2114,6 +2114,11 @@ EOF
  	close(OUT);
    }
    

--- a/package/libs/openssl/patches/160-disable_doc_tests.patch
+++ b/package/libs/openssl/patches/160-disable_doc_tests.patch
@@ -1,6 +1,6 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -138,7 +138,7 @@ FIPSCANLIB=
+@@ -139,7 +139,7 @@ FIPSCANLIB=
  
  BASEADDR=0xFB00000
  
@@ -9,7 +9,7 @@
  ENGDIRS= ccgost
  SHLIBDIRS= crypto ssl
  
-@@ -156,7 +156,7 @@ SDIRS=  \
+@@ -157,7 +157,7 @@ SDIRS=  \
  
  # tests to perform.  "alltests" is a special word indicating that all tests
  # should be performed.
@@ -18,7 +18,7 @@
  
  MAKEFILE= Makefile
  
-@@ -170,7 +170,7 @@ SHELL=/bin/sh
+@@ -171,7 +171,7 @@ SHELL=/bin/sh
  
  TOP=    .
  ONEDIRS=out tmp
@@ -27,7 +27,7 @@
  WDIRS=  windows
  LIBS=   libcrypto.a libssl.a
  SHARED_CRYPTO=libcrypto$(SHLIB_EXT)
-@@ -273,7 +273,7 @@ reflect:
+@@ -275,7 +275,7 @@ reflect:
  
  sub_all: build_all
  
@@ -36,7 +36,7 @@
  
  build_libs: build_libcrypto build_libssl openssl.pc
  
-@@ -530,7 +530,7 @@ dist:
+@@ -533,7 +533,7 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  
@@ -47,7 +47,7 @@
  	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -528,7 +528,7 @@ dist:
+@@ -531,7 +531,7 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  

--- a/package/libs/openssl/patches/190-remove_timestamp_check.patch
+++ b/package/libs/openssl/patches/190-remove_timestamp_check.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -184,7 +184,7 @@ TARFILE=        ../$(NAME).tar
+@@ -185,7 +185,7 @@ TARFILE=        ../$(NAME).tar
  EXHEADER=       e_os2.h
  HEADER=         e_os.h
  
@@ -9,7 +9,7 @@
  
  # as we stick to -e, CLEARENV ensures that local variables in lower
  # Makefiles remain local and variable. $${VAR+VAR} is tribute to Korn
-@@ -400,11 +400,6 @@ openssl.pc: Makefile
+@@ -403,11 +403,6 @@ openssl.pc: Makefile
  	    echo 'Version: '$(VERSION); \
  	    echo 'Requires: libssl libcrypto' ) > openssl.pc
  

--- a/package/libs/openssl/patches/200-parallel_build.patch
+++ b/package/libs/openssl/patches/200-parallel_build.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -279,17 +279,17 @@ build_libcrypto: build_crypto build_engi
+@@ -281,17 +281,17 @@ build_libcrypto: build_crypto build_engi
  build_libssl: build_ssl libssl.pc
  
  build_crypto:
@@ -24,7 +24,7 @@
  
  all_testapps: build_libs build_testapps
  build_testapps:
-@@ -461,7 +461,7 @@ update: errors stacks util/libeay.num ut
+@@ -464,7 +464,7 @@ update: errors stacks util/libeay.num ut
  	@set -e; target=update; $(RECURSIVE_BUILD_CMD)
  
  depend:
@@ -33,7 +33,7 @@
  
  lint:
  	@set -e; target=lint; $(RECURSIVE_BUILD_CMD)
-@@ -523,9 +523,9 @@ dist:
+@@ -526,9 +526,9 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  
@@ -45,7 +45,7 @@
  	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR) \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines \
-@@ -534,12 +534,19 @@ install_sw:
+@@ -537,12 +537,19 @@ install_sw:
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/misc \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/certs \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/private
@@ -66,7 +66,7 @@
  	@set -e; liblist="$(LIBS)"; for i in $$liblist ;\
  	do \
  		if [ -f "$$i" ]; then \
-@@ -623,12 +630,7 @@ install_html_docs:
+@@ -626,12 +633,7 @@ install_html_docs:
  		done; \
  	done
  
@@ -164,7 +164,7 @@
  	ctags $(SRC)
 --- a/test/Makefile
 +++ b/test/Makefile
-@@ -139,7 +139,7 @@ install:
+@@ -144,7 +144,7 @@ install:
  tags:
  	ctags $(SRC)
  
@@ -173,7 +173,7 @@
  
  apps:
  	@(cd ..; $(MAKE) DIRS=apps all)
-@@ -557,7 +557,7 @@ $(SSLV2CONFTEST)$(EXE_EXT): $(SSLV2CONFT
+@@ -577,7 +577,7 @@ $(DTLSTEST)$(EXE_EXT): $(DTLSTEST).o ssl
  #	fi
  
  dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)


### PR DESCRIPTION
Security fixes:
- (Severity: High) OCSP Status Request extension unbounded memory growth (CVE-2016-6304)
- (Severity: Moderate) SSL_peek() hang on empty record (CVE-2016-6305)
- (Severity: Moderate) Missing CRL sanity check (CVE-2016-7052)
- 10 Low severity issues

Security advisories:
https://www.openssl.org/news/secadv/20160922.txt
https://www.openssl.org/news/secadv/20160926.txt

Signed-off-by: Zoltan HERPAI wigyori@uid0.hu
