### PR TITLE
hostapd: fix VHT80 for encrypted mesh channel settings

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/033-mesh-fix-parsing-of-max_oper_chwidth.patch
+++ b/package/network/services/hostapd/patches/033-mesh-fix-parsing-of-max_oper_chwidth.patch
@@ -1,0 +1,45 @@
+From 444adf78eeb129e415d53fcb2fa2f05b6a69abdc Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven.eckelmann@openmesh.com>
+Date: Mon,  7 May 2018 15:24:29 +0200
+Subject: wpa_supplicant: Fix parsing of max_oper_chwidth
+
+The max_oper_chwidth is parsed in wpa_config_set as INT_RANGE (see
+ssid_fields). The actual parsing for INT_RANGE is done by
+wpa_config_parse_int which can only store the result as full integer.
+
+max_oper_chwidth is stored as u8 (a single byte) in wpa_ssid. This means
+that on little endian systems, the least significant byte of the parsed
+value are really stored in the max_oper_chwidth. But on big endian system,
+the only most significant byte is stored as max_oper_chwidth. This means
+that 0 is always stored because the provided range doesn't allow any other
+value for systems with multi-byte-wide integers.
+
+This also means that for common systems with 4-byte-wide integers, the
+remaining 3 bytes were written after the actual member of the struct. This
+should not have influenced the behavior of succeeding members because these
+bytes would have been part of the padding between the members on most
+systems.
+
+Increasing its size to a full int fixes the write operations outside of the
+member and allows to use the max_oper_chwidth setting on big endian
+systems.
+
+Fixes: 0f29bc68d18e ("IBSS/mesh: Add support for VHT80P80 configuration")
+Signed-off-by: Sven Eckelmann <sven.eckelmann@openmesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/909751/
+---
+ wpa_supplicant/config_ssid.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/wpa_supplicant/config_ssid.h
++++ b/wpa_supplicant/config_ssid.h
+@@ -503,7 +503,7 @@ struct wpa_ssid {
+ 
+ 	int vht;
+ 
+-	u8 max_oper_chwidth;
++	int max_oper_chwidth;
+ 
+ 	unsigned int vht_center_freq1;
+ 	unsigned int vht_center_freq2;


### PR DESCRIPTION
The max_oper_chwidth settings was parsed incorrectly for big endian system. This prevented the system to switch to VHT80 (or VHT160). Instead they were mapped to:

* HT20:   20MHz
* VHT20:  20MHz
* HT40:   40MHz
* VHT40:  40MHz
* VHT80:  40MHz
* VHT160: 40MHz

This happened because each max_oper_chwidth setting in the config file was parsed as "0" instead of the actual value.

Fixes: a4322eba2b12 ("hostapd: fix encrypted mesh channel settings")