### PR TITLE
gpio-nct5104d: Add support for new chip ID

### DIFF
--- a/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
+++ b/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
@@ -34,8 +34,9 @@
 #define SIO_UNLOCK_KEY		0x87	/* Key to enable Super-I/O */
 #define SIO_LOCK_KEY		0xAA	/* Key to disable Super-I/O */
 
-#define SIO_NCT5104D_ID					0x1061	/* Chip ID */
-#define SIO_PCENGINES_APU_NCT5104D_ID	0xc452	/* Chip ID */
+#define SIO_NCT5104D_ID			0x1061	/* Chip ID */
+#define SIO_PCENGINES_APU_NCT5104D_ID1	0xc452	/* Chip ID */
+#define SIO_PCENGINES_APU_NCT5104D_ID2	0xc453	/* Chip ID */
 
 enum chips { nct5104d };
 
@@ -350,7 +351,8 @@ static int __init nct5104d_find(int addr, struct nct5104d_sio *sio)
 	devid = superio_inw(addr, SIO_CHIPID);
 	switch (devid) {
 	case SIO_NCT5104D_ID:
-	case SIO_PCENGINES_APU_NCT5104D_ID:
+	case SIO_PCENGINES_APU_NCT5104D_ID1:
+	case SIO_PCENGINES_APU_NCT5104D_ID2:
 		sio->type = nct5104d;
 		/* enable GPIO0 and GPIO1 */
 		superio_select(addr, SIO_LD_GPIO);


### PR DESCRIPTION
**Compile tested:** (x86-64) Generic with current snapshot
**Run tested:** (x86-64) on PC Engines APU3b with current snapshot

**Description:**
The PC Engines APU3b has a new nct5104b version with chip ID 0xc453.
This adds support for that version.

**Test:**
```
Thu Feb 15 10:04:10 2018 kern.info kernel: [    3.562386] gpio-nct5104d: Found nct5104d at 0x2e chip id 0xc453
Thu Feb 15 10:04:10 2018 kern.info kernel: [    3.568670] gpio-nct5104d: platform_driver_register
Thu Feb 15 10:04:10 2018 kern.info kernel: [    3.574300] gpio-nct5104d: Device added
```

```
root@OpenWrt:/sys/class/gpio# ls -lah
drwxr-xr-x    2 root     root           0 Feb 15 10:04 .
drwxr-xr-x   41 root     root           0 Feb 15 10:04 ..
--w-------    1 root     root        4.0K Feb 15 10:05 export
lrwxrwxrwx    1 root     root           0 Feb 15 10:04 gpio1 -> ../../devices/platform/gpio-nct5104d/gpiochip0/gpio/gpio1
lrwxrwxrwx    1 root     root           0 Feb 15 10:04 gpiochip0 -> ../../devices/platform/gpio-nct5104d/gpio/gpiochip0
lrwxrwxrwx    1 root     root           0 Feb 15 10:04 gpiochip10 -> ../../devices/platform/gpio-nct5104d/gpio/gpiochip10
lrwxrwxrwx    1 root     root           0 Feb 15 10:04 gpiochip508 -> ../../devices/platform/leds-apu2/gpio/gpiochip508
--w-------    1 root     root        4.0K Feb 15 10:04 unexport
```

**Other info:**
[FreeBSD topic](https://forums.freebsd.org/threads/accessing-gpio-on-pc-engines-apu-3b4.62825/)
Not all APU3b's have this new chip ID, some still have 0xc452.

Signed-off-by: Jasper Scholte <NightNL@outlook.com>