### PR TITLE
ipq806x: mark AVM FB4040 switchport as untagged

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -15,7 +15,7 @@ case "$board" in
 avm,fritzbox-4040)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	ucidef_add_switch "switch0" \
-		"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+		"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 	;;
 linksys,ea8500)
 	hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)


### PR DESCRIPTION
This commit marks the CPUs switchport explicit as untagged.
Otherwise, an eth0.1 interface is created and the devices
LAN-ports are not working.