### PR TITLE
ramips: enable power LED and second uart on GL-MT300N-V2

### DIFF
--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -188,7 +188,7 @@ get_status_led() {
 		status_led="$boardname:blue:wifi"
 		;;
 	gl-mt300n-v2)
-		status_led="$boardname:red:wlan"
+		status_led="$boardname:green:power"
 		;;
 	m4-4M|\
 	m4-8M)

--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
+++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
@@ -21,6 +21,12 @@
 	gpio-leds {
 		compatible = "gpio-leds";
 
+		power {
+			label = "gl-mt300n-v2:green:power";
+			default-state = "on";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
 		wan {
 			label = "gl-mt300n-v2:blue:wan";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
@@ -73,7 +79,7 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "wdt", "gpio", "wled_an", "p0led_an", "i2s";
+			ralink,group = "wdt", "gpio", "wled_an", "p0led_an", "p1led_an", "i2s";
 			ralink,function = "gpio";
 		};
 	};
@@ -122,6 +128,10 @@
 			 reg = <0x50000 0xfb0000>;
 		};
 	};
+};
+
+&uart1 {
+	status = "okay";
 };
 
 &ehci {


### PR DESCRIPTION
The device has a second uart accessible via pin headers, so enable it.
I tested it and it works great for controlling other uart-based devices.

There is also a green power led which was not enabled previously, enable it too.

The [vendor image](https://github.com/gl-inet/lede-imagebuilder-ramips-mt7628/blob/master/target/linux/ramips/dts/GL-MT300N-V2.dts#L94) contains a different offset for the WiFi Mac and firmware partition size, but I left this unchanged as it works.

The same is true for USB which is configured differently on the vendor dts, but as it works on the stock OpenWRT one, I left that too.

Signed-off-by: Benjamin Valentin <benjamin.valentin@volatiles.de>

