### PR TITLE
uboot-kirkwood: fix malformed boot configuration

### DIFF
--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -627,7 +627,7 @@ NOTE: this patch is ready for upstream, LEDE-specific parts are in
 +#define CONFIG_EXTRA_ENV_SETTINGS \
 +	"console=console=ttyS0,115200\0"	\
 +	"mtdids=nand0=orion_nand\0"		\
-+	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 +
 +/*

--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -28,20 +28,20 @@ NOTE: this patch is ready for upstream, LEDE-specific parts are in
 @@ -56,6 +56,9 @@ config TARGET_GOFLEXHOME
  config TARGET_NAS220
  	bool "BlackArmor NAS220"
- 
+
 +config TARGET_NSA310
 +	bool "Zyxel NSA310 Board"
 +
  config TARGET_NSA310S
  	bool "Zyxel NSA310S"
- 
+
 @@ -80,6 +83,7 @@ source "board/raidsonic/ib62x0/Kconfig"
  source "board/Seagate/dockstar/Kconfig"
  source "board/Seagate/goflexhome/Kconfig"
  source "board/Seagate/nas220/Kconfig"
 +source "board/zyxel/nsa310/Kconfig"
  source "board/zyxel/nsa310s/Kconfig"
- 
+
  endif
 --- /dev/null
 +++ b/board/zyxel/nsa310/Kconfig

--- a/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
@@ -613,7 +613,7 @@
 +#define CONFIG_EXTRA_ENV_SETTINGS \
 +	"console=console=ttyS0,115200\0"	\
 +	"mtdids=nand0=orion_nand\0"		\
-+	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 +
 +/*

--- a/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/008-nsa325-uboot-generic.patch
@@ -3,19 +3,19 @@
 @@ -62,6 +62,9 @@ config TARGET_NSA310
  config TARGET_NSA310S
  	bool "Zyxel NSA310S"
- 
+
 +config TARGET_NSA325
 +	bool "Zyxel NSA325 board"
 +
  endchoice
- 
+
  config SYS_SOC
 @@ -85,5 +88,6 @@ source "board/Seagate/goflexhome/Kconfig
  source "board/Seagate/nas220/Kconfig"
  source "board/zyxel/nsa310/Kconfig"
  source "board/zyxel/nsa310s/Kconfig"
 +source "board/zyxel/nsa325/Kconfig"
- 
+
  endif
 --- /dev/null
 +++ b/board/zyxel/nsa325/Kconfig

--- a/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
+++ b/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
@@ -1212,7 +1212,7 @@
 +#define CONFIG_EXTRA_ENV_SETTINGS \
 +	"console=console=ttyS0,115200\0"	\
 +	"mtdids=nand0=orion_nand\0"		\
-+	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 +
 +/*

--- a/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
+++ b/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
@@ -3,13 +3,13 @@
 @@ -25,6 +25,9 @@ config TARGET_LSXL
  config TARGET_POGO_E02
  	bool "pogo_e02 Board"
- 
+
 +config TARGET_POGOPLUGV4
 +    bool "Pogoplug V4 Board"
 +
  config TARGET_DNS325
  	bool "dns325 Board"
- 
+
 @@ -77,6 +80,7 @@ source "board/Marvell/guruplug/Kconfig"
  source "board/Marvell/sheevaplug/Kconfig"
  source "board/buffalo/lsxl/Kconfig"
@@ -22,11 +22,11 @@
 +++ b/arch/arm/mach-kirkwood/include/mach/kw88f6192.h
 @@ -16,6 +16,6 @@
  #define KW_REGS_PHY_BASE		KW88F6192_REGS_PHYS_BASE
- 
+
  /* TCLK Core Clock defination */
 -#define CONFIG_SYS_TCLK	  166000000 /* 166MHz */
 +#define CONFIG_SYS_TCLK	  166666667 /* 166MHz */
- 
+
  #endif /* _CONFIG_KW88F6192_H */
 --- a/arch/arm/mach-kirkwood/include/mach/mpp.h
 +++ b/arch/arm/mach-kirkwood/include/mach/mpp.h
@@ -35,12 +35,12 @@
  #define MPP33_TDM_DTX		MPP( 33, 0x2, 0, 1, 0,   0,   1,   1    )
  #define MPP33_GE1_13		MPP( 33, 0x3, 0, 0, 0,   1,   1,   1    )
 +#define MPP33_SATA1_ACTn        MPP( 33, 0x5, 0, 1, 0,   1,   1,   1    )
- 
+
  #define MPP34_GPIO		MPP( 34, 0x0, 1, 1, 0,   1,   1,   1    )
  #define MPP34_TDM_SPI_CS1	MPP( 34, 0x2, 0, 1, 0,   0,   1,   1    )
  #define MPP34_GE1_14		MPP( 34, 0x3, 0, 0, 0,   1,   1,   1    )
 +#define MPP34_SATA1_ACTn       MPP( 34, 0x5, 0, 1, 0,   1,   1,   1    )
- 
+
  #define MPP35_GPIO		MPP( 35, 0x0, 1, 1, 1,   1,   1,   1    )
  #define MPP35_TDM_CH0_TX_QL	MPP( 35, 0x2, 0, 1, 0,   0,   1,   1    )
 --- /dev/null
@@ -619,7 +619,7 @@
  obj-$(CONFIG_MMC_SDHCI_XENON)		+= xenon_sdhci.o
  obj-$(CONFIG_MMC_SDHCI_ZYNQ)		+= zynq_sdhci.o
 +obj-$(CONFIG_KIRKWOOD_MMC)		+= kirkwood_mmc.o
- 
+
  obj-$(CONFIG_MMC_SUNXI)			+= sunxi_mmc.o
  obj-$(CONFIG_MMC_UNIPHIER)		+= uniphier-sd.o
 --- /dev/null
@@ -1112,7 +1112,7 @@
 @@ -117,4 +117,10 @@
  #define CONFIG_MTD_PARTITIONS
  #endif
- 
+
 +/*
 + * Kirkwood MMC
 + */

--- a/package/boot/uboot-kirkwood/patches/110-dockstar.patch
+++ b/package/boot/uboot-kirkwood/patches/110-dockstar.patch
@@ -5,7 +5,7 @@
  #define CONFIG_KW88F6281	1	/* SOC Name */
  #define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
 +#define CONFIG_SYS_MVFS
- 
+
  /*
   * mv-common.h should be defined after CMD configs since it used them
 @@ -36,27 +37,22 @@
@@ -15,7 +15,7 @@
 -#define CONFIG_ENV_ADDR			0x80000
 -#define CONFIG_ENV_OFFSET		0x80000	/* env starts here */
 +#define CONFIG_ENV_OFFSET		0xe0000	/* env starts here */
- 
+
  /*
   * Default environment variables
   */
@@ -29,7 +29,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
 +	"bootm 0x800000"
- 
+
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -	"console=console=ttyS0,115200\0" \
 -	"mtdids=nand0=orion_nand\0" \
@@ -41,7 +41,7 @@
 +	"mtdids=nand0=orion_nand\0"		\
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
 +	"bootargs_root=\0"
- 
+
  /*
   * Ethernet Driver configuration
 --- a/configs/dockstar_defconfig

--- a/package/boot/uboot-kirkwood/patches/110-dockstar.patch
+++ b/package/boot/uboot-kirkwood/patches/110-dockstar.patch
@@ -39,7 +39,7 @@
 -	"bootargs_root=ubi.mtd=1 root=ubi0:root rootfstype=ubifs ro\0"
 +	"console=console=ttyS0,115200\0"	\
 +	"mtdids=nand0=orion_nand\0"		\
-+	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 
  /*

--- a/package/boot/uboot-kirkwood/patches/120-iconnect.patch
+++ b/package/boot/uboot-kirkwood/patches/120-iconnect.patch
@@ -6,7 +6,7 @@
  #define CONFIG_ENV_SIZE		0x20000
 -#define CONFIG_ENV_OFFSET	0x80000
 +#define CONFIG_ENV_OFFSET	0xe0000
- 
+
  /*
   * Default environment variables
   */
@@ -18,7 +18,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
  	"bootm 0x800000"
- 
+
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"	\
  	"mtdids=nand0=orion_nand\0"		\
@@ -26,7 +26,7 @@
 -	"kernel=/boot/uImage\0"			\
 -	"bootargs_root=noinitrd ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs\0"
 +	"bootargs_root=\0"
- 
+
  /*
   * Ethernet driver configuration
 --- a/configs/iconnect_defconfig

--- a/package/boot/uboot-kirkwood/patches/120-iconnect.patch
+++ b/package/boot/uboot-kirkwood/patches/120-iconnect.patch
@@ -22,9 +22,10 @@
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"	\
  	"mtdids=nand0=orion_nand\0"		\
- 	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
+-	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
 -	"kernel=/boot/uImage\0"			\
 -	"bootargs_root=noinitrd ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs\0"
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 
  /*

--- a/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
+++ b/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
@@ -14,7 +14,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
 +	"bootm 0x800000"
- 
+
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"				\
  	"mtdids=nand0=orion_nand\0"					\
@@ -23,7 +23,7 @@
 -	"fdt=/boot/ib62x0.dtb\0"					\
 -	"bootargs_root=ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs rw\0"
 +	"bootargs_root=\0"
- 
+
  /*
   * Ethernet driver configuration
 --- a/configs/ib62x0_defconfig

--- a/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
+++ b/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
@@ -18,10 +18,11 @@
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"				\
  	"mtdids=nand0=orion_nand\0"					\
- 	"mtdparts="CONFIG_MTDPARTS_DEFAULT			\
+-	"mtdparts="CONFIG_MTDPARTS_DEFAULT			\
 -	"kernel=/boot/zImage\0"						\
 -	"fdt=/boot/ib62x0.dtb\0"					\
 -	"bootargs_root=ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs rw\0"
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"			\
 +	"bootargs_root=\0"
 
  /*

--- a/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
+++ b/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
@@ -29,7 +29,7 @@
 -	"ext2load usb 0:1 0x01100000 /uInitrd\0"
 +	"console=console=ttyS0,115200\0"	\
 +	"mtdids=nand0=orion_nand\0"		\
-+	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
 
  /*

--- a/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
+++ b/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
@@ -2,11 +2,11 @@
 +++ b/include/configs/pogo_e02.h
 @@ -44,23 +44,23 @@
  #endif
- 
+
  #define CONFIG_ENV_SIZE			0x20000	/* 128k */
 -#define CONFIG_ENV_OFFSET		0x60000	/* env starts here */
 +#define CONFIG_ENV_OFFSET		0xe0000	/* env starts here */
- 
+
  /*
   * Default environment variables
   */
@@ -19,7 +19,7 @@
 +	"ubifsmount ubi:rootfs; "					\
 +	"ubi read 0x800000 kernel; "					\
 +	"bootm 0x800000"
- 
+
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -	"mtdparts=mtdparts=orion_nand:1M(u-boot),4M(uImage)," \
 -	"32M(rootfs),-(data)\0"\
@@ -31,7 +31,7 @@
 +	"mtdids=nand0=orion_nand\0"		\
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT	\
 +	"bootargs_root=\0"
- 
+
  /*
   * Ethernet Driver configuration
 --- a/configs/pogo_e02_defconfig

--- a/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
+++ b/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
@@ -14,9 +14,10 @@
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0" \
  	"mtdids=nand0=orion_nand\0" \
- 	"mtdparts="CONFIG_MTDPARTS_DEFAULT \
+-	"mtdparts="CONFIG_MTDPARTS_DEFAULT \
 -	"kernel=/boot/uImage\0" \
 -	"bootargs_root=ubi.mtd=root root=ubi0:root rootfstype=ubifs ro\0"
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0" \
 +	"bootargs_root=\0"
 
  /*

--- a/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
+++ b/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
@@ -10,7 +10,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
  	"bootm 0x800000"
- 
+
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0" \
  	"mtdids=nand0=orion_nand\0" \
@@ -18,7 +18,7 @@
 -	"kernel=/boot/uImage\0" \
 -	"bootargs_root=ubi.mtd=root root=ubi0:root rootfstype=ubifs ro\0"
 +	"bootargs_root=\0"
- 
+
  /*
   * Ethernet Driver configuration
 --- a/configs/goflexhome_defconfig


### PR DESCRIPTION
With current boot default configuration the uboot will
fail to start the OpenWrt firmware with the following error:

```
unexpected character 'b' at the end of partition
Error initializing mtdparts!
incorrect device type in ubi
Partition ubi not found!
Error, no UBI device/partition selected!
Wrong Image Format for bootm command
Error occured, error code = 112
```

If the uboot configuration is examined with printenv
I can see that mdtparts line (on a nsa310) is wrong:

`mtdparts=mtdparts=orion_nand:0x0c0000(uboot),0x80000(uboot_env),0x7ec0000(ubi)bootargs_root=`
The "bootargs_root=" that was appended to it should not be there.

Fix the issue by adding a \0 line terminator to all affected lines.

This issue was detected and the fix tested on a nsa310, nsa325 and
a pogoplug v4, but it's not hardware-specific, so apply the same fix
to other devices as well.

Note that the issue is with the uboot's integrated boot configuration,
which is not used unless the uboot configuration in flash is unavailable
(erased or corrupted), which happens only on first time installation,
or if the user deletes the uboot configuration when upgrading uboot.
People just upgrading from an older uboot without erasing their previous
uboot configuration stored in flash would not have noticed this issue.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>

This was reported (and there are longer logs) in this forum thread https://forum.lede-project.org/t/installing-lede-on-nsa325/3611/44

@p-wassi might be interested in this.

@blogic or @mkresin can this also be ported to 18.06 branch too? uboot generated without this fix are unable to boot OpenWrt if someone is installing it on a new device.