### PR TITLE
Make odhcp6c more verbose

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -104,7 +104,7 @@ proto_dhcpv6_setup() {
 
 	proto_export "INTERFACE=$config"
 	proto_run_command "$config" odhcp6c \
-		-s /lib/netifd/dhcpv6.script \
+		-s /lib/netifd/dhcpv6.script -v \
 		$opts $iface
 }
 


### PR DESCRIPTION
I had an issue with DHCPv6-PD with odhcp6c that would have been much easier to debug if odhcp6c was more verbose in logging. Given that much less critical information shows up in logread, and given that it's relatively hard to find the file above to modify, I vote for an increase in logging.

Here is what will be added for everybody
```
root@OpenWrt:~# logread | grep odhcp6c
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: (re)starting transaction on eth1
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Starting SOLICIT transaction (timeout 4294967295s, max rc 0)
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 9ms
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 45ms
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Starting REQUEST transaction (timeout 4294967295s, max rc 10)
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Send REQUEST message (elapsed 0ms, rc 0)
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 6ms
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: entering stateful-mode on eth1
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Starting <POLL> transaction (timeout 1200s, max rc 0)
```
and here is in example of odhcp6c probably doing the wrong thing, but that's my own problem:
```
Fri Mar 30 11:02:46 2018 daemon.notice odhcp6c[6439]: Starting RENEW transaction (timeout 600s, max rc 0)
Fri Mar 30 11:02:46 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 0ms, rc 0)
Fri Mar 30 11:02:56 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 10240ms, rc 1)
Fri Mar 30 11:03:16 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 30720ms, rc 2)
Fri Mar 30 11:03:57 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 71040ms, rc 3)
Fri Mar 30 11:05:19 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 153600ms, rc 4)
Fri Mar 30 11:08:03 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 317440ms, rc 5)
Fri Mar 30 11:12:50 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 604160ms, rc 6)
Fri Mar 30 11:12:50 2018 daemon.notice odhcp6c[6439]: Starting REBIND transaction (timeout 84600s, max rc 0)
Fri Mar 30 11:12:50 2018 daemon.notice odhcp6c[6439]: Send REBIND message (elapsed 0ms, rc 0)
Fri Mar 30 11:12:50 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 15ms
Fri Mar 30 11:13:01 2018 daemon.notice odhcp6c[6439]: Send REBIND message (elapsed 11518ms, rc 1)
Fri Mar 30 11:13:02 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 11813ms
Fri Mar 30 11:13:23 2018 daemon.notice odhcp6c[6439]: Send REBIND message (elapsed 33278ms, rc 2)
Fri Mar 30 11:13:23 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 33280ms
Fri Mar 30 11:14:07 2018 daemon.notice odhcp6c[6439]: Send REBIND message (elapsed 77254ms, rc 3)
Fri Mar 30 11:14:07 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 77257ms
Fri Mar 30 11:15:33 2018 daemon.notice odhcp6c[6439]: Send REBIND message (elapsed 163438ms, rc 4)
Fri Mar 30 11:15:33 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 163448ms
```
