### PR TITLE
lantiq: td-w8980 and td-w9980: fix failsafe mode

### DIFF
--- a/target/linux/lantiq/base-files/lib/preinit/05_set_preinit_iface_lantiq
+++ b/target/linux/lantiq/base-files/lib/preinit/05_set_preinit_iface_lantiq
@@ -10,6 +10,12 @@ set_preinit_iface() {
 	TDW8970)
 		ifname=eth0
 		;;
+	TDW8980)
+		ifname=eth0
+		;;
+	TDW9980)
+		ifname=eth0
+		;;		
 	esac
 
 }


### PR DESCRIPTION
fix failsafe-mode access for TD-W8980 _(and for future builds TD-W9980)_ via ethernet. Kept *case* for readability.

Signed-off-by: Sven Rojek git@klottenkiste.de