### PR TITLE
brcm63xx: add Comtrend VR-3022eu support

### DIFF
--- a/target/linux/brcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/brcm63xx/base-files/etc/board.d/02_network
@@ -98,6 +98,11 @@ vr-3026e)
 		"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "8t@eth0"
 	;;
 
+vr-3022eu)
+	ucidef_add_switch "switch0" \
+		"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "5:wan:17" "8t@eth0"
+	;;
+
 ad1018-nor|\
 ar-5315u |\
 vh4032n)

--- a/target/linux/brcm63xx/base-files/etc/diag.sh
+++ b/target/linux/brcm63xx/base-files/etc/diag.sh
@@ -45,6 +45,9 @@ set_state() {
 	vh4032n)
 		status_led="VH4032N:red:power"
 		;;
+	vr-3022eu)
+		status_led="VR-3022eu:green:power"
+		;;
 	vr-3025un)
 		status_led="VR-3025un:green:power"
 		;;

--- a/target/linux/brcm63xx/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/brcm63xx/base-files/etc/uci-defaults/09_fix_crc
@@ -34,6 +34,7 @@ case "$(board_name)" in
 	v2110 |\
 	v2500v_bb |\
 	vh4032n |\
+	vr-3022eu |\
 	vr-3025u |\
 	vr-3025un |\
 	vr-3026e |\

--- a/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
+++ b/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
@@ -105,6 +105,9 @@ brcm63xx_dt_detect() {
 	"Comtrend CT-6373")
 		board_name="ct-6373"
 		;;
+	"Comtrend VR-3022eu")
+		board_name="vr-3022eu"
+		;;
 	"Comtrend VR-3025u")
 		board_name="vr-3025u"
 		;;

--- a/target/linux/brcm63xx/dts/vr-3022eu.dts
+++ b/target/linux/brcm63xx/dts/vr-3022eu.dts
@@ -1,0 +1,108 @@
+/dts-v1/;
+
+#include "bcm6368.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Comtrend VR-3022eu";
+	compatible = "comtrend,vr-3022eu", "brcm,bcm6368";
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		debounce-interval = <60>;
+
+		wlan {
+			label = "wlan";
+			gpios = <&pinctrl 32 1>;
+			linux,code = <KEY_WLAN>;
+		};
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 34 1>;
+			linux,code = <KEY_RESTART>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 35 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		dsl_green {
+			label = "VR-3022eu:green:dsl";
+			gpios = <&pinctrl 2 1>;
+		};
+		inet_green {
+			label = "VR-3022eu:green:inet";
+			gpios = <&pinctrl 5 0>;
+		};
+		power_green {
+			label = "VR-3022eu:green:power";
+			gpios = <&pinctrl 22 0>;
+			default-state = "on";
+		};
+		wps_green {
+			label = "VR-3022eu:green:wps";
+			gpios = <&pinctrl 23 1>;
+		};
+		power_red {
+			label = "VR-3022eu:red:power";
+			gpios = <&pinctrl 24 0>;
+		};
+		inet_red {
+			label = "VR-3022eu:red:inet";
+			gpios = <&pinctrl 31 0>;
+		};
+	};
+};
+
+&pflash {
+	status = "ok";
+
+	linux,part-probe = "bcm63xxpart";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cfe@0 {
+			label = "CFE";
+			reg = <0x000000 0x010000>;
+			read-only;
+		};
+
+		linux@10000 {
+			label = "linux";
+			reg = <0x010000 0x7e0000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		nvram@7f0000 {
+			label = "nvram";
+			reg = <0x7f0000 0x010000>;
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_pci &pinctrl_ephy0_led &pinctrl_ephy1_led
+		     &pinctrl_ephy2_led &pinctrl_ephy3_led>;
+};
+
+&uart0 {
+	status = "ok";
+};

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -429,6 +429,18 @@ define Device/CT-6373
 endef
 TARGET_DEVICES += CT-6373
 
+define Device/VR-3022eu
+  $(Device/bcm63xx)
+  DEVICE_TITLE := Comtrend VR-3022eu
+  DEVICE_DTS := vr-3022eu
+  CFE_BOARD_ID := 96368MT-1341N
+  CFE_CHIP_ID := 6368
+  FLASH_MB := 8
+  DEVICE_PACKAGES := \
+    $(B43_PACKAGES) $(USB2_PACKAGES)
+endef
+TARGET_DEVICES += VR-3022eu
+
 define Device/VR-3025u
   $(Device/bcm63xx)
   IMAGES += sysupgrade.bin

--- a/target/linux/brcm63xx/patches-4.14/581-board_VR-3022eu.patch
+++ b/target/linux/brcm63xx/patches-4.14/581-board_VR-3022eu.patch
@@ -1,0 +1,81 @@
+diff -Naurp a/arch/mips/bcm63xx/boards/board_bcm963xx.c b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 01:34:52.016352393 +0100
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 00:41:46.516155185 +0100
+@@ -2193,6 +2193,61 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct sprom_fixup __initdata vr3022eu_fixups[] = {
++	{ .offset = 219, .value = 0x4408 },
++};
++
++static struct board_info __initdata board_VR3022eu = {
++	.name					= "96368MT-1341N",
++	.expected_cpu_id			= 0x6368,
++
++	.has_pci				= 1,
++	.use_fallback_sprom			= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 2,
++
++	.has_enetsw				= 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "lan1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "lan2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "lan3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "lan4",
++			},
++			[5] = {
++				.used		= 1,
++				.phy_id		= 17,
++				.name		= "wan",
++				.force_speed	= 1000,
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type				= SPROM_BCM43222,
++		.pci_bus			= 0,
++		.pci_dev			= 1,
++		.board_fixups			= vr3022eu_fixups,
++		.num_board_fixups		= ARRAY_SIZE(vr3022eu_fixups),
++	},
++};
++
+ static struct sprom_fixup __initdata vr3025u_fixups[] = {
+ 	{ .offset = 97, .value = 0xfeb3 },
+ 	{ .offset = 98, .value = 0x1618 },
+@@ -2741,6 +2796,7 @@ static const struct board_info __initcon
+ 	&board_P870HW51A_V2,
+ 	&board_R1000H,
+ 	&board_VH4032N,
++	&board_VR3022eu,
+ 	&board_VR3025u,
+ 	&board_VR3025un,
+ 	&board_VR3026e,
+@@ -2847,6 +2903,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "adb,av4202n", .data = &board_AV4202N, },
+ 	{ .compatible = "brcm,bcm96368mvngr", .data = &board_96368mvngr, },
+ 	{ .compatible = "brcm,bcm96368mvwg", .data = &board_96368mvwg, },
++	{ .compatible = "comtrend,vr-3022eu", .data = &board_VR3022eu, },
+ 	{ .compatible = "comtrend,vr-3025u", .data = &board_VR3025u, },
+ 	{ .compatible = "comtrend,vr-3025un", .data = &board_VR3025un, },
+ 	{ .compatible = "comtrend,vr-3026e", .data = &board_VR3026e, },

--- a/target/linux/brcm63xx/patches-4.14/805-bcm63xx_enet_disabled_port_override_support.patch
+++ b/target/linux/brcm63xx/patches-4.14/805-bcm63xx_enet_disabled_port_override_support.patch
@@ -1,0 +1,143 @@
+diff -Naurp a/drivers/net/ethernet/broadcom/bcm63xx_enet.c b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 01:33:50.274681846 +0100
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 02:00:14.883196115 +0100
+@@ -2037,6 +2037,39 @@ static inline int bcm_enet_port_is_rgmii
+ 	return portid >= ENETSW_RGMII_PORT0;
+ }
+ 
++static u8 bcm_enetsw_port_override(struct bcm63xx_enetsw_port *port,
++				   int warn)
++{
++	u8 override = ENETSW_PORTOV_ENABLE_MASK;
++
++	switch (port->force_speed) {
++	case 1000:
++		override |= ENETSW_PORTOV_1000_MASK;
++		break;
++	case 100:
++		override |= ENETSW_PORTOV_100_MASK;
++		/* fall through */
++	case 10:
++		break;
++	case 0:
++		if (warn && port->bypass_link)
++			goto print_warning;
++		break;
++	default:
++		if (warn)
++			goto print_warning;
++		break;
++	print_warning:
++		pr_warn("invalid forced speed on port %s: assume 10\n",
++			port->name);
++	}
++
++	if (port->force_duplex_full)
++		override |= ENETSW_PORTOV_FDX_MASK;
++
++	return override;
++}
++
+ /*
+  * enet sw PHY polling
+  */
+@@ -2076,7 +2109,9 @@ static void swphy_poll_timer(unsigned lo
+ 		if (!up) {
+ 			dev_info(&priv->pdev->dev, "link DOWN on %s\n",
+ 				 port->name);
+-			enetsw_writeb(priv, ENETSW_PORTOV_ENABLE_MASK,
++
++			enetsw_writeb(priv,
++				      bcm_enetsw_port_override(port, false),
+ 				      ENETSW_PORTOV_REG(i));
+ 			enetsw_writeb(priv, ENETSW_PTCTRL_RXDIS_MASK |
+ 				      ENETSW_PTCTRL_TXDIS_MASK,
+@@ -2121,11 +2156,11 @@ static void swphy_poll_timer(unsigned lo
+ 			ENETSW_PORTOV_LINKUP_MASK;
+ 
+ 		if (speed == 1000)
+-			override |= ENETSW_IMPOV_1000_MASK;
++			override |= ENETSW_PORTOV_1000_MASK;
+ 		else if (speed == 100)
+-			override |= ENETSW_IMPOV_100_MASK;
++			override |= ENETSW_PORTOV_100_MASK;
+ 		if (duplex)
+-			override |= ENETSW_IMPOV_FDX_MASK;
++			override |= ENETSW_PORTOV_FDX_MASK;
+ 
+ 		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+ 		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
+@@ -2306,41 +2341,48 @@ static int bcm_enetsw_open(struct net_de
+ 	netif_carrier_on(dev);
+ 	netif_start_queue(dev);
+ 
+-	/* apply override config for bypass_link ports here. */
++	/* apply override config and setup auto negotiation. */
+ 	for (i = 0; i < priv->num_ports; i++) {
+ 		struct bcm63xx_enetsw_port *port;
++		int external_phy;
+ 		u8 override;
++		u16 val;
++
+ 		port = &priv->used_ports[i];
+ 		if (!port->used)
+ 			continue;
+ 
+-		if (!port->bypass_link)
+-			continue;
+-
+-		override = ENETSW_PORTOV_ENABLE_MASK |
+-			ENETSW_PORTOV_LINKUP_MASK;
++		override = bcm_enetsw_port_override(port, true);
+ 
+-		switch (port->force_speed) {
+-		case 1000:
+-			override |= ENETSW_IMPOV_1000_MASK;
+-			break;
+-		case 100:
+-			override |= ENETSW_IMPOV_100_MASK;
+-			break;
+-		case 10:
+-			break;
+-		default:
+-			pr_warn("invalid forced speed on port %s: assume 10\n",
+-			       port->name);
+-			break;
++		if (port->bypass_link) {
++			/* apply the override and enable the port */
++			override |= ENETSW_PORTOV_LINKUP_MASK;
++
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++			enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		} else if (override != ENETSW_PORTOV_ENABLE_MASK)
++			/* if the override value is different from that
++			 * which was already applied when disabling the
++			 * port then apply it but keep the port disabled */
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++
++		external_phy = bcm_enet_port_is_rgmii(i);
++
++		/* make sure flow-control capability is advertised */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_ADVERTISE);
++		if (!(val & ADVERTISE_PAUSE_CAP)) {
++			val |= ADVERTISE_PAUSE_CAP;
++			bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++					      MII_ADVERTISE, val);
+ 		}
+ 
+-		if (port->force_duplex_full)
+-			override |= ENETSW_IMPOV_FDX_MASK;
+-
+-
+-		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+-		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		/* enable & restart auto negotiation */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_BMCR);
++		val |= BMCR_ANENABLE | BMCR_ANRESTART;
++		bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++				      MII_BMCR, val);
+ 	}
+ 
+ 	/* start phy polling timer */

--- a/target/linux/brcm63xx/patches-4.4/581-board_VR-3022eu.patch
+++ b/target/linux/brcm63xx/patches-4.4/581-board_VR-3022eu.patch
@@ -1,0 +1,81 @@
+diff -Naurp a/arch/mips/bcm63xx/boards/board_bcm963xx.c b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 04:29:19.357406680 +0100
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 04:27:03.496342498 +0100
+@@ -2193,6 +2193,61 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct sprom_fixup __initdata vr3022eu_fixups[] = {
++	{ .offset = 219, .value = 0x4408 },
++};
++
++static struct board_info __initdata board_VR3022eu = {
++	.name					= "96368MT-1341N",
++	.expected_cpu_id			= 0x6368,
++
++	.has_pci				= 1,
++	.use_fallback_sprom			= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 2,
++
++	.has_enetsw				= 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "lan1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "lan2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "lan3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "lan4",
++			},
++			[5] = {
++				.used		= 1,
++				.phy_id		= 17,
++				.name		= "wan",
++				.force_speed	= 1000,
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type				= SPROM_BCM43222,
++		.pci_bus			= 0,
++		.pci_dev			= 1,
++		.board_fixups			= vr3022eu_fixups,
++		.num_board_fixups		= ARRAY_SIZE(vr3022eu_fixups),
++	},
++};
++
+ static struct sprom_fixup __initdata vr3025u_fixups[] = {
+ 	{ .offset = 97, .value = 0xfeb3 },
+ 	{ .offset = 98, .value = 0x1618 },
+@@ -2741,6 +2796,7 @@ static const struct board_info __initcon
+ 	&board_P870HW51A_V2,
+ 	&board_R1000H,
+ 	&board_VH4032N,
++	&board_VR3022eu,
+ 	&board_VR3025u,
+ 	&board_VR3025un,
+ 	&board_VR3026e,
+@@ -2847,6 +2903,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "adb,av4202n", .data = &board_AV4202N, },
+ 	{ .compatible = "brcm,bcm96368mvngr", .data = &board_96368mvngr, },
+ 	{ .compatible = "brcm,bcm96368mvwg", .data = &board_96368mvwg, },
++	{ .compatible = "comtrend,vr-3022eu", .data = &board_VR3022eu, },
+ 	{ .compatible = "comtrend,vr-3025u", .data = &board_VR3025u, },
+ 	{ .compatible = "comtrend,vr-3025un", .data = &board_VR3025un, },
+ 	{ .compatible = "comtrend,vr-3026e", .data = &board_VR3026e, },

--- a/target/linux/brcm63xx/patches-4.4/805-bcm63xx_enet_disabled_port_override_support.patch
+++ b/target/linux/brcm63xx/patches-4.4/805-bcm63xx_enet_disabled_port_override_support.patch
@@ -1,0 +1,143 @@
+diff -Naurp a/drivers/net/ethernet/broadcom/bcm63xx_enet.c b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 04:29:06.228883637 +0100
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 04:31:43.694162958 +0100
+@@ -2058,6 +2058,39 @@ static inline int bcm_enet_port_is_rgmii
+ 	return portid >= ENETSW_RGMII_PORT0;
+ }
+ 
++static u8 bcm_enetsw_port_override(struct bcm63xx_enetsw_port *port,
++				   int warn)
++{
++	u8 override = ENETSW_PORTOV_ENABLE_MASK;
++
++	switch (port->force_speed) {
++	case 1000:
++		override |= ENETSW_PORTOV_1000_MASK;
++		break;
++	case 100:
++		override |= ENETSW_PORTOV_100_MASK;
++		/* fall through */
++	case 10:
++		break;
++	case 0:
++		if (warn && port->bypass_link)
++			goto print_warning;
++		break;
++	default:
++		if (warn)
++			goto print_warning;
++		break;
++	print_warning:
++		pr_warn("invalid forced speed on port %s: assume 10\n",
++			port->name);
++	}
++
++	if (port->force_duplex_full)
++		override |= ENETSW_PORTOV_FDX_MASK;
++
++	return override;
++}
++
+ /*
+  * enet sw PHY polling
+  */
+@@ -2097,7 +2130,9 @@ static void swphy_poll_timer(unsigned lo
+ 		if (!up) {
+ 			dev_info(&priv->pdev->dev, "link DOWN on %s\n",
+ 				 port->name);
+-			enetsw_writeb(priv, ENETSW_PORTOV_ENABLE_MASK,
++
++			enetsw_writeb(priv,
++				      bcm_enetsw_port_override(port, false),
+ 				      ENETSW_PORTOV_REG(i));
+ 			enetsw_writeb(priv, ENETSW_PTCTRL_RXDIS_MASK |
+ 				      ENETSW_PTCTRL_TXDIS_MASK,
+@@ -2142,11 +2177,11 @@ static void swphy_poll_timer(unsigned lo
+ 			ENETSW_PORTOV_LINKUP_MASK;
+ 
+ 		if (speed == 1000)
+-			override |= ENETSW_IMPOV_1000_MASK;
++			override |= ENETSW_PORTOV_1000_MASK;
+ 		else if (speed == 100)
+-			override |= ENETSW_IMPOV_100_MASK;
++			override |= ENETSW_PORTOV_100_MASK;
+ 		if (duplex)
+-			override |= ENETSW_IMPOV_FDX_MASK;
++			override |= ENETSW_PORTOV_FDX_MASK;
+ 
+ 		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+ 		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
+@@ -2327,41 +2362,48 @@ static int bcm_enetsw_open(struct net_de
+ 	netif_carrier_on(dev);
+ 	netif_start_queue(dev);
+ 
+-	/* apply override config for bypass_link ports here. */
++	/* apply override config and setup auto negotiation. */
+ 	for (i = 0; i < priv->num_ports; i++) {
+ 		struct bcm63xx_enetsw_port *port;
++		int external_phy;
+ 		u8 override;
++		u16 val;
++
+ 		port = &priv->used_ports[i];
+ 		if (!port->used)
+ 			continue;
+ 
+-		if (!port->bypass_link)
+-			continue;
+-
+-		override = ENETSW_PORTOV_ENABLE_MASK |
+-			ENETSW_PORTOV_LINKUP_MASK;
++		override = bcm_enetsw_port_override(port, true);
+ 
+-		switch (port->force_speed) {
+-		case 1000:
+-			override |= ENETSW_IMPOV_1000_MASK;
+-			break;
+-		case 100:
+-			override |= ENETSW_IMPOV_100_MASK;
+-			break;
+-		case 10:
+-			break;
+-		default:
+-			pr_warn("invalid forced speed on port %s: assume 10\n",
+-			       port->name);
+-			break;
++		if (port->bypass_link) {
++			/* apply the override and enable the port */
++			override |= ENETSW_PORTOV_LINKUP_MASK;
++
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++			enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		} else if (override != ENETSW_PORTOV_ENABLE_MASK)
++			/* if the override value is different from that
++			 * which was already applied when disabling the
++			 * port then apply it but keep the port disabled */
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++
++		external_phy = bcm_enet_port_is_rgmii(i);
++
++		/* make sure flow-control capability is advertised */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_ADVERTISE);
++		if (!(val & ADVERTISE_PAUSE_CAP)) {
++			val |= ADVERTISE_PAUSE_CAP;
++			bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++					      MII_ADVERTISE, val);
+ 		}
+ 
+-		if (port->force_duplex_full)
+-			override |= ENETSW_IMPOV_FDX_MASK;
+-
+-
+-		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+-		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		/* enable & restart auto negotiation */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_BMCR);
++		val |= BMCR_ANENABLE | BMCR_ANRESTART;
++		bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++				      MII_BMCR, val);
+ 	}
+ 
+ 	/* start phy polling timer */

--- a/target/linux/brcm63xx/patches-4.9/581-board_VR-3022eu.patch
+++ b/target/linux/brcm63xx/patches-4.9/581-board_VR-3022eu.patch
@@ -1,0 +1,81 @@
+diff -Naurp a/arch/mips/bcm63xx/boards/board_bcm963xx.c b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 04:07:24.595640145 +0100
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c	2018-03-09 04:05:15.822399372 +0100
+@@ -2193,6 +2193,61 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct sprom_fixup __initdata vr3022eu_fixups[] = {
++	{ .offset = 219, .value = 0x4408 },
++};
++
++static struct board_info __initdata board_VR3022eu = {
++	.name					= "96368MT-1341N",
++	.expected_cpu_id			= 0x6368,
++
++	.has_pci				= 1,
++	.use_fallback_sprom			= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 2,
++
++	.has_enetsw				= 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "lan1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "lan2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "lan3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "lan4",
++			},
++			[5] = {
++				.used		= 1,
++				.phy_id		= 17,
++				.name		= "wan",
++				.force_speed	= 1000,
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type				= SPROM_BCM43222,
++		.pci_bus			= 0,
++		.pci_dev			= 1,
++		.board_fixups			= vr3022eu_fixups,
++		.num_board_fixups		= ARRAY_SIZE(vr3022eu_fixups),
++	},
++};
++
+ static struct sprom_fixup __initdata vr3025u_fixups[] = {
+ 	{ .offset = 97, .value = 0xfeb3 },
+ 	{ .offset = 98, .value = 0x1618 },
+@@ -2741,6 +2796,7 @@ static const struct board_info __initcon
+ 	&board_P870HW51A_V2,
+ 	&board_R1000H,
+ 	&board_VH4032N,
++	&board_VR3022eu,
+ 	&board_VR3025u,
+ 	&board_VR3025un,
+ 	&board_VR3026e,
+@@ -2847,6 +2903,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "adb,av4202n", .data = &board_AV4202N, },
+ 	{ .compatible = "brcm,bcm96368mvngr", .data = &board_96368mvngr, },
+ 	{ .compatible = "brcm,bcm96368mvwg", .data = &board_96368mvwg, },
++	{ .compatible = "comtrend,vr-3022eu", .data = &board_VR3022eu, },
+ 	{ .compatible = "comtrend,vr-3025u", .data = &board_VR3025u, },
+ 	{ .compatible = "comtrend,vr-3025un", .data = &board_VR3025un, },
+ 	{ .compatible = "comtrend,vr-3026e", .data = &board_VR3026e, },

--- a/target/linux/brcm63xx/patches-4.9/805-bcm63xx_enet_disabled_port_override_support.patch
+++ b/target/linux/brcm63xx/patches-4.9/805-bcm63xx_enet_disabled_port_override_support.patch
@@ -1,0 +1,143 @@
+diff -Naurp a/drivers/net/ethernet/broadcom/bcm63xx_enet.c b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 04:06:37.346386393 +0100
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c	2018-03-09 04:10:38.917458336 +0100
+@@ -2051,6 +2051,39 @@ static inline int bcm_enet_port_is_rgmii
+ 	return portid >= ENETSW_RGMII_PORT0;
+ }
+ 
++static u8 bcm_enetsw_port_override(struct bcm63xx_enetsw_port *port,
++				   int warn)
++{
++	u8 override = ENETSW_PORTOV_ENABLE_MASK;
++
++	switch (port->force_speed) {
++	case 1000:
++		override |= ENETSW_PORTOV_1000_MASK;
++		break;
++	case 100:
++		override |= ENETSW_PORTOV_100_MASK;
++		/* fall through */
++	case 10:
++		break;
++	case 0:
++		if (warn && port->bypass_link)
++			goto print_warning;
++		break;
++	default:
++		if (warn)
++			goto print_warning;
++		break;
++	print_warning:
++		pr_warn("invalid forced speed on port %s: assume 10\n",
++			port->name);
++	}
++
++	if (port->force_duplex_full)
++		override |= ENETSW_PORTOV_FDX_MASK;
++
++	return override;
++}
++
+ /*
+  * enet sw PHY polling
+  */
+@@ -2090,7 +2123,9 @@ static void swphy_poll_timer(unsigned lo
+ 		if (!up) {
+ 			dev_info(&priv->pdev->dev, "link DOWN on %s\n",
+ 				 port->name);
+-			enetsw_writeb(priv, ENETSW_PORTOV_ENABLE_MASK,
++
++			enetsw_writeb(priv,
++				      bcm_enetsw_port_override(port, false),
+ 				      ENETSW_PORTOV_REG(i));
+ 			enetsw_writeb(priv, ENETSW_PTCTRL_RXDIS_MASK |
+ 				      ENETSW_PTCTRL_TXDIS_MASK,
+@@ -2135,11 +2170,11 @@ static void swphy_poll_timer(unsigned lo
+ 			ENETSW_PORTOV_LINKUP_MASK;
+ 
+ 		if (speed == 1000)
+-			override |= ENETSW_IMPOV_1000_MASK;
++			override |= ENETSW_PORTOV_1000_MASK;
+ 		else if (speed == 100)
+-			override |= ENETSW_IMPOV_100_MASK;
++			override |= ENETSW_PORTOV_100_MASK;
+ 		if (duplex)
+-			override |= ENETSW_IMPOV_FDX_MASK;
++			override |= ENETSW_PORTOV_FDX_MASK;
+ 
+ 		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+ 		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
+@@ -2320,41 +2355,48 @@ static int bcm_enetsw_open(struct net_de
+ 	netif_carrier_on(dev);
+ 	netif_start_queue(dev);
+ 
+-	/* apply override config for bypass_link ports here. */
++	/* apply override config and setup auto negotiation. */
+ 	for (i = 0; i < priv->num_ports; i++) {
+ 		struct bcm63xx_enetsw_port *port;
++		int external_phy;
+ 		u8 override;
++		u16 val;
++
+ 		port = &priv->used_ports[i];
+ 		if (!port->used)
+ 			continue;
+ 
+-		if (!port->bypass_link)
+-			continue;
+-
+-		override = ENETSW_PORTOV_ENABLE_MASK |
+-			ENETSW_PORTOV_LINKUP_MASK;
++		override = bcm_enetsw_port_override(port, true);
+ 
+-		switch (port->force_speed) {
+-		case 1000:
+-			override |= ENETSW_IMPOV_1000_MASK;
+-			break;
+-		case 100:
+-			override |= ENETSW_IMPOV_100_MASK;
+-			break;
+-		case 10:
+-			break;
+-		default:
+-			pr_warn("invalid forced speed on port %s: assume 10\n",
+-			       port->name);
+-			break;
++		if (port->bypass_link) {
++			/* apply the override and enable the port */
++			override |= ENETSW_PORTOV_LINKUP_MASK;
++
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++			enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		} else if (override != ENETSW_PORTOV_ENABLE_MASK)
++			/* if the override value is different from that
++			 * which was already applied when disabling the
++			 * port then apply it but keep the port disabled */
++			enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
++
++		external_phy = bcm_enet_port_is_rgmii(i);
++
++		/* make sure flow-control capability is advertised */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_ADVERTISE);
++		if (!(val & ADVERTISE_PAUSE_CAP)) {
++			val |= ADVERTISE_PAUSE_CAP;
++			bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++					      MII_ADVERTISE, val);
+ 		}
+ 
+-		if (port->force_duplex_full)
+-			override |= ENETSW_IMPOV_FDX_MASK;
+-
+-
+-		enetsw_writeb(priv, override, ENETSW_PORTOV_REG(i));
+-		enetsw_writeb(priv, 0, ENETSW_PTCTRL_REG(i));
++		/* enable & restart auto negotiation */
++		val = bcmenet_sw_mdio_read(priv, external_phy,
++					   port->phy_id, MII_BMCR);
++		val |= BMCR_ANENABLE | BMCR_ANRESTART;
++		bcmenet_sw_mdio_write(priv, external_phy, port->phy_id,
++				      MII_BMCR, val);
+ 	}
+ 
+ 	/* start phy polling timer */


### PR DESCRIPTION
Add support for Comtrend VR-3022eu.
The device is very similar to the Comtrend VR-3025u, except it only has an 8MiB flash. While featuring a smaller flash, its PCB is more populated adding a 1Gbps port to the integrated switch via an external PHY, a second USB port, WLAN and WPS GPIO buttons and a WPS LED.

To support 1Gbps external PHY reliably a patch for the bcm63xx_enet driver was necessary, please see the commit adding the patch for details.

Specification:
- SoC: Broadcom BCM6368
- CPU: BMIPS4350 / 400 MHz (dual core)
- RAM: 64 MiB
- Flash: 8 MiB
- Wired Ethernet:
  - 1x 1Gbps Port
  - 4x 100Mbps Port
  - All ports connected to the integrated BCM6368 Roboswitch (b53) switch
- WLAN: Broadcom BCM43222, 2x non-detachable internal antenna
- USB: 2x USB 2.0 Port
- UART: plated through hole pads on the PCB, header needs to be soldered
- Buttons: Reset, WLAN Switch, WPS
- LEDs:
  - GPIO Controlled: Power (Reg/Green), Inet (Reg/Green), WPS (Green), DSL (Green)
  - HW Controlled: Internal 100Mbps PHY 1-4 (Green), External 1Gbps PHY (Red/Green), WLAN (Green)

Flash Instruction:
1. Connect your PC to one of the four 100Mbps ethernet ports of the device. Don't use the 1Gbps port!
2. Power up the device with the reset button pressed and keep it pressed for about 10 seconds.
3. Setup a static IP on your PC: 192.168.1.2/24
4. Visit the 192.168.1.1 webpage in your browser and follow the instruction there to upload / flash a new firmware.

Signed-off-by: Michal Růžička <michal.ruza@gmail.com>