### PR TITLE
mbedtls: Don't override optimization set by upstream

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -64,6 +64,7 @@ endef
 PKG_INSTALL:=1
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
 
 CMAKE_OPTIONS += \
 	-DCMAKE_BUILD_TYPE:String="Release" \


### PR DESCRIPTION
Don't override optimization set by upstream.
Provides a small speed increase, verified using OpenVPN on ramips and
mvebu.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>