### PR TITLE
sysfixtime: store recent timestamp to dummy file on reboot/shutdown

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -21,7 +21,9 @@ start() {
 
 stop() {
 	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV && \
-		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
+		logger -t sysfixtime "saved '$(date)' to $RTC_DEV" && exit 0
+
+	touch /etc/.adjtime
 }
 
 maxtime() {


### PR DESCRIPTION
By touching the dummy-file /etc/.adjtime on shutdown, the recent
date/time will (nearly) be restored on next bootup.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
