### PR TITLE
ppp: fix missing header file in pppoatm

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -182,6 +182,8 @@ $(call Build/Configure/Default,, \
 		$(LINUX_DIR)/include/linux/compiler.h \
 		$(LINUX_DIR)/include/$(LINUX_UAPI_DIR)linux/atm*.h \
 		$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
+	-cp $(LINUX_DIR)/include/linux/compiler_types.h \
+			$(PKG_BUILD_DIR)/pppd/plugins/pppoatm/linux/
 endef
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections


### PR DESCRIPTION
Commit in Linux kernel:
d15155824c linux/compiler.h: Split into compiler.h and compiler_types.h
which was backported to 4.14.9, causes fail in compilation of
ppp-mod-pppoa package for targets using 4.14 kernel. Fix it by copying
compiler_types.h in source directory if it exist.
