### PR TITLE
kernel: ipq806x low latency kernel does not boot

### DIFF
--- a/target/linux/ipq806x/patches-4.9/0038-clk-qcom-Add-support-for-High-Frequency-PLLs-HFPLLs.patch
+++ b/target/linux/ipq806x/patches-4.9/0038-clk-qcom-Add-support-for-High-Frequency-PLLs-HFPLLs.patch
@@ -117,7 +117,7 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +	 * H/W requires a 5us delay between disabling the bypass and
 +	 * de-asserting the reset. Delay 10us just to be safe.
 +	 */
-+	usleep_range(10, 100);
++	udelay(10);
 +
 +	/* De-assert active-low PLL reset. */
 +	regmap_update_bits(regmap, hd->mode_reg, PLL_RESET_N, PLL_RESET_N);
@@ -128,7 +128,7 @@ Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>
 +			regmap_read(regmap, hd->status_reg, &val);
 +		} while (!(val & BIT(hd->lock_bit)));
 +	} else {
-+		usleep_range(60, 100);
++		udelay(60);
 +	}
 +
 +	/* Enable PLL output. */


### PR DESCRIPTION
It keeps failing (R7800) with the stack trace below. The solution is provided by @dissent1 in https://forum.lede-project.org/t/kernel-fails-to-boot-bug-scheduling-while-atomic-ipq806x.

Tested on Netgear R7800.

```
[    3.319074] BUG: scheduling while atomic: kworker/0:1/26/0x00000002
[    3.319083] Modules linked in:
[    3.319097] CPU: 0 PID: 26 Comm: kworker/0:1 Tainted: G        W       4.9.91 #0
[    3.319103] Hardware name: Generic DT based system
[    3.319140] Workqueue: events dbs_work_handler
[    3.319184] [<c021581c>] (unwind_backtrace) from [<c02121d0>] (show_stack+0x10/0x14)
[    3.319209] [<c02121d0>] (show_stack) from [<c03932e4>] (dump_stack+0x7c/0x9c)
[    3.319240] [<c03932e4>] (dump_stack) from [<c0239b90>] (__schedule_bug+0x5c/0x80)
[    3.319271] [<c0239b90>] (__schedule_bug) from [<c05b7260>] (__schedule+0x50/0x3f4)
[    3.319292] [<c05b7260>] (__schedule) from [<c05b76a8>] (schedule+0xa4/0xd4)
[    3.319317] [<c05b76a8>] (schedule) from [<c05ba430>] (schedule_hrtimeout_range_clock+0xc8/0x100)
[    3.319339] [<c05ba430>] (schedule_hrtimeout_range_clock) from [<c05ba480>] (schedule_hrtimeout_range+0x18/0x20)
[    3.319359] [<c05ba480>] (schedule_hrtimeout_range) from [<c05b9f78>] (usleep_range+0x48/0x50)
[    3.319383] [<c05b9f78>] (usleep_range) from [<c03f333c>] (__clk_hfpll_enable+0x44/0xd0)
[    3.319400] [<c03f333c>] (__clk_hfpll_enable) from [<c03f3474>] (clk_hfpll_set_rate+0xac/0xc4)
[    3.319421] [<c03f3474>] (clk_hfpll_set_rate) from [<c03ec390>] (clk_change_rate+0xf4/0x1fc)
[    3.319438] [<c03ec390>] (clk_change_rate) from [<c03ec510>] (clk_core_set_rate_nolock+0x78/0x94)
[    3.319455] [<c03ec510>] (clk_core_set_rate_nolock) from [<c03ec54c>] (clk_set_rate+0x20/0x30)
[    3.319480] [<c03ec54c>] (clk_set_rate) from [<c0424168>] (dev_pm_opp_set_rate+0x190/0x26c)
[    3.319506] [<c0424168>] (dev_pm_opp_set_rate) from [<c04a8548>] (set_target+0x40/0x108)
[    3.319539] [<c04a8548>] (set_target) from [<c04a4190>] (__cpufreq_driver_target+0x3f4/0x488)
[    3.319561] [<c04a4190>] (__cpufreq_driver_target) from [<c04a7494>] (od_dbs_timer+0xcc/0x154)
[    3.319579] [<c04a7494>] (od_dbs_timer) from [<c04a7998>] (dbs_work_handler+0x2c/0x54)
[    3.319600] [<c04a7998>] (dbs_work_handler) from [<c02309e8>] (process_one_work+0x1c0/0x2f0)
[    3.319620] [<c02309e8>] (process_one_work) from [<c02319a8>] (worker_thread+0x2a4/0x404)
[    3.319646] [<c02319a8>] (worker_thread) from [<c0235944>] (kthread+0xd8/0xe8)
[    3.31;672] [<c0235944>] (kthread) from [<c020eef0>] (ret_from_fork+0x14/0x24)
[    3.319883] BUG: scheduling while atomic: kworker/0:1/26/0x00000002

```
Signed-off-by: Marc Benoit <marcb62185@gmail.com>
