### PR TITLE
ramips: Add support for Unitac V-FL500 a.k.a Skylink 4G V-FL500

### DIFF
--- a/package/kernel/i2c-aw9523-expander/Makefile
+++ b/package/kernel/i2c-aw9523-expander/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=i2c-aw9523-expander
+PKG_RELEASE:=2
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/i2c-leds-aw9523-expander
+  SUBMENU:=LED modules
+  TITLE:=Custom LED I2C AW9523 device
+  DEPENDS:=+kmod-i2c-core
+  FILES:=$(PKG_BUILD_DIR)/i2c-leds-aw9523.ko
+  AUTOLOAD:=$(call AutoLoad,40,i2c-leds-aw9523,1)
+endef
+
+define KernelPackage/i2c-leds-aw9523-expander/description
+ Kernel module for AW9523 i2c-led expander platform device.
+endef
+EXTRA_KCONFIG := CONFIG_I2C_LEDS_AW9523=m
+
+EXTRA_CFLAGS:= \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(EXTRA_KCONFIG)))) \
+	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(EXTRA_KCONFIG)))) \
+
+MAKE_OPTS:= \
+	$(KERNEL_MAKE_FLAGS) \
+	SUBDIRS="$(PKG_BUILD_DIR)" \
+	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+	$(EXTRA_KCONFIG)
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(MAKE_OPTS) \
+		modules
+endef
+
+$(eval $(call KernelPackage,i2c-leds-aw9523-expander))

--- a/package/kernel/i2c-aw9523-expander/src/Kconfig
+++ b/package/kernel/i2c-aw9523-expander/src/Kconfig
@@ -1,0 +1,8 @@
+config I2C_LED_AW9523
+	tristate "AW9523 GPIO-based I2C expander LED driver"
+	depends on LEDS_CLASS && I2C
+	help
+	  This is an I2C driver to register AW9523 LEDs expander.
+
+	  This support is also available as a module.  If so, the module
+	  will be called i2c-led-aw9523.

--- a/package/kernel/i2c-aw9523-expander/src/Makefile
+++ b/package/kernel/i2c-aw9523-expander/src/Makefile
@@ -1,0 +1,1 @@
+obj-${CONFIG_I2C_LEDS_AW9523}	+= i2c-leds-aw9523.o

--- a/package/kernel/i2c-aw9523-expander/src/i2c-leds-aw9523.c
+++ b/package/kernel/i2c-aw9523-expander/src/i2c-leds-aw9523.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-2.0+
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/init.h>
+#include <linux/i2c.h>
+#include <linux/gpio.h>
+#include <linux/delay.h>
+#include <linux/leds.h>
+#include <linux/platform_device.h>
+#include <linux/gpio/consumer.h>
+
+/*
+ * AW9523 registers
+ */
+#define AW9523_REG_INPUT_PORT0		0x00
+#define AW9523_REG_INPUT_PORT1		0x01
+#define AW9523_REG_OUTPUT_PORT0		0x02
+#define AW9523_REG_OUTPUT_PORT1		0x03
+#define AW9523_REG_CFG_PORT0		0x04	/* P0 0-7 config: 0 - OUT, 1 - IN */
+#define AW9523_REG_CFG_PORT1		0x05
+#define AW9523_REG_INTN_PORT0		0x06	/* P0 0-7 inten: - disabled, 1 - enabled */
+#define AW9523_REG_INTN_PORT1		0x07
+#define AW9523_REG_DEV_ID		0x10
+#define AW9523_REG_GPOMD		0x11	/* BIT(4) - P0 mode: 0 - Open-Drain, 1 - Push-Pull, BITS(1:0) - ISEL */
+#define AW9523_REG_MODE_PORT0		0x12	/* P0 mode switch: 0 - GPIO, 1 - LED */
+#define AW9523_REG_MODE_PORT1		0x13
+#define AW9523_REG_LED_BASE		0x20	/* PORT1-4 0x20-0x24, PORT0 0x24-0x2b, PORT1-5 0x2c-0x2f WR only */
+#define AW9523_REG_SWRESET		0x7F
+
+#define AW9523_P0_PUSHPULL		BIT(4)	/* 0 - open-drain, 1 - push-pull */
+
+#define AW9523_MAXGPIO			16
+#define AW9523_BANK(offs)		((offs) >> 3)
+#define AW9523_BIT(offs)		BIT((offs) & 0x7)
+#define MAX_BRIGHTNESS			255
+
+struct aw9523_led {
+	struct aw9523_priv_data *pdata;
+	struct led_classdev cdev;
+	uint8_t brighness;
+	uint8_t port;
+};
+
+struct aw9523_priv_data {
+	struct i2c_client *client;
+	struct mutex lock;	/* protect cached dir, dat_out */
+	uint8_t mode[2];	/* LED/GPIO bits */
+	uint8_t p0xmod;		/* AW9523 Port 0 mode */
+	struct aw9523_led leds[AW9523_MAXGPIO];
+};
+
+static int aw9523_i2c_read(struct i2c_client *client, u8 reg)
+{
+	int ret = i2c_smbus_read_byte_data(client, reg);
+
+	if (ret < 0)
+		dev_err(&client->dev, "Read Error\n");
+
+	return ret;
+}
+
+static int aw9523_i2c_write(struct i2c_client *client, u8 reg, u8 val)
+{
+	int ret = i2c_smbus_write_byte_data(client, reg, val);
+
+	if (ret < 0)
+		dev_err(&client->dev, "Write Error\n");
+
+	return ret;
+}
+
+static enum led_brightness aw9523_led_get_value(struct led_classdev *cdev)
+{
+	struct aw9523_led *led = container_of(cdev, struct aw9523_led, cdev);
+
+	return led->brighness;
+}
+
+static void aw9523_led_set_value(struct led_classdev *cdev, enum led_brightness value)
+{
+	struct aw9523_led *led = container_of(cdev, struct aw9523_led, cdev);
+	unsigned int port;
+
+	mutex_lock(&led->pdata->lock);
+
+	aw9523_i2c_write(led->pdata->client, AW9523_REG_LED_BASE + led->port, value);
+	led->brighness = value;
+	mutex_unlock(&led->pdata->lock);
+}
+
+static int aw9523_led_to_port(uint8_t led)
+{
+	if (led < 8)
+	    return 4 + led;
+	if (led > 12)
+	    return led;
+	return (led & 0x07);
+}
+
+static int aw9523_leds_register(struct aw9523_priv_data *dev, struct device_node *np)
+{
+	struct aw9523_led *led;
+	struct device_node *child;
+	int ret = 0, i;
+	unsigned int bit, bank;
+
+	for_each_available_child_of_node(np, child) {
+		ret = of_property_read_u32(child, "reg", &i);
+		if (!ret) {
+			led = &dev->leds[i & 0x0F];
+			led->cdev.name = of_get_property(child, "label", NULL);
+		}
+	}
+
+	for (i = 0; i < AW9523_MAXGPIO; i++){
+		bank = AW9523_BANK(i);
+		bit = AW9523_BIT(i);
+		if (!(dev->mode[bank] & bit)) {
+			led = &dev->leds[i];
+			led->pdata = dev;
+			led->port = aw9523_led_to_port(i);
+			led->cdev.brightness_get = aw9523_led_get_value;
+			led->cdev.brightness_set = aw9523_led_set_value;
+			led->cdev.max_brightness = MAX_BRIGHTNESS;
+			led->cdev.brightness = LED_OFF;
+			if (led->cdev.name == NULL)
+				led->cdev.name = devm_kasprintf(&dev->client->dev,
+						GFP_KERNEL, "aw9523:led%02d",i);
+			if (!led->cdev.name)
+				return -ENOMEM;
+			ret = led_classdev_register(&dev->client->dev, &led->cdev);
+			if (ret)
+				return ret;
+		}
+	}
+	return ret;
+}
+
+static int aw9523_leds_probe(struct i2c_client *client,
+					const struct i2c_device_id *id)
+{
+	struct device_node *np = client->dev.of_node;
+	struct aw9523_priv_data *dev;
+	struct gpio_desc *reset_gpio;
+	u8 val;
+	int ret, revid;
+
+	if (!i2c_check_functionality(client->adapter,
+					I2C_FUNC_SMBUS_BYTE_DATA)) {
+		dev_err(&client->dev, "SMBUS Byte Data not Supported\n");
+		return -EIO;
+	}
+
+	/* bring the chip out of reset if reset pin is provided*/
+	reset_gpio = devm_gpiod_get_optional(&client->dev, "reset", GPIOD_OUT_LOW);
+	if (IS_ERR(reset_gpio)) {
+		dev_warn(&client->dev, "Could not get reset-gpios\n");
+	} else {
+		gpiod_set_value_cansleep(reset_gpio, 0);
+		usleep_range(1000, 1100);
+		gpiod_set_value_cansleep(reset_gpio, 1);
+	}
+
+	dev = devm_kzalloc(&client->dev, sizeof(*dev), GFP_KERNEL);
+	if (!dev)
+		return -ENOMEM;
+
+	dev->client = client;
+
+	mutex_init(&dev->lock);
+
+	ret = aw9523_i2c_write(client, AW9523_REG_SWRESET, 0);
+	if (ret < 0)
+		goto err;
+
+	ret = aw9523_i2c_read(client, AW9523_REG_DEV_ID);
+	if (ret < 0)
+		goto err;
+
+	revid = ret;	/* 0x23 by default */
+
+	if (!device_property_read_u8(&client->dev, "led-current", &val))
+	    dev->p0xmod |= (val & 7);
+
+	ret = device_property_read_u8(&client->dev, "ch0-config", &val);
+	if (!ret) {
+		dev->mode[0] = val;
+	} else
+		dev->mode[0] = 0x0;
+
+	ret = device_property_read_u8(&client->dev, "ch1-config", &val);
+	if (!ret) {
+		dev->mode[1] = val;
+	} else
+		dev->mode[1] = 0x0;
+
+	/* Configure registers: port to OUT, interrupts DISABLE */
+	ret = aw9523_i2c_write(client, AW9523_REG_CFG_PORT0, 0);
+	ret |= aw9523_i2c_write(client, AW9523_REG_CFG_PORT1, 0);
+	ret |= aw9523_i2c_write(client, AW9523_REG_INTN_PORT0, 0xFF);
+	ret |= aw9523_i2c_write(client, AW9523_REG_INTN_PORT1, 0xFF);
+	ret |= aw9523_i2c_write(client, AW9523_REG_MODE_PORT0, dev->mode[0]);
+	ret |= aw9523_i2c_write(client, AW9523_REG_MODE_PORT1, dev->mode[1]);
+
+	ret |= aw9523_i2c_write(client, AW9523_REG_GPOMD, dev->p0xmod);
+
+	if (ret) {
+		dev_err(&client->dev, "Initial programming error\n");
+		goto err;
+	}
+
+	ret = aw9523_leds_register(dev, np);
+	if (ret) {
+		dev_err(&client->dev, "Register led class failed: %d\n", ret);
+		goto err;
+	}
+
+	dev_info(&client->dev, "I2C AW9523 Rev.: %d\n", revid);
+
+	i2c_set_clientdata(client, dev);
+
+	return 0;
+
+err:
+	return ret;
+}
+
+static int aw9523_leds_remove(struct i2c_client *client)
+{
+	struct aw9523_priv_data *dev = i2c_get_clientdata(client);
+	struct aw9523_led *led;
+	int i;
+
+	for (i = 0; i < AW9523_MAXGPIO; i++){
+		led = &dev->leds[i];
+		if (led->pdata)
+		    led_classdev_unregister(&led->cdev);
+	}
+
+	return 0;
+}
+
+static const struct of_device_id aw9523_of_match_table[] = {
+	{ .compatible = "allwinc,aw9523" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, aw9523_of_match_table);
+
+static const struct i2c_device_id aw9523_leds_id[] = {
+	{"aw9523-leds", 0},
+	{ }
+};
+
+MODULE_DEVICE_TABLE(i2c, aw9523_leds_id);
+
+static struct i2c_driver aw9523_leds_driver = {
+	.driver = {
+		    .name = "aw9523-leds",
+		    .of_match_table = of_match_ptr(aw9523_of_match_table),
+		   },
+	.probe = aw9523_leds_probe,
+	.remove = aw9523_leds_remove,
+};
+
+module_i2c_driver(aw9523_leds_driver);
+
+MODULE_DESCRIPTION("Allwinc AW9523 GPIO LED expander driver");
+MODULE_LICENSE("GPL");

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -354,6 +354,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "2:lan" "6t@eth0"
 		;;
+	v-fl500)
+		ucidef_add_switch "switch0" \
+			"2:lan:1" "3:lan:2" "4:wan" "6t@eth0"
+		;;
 	f5d8235-v1|\
 	tew-714tru|\
 	v11st-fe|\

--- a/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
@@ -17,6 +17,9 @@ ubnt-erx-sfp)
 	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "499"
 	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "500"
 	;;
+v-fl500)
+	ucidef_add_gpio_switch "minipci_power" "Mini-PCI power" "39" "1"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -244,6 +244,7 @@ get_status_led() {
 		status_led="px-4885:orange:wifi"
 		;;
 	re6500|\
+	v-fl500|\
 	whr-1166d|\
 	whr-600d)
 		status_led="$boardname:orange:wifi"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -541,6 +541,9 @@ ramips_board_detect() {
 	*"VR500")
 		name="vr500"
 		;;
+	*"V-FL500")
+		name="v-fl500"
+		;;
 	*"W150M")
 		name="w150m"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -158,6 +158,7 @@ platform_check_image() {
 	u7628-01-128M-16M|\
 	ur-326n4g|\
 	ur-336un|\
+	v-fl500|\
 	v22rw-2x2|\
 	vonets,var11n-300|\
 	vocore-8M|\

--- a/target/linux/ramips/dts/V-FL500.dts
+++ b/target/linux/ramips/dts/V-FL500.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "unitac,v-fl500", "ralink,mt7620n-soc";
+	model = "Unitac V-FL500";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "v-fl500:orange:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "breed-boot";
+			reg = <0x0 0x30000>;
+		};
+
+		partition@30000 {
+			label = "breed-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x7b0000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wled", "spi refclk", "nd_sd";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/dts/V-FL500.dts
+++ b/target/linux/ramips/dts/V-FL500.dts
@@ -93,6 +93,44 @@
 	};
 };
 
+&i2c {
+	clock-frequency = <400000>;
+	status = "okay";
+
+	leds: aw9523-leds@5b {
+		compatible = "allwinc,aw9523";
+		reg = <0x5b>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reset-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		reset-active-low;
+
+		led-current = <0>;
+		ch0-config = [fd];
+		ch1-config = [f1];
+
+		led1: led@1 {
+			label = "aw9523:signal";
+			reg = <1>;
+		};
+
+		led9: led@9 {
+			label = "aw9523:4g";
+			reg = <9>;
+		};
+
+		led10: led@10 {
+			label = "aw9523:internet";
+			reg = <10>;
+		};
+
+		led11: led@11 {
+			label = "aw9523:wps";
+			reg = <11>;
+		};
+	};
+};
+
 &ehci {
 	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -208,13 +208,6 @@
 			pinctrl-0 = <&spi_cs1>;
 		};
 
-		i2c_pins: i2c {
-			i2c {
-				ralink,group = "i2c";
-				ralink,function = "i2c";
-			};
-		};
-
 		uartlite: uartlite@c00 {
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
@@ -269,6 +262,13 @@
 			spi1 {
 				ralink,group = "spi_cs1";
 				ralink,function = "spi_cs1";
+			};
+		};
+
+		i2c_pins: i2c {
+			i2c {
+				ralink,group = "i2c";
+				ralink,function = "i2c";
 			};
 		};
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -684,6 +684,6 @@ TARGET_DEVICES += zte-q7
 define Device/v-fl500
   DTS := V-FL500
   DEVICE_TITLE := Unitac V-FL500
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-rndis kmod-usb-acm
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-rndis kmod-usb-acm kmod-i2c-leds-aw9523-expander
 endef
 TARGET_DEVICES += v-fl500

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -680,3 +680,10 @@ define Device/zte-q7
   DEVICE_TITLE := ZTE Q7
 endef
 TARGET_DEVICES += zte-q7
+
+define Device/v-fl500
+  DTS := V-FL500
+  DEVICE_TITLE := Unitac V-FL500
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-rndis kmod-usb-acm
+endef
+TARGET_DEVICES += v-fl500


### PR DESCRIPTION
ramips: Add support for Unitac V-FL500 a.k.a Skylink 4G V-FL500

Specification:
- SoC: MediaTek MT7620N
- Flash: 8 MB
- RAM: 64 MB
- Ethernet: 3 FE ports (LLW)
- Wireless radio: MT7620 for 2.4G
- UART: 1 x UART on PCB - 57600 8N1 (3.3v TTL Vcc,Tx,Rx,GND from ethernet ports)
- USB: 1 x USB 2.0 port routed to internal miniPCIe slot with Altair ALT3800 4G LTE modem
- LEDs: 1 - hardwired to Vcc, 1 - SoC GPIO,
  4x LEDs controlled via I2C Allwinc AW9523 GPIO controller in LED-driver mode
- 2x KEYs

Flash instruction:

Login to original firmware (RALINK SDK based on OpenWrt 14.07) and flash wia web.

Signed-off-by: Andrey Jr. Melnikov <temnota.am@gmail.com>

