### PR TITLE
netifd:update dhcp.script to handle dynamic routing.

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -19,8 +19,12 @@ setup_interface () {
 	# TODO: apply $broadcast
 
 	local i
+	local ip_net
+	eval "$(ipcalc.sh $ip/$mask)";ip_net="$NETWORK"
 	for i in $router; do
-		proto_add_ipv4_route "$i" 32 "" "$ip"
+		local gw_net
+		eval "$(ipcalc.sh $i/$mask)";gw_net="$NETWORK"
+		[ "$ip_net" != "$gw_net" ] && proto_add_ipv4_route "$i" 32 "" "$ip"
 		proto_add_ipv4_route 0.0.0.0 0 "$i" "$ip"
 
 		local r


### PR DESCRIPTION
Certain DHCP servers push a gateway outside of the assigned interface subnet,
to support those situations, install a host route towards the gateway.

If Gateway and IP are served in same network, openwrt quagga cannot learn
routes (rip routes are not getting added, showing inactive) whereas
working fine when Gateway and IP are in different network.

Signed-off-by: Mogula Pranay <mogula.pranay@nxp.com>