### PR TITLE
ar71xx: improve SPI flash performance

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-lima.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-lima.c
@@ -47,11 +47,25 @@ static struct gpio_keys_button lima_gpio_keys[] __initdata = {
 	}
 };
 
+static struct spi_board_info lima_spi_info[] = {
+	{
+		.bus_num	= 0,
+		.chip_select	= 0,
+		.max_speed_hz	= 25000000,
+		.modalias	= "m25p80",
+	}
+};
+
+static struct ath79_spi_platform_data lima_spi_data =
+{
+	.bus_num		= 0,
+	.num_chipselect 	= 1,
+	.use_hw_shiftreg 	= true,
+};
+
 static void __init lima_setup(void)
 {
 	u8 *art = (u8 *) KSEG1ADDR(0x1f080000);
-
-	ath79_register_m25p80(NULL);
 
 	ath79_register_gpio_keys_polled(-1, LIMA_KEYS_POLL_INTERVAL,
 					ARRAY_SIZE(lima_gpio_keys),
@@ -79,6 +93,7 @@ static void __init lima_setup(void)
 	ath79_register_eth(0);
 
 	ath79_register_wmac(art + LIMA_CALDATA_OFFSET, NULL);
+	ath79_register_spi(&lima_spi_data, lima_spi_info, ARRAY_SIZE(lima_spi_info));
 	ath79_register_usb();
 	ath79_register_pci();
 }

--- a/target/linux/ar71xx/patches-4.9/462-spi-ath79-add-hw-shiftreg-mode.patch
+++ b/target/linux/ar71xx/patches-4.9/462-spi-ath79-add-hw-shiftreg-mode.patch
@@ -1,0 +1,65 @@
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+@@ -494,6 +494,8 @@
+ #define AR71XX_SPI_REG_CTRL	0x04	/* SPI Control */
+ #define AR71XX_SPI_REG_IOC	0x08	/* SPI I/O Control */
+ #define AR71XX_SPI_REG_RDS	0x0c	/* Read Data Shift */
++#define AR71XX_SPI_REG_WDS	0x10	/* Write Data Shift */
++#define AR71XX_SPI_REG_CDS	0x14	/* Control Data Shift */
+ 
+ #define AR71XX_SPI_FS_GPIO	BIT(0)	/* Enable GPIO mode */
+ 
+@@ -509,6 +511,9 @@
+ #define AR71XX_SPI_IOC_CS_ALL	(AR71XX_SPI_IOC_CS0 | AR71XX_SPI_IOC_CS1 | \
+ 				 AR71XX_SPI_IOC_CS2)
+ 
++#define AR71XX_SPI_CDS_EN	BIT(31)	/* Enable Shifting */
++#define AR71XX_SPI_CDS_CS(n)	BIT(28 + (n)) /* CS enable */
++
+ /*
+  * GPIO block
+  */
+--- a/arch/mips/include/asm/mach-ath79/ath79_spi_platform.h
++++ b/arch/mips/include/asm/mach-ath79/ath79_spi_platform.h
+@@ -15,6 +15,7 @@ struct ath79_spi_platform_data {
+ 	unsigned	bus_num;
+ 	unsigned	num_chipselect;
+ 	int *cs_gpios;
++	bool		use_hw_shiftreg;
+ };
+ 
+ #endif /* _ATH79_SPI_PLATFORM_H */
+--- a/drivers/spi/spi-ath79.c
++++ b/drivers/spi/spi-ath79.c
+@@ -202,6 +202,19 @@ static u32 ath79_spi_txrx_mode0(struct s
+ 	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
+ }
+ 
++static u32 ath79_spi_txrx_shiftreg_mode0(struct spi_device *spi, unsigned nsecs,
++					u32 word, u8 bits)
++{
++	struct ath79_spi *sp = ath79_spidev_to_sp(spi);
++
++	ath79_spi_wr(sp, AR71XX_SPI_REG_WDS, word);
++	ath79_spi_wr(sp, AR71XX_SPI_REG_CDS, AR71XX_SPI_CDS_EN |
++					     AR71XX_SPI_CDS_CS(spi->chip_select) | bits);
++
++	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
++}
++
++
+ static bool ath79_spi_flash_read_supported(struct spi_device *spi)
+ {
+ 	if (spi->chip_select || gpio_is_valid(spi->cs_gpio))
+@@ -268,7 +281,10 @@ static int ath79_spi_probe(struct platfo
+ 
+ 	sp->bitbang.master = master;
+ 	sp->bitbang.chipselect = ath79_spi_chipselect;
+-	sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_mode0;
++	if (pdata->use_hw_shiftreg == true)
++		sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_shiftreg_mode0;
++	else
++		sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_mode0;
+ 	sp->bitbang.setup_transfer = spi_bitbang_setup_transfer;
+ 	sp->bitbang.flags = SPI_CS_HIGH;
+ 

--- a/target/linux/ar71xx/patches-4.9/463-mtd-m25p80-pass-bits-per-word-to-spi.patch
+++ b/target/linux/ar71xx/patches-4.9/463-mtd-m25p80-pass-bits-per-word-to-spi.patch
@@ -1,0 +1,16 @@
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -175,6 +175,13 @@ static ssize_t m25p80_read(struct spi_no
+ 	t[1].rx_buf = buf;
+ 	t[1].rx_nbits = m25p80_rx_nbits(nor);
+ 	t[1].len = min(len, spi_max_transfer_size(spi));
++
++	/* Set wider transaction if alignment and controller allows */
++	if (len % 4 == 0 && (spi->master->bits_per_word_mask & SPI_BPW_MASK(32)))
++		t[1].bits_per_word = 32;
++	else if (len % 2 == 0 && (spi->master->bits_per_word_mask & SPI_BPW_MASK(16)))
++		t[1].bits_per_word = 16;
++
+ 	spi_message_add_tail(&t[1], &m);
+ 
+ 	ret = spi_sync(spi, &m);


### PR DESCRIPTION
QCA953x, QCA955x SPI controller has a shift register that allows faster transfer compared to pure bitbang mode. This is mostly relevant to boards that can't use hardware mapping (due to flash using 4-byte opcodes, SPI-NAND or having non-standard chip select)

With this patch set I get 120% read performance gain on Lima dev board (1MB/s -> 2.2MB/s) on simple dd copy test.

For now I've enabled this only on Lima board, other boards should be tested before enabling this in platform data.

