### PR TITLE
update dhcp.script to handle dynamic routing.

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -20,7 +20,13 @@ setup_interface () {
 
 	local i
 	for i in $router; do
-		proto_add_ipv4_route "$i" 32 "" "$ip"
+		local ip_net
+		local gw_net
+		ip_net=$(ipcalc.sh $ip/$mask | grep "NETWORK" | awk -F '=' '{print $2}')
+		gw_net=$(ipcalc.sh $i/$mask | grep "NETWORK" | awk -F '=' '{print $2}')
+		if [ "$ip_net" != "$gw_net" ]; then
+			proto_add_ipv4_route "$i" 32 "" "$ip"
+		fi
 		proto_add_ipv4_route 0.0.0.0 0 "$i" "$ip"
 
 		local r

--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -19,14 +19,12 @@ setup_interface () {
 	# TODO: apply $broadcast
 
 	local i
+	local ip_net
+	eval "$(ipcalc.sh $ip/$mask)";ip_net="$NETWORK"
 	for i in $router; do
-		local ip_net
 		local gw_net
-		ip_net=$(ipcalc.sh $ip/$mask | grep "NETWORK" | awk -F '=' '{print $2}')
-		gw_net=$(ipcalc.sh $i/$mask | grep "NETWORK" | awk -F '=' '{print $2}')
-		if [ "$ip_net" != "$gw_net" ]; then
-			proto_add_ipv4_route "$i" 32 "" "$ip"
-		fi
+		eval "$(ipcalc.sh $i/$mask)";gw_net="$NETWORK"
+		[ "$ip_net" != "$gw_net" ] && proto_add_ipv4_route "$i" 32 "" "$ip"
 		proto_add_ipv4_route 0.0.0.0 0 "$i" "$ip"
 
 		local r


### PR DESCRIPTION
Certain DHCP servers push a gateway outside of the assigned interface subnet,
to support those situations, install a host route towards the gateway.

If Gateway and IP are served in same network, openwrt quagga cannot learn routes (rip routes are
not getting added, showing inactive) whereas working fine when Gateway and IP are in different network.

Signed-off-by: Mogula Pranay <mogula.pranay@nxp.com>


  