### PR TITLE
ramips: fix mt7620n ethernet switch description

### DIFF
--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -293,6 +293,13 @@
 
 		mediatek,switch = <&gsw>;
 
+		port@4 {
+			compatible = "mediatek,mt7620a-gsw-port", "mediatek,eth-port";
+			reg = <4>;
+
+			status = "disabled";
+		};
+
 		mdio-bus {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -310,7 +317,7 @@
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;
-		mediatek,port4 = "gmac";
+		mediatek,port4 = "ephy";
 	};
 
 	ehci: ehci@101c0000 {


### PR DESCRIPTION
According to the datasheet the mt7620n have a fixed switch configuration
with 5 ephy (10/100) port. No RGMII configuration is possible.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>