### PR TITLE
Default pins GPIO18/19 to GPIO.

### DIFF
--- a/target/linux/ramips/dts/LINKIT7688.dts
+++ b/target/linux/ramips/dts/LINKIT7688.dts
@@ -98,6 +98,17 @@
 			ralink,group = "wdt";
 			ralink,function = "gpio";
 		};
+
+		pwm0 {
+			ralink,group = "pwm0";
+			ralink,function = "gpio";
+		};
+
+		pwm1 {
+			ralink,group = "pwm1";
+			ralink,function = "gpio";
+		};
+
 	};
 };
 


### PR DESCRIPTION
LINKIT7688.dts: GPIO 18 and 19 were left dangling in pinmux.
￼supersedes #138
￼ Signed-off-by: Jakob Sloth Jepsen jsj@reseiwe.com
