### PR TITLE
ar71xx: Add RTC feature to generic target

### DIFF
--- a/target/linux/ar71xx/generic/target.mk
+++ b/target/linux/ar71xx/generic/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=Generic
-FEATURES += squashfs
+FEATURES += squashfs rtc
 
 define Target/Description
 	Build firmware images for generic Atheros AR71xx/AR913x/AR934x based boards.


### PR DESCRIPTION
This is needed to enable building RTC kernel mods as packages.
I compared kernel sizes as output on the end of building latest master.
And there is no size difference.
Version with RTC feature flag kernel size is 1354.21 kB and without it kernel size is 1354.30 kB

Fixes FS#1429

Signed-off-by: Robert Marko <robimarko@gmail.com>