### PR TITLE
ath79: port EG200 and DTC warnings cleanup

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -18,6 +18,12 @@ case "$board" in
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssi3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssi4" "wlan0" "80" "100"
 	;;
+"etactica,eg200")
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:red:eth0" "eth0"
+	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:red:wlan" "phy0tpt"
+	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"
+	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
+	;;
 "glinet,ar150")
 	ucidef_set_led_wlan "wlan" "WLAN" "gl-ar150:orange:wlan" "phy0tpt"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -8,6 +8,9 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	"etactica,eg200")
+		ucidef_set_interface_lan "eth0" "dhcp"
+		;;
 	"avm,fritz300e"|\
 	"tplink,tl-wr703n"|\
 	"ubnt,unifi")

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -27,8 +27,7 @@
 		#size-cells = <0>;
 
 		poll-interval = <20>;
-		button@0 {
-			label = "reset";
+		reset {
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
@@ -37,12 +36,12 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led@0 {
+		dome-green {
 			label = "ubnt:green:dome";
 			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@1 {
+		dome-orange {
 			label = "ubnt:orange:dome";
 			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
 		};
@@ -113,7 +112,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k@0000 {
+	ath9k@0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
 	};

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -26,8 +26,7 @@
 		#size-cells = <0>;
 
 		poll-interval = <20>;
-		button@0 {
-			label = "reset";
+		reset {
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
@@ -36,22 +35,22 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led@0 {
+		link1 {
 			label = "ubnt:red:link1";
 			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@1 {
+		link2 {
 			label = "ubnt:orange:link2";
 			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@2 {
+		link3 {
 			label = "ubnt:green:link3";
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		};
 
-		led@3 {
+		link4 {
 			label = "ubnt:green:link4";
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
@@ -122,7 +121,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k@0000 {
+	ath9k@0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
 	};

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -142,7 +142,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0000 {
+	ath9k: wifi@0 {
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -21,36 +21,31 @@
 		#size-cells = <0>;
 
 		poll-interval = <20>;
-		button@0 {
-			label = "usb";
+		usb {
 			linux,code = <BTN_2>;
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
 
-		button@1 {
-			label = "reset";
+		reset {
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
 
-		button@2 {
-			label = "movie_engine";
+		movie_engine {
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 			debounce-interval = <60>;
 		};
 
-		button@3 {
-			label = "aoss";
+		aoss {
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
 
-		button@4 {
-			label = "router_off";
+		router_off {
 			linux,code = <BTN_5>;
 			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 			debounce-interval = <60>;
@@ -60,12 +55,12 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led@0 {
+		security {
 			label = "buffalo:orange:security";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		led@1 {
+		diag {
 			label = "buffalo:red:diag";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
@@ -120,7 +115,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k@0000 {
+	ath9k@0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
 	};

--- a/target/linux/ath79/dts/ar9132_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tl-wr1043nd-v1.dts
@@ -141,7 +141,7 @@
 				read-only;
 			};
 
-			partition@020000 {
+			partition@20000 {
 				label = "firmware";
 				reg = <0x020000 0x7D0000>;
 			};

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -76,7 +76,7 @@
 			};
 		};
 
-		usb: usb@1b000100 {
+		usb: usb@1b000000 {
 			compatible = "chipidea,usb2";
 			reg = <0x1b000000 0x200>;
 

--- a/target/linux/ath79/dts/ar9330_glinet_ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_ar150.dts
@@ -89,7 +89,7 @@
 	num-chipselects = <1>;
 	status = "okay";
 
-	spiflash {
+	spiflash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";

--- a/target/linux/ath79/dts/ar9331_etactica-eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica-eg200.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "eTactica EG200";
+	compatible = "etactica,eg200", "rme-eg200";
+
+        aliases {
+                serial0 = &uart;
+        };
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <50>;
+
+		restore {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		modbus {
+			label = "eg200:red:modbus";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		etactica {
+			label = "eg200:red:etactica";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		eth0 {
+			label = "eg200:red:eth0";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wlan {
+			label = "eg200:red:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-addr-swap = <1>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&spi {
+	num-chipselects = <1>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot@0 {
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			uboot-env@40000 {
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware@50000 {
+				reg = <0x50000 0xfa0000>;
+			};
+
+			art: art@ff0000 {
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
@@ -74,15 +74,13 @@
 		#size-cells = <0>;
 		poll-interval = <20>;
 
-		button@0 {
-			label = "reset";
+		reset {
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
 
-		button@1 {
-			label = "wifi";
+		wifi {
 			linux,code = <KEY_RFKILL>;
 			linux,input-type = <EV_SW>;
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;

--- a/target/linux/ath79/dts/ath79.dtsi
+++ b/target/linux/ath79/dts/ath79.dtsi
@@ -51,6 +51,8 @@
 
 			mdio0: mdio-bus {
 				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 
 				regmap = <&eth0>;
 
@@ -70,6 +72,8 @@
 
 			mdio1: mdio-bus {
 				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <0>;
 
 				regmap = <&eth1>;
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -44,6 +44,15 @@ define Device/embeddedwireless_dorin
 endef
 TARGET_DEVICES += embeddedwireless_dorin
 
+define Device/etactica-eg200
+  ATH_SOC := ar9331
+  DEVICE_TITLE := eTactica EG200
+  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-ledtrig-oneshot \
+	kmod-usb-serial kmod-usb-serial-ftdi kmod-usb-storage  kmod-fs-ext4
+  SUPPORTED_DEVICES += etactica,eg200 rme-eg200
+endef
+TARGET_DEVICES += etactica-eg200
+
 define Device/glinet_ar150
   ATH_SOC := ar9330
   DEVICE_TITLE := GL.iNet GL-AR150


### PR DESCRIPTION
~This is a series based on blogic's ath79 staging tree~

Rebased on master now that the ath79 AHB wireless has landed.

It ports the existing etactica-eg200 from ar71xx, and fixes lots of warnings from the device tree compiler.

Tested on the eg200: ethernet, usb, wifi, leds and buttons