### PR TITLE
[for 18.06] dnsmasq: use "hostsdir" instead of "addn-hosts"

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -938,7 +938,7 @@ dnsmasq_start()
 
 	xappend "--dhcp-broadcast=tag:needs-broadcast"
 
-	xappend "--addn-hosts=$(dirname $HOSTFILE)"
+	xappend "--hostsdir=$(dirname $HOSTFILE)"
 
 	config_get dnsmasqconfdir "$cfg" confdir "/tmp/dnsmasq.d"
 	[ ! -d "$dnsmasqconfdir" ] && mkdir -p $dnsmasqconfdir


### PR DESCRIPTION
1.) "addn-hosts" per default point to a file (but it supports directory)
2.) "hostsdir" only support directory with the additional benefit: New or changed files are read automatically.

Signed-off-by: Christian Schoenebeck <<christian.schoenebeck@gmail.com>>
