### PR TITLE
package/utils/lua: cleanup source mirrors

### DIFF
--- a/package/utils/lua/Makefile
+++ b/package/utils/lua/Makefile
@@ -13,8 +13,6 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.lua.org/ftp/ \
-	http://ftp.gwdg.de/pub/languages/lua/ \
-	http://mirrors.dotsrc.org/lua/ \
 	http://www.tecgraf.puc-rio.br/lua/ftp/
 PKG_HASH:=2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
@jow- 

Remove inactive mirrors from the sources list.
[1] was last updated in 2008 (not serving the last 11 releases),
[2] directly gives a 404
The only mirror documented on the official website at [3] is [4] and therefore kept in place.

[1]:
http://ftp.gwdg.de/pub/languages/lua/

[2]:
http://mirrors.dotsrc.org/lua/

[3]:
https://www.lua.org/mirrors.html

[4]:
http://webserver2.tecgraf.puc-rio.br/lua/ftp/