### PR TITLE
kernel/modules: add kmod packages

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -427,3 +427,25 @@ endef
 $(eval $(call KernelPackage,hwmon-w83793))
 
 
+define KernelPackage/hwmon-adcxx
+  TITLE:=ADCxx monitoring support
+  KCONFIG:=CONFIG_SENSORS_ADCXX
+  FILES:=$(LINUX_DIR)/drivers/hwmon/adcxx.ko
+  AUTOLOAD:=$(call AutoLoad,60,adcxx)
+  $(call AddDepends/hwmon,)
+endef
+
+define KernelPackage/hwmon-adcxx/description
+  Kernel module for the National Semiconductor
+  ADC<bb><c>S<sss> chip family, where
+  * bb  is the resolution in number of bits (8, 10, 12)
+  * c   is the number of channels (1, 2, 4, 8)
+  * sss is the maximum conversion speed (021 for 200 kSPS, 051 for 500
+    kSPS and 101 for 1 MSPS)
+
+  Examples : ADC081S101, ADC124S501, ...
+endef
+
+$(eval $(call KernelPackage,hwmon-adcxx))
+
+

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -223,6 +223,22 @@ endef
 $(eval $(call KernelPackage,switch-ip17xx))
 
 
+define KernelPackage/switch-rtl8306
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Realtek RTL8306S switch support
+  DEPENDS:=+kmod-swconfig
+  KCONFIG:=CONFIG_RTL8306_PHY
+  FILES:=$(LINUX_DIR)/drivers/net/phy/rtl8306.ko
+  AUTOLOAD:=$(call AutoLoad,43,rtl8306)
+endef
+
+define KernelPackage/switch-rtl8306/description
+ Realtek RTL8306S switch support
+endef
+
+$(eval $(call KernelPackage,switch-rtl8306))
+
+
 define KernelPackage/switch-rtl8366-smi
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Realtek RTL8366 SMI switch interface support

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -110,6 +110,23 @@ endef
 $(eval $(call KernelPackage,mii))
 
 
+define KernelPackage/mdio-gpio
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:= Supports GPIO lib-based MDIO busses
+  DEPENDS:=+kmod-libphy @GPIO_SUPPORT
+  KCONFIG:=CONFIG_MDIO_BITBANG \
+		CONFIG_MDIO_GPIO
+  FILES:=$(LINUX_DIR)/drivers/net/phy/mdio-gpio.ko $(LINUX_DIR)/drivers/net/phy/mdio-bitbang.ko
+  AUTOLOAD:=$(call AutoProbe,mdio-gpio)
+endef
+
+define KernelPackage/mdio-gpio/description
+ Supports GPIO lib-based MDIO busses
+endef
+
+$(eval $(call KernelPackage,mdio-gpio))
+
+
 define KernelPackage/et131x
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Agere ET131x Gigabit Ethernet driver

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -883,6 +883,22 @@ endef
 
 $(eval $(call KernelPackage,random-omap))
 
+define KernelPackage/random-tpm
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Hardware Random Number Generator TPM support
+  KCONFIG:=CONFIG_HW_RANDOM_TPM
+  FILES:=$(LINUX_DIR)/drivers/char/hw_random/tpm-rng.ko
+  DEPENDS:= +kmod-random-core +kmod-tpm
+  AUTOLOAD:=$(call AutoProbe,tpm-rng)
+endef
+
+define KernelPackage/random-tpm/description
+ Kernel module for the Random Number Generator
+ in the Trusted Platform Module.
+endef
+
+$(eval $(call KernelPackage,random-tpm))
+
 define KernelPackage/thermal
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Generic Thermal sysfs driver


### PR DESCRIPTION
- kmod-random-tpm
If you have a TPM on the system you could use this as a RNG source and this must be export as a kmod.

- kmod-switch-rtl8306 and kmod-mdio-gpio
If the MDIO bus of the switch-rtl8306 is connected over GPIOs this two packages must be exported as a kmod.

- kmod-adcxx
If a x86 boards uses the adcxx we must export adcxx as kmod. 