### PR TITLE
ipq40xx: Remove unused reserved-memory nodes

### DIFF
--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-a42.dts
@@ -25,22 +25,6 @@
 	model = "OpenMesh A42";
 	compatible = "openmesh,a42", "qcom,ipq4019";
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-a42.dts
@@ -30,11 +30,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			no-map;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ex61x0v2.dtsi
@@ -25,22 +25,6 @@
 	model = "Netgear EX61X0v2";
 	compatible = "netgear,ex61x0v2", "qcom,ipq4019";
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-fritz4040.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-fritz4040.dts
@@ -36,11 +36,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			reusable;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-fritz4040.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-fritz4040.dts
@@ -31,22 +31,6 @@
 		led-upgrade = &flash;
 	};
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-jalapeno.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-jalapeno.dts
@@ -25,22 +25,6 @@
 	model = "8devices Jalapeno";
 	compatible = "8dev,jalapeno", "qcom,ipq4019";
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-jalapeno.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-jalapeno.dts
@@ -30,11 +30,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			no-map;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -36,22 +36,6 @@
 		led-upgrade = &power;
 	};
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -26,22 +26,6 @@
 	model = "Compex WPJ428";
 	compatible = "compex,wpj428", "qcom,ipq4019";
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -31,11 +31,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			no-map;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-gl-b1300.dts
@@ -40,31 +40,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		apps_bl@87000000 {
-			reg = <0x87000000 0x400000>;
-			no-map;
-		};
-
-		sbl@87400000 {
-			reg = <0x87400000 0x100000>;
-			no-map;
-		};
-
-		cnss_debug@87500000 {
-			reg = <0x87500000 0x600000>;
-			no-map;
-		};
-
-		cpu_context_dump@87b00000 {
-			reg = <0x87b00000 0x080000>;
-			no-map;
-		};
-
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			no-map;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-gl-b1300.dts
@@ -35,22 +35,6 @@
 		reg = <0x80000000 0x10000000>;
 	};
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
@@ -34,22 +34,6 @@
 		reg = <0x80000000 0x10000000>;
 	};
 
-	reserved-memory {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
-		ranges;
-
-		smem@87e00000 {
-			reg = <0x87e00000 0x080000>;
-			no-map;
-		};
-
-		tz@87e80000 {
-			reg = <0x87e80000 0x180000>;
-			no-map;
-		};
-	};
-
 	soc {
 		mdio@90000 {
 			status = "okay";

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
@@ -39,11 +39,6 @@
 		#size-cells = <0x1>;
 		ranges;
 
-		tz_apps@87b80000 {
-			reg = <0x87b80000 0x280000>;
-			reusable;
-		};
-
 		smem@87e00000 {
 			reg = <0x87e00000 0x080000>;
 			no-map;

--- a/target/linux/ipq40xx/patches-4.14/864-07-dts-ipq4019-ap-dk01.1-c1-add-spi-and-ram-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/864-07-dts-ipq4019-ap-dk01.1-c1-add-spi-and-ram-nodes.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm/boot/dts/qcom-ipq4019-ap.dk01.1-c1.dts
 +++ b/arch/arm/boot/dts/qcom-ipq4019-ap.dk01.1-c1.dts
-@@ -19,4 +19,112 @@
+@@ -19,4 +19,87 @@
  / {
  	model = "Qualcomm Technologies, Inc. IPQ40xx/AP-DK01.1-C1";
  
@@ -13,31 +13,6 @@
 +		#address-cells = <0x1>;
 +		#size-cells = <0x1>;
 +		ranges;
-+
-+		apps_bl@87000000 {
-+			reg = <0x87000000 0x400000>;
-+			no-map;
-+		};
-+
-+		sbl@87400000 {
-+			reg = <0x87400000 0x100000>;
-+			no-map;
-+		};
-+
-+		cnss_debug@87500000 {
-+			reg = <0x87500000 0x600000>;
-+			no-map;
-+		};
-+
-+		cpu_context_dump@87b00000 {
-+			reg = <0x87b00000 0x080000>;
-+			no-map;
-+		};
-+
-+		tz_apps@87b80000 {
-+			reg = <0x87b80000 0x280000>;
-+			no-map;
-+		};
 +
 +		smem@87e00000 {
 +			reg = <0x87e00000 0x080000>;

--- a/target/linux/ipq40xx/patches-4.14/864-07-dts-ipq4019-ap-dk01.1-c1-add-spi-and-ram-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/864-07-dts-ipq4019-ap-dk01.1-c1-add-spi-and-ram-nodes.patch
@@ -1,28 +1,12 @@
 --- a/arch/arm/boot/dts/qcom-ipq4019-ap.dk01.1-c1.dts
 +++ b/arch/arm/boot/dts/qcom-ipq4019-ap.dk01.1-c1.dts
-@@ -19,4 +19,87 @@
+@@ -19,4 +19,71 @@
  / {
  	model = "Qualcomm Technologies, Inc. IPQ40xx/AP-DK01.1-C1";
  
 +	memory {
 +		device_type = "memory";
 +		reg = <0x80000000 0x10000000>;
-+	};
-+
-+	reserved-memory {
-+		#address-cells = <0x1>;
-+		#size-cells = <0x1>;
-+		ranges;
-+
-+		smem@87e00000 {
-+			reg = <0x87e00000 0x080000>;
-+			no-map;
-+		};
-+
-+		tz@87e80000 {
-+			reg = <0x87e80000 0x180000>;
-+			no-map;
-+		};
 +	};
 +};
 +

--- a/target/linux/ipq40xx/patches-4.14/865-ARM-dts-ipq4019-Add-TZ-and-SMEM-reserved-regions.patch
+++ b/target/linux/ipq40xx/patches-4.14/865-ARM-dts-ipq4019-Add-TZ-and-SMEM-reserved-regions.patch
@@ -1,0 +1,88 @@
+From fc566294610fa49e9d8c31c4ecc9c82f49b11f59 Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven.eckelmann@openmesh.com>
+Date: Wed, 18 Apr 2018 09:10:44 +0200
+Subject: [PATCH] ARM: dts: ipq4019: Add TZ and SMEM reserved regions
+
+The QSEE (trustzone) is started on IPQ4019 before Linux is started.
+According to QCA, it is placed in in the the memory region
+0x87e80000-0x88000000 and must not be accessed directly. There is an
+additional memory region 0x87e00000-0x87E80000 smem which which can be used
+for communication with the TZ. The driver for the latter is not yet ready
+but it is still not allowed to use this memory region like any other
+memory region.
+
+Not reserving this memory region either leads to kernel crashes, kernel
+hangs (often during the boot) or bus errors for userspace programs. The
+latter happens when a program is using a memory region which is mapped to
+these physical memory regions.
+
+  [  571.758058] Unhandled fault: imprecise external abort (0xc06) at 0x01715ff8
+  [  571.758099] pgd = cebec000
+  [  571.763826] [01715ff8] *pgd=8e7fa835, *pte=87e7f75f, *ppte=87e7fc7f
+  Bus error
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@openmesh.com>
+
+Forwarded: https://patchwork.kernel.org/patch/10347459/
+---
+Cc: Sricharan Ramabadhran <srichara@qti.qualcomm.com>
+Cc: Senthilkumar N L <snlakshm@qti.qualcomm.com>
+
+There are additional memory regions which have to be initialized first by
+Linux. So they are currently not used. We were told by QCA that the
+features QSDK uses them for are:
+
+* crash dump feature
+  - a couple of regions used when 'qca,scm_restart_reason' dt node has the
+    value 'dload_status' not set to 1
+    + apps_bl <0x87000000 0x400000>
+    + sbl <0x87400000 0x100000>
+    + cnss_debug <0x87400000 0x100000>
+    + cpu_context_dump <0x87b00000 0x080000>
+  - required driver not available in Linux
+  - safe to remove
+* QSEE app execution
+  - region tz_apps <0x87b80000 0x280000>
+  - required driver not available in Linux
+  - safe to remove
+* communication with TZ/QSEE
+  - region smem <0x87b80000 0x280000>
+  - driver changes not yet upstreamed
+  - must not be removed because any access can crash kernel/program
+* trustzone (QSEE) private memory
+  - region tz <0x87e80000 0x180000>
+  - must not be removed because any access can crash kernel/program
+
+The problem with the missing regions was reported in 2016 [1]. So maybe
+this change qualifies for a stable@vger.kernel.org submission.
+
+[1] https://www.spinics.net/lists/linux-arm-msm/msg21536.html
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -23,6 +23,22 @@
+ 	compatible = "qcom,ipq4019";
+ 	interrupt-parent = <&intc>;
+ 
++	reserved-memory {
++		#address-cells = <0x1>;
++		#size-cells = <0x1>;
++		ranges;
++
++		smem_region: smem@87e00000 {
++			reg = <0x87e00000 0x080000>;
++			no-map;
++		};
++
++		tz@87e80000 {
++			reg = <0x87e80000 0x180000>;
++			no-map;
++		};
++	};
++
+ 	aliases {
+ 		spi0 = &spi_0;
+ 		spi1 = &spi_1;


### PR DESCRIPTION
The reserved-memory regions are mostly undocumented by QCA and are named very unspecific in the QSDK device trees. It was tried to clean them up by commit 71ed9f10a33e ("ipq40xx: Use detailed reserved memory for A42") and similar changes.

The features which require these regions were mostly unknown but Senthilkumar N L <snlakshm@qti.qualcomm.com> and Sricharan Ramabadhran <srichara@qti.qualcomm.com> provided some more insight in some of them:

* crash dump feature
  - a couple of regions used when 'qca,scm_restart_reason' dt node has the
    value 'dload_status' not set to 1
    + apps_bl <0x87000000 0x400000>
    + sbl <0x87400000 0x100000>
    + cnss_debug <0x87400000 0x100000>
    + cpu_context_dump <0x87b00000 0x080000>
  - required driver not available in Linux
  - safe to remove
* QSEE app execution
  - region tz_apps <0x87b80000 0x280000>
  - required driver not available in Linux
  - safe to remove
* communication with TZ/QSEE
  - region smem <0x87b80000 0x280000>
  - driver changes not yet upstreamed
  - must not be removed because any access can crash kernel/program
* trustzone (QSEE) private memory
  - region tz <0x87e80000 0x180000>
  - must not be removed because any access can crash kernel/program

Removing the unnecessary regions saves some kilobyte of reserved-memory and
cleans up the device tree:

* 2560 KiB
  - 8devices Jalapeno
  - AVM FRITZ!Box 4040
  - Compex WPJ428
  - Meraki MR33 Access Point
  - OpenMesh A42
* 14336 KiB
  - GL.iNet GL-B1300
  - Qualcomm Technologies, Inc. IPQ40xx/AP-DK01.1-C1

----

This is a result of a longer journey to get some documentation from QCA. We didn't receive any actual document but at least some info from the mentioned developers. I also gave @mkresin @chunkeey  access to parts of the discussion. I hope this is enough to them to understand why I think that tz and smem regions must be protected.

It also looks like Sricharan Ramabadhran will also add some reserved memory regions to the Linux AP-DK devices after I pointed out that some devices don't even boot or also have weird crashes when smem/tz are not marked as reserved memory.

I personally tested it on A42 and WPJ428. Devices which should be tested:

* 8devices Jalapeno: @robimarko 
* AVM FRITZ!Box 4040: @chunkeey 
* Meraki MR33 Access Point: @riptidewave93
* GL.iNet GL-B1300: @handongming
* Qualcomm Technologies, Inc. IPQ40xx/AP-DK01.1-C1: @yeryomin