### PR TITLE
netifd: drop conflicting 'device' interface property

### DIFF
--- a/package/network/config/netifd/files/etc/hotplug.d/iface/00-netstate
+++ b/package/network/config/netifd/files/etc/hotplug.d/iface/00-netstate
@@ -1,7 +1,6 @@
 [ ifup = "$ACTION" ] && {
 	uci_toggle_state network "$INTERFACE" up 1
 	[ -n "$DEVICE" ] && {
-		uci_toggle_state network "$INTERFACE" device "$(uci -q get network.$INTERFACE.ifname)"
 		uci_toggle_state network "$INTERFACE" ifname "$DEVICE"
 	}
 }

--- a/package/network/config/netifd/files/lib/network/config.sh
+++ b/package/network/config/netifd/files/lib/network/config.sh
@@ -41,15 +41,12 @@ fixup_interface() {
 
 	config_get type "$config" type
 	config_get ifname "$config" ifname
-	config_get device "$config" device "$ifname"
 	[ "bridge" = "$type" ] && ifname="br-$config"
-	config_set "$config" device "$ifname"
 	ubus_call "network.interface.$config" status || return 0
 	json_get_var l3dev l3_device
 	[ -n "$l3dev" ] && ifname="$l3dev"
 	json_init
 	config_set "$config" ifname "$ifname"
-	config_set "$config" device "$device"
 }
 
 scan_interfaces() {


### PR DESCRIPTION
Do not set `device` runtime property on interfaces in the hotplug handler
and in `fixup_interfaces()`. This property conflicts with `device` option
in several proto handlers (mainly QMI and other WWAN/3G protos) and does
not seem to be used anywhere.

Note: I previously tried to solicit feedback on this problem [on the lede-dev ML](http://lists.infradead.org/pipermail/lede-dev/2018-January/010788.html)
but nobody responded so far. @nbd168?