### PR TITLE
arAdd support for Mikrotik Routerboard wAP R

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -111,6 +111,7 @@ ar71xx_setup_interfaces()
 	rb-sxt2n|\
 	rb-sxt5n|\
 	rb-wap-2nd|\
+	rb-wapr-2nd|\
 	rb-wapg-5hact2hnd|\
 	re355|\
 	re450|\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1079,6 +1079,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD wAP 2nD r2")
 		name="rb-wap-2nd"
 		;;
+	*"RouterBOARD wAP R-2nD")
+		name="rb-wapr-2nd"
+		;;
 	*"RouterBOARD wAP G-5HacT2HnD")
 		name="rb-wapg-5hact2hnd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -703,7 +703,8 @@ platform_check_image() {
 	rb-map-2nd|\
 	rb-mapl-2nd|\
 	rb-wap-2nd|\
-	rb-wapg-5hact2hnd)
+	rb-wapg-5hact2hnd|\
+	rb-wapr-2nd)
 		return 0
 		;;
 	esac
@@ -729,7 +730,8 @@ platform_pre_upgrade() {
 	rb-map-2nd|\
 	rb-mapl-2nd|\
 	rb-wap-2nd|\
-	rb-wapg-5hact2hnd)
+	rb-wapg-5hact2hnd|\
+	rb-wapr-2nd)
 		# erase firmware if booted from initramfs
 		[ -z "$(rootfs_type)" ] && mtd erase firmware
 		;;

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1143,6 +1143,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
 	  MikroTik RouterBOARD wAP
+	  MikroTik RouterBOARD wAP R-2nD
 
 config ATH79_MACH_RBSXTLITE
 	bool "MikroTik RouterBOARD SXT Lite"

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -15,6 +15,7 @@
  *  - MikroTik RouterBOARD LHG 5nD
  *  - MikroTik RouterBOARD wAP2nD
  *  - MikroTik RouterBOARD wAP G-5HacT2HnDwAP (wAP AC)
+ *  - MikroTik RouterBOARD wAP R-2nD
  *
  *  Preliminary support for the following hardware
  *  - MikroTik RouterBOARD cAP2nD
@@ -1119,6 +1120,7 @@ MIPS_MACHINE_NONAME(ATH79_MACH_RB_962, "962", rb962_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_750UPR2, "750-hb", rb750upr2_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_LHG5, "lhg", rblhg_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAP, "wap-hb", rbwap_setup);
+MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAPR, "wap-lte", rbwap_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_CAP, "cap-hb", rbcap_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_MAP, "map2-hb", rbmap_setup);
 MIPS_MACHINE_NONAME(ATH79_MACH_RB_WAPAC, "wapg-sc", rbwapgsc_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -218,6 +218,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_MAP,			/* Mikrotik RouterBOARD mAP2nD */
 	ATH79_MACH_RB_MAPL,			/* Mikrotik RouterBOARD mAP L-2nD */
 	ATH79_MACH_RB_WAP,			/* Mikrotik RouterBOARD wAP2nD */
+	ATH79_MACH_RB_WAPR,			/* Mikrotik RouterBOARD wAPR2nD */
 	ATH79_MACH_RB_WAPAC,			/* Mikrotik RouterBOARD wAPG-5HacT2HnD */
 	ATH79_MACH_RB_SXTLITE2ND,		/* Mikrotik RouterBOARD SXT Lite 2nD */
 	ATH79_MACH_RB_SXTLITE5ND,		/* Mikrotik RouterBOARD SXT Lite 5nD */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -40,7 +40,7 @@ define Device/rb-nor-flash-16M
   LOADER_TYPE := elf
   KERNEL_INSTALL := 1
   KERNEL := kernel-bin | lzma | loader-kernel
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.9/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,31 @@ void __init prom_init(void)
+@@ -136,6 +136,32 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -22,6 +22,7 @@
 +	    strstr(arcs_cmdline, "board=map-hb") ||
 +	    strstr(arcs_cmdline, "board=map2-hb") ||
 +	    strstr(arcs_cmdline, "board=wap-hb") ||
++	    strstr(arcs_cmdline, "board=wap-lte") ||
 +	    strstr(arcs_cmdline, "board=wapg-sc") ||
 +	    strstr(arcs_cmdline, "board=2011L") ||
 +	    strstr(arcs_cmdline, "board=2011r") ||


### PR DESCRIPTION
This commit adds support for the Mikrotik wAP R (RBwAPR-2nD). The change
is based on 3b15eb0 which added support for the wAP 2nD. This change lacks
LED support.

Specifications:

- SoC: Qualcomm QCA9531 (650 MHz)
- RAM: 64 MB
- Storage: 16 MB NOR SPI flash
- Wireless: built-in QCA9531, 802.11b/g/n 2x2:2
- Ethernet: 1x100Mbps
- Power: 9-30V Passive PoE, 9-30V DC jack, 9-30V automotive jack
- SIM card slot
- Mini-PCIe slot

Installation:

1. Login to the Mikrotik WebUI to backup your licence key
2. Change the following settings in System->Routerboard->Settings:
  - Boot device: try ethernet once then NAND
  - Boot protocol: DHCP
  - Force Backup Booter: checked
3. Setup a DHCP/BOOTP server with:
  - DHCP-Option 66 (TFTP server name) pointing to a local TFTP
    server within the same subnet of the DHCP range
  - DHCP-Option 67 (Bootfile-Name) matching the initramfs filename
    of the to be booted image, e.g.
    openwrt-ar71xx-mikrotik-vmlinux-initramfs.elf
4. Power off the device
5. If this is the second attempt to boot OpenWRT or the boot device isn't
   "try ethernet once then NAND," press and hold the reset button while
   powered off. If this is the first attempt, this step isn't necessary.
6. Power on the device, holding the reset button for 15-20s if already
   pressed from the previous step.

The board should load and start the initramfs image from the TFTP
server. Login as root/without password to the started OpenWRT via SSH
listing on IPv4 address 192.168.1.1. Use sysupgrade to install OpenWRT.

Revert to RouterOS

Use the "rbcfg" package on in OpenWRT:
- rbcfg set boot_protocol bootp
- rbcfg set boot_device ethnand
- rbcfg apply

Open Netinstall and reboot routerboard. Now Netinstall sees RouterBOARD
and you can install RouterOS. If NetInstall gets stuck on Sending offer
just wait for it to timeout and then close and open Netinstall again.

Click on install again.

In order for RouterOS to function properly, you need to restore license
for the device. You can do that by including license in NetInstall.

Signed-off-by: David Ehrmann <ehrmann@gmail.com>