### PR TITLE
sunxi: Add Xunlong Orangepi PC support

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -150,6 +150,12 @@ define U-Boot/orangepi_r1
   BUILD_DEVICES:=sun8i-h2-plus-orangepi-r1
 endef
 
+define U-Boot/orangepi_pc
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Orange Pi PC (H3)
+  BUILD_DEVICES:=sun8i-h3-orangepi-pc
+endef
+
 define U-Boot/orangepi_plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi Plus (H3)
@@ -215,6 +221,7 @@ UBOOT_TARGETS := \
 	nanopi_neo \
 	nanopi_neo_plus2 \
 	orangepi_r1 \
+	orangepi_pc \
 	orangepi_plus \
 	orangepi_2 \
 	pangolin \

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -139,6 +139,16 @@ endef
 TARGET_DEVICES += sun8i-h3-nanopi-neo
 
 
+define Device/sun8i-h3-orangepi-pc
+  DEVICE_TITLE:=Xunlong Orange Pi PC
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
+  SUPPORTED_DEVICES:=xunlong,orangepi-pc
+  SUNXI_DTS:=sun8i-h3-orangepi-pc
+endef
+
+TARGET_DEVICES += sun8i-h3-orangepi-pc
+
+
 define Device/sun8i-h3-orangepi-plus
   DEVICE_TITLE:=Xunlong Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi


### PR DESCRIPTION
CPU: H3 Quad-core Cortex-A7 H.265/HEVC 4K @ 1.3 Ghz
GPU: Mali400MP2 GPU @ 600MHz (supports OpenGL ES 2.0)
Memory: 1GB DDR3 (shared with GPU)
Onboard: Storage TF card (Max. 64GB) / MMC card slot
Onboard: Network 10/100M Ethernet RJ45
Onboard header pinout: SPI, I2C, 1-WIRE
USB 2.0: Three USB 2.0 HOST, one USB 2.0 OTG
Buttons: Power Button(SW4)
Debug TTL UART: ..DC-IN.. >[GND][RX][TX] ..HDMI..

Signed-off-by: Vitalij Alshevsky <v_alshevsky@tut.by>
