### PR TITLE
uboot-envtools: add support for ESPRESSObin and MACCHIATObin

### DIFF
--- a/package/boot/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-envtools/files/mvebu
@@ -28,6 +28,10 @@ armada-385-turris-omnia)
 armada-xp-linksys-mamba)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
 	;;
+globalscale,espressobin|\
+marvell,armada8040-mcbin)
+	ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
+	;;
 esac
 
 config_load ubootenv


### PR DESCRIPTION
Updated mvebu script to add support for ESPRESSObin and MACCHIATObin

Signed-off-by: Damir Samardzic <damir.samardzic@sartura.hr>
