### PR TITLE
build: use busybox gzip compatible force option

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -134,7 +134,7 @@ define Build/lzma-no-dict
 endef
 
 define Build/gzip
-	gzip --force -9n -c $@ $(1) > $@.new
+	gzip -f -9n -c $@ $(1) > $@.new
 	@mv $@.new $@
 endef
 


### PR DESCRIPTION
commit 138c763 ("build: add --force option to gzip in Build/gzip")
added the --force flag to the gzip invocation.

Under environments with busybox gzip (e.g Alpine Linux), this fails
as busybox only recognizes "-f".

Both busybox and GNU gzip recognize "-f" as the force option, so use that.