### PR TITLE
ramips: fix switch and MAC address for WHR-G300N

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -110,6 +110,7 @@ ramips_setup_interfaces()
 	u7621-06-256M-16M|\
 	vr500|\
 	wf-2881|\
+	whr-g300n|\
 	witi|\
 	wl-wn575a3|\
 	wndr3700v5|\
@@ -440,7 +441,8 @@ ramips_setup_macs()
 	e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
-	gl-mt300n-v2)
+	gl-mt300n-v2|\
+	whr-g300n)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		;;
 	hc5*61|\

--- a/target/linux/ramips/dts/WHR-G300N.dts
+++ b/target/linux/ramips/dts/WHR-G300N.dts
@@ -107,6 +107,10 @@
 	};
 };
 
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
 &esw {
 	mediatek,portmap = <0x2f>;
 };


### PR DESCRIPTION
WHR-G300N has 5 ethernet ports (lan: 4, wan: 1), but there was no
correct configuration in 02_network script and 6 ports was configured
on the switch.
Also, since the MAC address was not acquired from factory partition,
incorrect values was set to LAN and WAN interfaces.

This commit fixes these issues.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>

compile tested: WHR-G300N
run tested: WHR-G300N