### PR TITLE
Add INITRAMFS for mt7620

### DIFF
--- a/target/linux/ramips/mt7620/target.mk
+++ b/target/linux/ramips/mt7620/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=mt7620
 BOARDNAME:=MT7620 based boards
-FEATURES+=usb
+FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc kmod-mt76 wpad-mini


### PR DESCRIPTION
Enable the compilation of "initramfs" images for testing without flashing in devices with mt7620.