### PR TITLE
AMD SB800: Update i2c-piix4 bus driver and sp5100_tco watchdog driver

### DIFF
--- a/target/linux/generic/backport-4.14/077-v4.15-0001-i2c-piix4-Fix-port-number-check-on-release.patch
+++ b/target/linux/generic/backport-4.14/077-v4.15-0001-i2c-piix4-Fix-port-number-check-on-release.patch
@@ -1,0 +1,35 @@
+From 45fd4470ba86e9ca2837b666a52cc65dc69f0fa3 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 7 Dec 2017 12:25:45 +0100
+Subject: i2c: piix4: Fix port number check on release
+
+The port number shift is still hard-coded to 1 while it now depends
+on the hardware.
+
+Thankfully 0 is always 0 no matter how you shift it, so this was a
+bug without consequences.
+
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Fixes: 0fe16195f891 ("i2c: piix4: Fix SMBus port selection for AMD Family 17h chips")
+Reviewed-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 174579d..462948e 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -983,7 +983,7 @@ static void piix4_adap_remove(struct i2c_adapter *adap)
+ 
+ 	if (adapdata->smba) {
+ 		i2c_del_adapter(adap);
+-		if (adapdata->port == (0 << 1)) {
++		if (adapdata->port == (0 << piix4_port_shift_sb800)) {
+ 			release_region(adapdata->smba, SMBIOSIZE);
+ 			if (adapdata->sb800_main)
+ 				release_region(SB800_PIIX4_SMB_IDX, 2);
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.14/077-v4.17-0001-i2c-piix4-Use-usleep_range.patch
+++ b/target/linux/generic/backport-4.14/077-v4.17-0001-i2c-piix4-Use-usleep_range.patch
@@ -1,0 +1,41 @@
+From 0e89b2fec748177899c1f9ebfbe87714ffa248eb Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Mon, 26 Feb 2018 12:46:52 -0800
+Subject: i2c: piix4: Use usleep_range()
+
+The piix4 i2c driver is extremely slow. Replacing msleep()
+with usleep_range() increases its speed substantially.
+Use sleep ranges similar to those used in the i2c-801 driver
+to keep things simple.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Reviewed-by: Jean Delvare <jdelvare@suse.de>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 462948e..4c1f6aa 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -462,13 +462,13 @@ static int piix4_transaction(struct i2c_adapter *piix4_adapter)
+ 
+ 	/* We will always wait for a fraction of a second! (See PIIX4 docs errata) */
+ 	if (srvrworks_csb5_delay) /* Extra delay for SERVERWORKS_CSB5 */
+-		msleep(2);
++		usleep_range(2000, 2100);
+ 	else
+-		msleep(1);
++		usleep_range(250, 500);
+ 
+ 	while ((++timeout < MAX_TIMEOUT) &&
+ 	       ((temp = inb_p(SMBHSTSTS)) & 0x01))
+-		msleep(1);
++		usleep_range(250, 500);
+ 
+ 	/* If the SMBus is still busy, we give up */
+ 	if (timeout == MAX_TIMEOUT) {
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.14/077-v4.17-0002-i2c-piix4-Use-request_muxed_region.patch
+++ b/target/linux/generic/backport-4.14/077-v4.17-0002-i2c-piix4-Use-request_muxed_region.patch
@@ -1,0 +1,170 @@
+From 04b6fcaba346e1ce76321ba9b0fd549da4c37ac2 Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Mon, 26 Feb 2018 12:46:53 -0800
+Subject: i2c: piix4: Use request_muxed_region
+
+Accesses to SB800_PIIX4_SMB_IDX can occur from multiple drivers.
+One example for another driver is the sp5100_tco driver.
+
+Use request_muxed_region() to ensure synchronization.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Reviewed-by: Jean Delvare <jdelvare@suse.de>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 55 +++++++++++++++++++-----------------------
+ 1 file changed, 25 insertions(+), 30 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 4c1f6aa..90946a8 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -40,7 +40,6 @@
+ #include <linux/dmi.h>
+ #include <linux/acpi.h>
+ #include <linux/io.h>
+-#include <linux/mutex.h>
+ 
+ 
+ /* PIIX4 SMBus address offsets */
+@@ -153,10 +152,7 @@ static const struct dmi_system_id piix4_dmi_ibm[] = {
+ 
+ /*
+  * SB800 globals
+- * piix4_mutex_sb800 protects piix4_port_sel_sb800 and the pair
+- * of I/O ports at SB800_PIIX4_SMB_IDX.
+  */
+-static DEFINE_MUTEX(piix4_mutex_sb800);
+ static u8 piix4_port_sel_sb800;
+ static u8 piix4_port_mask_sb800;
+ static u8 piix4_port_shift_sb800;
+@@ -298,12 +294,19 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 	else
+ 		smb_en = (aux) ? 0x28 : 0x2c;
+ 
+-	mutex_lock(&piix4_mutex_sb800);
++	if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2, "sb800_piix4_smb")) {
++		dev_err(&PIIX4_dev->dev,
++			"SMB base address index region 0x%x already in use.\n",
++			SB800_PIIX4_SMB_IDX);
++		return -EBUSY;
++	}
++
+ 	outb_p(smb_en, SB800_PIIX4_SMB_IDX);
+ 	smba_en_lo = inb_p(SB800_PIIX4_SMB_IDX + 1);
+ 	outb_p(smb_en + 1, SB800_PIIX4_SMB_IDX);
+ 	smba_en_hi = inb_p(SB800_PIIX4_SMB_IDX + 1);
+-	mutex_unlock(&piix4_mutex_sb800);
++
++	release_region(SB800_PIIX4_SMB_IDX, 2);
+ 
+ 	if (!smb_en) {
+ 		smb_en_status = smba_en_lo & 0x10;
+@@ -373,7 +376,12 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 			break;
+ 		}
+ 	} else {
+-		mutex_lock(&piix4_mutex_sb800);
++		if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2,
++					  "sb800_piix4_smb")) {
++			release_region(piix4_smba, SMBIOSIZE);
++			return -EBUSY;
++		}
++
+ 		outb_p(SB800_PIIX4_PORT_IDX_SEL, SB800_PIIX4_SMB_IDX);
+ 		port_sel = inb_p(SB800_PIIX4_SMB_IDX + 1);
+ 		piix4_port_sel_sb800 = (port_sel & 0x01) ?
+@@ -381,7 +389,7 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 				       SB800_PIIX4_PORT_IDX;
+ 		piix4_port_mask_sb800 = SB800_PIIX4_PORT_IDX_MASK;
+ 		piix4_port_shift_sb800 = SB800_PIIX4_PORT_IDX_SHIFT;
+-		mutex_unlock(&piix4_mutex_sb800);
++		release_region(SB800_PIIX4_SMB_IDX, 2);
+ 	}
+ 
+ 	dev_info(&PIIX4_dev->dev,
+@@ -679,7 +687,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	u8 port;
+ 	int retval;
+ 
+-	mutex_lock(&piix4_mutex_sb800);
++	if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2, "sb800_piix4_smb"))
++		return -EBUSY;
+ 
+ 	/* Request the SMBUS semaphore, avoid conflicts with the IMC */
+ 	smbslvcnt  = inb_p(SMBSLVCNT);
+@@ -695,8 +704,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	} while (--retries);
+ 	/* SMBus is still owned by the IMC, we give up */
+ 	if (!retries) {
+-		mutex_unlock(&piix4_mutex_sb800);
+-		return -EBUSY;
++		retval = -EBUSY;
++		goto release;
+ 	}
+ 
+ 	/*
+@@ -753,8 +762,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	if ((size == I2C_SMBUS_BLOCK_DATA) && adapdata->notify_imc)
+ 		piix4_imc_wakeup();
+ 
+-	mutex_unlock(&piix4_mutex_sb800);
+-
++release:
++	release_region(SB800_PIIX4_SMB_IDX, 2);
+ 	return retval;
+ }
+ 
+@@ -899,13 +908,6 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 		bool notify_imc = false;
+ 		is_sb800 = true;
+ 
+-		if (!request_region(SB800_PIIX4_SMB_IDX, 2, "smba_idx")) {
+-			dev_err(&dev->dev,
+-			"SMBus base address index region 0x%x already in use!\n",
+-			SB800_PIIX4_SMB_IDX);
+-			return -EBUSY;
+-		}
+-
+ 		if (dev->vendor == PCI_VENDOR_ID_AMD &&
+ 		    dev->device == PCI_DEVICE_ID_AMD_KERNCZ_SMBUS) {
+ 			u8 imc;
+@@ -922,20 +924,16 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 
+ 		/* base address location etc changed in SB800 */
+ 		retval = piix4_setup_sb800(dev, id, 0);
+-		if (retval < 0) {
+-			release_region(SB800_PIIX4_SMB_IDX, 2);
++		if (retval < 0)
+ 			return retval;
+-		}
+ 
+ 		/*
+ 		 * Try to register multiplexed main SMBus adapter,
+ 		 * give up if we can't
+ 		 */
+ 		retval = piix4_add_adapters_sb800(dev, retval, notify_imc);
+-		if (retval < 0) {
+-			release_region(SB800_PIIX4_SMB_IDX, 2);
++		if (retval < 0)
+ 			return retval;
+-		}
+ 	} else {
+ 		retval = piix4_setup(dev, id);
+ 		if (retval < 0)
+@@ -983,11 +981,8 @@ static void piix4_adap_remove(struct i2c_adapter *adap)
+ 
+ 	if (adapdata->smba) {
+ 		i2c_del_adapter(adap);
+-		if (adapdata->port == (0 << piix4_port_shift_sb800)) {
++		if (adapdata->port == (0 << piix4_port_shift_sb800))
+ 			release_region(adapdata->smba, SMBIOSIZE);
+-			if (adapdata->sb800_main)
+-				release_region(SB800_PIIX4_SMB_IDX, 2);
+-		}
+ 		kfree(adapdata);
+ 		kfree(adap);
+ 	}
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.14/078-v4.16-0001-watchdog-sp5100_tco-Always-use-SP5100_IO_PM_.patch
+++ b/target/linux/generic/backport-4.14/078-v4.16-0001-watchdog-sp5100_tco-Always-use-SP5100_IO_PM_.patch
@@ -1,0 +1,242 @@
+From 2b750cffe1ed05c9001d9524b5815e1f50461a44 Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Sun, 24 Dec 2017 13:04:06 -0800
+Subject: watchdog: sp5100_tco: Always use SP5100_IO_PM_{INDEX_REG,DATA_REG}
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+SP5100_IO_PM_INDEX_REG and SB800_IO_PM_INDEX_REG are used inconsistently
+and define the same value. Just use SP5100_IO_PM_INDEX_REG throughout.
+Do the same for SP5100_IO_PM_DATA_REG and SB800_IO_PM_DATA_REG.
+Use helper functions to access the indexed registers.
+
+Cc: Zoltán Böszörményi <zboszor@pr.hu>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/sp5100_tco.c | 94 ++++++++++++++++++++++---------------------
+ drivers/watchdog/sp5100_tco.h |  7 +---
+ 2 files changed, 51 insertions(+), 50 deletions(-)
+
+diff --git a/drivers/watchdog/sp5100_tco.c b/drivers/watchdog/sp5100_tco.c
+index 028618c..05f9d27 100644
+--- a/drivers/watchdog/sp5100_tco.c
++++ b/drivers/watchdog/sp5100_tco.c
+@@ -48,7 +48,6 @@
+ static u32 tcobase_phys;
+ static u32 tco_wdt_fired;
+ static void __iomem *tcobase;
+-static unsigned int pm_iobase;
+ static DEFINE_SPINLOCK(tco_lock);	/* Guards the hardware */
+ static unsigned long timer_alive;
+ static char tco_expect_close;
+@@ -132,25 +131,38 @@ static int tco_timer_set_heartbeat(int t)
+ 	return 0;
+ }
+ 
+-static void tco_timer_enable(void)
++static u8 sp5100_tco_read_pm_reg8(u8 index)
++{
++	outb(index, SP5100_IO_PM_INDEX_REG);
++	return inb(SP5100_IO_PM_DATA_REG);
++}
++
++static void sp5100_tco_update_pm_reg8(u8 index, u8 reset, u8 set)
+ {
+-	int val;
++	u8 val;
+ 
++	outb(index, SP5100_IO_PM_INDEX_REG);
++	val = inb(SP5100_IO_PM_DATA_REG);
++	val &= reset;
++	val |= set;
++	outb(val, SP5100_IO_PM_DATA_REG);
++}
++
++static void tco_timer_enable(void)
++{
+ 	if (!tco_has_sp5100_reg_layout(sp5100_tco_pci)) {
+ 		/* For SB800 or later */
+ 		/* Set the Watchdog timer resolution to 1 sec */
+-		outb(SB800_PM_WATCHDOG_CONFIG, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		val |= SB800_PM_WATCHDOG_SECOND_RES;
+-		outb(val, SB800_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SB800_PM_WATCHDOG_CONFIG,
++					  0xff, SB800_PM_WATCHDOG_SECOND_RES);
+ 
+ 		/* Enable watchdog decode bit and watchdog timer */
+-		outb(SB800_PM_WATCHDOG_CONTROL, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		val |= SB800_PCI_WATCHDOG_DECODE_EN;
+-		val &= ~SB800_PM_WATCHDOG_DISABLE;
+-		outb(val, SB800_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SB800_PM_WATCHDOG_CONTROL,
++					  ~SB800_PM_WATCHDOG_DISABLE,
++					  SB800_PCI_WATCHDOG_DECODE_EN);
+ 	} else {
++		u32 val;
++
+ 		/* For SP5100 or SB7x0 */
+ 		/* Enable watchdog decode bit */
+ 		pci_read_config_dword(sp5100_tco_pci,
+@@ -164,11 +176,9 @@ static void tco_timer_enable(void)
+ 				       val);
+ 
+ 		/* Enable Watchdog timer and set the resolution to 1 sec */
+-		outb(SP5100_PM_WATCHDOG_CONTROL, SP5100_IO_PM_INDEX_REG);
+-		val = inb(SP5100_IO_PM_DATA_REG);
+-		val |= SP5100_PM_WATCHDOG_SECOND_RES;
+-		val &= ~SP5100_PM_WATCHDOG_DISABLE;
+-		outb(val, SP5100_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SP5100_PM_WATCHDOG_CONTROL,
++					  ~SP5100_PM_WATCHDOG_DISABLE,
++					  SP5100_PM_WATCHDOG_SECOND_RES);
+ 	}
+ }
+ 
+@@ -321,6 +331,17 @@ static const struct pci_device_id sp5100_tco_pci_tbl[] = {
+ };
+ MODULE_DEVICE_TABLE(pci, sp5100_tco_pci_tbl);
+ 
++static u8 sp5100_tco_read_pm_reg32(u8 index)
++{
++	u32 val = 0;
++	int i;
++
++	for (i = 3; i >= 0; i--)
++		val = (val << 8) + sp5100_tco_read_pm_reg8(index + i);
++
++	return val;
++}
++
+ /*
+  * Init & exit routines
+  */
+@@ -329,7 +350,7 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	struct pci_dev *dev = NULL;
+ 	const char *dev_name = NULL;
+ 	u32 val;
+-	u32 index_reg, data_reg, base_addr;
++	u8 base_addr;
+ 
+ 	/* Match the PCI device */
+ 	for_each_pci_dev(dev) {
+@@ -351,35 +372,25 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	 */
+ 	if (tco_has_sp5100_reg_layout(sp5100_tco_pci)) {
+ 		dev_name = SP5100_DEVNAME;
+-		index_reg = SP5100_IO_PM_INDEX_REG;
+-		data_reg = SP5100_IO_PM_DATA_REG;
+ 		base_addr = SP5100_PM_WATCHDOG_BASE;
+ 	} else {
+ 		dev_name = SB800_DEVNAME;
+-		index_reg = SB800_IO_PM_INDEX_REG;
+-		data_reg = SB800_IO_PM_DATA_REG;
+ 		base_addr = SB800_PM_WATCHDOG_BASE;
+ 	}
+ 
+ 	/* Request the IO ports used by this driver */
+-	pm_iobase = SP5100_IO_PM_INDEX_REG;
+-	if (!request_region(pm_iobase, SP5100_PM_IOPORTS_SIZE, dev_name)) {
+-		pr_err("I/O address 0x%04x already in use\n", pm_iobase);
++	if (!request_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE,
++			    dev_name)) {
++		pr_err("I/O address 0x%04x already in use\n",
++		       SP5100_IO_PM_INDEX_REG);
+ 		goto exit;
+ 	}
+ 
+ 	/*
+ 	 * First, Find the watchdog timer MMIO address from indirect I/O.
++	 * Low three bits of BASE are reserved.
+ 	 */
+-	outb(base_addr+3, index_reg);
+-	val = inb(data_reg);
+-	outb(base_addr+2, index_reg);
+-	val = val << 8 | inb(data_reg);
+-	outb(base_addr+1, index_reg);
+-	val = val << 8 | inb(data_reg);
+-	outb(base_addr+0, index_reg);
+-	/* Low three bits of BASE are reserved */
+-	val = val << 8 | (inb(data_reg) & 0xf8);
++	val = sp5100_tco_read_pm_reg32(base_addr) & 0xfffffff8;
+ 
+ 	pr_debug("Got 0x%04x from indirect I/O\n", val);
+ 
+@@ -400,14 +411,7 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 				      SP5100_SB_RESOURCE_MMIO_BASE, &val);
+ 	} else {
+ 		/* Read SBResource_MMIO from AcpiMmioEn(PM_Reg: 24h) */
+-		outb(SB800_PM_ACPI_MMIO_EN+3, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+2, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+1, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+0, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
++		val = sp5100_tco_read_pm_reg32(SB800_PM_ACPI_MMIO_EN);
+ 	}
+ 
+ 	/* The SBResource_MMIO is enabled and mapped memory space? */
+@@ -470,7 +474,7 @@ setup_wdt:
+ unreg_mem_region:
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+ unreg_region:
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ exit:
+ 	return 0;
+ }
+@@ -517,7 +521,7 @@ static int sp5100_tco_init(struct platform_device *dev)
+ exit:
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	return ret;
+ }
+ 
+@@ -531,7 +535,7 @@ static void sp5100_tco_cleanup(void)
+ 	misc_deregister(&sp5100_tco_miscdev);
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ }
+ 
+ static int sp5100_tco_remove(struct platform_device *dev)
+diff --git a/drivers/watchdog/sp5100_tco.h b/drivers/watchdog/sp5100_tco.h
+index 1af4dee..f495fe0 100644
+--- a/drivers/watchdog/sp5100_tco.h
++++ b/drivers/watchdog/sp5100_tco.h
+@@ -24,10 +24,11 @@
+  * read them from a register.
+  */
+ 
+-/*  For SP5100/SB7x0 chipset */
++/*  For SP5100/SB7x0/SB8x0 chipset */
+ #define SP5100_IO_PM_INDEX_REG		0xCD6
+ #define SP5100_IO_PM_DATA_REG		0xCD7
+ 
++/* For SP5100/SB7x0 chipset */
+ #define SP5100_SB_RESOURCE_MMIO_BASE	0x9C
+ 
+ #define SP5100_PM_WATCHDOG_CONTROL	0x69
+@@ -44,11 +45,7 @@
+ 
+ #define SP5100_DEVNAME			"SP5100 TCO"
+ 
+-
+ /*  For SB8x0(or later) chipset */
+-#define SB800_IO_PM_INDEX_REG		0xCD6
+-#define SB800_IO_PM_DATA_REG		0xCD7
+-
+ #define SB800_PM_ACPI_MMIO_EN		0x24
+ #define SB800_PM_WATCHDOG_CONTROL	0x48
+ #define SB800_PM_WATCHDOG_BASE		0x48
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.14/078-v4.16-0002-watchdog-sp5100_tco-Use-request_muxed_region-where-possible.patch
+++ b/target/linux/generic/backport-4.14/078-v4.16-0002-watchdog-sp5100_tco-Use-request_muxed_region-where-possible.patch
@@ -1,0 +1,62 @@
+From 16e7730bd7ec7f4ec19628e5ddd172df28cf996d Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Sun, 24 Dec 2017 13:04:08 -0800
+Subject: watchdog: sp5100_tco: Use request_muxed_region where possible
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use request_muxed_region for multiplexed IO memory regions.
+Also, SP5100_IO_PM_INDEX_REG/SP5100_IO_PM_DATA_REG are only
+used during initialization; it is unnecessary to keep the
+address range reserved.
+
+Cc: Zoltán Böszörményi <zboszor@pr.hu>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/sp5100_tco.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/watchdog/sp5100_tco.c b/drivers/watchdog/sp5100_tco.c
+index 05f9d27..11109ac 100644
+--- a/drivers/watchdog/sp5100_tco.c
++++ b/drivers/watchdog/sp5100_tco.c
+@@ -379,8 +379,8 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	}
+ 
+ 	/* Request the IO ports used by this driver */
+-	if (!request_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE,
+-			    dev_name)) {
++	if (!request_muxed_region(SP5100_IO_PM_INDEX_REG,
++				  SP5100_PM_IOPORTS_SIZE, dev_name)) {
+ 		pr_err("I/O address 0x%04x already in use\n",
+ 		       SP5100_IO_PM_INDEX_REG);
+ 		goto exit;
+@@ -468,6 +468,7 @@ setup_wdt:
+ 	 */
+ 	tco_timer_stop();
+ 
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	/* Done */
+ 	return 1;
+ 
+@@ -521,7 +522,6 @@ static int sp5100_tco_init(struct platform_device *dev)
+ exit:
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	return ret;
+ }
+ 
+@@ -535,7 +535,6 @@ static void sp5100_tco_cleanup(void)
+ 	misc_deregister(&sp5100_tco_miscdev);
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ }
+ 
+ static int sp5100_tco_remove(struct platform_device *dev)
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/077-v4.14-0001-i2c-piix4-Disable-completely-the-IMC-during-SMBUS_BLOCK_DATA.patch
+++ b/target/linux/generic/backport-4.9/077-v4.14-0001-i2c-piix4-Disable-completely-the-IMC-during-SMBUS_BLOCK_DATA.patch
@@ -1,0 +1,261 @@
+From 88fa2dfb075a20c3464e3d303c57dd8ced9e8309 Mon Sep 17 00:00:00 2001
+From: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+Date: Tue, 10 Oct 2017 18:11:15 +0200
+Subject: i2c: piix4: Disable completely the IMC during SMBUS_BLOCK_DATA
+
+SMBUS_BLOCK_DATA transactions might fail due to a race condition with
+the IMC (Integrated Micro Controller), even when the IMC semaphore
+is used.
+
+This bug has been reported and confirmed by AMD, who suggested as a
+solution an IMC firmware upgrade (obtained via BIOS update) and
+disabling the IMC during SMBUS_BLOCK_DATA transactions.
+
+Even without the IMC upgrade, the SMBUS is much more stable with this
+patch.
+
+Tested on a Bettong-alike board.
+
+Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+Reviewed-by: Jean Delvare <jdelvare@suse.de>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 132 +++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 126 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 01f767e..174579d 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -85,6 +85,9 @@
+ /* SB800 constants */
+ #define SB800_PIIX4_SMB_IDX		0xcd6
+ 
++#define KERNCZ_IMC_IDX			0x3e
++#define KERNCZ_IMC_DATA			0x3f
++
+ /*
+  * SB800 port is selected by bits 2:1 of the smb_en register (0x2c)
+  * or the smb_sel register (0x2e), depending on bit 0 of register 0x2f.
+@@ -167,6 +170,7 @@ struct i2c_piix4_adapdata {
+ 
+ 	/* SB800 */
+ 	bool sb800_main;
++	bool notify_imc;
+ 	u8 port;		/* Port number, shifted */
+ };
+ 
+@@ -594,6 +598,67 @@ static s32 piix4_access(struct i2c_adapter * adap, u16 addr,
+ 	return 0;
+ }
+ 
++static uint8_t piix4_imc_read(uint8_t idx)
++{
++	outb_p(idx, KERNCZ_IMC_IDX);
++	return inb_p(KERNCZ_IMC_DATA);
++}
++
++static void piix4_imc_write(uint8_t idx, uint8_t value)
++{
++	outb_p(idx, KERNCZ_IMC_IDX);
++	outb_p(value, KERNCZ_IMC_DATA);
++}
++
++static int piix4_imc_sleep(void)
++{
++	int timeout = MAX_TIMEOUT;
++
++	if (!request_muxed_region(KERNCZ_IMC_IDX, 2, "smbus_kerncz_imc"))
++		return -EBUSY;
++
++	/* clear response register */
++	piix4_imc_write(0x82, 0x00);
++	/* request ownership flag */
++	piix4_imc_write(0x83, 0xB4);
++	/* kick off IMC Mailbox command 96 */
++	piix4_imc_write(0x80, 0x96);
++
++	while (timeout--) {
++		if (piix4_imc_read(0x82) == 0xfa) {
++			release_region(KERNCZ_IMC_IDX, 2);
++			return 0;
++		}
++		usleep_range(1000, 2000);
++	}
++
++	release_region(KERNCZ_IMC_IDX, 2);
++	return -ETIMEDOUT;
++}
++
++static void piix4_imc_wakeup(void)
++{
++	int timeout = MAX_TIMEOUT;
++
++	if (!request_muxed_region(KERNCZ_IMC_IDX, 2, "smbus_kerncz_imc"))
++		return;
++
++	/* clear response register */
++	piix4_imc_write(0x82, 0x00);
++	/* release ownership flag */
++	piix4_imc_write(0x83, 0xB5);
++	/* kick off IMC Mailbox command 96 */
++	piix4_imc_write(0x80, 0x96);
++
++	while (timeout--) {
++		if (piix4_imc_read(0x82) == 0xfa)
++			break;
++		usleep_range(1000, 2000);
++	}
++
++	release_region(KERNCZ_IMC_IDX, 2);
++}
++
+ /*
+  * Handles access to multiple SMBus ports on the SB800.
+  * The port is selected by bits 2:1 of the smb_en register (0x2c).
+@@ -634,6 +699,41 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 		return -EBUSY;
+ 	}
+ 
++	/*
++	 * Notify the IMC (Integrated Micro Controller) if required.
++	 * Among other responsibilities, the IMC is in charge of monitoring
++	 * the System fans and temperature sensors, and act accordingly.
++	 * All this is done through SMBus and can/will collide
++	 * with our transactions if they are long (BLOCK_DATA).
++	 * Therefore we need to request the ownership flag during those
++	 * transactions.
++	 */
++	if ((size == I2C_SMBUS_BLOCK_DATA) && adapdata->notify_imc) {
++		int ret;
++
++		ret = piix4_imc_sleep();
++		switch (ret) {
++		case -EBUSY:
++			dev_warn(&adap->dev,
++				 "IMC base address index region 0x%x already in use.\n",
++				 KERNCZ_IMC_IDX);
++			break;
++		case -ETIMEDOUT:
++			dev_warn(&adap->dev,
++				 "Failed to communicate with the IMC.\n");
++			break;
++		default:
++			break;
++		}
++
++		/* If IMC communication fails do not retry */
++		if (ret) {
++			dev_warn(&adap->dev,
++				 "Continuing without IMC notification.\n");
++			adapdata->notify_imc = false;
++		}
++	}
++
+ 	outb_p(piix4_port_sel_sb800, SB800_PIIX4_SMB_IDX);
+ 	smba_en_lo = inb_p(SB800_PIIX4_SMB_IDX + 1);
+ 
+@@ -650,6 +750,9 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	/* Release the semaphore */
+ 	outb_p(smbslvcnt | 0x20, SMBSLVCNT);
+ 
++	if ((size == I2C_SMBUS_BLOCK_DATA) && adapdata->notify_imc)
++		piix4_imc_wakeup();
++
+ 	mutex_unlock(&piix4_mutex_sb800);
+ 
+ 	return retval;
+@@ -701,7 +804,7 @@ static struct i2c_adapter *piix4_main_adapters[PIIX4_MAX_ADAPTERS];
+ static struct i2c_adapter *piix4_aux_adapter;
+ 
+ static int piix4_add_adapter(struct pci_dev *dev, unsigned short smba,
+-			     bool sb800_main, u8 port,
++			     bool sb800_main, u8 port, bool notify_imc,
+ 			     const char *name, struct i2c_adapter **padap)
+ {
+ 	struct i2c_adapter *adap;
+@@ -729,6 +832,7 @@ static int piix4_add_adapter(struct pci_dev *dev, unsigned short smba,
+ 	adapdata->smba = smba;
+ 	adapdata->sb800_main = sb800_main;
+ 	adapdata->port = port << piix4_port_shift_sb800;
++	adapdata->notify_imc = notify_imc;
+ 
+ 	/* set up the sysfs linkage to our parent device */
+ 	adap->dev.parent = &dev->dev;
+@@ -750,14 +854,15 @@ static int piix4_add_adapter(struct pci_dev *dev, unsigned short smba,
+ 	return 0;
+ }
+ 
+-static int piix4_add_adapters_sb800(struct pci_dev *dev, unsigned short smba)
++static int piix4_add_adapters_sb800(struct pci_dev *dev, unsigned short smba,
++				    bool notify_imc)
+ {
+ 	struct i2c_piix4_adapdata *adapdata;
+ 	int port;
+ 	int retval;
+ 
+ 	for (port = 0; port < PIIX4_MAX_ADAPTERS; port++) {
+-		retval = piix4_add_adapter(dev, smba, true, port,
++		retval = piix4_add_adapter(dev, smba, true, port, notify_imc,
+ 					   piix4_main_port_names_sb800[port],
+ 					   &piix4_main_adapters[port]);
+ 		if (retval < 0)
+@@ -791,6 +896,7 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 	     dev->device == PCI_DEVICE_ID_ATI_SBX00_SMBUS &&
+ 	     dev->revision >= 0x40) ||
+ 	    dev->vendor == PCI_VENDOR_ID_AMD) {
++		bool notify_imc = false;
+ 		is_sb800 = true;
+ 
+ 		if (!request_region(SB800_PIIX4_SMB_IDX, 2, "smba_idx")) {
+@@ -800,6 +906,20 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 			return -EBUSY;
+ 		}
+ 
++		if (dev->vendor == PCI_VENDOR_ID_AMD &&
++		    dev->device == PCI_DEVICE_ID_AMD_KERNCZ_SMBUS) {
++			u8 imc;
++
++			/*
++			 * Detect if IMC is active or not, this method is
++			 * described on coreboot's AMD IMC notes
++			 */
++			pci_bus_read_config_byte(dev->bus, PCI_DEVFN(0x14, 3),
++						 0x40, &imc);
++			if (imc & 0x80)
++				notify_imc = true;
++		}
++
+ 		/* base address location etc changed in SB800 */
+ 		retval = piix4_setup_sb800(dev, id, 0);
+ 		if (retval < 0) {
+@@ -811,7 +931,7 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 		 * Try to register multiplexed main SMBus adapter,
+ 		 * give up if we can't
+ 		 */
+-		retval = piix4_add_adapters_sb800(dev, retval);
++		retval = piix4_add_adapters_sb800(dev, retval, notify_imc);
+ 		if (retval < 0) {
+ 			release_region(SB800_PIIX4_SMB_IDX, 2);
+ 			return retval;
+@@ -822,7 +942,7 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 			return retval;
+ 
+ 		/* Try to register main SMBus adapter, give up if we can't */
+-		retval = piix4_add_adapter(dev, retval, false, 0, "",
++		retval = piix4_add_adapter(dev, retval, false, 0, false, "",
+ 					   &piix4_main_adapters[0]);
+ 		if (retval < 0)
+ 			return retval;
+@@ -849,7 +969,7 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 	if (retval > 0) {
+ 		/* Try to add the aux adapter if it exists,
+ 		 * piix4_add_adapter will clean up if this fails */
+-		piix4_add_adapter(dev, retval, false, 0,
++		piix4_add_adapter(dev, retval, false, 0, false,
+ 				  is_sb800 ? piix4_aux_port_name_sb800 : "",
+ 				  &piix4_aux_adapter);
+ 	}
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/077-v4.15-0001-i2c-piix4-Fix-port-number-check-on-release.patch
+++ b/target/linux/generic/backport-4.9/077-v4.15-0001-i2c-piix4-Fix-port-number-check-on-release.patch
@@ -1,0 +1,35 @@
+From 45fd4470ba86e9ca2837b666a52cc65dc69f0fa3 Mon Sep 17 00:00:00 2001
+From: Jean Delvare <jdelvare@suse.de>
+Date: Thu, 7 Dec 2017 12:25:45 +0100
+Subject: i2c: piix4: Fix port number check on release
+
+The port number shift is still hard-coded to 1 while it now depends
+on the hardware.
+
+Thankfully 0 is always 0 no matter how you shift it, so this was a
+bug without consequences.
+
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+Fixes: 0fe16195f891 ("i2c: piix4: Fix SMBus port selection for AMD Family 17h chips")
+Reviewed-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 174579d..462948e 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -983,7 +983,7 @@ static void piix4_adap_remove(struct i2c_adapter *adap)
+ 
+ 	if (adapdata->smba) {
+ 		i2c_del_adapter(adap);
+-		if (adapdata->port == (0 << 1)) {
++		if (adapdata->port == (0 << piix4_port_shift_sb800)) {
+ 			release_region(adapdata->smba, SMBIOSIZE);
+ 			if (adapdata->sb800_main)
+ 				release_region(SB800_PIIX4_SMB_IDX, 2);
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/077-v4.17-0001-i2c-piix4-Use-usleep_range.patch
+++ b/target/linux/generic/backport-4.9/077-v4.17-0001-i2c-piix4-Use-usleep_range.patch
@@ -1,0 +1,41 @@
+From 0e89b2fec748177899c1f9ebfbe87714ffa248eb Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Mon, 26 Feb 2018 12:46:52 -0800
+Subject: i2c: piix4: Use usleep_range()
+
+The piix4 i2c driver is extremely slow. Replacing msleep()
+with usleep_range() increases its speed substantially.
+Use sleep ranges similar to those used in the i2c-801 driver
+to keep things simple.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Reviewed-by: Jean Delvare <jdelvare@suse.de>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 462948e..4c1f6aa 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -462,13 +462,13 @@ static int piix4_transaction(struct i2c_adapter *piix4_adapter)
+ 
+ 	/* We will always wait for a fraction of a second! (See PIIX4 docs errata) */
+ 	if (srvrworks_csb5_delay) /* Extra delay for SERVERWORKS_CSB5 */
+-		msleep(2);
++		usleep_range(2000, 2100);
+ 	else
+-		msleep(1);
++		usleep_range(250, 500);
+ 
+ 	while ((++timeout < MAX_TIMEOUT) &&
+ 	       ((temp = inb_p(SMBHSTSTS)) & 0x01))
+-		msleep(1);
++		usleep_range(250, 500);
+ 
+ 	/* If the SMBus is still busy, we give up */
+ 	if (timeout == MAX_TIMEOUT) {
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/077-v4.17-0002-i2c-piix4-Use-request_muxed_region.patch
+++ b/target/linux/generic/backport-4.9/077-v4.17-0002-i2c-piix4-Use-request_muxed_region.patch
@@ -1,0 +1,170 @@
+From 04b6fcaba346e1ce76321ba9b0fd549da4c37ac2 Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Mon, 26 Feb 2018 12:46:53 -0800
+Subject: i2c: piix4: Use request_muxed_region
+
+Accesses to SB800_PIIX4_SMB_IDX can occur from multiple drivers.
+One example for another driver is the sp5100_tco driver.
+
+Use request_muxed_region() to ensure synchronization.
+
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Reviewed-by: Jean Delvare <jdelvare@suse.de>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+ drivers/i2c/busses/i2c-piix4.c | 55 +++++++++++++++++++-----------------------
+ 1 file changed, 25 insertions(+), 30 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
+index 4c1f6aa..90946a8 100644
+--- a/drivers/i2c/busses/i2c-piix4.c
++++ b/drivers/i2c/busses/i2c-piix4.c
+@@ -40,7 +40,6 @@
+ #include <linux/dmi.h>
+ #include <linux/acpi.h>
+ #include <linux/io.h>
+-#include <linux/mutex.h>
+ 
+ 
+ /* PIIX4 SMBus address offsets */
+@@ -153,10 +152,7 @@ static const struct dmi_system_id piix4_dmi_ibm[] = {
+ 
+ /*
+  * SB800 globals
+- * piix4_mutex_sb800 protects piix4_port_sel_sb800 and the pair
+- * of I/O ports at SB800_PIIX4_SMB_IDX.
+  */
+-static DEFINE_MUTEX(piix4_mutex_sb800);
+ static u8 piix4_port_sel_sb800;
+ static u8 piix4_port_mask_sb800;
+ static u8 piix4_port_shift_sb800;
+@@ -298,12 +294,19 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 	else
+ 		smb_en = (aux) ? 0x28 : 0x2c;
+ 
+-	mutex_lock(&piix4_mutex_sb800);
++	if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2, "sb800_piix4_smb")) {
++		dev_err(&PIIX4_dev->dev,
++			"SMB base address index region 0x%x already in use.\n",
++			SB800_PIIX4_SMB_IDX);
++		return -EBUSY;
++	}
++
+ 	outb_p(smb_en, SB800_PIIX4_SMB_IDX);
+ 	smba_en_lo = inb_p(SB800_PIIX4_SMB_IDX + 1);
+ 	outb_p(smb_en + 1, SB800_PIIX4_SMB_IDX);
+ 	smba_en_hi = inb_p(SB800_PIIX4_SMB_IDX + 1);
+-	mutex_unlock(&piix4_mutex_sb800);
++
++	release_region(SB800_PIIX4_SMB_IDX, 2);
+ 
+ 	if (!smb_en) {
+ 		smb_en_status = smba_en_lo & 0x10;
+@@ -373,7 +376,12 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 			break;
+ 		}
+ 	} else {
+-		mutex_lock(&piix4_mutex_sb800);
++		if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2,
++					  "sb800_piix4_smb")) {
++			release_region(piix4_smba, SMBIOSIZE);
++			return -EBUSY;
++		}
++
+ 		outb_p(SB800_PIIX4_PORT_IDX_SEL, SB800_PIIX4_SMB_IDX);
+ 		port_sel = inb_p(SB800_PIIX4_SMB_IDX + 1);
+ 		piix4_port_sel_sb800 = (port_sel & 0x01) ?
+@@ -381,7 +389,7 @@ static int piix4_setup_sb800(struct pci_dev *PIIX4_dev,
+ 				       SB800_PIIX4_PORT_IDX;
+ 		piix4_port_mask_sb800 = SB800_PIIX4_PORT_IDX_MASK;
+ 		piix4_port_shift_sb800 = SB800_PIIX4_PORT_IDX_SHIFT;
+-		mutex_unlock(&piix4_mutex_sb800);
++		release_region(SB800_PIIX4_SMB_IDX, 2);
+ 	}
+ 
+ 	dev_info(&PIIX4_dev->dev,
+@@ -679,7 +687,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	u8 port;
+ 	int retval;
+ 
+-	mutex_lock(&piix4_mutex_sb800);
++	if (!request_muxed_region(SB800_PIIX4_SMB_IDX, 2, "sb800_piix4_smb"))
++		return -EBUSY;
+ 
+ 	/* Request the SMBUS semaphore, avoid conflicts with the IMC */
+ 	smbslvcnt  = inb_p(SMBSLVCNT);
+@@ -695,8 +704,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	} while (--retries);
+ 	/* SMBus is still owned by the IMC, we give up */
+ 	if (!retries) {
+-		mutex_unlock(&piix4_mutex_sb800);
+-		return -EBUSY;
++		retval = -EBUSY;
++		goto release;
+ 	}
+ 
+ 	/*
+@@ -753,8 +762,8 @@ static s32 piix4_access_sb800(struct i2c_adapter *adap, u16 addr,
+ 	if ((size == I2C_SMBUS_BLOCK_DATA) && adapdata->notify_imc)
+ 		piix4_imc_wakeup();
+ 
+-	mutex_unlock(&piix4_mutex_sb800);
+-
++release:
++	release_region(SB800_PIIX4_SMB_IDX, 2);
+ 	return retval;
+ }
+ 
+@@ -899,13 +908,6 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 		bool notify_imc = false;
+ 		is_sb800 = true;
+ 
+-		if (!request_region(SB800_PIIX4_SMB_IDX, 2, "smba_idx")) {
+-			dev_err(&dev->dev,
+-			"SMBus base address index region 0x%x already in use!\n",
+-			SB800_PIIX4_SMB_IDX);
+-			return -EBUSY;
+-		}
+-
+ 		if (dev->vendor == PCI_VENDOR_ID_AMD &&
+ 		    dev->device == PCI_DEVICE_ID_AMD_KERNCZ_SMBUS) {
+ 			u8 imc;
+@@ -922,20 +924,16 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 
+ 		/* base address location etc changed in SB800 */
+ 		retval = piix4_setup_sb800(dev, id, 0);
+-		if (retval < 0) {
+-			release_region(SB800_PIIX4_SMB_IDX, 2);
++		if (retval < 0)
+ 			return retval;
+-		}
+ 
+ 		/*
+ 		 * Try to register multiplexed main SMBus adapter,
+ 		 * give up if we can't
+ 		 */
+ 		retval = piix4_add_adapters_sb800(dev, retval, notify_imc);
+-		if (retval < 0) {
+-			release_region(SB800_PIIX4_SMB_IDX, 2);
++		if (retval < 0)
+ 			return retval;
+-		}
+ 	} else {
+ 		retval = piix4_setup(dev, id);
+ 		if (retval < 0)
+@@ -983,11 +981,8 @@ static void piix4_adap_remove(struct i2c_adapter *adap)
+ 
+ 	if (adapdata->smba) {
+ 		i2c_del_adapter(adap);
+-		if (adapdata->port == (0 << piix4_port_shift_sb800)) {
++		if (adapdata->port == (0 << piix4_port_shift_sb800))
+ 			release_region(adapdata->smba, SMBIOSIZE);
+-			if (adapdata->sb800_main)
+-				release_region(SB800_PIIX4_SMB_IDX, 2);
+-		}
+ 		kfree(adapdata);
+ 		kfree(adap);
+ 	}
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/078-v4.16-0001-watchdog-sp5100_tco-Always-use-SP5100_IO_PM_.patch
+++ b/target/linux/generic/backport-4.9/078-v4.16-0001-watchdog-sp5100_tco-Always-use-SP5100_IO_PM_.patch
@@ -1,0 +1,242 @@
+From 2b750cffe1ed05c9001d9524b5815e1f50461a44 Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Sun, 24 Dec 2017 13:04:06 -0800
+Subject: watchdog: sp5100_tco: Always use SP5100_IO_PM_{INDEX_REG,DATA_REG}
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+SP5100_IO_PM_INDEX_REG and SB800_IO_PM_INDEX_REG are used inconsistently
+and define the same value. Just use SP5100_IO_PM_INDEX_REG throughout.
+Do the same for SP5100_IO_PM_DATA_REG and SB800_IO_PM_DATA_REG.
+Use helper functions to access the indexed registers.
+
+Cc: Zoltán Böszörményi <zboszor@pr.hu>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/sp5100_tco.c | 94 ++++++++++++++++++++++---------------------
+ drivers/watchdog/sp5100_tco.h |  7 +---
+ 2 files changed, 51 insertions(+), 50 deletions(-)
+
+diff --git a/drivers/watchdog/sp5100_tco.c b/drivers/watchdog/sp5100_tco.c
+index 028618c..05f9d27 100644
+--- a/drivers/watchdog/sp5100_tco.c
++++ b/drivers/watchdog/sp5100_tco.c
+@@ -48,7 +48,6 @@
+ static u32 tcobase_phys;
+ static u32 tco_wdt_fired;
+ static void __iomem *tcobase;
+-static unsigned int pm_iobase;
+ static DEFINE_SPINLOCK(tco_lock);	/* Guards the hardware */
+ static unsigned long timer_alive;
+ static char tco_expect_close;
+@@ -132,25 +131,38 @@ static int tco_timer_set_heartbeat(int t)
+ 	return 0;
+ }
+ 
+-static void tco_timer_enable(void)
++static u8 sp5100_tco_read_pm_reg8(u8 index)
++{
++	outb(index, SP5100_IO_PM_INDEX_REG);
++	return inb(SP5100_IO_PM_DATA_REG);
++}
++
++static void sp5100_tco_update_pm_reg8(u8 index, u8 reset, u8 set)
+ {
+-	int val;
++	u8 val;
+ 
++	outb(index, SP5100_IO_PM_INDEX_REG);
++	val = inb(SP5100_IO_PM_DATA_REG);
++	val &= reset;
++	val |= set;
++	outb(val, SP5100_IO_PM_DATA_REG);
++}
++
++static void tco_timer_enable(void)
++{
+ 	if (!tco_has_sp5100_reg_layout(sp5100_tco_pci)) {
+ 		/* For SB800 or later */
+ 		/* Set the Watchdog timer resolution to 1 sec */
+-		outb(SB800_PM_WATCHDOG_CONFIG, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		val |= SB800_PM_WATCHDOG_SECOND_RES;
+-		outb(val, SB800_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SB800_PM_WATCHDOG_CONFIG,
++					  0xff, SB800_PM_WATCHDOG_SECOND_RES);
+ 
+ 		/* Enable watchdog decode bit and watchdog timer */
+-		outb(SB800_PM_WATCHDOG_CONTROL, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		val |= SB800_PCI_WATCHDOG_DECODE_EN;
+-		val &= ~SB800_PM_WATCHDOG_DISABLE;
+-		outb(val, SB800_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SB800_PM_WATCHDOG_CONTROL,
++					  ~SB800_PM_WATCHDOG_DISABLE,
++					  SB800_PCI_WATCHDOG_DECODE_EN);
+ 	} else {
++		u32 val;
++
+ 		/* For SP5100 or SB7x0 */
+ 		/* Enable watchdog decode bit */
+ 		pci_read_config_dword(sp5100_tco_pci,
+@@ -164,11 +176,9 @@ static void tco_timer_enable(void)
+ 				       val);
+ 
+ 		/* Enable Watchdog timer and set the resolution to 1 sec */
+-		outb(SP5100_PM_WATCHDOG_CONTROL, SP5100_IO_PM_INDEX_REG);
+-		val = inb(SP5100_IO_PM_DATA_REG);
+-		val |= SP5100_PM_WATCHDOG_SECOND_RES;
+-		val &= ~SP5100_PM_WATCHDOG_DISABLE;
+-		outb(val, SP5100_IO_PM_DATA_REG);
++		sp5100_tco_update_pm_reg8(SP5100_PM_WATCHDOG_CONTROL,
++					  ~SP5100_PM_WATCHDOG_DISABLE,
++					  SP5100_PM_WATCHDOG_SECOND_RES);
+ 	}
+ }
+ 
+@@ -321,6 +331,17 @@ static const struct pci_device_id sp5100_tco_pci_tbl[] = {
+ };
+ MODULE_DEVICE_TABLE(pci, sp5100_tco_pci_tbl);
+ 
++static u8 sp5100_tco_read_pm_reg32(u8 index)
++{
++	u32 val = 0;
++	int i;
++
++	for (i = 3; i >= 0; i--)
++		val = (val << 8) + sp5100_tco_read_pm_reg8(index + i);
++
++	return val;
++}
++
+ /*
+  * Init & exit routines
+  */
+@@ -329,7 +350,7 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	struct pci_dev *dev = NULL;
+ 	const char *dev_name = NULL;
+ 	u32 val;
+-	u32 index_reg, data_reg, base_addr;
++	u8 base_addr;
+ 
+ 	/* Match the PCI device */
+ 	for_each_pci_dev(dev) {
+@@ -351,35 +372,25 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	 */
+ 	if (tco_has_sp5100_reg_layout(sp5100_tco_pci)) {
+ 		dev_name = SP5100_DEVNAME;
+-		index_reg = SP5100_IO_PM_INDEX_REG;
+-		data_reg = SP5100_IO_PM_DATA_REG;
+ 		base_addr = SP5100_PM_WATCHDOG_BASE;
+ 	} else {
+ 		dev_name = SB800_DEVNAME;
+-		index_reg = SB800_IO_PM_INDEX_REG;
+-		data_reg = SB800_IO_PM_DATA_REG;
+ 		base_addr = SB800_PM_WATCHDOG_BASE;
+ 	}
+ 
+ 	/* Request the IO ports used by this driver */
+-	pm_iobase = SP5100_IO_PM_INDEX_REG;
+-	if (!request_region(pm_iobase, SP5100_PM_IOPORTS_SIZE, dev_name)) {
+-		pr_err("I/O address 0x%04x already in use\n", pm_iobase);
++	if (!request_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE,
++			    dev_name)) {
++		pr_err("I/O address 0x%04x already in use\n",
++		       SP5100_IO_PM_INDEX_REG);
+ 		goto exit;
+ 	}
+ 
+ 	/*
+ 	 * First, Find the watchdog timer MMIO address from indirect I/O.
++	 * Low three bits of BASE are reserved.
+ 	 */
+-	outb(base_addr+3, index_reg);
+-	val = inb(data_reg);
+-	outb(base_addr+2, index_reg);
+-	val = val << 8 | inb(data_reg);
+-	outb(base_addr+1, index_reg);
+-	val = val << 8 | inb(data_reg);
+-	outb(base_addr+0, index_reg);
+-	/* Low three bits of BASE are reserved */
+-	val = val << 8 | (inb(data_reg) & 0xf8);
++	val = sp5100_tco_read_pm_reg32(base_addr) & 0xfffffff8;
+ 
+ 	pr_debug("Got 0x%04x from indirect I/O\n", val);
+ 
+@@ -400,14 +411,7 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 				      SP5100_SB_RESOURCE_MMIO_BASE, &val);
+ 	} else {
+ 		/* Read SBResource_MMIO from AcpiMmioEn(PM_Reg: 24h) */
+-		outb(SB800_PM_ACPI_MMIO_EN+3, SB800_IO_PM_INDEX_REG);
+-		val = inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+2, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+1, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
+-		outb(SB800_PM_ACPI_MMIO_EN+0, SB800_IO_PM_INDEX_REG);
+-		val = val << 8 | inb(SB800_IO_PM_DATA_REG);
++		val = sp5100_tco_read_pm_reg32(SB800_PM_ACPI_MMIO_EN);
+ 	}
+ 
+ 	/* The SBResource_MMIO is enabled and mapped memory space? */
+@@ -470,7 +474,7 @@ setup_wdt:
+ unreg_mem_region:
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+ unreg_region:
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ exit:
+ 	return 0;
+ }
+@@ -517,7 +521,7 @@ static int sp5100_tco_init(struct platform_device *dev)
+ exit:
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	return ret;
+ }
+ 
+@@ -531,7 +535,7 @@ static void sp5100_tco_cleanup(void)
+ 	misc_deregister(&sp5100_tco_miscdev);
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(pm_iobase, SP5100_PM_IOPORTS_SIZE);
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ }
+ 
+ static int sp5100_tco_remove(struct platform_device *dev)
+diff --git a/drivers/watchdog/sp5100_tco.h b/drivers/watchdog/sp5100_tco.h
+index 1af4dee..f495fe0 100644
+--- a/drivers/watchdog/sp5100_tco.h
++++ b/drivers/watchdog/sp5100_tco.h
+@@ -24,10 +24,11 @@
+  * read them from a register.
+  */
+ 
+-/*  For SP5100/SB7x0 chipset */
++/*  For SP5100/SB7x0/SB8x0 chipset */
+ #define SP5100_IO_PM_INDEX_REG		0xCD6
+ #define SP5100_IO_PM_DATA_REG		0xCD7
+ 
++/* For SP5100/SB7x0 chipset */
+ #define SP5100_SB_RESOURCE_MMIO_BASE	0x9C
+ 
+ #define SP5100_PM_WATCHDOG_CONTROL	0x69
+@@ -44,11 +45,7 @@
+ 
+ #define SP5100_DEVNAME			"SP5100 TCO"
+ 
+-
+ /*  For SB8x0(or later) chipset */
+-#define SB800_IO_PM_INDEX_REG		0xCD6
+-#define SB800_IO_PM_DATA_REG		0xCD7
+-
+ #define SB800_PM_ACPI_MMIO_EN		0x24
+ #define SB800_PM_WATCHDOG_CONTROL	0x48
+ #define SB800_PM_WATCHDOG_BASE		0x48
+-- 
+cgit v1.1
+

--- a/target/linux/generic/backport-4.9/078-v4.16-0002-watchdog-sp5100_tco-Use-request_muxed_region-where-possible.patch
+++ b/target/linux/generic/backport-4.9/078-v4.16-0002-watchdog-sp5100_tco-Use-request_muxed_region-where-possible.patch
@@ -1,0 +1,62 @@
+From 16e7730bd7ec7f4ec19628e5ddd172df28cf996d Mon Sep 17 00:00:00 2001
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Sun, 24 Dec 2017 13:04:08 -0800
+Subject: watchdog: sp5100_tco: Use request_muxed_region where possible
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use request_muxed_region for multiplexed IO memory regions.
+Also, SP5100_IO_PM_INDEX_REG/SP5100_IO_PM_DATA_REG are only
+used during initialization; it is unnecessary to keep the
+address range reserved.
+
+Cc: Zoltán Böszörményi <zboszor@pr.hu>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Signed-off-by: Wim Van Sebroeck <wim@iguana.be>
+---
+ drivers/watchdog/sp5100_tco.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/watchdog/sp5100_tco.c b/drivers/watchdog/sp5100_tco.c
+index 05f9d27..11109ac 100644
+--- a/drivers/watchdog/sp5100_tco.c
++++ b/drivers/watchdog/sp5100_tco.c
+@@ -379,8 +379,8 @@ static unsigned char sp5100_tco_setupdevice(void)
+ 	}
+ 
+ 	/* Request the IO ports used by this driver */
+-	if (!request_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE,
+-			    dev_name)) {
++	if (!request_muxed_region(SP5100_IO_PM_INDEX_REG,
++				  SP5100_PM_IOPORTS_SIZE, dev_name)) {
+ 		pr_err("I/O address 0x%04x already in use\n",
+ 		       SP5100_IO_PM_INDEX_REG);
+ 		goto exit;
+@@ -468,6 +468,7 @@ setup_wdt:
+ 	 */
+ 	tco_timer_stop();
+ 
++	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	/* Done */
+ 	return 1;
+ 
+@@ -521,7 +522,6 @@ static int sp5100_tco_init(struct platform_device *dev)
+ exit:
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ 	return ret;
+ }
+ 
+@@ -535,7 +535,6 @@ static void sp5100_tco_cleanup(void)
+ 	misc_deregister(&sp5100_tco_miscdev);
+ 	iounmap(tcobase);
+ 	release_mem_region(tcobase_phys, SP5100_WDT_MEM_MAP_SIZE);
+-	release_region(SP5100_IO_PM_INDEX_REG, SP5100_PM_IOPORTS_SIZE);
+ }
+ 
+ static int sp5100_tco_remove(struct platform_device *dev)
+-- 
+cgit v1.1
+


### PR DESCRIPTION
This allows i2c-piix4 to coexist with sp5100_tco (shared I/O region) and improves the performance of the
i2c-piix4 driver, which was really slow because of the used msleep(). 