### PR TITLE
Update libpcap to version 1.8.4

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpcap
-PKG_VERSION:=1.7.4
+PKG_VERSION:=1.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tcpdump.org/release/
-PKG_MD5SUM:=b2e13142bbaba857ab1c6894aedaf547
+PKG_MD5SUM:=3d48f9cd171ff12b0efd9134b52f1447,
 PKG_FIXUP:=patch-libtool
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.tcpdump.org/release/
-PKG_MD5SUM:=3d48f9cd171ff12b0efd9134b52f1447,
+PKG_MD5SUM:=3d48f9cd171ff12b0efd9134b52f1447
 PKG_FIXUP:=patch-libtool
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/libs/libpcap/patches/100-debian_shared_lib.patch
+++ b/package/libs/libpcap/patches/100-debian_shared_lib.patch
@@ -83,7 +83,17 @@ Index: libpcap-1.8.1/Makefile.in
  scanner.c: $(srcdir)/scanner.l
  	$(LEX) -P pcap_ --header-file=scanner.h --nounput -o scanner.c $<
  scanner.h: scanner.c
-@@ -472,9 +493,16 @@ grammar.o: grammar.c
+@@ -455,6 +476,9 @@ scanner.h: scanner.c
+ scanner.o: scanner.c grammar.h
+ 	$(CC) $(FULL_CFLAGS) -c scanner.c
+ 
++scanner_pic.o: scanner.c
++	$(CC) -fPIC $(FULL_CFLAGS) -o $@ -c scanner.c
++
+ pcap.o: pcap_version.h
+ 
+ grammar.c: $(srcdir)/grammar.y
+@@ -472,9 +496,16 @@ grammar.o: grammar.c
  gencode.o: $(srcdir)/gencode.c grammar.h scanner.h
  	$(CC) $(FULL_CFLAGS) -c $(srcdir)/gencode.c
  
@@ -100,7 +110,7 @@ Index: libpcap-1.8.1/Makefile.in
  snprintf.o: $(srcdir)/missing/snprintf.c
  	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/snprintf.c
  
-@@ -501,6 +529,9 @@ bpf_filter.c: $(srcdir)/bpf/net/bpf_filt
+@@ -501,6 +532,9 @@ bpf_filter.c: $(srcdir)/bpf/net/bpf_filt
  bpf_filter.o: bpf_filter.c
  	$(CC) $(FULL_CFLAGS) -c bpf_filter.c
  
@@ -110,7 +120,7 @@ Index: libpcap-1.8.1/Makefile.in
  #
  # Generate the pcap-config script.
  #
-@@ -626,11 +657,9 @@ install-shared: install-shared-$(DYEXT)
+@@ -626,11 +660,9 @@ install-shared: install-shared-$(DYEXT)
  install-shared-so: libpcap.so
  	[ -d $(DESTDIR)$(libdir) ] || \
  	    (mkdir -p $(DESTDIR)$(libdir); chmod 755 $(DESTDIR)$(libdir))

--- a/package/libs/libpcap/patches/100-debian_shared_lib.patch
+++ b/package/libs/libpcap/patches/100-debian_shared_lib.patch
@@ -1,9 +1,11 @@
 Debian-specific modifications to the upstream Makefile.in to
 build a shared library.
 
---- a/Makefile.in
-+++ b/Makefile.in
-@@ -40,6 +40,14 @@ mandir = @mandir@
+Index: libpcap-1.8.1/Makefile.in
+===================================================================
+--- libpcap-1.8.1.orig/Makefile.in
++++ libpcap-1.8.1/Makefile.in
+@@ -38,6 +38,14 @@ mandir = @mandir@
  srcdir = @srcdir@
  VPATH = @srcdir@
  
@@ -18,7 +20,7 @@ build a shared library.
  #
  # You shouldn't need to edit anything below.
  #
-@@ -63,7 +71,8 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
+@@ -62,7 +70,8 @@ DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
  PROG=libpcap
  
  # Standard CFLAGS
@@ -28,7 +30,7 @@ build a shared library.
  
  INSTALL = @INSTALL@
  INSTALL_PROGRAM = @INSTALL_PROGRAM@
-@@ -83,7 +92,11 @@ YACC = @V_YACC@
+@@ -77,7 +86,11 @@ YACC = @YACC@
  # problem if you don't own the file but can write to the directory.
  .c.o:
  	@rm -f $@
@@ -39,9 +41,9 @@ build a shared library.
 +	@rm -f $@
 +	$(CC) -fPIC $(FULL_CFLAGS) -c -o $@ $(srcdir)/$*.c
  
- PSRC =	pcap-@V_PCAP@.c @USB_SRC@ @BT_SRC@ @CAN_SRC@ @NETFILTER_SRC@ @CANUSB_SRC@ @DBUS_SRC@
- FSRC =  fad-@V_FINDALLDEVS@.c
-@@ -99,6 +112,7 @@ SRC =	$(PSRC) $(FSRC) $(CSRC) $(SSRC) $(
+ PSRC =	pcap-@V_PCAP@.c @USB_SRC@ @BT_SRC@ @BT_MONITOR_SRC@ @NETFILTER_SRC@ @DBUS_SRC@
+ FSRC =  @V_FINDALLDEVS@
+@@ -93,6 +106,7 @@ SRC =	$(PSRC) $(FSRC) $(CSRC) $(SSRC) $(
  # We would like to say "OBJ = $(SRC:.c=.o)" but Ultrix's make cannot
  # hack the extra indirection
  OBJ =	$(PSRC:.c=.o) $(FSRC:.c=.o) $(CSRC:.c=.o) $(SSRC:.c=.o) $(GENSRC:.c=.o) $(LIBOBJS)
@@ -49,7 +51,7 @@ build a shared library.
  PUBHDR = \
  	pcap.h \
  	pcap-bpf.h \
-@@ -153,7 +167,7 @@ TAGFILES = \
+@@ -157,7 +171,7 @@ TAGFILES = \
  
  CLEANFILES = $(OBJ) libpcap.* $(TESTS) \
  	$(PROG)-`cat $(srcdir)/VERSION`.tar.gz $(GENSRC) $(GENHDR) \
@@ -58,7 +60,7 @@ build a shared library.
  
  MAN1 = pcap-config.1
  
-@@ -363,7 +377,7 @@ libpcap.a: $(OBJ)
+@@ -365,7 +379,7 @@ libpcap.a: $(OBJ)
  	$(AR) rc $@ $(OBJ) $(ADDLARCHIVEOBJS)
  	$(RANLIB) $@
  
@@ -67,7 +69,7 @@ build a shared library.
  
  libpcap.so: $(OBJ)
  	@rm -f $@
-@@ -441,6 +455,13 @@ libpcap.shareda: $(OBJ)
+@@ -443,6 +457,13 @@ libpcap.shareda: $(OBJ)
  #
  libpcap.none:
  
@@ -79,25 +81,15 @@ build a shared library.
 +	ln -s $(SOLIBRARY).$(MAJ) $(SOLIBRARY)
 +
  scanner.c: $(srcdir)/scanner.l
- 	@rm -f $@
- 	$(srcdir)/runlex.sh $(LEX) -o$@ $<
-@@ -448,6 +469,9 @@ scanner.c: $(srcdir)/scanner.l
- scanner.o: scanner.c tokdefs.h
- 	$(CC) $(FULL_CFLAGS) -c scanner.c
- 
-+scanner_pic.o: scanner.c tokdefs.h
-+	$(CC) -fPIC $(FULL_CFLAGS) -o $@ -c scanner.c
-+
- pcap.o: version.h
- 
- tokdefs.h: grammar.c
-@@ -461,9 +485,16 @@ grammar.o: grammar.c
- 	@rm -f $@
- 	$(CC) $(FULL_CFLAGS) -Dyylval=pcap_lval -c grammar.c
+ 	$(LEX) -P pcap_ --header-file=scanner.h --nounput -o scanner.c $<
+ scanner.h: scanner.c
+@@ -472,9 +493,16 @@ grammar.o: grammar.c
+ gencode.o: $(srcdir)/gencode.c grammar.h scanner.h
+ 	$(CC) $(FULL_CFLAGS) -c $(srcdir)/gencode.c
  
 +grammar_pic.o: grammar.c
 +	@rm -f $@
-+	$(CC) -fPIC $(FULL_CFLAGS) -Dyylval=pcap_lval -o $@ -c grammar.c 
++	$(CC) -fPIC $(FULL_CFLAGS) -Dyylval=pcap_lval -o $@ -c grammar.c
 +
  version.o: version.c
  	$(CC) $(FULL_CFLAGS) -c version.c
@@ -108,7 +100,7 @@ build a shared library.
  snprintf.o: $(srcdir)/missing/snprintf.c
  	$(CC) $(FULL_CFLAGS) -o $@ -c $(srcdir)/missing/snprintf.c
  
-@@ -501,6 +532,9 @@ bpf_filter.c: $(srcdir)/bpf/net/bpf_filt
+@@ -501,6 +529,9 @@ bpf_filter.c: $(srcdir)/bpf/net/bpf_filt
  bpf_filter.o: bpf_filter.c
  	$(CC) $(FULL_CFLAGS) -c bpf_filter.c
  
@@ -118,7 +110,7 @@ build a shared library.
  #
  # Generate the pcap-config script.
  #
-@@ -618,11 +652,9 @@ install-shared: install-shared-$(DYEXT)
+@@ -626,11 +657,9 @@ install-shared: install-shared-$(DYEXT)
  install-shared-so: libpcap.so
  	[ -d $(DESTDIR)$(libdir) ] || \
  	    (mkdir -p $(DESTDIR)$(libdir); chmod 755 $(DESTDIR)$(libdir))
@@ -133,9 +125,11 @@ build a shared library.
  install-shared-dylib: libpcap.dylib
  	[ -d $(DESTDIR)$(libdir) ] || \
  	    (mkdir -p $(DESTDIR)$(libdir); chmod 755 $(DESTDIR)$(libdir))
---- a/aclocal.m4
-+++ b/aclocal.m4
-@@ -440,7 +440,7 @@ AC_DEFUN(AC_LBL_SHLIBS_INIT,
+Index: libpcap-1.8.1/aclocal.m4
+===================================================================
+--- libpcap-1.8.1.orig/aclocal.m4
++++ libpcap-1.8.1/aclocal.m4
+@@ -470,7 +470,7 @@ AC_DEFUN(AC_LBL_SHLIBS_INIT,
  			esac
  			;;
  		    esac
@@ -144,7 +138,7 @@ build a shared library.
  		    V_SONAME_OPT="-Wl,-soname,"
  		    V_RPATH_OPT="-Wl,-rpath,"
  		    ;;
-@@ -503,7 +503,7 @@ AC_DEFUN(AC_LBL_SHLIBS_INIT,
+@@ -533,7 +533,7 @@ AC_DEFUN(AC_LBL_SHLIBS_INIT,
  		    #
  		    # "cc" is GCC.
  		    #
@@ -153,8 +147,10 @@ build a shared library.
  		    V_SHLIB_CMD="\$(CC)"
  		    V_SHLIB_OPT="-shared"
  		    V_SONAME_OPT="-Wl,-soname,"
---- a/pcap-config.in
-+++ b/pcap-config.in
+Index: libpcap-1.8.1/pcap-config.in
+===================================================================
+--- libpcap-1.8.1.orig/pcap-config.in
++++ libpcap-1.8.1/pcap-config.in
 @@ -36,16 +36,6 @@ do
  	esac
  	shift

--- a/package/libs/libpcap/patches/103-makefile_flex_workaround.patch
+++ b/package/libs/libpcap/patches/103-makefile_flex_workaround.patch
@@ -1,14 +1,16 @@
 
 	Copyright (C) 2006 Markus Wigge
 
---- a/Makefile.in
-+++ b/Makefile.in
+Index: libpcap-1.8.1/Makefile.in
+===================================================================
+--- libpcap-1.8.1.orig/Makefile.in
++++ libpcap-1.8.1/Makefile.in
 @@ -57,7 +57,7 @@ LN_S = @LN_S@
  MKDEP = @MKDEP@
  CCOPT = @V_CCOPT@
  INCLS = -I. @V_INCLS@
--DEFS = @DEFS@ @V_DEFS@
-+DEFS = -D_BSD_SOURCE @DEFS@ @V_DEFS@
+-DEFS = -DBUILDING_PCAP @DEFS@ @V_DEFS@
++DEFS = -DBUILDING_PCAP -D_BSD_SOURCE @DEFS@ @V_DEFS@
  ADDLOBJS = @ADDLOBJS@
  ADDLARCHIVEOBJS = @ADDLARCHIVEOBJS@
  LIBS = @LIBS@

--- a/package/libs/libpcap/patches/201-space_optimization.patch
+++ b/package/libs/libpcap/patches/201-space_optimization.patch
@@ -1,6 +1,8 @@
---- a/gencode.c
-+++ b/gencode.c
-@@ -543,20 +543,6 @@ pcap_compile_nopcap(int snaplen_arg, int
+Index: libpcap-1.8.1/gencode.c
+===================================================================
+--- libpcap-1.8.1.orig/gencode.c
++++ libpcap-1.8.1/gencode.c
+@@ -780,20 +780,6 @@ pcap_compile_nopcap(int snaplen_arg, int
  }
  
  /*
@@ -21,9 +23,11 @@
   * Backpatch the blocks in 'list' to 'target'.  The 'sense' field indicates
   * which of the jt and jf fields has been resolved and which is a pointer
   * back to another unresolved block (or nil).  At least one of the fields
---- a/pcap.c
-+++ b/pcap.c
-@@ -1087,6 +1087,59 @@ static const u_char charmap[] = {
+Index: libpcap-1.8.1/pcap.c
+===================================================================
+--- libpcap-1.8.1.orig/pcap.c
++++ libpcap-1.8.1/pcap.c
+@@ -1119,6 +1119,59 @@ static const u_char charmap[] = {
  	(u_char)'\374', (u_char)'\375', (u_char)'\376', (u_char)'\377',
  };
  
@@ -83,58 +87,12 @@
  int
  pcap_strcasecmp(const char *s1, const char *s2)
  {
---- a/optimize.c
-+++ b/optimize.c
-@@ -2203,45 +2203,6 @@ icode_to_fcode(struct block *root, u_int
- 	return fp;
- }
- 
--/*
-- * Make a copy of a BPF program and put it in the "fcode" member of
-- * a "pcap_t".
-- *
-- * If we fail to allocate memory for the copy, fill in the "errbuf"
-- * member of the "pcap_t" with an error message, and return -1;
-- * otherwise, return 0.
-- */
--int
--install_bpf_program(pcap_t *p, struct bpf_program *fp)
--{
--	size_t prog_size;
--
--	/*
--	 * Validate the program.
--	 */
--	if (!bpf_validate(fp->bf_insns, fp->bf_len)) {
--		snprintf(p->errbuf, sizeof(p->errbuf),
--			"BPF program is not valid");
--		return (-1);
--	}
--
--	/*
--	 * Free up any already installed program.
--	 */
--	pcap_freecode(&p->fcode);
--
--	prog_size = sizeof(*fp->bf_insns) * fp->bf_len;
--	p->fcode.bf_len = fp->bf_len;
--	p->fcode.bf_insns = (struct bpf_insn *)malloc(prog_size);
--	if (p->fcode.bf_insns == NULL) {
--		snprintf(p->errbuf, sizeof(p->errbuf),
--			 "malloc: %s", pcap_strerror(errno));
--		return (-1);
--	}
--	memcpy(p->fcode.bf_insns, fp->bf_insns, prog_size);
--	return (0);
--}
--
- #ifdef BDEBUG
- static void
- dot_dump_node(struct block *block, struct bpf_program *prog, FILE *out)
---- a/pcap-common.c
-+++ b/pcap-common.c
-@@ -1372,14 +1372,23 @@ swap_pseudo_headers(int linktype, struct
- 	switch (linktype) {
+Index: libpcap-1.8.1/pcap-common.c
+===================================================================
+--- libpcap-1.8.1.orig/pcap-common.c
++++ libpcap-1.8.1/pcap-common.c
+@@ -1447,14 +1447,23 @@ swap_pseudo_headers(int linktype, struct
+ 		break;
  
  	case DLT_USB_LINUX:
 +#ifndef PCAP_SUPPORT_USB
@@ -157,3 +115,53 @@
  		swap_nflog_header(hdr, data);
  		break;
  	}
+Index: libpcap-1.8.1/optimize.c
+===================================================================
+--- libpcap-1.8.1.orig/optimize.c
++++ libpcap-1.8.1/optimize.c
+@@ -2227,45 +2227,6 @@ icode_to_fcode(compiler_state_t *cstate,
+ 	return fp;
+ }
+ 
+-/*
+- * Make a copy of a BPF program and put it in the "fcode" member of
+- * a "pcap_t".
+- *
+- * If we fail to allocate memory for the copy, fill in the "errbuf"
+- * member of the "pcap_t" with an error message, and return -1;
+- * otherwise, return 0.
+- */
+-int
+-install_bpf_program(pcap_t *p, struct bpf_program *fp)
+-{
+-	size_t prog_size;
+-
+-	/*
+-	 * Validate the program.
+-	 */
+-	if (!bpf_validate(fp->bf_insns, fp->bf_len)) {
+-		pcap_snprintf(p->errbuf, sizeof(p->errbuf),
+-			"BPF program is not valid");
+-		return (-1);
+-	}
+-
+-	/*
+-	 * Free up any already installed program.
+-	 */
+-	pcap_freecode(&p->fcode);
+-
+-	prog_size = sizeof(*fp->bf_insns) * fp->bf_len;
+-	p->fcode.bf_len = fp->bf_len;
+-	p->fcode.bf_insns = (struct bpf_insn *)malloc(prog_size);
+-	if (p->fcode.bf_insns == NULL) {
+-		pcap_snprintf(p->errbuf, sizeof(p->errbuf),
+-			 "malloc: %s", pcap_strerror(errno));
+-		return (-1);
+-	}
+-	memcpy(p->fcode.bf_insns, fp->bf_insns, prog_size);
+-	return (0);
+-}
+-
+ #ifdef BDEBUG
+ static void
+ dot_dump_node(struct icode *ic, struct block *block, struct bpf_program *prog,

--- a/package/libs/libpcap/patches/202-protocol_api.patch
+++ b/package/libs/libpcap/patches/202-protocol_api.patch
@@ -1,6 +1,8 @@
---- a/pcap-linux.c
-+++ b/pcap-linux.c
-@@ -414,7 +414,7 @@ static int	iface_get_id(int fd, const ch
+Index: libpcap-1.8.1/pcap-linux.c
+===================================================================
+--- libpcap-1.8.1.orig/pcap-linux.c
++++ libpcap-1.8.1/pcap-linux.c
+@@ -425,7 +425,7 @@ static int	iface_get_id(int fd, const ch
  static int	iface_get_mtu(int fd, const char *device, char *ebuf);
  static int 	iface_get_arptype(int fd, const char *device, char *ebuf);
  #ifdef HAVE_PF_PACKET_SOCKETS
@@ -9,16 +11,16 @@
  #ifdef IW_MODE_MONITOR
  static int	has_wext(int sock_fd, const char *device, char *ebuf);
  #endif /* IW_MODE_MONITOR */
-@@ -1028,7 +1028,7 @@ pcap_can_set_rfmon_linux(pcap_t *handle)
+@@ -1059,7 +1059,7 @@ pcap_can_set_rfmon_linux(pcap_t *handle)
  	 * (We assume that if we have Wireless Extensions support
  	 * we also have PF_PACKET support.)
  	 */
 -	sock_fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
 +	sock_fd = socket(PF_PACKET, SOCK_RAW, p->opt.proto);
  	if (sock_fd == -1) {
- 		(void)snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+ 		(void)pcap_snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
  		    "socket: %s", pcap_strerror(errno));
-@@ -1337,6 +1337,9 @@ pcap_activate_linux(pcap_t *handle)
+@@ -1456,6 +1456,9 @@ pcap_activate_linux(pcap_t *handle)
  	handle->read_op = pcap_read_linux;
  	handle->stats_op = pcap_stats_linux;
  
@@ -28,7 +30,7 @@
  	/*
  	 * The "any" device is a special device which causes us not
  	 * to bind to a particular device and thus to look at all
-@@ -3160,8 +3163,8 @@ activate_new(pcap_t *handle)
+@@ -3335,8 +3338,8 @@ activate_new(pcap_t *handle)
  	 * try a SOCK_RAW socket for the raw interface.
  	 */
  	sock_fd = is_any_device ?
@@ -39,16 +41,16 @@
  
  	if (sock_fd == -1) {
  		if (errno == EINVAL || errno == EAFNOSUPPORT) {
-@@ -3279,7 +3282,7 @@ activate_new(pcap_t *handle)
+@@ -3454,7 +3457,7 @@ activate_new(pcap_t *handle)
  				return PCAP_ERROR;
  			}
  			sock_fd = socket(PF_PACKET, SOCK_DGRAM,
 -			    htons(ETH_P_ALL));
 +			    handle->opt.proto);
  			if (sock_fd == -1) {
- 				snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+ 				pcap_snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
  				    "socket: %s", pcap_strerror(errno));
-@@ -3343,7 +3346,7 @@ activate_new(pcap_t *handle)
+@@ -3518,7 +3521,7 @@ activate_new(pcap_t *handle)
  		}
  
  		if ((err = iface_bind(sock_fd, handlep->ifindex,
@@ -57,7 +59,7 @@
  		    	close(sock_fd);
  			if (err < 0)
  				return err;
-@@ -5050,7 +5053,7 @@ iface_get_id(int fd, const char *device,
+@@ -5271,7 +5274,7 @@ iface_get_id(int fd, const char *device,
   *  or a PCAP_ERROR_ value on a hard error.
   */
  static int
@@ -66,7 +68,7 @@
  {
  	struct sockaddr_ll	sll;
  	int			err;
-@@ -5059,7 +5062,7 @@ iface_bind(int fd, int ifindex, char *eb
+@@ -5280,7 +5283,7 @@ iface_bind(int fd, int ifindex, char *eb
  	memset(&sll, 0, sizeof(sll));
  	sll.sll_family		= AF_PACKET;
  	sll.sll_ifindex		= ifindex;
@@ -75,18 +77,20 @@
  
  	if (bind(fd, (struct sockaddr *) &sll, sizeof(sll)) == -1) {
  		if (errno == ENETDOWN) {
-@@ -6049,7 +6052,7 @@ activate_old(pcap_t *handle)
+@@ -6325,7 +6328,7 @@ activate_old(pcap_t *handle)
  
  	/* Open the socket */
  
 -	handle->fd = socket(PF_INET, SOCK_PACKET, htons(ETH_P_ALL));
 +	handle->fd = socket(PF_INET, SOCK_PACKET, handle->opt.proto);
  	if (handle->fd == -1) {
- 		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+ 		pcap_snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
  			 "socket: %s", pcap_strerror(errno));
---- a/pcap.c
-+++ b/pcap.c
-@@ -562,6 +562,7 @@ pcap_create_common(const char *source, c
+Index: libpcap-1.8.1/pcap.c
+===================================================================
+--- libpcap-1.8.1.orig/pcap.c
++++ libpcap-1.8.1/pcap.c
+@@ -578,6 +578,7 @@ pcap_create_common(char *ebuf, size_t si
  	p->opt.promisc = 0;
  	p->opt.rfmon = 0;
  	p->opt.immediate = 0;
@@ -94,7 +98,7 @@
  	p->opt.tstamp_type = -1;	/* default to not setting time stamp type */
  	p->opt.tstamp_precision = PCAP_TSTAMP_PRECISION_MICRO;
  
-@@ -725,6 +726,15 @@ pcap_get_tstamp_precision(pcap_t *p)
+@@ -771,6 +772,15 @@ pcap_get_tstamp_precision(pcap_t *p)
  }
  
  int
@@ -110,9 +114,11 @@
  pcap_activate(pcap_t *p)
  {
  	int status;
---- a/pcap/pcap.h
-+++ b/pcap/pcap.h
-@@ -66,6 +66,7 @@ extern "C" {
+Index: libpcap-1.8.1/pcap/pcap.h
+===================================================================
+--- libpcap-1.8.1.orig/pcap/pcap.h
++++ libpcap-1.8.1/pcap/pcap.h
+@@ -68,6 +68,7 @@ extern "C" {
  #define PCAP_VERSION_MINOR 4
  
  #define PCAP_ERRBUF_SIZE 256
@@ -120,21 +126,23 @@
  
  /*
   * Compatibility for systems that have a bpf.h that
-@@ -283,6 +284,7 @@ int	pcap_set_timeout(pcap_t *, int);
- int	pcap_set_tstamp_type(pcap_t *, int);
- int	pcap_set_immediate_mode(pcap_t *, int);
- int	pcap_set_buffer_size(pcap_t *, int);
-+int	pcap_set_protocol(pcap_t *, unsigned short);
- int	pcap_set_tstamp_precision(pcap_t *, int);
- int	pcap_get_tstamp_precision(pcap_t *);
- int	pcap_activate(pcap_t *);
---- a/pcap-int.h
-+++ b/pcap-int.h
-@@ -109,6 +109,7 @@ struct pcap_opt {
- 	char	*source;
+@@ -287,6 +288,7 @@ PCAP_API int	pcap_set_timeout(pcap_t *,
+ PCAP_API int	pcap_set_tstamp_type(pcap_t *, int);
+ PCAP_API int	pcap_set_immediate_mode(pcap_t *, int);
+ PCAP_API int	pcap_set_buffer_size(pcap_t *, int);
++PCAP_API int	pcap_set_protocol(pcap_t *, unsigned short);
+ PCAP_API int	pcap_set_tstamp_precision(pcap_t *, int);
+ PCAP_API int	pcap_get_tstamp_precision(pcap_t *);
+ PCAP_API int	pcap_activate(pcap_t *);
+Index: libpcap-1.8.1/pcap-int.h
+===================================================================
+--- libpcap-1.8.1.orig/pcap-int.h
++++ libpcap-1.8.1/pcap-int.h
+@@ -111,6 +111,7 @@ struct pcap_opt {
+ 	char	*device;
  	int	timeout;	/* timeout for buffering */
- 	int	buffer_size;
-+	int	proto;      /* protocol for packet socket (linux) */
+ 	u_int	buffer_size;
++	int proto;
  	int	promisc;
  	int	rfmon;		/* monitor mode */
  	int	immediate;	/* immediate mode - deliver packets as soon as they arrive */


### PR DESCRIPTION
Upstream has fixed issue which caused pcap_loop to return this error:
pcap_loop: corrupted frame on kernel ring mac offset