### PR TITLE
i.MX6: Add support for DHCOM i.MX6 platform

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -125,6 +125,16 @@ define Build/fit
 	@mv $@.new $@
 endef
 
+define Build/fit-multi
+	$(TOPDIR)/scripts/mkitsmulti.sh \
+		-D $(DEVICE_NAME) -o $@.its -k $@ \
+		-C $(word 1,$(1)) -p $(word 2,$(1)) -d "$(wordlist 3, $(words $(1)), $(1))" \
+		-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+		-A $(LINUX_KARCH) -v $(LINUX_VERSION)
+	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
+	@mv $@.new $@
+endef
+
 define Build/lzma
 	$(call Build/lzma-no-dict,-lc1 -lp2 -pb2 $(1))
 endef

--- a/scripts/mkitsmulti.sh
+++ b/scripts/mkitsmulti.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Licensed under the terms of the GNU GPL License version 2 or later.
+#
+# Author: Peter Tyser <ptyser@xes-inc.com>
+# Editor: Johann Neuhauser <jneuhauser@dh-electronics.de>
+#
+# U-Boot firmware supports the booting of images in the Flattened Image
+# Tree (FIT) format.  The FIT format uses a device tree structure to
+# describe a kernel image, device tree blob, ramdisk, etc.  This script
+# creates an Image Tree Source (.its file) which can be passed to the
+# 'mkimage' utility to generate an Image Tree Blob (.itb file).  The .itb
+# file can then be booted by U-Boot (or other bootloaders which support
+# FIT images).  See doc/uImage.FIT/howto.txt and doc/uImage.FIT/multi.its 
+# in U-Boot source code for additional information on FIT images.
+#
+
+usage() {
+	echo "Usage: `basename $0` -A arch -C comp -a addr -e entry" \
+		"-v version -k kernel [-D name] -p path -d dtbs -o its_file"
+	echo -e "\t-A ==> set architecture to 'arch'"
+	echo -e "\t-C ==> set compression type 'comp'"
+	echo -e "\t-a ==> set load address to 'addr' (hex)"
+	echo -e "\t-e ==> set entry point to 'entry' (hex)"
+	echo -e "\t-v ==> set kernel version to 'version'"
+	echo -e "\t-k ==> include kernel image 'kernel'"
+	echo -e "\t-D ==> human friendly Device Tree Blob 'name'"
+	echo -e "\t-p ==> path to Device Tree Blobs"
+	echo -e "\t-d ==> include Device Tree Blobs 'dtbs'"
+	echo -e "\t-o ==> create output file 'its_file'"
+	exit 1
+}
+
+while getopts ":A:a:c:C:D:p:d:e:k:o:v:" OPTION
+do
+	case $OPTION in
+		A ) ARCH=$OPTARG;;
+		a ) LOAD_ADDR=$OPTARG;;
+		C ) COMPRESS=$OPTARG;;
+		D ) DEVICE=$OPTARG;;
+		p ) PATH_DTB=$OPTARG;;
+		d ) DTB=$OPTARG;;
+		e ) ENTRY_ADDR=$OPTARG;;
+		k ) KERNEL=$OPTARG;;
+		o ) OUTPUT=$OPTARG;;
+		v ) VERSION=$OPTARG;;
+		* ) echo "Invalid option passed to '$0' (options:$@)"
+		usage;;
+	esac
+done
+
+# Make sure user entered all required parameters
+if [ -z "${ARCH}" ] || [ -z "${COMPRESS}" ] || [ -z "${LOAD_ADDR}" ] || \
+	[ -z "${ENTRY_ADDR}" ] || [ -z "${VERSION}" ] || [ -z "${KERNEL}" ] || \
+	[ -z "${OUTPUT}" ] || [ -z "${DTB}" ] || [ -z "${PATH_DTB}" ]; then
+	usage
+fi
+
+ARCH_UPPER=`echo $ARCH | tr '[:lower:]' '[:upper:]'`
+
+# Conditionally create fdt information
+i=1
+for dtb in ${DTB}; do
+	# Ensure not .dtb is appended
+	dtb=${dtb%.dtb}
+	FDT="${FDT}
+		fdt@${i} {
+			description = \"${ARCH_UPPER} OpenWrt ${DEVICE} ${dtb}\";
+			data = /incbin/(\"${PATH_DTB}/${dtb}.dtb\");
+			type = \"flat_dt\";
+			arch = \"${ARCH}\";
+			compression = \"none\";
+			hash@1 {
+				algo = \"crc32\";
+			};
+			hash@2 {
+				algo = \"sha1\";
+			};
+		};
+"
+	let i=${i}+1
+done
+
+# Conditionally create config information
+i=1
+for dtb in ${DTB}; do
+	# Truncate to name only
+	dtb=${dtb%.dtb}
+	dtb=${dtb##*/}
+	CFG="${CFG}
+		${dtb} {
+			description = \"OpenWrt ${dtb}\";
+			kernel = \"kernel@1\";
+			fdt = \"fdt@${i}\";
+		};
+"
+	let i=${i}+1
+done
+
+# Create a default, fully populated DTS file
+DATA="/dts-v1/;
+
+/ {
+	description = \"${ARCH_UPPER} OpenWrt Multi FIT (Flattened Image Tree)\";
+	#address-cells = <1>;
+
+	images {
+	
+		kernel@1 {
+			description = \"${ARCH_UPPER} OpenWrt Linux-${VERSION}\";
+			data = /incbin/(\"${KERNEL}\");
+			type = \"kernel\";
+			arch = \"${ARCH}\";
+			os = \"linux\";
+			compression = \"${COMPRESS}\";
+			load = <${LOAD_ADDR}>;
+			entry = <${ENTRY_ADDR}>;
+			hash@1 {
+				algo = \"crc32\";
+			};
+			hash@2 {
+				algo = \"sha1\";
+			};
+		};
+${FDT}
+	};
+
+	configurations {
+${CFG}
+	};
+};"
+
+# Write .its file to disk
+echo "$DATA" > ${OUTPUT}

--- a/target/linux/imx6/Makefile
+++ b/target/linux/imx6/Makefile
@@ -18,7 +18,7 @@ KERNEL_PATCHVER:=4.14
 
 include $(INCLUDE_DIR)/target.mk
 
-KERNELNAME:=zImage dtbs
+KERNELNAME:=Image zImage dtbs
 
 DEFAULT_PACKAGES += uboot-envtools
 

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom2B-pdk1.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom2B-pdk1.dts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6dl.dtsi"
+#define IMX6_CPU_SOLO_DUALLITE // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW200 base
+#include "imx6qdl-dhcom2B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk1.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 DualLite DHCOM Premium Developer Kit (1)";
+	compatible = "fsl,imx6dl-dhcom2B-pdk1", "fsl,imx6dl";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-drc02.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-drc02.dts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6dl.dtsi"
+#define IMX6_CPU_SOLO_DUALLITE // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enables CAN2, disables micro SD card and UART 1 RTS/CTS
+#include "imx6qdl-dhcom_cfg-can2.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_drc02.dtsi"
+
+/ {
+	model = "Freescale i.MX6 DualLite DHCOM DRC02";
+	compatible = "fsl,imx6dl-dhcom3B-drc02", "fsl,imx6dl";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-pdk2.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-pdk2.dts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6dl.dtsi"
+#define IMX6_CPU_SOLO_DUALLITE // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk2.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 DualLite DHCOM Premium Developer Kit (2)";
+	compatible = "fsl,imx6dl-dhcom3B-pdk2", "fsl,imx6dl";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-picoitx02.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3B-picoitx02.dts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6dl.dtsi"
+#define IMX6_CPU_SOLO_DUALLITE // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_picoitx02.dtsi"
+
+/ {
+	model = "Freescale i.MX6 DualLite DHCOM picoITX02";
+	compatible = "fsl,imx6dl-dhcom3B-picoitx02", "fsl,imx6dl";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3H-pdk2.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6dl-dhcom3H-pdk2.dts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6dl.dtsi"
+#define IMX6_CPU_SOLO_DUALLITE // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Hispeed configuration
+//**********************************************************
+// Activate 1GBit ethernet onBoard, otherwise 100MBit onModule is active
+#define DHCOM_ETH_1G
+
+// HW300 hispeed
+#include "imx6qdl-dhcom3H.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk2.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 DualLite DHCOM Premium Developer Kit (2)";
+	compatible = "fsl,imx6dl-dhcom3H-pdk2", "fsl,imx6dl";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom2B-pdk1.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom2B-pdk1.dts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6q.dtsi"
+#define IMX6_CPU_DUAL_QUAD // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW200 base
+#include "imx6qdl-dhcom2B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk1.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 Quad DHCOM Premium Developer Kit (1)";
+	compatible = "fsl,imx6q-dhcom2B-pdk1", "fsl,imx6q";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-drc02.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-drc02.dts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6q.dtsi"
+#define IMX6_CPU_DUAL_QUAD // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enables CAN2, disables micro SD card and UART 1 RTS/CTS
+#include "imx6qdl-dhcom_cfg-can2.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_drc02.dtsi"
+
+/ {
+	model = "Freescale i.MX6 Quad DHCOM DRC02";
+	compatible = "fsl,imx6q-dhcom3B-drc02", "fsl,imx6q";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-pdk2.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-pdk2.dts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6q.dtsi"
+#define IMX6_CPU_DUAL_QUAD // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk2.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 Quad DHCOM Premium Developer Kit (2)";
+	compatible = "fsl,imx6q-dhcom3B-pdk2", "fsl,imx6q";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-picoitx02.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3B-picoitx02.dts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6q.dtsi"
+#define IMX6_CPU_DUAL_QUAD // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Basic configuration
+//**********************************************************
+// HW300 base
+#include "imx6qdl-dhcom3B.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_picoitx02.dtsi"
+
+/ {
+	model = "Freescale i.MX6 Quad DHCOM picoITX02";
+	compatible = "fsl,imx6q-dhcom3B-picoitx02", "fsl,imx6q";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3H-pdk2.dts
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6q-dhcom3H-pdk2.dts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 DH electronics GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+/dts-v1/;
+
+//******************************************************************************
+// C P U - T Y P E
+//******************************************************************************
+#include "imx6q.dtsi"
+#define IMX6_CPU_DUAL_QUAD // Used to distinguish the CPU types
+
+
+//******************************************************************************
+// D H C O M - M O D U L E
+//******************************************************************************
+
+// Hispeed configuration
+//**********************************************************
+// Activate 1GBit ethernet onBoard, otherwise 100MBit onModule is active
+#define DHCOM_ETH_1G
+
+// HW300 hispeed
+#include "imx6qdl-dhcom3H.dtsi"
+
+// Special configurations
+//**********************************************************
+// Enables NAND, disables eMMC
+//#include "imx6qdl-dhcom_cfg-nand.dtsi"
+
+// Enable RS485 for UART2 (ttymxc4)
+//#include "imx6qdl-dhcom_cfg-rs485.dtsi"
+
+// Enables WEIM example config with UIO-Driver
+//#include "imx6qdl-dhcom_cfg-weim.dtsi"
+
+
+//******************************************************************************
+// B O A R D - C O N F I G U R A T I O N
+//******************************************************************************
+#include "imx6qdl-dh_pdk2.dtsi"
+
+
+/ {
+	model = "Freescale i.MX6 Quad DHCOM Premium Developer Kit (2)";
+	compatible = "fsl,imx6q-dhcom3H-pdk2", "fsl,imx6q";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_drc02.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_drc02.dtsi
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/imx6qdl-clock.h>
+
+/ {
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	spidev@2 {								// ==> /dev/spidev0.2 (Display connector)
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <2>;							// SS2
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	status = "disabled";							// Not connected
+};
+
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+};
+
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+	eeprom@50 {
+		compatible = "atmel,24c04";					// Atmel AT24HC04B
+		reg = <0x50>;
+		pagesize = <16>;
+	};
+};
+
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+};
+
+&uart5 { 									// UART 2 (BT) ==> /dev/ttymxc4
+	fsl,rs485-mode;								// Enable rs485 mode
+	rts_gpio = <&gpio7 13 0>;						// GPIO P: rs485 rts = Receive Transmit Switch GPIO
+	rxen_gpio = <&gpio1 18 0>;						// GPIO Q: rs485 rxen = RX Enable GPIO
+	//rs485-rx-during-tx;							// Receive data during transfer
+	status = "okay";
+};
+
+&usbotg {									// USB OTG
+	status = "disabled";							// Not connected
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base &pinctrl_dhcom_hog>;
+
+	imx6qdl-drc02_base {
+		pinctrl_dhcom_hog: hog_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_2__GPIO1_IO02       0x400120B0	// GPIO A -> Display connector
+				MX6QDL_PAD_GPIO_4__GPIO1_IO04       0x400120B0	// GPIO B -> Display connector
+				MX6QDL_PAD_GPIO_5__GPIO1_IO05       0x400120B0	// GPIO C -> Display connector
+				MX6QDL_PAD_CSI0_DAT17__GPIO6_IO03   0x400120B0	// GPIO D -> OUT 2
+				MX6QDL_PAD_GPIO_19__GPIO4_IO05      0x400120B0	// GPIO E -> Display connector
+				MX6QDL_PAD_DI0_PIN4__GPIO4_IO20     0x400120B0	// GPIO F -> OUT 1
+				MX6QDL_PAD_EIM_D27__GPIO3_IO27      0x400120B0	// GPIO G -> IN 1
+				MX6QDL_PAD_KEY_ROW0__GPIO4_IO07     0x400120B0	// GPIO H -> Reset USB hub
+				MX6QDL_PAD_KEY_COL1__GPIO4_IO08     0x400120B0	// GPIO I -> UART1 RTS
+				MX6QDL_PAD_NANDF_CS1__GPIO6_IO14    0x400120B0	// GPIO J -> Code_HW_2
+				MX6QDL_PAD_NANDF_CS2__GPIO6_IO15    0x400120B0	// GPIO K -> Code_HW_1
+				MX6QDL_PAD_KEY_ROW1__GPIO4_IO09     0x400120B0	// GPIO L -> Code_HW_0
+				MX6QDL_PAD_SD3_DAT5__GPIO7_IO00     0x400120B0	// GPIO M -> UART1 CTS
+				MX6QDL_PAD_SD3_DAT4__GPIO7_IO01     0x400120B0	// GPIO N -> Extension connector (XLON U10R2, MBUS, ...)
+				MX6QDL_PAD_CSI0_VSYNC__GPIO5_IO21   0x400120B0	// GPIO O -> Extension connector (XLON U10R2, MBUS, ...)
+				MX6QDL_PAD_GPIO_18__GPIO7_IO13      0x400120B0	// GPIO P -> rs485 rts
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18      0x400120B0	// GPIO Q -> rs485 rxen
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16     0x400120B0	// GPIO R -> Not connected
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17     0x400120B0	// GPIO S -> Not connected
+				MX6QDL_PAD_SD1_DAT2__GPIO1_IO19     0x400120B0	// GPIO T -> Not connected
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20      0x400120B0	// GPIO U -> Not connected
+				MX6QDL_PAD_CSI0_PIXCLK__GPIO5_IO18  0x400120B0	// GPIO V -> Not connected
+				MX6QDL_PAD_CSI0_MCLK__GPIO5_IO19    0x400120B0	// GPIO W -> Not connected
+				MX6QDL_PAD_KEY_COL0__GPIO4_IO06     0x400120B0	// INT_HIGHEST_PRIORITY -> IN 2
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_pdk1.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_pdk1.dtsi
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	bl_display {
+		compatible = "pwm-backlight";
+		pwms = <&pwm1 0 50000 PWM_POLARITY_INVERTED>;			// PWM polarity can be overwritten by bootargs
+		backlight-sysfs-name = "display";
+		// brightness value  0 1  2  3  4  5  6  7   8   9   10
+		brightness-levels = <0 16 22 30 40 55 75 102 138 188 255>;
+		default-brightness-level = <8>;					// Default level can be set to 0 by bootargs
+		enable-gpios = <&gpio3 27 GPIO_ACTIVE_HIGH>;			// GPIO number and its polarity can be overwritten by bootargs
+		power-supply = <&reg_24v_ext>;
+		status = "okay";
+	};
+
+	regulators {
+		reg_24v_ext: 24V_EXT {
+			compatible = "regulator-fixed";
+			regulator-name = "24V_EXT";
+			regulator-min-microvolt = <24000000>;
+			regulator-max-microvolt = <24000000>;
+			regulator-always-on;
+		};
+	};
+
+	display@di0 {								// Parallel display interface
+		compatible = "fsl,imx-parallel-display";
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_ipu1>;
+		status = "okay";
+
+		port {
+			display0_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+
+		display-timings {
+			// DH display ID 13
+			DataImage_7inch_FG0700G3DSSW {
+				dh-display-ID = "013";
+				clock-frequency = <33260000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <42>;
+				hback-porch = <86>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <33>;
+				vsync-len = <2>;
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+	};
+
+	/* TODO GPIOs */
+	/*
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&gpio1 4 0>;
+			gpio-key,wakeup;
+			linux,code = <115>; 	// KEY_VOLUMEUP
+		};
+
+		volume-down {
+			label = "Volume Down";
+			gpios = <&gpio1 5 0>;
+			gpio-key,wakeup;
+			linux,code = <114>;	// KEY_VOLUMEDOWN
+		};
+	};*/
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&display0_in>;
+};
+
+&ldb {										// LVDS display interface
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+
+		// Set your LVDS display timings here
+		// To Avoid interference comment the parallel display timings out
+	/*	display-timings {						
+			// DH display ID 10
+			LG_7inch_LB070WV8 {
+				dh-display-ID = "010";
+				clock-frequency = <33250000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <64>;
+				hback-porch = <64>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <10>;
+				vsync-len = <25>;
+				hsync-active = <1>;
+				vsync-active = <1>;
+				de-active = <1>;
+				pixelclk-active = <0>;
+			};
+		};*/
+	};
+
+	lvds-channel@1 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+	};
+};
+
+&pwm1 {										// Backlight PWM
+	#pwm-cells = <3>;							// Needed for inversion
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_pwm1>;
+	status = "okay";
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	spidev@2 {								// ==> /dev/spidev0.2
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <2>;							// SS2
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	spidev@0 {								// ==> /dev/spidev1.0
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <0>;							// SS0
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+	tmg120_ts@20 {								// Touch controller "DH-Touch"
+		compatible = "dh,tmg120_ts";
+		reg = <0x20>;
+		interrupt-parent = <&gpio4>;
+		interrupts = <7 2>;
+		status = "okay";
+	};
+};
+
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+};
+
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+	tsc2004@49 {								// Touch controller TI TSC2014 (on Board)
+		status = "okay";
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base &pinctrl_dhcom_hog>;
+
+	imx6qdl-pdk {
+		pinctrl_dhcom_hog: hog_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_2__GPIO1_IO02       0x400120B0  // GPIO A
+				MX6QDL_PAD_GPIO_4__GPIO1_IO04       0x400120B0  // GPIO B
+				MX6QDL_PAD_GPIO_5__GPIO1_IO05       0x400120B0  // GPIO C
+				MX6QDL_PAD_CSI0_DAT17__GPIO6_IO03   0x400120B0  // GPIO D
+				MX6QDL_PAD_GPIO_19__GPIO4_IO05      0x400120B0  // GPIO E
+				MX6QDL_PAD_DI0_PIN4__GPIO4_IO20     0x400120B0  // GPIO F
+				MX6QDL_PAD_EIM_D27__GPIO3_IO27      0x120B0     // GPIO G -> Backlight Enable
+				MX6QDL_PAD_KEY_ROW0__GPIO4_IO07     0x120B0     // GPIO H -> Touch Interrupt picoITX dh-touch
+				MX6QDL_PAD_KEY_COL1__GPIO4_IO08     0x400120B0  // GPIO I
+				MX6QDL_PAD_NANDF_CS1__GPIO6_IO14    0x400120B0  // GPIO J
+				MX6QDL_PAD_NANDF_CS2__GPIO6_IO15    0x400120B0  // GPIO K
+				MX6QDL_PAD_KEY_ROW1__GPIO4_IO09     0x400120B0  // GPIO L
+				MX6QDL_PAD_SD3_DAT5__GPIO7_IO00     0x400120B0  // GPIO M
+				MX6QDL_PAD_SD3_DAT4__GPIO7_IO01     0x400120B0  // GPIO N
+				MX6QDL_PAD_CSI0_VSYNC__GPIO5_IO21   0x400120B0  // GPIO O
+				MX6QDL_PAD_GPIO_18__GPIO7_IO13      0x400120B0  // GPIO P
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18      0x400120B0  // GPIO Q
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16     0x400120B0  // GPIO R
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17     0x400120B0  // GPIO S
+				MX6QDL_PAD_SD1_DAT2__GPIO1_IO19     0x400120B0  // GPIO T
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20      0x400120B0  // GPIO U
+				MX6QDL_PAD_CSI0_PIXCLK__GPIO5_IO18  0x400120B0  // GPIO V
+				MX6QDL_PAD_CSI0_MCLK__GPIO5_IO19    0x400120B0  // GPIO W
+				MX6QDL_PAD_KEY_COL0__GPIO4_IO06     0x400120B0  // INT_HIGHEST_PRIORITY
+			>;
+		};
+
+		pinctrl_dhcom_ipu1: ipu1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_DI0_DISP_CLK__IPU1_DI0_DISP_CLK 0x10         // RGB_PCLK
+				MX6QDL_PAD_DI0_PIN15__IPU1_DI0_PIN15       0x10         // RGB_DATA_EN
+				MX6QDL_PAD_DI0_PIN2__IPU1_DI0_PIN02        0x10         // RGB_HSYNC
+				MX6QDL_PAD_DI0_PIN3__IPU1_DI0_PIN03        0x10         // RGB_VSYNC
+				MX6QDL_PAD_DISP0_DAT0__IPU1_DISP0_DATA00   0x10
+				MX6QDL_PAD_DISP0_DAT1__IPU1_DISP0_DATA01   0x10
+				MX6QDL_PAD_DISP0_DAT2__IPU1_DISP0_DATA02   0x10
+				MX6QDL_PAD_DISP0_DAT3__IPU1_DISP0_DATA03   0x10
+				MX6QDL_PAD_DISP0_DAT4__IPU1_DISP0_DATA04   0x10
+				MX6QDL_PAD_DISP0_DAT5__IPU1_DISP0_DATA05   0x10
+				MX6QDL_PAD_DISP0_DAT6__IPU1_DISP0_DATA06   0x10
+				MX6QDL_PAD_DISP0_DAT7__IPU1_DISP0_DATA07   0x10
+				MX6QDL_PAD_DISP0_DAT8__IPU1_DISP0_DATA08   0x10
+				MX6QDL_PAD_DISP0_DAT9__IPU1_DISP0_DATA09   0x10
+				MX6QDL_PAD_DISP0_DAT10__IPU1_DISP0_DATA10  0x10
+				MX6QDL_PAD_DISP0_DAT11__IPU1_DISP0_DATA11  0x10
+				MX6QDL_PAD_DISP0_DAT12__IPU1_DISP0_DATA12  0x10
+				MX6QDL_PAD_DISP0_DAT13__IPU1_DISP0_DATA13  0x10
+				MX6QDL_PAD_DISP0_DAT14__IPU1_DISP0_DATA14  0x10
+				MX6QDL_PAD_DISP0_DAT15__IPU1_DISP0_DATA15  0x10
+				MX6QDL_PAD_DISP0_DAT16__IPU1_DISP0_DATA16  0x10
+				MX6QDL_PAD_DISP0_DAT17__IPU1_DISP0_DATA17  0x10
+				MX6QDL_PAD_DISP0_DAT18__IPU1_DISP0_DATA18  0x10
+				MX6QDL_PAD_DISP0_DAT19__IPU1_DISP0_DATA19  0x10
+				MX6QDL_PAD_DISP0_DAT20__IPU1_DISP0_DATA20  0x10
+				MX6QDL_PAD_DISP0_DAT21__IPU1_DISP0_DATA21  0x10
+				MX6QDL_PAD_DISP0_DAT22__IPU1_DISP0_DATA22  0x10
+				MX6QDL_PAD_DISP0_DAT23__IPU1_DISP0_DATA23  0x10
+			>;
+		};
+
+		pinctrl_dhcom_pwm1: pwm1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_DAT3__PWM1_OUT       0x1b0b1
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_pdk2.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_pdk2.dtsi
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/imx6qdl-clock.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	bl_display {
+		compatible = "pwm-backlight";
+		pwms = <&pwm1 0 50000 PWM_POLARITY_INVERTED>;			// PWM polarity can be overwritten by bootargs
+		backlight-sysfs-name = "display";
+		// brightness value  0 1  2  3  4  5  6  7   8   9   10
+		brightness-levels = <0 16 22 30 40 55 75 102 138 188 255>;
+		default-brightness-level = <8>;					// Default level can be set to 0 by bootargs
+		enable-gpios = <&gpio3 27 GPIO_ACTIVE_HIGH>;			// GPIO number and its polarity can be overwritten by bootargs
+		power-supply = <&reg_24v_ext>;
+		status = "okay";
+	};
+
+	regulators {
+		reg_24v_ext: 24V_EXT {
+			compatible = "regulator-fixed";
+			regulator-name = "24V_EXT";
+			regulator-min-microvolt = <24000000>;
+			regulator-max-microvolt = <24000000>;
+			regulator-always-on;
+		};
+
+		reg_3p3v: 3P3V {
+			compatible = "regulator-fixed";
+			regulator-name = "3P3V";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+		};
+	};
+
+	display@di0 {								// Parallel display interface
+		compatible = "fsl,imx-parallel-display";
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_ipu1>;
+		status = "okay";
+
+		port {
+			display0_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+
+		display-timings {
+			// DH display ID 13
+			DataImage_7inch_FG0700G3DSSW {
+				dh-display-ID = "013";
+				clock-frequency = <33260000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <42>;
+				hback-porch = <86>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <33>;
+				vsync-len = <2>;
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+	};
+
+	/* GPIO keys */
+	/* Linux key codes ==> include/dt-bindings/input/linux-event-codes.h */
+	/*
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pdk2_ta1 {
+			label = "Esc";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;			// TA1: GPIO A
+			gpio-key,wakeup;
+			linux,code = <KEY_ESC>;
+		};
+
+		pdk2_ta2 {
+			label = "Enter";
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;			// TA2: GPIO B
+			gpio-key,wakeup;
+			linux,code = <KEY_ENTER>;
+		};
+
+		pdk2_ta3 {
+			label = "left";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;			// TA3: GPIO C
+			gpio-key,wakeup;
+			linux,code = <KEY_LEFT>;
+		};
+
+		pdk2_ta4 {
+			label = "right";
+			gpios = <&gpio6 3 GPIO_ACTIVE_LOW>;			// TA4: GPIO D
+			gpio-key,wakeup;
+			linux,code = <KEY_RIGHT>;
+		};
+	};*/
+
+	/* LEDs */
+	/*
+	leds {
+		compatible = "gpio-leds";
+
+		pdk2_led5 {							// ==> /sys/class/leds/led5
+			label = "led5";
+			gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;			// GPIO E
+			default-state = "keep";					// Keep bootloader state
+		};
+
+		pdk2_led6 {							// ==> /sys/class/leds/led6
+			label = "led6";
+			gpios = <&gpio4 20 GPIO_ACTIVE_HIGH>;			// GPIO F
+			default-state = "keep";					// Keep bootloader state
+		};
+
+		pdk2_led7 {							// ==> /sys/class/leds/led7
+			label = "led7";
+			gpios = <&gpio4 7 GPIO_ACTIVE_HIGH>;			// GPIO H
+			default-state = "keep";					// Keep bootloader state
+		};
+
+		pdk2_led8 {							// ==> /sys/class/leds/led8
+			label = "led8";
+			gpios = <&gpio4 8 GPIO_ACTIVE_HIGH>;			// GPIO I
+			default-state = "keep";					// Keep bootloader state
+		};
+	};*/
+
+	clocks {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clk_ext_audio_codec: clock@0 {
+			compatible = "fixed-clock";
+			reg = <0>;
+			#clock-cells = <0>;
+			clock-frequency = <24000000>;
+		};
+	};
+
+	sound {
+		compatible = "fsl,imx-audio-sgtl5000";
+		model = "imx-sgtl5000";
+		ssi-controller = <&ssi1>;
+		audio-codec = <&codec>;
+		audio-routing =
+			"MIC_IN", "Mic Jack",
+			"Mic Jack", "Mic Bias",
+			"LINE_IN", "Line In Jack",
+			"Headphone Jack", "HP_OUT";
+		mux-int-port = <1>;
+		mux-ext-port = <3>;
+	};
+};
+
+&audmux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_audmux_ext>;				// AUD3 <-> sgtl5000
+	status = "okay";
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&display0_in>;
+};
+
+&ldb {										// LVDS display interface
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+
+		// Set your LVDS display timings here
+		// To Avoid interference comment the parallel display timings out
+	/*	display-timings {						
+			// DH display ID 10
+			LG_7inch_LB070WV8 {
+				dh-display-ID = "010";
+				clock-frequency = <33250000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <64>;
+				hback-porch = <64>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <10>;
+				vsync-len = <25>;
+				hsync-active = <1>;
+				vsync-active = <1>;
+				de-active = <1>;
+				pixelclk-active = <0>;
+			};
+		};*/
+	};
+
+	lvds-channel@1 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+	};
+};
+
+&pwm1 {										// Backlight PWM
+	#pwm-cells = <3>;							// Needed for inversion
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_pwm1>;
+	status = "okay";
+};
+
+&ssi1 {
+	status = "okay";
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	spidev@2 {								// ==> /dev/spidev0.2
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <2>;							// SS2
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	spidev@0 {								// ==> /dev/spidev1.0
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <0>;							// SS0
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+	codec: sgtl5000@0a {							// Audio codec SGTL5000XNAA3/R2
+		compatible = "fsl,sgtl5000";
+		reg = <0x0a>;
+		clocks = <&clk_ext_audio_codec>;				// External clock
+		VDDA-supply = <&reg_3p3v>;
+		VDDIO-supply = <&reg_3p3v>;
+	};
+
+	tmg120_ts@20 {								// Touch controller "DH-Touch"
+		compatible = "dh,tmg120_ts";
+		reg = <0x20>;
+		interrupt-parent = <&gpio4>;
+		interrupts = <7 2>;
+		status = "okay";
+	};
+
+	polytouch: edt-ft5x06@38 {						// Glyn Polytouch
+		compatible = "edt,edt-ft5x06";
+		reg = <0x38>;
+		interrupt-parent = <&gpio4>;
+		interrupts = <5 0>;
+		//linux,wakeup;
+	};
+};
+
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+};
+
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+	tsc2004@49 {								// Touch controller TI TSC2014 (on Board)
+		status = "okay";
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base &pinctrl_dhcom_hog>;
+
+	imx6qdl-pdk2_base {
+		pinctrl_dhcom_hog: hog_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_2__GPIO1_IO02       0x400120B0	// GPIO A
+				MX6QDL_PAD_GPIO_4__GPIO1_IO04       0x400120B0	// GPIO B
+				MX6QDL_PAD_GPIO_5__GPIO1_IO05       0x400120B0	// GPIO C
+				MX6QDL_PAD_CSI0_DAT17__GPIO6_IO03   0x400120B0	// GPIO D
+				MX6QDL_PAD_GPIO_19__GPIO4_IO05      0x120B0	// GPIO E -> Touch Interrupt PDK2 Glyn Polytouch
+				MX6QDL_PAD_DI0_PIN4__GPIO4_IO20     0x400120B0	// GPIO F
+				MX6QDL_PAD_EIM_D27__GPIO3_IO27      0x120B0	// GPIO G -> Backlight Enable
+				MX6QDL_PAD_KEY_ROW0__GPIO4_IO07     0x120B0	// GPIO H -> Touch Interrupt picoITX dh-touch
+				MX6QDL_PAD_KEY_COL1__GPIO4_IO08     0x400120B0	// GPIO I
+				MX6QDL_PAD_NANDF_CS1__GPIO6_IO14    0x400120B0	// GPIO J -> PCIe Reset (if hispeed device tree)
+				MX6QDL_PAD_NANDF_CS2__GPIO6_IO15    0x400120B0	// GPIO K
+				MX6QDL_PAD_KEY_ROW1__GPIO4_IO09     0x400120B0	// GPIO L
+				MX6QDL_PAD_SD3_DAT5__GPIO7_IO00     0x400120B0	// GPIO M
+				MX6QDL_PAD_SD3_DAT4__GPIO7_IO01     0x400120B0	// GPIO N
+				MX6QDL_PAD_CSI0_VSYNC__GPIO5_IO21   0x400120B0	// GPIO O
+				MX6QDL_PAD_GPIO_18__GPIO7_IO13      0x400120B0	// GPIO P
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18      0x400120B0	// GPIO Q
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16     0x400120B0	// GPIO R
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17     0x400120B0	// GPIO S
+				MX6QDL_PAD_SD1_DAT2__GPIO1_IO19     0x400120B0	// GPIO T
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20      0x400120B0	// GPIO U
+				MX6QDL_PAD_CSI0_PIXCLK__GPIO5_IO18  0x400120B0	// GPIO V
+				MX6QDL_PAD_CSI0_MCLK__GPIO5_IO19    0x400120B0	// GPIO W
+				MX6QDL_PAD_KEY_COL0__GPIO4_IO06     0x400120B0	// INT_HIGHEST_PRIORITY
+			>;
+		};
+
+		pinctrl_dhcom_audmux_ext: audmux_ext_grp { 			// HW300: Audio on external clock
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT7__AUD3_RXD      0x130b0
+				MX6QDL_PAD_CSI0_DAT4__AUD3_TXC      0x130b0
+				MX6QDL_PAD_CSI0_DAT5__AUD3_TXD      0x110b0
+				MX6QDL_PAD_CSI0_DAT6__AUD3_TXFS     0x130b0
+			>;
+		};
+
+		pinctrl_dhcom_pwm1: pwm1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_DAT3__PWM1_OUT       0x1b0b1
+			>;
+		};
+
+		pinctrl_dhcom_ipu1: ipu1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_DI0_DISP_CLK__IPU1_DI0_DISP_CLK 0x10	// RGB_PCLK
+				MX6QDL_PAD_DI0_PIN15__IPU1_DI0_PIN15       0x10	// RGB_DATA_EN
+				MX6QDL_PAD_DI0_PIN2__IPU1_DI0_PIN02        0x10	// RGB_HSYNC
+				MX6QDL_PAD_DI0_PIN3__IPU1_DI0_PIN03        0x10	// RGB_VSYNC
+				MX6QDL_PAD_DISP0_DAT0__IPU1_DISP0_DATA00   0x10
+				MX6QDL_PAD_DISP0_DAT1__IPU1_DISP0_DATA01   0x10
+				MX6QDL_PAD_DISP0_DAT2__IPU1_DISP0_DATA02   0x10
+				MX6QDL_PAD_DISP0_DAT3__IPU1_DISP0_DATA03   0x10
+				MX6QDL_PAD_DISP0_DAT4__IPU1_DISP0_DATA04   0x10
+				MX6QDL_PAD_DISP0_DAT5__IPU1_DISP0_DATA05   0x10
+				MX6QDL_PAD_DISP0_DAT6__IPU1_DISP0_DATA06   0x10
+				MX6QDL_PAD_DISP0_DAT7__IPU1_DISP0_DATA07   0x10
+				MX6QDL_PAD_DISP0_DAT8__IPU1_DISP0_DATA08   0x10
+				MX6QDL_PAD_DISP0_DAT9__IPU1_DISP0_DATA09   0x10
+				MX6QDL_PAD_DISP0_DAT10__IPU1_DISP0_DATA10  0x10
+				MX6QDL_PAD_DISP0_DAT11__IPU1_DISP0_DATA11  0x10
+				MX6QDL_PAD_DISP0_DAT12__IPU1_DISP0_DATA12  0x10
+				MX6QDL_PAD_DISP0_DAT13__IPU1_DISP0_DATA13  0x10
+				MX6QDL_PAD_DISP0_DAT14__IPU1_DISP0_DATA14  0x10
+				MX6QDL_PAD_DISP0_DAT15__IPU1_DISP0_DATA15  0x10
+				MX6QDL_PAD_DISP0_DAT16__IPU1_DISP0_DATA16  0x10
+				MX6QDL_PAD_DISP0_DAT17__IPU1_DISP0_DATA17  0x10
+				MX6QDL_PAD_DISP0_DAT18__IPU1_DISP0_DATA18  0x10
+				MX6QDL_PAD_DISP0_DAT19__IPU1_DISP0_DATA19  0x10
+				MX6QDL_PAD_DISP0_DAT20__IPU1_DISP0_DATA20  0x10
+				MX6QDL_PAD_DISP0_DAT21__IPU1_DISP0_DATA21  0x10
+				MX6QDL_PAD_DISP0_DAT22__IPU1_DISP0_DATA22  0x10
+				MX6QDL_PAD_DISP0_DAT23__IPU1_DISP0_DATA23  0x10
+			>;
+		};
+	};
+};
+
+
+// Interfaces of the DHCOM hispeed connector will be activated here. Baord
+// specific configuration can also be made here. This section is only active if
+// you load an hispeed device tree e.g. imx6q-dhcom4H-pdk2
+#ifdef DHCOM_HISPEED
+
+#ifdef DHCOM_ETH_1G
+&fec {										// Ethernet (1GBit)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_enet_1G>;
+	phy-mode = "rgmii";
+	phy-reset-gpios = <&gpio3 29 GPIO_ACTIVE_LOW>;
+	//phy-reset-duration = <1>;						// 1ms is the default value
+	phy-reset-post-delay = <1>;
+	phy-handle = <&ethphy>;
+	//local-mac-address = [00 11 22 33 44 55];				// Is set by the bootloader
+	status = "okay";
+
+	mdio {									// PHY: Micrel KSZ9021RN
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ethphy: ethernet-phy@7 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <7>;
+			max-speed = <1000>;
+			ksz9021-skew-step-ps = <120>;	// Overwrite value from old specification (If unused the driver uses 200ps)
+							// KSZ 9021 (0.12ns/step) | KSZ 9031 (0.06ns/step)
+			txen-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			txc-skew-ps = <1800>;		// 0..1800 default=840    | 0..1860 default=900
+			rxdv-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			rxc-skew-ps = <1800>;		// 0..1800 default=840    | 0..1860 default=900
+			rxd0-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			rxd1-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			rxd2-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			rxd3-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			txd0-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			txd1-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			txd2-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+			txd3-skew-ps = <0>;		// 0..1800 default=840    | 0..900  default=420
+		};
+	};
+};
+#endif
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_pcie>;
+	reset-gpio = <&gpio6 14 GPIO_ACTIVE_LOW>;				// GPIO J
+	status = "okay";
+};
+
+// Only for DUAL and QUAD architecture
+#ifdef IMX6_CPU_DUAL_QUAD
+&sata {
+	status = "okay";
+};
+#endif
+
+&iomuxc {
+	imx6qdl-pdk2_hispeed {
+		pinctrl_dhcom_pcie: pcie_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DATA_EN__GPIO5_IO20 0x1b0b1	// PCIe_WAKE (#148)
+			>;
+		};
+
+		pinctrl_dhcom_enet_1G: enet_1G_grp {				// 1GBit ethernet
+			fsl,pins = <
+				MX6QDL_PAD_ENET_MDIO__ENET_MDIO       0x100b0
+				MX6QDL_PAD_ENET_MDC__ENET_MDC         0x100b0
+				MX6QDL_PAD_RGMII_TXC__RGMII_TXC       0x100b0
+				MX6QDL_PAD_RGMII_TD0__RGMII_TD0       0x100b0
+				MX6QDL_PAD_RGMII_TD1__RGMII_TD1       0x100b0
+				MX6QDL_PAD_RGMII_TD2__RGMII_TD2       0x100b0
+				MX6QDL_PAD_RGMII_TD3__RGMII_TD3       0x100b0
+				MX6QDL_PAD_RGMII_TX_CTL__RGMII_TX_CTL 0x100b0
+				MX6QDL_PAD_ENET_REF_CLK__ENET_TX_CLK  0x100b0
+				MX6QDL_PAD_RGMII_RXC__RGMII_RXC       0x1b0b0
+				MX6QDL_PAD_RGMII_RD0__RGMII_RD0       0x1b0b0
+				MX6QDL_PAD_RGMII_RD1__RGMII_RD1       0x1b0b0
+				MX6QDL_PAD_RGMII_RD2__RGMII_RD2       0x1b0b0
+				MX6QDL_PAD_RGMII_RD3__RGMII_RD3       0x1b0b0
+				MX6QDL_PAD_RGMII_RX_CTL__RGMII_RX_CTL 0x1b0b0
+				MX6QDL_PAD_EIM_D29__GPIO3_IO29        0x000b0	// RGMII_RESET
+				MX6QDL_PAD_GPIO_0__GPIO1_IO00         0x000b1	// RGMII_INT
+				MX6QDL_PAD_EIM_D26__GPIO3_IO26        0x000b1	// RGMII_WOL_INT
+			>;
+		};
+	};
+};
+#endif

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_picoitx02.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dh_picoitx02.dtsi
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/imx6qdl-clock.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	bl_display {
+		compatible = "pwm-backlight";
+		pwms = <&pwm1 0 50000 PWM_POLARITY_INVERTED>;			// PWM polarity can be overwritten by bootargs
+		backlight-sysfs-name = "display";
+		// brightness value  0 1  2  3  4  5  6  7   8   9   10
+		brightness-levels = <0 16 22 30 40 55 75 102 138 188 255>;
+		default-brightness-level = <8>;					// Default level can be set to 0 by bootargs
+		enable-gpios = <&gpio3 27 GPIO_ACTIVE_HIGH>;			// GPIO number and its polarity can be overwritten by bootargs
+		power-supply = <&reg_24v_ext>;
+		status = "okay";
+	};
+
+	regulators {
+		reg_24v_ext: 24V_EXT {
+			compatible = "regulator-fixed";
+			regulator-name = "24V_EXT";
+			regulator-min-microvolt = <24000000>;
+			regulator-max-microvolt = <24000000>;
+			regulator-always-on;
+		};
+	};
+
+	display@di0 {								// Parallel display interface
+		compatible = "fsl,imx-parallel-display";
+		interface-pix-fmt = "rgb24";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_ipu1>;
+		status = "okay";
+
+		port {
+			display0_in: endpoint {
+				remote-endpoint = <&ipu1_di0_disp0>;
+			};
+		};
+
+		display-timings {
+			// DH display ID 13
+			DataImage_7inch_FG0700G3DSSW {
+				dh-display-ID = "013";
+				clock-frequency = <33260000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <42>;
+				hback-porch = <86>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <33>;
+				vsync-len = <2>;
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <1>;
+				pixelclk-active = <1>;
+			};
+		};
+	};
+
+};
+
+&ipu1_di0_disp0 {
+	remote-endpoint = <&display0_in>;
+};
+
+&ldb {										// LVDS display interface
+	status = "okay";
+
+	lvds-channel@0 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+
+		// Set your LVDS display timings here
+		// To Avoid interference comment the parallel display timings out
+	/*	display-timings {						
+			// DH display ID 10
+			LG_7inch_LB070WV8 {
+				dh-display-ID = "010";
+				clock-frequency = <33250000>;
+				hactive = <800>;
+				vactive = <480>;
+				hfront-porch = <64>;
+				hback-porch = <64>;
+				hsync-len = <128>;
+				vfront-porch = <10>;
+				vback-porch = <10>;
+				vsync-len = <25>;
+				hsync-active = <1>;
+				vsync-active = <1>;
+				de-active = <1>;
+				pixelclk-active = <0>;
+			};
+		};*/
+	};
+
+	lvds-channel@1 {
+		fsl,data-mapping = "spwg";
+		fsl,data-width = <24>;
+		status = "okay";
+	};
+};
+
+&pwm1 {										// Backlight PWM
+	#pwm-cells = <3>;							// Needed for inversion
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_pwm1>;
+	status = "okay";
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	spidev@2 {								// ==> /dev/spidev0.2
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <2>;							// SS2
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	spidev@0 {								// ==> /dev/spidev1.0
+		compatible =  "spidev", "fsl,ecspi";
+		reg = <0>;							// SS0
+		spi-max-frequency = <54000000>;
+		spi-cpha;							// Shifted clock phase (CPHA) mode
+		spi-cpol;							// Inverse clock polarity (CPOL) mode
+	};
+};
+
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+	tmg120_ts@20 {								// Touch controller "DH-Touch"
+		compatible = "dh,tmg120_ts";
+		reg = <0x20>;
+		interrupt-parent = <&gpio4>;
+		interrupts = <7 2>;
+		status = "okay";
+	};
+
+	polytouch: edt-ft5x06@38 {						// Glyn Polytouch
+		compatible = "edt,edt-ft5x06";
+		reg = <0x38>;
+		interrupt-parent = <&gpio4>;
+		interrupts = <5 0>;
+		//linux,wakeup;
+	};
+};
+
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+};
+
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+	tsc2004@49 {								// Touch controller TI TSC2014 (on Board)
+		status = "okay";
+	};
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base &pinctrl_dhcom_hog>;
+
+	imx6qdl-pdk2_base {
+		pinctrl_dhcom_hog: hog_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_2__GPIO1_IO02       0x400120B0	// GPIO A
+				MX6QDL_PAD_GPIO_4__GPIO1_IO04       0x400120B0	// GPIO B
+				MX6QDL_PAD_GPIO_5__GPIO1_IO05       0x400120B0	// GPIO C
+				MX6QDL_PAD_CSI0_DAT17__GPIO6_IO03   0x400120B0	// GPIO D
+				MX6QDL_PAD_GPIO_19__GPIO4_IO05      0x120B0	// GPIO E -> Touch Interrupt PDK2 Glyn Polytouch
+				MX6QDL_PAD_DI0_PIN4__GPIO4_IO20     0x400120B0	// GPIO F
+				MX6QDL_PAD_EIM_D27__GPIO3_IO27      0x120B0	// GPIO G -> Backlight Enable
+				MX6QDL_PAD_KEY_ROW0__GPIO4_IO07     0x120B0	// GPIO H -> Touch Interrupt picoITX dh-touch
+				MX6QDL_PAD_KEY_COL1__GPIO4_IO08     0x400120B0	// GPIO I
+				MX6QDL_PAD_NANDF_CS1__GPIO6_IO14    0x400120B0	// GPIO J
+				MX6QDL_PAD_NANDF_CS2__GPIO6_IO15    0x400120B0	// GPIO K
+				MX6QDL_PAD_KEY_ROW1__GPIO4_IO09     0x400120B0	// GPIO L
+				MX6QDL_PAD_SD3_DAT5__GPIO7_IO00     0x400120B0	// GPIO M
+				MX6QDL_PAD_SD3_DAT4__GPIO7_IO01     0x400120B0	// GPIO N
+				MX6QDL_PAD_CSI0_VSYNC__GPIO5_IO21   0x400120B0	// GPIO O
+				MX6QDL_PAD_GPIO_18__GPIO7_IO13      0x400120B0	// GPIO P
+				MX6QDL_PAD_SD1_CMD__GPIO1_IO18      0x400120B0	// GPIO Q
+				MX6QDL_PAD_SD1_DAT0__GPIO1_IO16     0x400120B0	// GPIO R
+				MX6QDL_PAD_SD1_DAT1__GPIO1_IO17     0x400120B0	// GPIO S
+				MX6QDL_PAD_SD1_DAT2__GPIO1_IO19     0x400120B0	// GPIO T
+				MX6QDL_PAD_SD1_CLK__GPIO1_IO20      0x400120B0	// GPIO U
+				MX6QDL_PAD_CSI0_PIXCLK__GPIO5_IO18  0x400120B0	// GPIO V
+				MX6QDL_PAD_CSI0_MCLK__GPIO5_IO19    0x400120B0	// GPIO W
+				MX6QDL_PAD_KEY_COL0__GPIO4_IO06     0x400120B0	// INT_HIGHEST_PRIORITY
+			>;
+		};
+
+		pinctrl_dhcom_pwm1: pwm1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD1_DAT3__PWM1_OUT       0x1b0b1
+			>;
+		};
+
+		pinctrl_dhcom_ipu1: ipu1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_DI0_DISP_CLK__IPU1_DI0_DISP_CLK 0x10	// RGB_PCLK
+				MX6QDL_PAD_DI0_PIN15__IPU1_DI0_PIN15       0x10	// RGB_DATA_EN
+				MX6QDL_PAD_DI0_PIN2__IPU1_DI0_PIN02        0x10	// RGB_HSYNC
+				MX6QDL_PAD_DI0_PIN3__IPU1_DI0_PIN03        0x10	// RGB_VSYNC
+				MX6QDL_PAD_DISP0_DAT0__IPU1_DISP0_DATA00   0x10
+				MX6QDL_PAD_DISP0_DAT1__IPU1_DISP0_DATA01   0x10
+				MX6QDL_PAD_DISP0_DAT2__IPU1_DISP0_DATA02   0x10
+				MX6QDL_PAD_DISP0_DAT3__IPU1_DISP0_DATA03   0x10
+				MX6QDL_PAD_DISP0_DAT4__IPU1_DISP0_DATA04   0x10
+				MX6QDL_PAD_DISP0_DAT5__IPU1_DISP0_DATA05   0x10
+				MX6QDL_PAD_DISP0_DAT6__IPU1_DISP0_DATA06   0x10
+				MX6QDL_PAD_DISP0_DAT7__IPU1_DISP0_DATA07   0x10
+				MX6QDL_PAD_DISP0_DAT8__IPU1_DISP0_DATA08   0x10
+				MX6QDL_PAD_DISP0_DAT9__IPU1_DISP0_DATA09   0x10
+				MX6QDL_PAD_DISP0_DAT10__IPU1_DISP0_DATA10  0x10
+				MX6QDL_PAD_DISP0_DAT11__IPU1_DISP0_DATA11  0x10
+				MX6QDL_PAD_DISP0_DAT12__IPU1_DISP0_DATA12  0x10
+				MX6QDL_PAD_DISP0_DAT13__IPU1_DISP0_DATA13  0x10
+				MX6QDL_PAD_DISP0_DAT14__IPU1_DISP0_DATA14  0x10
+				MX6QDL_PAD_DISP0_DAT15__IPU1_DISP0_DATA15  0x10
+				MX6QDL_PAD_DISP0_DAT16__IPU1_DISP0_DATA16  0x10
+				MX6QDL_PAD_DISP0_DAT17__IPU1_DISP0_DATA17  0x10
+				MX6QDL_PAD_DISP0_DAT18__IPU1_DISP0_DATA18  0x10
+				MX6QDL_PAD_DISP0_DAT19__IPU1_DISP0_DATA19  0x10
+				MX6QDL_PAD_DISP0_DAT20__IPU1_DISP0_DATA20  0x10
+				MX6QDL_PAD_DISP0_DAT21__IPU1_DISP0_DATA21  0x10
+				MX6QDL_PAD_DISP0_DAT22__IPU1_DISP0_DATA22  0x10
+				MX6QDL_PAD_DISP0_DAT23__IPU1_DISP0_DATA23  0x10
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom2B.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom2B.dtsi
@@ -1,0 +1,531 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/imx6qdl-clock.h>
+#define DHCOM_HW200								// Use it in other device tree files, e.g. imx6qdl-dhcom_cfg-xxxx.dtsi
+
+/ {
+	aliases {
+		mmcblk0 = &usdhc2;
+		mmcblk1 = &usdhc3;
+		mmcblk2 = &usdhc4;
+		mmcblk3 = &usdhc1; 						// Unused at dhcom, put at the end to be compatible with uboot
+	};
+
+	memory {
+		reg = <0 0>;							// Will be filled by uboot
+	};
+	
+	chosen {
+		bootargs = "console=ttymxc0,115200";
+	};
+
+	regulators {
+		compatible = "simple-bus";
+
+		reg_usb_otg_vbus: usb_otg_vbus {
+			compatible = "regulator-fixed";
+			regulator-name = "usb_otg_vbus";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+		};
+
+		reg_usb_h1_vbus: usb_h1_vbus {
+			compatible = "regulator-fixed";
+			regulator-name = "usb_h1_vbus";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			gpio = <&gpio3 31 0>;					// GPIO: USB Host 1 Power
+			enable-active-high;
+		};
+
+		reg_3p3v: 3P3V {
+			compatible = "regulator-fixed";
+			regulator-name = "3P3V";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+		};
+	};
+
+	sound {
+		compatible = "fsl,imx-audio-sgtl5000";
+		model = "imx-sgtl5000";
+		ssi-controller = <&ssi1>;
+		audio-codec = <&codec>;
+		audio-routing =
+			"MIC_IN", "Mic Jack",
+			"Mic Jack", "Mic Bias",
+			"LINE_IN", "Line In Jack",
+			"Headphone Jack", "HP_OUT";
+		mux-int-port = <1>;
+		mux-ext-port = <3>;
+	};
+};
+
+&audmux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_audmux_int>;				// AUD3 <-> sgtl5000
+	status = "okay";
+};
+
+&can1 {										// CAN
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_flexcan1>;
+	status = "okay";
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	fsl,spi-num-chipselects = <4>;
+	cs-gpios = <&gpio2 30 1>, <0>, <&gpio4 11 1>, <0>;			// SS0, (SS1), SS2, (SS3)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_ecspi1>;
+	status = "okay";
+
+	s25fl116k@0 {								// SPI Flash: Spansion S25FL116K0PMFI010 (used to store bootloader)
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spansion,s25fl116k", "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+		reg = <0>;							// SS0
+		m25p,fast-read;
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	fsl,spi-num-chipselects = <4>;
+	cs-gpios = <&gpio5 29 1>, <0>, <0>, <0>;				// SS0, (SS1), (SS2), (SS3)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_ecspi2>;
+	status = "okay";
+};
+
+#ifndef DHCOM_ETH_1G
+&fec {										// Ethernet (100MBit)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_enet_100M>;
+	phy-mode = "rmii";
+	phy-reset-gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+	//phy-reset-duration = <1>;						// 1ms is the default value
+	phy-reset-post-delay = <1>;
+	phy-handle = <&ethphy>;
+	//local-mac-address = [00 11 22 33 44 55];				// Is set by the bootloader
+	power-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;				// Power for LAN-Transformer 7499111614A (Isn't yet supported by driver)
+	status = "okay";
+
+	mdio {									// PHY: SMSC LAN8710Ai
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ethphy: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+			max-speed = <100>;
+		};
+	};
+};
+#endif
+
+#define DHCOM_I2C1                  i2c1					// Use this define in board files!
+#define DHCOM_I2C1_PINCTRL          pinctrl_dhcom_i2c1				// ==> /dev/i2c-0
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C1_PINCTRL>;
+	status = "okay";
+};
+
+#define DHCOM_I2C2                  i2c2					// Use this define in board files!
+#define DHCOM_I2C2_PINCTRL          pinctrl_dhcom_i2c2				// ==> /dev/i2c-1
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C2_PINCTRL>;
+	status = "okay";
+};
+
+#define DHCOM_I2C_ONMODULE          i2c3					// Use this define in board files!
+#define DHCOM_I2C_ONMODULE_PINCTRL  pinctrl_dhcom_i2c3				// ==> /dev/i2c-2
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C_ONMODULE_PINCTRL>;
+	status = "okay";
+
+	codec: sgtl5000@0a {							// Audio codec SGTL5000XNAA3/R2
+		compatible = "fsl,sgtl5000";
+		reg = <0x0a>;
+		clocks = <&clks IMX6QDL_CLK_CKO>;
+		VDDA-supply = <&reg_3p3v>;
+		VDDIO-supply = <&reg_3p3v>;
+	};
+
+	/* TODO PMIC */
+	/*
+	pmic: ltc3676@3c {							// Power Management LTC3676EUJ#PBF
+		compatible = "lltc,ltc3676";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_pmic_hw200>;
+		reg = <0x3c>;
+		interrupt-parent = <&gpio6>;
+		interrupts = <27 2>;
+
+		regulators {
+			sw1_reg: sw1 {						// VCC_SOC
+				regulator-min-microvolt = <787500>;
+				regulator-max-microvolt = <1527272>;
+				lltc,fb-voltage-divider = <100000 110000>;
+				regulator-suspend-mem-microvolt = <1040000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw2_reg: sw2 {						// VCC_3V3
+				regulator-min-microvolt = <1885714>;
+				regulator-max-microvolt = <3657142>;
+				lltc,fb-voltage-divider = <100000 28000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw3_reg: sw3 {						// VCC_ARM
+				regulator-min-microvolt = <787500>;
+				regulator-max-microvolt = <1527272>;
+				lltc,fb-voltage-divider = <100000 110000>;
+				regulator-suspend-mem-microvolt = <980000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw4_reg: sw4 {						// VCC_DDR3
+				regulator-min-microvolt = <855571>;
+				regulator-max-microvolt = <1659291>;
+				lltc,fb-voltage-divider = <100000 93100>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo1_reg: ldo1 {					// VCC_SNVS
+				regulator-min-microvolt = <3240306>;
+				regulator-max-microvolt = <3240306>;
+				lltc,fb-voltage-divider = <102000 29400>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo2_reg: ldo2 {					// VCC_2V5_LDO2
+				regulator-min-microvolt = <2484708>;
+				regulator-max-microvolt = <2484708>;
+				lltc,fb-voltage-divider = <100000 41200>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};*/
+
+	tsc2004@49 {								// Touch controller TI TSC2014 (onModule)
+		compatible = "ti,tsc2014", "ti,tsc2004";
+		reg = <0x49>;
+		vio-supply = <&reg_3p3v>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_tsc2004_hw200>;
+		interrupts-extended = <&gpio6 28 IRQ_TYPE_EDGE_FALLING>;
+		status = "disabled";						// It isn't actived by default (if needed it should be actived in dts layers above)
+	};
+
+	/* Will be replaced, because there is a address conflict with the RTC
+	/*
+	eeprom@50 {								// EEPROM Microchip 24AA02E48T-I/OT
+		compatible = "atmel,24c02";
+		reg = <0x50>;
+		pagesize = <8>;
+	};*/
+
+	/* If not available use internal rtc (snvs-rtc-lp) */
+	rtc@56 {								// Micro Crystal RV-3029-C3 (onModule)
+		device_type = "rtc";						// ==> /dev/rtc0
+		compatible = "microc,rtc-rv3029c3", "microc,rtc-rv3029c2";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_rtc_hw200>;
+		reg = <0x56>;
+		interrupt-parent = <&gpio6>;
+		interrupts = <29 2>;
+		irq-gpios = <&gpio6 29 0>;
+		status = "disabled";						// TODO: If address conflict with eeprom is fixed change status to "okay"
+	};
+};
+
+&weim {										// Memory interface is not active by default
+	status = "disabled";
+};
+
+&ssi1 {
+	status = "okay";
+};
+
+&uart1 {									// UART 1 (FF)
+	pinctrl-names = "default";						// ==> /dev/ttymxc0
+	pinctrl-0 = <&pinctrl_dhcom_uart1>;
+	fsl,uart-has-rtscts;
+	dtr-gpios = <&gpio3 24 GPIO_ACTIVE_LOW>;
+	dsr-gpios = <&gpio3 25 GPIO_ACTIVE_LOW>;
+	dcd-gpios = <&gpio3 23 GPIO_ACTIVE_LOW>;
+	rng-gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&uart4 {									// UART 3 (STD)
+	pinctrl-names = "default";						// ==> /dev/ttymxc3
+	pinctrl-0 = <&pinctrl_dhcom_uart4>;
+	status = "okay";
+};
+
+&uart5 {									// UART 2 (BT)
+	pinctrl-names = "default";						// ==> /dev/ttymxc4
+	pinctrl-0 = <&pinctrl_dhcom_uart5>;
+	fsl,uart-has-rtscts;
+	status = "okay";
+};
+
+&usbh1 {									// USB Host 1
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usbh1>;
+	vbus-supply = <&reg_usb_h1_vbus>;
+	status = "okay";
+	dr_mode = "host";
+//	maximum-speed = "full-speed";						// Reducing speed (full-speed = 12M)
+};
+
+&usbotg {									// USB OTG
+	vbus-supply = <&reg_usb_otg_vbus>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usbotg>;					// Defined USB OTG ID pin
+	disable-over-current;
+	status = "okay";
+	dr_mode = "otg";							// "host", "peripheral" or "otg" default = "otg"
+//	maximum-speed = "full-speed";						// Reducing speed (full-speed = 12M)
+};
+
+&usdhc2 {									// SD card (external via DHCOM)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc2>;
+	cd-gpios = <&gpio6 16 GPIO_ACTIVE_HIGH>;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&usdhc3 {									// Micro SD card (onModule)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc3>;
+	cd-gpios = <&gpio7 8 GPIO_ACTIVE_LOW>;
+	fsl,wp-controller;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&usdhc4 {									// eMMC (onModule)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc4>;
+	non-removable;
+	bus-width = <8>;
+	no-1-8-v;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base>;
+
+	imx6qdl-dhcom_base {
+		pinctrl_dhcom_hog_base: hog_base_grp {
+			fsl,pins = <                                       	// DHCOM HW Version  | 100/200 | 300 | 400 |
+				MX6QDL_PAD_EIM_A19__GPIO2_IO19      0x120B0	// Code_HW_0 (#51)        0       1     0
+				MX6QDL_PAD_EIM_A23__GPIO6_IO06      0x120B0	// Code_HW_1 (#166)       0       0     1
+				MX6QDL_PAD_EIM_A22__GPIO2_IO16      0x120B0	// Code_HW_2 (#48)        0       0     0
+				MX6QDL_PAD_RGMII_TXC__GPIO6_IO19    0x120B0	// HW200: Code_DDR3_0 (#179)
+				MX6QDL_PAD_RGMII_TD0__GPIO6_IO20    0x120B0	// HW200: Code_DDR3_1 (#180)
+			>;
+		};
+
+		pinctrl_dhcom_pmic_hw200: pmic_hw200_grp {
+			fsl,pins = <
+				MX6QDL_PAD_RGMII_RD1__GPIO6_IO27    0x1B0B0	// GPIO 6.27: PMIC_IRQ#
+			>;
+		};
+
+		pinctrl_dhcom_tsc2004_hw200: tsc2004_hw200_grp {
+			fsl,pins = <
+				MX6QDL_PAD_RGMII_RD2__GPIO6_IO28    0x120B0	// GPIO 6.28: Touch Interrupt resistive
+			>;
+		};
+
+		pinctrl_dhcom_rtc_hw200: rtc_hw200_grp {
+			fsl,pins = <
+				MX6QDL_PAD_RGMII_RD3__GPIO6_IO29    0x120B0	// GPIO 6.29: RTC Interrupt pin (#189)
+			>;
+		};
+
+		pinctrl_dhcom_audmux_int: audmux_int_grp {			// HW200: Audio on internal clock
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT7__AUD3_RXD      0x130b0
+				MX6QDL_PAD_CSI0_DAT4__AUD3_TXC      0x130b0
+				MX6QDL_PAD_CSI0_DAT5__AUD3_TXD      0x110b0
+				MX6QDL_PAD_CSI0_DAT6__AUD3_TXFS     0x130b0
+				MX6QDL_PAD_GPIO_0__CCM_CLKO1        0x030b0	// SGTL5000 sys_mclk
+			>;
+		};
+
+		pinctrl_dhcom_ecspi1: ecspi1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D17__ECSPI1_MISO     0x100b1
+				MX6QDL_PAD_EIM_D18__ECSPI1_MOSI     0x100b1
+				MX6QDL_PAD_EIM_D16__ECSPI1_SCLK     0x100b1
+				MX6QDL_PAD_EIM_EB2__GPIO2_IO30      0x1b0b0	// SS0
+				MX6QDL_PAD_KEY_ROW2__GPIO4_IO11     0x1b0b0	// SS2
+			>;
+		};
+
+		pinctrl_dhcom_ecspi2: ecspi2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT10__ECSPI2_MISO  0x100b1
+				MX6QDL_PAD_CSI0_DAT9__ECSPI2_MOSI   0x100b1
+				MX6QDL_PAD_CSI0_DAT8__ECSPI2_SCLK   0x100b1
+				MX6QDL_PAD_CSI0_DAT11__GPIO5_IO29   0x1b0b0	// SS0
+			>;
+		};
+
+		pinctrl_dhcom_enet_100M: enet_100M_grp {			// 100MBit ethernet
+			fsl,pins = <
+				MX6QDL_PAD_ENET_MDIO__ENET_MDIO     0x1b0b0
+				MX6QDL_PAD_ENET_MDC__ENET_MDC       0x1b0b0
+				MX6QDL_PAD_ENET_CRS_DV__ENET_RX_EN  0x1b0b0
+				MX6QDL_PAD_ENET_RX_ER__ENET_RX_ER   0x1b0b0
+				MX6QDL_PAD_ENET_RXD0__ENET_RX_DATA0 0x1b0b0
+				MX6QDL_PAD_ENET_RXD1__ENET_RX_DATA1 0x1b0b0
+				MX6QDL_PAD_ENET_TX_EN__ENET_TX_EN   0x1b0b0
+				MX6QDL_PAD_ENET_TXD0__ENET_TX_DATA0 0x1b0b0
+				MX6QDL_PAD_ENET_TXD1__ENET_TX_DATA1 0x1b0b0
+				MX6QDL_PAD_GPIO_16__ENET_REF_CLK    0x4001b0a8
+				MX6QDL_PAD_EIM_WAIT__GPIO5_IO00     0x000b0	// ENET_RESET
+				MX6QDL_PAD_RGMII_RD0__GPIO6_IO25    0x000b1	// ENET_INT
+				MX6QDL_PAD_GPIO_7__GPIO1_IO07       0x120B0	// Power for LAN-Transformer 7499111614A
+			>;
+		};
+
+		pinctrl_dhcom_flexcan1: flexcan1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL2__FLEXCAN1_TX    0x1b0b0
+				MX6QDL_PAD_GPIO_8__FLEXCAN1_RX      0x1b0b0
+			>;
+		};
+
+		pinctrl_dhcom_i2c1: i2c1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D21__I2C1_SCL        0x4001b8b1
+				MX6QDL_PAD_EIM_D28__I2C1_SDA        0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_i2c2: i2c2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL3__I2C2_SCL       0x4001b8b1
+				MX6QDL_PAD_KEY_ROW3__I2C2_SDA       0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_i2c3: i2c3_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_3__I2C3_SCL         0x4001b8b1
+				MX6QDL_PAD_GPIO_6__I2C3_SDA         0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_uart1: uart1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_DAT7__UART1_TX_DATA  0x1b0b1
+				MX6QDL_PAD_SD3_DAT6__UART1_RX_DATA  0x1b0b1
+				MX6QDL_PAD_EIM_D20__UART1_RTS_B     0x1b0b1
+				MX6QDL_PAD_EIM_D19__UART1_CTS_B     0x4001b0b1
+				MX6QDL_PAD_EIM_D23__GPIO3_IO23      0x4001b0b1	// DCD
+				MX6QDL_PAD_EIM_D24__GPIO3_IO24      0x4001b0b1	// DTR
+				MX6QDL_PAD_EIM_D25__GPIO3_IO25      0x4001b0b1	// DSR
+				MX6QDL_PAD_EIM_EB3__GPIO2_IO31      0x4001b0b1	// RI
+			>;
+		};
+
+		pinctrl_dhcom_uart4: uart4_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT12__UART4_TX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT13__UART4_RX_DATA 0x1b0b1
+			>;
+		};
+	
+		pinctrl_dhcom_uart5: uart5_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT14__UART5_TX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT15__UART5_RX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT18__UART5_RTS_B   0x1b0b1
+				MX6QDL_PAD_CSI0_DAT19__UART5_CTS_B   0x4001b0b1
+			>;
+		};
+
+		pinctrl_dhcom_usbh1: usbh1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D31__GPIO3_IO31      0x120B0	// GPIO: USB Host 1 Power
+			>;
+		};
+
+		pinctrl_dhcom_usbotg: usbotg_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_1__USB_OTG_ID       0x17059
+			>;
+		};
+
+		pinctrl_dhcom_usdhc2: usdhc2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD2_CMD__SD2_CMD         0x17059
+				MX6QDL_PAD_SD2_CLK__SD2_CLK         0x10059
+				MX6QDL_PAD_SD2_DAT0__SD2_DATA0      0x17059
+				MX6QDL_PAD_SD2_DAT1__SD2_DATA1      0x17059
+				MX6QDL_PAD_SD2_DAT2__SD2_DATA2      0x17059
+				MX6QDL_PAD_SD2_DAT3__SD2_DATA3      0x17059
+				MX6QDL_PAD_NANDF_CS3__GPIO6_IO16    0x120B0	// GPIO: Card detection
+			>;
+		};
+
+		pinctrl_dhcom_usdhc3: usdhc3_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_CMD__SD3_CMD         0x17059
+				MX6QDL_PAD_SD3_CLK__SD3_CLK         0x10059
+				MX6QDL_PAD_SD3_DAT0__SD3_DATA0      0x17059
+				MX6QDL_PAD_SD3_DAT1__SD3_DATA1      0x17059
+				MX6QDL_PAD_SD3_DAT2__SD3_DATA2      0x17059
+				MX6QDL_PAD_SD3_DAT3__SD3_DATA3      0x17059
+				MX6QDL_PAD_SD3_RST__GPIO7_IO08      0x120B0	// GPIO: Card detection
+			>;
+		};
+
+		pinctrl_dhcom_usdhc4: usdhc4_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD4_CMD__SD4_CMD         0x17059
+				MX6QDL_PAD_SD4_CLK__SD4_CLK         0x10059
+				MX6QDL_PAD_SD4_DAT0__SD4_DATA0      0x17059
+				MX6QDL_PAD_SD4_DAT1__SD4_DATA1      0x17059
+				MX6QDL_PAD_SD4_DAT2__SD4_DATA2      0x17059
+				MX6QDL_PAD_SD4_DAT3__SD4_DATA3      0x17059
+				MX6QDL_PAD_SD4_DAT4__SD4_DATA4      0x17059
+				MX6QDL_PAD_SD4_DAT5__SD4_DATA5      0x17059
+				MX6QDL_PAD_SD4_DAT6__SD4_DATA6      0x17059
+				MX6QDL_PAD_SD4_DAT7__SD4_DATA7      0x17059
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom3B.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom3B.dtsi
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+#include <dt-bindings/gpio/gpio.h>
+#define DHCOM_HW300								// Use it in other device tree files, e.g. imx6qdl-dhcom_cfg-xxxx.dtsi
+
+/ {
+	aliases {
+		mmcblk0 = &usdhc2;
+		mmcblk1 = &usdhc3;
+		mmcblk2 = &usdhc4;
+		mmcblk3 = &usdhc1; 						// Unused at dhcom, put at the end to be compatible with uboot
+	};
+
+	memory {
+		reg = <0 0>;							// Will be filled by uboot
+	};
+	
+	chosen {
+		bootargs = "console=ttymxc0,115200";
+	};
+
+	regulators {
+		compatible = "simple-bus";
+
+		reg_usb_otg_vbus: usb_otg_vbus {
+			compatible = "regulator-fixed";
+			regulator-name = "usb_otg_vbus";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+		};
+
+		reg_usb_h1_vbus: usb_h1_vbus {
+			compatible = "regulator-fixed";
+			regulator-name = "usb_h1_vbus";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			gpio = <&gpio3 31 0>;					// GPIO: USB Host 1 Power
+			enable-active-high;
+		};
+
+		reg_3p3v: 3P3V {
+			compatible = "regulator-fixed";
+			regulator-name = "3P3V";
+			regulator-min-microvolt = <3300000>;
+			regulator-max-microvolt = <3300000>;
+			regulator-always-on;
+		};
+	};
+};
+
+&can1 {										// CAN
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_flexcan1>;
+	status = "okay";
+};
+
+&ecspi1 {									// ********** SPI 1 **********
+	fsl,spi-num-chipselects = <4>;
+	cs-gpios = <&gpio2 30 1>, <0>, <&gpio4 11 1>, <0>;			// SS0, (SS1), SS2, (SS3)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_ecspi1>;
+	status = "okay";
+
+	s25fl116k@0 {								// SPI Flash: Spansion S25FL116K0PMFI010 (used to store bootloader)
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spansion,s25fl116k", "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+		reg = <0>;							// SS0
+		m25p,fast-read;
+	};
+};
+
+&ecspi2 {									// ********** SPI 2 **********
+	fsl,spi-num-chipselects = <4>;
+	cs-gpios = <&gpio5 29 1>, <0>, <0>, <0>;				// SS0, (SS1), (SS2), (SS3)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_ecspi2>;
+	status = "okay";
+};
+
+#ifndef DHCOM_ETH_1G
+&fec {										// Ethernet (100MBit)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_enet_100M>;
+	phy-mode = "rmii";
+	phy-reset-gpios = <&gpio5 0 GPIO_ACTIVE_LOW>;
+	//phy-reset-duration = <1>;						// 1ms is the default value
+	phy-reset-post-delay = <1>;
+	phy-handle = <&ethphy>;
+	//local-mac-address = [00 11 22 33 44 55];				// Is set by the bootloader
+	power-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;				// Power for LAN-Transformer 7499111614A (Isn't yet supported by driver)
+	status = "okay";
+
+	mdio {									// PHY: SMSC LAN8710Ai
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ethphy: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+			max-speed = <100>;
+		};
+	};
+};
+#endif
+
+#define DHCOM_I2C1                  i2c2					// Use this define in board files!
+#define DHCOM_I2C1_PINCTRL          pinctrl_dhcom_i2c2				// ==> /dev/i2c-1
+&DHCOM_I2C1 {									// ********** I2C 1 **********
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C1_PINCTRL>;
+	status = "okay";
+};
+
+#define DHCOM_I2C2                  i2c1					// Use this define in board files!
+#define DHCOM_I2C2_PINCTRL          pinctrl_dhcom_i2c1				// ==> /dev/i2c-0
+&DHCOM_I2C2 {									// ********** I2C 2 **********
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C2_PINCTRL>;
+	status = "okay";
+};
+
+#define DHCOM_I2C_ONMODULE          i2c3					// Use this define in board files!
+#define DHCOM_I2C_ONMODULE_PINCTRL  pinctrl_dhcom_i2c3				// ==> /dev/i2c-2
+&DHCOM_I2C_ONMODULE {								// ****** I2C onModule *******
+	clock-frequency = <100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&DHCOM_I2C_ONMODULE_PINCTRL>;
+	status = "okay";
+
+	/* TODO PMIC */
+	/*
+	pmic: ltc3676@3c {							// Power Management LTC3676EUJ#PBF
+		compatible = "lltc,ltc3676";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_pmic_hw300>;
+		reg = <0x3c>;
+		interrupt-parent = <&gpio5>;
+		interrupts = <2 2>;
+
+		regulators {
+			sw1_reg: sw1 {						// VCC_SOC
+				regulator-min-microvolt = <787500>;
+				regulator-max-microvolt = <1527272>;
+				lltc,fb-voltage-divider = <100000 110000>;
+				regulator-suspend-mem-microvolt = <1040000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw2_reg: sw2 {						// VCC_3V3
+				regulator-min-microvolt = <1885714>;
+				regulator-max-microvolt = <3657142>;
+				lltc,fb-voltage-divider = <100000 28000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw3_reg: sw3 {						// VCC_ARM
+				regulator-min-microvolt = <787500>;
+				regulator-max-microvolt = <1527272>;
+				lltc,fb-voltage-divider = <100000 110000>;
+				regulator-suspend-mem-microvolt = <980000>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			sw4_reg: sw4 {						// VCC_DDR3
+				regulator-min-microvolt = <855571>;
+				regulator-max-microvolt = <1659291>;
+				lltc,fb-voltage-divider = <100000 93100>;
+				regulator-ramp-delay = <7000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo1_reg: ldo1 {					// VCC_SNVS
+				regulator-min-microvolt = <3240306>;
+				regulator-max-microvolt = <3240306>;
+				lltc,fb-voltage-divider = <102000 29400>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo2_reg: ldo2 {					// VCC_2V5_LDO2
+				regulator-min-microvolt = <2484708>;
+				regulator-max-microvolt = <2484708>;
+				lltc,fb-voltage-divider = <100000 41200>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};*/
+
+	tsc2004@49 {								// Touch controller TI TSC2014 (onModule)
+		compatible = "ti,tsc2014", "ti,tsc2004";
+		reg = <0x49>;
+		vio-supply = <&reg_3p3v>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_tsc2004_hw300>;
+		interrupts-extended = <&gpio4 14 IRQ_TYPE_EDGE_FALLING>;
+		status = "disabled";						// It isn't actived by default (if needed it should be actived in dts layers above)
+	};
+
+	eeprom@50 {								// EEPROM Microchip 24AA025E48T-I/OT
+		compatible = "atmel,24c02";
+		reg = <0x50>;
+		pagesize = <16>;
+	};
+
+	/* If not available use internal rtc (snvs-rtc-lp) */
+	rtc@56 {								// Micro Crystal RV-3029-C3 (onModule)
+		device_type = "rtc";						// ==> /dev/rtc0
+		compatible = "microc,rtc-rv3029c3", "microc,rtc-rv3029c2";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_dhcom_rtc_hw300>;
+		reg = <0x56>;
+		interrupt-parent = <&gpio7>;
+		interrupts = <12 2>;
+		irq-gpios = <&gpio7 12 0>;
+		status = "okay";
+	};
+};
+
+&weim {										// Memory interface is not active by default
+	status = "disabled";
+};
+
+&uart1 {									// UART 1 (FF)
+	pinctrl-names = "default";						// ==> /dev/ttymxc0
+	pinctrl-0 = <&pinctrl_dhcom_uart1>;
+	fsl,uart-has-rtscts;
+	dtr-gpios = <&gpio3 24 GPIO_ACTIVE_LOW>;
+	dsr-gpios = <&gpio3 25 GPIO_ACTIVE_LOW>;
+	dcd-gpios = <&gpio3 23 GPIO_ACTIVE_LOW>;
+	rng-gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&uart4 {									// UART 3 (STD)
+	pinctrl-names = "default";						// ==> /dev/ttymxc3
+	pinctrl-0 = <&pinctrl_dhcom_uart4>;
+	status = "okay";
+};
+
+&uart5 {									// UART 2 (BT)
+	pinctrl-names = "default";						// ==> /dev/ttymxc4
+	pinctrl-0 = <&pinctrl_dhcom_uart5>;
+	fsl,uart-has-rtscts;
+	status = "okay";
+};
+
+&usbh1 {									// USB Host 1
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usbh1>;
+	vbus-supply = <&reg_usb_h1_vbus>;
+	status = "okay";
+	dr_mode = "host";
+//	maximum-speed = "full-speed";						// Reducing speed (full-speed = 12M)
+};
+
+&usbotg {									// USB OTG
+	vbus-supply = <&reg_usb_otg_vbus>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usbotg>;					// Defined USB OTG ID pin
+	disable-over-current;
+	status = "okay";
+	dr_mode = "otg";							// "host", "peripheral" or "otg" default = "otg"
+//	maximum-speed = "full-speed";						// Reducing speed (full-speed = 12M)
+};
+
+&usdhc2 {									// SD card (external via DHCOM)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc2>;
+	cd-gpios = <&gpio6 16 GPIO_ACTIVE_HIGH>;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&usdhc3 {									// Micro SD card (onModule)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc3>;
+	cd-gpios = <&gpio7 8 GPIO_ACTIVE_LOW>;
+	fsl,wp-controller;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&usdhc4 {									// eMMC (onModule)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_usdhc4>;
+	non-removable;
+	bus-width = <8>;
+	no-1-8-v;
+	keep-power-in-suspend;
+	status = "okay";
+};
+
+&iomuxc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_hog_base>;
+
+	imx6qdl-dhcom_base {
+		pinctrl_dhcom_hog_base: hog_base_grp {
+			fsl,pins = <                                       	// DHCOM HW Version  | 100/200 | 300 | 400 |
+				MX6QDL_PAD_EIM_A19__GPIO2_IO19      0x120B0	// Code_HW_0 (#51)        0       1     0
+				MX6QDL_PAD_EIM_A23__GPIO6_IO06      0x120B0	// Code_HW_1 (#166)       0       0     1
+				MX6QDL_PAD_EIM_A22__GPIO2_IO16      0x120B0	// Code_HW_2 (#48)        0       0     0
+				MX6QDL_PAD_EIM_A16__GPIO2_IO22      0x120B0	// HW300: Code_DDR3_0 (#54)
+				MX6QDL_PAD_EIM_A17__GPIO2_IO21      0x120B0	// HW300: Code_DDR3_1 (#53)
+			>;
+		};
+
+		pinctrl_dhcom_pmic_hw300: pmic_hw300_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_A25__GPIO5_IO02      0x1B0B0	// GPIO 5.2: PMIC_IRQ#
+			>;
+		};
+
+		pinctrl_dhcom_tsc2004_hw300: tsc2004_hw300_grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL4__GPIO4_IO14     0x120B0	// GPIO 4.14: Touch Interrupt resistive
+			>;
+		};
+
+		pinctrl_dhcom_rtc_hw300: rtc_hw300_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_17__GPIO7_IO12      0x120B0	// GPIO 7.12: RTC Interrupt pin (#204)
+			>;
+		};
+
+		pinctrl_dhcom_ecspi1: ecspi1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D17__ECSPI1_MISO     0x100b1
+				MX6QDL_PAD_EIM_D18__ECSPI1_MOSI     0x100b1
+				MX6QDL_PAD_EIM_D16__ECSPI1_SCLK     0x100b1
+				MX6QDL_PAD_EIM_EB2__GPIO2_IO30      0x1b0b0	// SS0
+				MX6QDL_PAD_KEY_ROW2__GPIO4_IO11     0x1b0b0	// SS2
+			>;
+		};
+
+		pinctrl_dhcom_ecspi2: ecspi2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT10__ECSPI2_MISO  0x100b1
+				MX6QDL_PAD_CSI0_DAT9__ECSPI2_MOSI   0x100b1
+				MX6QDL_PAD_CSI0_DAT8__ECSPI2_SCLK   0x100b1
+				MX6QDL_PAD_CSI0_DAT11__GPIO5_IO29   0x1b0b0	// SS0
+			>;
+		};
+
+		pinctrl_dhcom_enet_100M: enet_100M_grp {			// 100MBit ethernet
+			fsl,pins = <
+				MX6QDL_PAD_ENET_MDIO__ENET_MDIO     0x1b0b0
+				MX6QDL_PAD_ENET_MDC__ENET_MDC       0x1b0b0
+				MX6QDL_PAD_ENET_CRS_DV__ENET_RX_EN  0x1b0b0
+				MX6QDL_PAD_ENET_RX_ER__ENET_RX_ER   0x1b0b0
+				MX6QDL_PAD_ENET_RXD0__ENET_RX_DATA0 0x1b0b0
+				MX6QDL_PAD_ENET_RXD1__ENET_RX_DATA1 0x1b0b0
+				MX6QDL_PAD_ENET_TX_EN__ENET_TX_EN   0x1b0b0
+				MX6QDL_PAD_ENET_TXD0__ENET_TX_DATA0 0x1b0b0
+				MX6QDL_PAD_ENET_TXD1__ENET_TX_DATA1 0x1b0b0
+				MX6QDL_PAD_GPIO_16__ENET_REF_CLK    0x4001b0a8
+				MX6QDL_PAD_EIM_WAIT__GPIO5_IO00     0x000b0	// ENET_RESET
+				MX6QDL_PAD_KEY_ROW4__GPIO4_IO15     0x000b1	// ENET_INT
+				MX6QDL_PAD_GPIO_7__GPIO1_IO07       0x120B0	// Power for LAN-Transformer 7499111614A
+			>;
+		};
+
+		pinctrl_dhcom_flexcan1: flexcan1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL2__FLEXCAN1_TX    0x1b0b0
+				MX6QDL_PAD_GPIO_8__FLEXCAN1_RX      0x1b0b0
+			>;
+		};
+
+		pinctrl_dhcom_i2c1: i2c1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D21__I2C1_SCL        0x4001b8b1
+				MX6QDL_PAD_EIM_D28__I2C1_SDA        0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_i2c2: i2c2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_KEY_COL3__I2C2_SCL       0x4001b8b1
+				MX6QDL_PAD_KEY_ROW3__I2C2_SDA       0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_i2c3: i2c3_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_3__I2C3_SCL         0x4001b8b1
+				MX6QDL_PAD_GPIO_6__I2C3_SDA         0x4001b8b1
+			>;
+		};
+
+		pinctrl_dhcom_uart1: uart1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_DAT7__UART1_TX_DATA  0x1b0b1
+				MX6QDL_PAD_SD3_DAT6__UART1_RX_DATA  0x1b0b1
+				MX6QDL_PAD_EIM_D20__UART1_RTS_B     0x1b0b1
+				MX6QDL_PAD_EIM_D19__UART1_CTS_B     0x4001b0b1
+				MX6QDL_PAD_EIM_D23__GPIO3_IO23      0x4001b0b1	// DCD
+				MX6QDL_PAD_EIM_D24__GPIO3_IO24      0x4001b0b1	// DTR
+				MX6QDL_PAD_EIM_D25__GPIO3_IO25      0x4001b0b1	// DSR
+				MX6QDL_PAD_EIM_EB3__GPIO2_IO31      0x4001b0b1	// RI
+			>;
+		};
+
+		pinctrl_dhcom_uart4: uart4_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT12__UART4_TX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT13__UART4_RX_DATA 0x1b0b1
+			>;
+		};
+	
+		pinctrl_dhcom_uart5: uart5_grp {
+			fsl,pins = <
+				MX6QDL_PAD_CSI0_DAT14__UART5_TX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT15__UART5_RX_DATA 0x1b0b1
+				MX6QDL_PAD_CSI0_DAT18__UART5_RTS_B   0x1b0b1
+				MX6QDL_PAD_CSI0_DAT19__UART5_CTS_B   0x4001b0b1
+			>;
+		};
+
+		pinctrl_dhcom_usbh1: usbh1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_D31__GPIO3_IO31      0x120B0	// GPIO: USB Host 1 Power
+			>;
+		};
+
+		pinctrl_dhcom_usbotg: usbotg_grp {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_1__USB_OTG_ID       0x17059
+			>;
+		};
+
+		pinctrl_dhcom_usdhc2: usdhc2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD2_CMD__SD2_CMD         0x17059
+				MX6QDL_PAD_SD2_CLK__SD2_CLK         0x10059
+				MX6QDL_PAD_SD2_DAT0__SD2_DATA0      0x17059
+				MX6QDL_PAD_SD2_DAT1__SD2_DATA1      0x17059
+				MX6QDL_PAD_SD2_DAT2__SD2_DATA2      0x17059
+				MX6QDL_PAD_SD2_DAT3__SD2_DATA3      0x17059
+				MX6QDL_PAD_NANDF_CS3__GPIO6_IO16    0x120B0	// GPIO: Card detection
+			>;
+		};
+
+		pinctrl_dhcom_usdhc3: usdhc3_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_CMD__SD3_CMD         0x17059
+				MX6QDL_PAD_SD3_CLK__SD3_CLK         0x10059
+				MX6QDL_PAD_SD3_DAT0__SD3_DATA0      0x17059
+				MX6QDL_PAD_SD3_DAT1__SD3_DATA1      0x17059
+				MX6QDL_PAD_SD3_DAT2__SD3_DATA2      0x17059
+				MX6QDL_PAD_SD3_DAT3__SD3_DATA3      0x17059
+				MX6QDL_PAD_SD3_RST__GPIO7_IO08      0x120B0	// GPIO: Card detection
+			>;
+		};
+
+		pinctrl_dhcom_usdhc4: usdhc4_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD4_CMD__SD4_CMD         0x17059
+				MX6QDL_PAD_SD4_CLK__SD4_CLK         0x10059
+				MX6QDL_PAD_SD4_DAT0__SD4_DATA0      0x17059
+				MX6QDL_PAD_SD4_DAT1__SD4_DATA1      0x17059
+				MX6QDL_PAD_SD4_DAT2__SD4_DATA2      0x17059
+				MX6QDL_PAD_SD4_DAT3__SD4_DATA3      0x17059
+				MX6QDL_PAD_SD4_DAT4__SD4_DATA4      0x17059
+				MX6QDL_PAD_SD4_DAT5__SD4_DATA5      0x17059
+				MX6QDL_PAD_SD4_DAT6__SD4_DATA6      0x17059
+				MX6QDL_PAD_SD4_DAT7__SD4_DATA7      0x17059
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom3H.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom3H.dtsi
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+#include "imx6qdl-dhcom3B.dtsi"							// Include interfaces from basic device tree
+#define DHCOM_HISPEED								// Use it in other device tree files, e.g. imx6qdl-dh_xxx.dtsi
+
+// Interfaces of the DHCOM hispeed connector will be configured here with the
+// status "disabled". If you need the interface set it to status "okay" in the
+// corresponding board file.
+&pcie {
+	status = "disabled";
+};
+
+// Only for DUAL and QUAD architecture
+#ifdef IMX6_CPU_DUAL_QUAD
+&sata {
+	status = "disabled";
+};
+#endif

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-can2.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-can2.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+&uart1 {									// UART 1
+	/delete-property/fsl,uart-has-rtscts;					// RTS/CTS pins are used by CAN 2
+	/delete-property/dtr-gpios;						// Remove useless DTR/DRS/DCD/RNG GPIOs
+	/delete-property/dsr-gpios;
+	/delete-property/dcd-gpios;
+	/delete-property/rng-gpios;
+
+};
+
+&usdhc3 {									// Micro SD card (onModule)
+	status = "disabled";							// This card slot isn't useable anymore,
+};										// because DATA0 and DATA1 are muxed to CAN 2 TX and RX
+
+&can2 {										// CAN 2
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_flexcan2>;
+	status = "okay";
+};
+
+&iomuxc {
+	imx6qdl-dhcom {
+		pinctrl_dhcom_flexcan2: flexcan2_grp {
+			fsl,pins = <
+				MX6QDL_PAD_SD3_DAT0__FLEXCAN2_TX    0x1b0b0
+				MX6QDL_PAD_SD3_DAT1__FLEXCAN2_RX    0x1b0b0
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-nand.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-nand.dtsi
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+&usdhc4 {									// Disable eMMC (onModule)
+	status = "disable";
+};
+
+&gpmi {										// GPMI (NAND)
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_gpmi_nand>;
+	nand-on-flash-bbt;
+	status = "okay";
+};
+
+&iomuxc {
+	imx6qdl-dhcom {
+		pinctrl_dhcom_gpmi_nand: gpmi_nand_grp {
+			fsl,pins = <
+				MX6QDL_PAD_NANDF_CLE__NAND_CLE      0xb0b1
+				MX6QDL_PAD_NANDF_ALE__NAND_ALE      0xb0b1
+				MX6QDL_PAD_NANDF_WP_B__NAND_WP_B    0xb0b1
+				MX6QDL_PAD_NANDF_RB0__NAND_READY_B  0xb000
+				MX6QDL_PAD_NANDF_CS0__NAND_CE0_B    0xb0b1
+				MX6QDL_PAD_SD4_CMD__NAND_RE_B       0xb0b1
+				MX6QDL_PAD_SD4_CLK__NAND_WE_B       0xb0b1
+				MX6QDL_PAD_NANDF_D0__NAND_DATA00    0xb0b1
+				MX6QDL_PAD_NANDF_D1__NAND_DATA01    0xb0b1
+				MX6QDL_PAD_NANDF_D2__NAND_DATA02    0xb0b1
+				MX6QDL_PAD_NANDF_D3__NAND_DATA03    0xb0b1
+				MX6QDL_PAD_NANDF_D4__NAND_DATA04    0xb0b1
+				MX6QDL_PAD_NANDF_D5__NAND_DATA05    0xb0b1
+				MX6QDL_PAD_NANDF_D6__NAND_DATA06    0xb0b1
+				MX6QDL_PAD_NANDF_D7__NAND_DATA07    0xb0b1
+				MX6QDL_PAD_SD4_DAT0__NAND_DQS       0x00b1
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-rs485.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-rs485.dtsi
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+&uart5 { 									// UART 2 (BT) ==> /dev/ttymxc4
+	fsl,rs485-mode;								// Enable rs485 mode
+	rts_gpio = <&gpio7 0 0>;						// GPIO M: rs485 rts = Receive Transmit Switch GPIO
+	rxen_gpio = <&gpio7 1 0>;						// GPIO N: rs485 rxen = RX Enable GPIO
+	//rs485-rx-during-tx;							// Receive data during transfer
+	status = "okay";
+};

--- a/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-weim.dtsi
+++ b/target/linux/imx6/files-4.14/arch/arm/boot/dts/imx6qdl-dhcom_cfg-weim.dtsi
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 DH electronics GmbH
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/ {
+	regulators {
+		reg_latch_oe_on: latch_oe_on {
+			compatible = "regulator-fixed";
+			regulator-name = "latch_oe_on";
+			#ifdef DHCOM_HW200
+				gpio = <&gpio6 30 0>;				// GPIO 6.30: LATCH_OE (#190)
+			#endif
+			#ifdef DHCOM_HW300
+				gpio = <&gpio3 22 0>;				// GPIO 3.22: LATCH_OE (#86)
+			#endif
+			//enable-active-high;					// Polarity of GPIO: Active low ==> Disable this property
+			regulator-always-on;
+		};
+	};
+};
+
+&weim {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_dhcom_weim &pinctrl_dhcom_weim_cs0 &pinctrl_dhcom_weim_cs1>;
+	#address-cells = <2>;
+	#size-cells = <1>;
+	/* it is necessary to setup 2x 64MB otherwise setting gpr fails */
+	ranges = <0 0  0x08000000  0x04000000>,					// Chip select 0 == DHCOM CS A
+		 <1 0  0x0c000000  0x04000000>;					// Chip select 1 == DHCOM CS B
+	fsl,weim-cs-gpr = <&gpr>;
+	status = "okay";
+
+	uiomap_cs0@0,0 {
+		compatible = "generic-uio";
+		reg = <0 0x00000000 0x04000000>;
+		reg-names = "uio_cs0";
+		interrupt-parent = <&gpio1>;
+		interrupts = <2 2>;						// Add gpio A == interrupt
+		#address-cells = <1>;
+		#size-cells = <1>;
+		fsl,weim-cs-timing = <0x00610089 0x00001002 0x0F011061
+				      0x00000000 0x0F068A31 0x00000000>;
+		status = "okay";
+	};
+
+	uiomap_cs1@0,1 {
+		compatible = "generic-uio";
+		reg = <1 0x00000000 0x04000000>;
+		reg-names = "uio_cs1";
+		interrupt-parent = <&gpio1>;
+		interrupts = <4 2>;						// Add gpio B == interrupt
+		#address-cells = <1>;
+		#size-cells = <1>;
+		fsl,weim-cs-timing = <0x00610089 0x00001002 0x0F011061
+				      0x00000000 0x0F068A31 0x00000000>;
+		status = "disabled";
+	};
+};
+
+&iomuxc {
+	imx6qdl-dhcom {
+		pinctrl_dhcom_weim: weim_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_OE__EIM_OE_B         0xb0a6
+				MX6QDL_PAD_EIM_RW__EIM_RW           0xb0a6	// Write Enable
+				MX6QDL_PAD_EIM_LBA__EIM_LBA_B       0xb060	// Latch Enable (LE)
+#ifdef DHCOM_HW200
+				MX6QDL_PAD_RGMII_RXC__GPIO6_IO30    0x130B0	// GPIO 6.30: LATCH_OE (#190)
+#endif
+#ifdef DHCOM_HW300
+				MX6QDL_PAD_EIM_D22__GPIO3_IO22      0x130B0	// GPIO 3.22: LATCH_OE (#86)
+#endif
+				/* address/data lines */
+				MX6QDL_PAD_EIM_DA15__EIM_AD15       0xb0a6
+				MX6QDL_PAD_EIM_DA14__EIM_AD14       0xb0a6
+				MX6QDL_PAD_EIM_DA13__EIM_AD13       0xb0a6
+				MX6QDL_PAD_EIM_DA12__EIM_AD12       0xb0a6
+				MX6QDL_PAD_EIM_DA11__EIM_AD11       0xb0a6
+				MX6QDL_PAD_EIM_DA10__EIM_AD10       0xb0a6
+				MX6QDL_PAD_EIM_DA9__EIM_AD09        0xb0a6
+				MX6QDL_PAD_EIM_DA8__EIM_AD08        0xb0a6
+				MX6QDL_PAD_EIM_DA7__EIM_AD07        0xb0a6
+				MX6QDL_PAD_EIM_DA6__EIM_AD06        0xb0a6
+				MX6QDL_PAD_EIM_DA5__EIM_AD05        0xb0a6
+				MX6QDL_PAD_EIM_DA4__EIM_AD04        0xb0a6
+				MX6QDL_PAD_EIM_DA3__EIM_AD03        0xb0a6
+				MX6QDL_PAD_EIM_DA2__EIM_AD02        0xb0a6
+				MX6QDL_PAD_EIM_DA1__EIM_AD01        0xb0a6
+				MX6QDL_PAD_EIM_DA0__EIM_AD00        0xb0a6
+			>;
+		};
+
+		pinctrl_dhcom_weim_cs0: weim_cs0_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_CS0__EIM_CS0_B       0xb0b1
+			>;
+		};
+
+		pinctrl_dhcom_weim_cs1: weim_cs1_grp {
+			fsl,pins = <
+				MX6QDL_PAD_EIM_CS1__EIM_CS1_B       0xb0b1
+			>;
+		};
+	};
+};

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -69,6 +69,12 @@ define Device/Default
   IMAGES :=
 endef
 
+define Device/FitImageMulti
+  KERNEL_SUFFIX := -fit-multi-uImage.itb
+  KERNEL = kernel-bin | gzip | fit-multi gzip $$(DTS_DIR) $$(DEVICE_DTS)
+  KERNEL_NAME := Image
+endef
+
 define Device/ventana
   DEVICE_TITLE := Gateworks Ventana family (normal NAND flash)
   DEVICE_DTS:= \
@@ -122,5 +128,23 @@ define Device/wandboard
   DEVICE_DTS := imx6dl-wandboard
 endef
 TARGET_DEVICES += wandboard
+
+define Device/dhcom-imx
+  $(call Device/FitImageMulti)
+  DEVICE_TITLE := DHCOM i.MX6
+  DEVICE_DTS := \
+    imx6dl-dhcom2B-pdk1 \
+    imx6dl-dhcom3B-drc02 \
+    imx6dl-dhcom3B-pdk2 \
+    imx6dl-dhcom3B-picoitx02 \
+    imx6dl-dhcom3H-pdk2 \
+    imx6q-dhcom2B-pdk1 \
+    imx6q-dhcom3B-drc02 \
+    imx6q-dhcom3B-pdk2 \
+    imx6q-dhcom3B-picoitx02 \
+    imx6q-dhcom3H-pdk2
+  KERNEL_INSTALL := 1
+endef
+TARGET_DEVICES += dhcom-imx
 
 $(eval $(call BuildImage))

--- a/target/linux/imx6/patches-4.14/300-dts_add_imx6-dhcom.patch
+++ b/target/linux/imx6/patches-4.14/300-dts_add_imx6-dhcom.patch
@@ -1,0 +1,26 @@
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -364,6 +364,11 @@ dtb-$(CONFIG_SOC_IMX6Q) += \
+ 	imx6dl-colibri-eval-v3.dtb \
+ 	imx6dl-cubox-i.dtb \
+ 	imx6dl-dfi-fs700-m60.dtb \
++	imx6dl-dhcom2B-pdk1.dtb \
++	imx6dl-dhcom3B-drc02.dtb \
++	imx6dl-dhcom3B-pdk2.dtb \
++	imx6dl-dhcom3B-picoitx02.dtb \
++	imx6dl-dhcom3H-pdk2.dtb \
+ 	imx6dl-gw51xx.dtb \
+ 	imx6dl-gw52xx.dtb \
+ 	imx6dl-gw53xx.dtb \
+@@ -408,6 +413,11 @@ dtb-$(CONFIG_SOC_IMX6Q) += \
+ 	imx6q-cm-fx6.dtb \
+ 	imx6q-cubox-i.dtb \
+ 	imx6q-dfi-fs700-m60.dtb \
++	imx6q-dhcom2B-pdk1.dtb \
++	imx6q-dhcom3B-drc02.dtb \
++	imx6q-dhcom3B-pdk2.dtb \
++	imx6q-dhcom3B-picoitx02.dtb \
++	imx6q-dhcom3H-pdk2.dtb \
+ 	imx6q-dmo-edmqmx6.dtb \
+ 	imx6q-evi.dtb \
+ 	imx6q-gk802.dtb \


### PR DESCRIPTION
Hello devs,

with the first commit i have created a new image command and a new script to create a fit image with multiple device tree and config sections.
That is our preferd way to build only one image for multiple board variations of one soc type.
Because of more included device trees, no config section would be set as default, so that bl should decide which configuration is needed. This would happen with "bootm #config" or with bootloader config option CONFIG_FIT_BEST_MATCH.
Don´t know if it would be better to modify the script mkits.sh to support both cases?

Now to the second commit and the new hw:

The DHCOM i.MX6 platform are single board computers in SODIMM-200 format.

This single board computers are available with i.MX6Solo, i.MX6DualLite,
i.MX6Dual and i.MX6Quad SoC and needs a baseboard for operation.
All variants are available with 256/512/1024/2048 MB RAM and 4/8/16 GB eMMC.

Bootloader U-Boot and environment is located on 2MB SPI-Flash (S25FL116K).
Bootloader configuration is mainline with "dh_imx6_defconfig".
Device tree files aren´t mainline but this is on todo list.

There are four baseboards available:
 - Premium Developer Kit 1/2 (pdk1/pdk2)
 - Pico-ITX2 (picoitx02)
 - DRC02 (drc02) -> DIN rail case

For more info: http://www.dh-electronics.de/en

Device Tree naming:
 - imx6dl       -> For i.MX6Solo and i.MX6DualLite
 - imx6q        -> For i.MX6Dual and i.MX6Quad
 - dhcom2B      -> For hw revision 2
 - dhcom3B      -> For hw revision 3 and 4
 - dhcom3H      -> For hw revision 3 and 4 with high speed interface
 - dh_drc02     -> For baseborad DHCON DRC02
 - dh_pdkX      -> For baseboard PDK1/2
 - dh_picoitx02 -> For baseboard Pico-ITX2
 - cfg-can2     -> Configures CAN2 and disables microSD and UART 1 RTS/CTS
 - cfg-rs486    -> Enables RS-485 mode for UART 2 (/dev/ttymxc4)
 - cfg-nand     -> Disables eMMC and enables NAND
 - cfg-weim     -> Enables Userspace I/O for i.MX6 parallel interface

```
Install procedure:
 - prepare SD-Card/eMMC with two ext3/ext4 partitions (boot and rootfs)
 - copy openwrt-imx6-dhcom-fit-multi-uImage.itb to first partition
 - extract openwrt-imx6-device-dhcom-rootfs.tar.gz to second partition
```

```
Boot procedure:
 For SD-Card:
  - setenv mmcdev 1
 For eMMC:
  - setenv mmcdev 2
 Generic:
  - setenv bootargs console=${console} root=/dev/mmcblk${mmcdev}p2 rw rootwait
  - load ${mmcdev}:1 ${loadaddr} openwrt-imx6-dhcom-fit-multi-uImage.itb
  - bootm [#imx6dl-dhcom3B-pdk2]
```

If our device will be accepted, that would be great.
Any suggestion for improvments?

Signed-off-by: Johann Neuhauser <jneuhauser@dh-electronics.de>