### PR TITLE
tcpdump Makefile change to compile 4.9.2 with old libpcap 1.5.x

### DIFF
--- a/package/network/utils/tcpdump/Makefile
+++ b/package/network/utils/tcpdump/Makefile
@@ -63,6 +63,7 @@ CONFIGURE_VARS += \
 	ac_cv_linux_vers=$(LINUX_VERSION) \
 	ac_cv_header_rpc_rpcent_h=no \
 	ac_cv_lib_rpc_main=no \
+	ac_cv_header_pcap_nflog_h=no \
 	ac_cv_path_PCAP_CONFIG=""
 
 MAKE_FLAGS :=


### PR DESCRIPTION
after updating tcpdump to latest version libpcap was not updated accordingly. so pcap/nflog.h tcpdump is looking for is just absent in current old version of libpcap in openwrt:

```
make[4]: Entering directory `/mnt/raw/gdwk/openwrt_mx/openwrt/build_dir/target-mips_34kc_uClibc-0.9.33.2/tcpdump-full/tcpdump-4.9.2'
ccache_cc -Os -pipe -mno-branch-likely -mips32r2 -mtune=34kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -ffunction-sections -fdata-sections -DHAVE_CONFIG_H -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/target-mips_34kc_uClibc-0.9.33.2/usr/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/target-mips_34kc_uClibc-0.9.33.2/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/toolchain-mips_34kc_gcc-4.8-linaro_uClibc-0.9.33.2/usr/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/toolchain-mips_34kc_gcc-4.8-linaro_uClibc-0.9.33.2/include   -D_U_="__attribute__((unused))" -I. -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/target-mips_34kc_uClibc-0.9.33.2/usr/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/target-mips_34kc_uClibc-0.9.33.2/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/toolchain-mips_34kc_gcc-4.8-linaro_uClibc-0.9.33.2/usr/include -I/mnt/raw/gdwk/openwrt_mx/openwrt/staging_dir/toolchain-mips_34kc_gcc-4.8-linaro_uClibc-0.9.33.2/include -Os -pipe -mno-branch-likely -mips32r2 -mtune=34kc -fno-caller-saves -fno-plt -fhonour-copts -Wno-error=unused-but-set-variable -Wno-error=unused-result -msoft-float -mips16 -minterlink-mips16 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -ffunction-sections -fdata-sections  -c ./print-nflog.c
cc1: note: someone does not honour COPTS correctly, passed 2 times
./print-nflog.c:39:24: fatal error: pcap/nflog.h: No such file or directory
 #include <pcap/nflog.h>
                        ^
```
quick fix - disable ac_cv_header_pcap_nflog_h flag 
good fix would be to update libpcap to latest version 1.8.1