### PR TITLE
ipq806x: remove block- and pagesize from AVM Fritz!BOX 4040

### DIFF
--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -77,8 +77,6 @@ define Device/avm_fritzbox-4040
 	$(call Device/FitImageLzma)
 	DEVICE_DTS := qcom-ipq4019-fritz4040
 	KERNEL_LOADADDR := 0x80208000
-	BLOCKSIZE := 4k
-	PAGESIZE := 256
 	BOARD_NAME := fritz4040
 	DEVICE_TITLE := AVM Fritz!Box 4040
 	IMAGE_SIZE := 29753344


### PR DESCRIPTION
This removes the block- and pagesize from the FritzBox 4040 image description, fixing incorrectly working sysupgrade. Approach taken from the GL-iNET B1300, which uses the same flash-chip.

Details about the problem are described in this related issue: https://bugs.lede-project.org/index.php?do=details&task_id=1357