### PR TITLE
ramips: Add support for MikroTik RouterBOARD RBM11g

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -262,6 +262,14 @@ m2m)
 	set_wifi_led "$boardname:blue:wifi"
 	ucidef_set_led_netdev "eth" "Ethernet" "$boardname:green:wan" "eth0"
 	;;
+mikrotik,rbm11g)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:green:rssi0" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "$boardname:green:rssi1" "wlan0" "20" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssi2" "wlan0" "40" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssi3" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssiveryhigh" "RSSIVERYHIGH" "$boardname:green:rssi4" "wlan0" "80" "100"
+	;;
 miniembplug)
 	set_wifi_led "$boardname:red:wlan"
 	set_usb_led "$boardname:green:mobile"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -52,6 +52,7 @@ ramips_setup_interfaces()
 	linkits7688 | \
 	m2m|\
 	microwrt|\
+	mikrotik,rbm11g|\
 	mpr-a2|\
 	ncs601w|\
 	omega2 | \

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -209,8 +209,9 @@ get_status_led() {
 	m4-8M)
 		status_led="m4:blue:status"
 		;;
+	mikrotik,rbm11g|\
 	mikrotik,rbm33g)
-		status_led="rbm33g:green:usr"
+		status_led="$boardname:green:usr"
 		;;
 	miwifi-mini|\
 	zte-q7)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -297,6 +297,7 @@ platform_check_image() {
 		nand_do_platform_check "$board" "$1"
 		return $?;
 		;;
+	mikrotik,rbm11g|\
 	mikrotik,rbm33g|\
 	re350-v1)
 		[ "$magic" != "01000000" ] && {
@@ -323,6 +324,7 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	mikrotik,rbm11g|\
 	mikrotik,rbm33g)
 		[ -z "$(rootfs_type)" ] && mtd erase firmware
 		;;

--- a/target/linux/ramips/dts/RBM11G.dts
+++ b/target/linux/ramips/dts/RBM11G.dts
@@ -1,0 +1,131 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "mikrotik,rbm11g", "mediatek,mt7621-soc";
+	model = "MikroTik RBM11G";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usr {
+			label = "rbm11g:green:usr";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi0 {
+			label = "rbm11g:green:rssi0";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "rbm11g:green:rssi1";
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "rbm11g:green:rssi2";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi3 {
+			label = "rbm11g:green:rssi3";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi4 {
+			label = "rbm11g:green:rssi4";
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+		res {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	pcie0_vcc_reg {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie0_vcc";
+
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+
+&spi0 {
+	status = "okay";
+
+	w25q128@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <3125000>;
+
+		partition@0 {
+			label = "routerboot";
+			reg = <0x000000 0x00F000>;
+			read-only;
+		};
+
+		factory: partition@f000 {
+			label = "factory";
+			reg = <0x00F000 0x031000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "firmware";
+			reg = <0x040000 0xFC0000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x0010>;
+	mtd-mac-address-increment = <1>;
+};
+
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart2", "wdt", "rgmii2";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -247,6 +247,19 @@ define Device/mikrotik_rbm33g
 endef
 TARGET_DEVICES += mikrotik_rbm33g
 
+define Device/mikrotik_rbm11g
+  DTS := RBM11G
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 16128k
+  DEVICE_TITLE := MikroTik RBM11G
+  LOADER_TYPE := elf
+  PLATFORM := mt7621
+  KERNEL := kernel-bin | patch-dtb | lzma | loader-kernel
+  IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | pad-to $$$$(BLOCKSIZE) | \
+        append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += mikrotik_rbm11g
+
 define Device/re350-v1
   DTS := RE350
   DEVICE_TITLE := TP-LINK RE350 v1


### PR DESCRIPTION
This commit adds support for the MikroTik RouterBOARD RBM11g.

# Hardware

The RBM11g is a mt7621 based device featuring one GbE port and one
miniPCIe slot with a sim card socket and USB 2.0.

## Switch

The single onboard Ethernet port is connected directly to the CPU. The internal switch is disabled.

## Flash

The device has one spi nor flash chip. It is a 128 Mbit winbond 25Q128FVS
connected to CS0.

## PCIe

The board features a single miniPCIe slot. It has a dedicated mini SIM
socket and a USB 2.0 port. Power to the miniPCIe slot is controlled via
GPIO9.

## USB

There are no external USB ports.

## Power

The board can accept both, passive PoE and external power via a 2.1 mm
barrel jack (center-positive). The input voltage range is 11-32 V.

## Serial port

The device does have an onboard UART on an unpopulated header next to the
flash chip:

```
GND: pin 2
 TX: pin 7
 RX: pin 6
```

Settings: 115200, 8N1

See below illustration for positioning of the header.

```
0 = screw hole
* = some pin
T = TX  pin
R = RX  pin
G = GND pin
```

Pinout:
```
+---------------
|O
|             __
|            /  \
|            \__/
|
|
|
|               +---+
|               |RAM|
| +--+          |   |
| |**|  <- unpopulated header with UART
| |*T|          +---+
| |R*|        +--------+
| |**|        |        |
| |G*|        |  CPU   |
| +--+        |        |
|    +--+     |        |
|    |  |     +--------+
|    +--+  <- flash chip
|O
|       +-----+
|       |     |
|+--+   |     |
||  |   |     |
+---------------------
```

# Installation

To install an OpenWRT image to the device two components must be built:

1. A openwrt initramfs image
2. A openwrt sysupgrade image

## initramfs & sysupgrade image

Select target devices "Mikrotik RBM11G" in
openwrt menuconfig and build the images. This will create the images
"openwrt-ramips-mt7621-mikrotik_rbm11g-initramfs-kernel.bin" and
"openwrt-ramips-mt7621-mikrotik_rbm11g-squashfs-sysupgrade.bin" in the
output directory.

## Installing

**Make sure to back up your RouterOS license in case you do ever want to
go back to RouterOS using "/system license output" and back up the
created license file.**

When rebooted the board will try booting via ethernet first. If your
board does not boot via ethernet automatically you will have to attach
to the serial port and set ethernet as boot device within RouterBOOT.

1. Set up a dhcp server that points the bootfile to tftp server serving
   the "openwrt-ramips-mt7621-mikrotik_rbm11g-initramfs-kernel.bin"
   initramfs image
2. Connect to ethernet port on board
3. Power on the board
4. Wait for OpenWrt to boot

Right now OpenWrt will be running with a SSH server listening. Now
OpenWrt must be flashed to the devices flash:

1. Copy "openwrt-ramips-mt7621-mikrotik_rbm11g-squashfs-sysupgrade.bin"
   to the device using scp.
2. Write openwrt to flash using "sysupgrade
   openwrt-ramips-mt7621-mikrotik_rbm11g-squashfs-sysupgrade.bin"

Once the flashing completes the board will reboot. Disconnect from the
devices ethernet port or stop the DHCP/TFTP server to prevent the device
from booting via ethernet again.
The device should now boot straight to OpenWrt.

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>