### PR TITLE
ath10k: add leds patch and fix VHT160

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -296,9 +296,9 @@ define KernelPackage/ath9k/config
 		bool "Support chips used in PC OEM cards"
 		depends on PACKAGE_kmod-ath9k
 
-       config ATH9K_TX99
-               bool "Enable TX99 support (WARNING: testing only, breaks normal operation!)"
-               depends on PACKAGE_kmod-ath9k
+	config ATH9K_TX99
+		bool "Enable TX99 support (WARNING: testing only, breaks normal operation!)"
+		depends on PACKAGE_kmod-ath9k
 
 	config ATH9K_UBNTHSR
 		bool "Support for Ubiquiti UniFi Outdoor+ access point"
@@ -341,11 +341,14 @@ PCI is supported.
 endef
 
 define KernelPackage/ath10k/config
-
-       config ATH10K_THERMAL
-               bool "Enable thermal sensors and throttling support"
-               depends on PACKAGE_kmod-ath10k
-
+	config ATH10K_THERMAL
+		bool "Enable thermal sensors and throttling support"
+		depends on PACKAGE_kmod-ath10k
+		   
+	config ATH10K_LEDS
+		bool "Enable led support LED support for chipset connected led pins"
+		default y
+		depends on PACKAGE_kmod-ath10k
 endef
 
 #Broadcom firmware
@@ -1636,6 +1639,7 @@ config-$(CONFIG_ATH9K_SUPPORT_PCOEM) += ATH9K_PCOEM
 config-$(CONFIG_ATH9K_TX99) += ATH9K_TX99
 config-$(CONFIG_ATH9K_UBNTHSR) += ATH9K_UBNTHSR
 config-$(CONFIG_ATH10K_THERMAL) += ATH10K_THERMAL
+config-$(CONFIG_ATH10K_LEDS) += ATH10K_LEDS
 
 config-$(call config_package,ath9k-htc) += ATH9K_HTC
 config-$(call config_package,ath10k) += ATH10K ATH10K_PCI

--- a/package/kernel/mac80211/patches/090-Revert-rt2800-use-TXOP_BACKOFF-for-probe-frames.patch
+++ b/package/kernel/mac80211/patches/090-Revert-rt2800-use-TXOP_BACKOFF-for-probe-frames.patch
@@ -21,11 +21,9 @@ Signed-off-by: Stanislaw Gruszka <sgruszka@redhat.com>
  drivers/net/wireless/ralink/rt2x00/rt2x00queue.c | 7 +++----
  1 file changed, 3 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c b/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
-index a6884e73d2ab..7ddee980048b 100644
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
-@@ -372,16 +372,15 @@ static void rt2x00queue_create_tx_descriptor_ht(struct rt2x00_dev *rt2x00dev,
+@@ -372,16 +372,15 @@ static void rt2x00queue_create_tx_descri
  
  	/*
  	 * Determine IFS values

--- a/package/kernel/mac80211/patches/100-remove-cryptoapi-dependencies.patch
+++ b/package/kernel/mac80211/patches/100-remove-cryptoapi-dependencies.patch
@@ -173,7 +173,8 @@
  #define AES_CCM_H
  
 -#include "aead_api.h"
--
++#include <linux/crypto.h>
+ 
 -#define CCM_AAD_LEN	32
 -
 -static inline struct crypto_aead *
@@ -201,8 +202,7 @@
 -			    be16_to_cpup((__be16 *)aad),
 -			    data, data_len, mic);
 -}
-+#include <linux/crypto.h>
- 
+-
 -static inline void ieee80211_aes_key_free(struct crypto_aead *tfm)
 -{
 -	return aead_key_free(tfm);
@@ -338,10 +338,10 @@
  #define AES_GCM_H
  
 -#include "aead_api.h"
--
--#define GCM_AAD_LEN	32
 +#include <linux/crypto.h>
  
+-#define GCM_AAD_LEN	32
+-
 -static inline int ieee80211_aes_gcm_encrypt(struct crypto_aead *tfm,
 -					    u8 *j_0, u8 *aad,  u8 *data,
 -					    size_t data_len, u8 *mic)

--- a/package/kernel/mac80211/patches/131-Revert-mac80211-aes-cmac-switch-to-shash-CMAC-driver.patch
+++ b/package/kernel/mac80211/patches/131-Revert-mac80211-aes-cmac-switch-to-shash-CMAC-driver.patch
@@ -20,12 +20,9 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 -void ieee80211_aes_cmac(struct crypto_shash *tfm, const u8 *aad,
 -			const u8 *data, size_t data_len, u8 *mic)
 +void gf_mulx(u8 *pad)
- {
--	SHASH_DESC_ON_STACK(desc, tfm);
--	u8 out[AES_BLOCK_SIZE];
++{
 +	int i, carry;
- 
--	desc->tfm = tfm;
++
 +	carry = pad[0] & 0x80;
 +	for (i = 0; i < AES_BLOCK_SIZE - 1; i++)
 +		pad[i] = (pad[i] << 1) | (pad[i + 1] >> 7);
@@ -33,20 +30,17 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	if (carry)
 +		pad[AES_BLOCK_SIZE - 1] ^= 0x87;
 +}
- 
--	crypto_shash_init(desc);
--	crypto_shash_update(desc, aad, AAD_LEN);
--	crypto_shash_update(desc, data, data_len - CMAC_TLEN);
--	crypto_shash_finup(desc, zero, CMAC_TLEN, out);
++
 +void aes_cmac_vector(struct crypto_cipher *tfm, size_t num_elem,
 +		     const u8 *addr[], const size_t *len, u8 *mac,
 +		     size_t mac_len)
-+{
+ {
+-	SHASH_DESC_ON_STACK(desc, tfm);
+-	u8 out[AES_BLOCK_SIZE];
 +	u8 cbc[AES_BLOCK_SIZE], pad[AES_BLOCK_SIZE];
 +	const u8 *pos, *end;
 +	size_t i, e, left, total_len;
- 
--	memcpy(mic, out, CMAC_TLEN);
++
 +	memset(cbc, 0, AES_BLOCK_SIZE);
 +
 +	total_len = 0;
@@ -93,10 +87,14 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		pad[i] ^= cbc[i];
 +	crypto_cipher_encrypt_one(tfm, pad, pad);
 +	memcpy(mac, pad, mac_len);
- }
++}
  
--void ieee80211_aes_cmac_256(struct crypto_shash *tfm, const u8 *aad,
-+
+-	desc->tfm = tfm;
+ 
+-	crypto_shash_init(desc);
+-	crypto_shash_update(desc, aad, AAD_LEN);
+-	crypto_shash_update(desc, data, data_len - CMAC_TLEN);
+-	crypto_shash_finup(desc, zero, CMAC_TLEN, out);
 +void ieee80211_aes_cmac(struct crypto_cipher *tfm, const u8 *aad,
 +			const u8 *data, size_t data_len, u8 *mic)
 +{
@@ -111,10 +109,12 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	len[1] = data_len - CMAC_TLEN;
 +	addr[2] = zero;
 +	len[2] = CMAC_TLEN;
-+
+ 
+-	memcpy(mic, out, CMAC_TLEN);
 +	aes_cmac_vector(tfm, 3, addr, len, mic, CMAC_TLEN);
-+}
-+
+ }
+ 
+-void ieee80211_aes_cmac_256(struct crypto_shash *tfm, const u8 *aad,
 +void ieee80211_aes_cmac_256(struct crypto_cipher *tfm, const u8 *aad,
  			    const u8 *data, size_t data_len, u8 *mic)
  {
@@ -122,8 +122,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	const u8 *addr[3];
 +	size_t len[3];
 +	u8 zero[CMAC_TLEN_256];
- 
--	desc->tfm = tfm;
++
 +	memset(zero, 0, CMAC_TLEN_256);
 +	addr[0] = aad;
 +	len[0] = AAD_LEN;
@@ -132,6 +131,8 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	addr[2] = zero;
 +	len[2] = CMAC_TLEN_256;
  
+-	desc->tfm = tfm;
+-
 -	crypto_shash_init(desc);
 -	crypto_shash_update(desc, aad, AAD_LEN);
 -	crypto_shash_update(desc, data, data_len - CMAC_TLEN_256);

--- a/package/kernel/mac80211/patches/303-v4.15-0003-brcmfmac-cleanup-brcmf_cfg80211_escan-function.patch
+++ b/package/kernel/mac80211/patches/303-v4.15-0003-brcmfmac-cleanup-brcmf_cfg80211_escan-function.patch
@@ -88,7 +88,7 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 -			spec_scan = true;
 -		} else
 -			brcmf_dbg(SCAN, "Broadcast scan\n");
- 
+-
 -		passive_scan = cfg->active_scan ? 0 : 1;
 -		err = brcmf_fil_cmd_int_set(ifp, BRCMF_C_SET_PASSIVE_SCAN,
 -					    passive_scan);
@@ -105,15 +105,17 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 -					  ssid_le.SSID);
 -			else
 -				brcmf_err("WLC_SCAN error (%d)\n", err);
-+	cfg->escan_info.run = brcmf_run_escan;
-+	err = brcmf_p2p_scan_prep(wiphy, request, vif);
-+	if (err)
-+		goto scan_out;
- 
+-
 -			brcmf_scan_config_mpc(ifp, 1);
 -			goto scan_out;
 -		}
 -	}
++
++	cfg->escan_info.run = brcmf_run_escan;
++	err = brcmf_p2p_scan_prep(wiphy, request, vif);
++	if (err)
++		goto scan_out;
++
 +	err = brcmf_do_escan(vif->ifp, request);
 +	if (err)
 +		goto scan_out;

--- a/package/kernel/mac80211/patches/311-v4.16-0007-brcmfmac-Remove-brcmf_sdiod_request_data.patch
+++ b/package/kernel/mac80211/patches/311-v4.16-0007-brcmfmac-Remove-brcmf_sdiod_request_data.patch
@@ -141,12 +141,12 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 -		func = SDIO_FUNC_0;
 -	else
 -		func = SDIO_FUNC_1;
- 
+-
 -	do {
 -		/* for retry wait for 1 ms till bus get settled down */
 -		if (retry)
 -			usleep_range(1000, 2000);
--
+ 
 -		ret = brcmf_sdiod_request_data(sdiodev, func, addr, regsz,
 -					       data, true);
 -

--- a/package/kernel/mac80211/patches/312-v4.16-0004-brcmfmac-Rename-replace-old-IO-functions-with-simple.patch
+++ b/package/kernel/mac80211/patches/312-v4.16-0004-brcmfmac-Rename-replace-old-IO-functions-with-simple.patch
@@ -198,14 +198,14 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
  	int retval;
  
 -	retval = brcmf_sdiod_reg_read(sdiodev, addr, 1, &data);
-+	retval = brcmf_sdiod_addrprep(sdiodev, &addr);
- 
+-
 -	if (ret)
 -		*ret = retval;
 -
 -	return data;
 -}
--
++	retval = brcmf_sdiod_addrprep(sdiodev, &addr);
+ 
 -u32 brcmf_sdiod_regrl(struct brcmf_sdio_dev *sdiodev, u32 addr, int *ret)
 -{
 -	u32 data;

--- a/package/kernel/mac80211/patches/312-v4.16-0006-brcmfmac-Remove-brcmf_sdiod_addrprep.patch
+++ b/package/kernel/mac80211/patches/312-v4.16-0006-brcmfmac-Remove-brcmf_sdiod_addrprep.patch
@@ -62,10 +62,10 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 +	if (!err)
  		sdiodev->sbwad = bar0;
 -	}
--
+ 
 -	*addr &= SBSDIO_SB_OFT_ADDR_MASK;
 -	*addr |= SBSDIO_SB_ACCESS_2_4B_FLAG;
- 
+-
 -	return 0;
 +	return err;
  }
@@ -99,14 +99,14 @@ Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
 +	retval = brcmf_sdiod_set_backplane_window(sdiodev, addr);
 +	if (retval)
 +		goto out;
-+
-+	addr &= SBSDIO_SB_OFT_ADDR_MASK;
-+	addr |= SBSDIO_SB_ACCESS_2_4B_FLAG;
  
 -	if (!retval)
 -		sdio_writel(sdiodev->func[1], data, addr, &retval);
-+	sdio_writel(sdiodev->func[1], data, addr, &retval);
++	addr &= SBSDIO_SB_OFT_ADDR_MASK;
++	addr |= SBSDIO_SB_ACCESS_2_4B_FLAG;
  
++	sdio_writel(sdiodev->func[1], data, addr, &retval);
++
 +out:
  	if (ret)
  		*ret = retval;

--- a/package/kernel/mac80211/patches/351-ath9k_hw-issue-external-reset-for-QCA955x.patch
+++ b/package/kernel/mac80211/patches/351-ath9k_hw-issue-external-reset-for-QCA955x.patch
@@ -29,6 +29,21 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 -		npend = ath9k_hw_numtxpending(ah, i);
 -		if (npend)
 -			break;
+-	}
+-
+-	if (ah->external_reset &&
+-	    (npend || type == ATH9K_RESET_COLD)) {
+-		int reset_err = 0;
+-
+-		ath_dbg(ath9k_hw_common(ah), RESET,
+-			"reset MAC via external reset\n");
+-
+-		reset_err = ah->external_reset();
+-		if (reset_err) {
+-			ath_err(ath9k_hw_common(ah),
+-				"External reset failed, err=%d\n",
+-				reset_err);
+-			return false;
 +	if (type == ATH9K_RESET_COLD)
 +		return true;
 +
@@ -44,47 +59,35 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		for (i = 0; i < AR_NUM_QCU; i++) {
 +			if (ath9k_hw_numtxpending(ah, i))
 +				return true;
-+		}
- 	}
- 
--	if (ah->external_reset &&
--	    (npend || type == ATH9K_RESET_COLD)) {
--		int reset_err = 0;
+ 		}
++	}
++
 +	return false;
 +}
- 
--		ath_dbg(ath9k_hw_common(ah), RESET,
--			"reset MAC via external reset\n");
++
 +static bool ath9k_hw_external_reset(struct ath_hw *ah, int type)
 +{
 +	int err;
- 
--		reset_err = ah->external_reset();
--		if (reset_err) {
--			ath_err(ath9k_hw_common(ah),
--				"External reset failed, err=%d\n",
--				reset_err);
--			return false;
--		}
++
 +	if (!ah->external_reset || !ath9k_hw_need_external_reset(ah, type))
 +		return true;
- 
--		REG_WRITE(ah, AR_RTC_RESET, 1);
++
 +	ath_dbg(ath9k_hw_common(ah), RESET,
 +		"reset MAC via external reset\n");
-+
+ 
+-		REG_WRITE(ah, AR_RTC_RESET, 1);
 +	err = ah->external_reset();
 +	if (err) {
 +		ath_err(ath9k_hw_common(ah),
 +			"External reset failed, err=%d\n", err);
 +		return false;
-+	}
-+
+ 	}
+ 
 +	if (AR_SREV_9550(ah)) {
 +		REG_WRITE(ah, AR_RTC_RESET, 0);
 +		udelay(10);
- 	}
- 
++	}
++
 +	REG_WRITE(ah, AR_RTC_RESET, 1);
 +	udelay(10);
 +

--- a/package/kernel/mac80211/patches/372-mac80211-minstrel-reduce-minstrel_mcs_groups-size.patch
+++ b/package/kernel/mac80211/patches/372-mac80211-minstrel-reduce-minstrel_mcs_groups-size.patch
@@ -136,72 +136,82 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 -	MCS_GROUP(1, 0, BW_20),
 -	MCS_GROUP(2, 0, BW_20),
 -	MCS_GROUP(3, 0, BW_20),
-+	MCS_GROUP(1, 0, BW_20, 5),
-+	MCS_GROUP(2, 0, BW_20, 4),
-+	MCS_GROUP(3, 0, BW_20, 4),
- 
+-
 -	MCS_GROUP(1, 1, BW_20),
 -	MCS_GROUP(2, 1, BW_20),
 -	MCS_GROUP(3, 1, BW_20),
-+	MCS_GROUP(1, 1, BW_20, 5),
-+	MCS_GROUP(2, 1, BW_20, 4),
-+	MCS_GROUP(3, 1, BW_20, 4),
- 
+-
 -	MCS_GROUP(1, 0, BW_40),
 -	MCS_GROUP(2, 0, BW_40),
 -	MCS_GROUP(3, 0, BW_40),
-+	MCS_GROUP(1, 0, BW_40, 4),
-+	MCS_GROUP(2, 0, BW_40, 4),
-+	MCS_GROUP(3, 0, BW_40, 4),
- 
+-
 -	MCS_GROUP(1, 1, BW_40),
 -	MCS_GROUP(2, 1, BW_40),
 -	MCS_GROUP(3, 1, BW_40),
-+	MCS_GROUP(1, 1, BW_40, 4),
-+	MCS_GROUP(2, 1, BW_40, 4),
-+	MCS_GROUP(3, 1, BW_40, 4),
- 
+-
 -	CCK_GROUP,
-+	CCK_GROUP(8),
- 
+-
 -	VHT_GROUP(1, 0, BW_20),
 -	VHT_GROUP(2, 0, BW_20),
 -	VHT_GROUP(3, 0, BW_20),
-+	VHT_GROUP(1, 0, BW_20, 5),
-+	VHT_GROUP(2, 0, BW_20, 4),
-+	VHT_GROUP(3, 0, BW_20, 4),
- 
+-
 -	VHT_GROUP(1, 1, BW_20),
 -	VHT_GROUP(2, 1, BW_20),
 -	VHT_GROUP(3, 1, BW_20),
-+	VHT_GROUP(1, 1, BW_20, 5),
-+	VHT_GROUP(2, 1, BW_20, 4),
-+	VHT_GROUP(3, 1, BW_20, 4),
- 
+-
 -	VHT_GROUP(1, 0, BW_40),
 -	VHT_GROUP(2, 0, BW_40),
 -	VHT_GROUP(3, 0, BW_40),
-+	VHT_GROUP(1, 0, BW_40, 4),
-+	VHT_GROUP(2, 0, BW_40, 4),
-+	VHT_GROUP(3, 0, BW_40, 4),
- 
+-
 -	VHT_GROUP(1, 1, BW_40),
 -	VHT_GROUP(2, 1, BW_40),
 -	VHT_GROUP(3, 1, BW_40),
-+	VHT_GROUP(1, 1, BW_40, 4),
-+	VHT_GROUP(2, 1, BW_40, 4),
-+	VHT_GROUP(3, 1, BW_40, 4),
- 
+-
 -	VHT_GROUP(1, 0, BW_80),
 -	VHT_GROUP(2, 0, BW_80),
 -	VHT_GROUP(3, 0, BW_80),
-+	VHT_GROUP(1, 0, BW_80, 4),
-+	VHT_GROUP(2, 0, BW_80, 4),
-+	VHT_GROUP(3, 0, BW_80, 4),
- 
+-
 -	VHT_GROUP(1, 1, BW_80),
 -	VHT_GROUP(2, 1, BW_80),
 -	VHT_GROUP(3, 1, BW_80),
++	MCS_GROUP(1, 0, BW_20, 5),
++	MCS_GROUP(2, 0, BW_20, 4),
++	MCS_GROUP(3, 0, BW_20, 4),
++
++	MCS_GROUP(1, 1, BW_20, 5),
++	MCS_GROUP(2, 1, BW_20, 4),
++	MCS_GROUP(3, 1, BW_20, 4),
++
++	MCS_GROUP(1, 0, BW_40, 4),
++	MCS_GROUP(2, 0, BW_40, 4),
++	MCS_GROUP(3, 0, BW_40, 4),
++
++	MCS_GROUP(1, 1, BW_40, 4),
++	MCS_GROUP(2, 1, BW_40, 4),
++	MCS_GROUP(3, 1, BW_40, 4),
++
++	CCK_GROUP(8),
++
++	VHT_GROUP(1, 0, BW_20, 5),
++	VHT_GROUP(2, 0, BW_20, 4),
++	VHT_GROUP(3, 0, BW_20, 4),
++
++	VHT_GROUP(1, 1, BW_20, 5),
++	VHT_GROUP(2, 1, BW_20, 4),
++	VHT_GROUP(3, 1, BW_20, 4),
++
++	VHT_GROUP(1, 0, BW_40, 4),
++	VHT_GROUP(2, 0, BW_40, 4),
++	VHT_GROUP(3, 0, BW_40, 4),
++
++	VHT_GROUP(1, 1, BW_40, 4),
++	VHT_GROUP(2, 1, BW_40, 4),
++	VHT_GROUP(3, 1, BW_40, 4),
++
++	VHT_GROUP(1, 0, BW_80, 4),
++	VHT_GROUP(2, 0, BW_80, 4),
++	VHT_GROUP(3, 0, BW_80, 4),
++
 +	VHT_GROUP(1, 1, BW_80, 4),
 +	VHT_GROUP(2, 1, BW_80, 4),
 +	VHT_GROUP(3, 1, BW_80, 4),

--- a/package/kernel/mac80211/patches/530-ath9k_extra_leds.patch
+++ b/package/kernel/mac80211/patches/530-ath9k_extra_leds.patch
@@ -103,8 +103,7 @@
 +		      GFP_KERNEL);
 +	if (!led)
 +		return -ENOMEM;
- 
--	ath9k_hw_set_gpio(sc->sc_ah, sc->sc_ah->led_pin, val);
++
 +	led->gpio = gpio = (struct gpio_led *) (led + 1);
 +	_name = (char *) (led->gpio + 1);
 +
@@ -117,7 +116,8 @@
 +	ret = ath_add_led(sc, led);
 +	if (unlikely(ret < 0))
 +		kfree(led);
-+
+ 
+-	ath9k_hw_set_gpio(sc->sc_ah, sc->sc_ah->led_pin, val);
 +	return ret;
  }
  
@@ -125,11 +125,11 @@
  {
 -	if (!sc->led_registered)
 -		return;
--
--	ath_led_brightness(&sc->led_cdev, LED_OFF);
--	led_classdev_unregister(&sc->led_cdev);
 +	struct ath_led *led;
  
+-	ath_led_brightness(&sc->led_cdev, LED_OFF);
+-	led_classdev_unregister(&sc->led_cdev);
+-
 -	ath9k_hw_gpio_free(sc->sc_ah, sc->sc_ah->led_pin);
 +	while (!list_empty(&sc->leds)) {
 +		led = list_first_entry(&sc->leds, struct ath_led, list);

--- a/package/kernel/mac80211/patches/552-ahb_of.patch
+++ b/package/kernel/mac80211/patches/552-ahb_of.patch
@@ -1,7 +1,5 @@
-Index: backports-2017-11-01/drivers/net/wireless/ath/ath9k/ahb.c
-===================================================================
---- backports-2017-11-01.orig/drivers/net/wireless/ath/ath9k/ahb.c
-+++ backports-2017-11-01/drivers/net/wireless/ath/ath9k/ahb.c
+--- a/drivers/net/wireless/ath/ath9k/ahb.c
++++ b/drivers/net/wireless/ath/ath9k/ahb.c
 @@ -19,7 +19,15 @@
  #include <linux/nl80211.h>
  #include <linux/platform_device.h>
@@ -310,10 +308,8 @@ Index: backports-2017-11-01/drivers/net/wireless/ath/ath9k/ahb.c
  	},
  	.id_table    = ath9k_platform_id_table,
  };
-Index: backports-2017-11-01/drivers/net/wireless/ath/ath9k/ath9k.h
-===================================================================
---- backports-2017-11-01.orig/drivers/net/wireless/ath/ath9k/ath9k.h
-+++ backports-2017-11-01/drivers/net/wireless/ath/ath9k/ath9k.h
+--- a/drivers/net/wireless/ath/ath9k/ath9k.h
++++ b/drivers/net/wireless/ath/ath9k/ath9k.h
 @@ -25,6 +25,7 @@
  #include <linux/time.h>
  #include <linux/hw_random.h>

--- a/package/kernel/mac80211/patches/972-ath10k_fix-crash-due-to-wrong-handling-of-peer_bw_rxnss_override-parameter.patch
+++ b/package/kernel/mac80211/patches/972-ath10k_fix-crash-due-to-wrong-handling-of-peer_bw_rxnss_override-parameter.patch
@@ -1,0 +1,132 @@
+From: Sebastian Gottschall <s.gottsch...@dd-wrt.com>
+
+current handling of peer_bw_rxnss_override parameter is based on guessing the 
+VHT160/8080 capability by rx rate. this is wrong and may lead
+to a non initialized peer_bw_rxnss_override parameter which is required since 
+VHT160 operation mode only supports 2x2 chainmasks in addition the original code
+initialized the parameter with wrong masked values.
+This patch uses the peer phymode and peer nss information for correct 
+initialisation of the peer_bw_rxnss_override parameter.
+if this peer information is not available, we initialize the parameter by 
+minimum nss which is suggested by QCA as temporary workaround according
+to the QCA sourcecodes.
+
+Signed-off-by: Sebastian Gottschall <s.gottsch...@dd-wrt.com>
+
+v2: remove debug messages
+v3: apply some cosmetics, update documentation
+v4: fix compile warning and truncate nss to maximum of 2x2 since current 
+chipsets only support 2x2 at vht160
+v5: handle maximum nss for chipsets supportig vht160 with 1x1 only
+v7: use more simple code variant and take care about hw/sw chainmask 
+configuration
+---
+ drivers/net/wireless/ath/ath10k/mac.c | 40 +++++++++++++++------------
+ drivers/net/wireless/ath/ath10k/wmi.c |  7 +----
+ drivers/net/wireless/ath/ath10k/wmi.h | 14 +++++++++-
+ 3 files changed, 36 insertions(+), 25 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -2466,7 +2466,7 @@ static void ath10k_peer_assoc_h_vht(stru
+ 	const u16 *vht_mcs_mask;
+ 	u8 ampdu_factor;
+ 	u8 max_nss, vht_mcs;
+-	int i;
++	int i, nss160;
+ 
+ 	if (WARN_ON(ath10k_mac_vif_chan(vif, &def)))
+ 		return;
+@@ -2526,23 +2526,27 @@ static void ath10k_peer_assoc_h_vht(stru
+ 		__le16_to_cpu(vht_cap->vht_mcs.tx_highest);
+ 	arg->peer_vht_rates.tx_mcs_set = ath10k_peer_assoc_h_vht_limit(
+ 		__le16_to_cpu(vht_cap->vht_mcs.tx_mcs_map), vht_mcs_mask);
++	arg->peer_bw_rxnss_override = 0;
++	nss160 = 1; /* 1x1 default config for VHT160 */
+ 
+-	ath10k_dbg(ar, ATH10K_DBG_MAC, "mac vht peer %pM max_mpdu %d flags 0x%x\n",
+-		   sta->addr, arg->peer_max_mpdu, arg->peer_flags);
+-
+-	if (arg->peer_vht_rates.rx_max_rate &&
+-	    (sta->vht_cap.cap & IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_MASK)) {
+-		switch (arg->peer_vht_rates.rx_max_rate) {
+-		case 1560:
+-			/* Must be 2x2 at 160Mhz is all it can do. */
+-			arg->peer_bw_rxnss_override = 2;
+-			break;
+-		case 780:
+-			/* Can only do 1x1 at 160Mhz (Long Guard Interval) */
+-			arg->peer_bw_rxnss_override = 1;
+-			break;
+-		}
++	/* only 4x4 configuration do support 2x2 for VHT160, everything else must use 1x1 */
++	if (ar->cfg_rx_chainmask == 15)
++		nss160 = arg->peer_num_spatial_streams <= 2 ? arg->peer_num_spatial_streams : 2;
++
++	/* in case if peer is connected with vht160 or vht80+80, we need to properly adjust rxnss parameters otherwise firmware will raise a assert */
++	switch(arg->peer_phymode) {
++	case MODE_11AC_VHT80_80:
++		arg->peer_bw_rxnss_override = BW_NSS_FWCONF_80_80(nss160);
++	/* fall through */
++	case MODE_11AC_VHT160:
++		arg->peer_bw_rxnss_override |= BW_NSS_FWCONF_160(nss160);
++	break;
++	default:
++	break;
+ 	}
++
++	ath10k_dbg(ar, ATH10K_DBG_MAC, "mac vht peer %pM max_mpdu %d flags 0x%x peer_bw_rxnss_override 0x%x\n",
++		   sta->addr, arg->peer_max_mpdu, arg->peer_flags, arg->peer_bw_rxnss_override);
+ }
+ 
+ static void ath10k_peer_assoc_h_qos(struct ath10k *ar,
+@@ -2694,9 +2698,9 @@ static int ath10k_peer_assoc_prepare(str
+ 	ath10k_peer_assoc_h_crypto(ar, vif, sta, arg);
+ 	ath10k_peer_assoc_h_rates(ar, vif, sta, arg);
+ 	ath10k_peer_assoc_h_ht(ar, vif, sta, arg);
++	ath10k_peer_assoc_h_phymode(ar, vif, sta, arg);
+ 	ath10k_peer_assoc_h_vht(ar, vif, sta, arg);
+ 	ath10k_peer_assoc_h_qos(ar, vif, sta, arg);
+-	ath10k_peer_assoc_h_phymode(ar, vif, sta, arg);
+ 
+ 	return 0;
+ }
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -6760,12 +6760,7 @@ ath10k_wmi_peer_assoc_fill_10_4(struct a
+ 	struct wmi_10_4_peer_assoc_complete_cmd *cmd = buf;
+ 
+ 	ath10k_wmi_peer_assoc_fill_10_2(ar, buf, arg);
+-	if (arg->peer_bw_rxnss_override)
+-		cmd->peer_bw_rxnss_override =
+-			__cpu_to_le32((arg->peer_bw_rxnss_override - 1) |
+-				      BIT(PEER_BW_RXNSS_OVERRIDE_OFFSET));
+-	else
+-		cmd->peer_bw_rxnss_override = 0;
++	cmd->peer_bw_rxnss_override = __cpu_to_le32(arg->peer_bw_rxnss_override);
+ }
+ 
+ static int
+--- a/drivers/net/wireless/ath/ath10k/wmi.h
++++ b/drivers/net/wireless/ath/ath10k/wmi.h
+@@ -6209,7 +6209,19 @@ struct wmi_10_2_peer_assoc_complete_cmd
+ 	__le32 info0; /* WMI_PEER_ASSOC_INFO0_ */
+ } __packed;
+ 
+-#define PEER_BW_RXNSS_OVERRIDE_OFFSET  31
++#define BW_NSS_FWCONF_MAP_ENABLE             (1 << 31)
++#define BW_NSS_FWCONF_MAP_160MHZ_S           (0)
++#define BW_NSS_FWCONF_MAP_160MHZ_M           (0x00000007)
++#define BW_NSS_FWCONF_MAP_80_80MHZ_S         (3)
++#define BW_NSS_FWCONF_MAP_80_80MHZ_M         (0x00000038)
++#define BW_NSS_FWCONF_MAP_M                  (0x0000003F)
++
++#define GET_BW_NSS_FWCONF_160(x)             ((((x) & BW_NSS_FWCONF_MAP_160MHZ_M) >> BW_NSS_FWCONF_MAP_160MHZ_S) + 1)
++#define GET_BW_NSS_FWCONF_80_80(x)           ((((x) & BW_NSS_FWCONF_MAP_80_80MHZ_M) >> BW_NSS_FWCONF_MAP_80_80MHZ_S) + 1)
++
++/* Values defined to set 160 MHz Bandwidth NSS Mapping into FW*/
++#define BW_NSS_FWCONF_160(x)          (BW_NSS_FWCONF_MAP_ENABLE | (((x - 1) << BW_NSS_FWCONF_MAP_160MHZ_S) & BW_NSS_FWCONF_MAP_160MHZ_M))
++#define BW_NSS_FWCONF_80_80(x)        (BW_NSS_FWCONF_MAP_ENABLE | (((x - 1) << BW_NSS_FWCONF_MAP_80_80MHZ_S) & BW_NSS_FWCONF_MAP_80_80MHZ_M))
+ 
+ struct wmi_10_4_peer_assoc_complete_cmd {
+ 	struct wmi_10_2_peer_assoc_complete_cmd cmd;

--- a/package/kernel/mac80211/patches/973-ath10k_fix-band_center_freq-handling-for-VHT160-in-recent-firmwares.patch
+++ b/package/kernel/mac80211/patches/973-ath10k_fix-band_center_freq-handling-for-VHT160-in-recent-firmwares.patch
@@ -1,0 +1,50 @@
+From: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+
+starting with firmware 10.4.3.4.x series QCA changed the handling of the channel property band_center_freq1 and band_center_freq2 in vht160 operation mode
+likelly for backward compatiblity with vht80 only capable clients.
+this patch adjusts the handling to get vht160 to work again with official qca firmwares newer than 3.3
+consider that this patch will not work with older firmwares anymore. to avoid undefined behaviour this we disable vht160 capability for outdated firmwares
+---
+ drivers/net/wireless/ath/ath10k/mac.c |  7 -------
+ drivers/net/wireless/ath/ath10k/wmi.c | 11 ++++++++---
+ 2 files changed, 8 insertions(+), 10 deletions(-)
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -4416,13 +4416,6 @@ static struct ieee80211_sta_vht_cap ath1
+ 		vht_cap.cap |= val;
+ 	}
+ 
+-	/* Currently the firmware seems to be buggy, don't enable 80+80
+-	 * mode until that's resolved.
+-	 */
+-	if ((ar->vht_cap_info & IEEE80211_VHT_CAP_SHORT_GI_160) &&
+-	    (ar->vht_cap_info & IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_MASK) == 0)
+-		vht_cap.cap |= IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_160MHZ;
+-
+ 	mcs_map = 0;
+ 	for (i = 0; i < 8; i++) {
+ 		if ((i < ar->num_rf_chains) && (ar->cfg_tx_chainmask & BIT(i)))
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -1660,13 +1660,18 @@ void ath10k_wmi_put_wmi_channel(struct w
+ 		flags |= WMI_CHAN_FLAG_HT40_PLUS;
+ 	if (arg->chan_radar)
+ 		flags |= WMI_CHAN_FLAG_DFS;
+-
++	ch->band_center_freq2 = 0;
+ 	ch->mhz = __cpu_to_le32(arg->freq);
+ 	ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1);
+ 	if (arg->mode == MODE_11AC_VHT80_80)
+ 		ch->band_center_freq2 = __cpu_to_le32(arg->band_center_freq2);
+-	else
+-		ch->band_center_freq2 = 0;
++	if (arg->mode == MODE_11AC_VHT160)  {
++		if (arg->freq < arg->band_center_freq1)
++			ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1 - 40);
++		else
++			ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1 + 40);		
++		ch->band_center_freq2 = __cpu_to_le32(arg->band_center_freq1);
++	}
+ 	ch->min_power = arg->min_power;
+ 	ch->max_power = arg->max_power;
+ 	ch->reg_power = arg->max_reg_power;

--- a/package/kernel/mac80211/patches/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/mac80211/patches/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -1,0 +1,617 @@
+From: Sebastian Gottschall <s.gottschall@newmedia-net.de>
+
+Adds LED and GPIO Control support for 988x, 9887, 9888, 99x0, 9984 based
+chipsets with on chipset connected led's using WMI Firmware API.  The LED
+device will get available named as "ath10k-phyX" at sysfs and can be controlled
+with various triggers.  adds also debugfs interface for gpio control.
+
+This patch is specific for OpenWRt base, as is use old backported package
+with old wireless source. Support for QCA9984 is removed and a simbol
+is added to local-simbol file to export the actually compile the code 
+with the ATH10K_LEDS simbol.
+
+
+Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+Reviewed-by: Steve deRosier <derosier@cal-sierra.com>
+[kvalo: major reorg and cleanup]
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+
+v13:
+
+* only compile tested!
+
+* fix all checkpatch warnings
+
+* fix commit log
+
+* sizeof(struct ath10k_gpiocontrol) -> sizeof(*gpio)
+
+* unsigned -> unsigned int
+
+* remove GPIOLIB code, that should be added in a separate patch
+
+* rename gpio.c to leds.c
+
+* add leds.h
+
+* rename some functions:
+
+  ath10k_attach_led() -> ath10k_leds_register()
+  ath10k_unregister_led() -> ath10k_leds_unregister()
+  ath10k_reset_led_pin() -> ath10k_leds_start()
+
+* call ath10k_leds_unregister() before ath10k_thermal_unregister() to preserve ordering
+
+* call ath10k_leds_start() only from ath10k_core_start() and not from mac.c
+
+* rename struct ath10k_gpiocontrol as anonymous function under struct
+  ath10k::leds, no need for memory allocation
+
+* merge ath10k_add_led() to ath10k_attach_led(), which is it's only caller
+
+* remove #if IS_ENABLED() checks from most of places, memory savings from those were not worth it
+
+* Kconfig help text improvement and move it lower in the menu, also don't enable it by default
+
+* switch to set_brightness_blocking() so that the callback can sleep,
+  then no need to use ath10k_wmi_cmd_send_nowait() and can take mutex
+  to access ar->state
+
+* don't touch ath10k_wmi_pdev_get_temperature()
+
+* as QCA6174/QCA9377 are not (yet) supported don't add the command to WMI-TLV interface
+
+* remove debugfs interface, that should be added in another patch
+
+* cleanup includes
+
+
+ drivers/net/wireless/ath/ath10k/Kconfig   |  10 +++
+ drivers/net/wireless/ath/ath10k/Makefile  |   1 +
+ drivers/net/wireless/ath/ath10k/core.c    |  22 +++++++
+ drivers/net/wireless/ath/ath10k/core.h    |   9 ++-
+ drivers/net/wireless/ath/ath10k/hw.h      |   1 +
+ drivers/net/wireless/ath/ath10k/leds.c    | 103 ++++++++++++++++++++++++++++++
+ drivers/net/wireless/ath/ath10k/leds.h    |  45 +++++++++++++
+ drivers/net/wireless/ath/ath10k/mac.c     |   1 +
+ drivers/net/wireless/ath/ath10k/wmi-ops.h |  32 ++++++++++
+ drivers/net/wireless/ath/ath10k/wmi-tlv.c |   2 +
+ drivers/net/wireless/ath/ath10k/wmi.c     |  54 ++++++++++++++++
+ drivers/net/wireless/ath/ath10k/wmi.h     |  35 ++++++++++
+ 12 files changed, 314 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/net/wireless/ath/ath10k/leds.c
+ create mode 100644 drivers/net/wireless/ath/ath10k/leds.h
+--- a/drivers/net/wireless/ath/ath10k/Kconfig
++++ b/drivers/net/wireless/ath/ath10k/Kconfig
+@@ -56,6 +56,16 @@ config ATH10K_DEBUGFS
+ 
+ 	  If unsure, say Y to make it easier to debug problems.
+ 
++config ATH10K_LEDS
++	bool "Atheros ath10k LED support"
++	depends on ATH10K
++	select MAC80211_LEDS
++	select LEDS_CLASS
++	select NEW_LEDS
++	default y
++	---help---
++	  This option is necessary, if you want LED support for chipset connected led pins. If unsure, say N.
++
+ config ATH10K_SPECTRAL
+ 	bool "Atheros ath10k spectral scan support"
+ 	depends on ATH10K_DEBUGFS
+--- a/drivers/net/wireless/ath/ath10k/Makefile
++++ b/drivers/net/wireless/ath/ath10k/Makefile
+@@ -18,6 +18,7 @@ ath10k_core-$(CPTCFG_ATH10K_SPECTRAL) +=
+ ath10k_core-$(CPTCFG_NL80211_TESTMODE) += testmode.o
+ ath10k_core-$(CPTCFG_ATH10K_TRACING) += trace.o
+ ath10k_core-$(CPTCFG_ATH10K_THERMAL) += thermal.o
++ath10k_core-$(CPTCFG_ATH10K_LEDS) += leds.o
+ ath10k_core-$(CPTCFG_MAC80211_DEBUGFS) += debugfs_sta.o
+ ath10k_core-$(CONFIG_PM) += wow.o
+ 
+--- a/local-symbols
++++ b/local-symbols
+@@ -144,6 +144,7 @@ ATH10K_DEBUG=
+ ATH10K_DEBUGFS=
+ ATH10K_SPECTRAL=
+ ATH10K_THERMAL=
++ATH10K_LEDS=
+ ATH10K_TRACING=
+ ATH10K_DFS_CERTIFIED=
+ WCN36XX=
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -32,6 +32,7 @@
+ #include "htt.h"
+ #include "testmode.h"
+ #include "wmi-ops.h"
++#include "leds.h"
+ 
+ unsigned int ath10k_debug_mask;
+ static unsigned int ath10k_cryptmode_param;
+@@ -56,6 +57,7 @@ static const struct ath10k_hw_params ath
+ 		.id = QCA988X_HW_2_0_VERSION,
+ 		.dev_id = QCA988X_2_0_DEVICE_ID,
+ 		.name = "qca988x hw2.0",
++		.led_pin = 1,
+ 		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+ 		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
+@@ -80,6 +82,7 @@ static const struct ath10k_hw_params ath
+ 		.id = QCA9887_HW_1_0_VERSION,
+ 		.dev_id = QCA9887_1_0_DEVICE_ID,
+ 		.name = "qca9887 hw1.0",
++		.led_pin = 1,
+ 		.patch_load_addr = QCA9887_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+ 		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
+@@ -199,6 +202,7 @@ static const struct ath10k_hw_params ath
+ 		.id = QCA99X0_HW_2_0_DEV_VERSION,
+ 		.dev_id = QCA99X0_2_0_DEVICE_ID,
+ 		.name = "qca99x0 hw2.0",
++		.led_pin = 17,
+ 		.patch_load_addr = QCA99X0_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+ 		.otp_exe_param = 0x00000700,
+@@ -228,6 +232,7 @@ static const struct ath10k_hw_params ath
+ 		.id = QCA9984_HW_1_0_DEV_VERSION,
+ 		.dev_id = QCA9984_1_0_DEVICE_ID,
+ 		.name = "qca9984/qca9994 hw1.0",
++		.led_pin = 17,
+ 		.patch_load_addr = QCA9984_HW_1_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+ 		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
+@@ -262,6 +267,7 @@ static const struct ath10k_hw_params ath
+ 		.id = QCA9888_HW_2_0_DEV_VERSION,
+ 		.dev_id = QCA9888_2_0_DEVICE_ID,
+ 		.name = "qca9888 hw2.0",
++		.led_pin = 17,
+ 		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
+ 		.uart_pin = 7,
+ 		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
+@@ -2254,6 +2260,10 @@ int ath10k_core_start(struct ath10k *ar,
+ 	if (status)
+ 		goto err_hif_stop;
+ 
++	status = ath10k_leds_start(ar);
++	if (status)
++		goto err_hif_stop;
++
+ 	return 0;
+ 
+ err_hif_stop:
+@@ -2471,9 +2481,18 @@ static void ath10k_core_register_work(st
+ 		goto err_spectral_destroy;
+ 	}
+ 
++	status = ath10k_leds_register(ar);
++	if (status) {
++		ath10k_err(ar, "could not register leds: %d\n",
++			   status);
++		goto err_thermal_unregister;
++	}
++
+ 	set_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags);
+ 	return;
+ 
++err_thermal_unregister:
++	ath10k_thermal_unregister(ar);
+ err_spectral_destroy:
+ 	ath10k_spectral_destroy(ar);
+ err_debug_destroy:
+@@ -2515,6 +2534,8 @@ void ath10k_core_unregister(struct ath10
+ 	if (!test_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags))
+ 		return;
+ 
++	ath10k_leds_unregister(ar);
++
+ 	ath10k_thermal_unregister(ar);
+ 	/* Stop spectral before unregistering from mac80211 to remove the
+ 	 * relayfs debugfs file cleanly. Otherwise the parent debugfs tree
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -24,6 +24,7 @@
+ #include <linux/pci.h>
+ #include <linux/uuid.h>
+ #include <linux/time.h>
++#include <linux/leds.h>
+ 
+ #include "htt.h"
+ #include "htc.h"
+@@ -789,7 +790,6 @@ struct ath10k {
+ 	u32 low_5ghz_chan;
+ 	u32 high_5ghz_chan;
+ 	bool ani_enabled;
+-
+ 	bool p2p;
+ 
+ 	struct {
+@@ -972,6 +972,13 @@ struct ath10k {
+ 	} testmode;
+ 
+ 	struct {
++		struct gpio_led wifi_led;
++		struct led_classdev cdev;
++		char label[48];
++		u32 gpio_state_pin;
++	} leds;
++
++	struct {
+ 		/* protected by data_lock */
+ 		u32 fw_crash_counter;
+ 		u32 fw_warm_reset_counter;
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -490,6 +490,7 @@ struct ath10k_hw_params {
+ 	const char *name;
+ 	u32 patch_load_addr;
+ 	int uart_pin;
++	int led_pin;
+ 	u32 otp_exe_param;
+ 
+ 	/* Type of hw cycle counter wraparound logic, for more info
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath10k/leds.c
+@@ -0,0 +1,103 @@
++/*
++ * Copyright (c) 2005-2011 Atheros Communications Inc.
++ * Copyright (c) 2011-2017 Qualcomm Atheros, Inc.
++ * Copyright (c) 2018 Sebastian Gottschall <s.gottschall@dd-wrt.com>
++ * Copyright (c) 2018, The Linux Foundation. All rights reserved.
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++#include <linux/leds.h>
++
++#include "core.h"
++#include "wmi.h"
++#include "wmi-ops.h"
++
++#include "leds.h"
++
++static int ath10k_leds_set_brightness_blocking(struct led_classdev *led_cdev,
++					       enum led_brightness brightness)
++{
++	struct ath10k *ar = container_of(led_cdev, struct ath10k,
++					 leds.cdev);
++	struct gpio_led *led = &ar->leds.wifi_led;
++
++	mutex_lock(&ar->conf_mutex);
++
++	if (ar->state != ATH10K_STATE_ON)
++		goto out;
++
++	ar->leds.gpio_state_pin = (brightness != LED_OFF) ^ led->active_low;
++	ath10k_wmi_gpio_output(ar, led->gpio, ar->leds.gpio_state_pin);
++
++out:
++	mutex_unlock(&ar->conf_mutex);
++
++	return 0;
++}
++
++int ath10k_leds_start(struct ath10k *ar)
++{
++	if (ar->hw_params.led_pin == 0)
++		/* leds not supported */
++		return 0;
++
++	/* under some circumstances, the gpio pin gets reconfigured
++	 * to default state by the firmware, so we need to
++	 * reconfigure it this behaviour has only ben seen on
++	 * QCA9984 and QCA99XX devices so far
++	 */
++	ath10k_wmi_gpio_config(ar, ar->hw_params.led_pin, 0,
++			       WMI_GPIO_PULL_NONE, WMI_GPIO_INTTYPE_DISABLE);
++	ath10k_wmi_gpio_output(ar, ar->hw_params.led_pin, 1);
++
++	return 0;
++}
++
++int ath10k_leds_register(struct ath10k *ar)
++{
++	int ret;
++
++	if (ar->hw_params.led_pin == 0)
++		/* leds not supported */
++		return 0;
++
++	snprintf(ar->leds.label, sizeof(ar->leds.label), "ath10k-%s",
++		 wiphy_name(ar->hw->wiphy));
++	ar->leds.wifi_led.active_low = 1;
++	ar->leds.wifi_led.gpio = ar->hw_params.led_pin;
++	ar->leds.wifi_led.name = ar->leds.label;
++	ar->leds.wifi_led.default_state = LEDS_GPIO_DEFSTATE_KEEP;
++
++	ar->leds.cdev.name = ar->leds.label;
++	ar->leds.cdev.brightness_set_blocking = ath10k_leds_set_brightness_blocking;
++
++	/* FIXME: this assignment doesn't make sense as it's NULL, remove it? */
++	ar->leds.cdev.default_trigger = ar->leds.wifi_led.default_trigger;
++
++	ret = led_classdev_register(wiphy_dev(ar->hw->wiphy), &ar->leds.cdev);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++void ath10k_leds_unregister(struct ath10k *ar)
++{
++	if (ar->hw_params.led_pin == 0)
++		/* leds not supported */
++		return;
++
++	led_classdev_unregister(&ar->leds.cdev);
++}
++
+--- /dev/null
++++ b/drivers/net/wireless/ath/ath10k/leds.h
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (c) 2018, The Linux Foundation. All rights reserved.
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++#ifndef _LEDS_H_
++#define _LEDS_H_
++
++#include "core.h"
++
++#ifdef CPTCFG_ATH10K_LEDS
++void ath10k_leds_unregister(struct ath10k *ar);
++int ath10k_leds_start(struct ath10k *ar);
++int ath10k_leds_register(struct ath10k *ar);
++#else
++static inline void ath10k_leds_unregister(struct ath10k *ar)
++{
++}
++
++static inline int ath10k_leds_start(struct ath10k *ar)
++{
++	return 0;
++}
++
++static inline int ath10k_leds_register(struct ath10k *ar)
++{
++	return 0;
++}
++
++#endif
++#endif /* _LEDS_H_ */
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -32,6 +32,7 @@
+ #include "wmi-tlv.h"
+ #include "wmi-ops.h"
+ #include "wow.h"
++#include "leds.h"
+ 
+ /*********/
+ /* Rates */
+--- a/drivers/net/wireless/ath/ath10k/wmi-ops.h
++++ b/drivers/net/wireless/ath/ath10k/wmi-ops.h
+@@ -197,6 +197,10 @@ struct wmi_ops {
+ 					(struct ath10k *ar,
+ 					 enum wmi_bss_survey_req_type type);
+ 	struct sk_buff *(*gen_echo)(struct ath10k *ar, u32 value);
++	struct sk_buff *(*gen_gpio_config)(struct ath10k *ar, u32 gpio_num,
++					   u32 input, u32 pull_type, u32 intr_mode);
++ 
++	struct sk_buff *(*gen_gpio_output)(struct ath10k *ar, u32 gpio_num, u32 set);
+ };
+ 
+ int ath10k_wmi_cmd_send(struct ath10k *ar, struct sk_buff *skb, u32 cmd_id);
+@@ -951,6 +955,35 @@ ath10k_wmi_force_fw_hang(struct ath10k *
+ 	return ath10k_wmi_cmd_send(ar, skb, ar->wmi.cmd->force_fw_hang_cmdid);
+ }
+ 
++static inline int ath10k_wmi_gpio_config(struct ath10k *ar, u32 gpio_num,
++					 u32 input, u32 pull_type, u32 intr_mode)
++{
++	struct sk_buff *skb;
++
++	if (!ar->wmi.ops->gen_gpio_config)
++		return -EOPNOTSUPP;
++
++	skb = ar->wmi.ops->gen_gpio_config(ar, gpio_num, input, pull_type, intr_mode);
++	if (IS_ERR(skb))
++		return PTR_ERR(skb);
++
++	return ath10k_wmi_cmd_send(ar, skb, ar->wmi.cmd->gpio_config_cmdid);
++}
++
++static inline int ath10k_wmi_gpio_output(struct ath10k *ar, u32 gpio_num, u32 set)
++{
++	struct sk_buff *skb;
++
++	if (!ar->wmi.ops->gen_gpio_config)
++		return -EOPNOTSUPP;
++
++	skb = ar->wmi.ops->gen_gpio_output(ar, gpio_num, set);
++	if (IS_ERR(skb))
++		return PTR_ERR(skb);
++
++	return ath10k_wmi_cmd_send(ar, skb, ar->wmi.cmd->gpio_output_cmdid);
++}
++
+ static inline int
+ ath10k_wmi_dbglog_cfg(struct ath10k *ar, u64 module_enable, u32 log_level)
+ {
+--- a/drivers/net/wireless/ath/ath10k/wmi-tlv.c
++++ b/drivers/net/wireless/ath/ath10k/wmi-tlv.c
+@@ -3619,6 +3619,8 @@ static const struct wmi_ops wmi_tlv_ops
+ 	.gen_echo = ath10k_wmi_tlv_op_gen_echo,
+ 	.gen_vdev_spectral_conf = ath10k_wmi_tlv_op_gen_vdev_spectral_conf,
+ 	.gen_vdev_spectral_enable = ath10k_wmi_tlv_op_gen_vdev_spectral_enable,
++	/* .gen_gpio_config not implemented */
++	/* .gen_gpio_output not implemented */
+ };
+ 
+ static const struct wmi_peer_flags_map wmi_tlv_peer_flags_map = {
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -6575,6 +6575,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
+ 	return skb;
+ }
+ 
++static struct sk_buff *ath10k_wmi_op_gen_gpio_config(struct ath10k *ar,
++						     u32 gpio_num, u32 input,
++						     u32 pull_type, u32 intr_mode)
++{
++	struct wmi_gpio_config_cmd *cmd;
++	struct sk_buff *skb;
++
++	skb = ath10k_wmi_alloc_skb(ar, sizeof(*cmd));
++	if (!skb)
++		return ERR_PTR(-ENOMEM);
++
++	cmd = (struct wmi_gpio_config_cmd *)skb->data;
++	cmd->pull_type = __cpu_to_le32(pull_type);
++	cmd->gpio_num = __cpu_to_le32(gpio_num);
++	cmd->input = __cpu_to_le32(input);
++	cmd->intr_mode = __cpu_to_le32(intr_mode);
++
++	ath10k_dbg(ar, ATH10K_DBG_WMI, "wmi gpio_config gpio_num 0x%08x input 0x%08x pull_type 0x%08x intr_mode 0x%08x\n",
++		   gpio_num, input, pull_type, intr_mode);
++
++	return skb;
++}
++
++static struct sk_buff *ath10k_wmi_op_gen_gpio_output(struct ath10k *ar,
++						     u32 gpio_num, u32 set)
++{
++	struct wmi_gpio_output_cmd *cmd;
++	struct sk_buff *skb;
++
++	skb = ath10k_wmi_alloc_skb(ar, sizeof(*cmd));
++	if (!skb)
++		return ERR_PTR(-ENOMEM);
++
++	cmd = (struct wmi_gpio_output_cmd *)skb->data;
++	cmd->gpio_num = __cpu_to_le32(gpio_num);
++	cmd->set = __cpu_to_le32(set);
++
++	ath10k_dbg(ar, ATH10K_DBG_WMI, "wmi gpio_output gpio_num 0x%08x set 0x%08x\n",
++		   gpio_num, set);
++
++	return skb;
++}
++
+ static struct sk_buff *
+ ath10k_wmi_op_gen_set_psmode(struct ath10k *ar, u32 vdev_id,
+ 			     enum wmi_sta_ps_mode psmode)
+@@ -8076,6 +8119,9 @@ static const struct wmi_ops wmi_ops = {
+ 	.fw_stats_fill = ath10k_wmi_main_op_fw_stats_fill,
+ 	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
+ 	.gen_echo = ath10k_wmi_op_gen_echo,
++	.gen_gpio_config = ath10k_wmi_op_gen_gpio_config,
++	.gen_gpio_output = ath10k_wmi_op_gen_gpio_output,
++
+ 	/* .gen_bcn_tmpl not implemented */
+ 	/* .gen_prb_tmpl not implemented */
+ 	/* .gen_p2p_go_bcn_ie not implemented */
+@@ -8146,6 +8192,8 @@ static const struct wmi_ops wmi_10_1_ops
+ 	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
+ 	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
+ 	.gen_echo = ath10k_wmi_op_gen_echo,
++	.gen_gpio_config = ath10k_wmi_op_gen_gpio_config,
++	.gen_gpio_output = ath10k_wmi_op_gen_gpio_output,
+ 	/* .gen_bcn_tmpl not implemented */
+ 	/* .gen_prb_tmpl not implemented */
+ 	/* .gen_p2p_go_bcn_ie not implemented */
+@@ -8217,6 +8265,8 @@ static const struct wmi_ops wmi_10_2_ops
+ 	.gen_delba_send = ath10k_wmi_op_gen_delba_send,
+ 	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
+ 	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
++	.gen_gpio_config = ath10k_wmi_op_gen_gpio_config,
++	.gen_gpio_output = ath10k_wmi_op_gen_gpio_output,
+ 	/* .gen_pdev_enable_adaptive_cca not implemented */
+ };
+ 
+@@ -8287,6 +8337,8 @@ static const struct wmi_ops wmi_10_2_4_o
+ 	.gen_pdev_enable_adaptive_cca =
+ 		ath10k_wmi_op_gen_pdev_enable_adaptive_cca,
+ 	.get_vdev_subtype = ath10k_wmi_10_2_4_op_get_vdev_subtype,
++	.gen_gpio_config = ath10k_wmi_op_gen_gpio_config,
++	.gen_gpio_output = ath10k_wmi_op_gen_gpio_output,
+ 	/* .gen_bcn_tmpl not implemented */
+ 	/* .gen_prb_tmpl not implemented */
+ 	/* .gen_p2p_go_bcn_ie not implemented */
+@@ -8362,6 +8414,8 @@ static const struct wmi_ops wmi_10_4_ops
+ 	.gen_pdev_bss_chan_info_req = ath10k_wmi_10_2_op_gen_pdev_bss_chan_info,
+ 	.gen_echo = ath10k_wmi_op_gen_echo,
+ 	.gen_pdev_get_tpc_config = ath10k_wmi_10_2_4_op_gen_pdev_get_tpc_config,
++	.gen_gpio_config = ath10k_wmi_op_gen_gpio_config,
++	.gen_gpio_output = ath10k_wmi_op_gen_gpio_output,
+ };
+ 
+ int ath10k_wmi_attach(struct ath10k *ar)
+--- a/drivers/net/wireless/ath/ath10k/wmi.h
++++ b/drivers/net/wireless/ath/ath10k/wmi.h
+@@ -2899,6 +2899,41 @@ enum wmi_10_4_feature_mask {
+ 
+ };
+ 
++/* WMI_GPIO_CONFIG_CMDID */
++enum {
++	WMI_GPIO_PULL_NONE,
++	WMI_GPIO_PULL_UP,
++	WMI_GPIO_PULL_DOWN,
++};
++
++enum {
++	WMI_GPIO_INTTYPE_DISABLE,
++	WMI_GPIO_INTTYPE_RISING_EDGE,
++	WMI_GPIO_INTTYPE_FALLING_EDGE,
++	WMI_GPIO_INTTYPE_BOTH_EDGE,
++	WMI_GPIO_INTTYPE_LEVEL_LOW,
++	WMI_GPIO_INTTYPE_LEVEL_HIGH
++};
++
++/* WMI_GPIO_CONFIG_CMDID */
++struct wmi_gpio_config_cmd {
++	__le32 gpio_num;             /* GPIO number to be setup */
++	__le32 input;                /* 0 - Output/ 1 - Input */
++	__le32 pull_type;            /* Pull type defined above */
++	__le32 intr_mode;            /* Interrupt mode defined above (Input) */
++} __packed;
++
++/* WMI_GPIO_OUTPUT_CMDID */
++struct wmi_gpio_output_cmd {
++	__le32 gpio_num;    /* GPIO number to be setup */
++	__le32 set;         /* Set the GPIO pin*/
++} __packed;
++
++/* WMI_GPIO_INPUT_EVENTID */
++struct wmi_gpio_input_event {
++	__le32 gpio_num;    /* GPIO number which changed state */
++} __packed;
++
+ struct wmi_ext_resource_config_10_4_cmd {
+ 	/* contains enum wmi_host_platform_type */
+ 	__le32 host_platform_config;


### PR DESCRIPTION
Currently if someone try to set 160 mhz on 5ghz, the firmware crash. Patch 972 and 973 fix this problem.
Also 974 introduce support for leds handled by the wireless chipset.

Tested on r7800

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>