### PR TITLE
lantiq: fix DM200 boot with fake uImage headers

### DIFF
--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -583,6 +583,10 @@ TARGET_DEVICES += bt_homehub-v5a
 define Device/netgear_dm200
   DEVICE_DTS := DM200
   IMAGES := sysupgrade.bin factory.img
+  IMAGE/sysupgrade.bin := append-kernel | \
+	pad-offset 64k 64 | append-uImage-fakeroot-hdr | \
+	pad-offset 64k 64 | append-uImage-fakeroot-hdr | \
+	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.img := $$(IMAGE/sysupgrade.bin) | netgear-dni
   IMAGE_SIZE := 7872k
   DEVICE_TITLE := Netgear DM200


### PR DESCRIPTION
The latest DM200 bootloader versions load the firmware into memory and call
`chk_dniimg` (defined in Netgear GPL release), which expects to find three
consecutive block-aligned uImages. This patch adds two fake uImage headers
after the kernel to fool this check.

This wastes up to 128k of space for alignment. The alternative would be
to put the rootfs in a second uImage, but this would limit the firmware
size to 0x710000 (the number of bytes loaded and verified by the
bootloader) instead of 0x7b0000 (the size of the firmware partition).

This issue was reported in this forum post:

https://forum.lede-project.org/t/netgear-dm200-missing-download-link-and-failed-tftp-flash/9926/22

Thanks!