### PR TITLE
rbcfg: move to Boot Loaders submenu of Utilities

### DIFF
--- a/package/boot/rbcfg/Makefile
+++ b/package/boot/rbcfg/Makefile
@@ -17,6 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/rbcfg
   SECTION:=utils
   CATEGORY:=Utilities
+  SUBMENU:=Boot Loaders
   TITLE:=RouterBOOT configuration tool
   DEPENDS:=@TARGET_ar71xx
 endef


### PR DESCRIPTION
Part of a wider housekeeping effort on the packages repository.

Signed-off-by: Alberto Bursi alberto.bursi@outlook.it
