### PR TITLE
nand-utils: add flash_erase utility

### DIFF
--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -47,7 +47,7 @@ endef
 
 define Package/nand-utils
  $(call Package/mtd-utils/Default)
-  TITLE:=Utilities for nand flash read/write/test
+  TITLE:=Utilities for nand flash erase/read/write/test
 endef
 
 define Package/nand-utils/description
@@ -72,7 +72,7 @@ endef
 define Package/nand-utils/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) \
-	$(PKG_INSTALL_DIR)/usr/sbin/{nanddump,nandwrite,nandtest,mtdinfo} $(1)/usr/sbin/
+	$(PKG_INSTALL_DIR)/usr/sbin/{flash_erase,nanddump,nandwrite,nandtest,mtdinfo} $(1)/usr/sbin/
 endef
 
 $(eval $(call BuildPackage,ubi-utils))


### PR DESCRIPTION
**flash_erase** utility allows to erase MTD partitions on NAND flash.
Useful when you want to clean or write an MTD partition from scratch.

e.g., before using _kobs-ng_ to flashing SPL images it's recommended
to erase the MTD partition to ensure it's empty.