### PR TITLE
include/image-commands.mk: shorter version in Netgear factory header (FS#1583)

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -60,7 +60,7 @@ endef
 
 define Build/netgear-dni
 	$(STAGING_DIR_HOST)/bin/mkdniimg \
-		-B $(NETGEAR_BOARD_ID) -v $(VERSION_DIST).$(REVISION) \
+		-B $(NETGEAR_BOARD_ID) -v $(VERSION_DIST).$(firstword $(subst -, ,$(REVISION))) \
 		$(if $(NETGEAR_HW_ID),-H $(NETGEAR_HW_ID)) \
 		-r "$(1)" \
 		-i $@ -o $@.new


### PR DESCRIPTION
Shorten the version string in Netgear factory image header in order to enable u-boot TFTP recovery flash mode to work again.

Other option could be to force a shorter hash in scripts/getver.sh, but as the problem only concerns Netgear routers, let's patch just them, as discussed with @nbd168 in #1063

Strip 'r7210-14cb05909a' into 'r7210' in the Netgear image header by removing the hash (anything after "-").

Note: this bug also affects 18.06, so the fix should be backported.

Tested with WNDR3800

**Background:**

Some Netgear routers have recently been unable to flash Openwrt factory image with the TFTP recovery flash mode provided by Netgear u-boot. That is due to over-long Openwrt version string overflowing
into the router type string in u-boot code. Modern git versions produce 10-digit short hashes for the Openwrt main repo, and that causes the version string to be too long in the image header, breaking the image ID verification by the TFTP flash routine.

master and 18.06 are affected if the image has been built with a buildhost with modern git producing 10-digit hash as they are branded "Openwrt", but 17.01 is not affected as it is "LEDE" = 3 chars shorter name.

**More detailed explanations in FS#1583  and below:**

The number of digits in hash returned by git depends on the amount of commits in the repository since git 2.11.

Some Netgear routers have recently been unable to flash Openwrt factory image with the TFTP recovery flash mode provided by Netgear u-boot. That is due to over-long Openwrt version string overflowing into the router type string in u-boot code.

Currently Openwrt buildbot slaves mostly set 7 digit hashes as they have ancient git versions, so the buildbot images are mostly usable, but private buildhosts with modern git return 10 digits for the Openwrt main repo hash.

master and 18.06 are affected if the image has been built with 10-digit hash as they are branded "Openwrt", but 17.01 is not affected as it is "LEDE" = 3 chars shorter name.

Master and 18.06 get fixed by forcing 7-digit hash, as that shortens the generated full version name in image header by just enough chars.

I have noticed the problem with WNDR3800 and R7800, but I am sure that most Netgear routers that provide the TFTP mode in u-boot are affected.

Does not work:
```
master
device:WNDR3800 version:VOpenWrt.r7161-c8677ca89e region: hd_id:29763654+16+128
18.06
device:WNDR3800 version:VOpenWrt.r6995-ba204d941c region: hd_id:29763654+16+128
```

Works:

```
master, this PR, no hash:
device:WNDR3800 version:VOpenWrt.r7210 region: hd_id:29763654+16+128
master, with short 7-digit hash
device:WNDR3800 version:VOpenWrt.r7161-c8677ca region: hd_id:29763654+16+128
17.01, my build
device:WNDR3800 version:VLEDE.r3898-4a38c0cad5 region: hd_id:29763654+16+128
master buildbot:
device:WNDR3800 version:VOpenWrt.r7161-c8677ca region: hd_id:29763654+16+128
17.01 buildbot:
device:WNDR3800 version:VLEDE.r3909-b6a1f43 region: hd_id:29763654+16+128
```
