### PR TITLE
 ramips: fix Archer C50v3 LEDs

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -410,8 +410,8 @@ tplink,c20-v4)
 tplink,c50-v3)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
-	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:green:wlan2g" "wlan1"
-	set_wifi_led "$boardname:green:wlan5g"
+	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
 tplink,tl-mr3420-v5)
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/dts/ArcherC50V3.dts
+++ b/target/linux/ramips/dts/ArcherC50V3.dts
@@ -43,12 +43,12 @@
 
 		wan {
 			label = "c50-v3:green:wan";
-			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_orange {
 			label = "c50-v3:orange:wan";
-			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
@@ -58,12 +58,12 @@
 
 		wlan5 {
 			label = "c50-v3:green:wlan5g";
-			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "c50-v3:green:wps";
-			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
This PR fixes the LED mapping on the Archer C50 v3. 

It also uses the WiFi phy as trigger for the LED status instead of the Interface. This way, we are able to display even in case the interface is not named wifiX.

This commit was tested with an Archer C50(EU) v3.0.