### PR TITLE
mvebu: armada-385-linksys-rango device tree fixes

### DIFF
--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -95,16 +95,6 @@
 						reg = <0x1>;
 					};
 
-					wlan_2g@2 {
-						label = "rango:white:wlan_2g";
-						reg = <0x2>;
-					};
-
-					wlan_5g@3 {
-						label = "rango:white:wlan_5g";
-						reg = <0x3>;
-					};
-
 					usb2@5 {
 						label = "rango:white:usb2";
 						reg = <0x5>;
@@ -340,17 +330,28 @@
 
 	gpio-leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&power_led_pin &sata_led_pin>;
+		pinctrl-0 = <&power_led_pin &sata_led_pin &wlan_2g_led_pin &wlan_5g_led_pin>;
 		pinctrl-names = "default";
 
-		power {
+		sata {
+                        label = "rango:white:sata";
+                        gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+                };
+ 
+                wlan_2g {
+                        label = "rango:white:wlan_2g";
+                        gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+                };
+ 
+                wlan_5g {
+                        label = "rango:white:wlan_5g";
+                        gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+                };
+ 
+                power {
+ 			label = "rango:white:power";power {
 			gpios = <&gpio1 25 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
-		};
-
-		sata {
-			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-			default-state = "off";
 		};
 	};
 
@@ -396,16 +397,6 @@
 				reg = <5>;
 				label = "cpu";
 			};
-		};
-	};
-
-	gpio-leds {
-		power {
-			label = "rango:white:power";
-		};
-
-		sata {
-			label = "rango:white:sata";
 		};
 	};
 

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -180,7 +180,7 @@
 				broken-cd;
 				wp-inverted;
 				bus-width = <8>;
-				status = "okay";
+				status = "disabled";
 			};
 
 			/* USB part of the eSATA/USB 2.0 port */

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -315,7 +315,7 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
-		gpio = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		gpio = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 	};
 
 	gpio_keys {

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -415,18 +415,28 @@
 };
 
 &pinctrl {
-	keys_pin: keys-pin {
-		marvell,pins = "mpp24", "mpp29";
-		marvell,function = "gpio";
-	};
-
-	power_led_pin: power-led-pin {
-		marvell,pins = "mpp56";
-		marvell,function = "gpio";
-	};
-
 	sata_led_pin: sata-led-pin {
 		marvell,pins = "mpp21";
+		marvell,function = "gpio";
+	};
+
+	wps_key_pin: wps-key-pin {
+		marvell,pins = "mpp24";
+		marvell,function = "gpio";
+	};
+
+	reset_key_pin: reset-key-pin {
+                marvell,pins = "mpp29";
+                marvell,function = "gpio";
+        };
+ 
+        wlan_2g_led_pin: wlan-2g-led-pin {
+                marvell,pins = "mpp45";
+                marvell,function = "gpio";
+        };
+ 
+        wlan_5g_led_pin: wlan-5g-led-pin {
+                marvell,pins = "mpp46";
 		marvell,function = "gpio";
 	};
 
@@ -434,4 +444,9 @@
 		marvell,pins = "mpp47";
 		marvell,function = "gpio";
 	};
+	
+ 	power_led_pin: power-led-pin {
+                marvell,pins = "mpp56";
+                marvell,function = "gpio";
+        };
 };

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-rango.dts
@@ -350,7 +350,7 @@
  
                 power {
  			label = "rango:white:power";power {
-			gpios = <&gpio1 25 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 	};


### PR DESCRIPTION
Disable sdhci node as it is not used in this device, fix regulator gpio address and also the power, e-sata and wireless leds.