### PR TITLE
CC: ar71xx: fix syntax error in /etc/uci-defaults/01_leds

### DIFF
--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
@@ -499,7 +499,7 @@ tl-wa830re-v2)
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan" "phy0tpt"
 	;;
 
-tl-wr841n-v9) | \
+tl-wr841n-v9 | \
 tl-wr841n-v11)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"


### PR DESCRIPTION
Fixes f98117a "CC: ar71xx: backport LED fix for TL-WR841N-v11".

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>