### PR TITLE
 ramips: Fix GB-PC1 cpuclock again

### DIFF
--- a/target/linux/ramips/dts/GB-PC1.dts
+++ b/target/linux/ramips/dts/GB-PC1.dts
@@ -104,7 +104,7 @@
 
 &cpuclock {
 	compatible = "fixed-clock";
-	clock-frequency = <90000000>;
+	clock-frequency = <900000000>;
 };
 
 &pcie {


### PR DESCRIPTION
Last change to this did not have enough 0s. Copy/Paste error I think.

Signed-off-by: Rosen Penev <rosenp@gmail.com>