### PR TITLE
toolchain: give choice to build hardened toolchain

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -37,6 +37,22 @@ config EXTRA_GCC_CONFIG_OPTIONS
 	help
 	    Any additional gcc options you may want to include....
 
+config GCC_DEFAULT_PIE
+	bool
+	prompt "Build executable with PIE enabled by default" if TOOLCHAINOPTS
+	depends on !GCC_USE_VERSION_5
+	default n
+	help
+	    Use gcc configure option --enable-default-pie to turn on -fPIE and -pie by default.
+
+config GCC_DEFAULT_SSP
+	bool
+	prompt "Build executable with Stack-Smashing Protection enabled by default" if TOOLCHAINOPTS
+	depends on !GCC_USE_VERSION_4_8
+	default n
+	help
+	    Use gcc configure option --enable-default-ssp to turn on -fstack-protector-strong by default.
+
 config SSP_SUPPORT
 	bool
 	prompt "Enable Stack-Smashing Protection support" if TOOLCHAINOPTS

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -133,6 +133,16 @@ ifndef GCC_VERSION_4_8
   GCC_CONFIGURE += --with-diagnostics-color=auto-if-env
 endif
 
+ifneq ($(CONFIG_GCC_DEFAULT_PIE),)
+  GCC_CONFIGURE+= \
+		--enable-default-pie
+endif
+
+ifneq ($(CONFIG_GCC_DEFAULT_SSP),)
+  GCC_CONFIGURE+= \
+		--enable-default-ssp
+endif
+
 ifneq ($(CONFIG_SSP_SUPPORT),)
   GCC_CONFIGURE+= \
 		--enable-libssp


### PR DESCRIPTION
Here is two commit for building hardened gcc.

The first commit add two menu options to enable gcc configure flags --enable-default-pie and --enable-default-ssp. Binaries produced will all be PIE and SSP without dealing with gcc flags. Note that packages using ld for linking instead of gcc won't be PIE (for example busybox)

The second commit is for enabling this by default. I don't know you are wanting it.
