### PR TITLE
ath79: Remove all memory nodes defined in dts

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -18,11 +18,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -14,11 +14,6 @@
 		led-status = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar7240_tl-wr740n-v2.dts
+++ b/target/linux/ath79/dts/ar7240_tl-wr740n-v2.dts
@@ -14,11 +14,6 @@
 		led-status = &led_system;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -14,11 +14,6 @@
 		led-status = &dome_green;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -9,11 +9,6 @@
 	compatible = "ubnt,xm", "qca,ar7241";
 	model = "Ubiquiti Networks XM (rev 1.0) board";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 /*	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -14,11 +14,6 @@
 		led-status = &power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	gpio-keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -10,11 +10,6 @@
 	compatible = "buffalo,wzr-hp-g450h", "qca,ar7242";
 	model = "Buffalo WZR-HP-G450H";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar7242_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tl-wr2543-v1.dts
@@ -18,11 +18,6 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/ar9132_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tl-wr1043nd-v1.dts
@@ -14,11 +14,6 @@
 		led-status = &system;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/ar9330_glinet_ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_ar150.dts
@@ -15,11 +15,6 @@
 		led-status = &wlan;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9331_dpt_module.dts
+++ b/target/linux/ath79/dts/ar9331_dpt_module.dts
@@ -14,11 +14,6 @@
 		serial0 = &uart;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9331_dragino_ms14.dts
+++ b/target/linux/ath79/dts/ar9331_dragino_ms14.dts
@@ -14,11 +14,6 @@
 		serial0 = &uart;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
@@ -15,11 +15,6 @@
 		serial0 = &uart;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9331_etactica-eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica-eg200.dts
@@ -14,11 +14,6 @@
                 serial0 = &uart;
         };
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar9331_omega.dts
+++ b/target/linux/ath79/dts/ar9331_omega.dts
@@ -14,11 +14,6 @@
 		serial0 = &uart;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9331_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tl-wr703n_tl-mr10u.dtsi
@@ -12,11 +12,6 @@
 		led-status = &led_system;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
@@ -13,11 +13,6 @@
 		led-status = &system;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
@@ -9,11 +9,6 @@
 	compatible = "glinet,ar300m", "qca,qca9533";
 	model = "GL.iNet GL-AR300M";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -10,11 +10,6 @@
 	compatible = "openmesh,om5p-ac-v2", "qca,qca9557";
 	model = "OpenMesh OM5P-AC V2";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;

--- a/target/linux/ath79/dts/qca9558_tl-archer-c7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tl-archer-c7.dtsi
@@ -7,11 +7,6 @@
 #include "qca9557.dtsi"
 
 / {
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ath79/dts/qca9558_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tl-wr1043nd.dtsi
@@ -7,11 +7,6 @@
 #include "qca9557.dtsi"
 
 / {
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
@@ -7,11 +7,6 @@
 #include "qca956x.dtsi"
 
 / {
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ath79/dts/qca9563_ubnt-unifiac-lite.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt-unifiac-lite.dts
@@ -10,11 +10,6 @@
 	compatible = "ubnt,ubnt-unifiac-lite", "qca,qca9563";
 	model = "Ubiquiti UniFi-AC-LITE/MESH/LR";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};


### PR DESCRIPTION
This target can automatically detect the memory size and we've been using it for long in ar71xx.
The automatic detection was tested on C301 (AR9344) which I hadn't create PR for it due to the ethernet problem. And it has already been used on K2T (QCA9563) in ath79.
I guess it works on other SoCs but I don't have routers to test.
As for the RFC in the title: I'm wondering why there are fixed memory defined in dts when it can be detected automatically.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
