### PR TITLE
libevent2: update to version 2.1.8 for openssl 1.1 compatibility

### DIFF
--- a/package/libs/libevent2/Makefile
+++ b/package/libs/libevent2/Makefile
@@ -8,12 +8,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevent2
-PKG_VERSION:=2.0.22
+PKG_VERSION:=2.1.8
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/libevent-$(PKG_VERSION)-stable
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/libevent/libevent
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_VERSION:=release-2.1.8-stable
+
 PKG_SOURCE:=libevent-$(PKG_VERSION)-stable.tar.gz
-PKG_SOURCE_URL:=@SF/levent
 PKG_HASH:=71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=BSD-3-Clause
@@ -46,7 +50,7 @@ endef
 
 define Package/libevent2
   $(call Package/libevent2/Default)
-  TITLE+= library (version 2.0)
+  TITLE+= library (version 2.1)
 endef
 
 define Package/libevent2/description
@@ -58,7 +62,7 @@ endef
 
 define Package/libevent2-core
   $(call Package/libevent2/Default)
-  TITLE+= core library (version 2.0)
+  TITLE+= core library (version 2.1)
 endef
 
 define Package/libevent2-core/description
@@ -70,7 +74,7 @@ endef
 
 define Package/libevent2-extra
   $(call Package/libevent2/Default)
-  TITLE+= extra library (version 2.0)
+  TITLE+= extra library (version 2.1)
 endef
 
 define Package/libevent2-extra/description
@@ -82,7 +86,7 @@ endef
 
 define Package/libevent2-openssl
   $(call Package/libevent2/Default)
-  TITLE+= OpenSSL library (version 2.0)
+  TITLE+= OpenSSL library (version 2.1)
   DEPENDS+=+libopenssl
 endef
 
@@ -95,7 +99,7 @@ endef
 
 define Package/libevent2-pthreads
   $(call Package/libevent2/Default)
-  TITLE+= Pthreads library (version 2.0)
+  TITLE+= Pthreads library (version 2.1)
   DEPENDS+=+libpthread
 endef
 
@@ -112,7 +116,8 @@ CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	--disable-debug-mode
-
+CONFIGURE_VARS += \
+	ac_cv_search_ERR_remove_thread_state=no
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)"
 
@@ -121,34 +126,34 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*.{la,a,so} $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.0.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.1.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libevent*.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libevent2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-core/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-extra/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-openssl/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-pthreads/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.1.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libevent2))


### PR DESCRIPTION
This version is compatible with openssl-1.1.0.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
