### PR TITLE
mvebu: initial support for Marvell Armada 3720 DB board

### DIFF
--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -46,6 +46,9 @@ armada-xp-gp)
 globalscale,espressobin)
 	ucidef_set_interfaces_lan_wan "lan0 lan1" "wan"
 	;;
+marvell,armada-3720-db)
+	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	;;
 marvell,armada8040-mcbin)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth3" "eth2"
 	;;

--- a/target/linux/mvebu/base-files/lib/mvebu.sh
+++ b/target/linux/mvebu/base-files/lib/mvebu.sh
@@ -20,6 +20,9 @@ mvebu_board_detect() {
 	*"Globalscale Marvell ESPRESSOBin Board")
 		name="globalscale,espressobin"
 		;;
+	*"Marvell Armada 3720 Development Board DB-88F3720-DDR3")
+		name="marvell,armada-3720-db"
+		;;
 	*"Marvell 8040 MACHIATOBin")
 		name="marvell,armada8040-mcbin"
 		;;

--- a/target/linux/mvebu/image/armada-3720-db.bootscript
+++ b/target/linux/mvebu/image/armada-3720-db.bootscript
@@ -1,0 +1,10 @@
+setenv bootargs "root=PARTUUID=@ROOT@-02 rw rootwait"
+
+if test -n "${console}"; then
+	setenv bootargs "${bootargs} ${console}"
+fi
+
+load mmc 0:1 ${fdt_addr} armada-3720-db.dtb
+load mmc 0:1 ${kernel_addr} Image
+
+booti ${kernel_addr} - ${fdt_addr}

--- a/target/linux/mvebu/image/cortex-a53.mk
+++ b/target/linux/mvebu/image/cortex-a53.mk
@@ -13,4 +13,17 @@ define Device/globalscale-espressobin
 endef
 TARGET_DEVICES += globalscale-espressobin
 
+define Device/armada-3720-db
+  KERNEL_NAME := Image
+  KERNEL := kernel-bin
+  DEVICE_TITLE := Marvell Armada 3720 Development Board DB-88F3720-DDR3
+  DEVICE_PACKAGES := e2fsprogs ethtool mkf2fs kmod-fs-vfat kmod-usb2 kmod-usb3 kmod-usb-storage
+  IMAGES := sdcard.img.gz
+  IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
+  DEVICE_DTS := armada-3720-db
+  DTS_DIR := $(DTS_DIR)/marvell
+  SUPPORTED_DEVICES := marvell,armada-3720-db
+endef
+TARGET_DEVICES += armada-3720-db
+
 endif


### PR DESCRIPTION
Add initial support for Marvell Armada cortex-a53 based DB-88F3720-DDR3-Modular development board.
