### PR TITLE
ath79: fixes for WNDR3800: bootcmd, MACs, LED config

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -10,6 +10,14 @@
 	compatible = "netgear,wndr3800", "qca,ar7161";
 	model = "Netgear WNDR3800";
 
+	aliases {
+		led-status = &power_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
 	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x8000000>;
@@ -25,9 +33,11 @@
 	reset-leds {
 		compatible = "reset-leds";
 
-		wps {
+		usb_led {
 			label = "netgear:green:usb";
 			resets = <&rst 12>;
+			trigger-sources = <&usb_ochi_port>, <&usb_echi_port>;
+			linux,default-trigger = "usbport";
 		};
 	};
 
@@ -40,15 +50,15 @@
 			default-state = "off";
 		};
 
-		power_green {
+		power_green: power_green {
 			label = "netgear:green:power";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
 		power_orange {
 			label = "netgear:orange:power";
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
@@ -71,21 +81,21 @@
 		#size-cells = <0>;
 		poll-interval = <100>;
 
-		button@0 {
+		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
-		button@1 {
+		reset {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
-		button@2 {
-			label = "wifi";
-			linux,code = <BTN_2>;
+		rfkill {
+			label = "rfkill";
+			linux,code = <KEY_RFKILL>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 	};
@@ -114,10 +124,20 @@
 
 &usb1 {
 	status = "okay";
+
+	usb_ochi_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 };
 
 &usb2 {
 	status = "okay";
+
+	usb_echi_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 };
 
 &pcie0 {
@@ -153,14 +173,15 @@
 			partition@1 {
 				label = "u-boot-env";
 				reg = <0x050000 0x020000>;
+				read-only;
 			};
 
 			partition@2 {
 				label = "firmware";
-				reg = <0x70000 0xf80000>;
+				reg = <0x070000 0xf80000>;
 			};
 
-			partition@3 {
+			art: partition@3 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
@@ -174,6 +195,8 @@
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
+	mtd-mac-address = <&art 0x00>;
+
 	fixed-link {
 		speed = <1000>;
 		full-duplex;
@@ -184,6 +207,8 @@
 	status = "okay";
 
 	pll-data = <0x11110000 0x00001099 0x00991099>;
+
+	mtd-mac-address = <&art 0x06>;
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/patches-4.14/0003-leds-add-reset-controller-based-driver.patch
+++ b/target/linux/ath79/patches-4.14/0003-leds-add-reset-controller-based-driver.patch
@@ -33,7 +33,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  
 --- /dev/null
 +++ b/drivers/leds/leds-reset.c
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,140 @@
 +/*
 + * Copyright (C) 2018 John Crispin <john@phrozen.org>
 + *
@@ -111,6 +111,9 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +		led->rst = __of_reset_control_get(np, NULL, 0, 0, 0);
 +		if (IS_ERR(led->rst))
 +			return ERR_PTR(-EINVAL);
++
++		fwnode_property_read_string(child, "linux,default-trigger",
++						&led->cdev.default_trigger);
 +
 +		led->cdev.brightness_set = reset_led_set;
 +		ret = devm_of_led_classdev_register(&pdev->dev, np, &led->cdev);


### PR DESCRIPTION
@blogic

Fixes for WNDR3800 in ath79:

DTS:
* fix bootcmd
* name partitions, so that art can be referenced for MACs
* set firmware partition's address similarly as others
* make u-boot-env read-only like in ar71xx
* read wan and lan MACs from art
* fix LED and button gpio values to match ar71xx
  (orange/green powerLED, reset button)
* enable power LED in dts by alias led-status
* change wifi button to KEY_RFKILL like in ar71xx

config:
* create USB LED config item in etc/board.d


-----

The router boots ok, serial console works, ssh works, LuCI works, USB stick is detected
No wireless, yet.
