### PR TITLE
udhcpc: no MSG_DONTROUTE when sending packet

### DIFF
--- a/package/utils/busybox/patches/204-udhcpc_no_msg_dontroute.patch
+++ b/package/utils/busybox/patches/204-udhcpc_no_msg_dontroute.patch
@@ -1,0 +1,11 @@
+--- a/networking/udhcp/dhcpc.c
++++ b/networking/udhcp/dhcpc.c
+@@ -700,7 +700,7 @@
+ 		return udhcp_send_kernel_packet(packet,
+ 			ciaddr, CLIENT_PORT,
+ 			server, SERVER_PORT,
+-			/*send_flags: "to hosts only on directly connected networks" */ MSG_DONTROUTE
++			0 /*Was MSG_DONTROUTE here. It prevented unicast renewal requests to server in different subnet*/
+ 		);
+ 	}
+ 	return raw_bcast_from_client_config_ifindex(packet, ciaddr);


### PR DESCRIPTION
**TL;DR** Don't set `MSG_DONTROUTE` when sending packets, otherwise it forces the client into non-compliant behaviour that is rejected by properly configured servers, thus creating unnecessary interruptions and connection breakages.

This patch reverts a [change made in Sep 2017 which introduced `MSG_DONTROUTE` flag](http://lists.busybox.net/pipermail/busybox-cvs/2017-September/037402.html) to prevent udhcpc from reaching out to servers on a different subnet. That change violates [RFC2131 ](https://tools.ietf.org/html/rfc2131)by forcing fully configured clients, who got their configurations through an offer relayed by a DHCP relay, from renewing through a unicast request directly to the DHCP server, resulting in the client resorting to boradcasting lease extension requests instead of unicasting them, further breaking [RFC2131](https://tools.ietf.org/html/rfc2131).

The problem with `MSG_DONTROUTE` appears when talking to a properly configured DHCP server that rejects non-compliant requests. Such server will reject lease extension attempts sent via broadcast rather than unicast, as is the case with Finnish ISPs Telia and DNA as well as Estonian ISP Starman. Once the lease expires without renewal, udhcpc enters init mode, taking down the interfaces with it, and thus causing interruption on every lease expiry. On some ISPs (such as the ones mentioned above) that can be once every 10-20 minutes. The interruptions appear in the logs as such:


```
udhcpc: sending renew to x.x.x.x
udhcpc: send: Network unreachable
udhcpc: sending renew to 0.0.0.0
udhcpc: sending renew to 0.0.0.0
...
udhcpc: lease lost, entering init state
Interface 'wan' has lost the connection
Interface 'wan' is now down
Network alias 'eth0' link is down
udhcpc: sending select for y.y.y.y
udhcpc: lease of y.y.y.y obtained, lease time 1200
Network alias 'eth0' link is up
Interface 'wan' is now up
```
This keeps repeating every lease period, breaking VPN connections, SSH sessions, etc.

During lease extension, a fully configured client should be able to [reach out to the server from which it received the lease for extension](https://www.netmanias.com/en/post/techdocs/6000/dhcp-network-protocol/understanding-dhcp-relay-agents), regardless in which network it is; that's up to the gateway to find. This patch ensures that.

It's worth noting that this correct behaviour exists in every mainstream DHCP client I checked, including the [Internet System Consortium's](https://fossies.org/linux/dhcp/client/dhclient.c).

**P.S.** I've made the change locally, built it, and have been testing it on my Archer C7 v2 for quite a while. This part of the logs from half an hour ago shows it's working as expected without interruption:
```
Wed Jun  6 22:39:07 2018 daemon.notice netifd: wan (1299): udhcpc: sending renew to x.x.x.x
Wed Jun  6 22:39:07 2018 daemon.notice netifd: wan (1299): udhcpc: lease of y.y.y.y obtained, lease time 1200
Wed Jun  6 22:49:07 2018 daemon.notice netifd: wan (1299): udhcpc: sending renew to x.x.x.x
Wed Jun  6 22:49:07 2018 daemon.notice netifd: wan (1299): udhcpc: lease of y.y.y.y obtained, lease time 1200
Wed Jun  6 22:59:07 2018 daemon.notice netifd: wan (1299): udhcpc: sending renew to x.x.x.x
Wed Jun  6 22:59:07 2018 daemon.notice netifd: wan (1299): udhcpc: lease of y.y.y.y obtained, lease time 1200
```