### PR TITLE
ath79: add support for Ubiquiti UniFi AC-Pro

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -98,6 +98,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan:1" "5:lan:2" "4:wan"
 		;;
+	"ubnt,ubnt-unifiac-pro")
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "3:wan"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -95,14 +95,15 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
-	"ubnt,ubnt-unifiac-lite")
+	"ubnt,ubnt-unifiac-lite"|\
+	"ubnt,ubnt-unifiac-pro")
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;
 	esac
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
-	phicomm,k2t)
+	"phicomm,k2t")
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(k2t_get_mac "5g_mac")
 

--- a/target/linux/ath79/dts/qca9563_ubnt-unifiac-lite.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt-unifiac-lite.dts
@@ -4,124 +4,11 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
-#include "qca956x.dtsi"
+#include "qca9563_ubnt-unifiac.dtsi"
 
 / {
 	compatible = "ubnt,ubnt-unifiac-lite", "qca,qca9563";
 	model = "Ubiquiti UniFi-AC-LITE/MESH/LR";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		wifi_ac {
-			label = "ubnt:white:dome";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wifi_n {
-			label = "ubnt:blue:dome";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-			linux,default-trigger = "phy1tpt";
-		};
-
-	};
-
-	keys {
-		compatible = "gpio-keys";
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-};
-
-&uart {
-	status = "okay";
-};
-
-&gpio {
-	status = "okay";
-};
-
-&pcie {
-	status = "okay";
-};
-
-&spi {
-	status = "okay";
-	num-cs = <1>;
-
-	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x060000>;
-				read-only;
-			};
-
-			partition@60000 {
-				label = "u-boot-env";
-				reg = <0x060000 0x010000>;
-				read-only;
-			};
-
-			partition@70000 {
-				label = "firmware";
-				reg = <0x070000 0x790000>;
-			};
-
-			partition@800000 {
-				label = "ubnt-airos";
-				reg = <0x800000 0x790000>;
-				read-only;
-			};
-
-			partition@f90000 {
-				label = "bs";
-				reg = <0xf90000 0x020000>;
-				read-only;
-			};
-
-			partition@fb0000 {
-				label = "cfg";
-				reg = <0xfb0000 0x040000>;
-				read-only;
-			};
-
-			eeprom: partition@ff0000 {
-				label = "EEPROM";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
-	};
 };
 
 &mdio0 {
@@ -139,10 +26,4 @@
 
 	mtd-mac-address = <&eeprom 0x0>;
 	phy-handle = <&phy4>;
-};
-
-&wmac {
-	status = "okay";
-	mtd-cal-data = <&eeprom 0x1000>;
-	mtd-mac-address = <&eeprom 0x0>;
 };

--- a/target/linux/ath79/dts/qca9563_ubnt-unifiac-pro.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt-unifiac-pro.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9563_ubnt-unifiac.dtsi"
+
+/ {
+	compatible = "ubnt,ubnt-unifiac-pro", "qca,qca9563";
+	model = "Ubiquiti UniFi-AC-PRO/MESH PRO";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+	qca,ar8327-initvals = <
+	    0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+	    0x7c 0x0000007e /* PORT0_STATUS */
+	>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&eeprom 0x0>;
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/dts/qca9563_ubnt-unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt-unifiac.dtsi
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi_ac {
+			label = "ubnt:white:dome";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_n {
+			label = "ubnt:blue:dome";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x060000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "u-boot-env";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "firmware";
+				reg = <0x070000 0x790000>;
+			};
+
+			partition@800000 {
+				label = "ubnt-airos";
+				reg = <0x800000 0x790000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "bs";
+				reg = <0xf90000 0x020000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			eeprom: partition@ff0000 {
+				label = "EEPROM";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&eeprom 0x1000>;
+	mtd-mac-address = <&eeprom 0x0>;
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -81,20 +81,25 @@ endef
 TARGET_DEVICES += ubnt_unifi
 
 define Device/ubnt-unifiac
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-  DEVICE_PROFILE := UBNT
+  ATH_SOC := qca9563
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
   IMAGE_SIZE := 7744k
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
 
 define Device/ubnt-unifiac-lite
   $(Device/ubnt-unifiac)
   DEVICE_TITLE := Ubiquiti UniFi AC-Lite
-  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
-  DEVICE_PROFILE += UBNTUNIFIACLITE
-  BOARDNAME := UBNT-UF-AC-LITE
-  ATH_SOC := qca9563
+  SUPPORTED_DEVICES := ubnt,ubnt-unifiac-lite ubnt-unifiac-lite
 endef
 TARGET_DEVICES += ubnt-unifiac-lite
+
+define Device/ubnt-unifiac-pro
+  $(Device/ubnt-unifiac)
+  DEVICE_TITLE := Ubiquiti UniFi AC-Pro
+  DEVICE_PACKAGES += kmod-usb-core kmod-usb2
+  SUPPORTED_DEVICES := ubnt,ubnt-unifiac-pro ubnt-unifiac-pro
+endef
+TARGET_DEVICES += ubnt-unifiac-pro


### PR DESCRIPTION
rework the dts to a common unifi-ac dtsi
pro network is connected via phy0 and has usb ports
lite network is connected via phy4 without usb ports

everything works

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
