### PR TITLE
ramips: Add i2c support for mt7620n

### DIFF
--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -160,6 +160,22 @@
 			status = "disabled";
 		};
 
+		i2c: i2c@900 {
+			compatible = "ralink,rt2880-i2c";
+			reg = <0x900 0x100>;
+
+			resets = <&rstctrl 16>;
+			reset-names = "i2c";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c_pins>;
+		};
+
 		spi0: spi@b00 {
 			compatible = "ralink,mt7620a-spi", "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
@@ -190,6 +206,13 @@
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&spi_cs1>;
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
+			};
 		};
 
 		uartlite: uartlite@c00 {


### PR DESCRIPTION
I2c is supported on mt7620n like on mt7620a when checking the datasheet

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>

