### PR TITLE
ipq806x: fix GL.iNet GL-B1300 LAN port

### DIFF
--- a/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq4019-gl-b1300.dts
+++ b/target/linux/ipq806x/files-4.9/arch/arm/boot/dts/qcom-ipq4019-gl-b1300.dts
@@ -191,6 +191,24 @@
 
 		edma@c080000 {
 			status = "okay";
+
+			/delete-node/ gmac0;
+
+			gmac0: gmac0 {
+				local-mac-address = [00 00 00 00 00 00];
+				qcom,phy_mdio_addr = <4>;
+				qcom,poll_required = <1>;
+				qcom,forced_speed = <1000>;
+				qcom,forced_duplex = <1>;
+				vlan_tag = <2 0x20>;
+			};
+
+			/delete-node/ gmac1;
+
+			gmac1: gmac1 {
+				local-mac-address = [00 00 00 00 00 00];
+				vlan_tag = <1 0x1f>;
+			};
 		};
 
 		wifi@a000000 {
@@ -297,20 +315,4 @@
 			reg = <0x180000 0x1e80000>;
 		};
 	};
-};
-
-&gmac0 {
-	qcom,phy_mdio_addr = <4>;
-	qcom,poll_required = <1>;
-	qcom,forced_speed = <1000>;
-	qcom,forced_duplex = <1>;
-	vlan_tag = <2 0x20>;
-};
-
-&gmac1 {
-	qcom,phy_mdio_addr = <3>;
-	qcom,poll_required = <1>;
-	qcom,forced_speed = <1000>;
-	qcom,forced_duplex = <1>;
-	vlan_tag = <1 0x10>;
 };


### PR DESCRIPTION
This patch fix one of two lan ports not working.
By convention GL.iNet devices have WAN bind to eth0, and LAN bind to eth1.
gmac dts node was learned from OpenMesh A42, and GL-B1300 differs for two lan ports.
