### PR TITLE
sysfixtime: always store/retrieve RTC as UTC normal value

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -16,10 +16,10 @@ boot() {
 }
 
 start() {
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -s -f $RTC_DEV
+	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -s -u -f $RTC_DEV
 }
 
 stop() {
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -f $RTC_DEV && \
+	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV && \
 		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
 }


### PR DESCRIPTION
Cherry-picking 9e8e8b7253e9b91c365a990009febec16fd99f0b from LEDE.