### PR TITLE
treewide: Use DHCP by default on single port devices

### DIFF
--- a/target/linux/apm821xx/base-files/etc/board.d/02_network
+++ b/target/linux/apm821xx/base-files/etc/board.d/02_network
@@ -11,7 +11,7 @@ case "$board" in
 meraki,mr24|\
 wd,mybooklive|\
 wd,mybooklive-duo)
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
 
 meraki,mx60|\

--- a/target/linux/at91/base-files/etc/board.d/02_network
+++ b/target/linux/at91/base-files/etc/board.d/02_network
@@ -14,7 +14,7 @@ sama5d3_xplained)
 	;;
 
 *)
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
 
 esac

--- a/target/linux/ath25/base-files/etc/board.d/02_network
+++ b/target/linux/ath25/base-files/etc/board.d/02_network
@@ -20,7 +20,7 @@ elif [ -d /sys/class/net/eth1 ]; then
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 
 else
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 fi
 
 board_config_flush

--- a/target/linux/brcm2708/base-files/etc/board.d/02_network
+++ b/target/linux/brcm2708/base-files/etc/board.d/02_network
@@ -17,7 +17,7 @@ raspberrypi,model-b-rev2 |\
 raspberrypi,2-model-b |\
 raspberrypi,3-model-b |\
 raspberrypi,3-model-b-plus)
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
 
 raspberrypi,model-zero-w)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -46,7 +46,7 @@ meraki,mr33 |\
 netgear,ex6100v2 |\
 netgear,ex6150v2 |\
 zyxel,wre6606)
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
 *)
 	echo "Unsupported hardware. Network interfaces not intialized"

--- a/target/linux/mcs814x/base-files/etc/board.d/02_network
+++ b/target/linux/mcs814x/base-files/etc/board.d/02_network
@@ -6,7 +6,7 @@
 . /lib/functions/uci-defaults.sh
 
 board_config_update
-ucidef_set_interface_lan "eth0"
+ucidef_set_interface_lan "eth0" "dhcp"
 board_config_flush
 
 exit 0

--- a/target/linux/mxs/base-files/etc/board.d/02_network
+++ b/target/linux/mxs/base-files/etc/board.d/02_network
@@ -9,7 +9,7 @@ board=$(board_name)
 
 case "$board" in
 *)
-	ucidef_set_interface_lan 'eth0'
+	ucidef_set_interface_lan 'eth0' 'dhcp'
 	;;
 esac
 

--- a/target/linux/orion/base-files/etc/board.d/02_network
+++ b/target/linux/orion/base-files/etc/board.d/02_network
@@ -7,7 +7,7 @@ board_config_update
 if grep -q lan1 /proc/net/dev; then
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 else
-	ucidef_set_interface_lan "eth0"
+	ucidef_set_interface_lan "eth0" "dhcp"
 fi
 
 board_config_flush

--- a/target/linux/sunxi/base-files/etc/board.d/02_network
+++ b/target/linux/sunxi/base-files/etc/board.d/02_network
@@ -19,7 +19,7 @@ case "$(board_name)" in
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;
 *)
-	ucidef_set_interface_lan 'eth0'
+	ucidef_set_interface_lan 'eth0' 'dhcp'
 	;;
 esac
 

--- a/target/linux/zynq/base-files/etc/board.d/02_network
+++ b/target/linux/zynq/base-files/etc/board.d/02_network
@@ -9,7 +9,7 @@ case "$(board_name)" in
 digilent,zynq-zybo | \
 xlnx,zynq-zc702 | \
 xlnx,zynq-zed)
-	ucidef_set_interface_lan 'eth0'
+	ucidef_set_interface_lan 'eth0' 'dhcp'
 	;;
 *)
 	echo "Unsupported hardware. Network interfaces not intialized"


### PR DESCRIPTION
Use dhcp by default if the device only has one port.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>
