### PR TITLE
ipq40xx: essedma: fixup ip align

### DIFF
--- a/target/linux/ipq40xx/patches-4.14/902-essedma-alloc-skb-ip-align.patch
+++ b/target/linux/ipq40xx/patches-4.14/902-essedma-alloc-skb-ip-align.patch
@@ -1,0 +1,26 @@
+From 17681f0bb474d0d227f07369144149d1555d8bce Mon Sep 17 00:00:00 2001
+From: Chen Minqiang <ptpt52@gmail.com>
+Date: Sun, 17 Jun 2018 04:14:13 +0800
+Subject: [PATCH] essedma: alloc skb ip align
+
+Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+---
+ drivers/net/ethernet/qualcomm/essedma/edma.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/qualcomm/essedma/edma.c b/drivers/net/ethernet/qualcomm/essedma/edma.c
+index a3c0d66..29bc9f8 100644
+--- a/drivers/net/ethernet/qualcomm/essedma/edma.c
++++ b/drivers/net/ethernet/qualcomm/essedma/edma.c
+@@ -193,7 +193,7 @@ static int edma_alloc_rx_buf(struct edma_common_info
+ 			skb = sw_desc->skb;
+ 		} else {
+ 			/* alloc skb */
+-			skb = netdev_alloc_skb(edma_netdev[0], length);
++			skb = netdev_alloc_skb_ip_align(edma_netdev[0], length);
+ 			if (!skb) {
+ 				/* Better luck next round */
+ 				break;
+-- 
+2.17.1
+


### PR DESCRIPTION
This fixup ip align in essedma driver rx path
see cat /proc/cpu/alignment
which reports alignment-fixups without this fix.

Tested on rt-acrh17