### PR TITLE
ramips: Fix tplink,c20-v1 sysupgrade error

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -468,6 +468,7 @@ define Device/tplink_c20-v1
   $(Device/Archer)
   DTS := ArcherC20v1
   SUPPORTED_DEVICES := c20v1
+  SUPPORTED_DEVICES += tplink,c20-v1
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc2000001
   TPLINK_HWREV := 0x44


### PR DESCRIPTION
Fix follow sysupgrade error for TP-Link ArcherC20 v1

> $sysupgrade openwrt-ramips-mt7620-tplink_c20-v1-squashfs-sysupgrade.bin
> Device tplink,c20-v1 not supported by this image
> Supported devices: c20v1
> Image check 'fwtool_check_image' failed.

Signed-off-by: Elantsev Oleg <baxneo@gmail.com>
