### PR TITLE
ramips: add missing package for YouHua WR1200JS

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -352,7 +352,7 @@ define Device/youhua_wr1200js
   IMAGE_SIZE := 16064k
   DEVICE_TITLE := YouHua WR1200JS
   DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini
 endef
 TARGET_DEVICES += youhua_wr1200js
 


### PR DESCRIPTION
The default build has no wifi support because of lacking the wpad-mini package.
Please cherry-pick this commit to branch openwrt-18.06 also.
