### PR TITLE
config: add config option for KERNEL_TASKSTATS

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -65,6 +65,27 @@ config KERNEL_PROFILING
 	  Enable the extended profiling support mechanisms used by profilers such
 	  as OProfile.
 
+config KERNEL_TASKSTATS
+	bool "Compile the kernel with task resource/io statistics and accounting"
+	default n
+	help
+	  Enable the collection and publishing of task/io statistics and
+	  accounting.  Enable this option to enable i/o monitoring in system
+	  monitors.
+
+if KERNEL_TASKSTATS
+
+	config KERNEL_TASK_DELAY_ACCT
+		def_bool y
+
+	config KERNEL_TASK_IO_ACCOUNTING
+		def_bool y
+
+	config KERNEL_TASK_XACCT
+		def_bool y
+
+endif
+
 config KERNEL_KALLSYMS
 	bool "Compile the kernel with symbol table information"
 	default y if !SMALL_FLASH


### PR DESCRIPTION
In order for monitoring tools such as atop and htop to track and report
i/o data, kernel support for task statistics and io accounting is
required.

Add a config option to enable building this support in the kernel.

The following kernel options are enabled with this option:
```
KERNEL_TASKSTATS
KERNEL_TASK_DELAY_ACCT
KERNEL_TASK_IO_ACCOUNTING
KERNEL_TASK_XACCT
```
This addition enables i/o stats in monitoring tools.  Adding a config option is for the convenience of enabling these features from a seed instead of modifying the kernel config.