### PR TITLE
cron: add procd listeners for crontabs

### DIFF
--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -11,7 +11,7 @@ validate_cron_section() {
 		'cronloglevel:uinteger'
 }
 
-start_service () {
+start_service() {
 	[ -z "$(ls /etc/crontabs/)" ] && return 1
 
 	loglevel="$(uci_get "system.@system[0].cronloglevel")"
@@ -29,10 +29,12 @@ start_service () {
 
 	procd_open_instance
 	procd_set_param command "$PROG" -f -c /etc/crontabs -l "${loglevel:-5}"
+	for crontab in /etc/crontabs/*; do
+		 procd_set_param file "$crontab"
+	done
 	procd_close_instance
 }
 
-service_triggers()
-{
+service_triggers() {
 	procd_add_validation validate_cron_section
 }


### PR DESCRIPTION
Add procd file listeners to check files in `/etc/crontabs/`.

Also unified a bit the function style.

Signed-off-by: Paul Spooren <mail@aparcar.org>