### PR TITLE
ar71xx: AVM / FRITZ!Box 4020 cleanup

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -373,7 +373,6 @@ epg5000)
 	ucidef_set_led_wlan "wlan5g" "WLAN 5 GHz" "$board:blue:wlan-5g" "phy0tpt"
 	;;
 fritz4020)
-	ucidef_set_led_default "power" "Power" "$board:green:power" "1"
 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -67,6 +67,7 @@ get_status_led() {
 	archer-c60-v2|\
 	archer-c7-v4|\
 	fritz300e|\
+	fritz4020|\
 	gl-usb150|\
 	mr12|\
 	mr16|\

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -1318,7 +1318,7 @@ endef
 define Device/fritz300e
   $(call Device/AVM)
   DEVICE_TITLE := AVM FRITZ!WLAN Repeater 300E
-  DEVICE_PACKAGES := rssileds -swconfig
+  DEVICE_PACKAGES += rssileds -swconfig
   BOARDNAME := FRITZ300E
   SUPPORTED_DEVICES := fritz300e
   IMAGE_SIZE := 15232k
@@ -1328,7 +1328,7 @@ TARGET_DEVICES += fritz300e
 define Device/fritz4020
   $(call Device/AVM)
   DEVICE_TITLE := AVM FRITZ!Box 4020
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage
+  DEVICE_PACKAGES += kmod-usb-core kmod-usb2 kmod-usb-storage
   BOARDNAME := FRITZ4020
   SUPPORTED_DEVICES := fritz4020
   IMAGE_SIZE := 15232k


### PR DESCRIPTION
This PR fixes unintended behaviour of the package selection on AVM devices.
Furthermore, the Power-LED of the FRITZ!Box 4020 is now used as a status LED.

It would be great if those fixes would make it into the pending release.

Thank to @mkresin for pointing out above points.