### PR TITLE
ramips: add support for DLINK DWR-921-C1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -162,6 +162,11 @@ dlink,dwr-116-a1|\
 mzk-ex300np)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+dlink,dwr-921-c1)
+	set_wifi_led "$boardname:green:wifi"
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
+	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:green:sigstrength" "0"
+	;;
 dir-810l|\
 mzk-750dhp|\
 mzk-dp150n|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -81,6 +81,7 @@ ramips_setup_interfaces()
 	dir-610-a1|\
 	dir-615-h1|\
 	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1|\
 	ew1200|\
 	firewrt|\
 	hc5661a|\
@@ -433,7 +434,8 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
 		;;
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -108,6 +108,9 @@ get_status_led() {
 	zbt-wg2626)
 		status_led="$boardname:green:status"
 		;;
+	dlink,dwr-921-c1)
+		status_led="$boardname:green:sigstrength"
+		;;
 	asl26555-8M|\
 	asl26555-16M)
 		status_led="asl26555:green:power"

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -54,7 +54,8 @@ board=$(board_name)
 case "$FIRMWARE" in
 "soc_wmac.eeprom")
 	case $board in
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -271,7 +271,8 @@ platform_check_image() {
 		}
 		return 0
 		;;
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		[ "$magic" != "0404242b" ] && {
 			echo "Invalid image type."
 			return 1

--- a/target/linux/ramips/dts/DWR-921-C1.dts
+++ b/target/linux/ramips/dts/DWR-921-C1.dts
@@ -1,0 +1,128 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dwr-921-c1", "ralink,mt7620n-soc";
+	model = "D-Link DWR-921 C1";
+
+	gpio-keys-polled {
+	compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		sms {
+			label = "dwr-921-c1:green:sms";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+		lan {
+			label = "dwr-921-c1:green:lan";
+			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+		};
+		sstrengthg {
+			label = "dwr-921-c1:green:sigstrength";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+		sstrengthr {
+			label = "dwr-921-c1:red:sigstrength";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+		4g {
+			label = "dwr-921-c1:green:4g";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+		3g {
+			label = "dwr-921-c1:green:3g";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+		wifi {
+			label = "dwr-921-c1:green:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "jboot";
+			reg = <0x0 0x10000>;
+			read-only;
+		};
+
+		partition@10000 {
+			label = "firmware";
+			reg = <0x10000 0xfe0000>;
+		};
+
+		config: partition@ff0000 {
+			label = "config";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	port@4 {
+		status = "okay";
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "spi refclk", "i2c", "ephy", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -162,6 +162,21 @@ define Device/dlink_dwr-116-a1
 endef
 TARGET_DEVICES += dlink_dwr-116-a1
 
+define Device/dlink_dwr-921-c1
+  DTS := DWR-921-C1
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := D-Link DWR-921 C1
+  DEVICE_PACKAGES := jboot-tools
+  DLINK_ROM_ID := DLK6E2414001
+  DLINK_FAMILY_MEMBER := 0x6E24
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+endef
+TARGET_DEVICES += dlink_dwr-921-c1
+
 define Device/e1700
   DTS := E1700
   IMAGES += factory.bin


### PR DESCRIPTION
The DWR-921-C1 Wireless Routers with LTE embedded modem is based on the MT7620N SoC.

Specification:

* MediaTek MT7620N (580 Mhz)
* 64 MB of RAM
* 16 MB of FLASH
* 802.11bgn radio
* 5x 10/100 Mbps Ethernet (1 WAN and 4 LAN)
* 2x external, detachable (LTE) antennas
* UART header on PCB (57600 8n1)
* 6x LED (GPIO-controlled)
* 1xbi-color Signal Strength LED (GPIO-controlled)
* 2x button
* JBOOT bootloader

Known issues:
* LTE Modem not yet working (subject for a new PR)
* No status led has been assigned

Installation:
Apply factory image via d-link http web-gui.

How to revert to OEM firmware:
1.) Push the reset button and turn on the power. Wait until LED start blinking (~10sec.)
2.) Upload original factory image via JBOOT http (IP: 192.168.123.254)
3.) If http doesn't work, it can be done with curl command:
    curl -F FN=@XXXXX.bin http://192.168.123.254/upg
    where XXXXX.bin is name of firmware file.

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>