### PR TITLE
kernel: generic: fix problem with w1-gpio-custom

### DIFF
--- a/target/linux/generic/pending-4.14/0931-w1-gpio-fix-problem-with-platfom-data-in-w1-gpio.patch
+++ b/target/linux/generic/pending-4.14/0931-w1-gpio-fix-problem-with-platfom-data-in-w1-gpio.patch
@@ -1,0 +1,43 @@
+From d9c8bc8c1408f3e8529db6e4e04017b4c579c342 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Sun, 18 Feb 2018 17:08:04 +0100
+Subject: [PATCH] w1: gpio: fix problem with platfom data in w1-gpio
+
+In devices, where fdt is used, is impossible to apply platform data
+without proper fdt node.
+
+This patch allow to use platform data in devices with fdt.
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/w1/masters/w1-gpio.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/w1/masters/w1-gpio.c b/drivers/w1/masters/w1-gpio.c
+index a90728ceec5a..7b80762941af 100644
+--- a/drivers/w1/masters/w1-gpio.c
++++ b/drivers/w1/masters/w1-gpio.c
+@@ -112,17 +112,16 @@ static int w1_gpio_probe_dt(struct platform_device *pdev)
+ static int w1_gpio_probe(struct platform_device *pdev)
+ {
+ 	struct w1_bus_master *master;
+-	struct w1_gpio_platform_data *pdata;
++	struct w1_gpio_platform_data *pdata = dev_get_platdata(&pdev->dev);
+ 	int err;
+ 
+-	if (of_have_populated_dt()) {
++	if (of_have_populated_dt() && !pdata) {
+ 		err = w1_gpio_probe_dt(pdev);
+ 		if (err < 0)
+ 			return err;
++		pdata = dev_get_platdata(&pdev->dev);
+ 	}
+ 
+-	pdata = dev_get_platdata(&pdev->dev);
+-
+ 	if (!pdata) {
+ 		dev_err(&pdev->dev, "No configuration data\n");
+ 		return -ENXIO;
+-- 
+2.14.1
+

--- a/target/linux/generic/pending-4.9/0931-w1-gpio-fix-problem-with-platfom-data-in-w1-gpio.patch
+++ b/target/linux/generic/pending-4.9/0931-w1-gpio-fix-problem-with-platfom-data-in-w1-gpio.patch
@@ -1,0 +1,43 @@
+From d9c8bc8c1408f3e8529db6e4e04017b4c579c342 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Sun, 18 Feb 2018 17:08:04 +0100
+Subject: [PATCH] w1: gpio: fix problem with platfom data in w1-gpio
+
+In devices, where fdt is used, is impossible to apply platform data
+without proper fdt node.
+
+This patch allow to use platform data in devices with fdt.
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/w1/masters/w1-gpio.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/w1/masters/w1-gpio.c b/drivers/w1/masters/w1-gpio.c
+index a90728ceec5a..7b80762941af 100644
+--- a/drivers/w1/masters/w1-gpio.c
++++ b/drivers/w1/masters/w1-gpio.c
+@@ -112,17 +112,16 @@ static int w1_gpio_probe_dt(struct platform_device *pdev)
+ static int w1_gpio_probe(struct platform_device *pdev)
+ {
+ 	struct w1_bus_master *master;
+-	struct w1_gpio_platform_data *pdata;
++	struct w1_gpio_platform_data *pdata = dev_get_platdata(&pdev->dev);
+ 	int err;
+ 
+-	if (of_have_populated_dt()) {
++	if (of_have_populated_dt() && !pdata) {
+ 		err = w1_gpio_probe_dt(pdev);
+ 		if (err < 0)
+ 			return err;
++		pdata = dev_get_platdata(&pdev->dev);
+ 	}
+ 
+-	pdata = dev_get_platdata(&pdev->dev);
+-
+ 	if (!pdata) {
+ 		dev_err(&pdev->dev, "No configuration data\n");
+ 		return -ENXIO;
+-- 
+2.14.1
+


### PR DESCRIPTION
In boards with fdt is impossible to use kmod-w1-gpio-custom.
w1-gpio-custom create platform structure for w1-gpio module,
but if board use fdt, data is ignored in w1-gpio probe.

This workaround fix the problem.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>