### PR TITLE
toolchain/glibc: unset LD_LIBRARY_PATH

### DIFF
--- a/toolchain/glibc/common.mk
+++ b/toolchain/glibc/common.mk
@@ -41,6 +41,7 @@ endif
 # only -O2 tested by upstream changeset
 # "Optimize i386 syscall inlining for GCC 5"
 GLIBC_CONFIGURE:= \
+	unset LD_LIBRARY_PATH; \
 	BUILD_CC="$(HOSTCC)" \
 	$(TARGET_CONFIGURE_OPTS) \
 	CFLAGS="-O2 $(filter-out -Os,$(call qstrip,$(TARGET_CFLAGS)))" \


### PR DESCRIPTION
When build with glibc instead of musl, the following error will occur.

**checking if mips-openwrt-linux-gnu-gcc is sufficient to build libc... yes
checking for mips-openwrt-linux-gnu-nm... mips-openwrt-linux-gnu-gcc-nm
checking for python3... python3
configure: WARNING:
*** These auxiliary programs are missing or incompatible versions: makeinfo
*** some features or tests will be disabled.
*** Check the INSTALL file for required versions.
checking LD_LIBRARY_PATH variable... contains current directory
configure: error: 
*** LD_LIBRARY_PATH shouldn't contain the current directory when
*** building glibc. Please change the environment variable
*** and run configure again.**

unset the environment variable 'LD_LIBRARY_PATH' when configuring glibc resolves the error.

Signed-off-by: Hyeonsik Song <blogcin@naver.com>

