### PR TITLE
ar71xx: Add support for TL-WA801ND v4

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wa801nd-v3.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wa801nd-v3.c
@@ -1,5 +1,6 @@
 /*
  *  TP-LINK TL-WA801ND v3 adapted from TP-LINK TL-WR841N/ND v9
+ *  TP-LINK TL-WA801ND v4
  *
  *  Copyright (C) 2014 Matthias Schiffer <mschiffer@universe-factory.net>
  *  Copyright (C) 2016 Tiziano Bacocco <tizbac2@gmail.com>

--- a/target/linux/ar71xx/image/tiny-tp-link.mk
+++ b/target/linux/ar71xx/image/tiny-tp-link.mk
@@ -203,6 +203,13 @@ define Device/tl-wa801nd-v3
 endef
 TARGET_DEVICES += tl-wa801nd-v3
 
+define Device/tl-wa801nd-v4
+  $(Device/tl-wa801nd-v3)
+  DEVICE_TITLE := TP-LINK TL-WA801N/ND v4
+  TPLINK_HWID := 0x08010004
+endef
+TARGET_DEVICES += tl-wa801nd-v4
+
 define Device/tl-wa830re-v1
   $(Device/tplink-4m)
   DEVICE_TITLE := TP-LINK TL-WA830RE v1


### PR DESCRIPTION
This add support for TP-Link TL-WA801ND v4 (same as TL-WA801ND v3) :

Specification:

- System-On-Chip: Qualcomm Atheros QCA9533
- CPU/Speed: 650 MHz
- Flash-Chip: Winbond W25Q32BVSIG
- Flash size: 4096 KiB
- RAM: 32 MiB
- Wireless No1: SoC-integrated: QCA9533 2.4GHz 802.11bgn

Flash instructions:

1) To flash the image, rename the file
   openwrt-ar71xx-generic-tl-wa801nd-v4-squashfs-factory.bin
   to firmware.bin
2) Connect your device to the LAN port, then upload the firmware
   through web interface. It will try to download the image and
   flash it.

It can take up to 2-3 minutes to finish. When it reaches 100%, the
router will reboot itself.

Signed-off-by: MARIADASSOU Romain <roms2000@free.fr>
