### PR TITLE
packages/util/util-linux: Update to 2.32

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -8,17 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=util-linux
-PKG_VERSION:=2.30.2
-PKG_RELEASE:=2
+PKG_VERSION:=2.32
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.30
-PKG_HASH:=7b5be5489e9b5b7177832836467aba1c87bf0e9bcbcb5a6f35d76cd4782589dc
+PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.32
+PKG_HASH:=6c7397abc764e32e8159c2e96042874a190303e77adceb4ac5bd502a272a4734
 PKG_CPE_ID:=cpe:/a:kernel:util-linux
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=	COPYING					\
-			getopt/COPYING				\
 			libblkid/COPYING			\
 			libmount/COPYING			\
 			Documentation/licenses/COPYING.GPLv2	\
@@ -462,7 +461,7 @@ endef
 define Package/wipefs
 $(call Package/util-linux/Default)
   TITLE:=wipe a signature from a device
-  DEPENDS:= +libblkid
+  DEPENDS:= +libblkid +libsmartcols
   SUBMENU:=Disc
 endef
 
@@ -473,14 +472,15 @@ define Package/wipefs/description
 endef
 
 CONFIGURE_ARGS += \
-	--disable-use-tty-group \
-	--disable-rpath \
-	--disable-tls		\
-	--disable-sulogin	\
-	--without-python	\
-	--without-udev		\
-	--without-readline	\
-	--disable-more		\
+	--disable-use-tty-group		\
+	--disable-rpath			\
+	--disable-tls			\
+	--disable-sulogin		\
+	--disable-makeinstall-chown	\
+	--without-python		\
+	--without-udev			\
+	--without-readline		\
+	--disable-more			\
 	--with-ncursesw
 
 TARGET_CFLAGS += $(FPIC) -std=gnu99

--- a/package/utils/util-linux/patches/003-fix_pkgconfig_files.patch
+++ b/package/utils/util-linux/patches/003-fix_pkgconfig_files.patch
@@ -10,7 +10,7 @@
  endif # BUILD_LIBUUID
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2255,18 +2255,23 @@ AC_CONFIG_HEADERS([config.h])
+@@ -2351,18 +2351,23 @@ AC_CONFIG_HEADERS([config.h])
  #
  AC_CONFIG_FILES([
  Makefile
@@ -42,7 +42,7 @@
  pkgconfig_DATA += libblkid/blkid.pc
 -PATHFILES      += libblkid/blkid.pc
  dist_man_MANS  += libblkid/libblkid.3
- EXTRA_DIST     += libblkid/libblkid.3 libblkid/COPYING
+ EXTRA_DIST     += libblkid/COPYING
  
 --- a/libmount/Makemodule.am
 +++ b/libmount/Makemodule.am


### PR DESCRIPTION
Compile tested for kirkwood, brcm47xx, ar71xx
Run tested on kirkwood
Partially run tested on brcm47xx, ar71xx

- Update to upstream 2.32
- License file 'getopt/COPYING' not present (any more)
- Disable 'chown root:root'-commands during 'make install'
- Add new dependency to wipefs (depends on libsmartcol)
- Refresh patch 003

The release notes for 2.32 are found at [1].

---

As the release notes for the previous 2.31 [2] mention the following for `fdisk`
> The fdisk menu behavior on ^C and ^D has been improved to stop the current
> operation and return to main menu rather than immediately terminating the fdisk
> program.

I've played around with fdisk and found a 'bug' on kirkwood and ar71xx, which does not occur
on my Debian 32 and 64 bit installations:
Start `fdisk /dev/sda` (or whatever disk (or dummy file)), then begin to change the type of any partition
with `t`. `fdisk` will then prompt `Hex code (type L to list all codes):`. Now enter ^D, Enter (or play around with ^D, ^C, ^D, ^C, ...) `fdisk` eventually enters an infinite loop of  `Hex code (type L to list all codes):`, which I can only escape with `killall fdisk`


[1]:
https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/v2.32-ReleaseNotes

[2]:
https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.31/v2.31-ReleaseNotes