### PR TITLE
ramips: use new image build code for WHR-G300N

### DIFF
--- a/target/linux/ramips/image/rt305x-legacy.mk
+++ b/target/linux/ramips/image/rt305x-legacy.mk
@@ -18,41 +18,6 @@ define BuildFirmware/DCS930/squashfs
 endef
 BuildFirmware/DCS930/initramfs=$(call BuildFirmware/OF/initramfs,$(1),$(2),$(3))
 
-# sign Buffalo images
-define BuildFirmware/Buffalo
-	if [ -e "$(call sysupname,$(1),$(2))" ]; then \
-		buffalo-enc -p $(3) -v 1.76 \
-			-i $(KDIR)/vmlinux-$(2).uImage \
-			-o $(KDIR)/vmlinux-$(2).uImage.enc; \
-		buffalo-enc -p $(3) -v 1.76 \
-			-i $(KDIR)/root.$(1) \
-			-o $(KDIR)/root.$(2).enc; \
-		buffalo-tag -b $(3) -p $(3) -a ram -v 1.76 -m 1.01 \
-			-l mlang8 -f 1 -r EU \
-			-i $(KDIR)/vmlinux-$(2).uImage.enc \
-			-i $(KDIR)/root.$(2).enc \
-			-o $(call imgname,$(1),$(2))-factory-EU.bin; \
-	fi
-endef
-
-# FIXME: this looks broken
-buffalo_whrg300n_mtd_size=3801088
-define BuildFirmware/WHRG300N/squashfs
-	$(call BuildFirmware/Default4M/$(1),$(1),whr-g300n,WHR-G300N)
-	# the following line has a bad argument 3 ... the old Makefile was already broken	
-	$(call BuildFirmware/Buffalo,$(1),whr-g300n,whr-g300n)
-	if [ -e "$(call sysupname,$(1),$(2))" ]; then \
-		( \
-			echo -n -e "# Airstation FirmWare\nrun u_fw\nreset\n\n" | \
-				dd bs=512 count=1 conv=sync; \
-			dd if=$(call sysupname,$(1),whr-g300n); \
-		) > $(KDIR)/whr-g300n-tftp.tmp && \
-		buffalo-tftp -i $(KDIR)/whr-g300n-tftp.tmp \
-			-o $(call imgname,$(1),whr-g300n)-tftp.bin; \
-	fi
-endef
-BuildFirmware/WHRG300N/initramfs=$(call BuildFirmware/OF/initramfs,$(1),whr-g300n,WHR-G300N)
-
 kernel_size_wl341v3=917504
 rootfs_size_wl341v3=2949120
 define BuildFirmware/WL-341V3/squashfs
@@ -84,7 +49,6 @@ endef
 Image/Build/Profile/DCS930=$(call BuildFirmware/DCS930/$(1),$(1),dcs-930,DCS-930)
 Image/Build/Profile/DCS930LB1=$(call BuildFirmware/DCS930/$(1),$(1),dcs-930l-b1,DCS-930L-B1)
 Image/Build/Profile/WL-341V3=$(call BuildFirmware/WL-341V3/$(1),$(1))
-Image/Build/Profile/WHRG300N=$(call BuildFirmware/WHRG300N/$(1),$(1))
 
 define LegacyDevice/ALL02393G
   DEVICE_TITLE := Allnet ALL0239-3G 
@@ -110,9 +74,3 @@ define LegacyDevice/WL-341V3
   DEVICE_TITLE := Sitecom WL-341 v3
 endef
 LEGACY_DEVICES += WL-341V3
-
-
-define LegacyDevice/WHRG300N
-  DEVICE_TITLE := Buffalo WHR-G300N
-endef
-LEGACY_DEVICES += WHRG300N

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1,6 +1,16 @@
 #
 # RT305X Profiles
 #
+define Build/buffalo-tftp-header
+  ( \
+    echo -n -e "# Airstation FirmWare\nrun u_fw\nreset\n\n" | \
+      dd bs=512 count=1 conv=sync; \
+    dd if=$@; \
+  ) > $@.tmp && \
+  $(STAGING_DIR_HOST)/bin/buffalo-tftp -i $@.tmp -o $@.new
+  mv $@.new $@
+endef
+
 define Build/dap-header
 	$(STAGING_DIR_HOST)/bin/mkdapimg $(1) -i $@ -o $@.new
 	mv $@.new $@
@@ -744,6 +754,17 @@ define Device/wcr-150gn
   DEVICE_TITLE := Sparklan WCR-150GN
 endef
 TARGET_DEVICES += wcr-150gn
+
+define Device/whr-g300n
+  DTS := WHR-G300N
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 3801088
+  DEVICE_TITLE := Buffalo WHR-G300N
+  IMAGES += tftp.bin
+  IMAGE/tftp.bin := $$(sysupgrade_bin) | \
+    check-size $$$$(IMAGE_SIZE) | buffalo-tftp-header
+endef
+TARGET_DEVICES += whr-g300n
 
 define Device/wizard8800
   DTS := WIZARD8800


### PR DESCRIPTION
The tftp.bin image for Buffalo WHR-G300N was not built, so I was fixed
it after rewriting to new image build code. And the code for
factory-EU.bin was broken, so I deleted it.

- compile test: WHR-G300N
- run test: WHR-G300N

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>