### PR TITLE
ath79: add support for UniFi AC-Mesh Pro

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -114,6 +114,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan:1" "5:lan:2" "4:wan"
 		;;
+	"ubnt,unifiac-mesh-pro"|\
 	"ubnt,unifiac-pro")
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -101,6 +101,7 @@ case "$FIRMWARE" in
 		;;
 	"ubnt,unifiac-lite"|\
 	"ubnt,unifiac-mesh"|\
+	"ubnt,unifiac-mesh-pro"|\
 	"ubnt,unifiac-pro")
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac-mesh-pro.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac-mesh-pro.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_ubnt_unifiac-pro.dtsi"
+
+/ {
+	compatible = "ubnt,unifiac-mesh-pro", "qca,qca9563";
+	model = "Ubiquiti UniFi-AC-MESH PRO";
+};

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "qca9563_ubnt_unifiac.dtsi"
+#include "qca9563_ubnt_unifiac-pro.dtsi"
 
 / {
 	compatible = "ubnt,unifiac-pro", "qca,qca9563";
-	model = "Ubiquiti UniFi-AC-PRO/MESH PRO";
+	model = "Ubiquiti UniFi-AC-PRO";
 };
 
 &usb_phy0 {
@@ -14,25 +14,4 @@
 
 &usb0 {
 	status = "okay";
-};
-
-&mdio0 {
-	status = "okay";
-	phy-mask = <0>;
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "sgmii";
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	mtd-mac-address = <&eeprom 0x0>;
-	phy-handle = <&phy0>;
 };

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dtsi
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_ubnt_unifiac.dtsi"
+
+&mdio0 {
+	status = "okay";
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&eeprom 0x0>;
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -103,6 +103,13 @@ define Device/ubnt_unifiac-mesh
 endef
 TARGET_DEVICES += ubnt_unifiac-mesh
 
+define Device/ubnt_unifiac-mesh-pro
+  $(Device/ubnt_unifiac)
+  DEVICE_TITLE := Ubiquiti UniFi AC-Mesh Pro
+  SUPPORTED_DEVICES += ubnt-unifiac-mesh-pro
+endef
+TARGET_DEVICES += ubnt_unifiac-mesh-pro
+
 define Device/ubnt_unifiac-pro
   $(Device/ubnt_unifiac)
   DEVICE_TITLE := Ubiquiti UniFi AC-Pro


### PR DESCRIPTION
The Unifi AC-Mesh Pro has identical hardware to the Unifi AC-Pro except
USB support.
Furthermore for setting parameters like antenna gain it is helpful to
know the exact device variant.