### PR TITLE
ramips: fix to mt7620a and add support for i2c on WD03

### DIFF
--- a/target/linux/ramips/dts/WD03.dts
+++ b/target/linux/ramips/dts/WD03.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ravpower,wd03", "ralink,mt7620a-soc";
+	compatible = "ravpower,wd03", "ralink,mt7620n-soc";
 	model = "Ravpower WD03";
 
 	chosen {
@@ -48,6 +48,10 @@
 
 &gpio3 {
 	status = "okay";
+};
+
+&i2c {
+        status = "okay";
 };
 
 &spi0 {


### PR DESCRIPTION
There was an error on initial commit, the proper soc is mt7620n (which is more limited than mt7620a).
Moreover, there is a battery management controller connected to the i2c port of the mt7620n. I have a small piece of i2c code to get battery level coming.

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>