### PR TITLE
ar71xx: Fix typo in wan LED color of gl-mifi

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
@@ -41,7 +41,7 @@
 
 static struct gpio_led gl_mifi_leds_gpio[] __initdata = {
 	{
-		.name = "gl-mifi:greeen:wan",
+		.name = "gl-mifi:green:wan",
 		.gpio = GL_MIFI_GPIO_LED_WAN,
 		.active_low = 0,
 	},


### PR DESCRIPTION
Signed-off-by: Reto Schneider <code@reto-schneider.ch>