### PR TITLE
base-files: /lib/functions.sh: fix postinstall uci-defaults removal

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -232,10 +232,9 @@ default_postinst() {
 	if [ -z "$root" ] && grep -q -s "^/etc/uci-defaults/" "/usr/lib/opkg/info/${pkgname}.list"; then
 		. /lib/functions/system.sh
 		[ -d /tmp/.uci ] || mkdir -p /tmp/.uci
-		for i in $(sed -ne 's!^/etc/uci-defaults/!!p' "/usr/lib/opkg/info/${pkgname}.list"); do (
-			cd /etc/uci-defaults
-			[ -f "$i" ] && . ./"$i" && rm -f "$i"
-		) done
+		for i in $(grep -s "^/etc/uci-defaults/" "/usr/lib/opkg/info/${pkgname}.list"); do
+			( [ -f "$i" ] && cd "$(dirname $i)" && . "$i" ) && rm -f "$i"
+		done
 		uci commit
 	fi
 


### PR DESCRIPTION
Commit 7f694582 introduced a bug where `default_postinst()` often fails to
remove a uci-defaults script after application, leaving it to run again
after a reboot.
(Note: commit 7f694582 also introduced FS#1021, now fixed by 73c745f6)

The subtle problem arises from the shell logical chain:
`[ -f "$i" ] && . "$i" && rm -f "$i"`

Most uci-defaults scripts contain a terminal `exit 0` statement which,
when sourced, results in the logic chain exiting before executing `rm -f`.
This was observed while testing upgrades of 'luci-app-sqm'.

The solution is to wrap the shell sourcing in a subshell relative to the
command `rm -f`:
`( [ -f "$i" ] && . "$i" ) && rm -f "$i"`

Revert to using 'grep' to prefilter the list of entries from the control
file, which yields the full path of uci-defaults scripts. This allows
keeping the existence check, directory change and script sourcing inside
the subshell, with the script removal correctly outside.

This approach avoids adding a second subshell only around the "." (source)
command. The change also preserves the fix FS#1021, since the full path is
used to source the script, which is POSIX-portable irrespective of PATH
variable or reference to the CWD.

Run Tested on: LEDE 17.01.4 running ar71xx, while tracing installation of
package luci-app-sqm with its associated /etc/uci-defaults/luci-sqm file.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
