### PR TITLE
fix sysupgrade for x86: dd use wrong ibs, should be fixed to 512

### DIFF
--- a/target/linux/x86/base-files/lib/upgrade/platform.sh
+++ b/target/linux/x86/base-files/lib/upgrade/platform.sh
@@ -119,12 +119,8 @@ platform_do_upgrade() {
 		if [ "$SAVE_PARTITIONS" = "1" ]; then
 			get_partitions "/dev/$diskdev" bootdisk
 
-			#get block size
-			if [ -f "/sys/block/$diskdev/queue/physical_block_size" ]; then
-				ibs="$(cat "/sys/block/$diskdev/queue/physical_block_size")"
-			else
-				ibs=512
-			fi
+			#it is fixed to 512
+			ibs=512
 
 			#extract the boot sector from the image
 			get_image "$@" | dd of=/tmp/image.bs count=1 bs=512b


### PR DESCRIPTION
sysupgrade for x86
we create an img for upgrade, the block_size is fixed as 512
/sys/block/sda/queue/physical_block_size is 4096 for many 1TGB disk
physical_block_size is for how we write, i.e. obs=physical_block_size*N
not the ibs