### PR TITLE
toolchain/musl: fix quoted time zone name handling

### DIFF
--- a/toolchain/musl/patches/400-fix_quoted_timezone.patch
+++ b/toolchain/musl/patches/400-fix_quoted_timezone.patch
@@ -1,0 +1,11 @@
+--- a/src/time/__tz.c
++++ b/src/time/__tz.c
+@@ -87,7 +87,7 @@
+ 	int i;
+ 	if (**p == '<') {
+ 		++*p;
+-		for (i=0; **p!='>' && i<TZNAME_MAX; i++)
++		for (i=0; (*p)[i]!='>' && i<TZNAME_MAX; i++)
+ 			d[i] = (*p)[i];
+ 		++*p;
+ 	} else {


### PR DESCRIPTION
Fix parsing and handling of the < > quoted time zone names:
Compare the correct character instead of repeatedly comparing the first character.

Briefly:
IANA time zone data maintainers are gradually changing time zones in the zoneinfo data to have quoted numeric names instead of the traditional invented abbreviations. Currently already 47 time zones have numeric names inside < >. 
Examples of new timezone strings (after 2016g):
```
'Antarctica/Troll', '<+00>0<+02>-2,M3.5.0/1,M10.5.0/3'
'Asia/Baku', '<+04>-4'
'Europe/Istanbul', '<+03>-3'
'Europe/Minsk', '<+03>-3'
``` 
This patch fixes the broken handling in musl, where faulty name string parsing makes it to ignore the zone. Name is parsed wrongly and the time offset is left at 0 as it can't be parsed. Discussion in https://github.com/openwrt/luci/issues/675 . Example of the brokenly parsed name: "+04>-4" instead of "+04"
```
Example:
root@...nWrt:~# cat /etc/TZ
<+04>-4
root@...nWrt:~# date
Wed Mar 30 08:02:59 +04>-4 2016
```

Longer explanation of the bug and the fix: http://www.openwall.com/lists/musl/2016/10/19/1

Patch has been submitted to musl upstream:  http://www.openwall.com/lists/musl/2016/10/24/3

* zoneinfo package has already been updated to a version that has zones with the new format.
* zone info embedded in LuCI will be updated soon

Please apply the patch to Openwrt to enable DD trunk builds to work ok with the current zone data.  (LEDE has already been fixed with this patch.) 