### PR TITLE
e2fsprogs: Fix setting of host compiler

### DIFF
--- a/package/utils/e2fsprogs/Makefile
+++ b/package/utils/e2fsprogs/Makefile
@@ -127,14 +127,14 @@ endef
 
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR)/util \
-		BUILDCC="$(HOSTCC)" \
+		BUILD_CC="$(HOSTCC)" \
 		CFLAGS="" \
 		CPPFLAGS="" \
 		LDFLAGS="" \
 		subst
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		LDFLAGS=-Wl,--gc-sections \
-		BUILDCC="$(HOSTCC)" \
+		BUILD_CC="$(HOSTCC)" \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
 		LIBBLKID="$(PKG_BUILD_DIR)/lib/libblkid.a -luuid" \
 		all


### PR DESCRIPTION
The variable is actually called BUILD_CC, not
BUILDCC. This didn't cause a lot of problems
since the default for HOSTCC in OpenWRT is the
same as the default for BUILD_CC (gcc).

Signed-off-by: Frank Lichtenheld <frank.lichtenheld@sophos.com>