### PR TITLE
[18.06] ipq806x: Fix sysupgrade (FS#1617), enlarge R7800 flash partition

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -270,11 +270,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x2000000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -235,11 +235,6 @@
 						reg = <0x3940000 0x46c0000>;
 						read-only;
 					};
-
-					firmware@1340000 {
-						label = "firmware";
-						reg = <0x1340000 0x1a00000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -271,11 +271,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x2000000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -327,11 +327,6 @@
 						reg = <0x7900000 0x0700000>;
 						read-only;
 					};
-
-					firmware@1480000 {
-						label = "firmware";
-						reg = <0x1480000 0x6480000>;
-					};
 				};
 			};
 		};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -319,13 +319,7 @@
 
 					ubi@1880000 {
 						label = "ubi";
-						reg = <0x1880000 0x1C00000>;
-					};
-
-					netgear@3480000 {
-						label = "netgear";
-						reg = <0x3480000 0x4480000>;
-						read-only;
+						reg = <0x1880000 0x6080000>;
 					};
 
 					reserve@7900000 {
@@ -336,7 +330,7 @@
 
 					firmware@1480000 {
 						label = "firmware";
-						reg = <0x1480000 0x2000000>;
+						reg = <0x1480000 0x6480000>;
 					};
 				};
 			};


### PR DESCRIPTION
@mkresin 

Backport combination of two PR:s to fix sysupgrade for Netgear ipq806x routers:

* #1003 - Enlarge R7800 flash partition - commit fb8a578aa7
     Use also "netgear" partition, enlarging the available flash space by 68 MB from 32 MB to 100 MB. In my mind it makes sense to backport this at the same time, as sysupgrade is already broken for the current 18.06 users (as rc1 was done after a1373bc6). The enlarged partition has been on master for some time now, and so far no negative feedback. Backporting this also allows cherry-picking the actual sysupgrade fix from #1119 

* #1119 - Fix sysupgrade for ipq806x Netgear routers  (FS#1617)
     Remove unused "firmware" definition to avoid double detection of "ubi", which can break sysupgrade after a1373bc6  ( 4645a6d in master). Btw, in the erroneous condition I actually got different results with 18.06: sysupgrade may fail but it may also work sometimes. Apparently the mtd parsing sometimes fails differently than in master.

Commits are direct cherry-picks
