### PR TITLE
adb: added patch for openssl 1.1.0 compatibility

### DIFF
--- a/package/utils/adb/Makefile
+++ b/package/utils/adb/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adb
 PKG_VERSION:=android.5.0.2_r1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://android.googlesource.com/platform/system/core

--- a/package/utils/adb/patches/010-openssl-1.1.patch
+++ b/package/utils/adb/patches/010-openssl-1.1.patch
@@ -1,0 +1,28 @@
+--- a/adb/adb_auth_host.c
++++ b/adb/adb_auth_host.c
+@@ -83,7 +83,13 @@ static int RSA_to_RSAPublicKey(RSA *rsa,
+     }
+ 
+     BN_set_bit(r32, 32);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    const BIGNUM *rsa_n, *rsa_e;
++    RSA_get0_key(rsa, &rsa_n, &rsa_e, NULL);
++    BN_copy(n, rsa_n);
++#else
+     BN_copy(n, rsa->n);
++#endif
+     BN_set_bit(r, RSANUMWORDS * 32);
+     BN_mod_sqr(rr, r, n, ctx);
+     BN_div(NULL, rem, n, r32, ctx);
+@@ -97,7 +103,11 @@ static int RSA_to_RSAPublicKey(RSA *rsa,
+         BN_div(n, rem, n, r32, ctx);
+         pkey->n[i] = BN_get_word(rem);
+     }
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    pkey->exponent = BN_get_word(rsa_e);
++#else
+     pkey->exponent = BN_get_word(rsa->e);
++#endif
+ 
+ out:
+     BN_free(n0inv);


### PR DESCRIPTION
Adapted code to RSA structure becoming opaque in openssl 1.1.0.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>