### PR TITLE
ramips: mt7688 watchdog register base addr bug

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -37,9 +37,9 @@
 			reg = <0x0 0x100>;
 		};
 
-		watchdog: watchdog@120 {
+		watchdog: watchdog@100 {
 			compatible = "ralink,mt7628an-wdt", "mediatek,mt7621-wdt";
-			reg = <0x120 0x10>;
+			reg = <0x100 0x30>;
 
 			resets = <&rstctrl 8>;
 			reset-names = "wdt";


### PR DESCRIPTION
Hi,

I found MT7688 watchdog not work,  in mt7628an.dtsi file the wathcdog reg base addr is 0x120, 

		watchdog: watchdog@120 {
			compatible = "ralink,mt7628an-wdt", "mediatek,mt7621-wdt";
			reg = <0x120 0x10>;


but linux kernel driver mt7621_wdt.c use base addr is 0x100, 

        #define TIMER_REG_TMRSTAT		0x00
        #define TIMER_REG_TMR1LOAD		0x24
        #define TIMER_REG_TMR1CTL	0x20

so i modify the mt7628an.dtsi use base addr 0x100.