### PR TITLE
apm821xx: Force Ethernet PHYID on MX60/MX60W

### DIFF
--- a/target/linux/apm821xx/dts/meraki-mx60.dts
+++ b/target/linux/apm821xx/dts/meraki-mx60.dts
@@ -107,7 +107,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		phy0: ethernet-phy@0 {
-			device_type = "ethernet-phy";
+			compatible = "ethernet-phy-id004d.d034";
 			reg = <0>;
 			qca,ar8327-initvals = <
 				0x0010 0x40000000


### PR DESCRIPTION
The MX60's uboot disables all the PHYs before starting linux.
This causes the PHY/switch detection code to malfunction
almost all of the time. To get around this, set a compatible
flag to force PHYID.

This bug was introduced when moving to 4.14 kernel, as 4.9 had a reset added at https://github.com/openwrt/openwrt/blob/e97f92bbf90470329085ffe2a7610d5a413e75e2/target/linux/apm821xx/patches-4.9/702-powerpc_ibm_phy_add_dt_parser.patch#L80

Signed-off-by: Christian Lamparter <chunkeey@googlemail.com>
Signed-off-by: Chris Blake <chrisrblake93@gmail.com>