### PR TITLE
kernel: package x86-optimized crypto-misc modules

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -441,8 +441,21 @@ $(eval $(call KernelPackage,crypto-michael-mic))
 
 define KernelPackage/crypto-misc
   TITLE:=Other CryptoAPI modules
-  DEPENDS:=+kmod-crypto-manager
+  DEPENDS:=+kmod-crypto-xts
   KCONFIG:= \
+	CONFIG_CRYPTO_CAMELLIA_X86_64 \
+	CONFIG_CRYPTO_BLOWFISH_X86_64 \
+	CONFIG_CRYPTO_TWOFISH_X86_64 \
+	CONFIG_CRYPTO_TWOFISH_X86_64_3WAY \
+	CONFIG_CRYPTO_SERPENT_SSE2_X86_64 \
+	CONFIG_CRYPTO_CAMELLIA_AESNI_AVX_X86_64 \
+	CONFIG_CRYPTO_CAST5_AVX_X86_64 \
+	CONFIG_CRYPTO_CAST6_AVX_X86_64 \
+	CONFIG_CRYPTO_TWOFISH_AVX_X86_64 \
+	CONFIG_CRYPTO_SERPENT_AVX_X86_64 \
+	CONFIG_CRYPTO_CAMELLIA_AESNI_AVX2_X86_64 \
+	CONFIG_CRYPTO_SERPENT_AVX2_X86_64 \
+	CONFIG_CRYPTO_SERPENT_SSE2_586 \
 	CONFIG_CRYPTO_ANUBIS \
 	CONFIG_CRYPTO_BLOWFISH \
 	CONFIG_CRYPTO_CAMELLIA \
@@ -472,14 +485,49 @@ define KernelPackage/crypto-misc
 	$(LINUX_DIR)/crypto/blowfish_common.ko \
 	$(LINUX_DIR)/crypto/blowfish_generic.ko \
 	$(LINUX_DIR)/crypto/serpent_generic.ko
+  AUTOLOAD:=$(call AutoLoad,10,anubis camellia_generic cast_common \
+	cast5_generic cast6_generic khazad tea tgr192 twofish_common \
+	wp512 blowfish_common serpent_generic)
+  ifndef CONFIG_TARGET_x86
+	AUTOLOAD+= $(call AutoLoad,10,twofish_generic blowfish_generic)
+  endif
   $(call AddDepends/crypto)
 endef
 
 ifndef CONFIG_TARGET_x86_64
   define KernelPackage/crypto-misc/x86
-    FILES+=$(LINUX_DIR)/arch/x86/crypto/twofish-i586.ko
+    FILES+= \
+	$(LINUX_DIR)/arch/x86/crypto/twofish-i586.ko \
+	$(LINUX_DIR)/arch/x86/crypto/serpent-sse2-i586.ko \
+	$(LINUX_DIR)/arch/x86/crypto/glue_helper.ko \
+	$(LINUX_DIR)/crypto/ablk_helper.ko \
+	$(LINUX_DIR)/crypto/cryptd.ko \
+	$(LINUX_DIR)/crypto/lrw.ko
+    AUTOLOAD+= $(call AutoLoad,10,lrw cryptd ablk_helper glue_helper \
+	serpent-sse2-i586 twofish-i586 blowfish_generic)
   endef
 endif
+
+define KernelPackage/crypto-misc/x86/64
+  FILES+= \
+	$(LINUX_DIR)/arch/x86/crypto/camellia-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/blowfish-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/twofish-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/twofish-x86_64-3way.ko \
+	$(LINUX_DIR)/arch/x86/crypto/serpent-sse2-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/camellia-aesni-avx-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/cast5-avx-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/cast6-avx-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/twofish-avx-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/serpent-avx-x86_64.ko \
+	$(LINUX_DIR)/arch/x86/crypto/camellia-aesni-avx2.ko \
+	$(LINUX_DIR)/arch/x86/crypto/serpent-avx2.ko \
+	$(LINUX_DIR)/crypto/ablk_helper.ko
+  AUTOLOAD+= $(call AutoLoad,10,ablk_helper camellia-x86_64 \
+	camellia-aesni-avx-x86_64 camellia-aesni-avx2 cast5-avx-x86_64 \
+	cast6-avx-x86_64 twofish-x86_64 twofish-x86_64-3way \
+	twofish-avx-x86_64 blowfish-x86_64 serpent-avx-x86_64 serpent-avx2)
+endef
 
 $(eval $(call KernelPackage,crypto-misc))
 


### PR DESCRIPTION
Some of the modules in the crypto-misc package have alternate
implementations optimized for different x86 instruction set extensions,
but only one of these was built for this package until now: twofish-i586.ko

Tested only with insmod, on both x86 and x86_64. The modules still do not
have an autoload, so the included dependencies must be manually loaded in
the correct order, which is not shown here.

Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>