### PR TITLE
ath79: preliminary support for TP-Link WDR3600 / WDR4300 (AR9344)

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -13,6 +13,12 @@ ath79_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 
+	"tplink,tl-wdr3600"|\
+	"tplink,tl-wdr4300")
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
+		;;
+
 	"tplink,tl-wr1043nd-v1")
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "5@eth0"

--- a/target/linux/ath79/base-files/etc/diag.sh
+++ b/target/linux/ath79/base-files/etc/diag.sh
@@ -2,6 +2,8 @@
 
 . /lib/functions/leds.sh
 
+status_led="$(get_dt_led status)"
+
 get_status_led() {
 	local board=$(board_name)
 	local boardname="${board##*,}"
@@ -23,7 +25,7 @@ get_status_led() {
 }
 
 set_state() {
-	get_status_led
+	[ -z "$status_led" ] && get_status_led
 
 	case "$1" in
 	preinit)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -50,6 +50,10 @@ case "$FIRMWARE" in
 	"avm,fritz300e")
 		ath9k_eeprom_extract_reverse "urloader" 5441 1088
 		;;
+	"tplink,tl-wdr3600"|\
+	"tplink,tl-wdr4300")
+		ath9k_eeprom_extract "art" 20480 1088
+		;;
 	"ubnt,unifi")
 		ath9k_eeprom_extract "art" 4096 2048
 		;;

--- a/target/linux/ath79/dts/ar9344.dtsi
+++ b/target/linux/ath79/dts/ar9344.dtsi
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x.dtsi"
+
+/ {
+	compatible = "qca,ar9344";
+};
+
+&apb {
+	pcie: pcie-controller@180c0000 {
+		compatible = "qcom,ar9340-pci", "qcom,ar7240-pci";
+		#address-cells = <3>;
+		#size-cells = <2>;
+		bus-range = <0x0 0x0>;
+		reg = <0x180c0000 0x1000>, /* CRP */
+				<0x180f0000 0x100>, /* CTRL */
+				<0x14000000 0x1000>; /* CFG */
+		reg-names = "crp_base", "ctrl_base", "cfg_base";
+		ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000 /* pci memory */
+				0x1000000 0 0x00000000 0x0000000 0 0x000001>; /* io space */
+		interrupt-parent = <&cpuintc>;
+		interrupts = <2>;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+
+		interrupt-map-mask = <0 0 0 1>;
+		interrupt-map = <0 0 0 0 &pcie 0>;
+		
+		status = "disabled";
+	};
+};

--- a/target/linux/ath79/dts/ar9344_tl-wdr3600.dts
+++ b/target/linux/ath79/dts/ar9344_tl-wdr3600.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tl-wdr4300.dtsi"
+
+/ {
+	model = "TP-Link WDR3600";
+	compatible = "tplink,tl-wdr3600";
+};

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dts
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tl-wdr4300.dtsi"
+
+/ {
+	model = "TP-Link WDR4300";
+	compatible = "tplink,tl-wdr4300";
+};

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "TP-Link WDR4300";
+	compatible = "tplink,tl-wdr4300";
+
+	aliases {
+		led-status = &system;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb1 {
+			label = "tp-link:green:usb1";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb2 {
+			label = "tp-link:green:usb2";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		button@0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button@1 {
+			label = "wifi";
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb1_power {
+			gpio-export,name = "tp-link:power:usb1";
+			gpio-export,output = <1>;
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_usb2_power {
+			gpio-export,name = "tp-link:power:usb2";
+			gpio-export,output = <1>;
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_ext_lna0 {
+			gpio-export,name = "tp-link:ext:lna0";
+			gpio-export,output = <1>;
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_ext_lna1 {
+			gpio-export,name = "tp-link:ext:lna1";
+			gpio-export,output = <1>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&usb {
+	status = "okay";
+
+	port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+
+		hub_port2: port@2 {
+			reg = <2>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@168c,0033 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&uboot 0x1fc00>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0x80000080 /* POWER_ON_STRIP */
+			0x50 0xc737c737 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x0030c300 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-2)>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/clock/ath79-clk.h>
+
+#include "ath79.dtsi"
+
+/ {
+	compatible = "qca,ar9340";
+
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "mips,mips74Kc";
+			clocks = <&pll ATH79_CLK_CPU>;
+			reg = <0>;
+		};
+	};
+
+	clocks {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		ref: ref {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-output-names = "ref";
+		};
+	};
+
+	ahb {
+		compatible = "simple-bus";
+		ranges;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		apb: apb {
+			compatible = "simple-bus";
+			ranges;
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			ddr_ctrl: memory-controller@18000000 {
+				compatible = "qca,ar9340-ddr-controller",
+						"qca,ar7240-ddr-controller";
+				reg = <0x18000000 0x12c>;
+
+				#qca,ddr-wb-channel-cells = <1>;
+			};
+
+			uart: uart@18020000 {
+				compatible = "ns16550a";
+				reg = <0x18020000 0x2c>;
+
+				interrupts = <3>;
+
+				clocks = <&pll ATH79_CLK_REF>;
+				clock-names = "uart";
+
+				reg-io-width = <4>;
+				reg-shift = <2>;
+				no-loopback-test;
+
+				status = "disabled";
+			};
+
+			gpio: gpio@18040000 {
+				compatible = "qca,ar9340-gpio";
+				reg = <0x18040000 0x2c>;
+
+				interrupts = <2>;
+				ngpios = <23>;
+
+				gpio-controller;
+				#gpio-cells = <2>;
+
+				interrupt-controller;
+				#interrupt-cells = <2>;
+			};
+
+			pinmux: pinmux@1804002c {
+				compatible = "pinctrl-single";
+
+				reg = <0x1804002c 0x44>;
+
+				#size-cells = <0>;
+
+				pinctrl-single,bit-per-mux;
+				pinctrl-single,register-width = <32>;
+				pinctrl-single,function-mask = <0x1>;
+				#pinctrl-cells = <2>;
+
+				jtag_disable_pins: pinmux_jtag_disable_pins {
+					pinctrl-single,bits = <0x40 0x2 0x2>;
+				};
+			};
+
+			pll: pll-controller@18050000 {
+				compatible = "qca,ar9340-pll", "syscon";
+				reg = <0x18050000 0x4c>;
+
+				#clock-cells = <1>;
+				clocks = <&ref>;
+				clock-names = "ref";
+				clock-output-names = "cpu", "ddr", "ahb";
+			};
+
+			wdt: wdt@18060008 {
+				compatible = "qca,ar9340-wdt", "qca,ar7130-wdt";
+				reg = <0x18060008 0x8>;
+
+				interrupts = <4>;
+
+				clocks = <&pll ATH79_CLK_AHB>;
+				clock-names = "wdt";
+			};
+
+			rst: reset-controller@1806001c {
+				compatible = "qca,ar9340-reset", "qca,ar7100-reset";
+				reg = <0x1806001c 0x4>;
+
+				#reset-cells = <1>;
+			};
+
+			gmac: gmac@18070000 {
+				compatible = "qca,ar9340-gmac", "qca,ar9330-gmac";
+				reg = <0x18070000 0x14>;
+			};
+		};
+
+		usb: usb@1b000000 {
+			compatible = "generic-ehci";
+			reg = <0x1b000000 0x1d8>;
+
+			interrupts = <3>;
+			resets = <&rst 5>;
+			reset-names = "usb-host";
+
+			has-transaction-translator;
+			caps-offset = <0x100>;
+
+			phy-names = "usb-phy";
+			phys = <&usb_phy>;
+
+			status = "disabled";
+		};
+
+		spi: spi@1f000000 {
+			compatible = "qca,ar9340-spi", "qca,ar7100-spi";
+			reg = <0x1f000000 0x1c>;
+
+			clocks = <&pll ATH79_CLK_AHB>;
+			clock-names = "ahb";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			status = "disabled";
+		};
+	};
+
+	usb_phy: usb-phy {
+		compatible = "qca,ar9340-usb-phy", "qca,ar7200-usb-phy";
+
+		reset-names = "usb-phy", "usb-suspend-override";
+		resets = <&rst 4>, <&rst 3>;
+
+		#phy-cells = <0>;
+
+		status = "disabled";
+	};
+};
+
+&cpuintc {
+	qca,ddr-wb-channel-interrupts = <2>, <3>, <4>, <5>;
+	qca,ddr-wb-channels = <&ddr_ctrl 3>, <&ddr_ctrl 2>,
+				<&ddr_ctrl 0>, <&ddr_ctrl 1>;
+};
+
+&mdio0 {
+	resets = <&rst 22>;
+	reset-names = "mdio";
+};
+
+&eth0 {
+	compatible = "qca,ar9340-eth", "syscon";
+
+	pll-data = <0x16000000 0x00000101 0x00001616>;
+	pll-reg = <0x4 0x2c 17>;
+	pll-handle = <&pll>;
+
+	resets = <&rst 8>, <&rst 9>;
+	reset-names = "mac", "phy";
+};
+
+&mdio1 {
+	resets = <&rst 23>;
+	reset-names = "mdio";
+	builtin-switch;
+};
+
+&eth1 {
+	compatible = "qca,ar9340-eth", "syscon";
+
+	resets = <&rst 12>, <&rst 13>;
+	reset-names = "mac", "phy";
+};

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -625,6 +625,7 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 			ath79_set_pll(ag);
 		} else if (of_device_is_compatible(np, "qca,ar9130-eth")) {
 		} else if (of_device_is_compatible(np, "qca,ar9340-eth")) {
+			ath79_set_pll(ag);
 		} else if (of_device_is_compatible(np, "qca,qca9550-eth")) {
 		} else if (of_device_is_compatible(np, "qca,qca9560-eth")) {
 		}

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -47,7 +47,7 @@ define Device/tplink
   KERNEL := kernel-bin | append-dtb | lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | tplink-v1-header
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade
+  IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade | append-metadata
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory
 endef
 
@@ -72,6 +72,12 @@ define Device/tplink-8m
   IMAGE_SIZE := 7936k
 endef
 
+define Device/tplink-8mlzma
+$(Device/tplink)
+  TPLINK_FLASHLAYOUT := 8Mlzma
+  IMAGE_SIZE := 7936k
+endef
+
 define Device/tl_wr1043nd_v1
   $(Device/tplink-8m)
   ATH_SOC := ar9132
@@ -81,3 +87,21 @@ define Device/tl_wr1043nd_v1
   SUPPORTED_DEVICES := tplink,tl-wr1043nd-v1 tl-wr1043nd
 endef
 #TARGET_DEVICES += tl_wr1043nd_v1
+
+define Device/tl-wdr3600
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9344
+  DEVICE_TITLE := TP-LINK TL-WDR3600
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x36000001
+  SUPPORTED_DEVICES := tplink,tl-wdr3600 tl-wdr3600
+endef
+TARGET_DEVICES += tl-wdr3600
+
+define Device/tl-wdr4300
+  $(Device/tl-wdr3600)
+  DEVICE_TITLE := TP-LINK TL-WDR4300
+  TPLINK_HWID := 0x43000001
+  SUPPORTED_DEVICES := tplink,tl-wdr4300 tl-wdr4300
+endef
+TARGET_DEVICES += tl-wdr4300


### PR DESCRIPTION
### working
 - leds
 - buttons
 - lan / wan
 - usb ports 1 + 2
 - wifi 5g
 - sysupgrade
 - ...

### not working
 - wifi 2g

### bootlog with two usb sticks attached
https://pastebin.com/XgeRN1pD

cpu is overclocked to 700 mhz, so the cpu speed in bootlog is real and not a error.

usb shows "not running at top speed" but speed is almost the same as on ar71xx

### usb benchmark
```
time dd if=/dev/zero of=/dev/sda1 bs=10M count=10 conv=fsync
10+0 records in
10+0 records out
real    0m 38.76s
user    0m 0.02s
sys     0m 1.74s
100M / 38.76 s = 2.58 M/s
```

### iperf nat benchmark (tcp) wan -> lan

with flow offloading:
```
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0-30.0 sec  3.24 GBytes   929 Mbits/sec
```

without flow offloading:
```
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0-30.0 sec  2.13 GBytes   611 Mbits/sec
```

### iperf nat benchmark (tcp) wan -> wifi 5g

with flow offloading (~30% idle):
```
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0-30.0 sec   680 MBytes   190 Mbits/sec
```

without flow offloading (~0% idle):
```
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0-30.0 sec   539 MBytes   151 Mbits/sec
```

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>