### PR TITLE
ath79: small fixes wr1043nd-v4

### DIFF
--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -385,10 +385,10 @@ define Device/tl-wr1043nd-v4
   BOARDNAME := TL-WR1043ND-v4
   DEVICE_PROFILE := TLWR1043
   TPLINK_HWID :=  0x10430004
-  MTDPARTS := spi0.0:128k(u-boot)ro,1536k(kernel),14016k(rootfs),128k(product-info)ro,320k(config)ro,64k(partition-table)ro,128k(logs)ro,64k(ART)ro,15552k@0x20000(firmware)
+  MTDPARTS := spi0.0:128k(u-boot)ro,15552k(firmware),128k(product-info)ro,320k(config)ro,64k(partition-table)ro,128k(logs)ro,64k(ART)ro
   IMAGE_SIZE := 15552k
   TPLINK_BOARD_ID := TLWR1043NDV4
-  KERNEL := kernel-bin | patch-cmdline | lzma | tplink-v1-header
+  KERNEL := kernel-bin | patch-cmdline | lzma | tplink-v1-header -O
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -92,12 +92,16 @@ ath79_setup_macs()
 	local board="$1"
 
 	case "$board" in
-	avm,fritz300e)
+	"avm,fritz300e")
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
-	phicomm,k2t)
+	"phicomm,k2t")
 		lan_mac=$(k2t_get_mac "lan_mac")
 		wan_mac=$(k2t_get_mac "wan_mac")
+		;;
+	"tplink,tl-wr1043nd-v4")
+		lan_mac=$(mtd_get_mac_binary product-info 8)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	esac
 

--- a/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
@@ -29,14 +29,6 @@
 			linux,default-trigger = "heartbeat";
 		};
 
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-			trigger-sources = <&hub_port0>;
-			linux,default-trigger = "usbport";
-		};
-
 		wifi_green {
 			label = "tp-link:green:wlan";
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
@@ -53,6 +45,12 @@
 		wan {
 			label = "tp-link:green:wan";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan_fail {
+			label = "tp-link:orange:wan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
@@ -119,19 +117,6 @@
 
 &gpio {
 	status = "okay";
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-
-	hub_port0: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
@@ -20,7 +20,7 @@
 		led-status = &system;
 	};
 
-	leds {
+	gpio_leds: leds {
 		compatible = "gpio-leds";
 
 		system: system {

--- a/target/linux/ath79/dts/qca9563_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043nd-v4.dts
@@ -9,15 +9,15 @@
 / {
 	compatible = "tplink,tl-wr1043nd-v4", "qca,qca9563";
 	model = "TP-Link TL-WR1043ND Version 4";
+};
 
-	leds {
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-			trigger-sources = <&hub_port0>;
-			linux,default-trigger = "usbport";
-		};
+&gpio_leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		default-state = "off";
+		trigger-sources = <&hub_port0>;
+		linux,default-trigger = "usbport";
 	};
 };
 

--- a/target/linux/ath79/dts/qca9563_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043nd-v4.dts
@@ -9,4 +9,27 @@
 / {
 	compatible = "tplink,tl-wr1043nd-v4", "qca,qca9563";
 	model = "TP-Link TL-WR1043ND Version 4";
+
+	leds {
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 };

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -57,7 +57,8 @@ define Device/tl-wr1043nd-v4
   TPLINK_HWID := 0x10430004
   TPLINK_BOARD_ID := TLWR1043NDV4
   KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header
-  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+    append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
   SUPPORTED_DEVICES := tplink,tl-wr1043nd-v4 tl-wr1043nd-v4
 endef

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -56,7 +56,7 @@ define Device/tl-wr1043nd-v4
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430004
   TPLINK_BOARD_ID := TLWR1043NDV4
-  KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header
+  KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header -O
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
     append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -818,15 +818,10 @@ static struct device_info boards[] = {
 		.support_trail = '\x00',
 		.soft_ver = NULL,
 
-		/**
-		    We use a bigger os-image partition than the stock images (and thus
-		    smaller file-system), as our kernel doesn't fit in the stock firmware's
-		    1MB os-image.
-		*/
+		/** We're using a dynamic kernel/rootfs split here */
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},
-			{"os-image", 0x20000, 0x200000},
-			{"file-system", 0x220000, 0xd30000},
+			{"firmware", 0x20000, 0xf30000},
 			{"default-mac", 0xf50000, 0x00200},
 			{"pin", 0xf50200, 0x00200},
 			{"product-info", 0xf50400, 0x0fc00},


### PR DESCRIPTION
fix sysupgrade check
move usb to v4 dts because v5 doesn't have it
make wan mac address behave like ar71xx target
switch tplink-safeloader to dynamic partitions

add orange wan led support, it can be userspace activated like

on:
`echo default-on > /sys/class/leds/tp-link\:orange\:wan/trigger`
off:
`echo none > /sys/class/leds/tp-link\:orange\:wan/trigger`

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
