### PR TITLE
ramips: fix Newifi D1 mtd partition

### DIFF
--- a/target/linux/ramips/dts/Newifi-D1.dts
+++ b/target/linux/ramips/dts/Newifi-D1.dts
@@ -106,7 +106,7 @@
 
 		partition@50000 {
 			label = "firmware";
-			reg = <0x50000 0x2000000>;
+			reg = <0x50000 0x1fb0000>;
 		};
 	};
 };


### PR DESCRIPTION
Newifi D1 has 32 MiB flash, so the firmware partition size should be `0x1fb0000`