### PR TITLE
Support for multiple tags for each host (dnsmasq).

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -343,13 +343,17 @@ dhcp_host_add() {
 	fi
 
 	config_get tag "$cfg" tag
+	tags=""
+	if [ -n "$tag" ]; then
+		for t in $tag; do append tags "$t" ",set:"; done
+	fi
 
 	config_get_bool broadcast "$cfg" broadcast 0
 	[ "$broadcast" = "0" ] && broadcast=
 
 	config_get leasetime "$cfg" leasetime
 
-	xappend "--dhcp-host=$macs${networkid:+,net:$networkid}${broadcast:+,set:needs-broadcast}${tag:+,set:$tag}${ip:+,$ip}${name:+,$name}${leasetime:+,$leasetime}"
+	xappend "--dhcp-host=$macs${networkid:+,net:$networkid}${broadcast:+,set:needs-broadcast}${tags:+,set:$tags}${ip:+,$ip}${name:+,$name}${leasetime:+,$leasetime}"
 }
 
 dhcp_tag_add() {


### PR DESCRIPTION
Currently, dnsmasq support assigning multiple tags to a host record
(--dhcp-host), but we only support only 1 tag for a host. The commit
makes the following config to be valid:

  config host
      option name 'computer'
      option mac '00:11:22:33:44:55'
      option ip '192.168.1.100'
      list tag 'vendor_class'
      list tag 'vendor_id'

  config tag 'vendor_class'
      list dhcp_option 'option:vendor-class,00:...<ommitted>'

  config tag 'vendor_id'
      option force '1'
      list dhcp_option 'option:vendor-id-encap,00:...<ommitted>'