### PR TITLE
ramips: add support for mqmaker witi 512mb version 

### DIFF
--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -280,6 +280,7 @@ get_status_led() {
 		;;
 	w306r-v20|\
 	witi|\
+	witi512|\
 	zbt-wr8305rt)
 		status_led="$boardname:green:sys"
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -580,6 +580,9 @@ ramips_board_detect() {
 	*"WiTi")
                 name="witi"
 		;;
+        *"WiTi-512")
+                name="witi-512"
+		;;
 	*"WIZARD 8800")
 		name="wizard8800"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -173,6 +173,7 @@ platform_check_image() {
 	widora,neo-16m|\
 	widora,neo-32m|\
 	witi|\
+	witi-512|\
 	wizfi630a|\
 	wl-330n|\
 	wl-330n3g|\

--- a/target/linux/ramips/base-files/sbin/fixup-mac-address
+++ b/target/linux/ramips/base-files/sbin/fixup-mac-address
@@ -13,6 +13,10 @@ case $board in
 		partname=factory
 		offset=$((0xe000))
 	;;
+        witi-512)
+                partname=factory
+                offset=$((0xe000))
+        ;;
 	*)
 		echo "Unsupported board"
 		exit 1

--- a/target/linux/ramips/dts/WITI512.dts
+++ b/target/linux/ramips/dts/WITI512.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+        compatible = "mqmaker,witi,witi512", "mediatek,mt7621-soc";
+        model = "MQmaker WiTi (512)";
+
+	memory@0 {
+		device_type = "memory";
+                reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	palmbus: palmbus@1E000000 {
+		i2c@900 {
+			status = "okay";
+
+			pcf8563: rtc@51 {
+				status = "okay";
+				compatible = "nxp,pcf8563";
+				reg = <0x51>;
+			};
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "jtag", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -320,6 +320,16 @@ define Device/witi
 endef
 TARGET_DEVICES += witi
 
+define Device/witi512
+  DTS := WITI512
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := MQmaker WiTi 512
+  DEVICE_PACKAGES := \
+       kmod-ata-core kmod-ata-ahci kmod-mt76x2 kmod-sdhci-mt7620 kmod-usb3 \
+       kmod-usb-ledtrig-usbport wpad-mini
+endef
+TARGET_DEVICES += witi512
+
 define Device/wndr3700v5
   DTS := WNDR3700V5
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
i add support for mqmaker witi model with 512 mb ram, boot from tftp ok, boot from flash ok , working for 3 days now without problem

be carefull to use sysupgrade -F fo upgrade the router

this is my first contrib, if i miss somethings, give me a feedback

davide ammirata davide.ammirata@tiscali.it