### PR TITLE
kernel: fix arm64 asm includes in 4.9 series

### DIFF
--- a/target/linux/generic/pending-4.9/930-fix-arm64-asm-headers.patch
+++ b/target/linux/generic/pending-4.9/930-fix-arm64-asm-headers.patch
@@ -1,0 +1,33 @@
+--- a/arch/arm64/include/asm/opcodes.h
++++ b/arch/arm64/include/asm/opcodes.h
+@@ -2,4 +2,4 @@
+ #define CONFIG_CPU_ENDIAN_BE8 CONFIG_CPU_BIG_ENDIAN
+ #endif
+ 
+-#include <../../arm/include/asm/opcodes.h>
++#include <../../../arm/include/asm/opcodes.h>
+--- a/arch/arm64/include/asm/xen/hypercall.h
++++ b/arch/arm64/include/asm/xen/hypercall.h
+@@ -1 +1 @@
+-#include <../../arm/include/asm/xen/hypercall.h>
++#include <../../../../arm/include/asm/xen/hypercall.h>
+--- a/arch/arm64/include/asm/xen/hypervisor.h
++++ b/arch/arm64/include/asm/xen/hypervisor.h
+@@ -1 +1 @@
+-#include <../../arm/include/asm/xen/hypervisor.h>
++#include <../../../../arm/include/asm/xen/hypervisor.h>
+--- a/arch/arm64/include/asm/xen/interface.h
++++ b/arch/arm64/include/asm/xen/interface.h
+@@ -1 +1 @@
+-#include <../../arm/include/asm/xen/interface.h>
++#include <../../../../arm/include/asm/xen/interface.h>
+--- a/arch/arm64/include/asm/xen/page-coherent.h
++++ b/arch/arm64/include/asm/xen/page-coherent.h
+@@ -1 +1 @@
+-#include <../../arm/include/asm/xen/page-coherent.h>
++#include <../../../../arm/include/asm/xen/page-coherent.h>
+--- a/arch/arm64/include/asm/xen/page.h
++++ b/arch/arm64/include/asm/xen/page.h
+@@ -1 +1 @@
+-#include <../../arm/include/asm/xen/page.h>
++#include <../../../../arm/include/asm/xen/page.h>


### PR DESCRIPTION
Kernel 4.9 has some arm64 headers, like opcodes.h, that include their
non-64bit equivalents. For example:

`arch/arm64/include/asm/opcodes.h`

tries to include

`<../../arm/include/asm/opcodes.h>`

It's obvious that there is one hierarchy level missing. This causes
build failures:

```
    CC [M]  /build/lede-snapshots/aarch64_cortex-a53/build/sdk/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710/dahdi-linux-2.11.1-20180111/drivers/dahdi/dahdi-base.o
  In file included from ./arch/arm64/include/asm/sysreg.h:25:0,
                   from ./arch/arm64/include/asm/cputype.h:94,
                   from ./arch/arm64/include/asm/cachetype.h:19,
                   from ./arch/arm64/include/asm/cache.h:19,
                   from ./include/linux/cache.h:5,
                   from ./include/linux/printk.h:8,
                   from ./include/linux/kernel.h:13,
                   from /build/lede-snapshots/aarch64_cortex-a53/build/sdk/build_dir/target-aarch64_cortex-a53_musl/linux-brcm2708_bcm2710/dahdi-linux-2.11.1-20180111/drivers/dahdi/dahdi-base.c:38:
  ./arch/arm64/include/asm/opcodes.h:5:10: fatal error: ../../arm/include/asm/opcodes.h: No such file or directory
   #include <../../arm/include/asm/opcodes.h>
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
```

Some example packages that fail to build are **dahdi-linux** and
**cryptodev-linux**.

Kernel 4.14 does **not** have these headers anymore.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>