### PR TITLE
ramips: fix mt7628 ephy led always blinking

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mtk/esw_rt3050.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mtk/esw_rt3050.c
@@ -618,24 +618,29 @@ static void esw_hw_init(struct rt305x_esw *esw)
 		fe_reset(RT5350_RESET_EPHY);
 
 		rt305x_mii_write(esw, 0, 31, 0x2000); /* change G2 page */
-		rt305x_mii_write(esw, 0, 26, 0x0020);
+		rt305x_mii_write(esw, 0, 26, 0x0000);
 
 		for (i = 0; i < 5; i++) {
-			rt305x_mii_write(esw, i, 31, 0x8000);
+			rt305x_mii_write(esw, i, 31, 0x8000); /* change L0 page */
 			rt305x_mii_write(esw, i,  0, 0x3100);
+
+			/* disable EEE */
+			rt305x_mii_write(esw, i, 13, 0x7);
+			rt305x_mii_write(esw, i, 14, 0x3c);
+			rt305x_mii_write(esw, i, 13, 0x4007);
+			rt305x_mii_write(esw, i, 14, 0x0);
+
 			rt305x_mii_write(esw, i, 30, 0xa000);
-			rt305x_mii_write(esw, i, 31, 0xa000);
+			rt305x_mii_write(esw, i, 31, 0xa000); /* change L2 page */
 			rt305x_mii_write(esw, i, 16, 0x0606);
 			rt305x_mii_write(esw, i, 23, 0x0f0e);
 			rt305x_mii_write(esw, i, 24, 0x1610);
 			rt305x_mii_write(esw, i, 30, 0x1f15);
 			rt305x_mii_write(esw, i, 28, 0x6111);
-			rt305x_mii_write(esw, i, 31, 0x2000);
-			rt305x_mii_write(esw, i, 26, 0x0000);
 		}
 
 		/* 100Base AOI setting */
-		rt305x_mii_write(esw, 0, 31, 0x5000);
+		rt305x_mii_write(esw, 0, 31, 0x5000); /* change G5 page */
 		rt305x_mii_write(esw, 0, 19, 0x004a);
 		rt305x_mii_write(esw, 0, 20, 0x015a);
 		rt305x_mii_write(esw, 0, 21, 0x00ee);
@@ -648,6 +653,11 @@ static void esw_hw_init(struct rt305x_esw *esw)
 		rt305x_mii_write(esw, 0, 28, 0x0233);
 		rt305x_mii_write(esw, 0, 29, 0x000a);
 		rt305x_mii_write(esw, 0, 30, 0x0000);
+
+		/* Fix EPHY idle state abnormal behavior */
+		rt305x_mii_write(esw, 0, 31, 0x4000); /* change G4 page */
+		rt305x_mii_write(esw, 0, 29, 0x000d);
+		rt305x_mii_write(esw, 0, 30, 0x0500);
 	} else {
 		rt305x_mii_write(esw, 0, 31, 0x8000);
 		for (i = 0; i < 5; i++) {


### PR DESCRIPTION
After porting OpenWrt to B-Link BL-R7628AE4 (#909) I found WAN/LAN led always blinking if the port is connected. But the official firmware do not have such issue.
So I compared the source code of [MTK driver](https://gist.github.com/ysc3839/d88242927c48f792fe2ac6dd8f1023a4#file-raether-c-L3989) and found this fixes the issue.
It works on my B-Link BL-R7628AE4. But I don't know why it works.

There's a code in MTK driver:
```
mii_mgr_read(i, 4, &phy_val);
phy_val |= (1 << 10);
mii_mgr_write(i, 4, phy_val);
```
But I can't find `mii_mgr_read` function in OpenWrt driver, so I didn't add it.