### PR TITLE
ramips: fix usbphy DT nodes on linux 4.14

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -427,8 +427,9 @@
 
 	usbphy: usbphy {
 		compatible = "mediatek,mt7620-usbphy";
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 
@@ -501,7 +502,7 @@
 		interrupt-parent = <&intc>;
 		interrupts = <18>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		status = "disabled";
@@ -514,7 +515,7 @@
 		interrupt-parent = <&intc>;
 		interrupts = <18>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		status = "disabled";

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,mt7620a-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -269,8 +269,9 @@
 
 	usbphy: usbphy {
 		compatible = "mediatek,mt7620-usbphy";
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 
@@ -327,7 +328,7 @@
 		interrupt-parent = <&intc>;
 		interrupts = <18>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		status = "disabled";
@@ -337,7 +338,7 @@
 		compatible = "generic-ohci";
 		reg = <0x101c1000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -33,7 +33,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,mt7620a-sysc";
+			compatible = "ralink,mt7620a-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -375,8 +375,9 @@
 	usbphy: usbphy@10120000 {
 		compatible = "ralink,mt7628an-usbphy", "mediatek,mt7620-usbphy";
 		reg = <0x10120000 0x1000>;
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 		clocks = <&clkctrl 22 &clkctrl 25>;
@@ -400,7 +401,7 @@
 		compatible = "generic-ehci";
 		reg = <0x101c0000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;
@@ -411,7 +412,7 @@
 		compatible = "generic-ohci";
 		reg = <0x101c1000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -34,7 +34,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,rt3050-sysc";
+			compatible = "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -287,6 +287,9 @@
 
 	usbphy: usbphy {
 		compatible = "ralink,rt3050-usbphy";
+		#phy-cells = <0>;
+
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22>;
 		reset-names = "host";
 		clocks = <&clkctrl 18>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,rt3352-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,rt3352-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -334,8 +334,9 @@
 
 	usbphy: usbphy {
 		compatible = "ralink,rt3352-usbphy";
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 		clocks = <&clkctrl 18 &clkctrl 20>;
@@ -356,7 +357,7 @@
 		compatible = "generic-ehci";
 		reg = <0x101c0000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;
@@ -369,7 +370,7 @@
 		compatible = "generic-ohci";
 		reg = <0x101c1000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,rt3883-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,rt3883-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -427,8 +427,9 @@
 
 	usbphy: usbphy {
 		compatible = "ralink,rt3352-usbphy";
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 		clocks = <&clkctrl 22 &clkctrl 25>;
@@ -449,7 +450,7 @@
 		compatible = "generic-ehci";
 		reg = <0x101c0000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;
@@ -462,7 +463,7 @@
 		compatible = "generic-ohci";
 		reg = <0x101c1000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -35,7 +35,7 @@
 		#size-cells = <1>;
 
 		sysc: sysc@0 {
-			compatible = "ralink,rt5350-sysc", "ralink,rt3050-sysc";
+			compatible = "ralink,rt5350-sysc", "ralink,rt3050-sysc", "syscon";
 			reg = <0x0 0x100>;
 		};
 
@@ -324,8 +324,9 @@
 
 	usbphy: usbphy {
 		compatible = "ralink,rt3352-usbphy";
-		#phy-cells = <1>;
+		#phy-cells = <0>;
 
+		ralink,sysctl = <&sysc>;
 		resets = <&rstctrl 22 &rstctrl 25>;
 		reset-names = "host", "device";
 		clocks = <&clkctrl 18>;
@@ -370,7 +371,7 @@
 		compatible = "generic-ehci";
 		reg = <0x101c0000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;
@@ -381,7 +382,7 @@
 		compatible = "generic-ohci";
 		reg = <0x101c1000 0x1000>;
 
-		phys = <&usbphy 1>;
+		phys = <&usbphy>;
 		phy-names = "usb";
 
 		interrupt-parent = <&intc>;


### PR DESCRIPTION
The Ralink USB PHY driver merged into mainline has a slightly different
device tree binding than the patch that was used with linux 4.9.
The new driver requires a `ralink,sysctl` node pointing to the `syscon`
node.

This patch also sets `#phy-cells` to 0, as recommended by the mainline
documentation [1].

[1] Documentation/devicetree/bindings/phy/ralink-usb-phy.txt

Signed-off-by: Vianney le Clément de Saint-Marcq <code@quartic.eu>