### PR TITLE
base-files: allow preconfigured root password

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -121,6 +121,8 @@ ifeq ($(CONFIG_NAND_SUPPORT),)
   endef
 endif
 
+ROOT_PASSWORD:=$(call qstrip,$(CONFIG_TARGET_ROOT_PASSWORD))
+
 define Package/base-files/install
 	$(CP) ./files/* $(1)/
 	$(Package/base-files/install-key)
@@ -174,6 +176,10 @@ define Package/base-files/install
 	$(LN) /tmp $(1)/var
 	mkdir -p $(1)/etc
 	$(LN) /tmp/resolv.conf /tmp/TZ /tmp/localtime $(1)/etc/
+
+	if [ -n '$(call dollar2,$(ROOT_PASSWORD))' ]; then \
+		$(SED) 's/^root::0:/root:$(call dollar2,$(ROOT_PASSWORD))::/' $(1)/etc/shadow; \
+	fi
 
 	chmod 0600 $(1)/etc/shadow
 	chmod 1777 $(1)/tmp

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -97,6 +97,13 @@ config TARGET_PREINIT_BROADCAST
 		Broadcast address to which to send preinit network messages, as
 		as failsafe messages
 
+config TARGET_ROOT_PASSWORD
+	string
+	prompt "Default root password (encrypted, with dollars doubled up)"
+	default ""
+	help
+		Default root password.
+
 
 menuconfig INITOPT
 	bool "Init configuration options" if IMAGEOPT

--- a/rules.mk
+++ b/rules.mk
@@ -32,6 +32,9 @@ comma:=,
 merge=$(subst $(space),,$(1))
 confvar=$(shell echo '$(foreach v,$(1),$(v)=$(subst ','\'',$($(v))))' | $(STAGING_DIR_HOST)/bin/mkhash md5)
 strip_last=$(patsubst %.$(lastword $(subst .,$(space),$(1))),%,$(1))
+# if you have a value containing dollars which is being interpolated
+# into a macro, then protect it with this
+dollar2=$(subst $$,$$$$,$(1))
 
 paren_left = (
 paren_right = )


### PR DESCRIPTION
It might be useful to build images that can be deployed with root
passwords (and hence with ssh enabled) without having to set the
password manually on a booted box on the console, etc.

Allow baking a preset (encrypted) password into the shadow file.