### PR TITLE
ramips: add support for ELECOM WRC-1167GHBK2-S

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -168,6 +168,7 @@ dlink,dwr-921-c1)
 	ucidef_set_led_default "sigstrength" "Signal Strength" "$boardname:green:sigstrength" "0"
 	;;
 dir-810l|\
+elecom,wrc-1167ghbk2-s|\
 iodata,wn-gx300gr|\
 mzk-750dhp|\
 mzk-dp150n|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -225,7 +225,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;
-	dir-860l-b1)
+	dir-860l-b1|\
+	elecom,wrc-1167ghbk2-s)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
@@ -449,6 +450,10 @@ ramips_setup_macs()
 	e1700)
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
+	elecom,wrc-1167ghbk2-s|\
+	sk-wb8)
+		wan_mac=$(mtd_get_mac_binary factory 57350)
+		;;
 	gl-mt300n-v2|\
 	whr-g300n)
 		wan_mac=$(mtd_get_mac_binary factory 4)
@@ -512,9 +517,6 @@ ramips_setup_macs()
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		lan_mac=$(macaddr_setbit_la "$lan_mac")
 		wan_mac=$(mtd_get_mac_binary factory 32772)
-		;;
-	sk-wb8)
-		wan_mac=$(mtd_get_mac_binary factory 57350)
 		;;
 	tew-691gr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 4)" 3)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -22,6 +22,7 @@ get_status_led() {
 	dch-m225|\
 	dir-860l-b1|\
 	e1700|\
+	elecom,wrc-1167ghbk2-s|\
 	ex2700|\
 	ex3700|\
 	fonera20n|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -54,6 +54,7 @@ platform_check_image() {
 	dir-810l|\
 	duzun-dm06|\
 	e1700|\
+	elecom,wrc-1167ghbk2-s|\
 	esr-9753|\
 	ew1200|\
 	ex2700|\

--- a/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
+++ b/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
@@ -1,0 +1,144 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "elecom,wrc-1167ghbk2-s", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-1167GHBK2-S";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "wrc-1167ghbk2-s:white:wlan2g";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "wrc-1167ghbk2-s:white:wlan5g";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		power_green {
+			label = "wrc-1167ghbk2-s:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_blue {
+			label = "wrc-1167ghbk2-s:blue:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "wrc-1167ghbk2-s:red:wps";
+			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_red {
+			label = "wrc-1167ghbk2-s:red:power";
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xf20000>;
+		};
+
+		partition@f70000 {
+			label = "user_data";
+			reg = <0xf70000 0x80000>;
+			read-only;
+		};
+
+		partition@ff0000 {
+			label = "NVRAM";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uart3", "jtag", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+	// WRC-1167GHBK2-S has MT7615D for 2.4/5 GHz wifi,
+	// but it's not supported in OpenWrt.
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -4,6 +4,18 @@
 
 DEVICE_VARS += TPLINK_BOARD_ID TPLINK_HEADER_VERSION TPLINK_HWID TPLINK_HWREV
 
+define Build/elecom-wrc-factory
+  $(eval product=$(word 1,$(1)))
+  $(eval version=$(word 2,$(1)))
+  $(STAGING_DIR_HOST)/bin/mkhash md5 $@ >> $@
+  ( \
+    echo -n "ELECOM $(product) v$(version)" | \
+      dd bs=32 count=1 conv=sync; \
+    dd if=$@; \
+  ) > $@.new
+  mv $@.new $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -64,6 +76,16 @@ define Device/mediatek_ap-mt7621a-v60
   DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
+
+define Device/elecom_wrc-1167ghbk2-s
+  DTS := WRC-1167GHBK2-S
+  IMAGE_SIZE := 15488k
+  DEVICE_TITLE := ELECOM WRC-1167GHBK2-S
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) |\
+    elecom-wrc-factory WRC-1167GHBK2-S 0.00
+endef
+TARGET_DEVICES += elecom_wrc-1167ghbk2-s
 
 define Device/ew1200
   DTS := EW1200


### PR DESCRIPTION
ELECOM WRC-1167GHBK2-S is a 2.4/5 GHz band 11ac router, based on
MediaTek MT7621A.

Specification:

- MT7621A (2-Cores, 4-Threads)
- 128 MB of RAM (DDR3)
- 16 MB of Flash (SPI)
- 2T2R 2.4/5 GHz
  - MediaTek MT7615D
- 5x 10/100/1000 Mbps Ethernet
- 6x LEDs, 2x keys
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - baudrate: 57600 bps

Flash instruction using factory image:

1. Rename the factory image to "wrc-1167ghbk2-s_v0.00.bin"
2. Connect the computer to the LAN port of WRC-1167GHBK2-S
3. Connect power cable to WRC-1167GHBK2-S and turn on it
4. Access to "http://192.168.2.1/details.html" and open firmware
update page ("手動更新（アップデート）")
5. Select the factory image and click apply ("適用") button
6. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>