### PR TITLE
Fix sysupgrade for ipq806x Netgear routers (FS#1617)

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -270,11 +270,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x2000000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -235,11 +235,6 @@
 						reg = <0x3940000 0x46c0000>;
 						read-only;
 					};
-
-					firmware@1340000 {
-						label = "firmware";
-						reg = <0x1340000 0x1a00000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -271,11 +271,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x2000000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -327,11 +327,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x6480000>;
-					};
 				};
 			};
 		};


### PR DESCRIPTION
@mkresin 
Reference to  https://bugs.openwrt.org/index.php?do=details&task_id=1617

Remove the "firmware" partition definition from the DTS of R7800 to fix sysupgrade.
(Do the same for D7800, R7500 and R7500v2 in a separate commit)

Commit 4645a6d defined CONFIG_MTD_SPLIT_UIMAGE_FW=y for ipq806x
and that causes mtd to misbehave as additional kernel and ubi
partitions are detected from inside the "firmware" partition.
```
  [    1.111324] 0x000001480000-0x000001880000 : "kernel"
  [    1.121005] 0x000001880000-0x000007900000 : "ubi"
  [    1.283912] 0x000007900000-0x000008000000 : "reserve"
  [    1.296407] 0x000001480000-0x000007900000 : "firmware"
  [    1.468043] no rootfs found after FIT image in "firmware"
  [    2.426860] 2 uimage-fw partitions found on MTD device firmware
  [    2.426931] 0x000001480000-0x000001880000 : "kernel"
  [    2.440420] 0x000001880000-0x000007900000 : "ubi"

```

Both kernel and ubi are already defined in DTS, so this duplication leads into errors in sysupgrade:
```
  Writing from <stdin> to kernel ...
  ubiattach: error!: strtoul: unable to parse the number '6 mtd10'
  ubiattach: error!: bad MTD device number: "6 mtd10"
```

The partition is defined to same area as kernel+ubi, and is not needed for sysupgrade anymore. 
Remove it to fix things.

After the change, sysupgrade works again normally.

Note: this needs to be backported to 18.06, as the same commit has been backported there.
