### PR TITLE
 ipq40xx: add eva-image for FRITZ!Box 4040 

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -186,6 +186,10 @@ define Build/append-ubi
 	rm $@.tmp
 endef
 
+define Build/append-uboot
+	dd if=$(UBOOT_PATH) >> $@
+endef
+
 define Build/pad-to
 	dd if=$@ of=$@.new bs=$(1) conv=sync
 	mv $@.new $@

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -80,7 +80,10 @@ define Device/avm_fritzbox-4040
 	BOARD_NAME := fritz4040
 	DEVICE_TITLE := AVM Fritz!Box 4040
 	IMAGE_SIZE := 29753344
-	IMAGES = sysupgrade.bin
+	UBOOT_PATH := $$(BIN_DIR)/u-boot-fritz4040/uboot-fritz4040.bin
+	UBOOT_PARTITION_SIZE := 524288
+	IMAGES = eva.bin sysupgrade.bin
+	IMAGE/eva.bin := append-uboot | pad-to $$$$(UBOOT_PARTITION_SIZE) | append-kernel | append-rootfs | pad-rootfs
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 	DEVICE_PACKAGES := fritz-tffs fritz-caldata u-boot-fritz4040
 endef


### PR DESCRIPTION
This adds an image flashable via the vendor EVA bootloader. 

This way we remove the need to solder UART for inital flashing (UART is currently needed to flash OpenWRT from the chainloaded U-Boot). The image created this way is verified working.