### PR TITLE
hostapd: add 802.11 elems in probe req

### DIFF
--- a/package/network/services/hostapd/patches/601-ubus-add-80211elems.patch
+++ b/package/network/services/hostapd/patches/601-ubus-add-80211elems.patch
@@ -1,0 +1,10 @@
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -733,6 +733,7 @@ void handle_probe_req(struct hostapd_dat
+ 		.type = HOSTAPD_UBUS_PROBE_REQ,
+ 		.mgmt_frame = mgmt,
+ 		.frame_info = fi,
++		.elems = &elems,
+ 	};
+ 
+ 	if (len < IEEE80211_HDRLEN)

--- a/package/network/services/hostapd/src/src/ap/ubus.h
+++ b/package/network/services/hostapd/src/src/ap/ubus.h
@@ -18,6 +18,7 @@ enum hostapd_ubus_event_type {
 struct hostapd_ubus_request {
 	enum hostapd_ubus_event_type type;
 	const struct ieee80211_mgmt *mgmt_frame;
+	const struct ieee802_11_elems *elems;
 	const struct hostapd_frame_info *frame_info;
 	const u8 *addr;
 };


### PR DESCRIPTION
Add 802.11 elems in the hostapd_ubus_request.
Signed-off-by: Nick Hainke vincent@systemli.org