### PR TITLE
rules.mk: drop `include_mk` build rule

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -355,10 +355,6 @@ define shexport
 export $(call shvar,$(1))=$$(call $(1))
 endef
 
-define include_mk
-$(eval -include $(if $(DUMP),,$(STAGING_DIR)/mk/$(strip $(1))))
-endef
-
 # Execute commands under flock
 # $(1) => The shell expression.
 # $(2) => The lock name. If not given, the global lock will be used.


### PR DESCRIPTION
The only users of this were the python packages
from the `packages` feed.
The 2 python interpreters would export some mk
files (e.g. python-package.mk) and then other
python packages would include it via this rule.

But there's a few things wrong with this approach,
most of them drawing from the fact that python host
needs to be built first, to export these mk files.

By now all uses of include_mk have been corrected
in the feeds and this can be removed.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>