### PR TITLE
tools/expat: Upgrade expat to 2.2.0 (support aarch64)

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2014 OpenWrt.org
+# Copyright (C) 2006-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_VERSION:=2.1.0
-
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=dd7dab7a5fea97d2a6a43f511449b7cd
+PKG_VERSION:=2.2.0
+ 
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_MD5SUM:=2f47841c829facb346eb6e3fab5212e2
 PKG_SOURCE_URL:=@SF/expat
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
Building OpenWRT on an aarch64 system (odroid C2) fails in configure for expat 2.1.0; upgrading to 2.2.0 adds support for building on aarch64. Tested by building OpenWRT and running on a Carambola2 test system.