### PR TITLE
Add kmod-igb as a default package for x86-64 builds

### DIFF
--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,6 +1,6 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
-DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169
+DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb
 ARCH_PACKAGES:=x86_64
 MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
 


### PR DESCRIPTION
I'm running an Intel i340-t4 four port gigabit card on my router. Adding this package to the x86-64 build means that this card and other common Intel cards supported by the kmod-igb kernel module will work out of the box. Without this module, OpenWrt upgrades are very frustrating because the configuration for the various interfaces becomes incorrect without the module installed.