### PR TITLE
base-files: fix usage of NO_CALLBACK in lists.

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -78,10 +78,12 @@ list() {
 	config_get len "$CONFIG_SECTION" "${varname}_LENGTH" 0
 	[ $len = 0 ] && append CONFIG_LIST_STATE "${CONFIG_SECTION}_${varname}"
 	len=$(($len + 1))
-	config_set "$CONFIG_SECTION" "${varname}_ITEM$len" "$value"
-	config_set "$CONFIG_SECTION" "${varname}_LENGTH" "$len"
+
+	export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_${varname}_ITEM$len=$value"
+	export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_${varname}_LENGTH=$len"
+
 	append "CONFIG_${CONFIG_SECTION}_${varname}" "$value" "$LIST_SEP"
-	list_cb "$varname" "$*"
+	[ -n "$NO_CALLBACK" ] || list_cb "$varname" "$*"
 }
 
 config_unset() {


### PR DESCRIPTION
Two issues fixed in `functions.sh`:

1. `NO_CALLBACK` did not work on lists.
2. When `NO_CALLBACK` was _not_ defined, the `option_cb` callback was called for each list entry with \<varname>_ITEM\<n> and then with \<varname>_LENGTH values (due to a call to `config_set`).
  
  