### PR TITLE
ar71xx: add support for TP-LINK Archer C7 v5

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -477,6 +477,7 @@ ar71xx_setup_interfaces()
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	archer-c7-v4|\
+	archer-c7-v5|\
 	tl-wdr4300|\
 	tl-wr1041n-v2)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -66,6 +66,7 @@ get_status_led() {
 	archer-c60-v1|\
 	archer-c60-v2|\
 	archer-c7-v4|\
+	archer-c7-v5|\
 	fritz300e|\
 	gl-usb150|\
 	mr12|\

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -65,7 +65,8 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
-	archer-c7-v4)
+	archer-c7-v4|\
+	archer-c7-v5)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -476,6 +476,9 @@ ar71xx_board_detect() {
 	*"Archer C7 v4")
 		name="archer-c7-v4"
 		;;
+	*"Archer C7 v5")
+		name="archer-c7-v5"
+		;;
 	*"Archer C58 v1")
 		name="archer-c58-v1"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -212,6 +212,7 @@ platform_check_image() {
 	archer-c60-v1|\
 	archer-c60-v2|\
 	archer-c7-v4|\
+	archer-c7-v5|\
 	bullet-m|\
 	c-55|\
 	carambola2|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
@@ -66,6 +66,7 @@ obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V1)		+= mach-archer-c60-v1.o
 obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V2)		+= mach-archer-c60-v1.o
 obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
 obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7-v4.o
+obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7-v5.o
 obj-$(CONFIG_ATH79_MACH_ARDUINO_YUN)		+= mach-arduino-yun.o
 obj-$(CONFIG_ATH79_MACH_AW_NR580)		+= mach-aw-nr580.o
 obj-$(CONFIG_ATH79_MACH_BHR_4GRV2)		+= mach-bhr-4grv2.o

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v5.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v5.c
@@ -1,0 +1,207 @@
+/*
+ * Atheros ARCHER_C7 reference board support
+ *
+ * Copyright (c) 2018 Arvid E. Picciani <aep@exys.org>
+ * Copyright (c) 2017 Felix Fietkau <nbd@nbd.name>
+ * Copyright (c) 2014 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include <linux/platform_device.h>
+#include <linux/ath9k_platform.h>
+#include <linux/ar8216_platform.h>
+#include <linux/proc_fs.h>
+#include <linux/gpio.h>
+#include <linux/spi/spi_gpio.h>
+#include <linux/spi/74x164.h>
+
+#include <asm/mach-ath79/ar71xx_regs.h>
+
+#include "common.h"
+#include "dev-m25p80.h"
+#include "machtypes.h"
+#include "pci.h"
+#include "dev-eth.h"
+#include "dev-gpio-buttons.h"
+#include "dev-leds-gpio.h"
+#include "dev-spi.h"
+#include "dev-usb.h"
+#include "dev-wmac.h"
+
+
+#define ARCHER_C7_GPIO_BTN_RESET	5
+#define ARCHER_C7_GPIO_BTN_WPS_WIFI	2
+
+#define ARCHER_C7_GPIO_LED_WLAN5	9
+#define ARCHER_C7_GPIO_LED_POWER	6
+#define ARCHER_C7_GPIO_LED_USB		7
+#define ARCHER_C7_GPIO_LED_WPS		1
+#define ARCHER_C7_GPIO_LED_LAN1		8
+#define ARCHER_C7_GPIO_LED_LAN2		17
+#define ARCHER_C7_GPIO_LED_LAN3		16
+#define ARCHER_C7_GPIO_LED_LAN4		15
+#define ARCHER_C7_GPIO_LED_WAN_GREEN	21
+#define ARCHER_C7_GPIO_LED_WAN_AMBER	20
+#define ARCHER_C7_GPIO_LED_WLAN2	14
+#define ARCHER_C7_GPIO_USB_PWR   19
+
+#define ARCHER_C7_KEYS_POLL_INTERVAL        20     /* msecs */
+#define ARCHER_C7_KEYS_DEBOUNCE_INTERVAL    (3 * ARCHER_C7_KEYS_POLL_INTERVAL)
+
+#define ARCHER_C7_MAC0_OFFSET               0
+#define ARCHER_C7_MAC1_OFFSET               6
+#define ARCHER_C7_WMAC_CALDATA_OFFSET       0x1000
+
+#define ARCHER_C7_GPIO_MDC			3
+#define ARCHER_C7_GPIO_MDIO			4
+
+static struct gpio_led archer_c7_v5_leds_gpio[] __initdata = {
+	{
+		.name		= "archer-c7-v5:green:power",
+		.gpio		= ARCHER_C7_GPIO_LED_POWER,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:wps",
+		.gpio		= ARCHER_C7_GPIO_LED_WPS,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:wlan2g",
+		.gpio		= ARCHER_C7_GPIO_LED_WLAN2,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:wlan5g",
+		.gpio		= ARCHER_C7_GPIO_LED_WLAN5,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:lan1",
+		.gpio		= ARCHER_C7_GPIO_LED_LAN1,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:lan2",
+		.gpio		= ARCHER_C7_GPIO_LED_LAN2,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:lan3",
+		.gpio		= ARCHER_C7_GPIO_LED_LAN3,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:lan4",
+		.gpio		= ARCHER_C7_GPIO_LED_LAN4,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:wan",
+		.gpio		=  ARCHER_C7_GPIO_LED_WAN_GREEN,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:amber:wan",
+		.gpio		=  ARCHER_C7_GPIO_LED_WAN_AMBER,
+		.active_low	= 1,
+	}, {
+		.name		= "archer-c7-v5:green:usb",
+		.gpio		=  ARCHER_C7_GPIO_LED_USB,
+		.active_low	= 1,
+	},
+};
+
+static struct gpio_keys_button archer_c7_v5_gpio_keys[] __initdata = {
+        {
+                .desc           = "WPS and WIFI button",
+                .type           = EV_KEY,
+                .code           = KEY_WPS_BUTTON,
+                .debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
+                .gpio           = ARCHER_C7_GPIO_BTN_WPS_WIFI,
+                .active_low     = 1,
+        },
+        {
+                .desc           = "Reset button",
+                .type           = EV_KEY,
+                .code           = KEY_RESTART,
+                .debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
+                .gpio           = ARCHER_C7_GPIO_BTN_RESET,
+                .active_low     = 1,
+        },
+};
+
+
+static struct ar8327_pad_cfg archer_c7_v5_ar8337_pad0_cfg = {
+	.mode = AR8327_PAD_MAC_SGMII,
+	.sgmii_delay_en = true,
+};
+
+static struct ar8327_platform_data archer_c7_v5_ar8337_data = {
+	.pad0_cfg = &archer_c7_v5_ar8337_pad0_cfg,
+	.port0_cfg = {
+		.force_link = 1,
+		.speed = AR8327_PORT_SPEED_1000,
+		.duplex = 1,
+		.txpause = 1,
+		.rxpause = 1,
+	},
+};
+
+static struct mdio_board_info archer_c7_v5_mdio0_info[] = {
+	{
+		.bus_id = "ag71xx-mdio.0",
+		.phy_addr = 0,
+		.platform_data = &archer_c7_v5_ar8337_data,
+	},
+};
+
+
+static void __init archer_c7_v5_setup(void)
+{
+	u8 *art = (u8 *) KSEG1ADDR(0x1f050000);
+	u8 *mac = (u8 *) KSEG1ADDR(0x1f060008);
+
+	ath79_register_m25p80(NULL);
+
+
+	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c7_v5_leds_gpio),
+				archer_c7_v5_leds_gpio);
+
+	ath79_register_gpio_keys_polled(-1, ARCHER_C7_KEYS_POLL_INTERVAL,
+					ARRAY_SIZE(archer_c7_v5_gpio_keys),
+					archer_c7_v5_gpio_keys);
+
+	ath79_register_usb();
+
+	ath79_gpio_output_select(ARCHER_C7_GPIO_MDC, QCA956X_GPIO_OUT_MUX_GE0_MDC);
+	ath79_gpio_output_select(ARCHER_C7_GPIO_MDIO, QCA956X_GPIO_OUT_MUX_GE0_MDO);
+
+	ath79_register_mdio(0, 0x0);
+
+	mdiobus_register_board_info(archer_c7_v5_mdio0_info,
+				    ARRAY_SIZE(archer_c7_v5_mdio0_info));
+
+	gpio_request_one(ARCHER_C7_GPIO_USB_PWR,
+			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
+			 "USB power");
+
+	ath79_register_wmac(art + ARCHER_C7_WMAC_CALDATA_OFFSET, mac);
+	ath79_register_pci();
+
+	/* GMAC0 is connected to an AR8337 switch */
+	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
+	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
+	ath79_eth0_data.speed = SPEED_1000;
+	ath79_eth0_data.duplex = DUPLEX_FULL;
+	ath79_eth0_data.phy_mask = BIT(0);
+	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+	ath79_register_eth(0);
+}
+
+MIPS_MACHINE(ATH79_MACH_ARCHER_C7_V5, "ARCHER-C7-V5", "TP-LINK Archer C7 v5",
+	     archer_c7_v5_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -52,6 +52,7 @@ enum ath79_mach_type {
 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
 	ATH79_MACH_ARCHER_C7_V4,		/* TP-LINK Archer C7 V4 board */
+	ATH79_MACH_ARCHER_C7_V5,		/* TP-LINK Archer C7 V5 board */
 	ATH79_MACH_ARDUINO_YUN,			/* Yun */
 	ATH79_MACH_AW_NR580,			/* AzureWave AW-NR580 */
 	ATH79_MACH_BHR_4GRV2,			/* Buffalo BHR-4GRV2 */

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -141,6 +141,17 @@ define Device/archer-c7-v4
 endef
 TARGET_DEVICES += archer-c7-v4
 
+define Device/archer-c7-v5
+  $(Device/archer-c7-v4)
+  DEVICE_TITLE := TP-LINK Archer C7 v5
+  BOARDNAME := ARCHER-C7-V5
+  TPLINK_BOARD_ID := ARCHER-C7-V5
+  IMAGE_SIZE := 15104k
+  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,1536k@0xc0000(kernel),13824k(rootfs),15360k@0xc0000(firmware)
+  SUPPORTED_DEVICES := archer-c7-v5
+endef
+TARGET_DEVICES += archer-c7-v5
+
 define Device/cpe510-520-v1
   DEVICE_TITLE := TP-LINK CPE510/520 v1
   DEVICE_PACKAGES := rssileds

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -573,6 +573,52 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the C7 v5*/
+	{
+		.id = "ARCHER-C7-V5",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:Archer C7,product_ver:5.0.0,special_id:00000000}\n"
+			"{product_name:Archer C7,product_ver:5.0.0,special_id:55530000}\n",
+
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.0.0\n",
+
+		/**
+		  We use a bigger os-image partition than the stock images (and thus
+		  smaller file-system), as our kernel doesn't fit in the stock firmware's
+		  1MB os-image.
+		  */
+		.partitions = {
+			{"factory-boot",    0x00000,  0x20000},
+			{"fs-uboot",        0x20000,  0x20000},
+			{"partition-table", 0x40000,  0x10000},
+			{"radio",           0x50000,  0x10000},
+			{"default-mac",     0x60000,  0x00200},
+			{"pin",             0x60200,  0x00200},
+			{"device-id",       0x60400,  0x00100},
+			{"product-info",    0x60500,  0x0fb00},
+			{"soft-version",    0x70000,  0x01000},
+			{"extra-para",      0x71000,  0x01000},
+			{"support-list",    0x72000,  0x0a000},
+			{"profile",         0x7c000,  0x04000},
+			{"user-config",     0x80000,  0x40000},
+
+
+			{"os-image",        0xc0000,  0x180000}, /* Stock: base 0xc0000  size 0x120000 */
+			{"file-system",     0x240000, 0xd80000}, /* Stock: base 0x1e0000 size 0xde0000 */
+
+			{"log",             0xfc0000, 0x20000},
+			{"certificate",     0xfe0000, 0x10000},
+			{"default-config",  0xff0000, 0x10000},
+			{NULL, 0, 0}
+
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the C9 */
 	{
 		.id = "ARCHERC9",
@@ -1384,7 +1430,7 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
-	} else if (strcasecmp(info->id, "ARCHER-C7-V4") == 0) {
+	} else if (strcasecmp(info->id, "ARCHER-C7-V4") == 0 || strcasecmp(info->id, "ARCHER-C7-V5") == 0) {
 		const char mdat[11] = {0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0xca, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
 	}


### PR DESCRIPTION
TP-Link Archer C7 v5 is a dual-band AC1750 router, based on Qualcomm/Atheros
QCA9563+QCA9880.

Specification:

- 750/400/250 MHz (CPU/DDR/AHB
- 128 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- 3T3R 2.4 GHz
- 3T3R 5 GHz
- 5x 10/100/1000 Mbps Ethernet
- 10x LED, 2x button
- UART header on PCB

Flash instruction:
1. Upload lede-ar71xx-generic-archer-c7-v5-squashfs-factory.bin via Web interface

Flash instruction using TFTP recovery:
1. Set PC to fixed ip address 192.168.0.66
2. Download lede-ar71xx-generic-archer-c7-v5-squashfs-factory.bin
and rename it to ArcherC7v5_tp_recovery.bin
3. Start a tftp server with the file tp_recovery.bin in its root directory
4. Turn off the router
5. Press and hold Reset button
6. Turn on router with the reset button pressed and wait ~15 seconds
7. Release the reset button and after a short time
the firmware should be transferred from the tftp server
8. Wait ~30 second to complete recovery.

Signed-off-by: Arvid E. Picciani <aep@exys.org>