### PR TITLE
Mvebu: update armada-385-linksys-rango.dts

### DIFF
--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -344,7 +344,7 @@
 		pinctrl-names = "default";
 
 		power {
-			gpios = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 


### PR DESCRIPTION
Fix Power LED issue. Reported as properly working now here: https://forum.openwrt.org/viewtopic.php?pid=347473#p347473

Signed-off-by: Sebastian Careba <nitroshift@yahoo.com>