### PR TITLE
ath79: fix qca956x SoC boot

### DIFF
--- a/target/linux/ath79/patches-4.14/0035-MIPS-ath79-fix-QCA956x-boot.patch
+++ b/target/linux/ath79/patches-4.14/0035-MIPS-ath79-fix-QCA956x-boot.patch
@@ -1,0 +1,17 @@
+--- a/arch/mips/ath79/clock.c	2018-06-01 13:56:30.376729328 +0300
++++ b/arch/mips/ath79/clock.c	2018-06-04 02:06:57.039616840 +0300
+@@ -525,6 +525,14 @@
+ 	u32 cpu_pll, ddr_pll;
+ 	u32 bootstrap;
+ 
++	/* QCA956x timer init workaround has to be applied right before setting
++	* up the clock. Else, there will be no jiffies */
++	u32 misc;
++
++	misc = ath79_reset_rr(AR71XX_RESET_REG_MISC_INT_ENABLE);
++	misc |= MISC_INT_MIPS_SI_TIMERINT_MASK;
++	ath79_reset_wr(AR71XX_RESET_REG_MISC_INT_ENABLE, misc);
++
+ 	bootstrap = ath79_reset_rr(QCA956X_RESET_REG_BOOTSTRAP);
+ 	if (bootstrap &	QCA956X_BOOTSTRAP_REF_CLK_40)
+ 		ref_rate = 40 * 1000 * 1000;


### PR DESCRIPTION
based on old ar71xx irq.c driver

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

