### PR TITLE
add support for witi board nand version

### DIFF
--- a/target/linux/ramips/dts/WITI-NAND.dts
+++ b/target/linux/ramips/dts/WITI-NAND.dts
@@ -1,0 +1,125 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+/ {
+	compatible = "witi", "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
+	model = "MQmaker WiTi";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	nand@1e003000 {
+		status = "okay";
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x1000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7E40000>;
+		};
+	};
+
+	palmbus: palmbus@1E000000 {
+		i2c@900 {
+			status = "okay";
+
+			pcf8563: rtc@51 {
+				status = "okay";
+				compatible = "nxp,pcf8563";
+				reg = <0x51>;
+			};
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 1>;
+			linux,code = <0x198>;
+		};
+	};
+};
+
+
+&sdhci {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "disabled";
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			mediatek,2ghz = <0>;
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			mediatek,5ghz = <0>;
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "jtag", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/dts/WITI-NAND.dts
+++ b/target/linux/ramips/dts/WITI-NAND.dts
@@ -1,20 +1,8 @@
 /dts-v1/;
 
-#include "mt7621.dtsi"
+#include "WITI.dtsi"
 
 / {
-	compatible = "witi", "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
-	model = "MQmaker WiTi";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	nand@1e003000 {
 		status = "okay";
 
@@ -47,79 +35,8 @@
 			reg = <0x140000 0x7E40000>;
 		};
 	};
-
-	palmbus: palmbus@1E000000 {
-		i2c@900 {
-			status = "okay";
-
-			pcf8563: rtc@51 {
-				status = "okay";
-				compatible = "nxp,pcf8563";
-				reg = <0x51>;
-			};
-		};
-	};
-
-	gpio-keys-polled {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 18 1>;
-			linux,code = <0x198>;
-		};
-	};
-};
-
-
-&sdhci {
-	status = "okay";
-};
-
-&xhci {
-	status = "okay";
 };
 
 &spi0 {
 	status = "disabled";
-};
-
-&pcie {
-	status = "okay";
-
-	pcie0 {
-		mt76@0,0 {
-			reg = <0x0000 0 0 0 0>;
-			device_type = "pci";
-			mediatek,mtd-eeprom = <&factory 0x8000>;
-			mediatek,2ghz = <0>;
-			mtd-mac-address = <&factory 0xe000>;
-		};
-	};
-
-	pcie1 {
-		mt76@1,0 {
-			reg = <0x0000 0 0 0 0>;
-			device_type = "pci";
-			mediatek,mtd-eeprom = <&factory 0x0000>;
-			mediatek,5ghz = <0>;
-			mtd-mac-address = <&factory 0xe000>;
-		};
-	};
-};
-
-&ethernet {
-	mtd-mac-address = <&factory 0xe000>;
-};
-
-&pinctrl {
-	state_default: pinctrl0 {
-		gpio {
-			ralink,group = "wdt", "rgmii2", "jtag", "mdio";
-			ralink,function = "gpio";
-		};
-	};
 };

--- a/target/linux/ramips/dts/WITI-SPI.dts
+++ b/target/linux/ramips/dts/WITI-SPI.dts
@@ -1,0 +1,38 @@
+/dts-v1/;
+
+#include "WITI.dtsi"
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80";
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/WITI.dtsi
+++ b/target/linux/ramips/dts/WITI.dtsi
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "mt7621.dtsi"
 
 / {
@@ -48,41 +46,6 @@
 
 &xhci {
 	status = "okay";
-};
-
-&spi0 {
-	status = "okay";
-
-	m25p80@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		linux,modalias = "m25p80";
-		spi-max-frequency = <10000000>;
-
-		partition@0 {
-			label = "u-boot";
-			reg = <0x0 0x30000>;
-			read-only;
-		};
-
-		partition@30000 {
-			label = "u-boot-env";
-			reg = <0x30000 0x10000>;
-			read-only;
-		};
-
-		factory: partition@40000 {
-			label = "factory";
-			reg = <0x40000 0x10000>;
-		};
-
-		partition@50000 {
-			label = "firmware";
-			reg = <0x50000 0xfb0000>;
-		};
-	};
 };
 
 &pcie {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -103,12 +103,13 @@ define Device/sap-g3200u3
 endef
 TARGET_DEVICES += sap-g3200u3
 
+witi_device_packages = kmod-usb3 kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci \
+	kmod-rtc-pcf8563 kmod-i2c-mt7621
 define Device/witi
-  DTS := WITI
+  DTS := WITI-SPI
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := MQmaker WiTi
-  DEVICE_PACKAGES := kmod-usb3 kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci \
-	kmod-rtc-pcf8563 kmod-i2c-mt7621
+  DEVICE_PACKAGES := ${witi_device_packages}
 endef
 TARGET_DEVICES += witi
 
@@ -121,11 +122,9 @@ define Device/witi-nand
   KERNEL := $(KERNEL_DTB) | pad-offset 131072 64 | uImage lzma
   IMAGE/sysupgrade.bin := append-kernel | append-ubi | check-size $$$$(IMAGE_SIZE)
   DEVICE_TITLE := MQmaker WiTi (NAND)
-  DEVICE_PACKAGES := kmod-usb3 kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci \
-        kmod-rtc-pcf8563 kmod-i2c-mt7621
+  DEVICE_PACKAGES := ${witi_device_packages}
 endef
 TARGET_DEVICES += witi-nand
-
 
 define Device/wndr3700v5
   DTS := WNDR3700V5

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -115,8 +115,6 @@ TARGET_DEVICES += witi
 
 define Device/witi-nand
   DTS := WITI-NAND
-  BLOCKSIZE := 128KiB
-  PAGESIZE := 2048
   FILESYSTEMS := squashfs
   IMAGE_SIZE := 132382720
   KERNEL := $(KERNEL_DTB) | pad-offset 131072 64 | uImage lzma

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -112,6 +112,21 @@ define Device/witi
 endef
 TARGET_DEVICES += witi
 
+define Device/witi-nand
+  DTS := WITI-NAND
+  BLOCKSIZE := 128KiB
+  PAGESIZE := 2048
+  FILESYSTEMS := squashfs
+  IMAGE_SIZE := 132382720
+  KERNEL := $(KERNEL_DTB) | pad-offset 131072 64 | uImage lzma
+  IMAGE/sysupgrade.bin := append-kernel | append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := MQmaker WiTi (NAND)
+  DEVICE_PACKAGES := kmod-usb3 kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci \
+        kmod-rtc-pcf8563 kmod-i2c-mt7621
+endef
+TARGET_DEVICES += witi-nand
+
+
 define Device/wndr3700v5
   DTS := WNDR3700V5
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
WiTi is a MT7621 SOC board. It support SPI(default) and NAND flash. This patch add support for nand version.