### PR TITLE
mbedtls: Cosmetic cleanups

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -64,9 +64,9 @@ endef
 PKG_INSTALL:=1
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS))
 
 CMAKE_OPTIONS += \
-	-DCMAKE_BUILD_TYPE:String="Release" \
 	-DUSE_SHARED_MBEDTLS_LIBRARY:Bool=ON \
 	-DENABLE_TESTING:Bool=OFF \
 	-DENABLE_PROGRAMS:Bool=ON


### PR DESCRIPTION
This is more of a cosmetic change and a reminder that the CMake script hardcodes -O2.
Source:
https://github.com/ARMmbed/mbedtls/blob/mbedtls-2.7/CMakeLists.txt#L73
https://github.com/ARMmbed/mbedtls/blob/master/CMakeLists.txt#L97

Remove the release type option as it's already provided by the toolchain.
Source:
https://github.com/openwrt/openwrt/blob/master/include/cmake.mk#L50

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>