### PR TITLE
hostapd: fix IEEE 802.11r (fast roaming) defaults

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -133,6 +133,10 @@ ifneq ($(LOCAL_TYPE),hostapd)
   ifdef CONFIG_WPA_SUPPLICANT_NO_TIMESTAMP_CHECK
     TARGET_CFLAGS += -DNO_TIMESTAMP_CHECK
   endif
+  ifeq ($(LOCAL_VARIANT),mini)
+    TARGET_CFLAGS += -flto
+    TARGET_LDFLAGS += -flto
+  endif
   ifdef CONFIG_WPA_RFKILL_SUPPORT
     DRIVER_MAKEOPTS += NEED_RFKILL=y
   endif

--- a/package/network/services/hostapd/files/hostapd-mini.config
+++ b/package/network/services/hostapd/files/hostapd-mini.config
@@ -142,7 +142,7 @@ CONFIG_PEERKEY=y
 #CONFIG_IPV6=y
 
 # IEEE Std 802.11r-2008 (Fast BSS Transition)
-#CONFIG_IEEE80211R=y
+CONFIG_IEEE80211R=y
 
 # Use the hostapd's IEEE 802.11 authentication (ACL), but without
 # the IEEE 802.11 Management capability (e.g., FreeBSD/net80211)


### PR DESCRIPTION
Use ft_psk_generate_local=1 by default, as it makes everything else fairly
trivial. All of the r0kh/r1kh and key management stuff goes away and hostapd
fairly much does it all	for us.

We do need to provide nas_identifier, which can	be derived from	the BSSID,
and we need to generate	a mobility_domain, for which we	default	to the first
four chars of the md5sum of the	SSID.

The complex manual setup should also still work, but the defaults also
now work easily out of the box. Verified by manually running hostapd
(with the autogenerated config) and watching the debug output:

wlan2: STA ac:37:43:a0:a6:ae WPA: FT authentication already completed - do not start 4-way handshake

 This was previous submitted to LEDE in
 https://github.com/lede-project/source/pull/1382

[dwmw2: Rewrote commit message]
Signed-off-by: Gospod Nassa <devianca@gmail.com>
Signed-off-by: David Woodhouse <dwmw2@infradead.org>
