### PR TITLE
ath3k: Add firmware support for QCA Rome

### DIFF
--- a/package/firmware/linux-firmware/qca.mk
+++ b/package/firmware/linux-firmware/qca.mk
@@ -4,6 +4,10 @@ define Package/ar3k-firmware/install
 	$(CP) \
 		$(PKG_BUILD_DIR)/ar3k/*.dfu \
 		$(1)/lib/firmware/ar3k
+	$(INSTALL_DIR) $(1)/lib/firmware/qca
+	$(CP) \
+		$(PKG_BUILD_DIR)/qca/*.bin \
+		$(1)/lib/firmware/qca
 endef
 $(eval $(call BuildPackage,ar3k-firmware))
 


### PR DESCRIPTION
Add needed firmware for newer QCA Rome Bluetooth family.
This enables use of bluetooth with ath3k driver on QCA9377/9378 devices.

Signed-off-by: Robert Marko <robimarko@gmail.com>
