### PR TITLE
ath9k: bypass eeprom power limit

### DIFF
--- a/package/kernel/mac80211/patches/800-ath9k-bypass-eeprom-power.patch
+++ b/package/kernel/mac80211/patches/800-ath9k-bypass-eeprom-power.patch
@@ -1,0 +1,14 @@
+--- a/drivers/net/wireless/ath/ath9k/ar9003_eeprom.c
++++ b/drivers/net/wireless/ath/ath9k/ar9003_eeprom.c
+@@ -5142,6 +5142,11 @@ static void ar9003_hw_set_power_per_rate
+ 	scaledPower = ath9k_hw_get_scaled_power(ah, powerLimit,
+ 						antenna_reduction);
+ 
++	minCtlPower = (u8) min(MAX_RATE_POWER, scaledPower);
++	for (i = 0; i < ar9300RateSize; i++)
++		pPwrArray[i] = (u8) minCtlPower;
++	return;
++
+ 	if (is2ghz) {
+ 		/* Setup for CTL modes */
+ 		/* CTL_11B, CTL_11G, CTL_2GHT20 */


### PR DESCRIPTION
With this patch, the eeprom power limits are ignored
and regulatory domain limits are considered.

Signed-off-by: Lorenzo Santina <lorenzo.santina@edu.unito.it>

