### PR TITLE
ipq806x: fix numbering for Netgear R7800 LAN ports

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -16,11 +16,14 @@ compex,wpq864 |\
 netgear,d7800 |\
 netgear,r7500 |\
 netgear,r7500v2 |\
-netgear,r7800 |\
 qcom,ipq8064-ap148 |\
 tplink,vr2600v)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
+	;;
+netgear,r7800)
+	ucidef_add_switch "switch0" \
+		"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "6@eth1" "5:wan" "0@eth0"
 	;;
 linksys,ea8500)
 	hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)


### PR DESCRIPTION
Netgear R7800 switch LAN ports are numbered backwards in LuCI,
i.e. numbering is not corresponding to the actual physical port labels,
patch fixes that.

Signed-off-by: Aleksandr V. Piskunov <aleksandr.v.piskunov@gmail.com>