### PR TITLE
ipq806x: Enlarge R7800 flash - use 68MB netgear partition

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -319,13 +319,7 @@
 
 					ubi@1880000 {
 						label = "ubi";
-						reg = <0x1880000 0x1C00000>;
-					};
-
-					netgear@3480000 {
-						label = "netgear";
-						reg = <0x3480000 0x4480000>;
-						read-only;
+						reg = <0x1880000 0x6080000>;
 					};
 
 					reserve@7900000 {
@@ -336,7 +330,7 @@
 
 					firmware@1480000 {
 						label = "firmware";
-						reg = <0x1480000 0x2000000>;
+						reg = <0x1480000 0x6480000>;
 					};
 				};
 			};


### PR DESCRIPTION
@blogic  @dissent1  @mkresin @pkgadd 

I propose that the Netgear R7800 starts to use the 68 MB netgear partition that has so far been left intact

Users are required to use TFTP in any case when updating to 4.14 (both in master and 18.06), so this change can be made at the same time. I propose that is is also backported into 18.06.

Tested with Openwrt master r7093-4fdc6ca31b and OEM V1.0.2.52

-----

Increase the available flash memory size in Netgear R7800 by taking into the use the unused "netgear" partition that is located after the firmware partition.

Available flash space for kernel+rootfs+overlay increases by 68 MB from 32 MB to 100 MB.
In a typical build, overlay space increases from 15 to 85, increasing the package installation possibilities greatly.

Reverting to the OEM firmware is still possible, as the OEM firmware contains logic to initialise the "netgear" partition if its contents do not match expectations. In OEM firmware, "netgear" contains 6 UBI sub-partitions that are defined in /etc/netgear.cfg and initialisation is done by /etc/preinit

**Tested with Openwrt master r7093-4fdc6ca31b and OEM V1.0.2.52:**
I flashed a modified Openwrt r7093-4fdc6ca31b build and filled overlay with random data, flashed the newest OEM firmware V1.0.2.52, played with OEM settings and let it re-create the certificate for VPN, and then flashed vanilla Openwrt to see the outcome. Both OEM and Openwrt worked ok.

**Reference to forum discussion in Netgear R7800 exploration thread (messages 1118-1158):**
https://forum.lede-project.org/t/netgear-r7800-exploration-ipq8065-qca9984/285/1118

Discussed also in https://forum.lede-project.org/t/netgear-r7800-only-19mb-flash-available/1115 since January 2017. I figured out the necessary DTS already then, and some users have being using that mod since then. Now the kernel 4.14 TFTP jump makes it worthwhile to propose the change for general use.

Note:
**Relevant OEM GPL source code for the re-initialisation logic (source from a github user's repo):**
* the six UBI partitions inside "netgear" are defined in netgear.cfg: https://github.com/paul-chambers/netgear-r7800/blob/eeac2e10190f6f45e32e4c7012c4babc351898d8/target/linux/ipq806x/base-files/etc/netgear.cfg 
* Netgear's preinit script seems to contain code that checks those partitions at preinit, and if necessary, reads the UBI definitions from netgear.cfg and rewrites those partitions: https://github.com/paul-chambers/netgear-r7800/blob/eeac2e10190f6f45e32e4c7012c4babc351898d8/target/linux/ipq806x/base-files/etc/preinit#L26
