### PR TITLE
pass only sensible manufacturer values

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -75,7 +75,7 @@ proto_ncm_setup() {
 
 	json_load "$(cat /etc/gcom/ncm.json)"
 	json_get_keys supported
-	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'index("'"$supported"'",$1){f=1;print tolower($1);exit} END{exit 1-f}'`
+	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'index("'"$supported"'",tolower($1)){f=1;sub(/\+CGMI: /,"");print tolower($1);exit} END{exit 1-f}'`
 	[ $? -ne 0 ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -77,18 +77,13 @@ proto_ncm_setup() {
 	json_get_keys supported
 	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'index("'"$supported"'",tolower($1)){f=1;sub(/\+CGMI: /,"");print tolower($1);exit} END{exit 1-f}'`
 	[ $? -ne 0 ] && {
-		echo "Failed to get modem information"
+		echo "Failed to get modem information, only ($supported) supported"
 		proto_notify_error "$interface" GETINFO_FAILED
+		proto_set_available "$interface" 0
 		return 1
 	}
 
 	json_select "$manufacturer"
-	[ $? -ne 0 ] && {
-		echo "Unsupported modem"
-		proto_notify_error "$interface" UNSUPPORTED_MODEM
-		proto_set_available "$interface" 0
-		return 1
-	}
 	json_get_values initialize initialize
 	for i in $initialize; do
 		eval COMMAND="$i" gcom -d "$device" -s /etc/gcom/runcommand.gcom || {

--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -73,14 +73,15 @@ proto_ncm_setup() {
 
 	[ -n "$delay" ] && sleep "$delay"
 
-	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }'`
+	json_load "$(cat /etc/gcom/ncm.json)"
+	json_get_keys supported
+	manufacturer=`gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'index("'"$supported"'",$1){f=1;print tolower($1);exit} END{exit 1-f}'`
 	[ $? -ne 0 ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED
 		return 1
 	}
 
-	json_load "$(cat /etc/gcom/ncm.json)"
 	json_select "$manufacturer"
 	[ $? -ne 0 ] && {
 		echo "Unsupported modem"


### PR DESCRIPTION
My Huawei E3372h-153 on random manages to produce rssi instead of manufacturer name:
```
root@LEDE:~# gcom -d /dev/ttyUSB0 -s /etc/gcom/getcardinfo.gcom  | awk 'NF && $0
 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }'
^rssi:31
root@LEDE:~#
```
This patch passes through only supported values, otherwise preserving original functionality. Also awk's exit code made to mimic grep

How to reopen PR? I know it's been nearly 2 years, but got bit by this again