### PR TITLE
openssl: update to 1.0.2o

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.0.2
-PKG_BUGFIX:=n
+PKG_BUGFIX:=o
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -24,7 +24,7 @@ PKG_SOURCE_URL:= \
 	http://gd.tuwien.ac.at/infosys/security/openssl/source/ \
 	http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe
+PKG_HASH:=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/150-no_engines.patch
+++ b/package/libs/openssl/patches/150-no_engines.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -2130,6 +2130,11 @@ EOF
+@@ -2136,6 +2136,11 @@ EOF
  	close(OUT);
    }
    

--- a/package/libs/openssl/patches/200-parallel_build.patch
+++ b/package/libs/openssl/patches/200-parallel_build.patch
@@ -164,7 +164,7 @@
  	ctags $(SRC)
 --- a/test/Makefile
 +++ b/test/Makefile
-@@ -144,7 +144,7 @@ install:
+@@ -145,7 +145,7 @@ install:
  tags:
  	ctags $(SRC)
  
@@ -173,7 +173,7 @@
  
  apps:
  	@(cd ..; $(MAKE) DIRS=apps all)
-@@ -578,7 +578,7 @@ $(DTLSTEST)$(EXE_EXT): $(DTLSTEST).o ssl
+@@ -586,7 +586,7 @@ $(DTLSTEST)$(EXE_EXT): $(DTLSTEST).o ssl
  #	fi
  
  dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)


### PR DESCRIPTION
- Update OpenSSL to 1.0.2o; this fixes CVE-2018-0739
- (Do some patch refreshing)

Compile and Run-tested on kirkwood

OpenSSL's security advisory is at [1], the ChangeLog at [2]

[1]:
https://www.openssl.org/news/secadv/20180327.txt

[2]:
https://www.openssl.org/news/cl102.txt