### PR TITLE
imx6: use DTS_DIR at image build code

### DIFF
--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -22,7 +22,7 @@ define Build/boot-overlay
 
 	$(foreach dts,$(DEVICE_DTS), \
 		$(CP) \
-			$(LINUX_DIR)/arch/$(ARCH)/boot/dts/$(dts).dtb \
+			$(DTS_DIR)/$(dts).dtb \
 			$@.boot/$(IMG_PREFIX)-$(dts).dtb; \
 		ln -sf \
 			$(IMG_PREFIX)-$(dts).dtb \


### PR DESCRIPTION
The usage of "_$(LINUX_DIR)/arch/$(LINUX_KARCH)/boot/dts_" prevents the correct _Device/*_ device-tree parameterization through the **DEVICE_DTS_DIR** and **DTS_DIR** variables.

Using "_$(DTS_DIR)_" instead, solves the problem and adds more flexibility in the Device configuration.