### PR TITLE
kexec-tools: get kexec compiling and running

### DIFF
--- a/package/boot/kexec-tools/patches/120-fail-to-get-symbol-debug.patch
+++ b/package/boot/kexec-tools/patches/120-fail-to-get-symbol-debug.patch
@@ -1,0 +1,31 @@
+Kernel symbol page_offset_base could be unavailable when mm KASLR code is
+not compiled in kernel. It's unappropriate to print out error message
+when failed to search for page_offset_base from /proc/kallsyms. Seems now
+there is not a way to find out if mm KASLR is compiled in or not. An
+alternative approach is only printing out debug message in get_kernel_sym
+if failed to search a expected kernel symbol.
+
+Do it in this patch, a simple fix.
+
+Signed-off-by: Baoquan He <bhe@redhat.com>
+---
+ kexec/arch/i386/crashdump-x86.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kexec/arch/i386/crashdump-x86.c b/kexec/arch/i386/crashdump-x86.c
+index 88aeee3..c4cf201 100644
+--- a/kexec/arch/i386/crashdump-x86.c
++++ b/kexec/arch/i386/crashdump-x86.c
+@@ -127,7 +127,7 @@ static unsigned long long get_kernel_sym(const char *symbol)
+ 		}
+ 	}
+ 
+-	fprintf(stderr, "Cannot get kernel %s symbol address\n", symbol);
++	dbgprintf("Cannot get kernel %s symbol address\n", symbol);
+ 	return 0;
+ }
+ 
+-- 
+2.5.5
+
+

--- a/package/boot/kexec-tools/patches/130-dont-use-percentL.patch
+++ b/package/boot/kexec-tools/patches/130-dont-use-percentL.patch
@@ -1,0 +1,149 @@
+--- kexec-tools-2.0.14/kexec/arch/s390/kexec-s390.c	2017-03-10 17:57:59.954871064 -0700
++++ kexec-tools-2.0.14/kexec/arch/s390/kexec-s390.c	2017-03-10 17:54:43.045437605 -0700
+@@ -170,7 +170,7 @@
+ 		if (current_range == MAX_MEMORY_RANGES)
+ 			break;
+ 
+-		sscanf(line,"%Lx-%Lx : %n", &start, &end, &cons);
++		sscanf(line,"%llx-%llx : %n", &start, &end, &cons);
+ 		str = line+cons;
+ 		if ((memcmp(str, sys_ram, strlen(sys_ram)) == 0) ||
+ 		    ((memcmp(str, crash_kernel, strlen(crash_kernel)) == 0) &&
+--- kexec-tools-2.0.14/kexec/arch/mips/crashdump-mips.c	2017-03-10 17:58:19.567014279 -0700
++++ kexec-tools-2.0.14/kexec/arch/mips/crashdump-mips.c	2017-03-10 17:54:52.065503065 -0700
+@@ -173,7 +173,7 @@
+ 		int type, consumed, count;
+ 		if (memory_ranges >= CRASH_MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+--- kexec-tools-2.0.14/kexec/arch/mips/kexec-mips.c	2017-03-10 17:58:29.271085171 -0700
++++ kexec-tools-2.0.14/kexec/arch/mips/kexec-mips.c	2017-03-10 17:55:00.589564950 -0700
+@@ -48,7 +48,7 @@
+ 	while (fgets(line, sizeof(line), fp) != 0) {
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n", &start, &end, &consumed);
++		count = sscanf(line, "%llx-%llx : %n", &start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;
+--- kexec-tools-2.0.14/kexec/arch/arm/kexec-arm.c	2016-12-09 02:42:06.000000000 -0700
++++ kexec-tools-2.0.14/kexec/arch/arm/kexec-arm.c	2017-03-10 17:55:29.969778375 -0700
+@@ -47,7 +47,7 @@
+ 		int count;
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+--- kexec-tools-2.0.14/kexec/arch/i386/kexec-x86-common.c	2016-12-09 02:42:06.000000000 -0700
++++ kexec-tools-2.0.14/kexec/arch/i386/kexec-x86-common.c	2017-03-10 17:56:18.586132027 -0700
+@@ -81,7 +81,7 @@
+ 		int count;
+ 		if (memory_ranges >= MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+--- kexec-tools-2.0.14/kexec/arch/i386/crashdump-x86.c	2017-03-10 17:59:04.351341571 -0700
++++ kexec-tools-2.0.14/kexec/arch/i386/crashdump-x86.c	2017-03-10 17:55:55.025960575 -0700
+@@ -119,7 +119,7 @@
+ 	}
+ 
+ 	while(fgets(line, sizeof(line), fp) != NULL) {
+-		if (sscanf(line, "%Lx %c %s", &vaddr, &type, sym) != 3)
++		if (sscanf(line, "%llx %c %s", &vaddr, &type, sym) != 3)
+ 			continue;
+ 		if (strcmp(sym, symbol) == 0) {
+ 			dbgprintf("kernel symbol %s vaddr = %16llx\n", symbol, vaddr);
+@@ -296,12 +296,12 @@
+ 
+ 		if (memory_ranges >= CRASH_MAX_MEMORY_RANGES)
+ 			break;
+-		count = sscanf(line, "%Lx-%Lx : %n",
++		count = sscanf(line, "%llx-%llx : %n",
+ 			&start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;
+-		dbgprintf("%016Lx-%016Lx : %s",
++		dbgprintf("%016llx-%016llx : %s",
+ 			start, end, str);
+ 		/* Only Dumping memory of type System RAM. */
+ 		if (memcmp(str, "System RAM\n", 11) == 0) {
+@@ -778,7 +778,7 @@
+ 		*addr = x86__pa(vaddr + (cpu * MAX_NOTE_BYTES));
+ 		*len = MAX_NOTE_BYTES;
+ 
+-		dbgprintf("crash_notes addr = %Lx\n",
++		dbgprintf("crash_notes addr = %llx\n",
+ 			  (unsigned long long)*addr);
+ 
+ 		fclose(fp);
+--- kexec-tools-2.0.14/kexec/arch/ia64/kexec-elf-rel-ia64.c	2016-12-09 03:53:45.000000000 -0700
++++ kexec-tools-2.0.14/kexec/arch/ia64/kexec-elf-rel-ia64.c	2017-03-10 17:56:26.282188064 -0700
+@@ -155,6 +155,6 @@
+ 	}
+ 	return;
+ overflow:
+-	die("overflow in relocation type %lu val %Lx\n", 
++	die("overflow in relocation type %lu val %llx\n",
+ 			r_type, value);
+ }
+--- kexec-tools-2.0.14/kexec/crashdump.c	2016-12-09 02:42:06.000000000 -0700
++++ kexec-tools-2.0.14/kexec/crashdump.c	2017-03-10 17:56:49.226355184 -0700
+@@ -98,7 +98,7 @@
+ 	}
+ 	if (!fgets(line, sizeof(line), fp))
+ 		die("Cannot parse %s: %s\n", crash_notes, strerror(errno));
+-	count = sscanf(line, "%Lx", &temp);
++	count = sscanf(line, "%llx", &temp);
+ 	if (count != 1)
+ 		die("Cannot parse %s: %s\n", crash_notes, strerror(errno));
+ 	*addr = (uint64_t) temp;
+@@ -112,7 +112,7 @@
+ 		if (!fgets(line, sizeof(line), fp))
+ 			die("Cannot parse %s: %s\n",
+ 			    crash_notes_size, strerror(errno));
+-		count = sscanf(line, "%Lu", &temp);
++		count = sscanf(line, "%llu", &temp);
+ 		if (count != 1)
+ 			die("Cannot parse %s: %s\n",
+ 			    crash_notes_size, strerror(errno));
+@@ -120,7 +120,7 @@
+ 		fclose(fp);
+ 	}
+ 
+-	dbgprintf("%s: crash_notes addr = %Lx, size = %Lu\n", __FUNCTION__,
++	dbgprintf("%s: crash_notes addr = %llx, size = %llu\n", __FUNCTION__,
+ 		  (unsigned long long)*addr, (unsigned long long)*len);
+ 
+ 	return 0;
+@@ -141,7 +141,7 @@
+ 
+ 	if (!fgets(line, sizeof(line), fp))
+ 		die("Cannot parse %s: %s\n", kdump_info, strerror(errno));
+-	count = sscanf(line, "%Lx %Lx", &temp, &temp2);
++	count = sscanf(line, "%llx %llx", &temp, &temp2);
+ 	if (count != 2)
+ 		die("Cannot parse %s: %s\n", kdump_info, strerror(errno));
+ 
+--- kexec-tools-2.0.14/kexec/kexec-iomem.c	2016-12-09 02:42:06.000000000 -0700
++++ kexec-tools-2.0.14/kexec/kexec-iomem.c	2017-03-10 17:57:00.802439555 -0700
+@@ -44,7 +44,7 @@
+ 		die("Cannot open %s\n", iomem);
+ 
+ 	while(fgets(line, sizeof(line), fp) != 0) {
+-		count = sscanf(line, "%Lx-%Lx : %n", &start, &end, &consumed);
++		count = sscanf(line, "%llx-%llx : %n", &start, &end, &consumed);
+ 		if (count != 2)
+ 			continue;
+ 		str = line + consumed;


### PR DESCRIPTION
Failure to find `page_offset_base` isn't catastrophic, so display
this as a debug message only.  Also, MUSL doesn't support `%L` when
used together with integer arguments, so substitute `%ll` instead.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>