### PR TITLE
ramips: default profile for rt288x images

### DIFF
--- a/target/linux/ramips/rt288x/profiles/00-default.mk
+++ b/target/linux/ramips/rt288x/profiles/00-default.mk
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+define Profile/Default
+	NAME:=Default Profile
+	PRIORITY:=1 
+endef
+
+define Profile/Default/Description
+	Default package set compatible with most boards.
+endef
+$(eval $(call Profile,Default))


### PR DESCRIPTION
Missing default profile for ramips/rt288x prevented image creation during build in trunk (without any error being cast). (as mentioned in a comment to pull request #330)
Adding this profile re-enables image creation for rt288x.

signed-off-by Yo Abe <abe.geel@gmail.com>