### PR TITLE
ramips: Change network config for ravpower wd03

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -210,7 +210,6 @@ ramips_setup_interfaces()
 	ubnt-erx|\
 	ubnt-erx-sfp|\
 	ur-326n4g|\
-	ravpower,wd03|\
 	wrtnode|\
 	wrtnode2p | \
 	wrtnode2r | \
@@ -304,6 +303,9 @@ ramips_setup_interfaces()
 	newifi-d1)
 		ucidef_add_switch "switch0" \
 		"1:lan:2" "2:lan:1" "4:wan" "6@eth0"
+		;;
+	ravpower,wd03)
+		ucidef_set_interface_lan "eth0"
 		;;
 	re350-v1)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Original config was wrong. This device has only one ethernet port and wifi, therefore the switch config was not necessary.
As by default wifi is off in OpenWrt, I have to leave the only remaining network interface in a Lan config.
Setting Wan for this ethernet interface would be more logical but then the firewall would block access.

Configuring Wan will have to be done by the user.

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>
