### PR TITLE
ath79: fix loader-okli, lzma-loader

### DIFF
--- a/target/linux/ath79/image/lzma-loader/src/Makefile
+++ b/target/linux/ath79/image/lzma-loader/src/Makefile
@@ -21,6 +21,7 @@ LOADER_DATA	:=
 BOARD		:=
 FLASH_OFFS	:=
 FLASH_MAX	:=
+KERNEL_CMDLINE	:= rootfstype=squashfs
 
 CC		:= $(CROSS_COMPILE)gcc
 LD		:= $(CROSS_COMPILE)ld


### PR DESCRIPTION
booting will hang most of the times on tl-wr1043nd-v1 without a KERNEL_CMDLINE value
add anything as a placeholder as kernel command line is taken from DTS

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
