### PR TITLE
Corrected URL to download kernel source

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -177,6 +177,7 @@ foreach my $mirror (@ARGV) {
 			push @extra, "$extra[0]/longterm/v$1";
 		}		
 		foreach my $dir (@extra) {
+			push @mirrors, "https://all.kernel.org/pub/$dir";
 			push @mirrors, "ftp://ftp.all.kernel.org/pub/$dir";
 			push @mirrors, "http://ftp.all.kernel.org/pub/$dir";
 		}


### PR DESCRIPTION
Corrected URL to download kernel source = https://all.kernel.org/pub
