### PR TITLE
uqmi: improvements

### DIFF
--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uqmi
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uqmi.git

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -90,7 +90,7 @@ proto_qmi_setup() {
 			mnc=${plmn:3}
 			echo "Setting PLMN to $plmn"
 		fi
-		uqmi -s -d "$device" --set-plmn --mcc "$mcc" --mnc "$mnc" || {
+		uqmi -s -d "$device" --set-plmn --mcc "$mcc" --mnc "$mnc" > /dev/null 2>&1 || {
 			echo "Unable to set PLMN"
 			proto_notify_error "$interface" PLMN_FAILED
 			proto_block_restart "$interface"
@@ -99,11 +99,11 @@ proto_qmi_setup() {
 	}
 
 	# Cleanup current state if any
-	uqmi -s -d "$device" --stop-network 0xffffffff --autoconnect
+	uqmi -s -d "$device" --stop-network 0xffffffff --autoconnect > /dev/null 2>&1
 
 	# Set IP format
-	uqmi -s -d "$device" --set-data-format 802.3
-	uqmi -s -d "$device" --wda-set-data-format 802.3
+	uqmi -s -d "$device" --set-data-format 802.3 > /dev/null 2>&1
+	uqmi -s -d "$device" --wda-set-data-format 802.3 > /dev/null 2>&1
 	dataformat="$(uqmi -s -d "$device" --wda-get-data-format)"
 
 	if [ "$dataformat" = '"raw-ip"' ]; then
@@ -117,7 +117,7 @@ proto_qmi_setup() {
 		echo "Y" > /sys/class/net/$ifname/qmi/raw_ip
 	fi
 
-	uqmi -s -d "$device" --sync
+	uqmi -s -d "$device" --sync > /dev/null 2>&1
 
 	echo "Waiting for network registration"
 	while uqmi -s -d "$device" --get-serving-system | grep '"searching"' > /dev/null; do
@@ -125,7 +125,7 @@ proto_qmi_setup() {
 		sleep 5;
 	done
 
-	[ -n "$modes" ] && uqmi -s -d "$device" --set-network-modes "$modes"
+	[ -n "$modes" ] && uqmi -s -d "$device" --set-network-modes "$modes" > /dev/null 2>&1
 
 	echo "Starting network $interface"
 
@@ -147,7 +147,7 @@ proto_qmi_setup() {
 			return 1
 		fi
 
-		uqmi -s -d "$device" --set-client-id wds,"$cid_4" --set-ip-family ipv4 > /dev/null
+		uqmi -s -d "$device" --set-client-id wds,"$cid_4" --set-ip-family ipv4 > /dev/null 2>&1
 
 		pdh_4=$(uqmi -s -d "$device" --set-client-id wds,"$cid_4" \
 			--start-network \
@@ -161,7 +161,7 @@ proto_qmi_setup() {
 		# pdh_4 is a numeric value on success
 		if ! [ "$pdh_4" -eq "$pdh_4" ] 2> /dev/null; then
 			echo "Unable to connect IPv4"
-			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds
+			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds > /dev/null 2>&1
 			proto_notify_error "$interface" CALL_FAILED
 			return 1
 		fi
@@ -170,7 +170,7 @@ proto_qmi_setup() {
 		connstat=$(uqmi -s -d "$device" --get-data-status)
 		[ "$connstat" == '"connected"' ] || {
 			echo "No data link!"
-			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds
+			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds > /dev/null 2>&1
 			proto_notify_error "$interface" CALL_FAILED
 			return 1
 		}
@@ -184,7 +184,7 @@ proto_qmi_setup() {
 			return 1
 		fi
 
-		uqmi -s -d "$device" --set-client-id wds,"$cid_6" --set-ip-family ipv6 > /dev/null
+		uqmi -s -d "$device" --set-client-id wds,"$cid_6" --set-ip-family ipv6 > /dev/null 2>&1
 
 		pdh_6=$(uqmi -s -d "$device" --set-client-id wds,"$cid_6" \
 			--start-network \
@@ -198,7 +198,7 @@ proto_qmi_setup() {
 		# pdh_6 is a numeric value on success
 		if ! [ "$pdh_6" -eq "$pdh_6" ] 2> /dev/null; then
 			echo "Unable to connect IPv6"
-			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds
+			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds > /dev/null 2>&1
 			proto_notify_error "$interface" CALL_FAILED
 			return 1
 		fi
@@ -207,7 +207,7 @@ proto_qmi_setup() {
 		connstat=$(uqmi -s -d "$device" --get-data-status)
 		[ "$connstat" == '"connected"' ] || {
 			echo "No data link!"
-			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds
+			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds > /dev/null 2>&1
 			proto_notify_error "$interface" CALL_FAILED
 			return 1
 		}

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -70,7 +70,15 @@ proto_qmi_setup() {
 
 	while uqmi -s -d "$device" --get-pin-status | grep '"UIM uninitialized"' > /dev/null; do
 		[ -e "$device" ] || return 1
-		sleep 1;
+		if [ "$uninitialized_timeout" -lt "$timeout" ]; then
+			let uninitialized_timeout++
+			sleep 1;
+		else
+			echo "SIM not initialized"
+			proto_notify_error "$interface" SIM_NOT_INITIALIZED
+			proto_block_restart "$interface"
+			return 1
+		fi
 	done
 
 	[ -n "$pincode" ] && {

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -123,9 +123,18 @@ proto_qmi_setup() {
 	uqmi -s -d "$device" --sync > /dev/null 2>&1
 
 	echo "Waiting for network registration"
+	local registration_timeout=0
 	while uqmi -s -d "$device" --get-serving-system | grep '"searching"' > /dev/null; do
 		[ -e "$device" ] || return 1
-		sleep 5;
+		if [ "$registration_timeout" -lt "$timeout" ]; then
+			let registration_timeout++
+			sleep 1;
+		else
+			echo "Network registration failed"
+			proto_notify_error "$interface" NETWORK_REGISTRATION_FAILED
+			proto_block_restart "$interface"
+			return 1
+		fi
 	done
 
 	[ -n "$modes" ] && uqmi -s -d "$device" --set-network-modes "$modes" > /dev/null 2>&1

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -94,6 +94,7 @@ proto_qmi_setup() {
 		. /usr/share/libubox/jshn.sh
 		json_load "$(uqmi -s -d "$device" --get-pin-status)"
 		json_get_var pin1_status pin1_status
+		json_get_var pin1_verify_tries pin1_verify_tries
 
 		case "$pin1_status" in
 			disabled)
@@ -106,6 +107,12 @@ proto_qmi_setup() {
 				return 1
 				;;
 			not_verified)
+				[ "$pin1_verify_tries" -lt "3" ] && {
+					echo "PIN verify count value is $pin1_verify_tries this is below the limit of 3"
+					proto_notify_error "$interface" PIN_TRIES_BELOW_LIMIT
+					proto_block_restart "$interface"
+					return 1
+				}
 				if [ -n "$pincode" ]; then
 					uqmi -s -d "$device" --verify-pin1 "$pincode" > /dev/null 2>&1 || uqmi -s -d "$device" --uim-verify-pin1 "$pincode" > /dev/null 2>&1 || {
 						echo "Unable to verify PIN"

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -22,17 +22,20 @@ proto_qmi_init_config() {
 	proto_config_add_boolean dhcpv6
 	proto_config_add_boolean autoconnect
 	proto_config_add_int plmn
+	proto_config_add_int timeout
 	proto_config_add_defaults
 }
 
 proto_qmi_setup() {
 	local interface="$1"
 	local dataformat connstat
-	local device apn auth username password pincode delay modes pdptype profile dhcpv6 autoconnect plmn $PROTO_DEFAULT_OPTIONS
+	local device apn auth username password pincode delay modes pdptype profile dhcpv6 autoconnect plmn timeout $PROTO_DEFAULT_OPTIONS
 	local ip4table ip6table
 	local cid_4 pdh_4 cid_6 pdh_6
 	local ip_6 ip_prefix_length gateway_6 dns1_6 dns2_6
-	json_get_vars device apn auth username password pincode delay modes pdptype profile dhcpv6 autoconnect plmn ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn auth username password pincode delay modes pdptype profile dhcpv6 autoconnect plmn ip4table ip6table timeout $PROTO_DEFAULT_OPTIONS
+
+	[ "$timeout" = "" ] && timeout="10"
 
 	[ "$metric" = "" ] && metric="0"
 

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -158,7 +158,7 @@ proto_qmi_setup() {
 			${password:+--password $password} \
 			${autoconnect:+--autoconnect})
 
-        # pdh_4 is a numeric value on success
+		# pdh_4 is a numeric value on success
 		if ! [ "$pdh_4" -eq "$pdh_4" ] 2> /dev/null; then
 			echo "Unable to connect IPv4"
 			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds
@@ -166,14 +166,14 @@ proto_qmi_setup() {
 			return 1
 		fi
 
-        # Check data connection state
+		# Check data connection state
 		connstat=$(uqmi -s -d "$device" --get-data-status)
-                [ "$connstat" == '"connected"' ] || {
-                        echo "No data link!"
-                        uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds
-                        proto_notify_error "$interface" CALL_FAILED
-                        return 1
-                }
+		[ "$connstat" == '"connected"' ] || {
+			echo "No data link!"
+			uqmi -s -d "$device" --set-client-id wds,"$cid_4" --release-client-id wds
+			proto_notify_error "$interface" CALL_FAILED
+			return 1
+		}
 	}
 
 	[ "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && {
@@ -195,7 +195,7 @@ proto_qmi_setup() {
 			${password:+--password $password} \
 			${autoconnect:+--autoconnect})
 
-        # pdh_6 is a numeric value on success
+		# pdh_6 is a numeric value on success
 		if ! [ "$pdh_6" -eq "$pdh_6" ] 2> /dev/null; then
 			echo "Unable to connect IPv6"
 			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds
@@ -203,14 +203,14 @@ proto_qmi_setup() {
 			return 1
 		fi
 
-        # Check data connection state
+		# Check data connection state
 		connstat=$(uqmi -s -d "$device" --get-data-status)
-                [ "$connstat" == '"connected"' ] || {
-                        echo "No data link!"
-                        uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds
-                        proto_notify_error "$interface" CALL_FAILED
-                        return 1
-                }
+		[ "$connstat" == '"connected"' ] || {
+			echo "No data link!"
+			uqmi -s -d "$device" --set-client-id wds,"$cid_6" --release-client-id wds
+			proto_notify_error "$interface" CALL_FAILED
+			return 1
+		}
 	}
 
 	echo "Setting up $ifname"


### PR DESCRIPTION
Changes:
* uqmi: fix indenting
fix indenting

* uqmi: redirect uqmi commands output to /dev/null
Move uqmi std and error output on commands without using them to /dev/null.
This will remove useless outputs in the syslog.

*   uqmi: do not block proto handler if SIM is uninitialized
QMI proto setup-handler will wait forever if SIM does not get initialized.
To fix this stop polling pin status and notify netifd. Netifd will generate
then a "ifup-failed" ACTION.

* uqmi: do not block proto handler if modem is unable to registrate
QMI proto setup-handler will wait forever if it is unable to registrate to
the mobile network. To fix this stop polling network registration status
and notify netifd. Netifd will generate then a "ifup-failed" ACTION.

*  uqmi: add timeout option value
This value will be used for now during following situations:
Ask the sim with the uqmi --get-pin-status command.
Wait for network registration with the uqmi --get-serving-system command.
This two commands wait forever in a while loop. Add a timeout to stop
waiting and so inform netifd.

*  uqmi: update PKG_RELEASE version
update PKG_RELEASE

*  uqmi: evaluate pin-status output in qmi_setup function
Load the json output from uqmi --get-pin-status command and evaluate the
"pin1_status" value. If this is supported by the modem.
The following uqmi "pin1_status" values are evaluated:
**disabled**:
Do not verify PIN because SIM verification is disabled on this SIM
**blocked**:
Stop qmi_setup because SIM is locked and a PUK is required
**not_verified**:
SIM is not yet verified. Do a uqmi --verify-pin1 command if a SIM is
specified
**verified**:
Do not verify the PIN because this was already done before

*  uqmi: stop proto handler if verify pin count is not 3
Check pin count value from pin status and stop verification the pin if
the value is less then 3. This should prevent the proto-handler to
lock the SIM. If SIM is locked then the PUK is needed.