### PR TITLE
mvebu: update crypto engine

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -711,13 +711,15 @@ endef
 $(eval $(call KernelPackage,crypto-xts))
 
 
-define KernelPackage/crypto-mv-cesa
-  TITLE:=Marvell crypto engine
-  DEPENDS:=+kmod-crypto-manager @TARGET_kirkwood||TARGET_orion
-  KCONFIG:=CONFIG_CRYPTO_DEV_MV_CESA
-  FILES:=$(LINUX_DIR)/drivers/crypto/mv_cesa.ko
-  AUTOLOAD:=$(call AutoLoad,09,mv_cesa)
+define KernelPackage/crypto-marvell-cesa
+  TITLE:=New Marvell crypto engine
+  DEPENDS:=+kmod-crypto-manager @TARGET_kirkwood||TARGET_orion||TARGET_mvebu
+  KCONFIG:= \
+	CONFIG_CRYPTO_DEV_MARVELL_CESA \
+	CONFIG_CRYPTO_HW=y
+  FILES:=$(LINUX_DIR)/drivers/crypto/marvell/marvell-cesa.ko
+  AUTOLOAD:=$(call AutoLoad,09,marvell-cesa)
   $(call AddDepends/crypto)
 endef
 
-$(eval $(call KernelPackage,crypto-mv-cesa))
+$(eval $(call KernelPackage,crypto-marvell-cesa))


### PR DESCRIPTION
Removed obsolete mv-cesa module. It has been replaced by marvell-cesa.

Signed-off-by: Sebastian Careba <nitroshift@yahoo.com>