### PR TITLE
libubox: do not use true or false for u8 formating

### DIFF
--- a/package/libs/libubox/patches/001-json-u8-no-bool.patch
+++ b/package/libs/libubox/patches/001-json-u8-no-bool.patch
@@ -1,0 +1,11 @@
+--- a/blobmsg_json.c
++++ b/blobmsg_json.c
+@@ -247,7 +247,7 @@ static void blobmsg_format_element(struc
+ 		sprintf(buf, "null");
+ 		break;
+ 	case BLOBMSG_TYPE_BOOL:
+-		sprintf(buf, "%s", *(uint8_t *)data ? "true" : "false");
++		sprintf(buf, "%d", *(uint8_t *)data);
+ 		break;
+ 	case BLOBMSG_TYPE_INT16:
+ 		sprintf(buf, "%d", be16_to_cpu(*(uint16_t *)data));


### PR DESCRIPTION
DON'T MERGE!
THERE IS STILL SOMEWHERE A PROBLEM!!!

This is a serious problem that still has to be fixed.
Using this patch it's craching somewhere else when parsing u8 values from a json string...
All u8 values will be lost if this isn't fixed somehow if they are converted to json!
Either switch all u8 values to u32 or fix this somehow.

u8 is a normal file format and not used only for bool values.
I.e. 802.11 supported rates are u8 and other stuff.
Signed-off-by: Nick Hainke vincent@systemli.org
