### PR TITLE
Use upstream IPQ40xx BDFs

### DIFF
--- a/package/kernel/mac80211/patches/081-ath10k-calibration-variant.patch
+++ b/package/kernel/mac80211/patches/081-ath10k-calibration-variant.patch
@@ -1,5 +1,6 @@
+From d06f26c5c8a41f246a9c40862a77a55725cedbd3 Mon Sep 17 00:00:00 2001
 From: Sven Eckelmann <sven.eckelmann@openmesh.com>
-Date: Fri, 10 Mar 2017 09:06:15 +0100
+Date: Fri, 8 Dec 2017 11:37:42 +0100
 Subject: ath10k: search DT for qcom,ath10k-calibration-variant
 
 Board Data File (BDF) is loaded upon driver boot-up procedure. The right
@@ -7,7 +8,7 @@ board data file is identified on QCA4019 using bus, bmi-chip-id and
 bmi-board-id.
 
 The problem, however, can occur when the (default) board data file cannot
-fulfill the vendor requirements and it is necessary to use a different
+fulfill with the vendor requirements and it is necessary to use a different
 board data file.
 
 This problem was solved for SMBIOS by adding a special SMBIOS type 0xF8.
@@ -33,13 +34,16 @@ This would create the boarddata identifiers for the board-2.bin search
  *  bus=ahb,bmi-chip-id=0,bmi-board-id=17,variant=RT-AC58U
 
 Signed-off-by: Sven Eckelmann <sven.eckelmann@openmesh.com>
-
-Origin: other, https://patchwork.kernel.org/patch/9615185/
+Signed-off-by: Kalle Valo <kvalo@qca.qualcomm.com>
 ---
+ drivers/net/wireless/ath/ath10k/core.c | 40 ++++++++++++++++++++++++++++------
+ 1 file changed, 33 insertions(+), 7 deletions(-)
 
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index b29fdbd..6264e2c 100644
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -860,6 +860,25 @@ static int ath10k_core_check_smbios(stru
+@@ -860,6 +860,28 @@ static int ath10k_core_check_smbios(struct ath10k *ar)
  	return 0;
  }
  
@@ -57,7 +61,10 @@ Origin: other, https://patchwork.kernel.org/patch/9615185/
 +	if (!variant)
 +		return -ENODATA;
 +
-+	strscpy(ar->id.bdf_ext, variant, sizeof(ar->id.bdf_ext));
++	if (strscpy(ar->id.bdf_ext, variant, sizeof(ar->id.bdf_ext)) < 0)
++		ath10k_dbg(ar, ATH10K_DBG_BOOT,
++			   "bdf variant string is longer than the buffer can accommodate (variant: %s)\n",
++			    variant);
 +
 +	return 0;
 +}
@@ -65,7 +72,7 @@ Origin: other, https://patchwork.kernel.org/patch/9615185/
  static int ath10k_download_and_run_otp(struct ath10k *ar)
  {
  	u32 result, address = ar->hw_params.patch_load_addr;
-@@ -1231,19 +1250,19 @@ static int ath10k_core_create_board_name
+@@ -1231,19 +1253,19 @@ static int ath10k_core_create_board_name(struct ath10k *ar, char *name,
  	/* strlen(',variant=') + strlen(ar->id.bdf_ext) */
  	char variant[9 + ATH10K_SMBIOS_BDF_EXT_STR_LENGTH] = { 0 };
  
@@ -91,7 +98,7 @@ Origin: other, https://patchwork.kernel.org/patch/9615185/
  	scnprintf(name, name_len,
  		  "bus=%s,vendor=%04x,device=%04x,subsystem-vendor=%04x,subsystem-device=%04x%s",
  		  ath10k_bus_str(ar->hif.bus),
-@@ -2343,7 +2362,11 @@ static int ath10k_core_probe_fw(struct a
+@@ -2343,7 +2365,11 @@ static int ath10k_core_probe_fw(struct ath10k *ar)
  
  	ret = ath10k_core_check_smbios(ar);
  	if (ret)
@@ -104,3 +111,6 @@ Origin: other, https://patchwork.kernel.org/patch/9615185/
  
  	ret = ath10k_core_fetch_board_file(ar);
  	if (ret) {
+-- 
+cgit v1.1
+


### PR DESCRIPTION
Several `ipq40xx` devices require custom board calibration data. This was previously provided by the `ipq-wifi` pakage for nearly all these devices due to limitations on how the `ath10k` driver loaded firmware. These limitations have been gone for a while now, and the board calibration for several devices just got upstreamed into `ath10k-firmware`. Use the upstream BDFs wherever possible instead of providing our own in `ipq-wifi`.