### PR TITLE
ar71xx: Fix 5 GHz Wi-Fi on NBG6716

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -18,11 +18,17 @@ ath10kcal_extract() {
 	local part=$1
 	local offset=$2
 	local count=$3
-	local mtd
+	local mtd cal_size
 
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || \
 		ath10kcal_die "no mtd device found for partition $part"
+
+	# Check that the calibration data size in header equals the desired size
+	cal_size=$(dd if=$mtd bs=2 count=1 skip=$(( $offset / 2 )) conv=swab 2>/dev/null | hexdump -ve '1/2 "%d"')
+
+	[ "$count" = "$cal_size" ] || \
+		ath10kcal_die "no calibration data found in $part"
 
 	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $mtd"


### PR DESCRIPTION
NBG6716 has calibration data in the PCI-E card EEPROM, not in flash.

See: https://forum.lede-project.org/t/17-01-1-2-3-qca988x-ath10k-5ghz-firmware-crashed-zyxel-nbg6716/1911?u=malaakso

Signed-off-by: Matti Laakso <matti.laakso@outlook.com>
