### PR TITLE
mips: fix dynamic ftrace

### DIFF
--- a/target/linux/generic/pending-4.9/305-mips_module_reloc.patch
+++ b/target/linux/generic/pending-4.9/305-mips_module_reloc.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/arch/mips/Makefile
 +++ b/arch/mips/Makefile
-@@ -93,8 +93,13 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
+@@ -93,8 +93,18 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
  cflags-y			+= -G 0 -mno-abicalls -fno-pic -pipe -mno-branch-likely
  cflags-y			+= -msoft-float
  LDFLAGS_vmlinux			+= -G 0 -static -n -nostdlib
@@ -19,8 +19,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  KBUILD_AFLAGS_MODULE		+= -mlong-calls
  KBUILD_CFLAGS_MODULE		+= -mlong-calls
 +else
-+KBUILD_AFLAGS_MODULE		+= -mno-long-calls
-+KBUILD_CFLAGS_MODULE		+= -mno-long-calls
++  ifdef CONFIG_DYNAMIC_FTRACE
++    KBUILD_AFLAGS_MODULE	+= -mlong-calls
++    KBUILD_CFLAGS_MODULE	+= -mlong-calls
++  else
++    KBUILD_AFLAGS_MODULE	+= -mno-long-calls
++    KBUILD_CFLAGS_MODULE	+= -mno-long-calls
++  endif
 +endif
  
  ifeq ($(CONFIG_RELOCATABLE),y)


### PR DESCRIPTION
The kernel patch *-mips_module_reloc.patch breaks dynamic ftrace as
dynamic ftrace depends on -mlong-calls.
This commit always sets -mlong-calls if the kernel is being compiled with dynamic ftrace support.

Here is the oops on boot:
```
    kmodloader: loading kernel modules from /etc/modules-boot.d/*
    CPU 0 Unable to handle kernel paging request at virtual address ffffd6bb, epc == 80202b88, ra == 80202ff0
    Oops[#1]:
    CPU: 0 PID: 352 Comm: kmodloader Not tainted 4.4.129 #0
    task: 87d66eb0 ti: 87fd0000 task.ti: 87fd0000
    $ 0   : 00000000 80145b5c ffffd6bb 805e0000
    $ 4   : ffffd6bb ffffd6bb 00000040 00001c6a
    $ 8   : 00000000 802084f0 00000001 62696e3a
    $12   : 00000000 00200040 00000000 2f736269
    $16   : 8740e180 8740e190 00000100 00000000
    $20   : 80520000 805dbf70 ffffd6bb 024000c0
    $24   : 00000002 00000000                  
    $28   : 87fd0000 87fd1c48 800cfb70 80202ff0
    Hi    : 00000008
    Lo    : 00000012
    epc   : 80202b88 strlen+0x4/0x20
    ra    : 80202ff0 strlcpy+0x24/0x7c
    Status: 1100d403 KERNEL EXL IE 
    Cause : 00800008 (ExcCode 02)
    BadVA : ffffd6bb
    PrId  : 0001974c (MIPS 74Kc)
    Modules linked in: usbcore(+) nls_base usb_common
    Process kmodloader (pid: 352, threadinfo=87fd0000, task=87d66eb0, tls=77861d48)
    Stack : 8741aaf0 801a2414 804ca9b8 00000000 000000b4 8740e180 000000b4 00000100
              00000000 80145bac 00000000 00000000 00000023 8052bae0 00000000 87440000
              87440000 00000000 00000100 000000b4 ffffd6bb 801460e0 8743d5a0 8025e394
              87fc636c 00000000 00000000 87440000 87440000 80500000 00000000 00000000
              00000023 874307e4 8743ac1c 00000982 87440000 87440000 00000000 87440000
              ...
    Call Trace:
    [<80202b88>] strlen+0x4/0x20
    [<80202ff0>] strlcpy+0x24/0x7c
    [<80145bac>] __register_chrdev_region+0xc0/0x1b8
    [<801460e0>] __register_chrdev+0x4c/0x11c
    [<874307e4>] usb_major_init+0x40/0x6c [usbcore]
    [<874400e0>] init_module+0xe0/0x1ac [usbcore]
    [<80060ab4>] do_one_initcall+0x1f4/0x220
    [<80102660>] do_init_module+0x88/0x1f8
    [<800d2a58>] load_module+0x1838/0x1ce4
    [<800d302c>] SyS_init_module+0x128/0x178
    [<8007066c>] syscall_common+0x30/0x54

    Code: 03e00008  00000000  00801021 <80430000> 10600003  00000000  1000fffc  24420001  03e00008 
     ---[ end trace 3c8260a947e9225c ]---
```

Disassembled:
```
    03e00008: j loc_0003800c
    00000000: nop
    00801021: addi s0, t0,-32768 // s0 = t0 + (-32768)
    <80430000>: sll t0, zero, 0xe // t0 = 0 << 15
    03006010: ???
    00000000: nop
    FCFF0010: sd ra, 16(a3) // store double -> ra = 0xa3
    01004224: ???
    0800e003: j loc_0003800c
```

As far as I can see the addresses of the ftrace return and caller addresses get corrupted.

The relevant part of mips ftrace for this bug is as follows:

> To enable module support, we need to enable the -mlong-calls option
> of gcc for module, after using this option, we can not get the real
> offset of the calling to _mcount, but the offset of the lui
> instruction or the addiu one. herein, we record the address of the
> first one, and then we can replace this instruction by a branch
> instruction to jump over the profiling function to filter the
> indicated functions, or swith back to the lui instruction to trace
> them, which means dynamic tracing.
See http://patchwork.linux-mips.org/patch/675/

@nbd168 As you have written the patch do you think this is the right approach?