### PR TITLE
mac80211: ath: set phy regulatory domain

### DIFF
--- a/package/kernel/mac80211/patches/407-ath_phy_regd.patch
+++ b/package/kernel/mac80211/patches/407-ath_phy_regd.patch
@@ -1,0 +1,13 @@
+--- a/drivers/net/wireless/ath/regd.c
++++ b/drivers/net/wireless/ath/regd.c
+@@ -511,6 +511,10 @@ static int __ath_reg_dyn_country(struct
+ 
+ 	ath_reg_apply_world_flags(wiphy, request->initiator, reg);
+ 
++	// apply regulatory to phy devices
++	if (regulatory_hint(wiphy, reg->alpha2))
++		printk(KERN_DEBUG "ath: regulatory_hint error!\n");
++
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
Allows the atheros driver to set the regulatory domain
for the phy devices too.

IE:
usign "iw reg set AU" now the regulatory domain
is set for both "global" and "phy#0".

```
root@TL841v8:~# iw reg get
global
country US: DFS-FCC
	(2402 - 2472 @ 40), (N/A, 30), (N/A)
	(5170 - 5250 @ 80), (N/A, 23), (N/A), AUTO-BW
	(5250 - 5330 @ 80), (N/A, 23), (0 ms), DFS, AUTO-BW
	(5490 - 5730 @ 160), (N/A, 23), (0 ms), DFS
	(5735 - 5835 @ 80), (N/A, 30), (N/A)
	(57240 - 63720 @ 2160), (N/A, 40), (N/A)

phy#0
country US: DFS-FCC
	(2402 - 2472 @ 40), (N/A, 30), (N/A)
	(5170 - 5250 @ 80), (N/A, 23), (N/A), AUTO-BW
	(5250 - 5330 @ 80), (N/A, 23), (0 ms), DFS, AUTO-BW
	(5490 - 5730 @ 160), (N/A, 23), (0 ms), DFS
	(5735 - 5835 @ 80), (N/A, 30), (N/A)
	(57240 - 63720 @ 2160), (N/A, 40), (N/A)

root@TL841v8:~# iw reg set AU
root@TL841v8:~# iw reg get
global
country AU: DFS-ETSI
	(2400 - 2483 @ 40), (N/A, 36), (N/A)
	(5150 - 5250 @ 80), (N/A, 23), (N/A), NO-OUTDOOR, AUTO-BW
	(5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS, AUTO-BW
	(5470 - 5600 @ 80), (N/A, 27), (0 ms), DFS
	(5650 - 5730 @ 80), (N/A, 27), (0 ms), DFS
	(5730 - 5850 @ 80), (N/A, 36), (N/A)
	(57000 - 66000 @ 2160), (N/A, 43), (N/A), NO-OUTDOOR

phy#0
country AU: DFS-ETSI
	(2400 - 2483 @ 40), (N/A, 36), (N/A)
	(5150 - 5250 @ 80), (N/A, 23), (N/A), NO-OUTDOOR, AUTO-BW
	(5250 - 5350 @ 80), (N/A, 20), (0 ms), NO-OUTDOOR, DFS, AUTO-BW
	(5470 - 5600 @ 80), (N/A, 27), (0 ms), DFS
	(5650 - 5730 @ 80), (N/A, 27), (0 ms), DFS
	(5730 - 5850 @ 80), (N/A, 36), (N/A)
	(57000 - 66000 @ 2160), (N/A, 43), (N/A), NO-OUTDOOR

root@TL841v8:~# 
```

Signed-off-by: Lorenzo Santina <lorenzo.santina@edu.unito.it>
