### PR TITLE
Add kmod-igbvf kernel module for Intel(R) 82576 Virtual Function Ethernet adapters

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -523,6 +523,23 @@ endef
 
 $(eval $(call KernelPackage,igb))
 
+define KernelPackage/igbvf
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) 82576 Virtual Function Ethernet support
+  DEPENDS:=@PCI_SUPPORT
+  KCONFIG:=CONFIG_IGBVF \
+    CONFIG_IGB_HWMON=n \
+    CONFIG_IGB_DCA=n
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/igbvf/igbvf.ko
+  AUTOLOAD:=$(call AutoLoad,35,igbvf)
+endef
+
+define KernelPackage/igbvf/description
+ Kernel modules for Intel(R) 82576 Virtual Function Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,igbvf))
+
 
 define KernelPackage/b44
   TITLE:=Broadcom 44xx driver


### PR DESCRIPTION
Intel 82576 is an adapter which supports [SR-IOV](https://en.wikipedia.org/wiki/Single-root_input/output_virtualization). Thus the host can assign Virtual Functions (VFs) to different by the PCI-E Passthrough (e.g. VFIO for KVM), to gain different advantages (performance, VF to VF communications, host kernel offload, etc.).

The driver of the passthroughed VFs is the `igbvf` (`igb` is **NOT** compatible).

This is essential for VM guests, to enable them to utilize this feature.