### PR TITLE
ramips: add support for Blueendless Kimax U35WF

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -244,6 +244,10 @@ ht-tm02)
 	ucidef_set_led_netdev "eth" "Ethernet" "$boardname:green:lan" "eth0"
 	set_wifi_led "$boardname:blue:wlan"
 	;;
+kimax,u35wf)
+ 	set_wifi_led "$boardname:blue:wifi"
+ 	ucidef_set_led_netdev "eth" "ETH" "$boardname:green:eth" "eth0"
+ 	;;
 kn|\
 nbg-419n2)
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -49,6 +49,7 @@ ramips_setup_interfaces()
 	dcs-930|\
 	dcs-930l-b1|\
 	ht-tm02|\
+	kimax,u35wf|\
 	linkits7688 | \
 	m2m|\
 	microwrt|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -199,6 +199,7 @@ get_status_led() {
 	linkits7688)
 		status_led="linkit-smart-7688:orange:wifi"
 		;;
+	kimax,u35wf|\
 	m2m)
 		status_led="$boardname:blue:wifi"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -82,6 +82,7 @@ platform_check_image() {
 	jhr-n825r|\
 	jhr-n926r|\
 	k2p|\
+	kimax,u35wf|\
 	kn|\
 	kn_rc|\
 	kn_rf|\

--- a/target/linux/ramips/dts/U35WF.dts
+++ b/target/linux/ramips/dts/U35WF.dts
@@ -1,0 +1,106 @@
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "kimax,u35wf","ralink,mt7620n-soc";
+	model = "Kimax U35WF";
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "u35wf:blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "u35wf:green:eth";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xfb0000>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "ephy", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -244,6 +244,13 @@ define Device/u25awf-h1
 endef
 TARGET_DEVICES += u25awf-h1
 
+define Device/kimax_u35wf
+  DTS := U35WF
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := Kimax U35WF
+endef
+TARGET_DEVICES += kimax_u35wf
+
 define Device/gl-mt300n
   DTS := GL-MT300N
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Blueendless Kimax U35WF is a 3,5" HDD Enclosure with Wi-Fi and Ethernet

Patch rewritten from: https://forum.openwrt.org/viewtopic.php?id=66908
Based on: https://github.com/lede-project/source/pull/965

Specification:
- SoC: MediaTek MT7620N
- CPU/Speed: 580 MHz
- Flash-Chip: KH25L12835F Spi Flash
- Flash size: 16 MiB
- RAM: 64 MiB
- LAN: 1x 100 Mbps Ethernet
- WiFi SoC-integrated: 802.11bgn
- 1x USB 2.0
- UART: for serial console

Installation:
1. Download sysupgrade.bin
2. Open vendor web interface
3. Choose to upgrade firmware
3. After reboot connect via ethernet at 192.168.1.1

Signed-off-by: Ademar Arvati Filho <arvati@hotmail.com>