### PR TITLE
ramips: add switch port index for I-O DATA WN-GX300GR

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -195,7 +195,6 @@ ramips_setup_interfaces()
 	gl-mt300n|\
 	gl-mt750|\
 	hg255d|\
-	iodata,wn-gx300gr|\
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
@@ -228,7 +227,8 @@ ramips_setup_interfaces()
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;
 	dir-860l-b1|\
-	elecom,wrc-1167ghbk2-s)
+	elecom,wrc-1167ghbk2-s|\
+	iodata,wn-gx300gr)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;


### PR DESCRIPTION
WN-GX300GR has 5x RJ45 ports (port 0-5), and these ports are
orderd on the device as follows:
4 3 2 1 0

1-4: lan
0: wan

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>