### PR TITLE
base-files: call [b][z]cat cmd directly in get_image

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -89,7 +89,7 @@ get_image() { # <source> [ <command> ]
 		esac
 	fi
 
-	cat "$from" 2>/dev/null | $cmd
+	"$cmd" "$from" 2>/dev/null
 }
 
 get_magic_word() {


### PR DESCRIPTION
Don't pipe cat + cat/zcat/bzcat.
Saves some cycles of stdin + stdout piping.

This also seems to fix some issues with zcat during sysupgrade (at least on
RPi), where `zcat` complains with error `zcat: write error: Broken pipe`.

The error itself doesn't seem to prevent writing the image (of the RPi) to
the SD-Card during sysupgrade.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>