### PR TITLE
ipq40xx: ex61x0v2: Disable unused GMACs

### DIFF
--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ex61x0v2.dtsi
@@ -88,6 +88,7 @@
 
 		edma@c080000 {
 			status = "okay";
+			qcom,num_gmac = <1>;
 		};
 	};
 


### PR DESCRIPTION
These devices have only one ethernet port. It doesn't make sense to expose the unused GMACs as separate network devices.