### PR TITLE
ramips: add support for Zorlik ZL5900V2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -527,6 +527,9 @@ zbt-wr8305rt)
 	set_usb_led "$boardname:green:usb"
 	set_wifi_led "$boardname:green:wifi"
 	;;
+zorlik,zl5900v2)
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" eth0
+	;;
 zte-q7)
 	set_wifi_led "$boardname:blue:status"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -61,6 +61,7 @@ ramips_setup_interfaces()
 	widora,neo-32m|\
 	wnce2001|\
 	zbt-cpe102|\
+	zorlik,zl5900v2|\
 	zte-q7)
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "false"

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -152,7 +152,8 @@ get_status_led() {
 	wli-tx4-ag300n|\
 	y1|\
 	y1s|\
-	youku-yk1)
+	youku-yk1|\
+	zorlik,zl5900v2)
 		status_led="$boardname:blue:power"
 		;;
 	dlink,dap-1522-a1|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -218,6 +218,7 @@ platform_check_image() {
 	zbt-wg3526-16M|\
 	zbt-wg3526-32M|\
 	zbt-wr8305rt|\
+	zorlik,zl5900v2|\
 	zte-q7|\
 	youku-yk1)
 		[ "$magic" != "27051956" ] && {

--- a/target/linux/ramips/dts/ZL5900V2.dts
+++ b/target/linux/ramips/dts/ZL5900V2.dts
@@ -1,0 +1,95 @@
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zorlik,zl5900v2", "ralink,rt5350-soc";
+	model = "Zorlik ZL5900V2";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "zl5900v2:green:lan";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		power {
+			label = "zl5900v2:blue:power";
+			gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "jtag", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0>;
+	mediatek,portdisable = <0x2f>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -893,3 +893,10 @@ define Device/kn
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += kn
+
+define Device/zorlik_zl5900v2
+  DTS := ZL5900V2
+  DEVICE_TITLE := Zorlik ZL5900V2
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-ledtrig-netdev
+endef
+TARGET_DEVICES += zorlik_zl5900v2


### PR DESCRIPTION
The Zorlik ZL5900V2 is an unbranded clone of HAME MPR-A1/2.  It is
marketed as "3G Wi-Fi Router".  Only the PCB has the model name
"ZL5900V2" printed on it.

Specifications:
- Ralink RT5350F (360 MHz)
- 32 MB RAM
- 8 MB Flash
- 802.11bgn 1T1R
- 1x 10/100 Mbps Ethernet
- 1x USB 2.0 (Type-A)
- 5200 mAh battery

The ramdisk image (not the squashfs sysupgrade image) can be flashed
through the web interface (named "GoAhead") of the factory firmware.
However, as the factory firmware does not cleanly unmount the rootfs
before flashing, the device may hang instead of rebooting after
successful write.  Power cycling the device gets you in OpenWrt where
the squashfs image may be flashed through normal sysupgrade procedure.

Signed-off-by: Vianney le Clément de Saint-Marcq <code@quartic.eu>