### PR TITLE
fix compilation error for macOS 10.13.3 (17D47)

### DIFF
--- a/scripts/bundle-libraries.sh
+++ b/scripts/bundle-libraries.sh
@@ -87,7 +87,12 @@ _runas_so() {
 			return 0;
 		}
 
-		__attribute__((section(".init_array")))
+		#ifdef __APPLE__
+			__attribute__((section("__DATA,__mod_init_func")))
+		#else
+			__attribute__((section(".init_array")))
+		#endif
+
 		static void *mangle_arg0_constructor = &mangle_arg0;
 	EOT
 


### PR DESCRIPTION
Fixes the following stacktrace:

```bash
<stdin>:16:24: error: argument to 'section' attribute is not valid for this target: mach-o section specifier requires a segment and section separated by a comma
__attribute__((section(".init_array")))
```


Inspiration:
https://bugs.openwrt.org/index.php?do=details&task_id=1493&pagenum=7&order=summary&sort=desc&order2=severity&sort2=desc