### PR TITLE
iperf3: update to 3.6

### DIFF
--- a/package/network/utils/iperf3/Makefile
+++ b/package/network/utils/iperf3/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iperf
-PKG_VERSION:=3.5
+PKG_VERSION:=3.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://downloads.es.net/pub/iperf
-PKG_HASH:=539bd9ecdca1b8c1157ff85b70ed09b3c75242e69886fc16b54883b399f72cd5
+PKG_SOURCE_URL:=https://downloads.es.net/pub/iperf
+PKG_HASH:=de5d51e46dc460cc590fb4d44f95e7cad54b74fea1eba7d6ebd6f8887d75946e
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Maintainer: @nbd168
Built and tested x86_64/generic, HEAD (4fdc6ca).

Copied over iperf3-ssl `.ipk` and installed it.  Did basic tests.
