### PR TITLE
libnl-tiny: compile when _GNU_SOURCE not defined

### DIFF
--- a/package/libs/libnl-tiny/patches/100-manually-define-struct-ucred-when-gnu-source-not-defined.patch
+++ b/package/libs/libnl-tiny/patches/100-manually-define-struct-ucred-when-gnu-source-not-defined.patch
@@ -1,0 +1,57 @@
+--- src/include/netlink/handlers.h
++++ src/include/netlink/handlers.h
+@@ -24,6 +24,21 @@
+ extern "C" {
+ #endif
+ 
++/*
++ * struct ucred is only available under _GNU_SOURCE
++ * in sys/socket.h
++ */
++#ifndef _GNU_SOURCE
++#ifndef __LIBNL_TINY_UCRED_PATCHED
++#define __LIBNL_TINY_UCRED_PATCHED
++struct ucred {
++	pid_t pid;
++	uid_t uid;
++	gid_t gid;
++};
++#endif /* __LIBNL_TINY_UCRED_PATCHED */
++#endif /* _GNU_SOURCE */
++
+ struct nl_sock;
+ struct nl_msg;
+ struct nl_cb;
+@@ -117,7 +132,7 @@
+ {
+ 	nl_recvmsg_msg_cb_t	cb_set[NL_CB_TYPE_MAX+1];
+ 	void *			cb_args[NL_CB_TYPE_MAX+1];
+-	
++
+ 	nl_recvmsg_err_cb_t	cb_err;
+ 	void *			cb_err_arg;
+ 
+--- src/include/netlink/msg.h
++++ src/include/netlink/msg.h
+@@ -19,6 +19,21 @@
+ extern "C" {
+ #endif
+ 
++/*
++ * struct ucred is only available under _GNU_SOURCE
++ * in sys/socket.h
++ */
++#ifndef _GNU_SOURCE
++#ifndef __LIBNL_TINY_UCRED_PATCHED
++#define __LIBNL_TINY_UCRED_PATCHED
++struct ucred {
++	pid_t pid;
++	uid_t uid;
++	gid_t gid;
++};
++#endif /* __LIBNL_TINY_UCRED_PATCHED */
++#endif /* _GNU_SOURCE */
++
+ struct nla_policy;
+ 
+ #define NL_DONTPAD	0


### PR DESCRIPTION
Signed-off-by: Awais Chishti <chishtiawais@hotmail.com>

### Compilation workaround regarding the SDK for LEDE 17.01, ar71xx

Some `libnl-tiny` headers required the definition of `struct ucred`.
`struct ucred` is not defined without `-D_GNU_SOURCE`, see `sys/socket.h`.
This caused compilation with `libnl-tiny` to fail.

The provided patch adds the definition of `struct ucred` where needed.
The added definitions are only included in the concerned files if:
- `_GNU_SOURCE` is not defined
- No other definition added by the patch is in scope

`_GNU_SOURCE` can stay either defined or undefined throughout compilation.
Otherwise, duplicate/missing definition problems can arise when e.g.:
- `_GNU_SOURCE` is defined only while `sys/socket.h` is preprocessed
- `_GNU_SOURCE` is undefined only while `sys/socket.h` is preprocessed

Any suggestions on how to handle these cases?

Relevant part of the compilation failure:
```
In file included from /home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/netlink.h:30:0,
                 from /home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/genl/ctrl.h:15,
                 from ../set_channel/set_channel.h:11,
                 from deauth_wild.c:51:
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/handlers.h:134:19: warning: 'struct ucred' declared inside parameter list will not be visible outside of this definition or declaration
            struct ucred **);
                   ^~~~~
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/handlers.h:208:36: warning: 'struct ucred' declared inside parameter list will not be visible outside of this definition or declaration
           unsigned char **, struct ucred **))
                                    ^~~~~
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/handlers.h: In function 'nl_cb_overwrite_recv':
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/handlers.h:210:17: warning: assignment from incompatible pointer type [-Wincompatible-pointer-types]
  cb->cb_recv_ow = func;
                 ^
In file included from /home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/genl/ctrl.h:15:0,
                 from ../set_channel/set_channel.h:11,
                 from deauth_wild.c:51:
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/netlink.h: At top level:
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/netlink.h:57:13: warning: 'struct ucred' declared inside parameter list will not be visible outside of this definition or declaration
      struct ucred **);
             ^~~~~
In file included from /home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/cache.h:16:0,
                 from /home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/genl/ctrl.h:16,
                 from ../set_channel/set_channel.h:11,
                 from deauth_wild.c:51:
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/msg.h:52:16: error: field 'nm_creds' has incomplete type
  struct ucred  nm_creds;
                ^~~~~~~~
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/msg.h: In function 'nlmsg_set_creds':
/home/caffeine/Documents/Development/source_code/openwrt-sdk-ar71xx-generic_gcc-7.3.0_musl.Linux-x86_64/staging_dir/target-mips_24kc_musl/usr/include/libnl-tiny/netlink/msg.h:207:39: error: dereferencing pointer to incomplete type 'struct ucred'
  memcpy(&msg->nm_creds, creds, sizeof(*creds));
                                       ^~~~~~
Makefile:8: recipe for target 'deauth_wild.o' failed
```