### PR TITLE
iptables: Do not override PATCH_DIR with external kernel tree

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -24,10 +24,6 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0
 
-ifneq ($(CONFIG_EXTERNAL_KERNEL_TREE),"")
-PATCH_DIR:=
-endif
-
 include $(INCLUDE_DIR)/package.mk
 ifeq ($(DUMP),)
   -include $(LINUX_DIR)/.config


### PR DESCRIPTION
When CONFIG_EXTERNAL_KERNEL_TREE was selected, the makefile overrode
PATCH_DIR to nothing. This in term caused itables patches to not be
applied, resulting in several soname renames no longer being picked
up in the build. This in term caused the build to fail, as certain
libraries could not be found.

This behavior was introduced in the following commit:
* 81cebd9 [package] iptables: don't apply patches if building an external kernel
However, no reasoning was given as to why this was done. Additionally,
no other package makes use of this override, this it seems saner to
remove it altogether.

Signed-off-by: Alexandru Gagniuc <alex.g@adaptrum.com>