### PR TITLE
igmpproxy: fix creation of firewall rules

### DIFF
--- a/package/network/services/igmpproxy/Makefile
+++ b/package/network/services/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.1
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@SF/igmpproxy

--- a/package/network/services/igmpproxy/files/igmpproxy.config
+++ b/package/network/services/igmpproxy/files/igmpproxy.config
@@ -2,11 +2,13 @@ config igmpproxy
 	option quickleave 1
 #	option verbose [0-2]
 
-config phyint wan
+config phyint
 	option network wan
+	option zone wan
 	option direction upstream
 	list altnet 192.168.1.0/24
 
-config phyint lan
+config phyint
 	option network lan
+	option zone lan
 	option direction downstream

--- a/package/network/services/igmpproxy/files/igmpproxy.init
+++ b/package/network/services/igmpproxy/files/igmpproxy.init
@@ -62,15 +62,15 @@ igmp_add_network() {
 }
 
 igmp_add_firewall_routing() {
-	config_get network $1 network
 	config_get direction $1 direction
+	config_get zone $1 zone
 
-	[[ "$direction" = "downstream" ]] || return 0
+	[[ "$direction" = "downstream" && ! -z "$zone" ]] || return 0
 
 	json_add_object ""
 	json_add_string type rule
 	json_add_string src "$upstream"
-	json_add_string dest "$network"
+	json_add_string dest "$zone"
 	json_add_string family ipv4
 	json_add_string proto udp
 	json_add_string dest_ip "224.0.0.0/4"
@@ -79,18 +79,21 @@ igmp_add_firewall_routing() {
 }
 
 igmp_add_firewall_network() {
-	config_get network $1 network
 	config_get direction $1 direction
+	config_get zone $1 zone
+
+	[ ! -z "$zone" ] || return
 
 	json_add_object ""
 	json_add_string type rule
-	json_add_string src "$network"
+	json_add_string src "$zone"
+	json_add_string family ipv4
 	json_add_string proto igmp
 	json_add_string target ACCEPT
 	json_close_object
 
 	[[ "$direction" = "upstream" ]] && {
-		upstream="$network"
+		upstream="$zone"
 		config_foreach igmp_add_firewall_routing phyint
 	}
 }


### PR DESCRIPTION
The init script for igmpproxy uses the option 'network' both as an interface name for fetching the l3_device name and for creating the firewall rules. This only works if the name of the network and firewall zone are identical.

This commit introduces a new option 'zone' for configuring the upstream and downstream firewall zones in order for the init script to create the required firewall rules automatically. When no such options are given, the init script falls back to not creating the firewall rules and the user can opt to create these manually.

Also deleted the phyint name from the example config, because it might cause confusion what this value should be set to, even though this doesn't do anything.