### PR TITLE
ramips:  add support for RAK633

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -332,6 +332,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "2:lan" "6t@eth0"
 		;;
+	rak633)
+		ucidef_add_switch "switch0" \
+			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
+		;;
 	f5d8235-v1|\
 	tew-714tru|\
 	v11st-fe|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -418,6 +418,9 @@ ramips_board_detect() {
 	*"R6220")
 		name="r6220"
 		;;
+	*"RAK633")
+		name="rak633"
+		;;
 	*"RB750Gr3")
 		name="rb750gr3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -126,6 +126,7 @@ platform_check_image() {
 	psr-680w|\
 	px-4885-4M|\
 	px-4885-8M|\
+	rak633|\
 	rb750gr3|\
 	re6500|\
 	rp-n53|\

--- a/target/linux/ramips/dts/RAK633.dts
+++ b/target/linux/ramips/dts/RAK633.dts
@@ -1,0 +1,117 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "rakwireless,rak633", "mediatek,mt7628an-soc";
+	model = "RAK633";
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+	
+	gpio-leds {
+		compatible = "gpio-leds";
+
+			wifiled {
+				label = "rak633:blue:wifiled";
+				gpios = <&gpio1 44 GPIO_ACTIVE_LOW>;
+			};
+			
+			link0 {
+				label = "rak633:link0";
+				gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			};
+			link1 {
+				label = "rak633:link1";
+				gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+			};
+			link2 {
+				label = "rak633:link2";
+				gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			};
+			link3 {
+				label = "rak633:link3";
+				gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			};
+			link4 {
+				label = "rak633:link4";
+				gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;
+			};
+	};
+	
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wled_an", "refclk", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&i2s {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&gdma {
+	status = "okay";
+};
+  
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -284,3 +284,10 @@ define Device/zbtlink_zbt-we1226
   DEVICE_TITLE := ZBTlink ZBT-WE1226
 endef
 TARGET_DEVICES += zbtlink_zbt-we1226
+
+define Device/rak633
+  DTS := RAK633
+  DEVICE_TITLE := Rakwireless RAK633
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-i2c-core kmod-i2c-mt7628
+endef
+TARGET_DEVICES += rak633


### PR DESCRIPTION
Specification:

CPU: MT7628  580 MHz. MIPS 24K
RAM: 64 MB
Flash: 8 MB
USB 2.0
5 Port ethernet switch

Product Specification
http://docs.rakwireless.com/en/RAK633/Hardware%20Design/RAK633_Product_Specification_V1.0.pdf

Installation:
Use the Installed uboot Bootloader. Connect a cable to serialport 0. Turn power on.
Choose the option: “Load system code then write to Flash via TFTP” and follow the instructions.

Notes:
The I2C Kernel module work not correctly. You can send and receive data. But the command i2cdetect doesn’t work. FS#845

Signed-off-by: Eike Feldmann <eike.feldmann@outlook.com>

