### PR TITLE
Use curl in preference to wget if it's present

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -77,7 +77,8 @@ my $hash_cmd = hash_cmd();
 sub download
 {
 	my $mirror = shift;
-	my $options = $ENV{WGET_OPTIONS} || "";
+	my $wget_options = $ENV{WGET_OPTIONS} || "";
+	my $curl_options = $ENV{CURL_OPTIONS} || "";
 
 	$mirror =~ s!/$!!;
 
@@ -124,8 +125,8 @@ sub download
 			}
 		};
 	} else {
-		open WGET, "wget -t5 --timeout=20 --no-check-certificate $options -O- '$mirror/$url_filename' |" or die "Cannot launch wget.\n";
-		$hash_cmd and do {
+		open WGET, "which curl >/dev/null 2>&1 && curl -k $curl_options '$mirror/$filename' || wget -t5 --timeout=20 --no-check-certificate $wget_options -O- '$mirror/$filename' |" or die "Cannot launch curl or wget.\n";
+ 		$hash_cmd and do {
 			open MD5SUM, "| $hash_cmd > '$target/$filename.hash'" or die "Cannot launch $hash_cmd.\n";
 		};
 		open OUTPUT, "> $target/$filename.dl" or die "Cannot create file $target/$filename.dl: $!\n";


### PR DESCRIPTION
Because wget doesn't know how to do Negotiate authentication with a proxy and curl does, use curl if it's present. The user is expected to have a ~/.curlrc that sets the options necessary for any proxy authentication.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>