### PR TITLE
packages: lzo: Update LZO Makefile to repair dead Main URL

### DIFF
--- a/package/libs/lzo/Makefile
+++ b/package/libs/lzo/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=2.09
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.oberhumer.com/opensource/lzo/download/
+PKG_SOURCE_URL:=https://ftp.osuosl.org/pub/blfs/conglomeration/lzo/
 PKG_MD5SUM:=c7ffc9a103afe2d1bba0b015e7aa887f
 
 PKG_FIXUP:=autoreconf
@@ -27,7 +27,7 @@ define Package/liblzo
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=A real-time data compression library
-  URL:=http://www.oberhumer.com/opensource/lzo/
+  URL:=https://ftp.osuosl.org/pub/blfs/conglomeration/lzo/
 endef
 
 define Package/liblzo/description


### PR DESCRIPTION
Upgraded URL from the dead http://www.oberhumer.com/opensource/lzo/download/ to https://ftp.osuosl.org/pub/blfs/conglomeration/lzo/ (Oregon State University)