### PR TITLE
ramips: add support for Axing W06

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -367,6 +367,10 @@ rt-n14u)
 	set_wifi_led "$boardname:blue:air"
 	set_usb_led "$boardname:blue:usb"
 	;;
+tama,w06)
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:green:wlan" "phy0tpt"
+	;;
 tew-714tru)
 	set_usb_led "$boardname:red:usb"
 	set_wifi_led "$boardname:green:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -251,6 +251,7 @@ ramips_setup_interfaces()
 	mzk-ex750np|\
 	na930|\
 	pbr-d1|\
+	tama,w06|\
 	u25awf-h1|\
 	wli-tx4-ag300n|\
 	wmdr-143n|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -141,6 +141,7 @@ platform_check_image() {
 	sap-g3200u3|\
 	sk-wb8|\
 	sl-r7205|\
+	tama,w06|\
 	tew-638apb-v2|\
 	tew-691gr|\
 	tew-692gr|\

--- a/target/linux/ramips/dts/W06.dts
+++ b/target/linux/ramips/dts/W06.dts
@@ -1,0 +1,115 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tama,w06", "mediatek,mt7628an-soc";
+	model = "tama W06";
+
+	memory@0{
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "w06:green:wps";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "w06:green:wan";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wireless {
+			label = "w06:green:wlan";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart1", "p0led_an", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xeb0000>;
+		};
+
+		partition@f00000 {
+			label = "user-data";
+			reg = <0xf00000 0x100000>;
+			read-only;
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -19,6 +19,14 @@ endef
 DEVICE_VARS += TPLINK_FLASHLAYOUT TPLINK_HWID TPLINK_HWREV TPLINK_HWREVADD TPLINK_HVERSION
 
 
+define Device/tama_w06
+  DTS := W06
+  IMAGE_SIZE := 15040k
+  DEVICE_TITLE := tama W06
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += tama_w06
+
 define Device/duzun-dm06
   DTS := DUZUN-DM06
   DEVICE_TITLE := DuZun DM06


### PR DESCRIPTION
Tama Electric Axing W06 is a 2.4 GHz band 11n router, based on Mediatek
MT7688AN.

Specification:

- MT7688AN (575 MHz)
- 64 MB of RAM (DDR2 SDRAM)
- 16 MB of Flash (SPI)
- 1T1R 2.4 GHz
- 1x 10/100/1000 Mbps Ethernet
- 4x LEDs (GPIO connected: 3), 1x button
- 1x USB 2.0 Type-A (host)
- UART header on PCB (GND, RX, TX, Vcc from RJ45 side)

Flash instruction using factory image:
1. Connect micro-USB cable for power supply into W06 and turn on the
router
2. Connect to wifi with SSID "tama-*" with password. Complete SSID and
password are listed on the back of the router
3. Access to 192.168.1.1 and login with user name "admin" and password
empty
4. In firmware update（ファームウェア更新） page, click "参照" button
and click "ブラウザー" button to open file browser, select the factory
image and press OK button
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>

W06 has a "Power" LED, but it's not connected to GPIO.

compile tested: W06
run tested: W06