### PR TITLE
Layerscape fmc support

### DIFF
--- a/package/libs/layerscape/fmlib/Makefile
+++ b/package/libs/layerscape/fmlib/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright 2017 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fmlib
+PKG_VERSION:=2017.12
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/qoriq-open-source/fmlib.git
+PKG_SOURCE_VERSION:=95f34b1fe585ba0eced11433c88a593a16baf281
+PKG_MIRROR_HASH:=595f55cb083e3c0ceabc7e8742b6401853da47707a402922e3cd05b2c30de234
+
+PKG_BUILD_PARALLEL:=0
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fmlib
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Layerscape Frame Manager User Space Library
+  DEPENDS:=@TARGET_layerscape
+endef
+
+define Package/fmlib/description
+  The Frame Manager library provides an API on top of the
+  Frame Manager driver ioctl calls, that provides a user
+  space application with a simple way to configure driver
+  parameters and PCD (parse - classify - distribute) rules.
+endef
+
+MAKE_FLAGS += \
+	all install-libfm-arm \
+	KERNEL_SRC="$(LINUX_DIR)" \
+	PREFIX="$(PKG_INSTALL_DIR)"
+
+define Build/InstallDev
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+define Package/fmlib/install
+	$(INSTALL_DIR) $(1)/lib
+	$(CP) $(PKG_INSTALL_DIR)/lib/* $(1)/lib/
+endef
+
+$(eval $(call BuildPackage,fmlib))

--- a/package/libs/libxml2/Makefile
+++ b/package/libs/libxml2/Makefile
@@ -1,0 +1,141 @@
+#
+# Copyright (C) 2006-2016 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=libxml2
+PKG_VERSION:=2.9.8
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://xmlsoft.org/sources/
+PKG_HASH:=0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732
+
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=COPYING
+
+PKG_MAINTAINER:=Michael Heimpold <mhei@heimpold.de>
+
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=0
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libxml2
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Gnome XML library
+  URL:=http://xmlsoft.org/
+  DEPENDS:=+libpthread +zlib
+endef
+
+define Package/libxml2/description
+  A library for manipulating XML and HTML resources.
+endef
+
+TARGET_CFLAGS += $(FPIC)
+
+CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--with-c14n \
+	--without-catalog \
+	--with-debug \
+	--without-docbook \
+	--with-html \
+	--without-ftp \
+	--without-http \
+	--without-iconv \
+	--without-iso8859x \
+	--without-legacy \
+	--with-output \
+	--without-pattern \
+	--without-push \
+	--without-python \
+	--with-reader \
+	--without-readline \
+	--without-regexps \
+	--with-sax1 \
+	--with-schemas \
+	--with-threads \
+	--with-tree \
+	--with-valid \
+	--with-writer \
+	--with-xinclude \
+	--with-xpath \
+	--with-xptr \
+	--with-zlib=$(STAGING_DIR)/usr \
+	--without-lzma
+
+HOST_CONFIGURE_ARGS += \
+	--enable-shared \
+	--enable-static \
+	--with-c14n \
+	--without-catalog \
+	--with-debug \
+	--without-docbook \
+	--with-html \
+	--without-ftp \
+	--without-http \
+	--without-iconv \
+	--without-iso8859x \
+	--without-legacy \
+	--with-output \
+	--without-pattern \
+	--without-push \
+	--without-python \
+	--with-reader \
+	--without-readline \
+	--without-regexps \
+	--with-sax1 \
+	--with-schemas \
+	--with-threads \
+	--with-tree \
+	--with-valid \
+	--with-writer \
+	--with-xinclude \
+	--with-xpath \
+	--with-xptr \
+	--with-zlib \
+	--without-lzma
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(2)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/xml2-config $(2)/bin/
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(2)/bin/xml2-config
+
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/libxml2 $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxml2.{la,a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/cmake/libxml2
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/cmake/libxml2/libxml2-config.cmake \
+		$(1)/usr/lib/cmake/libxml2
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libxml-2.0.pc $(1)/usr/lib/pkgconfig/
+
+	$(INSTALL_DIR) $(2)/share/aclocal/
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(2)/share/aclocal
+endef
+
+define Package/libxml2/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libxml2.so* $(1)/usr/lib/
+endef
+
+define Host/Install
+	$(SED) 's,^\(prefix\|exec_prefix\)=.*,\1=$(STAGING_DIR)/usr,g' $(HOST_BUILD_DIR)/xml2-config
+	$(call Host/Install/Default)
+endef
+
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,libxml2))

--- a/package/libs/tclap/Makefile
+++ b/package/libs/tclap/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright 2017 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=tclap
+PKG_VERSION:=1.2.2
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=@SF/$(PKG_NAME)
+PKG_HASH:=f5013be7fcaafc69ba0ce2d1710f693f61e9c336b6292ae4f57554f59fde5837
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/tclap
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=Templatized C++ Command Line Parser Library
+  URL:=http://tclap.sourceforge.net
+endef
+
+define Package/tclap/description
+  TCLAP is a small, flexible library that provides a simple
+  interface for defining and accessing command line arguments.
+endef
+
+define Build/InstallDev
+	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+endef
+
+define Package/tclap/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,tclap))

--- a/package/network/utils/layerscape/fmc-eth-config/Makefile
+++ b/package/network/utils/layerscape/fmc-eth-config/Makefile
@@ -1,0 +1,38 @@
+#
+# Copyright 2017 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fmc-eth-config
+PKG_SOURCE_DATE:=2016-12-22
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/qoriq-open-source/eth-config.git
+PKG_SOURCE_VERSION:=e3dcd110638dab004bcc759f6f51a0994bdfd8d5
+PKG_MIRROR_HASH:=6e1b65b4c0d1d62731054c130e5274b08bc091bac8d5544a54847b67eb675390
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fmc-eth-config
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=@TARGET_layerscape
+  TITLE:=Layerscape Ethernet Configuration Files
+endef
+
+define Build/Compile
+endef
+
+define Package/fmc-eth-config/install
+	$(INSTALL_DIR) $(1)/etc/fmc/config/
+	$(CP) $(PKG_BUILD_DIR)/obsolete $(1)/etc/fmc/config/
+	$(CP) $(PKG_BUILD_DIR)/private $(1)/etc/fmc/config/
+	$(CP) $(PKG_BUILD_DIR)/shared_mac $(1)/etc/fmc/config/
+endef
+
+$(eval $(call BuildPackage,fmc-eth-config))

--- a/package/network/utils/layerscape/fmc/Makefile
+++ b/package/network/utils/layerscape/fmc/Makefile
@@ -1,0 +1,49 @@
+#
+# Copyright 2017 NXP
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=fmc
+PKG_SOURCE_DATE:=2017-09-22
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/qoriq-open-source/fmc.git
+PKG_SOURCE_VERSION:=8c9f127138dc803bf58bef75e9fc092dc60f9c53
+PKG_MIRROR_HASH:=199b91c0a49ab4a4aa1eded7703ea1c11241e22d21a41f00fe992c043b28b467
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/fmc
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=@TARGET_layerscape +libxml2 +tclap +fmlib +libstdcpp
+  TITLE:=Layerscape Frame Manager Configuration Tool
+endef
+
+define Package/fmc/description
+  The Frame Manager Configuration tool is a software package whose
+  primary purpose is converting Parse-Classify-Police-Distribute
+  (PCD) descriptions of network packets flow into hardware
+  configuration.
+endef
+
+MAKE_FLAGS += \
+	-C source \
+	FMD_USPACE_HEADER_PATH="$(STAGING_DIR)/include/fmd" \
+	FMD_USPACE_LIB_PATH="$(STAGING_DIR)/lib" \
+	LIBXML2_HEADER_PATH="$(STAGING_DIR)/usr/include/libxml2" \
+	TCLAP_HEADER_PATH="$(STAGING_DIR)/usr/include"
+
+define Package/fmc/install
+	$(INSTALL_DIR) $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/source/fmc $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/etc/
+	$(CP) $(PKG_BUILD_DIR)/etc/* $(1)/etc/
+endef
+
+$(eval $(call BuildPackage,fmc))

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -67,7 +67,8 @@ endef
 define Device/ls1043ardb
   DEVICE_TITLE := ls1043ardb-$(SUBTARGET)
   DEVICE_PACKAGES +=	rcw-layerscape-ls1043ardb uboot-layerscape-$(SUBTARGET)-ls1043ardb \
-			fman-layerscape-ls1043ardb layerscape-ppa-ls1043ardb fmc
+			fman-layerscape-ls1043ardb layerscape-ppa-ls1043ardb fmc \
+			fmc-eth-config
   DEVICE_DTS = ../../../arm64/boot/dts/freescale/fsl-ls1043a-rdb-sdk
   IMAGE/firmware.bin =	append-ls-rcw $(1) | pad-to 1M | \
 			append-ls-uboot $(1) | pad-to 4M | \
@@ -82,7 +83,8 @@ TARGET_DEVICES += ls1043ardb
 define Device/ls1046ardb
   DEVICE_TITLE := ls1046ardb-$(SUBTARGET)
   DEVICE_PACKAGES +=	rcw-layerscape-ls1046ardb uboot-layerscape-$(SUBTARGET)-ls1046ardb \
-			fman-layerscape-ls1046ardb layerscape-ppa-ls1046ardb fmc
+			fman-layerscape-ls1046ardb layerscape-ppa-ls1046ardb fmc \
+			fmc-eth-config
   DEVICE_DTS = ../../../arm64/boot/dts/freescale/fsl-ls1046a-rdb-sdk
   FILESYSTEMS := ubifs
   UBIFS_OPTS := -m 1 -e 262016 -c 128

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -67,7 +67,7 @@ endef
 define Device/ls1043ardb
   DEVICE_TITLE := ls1043ardb-$(SUBTARGET)
   DEVICE_PACKAGES +=	rcw-layerscape-ls1043ardb uboot-layerscape-$(SUBTARGET)-ls1043ardb \
-			fman-layerscape-ls1043ardb layerscape-ppa-ls1043ardb
+			fman-layerscape-ls1043ardb layerscape-ppa-ls1043ardb fmc
   DEVICE_DTS = ../../../arm64/boot/dts/freescale/fsl-ls1043a-rdb-sdk
   IMAGE/firmware.bin =	append-ls-rcw $(1) | pad-to 1M | \
 			append-ls-uboot $(1) | pad-to 4M | \
@@ -82,7 +82,7 @@ TARGET_DEVICES += ls1043ardb
 define Device/ls1046ardb
   DEVICE_TITLE := ls1046ardb-$(SUBTARGET)
   DEVICE_PACKAGES +=	rcw-layerscape-ls1046ardb uboot-layerscape-$(SUBTARGET)-ls1046ardb \
-			fman-layerscape-ls1046ardb layerscape-ppa-ls1046ardb
+			fman-layerscape-ls1046ardb layerscape-ppa-ls1046ardb fmc
   DEVICE_DTS = ../../../arm64/boot/dts/freescale/fsl-ls1046a-rdb-sdk
   FILESYSTEMS := ubifs
   UBIFS_OPTS := -m 1 -e 262016 -c 128


### PR DESCRIPTION
The old pull request was merged leaving out fmc packages patches since they depended on libxml2 which was in package feed.
https://github.com/openwrt/openwrt/pull/724

This pull request moved libxml2 to core openwrt and added layerscape fmc support.
(packages.git libxml2 pull request: https://github.com/openwrt/packages/pull/6052)
Please help to review.

