### PR TITLE
ramips: Add SD Card support for HC5661A.

### DIFF
--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -18,6 +18,10 @@
 		reg = <0x0 0x8000000>;
 	};
 
+	sdhci@10130000 {
+		status = "okay";
+	};
+
 	gpio-leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/mt6575_sd.h
+++ b/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/mt6575_sd.h
@@ -234,6 +234,7 @@ enum {
 #define MSDC_IOCON_SDR104CKS    (0x1  << 0)     /* RW */
 #define MSDC_IOCON_RSPL         (0x1  << 1)     /* RW */
 #define MSDC_IOCON_DSPL         (0x1  << 2)     /* RW */
+#define MSDC_IOCON_WDSPL        (0x1  << 8)     /* RW */
 #define MSDC_IOCON_DDLSEL       (0x1  << 3)     /* RW */
 #define MSDC_IOCON_DDR50CKD     (0x1  << 4)     /* RW */
 #define MSDC_IOCON_DSPLSEL      (0x1  << 5)     /* RW */

--- a/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
@@ -1796,6 +1796,9 @@ static void msdc_ops_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 				      MSDC_SMPL_FALLING);
 			sdr_set_field(MSDC_IOCON, MSDC_IOCON_DSPL,
 				      MSDC_SMPL_FALLING);
+			/* sdxc: set sample crc by clock falling edge. Added by zhangzf */
+			if (ralink_soc == MT762X_SOC_MT7628AN)
+				sdr_set_field(MSDC_IOCON, MSDC_IOCON_WDSPL, MSDC_SMPL_FALLING);
 			//} /* for tuning debug */
 		} else { /* default value */
 			sdr_write32(MSDC_IOCON,      0x00000000);
@@ -2205,7 +2208,7 @@ static int msdc_drv_probe(struct platform_device *pdev)
 	struct msdc_host *host;
 	struct msdc_hw *hw;
 	int ret;
-	u32 reg;
+	u32 reg, reg1;
 
 	// Set the pins for sdxc to sdxc mode
 	//FIXME: this should be done by pinctl and not by the sd driver
@@ -2215,6 +2218,17 @@ static int msdc_drv_probe(struct platform_device *pdev)
 						  0x60)) & ~(0x3 << 18);
 		if (ralink_soc == MT762X_SOC_MT7620A)
 			reg |= 0x1 << 18;
+	}
+	else if (ralink_soc == MT762X_SOC_MT7628AN) {
+		/* Fixed MT7628 SDXC init by zhangzf */
+		reg &= ~((0x3 << 0)|(0x3 << 6)|(0x3 << 10)|(0x1 << 15)|(0x3 << 20)|(0x3 << 24));
+		reg |=  ((0x1 << 0)|(0x1 << 6)|(0x1 << 10)|(0x1 << 15)|(0x1 << 20)|(0x1 << 24));
+#if defined (CONFIG_MTK_MMC_EMMC_8BIT)
+		reg |= 0x3 << 26 | 0x3 << 28 | 0x3 << 30;
+#endif
+		reg1 = sdr_read32((void __iomem *)(RALINK_SYSCTL_BASE + 0x1340));
+		reg1 |= (0x1 << 11); //Normal mode(AP mode), SDXC CLK=PAD_GPIO0=GPIO11, driving = 8mA
+		sdr_write32((void __iomem *)(RALINK_SYSCTL_BASE + 0x1340), reg1);
 	} else {
 		reg = sdr_read32((void __iomem *)(RALINK_SYSCTL_BASE + 0x3c));
 		reg |= 0x1e << 16;

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -54,6 +54,8 @@ define Device/hc5661a
   DTS := HC5661A
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5661A
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+    kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += hc5661a
 


### PR DESCRIPTION
Now HC5661A has a SD Card driver while every network interfaces working well.

Thanks a lot to @gigibox 
Signed-off-by: LoveSy <shana@zju.edu.cn>