### PR TITLE
network/uqmi: pipe the output off qmi_wds_stop to /dev/null

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -250,10 +250,15 @@ qmi_wds_stop() {
 
 	uqmi -s -d "$device" --set-client-id wds,"$cid" \
 		--stop-network 0xffffffff \
-		--autoconnect > /dev/null
+		--autoconnect > /dev/null 2>&1
 
-	[ -n "$pdh" ] && uqmi -s -d "$device" --set-client-id wds,"$cid" --stop-network "$pdh"
-	uqmi -s -d "$device" --set-client-id wds,"$cid" --release-client-id wds
+	[ -n "$pdh" ] && {
+		uqmi -s -d "$device" --set-client-id wds,"$cid" \
+			--stop-network "$pdh" > /dev/null 2>&1
+	}
+
+	uqmi -s -d "$device" --set-client-id wds,"$cid" \
+		--release-client-id wds > /dev/null 2>&1
 }
 
 proto_qmi_teardown() {


### PR DESCRIPTION
Pipe uqmi output from qmi_wds_stop function into /dev/null.
This will supress the following output in proto teardown.

netifd: wwan (x): "No effect"
netifd: wwan (x): Command failed: Permission denied

Signed-off-by: Florian Eckert <fe@dev.tdt.de>
