### PR TITLE
tools/ccache: update to 3.3.6

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=3.3.4
+PKG_VERSION:=3.3.6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://download.samba.org/pub/ccache/ \
 		https://samba.org/ftp/ccache/
-PKG_HASH:=24f15bf389e38c41548c9c259532187774ec0cb9686c3497bbb75504c8dc404f
+PKG_HASH:=410a27fdaff64ead6df3fa57fa74bca0eca6b5f6ac77d7288af1256f6b12141d
 
 include $(INCLUDE_DIR)/host-build.mk
 

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/ccache.c
 +++ b/ccache.c
-@@ -1790,6 +1790,7 @@ calculate_object_hash(struct args *args,
+@@ -1803,6 +1803,7 @@ calculate_object_hash(struct args *args,
  			"CPLUS_INCLUDE_PATH",
  			"OBJC_INCLUDE_PATH",
  			"OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Update ccache to 3.3.5

Release notes:
https://ccache.samba.org/releasenotes.html#_ccache_3_3_5

compile-tested with ipq806x/R7800 build
