### PR TITLE
ipq806x: support new location of USB PHY kernel module

### DIFF
--- a/target/linux/ipq806x/modules.mk
+++ b/target/linux/ipq806x/modules.mk
@@ -18,7 +18,9 @@ define KernelPackage/usb-phy-qcom-dwc3
   TITLE:=DWC3 USB QCOM PHY driver
   DEPENDS:=@TARGET_ipq806x +kmod-usb-dwc3-of-simple
   KCONFIG:= CONFIG_PHY_QCOM_DWC3
-  FILES:= $(LINUX_DIR)/drivers/phy/phy-qcom-dwc3.ko
+  FILES:= \
+    $(LINUX_DIR)/drivers/phy/phy-qcom-dwc3.ko@lt4.13 \
+    $(LINUX_DIR)/drivers/phy/qualcomm/phy-qcom-dwc3.ko@ge4.13
   AUTOLOAD:=$(call AutoLoad,45,phy-qcom-dwc3,1)
   $(call AddDepends/usb)
 endef


### PR DESCRIPTION
PHY drivers were grouped into vendor specific directories
by upstream commit 0b56e9a7e8358e59b21d8a425e463072bfae523c

This is in preparation to support Kernel 4.14 on ipq806x
using the out-of-tree USB PHY driver.

Signed-off-by: Luis Araneda <luaraneda@gmail.com>