### PR TITLE
hwmon-nct6775, hwmon-coretemp: hardware monitors for current Xeon systems

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -78,6 +78,21 @@ endef
 $(eval $(call KernelPackage,hwmon-adt7475))
 
 
+define KernelPackage/hwmon-nct6775
+  TITLE:=NCT6106D/6775F/6776F/6779D/6791D/6792D/6793D and compatibles monitoring support
+  KCONFIG:=CONFIG_SENSORS_NCT6775
+  FILES:=$(LINUX_DIR)/drivers/hwmon/nct6775.ko
+  AUTOLOAD:=$(call AutoProbe,nct6775)
+  $(call AddDepends/hwmon,@PCI_SUPPORT @TARGET_x86 +kmod-hwmon-vid)
+endef
+
+define KernelPackage/hwmon-nct6775/description
+ Kernel module for NCT6106D/6775F/6776F/6779D/6791D/6792D/6793D thermal monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-nct6775))
+
+
 define KernelPackage/hwmon-ina2xx
   TITLE:=INA2XX monitoring support
   KCONFIG:=CONFIG_SENSORS_INA2XX

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -93,6 +93,21 @@ endef
 $(eval $(call KernelPackage,hwmon-nct6775))
 
 
+define KernelPackage/hwmon-coretemp
+  TITLE:=Intel Core/Core2/Atom thermal monitoring support
+  KCONFIG:=CONFIG_SENSORS_CORETEMP
+  FILES:=$(LINUX_DIR)/drivers/hwmon/coretemp.ko
+  AUTOLOAD:=$(call AutoProbe,coretemp)
+  $(call AddDepends/hwmon,@TARGET_x86)
+endef
+
+define KernelPackage/hwmon-coretemp/description
+ Kernel module for Intel Core/Core2/Atom thermal monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-coretemp))
+
+
 define KernelPackage/hwmon-ina2xx
   TITLE:=INA2XX monitoring support
   KCONFIG:=CONFIG_SENSORS_INA2XX


### PR DESCRIPTION
The w83627ehf is a deprecated driver and the nct6775/6776 families now have their own driver.

The on-chip temperature sensor for Core/Core2/Atom chips is supported by coretemp.ko.

Built and tested against head (8784268) on a Sandybridge server.