### PR TITLE
packages: nvram: fix memory leak in _nvram_free

### DIFF
--- a/package/utils/nvram/src/nvram.c
+++ b/package/utils/nvram/src/nvram.c
@@ -47,6 +47,7 @@ static void _nvram_free(nvram_handle_t *h)
 	for (i = 0; i < NVRAM_ARRAYSIZE(h->nvram_hash); i++) {
 		for (t = h->nvram_hash[i]; t; t = next) {
 			next = t->next;
+			free(t->value);
 			free(t);
 		}
 		h->nvram_hash[i] = NULL;
@@ -55,6 +56,7 @@ static void _nvram_free(nvram_handle_t *h)
 	/* Free dead table */
 	for (t = h->nvram_dead; t; t = next) {
 		next = t->next;
+		free(t->value);
 		free(t);
 	}
 


### PR DESCRIPTION
The value of nvram_tuple_t is allocated in _nvram_realloc, but it is not freed in _nvram_free.

Signed-off-by: Zhai Zhaoxuan <zhaizhaoxuan@xiaomi.com>