### PR TITLE
ath79: fix rx ring buffer stall  qca956x

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -637,7 +637,8 @@ __ag71xx_link_adjust(struct ag71xx *ag, bool update)
 	ag71xx_wr(ag, AG71XX_REG_FIFO_CFG5, fifo5);
 	ag71xx_wr(ag, AG71XX_REG_MAC_IFCTL, ifctl);
 
-	if (of_device_is_compatible(np, "qca,qca9530-eth")) {
+	if (of_device_is_compatible(np, "qca,qca9530-eth") ||
+	    of_device_is_compatible(np, "qca,qca9560-eth")) {
 		/*
 		 * The rx ring buffer can stall on small packets on QCA953x and
 		 * QCA956x. Disabling the inline checksum engine fixes the stall.


### PR DESCRIPTION
when ported from ar71xx to ath79 the qca9560-eth was omitted

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
