### PR TITLE
kernel: add makefile entry for IXGBE SRIOV VF

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -523,6 +523,7 @@ endef
 
 $(eval $(call KernelPackage,igb))
 
+
 define KernelPackage/igbvf
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Intel(R) 82576 Virtual Function Ethernet support
@@ -558,6 +559,25 @@ define KernelPackage/ixgbe/description
 endef
 
 $(eval $(call KernelPackage,ixgbe))
+
+
+define KernelPackage/ixgbevf
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) 82599 Virtual Function Ethernet support
+  DEPENDS:=@PCI_SUPPORT +kmod-ixgbe
+  KCONFIG:=CONFIG_IXGBEVF \
+    CONFIG_IXGBE_VXLAN=n \
+    CONFIG_IXGBE_HWMON=n \
+    CONFIG_IXGBE_DCA=n
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/ixgbevf/ixgbevf.ko
+  AUTOLOAD:=$(call AutoLoad,35,ixgbevf)
+endef
+
+define KernelPackage/ixgbevf/description
+ Kernel modules for Intel(R) 82599 Virtual Function Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,ixgbevf))
 
 
 define KernelPackage/b44


### PR DESCRIPTION
Building off PR #302 / #313 - including ixgbe SR-IOV virtual function network driver. Tested against SR-IOV VF on Intel X520 as KVM guest (built with target x86_64).