### PR TITLE
ramips: add support for Ravpower WD03

### DIFF
--- a/package/system/procd/files/hotplug-preinit.json
+++ b/package/system/procd/files/hotplug-preinit.json
@@ -12,7 +12,9 @@
 		]
 	} ],
 	[ "if",
-		[ "eq", "SUBSYSTEM", "button" ],
+		["and",
+			[ "eq", "SUBSYSTEM", "button" ],
+			[ "not" , [ "eq", "BUTTON", "eject" ] ] ],
 		[ "exec", "/etc/rc.button/failsafe" ]
 	]
 ]

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -207,6 +207,7 @@ ramips_setup_interfaces()
 	ubnt-erx|\
 	ubnt-erx-sfp|\
 	ur-326n4g|\
+	wd03|\
 	wrtnode|\
 	wrtnode2p | \
 	wrtnode2r | \

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -559,6 +559,9 @@ ramips_board_detect() {
 	*"WCR-150GN")
 		name="wcr-150gn"
 		;;
+        *"WD-03")
+                name="wd03"
+                ;;
 	*"WE1026-5G (16M)")
 		name="we1026-5g-16m"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,7 @@ platform_check_image() {
 	w2914nsv2|\
 	w306r-v20|\
 	w502u|\
+	wd03|\
 	wf-2881|\
 	whr-1166d|\
 	whr-300hp2|\

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -480,6 +480,14 @@ define Device/vonets_var11n-300
 endef
 TARGET_DEVICES += vonets_var11n-300
 
+define Device/wd03
+  DTS := WD03
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := Ravpower WD03
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76
+endef
+TARGET_DEVICES += wd03
+
 define Device/whr-1166d
   DTS := WHR-1166D
   IMAGE_SIZE := 15040k


### PR DESCRIPTION
The RavPower WD03 is a battery powered SD card reader and a USB port.

Specifications:
MediaTek MT7620N
Battery 6000mah
802.11bg
1x 10/100 Mbps Ethernet
1x USB 2.0 (Type-A)
Ram : 32 Mb
8 MB Flash
Sd Card reader

I add to change the hotplug script as inserting an SD card triggers a button event (which is usefull to mount it automatically) but make openwrt enter failsafe mode.


Signed-off-by: badzz <mbadaire@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
