### PR TITLE
opkg: sync with current patchlevel at lede-project

### DIFF
--- a/package/system/opkg/Makefile
+++ b/package/system/opkg/Makefile
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2016 LEDE Project
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -12,13 +13,14 @@ include $(INCLUDE_DIR)/feeds.mk
 PKG_NAME:=opkg
 PKG_REV:=9c97d5ecd795709c8584e972bfdf3aee3a5b846d
 PKG_VERSION:=$(PKG_REV)
-PKG_RELEASE:=12
+PKG_RELEASE:=15
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_REV)
 PKG_SOURCE_SUBDIR:=opkg-$(PKG_VERSION)
 PKG_SOURCE_URL:=http://git.yoctoproject.org/git/opkg
-PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.gz
+PKG_SOURCE:=$(PKG_SOURCE_SUBDIR).tar.xz
+PKG_MIRROR_MD5SUM:=abba824695a7dd4acf2a6371c4e22142656b3d1f0fa93c04410116d2170ce1a9
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES = autogen.sh aclocal.m4
@@ -26,8 +28,9 @@ PKG_REMOVE_FILES = autogen.sh aclocal.m4
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING
 
-PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
+PKG_FLAGS := nonshared
 PKG_CONFIG_DEPENDS := CONFIG_SIGNED_PACKAGES
 
 PKG_BUILD_PARALLEL:=1

--- a/package/system/opkg/patches/007-force_static.patch
+++ b/package/system/opkg/patches/007-force_static.patch
@@ -1,6 +1,6 @@
 --- a/libopkg/Makefile.am
 +++ b/libopkg/Makefile.am
-@@ -38,16 +38,10 @@
+@@ -38,16 +38,10 @@ if HAVE_SHA256
  opkg_util_sources += sha256.c sha256.h
  endif
  
@@ -22,7 +22,7 @@
 +libopkg_a_LIBADD = $(top_builddir)/libbb/libbb.a
 --- a/libbb/Makefile.am
 +++ b/libbb/Makefile.am
-@@ -2,9 +2,9 @@
+@@ -2,9 +2,9 @@ HOST_CPU=@host_cpu@
  BUILD_CPU=@build_cpu@
  ALL_CFLAGS=-g -O -Wall -DHOST_CPU_STR=\"$(HOST_CPU)\" -DBUILD_CPU=@build_cpu@
  
@@ -36,7 +36,7 @@
  	wfopen.c \
 --- a/tests/Makefile.am
 +++ b/tests/Makefile.am
-@@ -4,11 +4,11 @@
+@@ -4,11 +4,11 @@ AM_CFLAGS = $(ALL_CFLAGS) -Wall -g -O3 -
  #noinst_PROGRAMS = libopkg_test opkg_active_list_test
  noinst_PROGRAMS = libopkg_test
  
@@ -50,7 +50,7 @@
  #opkg_extract_test_SOURCES = opkg_extract_test.c
  #opkg_extract_test_CFLAGS = $(ALL_CFLAGS) -I$(top_srcdir)
  
-@@ -16,7 +16,7 @@
+@@ -16,7 +16,7 @@ noinst_PROGRAMS = libopkg_test
  #opkg_active_list_test_SOURCES = opkg_active_list_test.c
  #opkg_active_list_test_CFLAGS = $(ALL_CFLAGS) -I$(top_srcdir)
  
@@ -61,7 +61,7 @@
  
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -2,5 +2,5 @@
+@@ -2,5 +2,5 @@ AM_CFLAGS = -I${top_srcdir}/libopkg ${AL
  bin_PROGRAMS = opkg-cl
  
  opkg_cl_SOURCES = opkg-cl.c

--- a/package/system/opkg/patches/110-upgrade.patch
+++ b/package/system/opkg/patches/110-upgrade.patch
@@ -1,6 +1,6 @@
 --- a/libopkg/opkg_install.c
 +++ b/libopkg/opkg_install.c
-@@ -1405,9 +1405,10 @@
+@@ -1405,9 +1405,11 @@ opkg_install_pkg(pkg_t *pkg, int from_up
  	  opkg_state_changed++;
  	  pkg->state_flag |= SF_FILELIST_CHANGED;
  
@@ -8,12 +8,13 @@
 +	  if (old_pkg) {
                 pkg_remove_orphan_dependent(pkg, old_pkg);
 -
++	       old_pkg->is_upgrade = 1;
 +	       pkg->is_upgrade = 1;
 +	  }
  	  /* XXX: BUG: we really should treat replacement more like an upgrade
  	   *      Instead, we're going to remove the replacees
  	   */
-@@ -1466,7 +1467,7 @@
+@@ -1466,7 +1468,7 @@ opkg_install_pkg(pkg_t *pkg, int from_up
  	  }
  
  
@@ -24,7 +25,7 @@
  			       " Package debris may remain!\n",
 --- a/libopkg/pkg.c
 +++ b/libopkg/pkg.c
-@@ -1285,6 +1285,12 @@
+@@ -1285,6 +1285,12 @@ pkg_run_script(pkg_t *pkg, const char *s
       setenv("PKG_ROOT",
  	    pkg->dest ? pkg->dest->root_dir : conf->default_dest->root_dir, 1);
  
@@ -39,7 +40,7 @@
  	  return 0;
 --- a/libopkg/pkg.h
 +++ b/libopkg/pkg.h
-@@ -184,6 +184,7 @@
+@@ -184,6 +184,7 @@ struct pkg
       /* this flag specifies whether the package was installed to satisfy another
        * package's dependancies */
       int auto_installed;

--- a/package/system/opkg/patches/200-usign_support.patch
+++ b/package/system/opkg/patches/200-usign_support.patch
@@ -59,7 +59,7 @@
  #include <stdio.h>
  #include <unistd.h>
  #include <libgen.h>
-@@ -342,7 +343,28 @@ opkg_prepare_url_for_install(const char 
+@@ -342,7 +343,28 @@ opkg_prepare_url_for_install(const char
  int
  opkg_verify_file (char *text_file, char *sig_file)
  {

--- a/package/system/opkg/patches/220-drop-release-support.patch
+++ b/package/system/opkg/patches/220-drop-release-support.patch
@@ -1,6 +1,6 @@
 --- a/libopkg/Makefile.am
 +++ b/libopkg/Makefile.am
-@@ -15,7 +15,6 @@
+@@ -15,7 +15,6 @@ opkg_cmd_sources = opkg_cmd.c opkg_cmd.h
  		   opkg_upgrade.c opkg_upgrade.h \
  		   opkg_remove.c opkg_remove.h
  opkg_db_sources = opkg_conf.c opkg_conf.h \
@@ -8,7 +8,7 @@
  		  opkg_utils.c opkg_utils.h pkg.c pkg.h hash_table.h \
  		  pkg_depends.c pkg_depends.h pkg_extract.c pkg_extract.h \
  		  hash_table.c pkg_hash.c pkg_hash.h pkg_parse.c pkg_parse.h \
-@@ -28,7 +27,6 @@
+@@ -28,7 +27,6 @@ opkg_list_sources = conffile.c conffile.
  		    active_list.c active_list.h list.h 
  opkg_util_sources = file_util.c file_util.h opkg_message.h opkg_message.c md5.c md5.h \
  		    parse_util.c parse_util.h \
@@ -719,7 +719,7 @@
  #include "pkg.h"
  #include "pkg_dest.h"
  #include "pkg_parse.h"
-@@ -114,39 +113,6 @@
+@@ -114,39 +113,6 @@ opkg_update_cmd(int argc, char **argv)
       }
  
  
@@ -769,7 +769,7 @@
  #include "pkg.h"
  #include "opkg_message.h"
  #include "pkg_vec.h"
-@@ -183,40 +182,6 @@
+@@ -183,40 +182,6 @@ pkg_hash_load_feeds(void)
  	lists_dir = conf->restrict_to_default_dest ?
  		conf->default_dest->lists_dir : conf->lists_dir;
  

--- a/package/system/opkg/patches/270-fix-use-after-free.patch
+++ b/package/system/opkg/patches/270-fix-use-after-free.patch
@@ -1,0 +1,11 @@
+--- a/libopkg/opkg_download.c
++++ b/libopkg/opkg_download.c
+@@ -335,7 +335,7 @@ opkg_prepare_url_for_install(const char
+      hash_insert_pkg(pkg, 1);
+ 
+      if (namep) {
+-	  *namep = pkg->name;
++	  *namep = xstrdup(pkg->name);
+      }
+      return 0;
+ }

--- a/package/system/opkg/patches/280-call-prerm-and-postrm-scripts-on-upgrade.patch
+++ b/package/system/opkg/patches/280-call-prerm-and-postrm-scripts-on-upgrade.patch
@@ -1,0 +1,73 @@
+From a8555d352d2851ee1482b74b57ba9eacfb354c18 Mon Sep 17 00:00:00 2001
+From: Peter Urbanec <peteru@urbanec.net>
+Date: Thu, 23 Oct 2014 01:05:35 +1100
+Subject: [PATCH] opkg_install: Call prerm and postrm scripts on package
+ upgrade
+
+When upgrading a package from v1 to v2, run "v1-prerm upgrade v2" and
+"v1-postrm upgrade v2", similarly to what dpkg does.
+
+This patch fixes issue 104.
+
+Signed-off-by: Peter Urbanec <openembedded-devel@urbanec.net>
+Signed-off-by: Paul Barker <paul@paulbarker.me.uk>
+---
+ libopkg/opkg_install.c | 40 ++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 38 insertions(+), 2 deletions(-)
+
+--- a/libopkg/opkg_install.c
++++ b/libopkg/opkg_install.c
+@@ -528,7 +528,25 @@ prerm_upgrade_old_pkg(pkg_t *pkg, pkg_t
+ 	   Error unwind, for both the above cases:
+ 	   old-postinst abort-upgrade new-version
+      */
+-     return 0;
++    int err;
++    char *script_args;
++    char *new_version;
++
++    if (!old_pkg || !pkg)
++        return 0;
++
++    new_version = pkg_version_str_alloc(pkg);
++
++    sprintf_alloc(&script_args, "upgrade %s", new_version);
++    free(new_version);
++    err = pkg_run_script(old_pkg, "prerm", script_args);
++    free(script_args);
++    if (err != 0) {
++        opkg_msg(ERROR, "prerm script for package \"%s\" failed\n",
++                 old_pkg->name);
++        return -1;
++    }
++    return 0;
+ }
+ 
+ static int
+@@ -925,7 +943,25 @@ postrm_upgrade_old_pkg(pkg_t *pkg, pkg_t
+ 	   new-postrm failed-upgrade old-version
+ 	Error unwind, for both cases:
+ 	   old-preinst abort-upgrade new-version    */
+-     return 0;
++    int err;
++    char *script_args;
++    char *new_version;
++
++    if (!old_pkg || !pkg)
++        return 0;
++
++    new_version = pkg_version_str_alloc(pkg);
++
++    sprintf_alloc(&script_args, "upgrade %s", new_version);
++    free(new_version);
++    err = pkg_run_script(old_pkg, "postrm", script_args);
++    free(script_args);
++    if (err != 0) {
++        opkg_msg(ERROR, "postrm script for package \"%s\" failed\n",
++                 old_pkg->name);
++        return -1;
++    }
++    return 0;
+ }
+ 
+ static int


### PR DESCRIPTION
@jow-  do agree or see any problems

- fix use-after-free with duplicate packages on the command line
  https://git.lede-project.org/?p=source.git;a=commit;h=4c60a6f803759105d59b3e1fc52a9e37eecd08cd

- set PKG_UPGRADE also when running scripts for the old package
  https://git.lede-project.org/?p=source.git;a=commit;h=a58f176ef2367f000a60a5ce477beb3cbdedf82e

- run prerm scripts for the old version also on upgrade
  https://git.lede-project.org/?p=source.git;a=commit;h=88a14bfd1da55bbddf5a86b3c452f1d8b1c46a60

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
