### PR TITLE
ath10k-caldata: avoid repeated writes to flash frequently

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -10,8 +10,11 @@ ath10kcal_from_file() {
 	local offset=$2
 	local count=$3
 
-	dd if=$source of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
+	FWTMP=`mktemp`
+	dd if=$source of=$FWTMP bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $source"
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 ath10kcal_extract() {
@@ -24,8 +27,11 @@ ath10kcal_extract() {
 	[ -n "$mtd" ] || \
 		ath10kcal_die "no mtd device found for partition $part"
 
-	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
+	FWTMP=`mktemp`
+	dd if=$mtd of=$FWTMP bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $mtd"
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 ath10kcal_patch_mac() {
@@ -33,7 +39,11 @@ ath10kcal_patch_mac() {
 
 	[ -z "$mac" ] && return
 
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=6 count=6
+	FWTMP=`mktemp`
+	cp /lib/firmware/$FIRMWARE $FWTMP
+	macaddr_2bin $mac | dd of=$FWTMP conv=notrunc bs=1 seek=6 count=6
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -10,8 +10,11 @@ ath10kcal_from_file() {
 	local offset=$2
 	local count=$3
 
-	dd if=$source of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
+	FWTMP=`mktemp`
+	dd if=$source of=$FWTMP bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $source"
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 ath10kcal_extract() {
@@ -24,8 +27,11 @@ ath10kcal_extract() {
 	[ -n "$mtd" ] || \
 		ath10kcal_die "no mtd device found for partition $part"
 
-	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
+	FWTMP=`mktemp`
+	dd if=$mtd of=$FWTMP bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $mtd"
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 ath10kcal_patch_mac() {
@@ -33,7 +39,11 @@ ath10kcal_patch_mac() {
 
 	[ -z "$mac" ] && return
 
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=6 count=6
+	FWTMP=`mktemp`
+	cp /lib/firmware/$FIRMWARE $FWTMP
+	macaddr_2bin $mac | dd of=$FWTMP conv=notrunc bs=1 seek=6 count=6
+	diff -q $FWTMP /lib/firmware/$FIRMWARE >/dev/null 2>&1 || cp $FWTMP /lib/firmware/$FIRMWARE
+	rm -f $FWTMP
 }
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0


### PR DESCRIPTION
Flash is very fragile and should be avoided frequently written
This modification avoids writing every time system boot up