### PR TITLE
odhcp6c: check if fw3 binary is present

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -136,7 +136,9 @@ setup_interface () {
 		MAPRULE="$LW4O6"
 	fi
 
-	[ -n "$ZONE" ] || ZONE=$(fw3 -q network $INTERFACE 2>/dev/null)
+	[ -n "$ZONE" ] || {
+		which fw3 >/dev/null && ZONE=$(fw3 -q network $INTERFACE 2>/dev/null)
+	}
 
 	if [ "$IFACE_MAP" != 0 -a -n "$MAPTYPE" -a -n "$MAPRULE" ]; then
 		[ -z "$IFACE_MAP" -o "$IFACE_MAP" = 1 ] && IFACE_MAP=${INTERFACE}_4


### PR DESCRIPTION
If PACKAGE_firewall is not installed and hence no fw3 binary, odhcp6c's script reports an error.

With this patch presence of fw3 binary is checked before its access.