### PR TITLE
Initial support for SolidRun CuBox-i devices based on i.MX6 processors (i1, i2, i2eX, and i4Pro).

### DIFF
--- a/package/boot/uboot-imx6/Makefile
+++ b/package/boot/uboot-imx6/Makefile
@@ -20,6 +20,12 @@ define U-Boot/Default
   UBOOT_IMAGE:=u-boot.imx
 endef
 
+define U-Boot/mx6cuboxi
+   NAME:=SolidRun Cubox-i boards
+   UBOOT_IMAGE:=SPL u-boot.img
+   UBOOT_MAKE_FLAGS:=SPL u-boot.img
+endef
+
 define U-Boot/mx6sabresd
   NAME:=SABRE i.MX6Quad board
 endef
@@ -54,6 +60,7 @@ define U-Boot/wandboard
 endef
 
 UBOOT_TARGETS := \
+	mx6cuboxi \
 	mx6sabresd \
 	nitrogen6dl \
 	nitrogen6dl2g \

--- a/target/linux/imx6/base-files/etc/board.d/02_network
+++ b/target/linux/imx6/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ board=$(board_name)
 board_config_update
 
 case "$board" in
+cubox-i |\
 *gw51xx |\
 *gw52xx |\
 *gw5904)

--- a/target/linux/imx6/base-files/lib/imx6.sh
+++ b/target/linux/imx6/base-files/lib/imx6.sh
@@ -54,6 +54,11 @@ imx6_board_detect() {
 		name="gw5904"
 		;;
 
+	"SolidRun Cubox-i Solo/DualLite" |\
+	"SolidRun Cubox-i Dual/Quad")
+		name="cubox-i"
+		;;
+
 	"Wandboard i.MX6 Dual Lite Board")
 		name="wandboard"
 		;;

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -51,6 +51,13 @@ define Build/bootfs.tar.gz
 		-czvf $@ .
 endef
 
+define Build/boot-scr
+	mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
+	-n '$(DEVICE_ID) OpenWrt bootscript' \
+	-d ./bootscript-$(DEVICE_NAME) \
+	$(BIN_DIR)/boot.scr
+endef
+
 #################################################
 # Devices
 #################################################
@@ -122,5 +129,14 @@ define Device/wandboard
   DEVICE_DTS := imx6dl-wandboard
 endef
 TARGET_DEVICES += wandboard
+
+define Device/cubox-i
+  KERNEL := kernel-bin | install-dtb | boot-scr
+  DEVICE_NAME := cubox
+  DEVICE_TITLE := SolidRun CuBox-i
+  DEVICE_PACKAGES := u-boot-mx6cuboxi kmod-drm-imx kmod-drm-imx-hdmi kmod-usb-hid
+  DEVICE_DTS := imx6q-cubox-i imx6dl-cubox-i
+endef
+TARGET_DEVICES += cubox-i
 
 $(eval $(call BuildImage))

--- a/target/linux/imx6/image/bootscript-cubox
+++ b/target/linux/imx6/image/bootscript-cubox
@@ -1,0 +1,26 @@
+echo "CuBox OpenWrt Boot script"
+
+# Set console variable for both UART and HDMI
+setenv console console=ttymxc0,115200 video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32
+
+# Find correct dtb
+if test ${board_name} = CUBOXI && test ${board_rev} = MX6DL; then
+	setenv fdt_name imx6dl.dtb;
+elif test ${board_name} = CUBOXI && test ${board_rev} = MX6Q; then
+	setenv fdt_name imx6q-cubox-i.dtb;
+fi
+
+# Set correct devtype and partition
+if test ${devtype} != mmc; then setenv devtype mmc; fi
+if mmc dev 0; then
+	setenv mmcdev 0
+elif mmc dev 1; then
+	setenv mmcdev 1
+fi
+
+# Boot from the SD card is supported at the moment
+setenv bootargs "${console} root=/dev/mmcblk1p1 rw rootwait"
+mmc dev ${mmcdev}
+load ${devtype} ${mmcdev}:${devplist} ${kernel_addr_r} /boot/openwrt-imx6-cubox-i-uImage
+load ${devtype} ${mmcdev}:${devplist} ${fdt_addr_r} /boot/openwrt-imx6-${fdt_name}
+bootz ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
**NOTE: this commit depends on https://github.com/openwrt/openwrt/pull/904 for the u-boot support as the mainline OpenWrt uboot-imx6 is broken and cannot be compiled at the moment. Current u-boot has been patched for the reviewing purposes only. Once the commit is approved (and #904 is merged) I will resubmit updated PR.**

Specifications

CuBox i1:
- SoC: i.MX6 Solo
- Cores: 1
- Memory Size: 512MB
- GPU: GC880
- Wifi/Bluetooth: Optional
- USB 2.0 ports: 2
- Ethernet: 10/100/1000 Mbps

CuBox i2 | i2eX:
- SoC: i.MX6 Dual Lite
- Cores: 2
- Memory Size: 1GB
- GPU: GC2000
- Wifi/Bluetooth: Optional
- USB 2.0 ports: 2
- Ethernet: 10/100/1000 Mbps

CuBox i4Pro | i4x4:
- SoC: i.MX6 Quad
- Cores: 4
- Memory Size: 2/4 GB
- GPU: GC2000
- Wifi/Bluetooth: Build In
- USB 2.0 ports: 2
- Ethernet: 10/100/1000 Mbps

Built-in u-boot requires SPL (secondary program loader) to be present on the SD-card regardless of the image type which will be loaded.
SPL is generated by the u-boot-mx6cuboxi package which is preselected by the target device and can be found in bin/u-boot-mx6cuboxi directory.

Flashing the SPL:
dd if=/dev/zero of=/dev/mmcblk0 bs=1M count=4
dd if=bin/targets/imx6/generic/u-boot-mx6cuboxi/SPL of=/dev/mmcblk0 bs=1K seek=1

Preparing the firmware on the SD-card:
(echo o; echo n; echo p; echo 1; echo ''; echo ''; echo w) | fdisk /dev/mmcblk0
mkfs.ext4 /dev/mmcblk0p1
mount /dev/mmcblk0p1 /mnt
tar -xzf bin/targets/imx6/generic/openwrt-imx6-device-cubox-i-rootfs.tar.gz -C /mnt/
mkdir -p /mnt/boot
cp bin/targets/imx6/generic/{*-uImage,*.dtb} /mnt/boot/

Generated u-boot.img needs to be placed on the first partition:
cp bin/targets/imx6/generic/u-boot-mx6cuboxi/u-boot.img /mnt/

To boot from the SD card:

setenv image_name 'openwrt-imx6-cubox-i-uImage'; setenv fdt_name 'openwrt-imx6-imx6q-cubox-i.dtb'
setenv kernel_addr_r '0x13000000'; setenv fdt_addr_r 0x12000000; setenv bootargs '$console root=/dev/mmcblk1p1 rw rootwait'
mmc dev 0; ext4load mmc 0:1 $kernel_addr_r /boot/$image_name; ext4load mmc 0:1 $fdt_addr_r /boot/$fdt_name; bootz $kernel_addr_r - $fdt_addr_r

Currently imx6dl-cubox-i.dtb (Dual Lite) and imx6q-cubox-i.dtb (Quad) device trees are available.

Tested on i4Pro, wireless and bluetooth are broken ATM. According to SolidRun forums, BCM4329/BCM4330 firmware is used which works fine on older kernel.

Signed-off-by: Vladimir Vid <vladimir.vid@sartura.hr>