### PR TITLE
base-files: /lib/functions.sh: fix UCI config parsing and callback handling

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -57,16 +57,16 @@ config () {
 	export ${NO_EXPORT:+-n} CONFIG_NUM_SECTIONS=$(($CONFIG_NUM_SECTIONS + 1))
 	name="${name:-cfg$CONFIG_NUM_SECTIONS}"
 	append CONFIG_SECTIONS "$name"
-	[ -n "$NO_CALLBACK" ] || config_cb "$cfgtype" "$name"
 	export ${NO_EXPORT:+-n} CONFIG_SECTION="$name"
-	export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_TYPE=$cfgtype"
+	config_set "$CONFIG_SECTION" "TYPE" "${cfgtype}"
+	[ -n "$NO_CALLBACK" ] || config_cb "$cfgtype" "$name"
 }
 
 option () {
 	local varname="$1"; shift
 	local value="$*"
 
-	export ${NO_EXPORT:+-n} "CONFIG_${CONFIG_SECTION}_${varname}=$value"
+	config_set "$CONFIG_SECTION" "${varname}" "${value}"
 	[ -n "$NO_CALLBACK" ] || option_cb "$varname" "$*"
 }
 
@@ -81,7 +81,7 @@ list() {
 	config_set "$CONFIG_SECTION" "${varname}_ITEM$len" "$value"
 	config_set "$CONFIG_SECTION" "${varname}_LENGTH" "$len"
 	append "CONFIG_${CONFIG_SECTION}_${varname}" "$value" "$LIST_SEP"
-	list_cb "$varname" "$*"
+	[ -n "$NO_CALLBACK" ] || list_cb "$varname" "$*"
 }
 
 config_unset() {
@@ -113,11 +113,8 @@ config_set() {
 	local section="$1"
 	local option="$2"
 	local value="$3"
-	local old_section="$CONFIG_SECTION"
 
-	CONFIG_SECTION="$section"
-	option "$option" "$value"
-	CONFIG_SECTION="$old_section"
+	export ${NO_EXPORT:+-n} "CONFIG_${section}_${option}=${value}"
 }
 
 config_foreach() {


### PR DESCRIPTION
There are several long-standing issues present in the UCI shell API as
documented in https://wiki.openwrt.org/doc/devel/config-scripting. They
relate both to high-level, user-defined callback functions used to
process UCI config files, and also to low-level functions used within
scripts generally.

The related problems have been encountered now and in the past, e.g.
https://forum.openwrt.org/viewtopic.php?id=54295, and include:

a) UCI parsing `option()` function and user-defined `option_cb()` callbacks
being erroneously called during processing of "list" config file entries;

b) normal usage of the low-level `config_set()` unexpectedy calling any
defined `option_cb()` if present; and

c) handling of the `list_cb()` not respecting the `NO_CALLBACK` variable.

Root causes include a function stack "inversion", where the low-level
`config_set()` function incorrectly calls the high-level `option()` function,
intended only for processing the "option" keyword of UCI config files.

This change addresses the inversion and other issues, making the option
handling code more consistent and smaller, and simplifying developers'
usage of UCI callbacks.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>

Tested on LEDE 17.01.4 (ar71xx) as part of converting a package to use UCI callback processing.