### PR TITLE
[KERNEL-BUILD] Fix kernel compilation when CONFIG_STRIP_KERNEL_EXPORTS

### DIFF
--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -20,6 +20,7 @@ include $(INCLUDE_DIR)/kernel-defaults.mk
 
 define Kernel/Prepare
 	$(call Kernel/Prepare/Default)
+	$(if $(CONFIG_STRIP_KERNEL_EXPORTS), touch $(KERNEL_BUILD_DIR)/symtab.h)
 endef
 
 define Kernel/Configure


### PR DESCRIPTION
is enabled

When you enable CONFIG_STRIP_KERNEL_EXPORTS on PI3 at least the kernel
can't be compiled because 'vdso' complains about missing 'symtab.h'
which seems to be created later at the image installation.

Fix this by moving up when the file is generated (just after modules are
built)