### PR TITLE
rules.mk: add ESED command

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -264,6 +264,7 @@ TARGET_CC:=$(TARGET_CROSS)gcc
 TARGET_CXX:=$(TARGET_CROSS)g++
 KPATCH:=$(SCRIPT_DIR)/patch-kernel.sh
 SED:=$(STAGING_DIR_HOST)/bin/sed -i -e
+ESED:=$(STAGING_DIR_HOST)/bin/sed -E -i -e
 CP:=cp -fpR
 LN:=ln -sf
 XARGS:=xargs -r


### PR DESCRIPTION
ESED is SED with extended regular expressions turned on.
Command line and usage are the same as for SED.

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>