### PR TITLE
ath79: fix gmac compatible in ar9330.dtsi and ag71xx_setup_gmac_933x

### DIFF
--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -104,7 +104,7 @@
 		};
 
 		gmac: gmac@18070000 {
-			compatible = "qca,qr9330-gmac";
+			compatible = "qca,ar9330-gmac";
 			reg = <0x18070000 0x4>;
 		};
 	};

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1317,7 +1317,7 @@ static int ag71xx_setup_gmac(struct device_node *np)
 	}
 
 	if (of_device_is_compatible(np_dev, "qca,ar9330-gmac"))
-		ag71xx_setup_gmac_933x(np_dev, base);
+		ag71xx_setup_gmac_933x(np, base);
 
 	iounmap(base);
 


### PR DESCRIPTION
Fix gmac compatible in ar9330.dtsi and ag71xx_setup_gmac_933x.

1. compatible property in node gmac was wrong

1. ag71xx_setup_gmac_933x should use np of gmac-config and not the pointer to gmac. gmac is only used for the reg address.


This is used currently only in ar9331_ew_dorin.dts and ar9330_gl_ar150.dts.
But gmac register would be needed by other devices in the future too.

Example nodes:

ar9330.dtsi
```
ahb {
    ...
    gmac: gmac@18070000 {
        compatible = "qca,ar9330-gmac";
        reg = <0x18070000 0x4>;
    };
};
```

ar9331_ew_dorin.dts
```
&eth1 {
    ...
    gmac-config {
        device = <&gmac>;
        switch-phy-addr-swap = <1>;
        switch-phy-swap = <1>;
    };
};
```

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>
