### PR TITLE
x86: add support to set GRUB menu entry title

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -230,6 +230,14 @@ menu "Target Images"
 		help
 		  If you don't know, 5 seconds is a reasonable default.
 
+	config GRUB_TITLE
+		string "Title for the menu entry in GRUB"
+		depends on GRUB_IMAGES
+		default "OpenWrt"
+		help
+		  This is the title of the GRUB menu entry.
+		  If unspecified, it defaults to OpenWrt.
+
 	config VDI_IMAGES
 		bool "Build VirtualBox image files (VDI)"
 		depends on TARGET_x86 || TARGET_x86_64

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -46,6 +46,7 @@ ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(SIGNATURE)-02)
 
 GRUB_TIMEOUT:=$(call qstrip,$(CONFIG_GRUB_TIMEOUT))
+GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
 
 ifneq ($(CONFIG_TARGET_x86_xen_domu),)
   GRUB_ROOT = xen/xvda,msdos1
@@ -82,6 +83,7 @@ ifneq ($(CONFIG_GRUB_IMAGES),)
 		-e 's#@CMDLINE@#$(strip $(call Image/cmdline/$(1)) $(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE))#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@ROOT@#$(GRUB_ROOT)#g' \
+		-e 's#@TITLE@#$(GRUB_TITLE)#g' \
 		./grub.cfg > $(KDIR)/root.grub/boot/grub/grub.cfg
 	PADDING="$(CONFIG_TARGET_IMAGES_PAD)" SIGNATURE="$(SIGNATURE)" PATH="$(TARGET_PATH)" $(SCRIPT_DIR)/gen_image_generic.sh \
 		$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img \
@@ -119,6 +121,7 @@ define Image/Build/iso
 		-e 's#@TERMINAL_CONFIG@#$(strip $(GRUB_TERMINAL_CONFIG))#g' \
 		-e 's#@CMDLINE@#root=/dev/sr0 rootfstype=iso9660 rootwait $(strip $(call Image/cmdline/$(1)) $(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE))#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
+		-e 's#@TITLE@#$(GRUB_TITLE)#g' \
 		./grub-iso.cfg > $(KDIR)/root.grub/boot/grub/grub.cfg
 	mkisofs -R -b boot/grub/eltorito.img -no-emul-boot -boot-info-table \
 		-o $(KDIR)/root.iso $(KDIR)/root.grub $(TARGET_DIR)

--- a/target/linux/x86/image/grub-iso.cfg
+++ b/target/linux/x86/image/grub-iso.cfg
@@ -5,6 +5,6 @@ set default="0"
 set timeout="@TIMEOUT@"
 set root='(cd)'
 
-menuentry "OpenWrt" {
+menuentry "@TITLE@" {
 	linux /boot/vmlinuz @CMDLINE@ noinitrd
 }

--- a/target/linux/x86/image/grub.cfg
+++ b/target/linux/x86/image/grub.cfg
@@ -5,9 +5,9 @@ set default="0"
 set timeout="@TIMEOUT@"
 set root='(@ROOT@)'
 
-menuentry "OpenWrt" {
+menuentry "@TITLE@" {
 	linux /boot/vmlinuz @CMDLINE@ noinitrd
 }
-menuentry "OpenWrt (failsafe)" {
+menuentry "@TITLE@ (failsafe)" {
 	linux /boot/vmlinuz failsafe=true @CMDLINE@ noinitrd
 }


### PR DESCRIPTION
Makes it possible to change the title to whatever you want (e.g. "Optimized OpenWrt") using `make menuconfig`.