### PR TITLE
dnsmasq: Delay init to avoid race conditions

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1068,6 +1068,7 @@ boot()
 }
 
 start_service() {
+	sleep 5
 	local instance="$1"
 	local instance_found=0
 


### PR DESCRIPTION
Delay startup of dnsmasq so interfaces have time to initialize
Fixes FS#1542 (and yes, it's ugly) :-)

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>