### PR TITLE
scripts/getver.sh: use 7-digit hash in version string (FS#1583)

### DIFF
--- a/scripts/getver.sh
+++ b/scripts/getver.sh
@@ -40,7 +40,7 @@ try_git() {
 			REV="${UPSTREAM_REV}+$((REV - UPSTREAM_REV))"
 		fi
 
-		REV="${REV:+r$REV-$(git log -n 1 --format="%h" $UPSTREAM_BASE)}"
+		REV="${REV:+r$REV-$(git log -n 1 --format="%h" --abbrev=7 $UPSTREAM_BASE)}"
 
 		;;
 	esac


### PR DESCRIPTION
Use only 7-digit hash in version string, e.g. 'r7200-2f3c5fe'

The number of digits in hash returned by git depends on the amount of commits in the repository since git 2.11.

Some Netgear routers have recently been unable to flash Openwrt factory image with the TFTP recovery flash mode provided by Netgear u-boot. That is due to over-long Openwrt version string overflowing into the router type string in u-boot code.

Currently Openwrt buildbot slaves mostly set 7 digit hashes as they have ancient git versions, so the buildbot images are mostly usable, but private buildhosts with modern git return 10 digits for the Openwrt main repo hash.

master and 18.06 are affected if the image has been built with 10-digit hash as they are branded "Openwrt", but 17.01 is not affected as it is "LEDE" = 3 chars shorter name.

Master and 18.06 get fixed by forcing 7-digit hash, as that shortens the generated full version name in image header by just enough chars.

I have noticed the problem with WNDR3800 and R7800, but I am sure that most Netgear routers that provide the TFTP mode in u-boot are affected.

Does not work:
```
master
device:WNDR3800 version:VOpenWrt.r7161-c8677ca89e region: hd_id:29763654+16+128
18.06
device:WNDR3800 version:VOpenWrt.r6995-ba204d941c region: hd_id:29763654+16+128
```

Works:
```
master, same build but with short 7-digit hash
device:WNDR3800 version:VOpenWrt.r7161-c8677ca region: hd_id:29763654+16+128
17.01, my build
device:WNDR3800 version:VLEDE.r3898-4a38c0cad5 region: hd_id:29763654+16+128
master buildbot:
device:WNDR3800 version:VOpenWrt.r7161-c8677ca region: hd_id:29763654+16+128
17.01 buildbot:
device:WNDR3800 version:VLEDE.r3909-b6a1f43 region: hd_id:29763654+16+128
```

More discussion in FS#1583:
https://bugs.openwrt.org/index.php?do=details&task_id=1583
