### PR TITLE
mvebu: backport ahci_mvebu errata patchset

### DIFF
--- a/target/linux/mvebu/patches-4.14/530-ATA-ahci_mvebu-enable-stop_engine-override.patch
+++ b/target/linux/mvebu/patches-4.14/530-ATA-ahci_mvebu-enable-stop_engine-override.patch
@@ -1,0 +1,224 @@
+From fa89f53bd7288d6aa7a982841119e7123faf5a53 Mon Sep 17 00:00:00 2001
+From: Evan Wang <xswang@marvell.com>
+Date: Fri, 13 Apr 2018 12:32:30 +0800
+Subject: [PATCH] libahci: Allow drivers to override stop_engine
+
+Marvell armada37xx, armada7k and armada8k share the same
+AHCI sata controller IP, and currently there is an issue
+(Errata Ref#226)that the SATA can not be detected via SATA
+Port-MultiPlayer(PMP). After debugging, the reason is
+found that the value of Port-x FIS-based Switching Control
+(PxFBS@0x40) became wrong.
+According to design, the bits[11:8, 0] of register PxFBS
+are cleared when Port Command and Status (0x18) bit[0]
+changes its value from 1 to 0, i.e. falling edge of Port
+Command and Status bit[0] sends PULSE that resets PxFBS
+bits[11:8; 0].
+So it needs save the port PxFBS register before PxCMD
+ST write and restore the port PxFBS register afterwards
+in ahci_stop_engine().
+
+This commit allows drivers to override ahci_stop_engine
+behavior for use by the Marvell AHCI driver(and potentially
+other drivers in the future).
+
+Signed-off-by: Evan Wang <xswang@marvell.com>
+Cc: Ofer Heifetz <oferh@marvell.com>
+Cc: Tejun Heo <tj@kernel.org>
+Cc: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ drivers/ata/ahci.c          |  6 +++---
+ drivers/ata/ahci.h          |  7 +++++++
+ drivers/ata/ahci_qoriq.c    |  2 +-
+ drivers/ata/ahci_xgene.c    |  4 ++--
+ drivers/ata/libahci.c       | 20 ++++++++++++--------
+ drivers/ata/sata_highbank.c |  2 +-
+ 6 files changed, 26 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/ata/ahci.c b/drivers/ata/ahci.c
+index 1ff17799769d0..6389c88b3500a 100644
+--- a/drivers/ata/ahci.c
++++ b/drivers/ata/ahci.c
+@@ -698,7 +698,7 @@ static int ahci_vt8251_hardreset(struct ata_link *link, unsigned int *class,
+ 
+ 	DPRINTK("ENTER\n");
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	rc = sata_link_hardreset(link, sata_ehc_deb_timing(&link->eh_context),
+ 				 deadline, &online, NULL);
+@@ -724,7 +724,7 @@ static int ahci_p5wdh_hardreset(struct ata_link *link, unsigned int *class,
+ 	bool online;
+ 	int rc;
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	/* clear D2H reception area to properly wait for D2H FIS */
+ 	ata_tf_init(link->device, &tf);
+@@ -788,7 +788,7 @@ static int ahci_avn_hardreset(struct ata_link *link, unsigned int *class,
+ 
+ 	DPRINTK("ENTER\n");
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	for (i = 0; i < 2; i++) {
+ 		u16 val;
+diff --git a/drivers/ata/ahci.h b/drivers/ata/ahci.h
+index a9d996e17d75e..824bd399f02ea 100644
+--- a/drivers/ata/ahci.h
++++ b/drivers/ata/ahci.h
+@@ -365,6 +365,13 @@ struct ahci_host_priv {
+ 	 * be overridden anytime before the host is activated.
+ 	 */
+ 	void			(*start_engine)(struct ata_port *ap);
++	/*
++	 * Optional ahci_stop_engine override, if not set this gets set to the
++	 * default ahci_stop_engine during ahci_save_initial_config, this can
++	 * be overridden anytime before the host is activated.
++	 */
++	int			(*stop_engine)(struct ata_port *ap);
++
+ 	irqreturn_t 		(*irq_handler)(int irq, void *dev_instance);
+ 
+ 	/* only required for per-port MSI(-X) support */
+diff --git a/drivers/ata/ahci_qoriq.c b/drivers/ata/ahci_qoriq.c
+index 2685f28160f70..cfdef4d44ae92 100644
+--- a/drivers/ata/ahci_qoriq.c
++++ b/drivers/ata/ahci_qoriq.c
+@@ -96,7 +96,7 @@ static int ahci_qoriq_hardreset(struct ata_link *link, unsigned int *class,
+ 
+ 	DPRINTK("ENTER\n");
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	/*
+ 	 * There is a errata on ls1021a Rev1.0 and Rev2.0 which is:
+diff --git a/drivers/ata/ahci_xgene.c b/drivers/ata/ahci_xgene.c
+index c2b5941d9184d..ad58da7c9affd 100644
+--- a/drivers/ata/ahci_xgene.c
++++ b/drivers/ata/ahci_xgene.c
+@@ -165,7 +165,7 @@ static int xgene_ahci_restart_engine(struct ata_port *ap)
+ 				    PORT_CMD_ISSUE, 0x0, 1, 100))
+ 		  return -EBUSY;
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 	ahci_start_fis_rx(ap);
+ 
+ 	/*
+@@ -421,7 +421,7 @@ static int xgene_ahci_hardreset(struct ata_link *link, unsigned int *class,
+ 	portrxfis_saved = readl(port_mmio + PORT_FIS_ADDR);
+ 	portrxfishi_saved = readl(port_mmio + PORT_FIS_ADDR_HI);
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	rc = xgene_ahci_do_hardreset(link, deadline, &online);
+ 
+diff --git a/drivers/ata/libahci.c b/drivers/ata/libahci.c
+index 7adcf3caabd00..e5d90977caec2 100644
+--- a/drivers/ata/libahci.c
++++ b/drivers/ata/libahci.c
+@@ -560,6 +560,9 @@ void ahci_save_initial_config(struct device *dev, struct ahci_host_priv *hpriv)
+ 	if (!hpriv->start_engine)
+ 		hpriv->start_engine = ahci_start_engine;
+ 
++	if (!hpriv->stop_engine)
++		hpriv->stop_engine = ahci_stop_engine;
++
+ 	if (!hpriv->irq_handler)
+ 		hpriv->irq_handler = ahci_single_level_irq_intr;
+ }
+@@ -897,9 +900,10 @@ static void ahci_start_port(struct ata_port *ap)
+ static int ahci_deinit_port(struct ata_port *ap, const char **emsg)
+ {
+ 	int rc;
++	struct ahci_host_priv *hpriv = ap->host->private_data;
+ 
+ 	/* disable DMA */
+-	rc = ahci_stop_engine(ap);
++	rc = hpriv->stop_engine(ap);
+ 	if (rc) {
+ 		*emsg = "failed to stop engine";
+ 		return rc;
+@@ -1310,7 +1314,7 @@ int ahci_kick_engine(struct ata_port *ap)
+ 	int busy, rc;
+ 
+ 	/* stop engine */
+-	rc = ahci_stop_engine(ap);
++	rc = hpriv->stop_engine(ap);
+ 	if (rc)
+ 		goto out_restart;
+ 
+@@ -1549,7 +1553,7 @@ int ahci_do_hardreset(struct ata_link *link, unsigned int *class,
+ 
+ 	DPRINTK("ENTER\n");
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	/* clear D2H reception area to properly wait for D2H FIS */
+ 	ata_tf_init(link->device, &tf);
+@@ -2075,14 +2079,14 @@ void ahci_error_handler(struct ata_port *ap)
+ 
+ 	if (!(ap->pflags & ATA_PFLAG_FROZEN)) {
+ 		/* restart engine */
+-		ahci_stop_engine(ap);
++		hpriv->stop_engine(ap);
+ 		hpriv->start_engine(ap);
+ 	}
+ 
+ 	sata_pmp_error_handler(ap);
+ 
+ 	if (!ata_dev_enabled(ap->link.device))
+-		ahci_stop_engine(ap);
++		hpriv->stop_engine(ap);
+ }
+ EXPORT_SYMBOL_GPL(ahci_error_handler);
+ 
+@@ -2129,7 +2133,7 @@ static void ahci_set_aggressive_devslp(struct ata_port *ap, bool sleep)
+ 		return;
+ 
+ 	/* set DITO, MDAT, DETO and enable DevSlp, need to stop engine first */
+-	rc = ahci_stop_engine(ap);
++	rc = hpriv->stop_engine(ap);
+ 	if (rc)
+ 		return;
+ 
+@@ -2189,7 +2193,7 @@ static void ahci_enable_fbs(struct ata_port *ap)
+ 		return;
+ 	}
+ 
+-	rc = ahci_stop_engine(ap);
++	rc = hpriv->stop_engine(ap);
+ 	if (rc)
+ 		return;
+ 
+@@ -2222,7 +2226,7 @@ static void ahci_disable_fbs(struct ata_port *ap)
+ 		return;
+ 	}
+ 
+-	rc = ahci_stop_engine(ap);
++	rc = hpriv->stop_engine(ap);
+ 	if (rc)
+ 		return;
+ 
+diff --git a/drivers/ata/sata_highbank.c b/drivers/ata/sata_highbank.c
+index aafb8cc035232..e67815b896fcc 100644
+--- a/drivers/ata/sata_highbank.c
++++ b/drivers/ata/sata_highbank.c
+@@ -410,7 +410,7 @@ static int ahci_highbank_hardreset(struct ata_link *link, unsigned int *class,
+ 	int rc;
+ 	int retry = 100;
+ 
+-	ahci_stop_engine(ap);
++	hpriv->stop_engine(ap);
+ 
+ 	/* clear D2H reception area to properly wait for D2H FIS */
+ 	ata_tf_init(link->device, &tf);
+

--- a/target/linux/mvebu/patches-4.14/531-ATA-ahci_mvebu-pmp-stop-errata-226.patch
+++ b/target/linux/mvebu/patches-4.14/531-ATA-ahci_mvebu-pmp-stop-errata-226.patch
@@ -1,0 +1,110 @@
+From daa2e3bdbb0b3e691cf20a042350817310cb8cb5 Mon Sep 17 00:00:00 2001
+From: Evan Wang <xswang@marvell.com>
+Date: Fri, 13 Apr 2018 12:32:31 +0800
+Subject: [PATCH] ata: ahci: mvebu: override ahci_stop_engine for mvebu AHCI
+
+There is an issue(Errata Ref#226) that the SATA can not be
+detected via SATA Port-MultiPlayer(PMP) with following
+error log:
+  ata1.15: PMP product ID mismatch
+  ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
+  ata1.15: Port Multiplier vendor mismatch '0x1b4b'!='0x0'
+  ata1.15: PMP revalidation failed (errno=-19)
+
+After debugging, the reason is found that the value Port-x
+FIS-based Switching Control(PxFBS@0x40) become wrong.
+According to design, the bits[11:8, 0] of register PxFBS
+are cleared when Port Command and Status (0x18) bit[0]
+changes its value from 1 to 0, i.e. falling edge of Port
+Command and Status bit[0] sends PULSE that resets PxFBS
+bits[11:8; 0].
+So it needs a mvebu SATA WA to save the port PxFBS register
+before PxCMD ST write and restore it afterwards.
+
+This patch implements the WA in a separate function of
+ahci_mvebu_stop_engine to override ahci_stop_gngine.
+
+Signed-off-by: Evan Wang <xswang@marvell.com>
+Cc: Ofer Heifetz <oferh@marvell.com>
+Cc: Tejun Heo <tj@kernel.org>
+Cc: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ drivers/ata/ahci_mvebu.c | 56 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/drivers/ata/ahci_mvebu.c b/drivers/ata/ahci_mvebu.c
+index de7128d81e9cc..0045dacd814b4 100644
+--- a/drivers/ata/ahci_mvebu.c
++++ b/drivers/ata/ahci_mvebu.c
+@@ -62,6 +62,60 @@ static void ahci_mvebu_regret_option(struct ahci_host_priv *hpriv)
+ 	writel(0x80, hpriv->mmio + AHCI_VENDOR_SPECIFIC_0_DATA);
+ }
+ 
++/**
++ * ahci_mvebu_stop_engine
++ *
++ * @ap:	Target ata port
++ *
++ * Errata Ref#226 - SATA Disk HOT swap issue when connected through
++ * Port Multiplier in FIS-based Switching mode.
++ *
++ * To avoid the issue, according to design, the bits[11:8, 0] of
++ * register PxFBS are cleared when Port Command and Status (0x18) bit[0]
++ * changes its value from 1 to 0, i.e. falling edge of Port
++ * Command and Status bit[0] sends PULSE that resets PxFBS
++ * bits[11:8; 0].
++ *
++ * This function is used to override function of "ahci_stop_engine"
++ * from libahci.c by adding the mvebu work around(WA) to save PxFBS
++ * value before the PxCMD ST write of 0, then restore PxFBS value.
++ *
++ * Return: 0 on success; Error code otherwise.
++ */
++int ahci_mvebu_stop_engine(struct ata_port *ap)
++{
++	void __iomem *port_mmio = ahci_port_base(ap);
++	u32 tmp, port_fbs;
++
++	tmp = readl(port_mmio + PORT_CMD);
++
++	/* check if the HBA is idle */
++	if ((tmp & (PORT_CMD_START | PORT_CMD_LIST_ON)) == 0)
++		return 0;
++
++	/* save the port PxFBS register for later restore */
++	port_fbs = readl(port_mmio + PORT_FBS);
++
++	/* setting HBA to idle */
++	tmp &= ~PORT_CMD_START;
++	writel(tmp, port_mmio + PORT_CMD);
++
++	/*
++	 * bit #15 PxCMD signal doesn't clear PxFBS,
++	 * restore the PxFBS register right after clearing the PxCMD ST,
++	 * no need to wait for the PxCMD bit #15.
++	 */
++	writel(port_fbs, port_mmio + PORT_FBS);
++
++	/* wait for engine to stop. This could be as long as 500 msec */
++	tmp = ata_wait_register(ap, port_mmio + PORT_CMD,
++				PORT_CMD_LIST_ON, PORT_CMD_LIST_ON, 1, 500);
++	if (tmp & PORT_CMD_LIST_ON)
++		return -EIO;
++
++	return 0;
++}
++
+ #ifdef CONFIG_PM_SLEEP
+ static int ahci_mvebu_suspend(struct platform_device *pdev, pm_message_t state)
+ {
+@@ -112,6 +166,8 @@ static int ahci_mvebu_probe(struct platform_device *pdev)
+ 	if (rc)
+ 		return rc;
+ 
++	hpriv->stop_engine = ahci_mvebu_stop_engine;
++
+ 	if (of_device_is_compatible(pdev->dev.of_node,
+ 				    "marvell,armada-380-ahci")) {
+ 		dram = mv_mbus_dram_info();
+


### PR DESCRIPTION
Marvell ahci hardware requires a workaround to prevent eSATA failures
on hotplug/reset when used with multi-bay external enclosures.

These patches backport the workaround from 4.17.
```
Errata Ref#226 - SATA Disk HOT swap issue when connected through
Port Multiplier in FIS-based Switching mode.
```
In my testing on WRT1900ACS (shelby) this patchset addresses the following functional issues with multi-bay eSATA enclosures:
* Hotplug may fail, requiring a reboot for device to connect
* Devices may not re-connect after SRST
```
ata1.15: PMP product ID mismatch
ata1.15: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
ata1.15: Port Multiplier vendor mismatch '0x1b4b'!='0x0'
ata1.15: PMP revalidation failed (errno=-19)
```

The patches are the unmodified commits from 4.17, there haven't been any other mvebu ata changes since 4.5.

https://github.com/torvalds/linux/commit/fa89f53bd7288d6aa7a982841119e7123faf5a53
https://github.com/torvalds/linux/commit/daa2e3bdbb0b3e691cf20a042350817310cb8cb5

