### PR TITLE
ramips: Fix cpuclock for the GB-PC1

### DIFF
--- a/target/linux/ramips/dts/GB-PC1.dts
+++ b/target/linux/ramips/dts/GB-PC1.dts
@@ -102,6 +102,11 @@
 	};
 };
 
+&cpuclock {
+			compatible = "fixed-clock";
+			clock-frequency = <90000000>;
+};
+
 &pcie {
 	status = "okay";
 };


### PR DESCRIPTION
The GnuBee PC1 stock bootloader runs at 900Mhz. This fixes bad clock drift when running the platform.

Signed-off-by: Rosen Penev <rosenp@gmail.com>