### PR TITLE
mt7621 CPU_TYPE=1004kc

### DIFF
--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -5,7 +5,7 @@
 SUBTARGET:=mt7621
 BOARDNAME:=MT7621 based boards
 FEATURES+=nand ramdisk rtc usb minor
-CPU_TYPE:=24kc
+CPU_TYPE:=1004kc
 
 define Target/Description
 	Build firmware images for Ralink MT7621 based boards.


### PR DESCRIPTION
CPU_TYPE is 1004kc instead of 24kc. MIPS 24kc has an 8-stage pipeline whereas 1004kc has a 9-stage pipeline.
Tested with OpenWRT master r7360-e15565a01c on a D-Link DIR860L

Signed-off-by: Bart van Zoest <bartvanzoest@gmail.com>
