### PR TITLE
ramips: add support for TP-Link TL-WR842N v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -414,7 +414,8 @@ tplink,c50-v3)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
-tplink,tl-mr3420-v5)
+tplink,tl-mr3420-v5|\
+tplink,tl-wr842n-v5)
 	set_usb_led "$boardname:green:usb"
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -205,6 +205,7 @@ ramips_setup_interfaces()
 	tplink,c20-v4|\
 	tplink,c50-v3|\
 	tplink,tl-mr3420-v5|\
+	tplink,tl-wr842n-v5|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\
 	tl-wr841n-v13|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -42,6 +42,7 @@ get_status_led() {
 	tplink,c20-v4|\
 	tplink,c50-v3|\
 	tplink,tl-mr3420-v5|\
+	tplink,tl-wr842n-v5|\
 	tplink,tl-wr902ac-v3|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -255,6 +255,7 @@ platform_check_image() {
 	tplink,c20-v4|\
 	tplink,c50-v3|\
 	tplink,tl-mr3420-v5|\
+	tplink,tl-wr842n-v5|\
 	tplink,tl-wr902ac-v3|\
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\

--- a/target/linux/ramips/dts/TL-WR842NV5.dts
+++ b/target/linux/ramips/dts/TL-WR842NV5.dts
@@ -1,0 +1,86 @@
+/dts-v1/;
+
+#include "TPLINK-8M.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr842n-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR842N v5";
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tl-wr842n-v5:green:lan";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "tl-wr842n-v5:green:power";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "tl-wr842n-v5:green:usb";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tl-wr842n-v5:green:wan";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tl-wr842n-v5:amber:wan";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-wr842n-v5:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tl-wr842n-v5:green:wps";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "i2s", "p2led_an", "refclk", "uart1", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -196,6 +196,20 @@ define Device/tplink_tl-mr3420-v5
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v5
 
+define Device/tplink_tl-wr842n-v5
+  $(Device/tplink) 
+  DTS := TL-WR842NV5
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link TL-WR842N v5
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08420005
+  TPLINK_HWREV := 0x5
+  TPLINK_HWREVADD := 0x5
+  TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += tplink_tl-wr842n-v5
+
 define Device/tplink_tl-wr902ac-v3
   $(Device/tplink)
   DTS := TL-WR902ACV3


### PR DESCRIPTION
TP-Link TL-WR842N v5 are simple N300 router with
5-port FE switch and non-detachable antennas.
Its very similar to TP-Link TL-MR3420 V5 (differs only by two GPIO's).

Specification:

- MT7628N/N (580 MHz)
- 64 MB of RAM (DDR2)
- 8 MB of FLASH
- 2T2R 2.4 GHz
- 5x 10/100 Mbps Ethernet
- 2x external, non-detachable antennas
- USB 2.0 Port
- UART (J1) header on PCB (115200 8n1)
- 7x LED, 2x button, power input switch

Flash instruction:

The only way to flash OpenWRT image in wr842nv5 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.0.225/24 and tftp server.
2. Rename "lede-ramips-mt7628-tplink_tl-wr842n-v5-squashfs-tftp-recovery.bin"
   to "tp_recovery.bin" and place it in tftp server directory.
3. Connect PC with one of LAN ports, press the reset button, power up
   the router and keep button pressed for around 6-7 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and reboot.