### PR TITLE
set return value always to zero of platform_check_image() 

### DIFF
--- a/target/linux/kirkwood/base-files/lib/upgrade/platform.sh
+++ b/target/linux/kirkwood/base-files/lib/upgrade/platform.sh
@@ -4,7 +4,7 @@ RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 REQUIRE_IMAGE_METADATA=1
 
 platform_check_image() {
-	return 1
+	return 0
 }
 
 platform_do_upgrade() {


### PR DESCRIPTION
since we will distinguish device type by device_name from dts, the old platform_check_image() was set to always return zero.