### PR TITLE
add tpm support

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -890,6 +890,25 @@ endef
 
 $(eval $(call KernelPackage,random-omap))
 
+
+define KernelPackage/random-tpm
+  TITLE:= TPM hardware random support
+  SUBMENU:=$(OTHER_MENU)
+  KCONFIG:= \
+    CONFIG_HW_RANDOM_TPM=y
+  FILES:= \
+    $(LINUX_DIR)/drivers/char/hw_random/tpm-rng.ko
+  AUTOLOAD:= $(call AutoProbe, tpm-rng)
+  DEPENDS:=+kmod-random-core kmod-tpm
+endef
+
+define KernelPackage/random-tpm/description
+  TPM backed random support.
+endef
+
+$(eval $(call KernelPackage,random-tpm))
+
+
 define KernelPackage/thermal
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Generic Thermal sysfs driver
@@ -1073,5 +1092,40 @@ define KernelPackage/virtio-mmio/description
 endef
 
 $(eval $(call KernelPackage,virtio-mmio))
+
+
+define KernelPackage/tpm
+  TITLE:= TPM support
+  SUBMENU:=$(OTHER_MENU)
+  KCONFIG:= \
+    CONFIG_TCG_TPM=y
+  FILES:= \
+    $(LINUX_DIR)/drivers/char/tpm/tpm.ko
+  AUTOLOAD:= $(call AutoProbe, tpm)
+endef
+
+define KernelPackage/tpm/description
+  TPM support.
+endef
+
+$(eval $(call KernelPackage,tpm))
+
+
+define KernelPackage/tpm-i2c-infineon
+  TITLE:= TPM 1.2 infineon i2c driver
+  SUBMENU:=$(OTHER_MENU)
+  KCONFIG:= \
+    CONFIG_TCG_TIS_I2C_INFINEON=y
+  FILES:= \
+    $(LINUX_DIR)/drivers/char/tpm/tpm_i2c_infineon.ko
+  AUTOLOAD:= $(call AutoProbe, tpm_i2c_infineon)
+  DEPENDS:=+kmod-tpm kmod-i2c-core
+endef
+
+define KernelPackage/tpm-i2c-infineon/description
+  TPM 1.2 support for infineon i2c devices.
+endef
+
+$(eval $(call KernelPackage,tpm-i2c-infineon))
 
 

--- a/target/linux/generic/config-3.18
+++ b/target/linux/generic/config-3.18
@@ -3894,6 +3894,16 @@ CONFIG_SYSVIPC_SYSCTL=y
 # CONFIG_TASKS_RCU is not set
 # CONFIG_TC35815 is not set
 # CONFIG_TCG_TPM is not set
+# CONFIG_TCG_TIS is not set
+# CONFIG_TCG_TIS_I2C_ATMEL is not set
+# CONFIG_TCG_TIS_I2C_INFINEON is not set
+# CONFIG_TCG_TIS_I2C_NUVOTON is not set
+# CONFIG_TCG_NSC is not set
+# CONFIG_TCG_ATMEL is not set
+# CONFIG_TCG_INFINEON is not set
+# CONFIG_TCG_IBMVTPM is not set
+# CONFIG_TCG_ST33_I2C is not set
+# CONFIG_TCG_XEN is not set
 # CONFIG_TCIC is not set
 CONFIG_TCP_CONG_ADVANCED=y
 # CONFIG_TCP_CONG_BIC is not set

--- a/target/linux/generic/config-4.1
+++ b/target/linux/generic/config-4.1
@@ -4053,6 +4053,17 @@ CONFIG_SYSVIPC_SYSCTL=y
 # CONFIG_TASKS_RCU is not set
 # CONFIG_TC35815 is not set
 # CONFIG_TCG_TPM is not set
+# CONFIG_TCG_TIS is not set
+# CONFIG_TCG_TIS_I2C_ATMEL is not set
+# CONFIG_TCG_TIS_I2C_INFINEON is not set
+# CONFIG_TCG_TIS_I2C_NUVOTON is not set
+# CONFIG_TCG_NSC is not set
+# CONFIG_TCG_ATMEL is not set
+# CONFIG_TCG_INFINEON is not set
+# CONFIG_TCG_IBMVTPM is not set
+# CONFIG_TCG_TIS_ST33ZP24 is not set
+# CONFIG_TCG_XEN is not set
+# CONFIG_TCG_CRB is not set
 # CONFIG_TCIC is not set
 CONFIG_TCP_CONG_ADVANCED=y
 # CONFIG_TCP_CONG_BIC is not set

--- a/target/linux/generic/config-4.4
+++ b/target/linux/generic/config-4.4
@@ -4065,6 +4065,17 @@ CONFIG_SYSVIPC_SYSCTL=y
 # CONFIG_TASKS_RCU is not set
 # CONFIG_TC35815 is not set
 # CONFIG_TCG_TPM is not set
+# CONFIG_TCG_TIS is not set
+# CONFIG_TCG_TIS_I2C_ATMEL is not set
+# CONFIG_TCG_TIS_I2C_INFINEON is not set
+# CONFIG_TCG_TIS_I2C_NUVOTON is not set
+# CONFIG_TCG_NSC is not set
+# CONFIG_TCG_ATMEL is not set
+# CONFIG_TCG_INFINEON is not set
+# CONFIG_TCG_IBMVTPM is not set
+# CONFIG_TCG_TIS_ST33ZP24 is not set
+# CONFIG_TCG_XEN is not set
+# CONFIG_TCG_CRB is not set
 # CONFIG_TCIC is not set
 CONFIG_TCP_CONG_ADVANCED=y
 # CONFIG_TCP_CONG_BIC is not set


### PR DESCRIPTION
This adds kernel support for tpm's providing:
- kmod-tpm - tpm framework
- kmod-tpm-i2c-infineon - infineon i2c 1.2 spec tpm
- kmod-random-tpm - tpm backed rng

Compile and runtime tested with pistachio board that uses it currently PR'd in #95. Packages that make use of it to come.

I have added the TPM menu in order to try and follow what is done in the kernel but open to suggestions in terms of menu layout.
