### PR TITLE
ath10k-ct: reduce memory consumption

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct
-PKG_RELEASE=2
+PKG_RELEASE=3
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=

--- a/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
+++ b/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
@@ -1,0 +1,11 @@
+--- a/ath10k-4.13/htt.h
++++ b/ath10k-4.13/htt.h
+@@ -199,7 +199,7 @@ enum htt_rx_ring_flags {
+ };
+ 
+ #define HTT_RX_RING_SIZE_MIN 128
+-#define HTT_RX_RING_SIZE_MAX 2048
++#define HTT_RX_RING_SIZE_MAX 512
+ 
+ struct htt_rx_ring_setup_ring {
+ 	__le32 fw_idx_shadow_reg_paddr;

--- a/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
+++ b/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
@@ -1,0 +1,38 @@
+--- a/ath10k-4.13/pci.c
++++ b/ath10k-4.13/pci.c
+@@ -128,7 +128,7 @@ static struct ce_attr host_ce_config_wla
+ 		.flags = CE_ATTR_FLAGS,
+ 		.src_nentries = 0,
+ 		.src_sz_max = 2048,
+-		.dest_nentries = 512,
++		.dest_nentries = 128,
+ 		.recv_cb = ath10k_pci_htt_htc_rx_cb,
+ 	},
+ 
+@@ -137,7 +137,7 @@ static struct ce_attr host_ce_config_wla
+ 		.flags = CE_ATTR_FLAGS,
+ 		.src_nentries = 0,
+ 		.src_sz_max = 2048,
+-		.dest_nentries = 128,
++		.dest_nentries = 64,
+ 		.recv_cb = ath10k_pci_htc_rx_cb,
+ 	},
+ 
+@@ -164,7 +164,7 @@ static struct ce_attr host_ce_config_wla
+ 		.flags = CE_ATTR_FLAGS,
+ 		.src_nentries = 0,
+ 		.src_sz_max = 512,
+-		.dest_nentries = 512,
++		.dest_nentries = 128,
+ 		.recv_cb = ath10k_pci_htt_rx_cb,
+ 	},
+ 
+@@ -189,7 +189,7 @@ static struct ce_attr host_ce_config_wla
+ 		.flags = CE_ATTR_FLAGS,
+ 		.src_nentries = 0,
+ 		.src_sz_max = 2048,
+-		.dest_nentries = 128,
++		.dest_nentries = 96,
+ 		.recv_cb = ath10k_pci_pktlog_rx_cb,
+ 	},
+ 


### PR DESCRIPTION
ath10k uses a rather high number of buffers to communicate with the QCA firmware. Especially the HTC (host-target-communication) and HTT (host-target-transport) can take up a lot of memory when data is transferred over a ath10k wifi link.

This problem was already worked around in commit cc189c0b7fa0 ("mac80211: enable ath10k AHB support for QCA4019") for the ath10k driver from mac80211. But this change was forgotton for the ath10k-ct driver.
