### PR TITLE
ramips: add support for TP-Link Archer C2

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
@@ -18,6 +18,7 @@
 #include <linux/of.h>
 #include <linux/of_platform.h>
 #include <linux/of_gpio.h>
+#include <linux/of_mdio.h>
 #include <linux/rtl8366.h>
 #include <linux/version.h>
 #include <linux/of_mdio.h>
@@ -199,7 +200,7 @@ static int rtl8366_smi_read_byte1(struct rtl8366_smi *smi, u8 *data)
 	return 0;
 }
 
-int rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
+static int __rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 {
 	unsigned long flags;
 	u8 lo = 0;
@@ -239,6 +240,101 @@ int rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 	spin_unlock_irqrestore(&smi->lock, flags);
 
 	return ret;
+}
+/* Read/write via mdiobus */
+#define MDC_MDIO_CTRL0_REG		31
+#define MDC_MDIO_START_REG		29
+#define MDC_MDIO_CTRL1_REG		21
+#define MDC_MDIO_ADDRESS_REG		23
+#define MDC_MDIO_DATA_WRITE_REG		24
+#define MDC_MDIO_DATA_READ_REG		25
+
+#define MDC_MDIO_START_OP		0xFFFF
+#define MDC_MDIO_ADDR_OP		0x000E
+#define MDC_MDIO_READ_OP		0x0001
+#define MDC_MDIO_WRITE_OP		0x0003
+#define MDC_REALTEK_PHY_ADDR		0x0
+
+int __rtl8366_mdio_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
+{
+	u32 phy_id = MDC_REALTEK_PHY_ADDR;
+	struct mii_bus *mbus = smi->ext_mbus;
+
+	BUG_ON(in_interrupt());
+
+	mutex_lock(&mbus->mdio_lock);
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write address control code to register 31 */
+	mbus->write(mbus, phy_id, MDC_MDIO_CTRL0_REG, MDC_MDIO_ADDR_OP);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write address to register 23 */
+	mbus->write(mbus, phy_id, MDC_MDIO_ADDRESS_REG, addr);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write read control code to register 21 */
+	mbus->write(mbus, phy_id, MDC_MDIO_CTRL1_REG, MDC_MDIO_READ_OP);
+
+	/* Write Start command to register 29 */
+	mbus->write(smi->ext_mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Read data from register 25 */
+	*data = mbus->read(mbus, phy_id, MDC_MDIO_DATA_READ_REG);
+
+	mutex_unlock(&mbus->mdio_lock);
+
+	return 0;
+}
+
+static int __rtl8366_mdio_write_reg(struct rtl8366_smi *smi, u32 addr, u32 data)
+{
+	u32 phy_id = MDC_REALTEK_PHY_ADDR;
+	struct mii_bus *mbus = smi->ext_mbus;
+
+	BUG_ON(in_interrupt());
+
+	mutex_lock(&mbus->mdio_lock);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write address control code to register 31 */
+	mbus->write(mbus, phy_id, MDC_MDIO_CTRL0_REG, MDC_MDIO_ADDR_OP);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write address to register 23 */
+	mbus->write(mbus, phy_id, MDC_MDIO_ADDRESS_REG, addr);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write data to register 24 */
+	mbus->write(mbus, phy_id, MDC_MDIO_DATA_WRITE_REG, data);
+
+	/* Write Start command to register 29 */
+	mbus->write(mbus, phy_id, MDC_MDIO_START_REG, MDC_MDIO_START_OP);
+
+	/* Write data control code to register 21 */
+	mbus->write(mbus, phy_id, MDC_MDIO_CTRL1_REG, MDC_MDIO_WRITE_OP);
+
+	mutex_unlock(&mbus->mdio_lock);
+	return 0;
+}
+
+int rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
+{
+    if(smi->ext_mbus)
+	return __rtl8366_mdio_read_reg(smi, addr, data);
+    else
+	return __rtl8366_smi_read_reg(smi, addr, data);
 }
 EXPORT_SYMBOL_GPL(rtl8366_smi_read_reg);
 
@@ -291,6 +387,9 @@ static int __rtl8366_smi_write_reg(struct rtl8366_smi *smi,
 
 int rtl8366_smi_write_reg(struct rtl8366_smi *smi, u32 addr, u32 data)
 {
+    if(smi->ext_mbus)
+	return __rtl8366_mdio_write_reg(smi, addr, data);
+    else
 	return __rtl8366_smi_write_reg(smi, addr, data, true);
 }
 EXPORT_SYMBOL_GPL(rtl8366_smi_write_reg);
@@ -1282,18 +1381,20 @@ static int __rtl8366_smi_init(struct rtl8366_smi *smi, const char *name)
 {
 	int err;
 
-	err = gpio_request(smi->gpio_sda, name);
-	if (err) {
-		printk(KERN_ERR "rtl8366_smi: gpio_request failed for %u, err=%d\n",
-			smi->gpio_sda, err);
-		goto err_out;
-	}
+	if(!smi->ext_mbus) {
+		err = gpio_request(smi->gpio_sda, name);
+		if (err) {
+			printk(KERN_ERR "rtl8366_smi: gpio_request failed for %u, err=%d\n",
+				smi->gpio_sda, err);
+			goto err_out;
+		}
 
-	err = gpio_request(smi->gpio_sck, name);
-	if (err) {
-		printk(KERN_ERR "rtl8366_smi: gpio_request failed for %u, err=%d\n",
-			smi->gpio_sck, err);
-		goto err_free_sda;
+		err = gpio_request(smi->gpio_sck, name);
+		if (err) {
+			printk(KERN_ERR "rtl8366_smi: gpio_request failed for %u, err=%d\n",
+				smi->gpio_sck, err);
+			goto err_free_sda;
+		}
 	}
 
 	spin_lock_init(&smi->lock);
@@ -1316,9 +1417,10 @@ static void __rtl8366_smi_cleanup(struct rtl8366_smi *smi)
 {
 	if (smi->hw_reset)
 		smi->hw_reset(smi, true);
-
-	gpio_free(smi->gpio_sck);
-	gpio_free(smi->gpio_sda);
+	if(!smi->ext_mbus) {
+		gpio_free(smi->gpio_sck);
+		gpio_free(smi->gpio_sda);
+	}
 }
 
 enum rtl8366_type rtl8366_smi_detect(struct rtl8366_platform_data *pdata)
@@ -1371,8 +1473,11 @@ int rtl8366_smi_init(struct rtl8366_smi *smi)
 	if (err)
 		goto err_out;
 
-	dev_info(smi->parent, "using GPIO pins %u (SDA) and %u (SCK)\n",
+	if(!smi->ext_mbus)
+		dev_info(smi->parent, "using GPIO pins %u (SDA) and %u (SCK)\n",
 		 smi->gpio_sda, smi->gpio_sck);
+	else
+		dev_info(smi->parent, "using MDIO bus '%s'\n", smi->ext_mbus->name);
 
 	err = smi->ops->detect(smi);
 	if (err) {
@@ -1437,7 +1542,24 @@ int rtl8366_smi_probe_of(struct platform_device *pdev, struct rtl8366_smi *smi)
 {
 	int sck = of_get_named_gpio(pdev->dev.of_node, "gpio-sck", 0);
 	int sda = of_get_named_gpio(pdev->dev.of_node, "gpio-sda", 0);
+	struct device_node *np = pdev->dev.of_node;;
+	struct device_node *mdio_node = NULL;
 
+	mdio_node = of_parse_phandle(np, "mii-bus", 0);
+	if (!mdio_node) {
+		dev_err(&pdev->dev, "cannot find mdio node phandle");
+		goto try_gpio;
+	}
+
+	smi->ext_mbus = of_mdio_find_bus(mdio_node);
+	if (!smi->ext_mbus) {
+		dev_err(&pdev->dev,
+			"cannot find mdio bus from bus handle");
+		goto try_gpio;
+	}
+	return 0;
+
+try_gpio:
 	if (!gpio_is_valid(sck) || !gpio_is_valid(sda)) {
 		dev_err(&pdev->dev, "gpios missing in devictree\n");
 		return -EINVAL;

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.h
@@ -63,6 +63,7 @@ struct rtl8366_smi {
 	u16			dbg_reg;
 	u8			dbg_vlan_4k_page;
 #endif
+	struct mii_bus		*ext_mbus;
 };
 
 struct rtl8366_vlan_mc {

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -396,6 +396,11 @@ tl-wr841n-v13)
 	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
+tplink,c2)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch1" "0x1e"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch1" "0x01"
+	set_usb_led "$boardname:green:usb" "2-1"
+	set_wifi_led "$boardname:green:wlan"
 tplink,c20-v1)
 	ucidef_set_led_switch "lan" "lan" "$boardname:blue:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x01"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -219,6 +219,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
+	tplink,c2)
+		ucidef_add_switch "switch1" \
+			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
+		;;
 	c50|\
 	tplink,c20-v1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -74,6 +74,7 @@ get_status_led() {
 		;;
 	alfa-network,ac1200rm|\
 	awapn2403|\
+	tplink,c2|\
 	dir-645|\
 	sk-wb8|\
 	wrh-300cr)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -250,6 +250,7 @@ platform_check_image() {
 	c20i|\
 	c50|\
 	mr200|\
+	tplink,c2|\
 	tplink,c20-v1|\
 	tplink,c20-v4|\
 	tplink,c50-v3|\

--- a/target/linux/ramips/dts/ArcherC2.dts
+++ b/target/linux/ramips/dts/ArcherC2.dts
@@ -1,0 +1,175 @@
+/dts-v1/;
+
+/include/ "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,c2", "ralink,mt7620a-soc";
+	model = "TP-Link Archer C2";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+
+	pinctrl {
+		state_default: pinctrl0 {
+			gpio {
+				ralink,group = "i2c", "uartf", "wled", "ephy", "spi refclk";
+				ralink,function = "gpio";
+			};
+		};
+	};
+
+	gpio-leds { 
+		compatible = "gpio-leds";
+
+		lan {
+			label = "c2:green:lan";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		};
+		usb {
+			label = "c2:green:usb";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+		wps {
+			label = "c2:green:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+		wan {
+			label = "c2:green:wan";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+		wlan {
+			label = "c2:green:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset_wps { 
+			label = "reset_wps"; 
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>; 
+			linux,code = <KEY_RESTART>; 
+		}; 
+
+		rfkill { 
+			label = "rfkill"; 
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>; 
+			linux,code = <KEY_RFKILL>; 
+		}; 
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b", "rtl8367b";
+		cpu_port = <6>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x20000 0x7a0000>;
+		};
+
+		partition@7c0000 {
+			label = "config";
+			reg = <0x7c0000 0x10000>;
+			read-only;
+		};
+
+		rom: partition@7d0000 {
+			label = "rom";
+			reg = <0x7d0000 0x10000>;
+			read-only;
+		};
+
+		partition@7e0000 {
+			label = "romfile";
+			reg = <0x7e0000 0x10000>;
+			read-only;
+		};
+
+		radio: partition@7f0000 {
+			label = "radio";
+			reg = <0x7f0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&rom 0xf100>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+	};
+};
+
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&radio 0>;
+	mtd-mac-address = <&rom 0xf100>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&radio 0x8000>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/kng_rc.dts
+++ b/target/linux/ramips/dts/kng_rc.dts
@@ -78,7 +78,7 @@
 		compatible = "realtek,rtl8367b";
 		cpu_port = <7>;
 		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
-		mdio = <&mdio0>;
+		mii-bus = <&mdio0>;
 	};
 };
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -464,6 +464,19 @@ define Device/tiny-ac
 endef
 TARGET_DEVICES += tiny-ac
 
+define Device/tplink_c2
+  $(Device/Archer)
+  DTS := ArcherC2
+  SUPPORTED_DEVICES := c2
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0xc7500001
+  TPLINK_HWREV := 50
+  IMAGES += factory.bin
+  DEVICE_TITLE := TP-Link ArcherC2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += tplink_c2
+
 define Device/tplink_c20-v1
   $(Device/Archer)
   DTS := ArcherC20v1


### PR DESCRIPTION
It was made by Serge Vasilugin <vasilugin@yandex.ru> based on these patches:
https://patchwork.ozlabs.org/patch/894715/
https://pastebin.com/UEjhWJap

Specification:
- System-On-Chip:	MT7620A
- CPU/Speed: 580 MHz
- Flash-Chip: Winbond 25Q64BVSIG
- Flash size: 8192 KiB
- RAM: 64 MiB
- Wireless No1: SoC-integrated: MT7620A 2.4GHz 802.11bgn
- Wireless No2: On-board chip: MT7610EN 5GHz 802.11ac
- Switch: RTL8367RB Gigabit Switch
- USB: Yes 1 x 2.0

Installation Instructions can be found here:
https://openwrt.org/toh/tp-link/ac750#installation_v1_model_only

I've successfully tested it with my Archer C2 V1.1.

I also want to mention that with this patch only the 2.4GHz wifi works. 5GHz can only be used with some non-free SW from mediatek.

Signed-off-by: Franz Flasch <franz.flasch@gmx.at>
