### PR TITLE
ramips: fix USB init on MT7620A w/kernel 4.14

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -428,6 +428,8 @@
 	usbphy: usbphy {
 		compatible = "mediatek,mt7620-usbphy";
 		#phy-cells = <1>;
+
+		ralink,sysctl = <&sysc>;
 
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";


### PR DESCRIPTION
The old phy driver just used direct register access;
upstream uses syscon, so add it to the device tree.

I am not sure this fix is fully correct, because I'm not familiar enough with syscon to tell if adding it to the DT can actually break stuff, but it gets the phy initialized properly and devices are detected - tested by me on MiWifi Mini and @mrkiko on their MR200.

Also, mt7620n/mt7628an probably need the same changes, but I don't have any hardware to test on, and I'm not familiar enough with the SoC to be confident it'll work without testing, so I don't want to be the one making the change.

Also, upstream already has a very similar setup for [mt7628a](https://github.com/torvalds/linux/blob/master/arch/mips/boot/dts/ralink/mt7628a.dtsi).

Signed-off-by: Ilya Katsnelson <me@0upti.me>