### PR TITLE
ramips: add support for Ravpower WD03

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -207,6 +207,7 @@ ramips_setup_interfaces()
 	ubnt-erx|\
 	ubnt-erx-sfp|\
 	ur-326n4g|\
+	ravpower,wd03|\
 	wrtnode|\
 	wrtnode2p | \
 	wrtnode2r | \

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,7 @@ platform_check_image() {
 	w2914nsv2|\
 	w306r-v20|\
 	w502u|\
+	ravpower,wd03|\
 	wf-2881|\
 	whr-1166d|\
 	whr-300hp2|\

--- a/target/linux/ramips/dts/WD03.dts
+++ b/target/linux/ramips/dts/WD03.dts
@@ -1,0 +1,119 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ravpower,wd03", "ralink,mt7620a-soc";
+	model = "Ravpower WD03";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		green-wifi {
+			label = "wd03:green:wifi";
+			gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		};
+
+
+		blue-wifi {
+			label = "wd03:blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		reset {
+			label = "reset";
+			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		KEY_EJECTCD {
+			label = "sdcard";
+			gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_EJECTCD>;
+		};
+
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+		
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4000>;
+	ralink,port-map = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wled","ephy";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -480,6 +480,14 @@ define Device/vonets_var11n-300
 endef
 TARGET_DEVICES += vonets_var11n-300
 
+define Device/ravpower_wd03
+  DTS := WD03
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := Ravpower WD03
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-usb-ehci
+endef
+TARGET_DEVICES += ravpower_wd03
+
 define Device/whr-1166d
   DTS := WHR-1166D
   IMAGE_SIZE := 15040k


### PR DESCRIPTION
The RavPower WD03 is a battery powered SD card reader and a USB port.

Specifications:
SOC: MediaTek MT7620N
BATTERY:  6000mah
WLAN: 802.11bgn
1x 10/100 Mbps Ethernet
1x USB 2.0 (Type-A)
RAM: PM Tech PMD708416CTR-5CN 32 Mb
FLASH: Holtek HT66F40 - 8 MB Flash
LED: Power button and 4 leds to indicate power level of the battery (could not get control of that)
INPUT: Power, reset button, SD Card indicator (to detect insertion)
OTHER: Sd Card reader

Tested and working:
WARNING : You need an SDCard in the slot to let openwrt boot normally. If the card is in it, it will go in failsafe
 - Ethernet
 - 2.4 GHz WiFi (Correct MAC-address)
 - installation from tftp
 - OpenWRT sysupgrade (Preserving and non-preserving)
 - LEDs
 - Buttons

Installation
 - Download the sysupgrade image
 - Place it in the root of a clean TFTP server running on your computer.
 - Rename the image to "kernel" — be sure there is no file extension.
 - Plug the WD03 into your computer via ethernet.
 - Set your computer to use 10.10.10.254 as its IP address.
 - With your WD03 shut down, hold down the power button until the first white LED lights up.
 - Push and hold the reset button and release the power button. Continue holding the reset button for 30 seconds or until it begins searching for files on your TFTP server, whichever comes first.
 - The WD03 will look for your computer at 10.10.10.254 (its ip is 10.10.10.128) and install the kernel file. Once it has finished installation of the kernel file, it will search for a (nonexistent) rootfs file — when it begins searching for this file, shut down the WD03 by holding the power button normally.
 - Start up your WD03 normally.

WARNING : There is no procedure to revert to default stock firmware after installing openwrt

Signed-off-by: badzz <mbadaire@gmail.com>
