### PR TITLE
ath79: update qca9533 to new irq driver

### DIFF
--- a/target/linux/ath79/dts/qca9533.dtsi
+++ b/target/linux/ath79/dts/qca9533.dtsi
@@ -20,9 +20,11 @@
 		};
 	};
 
-	ref: ref {
+	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <25000000>;
 	};
 
 	ahb {
@@ -90,9 +92,7 @@
 				#pinctrl-cells = <2>;
 
 				jtag_disable_pins: pinmux_jtag_disable_pins {
-					pinctrl-single,bits = <
-						0x40 0x2 0x2
-						>;
+					pinctrl-single,bits = <0x40 0x2 0x2>;
 				};
 			};
 
@@ -101,9 +101,8 @@
 				reg = <0x18050000 0x48>;
 
 				#clock-cells = <1>;
-				clocks = <&ref>;
-				clock-names = "ref";
 				clock-output-names = "cpu", "ddr", "ahb";
+				clocks = <&extosc>;
 			};
 
 			wdt: wdt@18060008 {
@@ -124,15 +123,20 @@
 				#reset-cells = <1>;
 
 				intc2: interrupt-controller@2 {
-					compatible = "qcom,qca9556-intc";
+					compatible = "qca,ar9340-intc";
 
+					interrupt-parent = <&cpuintc>;
 					interrupts = <2>;
 
 					interrupt-controller;
 					#interrupt-cells = <1>;
 
-					qcom,pending-bits = <0x1f0>,	/* pcie rc1 */
-							    <0xf>;	/* wmac */
+					qca,int-status-addr = <0xac>;
+					qca,pending-bits = <0xf>,       /* wmac */
+							<0x1f0>;        /* pcie rc1 */
+
+					qca,ddr-wb-channel-interrupts = <0>, <1>;
+					qca,ddr-wb-channels = <&ddr_ctrl 4>, <&ddr_ctrl 3>;
 				};
 			};
 
@@ -148,7 +152,7 @@
 				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
 				interrupt-parent = <&intc2>;
-				interrupts = <0>;
+				interrupts = <1>;
 
 				interrupt-controller;
 				#interrupt-cells = <1>;
@@ -158,12 +162,17 @@
 				status = "disabled";
 			};
 
-			wmac: gmac@18100000 {
+			gmac: gmac@18070000 {
+				compatible = "qca,ar9340-gmac";
+				reg = <0x18070000 0x4>;
+			};
+
+			wmac: wmac@18100000 {
 				compatible = "qca,qca9530-wmac";
 				reg = <0x18100000 0x230000>;
 
-				interrupt-parent = <&cpuintc>;
-				interrupts = <2>;
+				interrupt-parent = <&intc2>;
+				interrupts = <0>;
 
 				status = "disabled";
 			};
@@ -204,6 +213,12 @@
 
 };
 
+&cpuintc {
+	qca,ddr-wb-channel-interrupts = <3>, <4>, <5>;
+	qca,ddr-wb-channels = <&ddr_ctrl 2>, <&ddr_ctrl 0>,
+						<&ddr_ctrl 1>;
+};
+
 &mdio0 {
 	resets = <&rst 22>;
 	reset-names = "mdio";
@@ -223,8 +238,8 @@
 
 
 &mdio1 {
-	resets = <&rst 23>;
-	reset-names = "mdio";
+	resets = <&rst 23>, <&rst 8>;
+	reset-names = "mdio", "switch";
 	builtin-switch;
 };
 

--- a/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
@@ -9,13 +9,6 @@
 	compatible = "glinet,ar300m", "qca,qca9533";
 	model = "GL.iNet GL-AR300M";
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <25000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;
@@ -90,10 +83,6 @@
 
 &usb_phy {
 	status = "okay";
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &mdio0 {


### PR DESCRIPTION
Commit c7efc93 renamed controller name
to qca,ar9340-intc and added some functions but qca9533.dtsi was overlooked.
Correct the dtsi and adust it to the new format

Add gmac and correct reset for cascaded irq and build-in switch
Also add the reference clock to soc dtsi so we don't have to have it in every dts

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
