### PR TITLE
target.mk: check that CPU_TYPE has known CPU_CFLAGS mapping

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -269,6 +269,11 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_arc700 = -marc700
     CPU_CFLAGS_archs = -marchs
   endif
+  ifneq ($(CPU_TYPE),)
+    ifndef CPU_CFLAGS_$(CPU_TYPE)
+      $(warning CPU_TYPE "$(CPU_TYPE)" doesn't correspond to a known type)
+    endif
+  endif
   DEFAULT_CFLAGS=$(strip $(CPU_CFLAGS) $(CPU_CFLAGS_$(CPU_TYPE)) $(CPU_CFLAGS_$(CPU_SUBTYPE)))
 endif
 


### PR DESCRIPTION
If someone creates a target and indicates a CPU_TYPE, but there's
no corresponding support for that CPU_TYPE's flags in include/target.mk
then that should probably be indicated rather than silently ignored.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>