### PR TITLE
ramips: add support for the YouHua WR1200JS

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -490,6 +490,11 @@ y1s)
 	ucidef_set_led_netdev "wifi5g" "WIFI5G" "$boardname:blue:wifi" "wlan0"
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:internet" "eth0.2" "tx rx"
 	;;
+youhua,wr1200js)
+	ucidef_set_led_switch "internet" "INTERNET" "$boardname:green:wan" "switch0" "0x01"
+	ucidef_set_led_usbdev "usb" "USB" "$boardname:blue:usb" "1-2"
+	ucidef_set_led_default "wps" "wps" "$boardname:blue:wps" "0"
+	;;
 zbt-ape522ii)
 	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "$boardname:green:wlan2g4" "wlan1"
 	ucidef_set_led_netdev "sys1" "wlan1" "$boardname:green:sys1" "wlan1" "tx rx"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -209,6 +209,7 @@ ramips_setup_interfaces()
 	wrtnode|\
 	wrtnode2p | \
 	wrtnode2r | \
+	youhua,wr1200js|\
 	zbt-wa05)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -129,7 +129,8 @@ get_status_led() {
 		status_led="$boardname:yellow:status"
 		;;
 	cy-swr1100|\
-	w502u)
+	w502u|\
+	youhua,wr1200js)
 		status_led="$boardname:blue:wps"
 		;;
 	d240|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -204,6 +204,7 @@ platform_check_image() {
 	x8|\
 	y1|\
 	y1s|\
+	youhua,wr1200js|\
 	we1026-5g-16m|\
 	zbt-ape522ii|\
 	zbt-cpe102|\

--- a/target/linux/ramips/dts/WR1200JS.dts
+++ b/target/linux/ramips/dts/WR1200JS.dts
@@ -1,0 +1,139 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "youhua,wr1200js", "mediatek,mt7621-soc";
+	model = "YouHua WR1200JS";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		internet {
+			label = "wr1200js:blue:internet";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wr1200js:blue:wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "wr1200js:blue:usb";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+
+			led {
+				led-sources = <2>;
+				led-active-low;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uart2", "uart3", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -328,6 +328,15 @@ define Device/wndr3700v5
 endef
 TARGET_DEVICES += wndr3700v5
 
+define Device/youhua_wr1200js
+  DTS := WR1200JS
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := YouHua WR1200JS
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += youhua_wr1200js
+
 define Device/wsr-1166
   DTS := WSR-1166
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata


### PR DESCRIPTION
YouHua tech WR1200JS is an AC1200 router with 5 1Gb
ports(4 Lan, 1 Wan) and 1 USB 2.0 port. Devices is
base on MediaTek MT7621AT + MT7603E + MT7612E.

Specification:

- MT7612AT (880 MHz)
- 128 MB of RAM
- 16 MB of FLASH (SPI NOR)
- 5x 10/100/1000 Mbps Ethernet
- 2T2R 2.4 GHz (MT7603E)
- 2T2R 5 GHz (MT7612E)
- 1x USB 2.0
- 10x LED (Power 2G 5G WPS Internet LAN4-1 USB)
- 3x button (reset wifi wps)
- DC jack for main power input (12V)

Signed-off-by: Zheng Qian <sotux82@gmail.com>
