### PR TITLE
openvpn: added param --verify-client-cert

### DIFF
--- a/package/network/services/openvpn/files/openvpn.options
+++ b/package/network/services/openvpn/files/openvpn.options
@@ -132,6 +132,7 @@ txqueuelen
 up
 user
 verb
+verify_client_cert
 verify_x509_name
 x509_username_field
 '


### PR DESCRIPTION
--client-cert-not-required DEPRECATED in v2.4, This option will be
removed in OpenVPN 2.5. Replaced by param
--verify-client-cert none|optional|require in v2.4
https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--client-cert-not-required

Signed-off-by: Christian Bayer <cave@cavebeat.org>