### PR TITLE
kexec-tools: issue warning when dd'ing vmcore

### DIFF
--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kexec-tools
 PKG_VERSION:=2.0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kexec

--- a/package/boot/kexec-tools/files/kdump.init
+++ b/package/boot/kexec-tools/files/kdump.init
@@ -43,8 +43,10 @@ run_kdump() {
 	timestamp=$(date "+%Y%m%dT%H%M%S")
 
 	if [ "$save_vmcore" -eq 1 ]; then
+		echo -n "Saving vmcore (this may take a while)..."
 		# would like 'sparse' but busybox doesn't support it
 		dd if=/proc/vmcore of="$path/vmcore-$timestamp" conv=fsync bs=1M
+		echo " done"
 	fi
 
 	if [ "$save_dmesg" -eq 1 ]; then


### PR DESCRIPTION
Without giving a warning, it just looks like the box has hung during boot.

We don't want users resetting it without having captured a crashdump.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>

  