### PR TITLE
ipq806x: implement full dual-boot support for the nbg6817

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -21,6 +21,7 @@ zyxel_do_flash() {
 	local tar_file=$1
 	local kernel=$2
 	local rootfs=$3
+	local dualflagmtd=$4
 
 	# keep sure its unbound
 	losetup --detach-all || {
@@ -63,6 +64,16 @@ zyxel_do_flash() {
 		umount /tmp/new_root
 	}
 
+	# flashing successful, toggle the dualflag
+	case "$rootfs" in
+		"/dev/mmcblk0p5")
+			printf "\xff" >$dualflagmtd
+			;;
+		"/dev/mmcblk0p8")
+			printf "\x01" >$dualflagmtd
+			;;
+	esac
+
 	# Cleanup
 	losetup -d $loopdev >/dev/null 2>&1
 	sync
@@ -79,12 +90,21 @@ zyxel_do_upgrade() {
 	[ -b "${rootfs}" ] || return 1
 	case "$board" in
 	zyxel,nbg6817)
+		local dualflagmtd="$(find_mtd_part 0:DUAL_FLAG)"
+		[ -b $dualflagmtd ] || return 1
+
 		case "$rootfs" in
 			"/dev/mmcblk0p5")
-				kernel="/dev/mmcblk0p4"
+				# booted from the primary partition set
+				# write to the alternative set
+				kernel="/dev/mmcblk0p7"
+				rootfs="/dev/mmcblk0p8"
 			;;
 			"/dev/mmcblk0p8")
-				kernel="/dev/mmcblk0p7"
+				# booted from the alternative partition set
+				# write to the primary set
+				kernel="/dev/mmcblk0p4"
+				rootfs="/dev/mmcblk0p5"
 			;;
 			*)
 				return 1
@@ -96,7 +116,7 @@ zyxel_do_upgrade() {
 		;;
 	esac
 
-	zyxel_do_flash $tar_file $kernel $rootfs
+	zyxel_do_flash $tar_file $kernel $rootfs $dualflagmtd
 
 	return 0
 }

--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -47,23 +47,24 @@ zyxel_do_flash() {
 	}
 
 	# Mount loop for rootfs_data
-	losetup -o $offset /dev/loop0 "${rootfs}" || {
+	local loopdev="$(losetup -f)"
+	losetup -o $offset $loopdev $rootfs || {
 		echo "Failed to mount looped rootfs_data."
 		sleep 10
 		reboot -f
 	}
 
 	echo "Format new rootfs_data at position ${offset}."
-	mkfs.ext4 -F -L rootfs_data /dev/loop0
+	mkfs.ext4 -F -L rootfs_data $loopdev
 	mkdir /tmp/new_root
-	mount -t ext4 /dev/loop0 /tmp/new_root && {
+	mount -t ext4 $loopdev /tmp/new_root && {
 		echo "Saving config to rootfs_data at position ${offset}."
 		cp -v /tmp/sysupgrade.tgz /tmp/new_root/
 		umount /tmp/new_root
 	}
 
 	# Cleanup
-	losetup -d /dev/loop0 >/dev/null 2>&1
+	losetup -d $loopdev >/dev/null 2>&1
 	sync
 	umount -a
 	reboot -f

--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -32,8 +32,8 @@ zyxel_do_flash() {
 	local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
 	board_dir=${board_dir%/}
 
-	echo "flashing kernel to /dev/${kernel}"
-	tar xf $tar_file ${board_dir}/kernel -O >/dev/$kernel
+	echo "flashing kernel to $kernel"
+	tar xf $tar_file ${board_dir}/kernel -O >$kernel
 
 	echo "flashing rootfs to ${rootfs}"
 	tar xf $tar_file ${board_dir}/root -O >"${rootfs}"
@@ -80,10 +80,10 @@ zyxel_do_upgrade() {
 	zyxel,nbg6817)
 		case "$rootfs" in
 			"/dev/mmcblk0p5")
-				kernel=mmcblk0p4
+				kernel="/dev/mmcblk0p4"
 			;;
 			"/dev/mmcblk0p8")
-				kernel=mmcblk0p7
+				kernel="/dev/mmcblk0p7"
 			;;
 			*)
 				return 1


### PR DESCRIPTION
Actually implement full dual-boot support for sysupgrade by always writing to the other, currently inactive, partition set and toggling the dualflag after a successful flash. This mimicks both the behaviour of the OEM firmware and the strategy for other dual-boot capable routers in LEDE/ OpenWrt (Linksys EA8500, Linksys WRT3200ACM, ...).

Before this pull request it was already possible to flash LEDE/ OpenWrt to either partition set, but it always upgraded the currently active one in-place, rather than writing to the inactive set.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>