### PR TITLE
[PATCH 00/05] rt2x00: reduce power consumption on mt7620

### DIFF
--- a/980-rt2x00-reduce-power-consumption-on-mt7620.patch
+++ b/980-rt2x00-reduce-power-consumption-on-mt7620.patch
@@ -1,0 +1,43 @@
+From: Tomislav Požega <pozega.tomislav@gmail.com>
+
+rt2x00: write registers required for reducing power consumption
+
+Write registers required for reducing power consumption like the vendor
+driver does when ADJUST_POWER_CONSUMPTION_SUPPORT is set.
+This helps devices to sync at better TX/RX rates and improves overall
+performance.
+
+Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+[daniel@makrotopia.org: edited commit message]
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -8717,6 +8717,24 @@ static void rt2800_init_rfcsr_6352(struc
+ 	rt2800_rfcsr_write_chanreg(rt2x00dev, 58, 0x02);
+ 	rt2800_rfcsr_write_chanreg(rt2x00dev, 60, 0xC7);
+ 
++	/* reduce power consumption */
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 43, 0x53);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 44, 0x53);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 45, 0x53);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 47, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 47, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 48, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 49, 0x02);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 55, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 55, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 56, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 57, 0x02);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 58, 0x27);
++	rt2800_rfcsr_write_bank(rt2x00dev, 4, 59, 0x24);
++	rt2800_rfcsr_write_bank(rt2x00dev, 6, 59, 0x64);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 60, 0x4F);
++	rt2800_rfcsr_write_chanreg(rt2x00dev, 61, 0x02);
++
+ 	/* Initialize RF DC calibration register to default value */
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 0, 0x47);
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 1, 0x00);


### PR DESCRIPTION
This helps devices to sync at better TX/RX rates and improves overall
performance.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>
