### PR TITLE
ramips: Add support for TL-WA801ND v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -421,6 +421,10 @@ tplink,c50-v3)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
+tplink,tl-wa801nd-v5)
+	ucidef_set_led_wlan "wlan" "wlan" "$boardname:green:wlan" "phy0tpt"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
+	;;
 tplink,tl-mr3420-v5|\
 tplink,tl-wr842n-v5)
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -57,6 +57,7 @@ ramips_setup_interfaces()
 	omega2 | \
 	omega2p | \
 	timecloud|\
+	tplink,tl-wa801nd-v5|\
 	w150m|\
 	widora,neo-16m|\
 	widora,neo-32m|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -42,6 +42,7 @@ get_status_led() {
 	r6220|\
 	tplink,c20-v4|\
 	tplink,c50-v3|\
+	tplink,tl-wa801nd-v5|\
 	tplink,tl-mr3420-v5|\
 	tplink,tl-wr842n-v5|\
 	tplink,tl-wr902ac-v3|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -490,6 +490,9 @@ ramips_board_detect() {
 	*"Timecloud")
 		name="timecloud"
 		;;
+	*"TL-WA801ND v5")
+		name="tplink,tl-wa801nd-v5"
+		;;
 	*"TL-WR840N v4")
 		name="tl-wr840n-v4"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -258,6 +258,7 @@ platform_check_image() {
 	tplink,c20-v4|\
 	tplink,c50-v3|\
 	tplink,tl-mr3420-v5|\
+	tplink,tl-wa801nd-v5|\
 	tplink,tl-wr842n-v5|\
 	tplink,tl-wr902ac-v3|\
 	tl-wr840n-v4|\

--- a/target/linux/ramips/dts/TL-WA801NDV5.dts
+++ b/target/linux/ramips/dts/TL-WA801NDV5.dts
@@ -1,0 +1,57 @@
+/dts-v1/;
+
+#include "TPLINK-8M.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wa801nd-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WA801ND v5";
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "tl-wa801nd-v5:green:power";
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tl-wa801nd-v5:green:lan";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-wa801nd-v5:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tl-wa801nd-v5:orange:wps";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "perst", "refclk", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -114,6 +114,19 @@ define Device/pbr-d1
 endef
 TARGET_DEVICES += pbr-d1
 
+define Device/tplink_tl-wa801nd-v5
+  $(Device/tplink)
+  DTS := TL-WA801NDV5
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link TL-WA801ND v5
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08010005
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x5
+  TPLINK_HVERSION := 3
+endef
+TARGET_DEVICES += tplink_tl-wa801nd-v5
+
 define Device/tl-wr840n-v4
   $(Device/tplink)
   DTS := TL-WR840NV4


### PR DESCRIPTION
Add support for TL-WA801ND v5 (similar to TL-WR840Nv4 but as AP only)

Specification:

- System-On-Chip: MediaTek MT7628NN
- CPU/Speed: 580 MHz
- Flash-Chip: ELM Technology GD25Q64
- Flash size: 8192 KiB
- RAM: 64 MiB
- Wireless No1: SoC-integrated: MT7628N 2.4GHz 802.11bgn

Currently the only method to install openwrt for the first time is via
TFTP recovery. After first install you can use regular updates.

Flash instructions:

1) To flash the recovery image, start a TFTP server with IP address
   192.168.0.66 and serve the recovery image named tp_recovery.bin.
2) Connect your device to the LAN port, then press the WPS and Reset
   button and power it up. Keep pressing the WPS/Reset button for
   10 seconds or until the lock LED is lighting up.
   It will try to download the recovery image and flash it.

It can take up to 2-3 minutes to finish. When it reaches 100%, the
router will reboot itself.

Signed-off-by: Romain MARIADASSOU <roms2000@free.fr>
