### PR TITLE
libs/libnl: Update to 3.4.0

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
-PKG_VERSION:=3.3.0
+PKG_VERSION:=3.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl3_3_0
-PKG_HASH:=705468b5ae4cd1eb099d2d1c476d6a3abe519bc2810becf12fb1e32de1e074e4
+PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl3_4_0
+PKG_HASH:=b7287637ae71c6db6f89e1422c995f0407ff2fe50cecd61a312b6a9b0921f5bf
 PKG_LICENSE:=LGPL-2.1
 
 PKG_INSTALL:=1
@@ -78,7 +78,7 @@ define Package/libnl/description
  message construction and parsing, object caching system, etc.
 endef
 
-TARGET_CFLAGS += -ffunction-sections $(FPIC)
+TARGET_CFLAGS += -ffunction-sections -fdata-sections $(FPIC)
 
 CONFIGURE_ARGS += \
 	--disable-debug

--- a/package/libs/libnl/patches/100-build-add-Libs.private-field-in-libnl-pkg-config-file.patch
+++ b/package/libs/libnl/patches/100-build-add-Libs.private-field-in-libnl-pkg-config-file.patch
@@ -15,8 +15,6 @@ Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
  libnl-3.0.pc.in | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/libnl-3.0.pc.in b/libnl-3.0.pc.in
-index b87e3dc..ddbc999 100644
 --- a/libnl-3.0.pc.in
 +++ b/libnl-3.0.pc.in
 @@ -7,4 +7,5 @@ Name: libnl
@@ -25,6 +23,3 @@ index b87e3dc..ddbc999 100644
  Libs: -L${libdir} -lnl-@MAJ_VERSION@
 +Libs.private: @LIBS@
  Cflags: -I${includedir}/libnl@MAJ_VERSION@
--- 
-2.1.0
-

--- a/package/libs/libnl/patches/101-add-musl-workaround-to-the-libc-compat.h-copy.patch
+++ b/package/libs/libnl/patches/101-add-musl-workaround-to-the-libc-compat.h-copy.patch
@@ -1,6 +1,5 @@
-diff -Naur libnl-3.3.0_rc1.orig/include/linux-private/linux/if_ether.h libnl-3.3.0_rc1/include/linux-private/linux/if_ether.h
---- /include/linux-private/linux/if_ether.h	2017-03-08 19:56:31.824516933 -0800
-+++ /include/linux-private/linux/if_ether.h	2017-03-08 20:07:01.938237767 -0800
+--- a/include/linux-private/linux/if_ether.h
++++ b/include/linux-private/linux/if_ether.h
 @@ -22,6 +22,7 @@
  #define _LINUX_IF_ETHER_H
  
@@ -22,9 +21,8 @@ diff -Naur libnl-3.3.0_rc1.orig/include/linux-private/linux/if_ether.h libnl-3.3
 +#endif
  
  #endif	/* _LINUX_IF_ETHER_H */
-diff -Naur libnl-3.3.0_rc1.orig/include/linux-private/linux/libc-compat.h libnl-3.3.0_rc1/include/linux-private/linux/libc-compat.h
---- /include/linux-private/linux/libc-compat.h	2017-03-08 19:56:31.823516923 -0800
-+++ /include/linux-private/linux/libc-compat.h	2017-03-08 20:12:30.376843489 -0800
+--- a/include/linux-private/linux/libc-compat.h
++++ b/include/linux-private/linux/libc-compat.h
 @@ -48,10 +48,18 @@
  #ifndef _LIBC_COMPAT_H
  #define _LIBC_COMPAT_H

--- a/package/libs/libnl/patches/102-revert-build-enable-building-cli-during-tests.patch
+++ b/package/libs/libnl/patches/102-revert-build-enable-building-cli-during-tests.patch
@@ -26,8 +26,6 @@ Upstream status: https://github.com/thom311/libnl/pull/141
  Makefile.am | 21 ++++++---------------
  1 file changed, 6 insertions(+), 15 deletions(-)
 
-diff --git a/Makefile.am b/Makefile.am
-index 1b95a559304f..279548394650 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -3,8 +3,6 @@
@@ -39,7 +37,7 @@ index 1b95a559304f..279548394650 100644
  
  check_PROGRAMS =
  check_programs =
-@@ -500,6 +498,8 @@ EXTRA_lib_libnl_xfrm_3_la_DEPENDENCIES = \
+@@ -511,6 +509,8 @@ EXTRA_lib_libnl_xfrm_3_la_DEPENDENCIES =
  lib_libnl_xfrm_3_la_LIBADD = \
  	lib/libnl-3.la
  
@@ -48,7 +46,7 @@ index 1b95a559304f..279548394650 100644
  lib_cli_ltlibraries_cls = \
  	lib/cli/cls/basic.la \
  	lib/cli/cls/cgroup.la
-@@ -513,15 +513,11 @@ lib_cli_ltlibraries_qdisc = \
+@@ -524,15 +524,11 @@ lib_cli_ltlibraries_qdisc = \
  	lib/cli/qdisc/pfifo.la \
  	lib/cli/qdisc/plug.la
  
@@ -58,19 +56,15 @@ index 1b95a559304f..279548394650 100644
  pkglib_cls_LTLIBRARIES = $(lib_cli_ltlibraries_cls)
  pkglib_qdisc_LTLIBRARIES = $(lib_cli_ltlibraries_qdisc)
 -else
--noinst_LTLIBRARIES += \
+-check_LTLIBRARIES += \
 -	$(lib_cli_ltlibraries_cls) \
 -	$(lib_cli_ltlibraries_qdisc)
 +
  endif
  
  lib_cli_ldflags = \
-@@ -550,13 +546,8 @@ lib_cli_qdisc_plug_la_LDFLAGS       = $(lib_cli_ldflags)
+@@ -565,9 +561,6 @@ src_lib_ldflags =
  
- ###############################################################################
- 
--src_lib_ldflags =
--
  if ENABLE_CLI
  lib_LTLIBRARIES += src/lib/libnl-cli-3.la
 -src_lib_ldflags += -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
@@ -79,7 +73,7 @@ index 1b95a559304f..279548394650 100644
  endif
  
  src_lib_libnl_cli_3_la_SOURCES = \
-@@ -583,7 +574,7 @@ src_lib_libnl_cli_3_la_CPPFLAGS = \
+@@ -594,7 +587,7 @@ src_lib_libnl_cli_3_la_CPPFLAGS = \
  	-I$(srcdir)/include \
  	-I$(builddir)/include
  src_lib_libnl_cli_3_la_LDFLAGS = \
@@ -88,7 +82,7 @@ index 1b95a559304f..279548394650 100644
  	-Wl,--version-script=$(srcdir)/libnl-cli-3.sym
  src_lib_libnl_cli_3_la_LIBADD = \
  	lib/libnl-3.la \
-@@ -668,8 +659,6 @@ else
+@@ -679,8 +672,6 @@ else
  noinst_PROGRAMS += $(cli_programs)
  endif
  endif
@@ -97,7 +91,7 @@ index 1b95a559304f..279548394650 100644
  endif
  
  src_genl_ctrl_list_CPPFLAGS =       $(src_cppflags)
-@@ -847,10 +836,12 @@ tests_test_complex_HTB_with_hash_filters_LDADD    = $(tests_ldadd)
+@@ -858,10 +849,12 @@ tests_test_complex_HTB_with_hash_filters
  tests_test_u32_filter_with_actions_CPPFLAGS       = $(tests_cppflags)
  tests_test_u32_filter_with_actions_LDADD          = $(tests_ldadd)
  
@@ -110,6 +104,3 @@ index 1b95a559304f..279548394650 100644
  
  tests_cli_ldadd = \
  	$(tests_ldadd) \
--- 
-2.11.0
-


### PR DESCRIPTION
update libnl to 3.4.0
refresh existing patches
cherry-pick upstream patches:
- Geneve support
- fix memory leaks, memory corruptions, heap overflows
- ISO C90 fixes
- change rtnl_link_af_ops.ao_override_rtm behavior
- separate function to set netem qdisc delay distribution
- add test to {de}activate loopback interface
- fix for cgroup filter addition problem
- new function for setting ifindex and parent of a classifier cache
- disassociate link name of peer name in veth
- various fixes

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>