### PR TITLE
linux/modules/fs: Fix missing vfat dependencies

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -463,7 +463,7 @@ define KernelPackage/fs-vfat
 	$(LINUX_DIR)/fs/fat/fat.ko \
 	$(LINUX_DIR)/fs/fat/vfat.ko
   AUTOLOAD:=$(call AutoLoad,30,fat vfat)
-  $(call AddDepends/nls)
+  $(call AddDepends/nls,cp437 iso8859-1 utf8)
 endef
 
 define KernelPackage/fs-vfat/description


### PR DESCRIPTION
vfat filesystem fails to mount due to missing codepages with
factory-formatted flash drives.  Depend on cp437 iso8559-1 and
utf8 nls modules as this covers most factory-formatted vfat
filesystems.

Signed-off-by: Daniel Dickinson openwrt@cshore.thecshore.com
