### PR TITLE
CC: brcm2708-gpu-fw: update md5sum in Makefile

### DIFF
--- a/package/kernel/brcm2708-gpu-fw/Makefile
+++ b/package/kernel/brcm2708-gpu-fw/Makefile
@@ -14,7 +14,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_REV).tar.gz
 PKG_SOURCE_URL:=https://github.com/Hexxeh/rpi-firmware/archive/
-PKG_MD5SUM:=f5683c1dcb255714942f7c9fd61b3a0a
+PKG_MD5SUM:=edefa7a1684d5b0a2b11acd058adceff
 
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)/rpi-firmware-$(PKG_REV)
 


### PR DESCRIPTION
Need to upgrade the MD5 of the firmware for Raspberry Pi to enable build on the Chaos Calmer / 15.05.1 target again. 
The checksum changed due to changes of the Github Tar Handling as described here: https://github.com/raspberrypi/firmware/issues/873
After that change, builds for RPi on 15.05.1 succeed again.