### PR TITLE
build: cleanup SSP_SUPPORT configure option

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -194,11 +194,11 @@ menu "Global build settings"
 			bool "None"
 		config PKG_CC_STACKPROTECTOR_REGULAR
 			bool "Regular"
-			select SSP_SUPPORT if !USE_MUSL
+			select GCC_LIBSSP if !USE_MUSL
 			depends on KERNEL_CC_STACKPROTECTOR_REGULAR
 		config PKG_CC_STACKPROTECTOR_STRONG
 			bool "Strong"
-			select SSP_SUPPORT if !USE_MUSL
+			select GCC_LIBSSP if !USE_MUSL
 			depends on !GCC_VERSION_4_8
 			depends on KERNEL_CC_STACKPROTECTOR_STRONG
 	endchoice

--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-PKG_DEFAULT_DEPENDS = +libc +SSP_SUPPORT:libssp +USE_GLIBC:librt +USE_GLIBC:libpthread
+PKG_DEFAULT_DEPENDS = +libc +GCC_LIBSSP:libssp +USE_GLIBC:librt +USE_GLIBC:libpthread
 
 ifneq ($(PKG_NAME),toolchain)
   PKG_FIXUP_DEPENDS = $(if $(filter kmod-%,$(1)),$(2),$(PKG_DEFAULT_DEPENDS) $(filter-out $(PKG_DEFAULT_DEPENDS),$(2)))

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -83,7 +83,7 @@ endef
 
 define Package/libssp
 $(call Package/gcc/Default)
-  DEPENDS+=@SSP_SUPPORT
+  DEPENDS+=@GCC_LIBSSP
   TITLE:=GCC support library
 endef
 

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -286,6 +286,10 @@ config USE_MUSL
 	default y if !TOOLCHAINOPTS && !EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN && !(arc || powerpc64)
 	bool
 
+config SSP_SUPPORT
+	default y if USE_MUSL || GCC_LIBSSP
+	bool
+
 config USE_EXTERNAL_LIBC
 	bool
 	default y if EXTERNAL_TOOLCHAIN || NATIVE_TOOLCHAIN

--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -37,9 +37,9 @@ config EXTRA_GCC_CONFIG_OPTIONS
 	help
 	    Any additional gcc options you may want to include....
 
-config SSP_SUPPORT
+config GCC_LIBSSP
 	bool
-	prompt "Enable Stack-Smashing Protection support" if TOOLCHAINOPTS
+	prompt "Build gcc libssp" if TOOLCHAINOPTS
 	depends on !USE_MUSL
 	default y if !USE_MUSL
 	help

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -133,7 +133,7 @@ ifndef GCC_VERSION_4_8
   GCC_CONFIGURE += --with-diagnostics-color=auto-if-env
 endif
 
-ifneq ($(CONFIG_SSP_SUPPORT),)
+ifneq ($(CONFIG_GCC_LIBSSP),)
   GCC_CONFIGURE+= \
 		--enable-libssp
 else


### PR DESCRIPTION
Configure variable SSP_SUPPORT is ambiguous for packages (tor, openssh,
avahi, freeswitch). It means 'toolchain supporting SSP', but for toolchain
and depends it means 'build gcc with libssp'.

Musl no longer uses libssp (1877bc9d8f), it has internal support, so
SSP_SUPPORT was disabled leading some package to not use SSP.

No information why Glibc and uClibc use libssp, but they may also provide
their own SSP support. uClibc used it own with commit 933b588e25 but it was
reverted in f3cacb9e84 without details.

Create an new configure GCC_LIBSSP and automatically enable SSP_SUPPORT
if either USE_MUSL or GCC_LIBSSP.

Signed-off-by: Julien Dusser <julien.dusser@free.fr>