### PR TITLE
unpack.mk: add lz support

### DIFF
--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -44,6 +44,9 @@ ifeq ($(strip $(UNPACK_CMD)),)
     ifeq ($(EXT),zip)
       UNPACK_CMD=$(UNZIP_CMD)
     endif
+    ifeq ($(EXT),lz)
+      UNPACK_CMD=$(DECOMPRESS_CMD) $(TAR_CMD) --lzip
+    endif
   endif
 
   # compatibility code for packages that set PKG_CAT


### PR DESCRIPTION
for *.tar.lz, tar asks for explicit --lzip option
lzip package needs to be installed on the host system

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
