### PR TITLE
[RFC] [RFT]ipv6: Re-enable arbitrary IPv6 addresses as outer ip4-in-ip6 tunnel source adress

### DIFF
--- a/target/linux/generic/pending-3.18/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
+++ b/target/linux/generic/pending-3.18/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
@@ -258,7 +258,7 @@ Signed-off-by: Steven Barth <cyrus@openwrt.org>
  		skb_reset_network_header(skb);
  		skb->protocol = htons(protocol);
  		memset(skb->cb, 0, sizeof(struct inet6_skb_parm));
-+		if (protocol == ETH_P_IP &&
++		if (protocol == ETH_P_IP && t->parms.fmrs &&
 +			!ipv6_addr_equal(&ipv6h->saddr, &t->parms.raddr)) {
 +				/* Packet didn't come from BR, so lookup FMR */
 +				struct __ip6_tnl_fmr *fmr;

--- a/target/linux/generic/pending-4.14/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
+++ b/target/linux/generic/pending-4.14/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
@@ -268,7 +268,7 @@ Signed-off-by: Steven Barth <cyrus@openwrt.org>
  	skb_reset_network_header(skb);
  	memset(skb->cb, 0, sizeof(struct inet6_skb_parm));
  
-+	if (tpi->proto == htons(ETH_P_IP) &&
++	if (tpi->proto == htons(ETH_P_IP) && tunnel->parms.fmrs &&
 +		!ipv6_addr_equal(&ipv6h->saddr, &tunnel->parms.raddr)) {
 +			/* Packet didn't come from BR, so lookup FMR */
 +			struct __ip6_tnl_fmr *fmr;

--- a/target/linux/generic/pending-4.4/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
+++ b/target/linux/generic/pending-4.4/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
@@ -273,7 +273,7 @@ Signed-off-by: Steven Barth <cyrus@openwrt.org>
  		skb_reset_network_header(skb);
  		skb->protocol = htons(protocol);
  		memset(skb->cb, 0, sizeof(struct inet6_skb_parm));
-+		if (protocol == ETH_P_IP &&
++		if (protocol == ETH_P_IP && t->parms.fmrs &&
 +			!ipv6_addr_equal(&ipv6h->saddr, &t->parms.raddr)) {
 +				/* Packet didn't come from BR, so lookup FMR */
 +				struct __ip6_tnl_fmr *fmr;

--- a/target/linux/generic/pending-4.9/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
+++ b/target/linux/generic/pending-4.9/666-Add-support-for-MAP-E-FMRs-mesh-mode.patch
@@ -268,7 +268,7 @@ Signed-off-by: Steven Barth <cyrus@openwrt.org>
  	skb_reset_network_header(skb);
  	memset(skb->cb, 0, sizeof(struct inet6_skb_parm));
  
-+	if (tpi->proto == htons(ETH_P_IP) &&
++	if (tpi->proto == htons(ETH_P_IP) && tunnel->parms.fmrs &&
 +		!ipv6_addr_equal(&ipv6h->saddr, &tunnel->parms.raddr)) {
 +			/* Packet didn't come from BR, so lookup FMR */
 +			struct __ip6_tnl_fmr *fmr;


### PR DESCRIPTION
for 3.18, 4.4, 4.9, and 4.14 kernels

The 666-Add-support-for-MAP-E-FMRs-mesh-mode.patch kernel patches
break the possibility for using an ip4ip6 tunnel interface as a fall
back interface accepting ip4-in-ip6 tunneled packets from any remote
address. This works out of the box with any normal (non-666-patched)
kernel and can be configured by setting up an 'ip -6 tunnel' with type
'any' or 'ip4ip6' and a remote address of '::'.

The misbehavior comes with line 290 the patch which discards all packets
that do not show the expected saddr, even if no single fmr rule was
defined and despite the validity of the saddr was already approved earlier.

Signed-off-by: Axel Neumann <neumann@cgws.de>
Signed-off-by: Paul Spooren <mail@aparcar.org>