### PR TITLE
lantiq: enlarge AVM Fritz!Box 3370 flash

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2-HYNIX.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2-HYNIX.dts
@@ -31,24 +31,7 @@
 
 			partition@400000 {
 				label = "ubi";
-				reg = <0x400000 0x3000000>;
-			};
-
-			partition@3400000 {
-				label = "reserved-kernel";
-				reg = <0x3400000 0x400000>;
-			};
-			partition@3800000 {
-				label = "reserved-filesystem";
-				reg = <0x3800000 0x3000000>;
-			};
-			partition@6800000 {
-				label = "config";
-				reg = <0x6800000 0x200000>;
-			};
-			partition@6a00000 {
-				label = "nand-filesystem";
-				reg = <0x6a00000 0x1600000>;
+				reg = <0x400000 0x7c00000>;
 			};
 		};
 	};

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2-MICRON.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2-MICRON.dts
@@ -29,24 +29,7 @@
 
 			partition@400000 {
 				label = "ubi";
-				reg = <0x400000 0x3000000>;
-			};
-
-			partition@3400000 {
-				label = "reserved-kernel";
-				reg = <0x3400000 0x400000>;
-			};
-			partition@3800000 {
-				label = "reserved-filesystem";
-				reg = <0x3800000 0x3000000>;
-			};
-			partition@6800000 {
-				label = "config";
-				reg = <0x6800000 0x200000>;
-			};
-			partition@6a00000 {
-				label = "nand-filesystem";
-				reg = <0x6a00000 0x1600000>;
+				reg = <0x400000 0x7c00000>;
 			};
 		};
 	};


### PR DESCRIPTION
Increase the available flash memory size in AVM Fritz!Box 3370 by
incorporating the unused extra partitions located after the ubi partition.

Available flash space for rootfs+overlay increases from 48MB to 124MB.

Reverting to the OEM firmware is still possible (via the recovery utility
provided by AVM) as the OEM firmware appears to reformat the _config_ and
_nand-filesystem_ partitions upon first boot if necessary. The
_reserved-kernel_ and _reserved-filesystem_ partitions are overwritten by the
OEM firmware when installing an update, so their contents do not matter.

Boot loader and device-specific information (MAC addresses, calibration
data, etc.) are not located in NAND flash and remain unharmed by this
changed.

Tested with OEM firmware 06.54 on device with HWRevision 5 and Micron
flash chip.

@mkresin, can you have a look?