### PR TITLE
include/image.mk: Convert spaces to dashes in sanitize function

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -18,7 +18,7 @@ KDIR=$(KERNEL_BUILD_DIR)
 KDIR_TMP=$(KDIR)/tmp
 DTS_DIR:=$(LINUX_DIR)/arch/$(LINUX_KARCH)/boot/dts
 
-sanitize = $(call tolower,$(subst _,-,$(1)))
+sanitize = $(call tolower,$(subst $(space),-,$(subst _,-,$(1))))
 
 DIST_SANITIZED:=$(call sanitize,$(VERSION_DIST))
 EXTRA_NAME_SANITIZED=$(call sanitize,$(EXTRA_IMAGE_NAME))


### PR DESCRIPTION
If VERSION_DIST contains spaces, then IMG_PREFIX will end up
containing spaces as well. This then breaks the build for the arches
that call $(CP) on $(IMG_PREFIX). To resolve this, simply substitute
the spaces with dashes.

Signed-off-by: Alexandru Gagniuc <alex.g@adaptrum.com>