### PR TITLE
leds-apu2: change leds-gpio instance id from -1 to 0

### DIFF
--- a/package/kernel/leds-apu2/src/leds-apu2.c
+++ b/package/kernel/leds-apu2/src/leds-apu2.c
@@ -354,7 +354,7 @@ static int __init gpio_apu2_init (void)
 
 	pr_info ("%s: APU2 GPIO/LED driver module loaded\n", DEVNAME);
 
-	register_leds_gpio(-1, ARRAY_SIZE(apu2_leds_gpio), apu2_leds_gpio);
+	register_leds_gpio(0, ARRAY_SIZE(apu2_leds_gpio), apu2_leds_gpio);
 	register_gpio_keys_polled(-1, 20, ARRAY_SIZE(apu2_gpio_keys), apu2_gpio_keys);
 	return 0;
 


### PR DESCRIPTION
This is needed to support additional leds-gpio devices.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
