### PR TITLE
ar71xx: TL-WR1043N v4/v5: add orange WAN LED support, fix inconsistency in constant name, fix port mapping

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -304,7 +304,7 @@ ar71xx_setup_interfaces()
 	sr3200|\
 	tl-wr1043n-v5)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
 	dap-2695-a1)
 		ucidef_add_switch "switch0" "0@eth0" "2:lan" "3:wan" "6@eth1"

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr1043nd-v4.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr1043nd-v4.c
@@ -49,7 +49,8 @@
 
 #define TL_WR1043_V4_GPIO_USB_POWER		8
 
-#define TL_WR1043_V4_GPIO_LED_WAN		15
+#define TL_WR1043_V4_GPIO_LED_INET		15
+#define TL_WR1043_V4_GPIO_LED_WAN		16
 #define TL_WR1043_V4_GPIO_LED_LAN1		9
 #define TL_WR1043_V4_GPIO_LED_LAN2		14
 #define TL_WR1043_V4_GPIO_LED_LAN3		21
@@ -63,7 +64,7 @@
 #define TL_WR1043_V4_EEPROM_ADDR		0x1fff0000
 #define TL_WR1043_V4_WMAC_CALDATA_OFFSET	0x1000
 
-#define TL_WR1043N_V5_MAC_LOCATION		0x1ff00008
+#define TL_WR1043_V5_MAC_LOCATION		0x1ff00008
 
 static struct gpio_led tl_wr1043nd_v4_leds_gpio[] __initdata = {
 	{
@@ -88,6 +89,11 @@ static struct gpio_led tl_wr1043nd_v4_leds_gpio[] __initdata = {
 	},
 	{
 		.name		= "tp-link:green:wan",
+		.gpio		= TL_WR1043_V4_GPIO_LED_INET,
+		.active_low	= 1,
+	},
+	{
+		.name		= "tp-link:orange:wan",
 		.gpio		= TL_WR1043_V4_GPIO_LED_WAN,
 		.active_low	= 1,
 	},
@@ -210,6 +216,11 @@ static struct gpio_led tl_wr1043n_v5_leds_gpio[] __initdata = {
 	},
 	{
 		.name		= "tp-link:green:wan",
+		.gpio		= TL_WR1043_V4_GPIO_LED_INET,
+		.active_low	= 1,
+	},
+	{
+		.name		= "tp-link:orange:wan",
 		.gpio		= TL_WR1043_V4_GPIO_LED_WAN,
 		.active_low	= 1,
 	},
@@ -240,7 +251,7 @@ static struct gpio_led tl_wr1043n_v5_leds_gpio[] __initdata = {
 static void __init tl_wr1043nv5_setup(void)
 {
 	u8 *art = (u8 *) KSEG1ADDR(TL_WR1043_V4_EEPROM_ADDR);
-	u8 *mac = (u8 *) KSEG1ADDR(TL_WR1043N_V5_MAC_LOCATION);
+	u8 *mac = (u8 *) KSEG1ADDR(TL_WR1043_V5_MAC_LOCATION);
 
 	ath79_register_m25p80(NULL);
 


### PR DESCRIPTION
Add missing definitions for the orange WAN LED on the
TL-WR1043N(D) v4 and v5.

Change the name of a MAC address offset constant to
make it consistent with the format of the
existing constants.

Signed-off-by: Tim Thorpe <tim@tfthorpe.net>