### PR TITLE
hostapd: return with 80211 codes in handle event function

### DIFF
--- a/package/network/services/hostapd/patches/600-ubus_support.patch
+++ b/package/network/services/hostapd/patches/600-ubus_support.patch
@@ -84,7 +84,7 @@
  		   __func__, driver, drv_priv);
 --- a/src/ap/ieee802_11.c
 +++ b/src/ap/ieee802_11.c
-@@ -1587,7 +1587,8 @@ ieee802_11_set_radius_info(struct hostap
+@@ -1587,12 +1587,13 @@ ieee802_11_set_radius_info(struct hostap
  
  
  static void handle_auth(struct hostapd_data *hapd,
@@ -94,6 +94,12 @@
  {
  	u16 auth_alg, auth_transaction, status_code;
  	u16 resp = WLAN_STATUS_SUCCESS;
+ 	struct sta_info *sta = NULL;
+-	int res, reply_res;
++	int res, reply_res, ubus_resp;
+ 	u16 fc;
+ 	const u8 *challenge = NULL;
+ 	u32 session_timeout, acct_interim_interval;
 @@ -1603,6 +1604,11 @@ static void handle_auth(struct hostapd_d
  	char *identity = NULL;
  	char *radius_cui = NULL;
@@ -106,20 +112,21 @@
  
  	if (len < IEEE80211_HDRLEN + sizeof(mgmt->u.auth)) {
  		wpa_printf(MSG_INFO, "handle_auth - too short payload (len=%lu)",
-@@ -1757,6 +1763,12 @@ static void handle_auth(struct hostapd_d
+@@ -1757,6 +1763,13 @@ static void handle_auth(struct hostapd_d
  		resp = WLAN_STATUS_UNSPECIFIED_FAILURE;
  		goto fail;
  	}
-+	if (hostapd_ubus_handle_event(hapd, &req)) {
++	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
++	if (ubus_resp) {
 +		wpa_printf(MSG_DEBUG, "Station " MACSTR " rejected by ubus handler.\n",
 +			MAC2STR(mgmt->sa));
-+		resp = WLAN_STATUS_UNSPECIFIED_FAILURE;
++		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
 +		goto fail;
 +	}
  	if (res == HOSTAPD_ACL_PENDING)
  		return;
  
-@@ -2870,7 +2882,7 @@ void fils_hlp_timeout(void *eloop_ctx, v
+@@ -2870,12 +2883,12 @@ void fils_hlp_timeout(void *eloop_ctx, v
  
  static void handle_assoc(struct hostapd_data *hapd,
  			 const struct ieee80211_mgmt *mgmt, size_t len,
@@ -128,7 +135,13 @@
  {
  	u16 capab_info, listen_interval, seq_ctrl, fc;
  	u16 resp = WLAN_STATUS_SUCCESS, reply_res;
-@@ -2884,6 +2896,11 @@ static void handle_assoc(struct hostapd_
+ 	const u8 *pos;
+-	int left, i;
++	int left, i, ubus_resp;
+ 	struct sta_info *sta;
+ 	u8 *tmp = NULL;
+ 	struct hostapd_sta_wpa_psk_short *psk = NULL;
+@@ -2884,6 +2897,11 @@ static void handle_assoc(struct hostapd_
  #ifdef CONFIG_FILS
  	int delay_assoc = 0;
  #endif /* CONFIG_FILS */
@@ -140,21 +153,22 @@
  
  	if (len < IEEE80211_HDRLEN + (reassoc ? sizeof(mgmt->u.reassoc_req) :
  				      sizeof(mgmt->u.assoc_req))) {
-@@ -3051,6 +3068,13 @@ static void handle_assoc(struct hostapd_
+@@ -3051,6 +3069,14 @@ static void handle_assoc(struct hostapd_
  	}
  #endif /* CONFIG_MBO */
  
-+	if (hostapd_ubus_handle_event(hapd, &req)) {
++	ubus_resp = hostapd_ubus_handle_event(hapd, &req);
++	if (ubus_resp) {
 +		wpa_printf(MSG_DEBUG, "Station " MACSTR " assoc rejected by ubus handler.\n",
 +		       MAC2STR(mgmt->sa));
-+		resp = WLAN_STATUS_UNSPECIFIED_FAILURE;
++		resp = ubus_resp > 0 ? (u16) ubus_resp : WLAN_STATUS_UNSPECIFIED_FAILURE;
 +		goto fail;
 +	}
 +
  	/*
  	 * sta->capability is used in check_assoc_ies() for RRM enabled
  	 * capability element.
-@@ -3258,6 +3282,7 @@ static void handle_disassoc(struct hosta
+@@ -3258,6 +3284,7 @@ static void handle_disassoc(struct hosta
  	wpa_printf(MSG_DEBUG, "disassocation: STA=" MACSTR " reason_code=%d",
  		   MAC2STR(mgmt->sa),
  		   le_to_host16(mgmt->u.disassoc.reason_code));
@@ -162,7 +176,7 @@
  
  	sta = ap_get_sta(hapd, mgmt->sa);
  	if (sta == NULL) {
-@@ -3323,6 +3348,8 @@ static void handle_deauth(struct hostapd
+@@ -3323,6 +3350,8 @@ static void handle_deauth(struct hostapd
  		" reason_code=%d",
  		MAC2STR(mgmt->sa), le_to_host16(mgmt->u.deauth.reason_code));
  
@@ -171,7 +185,7 @@
  	sta = ap_get_sta(hapd, mgmt->sa);
  	if (sta == NULL) {
  		wpa_msg(hapd->msg_ctx, MSG_DEBUG, "Station " MACSTR " trying "
-@@ -3637,7 +3664,7 @@ int ieee802_11_mgmt(struct hostapd_data
+@@ -3637,7 +3666,7 @@ int ieee802_11_mgmt(struct hostapd_data
  
  
  	if (stype == WLAN_FC_STYPE_PROBE_REQ) {
@@ -180,7 +194,7 @@
  		return 1;
  	}
  
-@@ -3657,17 +3684,17 @@ int ieee802_11_mgmt(struct hostapd_data
+@@ -3657,17 +3686,17 @@ int ieee802_11_mgmt(struct hostapd_data
  	switch (stype) {
  	case WLAN_FC_STYPE_AUTH:
  		wpa_printf(MSG_DEBUG, "mgmt::auth");

--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -677,7 +677,7 @@ void hostapd_ubus_free_bss(struct hostapd_data *hapd)
 
 struct ubus_event_req {
 	struct ubus_notify_request nreq;
-	bool deny;
+	int resp;
 };
 
 static void
@@ -685,8 +685,7 @@ ubus_event_cb(struct ubus_notify_request *req, int idx, int ret)
 {
 	struct ubus_event_req *ureq = container_of(req, struct ubus_event_req, nreq);
 
-	if (ret)
-		ureq->deny = true;
+	ureq->resp = ret;
 }
 
 int hostapd_ubus_handle_event(struct hostapd_data *hapd, struct hostapd_ubus_request *req)
@@ -708,10 +707,10 @@ int hostapd_ubus_handle_event(struct hostapd_data *hapd, struct hostapd_ubus_req
 
 	ban = avl_find_element(&hapd->ubus.banned, addr, ban, avl);
 	if (ban)
-		return -2;
+		return WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA;
 
 	if (!hapd->ubus.obj.has_subscribers)
-		return 0;
+		return WLAN_STATUS_SUCCESS;
 
 	if (req->type < ARRAY_SIZE(types))
 		type = types[req->type];
@@ -726,19 +725,19 @@ int hostapd_ubus_handle_event(struct hostapd_data *hapd, struct hostapd_ubus_req
 
 	if (!hapd->ubus.notify_response) {
 		ubus_notify(ctx, &hapd->ubus.obj, type, b.head, -1);
-		return 0;
+		return WLAN_STATUS_SUCCESS;
 	}
 
 	if (ubus_notify_async(ctx, &hapd->ubus.obj, type, b.head, &ureq.nreq))
-		return 0;
+		return WLAN_STATUS_SUCCESS;
 
 	ureq.nreq.status_cb = ubus_event_cb;
 	ubus_complete_request(ctx, &ureq.nreq.req, 100);
 
-	if (ureq.deny)
-		return -1;
+	if (ureq.resp)
+		return ureq.resp;
 
-	return 0;
+	return WLAN_STATUS_SUCCESS;
 }
 
 void hostapd_ubus_notify(struct hostapd_data *hapd, const char *type, const u8 *addr)


### PR DESCRIPTION
If the auth or assoc request was denied the reason
was always WLAN_STATUS_UNSPECIFIED_FAILURE.
That's why for example the a client was always
trying to reconnect to the AP.
Now it's possible to give reasoncodes (status codes) why the auth
or assoc was denied.

Signed-off-by: Nick Hainke <vincent@systemli.org>