### PR TITLE
samba36: add hotplug script for autoshare

### DIFF
--- a/package/network/services/samba36/Makefile
+++ b/package/network/services/samba36/Makefile
@@ -60,6 +60,11 @@ define Package/samba36-server/config
 		int "Maximum level of compiled-in debug messages"
 		depends on PACKAGE_samba36-server || PACKAGE_samba36-client
 		default -1
+	config PACKAGE_SAMBA_SERVER_HOTPLUG
+		bool "Hotplug script of autoshare"
+		depends on PACKAGE_samba36-server
+		select PACKAGE_block-mount
+		default n
 endef
 
 define Package/samba36-server/description
@@ -147,6 +152,12 @@ define Package/samba36-server/install
 	$(INSTALL_CONF) ./files/samba.config $(1)/etc/config/samba
 	$(INSTALL_DIR) $(1)/etc/samba
 	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/samba
+ifeq ($(CONFIG_PACKAGE_SAMBA_SERVER_HOTPLUG),y)
+	$(INSTALL_DIR) $(1)/lib/samba
+	$(INSTALL_DATA) ./files/lib/samba.sh $(1)/lib/samba/samba.sh
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/block
+	$(INSTALL_DATA) ./files/samba.hotplug $(1)/etc/hotplug.d/block/60-samba
+endif
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/codepages/lowcase.dat $(1)/etc/samba
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/codepages/upcase.dat $(1)/etc/samba
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/codepages/valid.dat $(1)/etc/samba

--- a/package/network/services/samba36/files/lib/samba.sh
+++ b/package/network/services/samba36/files/lib/samba.sh
@@ -1,0 +1,83 @@
+. /lib/functions.sh
+
+FLAG_DEV_TYPE=
+FLAG_DEV_MOPT=
+FLAG_HAS_SECT=
+
+samba_dev_filter() { # <devname> <[path,/dev/]>
+	case $1 in
+	${2}mtdblock*|\
+	${2}ubi*)
+		FLAG_DEV_TYPE="mtd"
+		;;
+	${2}loop*|\
+	${2}mmcblk*|\
+	${2}sd*|\
+	${2}hd*|\
+	${2}md*|\
+	${2}nvme*|\
+	${2}vd*|\
+	${2}xvd*)
+		FLAG_DEV_TYPE="not-mtd"
+		;;
+	*)
+		[ -b ${2}${1} ] && FLAG_DEV_TYPE="not-mtd"
+		[ -b /dev/mapper/$1 ] && FLAG_DEV_TYPE="not-mtd"
+		;;
+	esac
+}
+
+samba_cfg_lookup() { # <section> <name>
+	config_get name $1 name
+	[ "$name" = "$2" ] || return
+	FLAG_HAS_SECT=y
+}
+
+samba_cfg_delete() { # <section> <name>
+	config_get name $1 name
+	[ "$name" = "$2" ] || return
+	uci -q delete samba.$1
+}
+
+samba_find_mount_point() { # <devname>
+	# search mount point in /proc/mounts
+	while read l; do
+		local d=$(echo $l | awk '/^\/dev/ {print $1}')
+		[ "$d" = "/dev/$1" ] || continue
+
+		FLAG_DEV_MOPT=$(echo $l | awk '/^\/dev/ {print $2}')
+		break
+	done < /proc/mounts
+}
+
+_samba_add_section() { # <devname> <mount point>
+	uci -q batch <<-EOF
+		add samba sambashare
+		set samba.@sambashare[-1].browseable='yes'
+		set samba.@sambashare[-1].name='$1'
+		set samba.@sambashare[-1].path='$2'
+		set samba.@sambashare[-1].users='root'
+		set samba.@sambashare[-1].read_only='no'
+		set samba.@sambashare[-1].guest_ok='yes'
+		set samba.@sambashare[-1].create_mask='0755'
+		set samba.@sambashare[-1].dir_mask='0755'
+	EOF
+}
+
+samba_add_section() { # <devname> [<mount point>]
+	FLAG_HAS_SECT=
+	FLAG_DEV_MOPT=
+
+	config_foreach samba_cfg_lookup sambashare $1
+	[ -z "$FLAG_HAS_SECT" ] || return
+
+	samba_find_mount_point $1
+	[ -n "$FLAG_DEV_MOPT" ] || return
+
+	[ -n "$2" -a "$2" = "$FLAG_DEV_MOPT" ] || \
+		_samba_add_section $1 $FLAG_DEV_MOPT
+}
+
+samba_delete_section() { # <devname>
+	config_foreach samba_cfg_delete sambashare $1
+}

--- a/package/network/services/samba36/files/samba.hotplug
+++ b/package/network/services/samba36/files/samba.hotplug
@@ -1,0 +1,11 @@
+. /lib/samba/samba.sh
+
+samba_dev_filter $DEVNAME
+[ "$FLAG_DEV_TYPE" = "not-mtd" ]  || exit
+
+config_load samba
+case $ACTION in
+	add) samba_add_section $DEVNAME;;
+	remove) samba_delete_section $DEVNAME;;
+esac
+uci commit


### PR DESCRIPTION
  Add hotplug handle script for storage devices,
  this will add corresponding option in the
  /etc/config/samba file automatically.

  If user do not want this feature, it can be cancel
  via samba relevant menu option.
