### PR TITLE
CC15.05: scripts/getver.sh: Fix revision numbering (for Github-based repo)

### DIFF
--- a/scripts/getver.sh
+++ b/scripts/getver.sh
@@ -17,9 +17,9 @@ try_svn() {
 }
 
 try_git() {
-	[ -e .git ] || return 1
-	REV="$(git log | grep -m 1 git-svn-id | awk '{ gsub(/.*@/, "", $0); print $1 }')"
-	REV="${REV:+r$REV}"
+	git rev-parse --git-dir >/dev/null 2>&1 || return 1
+	REV="$(git describe --tags | sed "s/v15.05.1-\([0-9]*\)-.*/\1/g")"
+	REV="${REV:+r$((REV+49254))}"
 	[ -n "$REV" ]
 }
 
@@ -30,5 +30,5 @@ try_hg() {
 	[ -n "$REV" ]
 }
 
-try_version || try_svn || try_git || try_hg || REV="unknown"
+try_version || try_git || try_hg || REV="unknown"
 echo "$REV"


### PR DESCRIPTION
Fix revision numbering in the Chaos Calmer branch. CC has been stuck at r49389 since the final move to Github as revision number evaluation has still been based on git-svn-id that is not found in the new original Github commits. So the revision has been stuck at the last svn commit in June.

This patch
- copies the git revision logic from master and uses the `v15.05.1` tag as the base. As the last commit with a known svn revision 49389 was cb4f071 with tag+135, use 49254 as the adjustment. That produces r49461 for the current 8a1f7c9 (and 49389 for cb4f071, as expected).
- removes the useless svn evaluation (similarly as in master).

Note that this patch also keeps the traditional 'r' prefix (which has accidentally(?) been dropped from master in the last change).
