### PR TITLE
ipq806x: enable sata port for d7800

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -148,6 +148,7 @@
 		};
 
 		sata@29000000 {
+			ports-implemented = <0x1>;
 			status = "ok";
 		};
 


### PR DESCRIPTION
d7800 requires ports-implemented binding in dts to enable sata port
