### PR TITLE
 ramips: add lte-modem support on dlink dwr-921-c1

### DIFF
--- a/target/linux/generic/pending-4.14/181-net-usb-add-lte-modem-wistron-neweb-d18q1.patch
+++ b/target/linux/generic/pending-4.14/181-net-usb-add-lte-modem-wistron-neweb-d18q1.patch
@@ -1,0 +1,65 @@
+From 989dd5b0346a17555888a7ab92ca2fdab6691c74 Mon Sep 17 00:00:00 2001
+From: Giuseppe Lippolis <giu.lippolis@gmail.com>
+Date: Fri, 23 Mar 2018 07:15:30 +0100
+Subject: [PATCH] net-usb: add qmi_wwan if on lte modem wistron neweb d18q1
+
+    This modem is embedded on dlink dwr-921 router.
+    The oem configuration states:
+
+    T:  Bus=02 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#=  2 Spd=480 MxCh= 0
+    D:  Ver= 2.00 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
+    P:  Vendor=1435 ProdID=0918 Rev= 2.32
+    S:  Manufacturer=Android
+    S:  Product=Android
+    S:  SerialNumber=0123456789ABCDEF
+    C:* #Ifs= 7 Cfg#= 1 Atr=80 MxPwr=500mA
+    I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
+    E:  Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+    E:  Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+    E:  Ad=84(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=86(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=88(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 5 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=8a(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 6 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+    E:  Ad=8b(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=07(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>
+---
+ drivers/net/usb/qmi_wwan.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/net/usb/qmi_wwan.c b/drivers/net/usb/qmi_wwan.c
+index 5894e3c..b1f9b0a 100644
+--- a/drivers/net/usb/qmi_wwan.c
++++ b/drivers/net/usb/qmi_wwan.c
+@@ -1100,6 +1100,9 @@ static const struct usb_device_id products[] = {
+ 	{QMI_FIXED_INTF(0x0846, 0x68a2, 8)},
+ 	{QMI_FIXED_INTF(0x12d1, 0x140c, 1)},	/* Huawei E173 */
+ 	{QMI_FIXED_INTF(0x12d1, 0x14ac, 1)},	/* Huawei E1820 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 3)},	/* Wistron NeWeb D18Q1 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 4)},	/* Wistron NeWeb D18Q1 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 5)},	/* Wistron NeWeb D18Q1 */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6003, 0)},	/* CMOTech 6003 */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6007, 0)},	/* CMOTech CHE-628S */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6008, 0)},	/* CMOTech CMU-301 */
+-- 
+2.7.4
+

--- a/target/linux/generic/pending-4.9/181-net-usb-add-lte-modem-wistron-neweb-d18q1.patch
+++ b/target/linux/generic/pending-4.9/181-net-usb-add-lte-modem-wistron-neweb-d18q1.patch
@@ -1,0 +1,65 @@
+From 989dd5b0346a17555888a7ab92ca2fdab6691c74 Mon Sep 17 00:00:00 2001
+From: Giuseppe Lippolis <giu.lippolis@gmail.com>
+Date: Fri, 23 Mar 2018 07:15:30 +0100
+Subject: [PATCH] net-usb: add qmi_wwan if on lte modem wistron neweb d18q1
+
+    This modem is embedded on dlink dwr-921 router.
+    The oem configuration states:
+
+    T:  Bus=02 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#=  2 Spd=480 MxCh= 0
+    D:  Ver= 2.00 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
+    P:  Vendor=1435 ProdID=0918 Rev= 2.32
+    S:  Manufacturer=Android
+    S:  Product=Android
+    S:  SerialNumber=0123456789ABCDEF
+    C:* #Ifs= 7 Cfg#= 1 Atr=80 MxPwr=500mA
+    I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
+    E:  Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+    E:  Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+    E:  Ad=84(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=86(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=88(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 5 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+    E:  Ad=8a(I) Atr=03(Int.) MxPS=  64 Ivl=32ms
+    E:  Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    I:* If#= 6 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+    E:  Ad=8b(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+    E:  Ad=07(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>
+---
+ drivers/net/usb/qmi_wwan.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/net/usb/qmi_wwan.c b/drivers/net/usb/qmi_wwan.c
+index 5894e3c..b1f9b0a 100644
+--- a/drivers/net/usb/qmi_wwan.c
++++ b/drivers/net/usb/qmi_wwan.c
+@@ -1100,6 +1100,9 @@ static const struct usb_device_id products[] = {
+ 	{QMI_FIXED_INTF(0x0846, 0x68a2, 8)},
+ 	{QMI_FIXED_INTF(0x12d1, 0x140c, 1)},	/* Huawei E173 */
+ 	{QMI_FIXED_INTF(0x12d1, 0x14ac, 1)},	/* Huawei E1820 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 3)},	/* Wistron NeWeb D18Q1 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 4)},	/* Wistron NeWeb D18Q1 */
++	{QMI_FIXED_INTF(0x1435, 0xd181, 5)},	/* Wistron NeWeb D18Q1 */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6003, 0)},	/* CMOTech 6003 */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6007, 0)},	/* CMOTech CHE-628S */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6008, 0)},	/* CMOTech CMU-301 */
+-- 
+2.7.4
+

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -162,6 +162,11 @@ dlink,dwr-116-a1|\
 mzk-ex300np)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+dlink,dwr-921-c1)
+	set_wifi_led "$boardname:green:wifi"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "br-lan"
+	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:red:sigstrength" "0"
+	;;
 dir-810l|\
 mzk-750dhp|\
 mzk-dp150n|\

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -164,8 +164,8 @@ mzk-ex300np)
 	;;
 dlink,dwr-921-c1)
 	set_wifi_led "$boardname:green:wifi"
-	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "br-lan"
-	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:red:sigstrength" "0"
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
+	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:green:sigstrength" "0"
 	;;
 dir-810l|\
 mzk-750dhp|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -81,6 +81,7 @@ ramips_setup_interfaces()
 	dir-610-a1|\
 	dir-615-h1|\
 	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1|\
 	ew1200|\
 	firewrt|\
 	hc5661a|\
@@ -433,7 +434,8 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
 		;;
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -108,6 +108,9 @@ get_status_led() {
 	zbt-wg2626)
 		status_led="$boardname:green:status"
 		;;
+	dlink,dwr-921-c1)
+		status_led="$boardname:red:sigstrength"
+		;;
 	asl26555-8M|\
 	asl26555-16M)
 		status_led="asl26555:green:power"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -109,7 +109,7 @@ get_status_led() {
 		status_led="$boardname:green:status"
 		;;
 	dlink,dwr-921-c1)
-		status_led="$boardname:red:sigstrength"
+		status_led="$boardname:green:sigstrength"
 		;;
 	asl26555-8M|\
 	asl26555-16M)

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -54,7 +54,8 @@ board=$(board_name)
 case "$FIRMWARE" in
 "soc_wmac.eeprom")
 	case $board in
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -271,7 +271,8 @@ platform_check_image() {
 		}
 		return 0
 		;;
-	dlink,dwr-116-a1)
+	dlink,dwr-116-a1|\
+	dlink,dwr-921-c1)
 		[ "$magic" != "0404242b" ] && {
 			echo "Invalid image type."
 			return 1

--- a/target/linux/ramips/dts/DWR-921-C1.dts
+++ b/target/linux/ramips/dts/DWR-921-C1.dts
@@ -1,0 +1,128 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dwr-921-c1", "ralink,mt7620n-soc";
+	model = "D-Link DWR-921 C1";
+
+	gpio-keys-polled {
+	compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		sms {
+			label = "dwr-921-c1:green:sms";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+		lan {
+			label = "dwr-921-c1:green:lan";
+			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+		};
+		sstrengthg {
+			label = "dwr-921-c1:green:sigstrength";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+		sstrengthr {
+			label = "dwr-921-c1:red:sigstrength";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+		4g {
+			label = "dwr-921-c1:green:4g";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+		3g {
+			label = "dwr-921-c1:green:3g";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+		wifi {
+			label = "dwr-921-c1:green:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "jboot";
+			reg = <0x0 0x10000>;
+			read-only;
+		};
+
+		partition@10000 {
+			label = "firmware";
+			reg = <0x10000 0xfe0000>;
+		};
+
+		config: partition@ff0000 {
+			label = "config";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	port@4 {
+		status = "okay";
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "spi refclk", "i2c", "ephy", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/dts/DWR-921-C1.dts
+++ b/target/linux/ramips/dts/DWR-921-C1.dts
@@ -60,6 +60,17 @@
 		};
 	};
 
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		lte_modem_enable {
+			gpio-export,name = "lte_modem_enable";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
 };
 
 &gpio1 {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -166,7 +166,7 @@ define Device/dlink_dwr-921-c1
   DTS := DWR-921-C1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := D-Link DWR-921 C1
-  DEVICE_PACKAGES := jboot-tools jboot-tools kmod-usb2 kmod-usb-net-qmi-wwan |\
+  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-net-qmi-wwan |\
 			kmod-usb-serial-option uqmi
   DLINK_ROM_ID := DLK6E2414001
   DLINK_FAMILY_MEMBER := 0x6E24

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -162,6 +162,21 @@ define Device/dlink_dwr-116-a1
 endef
 TARGET_DEVICES += dlink_dwr-116-a1
 
+define Device/dlink_dwr-921-c1
+  DTS := DWR-921-C1
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := D-Link DWR-921 C1
+  DEVICE_PACKAGES := jboot-tools
+  DLINK_ROM_ID := DLK6E2414001
+  DLINK_FAMILY_MEMBER := 0x6E24
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+endef
+TARGET_DEVICES += dlink_dwr-921-c1
+
 define Device/e1700
   DTS := E1700
   IMAGES += factory.bin

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -166,7 +166,8 @@ define Device/dlink_dwr-921-c1
   DTS := DWR-921-C1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := D-Link DWR-921 C1
-  DEVICE_PACKAGES := jboot-tools
+  DEVICE_PACKAGES := jboot-tools jboot-tools kmod-usb2 kmod-usb-net-qmi-wwan |\
+			kmod-usb-serial-option uqmi
   DLINK_ROM_ID := DLK6E2414001
   DLINK_FAMILY_MEMBER := 0x6E24
   DLINK_FIRMWARE_SIZE := 0xFE0000


### PR DESCRIPTION
The dlink dwr-921-c1 embeds the Wistron NeWeb d18q1 LTE modem.
This patch make it working through the qmi-wwan.