### PR TITLE
mvebu: initial support for Marvell Armada 7k and 8k DB boards

### DIFF
--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -49,6 +49,12 @@ globalscale,espressobin)
 marvell,armada8040-mcbin)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth3" "eth2"
 	;;
+marvell,armada8040-db)
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
+	;;
+marvell,armada7040-db)
+	ucidef_set_interfaces_lan_wan "eth0 eth2" "eth1"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/mvebu/base-files/lib/mvebu.sh
+++ b/target/linux/mvebu/base-files/lib/mvebu.sh
@@ -23,6 +23,12 @@ mvebu_board_detect() {
 	*"Marvell 8040 MACHIATOBin")
 		name="marvell,armada8040-mcbin"
 		;;
+	*"Marvell Armada 8040 DB board")
+		name="marvell,armada8040-db"
+		;;
+	*"Marvell Armada 7040 DB board")
+		name="marvell,armada7040-db"
+		;;
 	*"Globalscale Mirabox")
 		name="mirabox"
 		;;

--- a/target/linux/mvebu/image/cortex-a72.mk
+++ b/target/linux/mvebu/image/cortex-a72.mk
@@ -13,4 +13,30 @@ define Device/armada-macchiatobin
 endef
 TARGET_DEVICES += armada-macchiatobin
 
+define Device/armada-8040-db
+  KERNEL_NAME := Image
+  KERNEL := kernel-bin
+  DEVICE_TITLE := Marvell Armada 8040 DB board
+  DEVICE_PACKAGES := e2fsprogs ethtool mkf2fs kmod-fs-vfat kmod-mmc
+  IMAGES := sdcard.img.gz
+  IMAGE/sdcard.img.gz := boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
+  DEVICE_DTS := armada-8040-db
+  DTS_DIR := $(DTS_DIR)/marvell
+  SUPPORTED_DEVICES := marvell,armada8040-db
+endef
+TARGET_DEVICES += armada-8040-db
+
+define Device/armada-7040-db
+  KERNEL_NAME := Image
+  KERNEL := kernel-bin
+  DEVICE_TITLE := Marvell Armada 7040 DB board
+  DEVICE_PACKAGES := e2fsprogs ethtool mkf2fs kmod-fs-vfat kmod-mmc
+  IMAGES := sdcard.img.gz
+  IMAGE/sdcard.img.gz := boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
+  DEVICE_DTS := armada-7040-db
+  DTS_DIR := $(DTS_DIR)/marvell
+  SUPPORTED_DEVICES := marvell,armada7040-db
+endef
+TARGET_DEVICES += armada-7040-db
+
 endif


### PR DESCRIPTION
Add initial support for cortex-a72 based Armada DB-88F8040-Modular and
DB-88F7040-Modular development boards.
