### PR TITLE
logd: create log directory if not existing

### DIFF
--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -55,6 +55,8 @@ start_service_file()
 	}
 	[ -z "${log_file}" ] && return
 
+	mkdir -p "$(dirname "${log_file}")"
+
 	procd_open_instance
 	procd_set_param command "$PROG" -f -F "$log_file" -p "$pid_file"
 	[ -n "${log_size}" ] && procd_append_param command -S "$log_size"


### PR DESCRIPTION
If log_file is specified, create it's directory if it didn't exist.

Signed-off-by: Karl Palsson <karlp@etactica.com>

