### PR TITLE
ramips: add ip17xx support to WLI-TX4-AG300N

### DIFF
--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -59,6 +59,7 @@ define Device/wli-tx4-ag300n
   DTS := WLI-TX4-AG300N
   IMAGE_SIZE := $(ralink_default_fw_size_4M)
   DEVICE_TITLE := Buffalo WLI-TX4-AG300N
+  DEVICE_PACKAGES := kmod-switch-ip17xx
 endef
 TARGET_DEVICES += wli-tx4-ag300n
 


### PR DESCRIPTION
ramips/rt288x WLI-TX4-AG300N was missing support for its 100Mbit switch which should be included by default.

This patch requires patches from pull request #330 (100Mbit LAN setting) and #358 (repair missing image creation for rt288x).

signed-off-by Yo Abe <abe.geel@gmail.com>