### PR TITLE
Update download.pl

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -202,6 +202,7 @@ foreach my $mirror (@ARGV) {
 #push @mirrors, 'http://mirror1.openwrt.org';
 push @mirrors, 'http://mirror2.openwrt.org/sources';
 push @mirrors, 'http://downloads.openwrt.org/sources';
+push @mirrors, "https://sources.lede-project.org";
 
 while (!$ok) {
 	my $mirror = shift @mirrors;


### PR DESCRIPTION
Latest versions of dependency packages were not available in "http://mirror2.openwrt.org/sources" and "http://downloads.openwrt.org/sources". For example, tmux package, versions till 1.6 were available in the above urls. So adding another url "https://sources.lede-project.org/" which contain latest versions of tmux package , versions from 1.9 to 2.3.