### PR TITLE
ramips: Add support for new Widora Neo revision

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -57,7 +57,8 @@ ramips_setup_interfaces()
 	omega2p | \
 	timecloud|\
 	w150m|\
-	widora-neo|\
+	widora-neo-16M|\
+	widora-neo-32M|\
 	wnce2001|\
 	zbt-cpe102|\
 	zte-q7)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -284,8 +284,11 @@ get_status_led() {
 	zbt-we2026)
 		status_led="$boardname:red:power"
 		;;
-	widora-neo)
-		status_led="widora:orange:wifi"
+	widora-neo-16M)
+		status_led="$boardname:orange:wifi"
+		;;
+	widora-neo-32M)
+		status_led="$boardname:orange:wifi"
 		;;
 	wzr-agl300nh)
 		status_led="$boardname:green:router"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -580,8 +580,11 @@ ramips_board_detect() {
 	*"WHR-G300N")
 		name="whr-g300n"
 		;;
-	*"Widora-NEO")
-		name="widora-neo"
+	*"Widora-NEO-16M")
+		name="widora-neo-16M"
+		;;
+	*"Widora-NEO-32M")
+		name="widora-neo-32M"
 		;;
 	*"WiTi")
                 name="witi"

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -166,7 +166,8 @@ platform_check_image() {
 	whr-300hp2|\
 	whr-600d|\
 	whr-g300n|\
-	widora-neo|\
+	widora-neo-16M|\
+	widora-neo-32M|\
 	witi|\
 	wizfi630a|\
 	wl-330n|\

--- a/target/linux/ramips/dts/WIDORA-NEO-16M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-16M.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "widora,neo", "mediatek,mt7628an-soc";
-	model = "Widora-NEO";
+	model = "Widora-NEO-16M";
 
 	chosen {
 		bootargs = "console=ttyS0,115200";

--- a/target/linux/ramips/dts/WIDORA-NEO-32M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-32M.dts
@@ -1,0 +1,171 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "widora,neo", "mediatek,mt7628an-soc";
+	model = "Widora-NEO-32M";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "widora:orange:wifi";
+			gpios = <&wgpio 0 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	wgpio: gpio-wifi {
+		compatible = "mediatek,gpio-wifi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		perst {
+			ralink,group = "perst";
+			ralink,function = "gpio";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		spis {
+			ralink,group = "spis";
+			ralink,function = "gpio";
+		};
+
+		wled_kn {
+			ralink,group = "wled_kn";
+			ralink,function = "gpio";
+		};
+
+		wled_an {
+			ralink,group = "wled_an";
+			ralink,function = "wled_an";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x1fb0000>;
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-low;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -79,7 +79,7 @@ define Device/omega2
   DEVICE_TITLE := Onion Omega2
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
 endef
-TARGET_DEVICES += omega2
+
 
 define Device/omega2p
   DTS := OMEGA2P
@@ -202,13 +202,23 @@ define Device/wl-wn575a3
 endef
 TARGET_DEVICES += wl-wn575a3
 
-define Device/widora-neo
-  DTS := WIDORA-NEO
+define Device/widora-neo-16M
+  DTS := WIDORA-NEO-16M
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
-  DEVICE_TITLE := Widora-NEO
+  DEVICE_TITLE := Widora-NEO-16M
+  SUPPORTED_DEVICES += widora-neo
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
-TARGET_DEVICES += widora-neo
+TARGET_DEVICES += widora-neo-16M
+
+define Device/widora-neo-32M
+  DTS := WIDORA-NEO-32M
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Widora-NEO-32M
+  SUPPORTED_DEVICES += widora-neo
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += widora-neo-32M
 
 define Device/wrtnode2p
   DTS := WRTNODE2P


### PR DESCRIPTION
Widora has updated their Widora Neo board recently.

The new model uses 32MB WSON-8 factor SPI flash
instead of the original 16MB SOP-8 factor SPI flash.

All the other hardware components are the same as
the first revision.

Detailed hardware specs listed below:

- CPU: MTK MT7688AN
- RAM: 128MB DDR2
- ROM: **32MB WSON-8 factor SPI Flash (Winbond)** <- the only difference between two rev.
- WiFi: Built-in 802.11n 150Mbps?
- Ethernet: 10/100Mbps x1
- Audio codec: WM8960
- Other IO: 
   * USB OTG;
   * USB Power+Serial (CP2104);
   * LEDs (Power, LAN, WiFi);
   * 2x Keys (WPS, CPU Reset)
   * 1x Audio In/Out
   * 1x IPEX antenna port
   * 1x Micro SD slot

Signed-off-by: Jackson Ming Hu <huming2207@gmail.com>
  