### PR TITLE
kconfig: double up dollar signs in strings

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -137,12 +137,12 @@ define Package/base-files/install
 		fi; \
 	)
 
-	$(VERSION_SED) \
+	$(call dollar2,$(VERSION_SED)) \
 		$(1)/etc/banner \
 		$(1)/etc/openwrt_version \
 		$(1)/usr/lib/os-release
 
-	$(VERSION_SED_SCRIPT) \
+	$(call dollar2,$(VERSION_SED_SCRIPT)) \
 		$(1)/etc/openwrt_release \
 		$(1)/etc/device_info \
 		$(1)/usr/lib/os-release
@@ -194,7 +194,7 @@ define Package/base-files/install
 	$(if $(CONFIG_CLEAN_IPKG),, \
 		mkdir -p $(1)/etc/opkg; \
 		$(call FeedSourcesAppend,$(1)/etc/opkg/distfeeds.conf); \
-		$(VERSION_SED) $(1)/etc/opkg/distfeeds.conf)
+		$(call dollar2,$(VERSION_SED)) $(1)/etc/opkg/distfeeds.conf)
 endef
 
 ifneq ($(DUMP),1)

--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -91,7 +91,7 @@ define Package/uhttpd/install
 	$(INSTALL_BIN) ./files/uhttpd.init $(1)/etc/init.d/uhttpd
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/uhttpd.config $(1)/etc/config/uhttpd
-	$(VERSION_SED_SCRIPT) $(1)/etc/config/uhttpd
+	$(call dollar2,$(VERSION_SED_SCRIPT)) $(1)/etc/config/uhttpd
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uhttpd $(1)/usr/sbin/uhttpd
 endef

--- a/rules.mk
+++ b/rules.mk
@@ -32,6 +32,7 @@ comma:=,
 merge=$(subst $(space),,$(1))
 confvar=$(shell echo '$(foreach v,$(1),$(v)=$(subst ','\'',$($(v))))' | $(STAGING_DIR_HOST)/bin/mkhash md5)
 strip_last=$(patsubst %.$(lastword $(subst .,$(space),$(1))),%,$(1))
+dollar2=$(subst $$,$$$$,$(1))
 
 paren_left = (
 paren_right = )

--- a/scripts/config/confdata.c
+++ b/scripts/config/confdata.c
@@ -161,9 +161,13 @@ static int conf_set_sym_val(struct symbol *sym, int def, int def_flags, char *p)
 	case S_STRING:
 		if (*p++ != '"')
 			break;
-		for (p2 = p; (p2 = strpbrk(p2, "\"\\")); p2++) {
+		for (p2 = p; (p2 = strpbrk(p2, "\"\\$")); p2++) {
 			if (*p2 == '"') {
 				*p2 = 0;
+				break;
+			}
+			else if (*p2 == '$' && p2[1] != '$') {
+				conf_warning("invalid string found");
 				break;
 			}
 			memmove(p2, p2 + 1, strlen(p2));

--- a/scripts/config/symbol.c
+++ b/scripts/config/symbol.c
@@ -928,7 +928,7 @@ const char *sym_escape_string_value(const char *in)
 
 	p = in;
 	for (;;) {
-		l = strcspn(p, "\"\\");
+		l = strcspn(p, "\"\\$");
 		p += l;
 
 		if (p[0] == '\0')
@@ -945,14 +945,17 @@ const char *sym_escape_string_value(const char *in)
 
 	p = in;
 	for (;;) {
-		l = strcspn(p, "\"\\");
+		l = strcspn(p, "\"\\$");
 		strncat(res, p, l);
 		p += l;
 
 		if (p[0] == '\0')
 			break;
 
-		strcat(res, "\\");
+		if (p[0] == '$')
+			strcat(res, "$");
+		else
+			strcat(res, "\\");
 		strncat(res, p++, 1);
 	}
 


### PR DESCRIPTION
Since kconfig reads and writes makefiles, reflect that dollars need
to be doubled up in make syntax so that they're not interpolated.

Example: if we have a `CONFIG_VAR` of type string that we want to have
the value of `"abc$def"` then it must be written to the file `.config`
file as:

`CONFIG_VAR="abc$$def"`

to avoid the `$d` from being interpolated as the` $(d)`.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
