### PR TITLE
Fix #5587: PtP connection requires peer address

### DIFF
--- a/package/network/services/wireguard/files/wireguard.sh
+++ b/package/network/services/wireguard/files/wireguard.sh
@@ -158,7 +158,7 @@ proto_wireguard_setup() {
         proto_add_ipv6_address "${address%%/*}" "${address##*/}"
       ;;
       *.*/*)
-        proto_add_ipv4_address "${address%%/*}" "${address##*/}"
+        proto_add_ipv4_address ${address//\// }
       ;;
       *:*)
         proto_add_ipv6_address "${address%%/*}" "128"


### PR DESCRIPTION
`proto_add_ipv4_address` in `/lib/netifd/netifd-proto.sh` waits for 4 parameters and transforms them to "$address/$mask/$broadcast/$ptp"
Now only two parameters can be used in wireguard.sh script. I guess it is a good idea to send all parameters