### PR TITLE
qos-scripts: fix uci callback handling

### DIFF
--- a/package/network/config/qos-scripts/Makefile
+++ b/package/network/config/qos-scripts/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qos-scripts
-PKG_VERSION:=1.3.0
+PKG_VERSION:=1.3.1
 PKG_RELEASE:=1
 PKG_LICENSE:=GPL-2.0
 

--- a/package/network/config/qos-scripts/files/usr/bin/qos-stat
+++ b/package/network/config/qos-scripts/files/usr/bin/qos-stat
@@ -14,16 +14,17 @@ get_ifname() {
 	[ "$cfgt" = "interface" ] && config_get "$interface" ifname
 }
 
-config_cb() {
-	config_get TYPE "$CONFIG_SECTION" TYPE
+qos_set_device() {
+	config_get TYPE "$1" TYPE
 	[ "interface" = "$TYPE" ] && {
-		config_get device "$CONFIG_SECTION" ifname
-		[ -z "$device" ] && device="$(get_ifname ${CONFIG_SECTION})"
-		config_set "$CONFIG_SECTION" device "$device"
+		config_get device "$1" ifname
+		[ -z "$device" ] && device="$(get_ifname $1)"
+		config_set "$1" device "$device"
 	}
 }
 
 config_load qos
+config_foreach qos_set_device
 
 print_comments() {
 	echo ''

--- a/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
+++ b/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
@@ -191,8 +191,6 @@ config_cb() {
 	option_cb() {
 		return 0
 	}
-
-	# Section start
 	case "$1" in
 		interface)
 			config_set "$2" "classgroup" "Default"
@@ -200,42 +198,40 @@ config_cb() {
 		;;
 		classify|default|reclassify)
 			option_cb() {
-				append options "$1"
+				append "CONFIG_${CONFIG_SECTION}_options" "$1"
 			}
 		;;
 	esac
+}
 
-    # Section end
-	config_get TYPE "$CONFIG_SECTION" TYPE
+qos_parse_config() {
+	config_get TYPE "$1" TYPE
 	case "$TYPE" in
 		interface)
-			config_get_bool enabled "$CONFIG_SECTION" enabled 1
-			[ 1 -eq "$enabled" ] || return 0
-			config_get classgroup "$CONFIG_SECTION" classgroup
-			config_set "$CONFIG_SECTION" ifbdev "$C"
-			C=$(($C+1))
-			append INTERFACES "$CONFIG_SECTION"
-			config_set "$classgroup" enabled 1
-			config_get device "$CONFIG_SECTION" device
-			[ -z "$device" ] && {
-				device="$(find_ifname ${CONFIG_SECTION})"
-				config_set "$CONFIG_SECTION" device "$device"
+			config_get_bool enabled "$1" enabled 1
+			[ 1 -eq "$enabled" ] && {
+				config_get classgroup "$1" classgroup
+				config_set "$1" ifbdev "$C"
+				C=$(($C+1))
+				append INTERFACES "$1"
+				config_set "$classgroup" enabled 1
+				config_get device "$1" device
+				[ -z "$device" ] && {
+					device="$(find_ifname $1)"
+					config_set "$1" device "$device"
+				}
 			}
 		;;
-		classgroup) append CG "$CONFIG_SECTION";;
+		classgroup) append CG "$1";;
 		classify|default|reclassify)
 			case "$TYPE" in
 				classify) var="ctrules";;
 				*) var="rules";;
 			esac
-			config_get target "$CONFIG_SECTION" target
-			config_set "$CONFIG_SECTION" options "$options"
-			append "$var" "$CONFIG_SECTION"
-			unset options
+			append "$var" "$1"
 		;;
 	esac
 }
-
 
 enum_classes() {
 	local c="0"
@@ -500,7 +496,10 @@ INTERFACES=""
 [ -e ./qos.conf ] && {
 	. ./qos.conf
 	config_cb
-} || config_load qos
+} || {
+	config_load qos
+	config_foreach qos_parse_config
+}
 
 C="0"
 for iface in $INTERFACES; do


### PR DESCRIPTION
Maintainer: Felix Fietkau (@nbd168 )
Run tested: ar71xx/mips24kc under LEDE 17.01.4
(by comparing different versions' output of `generate.sh all` using the package default config)

Description:
Hi Felix,

This follows up a [request](https://github.com/openwrt/openwrt/pull/805#issuecomment-395434782) from @jow about a `qos-scripts` config parsing issue, and might also be relevant to this [report](https://forum.lede-project.org/t/anyone-having-issues-with-qos-app-on-f18f08d/15549) on the LEDE Forum. The root problem was in `qos-scripts` handling of start-of-section and end-of-section config parsing.

This should also be cherry-picked for `lede-17.01` and `openwrt-18.06` since those branches are identical.

Thanks,
Tony