### PR TITLE
ar71xx: remove bs-partition ro-flag for UniFi AC

### DIFF
--- a/target/linux/ar71xx/image/generic-ubnt.mk
+++ b/target/linux/ar71xx/image/generic-ubnt.mk
@@ -113,7 +113,7 @@ define Device/ubnt-unifiac
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
   DEVICE_PROFILE := UBNT
   IMAGE_SIZE := 7744k
-  MTDPARTS := spi0.0:384k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),7744k(ubnt-airos)ro,128k(bs)ro,256k(cfg)ro,64k(EEPROM)ro
+  MTDPARTS := spi0.0:384k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),7744k(ubnt-airos)ro,128k(bs),256k(cfg)ro,64k(EEPROM)ro
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
 endef


### PR DESCRIPTION
This removes the read-only flag from the bs (bootselect) partition
on UniFi AC devices. This allows to correct the indicator from which
partition the device is booting its kernel from.

See also:
 - https://github.com/freifunk-gluon/gluon/issues/1301
 - https://bugs.lede-project.org/index.php?do=details&task_id=662