### PR TITLE
ramips: Use patch-dtb for F5D8235 V1

### DIFF
--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -47,13 +47,11 @@ endef
 TARGET_DEVICES += dlink_dap-1522-a1
 
 define Device/f5d8235-v1
+  DTS := F5D8235_V1
   IMAGE_SIZE := 7744k
   DEVICE_TITLE := Belkin F5D8235 V1
   DEVICE_PACKAGES := kmod-switch-rtl8366s kmod-usb-core kmod-usb-ohci \
     kmod-usb-ohci-pci kmod-usb2 kmod-usb2-pci kmod-usb-ledtrig-usbport
-  DEVICE_DTS := F5D8235_V1
-  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
 endef
 TARGET_DEVICES += f5d8235-v1
 


### PR DESCRIPTION
The old DTB method (OWRTDTB) is not recognized by the boot process anymore with 4.9/4.14. This patch reuses KERNEL_DTB to get a valid DTB applied to the kernel image.

The box itself will not boot anyway because of [another issue](https://bugs.openwrt.org/index.php?do=details&task_id=1511) introduced with 4.14. This PR is only to fix the basic device support.