### PR TITLE
busybox: don't install NTP scripts if NTP isn't configured

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -110,12 +110,19 @@ define Build/Compile
 endef
 
 define Package/busybox/install
+	# don't create init.d directory unless installing scripts
+ifneq ($(CONFIG_BUSYBOX_CONFIG_CROND)$(CONFIG_BUSYBOX_CONFIG_NTPD),)
 	$(INSTALL_DIR) $(1)/etc/init.d
+endif
 	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+ifneq ($(CONFIG_BUSYBOX_CONFIG_CROND),)
 	$(INSTALL_BIN) ./files/cron $(1)/etc/init.d/cron
+endif
+ifneq ($(CONFIG_BUSYBOX_CONFIG_NTPD),)
 	$(INSTALL_BIN) ./files/sysntpd $(1)/etc/init.d/sysntpd
 	$(INSTALL_BIN) ./files/ntpd-hotplug $(1)/usr/sbin/ntpd-hotplug
-	-rm -rf $(1)/lib64
+endif
+	rm -rf $(1)/lib64
 endef
 
 $(eval $(call BuildPackage,busybox))


### PR DESCRIPTION
If you're using Chrony or NTPD you don't want the busybox NTP server
as well.  Make its installation truly conditional.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>