### PR TITLE
ramips: gpio: fix compilation if CONFIG_GPIO_SYSFS=n

### DIFF
--- a/target/linux/ramips/patches-4.9/0024-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/ramips/patches-4.9/0024-GPIO-add-named-gpio-exports.patch
@@ -127,11 +127,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  static int match_export(struct device *dev, const void *desc)
 --- a/include/asm-generic/gpio.h
 +++ b/include/asm-generic/gpio.h
-@@ -126,6 +126,12 @@ static inline int gpio_export(unsigned g
+@@ -126,6 +126,11 @@ static inline int gpio_export(unsigned g
  	return gpiod_export(gpio_to_desc(gpio), direction_may_change);
  }
  
-+int __gpiod_export(struct gpio_desc *desc, bool direction_may_change, const char *name);
 +static inline int gpio_export_with_name(unsigned gpio, bool direction_may_change, const char *name)
 +{
 +	return __gpiod_export(gpio_to_desc(gpio), direction_may_change, name);
@@ -146,7 +145,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #if IS_ENABLED(CONFIG_GPIOLIB) && IS_ENABLED(CONFIG_GPIO_SYSFS)
  
-+int _gpiod_export(struct gpio_desc *desc, bool direction_may_change, const char *name);
++int __gpiod_export(struct gpio_desc *desc, bool direction_may_change, const char *name);
  int gpiod_export(struct gpio_desc *desc, bool direction_may_change);
  int gpiod_export_link(struct device *dev, const char *name,
  		      struct gpio_desc *desc);
@@ -154,9 +153,9 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #else  /* CONFIG_GPIOLIB && CONFIG_GPIO_SYSFS */
  
-+static inline int _gpiod_export(struct gpio_desc *desc,
-+			       bool direction_may_change,
-+			       const char *name)
++static inline int __gpiod_export(struct gpio_desc *desc,
++				 bool direction_may_change,
++				 const char *name)
 +{
 +	return -ENOSYS;
 +}


### PR DESCRIPTION
If CONFIG_GPIO_SYSFS=n, compilation fails with
  drivers/built-in.o: In function `gpio_export_with_name':
  include/asm-generic/gpio.h:128: undefined reference to `__gpiod_export'

This is because the stub in that case has the wrong name,
_gpiod_export() - note the missing underscore (_) at the
start.

Fix the stub, and add the correct prototype for the real
implementation.

Signed-off-by: André Draszik <git@andred.net>