### PR TITLE
ar71xx: add support for MikroTik RouterBOARD wAP G-5HacT2HnD

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -103,6 +103,7 @@ ar71xx_setup_interfaces()
 	rb-sxt2n|\
 	rb-sxt5n|\
 	rb-wap-2nd|\
+	rb-wapg-5hact2hnd|\
 	re450|\
 	rocket-m-xw|\
 	sc300m |\

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -94,7 +94,8 @@ case "$FIRMWARE" in
 		ath10kcal_extract "caldata" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) +2)
 		;;
-	rb-952ui-5ac2nd)
+	rb-952ui-5ac2nd|\
+	rb-wapg-5hact2hnd)
 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
 		;;
 	re450|\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -983,6 +983,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD wAP 2nD r2")
 		name="rb-wap-2nd"
 		;;
+	*"RouterBOARD wAP G-5HacT2HnD") 
+		name="rb-wapg-5hact2hnd"
+		;;
 	*"RouterStation")
 		name="routerstation"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -662,7 +662,8 @@ platform_check_image() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
-	rb-wap-2nd)
+	rb-wap-2nd|\
+	rb-wapg-5hact2hnd)
 		return 0
 		;;
 	esac
@@ -724,7 +725,8 @@ platform_pre_upgrade() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
-	rb-wap-2nd)
+	rb-wap-2nd|\
+	rb-wapg-5hact2hnd)
 		# erase firmware if booted from initramfs
 		[ -z "$(rootfs_type)" ] && mtd erase firmware
 		;;

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -12,6 +12,7 @@
  *  - MikroTik RouterBOARD 750 r2
  *  - MikroTik RouterBOARD LHG 5nD
  *  - MikroTik RouterBOARD wAP2nD
+ *  - MikroTik RouterBOARD wAP G-5HacT2HnDwAP (wAP AC)
  *
  *  Preliminary support for the following hardware
  *  - MikroTik RouterBOARD cAP2nD
@@ -41,6 +42,8 @@
 #include <linux/mtd/partitions.h>
 
 #include <linux/ar8216_platform.h>
+#include <linux/platform_data/phy-at803x.h>
+#include <linux/platform_data/mdio-gpio.h>
 
 #include <asm/prom.h>
 #include <asm/mach-ath79/ar71xx_regs.h>
@@ -134,9 +137,21 @@ static struct flash_platform_data rbspi_spi_flash_data = {
 	.nr_parts = ARRAY_SIZE(rbspi_spi_partitions),
 };
 
-/* Several boards only have a single reset button wired to GPIO 16 */
+/* Several boards only have a single reset button, wired to GPIO 1, 16 or 20 */
+#define RBSPI_GPIO_BTN_RESET01	1
 #define RBSPI_GPIO_BTN_RESET16	16
 #define RBSPI_GPIO_BTN_RESET20	20
+
+static struct gpio_keys_button rbspi_gpio_keys_reset01[] __initdata = {
+	{
+		.desc = "Reset button",
+		.type = EV_KEY,
+		.code = KEY_RESTART,
+		.debounce_interval = RBSPI_KEYS_DEBOUNCE_INTERVAL,
+		.gpio = RBSPI_GPIO_BTN_RESET01,
+		.active_low = 1,
+	},
+};
 
 static struct gpio_keys_button rbspi_gpio_keys_reset16[] __initdata = {
 	{
@@ -485,6 +500,40 @@ static struct gpio_keys_button rblhg_gpio_keys[] __initdata = {
 	},
 };
 
+/* RB w APG-5HacT2HnD (wAP AC) gpios*/
+#define RBWAPGSC_LED1		1
+#define RBWAPGSC_LED2		8
+#define RBWAPGSC_LED3		9
+#define RBWAPGSC_POWERLED		16
+#define RBWAPGSC_GPIO_MDIO_MDC		12
+#define RBWAPGSC_GPIO_MDIO_DATA		11
+#define RBWAPGSC_MDIO_PHYMASK		0
+
+static struct gpio_led rbwapgsc_leds[] __initdata = {
+	{
+		.name = "rb:green:led1",
+		.gpio = RBWAPGSC_LED1,
+		.active_low = 1,
+	},{
+		.name = "rb:blue:power",
+		.gpio = RBWAPGSC_POWERLED,
+		.active_low = 1,
+	},
+};
+
+static struct mdio_gpio_platform_data rbwapgsc_mdio_data = {
+	.mdc = RBWAPGSC_GPIO_MDIO_MDC,
+	.mdio = RBWAPGSC_GPIO_MDIO_DATA,
+	.phy_mask = ~BIT(RBWAPGSC_MDIO_PHYMASK),
+};
+
+static struct platform_device rbwapgsc_phy_device = {
+	.name = "mdio-gpio",
+	.id = 1,
+	.dev = {
+		.platform_data = &rbwapgsc_mdio_data
+	},
+};
 
 static struct gen_74x164_chip_platform_data rbspi_ssr_data = {
 	.base = RBSPI_SSR_GPIO_BASE,
@@ -538,7 +587,7 @@ void __init rbspi_wlan_init(u16 id, int wmac_offset)
 }
 
 #define RBSPI_MACH_BUFLEN	64
-/* 
+/*
  * Common platform init routine for all SPI NOR devices.
  */
 static int __init rbspi_platform_setup(void)
@@ -641,7 +690,7 @@ static void __init rbspi_network_setup(u32 flags, int gmac1_offset,
 		rbspi_wlan_init(1, wmac1_offset);
 }
 
-/* 
+/*
  * Init the mAP lite hardware (QCA953x).
  * The mAP L-2nD (mAP lite) has a single ethernet port, connected to PHY0.
  * Trying to use GMAC0 in direct mode was unsucessful, so we're
@@ -958,6 +1007,47 @@ static void __init rbmap_setup(void)
 					rbspi_gpio_keys_reset16);
 }
 
+/*
+ * Init the wAPGSC (RB wAPG-5HacT2HnD // wAP AC) hardware.
+ * The wAPGSC has one Ethernet port via AR8033 with PoE input, dual radio (SoC
+ * 2.4 GHz and external QCA9880) and a ZT2046Q temperature and voltage sensor
+ * (currently not supported).
+ */
+static void __init rbwapgsc_setup(void)
+{
+	u32 flags = RBSPI_HAS_PCI;
+
+	if (rbspi_platform_setup())
+		return;
+
+	rbspi_peripherals_setup(flags);
+
+	platform_device_register(&rbwapgsc_phy_device);
+
+	ath79_init_mac(ath79_eth1_data.mac_addr, ath79_mac_base, 0);
+	ath79_eth1_data.mii_bus_dev = &rbwapgsc_phy_device.dev;
+	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
+	ath79_eth1_data.phy_mask = BIT(RBWAPGSC_MDIO_PHYMASK);
+	ath79_eth1_pll_data.pll_1000 = 0x03000101;
+	ath79_eth1_pll_data.pll_100 = 0x80000101;
+	ath79_eth1_pll_data.pll_10 = 0x80001313;
+	ath79_eth1_data.speed = SPEED_1000;
+	ath79_eth1_data.duplex = DUPLEX_FULL;
+	ath79_register_eth(1);
+
+	rbspi_wlan_init(1, 2);
+
+	ath79_register_gpio_keys_polled(-1, RBSPI_KEYS_POLL_INTERVAL,
+		ARRAY_SIZE(rbspi_gpio_keys_reset01),
+		rbspi_gpio_keys_reset01);
+
+	ath79_gpio_function_enable(QCA955X_GPIO_FUNC_JTAG_DISABLE|
+				QCA955X_GPIO_REG_OUT_FUNC4|
+				QCA955X_GPIO_REG_OUT_FUNC3);
+
+	ath79_register_leds_gpio(-1, ARRAY_SIZE(rbwapgsc_leds),
+			rbwapgsc_leds);
+}
 
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_MAPL, "map-hb", rbmapl_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_941, "H951L", rbhapl_setup);
@@ -968,3 +1058,4 @@ MIPS_MACHINE_NONAME(ATH79_MACH_RB_LHG5, "lhg", rblhg_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAP, "wap-hb", rbwap_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_CAP, "cap-hb", rbcap_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_MAP, "map2-hb", rbmap_setup);
+MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAPAC, "wapg-sc", rbwapgsc_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -197,6 +197,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */
 	ATH79_MACH_RB_MAPL,			/* Mikrotik RouterBOARD mAP L-2nD */
 	ATH79_MACH_RB_WAP,			/* Mikrotik RouterBOARD wAP2nD */
+	ATH79_MACH_RB_WAPAC,			/* Mikrotik RouterBOARD wAPG-5HacT2HnD */
 	ATH79_MACH_RB_SXTLITE2ND,		/* Mikrotik RouterBOARD SXT Lite 2nD */
 	ATH79_MACH_RB_SXTLITE5ND,		/* Mikrotik RouterBOARD SXT Lite 5nD */
 	ATH79_MACH_RE450,			/* TP-LINK RE450 */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -50,5 +50,6 @@ define Device/rb-nor-flash-16M-ac
   $(Device/rb-nor-flash-16M)
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR, 802.11ac)
   DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887
+  SUPPORTED_DEVICES := rb-wapg-5hact2hnd
 endef
 TARGET_DEVICES += rb-nor-flash-16M-ac

--- a/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.4/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,29 @@ void __init prom_init(void)
+@@ -136,6 +136,30 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -22,11 +22,12 @@
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=map2-hb") ||
 +	    strstr(arcs_cmdline, "board=wap-hb") ||
++	    strstr(arcs_cmdline, "board=wapg-sc") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||
 +	    strstr(arcs_cmdline, "board=922gs"))
 +		ath79_prom_append_cmdline("console", "ttyS0,115200");
  }
- 
+
  void __init prom_free_prom_memory(void)

--- a/target/linux/ar71xx/patches-4.4/741-MIPS-ath79-add-PCI-for-QCA9556-SoC.patch
+++ b/target/linux/ar71xx/patches-4.4/741-MIPS-ath79-add-PCI-for-QCA9556-SoC.patch
@@ -1,0 +1,12 @@
+--- a/arch/mips/ath79/pci.c
++++ b/arch/mips/ath79/pci.c
+@@ -324,7 +324,8 @@ int __init ath79_register_pci(void)
+						 QCA953X_PCI_MEM_SIZE,
+						 0,
+						 ATH79_IP2_IRQ(0));
+-	} else if (soc_is_qca9558()) {
++	} else if (soc_is_qca9558() ||
++		   soc_is_qca9556()) {
+		pdev = ath79_register_pci_ar724x(0,
+						 QCA955X_PCI_CFG_BASE0,
+						 QCA955X_PCI_CTRL_BASE0,

--- a/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,29 @@ void __init prom_init(void)
+@@ -136,6 +136,30 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -22,11 +22,12 @@
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=map2-hb") ||
 +	    strstr(arcs_cmdline, "board=wap-hb") ||
++	    strstr(arcs_cmdline, "board=wapg-sc") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||
 +	    strstr(arcs_cmdline, "board=922gs"))
 +		ath79_prom_append_cmdline("console", "ttyS0,115200");
  }
- 
+
  void __init prom_free_prom_memory(void)

--- a/target/linux/ar71xx/patches-4.9/741-MIPS-ath79-add-PCI-for-QCA9556-SoC.patch
+++ b/target/linux/ar71xx/patches-4.9/741-MIPS-ath79-add-PCI-for-QCA9556-SoC.patch
@@ -1,0 +1,12 @@
+--- a/arch/mips/ath79/pci.c
++++ b/arch/mips/ath79/pci.c
+@@ -324,7 +324,8 @@ int __init ath79_register_pci(void)
+						 QCA953X_PCI_MEM_SIZE,
+						 0,
+						 ATH79_IP2_IRQ(0));
+-	} else if (soc_is_qca9558()) {
++	} else if (soc_is_qca9558() ||
++		   soc_is_qca9556()) {
+		pdev = ath79_register_pci_ar724x(0,
+						 QCA955X_PCI_CFG_BASE0,
+						 QCA955X_PCI_CTRL_BASE0,


### PR DESCRIPTION
This pull requests consists of two commits that do the following:
 - activate the PCI bus on the QCA9556 SoC, similarly to how it is done on the QCA9558
 - add support for MikroTik RouterBOARD wAP G-5HacT2HnD (wAP AC) devices (which is based on the QCA9556 SoC), with board detection, sysupgrade, Ethernet and both radios working.