### PR TITLE
u-boot.mk: enable u-boot packages by default for multi-profile target

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -61,6 +61,7 @@ define Build/U-Boot/Target
       DEPENDS += @$(TARGET_DEP)
       ifneq ($(BUILD_DEVICES),)
         DEFAULT := y if ($(TARGET_DEP)_Default \
+		|| TARGET_MULTI_PROFILE \
 		$(patsubst %,|| $(TARGET_DEP)_DEVICE_%,$(BUILD_DEVICES)) \
 		$(patsubst %,|| $(patsubst TARGET_%,TARGET_DEVICE_%,$(TARGET_DEP))_DEVICE_%,$(BUILD_DEVICES)))
       endif


### PR DESCRIPTION
Some targets don't define a Default profile.
At the moment, if a `CONFIG_TARGET_<target>_Default=y` symbol
is defined, all u-boot packages are selected.
    
This does not happen if `CONFIG_TARGET_MULTI_PROFILE=y`
symbol is selected and the target does not define a Default profile.
It makes sense to also enable (by default)
all u-boot packages for this profile as well.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>