### PR TITLE
ramips: add support for ZyXEL Keenetic Extra II

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -547,6 +547,11 @@ zorlik,zl5900v2)
 zte-q7)
 	set_wifi_led "$boardname:blue:status"
 	;;
+zyxel,keenetic-extra-ii)
+	set_wifi_led "$boardname:green:wifi"
+	set_usb_led "$boardname:green:usb"
+	ucidef_set_led_switch "internet" "internet" "$boardname:green:internet" "switch0" "0x01"
+	;;
 youku-yk1)
 	set_wifi_led "$boardname:blue:air"
 	set_usb_led "$boardname:blue:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -218,7 +218,8 @@ ramips_setup_interfaces()
 	wrtnode2p | \
 	wrtnode2r | \
 	youhua,wr1200js|\
-	zbt-wa05)
+	zbt-wa05|\
+	zyxel,keenetic-extra-ii)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -54,7 +54,8 @@ get_status_led() {
 	x5|\
 	x8|\
 	xdxrn502j|\
-	wn3000rpv3)
+	wn3000rpv3|\
+	zyxel,keenetic-extra-ii)
 		status_led="$boardname:green:power"
 		;;
 	3g-6200nl)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -226,6 +226,7 @@ platform_check_image() {
 	zbt-wr8305rt|\
 	zorlik,zl5900v2|\
 	zte-q7|\
+	zyxel,keenetic-extra-ii|\
 	youku-yk1)
 		[ "$magic" != "27051956" ] && {
 			echo "Invalid image type."

--- a/target/linux/ramips/dts/ki_rb.dts
+++ b/target/linux/ramips/dts/ki_rb.dts
@@ -1,0 +1,206 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,keenetic-extra-ii", "mediatek,mt7628an-soc";
+	model = "ZyXEL Keenetic Extra II";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		fn {
+			label = "fn";
+			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "keenetic-extra-ii:green:power";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		internet {
+			label = "keenetic-extra-ii:green:internet";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "keenetic-extra-ii:green:wifi";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "keenetic-extra-ii:green:usb";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+	
+		partition@30000 {
+			label = "u-config";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "rf-eeprom";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xe90000>;
+		};
+
+		partition@ee0000 {
+			label = "config_1";
+			reg = <0xee0000 0x10000>;
+			read-only;
+		};
+
+		partition@ef0000 {
+			label = "storage";
+			reg = <0xef0000 0x100000>;
+			read-only;
+		};
+
+		partition@ff0000 {
+			label = "dump";
+			reg = <0xff0000 0x10000>;
+			read-only;
+		};
+
+		partition@1000000 {
+			label = "u-state";
+			reg = <0x1000000 0x30000>;
+			read-only;
+		};
+
+		partition@1030000 {
+			label = "u-config_res";
+			reg = <0x1030000 0x10000>;
+			read-only;
+		};
+
+		partition@1040000 {
+			label = "rf-eeprom_res";
+			reg = <0x1040000 0x10000>;
+			read-only;
+		};
+
+		partition@1050000 {
+			label = "firmware_2";
+			reg = <0x1050000 0xe90000>;
+			read-only;
+		};
+
+		partition@1ee0000 {
+			label = "config_2";
+			reg = <0x1ee0000 0x10000>;
+			read-only;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	status = "okay";
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&pcie {
+	status = "okay";
+
+	pcie-bridge {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+			mtd-mac-address = <&factory 0x8004>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio", "i2s", "refclk", "spi cs1", "uart1", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -147,6 +147,10 @@ define Build/mkdlinkfw-factory
 	mv $@.new $@
 endef
 
+define Build/zyimage
+	$(STAGING_DIR_HOST)/bin/zyimage $(1) $@
+endef
+
 #
 # The real magic happens inside these templates
 #

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -16,10 +16,6 @@ define Build/elecom-header
 		-f $@ -C $(KDIR) v_0.0.0.bin v_0.0.0.md5
 endef
 
-define Build/zyimage
-	$(STAGING_DIR_HOST)/bin/zyimage $(1) $@
-endef
-
 define Device/ai-br100
   DTS := AI-BR100
   IMAGE_SIZE := 7936k

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -313,3 +313,14 @@ define Device/zbtlink_zbt-we1226
   DEVICE_TITLE := ZBTlink ZBT-WE1226
 endef
 TARGET_DEVICES += zbtlink_zbt-we1226
+
+define Device/zyxel_keenetic-extra-ii
+  DTS := ki_rb
+  IMAGE_SIZE := 14912k
+  DEVICE_TITLE := ZyXEL Keenetic Extra II
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 64k | check-size $$$$(IMAGE_SIZE) | \
+	zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
+endef
+TARGET_DEVICES += zyxel_keenetic-extra-ii


### PR DESCRIPTION
Specification:
- System-On-Chip: MT7628N/N
- CPU/Speed: 580 MHz
- Flash-Chip: Winbond w25q256
- Flash size: 32768 KiB
- RAM: 128 MiB
- 5x 10/100 Mbps Ethernet
- 4x external, non-detachable antennas
- UART (J1) header on PCB (57600 8n1)
- Wireless No1 (2T2R): SoC-integrated: MT7628N 2.4GHz 802.11bgn
- Wireless No2 (2T2R): On-board chip: MT7612EN 5GHz 802.11ac
- USB: Yes 1 x 2.0
- 4x LED, 3x button

The device supports dual boot mode. So we use only first half of flash.

Flash instruction:

The only way to flash OpenWrt image is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. Rename "openwrt-ramips-mt76x8-zyxel_keenetic-extra-ii-squashfs-factory.bin"
   to "kextra2_recovery.bin" and place it in tftp server directory.
3. Connect PC with one of LAN ports, press the reset button, power up
   the router and keep button pressed until power led start blinking.
4. Router will download file from server, write it to flash and reboot.