### PR TITLE
rt2x00: fix tx queue stop unexpected

### DIFF
--- a/package/kernel/mac80211/patches/970-rt2x00-fix-tx-queue-stop-unexpected.patch
+++ b/package/kernel/mac80211/patches/970-rt2x00-fix-tx-queue-stop-unexpected.patch
@@ -1,0 +1,128 @@
+From 2bf2505bf4dab0b60b513fb320030660ebd22c77 Mon Sep 17 00:00:00 2001
+From: Chen Minqiang <ptpt52@gmail.com>
+Date: Thu, 15 Mar 2018 00:00:28 +0800
+Subject: [PATCH] rt2x00: fix tx queue stop unexpected
+
+Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800mmio.c | 57 ++++++++++++++++++++++---
+ drivers/net/wireless/ralink/rt2x00/rt2800mmio.h |  1 +
+ drivers/net/wireless/ralink/rt2x00/rt2800soc.c  |  1 +
+ 3 files changed, 53 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c b/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c
+index 6a26d0d..d29f936 100644
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c
+@@ -427,8 +427,6 @@ EXPORT_SYMBOL_GPL(rt2800mmio_autowake_tasklet);
+ static void rt2800mmio_txstatus_interrupt(struct rt2x00_dev *rt2x00dev,
+ 					  u32 status)
+ {
+-	int i;
+-
+ 	/*
+ 	 * The TX_FIFO_STATUS interrupt needs special care. We should
+ 	 * read TX_STA_FIFO but we should do it immediately as otherwise
+@@ -447,7 +445,6 @@ static void rt2800mmio_txstatus_interrupt(struct rt2x00_dev *rt2x00dev,
+ 	 * Since we have only one producer and one consumer we don't
+ 	 * need to lock the kfifo.
+ 	 */
+-	i = 0;
+ 	do {
+ 		if (!kfifo_put(&rt2x00dev->txstatus_fifo, status)) {
+ 			rt2x00_warn(rt2x00dev,
+@@ -455,9 +452,6 @@ static void rt2800mmio_txstatus_interrupt(struct rt2x00_dev *rt2x00dev,
+ 			break;
+ 		}
+ 
+-		if (++i >= rt2x00dev->tx->limit)
+-			break;
+-
+ 		status = rt2x00mmio_register_read(rt2x00dev, TX_STA_FIFO);
+ 	} while (rt2x00_get_field32(status, TX_STA_FIFO_VALID));
+ 
+@@ -663,6 +657,57 @@ void rt2800mmio_kick_queue(struct data_queue *queue)
+ }
+ EXPORT_SYMBOL_GPL(rt2800mmio_kick_queue);
+ 
++static bool rt2800mmio_flush_entry(struct queue_entry *entry, void *data)
++{
++	rt2800_txdone_entry(entry, 0, rt2800mmio_get_txwi(entry), true);
++	return false;
++}
++
++static void rt2800mmio_flush_queue(struct data_queue *queue)
++{
++	rt2x00queue_for_each_entry(queue, Q_INDEX_DONE, Q_INDEX, NULL, rt2800mmio_flush_entry);
++}
++
++static void rt2800mmio_watchdog_tx_dma(struct data_queue *queue)
++{
++	rt2x00_warn(queue->rt2x00dev, "TX queue %d DMA timed out, invoke forced reset\n", queue->qid);
++
++	rt2x00queue_stop_queue(queue);
++	rt2800mmio_flush_queue(queue);
++	rt2x00queue_start_queue(queue);
++}
++
++static int rt2800mmio_dma_timeout(struct data_queue *queue)
++{
++	struct queue_entry *entry;
++
++	entry = rt2x00queue_get_entry(queue, Q_INDEX_DMA_DONE);
++	if (!test_bit(ENTRY_OWNER_DEVICE_DATA, &entry->flags))
++		return false;
++	return time_after(jiffies, entry->last_action + msecs_to_jiffies(500));
++}
++
++void rt2800mmio_watchdog(struct rt2x00_dev *rt2x00dev)
++{
++	struct data_queue *queue;
++
++	tx_queue_for_each(rt2x00dev, queue) {
++		if (!rt2x00queue_empty(queue)) {
++			if (rt2800mmio_dma_timeout(queue)) {
++				rt2800mmio_watchdog_tx_dma(queue);
++				spin_lock_bh(&queue->tx_lock);
++				rt2x00queue_unpause_queue(queue);
++				spin_unlock_bh(&queue->tx_lock);
++			}
++		} else {
++			spin_lock_bh(&queue->tx_lock);
++			rt2x00queue_unpause_queue(queue);
++			spin_unlock_bh(&queue->tx_lock);
++		}
++	}
++}
++EXPORT_SYMBOL_GPL(rt2800mmio_watchdog);
++
+ void rt2800mmio_stop_queue(struct data_queue *queue)
+ {
+ 	struct rt2x00_dev *rt2x00dev = queue->rt2x00dev;
+diff --git a/drivers/net/wireless/ralink/rt2x00/rt2800mmio.h b/drivers/net/wireless/ralink/rt2x00/rt2800mmio.h
+index b63312c..32aebfa 100644
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800mmio.h
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800mmio.h
+@@ -146,6 +146,7 @@ void rt2800mmio_toggle_irq(struct rt2x00_dev *rt2x00dev,
+ 			   enum dev_state state);
+ 
+ /* Queue handlers */
++void rt2800mmio_watchdog(struct rt2x00_dev *rt2x00dev);
+ void rt2800mmio_start_queue(struct data_queue *queue);
+ void rt2800mmio_kick_queue(struct data_queue *queue);
+ void rt2800mmio_stop_queue(struct data_queue *queue);
+diff --git a/drivers/net/wireless/ralink/rt2x00/rt2800soc.c b/drivers/net/wireless/ralink/rt2x00/rt2800soc.c
+index fb934fc..8e121cf 100644
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800soc.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800soc.c
+@@ -191,6 +191,7 @@ static const struct rt2x00lib_ops rt2800soc_rt2x00_ops = {
+ 	.link_stats		= rt2800_link_stats,
+ 	.reset_tuner		= rt2800_reset_tuner,
+ 	.link_tuner		= rt2800_link_tuner,
++	.watchdog		= rt2800mmio_watchdog,
+ 	.gain_calibration	= rt2800_gain_calibration,
+ 	.vco_calibration	= rt2800_vco_calibration,
+ 	.start_queue		= rt2800mmio_start_queue,
+-- 
+2.7.4
+


### PR DESCRIPTION
This trying to fix 2.4G wifi stuck in MT7620 with rt2800
see https://bugs.openwrt.org/index.php?do=details&task_id=896

my test seems ok, "Error - Dropping frame..." printk msg still but no stuck.

 - add watchdog for tx queues to force reset tx queues when it get stuck
   it does exist that: at high loads, status is sure to be missing. we can not avoid it
   so a watchdog to do reset for tx queue is necessary
 - remove the read limit for 'status' in irq.

