### PR TITLE
ar8216: flush ARL table during reset after init_globals

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/ar8216.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8216.c
@@ -1181,6 +1181,7 @@ ar8xxx_sw_reset_switch(struct switch_dev *dev)
 	priv->arl_age_time = AR8XXX_DEFAULT_ARL_AGE_TIME;
 
 	chip->init_globals(priv);
+	chip->atu_flush(priv);
 
 	mutex_unlock(&priv->reg_mutex);
 


### PR DESCRIPTION
commit 507685b8a5d96fddb9259cb9621f28e59b705ab9 (r46381)
"ar8216: adjust ATU flushing in case of link changes"
introduced portwise flushing on link down events. Now the ARL table could
be in a chaotic state after boot where ar8xxx_sw_get_arl_table looped
forever (depending on the entries collected while booting).

Signed-off-by: Günther Kelleter <guenther.kelleter@devolo.de>