### PR TITLE
ath79: fix irq cascade driver and add wmac for ar934x

### DIFF
--- a/target/linux/ath79/dts/ar9341.dtsi
+++ b/target/linux/ath79/dts/ar9341.dtsi
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar934x.dtsi"
+
+/ {
+	compatible = "qca,ar9341";
+};
+
+&cpuintc {
+	qca,ddr-wb-channel-interrupts = <2>, <3>, <4>, <5>;
+	qca,ddr-wb-channels = <&ddr_ctrl 4>, <&ddr_ctrl 2>,
+				<&ddr_ctrl 0>, <&ddr_ctrl 1>;
+};
+
+&wmac {
+	interrupt-parent = <&cpuintc>;
+	interrupts = <2>;
+};

--- a/target/linux/ath79/dts/ar9344.dtsi
+++ b/target/linux/ath79/dts/ar9344.dtsi
@@ -6,6 +6,31 @@
 	compatible = "qca,ar9344";
 };
 
+&cpuintc {
+	qca,ddr-wb-channel-interrupts = <3>, <4>, <5>;
+	qca,ddr-wb-channels = <&ddr_ctrl 2>, <&ddr_ctrl 0>,
+			<&ddr_ctrl 1>;
+};
+
+&rst {
+	intc2: interrupt-controller@2 {
+		compatible = "qca,ar9340-intc";
+
+		interrupt-parent = <&cpuintc>;
+		interrupts = <2>;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+
+		qca,int-status-addr = <0xac>;
+		qca,pending-bits = <0xf>,	/* wmac */
+				<0x1f0>;	/* pcie rc1 */
+
+		qca,ddr-wb-channel-interrupts = <0>, <1>;
+		qca,ddr-wb-channels = <&ddr_ctrl 4>, <&ddr_ctrl 3>;
+	};
+};
+
 &apb {
 	pcie: pcie-controller@180c0000 {
 		compatible = "qcom,ar9340-pci", "qcom,ar7240-pci";
@@ -18,8 +43,8 @@
 		reg-names = "crp_base", "ctrl_base", "cfg_base";
 		ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000 /* pci memory */
 				0x1000000 0 0x00000000 0x0000000 0 0x000001>; /* io space */
-		interrupt-parent = <&cpuintc>;
-		interrupts = <2>;
+		interrupt-parent = <&intc2>;
+		interrupts = <1>;
 
 		interrupt-controller;
 		#interrupt-cells = <1>;
@@ -29,4 +54,9 @@
 		
 		status = "disabled";
 	};
+};
+
+&wmac {
+	interrupt-parent = <&intc2>;
+	interrupts = <0>;
 };

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
@@ -158,7 +158,7 @@
 				reg = <0x020000 0x7d0000>;
 			};
 
-			partition@7f0000 {
+			art: partition@7f0000 {
 				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
@@ -201,6 +201,14 @@
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -138,6 +138,13 @@
 				compatible = "qca,ar9340-gmac", "qca,ar9330-gmac";
 				reg = <0x18070000 0x14>;
 			};
+
+			wmac: wmac@18100000 {
+				compatible = "qca,ar9340-wmac";
+				reg = <0x18100000 0x20000>;
+
+				status = "disabled";
+			};
 		};
 
 		usb: usb@1b000000 {
@@ -181,12 +188,6 @@
 
 		status = "disabled";
 	};
-};
-
-&cpuintc {
-	qca,ddr-wb-channel-interrupts = <2>, <3>, <4>, <5>;
-	qca,ddr-wb-channels = <&ddr_ctrl 3>, <&ddr_ctrl 2>,
-				<&ddr_ctrl 0>, <&ddr_ctrl 1>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -137,15 +137,31 @@
 				#reset-cells = <1>;
 				interrupt-parent = <&cpuintc>;
 
-				intc3: interrupt-controller@3 {
-					compatible = "qcom,qca9556-intc";
+				intc2: interrupt-controller@2 {
+					compatible = "qca,ar9340-intc";
 
+					interrupt-parent = <&cpuintc>;
+					interrupts = <2>;
+
+					interrupt-controller;
+					#interrupt-cells = <1>;
+
+					qca,int-status-addr = <0xac>;
+					qca,pending-bits = <0xf>,	/* wmac */
+							<0x1f0>;	/* pcie rc 0 */
+				};
+
+				intc3: interrupt-controller@3 {
+					compatible = "qca,ar9340-intc";
+
+					interrupt-parent = <&cpuintc>;
 					interrupts = <3>;
 
 					interrupt-controller;
 					#interrupt-cells = <1>;
 
-					qcom,pending-bits = <0x1f000>,		/* pcie rc */
+					qca,int-status-addr = <0xac>;
+					qca,pending-bits = <0x1f000>,		/* pcie rc 1 */
 							    <0x1000000>,	/* usb1 */
 							    <0x10000000>;	/* usb2 */
 				};
@@ -160,7 +176,29 @@
 				#reset-cells = <1>;
 			};
 
-			pcie: pcie-controller@18250000 {
+			pcie0: pcie-controller@180c0000 {
+				compatible = "qcom,ar7240-pci";
+				#address-cells = <3>;
+				#size-cells = <2>;
+				bus-range = <0x0 0x0>;
+				reg = <0x180c0000 0x1000>, /* CRP */
+				      <0x180f0000 0x100>,  /* CTRL */
+				      <0x14000000 0x1000>; /* CFG */
+				reg-names = "crp_base", "ctrl_base", "cfg_base";
+				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
+					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+				interrupt-parent = <&intc2>;
+				interrupts = <1>;
+
+				interrupt-controller;
+				#interrupt-cells = <1>;
+
+				interrupt-map-mask = <0 0 0 1>;
+				interrupt-map = <0 0 0 0 &pcie0 0>;
+				status = "disabled";
+			};
+
+			pcie1: pcie-controller@18250000 {
 				compatible = "qcom,ar7240-pci";
 				#address-cells = <3>;
 				#size-cells = <2>;
@@ -178,7 +216,7 @@
 				#interrupt-cells = <1>;
 
 				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie 0>;
+				interrupt-map = <0 0 0 0 &pcie1 0>;
 				status = "disabled";
 			};
 
@@ -186,8 +224,8 @@
 				compatible = "qca,qca9550-wmac";
 				reg = <0x18100000 0x10000>;
 
-				interrupt-parent = <&cpuintc>;
-				interrupts = <2>;
+				interrupt-parent = <&intc2>;
+				interrupts = <0>;
 
 				status = "disabled";
 			};

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -90,7 +90,7 @@
 	};
 };
 
-&pcie {
+&pcie0 {
 	status = "okay";
 };
 

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -115,14 +115,16 @@
 				interrupt-parent = <&cpuintc>;
 
 				intc3: interrupt-controller@3 {
-					compatible = "qcom,qca9556-intc";
+					compatible = "qca,ar9340-intc";
 
+					interrupt-parent = <&cpuintc>;
 					interrupts = <3>;
 
 					interrupt-controller;
 					#interrupt-cells = <1>;
 
-					qcom,pending-bits = <0x1f000>,		/* pcie rc */
+					qca,int-status-addr = <0xac>;
+					qca,pending-bits = <0x1f000>,		/* pcie rc */
 							    <0x1000000>,	/* usb1 */
 							    <0x10000000>;	/* usb2 */
 				};

--- a/target/linux/ath79/patches-4.14/0007-irqchip-irq-ath79-intc-add-irq-cascade-driver-for-QC.patch
+++ b/target/linux/ath79/patches-4.14/0007-irqchip-irq-ath79-intc-add-irq-cascade-driver-for-QC.patch
@@ -23,7 +23,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  obj-$(CONFIG_ARCH_BCM2835)		+= irq-bcm2836.o
 --- /dev/null
 +++ b/drivers/irqchip/irq-ath79-intc.c
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,142 @@
 +/*
 + *  Atheros AR71xx/AR724x/AR913x specific interrupt handling
 + *
@@ -50,7 +50,9 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	struct irq_chip chip;
 +	u32 irq;
 +	u32 pending_mask;
++	u32 int_status;
 +	u32 irq_mask[ATH79_MAX_INTC_CASCADE];
++	u32 irq_wb_chan[ATH79_MAX_INTC_CASCADE];
 +};
 +
 +static void ath79_intc_irq_handler(struct irq_desc *desc)
@@ -59,26 +61,33 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	struct ath79_intc *intc = domain->host_data;
 +	u32 pending;
 +
-+	pending = ath79_reset_rr(QCA955X_RESET_REG_EXT_INT_STATUS);
++	pending = ath79_reset_rr(intc->int_status);
 +	pending &= intc->pending_mask;
 +
 +	if (pending) {
 +		int i;
 +
 +		for (i = 0; i < domain->hwirq_max; i++)
-+			if (pending & intc->irq_mask[i])
++			if (pending & intc->irq_mask[i]) {
++				if (intc->irq_wb_chan[i] != 0xffffffff)
++					ath79_ddr_wb_flush(intc->irq_wb_chan[i]);
 +				generic_handle_irq(irq_find_mapping(domain, i));
++			}
 +	} else {
 +		spurious_interrupt();
 +	}
 +}
 +
-+static void ath79_intc_irq_unmask(struct irq_data *d)
++static void ath79_intc_irq_enable(struct irq_data *d)
 +{
++	struct ath79_intc *intc = d->domain->host_data;
++	enable_irq(intc->irq);
 +}
 +
-+static void ath79_intc_irq_mask(struct irq_data *d)
++static void ath79_intc_irq_disable(struct irq_data *d)
 +{
++	struct ath79_intc *intc = d->domain->host_data;
++	disable_irq(intc->irq);
 +}
 +
 +static int ath79_intc_map(struct irq_domain *d, unsigned int irq, irq_hw_number_t hw)
@@ -95,27 +104,56 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	.map = ath79_intc_map,
 +};
 +
-+static int __init qca9556_intc_of_init(
++static int __init ath79_intc_of_init(
 +	struct device_node *node, struct device_node *parent)
 +{
 +	struct irq_domain *domain;
 +	struct ath79_intc *intc;
-+	int cnt, i;
++	int cnt, cntwb, i, err;
 +
-+	cnt = of_property_count_u32_elems(node, "qcom,pending-bits");
++	cnt = of_property_count_u32_elems(node, "qca,pending-bits");
 +	if (cnt > ATH79_MAX_INTC_CASCADE)
 +		panic("Too many INTC pending bits\n");
 +
 +	intc = kzalloc(sizeof(*intc), GFP_KERNEL);
 +	if (!intc)
 +		panic("Failed to allocate INTC memory\n");
++	intc->chip = dummy_irq_chip;
 +	intc->chip.name = "INTC";
-+	intc->chip.irq_unmask = ath79_intc_irq_unmask,
-+	intc->chip.irq_mask = ath79_intc_irq_mask,
++	intc->chip.irq_disable = ath79_intc_irq_disable;
++	intc->chip.irq_enable = ath79_intc_irq_enable;
 +
-+	of_property_read_u32_array(node, "qcom,pending-bits", intc->irq_mask, cnt);
-+	for (i = 0; i < cnt; i++)
++	if (of_property_read_u32(node, "qca,int-status-addr", &intc->int_status) < 0) {
++		panic("Missing address of interrupt status register\n");
++	}
++
++	of_property_read_u32_array(node, "qca,pending-bits", intc->irq_mask, cnt);
++	for (i = 0; i < cnt; i++) {
 +		intc->pending_mask |= intc->irq_mask[i];
++		intc->irq_wb_chan[i] = 0xffffffff;
++	}
++
++	cntwb = of_count_phandle_with_args(
++		node, "qca,ddr-wb-channels", "#qca,ddr-wb-channel-cells");
++
++	for (i = 0; i < cntwb; i++) {
++		struct of_phandle_args args;
++		u32 irq = i;
++
++		of_property_read_u32_index(
++			node, "qca,ddr-wb-channel-interrupts", i, &irq);
++		if (irq >= ATH79_MAX_INTC_CASCADE)
++			continue;
++
++		err = of_parse_phandle_with_args(
++			node, "qca,ddr-wb-channels",
++			"#qca,ddr-wb-channel-cells",
++			i, &args);
++		if (err)
++			return err;
++
++		intc->irq_wb_chan[irq] = args.args[0];
++	}
 +
 +	intc->irq = irq_of_parse_and_map(node, 0);
 +	if (!intc->irq)
@@ -126,5 +164,5 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +
 +	return 0;
 +}
-+IRQCHIP_DECLARE(qca9556_intc, "qcom,qca9556-intc",
-+		qca9556_intc_of_init);
++IRQCHIP_DECLARE(ath79_intc, "qca,ar9340-intc",
++		ath79_intc_of_init);


### PR DESCRIPTION
Add the missing enable and disable function.
Remove dummy mask and unmask function and use the one provided by irq_dummy_chip.
Allow interrupt status register being defined from dts and add ddr_wb_flush for ar934x/qca953x.
Tested on Qihoo C301 (AR9344 + QCA9882), both PCIE and WMAC works fine.