### PR TITLE
ath79: remove bs-partition ro-flag for UniFi AC devices

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -97,7 +97,6 @@
 			partition@f90000 {
 				label = "bs";
 				reg = <0xf90000 0x020000>;
-				read-only;
 			};
 
 			partition@fb0000 {


### PR DESCRIPTION
This removes the read-only flag from the bs (bootselect) partition
on UniFi AC devices. This allows to correct the indicator from which
partition the device is booting its kernel from.

See also:
 - freifunk-gluon/gluon#1301
 - https://bugs.lede-project.org/index.php?do=details&task_id=662

Inspiration taken from: https://github.com/openwrt/openwrt/commit/f17173f5a36999f070a2ccbde2953d5d0d98001b