### PR TITLE
mac80211: join 5GHz checks

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -82,14 +82,11 @@ detect_mac80211() {
 		ht_capab=""
 
 		iw phy "$dev" info | grep -q 'Capabilities:' && htmode=HT20
-		iw phy "$dev" info | grep -q '2412 MHz' || { mode_band="a"; channel="36"; }
 
-		vht_cap=$(iw phy "$dev" info | grep -c 'VHT Capabilities')
-		cap_5ghz=$(iw phy "$dev" info | grep -c "Band 2")
-		[ "$vht_cap" -gt 0 -a "$cap_5ghz" -gt 0 ] && {
-			mode_band="a";
+		iw phy "$dev" info | grep -q '5180 MHz' && {
+			mode_band="a"
 			channel="36"
-			htmode="VHT80"
+			iw phy "$dev" info | grep -q 'VHT Capabilities' && htmode="VHT80"
 		}
 
 		[ -n "$htmode" ] && ht_capab="set wireless.radio${devidx}.htmode=$htmode"


### PR DESCRIPTION
Before this commit, devices supporting both 2.4GHz and 5GHz would be configured for 2.4GHz by default - unless they have VHT capabilities.

With this commit, channel 36 is only set when the frequency is supported.
VHT isn't checked unless that is the case.