### PR TITLE
lantiq: td-w8980: fix failsafe mode

### DIFF
--- a/target/linux/lantiq/base-files/lib/preinit/05_set_preinit_iface_lantiq
+++ b/target/linux/lantiq/base-files/lib/preinit/05_set_preinit_iface_lantiq
@@ -7,7 +7,7 @@ set_preinit_iface() {
 	board=$(lantiq_board_name)
 
 	case "$board" in
-	TDW8970)
+	TDW8970|TDW8980)
 		ifname=eth0
 		;;
 	esac


### PR DESCRIPTION
fix failsafe-mode access for TD-W8980 (and for future builds TD-W9980) via ethernet. Kept case for readability.

Signed-off-by: Sven Rojek <git@klottenkiste.de>