### PR TITLE
ramips: add support for Netgear AC 1200 R6120

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -115,6 +115,16 @@ define Build/tplink-safeloader
 		$(if $(findstring sysupgrade,$(word 1,$(1))),-S) && mv $@.new $@ || rm -f $@
 endef
 
+define Build/mksercommfw
+	-$(STAGING_DIR_HOST)/bin/mksercommfw \
+		$@ \
+		$(KERNEL_OFFSET) \
+		$(HWID) \
+		$(HWVER) \
+		$(SWVER)
+endef
+
+
 define Build/append-dtb
 	cat $(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb >> $@
 endef

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -313,6 +313,11 @@ mzk-ex750np)
 na930)
 	set_usb_led "$boardname:blue:status"
 	;;
+netgear,r6120)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
+	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "$boardname:green:wlan5g" "phy1tpt"
+	;;
 newifi-d1)
 	set_usb_led "$boardname:red:status"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -103,6 +103,7 @@ ramips_setup_interfaces()
 	mzk-750dhp|\
 	mzk-w300nh2|\
 	d-team,newifi-d2|\
+	netgear,r6120|\
 	nixcore-x1-8M|\
 	nixcore-x1-16M|\
 	oy-0001|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -131,6 +131,7 @@ platform_check_image() {
 	psr-680w|\
 	px-4885-4M|\
 	px-4885-8M|\
+	netgear,r6120|\
 	rb750gr3|\
 	re6500|\
 	rp-n53|\

--- a/target/linux/ramips/dts/R6120.dts
+++ b/target/linux/ramips/dts/R6120.dts
@@ -1,0 +1,144 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6120", "mediatek,mt7628an-soc";
+	model = "Netgear AC1200 R6120";
+
+	aliases {
+		led-status = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "r6120:green:lan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "r6120:green:power";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "r6120:green:wlan2g";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_orange {
+			label = "r6120:orange:wlan2g";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5 {
+			label = "r6120:green:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5_orange {
+			label = "r6120:orange:wlan5g";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p1led_an", "p2led_an",
+				       "p3led_an", "p4led_an", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x20000>;
+			read-only;
+		};
+
+		nvram: partition@60000 {
+			label = "nvram";
+			reg = <0x60000 0x30000>;
+			read-only;
+		};
+
+		partition@90000 {
+			label = "firmware";
+			reg = <0x90000 0xf60000>;
+		};
+
+		partition@ff0000 {
+			label = "reserved";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&nvram 0x100B0>;
+	mediatek,mtd-eeprom = <&factory 0x20000>;
+};
+
+&ethernet {
+	mtd-mac-address = <&nvram 0x100B0>;
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x28000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+			mtd-mac-address = <&nvram 0x100B0>;
+			mtd-mac-address-increment = <(2)>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -90,6 +90,23 @@ define Device/mt7628
 endef
 TARGET_DEVICES += mt7628
 
+define Device/netgear_r6120
+  DTS := R6120
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Netgear AC1200 R6120
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  HWID := CGQ
+  KERNEL_OFFSET := 90000
+  HWVER := A001
+  SWVER := 0040
+  IMAGE/default := append-kernel | pad-to 64k | append-rootfs | pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGES += factory.img
+  IMAGE/factory.img := $$(IMAGE/default) | mksercommfw
+endef
+TARGET_DEVICES += netgear_r6120
+
 define Device/omega2
   DTS := OMEGA2
   IMAGE_SIZE := $(ralink_default_fw_size_16M)

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -84,6 +84,7 @@ define Host/Compile
 	$(call cc,mkdhpimg buffalo-lib, -Wall)
 	$(call cc,mkdlinkfw mkdlinkfw-lib, -lz -Wall --std=gnu99)
 	$(call cc,dns313-header, -Wall)
+	$(call cc,mksercommfw, -Wall --std=gnu99)
 endef
 
 define Host/Install

--- a/tools/firmware-utils/src/mksercommfw.c
+++ b/tools/firmware-utils/src/mksercommfw.c
@@ -1,0 +1,254 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+/* #define DEBUG 1 */
+
+/*
+ * Fw Header Layout for Netgear / Sercomm devices
+ * */
+static const char *magic = "sErCoMm"; /* 7 */
+/* 7-11: version control/download control ? */
+unsigned char version[4] = {0x00, 0x01, 0x00, 0x00};
+char *hwID = ""; /* 11-43 , ASCII/HEX */
+char *hwVer = ""; /* 44-57 , ASCII/HEX */
+char *swVer = ""; /* 58-62 , ASCII/HEX */
+/* magic again. */
+
+#define HEADER_SIZE 71
+
+/* null bytes until 511 */
+u_int32_t checksum = 0xFF; /* checksum */
+/* 512 onwards -> ZIP containing rootfs with the same Header */
+
+
+/* appended on rootfs for the Header. */
+const int footer_size = 128;
+
+struct file_info {
+	char		*file_name;	/* name of the file */
+	char		*file_data;	/* data of the file in memory */
+	u_int32_t	 file_size;	/* length of the file */
+};
+
+u_int8_t getCheckSum(char *data, int len)
+{
+
+	int32_t previous = 0;
+	u_int32_t new = 0;
+
+	for (u_int32_t i = 0; i < len; i++) {
+		new = (data[i] + previous) % 256;
+		previous = new | previous & -256;
+	}
+	return (u_int8_t) new;
+}
+
+void *bufferFile(struct file_info *finfo, int dontload)
+{
+	int fs = 0;
+	FILE *f = NULL;
+
+#ifdef DEBUG
+	printf("Opening file: %s\n", finfo->file_name);
+#endif
+	f = fopen(finfo->file_name, "rb");
+	if (f == NULL) {
+		perror("Error");
+		exit(1);
+	}
+
+	fseek(f, 0L, SEEK_END);
+	fs = ftell(f);
+	rewind(f);
+
+#ifdef DEBUG
+	printf("Filesize: %i .\n", fs);
+#endif
+
+	finfo->file_size = fs;
+
+	if (dontload) {
+		return 0;
+	}
+
+	char *data = malloc(fs);
+	finfo->file_data = data;
+
+	int read = fread(data, fs, 1, f);
+
+	if (read != 1) {
+		printf("Error reading file %s.", finfo->file_name);
+		exit(1);
+	}
+
+#ifdef DEBUG
+	printf("File: read successfully %i bytes.\n", read*fs);
+#endif
+	fclose(f);
+}
+
+void *writeFile(struct file_info *finfo)
+{
+
+#ifdef DEBUG
+	printf("Writing file: %s.\n", finfo->file_name);
+#endif
+
+	FILE *fout = fopen(finfo->file_name, "w");
+
+	if (!fwrite(finfo->file_data, finfo->file_size, 1, fout)) {
+		printf("Wanted to write, but something went wrong.\n");
+		fclose(fout);
+		exit(1);
+	}
+	fclose(fout);
+}
+
+void *rmFile(struct file_info *finfo)
+{
+	remove(finfo->file_name);
+	free(finfo->file_data);
+	finfo->file_size = 0;
+}
+
+void *usage(char *argv[])
+{
+	printf("Usage: %s <sysupgradefile> <kernel_offset> <HWID> <HWVER> <SWID>\n"
+		"All are positional arguments ...	\n"
+		"	sysupgradefile:		File with the kernel uimage at 0\n"
+		"	kernel_offset:		Offset in Hex where the kernel is located\n"
+		"	HWID:			Hardware ID, ASCII\n"
+		"	HWVER:			Hardware Version, ASCII\n"
+		"	SWID:			Software Version, Hex\n"
+		"	\n"
+		"	", argv[0]);
+}
+
+int main(int argc, char *argv[])
+{
+	printf("Building fw image for sercomm devices.\n");
+
+	if (argc == 2) {
+		struct file_info myfile = {argv[1], 0, 0};
+		bufferFile(&myfile, 0);
+		char chksum = getCheckSum(myfile.file_data, myfile.file_size);
+		printf("Checksum for File: %X.\n", chksum);
+		return;
+	}
+
+	if (argc != 6) {
+		usage(argv);
+		return 1;
+	}
+
+	/* Args */
+
+	struct file_info sysupgrade = {argv[1], 0, 0};
+	bufferFile(&sysupgrade, 0);
+
+	int kernel_offset = 0x90000; /* offset for the kernel inside the rootfs, default val */
+	sscanf(argv[2], "%X", &kernel_offset);
+#ifdef DEBUG
+	printf("Kernel_offset: at %X/%i bytes.\n", kernel_offset, kernel_offset);
+#endif
+	char *hwID = argv[3];
+	char *hwVer = argv[4];
+	u_int32_t swVer = 0;
+	sscanf(argv[5],"%4X",&swVer);
+	swVer = bswap_32(swVer);
+
+	char *rootfsname = malloc(2*strlen(sysupgrade.file_name) + 8);
+	sprintf(rootfsname, "%s.rootfs", sysupgrade.file_name);
+
+	char *zipfsname = malloc(2*strlen(rootfsname) + 5);
+	sprintf(zipfsname, "%s.zip", rootfsname);
+	/* / Args */
+
+#ifdef DEBUG
+	printf("Building header: %s %s %2X %s.\n", hwID , hwVer, swVer, magic);
+#endif
+	/* Construct the firmware header/magic */
+	struct file_info header = {0, 0, 0};
+	header.file_size = HEADER_SIZE;
+	header.file_data = malloc(HEADER_SIZE);
+	bzero(header.file_data, header.file_size);
+
+	char *tg = header.file_data;
+	strcpy(tg, magic);
+	memcpy(tg+7, version, 4*sizeof(char));
+	strcpy(tg+11, hwID);
+	strcpy(tg+45, hwVer);
+	memcpy(tg+55, &swVer,sizeof(u_int32_t));
+	strcpy(tg+63, magic);
+
+#ifdef DEBUG
+	printf("Header done, now creating rootfs.");
+#endif
+	/* Construct a rootfs */
+	struct file_info rootfs = {0, 0, 0};
+	rootfs.file_size = sysupgrade.file_size + kernel_offset + footer_size;
+	rootfs.file_data =  malloc(rootfs.file_size);
+	bzero(rootfs.file_data, rootfs.file_size);
+	rootfs.file_name = rootfsname;
+
+	/* copy Owrt image to Kernel location */
+	memcpy(rootfs.file_data+kernel_offset, sysupgrade.file_data, sysupgrade.file_size);
+
+	/* 22 added to get away from sysup image, no other reason.
+	 *  updater searches for magic anyway */
+	tg = rootfs.file_data + kernel_offset + sysupgrade.file_size+22;
+
+	memcpy(tg, header.file_data, header.file_size);
+	writeFile(&rootfs);
+
+#ifdef DEBUG
+	printf("Preparing to zip.\n");
+#endif
+	/* now that we got the rootfs, repeat the whole thing again(sorta):
+	 * 1. zip the rootfs */
+	char *zipper = malloc(5 + 2*strlen(rootfs.file_name) + 4);
+	sprintf(zipper, "%s %s %s", "zip ", zipfsname, rootfs.file_name);
+	int ret = system(zipper);
+
+	/* clear rootfs file */
+	rmFile(&rootfs);
+
+	/* and load zipped fs */
+	struct file_info zippedfs = {zipfsname, 0, 0};
+	bufferFile(&zippedfs, 0);
+
+#ifdef DEBUG
+	printf("Creating Image.\n");
+#endif
+
+	/* 2. create new file 512+rootfs size */
+	struct file_info image = {argv[1], 0, 0};
+	image.file_data = malloc(zippedfs.file_size + 512);
+	image.file_size = zippedfs.file_size + 512;
+
+	/* 3. copy zipfile at loc 512 */
+	memcpy(image.file_data+512, zippedfs.file_data, zippedfs.file_size);
+	rmFile(&zippedfs);
+
+	/* 4. add header to file */
+	memcpy(image.file_data, header.file_data, header.file_size);
+
+	/* 5. do a checksum run, and compute checksum */
+	char chksum = getCheckSum(image.file_data, image.file_size);
+#ifdef DEBUG
+	printf("Checksum for Image: %X.\n", chksum);
+#endif
+
+	/* 6. write the checksum invert into byte 511 to bring it to 0 */
+	chksum = (chksum ^ 0xFF) + 1;
+	memcpy(image.file_data+511, &chksum, 1);
+
+	chksum = getCheckSum(image.file_data, image.file_size);
+#ifdef DEBUG
+	printf("Checksum for after fix: %X.\n", chksum);
+#endif
+	/* 7. pray that the updater will accept the file */
+	writeFile(&image);
+	return 0;
+}


### PR DESCRIPTION
Hello!
These commits should add support for the Netgear dual-band router r6120, as well as basic support for the Sercomm/Netgear firmware file format.

It is not 100% in a mergeable state, but i wanted to get feedback on some issues.
(and ofc, all other issues that are still present... :+1: )

Open Questions:
1. The GPIO/LEDs are all working, but the ralink,group is most likely not correct - somebody with more info on the mappings should clarify that.
2. The firmware format is accepted by the nmrp as well as the webinterface, but the webinterface only copies a first part. Anybody has any ideas on that - i am willing to provide flashdumps and other support if needed, as i am out of ideas.

Otherwise I tested all things i know, macs, wifi, ethernet, sysupgrade is all working as it should.

Greetings,

Brother Lal