### PR TITLE
perf, libunwind: enable userspace code profiling with perf

### DIFF
--- a/package/devel/perf/Makefile
+++ b/package/devel/perf/Makefile
@@ -26,7 +26,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/perf
   SECTION:=devel
   CATEGORY:=Development
-  DEPENDS:= +libelf1 +libdw +libpthread +librt +objdump @!LINUX_3_18 @!IN_SDK @!TARGET_arc770 @KERNEL_PERF_EVENTS
+  DEPENDS:= +libelf1 +libdw +libunwind +libpthread +librt +objdump @!LINUX_3_18 @!IN_SDK @!TARGET_arc770 @KERNEL_PERF_EVENTS
   TITLE:=Linux performance monitoring tool
   VERSION:=$(LINUX_VERSION)-$(PKG_RELEASE)
   URL:=http://www.kernel.org

--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -32,7 +32,7 @@ define Package/libunwind
   CATEGORY:=Libraries
   TITLE:=The libunwind project
   URL:=http://www.nongnu.org/libunwind/
-  DEPENDS:=@(mips||mipsel||powerpc||i386||x86_64)
+  DEPENDS:=@(mips||mipsel||powerpc||i386||x86_64||arm)
 endef
 
 define Package/libunwind/description


### PR DESCRIPTION
Without libunwind perf does not show userspace stack frames.
Tested on mvebu.

Signed-off-by: Maxim Gorbachyov <maxim.gorbachyov@gmail.com>