### PR TITLE
odhcpd: add patch to fix mis-announcing dhcpv6

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(LEDE_GIT)/project/odhcpd.git

--- a/package/network/services/odhcpd/patches/fs#1457.patch
+++ b/package/network/services/odhcpd/patches/fs#1457.patch
@@ -1,0 +1,18 @@
+--- a/src/router.c
++++ b/src/router.c
+@@ -279,11 +279,12 @@ static uint64_t send_router_advert(struct interface *iface, const struct in6_add
+ 	if (hlim > 0)
+ 		adv.h.nd_ra_curhoplimit = hlim;
+ 
+-	if (iface->dhcpv6)
++	if (iface->dhcpv6) {
+ 		adv.h.nd_ra_flags_reserved = ND_RA_FLAG_OTHER;
+ 
+-	if (iface->managed >= RELAYD_MANAGED_MFLAG)
+-		adv.h.nd_ra_flags_reserved |= ND_RA_FLAG_MANAGED;
++		if (iface->managed >= RELAYD_MANAGED_MFLAG)
++			adv.h.nd_ra_flags_reserved |= ND_RA_FLAG_MANAGED;
++	}
+ 
+ 	if (iface->route_preference < 0)
+ 		adv.h.nd_ra_flags_reserved |= ND_RA_PREF_LOW;


### PR DESCRIPTION
This is a port of the patch from FS#1457 to fix the problem
where odhcpd was mistakenly announcing DHCPv6 support when it
doesn't exist.

The patch being ported is:

413652910234f44e11d6550abf6871621474b8cb
https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob;f=package/network/services/odhcpd/Makefile;h=f78fb9485bd599a26e7a0d180a62c41b53e1853d;hb=HEAD#l17

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>
