### PR TITLE
scripts/download.pl: Fix distribution mirrors

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -258,9 +258,8 @@ foreach my $mirror (@ARGV) {
 }
 
 #push @mirrors, 'http://mirror1.openwrt.org';
-push @mirrors, 'http://sources.lede-project.org';
+push @mirrors, 'http://sources.openwrt.org';
 push @mirrors, 'http://mirror2.openwrt.org/sources';
-push @mirrors, 'http://downloads.openwrt.org/sources';
 
 while (!-f "$target/$filename") {
 	my $mirror = shift @mirrors;


### PR DESCRIPTION
Rename sources.lede-project.org to sources.openwrt.org
Remove last mirror as it returns 404

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>