### PR TITLE
scripts/getver: Use git hash instead of numbers for git repos

### DIFF
--- a/scripts/getver.sh
+++ b/scripts/getver.sh
@@ -18,8 +18,7 @@ try_svn() {
 
 try_git() {
 	git rev-parse --git-dir >/dev/null 2>&1 || return 1
-	REV="$(git describe --tags | sed "s/trunk-\([0-9]*\)-.*/\1/g")"
-	REV="$((REV+12009))"
+	REV="$(git describe --always --dirty)"
 	[ -n "$REV" ]
 }
 


### PR DESCRIPTION
Monotonically increasing version numbers don't make sense because they
are not unique between branches. For example two branches with a
common parent will have the same version when they have the same
number of commits on top of the parent.

The sed script after "git describe --tags" assumed that there is a tag
named 'trunk' and that there is no other tag. This assumption breaks
when there is a more recent tag than 'trunk'. In that case, try_git
will always return 12009.

To fix all these issues, use 'git describe --always', which is
guaranteed to always produce a unique hash.