### PR TITLE
lantiq: Add initial support for Bintec RS353xx xDSL router

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -152,7 +152,15 @@ WBMR300)
 	ucidef_add_switch "switch0" \
 		"2:lan:1" "3:lan:2" "5:lan:3" "4:wan:1" "6t@eth0"
 	;;
-
+RS353)
+	ucidef_add_switch "switch0" \
+		"4:lan:1" "2:lan:2" "1:lan:3" "0:lan:4" "5:lan:5" "6t@eth0"
+	# Little hack to get the macaddr from flash and reorder bytes
+	mac1=$(mtd_get_mac_binary logic_config 1064 | cut -d ":" -f 1,2)
+	mac2=$(mtd_get_mac_binary logic_config 1066 | cut -d ":" -f 1,2)
+	mac3=$(mtd_get_mac_binary logic_config 1066 | cut -d ":" -f 5,6)
+	lan_mac=$mac2:$mac1:$mac3
+	;;
 *)
 	ucidef_set_interface_lan 'eth0'
 	;;

--- a/target/linux/lantiq/dts/RS353.dts
+++ b/target/linux/lantiq/dts/RS353.dts
@@ -1,0 +1,289 @@
+/dts-v1/;
+
+/include/ "vr9.dtsi"
+
+/ {
+	model = "RS353 - Bintec Elmeg RS353";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200 init=/etc/preinit";
+		leds {
+			running = &status;
+			boot = &status;
+			wifi = &wlan;
+			usb2 = &usb; /* Front port is mapped to device 2 */
+			dsl = &dsl;
+		};
+	};
+
+	memory@0 {
+		reg = <0x0 0x8000000>;
+	};
+
+	fpi@10000000 {
+		localbus@0 {
+			nor-boot@0 {
+				compatible = "lantiq,nor";
+				bank-width = <2>;
+				reg = <0 0x0 0x2000000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					boardconfig: partition@0 {
+						label = "logic_config";
+						reg = <0x0 0x20000>;
+						read-only;
+					};
+
+					partition@0x20000 {
+						label = "logic_addr";
+						reg = <0x20000 0x20000>;
+						read-only;
+					};
+
+					partition@0x40000 {
+						label = "bootmonitor";
+						reg = <0x40000 0x20000>;
+						read-only;
+					};
+
+					partition@0x80000 {
+						label = "flash_config";
+						reg = <0x80000 0x40000>;
+						read-only;
+					};
+
+					partition@0xc0000 {
+						label = "uboot";
+						reg = <0xc0000 0x40000>;
+					};
+
+					partition@0x100000 {
+						label = "uboot-env";
+						reg = <0x100000 0x20000>;
+					};
+					
+					partition@0x120000 {
+						label = "firmware";
+						reg = <0x120000 0x1EC0000>;
+					};
+
+					partition@0x1FE0000 {
+						label = "GPHY_CPR";
+						reg = <0x1FE0000 0x20000>;
+					};
+				};
+			};
+		};
+
+		gpio: pinmux@E100B10 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&state_default>;
+
+			state_default: pinmux {
+				mdio {
+					lantiq,groups = "mdio";
+					lantiq,function = "mdio";
+				};
+				i2c {
+				 	lantiq,pins = "io19", "io20"; /* port i2c */
+				 	lantiq,open-drain;
+				 	lantiq,pull = <2>;
+				};
+				gphy-leds {
+					lantiq,groups = "gphy0 led0", "gphy0 led1",
+					"gphy0 led2", "gphy1 led0",
+					"gphy1 led1", "gphy1 led2";
+					lantiq,function = "gphy";
+					lantiq,pull = <2>;
+					lantiq,open-drain = <0>;
+					lantiq,output = <1>;
+				};
+			};
+		};
+
+		ifxhcd@E101000 {
+			status = "okay";
+		};
+
+		ifxhcd@E106000 {
+			status = "okay";
+		};
+
+		pcie@d900000 {
+			status = "okay";
+			gpio-reset = <&gpio 18 0>;
+		};
+	};
+
+	i2c@0 {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 20 0 /* sda */
+	 		&gpio 19 0 /* scl */
+			>;
+		i2c-gpio,delay-us = <2>;	/* ~100 kHz */
+		
+		#address-cells = <1>;
+		#size-cells = <0>;
+		s35390a: s35390a@30 {
+			compatible = "ssi,s35390a";
+			reg = <0x30>;
+		};
+	};
+
+	gphy-xrx200 {
+		compatible = "lantiq,phy-xrx200";
+		firmware1 = "lantiq/vr9_phy11g_a1x.bin";	/*VR9 1.1*/
+		firmware2 = "lantiq/vr9_phy11g_a2x.bin";	/*VR9 1.2*/
+		phys = [ 00 01 ];
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 34 0>;
+			linux,code = <0x198>;
+		};
+		function {
+			label = "function";
+			gpios = <&gpio 35 0>;
+			linux,code = <0x100>; /*BTN_0*/
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wlan: wlan {
+			label = "rs353:green:wlan";
+			gpios = <&gpio 28 1>;
+		};
+
+		dsl: dsl {
+			label = "rs353:green:dsl";
+			gpios = <&gpio 8 1>;
+		};
+
+		usb: usb {
+			label = "rs353:green:usb";
+			gpios = <&gpio 11 1>;
+		};
+
+		status: status {
+			label = "rs353:green:status";
+			gpios = <&gpio 12 1>;
+		};
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		mac-address = [ 00 11 22 33 44 55 ];
+		lantiq,switch;
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
+		};
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy1>;
+		};
+
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy2>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			lantiq,led0h = <0x20>;
+			lantiq,led0l = <0x00>;
+			lantiq,led1h = <0x40>;
+			lantiq,led1l = <0x00>;
+			lantiq,led2h = <0x70>;
+			lantiq,led2l = <0x03>;
+		};
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			lantiq,led0h = <0x20>;
+			lantiq,led0l = <0x00>;
+			lantiq,led1h = <0x40>;
+			lantiq,led1l = <0x00>;
+			lantiq,led2h = <0x70>;
+			lantiq,led2l = <0x03>;
+		};
+		phy2: ethernet-phy@2 {
+			reg = <0x2>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			lantiq,led0h = <0x20>;
+			lantiq,led0l = <0x00>;
+			lantiq,led1h = <0x40>;
+			lantiq,led1l = <0x00>;
+			lantiq,led2h = <0x70>;
+			lantiq,led2l = <0x03>;
+		};
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			lantiq,led0h = <0x20>;
+			lantiq,led0l = <0x00>;
+			lantiq,led1h = <0x40>;
+			lantiq,led1l = <0x00>;
+			lantiq,led2h = <0x70>;
+			lantiq,led2l = <0x03>;
+		};
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+			lantiq,led0h = <0x20>;
+			lantiq,led0l = <0x00>;
+			lantiq,led1h = <0x40>;
+			lantiq,led1l = <0x00>;
+			lantiq,led2h = <0x70>;
+			lantiq,led2l = <0x03>;
+		};
+	};
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -687,6 +687,14 @@ define LegacyDevice/FRITZ7360SL
 endef
 LEGACY_DEVICES += FRITZ7360L
 
+define Device/RS353
+  DEVICE_PROFILE := RS353
+  DEVICE_TITLE := Bintec RS353
+  IMAGE_SIZE := 31232k
+  DEVICE_PACKAGES := kmod-usb-dwc2 kmod-ath9k wpad-mini kmod-i2c-gpio kmod-swconfig wpad-mini kmod-ledtrig-usbdev
+endef
+TARGET_DEVICES += RS353
+
 Image/Prepare/Profile/VG3503J=$(call Image/Prepare/Template,VG3503J)
 Image/BuildKernel/Profile/VG3503J=$(call Image/BuildKernelLoader/Template,VG3503J)
 Image/Build/Profile/VG3503J=$(call Image/BuildLoader/$(1),$(1),VG3503J)


### PR DESCRIPTION
Based on work described in the forum : https://forum.openwrt.org/viewtopic.php?pid=346580#p346580

Manufacturer website: http://www.bintec-elmeg.com/en/bintec-RS353aw-837.html

Specs :

- CPU : VRX288 v1.2 (PSB 80920 EL) @500MHz
- RAM : 128 MiB
- Flash : 32 MiB (AMD/Spansion S29GL256FLT2I)
- 5 Gigabit Ethernet ports ( 2 integrated and 3 PEF7071 )
- Wireless : Atheros AR9300 Rev:4 (RS353aw version)
- xDSL modem (ADSL2/VDSL VRX208)
- 1 USB 2.0 host port
- 1 uart port (accessible via front USB device port)
- 1 JTAG header (standard 14pin Mips)
- S-35390A real time clock on i2c-gpio bus

Signed-off-by: Sebastien Decourriere <sebtx452@gmail.com>