### PR TITLE
map: Add missing proto_config_add_int for ealen

### DIFF
--- a/package/network/ipv6/map/files/map.sh
+++ b/package/network/ipv6/map/files/map.sh
@@ -223,6 +223,7 @@ proto_map_init_config() {
 	proto_config_add_int "ealen"
 	proto_config_add_int "psidlen"
 	proto_config_add_int "psid"
+	proto_config_add_int "ealen"
 	proto_config_add_int "offset"
 
 	proto_config_add_string "tunlink"


### PR DESCRIPTION
Because of the missing proto_config_add_int ealen is not usable in proto_map_setup. As ealen is a mandatory parameter this causes all MAP interfaces to fail.