### PR TITLE
mbedtls: Update to 2.9.0

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.8.0
+PKG_VERSION:=2.9.0
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-gpl.tgz
 PKG_SOURCE_URL:=https://tls.mbed.org/download/
-PKG_HASH:=649eb27187154590edda52943a7f468e740ec08807e5bf68ff45f4e8ffd68923
+PKG_HASH:=361837d0d8d4e178ac51ea1a4eacfbc0c57ea3cafb460fd6b46a1f4223a4e151
 
 PKG_BUILD_PARALLEL:=1
 PKG_LICENSE:=GPL-2.0+
@@ -64,6 +64,7 @@ endef
 PKG_INSTALL:=1
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
 
 CMAKE_OPTIONS += \
 	-DCMAKE_BUILD_TYPE:String="Release" \

--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -1,6 +1,6 @@
 --- a/include/mbedtls/config.h
 +++ b/include/mbedtls/config.h
-@@ -566,17 +566,17 @@
+@@ -599,17 +599,17 @@
   *
   * Comment macros to disable the curve and functions for it
   */
@@ -24,9 +24,9 @@
 +//#define MBEDTLS_ECP_DP_BP384R1_ENABLED
 +//#define MBEDTLS_ECP_DP_BP512R1_ENABLED
  #define MBEDTLS_ECP_DP_CURVE25519_ENABLED
+ #define MBEDTLS_ECP_DP_CURVE448_ENABLED
  
- /**
-@@ -601,8 +601,8 @@
+@@ -635,8 +635,8 @@
   * Requires: MBEDTLS_HMAC_DRBG_C
   *
   * Comment this macro to disable deterministic ECDSA.
@@ -36,7 +36,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-@@ -655,7 +655,7 @@
+@@ -689,7 +689,7 @@
   *             See dhm.h for more details.
   *
   */
@@ -45,7 +45,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-@@ -674,8 +674,8 @@
+@@ -708,8 +708,8 @@
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_ECDHE_PSK_WITH_RC4_128_SHA
@@ -55,7 +55,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-@@ -700,7 +700,7 @@
+@@ -734,7 +734,7 @@
   *      MBEDTLS_TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
   *      MBEDTLS_TLS_RSA_PSK_WITH_RC4_128_SHA
   */
@@ -64,7 +64,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-@@ -834,7 +834,7 @@
+@@ -868,7 +868,7 @@
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -73,7 +73,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-@@ -858,7 +858,7 @@
+@@ -892,7 +892,7 @@
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
   */
@@ -82,7 +82,7 @@
  
  /**
   * \def MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-@@ -962,7 +962,7 @@
+@@ -996,7 +996,7 @@
   * This option is only useful if both MBEDTLS_SHA256_C and
   * MBEDTLS_SHA512_C are defined. Otherwise the available hash module is used.
   */
@@ -91,7 +91,7 @@
  
  /**
   * \def MBEDTLS_ENTROPY_NV_SEED
-@@ -1057,14 +1057,14 @@
+@@ -1091,14 +1091,14 @@
   * Uncomment this macro to disable the use of CRT in RSA.
   *
   */
@@ -108,7 +108,7 @@
  
  /**
   * \def MBEDTLS_SHA256_SMALLER
-@@ -1080,7 +1080,7 @@
+@@ -1114,7 +1114,7 @@
   *
   * Uncomment to enable the smaller implementation of SHA256.
   */
@@ -117,7 +117,7 @@
  
  /**
   * \def MBEDTLS_SSL_ALL_ALERT_MESSAGES
-@@ -1207,7 +1207,7 @@
+@@ -1241,7 +1241,7 @@
   *          configuration of this extension).
   *
   */
@@ -126,7 +126,7 @@
  
  /**
   * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
-@@ -1381,8 +1381,8 @@
+@@ -1415,8 +1415,8 @@
   * callbacks are provided by MBEDTLS_SSL_TICKET_C.
   *
   * Comment this macro to disable support for SSL session tickets
@@ -136,7 +136,7 @@
  
  /**
   * \def MBEDTLS_SSL_EXPORT_KEYS
-@@ -1412,7 +1412,7 @@
+@@ -1446,7 +1446,7 @@
   *
   * Comment this macro to disable support for truncated HMAC in SSL
   */
@@ -145,7 +145,7 @@
  
  /**
   * \def MBEDTLS_SSL_TRUNCATED_HMAC_COMPAT
-@@ -1470,8 +1470,8 @@
+@@ -1504,8 +1504,8 @@
   * Requires: MBEDTLS_VERSION_C
   *
   * Comment this to disable run-time checking and save ROM space
@@ -155,7 +155,7 @@
  
  /**
   * \def MBEDTLS_X509_ALLOW_EXTENSIONS_NON_V3
-@@ -1801,7 +1801,7 @@
+@@ -1835,7 +1835,7 @@
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
   *      MBEDTLS_TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
   */
@@ -164,7 +164,7 @@
  
  /**
   * \def MBEDTLS_CCM_C
-@@ -1815,7 +1815,7 @@
+@@ -1849,7 +1849,7 @@
   * This module enables the AES-CCM ciphersuites, if other requisites are
   * enabled as well.
   */
@@ -173,7 +173,7 @@
  
  /**
   * \def MBEDTLS_CERTS_C
-@@ -1827,7 +1827,7 @@
+@@ -1861,7 +1861,7 @@
   *
   * This module is used for testing (ssl_client/server).
   */
@@ -182,7 +182,7 @@
  
  /**
   * \def MBEDTLS_CIPHER_C
-@@ -1880,7 +1880,7 @@
+@@ -1914,7 +1914,7 @@
   *
   * This module provides debugging functions.
   */
@@ -191,7 +191,7 @@
  
  /**
   * \def MBEDTLS_DES_C
-@@ -1909,7 +1909,7 @@
+@@ -1943,7 +1943,7 @@
   * \warning   DES is considered a weak cipher and its use constitutes a
   *            security risk. We recommend considering stronger ciphers instead.
   */
@@ -200,7 +200,7 @@
  
  /**
   * \def MBEDTLS_DHM_C
-@@ -2070,8 +2070,8 @@
+@@ -2104,8 +2104,8 @@
   * Requires: MBEDTLS_MD_C
   *
   * Uncomment to enable the HMAC_DRBG random number geerator.
@@ -210,7 +210,7 @@
  
  /**
   * \def MBEDTLS_MD_C
-@@ -2365,7 +2365,7 @@
+@@ -2399,7 +2399,7 @@
   * Caller:  library/md.c
   *
   */
@@ -219,7 +219,7 @@
  
  /**
   * \def MBEDTLS_RSA_C
-@@ -2449,8 +2449,8 @@
+@@ -2483,8 +2483,8 @@
   * Caller:
   *
   * Requires: MBEDTLS_SSL_CACHE_C
@@ -229,7 +229,7 @@
  
  /**
   * \def MBEDTLS_SSL_COOKIE_C
-@@ -2471,8 +2471,8 @@
+@@ -2505,8 +2505,8 @@
   * Caller:
   *
   * Requires: MBEDTLS_CIPHER_C
@@ -239,7 +239,7 @@
  
  /**
   * \def MBEDTLS_SSL_CLI_C
-@@ -2571,8 +2571,8 @@
+@@ -2605,8 +2605,8 @@
   * Module:  library/version.c
   *
   * This module provides run-time version information.
@@ -249,7 +249,7 @@
  
  /**
   * \def MBEDTLS_X509_USE_C
-@@ -2682,7 +2682,7 @@
+@@ -2716,7 +2716,7 @@
   * Module:  library/xtea.c
   * Caller:
   */


### PR DESCRIPTION
Update mbedtls to 2.9.0
Strip any optmization set by toolchain as upstream sets
O2 anyway if you define release as build type in CMake.
This is a cosmetic fix and also acts as a reminder that toolchain
setting isn't honored.
https://github.com/ARMmbed/mbedtls/blob/master/CMakeLists.txt#L73

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>