### PR TITLE
mac80211: Re-enable encrypted 11s meshpoint

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=mac80211
 
 PKG_VERSION:=2017-11-01
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources
 PKG_HASH:=8437ab7886b988c8152e7a4db30b7f41009e49a3b2cb863edd05da1ecd7eb05a
 

--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -634,8 +634,8 @@ mac80211_setup_vif() {
 	case "$mode" in
 		mesh)
 			json_get_vars key
+			wireless_vif_parse_encryption
 			if [ "$wpa" -gt 0 -o "$auto_channel" -gt 0 ] || chan_is_dfs "$phy" "$channel"; then
-				wireless_vif_parse_encryption
 				freq="$(get_freq "$phy" "$channel")"
 				mac80211_setup_supplicant || failed=1
 			else


### PR DESCRIPTION
The commit 574e4377fad5 ("mac80211: properly setup mesh interface") uses the variable $wpa to decide whether encrypted meshpoint is requested by the user or not. But the variable $wpa will only be set correctly after the function wireless_vif_parse_encryption is called.

Fixes: 574e4377fad5 ("mac80211: properly setup mesh interface")

----
@dangowrt, you might be interested in this change.