### PR TITLE
include/verbose.mk: quote SUBMAKE options

### DIFF
--- a/include/verbose.mk
+++ b/include/verbose.mk
@@ -54,7 +54,7 @@ ifeq ($(findstring s,$(OPENWRT_VERBOSE)),)
   else
     SILENT:=>/dev/null $(if $(findstring w,$(OPENWRT_VERBOSE)),,2>&1)
     export QUIET:=1
-    SUBMAKE=cmd() { $(SILENT) $(MAKE) -s $$* < /dev/null || { echo "make $$*: build failed. Please re-run make with -j1 V=s to see what's going on"; false; } } 8>&1 9>&2; cmd
+    SUBMAKE=cmd() { $(SILENT) $(MAKE) -s "$$@" < /dev/null || { echo "make $$*: build failed. Please re-run make with -j1 V=s to see what's going on"; false; } } 8>&1 9>&2; cmd
   endif
 
   .SILENT: $(MAKECMDGOALS)


### PR DESCRIPTION
build openwrt on centos 6 I should use devtoolset-3 to get gcc 4.9, but
it fail when make menuconfig. so I have to give option HOSTCC='gcc
-Wl,--copy-dt-needed-entries' to make. But it passed to sub make to
HOSTCC=gcc as micro SUBMAKE expand to HOSTCC=gcc
-Wl,--copy-dt-needed-entries. This patch fix this issue.

make -C build menuconfig HOSTCC='gcc -Wl,--copy-dt-needed-entries' V='1'
make: Entering directory `/work/openwrt/openwrt/build'
/opt/rh/devtoolset-3/root/usr/libexec/gcc/x86_64-redhat-linux/4.9.2/ld:
lxdialog/checklist.o: undefined reference to symbol 'acs_map'
//lib64/libtinfo.so.5: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [mconf] Error 1
make -s -C scripts/config all CC=gcc -Wl,--copy-dt-needed-entries: build
failed. Please re-run make with -j1 V=s to see what's going on
make: *** [scripts/config/mconf] Error 1
make: Leaving directory `/work/openwrt/openwrt/build'

Signed-off-by: 李国 <uxgood.org@gmail.com>