### PR TITLE
mac80211/ ath10k: Suppress "Unknown eventid: 36925" warnings

### DIFF
--- a/package/kernel/mac80211/patches/082-ath10k-suppress-Unknown-eventid-36925-warnings.patch
+++ b/package/kernel/mac80211/patches/082-ath10k-suppress-Unknown-eventid-36925-warnings.patch
@@ -1,0 +1,36 @@
+From 606204bb863fa3b0bb54929d79b4dc46338f9180 Mon Sep 17 00:00:00 2001
+From: Sathishkumar Muruganandam <murugana@codeaurora.org>
+Date: Tue, 27 Mar 2018 11:26:46 +0300
+Subject: [PATCH] ath10k: suppress "Unknown eventid: 36925" warnings
+
+FW has Smart Logging feature enabled by default for detecting failures
+and processing FATAL_CONDITION_EVENTID (36925 - 0x903D) back to host.
+
+Since ath10k doesn't implement the Smart Logging and FATAL CONDITION
+EVENT processing yet, suppressing the unknown event ID warning by moving
+this under ATH10K_DBG_WMI.
+
+Simulated the same issue by having associated STA powered off when
+ping flood was running from AP backbone. This triggerd STA KICKOUT
+in AP followed by FATAL CONDITION event 36925.
+
+Issue was reproduced and verified in below DUT
+------------------------------------------------
+AP mode of OpenWRT QCA9984 running 6.0.8 with FW ver 10.4-3.5.3-00053
+
+Signed-off-by: Sathishkumar Muruganandam <murugana@codeaurora.org>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+---
+ drivers/net/wireless/ath/ath10k/wmi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -5462,6 +5462,7 @@ static void ath10k_wmi_10_4_op_rx(struct
+ 	case WMI_10_4_WOW_WAKEUP_HOST_EVENTID:
+ 	case WMI_10_4_PEER_RATECODE_LIST_EVENTID:
+ 	case WMI_10_4_WDS_PEER_EVENTID:
++	case WMI_10_4_DEBUG_FATAL_CONDITION_EVENTID:
+ 		ath10k_dbg(ar, ATH10K_DBG_WMI,
+ 			   "received event id %d not implemented\n", id);
+ 		break;


### PR DESCRIPTION
This is basically just a minor cosmetic fix I wouldn't bother to file a pull request for and rather wait for the next upstream merge for compat-wireless/ backports/ "mac80211", but with the next release on the door step it would be nice to get fixed nevertheless. "Unknown eventid: 36925" happens on QCA9984 since upstream firmware 10.4-3.5.3-00053, it's not happening often - but is still noticed by users (as evidenced in the r7800 exploration thread) and leads to unfounded concerns, so just follow upstream and silence the warning.

This patch has been accepted to wireless-drivers-next and should become part of kernel v4.17.

Merge upstream patch from Sathishkumar Muruganandam
<murugana@codeaurora.org> for OpenWrt's backports package:
https://lkml.kernel.org/r/<1522049641-19521-1-git-send-email-murugana@codeaurora.org>
Commit-ID: 606204bb863fa3b0bb54929d79b4dc46338f9180

* FW has Smart Logging feature enabled by default for detecting failures
* and processing FATAL_CONDITION_EVENTID (36925 - 0x903D) back to host.
*
* Since ath10k doesn't implement the Smart Logging and FATAL CONDITION
* EVENT processing yet, suppressing the unknown event ID warning by moving
* this under ATH10K_DBG_WMI.
*
* Simulated the same issue by having associated STA powered off when
* ping flood was running from AP backbone. This triggerd STA KICKOUT
* in AP followed by FATAL CONDITION event 36925.
*
* Issue was reproduced and verified in below DUT
* ------------------------------------------------
* AP mode of OpenWRT QCA9984 running 6.0.8 with FW ver 10.4-3.5.3-00053
*
* Signed-off-by: Sathishkumar Muruganandam <murugana@codeaurora.org>

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>