### PR TITLE
lantiq: danube fxs bugfix: changed compatible attribute of vmmc

### DIFF
--- a/target/linux/lantiq/dts/danube.dtsi
+++ b/target/linux/lantiq/dts/danube.dtsi
@@ -70,7 +70,7 @@
 
 		vmmc@107000 {
 			status = "disabled";
-			compatible = "lantiq,vmmc";
+			compatible = "lantiq,vmmc-xway";
 			reg = <0x103000 0x400>;
 			interrupt-parent = <&icu0>;
 			interrupts = <150 151 152 153 154 155>;


### PR DESCRIPTION
This bugfix enables FXS support on dabube based devices.
Changed "compatible" attribute from "vmmc" to "vmmc-xway".
The vmmc driver uses "vmmc-xway".

Signed-off-by: Stefan Koch stefan.koch10@gmail.com
