### PR TITLE
brcm2708: platform.sh: fix tar directory directive

### DIFF
--- a/target/linux/brcm2708/base-files/lib/upgrade/platform.sh
+++ b/target/linux/brcm2708/base-files/lib/upgrade/platform.sh
@@ -97,7 +97,7 @@ platform_copy_config() {
 		mkdir -p /boot
 		[ -f /boot/kernel.img ] || mount -t vfat -o rw,noatime "/dev/$partdev" /boot
 		cp -af "$CONF_TAR" /boot/
-		tar --directory / -xvf "$CONF_TAR" boot/config.txt
+		tar -C / -xvf "$CONF_TAR" boot/config.txt
 		sync
 		unmount /boot
 	fi


### PR DESCRIPTION
BusyBox's `tar` command does not support the `--directory` directive, which
is essentially `-C` in short-form option.
BusyBox's `tar` command supports `-C`.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>