### PR TITLE
kmod-br-netfilter: change sysctl defaults

### DIFF
--- a/package/kernel/linux/files/sysctl-br-netfilter.conf
+++ b/package/kernel/linux/files/sysctl-br-netfilter.conf
@@ -1,7 +1,7 @@
 # Do not edit, changes to this file will be lost on upgrades
 # /etc/sysctl.conf can be used to customize sysctl settings
 
-# disable bridge firewalling by default
-net.bridge.bridge-nf-call-arptables=0
-net.bridge.bridge-nf-call-ip6tables=0
-net.bridge.bridge-nf-call-iptables=0
+# enable bridge firewalling by default
+net.bridge.bridge-nf-call-arptables=1
+net.bridge.bridge-nf-call-ip6tables=1
+net.bridge.bridge-nf-call-iptables=1


### PR DESCRIPTION
kmod-br-netfilter pulls in the sysctl-br-netfilter.conf file. Since people installing this kernel module are probably interested in applying netfilter to bridges, as that's what it is made for, enabling this by default are the more sensible default values.