### PR TITLE
usb: Remove annoying warning about bogus URB

### DIFF
--- a/target/linux/generic/patches-4.4/821-usb-Remove-annoying-warning-about-bogus-URB.patch
+++ b/target/linux/generic/patches-4.4/821-usb-Remove-annoying-warning-about-bogus-URB.patch
@@ -1,0 +1,14 @@
+--- a/drivers/usb/core/urb.c
++++ b/drivers/usb/core/urb.c
+@@ -443,11 +443,6 @@ int usb_submit_urb(struct urb *urb, gfp_t mem_flags)
+ 	 * cause problems in HCDs if they get it wrong.
+ 	 */
+ 
+-	/* Check that the pipe's type matches the endpoint's type */
+-	if (usb_pipetype(urb->pipe) != pipetypes[xfertype])
+-		dev_WARN(&dev->dev, "BOGUS urb xfer, pipe %x != type %x\n",
+-			usb_pipetype(urb->pipe), pipetypes[xfertype]);
+-
+ 	/* Check against a simple/standard policy */
+ 	allowed = (URB_NO_TRANSFER_DMA_MAP | URB_NO_INTERRUPT | URB_DIR_MASK |
+ 			URB_FREE_BUFFER);


### PR DESCRIPTION
When USB Wi-Fi dongle based on Atheros AR9271 is connected to OHCI
(USB 1.1) controller following warnings flood debug console:
------------------------>8---------------------------
usb 1-1: new full-speed USB device number 2 using ohci-platform
usb 1-1: ath9k_htc: Firmware ath9k_htc/htc_9271-1.4.0.fw requested
usb 1-1: ath9k_htc: Transferred FW: ath9k_htc/htc_9271-1.4.0.fw, size: 51008
------------[ cut here ]------------
WARNING: CPU: 0 PID: 4 at drivers/usb/core/urb.c:450
usb_submit_urb+0x162/0x404
usb 1-1: BOGUS urb xfer, pipe 1 != type 3
Modules linked in:
CPU: 0 PID: 4 Comm: kworker/0:0 Not tainted 4.6.3 #10
Workqueue: events request_firmware_work_func

Stack Trace:
  arc_unwind_core.constprop.1+0x94/0x10c
---[ end trace 2249b79eac9991d1 ]---
------------[ cut here ]------------
WARNING: CPU: 0 PID: 4 at drivers/usb/core/urb.c:450 usb_submit_urb+0x162/0x404
usb 1-1: BOGUS urb xfer, pipe 1 != type 3
Modules linked in:
CPU: 0 PID: 4 Comm: kworker/0:0 Tainted: G        W       4.6.3 #10
Workqueue: events request_firmware_work_func

Stack Trace:
  arc_unwind_core.constprop.1+0x94/0x10c
---[ end trace 2249b79eac9991d2 ]---
------------[ cut here ]------------
WARNING: CPU: 0 PID: 4 at drivers/usb/core/urb.c:450 usb_submit_urb+0x162/0x404
usb 1-1: BOGUS urb xfer, pipe 1 != type 3
Modules linked in:
CPU: 0 PID: 4 Comm: kworker/0:0 Tainted: G        W       4.6.3 #10
Workqueue: events request_firmware_work_func

Stack Trace:
  arc_unwind_core.constprop.1+0x94/0x10c
---[ end trace 2249b79eac9991d3 ]---

...
------------------------>8---------------------------

With removed warning Wi-Fi dongle works properly.

Even though this is not the best solution it gets us a working Wireless
AP. Anyways new discussion was started in linux-usb mailing list to find
a proper solution instead of that hack.

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>
Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>