### PR TITLE
package/libs/mbedtls: add package with some mbedtls binaries.

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -24,7 +24,6 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 define Package/mbedtls/Default
-  SUBMENU:=SSL
   TITLE:=Embedded SSL
   URL:=https://tls.mbed.org
 endef
@@ -38,13 +37,28 @@ define Package/libmbedtls
 $(call Package/mbedtls/Default)
   SECTION:=libs
   CATEGORY:=Libraries
+  SUBMENU:=SSL
   TITLE+= (library)
   ABI_VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
+endef
+
+define Package/mbedtls-util
+$(call Package/mbedtls/Default)
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE+= (utilities)
+  DEPENDS:=+libmbedtls
 endef
 
 define Package/libmbedtls/description
 $(call Package/mbedtls/Default/description)
 This package contains the mbedtls library.
+endef
+
+define Package/mbedtls-util/description
+$(call Package/mbedtls/Default/description)
+This package contains mbedtls helper programs for private key and
+CSR generation (gen_key, cert_req)
 endef
 
 PKG_INSTALL:=1
@@ -55,7 +69,7 @@ CMAKE_OPTIONS += \
 	-DCMAKE_BUILD_TYPE:String="Release" \
 	-DUSE_SHARED_MBEDTLS_LIBRARY:Bool=ON \
 	-DENABLE_TESTING:Bool=OFF \
-	-DENABLE_PROGRAMS:Bool=OFF \
+	-DENABLE_PROGRAMS:Bool=ON
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
@@ -70,4 +84,11 @@ define Package/libmbedtls/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so* $(1)/usr/lib/
 endef
 
+define Package/mbedtls-util/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gen_key $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cert_req $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,libmbedtls))
+$(eval $(call BuildPackage,mbedtls-util))


### PR DESCRIPTION
Maintainer: [unknown]
Compile tested: ar71xx, kirkwood
Run tested: ar71xx, kirkwood

Description:
Add some basic binaries required for private key and CSR generation.

Use case: install openvpn-mbedtls on your router and run it as a VPN client.
Ideally, the private key (and CSR) are generated on the client itself (and not on
the server, like it is often done with easy-rsa-tools). Since libopenssl / openssl
is too fat for 4MB flash devices, mbedtls' own helper programs come in handy.

This commit adds gen_key and cert_req for private key generation and certificate
sign request generation, but mbedtls provides MANY more of those small programs.
Maybe also others should be added as well, but anyway things should not be bloated
to meet openssl's size. Any thoughts?