### PR TITLE
package/libs/libnfnetlink: Remove dead mirror

### DIFF
--- a/package/libs/libnfnetlink/Makefile
+++ b/package/libs/libnfnetlink/Makefile
@@ -14,8 +14,7 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	http://www.netfilter.org/projects/libnfnetlink/files/ \
-	ftp://ftp.netfilter.org/pub/libnfnetlink/ \
-	http://mirrors.evolva.ro/netfilter.org/libnfnetlink/
+	ftp://ftp.netfilter.org/pub/libnfnetlink/
 PKG_HASH:=f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=GPL-2.0+


### PR DESCRIPTION
Remove mirrors.evolva.ro as it's no longer available

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>