### PR TITLE
patch-kernel.sh: handle broken tarballs w/ 444 mode files

### DIFF
--- a/scripts/patch-kernel.sh
+++ b/scripts/patch-kernel.sh
@@ -36,6 +36,10 @@ for i in ${patchdir}/${patchpattern} ; do
     esac
     [ -d "${i}" ] && echo "Ignoring subdirectory ${i}" && continue	
     echo ""
+    # because some people publish tarballs containing files with modes u-w
+    awk -e '/^\+\+\+ / { n = match($2, "/"); print substr($2, n + 1); }' "${i}" | while read file; do
+	[ ! -f ${targetdir}/$file -o -w ${targetdir}/$file ] || chmod u+w ${targetdir}/$file
+    done
     echo "Applying ${i} using ${type}: " 
     ${uncomp} ${i} | ${PATCH:-patch} -f -p1 -d ${targetdir}
     if [ $? != 0 ] ; then


### PR DESCRIPTION
Latest perl release (5.24.1) has all files with modes 444 which breaks patch-kernel.sh
