### PR TITLE
lantiq: Fix for wbmr300 network settings

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -145,15 +145,16 @@ VGV7510KW22)
 	ucidef_add_switch "switch0" \
 		"2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "6t@eth0"
 	;;
-*)
-	ucidef_set_interface_lan 'eth0'
-	;;
 
 WBMR300)
 	lan_mac=$(mtd_get_mac_ascii ubootconfig ethaddr)
 	wan_mac="$lan_mac"
 	ucidef_add_switch "switch0" \
 		"2:lan:1" "3:lan:2" "5:lan:3" "4:wan:1" "6t@eth0"
+	;;
+
+*)
+	ucidef_set_interface_lan 'eth0'
 	;;
 
 esac


### PR DESCRIPTION
Fix for WBMR300 in /etc/board.d/02_network 

The default statement was placed before the WBMR300 statement (see commit bb7bcc20eb92325c316ab6d4739385cb77851686), resulting ignored settings. It there a reason for that ?


Signed-off-by: Sebastien Decourriere <sebtx452@gmail.com>