### PR TITLE
base-files: /lib/functions.sh: fix prerm return value, align with postinst code

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -155,22 +155,27 @@ config_list_foreach() {
 
 default_prerm() {
 	local root="${IPKG_INSTROOT}"
-	local name
+	local pkgname="$(basename ${1%.*})"
+	local ret=0
 
-	name=$(basename ${1%.*})
-	[ -f "$root/usr/lib/opkg/info/${name}.prerm-pkg" ] && . "$root/usr/lib/opkg/info/${name}.prerm-pkg"
+	if [ -f "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" ]; then
+		( . "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" )
+		ret=$?
+	fi
 
 	local shell="$(which bash)"
-	for i in `cat "$root/usr/lib/opkg/info/${name}.list" | grep "^/etc/init.d/"`; do
+	for i in $(grep -s "^/etc/init.d/" "$root/usr/lib/opkg/info/${pkgname}.list"); do
 		if [ -n "$root" ]; then
 			${shell:-/bin/sh} "$root/etc/rc.common" "$root$i" disable
 		else
 			if [ "$PKG_UPGRADE" != "1" ]; then
 				"$i" disable
 			fi
-			"$i" stop || /bin/true
+			"$i" stop
 		fi
 	done
+
+	return $ret
 }
 
 add_group_and_user() {


### PR DESCRIPTION
The return value of a package prerm script is discarded and not returned
correctly by default_prerm(). This allows other operations like service
shutdown to "leak" their return value, prompting workarounds like commit
48cfc826 which do not address the root cause.

Preserve a package prerm script return value for use by `default_prerm()`,
sharing the corresponding code from `default_postinst()` for consistency.
Also use consistent code for handling of `/etc/init.d/` scripts.

Run Tested on: LEDE 17.01.4 running ar71xx.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
