### PR TITLE
kernel: add IEEE-1284 parallel port support [v2]

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -285,18 +285,51 @@ endef
 $(eval $(call KernelPackage,gpio-pcf857x))
 
 
-define KernelPackage/lp
+define KernelPackage/ppdev
   SUBMENU:=$(OTHER_MENU)
-  TITLE:=Parallel port and line printer support
+  TITLE:=Parallel port support
   KCONFIG:= \
 	CONFIG_PARPORT \
-	CONFIG_PRINTER \
 	CONFIG_PPDEV
   FILES:= \
 	$(LINUX_DIR)/drivers/parport/parport.ko \
-	$(LINUX_DIR)/drivers/char/lp.ko \
 	$(LINUX_DIR)/drivers/char/ppdev.ko
-  AUTOLOAD:=$(call AutoLoad,50,parport lp ppdev)
+  AUTOLOAD:=$(call AutoLoad,50,parport ppdev)
+endef
+
+$(eval $(call KernelPackage,ppdev))
+
+
+define KernelPackage/parport-pc
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Parallel port interface (PC-style) support
+  DEPENDS:=+kmod-ppdev
+  KCONFIG:= \
+	CONFIG_PARPORT_PC \
+	CONFIG_PARPORT_1284=y \
+	CONFIG_PARPORT_PC_FIFO=y \
+	CONFIG_PARPORT_PC_SUPERIO=y \
+	CONFIG_PARPORT_SERIAL=n \
+	CONFIG_PARIDE=n \
+	CONFIG_SCSI_IMM=n \
+	CONFIG_SCSI_PPA=n
+  FILES:= \
+	$(LINUX_DIR)/drivers/parport/parport_pc.ko
+  AUTOLOAD:=$(call AutoLoad,51,parport_pc)
+endef
+
+$(eval $(call KernelPackage,parport-pc))
+
+
+define KernelPackage/lp
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Parallel port line printer device support
+  DEPENDS:=+kmod-ppdev
+  KCONFIG:= \
+	CONFIG_PRINTER
+  FILES:= \
+	$(LINUX_DIR)/drivers/char/lp.ko
+  AUTOLOAD:=$(call AutoLoad,52,lp)
 endef
 
 $(eval $(call KernelPackage,lp))


### PR DESCRIPTION
It has not been otherwise possible to enable the module for PC-style
parport hardware for use with kmod-lp.

Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>
