### PR TITLE
wwan: update proto to serve more than one interface

### DIFF
--- a/package/network/utils/wwan/files/data/1199-68c0
+++ b/package/network/utils/wwan/files/data/1199-68c0
@@ -1,0 +1,4 @@
+{
+	"desc": "Sierra MC7304",
+	"type": "qmi"
+}

--- a/package/network/utils/wwan/files/data/2c7c-0125
+++ b/package/network/utils/wwan/files/data/2c7c-0125
@@ -1,0 +1,4 @@
+{
+	"desc": "Quectel EC25",
+	"type": "qmi",
+}

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -100,11 +100,11 @@ proto_wwan_setup() {
 	uci_set_state network $interface dat_device "$dat_device"
 
 	case $driver in
-	qmi_wwan)		proto_qmi_setup $@ ;;
-	cdc_mbim)		proto_mbim_setup $@ ;;
-	sierra_net)		proto_directip_setup $@ ;;
-	comgt)			proto_3g_setup $@ ;;
-	cdc_ether|*cdc_ncm)	proto_ncm_setup $@ ;;
+	qmi_wwan)		proto_qmi_setup "$@" ;;
+	cdc_mbim)		proto_mbim_setup "$@" ;;
+	sierra_net)		proto_directip_setup "$@" ;;
+	comgt)			proto_3g_setup "$@" ;;
+	cdc_ether|*cdc_ncm)	proto_ncm_setup "$@" ;;
 	esac
 }
 
@@ -115,11 +115,11 @@ proto_wwan_teardown() {
 	dat_device=$(uci_get_state network $interface dat_device)
 
 	case $driver in
-	qmi_wwan)		proto_qmi_teardown $@ ;;
-	cdc_mbim)		proto_mbim_teardown $@ ;;
-	sierra_net)		proto_mbim_teardown $@ ;;
-	comgt)			proto_3g_teardown $@ ;;
-	cdc_ether|*cdc_ncm)	proto_ncm_teardown $@ ;;
+	qmi_wwan)		proto_qmi_teardown "$@" ;;
+	cdc_mbim)		proto_mbim_teardown "$@" ;;
+	sierra_net)		proto_mbim_teardown "$@" ;;
+	comgt)			proto_3g_teardown "$@" ;;
+	cdc_ether|*cdc_ncm)	proto_ncm_teardown "$@" ;;
 	esac
 }
 

--- a/package/network/utils/wwan/files/wwan.sh
+++ b/package/network/utils/wwan/files/wwan.sh
@@ -42,12 +42,12 @@ proto_wwan_setup() {
 
 	for a in `ls /sys/bus/usb/devices`; do
 		local vendor product
-		[ -z "$usb" -a -f /sys/bus/usb/devices/$a/idVendor -a -f /sys/bus/usb/devices/$a/idProduct ] || continue
-		vendor=$(cat /sys/bus/usb/devices/$a/idVendor)
-		product=$(cat /sys/bus/usb/devices/$a/idProduct)
+		[ -z "$usb" -a -f "/sys/bus/usb/devices/$a/idVendor" -a -f "/sys/bus/usb/devices/$a/idProduct" ] || continue
+		vendor=$(cat "/sys/bus/usb/devices/$a/idVendor")
+		product=$(cat "/sys/bus/usb/devices/$a/idProduct")
 		for endpoint in "/sys/bus/usb/devices/$a/"*/; do
 			[ -d "${endpoint}net/${ifname}" ] && {
-				[ -f /lib/network/wwan/$vendor:$product ] && {
+				[ -f "/lib/network/wwan/$vendor:$product" ] && {
 					usb="/lib/network/wwan/$vendor:$product"
 					devicename="$a"
 				}
@@ -60,10 +60,10 @@ proto_wwan_setup() {
 
 		json_set_namespace wwan old_cb
 		json_init
-		json_load "$(cat $usb)"
+		json_load "$(cat "$usb")"
 		json_select
 		json_get_vars desc control data
-		json_set_namespace $old_cb
+		json_set_namespace "$old_cb"
 
 		[ -n "$control" -a -n "$data" ] && {
 			ttys=$(ls -d /sys/bus/usb/devices/$devicename/${devicename}*/tty* | sed "s/.*\///g" | tr "\n" " ")
@@ -75,13 +75,13 @@ proto_wwan_setup() {
 
 	[ -z "$ctl_device" ] && for net in $(ls /sys/class/net/ | grep -e wwan -e usb); do
 		[ "$net" = "$ifname" ] || continue
-		driver=$(grep DRIVER /sys/class/net/$net/device/uevent | cut -d= -f2)
+		driver=$(grep DRIVER "/sys/class/net/$net/device/uevent" | cut -d= -f2)
 		case "$driver" in
 		qmi_wwan|cdc_mbim)
-			ctl_device=/dev/$(ls /sys/class/net/$net/device/usbmisc)
+			ctl_device=/dev/$(ls "/sys/class/net/$net/device/usbmisc")
 			;;
 		sierra_net|cdc_ether|*cdc_ncm)
-			ctl_device=/dev/$(cd /sys/class/net/$net/; find ../../../ -name ttyUSB* |xargs -n1 basename | head -n1)
+			ctl_device=/dev/$(cd "/sys/class/net/$net/"; find ../../../ -name ttyUSB* |xargs -n1 basename | head -n1)
 			;;
 		*) continue;;
 		esac
@@ -95,9 +95,9 @@ proto_wwan_setup() {
 		return 1
 	}
 
-	uci_set_state network $interface driver "$driver"
-	uci_set_state network $interface ctl_device "$ctl_device"
-	uci_set_state network $interface dat_device "$dat_device"
+	uci_set_state network "$interface" driver "$driver"
+	uci_set_state network "$interface" ctl_device "$ctl_device"
+	uci_set_state network "$interface" dat_device "$dat_device"
 
 	case $driver in
 	qmi_wwan)		proto_qmi_setup "$@" ;;
@@ -110,9 +110,9 @@ proto_wwan_setup() {
 
 proto_wwan_teardown() {
 	local interface=$1
-	local driver=$(uci_get_state network $interface driver)
-	ctl_device=$(uci_get_state network $interface ctl_device)
-	dat_device=$(uci_get_state network $interface dat_device)
+	local driver=$(uci_get_state network "$interface" driver)
+	ctl_device=$(uci_get_state network "$interface" ctl_device)
+	dat_device=$(uci_get_state network "$interface" dat_device)
 
 	case $driver in
 	qmi_wwan)		proto_qmi_teardown "$@" ;;


### PR DESCRIPTION
- Add ec25 to database
- Add mc7304 to database
- check ifname on proto event -> updates proto to use more then one interface with this proto
- fix shellcheck warnings


This is a updated pullrequest from 
https://github.com/lede-project/source/pull/1310