### PR TITLE
config: Change conf.c remove compiler warnings

### DIFF
--- a/scripts/config/conf.c
+++ b/scripts/config/conf.c
@@ -75,9 +75,9 @@ static void strip(char *str)
 static void check_stdin(void)
 {
 	if (!valid_stdin) {
-		printf(_("aborted!\n\n"));
-		printf(_("Console input/output is redirected. "));
-		printf(_("Run 'make oldconfig' to update configuration.\n\n"));
+	        printf("%s",_("aborted!\n\n"));
+		printf("%s",_("Console input/output is redirected. "));
+		printf("%s",_("Run 'make oldconfig' to update configuration.\n\n"));
 		exit(1);
 	}
 }
@@ -87,7 +87,7 @@ static int conf_askvalue(struct symbol *sym, const char *def)
 	enum symbol_type type = sym_get_type(sym);
 
 	if (!sym_has_value(sym))
-		printf(_("(NEW) "));
+	        printf("%s",_("(NEW) "));
 
 	line[0] = '\n';
 	line[1] = 0;
@@ -288,7 +288,7 @@ static int conf_choice(struct menu *menu)
 			if (child->sym->name)
 				printf(" (%s)", child->sym->name);
 			if (!sym_has_value(child->sym))
-				printf(_(" (NEW)"));
+			        printf("%s",_(" (NEW)"));
 			printf("\n");
 		}
 		printf(_("%*schoice"), indent - 1, "");
@@ -436,7 +436,7 @@ static void check_conf(struct menu *menu)
 				}
 			} else if (input_mode != olddefconfig) {
 				if (!conf_cnt++)
-					printf(_("*\n* Restart config...\n*\n"));
+				        printf("%s",_("*\n* Restart config...\n*\n"));
 				rootEntry = menu_get_parent_menu(menu);
 				conf(rootEntry);
 			}


### PR DESCRIPTION
Compiler is producing the warning:
   warning: format not a string literal and no format arguments
   [-Wformat-security]

This patch makes the format a literal string in printf statements.