### PR TITLE
lantiq/xrx200: add usif support to dts files

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
@@ -184,11 +184,11 @@
 			interrupts = <126 127 128 129 130 131>;
 		};
 
-		asc0: serial@e100400 {
-			compatible = "lantiq,asc";
-			reg = <0xe100400 0x400>;
+		usif: usif@da00000 {
+			compatible = "lantiq,usif";
+			reg = <0xDA00000 0x1000000>;
 			interrupt-parent = <&icu0>;
-			interrupts = <104 105 106>;
+			interrupts = <29 125 107 108 109 110>;
 			status = "disabled";
 		};
 

--- a/target/linux/lantiq/files-4.9/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files-4.9/arch/mips/boot/dts/vr9.dtsi
@@ -126,11 +126,11 @@
 			interrupts = <126 127 128 129 130 131>;
 		};
 
-		asc0: serial@E100400 {
-			compatible = "lantiq,asc";
-			reg = <0xE100400 0x400>;
+		usif: usif@da00000 {
+			compatible = "lantiq,usif";
+			reg = <0xDA00000 0x1000000>;
 			interrupt-parent = <&icu0>;
-			interrupts = <104 105 106>;
+			interrupts = <29 125 107 108 109 110>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The Lantiq XRX200 aka VR9 doesn't have an asc0. Instead,
there is an USIF module which can either be an UART or a
SPI Controller.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
