### PR TITLE
ramips: add support for I-O DATA WN-AX1167GR

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -169,6 +169,7 @@ dlink,dwr-921-c1)
 	;;
 dir-810l|\
 elecom,wrc-1167ghbk2-s|\
+iodata,wn-ax1167gr|\
 iodata,wn-gx300gr|\
 mzk-750dhp|\
 mzk-dp150n|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -228,6 +228,7 @@ ramips_setup_interfaces()
 		;;
 	dir-860l-b1|\
 	elecom,wrc-1167ghbk2-s|\
+	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
@@ -475,6 +476,7 @@ ramips_setup_macs()
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
+	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary Factory 4)" 1)
 		;;

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -28,6 +28,7 @@ get_status_led() {
 	fonera20n|\
 	firewrt|\
 	hg255d|\
+	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr|\
 	kn|\
 	kn_rc|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -76,6 +76,7 @@ platform_check_image() {
 	hpm|\
 	ht-tm02|\
 	hw550-3g|\
+	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr|\
 	ip2202|\
 	jhr-n805r|\

--- a/target/linux/ramips/dts/WN-AX1167GR.dts
+++ b/target/linux/ramips/dts/WN-AX1167GR.dts
@@ -1,0 +1,165 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-ax1167gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-AX1167GR";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "wn-ax1167gr:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wn-ax1167gr:green:wps";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		custom {
+			label = "custom";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "Config";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		Factory: partition@40000 {
+			label = "Factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		iNIC_rf: partition@50000 {
+			label = "iNIC_rf";
+			reg = <0x50000 0x10000>;
+			read-only;
+		};
+
+		partition@60000 {
+			label = "firmware";
+			reg = <0x60000 0xf30000>;
+		};
+
+		partition@f90000 {
+			label = "Key";
+			reg = <0xf90000 0x10000>;
+			read-only;
+		};
+
+		partition@fa0000 {
+			label = "backup";
+			reg = <0xfa0000 0x10000>;
+			read-only;
+		};
+
+		partition@fb0000 {
+			label = "storage";
+			reg = <0xfb0000 0x50000>;
+			read-only;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&iNIC_rf 0x4>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart2", "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&Factory 0x0>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -16,6 +16,23 @@ define Build/elecom-wrc-factory
   mv $@.new $@
 endef
 
+define Build/iodata-factory
+  $(eval fw_size=$(word 1,$(1)))
+  $(eval fw_type=$(word 2,$(1)))
+  $(eval product=$(word 3,$(1)))
+  $(eval factory_bin=$(word 4,$(1)))
+  if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(fw_size)" ]; then \
+    $(CP) $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) $(factory_bin); \
+    $(STAGING_DIR_HOST)/bin/mksenaofw \
+      -r 0x30a -p $(product) -t $(fw_type) \
+      -e $(factory_bin) -o $(factory_bin).new; \
+    mv $(factory_bin).new $(factory_bin); \
+    $(CP) $(factory_bin) $(BIN_DIR)/; \
+	else \
+		echo "WARNING: initramfs kernel image too big, cannot generate factory image" >&2; \
+	fi
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -135,6 +152,16 @@ define Device/hc5962
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 wpad-mini
 endef
 TARGET_DEVICES += hc5962
+
+define Device/iodata_wn-ax1167gr
+  DTS := WN-AX1167GR
+  IMAGE_SIZE := 15552k
+  KERNEL_INITRAMFS := $$(KERNEL) | \
+    iodata-factory 7864320 4 0x1055 $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
+  DEVICE_TITLE := I-O DATA WN-AX1167GR
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-mini
+endef
+TARGET_DEVICES += iodata_wn-ax1167gr
 
 define Device/iodata_wn-gx300gr
   DTS := WN-GX300GR


### PR DESCRIPTION
I-O DATA WN-AX1167GR is a 2.4/5 GHz band 11ac router, based on
MediaTek MT7621A.

Specification:

- MT7621A (2-Cores, 4-Threads)
- 64 MB of RAM (DDR2)
- 16 MB of Flash (SPI)
- 2T2R 2.4/5 GHz
- 5x 10/100/1000 Mbps Ethernet
- 2x LEDs, 4x keys (2x buttons, 1x slide switch)
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - baudrate: 115200 bps (U-Boot, OpenWrt)

Flash instruction using factory image:

1. Connect the computer to the LAN port of WN-AX1167GR
2. Connect power cable to WN-AX1167GR and turn on it
3. Access to "192.168.0.1" on the web browser and open firmware
update page ("ファームウェア")
4. Select the OpenWrt factory image and perform firmware update
5. On the initramfs image, execute "mtd erase firmware" to erase stock
firmware and execute sysupgrade with sysupgrade image for WN-AX1167GR
6. Wait ~180 seconds to complete flasing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>