### PR TITLE
ramips: Add support for Phicomm K2G

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -308,6 +308,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 		"1:lan:2" "2:lan:1" "4:wan" "6@eth0"
 		;;
+	phicomm,k2g)
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5:wan" "6@eth0"
+		;;
 	re350-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
@@ -506,7 +510,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(mtd_get_mac_binary factory 46)
 		;;
-	oy-0001)
+	oy-0001|\
+	phicomm,k2g)
 		lan_mac=$(mtd_get_mac_binary factory 40)
 		wan_mac=$(mtd_get_mac_binary factory 46)
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -161,6 +161,7 @@ get_status_led() {
 		status_led="$boardname:blue:power"
 		;;
 	dlink,dap-1522-a1|\
+	phicomm,k2g|\
 	k2p|\
 	m3|\
 	mir3g|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -122,6 +122,7 @@ platform_check_image() {
 	oy-0001|\
 	pbr-d1|\
 	pbr-m1|\
+	phicomm,k2g|\
 	psg1208|\
 	psg1218a|\
 	psg1218b|\

--- a/target/linux/ramips/dts/K2G.dts
+++ b/target/linux/ramips/dts/K2G.dts
@@ -1,0 +1,139 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "phicomm,k2g", "ralink,mt7620a-soc";
+	model = "Phicomm K2G";
+
+	aliases {
+		serial0 = &uartlite;
+		led-status = &led_blue;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		led_blue: blue {
+			label = "k2g:blue:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		yellow {
+			label = "k2g:yellow:status";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		red {
+			label = "k2g:red:status";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			u-boot@0 {
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			u-boot-env@30000 {
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: factory@40000 {
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			permanent_config@50000 {
+				reg = <0x50000 0x50000>;
+				read-only;
+			};
+
+			firmware@a0000 {
+				reg = <0xa0000 0x760000>;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+	mtd-mac-address = <&factory 0x28>;
+	mediatek,portmap = "llllw";
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -431,6 +431,14 @@ define Device/psg1218b
 endef
 TARGET_DEVICES += psg1218b
 
+define Device/phicomm_k2g
+  DTS := K2G
+  IMAGE_SIZE := 7733248
+  DEVICE_TITLE := Phicomm K2G
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += phicomm_k2g
+
 define Device/rp-n53
   DTS := RP-N53
   DEVICE_TITLE := Asus RP-N53


### PR DESCRIPTION
Specification:
- SoC: MediaTek MT7620A
- Flash: 8 MB
- RAM: 64 MB
- Ethernet: 4 FE ports and 1 GE port (RTL8211F on port 5)
- Wireless radio: MT7620 for 2.4G and MT7612E for 5G, both equipped with external PA.
- UART: 1 x UART on PCB - 57600 8N1

Flash instruction:
The U-boot is based on Ralink SDK so we can flash the firmware using UART:
1. Configure PC with a static IP address and setup an TFTP server.
2. Put the firmware into the tftp directory.
3. Connect the UART line as described on the PCB.
4. Power up the device and press 2, follow the instruction to
   set device and tftp server IP address and input the firmware
   file name. U-boot will then load the firmware and write it into
   the flash.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
