### PR TITLE
octeon: Add and set CPU type Octeon+ as default

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -176,6 +176,7 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_24kc = -mips32r2 -mtune=24kc
     CPU_CFLAGS_74kc = -mips32r2 -mtune=74kc
     CPU_CFLAGS_octeon = -march=octeon -mabi=64
+    CPU_CFLAGS_octeonplus = -march=octeon+ -mabi=64
   endif
   ifeq ($(ARCH),i386)
     CPU_TYPE ?= pentium

--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -10,7 +10,7 @@ ARCH:=mips64
 BOARD:=octeon
 BOARDNAME:=Cavium Networks Octeon
 FEATURES:=squashfs ramdisk pci usb
-CPU_TYPE:=octeon
+CPU_TYPE:=octeonplus
 MAINTAINER:=John Crispin <john@phrozen.org>
 
 KERNEL_PATCHVER:=4.14


### PR DESCRIPTION
The lowest CPU type used by supported Octeon platform
is Octeon+ (EdgeRouter Lite) while EdgeRouter Pro/ER-8 uses
Octeon II which is backwards compatible with Octeon+.

Sources:
https://community.ubnt.com/t5/EdgeRouter/EdgeRouter-Pro-CPU/td-p/654599
https://www.cavium.com/octeon-II-CN68XX.html
"OCTEON II family is fully software compatible with the widely-adopted
OCTEON Plus family"

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>