### PR TITLE
ar71xx: add model detection for UBNT AC-Mesh

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -98,6 +98,27 @@ ubnt_xm_board_detect() {
 	[ -z "$model" ] || AR71XX_MODEL="${model}${magic:3:1}"
 }
 
+ubnt_ac_lite_get_mtd_part_magic() {
+	ar71xx_get_mtd_offset_size_format EEPROM 12 2 %02x
+}
+
+ubnt_ac_lite_board_detect() {
+	local model
+	local magic
+
+	magic="$(ubnt_ac_lite_get_mtd_part_magic)"
+	case ${magic:0:4} in
+	"e517")
+		model="Ubiquiti UniFi-AC-LITE"
+		;;
+	"e557")
+		model="Ubiquiti UniFi-AC-MESH"
+		;;
+	esac
+
+	[ -z "$model" ] || AR71XX_MODEL="${model}"
+}
+
 cybertan_get_hw_magic() {
 	local part
 
@@ -1297,6 +1318,7 @@ ar71xx_board_detect() {
 		;;
 	*"UniFi-AC-LITE/MESH")
 		name="unifiac-lite"
+		ubnt_ac_lite_board_detect
 		;;
 	*"UniFi-AC-PRO")
 		name="unifiac-pro"


### PR DESCRIPTION
This commit adds correct model detection for UniFi AC-Mesh. 
Previously said device was incorrectly detected as UniFi AC-Lite.

The Information about the device is stored at 0xC in the EEPROM partition. 
It corresponds to the sysid in /etc/board.info of the Ubiquiti stock firmware.