### PR TITLE
fstools: media change detection (eg:sdcard) using kernel polling

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -110,6 +110,7 @@ define Package/block-mount/install
 	$(INSTALL_BIN) ./files/fstab.init $(1)/etc/init.d/fstab
 	$(INSTALL_CONF) ./files/fstab.default $(1)/etc/uci-defaults/10-fstab
 	$(INSTALL_CONF) ./files/mount.hotplug $(1)/etc/hotplug.d/block/10-mount
+	$(INSTALL_CONF) ./files/media-change.hotplug  $(1)/etc/hotplug.d/block/00-media-change
 
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/block $(1)/sbin/
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libblkid-tiny.so $(1)/lib/

--- a/package/system/fstools/files/media-change.hotplug
+++ b/package/system/fstools/files/media-change.hotplug
@@ -1,0 +1,3 @@
+[ -n "$DISK_MEDIA_CHANGE" ] && /sbin/block info
+
+[ $ACTION == "add" -a $DEVTYPE == "disk" -a $DEVICENAME != mtd* ] && { echo 2000 > /sys/block/$DEVNAME/events_poll_msecs; }


### PR DESCRIPTION
Linux kernel has a polling mechanism that can be activated by changing the parameter /sys/module/block/parameters/events_dfl_poll_msecs which is deactivated by default or the /sys/block/[device]/events_poll_msecs for one device.
This patch set the events_poll_msecs when a disk is inserted.
Once the media disk change event is sent by the kernel then we force a re-read of the devices using /sbin/block info

With this patch, insertion and ejection of sd card will automatically generate partition devices in /dev

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>

