### PR TITLE
ar71xx: reduce cpuload and flickering on devices using rssileds

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -21,14 +21,14 @@ alfa-nx)
 	;;
 
 all0258n)
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "all0258n:red:rssilow" "wlan0" "1" "40" "0" "6"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "all0258n:yellow:rssimedium" "wlan0" "30" "80" "-29" "5"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "all0258n:green:rssihigh" "wlan0" "70" "100" "-69" "8"
 	;;
 
 all0315n)
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "all0315n:red:rssilow" "wlan0" "1" "40" "0" "6"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "all0315n:yellow:rssimedium" "wlan0" "30" "80" "-29" "5"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "all0315n:green:rssihigh" "wlan0" "70" "100" "-69" "8"
@@ -131,7 +131,7 @@ cpe210|\
 cpe510)
 	ucidef_set_led_switch "lan0" "LAN0" "tp-link:green:lan0" "switch0" "0x20"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:green:link1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:green:link2" "wlan0" "26" "100" "-25" "13"
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "51" "100" "-50" "13"
@@ -354,7 +354,7 @@ mynet-n600)
 
 mynet-rext)
 	ucidef_set_led_netdev "lan" "LAN" "wd:blue:ethernet" "eth0"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "wd:blue:quality1" "wlan0" "1" "40" "0" "6"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "wd:blue:quality2" "wlan0" "30" "80" "-29" "5"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "wd:blue:quality3" "wlan0" "70" "100" "-69" "8"
@@ -499,7 +499,7 @@ tl-mr3420-v2)
 
 tl-wa7210n-v2)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:green:signal1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:green:signal2" "wlan0" "26" "100" "-25" "13"
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:signal3" "wlan0" "51" "100" "-50" "13"
@@ -509,7 +509,7 @@ tl-wa7210n-v2)
 tl-wa750re)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:orange:lan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:orange:wlan" "phy0tpt"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:orange:signal1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:orange:signal2" "wlan0" "20" "100" "-19" "13"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "tp-link:orange:signal3" "wlan0" "40" "100" "-39" "13"
@@ -520,7 +520,7 @@ tl-wa750re)
 tl-wa850re)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:blue:lan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:blue:wlan" "phy0tpt"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:blue:signal1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:blue:signal2" "wlan0" "20" "100" "-19" "13"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "tp-link:blue:signal3" "wlan0" "40" "100" "-39" "13"
@@ -683,7 +683,7 @@ tl-wr2543n)
 
 tube2h)
 	ucidef_set_led_netdev "lan" "LAN" "alfa:blue:lan" "eth0"
-	ucidef_set_rssimon "wlan0" "40000" "1"
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "signal1" "SIGNAL1" "alfa:red:signal1" "wlan0" "1" "100" "0" "13"
 	ucidef_set_led_rssi "signal2" "SIGNAL2" "alfa:orange:signal2" "wlan0" "26" "100" "-25" "13"
 	ucidef_set_led_rssi "signal3" "SIGNAL3" "alfa:green:signal3" "wlan0" "51" "100" "-50" "13"


### PR DESCRIPTION
Signed-off-by: Martin Weinelt <martin@darmstadt.freifunk.net>

The RSSI LEDs process currently consumes and unreasonable amount of cpuload and causes flickering on the devices LEDs. Lowering its refresh rate to a more reasonable interval will not impair the usage of the LEDs while consuming a less significant portion of cpu resources.

Downstream-Issue: https://github.com/freifunk-gluon/gluon/issues/897
```
Mem: 28276K used, 32520K free, 252K shrd, 2216K buff, 7316K cached
CPU:  20% usr  26% sys   0% nic  16% idle   0% io   0% irq  36% sirq
Load average: 1.86 1.97 1.90 1/51 9861
  PID  PPID USER     STAT   VSZ %VSZ %CPU COMMAND
 1644     1 root     R     3408   6%  49% /usr/bin/fastd --config - --daemon --
 1751     1 root     R     1216   2%  12% /usr/sbin/rssileds ibss0 40000 1 tp-l
 1606     1 root     R     1532   3%   5% /usr/sbin/hostapd -P /var/run/wifi-ph
```