### PR TITLE
ath79: Fix builtin-switch support for ar934x

### DIFF
--- a/target/linux/ath79/dts/ar9341.dtsi
+++ b/target/linux/ath79/dts/ar9341.dtsi
@@ -16,3 +16,8 @@
 	interrupt-parent = <&cpuintc>;
 	interrupts = <2>;
 };
+
+&eth0 {
+	phy-mode = "mii";
+	qca,delay-probe;
+};

--- a/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tl-wdr4300.dtsi
@@ -243,4 +243,9 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+	};
 };

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -135,7 +135,7 @@
 			};
 
 			gmac: gmac@18070000 {
-				compatible = "qca,ar9340-gmac", "qca,ar9330-gmac";
+				compatible = "qca,ar9340-gmac";
 				reg = <0x18070000 0x14>;
 			};
 
@@ -202,19 +202,25 @@
 	pll-reg = <0x4 0x2c 17>;
 	pll-handle = <&pll>;
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "mac", "phy";
+	resets = <&rst 9>;
+	reset-names = "mac";
 };
 
 &mdio1 {
-	resets = <&rst 23>;
-	reset-names = "mdio";
+	resets = <&rst 23>, <&rst 8>;
+	reset-names = "mdio", "switch";
 	builtin-switch;
 };
 
 &eth1 {
 	compatible = "qca,ar9340-eth", "syscon";
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "mac", "phy";
+	resets = <&rst 13>;
+	reset-names = "mac";
+	phy-mode = "gmii";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -1313,7 +1313,16 @@ void ag71xx_ar7240_start(struct ag71xx *ag)
 
 int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np)
 {
+	struct reset_control *switch_reset;
 	struct ar7240sw *as;
+
+	switch_reset = of_reset_control_get_exclusive(np, "switch");
+	if (!IS_ERR(switch_reset)) {
+		reset_control_assert(switch_reset);
+		msleep(100);
+		reset_control_deassert(switch_reset);
+		msleep(200);
+	}
 
 	as = ar7240_probe(ag, np);
 	if (!as)


### PR DESCRIPTION
Please check commit message on each commit for details. I'm too lazy to type them again :-D
It's only tested AR9344.

To use this on AR934x with phy0 and phy4 swapped:
```
&mdio1 {
	status = "okay";
	phy4-mii-enable;
	phy0: ethernet-phy@0 {
		reg = <0>;
		phy-mode = "mii";
	};
};

&eth1 {
	status = "okay";

	gmac-config {
		device = <&gmac>;
		switch-phy-swap = <1>;
		/* The following line is only needed for AR9344. Remove this if you are using AR9341 */
		switch-only-mode = <1>;
	};
};

&eth0 {
	status = "okay";
	phy-mode = "mii";
	phy-handle = <&phy0>;
	qca,delay-probe;
};

```
To use this on AR934x without phy0 and phy4 swapped:
```
&mdio1 {
	status = "okay";
	phy4-mii-enable;
	phy4: ethernet-phy@4 {
		reg = <4>;
		phy-mode = "mii";
	};
};

&eth1 {
	status = "okay";

	gmac-config {
		device = <&gmac>;
		/* The following line is only needed for AR9344. Remove this if you are using AR9341 */
		/* gmac-config is still needed even if it doesn't set anything because we want to clear bits in ETH_CFG that might be set by U-boot. */
		switch-only-mode = <1>;
	};
};

&eth0 {
	status = "okay";
	phy-mode = "mii";
	phy-handle = <&phy4>;
	qca,delay-probe;
};
```