### PR TITLE
Busybox host compatibility

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -135,7 +135,7 @@ define Build/lzma-no-dict
 endef
 
 define Build/gzip
-	gzip --force -9n -c $@ $(1) > $@.new
+	gzip -f -9n -c $@ $(1) > $@.new
 	@mv $@.new $@
 endef
 

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -138,9 +138,10 @@ $(eval $(call SetupHostCommand,bzip2,Please install 'bzip2', \
 $(eval $(call SetupHostCommand,wget,Please install GNU 'wget', \
 	wget --version | grep GNU))
 
-$(eval $(call SetupHostCommand,gtime,Please install GNU 'time', \
+$(eval $(call SetupHostCommand,time,Please install GNU 'time' or BusyBox 'time', \
 	gtime --version 2>&1 | grep GNU, \
-	time --version 2>&1 | grep GNU))
+	time --version 2>&1 | grep GNU, \
+	busybox time 2>&1 | grep BusyBox))
 
 $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))

--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -43,7 +43,7 @@ log_make = \
 	 $(if $(BUILD_LOG), \
 		set -o pipefail; \
 		mkdir -p $(BUILD_LOG_DIR)/$(1)$(if $(4),/$(4));) \
-	gtime -f "time: $(1)$(if $(4),/$(4))/$(if $(3),$(3)-)$(2)\#%U\#%S\#%e" -- \
+	env time -f "time: $(1)$(if $(4),/$(4))/$(if $(3),$(3)-)$(2)\#%U\#%S\#%e" -- \
 	$$(SUBMAKE) $(subdir_make_opts) $(if $(3),$(3)-)$(2) \
 		$(if $(BUILD_LOG),SILENT= 2>&1 | tee $(BUILD_LOG_DIR)/$(1)$(if $(4),/$(4))/$(if $(3),$(3)-)$(2).txt)
 


### PR DESCRIPTION
This PR removes a couple of GNU-isms from buildroot-ng:

Busybox time supports the GNU time '-f' syntax used by the build time
logging implemented in ff6e62b288c, however the prerequisite check added
only works with GNU time installed as `time` or `gtime`.
    
busybox gzip does not support "--force" unless busybox is explicitly
compiled with FEATURE_GZIP_LONG_OPTIONS=y. As a result most
installations of busybox gzip can't handle "--force" including those
provided by OpenWrt and Alpine Linux.
    
Refer to the commit messages for full details on each fix.