### PR TITLE
kernel: add kmod-tcp-bbr

### DIFF
--- a/package/kernel/linux/files/sysctl-tcp-bbr-k4_9.conf
+++ b/package/kernel/linux/files/sysctl-tcp-bbr-k4_9.conf
@@ -1,0 +1,5 @@
+# Do not edit, changes to this file will be lost on upgrades
+# /etc/sysctl.conf can be used to customize sysctl settings
+
+net.ipv4.tcp_congestion_control=bbr
+net.core.default_qdisc=fq

--- a/package/kernel/linux/files/sysctl-tcp-bbr.conf
+++ b/package/kernel/linux/files/sysctl-tcp-bbr.conf
@@ -1,0 +1,4 @@
+# Do not edit, changes to this file will be lost on upgrades
+# /etc/sysctl.conf can be used to customize sysctl settings
+
+net.ipv4.tcp_congestion_control=bbr

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -777,6 +777,37 @@ endef
 $(eval $(call KernelPackage,sched))
 
 
+define KernelPackage/tcp-bbr
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=BBR TCP congestion control
+  DEPENDS:=@!LINUX_3_18 @!LINUX_4_1 @!LINUX_4_4 +LINUX_4_9:kmod-sched
+  KCONFIG:= \
+	CONFIG_TCP_CONG_ADVANCED=y \
+	CONFIG_TCP_CONG_BBR
+  FILES:=$(LINUX_DIR)/net/ipv4/tcp_bbr.ko
+  AUTOLOAD:=$(call AutoLoad,74,tcp_bbr)
+endef
+
+define KernelPackage/tcp-bbr/description
+ Kernel module for BBR (Bottleneck Bandwidth and RTT) TCP congestion
+ control. It requires the fq ("Fair Queue") pacing packet scheduler.
+ For kernel 4.13+, TCP internal pacing is implemented as fallback.
+endef
+
+ifdef CONFIG_LINUX_4_9
+  TCP_BBR_SYSCTL_CONF:=sysctl-tcp-bbr-k4_9.conf
+else
+  TCP_BBR_SYSCTL_CONF:=sysctl-tcp-bbr.conf
+endif
+
+define KernelPackage/tcp-bbr/install
+	$(INSTALL_DIR) $(1)/etc/sysctl.d
+	$(INSTALL_DATA) ./files/$(TCP_BBR_SYSCTL_CONF) $(1)/etc/sysctl.d/12-tcp-bbr.conf
+endef
+
+$(eval $(call KernelPackage,tcp-bbr))
+
+
 define KernelPackage/ax25
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=AX25 support


### PR DESCRIPTION
This adds support for BBR (Bottleneck Bandwidth and RTT) TCP
congestion control. Applications (e.g. webservers, VPN client/server)
which initiate connections from router side can benefit from this.

This provide an easier way for users to use BBR by selecting /
installing kmod-tcp-bbr instead of altering kernel config and
compiling firmware by themselves.

Signed-off-by: Keith Wong <keithwky@gmail.com>
