### PR TITLE
zram-swap: Support more zram config options

### DIFF
--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zram-swap
-PKG_VERSION:=1
+PKG_VERSION:=1.1
 PKG_RELEASE:=2
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -93,6 +93,19 @@ zram_comp_algo()
 	fi
 }
 
+zram_comp_streams()
+{
+	local dev="$1"
+	local logical_cpus=$( grep -ci "^processor" /proc/cpuinfo )
+	[ $logical_cpus -gt 1 ] || return 1
+	local zram_comp_streams="$( uci -q get system.@system[0].zram_comp_streams )"
+	[ -n "$zram_comp_streams" ] && [ "$zram_comp_streams" -le "$logical_cpus" ] || zram_comp_streams=$logical_cpus
+	if [ -e /sys/block/$( basename $dev )/max_comp_streams ]; then
+		logger -s -t zram_comp_streams -p daemon.debug "Set max compression streams to '$zram_comp_streams' for zram '$dev'"
+		echo $zram_comp_streams > /sys/block/$( basename $dev )/max_comp_streams
+	fi
+}
+
 start()
 {
 	local zram_size="$( zram_size )"
@@ -110,6 +123,7 @@ start()
 
 	zram_reset "$zram_dev" "enforcing defaults"
 	zram_comp_algo "$zram_dev"
+	zram_comp_streams "$zram_dev"
 	echo $(( $zram_size * 1024 * 1024 )) >"/sys/block/$( basename "$zram_dev" )/disksize"
 	mkswap "$zram_dev"
 	swapon "$zram_dev"

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -69,6 +69,23 @@ zram_reset()
 	echo "1" >"$proc_entry"
 }
 
+zram_comp_algo()
+{
+	local dev="$1"
+	local zram_comp_algo="$( uci -q get system.@system[0].zram_comp_algo )"
+
+	if [ -z "$zram_comp_algo" ] || [ ! -e /sys/block/$( basename $dev )/comp_algorithm ]; then
+		return 0
+	fi
+
+	if [ `grep -c "$zram_comp_algo" /sys/block/$( basename $dev )/comp_algorithm` -ne 0 ]; then
+		logger -s -t zram_comp_algo -p daemon.debug "Set compression algorithm '$zram_comp_algo' for zram '$dev'"
+		echo $zram_comp_algo > "/sys/block/$( basename $dev )/comp_algorithm"
+	else
+		logger -s -t zram_comp_algo -p daemon.debug "Compression algorithm '$zram_comp_algo' is not supported for '$dev'"
+	fi
+}
+
 list_cpu_idx()
 {
 	# Offset by 1 if /dev/zram0 is in use by /tmp
@@ -108,6 +125,7 @@ start()
 
 		zram_reset "$zram_dev" "enforcing defaults"
 		echo $(( zram_size * 1024 * 1024 )) >"/sys/block/$( basename "$zram_dev" )/disksize"
+		zram_comp_algo "$zram_dev"
 		mkswap "$zram_dev"
 		swapon "$zram_dev"
 	} done

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -133,18 +133,16 @@ start()
 
 stop()
 {
-	local zram_dev proc_entry
+	local zram_dev
 
-	for core in $( list_cpu_idx ); do {
-		zram_dev="$( zram_dev "$core" )"
-		proc_entry="/sys/block/$( basename "$zram_dev" )/reset"
-
-		grep -sq ^"$zram_dev " /proc/swaps && {
-			logger -s -t zram_stop -p daemon.debug "deactivate swap $zram_dev"
-			swapoff "$zram_dev"
-		}
-
-		zram_reset "$zram_dev" "claiming memory back"
+	for zram_dev in $( grep zram /proc/swaps |awk '{print $1}' ); do {
+		logger -s -t zram_stop -p daemon.debug "deactivate swap $zram_dev"
+		swapoff "$zram_dev" && zram_reset "$zram_dev" "claiming memory back"
+		local dev_index="$( echo $zram_dev | grep -o "[0-9]*$" )"
+		if [ $dev_index -ne 0 ]; then
+			logger -s -t zram_stop -p daemon.debug "removing zram $zram_dev"
+			echo $dev_index > /sys/class/zram-control/hot_remove
+		fi
 	} done
 }
 

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -26,11 +26,6 @@ zram_applicable()
 {
 	local zram_dev="$1"
 
-	grep -sq ^"$zram_dev " /proc/swaps && {
-		logger -s -t zram_applicable -p daemon.notice "[OK] '$zram_dev' already active"
-		return 1
-	}
-
 	[ -e "$zram_dev" ] || {
 		logger -s -t zram_applicable -p daemon.crit "[ERROR] device '$zram_dev' not found"
 		return 1
@@ -54,9 +49,8 @@ zram_applicable()
 
 zram_dev()
 {
-	local core="$1"
-
-	echo "/dev/zram${core:-0}"
+	local idx="$1"
+	echo "/dev/zram${idx:-0}"
 }
 
 zram_reset()
@@ -67,6 +61,19 @@ zram_reset()
 
 	logger -s -t zram_reset -p daemon.debug "$message via $proc_entry"
 	echo "1" >"$proc_entry"
+}
+
+zram_getdev()
+{
+	#get unallocated zram dev
+	local zdev=$( zram_dev )
+
+	if [ "$(mount | grep $zdev)" ]; then
+		local idx=`cat /sys/class/zram-control/hot_add`
+		zdev="$( zram_dev $idx )"
+	fi
+
+	echo $zdev
 }
 
 zram_comp_algo()
@@ -86,49 +93,26 @@ zram_comp_algo()
 	fi
 }
 
-list_cpu_idx()
-{
-	# Offset by 1 if /dev/zram0 is in use by /tmp
-	if mount | grep -q /dev/zram0; then
-		local line i=1
-		# Hot-add new ZRAM device (if necessary)
-		if [ ! -b /dev/zram1 ]; then
-			cat /sys/class/zram-control/hot_add
-		fi
-	else
-		local line i=0
-	fi
-
-	while read line; do {
-		case "$line" in
-			[Pp]rocessor*)
-				echo $i
-				i=$(( i + 1 ))
-			;;
-		esac
-	} done <"/proc/cpuinfo"
-}
-
 start()
 {
-	# http://shmilyxbq-compcache.googlecode.com/hg/README
-	# if >1 cpu_core, reinit kmodule with e.g. num_devices=4
-
 	local zram_size="$( zram_size )"
-	local zram_dev core
+	local zram_dev
 
-	for core in $( list_cpu_idx ); do {
-		zram_dev="$( zram_dev "$core" )"
-		zram_applicable "$zram_dev" || return 1
+	if [ $( grep -cs zram /proc/swaps ) -ne 0 ]; then
+		logger -s -t zram_start -p daemon.notice "[OK] zram swap is already mounted"
+		return 1
+	fi
 
-		logger -s -t zram_start -p daemon.debug "activating '$zram_dev' for swapping ($zram_size MegaBytes)"
+	zram_dev="$( zram_getdev )"
+	zram_applicable "$zram_dev" || return 1
 
-		zram_reset "$zram_dev" "enforcing defaults"
-		echo $(( zram_size * 1024 * 1024 )) >"/sys/block/$( basename "$zram_dev" )/disksize"
-		zram_comp_algo "$zram_dev"
-		mkswap "$zram_dev"
-		swapon "$zram_dev"
-	} done
+	logger -s -t zram_start -p daemon.debug "activating '$zram_dev' for swapping ($zram_size MegaBytes)"
+
+	zram_reset "$zram_dev" "enforcing defaults"
+	zram_comp_algo "$zram_dev"
+	echo $(( $zram_size * 1024 * 1024 )) >"/sys/block/$( basename "$zram_dev" )/disksize"
+	mkswap "$zram_dev"
+	swapon "$zram_dev"
 }
 
 stop()


### PR DESCRIPTION
+ "compression algorithm" configuration
  Compression algorithms for zram are provided by kernel crypto API, could be
  any of [lzo|zl4|deflate|<some_more>] depending on kernel modules.
  Compress algo for zram-swap could be defined via 'zram_comp_algo' option in
  'system' section of '/etc/config/system' file,
  or via cli (for e.x. with 'uci set system.@system[0].zram_comp_algo=lz4 && uci commit system').
  check available algo's via 'cat /sys/block/zram0/comp_algorithm'

+ "max compression streams" configuration
  Config option to limit maximum compression streams for zram dev for multicore CPU's.
  This could be defined via 'zram_comp_streams' option in the 'system' section of '/etc/config/system' file
  or via cli (for e.x. with 'uci set system.@system[0].zram_comp_streams=2 && uci commit system').
  Default is number of logical CPU cores.

* fix: use only one zram swap device of the specified size instead of [N x $size] devices for multicore CPUs
  Now zram module uses multiple compression streams for each dev, so we do not need
  to create several zram devs to utilize multicore CPUs.

* fix: zram dev reset for multicore cpu devices
  "zram stop" could reset up to $(num_of_cores) zram devices even if some of those
  were not mounted as swap dev's. This fix tries to enumerate only swap zram dev's before making reset

* fix: hot-add new zram dev for swap if zram0 is already mounted (for ex. /tmp)

* remove hot-added zram devs on stop

tested on:
 - trunk mt7621 kern 4.14.32 multicore
 - lede 17.1 ar71 kern 4.4.92 single core
 - CC 15.05 ar71 kern 3.18.20 single core

Signed-off-by: Emil Muratov <gpm@hotplug.ru>
