### PR TITLE
ar71xx: add kmod-usb-ehci to fix USB on RB hAP AC

### DIFF
--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -49,7 +49,7 @@ TARGET_DEVICES += rb-nor-flash-16M
 define Device/rb-nor-flash-16M-ac
   $(Device/rb-nor-flash-16M)
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR, 802.11ac)
-  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x ath10k-firmware-qca9887 kmod-usb-ehci
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef
 TARGET_DEVICES += rb-nor-flash-16M-ac


### PR DESCRIPTION
This might also apply to other devices, but I don't have any way of testing them.

Thanks!