### PR TITLE
ramips: add support for I-O DATA WN-GX300GR

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -168,6 +168,7 @@ dlink,dwr-921-c1)
 	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:green:sigstrength" "0"
 	;;
 dir-810l|\
+iodata,wn-gx300gr|\
 mzk-750dhp|\
 mzk-dp150n|\
 vr500)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -194,6 +194,7 @@ ramips_setup_interfaces()
 	gl-mt300n|\
 	gl-mt750|\
 	hg255d|\
+	iodata,wn-gx300gr|\
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
@@ -458,6 +459,9 @@ ramips_setup_macs()
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	iodata,wn-gx300gr)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary Factory 4)" 1)
 		;;
 	kn_rc|\
 	kn_rf|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -27,6 +27,7 @@ get_status_led() {
 	fonera20n|\
 	firewrt|\
 	hg255d|\
+	iodata,wn-gx300gr|\
 	kn|\
 	kn_rc|\
 	kn_rf|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -75,6 +75,7 @@ platform_check_image() {
 	hpm|\
 	ht-tm02|\
 	hw550-3g|\
+	iodata,wn-gx300gr|\
 	ip2202|\
 	jhr-n805r|\
 	jhr-n825r|\

--- a/target/linux/ramips/dts/WN-GX300GR.dts
+++ b/target/linux/ramips/dts/WN-GX300GR.dts
@@ -1,0 +1,156 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-gx300gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-GX300GR";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "wn-gx300gr:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wn-gx300gr:green:wps";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		custom {
+			label = "custom";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "Config";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		Factory: partition@40000 {
+			label = "Factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "iNIC_rf";
+			reg = <0x50000 0x10000>;
+			read-only;
+		};
+
+		partition@60000 {
+			label = "firmware";
+			reg = <0x60000 0x770000>;
+		};
+
+		partition@7d0000 {
+			label = "Key";
+			reg = <0x7d0000 0x10000>;
+			read-only;
+		};
+
+		partition@7e0000 {
+			label = "backup";
+			reg = <0x7e0000 0x10000>;
+			read-only;
+		};
+
+		partition@7f0000 {
+			label = "storage";
+			reg = <0x7f0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&Factory 0x4>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart2", "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&Factory 0x0>;
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -114,6 +114,14 @@ define Device/hc5962
 endef
 TARGET_DEVICES += hc5962
 
+define Device/iodata_wn-gx300gr
+  DTS := WN-GX300GR
+  IMAGE_SIZE := 7798784
+  DEVICE_TITLE := I-O DATA WN-GX300GR
+  DEVICE_PACKAGES := kmod-mt7603 wpad-mini
+endef
+TARGET_DEVICES += iodata_wn-gx300gr
+
 define Device/k2p
   DTS := K2P
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
I-O DATA WN-GX300GR is a 2.4 GHz band 11n router, based on MediaTek
MT7621S.

Specification:

- MT7621S (1-Core, 2-Threads)
- 64 MB of RAM
- 8 MB of Flash (SPI)
- 2T2R 2.4 GHz
- 5x 10/100/1000 Mbps Ethernet
- 2x LEDs, 4x keys (2x buttons, 1x slide switch)
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - baudrate: 115200 bps (U-Boot, OpenWrt)

Flash instruction using initramfs image:

1. Connect serial cable to UART header
2. Rename OpenWrt initramfs image for WN-GX300GR to "uImageWN-GX300GR"
and place it in the TFTP directory
3. Set the IP address of the computer to 192.168.99.8, connect to the
LAN port of WN-GX300GR, and start the TFTP server on the computer
4. Connect power cable to WN-GX300GR and turn on the router
5. Press "1" key on the serial console to interrupt boot process on
U-Boot, press Enter key 3 times and start firmware download via TFTP
6. WN-GX300GR downloads initramfs image and boot with it
7. On the initramfs image, execute "mtd erase firmware" to erase stock
firmware and execute sysupgrade with sysupgrade image for WN-GX300GR
8. Wait ~150 seconds to complete flasing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>