### PR TITLE
fix Xiaomi R1CL wrong partition size of firmware.

### DIFF
--- a/target/linux/ramips/dts/MIWIFI-NANO.dts
+++ b/target/linux/ramips/dts/MIWIFI-NANO.dts
@@ -81,7 +81,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0x7b0000>;
+			reg = <0x50000 0xba0000>;
 		};
 	};
 };


### PR DESCRIPTION
Xiaomi nano router, partition size of firmware is wrong
with original firmware  the partition size as follow:
[    1.530000] 0x000000000000-0x000001000000 : "ALL"
[    1.540000] 0x000000000000-0x000000030000 : "Bootloader"
[    1.540000] 0x000000030000-0x000000040000 : "Config"
[    1.550000] 0x000000040000-0x000000050000 : "Factory"
[    1.560000] 0x000000050000-0x000000bf0000 : "OS1"

so the OS1 partition size is 0xba0000