### PR TITLE
ar71xx: Fix offset to WMAC for 8devices Lima

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-lima.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-lima.c
@@ -35,7 +35,6 @@
 #define LIMA_MAC1_OFFSET	0x0006
 
 #define LIMA_CALDATA_OFFSET	0x1000
-#define LIMA_WMAC_MAC_OFFSET	0x0800
 
 static struct gpio_keys_button lima_gpio_keys[] __initdata = {
 	{
@@ -79,8 +78,7 @@ static void __init lima_setup(void)
 	ath79_eth0_data.phy_mask = BIT(0);
 	ath79_register_eth(0);
 
-	ath79_register_wmac(art + LIMA_CALDATA_OFFSET,
-			art + LIMA_WMAC_MAC_OFFSET);
+	ath79_register_wmac(art + LIMA_CALDATA_OFFSET, NULL);
 	ath79_register_usb();
 	ath79_register_pci();
 }


### PR DESCRIPTION
The ART partition of the Lima board stores exactly three mac addresses:

* 0x0: eth0
* 0x6: eth1
* 0x1002: wmac

The first two are correctly assigned in the mach file but the latter points to 0x0800. But this position is set to ff:ff:ff:ff:ff:ff. Luckily, the driver falls back in ath9k_hw_init_macaddr to the EEPROM mac address when it doesn't find a valid mac address in the platform_data.

Remove this bogus offset to the ART partition to directly load the wmac via the EEPROM data in the ART partition.

----

@karoiz, I already asked you about it in https://github.com/openwrt/openwrt/commit/58fc50f1b088a4bf89b2ce355fc8a4cef3dffcd2#commitcomment-29278862 but maybe it is better to have this in this PR. I also couldn't find any reference to it in the original PR https://github.com/lede-project/source/pull/815