### PR TITLE
firmware-utils: tplink-safeloader: add calloc error handling

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1562,6 +1562,10 @@ static int add_flash_partition(
 	}
 
 	part_list->name = calloc(1, strlen(name) + 1);
+	if (!part_list->name) {
+		error(1, 0, "Unable to allocate memory");
+	}
+
 	memcpy((char *)part_list->name, name, strlen(name));
 	part_list->base = base;
 	part_list->size = size;


### PR DESCRIPTION
If calloc has failed it returns NULL.
