### PR TITLE
uboot-envtools: add support for Arcadyan VGV7510KW22 (o2 Box 6431)

### DIFF
--- a/package/boot/uboot-envtools/files/lantiq
+++ b/package/boot/uboot-envtools/files/lantiq
@@ -13,6 +13,9 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+arcadyan,vgv7510kw22-nor)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x20000" "0x20000" "1"
+	;;
 bt,homehub-v2b)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000" "1"
 	;;


### PR DESCRIPTION
This requires the uboot-env partition to be initialized from u-boot:

```
VGV7510KW22 # saveenv
Saving Environment to Flash...
. done
Un-Protected 1 sectors
Erasing Flash...
. done
Erased 1 sectors
Writing to Flash... 10....9....8....7....6....5....4....3....2....1....done
. done
Protected 1 sectors
```

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>