### PR TITLE
bcm2708: change C library to glibc

### DIFF
--- a/target/linux/brcm2708/bcm2709/config-4.9
+++ b/target/linux/brcm2708/bcm2709/config-4.9
@@ -425,3 +425,5 @@ CONFIG_XZ_DEC_ARM=y
 CONFIG_XZ_DEC_BCJ=y
 CONFIG_ZBOOT_ROM_BSS=0x0
 CONFIG_ZBOOT_ROM_TEXT=0x0
+# Add for Raspberry Pi Serial, change c library to glibc for Java etc.
+CONFIG_LIBC="glibc"


### PR DESCRIPTION
As the title, I have change C implement from MUSL to GNULIBC(GLIBC) by default for Raspberry PI.
Then we can run Java(ARM version) well, and more software which using glibc.
At the last one year, I have tested it's compatible and performance, it works very well in my Raspberry PI 3 model B.
So I create this PR from request merging. tks!