### PR TITLE
ramips: set REQUIRE_IMAGE_METADATA=1 on boards

### DIFF
--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -313,6 +313,7 @@ platform_do_upgrade() {
 	r6220|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
+		REQUIRE_IMAGE_METADATA=1
 		nand_do_upgrade "$ARGV"
 		;;
 	*)


### PR DESCRIPTION
for these board we must set REQUIRE_IMAGE_METADATA=1 to make sure upgrade checking