### PR TITLE
Adds support for Cisco ON100

### DIFF
--- a/package/libs/lzo/Makefile
+++ b/package/libs/lzo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lzo
-PKG_VERSION:=2.08
+PKG_VERSION:=2.09
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://downloads.openwrt.org/sources/
-PKG_MD5SUM:=fcec64c26a0f4f4901468f360029678f
+PKG_SOURCE_URL:=http://www.oberhumer.com/opensource/lzo/download/
+PKG_MD5SUM:=c7ffc9a103afe2d1bba0b015e7aa887f
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/package/libs/lzo/Makefile
+++ b/package/libs/lzo/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lzo
-PKG_VERSION:=2.09
+PKG_VERSION:=2.08
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.oberhumer.com/opensource/lzo/download/
-PKG_MD5SUM:=c7ffc9a103afe2d1bba0b015e7aa887f
+PKG_SOURCE_URL:=http://downloads.openwrt.org/sources/
+PKG_MD5SUM:=fcec64c26a0f4f4901468f360029678f
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -203,6 +203,9 @@ Image/InstallKernel/Template/GuruplugServerPlus=$(call Image/InstallKernel/Templ
 Image/BuildKernel/Template/Topkick1281P2=$(call Image/BuildKernel/Template,topkick)
 Image/InstallKernel/Template/Topkick1281P2=$(call Image/InstallKernel/Template,topkick)
 
+Image/BuildKernel/Template/CiscoON100=$(call Image/BuildKernel/Template,CiscoON100)
+Image/InstallKernel/Template/CiscoON100=$(call Image/InstallKernel/Template,CiscoON100)
+
 define Image/BuildKernel
 	$(call Image/BuildKernel/Template/$(PROFILE))
 endef

--- a/target/linux/kirkwood/profiles/115-router.mk
+++ b/target/linux/kirkwood/profiles/115-router.mk
@@ -30,3 +30,24 @@ define Profile/VIPER/Description
 endef
 
 $(eval $(call Profile,VIPER))
+
+
+
+define Profile/CiscoON100
+  NAME:=Cisco Systems ON100
+  PACKAGES:= \
+        kmod-mmc kmod-mvsdio kmod-usb2 kmod-usb-storage \
+        kmod-i2c-core kmod-i2c-mv64xxx \
+        kmod-ata-core \
+        kmod-btmrvl kmod-btmrvl-sdio kmod-libertas kmod-libertas-sdio \
+        wpad-mini
+endef
+
+define Profile/CiscoON100/Description
+ Package set compatible with Cisco Systems ON100.
+endef
+
+CiscoON100_UBIFS_OPTS:="-m 2048 -e 126KiB -c 4096"
+CiscoON100_UBI_OPTS:="-m 2048 -p 128KiB -s 512"
+
+$(eval $(call Profile,CiscoON100))


### PR DESCRIPTION
Adding build target for Cisco ON100 (Marvell Kirkwood chip), changes as per https://wiki.openwrt.org/inbox/cisco/cisco_on-100_k9_v01#make_changes_to_guruplugserverplus_flash_layout