### PR TITLE
env: only use color diffs on terminals

### DIFF
--- a/scripts/env
+++ b/scripts/env
@@ -104,7 +104,7 @@ env_list() {
 env_diff() {
 	env_init
 	env_sync_data
-	git diff --cached --color
+	git diff --cached --color=auto
 	env_link_config
 }
 


### PR DESCRIPTION
When sending `script/env diff`'s output to a file or pipeline, you
don't want escape characters for ANSI color sequences fouling the
byte stream.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
