### PR TITLE
procd: fix mdns TXT forwarding

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -388,7 +388,7 @@ procd_add_mdns_service() {
 	json_add_int port "$port"
 	[ -n "$1" ] && {
 		json_add_array txt
-		for txt in $@; do json_add_string "" $txt; done
+		for txt in "$@"; do json_add_string "" "$txt"; done
 		json_select ..
 	}
 	json_select ..
@@ -397,7 +397,7 @@ procd_add_mdns_service() {
 procd_add_mdns() {
 	procd_open_data
 	json_add_object "mdns"
-	procd_add_mdns_service $@
+	procd_add_mdns_service "$@"
 	json_close_object
 	procd_close_data
 }


### PR DESCRIPTION
There were a few quotation marks missing, which made it impossible to
set TXT strings for mdns containing spaces, e.g.

procd_add_mdns pdl-datastream 9100 tcp "usb_MFG=KONICA MINOLTA"

would lead to ["usb_MFG=KONICA","MINOLTA"], which is wrong.
Adding the quotation marks fixes this.