### PR TITLE
ramips: add support for B-Link BL-R7628AE4

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -36,6 +36,7 @@ wf-2881)
 	set_wifi_led "$boardname:amber:wlan"
 	set_usb_led "$boardname:blue:3g"
 	;;
+b-link,bl-r7628ae4|\
 3g-6200nl|\
 wnce2001)
 	set_wifi_led "$boardname:green:wlan"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -185,6 +185,7 @@ ramips_setup_interfaces()
 	atp-52b|\
 	awm002-evb-4M|\
 	awm002-evb-8M|\
+	b-link,bl-r7628ae4|\
 	c20i|\
 	dir-645|\
 	f5d8235-v2|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -31,6 +31,7 @@ platform_check_image() {
 	awm002-evb-4M|\
 	awm002-evb-8M|\
 	bc2|\
+	b-link,bl-r7628ae4|\
 	broadway|\
 	c108|\
 	carambola|\

--- a/target/linux/ramips/dts/BL-R7628AE4.dts
+++ b/target/linux/ramips/dts/BL-R7628AE4.dts
@@ -1,0 +1,98 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "b-link,bl-r7628ae4", "mediatek,mt7628an-soc";
+	model = "B-Link BL-R7628AE4";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x2000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "bl-r7628ae4:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "blink";
+			reg = <0x20000 0x10000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "config";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x3b0000>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -299,3 +299,11 @@ define Device/zbtlink_zbt-we1226
   DEVICE_TITLE := ZBTlink ZBT-WE1226
 endef
 TARGET_DEVICES += zbtlink_zbt-we1226
+
+define Device/b-link_bl-r7628ae4
+  DTS := BL-R7628AE4
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  DEVICE_TITLE := B-Link BL-R7628AE4
+endef
+TARGET_DEVICES += b-link_bl-r7628ae4


### PR DESCRIPTION
The model of this router is BL-WR4000. Only the PCB has the model name
"BL-R7628AE4" printed on it.

Specifications:
- MediaTek MT7628N/N (575 MHz)
- 32 MB RAM
- 4 MB Flash
- 802.11bgn radio
- 5x 10/100 Mbps Ethernet (1 WAN and 4 LAN)
- 7x LED (Power WLAN WAN LAN1-4)
- 1x Reset button

Flash instruction:

The only way to flash OpenWrt image in BL-R7628AE4 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.16.123/24 and tftp server.
2. Rename "openwrt-ramips-mt76x8-b-link_bl-r7628ae4-squashfs-sysupgrade.bin"
   to "uImage" and place it in tftp server directory.
3. Connect PC with the LAN port, press the reset button, power up
   the router and keep button pressed for around 6-7 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and
   reboot.

Known issue:
1. Turning on/off wireless cause ethernet disconnect and then connect. `lede-17.01` branch do not have this issue.
2. WAN/LAN leds always blinking if the port is connected. Same issue in `lede-17.01` branch.