### PR TITLE
[backport] [lede-17.01.5] uci: add missing 'option' support to uci_rename()

### DIFF
--- a/package/system/uci/files/lib/config/uci.sh
+++ b/package/system/uci/files/lib/config/uci.sh
@@ -118,9 +118,10 @@ uci_add() {
 uci_rename() {
 	local PACKAGE="$1"
 	local CONFIG="$2"
-	local VALUE="$3"
+	local OPTION="$3"
+	local VALUE="$4"
 
-	/sbin/uci ${UCI_CONFIG_DIR:+-c $UCI_CONFIG_DIR} rename "$PACKAGE.$CONFIG=$VALUE"
+	/sbin/uci ${UCI_CONFIG_DIR:+-c $UCI_CONFIG_DIR} rename "$PACKAGE.$CONFIG${VALUE:+.$OPTION}=${VALUE:-$OPTION}"
 }
 
 uci_remove() {


### PR DESCRIPTION
### Description
When using the uci.sh wrapper, allow parameters to match those supported
by the uci binary i.e. `uci rename <config>.<section>[.<option>]=<name>`.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
(backport commit a367645f23d2ed93ea29c7237fa1b2d6c3ded7e4 from master)

### Note
@hauke I just noticed your call for backports/regressions in anticipation of the 17.01.5 release. This change is a straight cherry-pick, originally tested on 17.01.4 and already committed to `master` and `openwrt-18.06`.