### PR TITLE
mwlwifi: add and use individual firmware packages

### DIFF
--- a/package/kernel/mwlwifi/Makefile
+++ b/package/kernel/mwlwifi/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define KernelPackage/mwlwifi
   SUBMENU:=Wireless Drivers
-  TITLE:=Marvell 88W8864 wireless driver
+  TITLE:=Marvell 88W8864/88W8897/88W8964 wireless driver
   DEPENDS:=+kmod-mac80211 +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT +@DRIVER_11W_SUPPORT @PCI_SUPPORT @TARGET_mvebu
   FILES:=$(PKG_BUILD_DIR)/mwlwifi.ko
   AUTOLOAD:=$(call AutoLoad,50,mwlwifi)
@@ -49,13 +49,45 @@ define Build/Compile
 		modules
 endef
 
-define KernelPackage/mwlwifi/install
+define Package/mwlwifi-firmware-default
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  TITLE:=Marvell $(1) firmware
+  DEPENDS:=+kmod-mwlwifi @TARGET_mvebu
+endef
+
+define Package/mwlwifi-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware
 	$(INSTALL_DIR) $(1)/lib/firmware/mwlwifi
-	$(CP) $(PKG_BUILD_DIR)/bin/firmware/88W8864.bin $(1)/lib/firmware/mwlwifi/
-	$(CP) $(PKG_BUILD_DIR)/bin/firmware/88W8897.bin $(1)/lib/firmware/mwlwifi/
-	$(CP) $(PKG_BUILD_DIR)/bin/firmware/88W8964.bin $(1)/lib/firmware/mwlwifi/
-	$(CP) $(PKG_BUILD_DIR)/bin/firmware/Marvell_license.txt $(1)/lib/firmware/mwlwifi/
+	$(CP) $(PKG_BUILD_DIR)/bin/firmware/$(2) $(1)/lib/firmware/mwlwifi/
+	$(CP) $(PKG_BUILD_DIR)/bin/firmware/Marvell_license.txt $(1)/lib/firmware/mwlwifi/$(2).Marvell_license.txt
+endef
+
+define Package/mwlwifi-firmware-88w8864
+$(call Package/mwlwifi-firmware-default,88W8864)
+endef
+
+define Package/mwlwifi-firmware-88w8864/install
+	$(call Package/mwlwifi-firmware/install,$(1),88W8864.bin)
+endef
+
+define Package/mwlwifi-firmware-88w8897
+$(call Package/mwlwifi-firmware-default,88W8897)
+endef
+
+define Package/mwlwifi-firmware-88w8897/install
+	$(call Package/mwlwifi-firmware/install,$(1),88W8897.bin)
+endef
+
+define Package/mwlwifi-firmware-88w8964
+$(call Package/mwlwifi-firmware-default,88W8964)
+endef
+
+define Package/mwlwifi-firmware-88w8964/install
+	$(call Package/mwlwifi-firmware/install,$(1),88W8964.bin)
 endef
 
 $(eval $(call KernelPackage,mwlwifi))
+$(eval $(call BuildPackage,mwlwifi-firmware-88w8864))
+$(eval $(call BuildPackage,mwlwifi-firmware-88w8897))
+$(eval $(call BuildPackage,mwlwifi-firmware-88w8964))

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -105,6 +105,7 @@ define Device/linksys-wrt1200ac
   $(call Device/linksys,WRT1200AC (Caiman))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-caiman
+  DEVICE_PACKAGES += mwlwifi-firmware-88w8864
 endef
 TARGET_DEVICES += linksys-wrt1200ac
 
@@ -112,6 +113,7 @@ define Device/linksys-wrt1900acv2
   $(call Device/linksys,WRT1900ACv2 (Cobra))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-cobra
+  DEVICE_PACKAGES += mwlwifi-firmware-88w8864
 endef
 TARGET_DEVICES += linksys-wrt1900acv2
 
@@ -119,6 +121,7 @@ define Device/linksys-wrt3200acm
   $(call Device/linksys,WRT3200ACM (Rango))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-rango
+  DEVICE_PACKAGES += mwlwifi-firmware-88w8964
   DEVICE_PACKAGES += kmod-btmrvl kmod-mwifiex-sdio
 endef
 TARGET_DEVICES += linksys-wrt3200acm
@@ -127,12 +130,14 @@ define Device/linksys-wrt1900acs
   $(call Device/linksys,WRT1900ACS (Shelby))
   $(Device/armada-385-linksys)
   DEVICE_DTS := armada-385-linksys-shelby
+  DEVICE_PACKAGES += mwlwifi-firmware-88w8864
 endef
 TARGET_DEVICES += linksys-wrt1900acs
 
 define Device/linksys-wrt1900ac
   $(call Device/linksys,WRT1900AC (Mamba))
   DEVICE_DTS := armada-xp-linksys-mamba
+  DEVICE_PACKAGES += mwlwifi-firmware-88w8864
   $(Device/NAND-128K)
   $(Device/UBI-factory)
   KERNEL_SIZE := 3072k


### PR DESCRIPTION
As each mvebu device only uses one of the firmwares provided by mwlwifi
package, it makes sense to put them in separate packages and only install
the one that is needed.

Current mwlwifi version's firmware sizes and usages by devices:
88W8864.bin  118776  caiman, mamba, cobra, shelby
88W8897.bin  489932  (none)
88W8964.bin  449420  rango

Changes by this commit:
 * indicate in title that mwlwifi also is driver for 88W8897 and 88W8964
 * remove mwlwifi package's firmware installation rules
 * add 3 new individual firmware packages (all depends on kmod-mwlwifi):
    - mwlwifi-firmware-88w8864
    - mwlwifi-firmware-88w8897
    - mwlwifi-firmware-88w8964
 * add firmware package to mvebu devices' DEVICE_PACKAGES accordingly
