### PR TITLE
ccache updates

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -59,7 +59,7 @@ menuconfig DEVEL
 		bool "Use ccache" if DEVEL
 		default n
 		help
-		  Compiler cache; see http://ccache.samba.org/.
+		  Compiler cache; see https://ccache.samba.org/.
 
 	config EXTERNAL_KERNEL_TREE
 		string "Use external kernel tree" if DEVEL

--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -30,7 +30,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ppp/Default
   SECTION:=net
   CATEGORY:=Network
-  URL:=http://ppp.samba.org/
+  URL:=https://ppp.samba.org/
 endef
 
 define Package/ppp

--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -11,8 +11,8 @@ PKG_NAME:=samba
 PKG_VERSION:=3.6.25
 PKG_RELEASE:=5
 
-PKG_SOURCE_URL:=http://ftp.samba.org/pub/samba \
-	http://ftp.samba.org/pub/samba/stable
+PKG_SOURCE_URL:=https://download.samba.org/pub/samba \
+	https://download.samba.org/pub/samba/stable
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_MD5SUM:=76da2fa64edd94a0188531e7ecb27c4e
 
@@ -34,7 +34,7 @@ define Package/samba36-server
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Samba 3.6 SMB/CIFS server
-  URL:=http://www.samba.org/
+  URL:=https://www.samba.org/
   DEPENDS:=+USE_GLIBC:librt $(ICONV_DEPENDS)
 endef
 
@@ -42,7 +42,7 @@ define Package/samba36-client
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Samba 3.6 SMB/CIFS client
-  URL:=http://www.samba.org/
+  URL:=https://www.samba.org/
   DEPENDS:=+libreadline +libncurses
 endef
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -79,7 +79,7 @@ $(curdir)/gengetopt/compile := $(curdir)/libtool/install
 $(curdir)/patchelf/compile := $(curdir)/libtool/install
 
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)
-$(foreach tool, $(filter-out patch,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/install))
+$(foreach tool, $(filter-out xz patch,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/install))
 tools-y += ccache
 endif
 

--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=3.1.11
+PKG_VERSION:=3.3.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://samba.org/ftp/ccache/
-PKG_MD5SUM:=0f6df80c8941d9020a1fd5df5ad57dd7
+PKG_MD5SUM:=2767d8f88f5ec218983a2f05c9e20df2
 
 include $(INCLUDE_DIR)/host-build.mk
 

--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -11,7 +11,8 @@ PKG_NAME:=ccache
 PKG_VERSION:=3.3.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=http://samba.org/ftp/ccache/
+PKG_SOURCE_URL:=https://download.samba.org/pub/ccache/ \
+                https://samba.org/ftp/ccache/
 PKG_MD5SUM:=2767d8f88f5ec218983a2f05c9e20df2
 
 include $(INCLUDE_DIR)/host-build.mk

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,33 +1,12 @@
-From 90762a9b8d9a50b6176f10bd6c2e2b9501117561 Mon Sep 17 00:00:00 2001
-From: Karl Vogel <karl.vogel@gmail.com>
-Date: Tue, 14 Jul 2015 11:05:33 +0200
-Subject: [PATCH] Include environment variable GCC_HONOUR_COPTS in hash.
-
-The OpenWRT patch, 910-mbsd_multi.patch, to GCC adds an extra
-compilation flag, -fhonour-copts, which is influenced by an
-environment variable called GCC_HONOUR_COPTS.
-
-Include this environment var in the hash calculation as otherwise
-the gcc stdout warning from a previous compilation might be shown
-where, even when GCC_HONOUR_COPTS is in 's'ilent mode.
-
-Signed-off-by: Karl Vogel <karl.vogel@gmail.com>
----
- ccache.c | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/ccache.c b/ccache.c
-index e41af13..b736a9c 100644
+index 88e0ec5..7dffeb4 100644
 --- a/ccache.c
 +++ b/ccache.c
-@@ -965,6 +965,7 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
+@@ -1762,6 +1762,7 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
  			"CPLUS_INCLUDE_PATH",
  			"OBJC_INCLUDE_PATH",
- 			"OBJCPLUS_INCLUDE_PATH", /* clang */
+ 			"OBJCPLUS_INCLUDE_PATH", // clang
 +			"GCC_HONOUR_COPTS",
  			NULL
  		};
- 		for (p = envvars; *p != NULL ; ++p) {
--- 
-1.9.1
-
+ 		for (const char **p = envvars; *p; ++p) {

--- a/tools/ccache/patches/110-disable-assembler-support.patch
+++ b/tools/ccache/patches/110-disable-assembler-support.patch
@@ -1,0 +1,32 @@
+--- a/language.c
++++ b/language.c
+@@ -37,14 +37,18 @@ static const struct {
+ 	{".m",   "objective-c"},
+ 	{".M",   "objective-c++"},
+ 	{".mm",  "objective-c++"},
++#if 0
+ 	{".sx",  "assembler-with-cpp"},
+ 	{".S",   "assembler-with-cpp"},
++#endif
+ 	// Preprocessed:
+ 	{".i",   "cpp-output"},
+ 	{".ii",  "c++-cpp-output"},
+ 	{".mi",  "objective-c-cpp-output"},
+ 	{".mii", "objective-c++-cpp-output"},
++#if 0
+ 	{".s",   "assembler"},
++#endif
+ 	// Header file (for precompilation):
+ 	{".h",   "c-header"},
+ 	{".H",   "c++-header"},
+@@ -109,8 +113,10 @@ static const struct {
+ 	{"objective-c++-header",     "objective-c++-cpp-output"},
+ 	{"objective-c++-cpp-output", "objective-c++-cpp-output"},
+ 	{"cuda",                     "cuda-output"},
++#if 0
+ 	{"assembler-with-cpp",       "assembler"},
+ 	{"assembler",                "assembler"},
++#endif
+ 	{"f77-cpp-input",            "f77"},
+ 	{"f77",                      "f77"},
+ #if 0 // Could generate module files, ignore for now!

--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -18,6 +18,9 @@ HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
+HOSTCC := $(HOSTCC_NOCACHE)
+HOSTCXX := $(HOSTCXX_NOCACHE)
+
 HOST_CONFIGURE_ARGS += \
 	--enable-static=yes \
 	--enable-shared=no \


### PR DESCRIPTION
 - backport ccache updates to 3.3.2 from lede
 - move URLs to use https instead of http
