### PR TITLE
ltq-vdsl-mei: reset g_tx_link_rate on showtime exit

### DIFF
--- a/package/kernel/lantiq/ltq-vdsl-mei/patches/110-reset-g_tx_link_rate-on-showtime-exit.patch
+++ b/package/kernel/lantiq/ltq-vdsl-mei/patches/110-reset-g_tx_link_rate-on-showtime-exit.patch
@@ -1,0 +1,12 @@
+--- a/src/drv_mei_cpe_api_atm_ptm_intern.c
++++ b/src/drv_mei_cpe_api_atm_ptm_intern.c
+@@ -124,6 +124,9 @@ IFX_int32_t MEI_InternalXtmSwhowtimeExit
+    /* Get line number*/
+    dslLineNum = pMeiDynCntrl->pMeiDev->meiDrvCntrl.dslLineNum;
+ 
++   g_tx_link_rate[dslLineNum][0] = 0;
++   g_tx_link_rate[dslLineNum][1] = 0;
++
+    /* get NULL or function pointer */
+    mei_showtime_exit =
+         (ltq_mei_atm_showtime_exit_t)ppa_callback_get(LTQ_MEI_SHOWTIME_EXIT);


### PR DESCRIPTION
Without this change, ifx_mei_atm_showtime_check() will always return
"showtime" after one call of MEI_InternalXtmSwhowtimeEntrySignal()
was done, even if MEI_InternalXtmSwhowtimeExitSignal() was called
in the meantime.

The ifx_mei_atm_showtime_check() function is used by the ltq-atm and
ltq-ptm driver.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
