### PR TITLE
ramips: add support for HiWiFi HC5611

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -205,6 +205,9 @@ hc5661a)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
 	set_wifi_led "$boardname:blue:wlan2g"
 	;;
+hc5611)
+	ucidef_set_led_default "system" "system" "$boardname:green:system" "1"
+	;;
 hc5761)
 	ucidef_set_led_default "system" "system" "$boardname:blue:system" "1"
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -125,6 +125,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	hc5611)
+		ucidef_add_switch "switch0" \
+			"3:lan" "6@eth0"
+		;;
 	mir3g)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "1:wan" "6t@eth0"
@@ -426,6 +430,7 @@ ramips_setup_macs()
 		;;
 	hc5*61|\
 	hc5661a|\
+	hc5611|\
 	hc5962)
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -162,6 +162,7 @@ get_status_led() {
 		;;
 	hc5*61|\
 	hc5661a|\
+	hc5611|\
 	jhr-n805r|\
 	jhr-n926r|\
 	mlw221|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -223,6 +223,9 @@ ramips_board_detect() {
 	*"HC5661A")
 		name="hc5661a"
 		;;
+	*"HC5611")
+		name="hc5611"
+		;;
 	*"HC5761")
 		name="hc5761"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -67,6 +67,7 @@ platform_check_image() {
 	gl-mt300n-v2|\
 	hc5*61|\
 	hc5661a|\
+	hc5611|\
 	hg255d|\
 	hlk-rm04|\
 	hpm|\

--- a/target/linux/ramips/dts/HC5611.dts
+++ b/target/linux/ramips/dts/HC5611.dts
@@ -1,0 +1,126 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hiwifi,hc5611", "mediatek,mt7628an-soc";
+	model = "HiWiFi HC5611";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		system {
+			label = "hc5611:green:system";
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power-led {
+			gpio-export,name = "power-led";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "refclk", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "w25q128";
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "hw_panic";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xf70000>;
+		};
+
+		partition@fc0000 {
+			label = "oem";
+			reg = <0xfc0000 0x20000>;
+			read-only;
+		};
+
+		bdinfo: partition@fe0000 {
+			label = "bdinfo";
+			reg = <0xfe0000 0x10000>;
+			read-only;
+		};
+
+		partition@ff0000 {
+			label = "backup";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -41,6 +41,13 @@ define Device/hc5661a
 endef
 TARGET_DEVICES += hc5661a
 
+define Device/hc5611
+  DTS := HC5611
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := HiWiFi HC5611
+endef
+TARGET_DEVICES += hc5611
+
 define Device/LinkIt7688
   DTS := LINKIT7688
   IMAGE_SIZE := $(ralink_default_fw_size_32M)


### PR DESCRIPTION
## Hardware:
CPU: MediaTek MT7628AN @ 575 MHz
Flash: 16 MB
RAM: 128 MB
Ethernet: 10/100Mbps x 1
Wlan: 300 Mbps
USB: USB 2.0 x 1
LED: red/green x 1
Button: reset x 1

## Installation:
1. Apply for developer mode on https://app.hiwifi.com
2. Install the developer mode plugin
3. Upload the openwrt firmware to the router via SCP
4. Login the router via SSH
5. Run `mtd -r write path_to_firmware.bin firmware`