### PR TITLE
scripts/config: cleanup leftover qconf files

### DIFF
--- a/scripts/config/Makefile
+++ b/scripts/config/Makefile
@@ -33,7 +33,7 @@ lxdialog-objs := \
 
 clean-files	:= zconf.tab.c lex.zconf.c zconf.hash.c
 # Remove qconf junk files
-clean-files	+= $(qconf-cxxobjs) qconf.moc .tmp_qtcheck
+clean-files	+= $(qconf-cxxobjs) qconf.moc .tmp_qtcheck qconf
 
 all: conf mconf
 


### PR DESCRIPTION
``make xconfig`` toplevel target will invoke ``make qconf`` inside
./scripts/config directory, which results a ``qconf`` executable.

This commit removes leftover ``qconf`` executable during ``make
config-clean``.
