### PR TITLE
ramips: Repair unbootable WLI-TX4-AG300N image without LAN access.

### DIFF
--- a/target/linux/ramips/dts/WLI-TX4-AG300N.dts
+++ b/target/linux/ramips/dts/WLI-TX4-AG300N.dts
@@ -35,7 +35,7 @@
 		};
 
 		partition@50000 {
-			label = "linux";
+			label = "firmware";
 			reg = <0x50000 0x3b0000>;
 		};
 	};
@@ -94,7 +94,15 @@
 	mtd-mac-address = <&factory 0x4>;
 
 	port@0 {
-		mediatek,fixed-link = <1000 1 1 1>;
+		mediatek,fixed-link = <100 1 1 1>;
+	};
+	
+	mdio-bus {
+		status = "okay";
+		phy0: ethernet-phy@0 {
+			phy-mode = "mii";
+			reg = <0>;
+		};
 	};
 };
 


### PR DESCRIPTION
Partition label "linux" seems to prevent the root file system to be mounted at boot time leading to a kernel panic.
After changing it to "firmware", the 2 uimage partitions "kernel", "rootfs" and squashfs "rootfs_data" are correctly recognized.

The attached IP175C 10/100 switch cannot connect to a link with fixed 1000Mbit speed. The correct link speed is 100. The switch is detected and can be configured via mdio bus and should allow two separable VLANs to be configured for the 4 available ports.

This patch has only been tested on a pre-compiled image generator and needs to be verified in a full build.

signed-off-by Yo Abe<abe.geel@gmail.com>