### PR TITLE
ipq806x: switch the NBG6817 wlan LEDs from amber to white

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -43,8 +43,6 @@ tplink,vr2600v)
 	ucidef_set_led_switch "wan" "wan" "${boardname}:white:wan" "switch0" "0x20"
 	;;
 zyxel,nbg6817)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:amber:wifi2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:amber:wifi5g" "phy0tpt"
 	ucidef_set_led_netdev "wan" "WAN" "${boardname}:white:internet" "eth1"
 	;;
 *)


### PR DESCRIPTION
The original device support patch configured the amber wlan LEDs (which
are meant as error indicator by the OEM) controlled by the SOC's GPIO
as wlan traffic indicators, as the correct white wlan LEDs are
connected to GPIOs controlled by the QCA9984/ ath10k wlan cards were
not accessible. The recent addition of GPIO/ LED support to ath10k now
makes it possible to use the correct white LEDs instead - and
"mac80211: ath10k: use tpt LED trigger by default" also enables them by
default. While both LEDs are independent of each other (two separate
LEDs sharing one light tunnel), triggering both on wlan traffic is not
the intended behaviour (bright yellow light).

Tested on the ZyXEL NBG6817.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>

This patch depends on:

- 61d57a2f88b90ba951012e66c7c6fae9234c97b4 "mac80211: ath10k add leds support"
  cherry-picked to openwrt-18.06 as 843e421a05070b6a0f7eff710d2099d03b45410d
- 60deb3cdef4ac50a7d0fe9964a0f4a55aca1567e "mac80211: ath10k: use tpt LED trigger by default"
  only in master so far
- 34e22653ac18b6ac7fd368ca47625f665808067f "mac80211: enable ath10k LED support by default"
  only in master so far

~~Given that the first patch has already been cherry-picked for the openwrt-18.06 branch, it would be nice to have this pull request and its two dependencies cherry-picked as well - however, as long as 60deb3cdef4ac50a7d0fe9964a0f4a55aca1567e and 34e22653ac18b6ac7fd368ca47625f665808067f are kept out of the openwrt-18.06 branch, this patch isn't strictly required either (as 61d57a2f88b90ba951012e66c7c6fae9234c97b4 remains inactive without mkresin's and stintel's subsequent bugfixes).~~ This patch should not be backported alone, without its dependencies (as that would disable both LEDs, amber (enabled in 17.01.x) and white).

EDIT: as clarified with jow, 60deb3cdef4ac50a7d0fe9964a0f4a55aca1567e and 34e22653ac18b6ac7fd368ca47625f665808067f will be kept out of 18.06.0, which means the openwrt-18.06 branch is fine as it is - and this pull request is only needed for master.