### PR TITLE
ath79: ag71xx: Add gmac config for ar934x/qca9558 and split eth/mdio/switch apart

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -43,7 +43,6 @@ ath79_setup_interfaces()
 		;;
 
 	"tplink,tl-archer-c7-v2")
-		ucidef_set_interfaces_lan_wan "eth1.1" "eth0.2"
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
 		;;

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -44,6 +44,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 
 		mdio-bus {
 			swphy4: ethernet-phy@4 {

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -59,8 +59,8 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "phy", "mac";
+	resets = <&rst 9>;
+	reset-names = "mac";
 	phy-mode = "mii";
 	phy-handle = <&swphy4>;
 };
@@ -70,8 +70,8 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "phy", "mac";
+	resets = <&rst 13>;
+	reset-names = "mac";
 
 	phy-mode = "gmii";
 

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -33,7 +33,25 @@
 };
 
 &mdio0 {
+	status = "okay";
+
+	compatible = "qca,ar7240-mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8216-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+
+		mdio-bus {
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth0 {
@@ -43,10 +61,8 @@
 
 	resets = <&rst 8>, <&rst 9>;
 	reset-names = "phy", "mac";
-};
-
-&mdio1 {
-	builtin-switch;
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
 };
 
 &eth1 {

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -103,8 +103,6 @@
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy4>;
-
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;
 };
@@ -114,15 +112,6 @@
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar7240_tl-wr740n-v2.dts
+++ b/target/linux/ath79/dts/ar7240_tl-wr740n-v2.dts
@@ -123,8 +123,6 @@
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy4>;
-
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;
 };
@@ -134,15 +132,6 @@
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -63,6 +63,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 
 		mdio-bus {
 			swphy4: ethernet-phy@4 {

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -39,13 +39,6 @@
 	};
 };
 
-&mdio0 {
-	regmap = <&eth1>;
-	builtin-switch;
-	resets = <&rst 22>;
-	reset-names = "mdio";
-};
-
 &eth0 {
 	compatible = "qca,ar7241-eth", "syscon";
 
@@ -53,16 +46,35 @@
 
 	resets = <&rst 8>, <&rst 9>;
 	reset-names = "mac", "phy";
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
 };
 
 &mdio1 {
+	status = "okay";
+
 	resets = <&rst 23>;
 	reset-names = "mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8216-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+
+		mdio-bus {
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth1 {
-	compatible = "qca,ar7241-eth", "syscon";
+	compatible = "qca,ar7241-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -44,8 +44,8 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "mac", "phy";
+	resets = <&rst 9>;
+	reset-names = "mac";
 	phy-mode = "mii";
 	phy-handle = <&swphy4>;
 };
@@ -78,8 +78,8 @@
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "mac", "phy";
+	resets = <&rst 13>;
+	reset-names = "mac";
 
 	phy-mode = "gmii";
 

--- a/target/linux/ath79/dts/ar7241_tp-link.dtsi
+++ b/target/linux/ath79/dts/ar7241_tp-link.dtsi
@@ -97,8 +97,6 @@
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy4>;
-
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;
 };
@@ -108,15 +106,6 @@
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
 };
 
 &gpio {

--- a/target/linux/ath79/dts/ar7241_ubnt_bullet-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_bullet-m.dts
@@ -9,5 +9,5 @@
 };
 
 &eth1 {
-	compatible = "syscon";
+	compatible = "syscon", "simple-mfd";
 };

--- a/target/linux/ath79/dts/ar7241_ubnt_rocket-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_rocket-m.dts
@@ -9,7 +9,7 @@
 };
 
 &eth1 {
-	compatible = "syscon";
+	compatible = "syscon", "simple-mfd";
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -117,24 +117,14 @@
 	};
 };
 
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
 &eth0 {
 	status = "okay";
 
 	mtd-mac-address = <&art 0x0>;
-	phy-handle = <&phy4>;
 };
 
 &eth1 {
 	status = "okay";
 
-	compatible = "syscon";
+	compatible = "syscon", "simple-mfd";
 };

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -122,22 +122,10 @@
 	};
 };
 
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
 &eth0 {
 	status = "okay";
 
 	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "mii";
-	phy-handle = <&phy4>;
 };
 
 &eth1 {

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -45,7 +45,7 @@
 };
 
 &eth0 {
-	compatible = "qca,ar7242-eth", "syscon";
+	compatible = "qca,ar7242-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	pll-reg = <0x4 0x2c 17>;
@@ -59,11 +59,25 @@
 	resets = <&rst 23>;
 	reset-names = "mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8216-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x1f>;
+	};
 };
 
 &eth1 {
-	compatible = "qca,ar7242-eth", "syscon";
+	compatible = "qca,ar7242-eth", "syscon", "simple-mfd";
 
 	resets = <&rst 12>, <&rst 13>;
 	reset-names = "mac", "phy";
+
+	phy-mode = "gmii";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -51,8 +51,8 @@
 	pll-reg = <0x4 0x2c 17>;
 	pll-handle = <&pll>;
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "mac", "phy";
+	resets = <&rst 9>;
+	reset-names = "mac";
 };
 
 &mdio1 {
@@ -71,8 +71,8 @@
 &eth1 {
 	compatible = "qca,ar7242-eth", "syscon", "simple-mfd";
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "mac", "phy";
+	resets = <&rst 13>;
+	reset-names = "mac";
 
 	phy-mode = "gmii";
 

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -65,6 +65,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 	};
 };
 

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -166,6 +166,7 @@
 
 &mdio1 {
 	status = "okay";
+	compatible = "qca,ar9330-mdio";
 
 	resets = <&rst 23>;
 	reset-names = "mdio";

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -160,28 +160,44 @@
 
 	resets = <&rst 9>;
 	reset-names = "mac";
-};
-
-&mdio0 {
-	regmap = <&eth1>;
-	builtin-switch;
-	resets = <&rst 23>;
-	reset-names = "mdio";
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
 };
 
 &mdio1 {
+	status = "okay";
+
 	resets = <&rst 23>;
 	reset-names = "mdio";
-
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8216-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+
+		mdio-bus {
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth1 {
-	compatible = "qca,ar9330-eth", "syscon";
+	compatible = "qca,ar9330-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 	phy-mode = "gmii";
 
 	resets = <&rst 13>;
 	reset-names = "mac";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -178,6 +178,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 
 		mdio-bus {
 			swphy4: ethernet-phy@4 {

--- a/target/linux/ath79/dts/ar9330_glinet_ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_ar150.dts
@@ -123,32 +123,16 @@
 	};
 };
 
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
 &eth0 {
 	status = "okay";
 
 	mtd-mac-address = <&art 0x0>;
-
-	phy-handle = <&phy4>;
 };
 
 &eth1 {
 	status = "okay";
 
 	mtd-mac-address = <&art 0x0>;
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
 
 	gmac-config {
 		device = <&gmac>;

--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
@@ -108,12 +108,6 @@
 
 	mtd-mac-address = <&art 0x1002>;
 	mtd-mac-address-increment = <0x40>;
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
-
 };
 
 &mdio1 {

--- a/target/linux/ath79/dts/ar9331_etactica-eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica-eg200.dts
@@ -73,24 +73,20 @@
 	status = "okay";
 };
 
-&mdio0 {
-	status = "okay";
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
 &eth0 {
 	status = "okay";
 	mtd-mac-address = <&art 0x0>;
-	phy-handle = <&phy4>;
 
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-addr-swap = <1>;
 		switch-phy-swap = <1>;
 	};
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar9331_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tl-mr3020-v1.dts
@@ -155,29 +155,22 @@
 	};
 };
 
-&mdio1 {
+
+&eth0 {
 	status = "okay";
-	phy4: ethernet-phy@4 {
-		reg = <4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
 	};
 };
 
 &eth1 {
 	status = "okay";
-	phy-handle = <&phy4>;
-
-	mtd-mac-address = <&uboot 0x1fc00>;
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
-
-	gmac-config {
-	        device = <&gmac>;
-
-		switch-phy-addr-swap = <1>;
-		switch-phy-swap = <1>;
-	};
+	compatible = "syscon", "simple-mfd";
 };
 
 &wmac {

--- a/target/linux/ath79/dts/ar9331_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tl-wr703n_tl-mr10u.dtsi
@@ -84,8 +84,6 @@
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy4>;
-
 	mtd-mac-address = <&uboot 0x1fc00>;
 
 	gmac-config {
@@ -96,17 +94,13 @@
 	};
 };
 
-&gpio {
+&eth1 {
 	status = "okay";
+	compatible = "syscon", "simple-mfd";
 };
 
-&mdio0 {
+&gpio {
 	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
 };
 
 &uart {

--- a/target/linux/ath79/dts/ar9331_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tl-wr741nd-v4.dtsi
@@ -121,19 +121,8 @@
 	};
 };
 
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
 &eth0 {
 	status = "okay";
-
-	phy-handle = <&phy4>;
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
@@ -151,11 +140,6 @@
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
 };
 
 &gpio {

--- a/target/linux/ath79/dts/ar9341.dtsi
+++ b/target/linux/ath79/dts/ar9341.dtsi
@@ -16,3 +16,11 @@
 	interrupt-parent = <&cpuintc>;
 	interrupts = <2>;
 };
+
+&eth0 {
+	phy-mode = "mii";
+};
+
+&eth1 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -191,12 +191,13 @@
 };
 
 &mdio0 {
+	compatible = "qca,ar9340-mdio";
 	resets = <&rst 22>;
 	reset-names = "mdio";
 };
 
 &eth0 {
-	compatible = "qca,ar9340-eth", "syscon";
+	compatible = "qca,ar9340-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	pll-reg = <0x4 0x2c 17>;
@@ -207,13 +208,38 @@
 };
 
 &mdio1 {
+	status = "okay";
+
+	compatible = "qca,ar9340-mdio";
 	resets = <&rst 23>;
 	reset-names = "mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8229-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+		phy-mode = "gmii";
+		phy4-mii-enable;
+
+		mdio-bus {
+			swphy0: ethernet-phy@0 {
+				reg = <0>;
+				phy-mode = "mii";
+			};
+
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth1 {
-	compatible = "qca,ar9340-eth", "syscon";
+	compatible = "qca,ar9340-eth", "syscon", "simple-mfd";
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -221,6 +221,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 		phy-mode = "gmii";
 		phy4-mii-enable;
 

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -135,7 +135,7 @@
 			};
 
 			gmac: gmac@18070000 {
-				compatible = "qca,ar9340-gmac", "qca,ar9330-gmac";
+				compatible = "qca,ar9340-gmac";
 				reg = <0x18070000 0x14>;
 			};
 
@@ -202,8 +202,8 @@
 	pll-reg = <0x4 0x2c 17>;
 	pll-handle = <&pll>;
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "mac", "phy";
+	resets = <&rst 9>;
+	reset-names = "mac";
 };
 
 &mdio1 {
@@ -215,6 +215,12 @@
 &eth1 {
 	compatible = "qca,ar9340-eth", "syscon";
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "mac", "phy";
+	resets = <&rst 13>;
+	reset-names = "mac";
+	phy-mode = "gmii";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/ath79.dtsi
+++ b/target/linux/ath79/dts/ath79.dtsi
@@ -43,7 +43,7 @@
 		eth0: eth@19000000 {
 			status = "disabled";
 
-			compatible = "qca,ath79-eth", "syscon";
+			compatible = "qca,ath79-eth", "syscon", "simple-mfd";
 			reg = <0x19000000 0x200>;
 
 			interrupts = <4>;
@@ -51,6 +51,8 @@
 
 			mdio0: mdio-bus {
 				status = "disabled";
+
+				compatible = "qca,ath79-mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;
 
@@ -64,7 +66,7 @@
 		eth1: eth@1a000000 {
 			status = "disabled";
 
-			compatible = "qca,ath79-eth", "syscon";
+			compatible = "qca,ath79-eth", "syscon", "simple-mfd";
 			reg = <0x1a000000 0x200>;
 
 			interrupts = <5>;
@@ -72,6 +74,8 @@
 
 			mdio1: mdio-bus {
 				status = "disabled";
+
+				compatible = "qca,ath79-mdio";
 				#address-cells = <1>;
 				#size-cells = <0>;
 

--- a/target/linux/ath79/dts/qca9533.dtsi
+++ b/target/linux/ath79/dts/qca9533.dtsi
@@ -8,6 +8,10 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
 	cpus {
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/ath79/dts/qca9533.dtsi
+++ b/target/linux/ath79/dts/qca9533.dtsi
@@ -219,11 +219,6 @@
 						<&ddr_ctrl 1>;
 };
 
-&mdio0 {
-	resets = <&rst 22>;
-	reset-names = "mdio";
-};
-
 &eth0 {
 	compatible = "qca,qca9530-eth", "syscon";
 	pll-data = <0x82000101 0x80000101 0x80001313>;
@@ -234,17 +229,51 @@
 
 	reset-names = "mac";
 	resets = <&rst 9>;
+
+	phy-mode = "mii";
 };
 
 
 &mdio1 {
+	status = "okay";
 	resets = <&rst 23>;
 	reset-names = "mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8229-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+		phy-mode = "gmii";
+		phy4-mii-enable;
+
+		mdio-bus {
+			swphy0: ethernet-phy@0 {
+				reg = <0>;
+				phy-mode = "mii";
+			};
+
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth1 {
-	compatible = "qca,qca9530-eth", "syscon";
+	status = "okay";
+
+	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
 	resets = <&rst 13>;
 	reset-names = "mac";
+
+	phy-mode = "gmii";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/qca9533.dtsi
+++ b/target/linux/ath79/dts/qca9533.dtsi
@@ -20,9 +20,11 @@
 		};
 	};
 
-	ref: ref {
+	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <25000000>;
 	};
 
 	ahb {
@@ -90,9 +92,7 @@
 				#pinctrl-cells = <2>;
 
 				jtag_disable_pins: pinmux_jtag_disable_pins {
-					pinctrl-single,bits = <
-						0x40 0x2 0x2
-						>;
+					pinctrl-single,bits = <0x40 0x2 0x2>;
 				};
 			};
 
@@ -101,9 +101,8 @@
 				reg = <0x18050000 0x48>;
 
 				#clock-cells = <1>;
-				clocks = <&ref>;
-				clock-names = "ref";
 				clock-output-names = "cpu", "ddr", "ahb";
+				clocks = <&extosc>;
 			};
 
 			wdt: wdt@18060008 {
@@ -124,15 +123,20 @@
 				#reset-cells = <1>;
 
 				intc2: interrupt-controller@2 {
-					compatible = "qcom,qca9556-intc";
+					compatible = "qca,ar9340-intc";
 
+					interrupt-parent = <&cpuintc>;
 					interrupts = <2>;
 
 					interrupt-controller;
 					#interrupt-cells = <1>;
 
-					qcom,pending-bits = <0x1f0>,	/* pcie rc1 */
-							    <0xf>;	/* wmac */
+					qca,int-status-addr = <0xac>;
+					qca,pending-bits = <0xf>,       /* wmac */
+							<0x1f0>;        /* pcie rc1 */
+
+					qca,ddr-wb-channel-interrupts = <0>, <1>;
+					qca,ddr-wb-channels = <&ddr_ctrl 4>, <&ddr_ctrl 3>;
 				};
 			};
 
@@ -148,7 +152,7 @@
 				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
 				interrupt-parent = <&intc2>;
-				interrupts = <0>;
+				interrupts = <1>;
 
 				interrupt-controller;
 				#interrupt-cells = <1>;
@@ -158,12 +162,17 @@
 				status = "disabled";
 			};
 
-			wmac: gmac@18100000 {
+			gmac: gmac@18070000 {
+				compatible = "qca,ar9330-gmac";
+				reg = <0x18070000 0x4>;
+			};
+
+			wmac: wmac@18100000 {
 				compatible = "qca,qca9530-wmac";
 				reg = <0x18100000 0x230000>;
 
-				interrupt-parent = <&cpuintc>;
-				interrupts = <2>;
+				interrupt-parent = <&intc2>;
+				interrupts = <0>;
 
 				status = "disabled";
 			};
@@ -202,6 +211,12 @@
 
 	};
 
+};
+
+&cpuintc {
+	qca,ddr-wb-channel-interrupts = <3>, <4>, <5>;
+	qca,ddr-wb-channels = <&ddr_ctrl 2>, <&ddr_ctrl 0>,
+						<&ddr_ctrl 1>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/qca9533.dtsi
+++ b/target/linux/ath79/dts/qca9533.dtsi
@@ -250,6 +250,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 		phy-mode = "gmii";
 		phy4-mii-enable;
 

--- a/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
@@ -85,37 +85,14 @@
 	status = "okay";
 };
 
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-		phy-mode = "mii";
-	};
-};
-
-&mdio1 {
-	status = "okay";
-};
-
 &eth0 {
 	status = "okay";
-
 	mtd-mac-address = <&art 0x0>;
-	phy-handle = <&phy4>;
-	phy-mode = "mii";
+	phy-handle = <&swphy4>;
 };
 
 &eth1 {
-	status = "okay";
-
 	mtd-mac-address = <&art 0x6>;
-	phy-mode = "gmii";
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
@@ -9,13 +9,6 @@
 	compatible = "glinet,ar300m", "qca,qca9533";
 	model = "GL.iNet GL-AR300M";
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <25000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;
@@ -90,10 +83,6 @@
 
 &usb_phy {
 	status = "okay";
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -293,7 +293,7 @@
 };
 
 &eth0 {
-	compatible = "qca,qca9550-eth", "syscon";
+	compatible = "qca,qca9550-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x82000101 0x80000101 0x80001313>;
 	phy-mode = "rgmii";
@@ -308,7 +308,7 @@
 };
 
 &eth1 {
-	compatible = "qca,qca9550-eth", "syscon";
+	compatible = "qca,qca9550-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x82000101 0x80000101 0x80001313>;
 	phy-mode = "sgmii";

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -220,6 +220,11 @@
 				status = "disabled";
 			};
 
+			gmac: gmac@18070000 {
+				compatible = "qca,qca9550-gmac";
+				reg = <0x18070000 0x14>;
+			};
+
 			wmac: wmac@18100000 {
 				compatible = "qca,qca9550-wmac";
 				reg = <0x18100000 0x10000>;

--- a/target/linux/ath79/dts/qca9558_tl-archer-c7-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tl-archer-c7-v2.dts
@@ -11,6 +11,36 @@
 	model = "TP-Link Archer C7 Version 2";
 };
 
-&rfkill {
-	gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+&gpio_keys {
+	rfkill {
+		gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		linux,code = <KEY_RFKILL>;
+		linux,input-type = <EV_SW>;
+		debounce-interval = <60>;
+	};
+};
+
+&gpio_leds {
+	wlan5g {
+		label = "tp-link:green:wlan5g";
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		default-state = "off";
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&mtdparts {
+	uboot: u-boot@0 {
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	firmware@20000 {
+		reg = <0x020000 0xfd0000>;
+	};
+
+	art: art@ff0000 {
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
 };

--- a/target/linux/ath79/dts/qca9558_tl-archer-c7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tl-archer-c7.dtsi
@@ -15,7 +15,7 @@
 		led-status = &system;
 	};
 
-	leds {
+	gpio_leds: leds {
 		compatible = "gpio-leds";
 
 		system: system {
@@ -40,7 +40,7 @@
 			linux,default-trigger = "usbport";
 		};
 
-		wlan2g {
+		led_wlan2g: wlan2g {
 			label = "tp-link:green:wlan2g";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			default-state = "off";
@@ -52,16 +52,9 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-			linux,default-trigger = "phy0tpt";
-		};
 	};
 
-	keys {
+	gpio_keys: keys {
 		compatible = "gpio-keys";
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -70,12 +63,6 @@
 			label = "Reset button";
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		rfkill: wifi {
-			linux,code = <KEY_RFKILL>;
-			linux,input-type = <EV_SW>;
 			debounce-interval = <60>;
 		};
 	};
@@ -148,27 +135,10 @@
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
-		partitions {
+		mtdparts: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			partition@20000 {
-				label = "firmware";
-				reg = <0x020000 0xfd0000>;
-			};
-
-			art: partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
 		};
 	};
 };
@@ -192,27 +162,23 @@
 	};
 };
 
-&mdio1 {
-	status = "okay";
-
-	phy1: ethernet-phy@1 {
-		reg = <1>;
-	};
-};
-
 &eth0 {
 	status = "okay";
 
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
 	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
 };
 
 &eth1 {
 	status = "okay";
 
 	mtd-mac-address = <&uboot 0x1fc00>;
-	phy-handle = <&phy1>;
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tl-wr1043n.dtsi
@@ -193,6 +193,7 @@
 	status = "okay";
 
 	mtd-mac-address = <&info 0x8>;
+	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
 };
 

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -253,26 +253,47 @@
 };
 
 &eth0 {
-	compatible = "qca,qca9560-eth", "syscon";
+	compatible = "qca,qca9560-eth", "syscon", "simple-mfd";
 
 	pll-data = <0x03000000 0x00000101 0x00001919>;
 	pll-reg = <0 0x48 0>;
 	pll-handle = <&pll>;
-
-	phy-mode = "sgmii";
 
 	resets = <&rst 9>;
 	reset-names = "mac";
 };
 
 &mdio1 {
+	status = "okay";
 	resets = <&rst 23>;
 	reset-names = "mdio";
 	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8229-builtin";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reg = <0x1f>;
+		phy-mode = "gmii";
+		phy4-mii-enable;
+
+		mdio-bus {
+			swphy0: ethernet-phy@0 {
+				reg = <0>;
+				phy-mode = "mii";
+			};
+
+			swphy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "mii";
+			};
+		};
+	};
 };
 
 &eth1 {
-	compatible = "qca,qca9560-eth", "syscon";
+	compatible = "qca,qca9560-eth", "syscon", "simple-mfd";
 
 	phy-mode = "gmii";
 
@@ -280,4 +301,9 @@
 	reset-names = "mac";
 
 	status = "disabled";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
 };

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -275,6 +275,8 @@
 		#size-cells = <0>;
 
 		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
 		phy-mode = "gmii";
 		phy4-mii-enable;
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
@@ -3,6 +3,7 @@
 #
 
 ag71xx-y	+= ag71xx_main.o
+ag71xx-y	+= ag71xx_gmac.o
 ag71xx-y	+= ag71xx_ethtool.o
 ag71xx-y	+= ag71xx_phy.o
 ag71xx-y	+= ag71xx_mdio.o

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
@@ -6,10 +6,9 @@ ag71xx-y	+= ag71xx_main.o
 ag71xx-y	+= ag71xx_gmac.o
 ag71xx-y	+= ag71xx_ethtool.o
 ag71xx-y	+= ag71xx_phy.o
-ag71xx-y	+= ag71xx_ar7240.o
 
 ag71xx-$(CONFIG_AG71XX_DEBUG_FS)	+= ag71xx_debugfs.o
 
+obj-$(CONFIG_AG71XX)	+= ag71xx_ar7240.o
 obj-$(CONFIG_AG71XX)	+= ag71xx_mdio.o
 obj-$(CONFIG_AG71XX)	+= ag71xx.o
-

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Makefile
@@ -6,10 +6,10 @@ ag71xx-y	+= ag71xx_main.o
 ag71xx-y	+= ag71xx_gmac.o
 ag71xx-y	+= ag71xx_ethtool.o
 ag71xx-y	+= ag71xx_phy.o
-ag71xx-y	+= ag71xx_mdio.o
 ag71xx-y	+= ag71xx_ar7240.o
 
 ag71xx-$(CONFIG_AG71XX_DEBUG_FS)	+= ag71xx_debugfs.o
 
+obj-$(CONFIG_AG71XX)	+= ag71xx_mdio.o
 obj-$(CONFIG_AG71XX)	+= ag71xx.o
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -170,12 +170,10 @@ struct ag71xx {
 	 */
 	void __iomem		*mac_base;
 	void __iomem		*mii_base;
-	struct regmap		*mii_regmap;
 
 	struct ag71xx_desc	*stop_desc;
 	dma_addr_t		stop_desc_dma;
 
-	struct mii_bus		*mii_bus;
 	struct phy_device	*phy_dev;
 	void			*phy_priv;
 	int			phy_if_mode;
@@ -189,7 +187,6 @@ struct ag71xx {
 
 	struct reset_control *mac_reset;
 	struct reset_control *phy_reset;
-	struct reset_control *mdio_reset;
 
 	u32			fifodata[3];
 	u32			plldata[3];
@@ -199,6 +196,12 @@ struct ag71xx {
 #ifdef CONFIG_AG71XX_DEBUG_FS
 	struct ag71xx_debug	debug;
 #endif
+};
+
+struct ag71xx_mdio {
+	struct reset_control *mdio_reset;
+	struct mii_bus		*mii_bus;
+	struct regmap		*mii_regmap;
 };
 
 extern struct ethtool_ops ag71xx_ethtool_ops;
@@ -440,11 +443,6 @@ static inline void ag71xx_debugfs_update_napi_stats(struct ag71xx *ag,
 
 int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np);
 void ag71xx_ar7240_cleanup(struct ag71xx *ag);
-
-int ag71xx_mdio_init(struct ag71xx *ag);
-void ag71xx_mdio_cleanup(struct ag71xx *ag);
-int ag71xx_mdio_mii_read(struct mii_bus *bus, int addr, int reg);
-int ag71xx_mdio_mii_write(struct mii_bus *bus, int addr, int reg, u16 val);
 
 int ag71xx_setup_gmac(struct device_node *np);
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -440,7 +440,6 @@ static inline void ag71xx_debugfs_update_napi_stats(struct ag71xx *ag,
 
 int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np);
 void ag71xx_ar7240_cleanup(struct ag71xx *ag);
-void ag71xx_ar7240_start(struct ag71xx *ag);
 
 int ag71xx_mdio_init(struct ag71xx *ag);
 void ag71xx_mdio_cleanup(struct ag71xx *ag);

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -447,6 +447,8 @@ void ag71xx_mdio_cleanup(struct ag71xx *ag);
 int ag71xx_mdio_mii_read(struct mii_bus *bus, int addr, int reg);
 int ag71xx_mdio_mii_write(struct mii_bus *bus, int addr, int reg, u16 val);
 
+int ag71xx_setup_gmac(struct device_node *np);
+
 int ar7240sw_phy_read(struct mii_bus *mii, int addr, int reg);
 int ar7240sw_phy_write(struct mii_bus *mii, int addr, int reg, u16 val);
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -1218,6 +1218,7 @@ ag71xx_ar7240_probe(struct mdio_device *mdiodev)
 	struct mii_bus *mii = mdiodev->bus;
 	struct ar7240sw *as;
 	struct switch_dev *swdev;
+	struct reset_control *switch_reset;
 	u32 ctrl;
 	int phy_if_mode, err, i;
 
@@ -1230,6 +1231,14 @@ ag71xx_ar7240_probe(struct mdio_device *mdiodev)
 	as->mdio_node = of_get_child_by_name(as->of_node, "mdio-bus");
 
 	swdev = &as->swdev;
+
+	switch_reset = devm_reset_control_get_optional(&mdiodev->dev, "switch");
+	if (switch_reset) {
+		reset_control_assert(switch_reset);
+		msleep(50);
+		reset_control_deassert(switch_reset);
+		msleep(200);
+	}
 
 	ctrl = ar7240sw_reg_read(mii, AR7240_REG_MASK_CTRL);
 	as->ver = (ctrl >> AR7240_MASK_CTRL_VERSION_S) &

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -753,20 +753,6 @@ static void ar7240sw_setup_port(struct ar7240sw *as, unsigned port, u8 portmask)
 	}
 }
 
-static int ar7240_set_addr(struct ar7240sw *as, u8 *addr)
-{
-	struct mii_bus *mii = as->mii_bus;
-	u32 t;
-
-	t = (addr[4] << 8) | addr[5];
-	ar7240sw_reg_write(mii, AR7240_REG_MAC_ADDR0, t);
-
-	t = (addr[0] << 24) | (addr[1] << 16) | (addr[2] << 8) | addr[3];
-	ar7240sw_reg_write(mii, AR7240_REG_MAC_ADDR1, t);
-
-	return 0;
-}
-
 static int
 ar7240_set_vid(struct switch_dev *dev, const struct switch_attr *attr,
 		struct switch_val *val)
@@ -1298,19 +1284,6 @@ err_free:
 	return NULL;
 }
 
-void ag71xx_ar7240_start(struct ag71xx *ag)
-{
-	struct ar7240sw *as = ag->phy_priv;
-
-	if (!as)
-		return;
-
-	ar7240sw_reset(as);
-
-	ar7240_set_addr(as, ag->dev->dev_addr);
-	ar7240_hw_apply(&as->swdev);
-}
-
 int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np)
 {
 	struct ar7240sw *as;
@@ -1321,6 +1294,7 @@ int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np)
 
 	ag->phy_priv = as;
 	ar7240sw_reset(as);
+	ar7240_hw_apply(&as->swdev);
 
 	rwlock_init(&as->stats_lock);
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -12,6 +12,8 @@
 #include <linux/etherdevice.h>
 #include <linux/list.h>
 #include <linux/netdevice.h>
+#include <linux/of_mdio.h>
+#include <linux/of_net.h>
 #include <linux/phy.h>
 #include <linux/mii.h>
 #include <linux/bitops.h>
@@ -291,7 +293,9 @@ struct ar7240sw_port_stat {
 
 struct ar7240sw {
 	struct mii_bus	*mii_bus;
-	struct ag71xx_switch_platform_data *swdata;
+	struct mii_bus	*switch_mii_bus;
+	struct device_node *of_node;
+	struct device_node *mdio_node;
 	struct switch_dev swdev;
 	int num_ports;
 	u8 ver;
@@ -366,9 +370,11 @@ static u32 __ar7240sw_reg_read(struct mii_bus *mii, u32 reg)
 	phy_reg = mk_phy_reg(reg);
 
 	local_irq_save(flags);
-	ag71xx_mdio_mii_write(mii, 0x1f, 0x10, mk_high_addr(reg));
-	lo = (u32) ag71xx_mdio_mii_read(mii, phy_addr, phy_reg);
-	hi = (u32) ag71xx_mdio_mii_read(mii, phy_addr, phy_reg + 1);
+	mutex_lock(&mii->mdio_lock);
+	mii->write(mii, 0x1f, 0x10, mk_high_addr(reg));
+	lo = (u32) mii->read(mii, phy_addr, phy_reg);
+	hi = (u32) mii->read(mii, phy_addr, phy_reg + 1);
+	mutex_unlock(&mii->mdio_lock);
 	local_irq_restore(flags);
 
 	return (hi << 16) | lo;
@@ -385,9 +391,11 @@ static void __ar7240sw_reg_write(struct mii_bus *mii, u32 reg, u32 val)
 	phy_reg = mk_phy_reg(reg);
 
 	local_irq_save(flags);
-	ag71xx_mdio_mii_write(mii, 0x1f, 0x10, mk_high_addr(reg));
-	ag71xx_mdio_mii_write(mii, phy_addr, phy_reg + 1, (val >> 16));
-	ag71xx_mdio_mii_write(mii, phy_addr, phy_reg, (val & 0xffff));
+	mutex_lock(&mii->mdio_lock);
+	mii->write(mii, 0x1f, 0x10, mk_high_addr(reg));
+	mii->write(mii, phy_addr, phy_reg + 1, (val >> 16));
+	mii->write(mii, phy_addr, phy_reg, (val & 0xffff));
+	mutex_unlock(&mii->mdio_lock);
 	local_irq_restore(flags);
 }
 
@@ -463,10 +471,12 @@ static int ar7240sw_reg_wait(struct mii_bus *mii, u32 reg, u32 mask, u32 val,
 	return ret;
 }
 
-int ar7240sw_phy_read(struct mii_bus *mii, int phy_addr, int reg_addr)
+int ar7240sw_phy_read(struct mii_bus *bus, int phy_addr, int reg_addr)
 {
 	u32 t, val = 0xffff;
 	int err;
+	struct ar7240sw *as = bus->priv;
+	struct mii_bus *mii = as->mii_bus;
 
 	if (phy_addr >= AR7240_NUM_PHYS)
 		return 0xffff;
@@ -488,11 +498,13 @@ int ar7240sw_phy_read(struct mii_bus *mii, int phy_addr, int reg_addr)
 	return val & AR7240_MDIO_CTRL_DATA_M;
 }
 
-int ar7240sw_phy_write(struct mii_bus *mii, int phy_addr, int reg_addr,
+int ar7240sw_phy_write(struct mii_bus *bus, int phy_addr, int reg_addr,
 		       u16 reg_val)
 {
 	u32 t;
 	int ret;
+	struct ar7240sw *as = bus->priv;
+	struct mii_bus *mii = as->mii_bus;
 
 	if (phy_addr >= AR7240_NUM_PHYS)
 		return -EINVAL;
@@ -646,6 +658,7 @@ ar7240sw_phy_poll_reset(struct mii_bus *bus)
 static int ar7240sw_reset(struct ar7240sw *as)
 {
 	struct mii_bus *mii = as->mii_bus;
+	struct mii_bus *swmii = as->switch_mii_bus;
 	int ret;
 	int i;
 
@@ -665,13 +678,13 @@ static int ar7240sw_reset(struct ar7240sw *as)
 
 	/* setup PHYs */
 	for (i = 0; i < AR7240_NUM_PHYS; i++) {
-		ar7240sw_phy_write(mii, i, MII_ADVERTISE,
+		ar7240sw_phy_write(swmii, i, MII_ADVERTISE,
 				   ADVERTISE_ALL | ADVERTISE_PAUSE_CAP |
 				   ADVERTISE_PAUSE_ASYM);
-		ar7240sw_phy_write(mii, i, MII_BMCR,
+		ar7240sw_phy_write(swmii, i, MII_BMCR,
 				   BMCR_RESET | BMCR_ANENABLE);
 	}
-	ret = ar7240sw_phy_poll_reset(mii);
+	ret = ar7240sw_phy_poll_reset(swmii);
 	if (ret)
 		return ret;
 
@@ -1199,31 +1212,22 @@ static const struct switch_dev_ops ar7240_ops = {
 	.get_port_stats = ar7240_get_port_stats,
 };
 
-static struct ar7240sw *
-ar7240_probe(struct ag71xx *ag, struct device_node *np)
+static int
+ag71xx_ar7240_probe(struct mdio_device *mdiodev)
 {
-	struct mii_bus *mii = ag->mii_bus;
+	struct mii_bus *mii = mdiodev->bus;
 	struct ar7240sw *as;
 	struct switch_dev *swdev;
 	u32 ctrl;
-	u16 phy_id1;
-	u16 phy_id2;
-	int i;
+	int phy_if_mode, err, i;
 
-	phy_id1 = ar7240sw_phy_read(mii, 0, MII_PHYSID1);
-	phy_id2 = ar7240sw_phy_read(mii, 0, MII_PHYSID2);
-	if ((phy_id1 != AR7240_PHY_ID1 || phy_id2 != AR7240_PHY_ID2) &&
-	    (phy_id1 != AR934X_PHY_ID1 || phy_id2 != AR934X_PHY_ID2)) {
-		pr_err("%s: unknown phy id '%04x:%04x'\n",
-		       dev_name(&mii->dev), phy_id1, phy_id2);
-		return NULL;
-	}
-
-	as = kzalloc(sizeof(*as), GFP_KERNEL);
+	as = devm_kzalloc(&mdiodev->dev, sizeof(*as), GFP_KERNEL);
 	if (!as)
-		return NULL;
+		return -ENOMEM;
 
 	as->mii_bus = mii;
+	as->of_node = mdiodev->dev.of_node;
+	as->mdio_node = of_get_child_by_name(as->of_node, "mdio-bus");
 
 	swdev = &as->swdev;
 
@@ -1236,20 +1240,21 @@ ar7240_probe(struct ag71xx *ag, struct device_node *np)
 		swdev->ports = AR7240_NUM_PORTS - 1;
 	} else if (sw_is_ar934x(as)) {
 		swdev->name = "AR934X built-in switch";
+		phy_if_mode = of_get_phy_mode(as->of_node);
 
-		if (ag->phy_if_mode == PHY_INTERFACE_MODE_GMII) {
+		if (phy_if_mode == PHY_INTERFACE_MODE_GMII) {
 			ar7240sw_reg_set(mii, AR934X_REG_OPER_MODE0,
 					 AR934X_OPER_MODE0_MAC_GMII_EN);
-		} else if (ag->phy_if_mode == PHY_INTERFACE_MODE_MII) {
+		} else if (phy_if_mode == PHY_INTERFACE_MODE_MII) {
 			ar7240sw_reg_set(mii, AR934X_REG_OPER_MODE0,
 					 AR934X_OPER_MODE0_PHY_MII_EN);
 		} else {
 			pr_err("%s: invalid PHY interface mode\n",
-			       dev_name(&mii->dev));
-			goto err_free;
+			       dev_name(&mdiodev->dev));
+			return -EINVAL;
 		}
 
-		if (of_property_read_bool(np, "phy4-mii-enable")) {
+		if (of_property_read_bool(as->of_node, "phy4-mii-enable")) {
 			ar7240sw_reg_set(mii, AR934X_REG_OPER_MODE1,
 					 AR934X_REG_OPER_MODE1_PHY4_MII_EN);
 			swdev->ports = AR7240_NUM_PORTS - 1;
@@ -1258,57 +1263,69 @@ ar7240_probe(struct ag71xx *ag, struct device_node *np)
 		}
 	} else {
 		pr_err("%s: unsupported chip, ctrl=%08x\n",
-			dev_name(&mii->dev), ctrl);
-		goto err_free;
+			dev_name(&mdiodev->dev), ctrl);
+		return -EINVAL;
 	}
 
 	swdev->cpu_port = AR7240_PORT_CPU;
 	swdev->vlans = AR7240_MAX_VLANS;
 	swdev->ops = &ar7240_ops;
+	swdev->alias = dev_name(&mdiodev->dev);
 
-	if (register_switch(&as->swdev, ag->dev) < 0)
-		goto err_free;
+	if ((err = register_switch(&as->swdev, NULL)) < 0)
+		return err;
 
-	pr_info("%s: Found an %s\n", dev_name(&mii->dev), swdev->name);
+	pr_info("%s: Found an %s\n", dev_name(&mdiodev->dev), swdev->name);
+
+	as->switch_mii_bus = devm_mdiobus_alloc(&mdiodev->dev);
+	as->switch_mii_bus->name = "ar7240sw_mdio";
+	as->switch_mii_bus->read = ar7240sw_phy_read;
+	as->switch_mii_bus->write = ar7240sw_phy_write;
+	as->switch_mii_bus->priv = as;
+	as->switch_mii_bus->parent = &mdiodev->dev;
+	snprintf(as->switch_mii_bus->id, MII_BUS_ID_SIZE, "%s", dev_name(&mdiodev->dev));
+
+	if(as->mdio_node) {
+		err = of_mdiobus_register(as->switch_mii_bus, as->mdio_node);
+		if (err)
+			return err;
+	}
 
 	/* initialize defaults */
 	for (i = 0; i < AR7240_MAX_VLANS; i++)
 		as->vlan_id[i] = i;
 
 	as->vlan_table[0] = ar7240sw_port_mask_all(as);
-
-	return as;
-
-err_free:
-	kfree(as);
-	return NULL;
-}
-
-int ag71xx_ar7240_init(struct ag71xx *ag, struct device_node *np)
-{
-	struct ar7240sw *as;
-
-	as = ar7240_probe(ag, np);
-	if (!as)
-		return -ENODEV;
-
-	ag->phy_priv = as;
 	ar7240sw_reset(as);
 	ar7240_hw_apply(&as->swdev);
-
 	rwlock_init(&as->stats_lock);
-
+	dev_set_drvdata(&mdiodev->dev, as);
 	return 0;
 }
 
-void ag71xx_ar7240_cleanup(struct ag71xx *ag)
+static void
+ag71xx_ar7240_remove(struct mdio_device *mdiodev)
 {
-	struct ar7240sw *as = ag->phy_priv;
-
-	if (!as)
-		return;
-
+	struct ar7240sw *as = dev_get_drvdata(&mdiodev->dev);
+	if(as->mdio_node)
+		mdiobus_unregister(as->switch_mii_bus);
 	unregister_switch(&as->swdev);
-	kfree(as);
-	ag->phy_priv = NULL;
 }
+
+static const struct of_device_id ag71xx_sw_of_match[] = {
+	{ .compatible = "qca,ar8216-builtin" },
+	{ .compatible = "qca,ar8229-builtin" },
+	{ /* sentinel */ },
+};
+
+static struct mdio_driver ag71xx_sw_driver = {
+	.probe  = ag71xx_ar7240_probe,
+	.remove = ag71xx_ar7240_remove,
+	.mdiodrv.driver = {
+		.name = "ag71xx-switch",
+		.of_match_table = ag71xx_sw_of_match,
+	},
+};
+
+mdio_module_driver(ag71xx_sw_driver);
+MODULE_LICENSE("GPL");

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
@@ -1,0 +1,113 @@
+/*
+ *  Atheros AR71xx built-in ethernet mac driver
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 as published
+ *  by the Free Software Foundation.
+ */
+
+#include <linux/sizes.h>
+#include <linux/of_address.h>
+#include "ag71xx.h"
+
+static void ag71xx_of_set(struct device_node *np, const char *prop,
+			  u32 *reg, u32 shift, u32 mask)
+{
+	u32 val;
+
+	if (of_property_read_u32(np, prop, &val))
+		return;
+
+	*reg &= ~(mask << shift);
+	*reg |= ((val & mask) << shift);
+}
+
+static void ag71xx_of_bit(struct device_node *np, const char *prop,
+			  u32 *reg, u32 mask)
+{
+	u32 val;
+
+	if (of_property_read_u32(np, prop, &val))
+		return;
+
+	if (val)
+		*reg |= mask;
+	else
+		*reg &= ~mask;
+}
+
+static void ag71xx_setup_gmac_933x(struct device_node *np, void __iomem *base)
+{
+	u32 val = __raw_readl(base + AR933X_GMAC_REG_ETH_CFG);
+
+	ag71xx_of_bit(np, "switch-phy-swap", &val, AR933X_ETH_CFG_SW_PHY_SWAP);
+	ag71xx_of_bit(np, "switch-phy-addr-swap", &val,
+		AR933X_ETH_CFG_SW_PHY_ADDR_SWAP);
+
+	__raw_writel(val, base + AR933X_GMAC_REG_ETH_CFG);
+}
+
+static void ag71xx_setup_gmac_934x(struct device_node *np, void __iomem *base)
+{
+	u32 val = __raw_readl(base + AR934X_GMAC_REG_ETH_CFG);
+
+	ag71xx_of_bit(np, "rgmii-gmac0", &val, AR934X_ETH_CFG_RGMII_GMAC0);
+	ag71xx_of_bit(np, "mii-gmac0", &val, AR934X_ETH_CFG_MII_GMAC0);
+	ag71xx_of_bit(np, "gmii-gmac0", &val, AR934X_ETH_CFG_GMII_GMAC0);
+	ag71xx_of_bit(np, "switch-phy-swap", &val, AR934X_ETH_CFG_SW_PHY_SWAP);
+	ag71xx_of_bit(np, "switch-only-mode", &val,
+		AR934X_ETH_CFG_SW_ONLY_MODE);
+
+	__raw_writel(val, base + AR934X_GMAC_REG_ETH_CFG);
+}
+
+static void ag71xx_setup_gmac_955x(struct device_node *np, void __iomem *base)
+{
+	u32 val = __raw_readl(base + QCA955X_GMAC_REG_ETH_CFG);
+
+	ag71xx_of_bit(np, "rgmii-enabled", &val, QCA955X_ETH_CFG_RGMII_EN);
+	ag71xx_of_bit(np, "ge0-sgmii", &val, QCA955X_ETH_CFG_GE0_SGMII);
+	ag71xx_of_set(np, "txen-delay", &val, QCA955X_ETH_CFG_TXE_DELAY_SHIFT, 0x3);
+	ag71xx_of_set(np, "txd-delay", &val, QCA955X_ETH_CFG_TXD_DELAY_SHIFT, 0x3);
+	ag71xx_of_set(np, "rxdv-delay", &val, QCA955X_ETH_CFG_RDV_DELAY_SHIFT, 0x3);
+	ag71xx_of_set(np, "rxd-delay", &val, QCA955X_ETH_CFG_RXD_DELAY_SHIFT, 0x3);
+
+	__raw_writel(val, base + QCA955X_GMAC_REG_ETH_CFG);
+}
+
+int ag71xx_setup_gmac(struct device_node *np)
+{
+	struct device_node *np_dev;
+	void __iomem *base;
+	int err = 0;
+
+	np = of_get_child_by_name(np, "gmac-config");
+	if (!np)
+		return 0;
+
+	np_dev = of_parse_phandle(np, "device", 0);
+	if (!np_dev)
+		goto out;
+
+	base = of_iomap(np_dev, 0);
+	if (!base) {
+		pr_err("%pOF: can't map GMAC registers\n", np_dev);
+		err = -ENOMEM;
+		goto err_iomap;
+	}
+
+	if (of_device_is_compatible(np_dev, "qca,ar9330-gmac"))
+		ag71xx_setup_gmac_933x(np, base);
+	else if (of_device_is_compatible(np_dev, "qca,ar9340-gmac"))
+		ag71xx_setup_gmac_934x(np, base);
+	else if (of_device_is_compatible(np_dev, "qca,qca9550-gmac"))
+		ag71xx_setup_gmac_955x(np, base);
+
+	iounmap(base);
+
+err_iomap:
+	of_node_put(np_dev);
+out:
+	of_node_put(np);
+	return err;
+}

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -14,6 +14,7 @@
 #include <linux/sizes.h>
 #include <linux/of_net.h>
 #include <linux/of_address.h>
+#include <linux/of_platform.h>
 #include "ag71xx.h"
 
 #define AG71XX_DEFAULT_MSG_ENABLE	\
@@ -1273,6 +1274,7 @@ static const char *ag71xx_get_phy_if_mode_name(phy_interface_t mode)
 static int ag71xx_probe(struct platform_device *pdev)
 {
 	struct device_node *np = pdev->dev.of_node;
+	struct device_node *mdio_node;
 	struct net_device *dev;
 	struct resource *res;
 	struct ag71xx *ag;
@@ -1438,6 +1440,12 @@ static int ag71xx_probe(struct platform_device *pdev)
 
 	ag71xx_wr(ag, AG71XX_REG_MAC_CFG1, 0);
 	ag71xx_hw_init(ag);
+
+	if(!of_device_is_compatible(np, "simple-mfd")) {
+		mdio_node = of_get_child_by_name(np, "mdio-bus");
+		if(!IS_ERR(mdio_node))
+			of_platform_device_create(mdio_node, NULL, NULL);
+	}
 
 	err = ag71xx_phy_connect(ag);
 	if (err)

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -735,7 +735,6 @@ static int ag71xx_open(struct net_device *dev)
 	if (ret)
 		goto err;
 
-	ag71xx_ar7240_start(ag);
 	phy_start(ag->phy_dev);
 
 	return 0;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1438,11 +1438,10 @@ static int ag71xx_probe(struct platform_device *pdev)
 
 	ag71xx_wr(ag, AG71XX_REG_MAC_CFG1, 0);
 	ag71xx_hw_init(ag);
-	ag71xx_mdio_init(ag);
 
 	err = ag71xx_phy_connect(ag);
 	if (err)
-		goto err_mdio_free;
+		goto err_free;
 
 	err = ag71xx_debugfs_init(ag);
 	if (err)
@@ -1466,8 +1465,6 @@ static int ag71xx_probe(struct platform_device *pdev)
 
 err_phy_disconnect:
 	ag71xx_phy_disconnect(ag);
-err_mdio_free:
-	ag71xx_mdio_cleanup(ag);
 err_free:
 	free_netdev(dev);
 	return err;
@@ -1484,7 +1481,6 @@ static int ag71xx_remove(struct platform_device *pdev)
 	ag = netdev_priv(dev);
 	ag71xx_debugfs_exit(ag);
 	ag71xx_phy_disconnect(ag);
-	ag71xx_mdio_cleanup(ag);
 	unregister_netdev(dev);
 	free_irq(dev->irq, dev);
 	iounmap(ag->mac_base);

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
@@ -20,7 +20,7 @@
 
 static int bus_count;
 
-static int ag71xx_mdio_wait_busy(struct ag71xx *ag)
+static int ag71xx_mdio_wait_busy(struct ag71xx_mdio *am)
 {
 	int i;
 
@@ -29,57 +29,57 @@ static int ag71xx_mdio_wait_busy(struct ag71xx *ag)
 
 		udelay(AG71XX_MDIO_DELAY);
 
-		regmap_read(ag->mii_regmap, AG71XX_REG_MII_IND, &busy);
+		regmap_read(am->mii_regmap, AG71XX_REG_MII_IND, &busy);
 		if (!busy)
 			return 0;
 
 		udelay(AG71XX_MDIO_DELAY);
 	}
 
-	pr_err("%s: MDIO operation timed out\n", ag->mii_bus->name);
+	pr_err("%s: MDIO operation timed out\n", am->mii_bus->name);
 
 	return -ETIMEDOUT;
 }
 
-int ag71xx_mdio_mii_read(struct mii_bus *bus, int addr, int reg)
+static int ag71xx_mdio_mii_read(struct mii_bus *bus, int addr, int reg)
 {
-	struct ag71xx *ag = bus->priv;
+	struct ag71xx_mdio *am = bus->priv;
 	int err;
 	int ret;
 
-	err = ag71xx_mdio_wait_busy(ag);
+	err = ag71xx_mdio_wait_busy(am);
 	if (err)
 		return 0xffff;
 
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_WRITE);
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_ADDR,
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_WRITE);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_ADDR,
 			((addr & 0xff) << MII_ADDR_SHIFT) | (reg & 0xff));
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_READ);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_READ);
 
-	err = ag71xx_mdio_wait_busy(ag);
+	err = ag71xx_mdio_wait_busy(am);
 	if (err)
 		return 0xffff;
 
-	regmap_read(ag->mii_regmap, AG71XX_REG_MII_STATUS, &ret);
+	regmap_read(am->mii_regmap, AG71XX_REG_MII_STATUS, &ret);
 	ret &= 0xffff;
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_WRITE);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CMD, MII_CMD_WRITE);
 
 	DBG("mii_read: addr=%04x, reg=%04x, value=%04x\n", addr, reg, ret);
 
 	return ret;
 }
 
-int ag71xx_mdio_mii_write(struct mii_bus *bus, int addr, int reg, u16 val)
+static int ag71xx_mdio_mii_write(struct mii_bus *bus, int addr, int reg, u16 val)
 {
-	struct ag71xx *ag = bus->priv;
+	struct ag71xx_mdio *am = bus->priv;
 
 	DBG("mii_write: addr=%04x, reg=%04x, value=%04x\n", addr, reg, val);
 
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_ADDR,
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_ADDR,
 			((addr & 0xff) << MII_ADDR_SHIFT) | (reg & 0xff));
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CTRL, val);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CTRL, val);
 
-	ag71xx_mdio_wait_busy(ag);
+	ag71xx_mdio_wait_busy(am);
 
 	return 0;
 }
@@ -97,23 +97,22 @@ static int ar934x_mdio_clock_div(unsigned int rate)
 static int ag71xx_mdio_reset(struct mii_bus *bus)
 {
 	struct device_node *np = bus->dev.of_node;
-	struct ag71xx *ag = bus->priv;
-	struct device_node *np_ag = ag->pdev->dev.of_node;
+	struct ag71xx_mdio *am = bus->priv;
 	bool builtin_switch;
 	u32 t;
 
 	builtin_switch = of_property_read_bool(np, "builtin-switch");
 
-	if (of_device_is_compatible(np_ag, "qca,ar7240-eth"))
+	if (of_device_is_compatible(np, "qca,ar7240-mdio"))
 		t = MII_CFG_CLK_DIV_6;
-	else if (of_device_is_compatible(np_ag, "qca,ar9340-eth"))
+	else if (of_device_is_compatible(np, "qca,ar9340-mdio"))
 		t = MII_CFG_CLK_DIV_58;
 	else if (builtin_switch)
 		t = MII_CFG_CLK_DIV_10;
 	else
 		t = MII_CFG_CLK_DIV_28;
 
-	if (builtin_switch && of_device_is_compatible(np_ag, "qca,ar9340-eth")) {
+	if (builtin_switch && of_device_is_compatible(np, "qca,ar9340-mdio")) {
 		struct clk *ref_clk = of_clk_get(np, 0);
 		int clock_rate;
 
@@ -126,56 +125,45 @@ static int ag71xx_mdio_reset(struct mii_bus *bus)
 		clk_put(ref_clk);
 	}
 
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CFG, t | MII_CFG_RESET);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CFG, t | MII_CFG_RESET);
 	udelay(100);
 
-	regmap_write(ag->mii_regmap, AG71XX_REG_MII_CFG, t);
+	regmap_write(am->mii_regmap, AG71XX_REG_MII_CFG, t);
 	udelay(100);
 
 	return 0;
 }
 
-int ag71xx_mdio_init(struct ag71xx *ag)
+static int ag71xx_mdio_probe(struct platform_device *pdev)
 {
-	struct device *parent = &ag->pdev->dev;
-	struct device_node *np;
+	struct device *amdev = &pdev->dev;
+	struct device_node *np = pdev->dev.of_node;
+	struct ag71xx_mdio *am;
 	struct mii_bus *mii_bus;
 	bool builtin_switch;
 	int i, err;
 
-	np = of_get_child_by_name(parent->of_node, "mdio-bus");
-	if (!np)
-		return -ENODEV;
+	am = devm_kzalloc(amdev, sizeof(*am), GFP_KERNEL);
+	if (!am)
+		return -ENOMEM;
 
-	if (!of_device_is_available(np)) {
-		err = 0;
-		goto err_out;
-	}
-
-	ag->mii_regmap = syscon_regmap_lookup_by_phandle(np, "regmap");
-	if (!ag->mii_regmap)
+	am->mii_regmap = syscon_regmap_lookup_by_phandle(np, "regmap");
+	if (!am->mii_regmap)
 		return -ENOENT;
 
-	mii_bus = devm_mdiobus_alloc(parent);
-	if (!mii_bus) {
-		err = -ENOMEM;
-		goto err_out;
-	}
+	mii_bus = devm_mdiobus_alloc(amdev);
+	if (!mii_bus)
+		return -ENOMEM;
 
-	ag->mdio_reset = of_reset_control_get_exclusive(np, "mdio");
+	am->mdio_reset = of_reset_control_get_exclusive(np, "mdio");
 	builtin_switch = of_property_read_bool(np, "builtin-switch");
 
-	mii_bus->name = "mdio";
-	if (builtin_switch) {
-		mii_bus->read = ar7240sw_phy_read;
-		mii_bus->write = ar7240sw_phy_write;
-	} else {
-		mii_bus->read = ag71xx_mdio_mii_read;
-		mii_bus->write = ag71xx_mdio_mii_write;
-	}
+	mii_bus->name = "ag71xx_mdio";
+	mii_bus->read = ag71xx_mdio_mii_read;
+	mii_bus->write = ag71xx_mdio_mii_write;
 	mii_bus->reset = ag71xx_mdio_reset;
-	mii_bus->priv = ag;
-	mii_bus->parent = parent;
+	mii_bus->priv = am;
+	mii_bus->parent = amdev;
 	snprintf(mii_bus->id, MII_BUS_ID_SIZE, "%s.%d", np->name, bus_count++);
 
 	if (!builtin_switch &&
@@ -185,34 +173,46 @@ int ag71xx_mdio_init(struct ag71xx *ag)
 	for (i = 0; i < PHY_MAX_ADDR; i++)
 		mii_bus->irq[i] = PHY_POLL;
 
-	if (!IS_ERR(ag->mdio_reset)) {
-		reset_control_assert(ag->mdio_reset);
+	if (!IS_ERR(am->mdio_reset)) {
+		reset_control_assert(am->mdio_reset);
 		msleep(100);
-		reset_control_deassert(ag->mdio_reset);
+		reset_control_deassert(am->mdio_reset);
 		msleep(200);
 	}
 
 	err = of_mdiobus_register(mii_bus, np);
 	if (err)
-		goto err_out;
+		return err;
 
-	ag->mii_bus = mii_bus;
-
-	if (builtin_switch)
-		ag71xx_ar7240_init(ag, np);
+	am->mii_bus = mii_bus;
+	platform_set_drvdata(pdev, am);
 
 	return 0;
-
-err_out:
-	of_node_put(np);
-	return err;
 }
 
-void ag71xx_mdio_cleanup(struct ag71xx *ag)
+static int ag71xx_mdio_remove(struct platform_device *pdev)
 {
-	if (!ag->mii_bus)
-		return;
+	struct ag71xx_mdio *am = platform_get_drvdata(pdev);
 
-	ag71xx_ar7240_cleanup(ag);
-	mdiobus_unregister(ag->mii_bus);
+	mdiobus_unregister(am->mii_bus);
+	return 0;
 }
+
+static const struct of_device_id ag71xx_mdio_match[] = {
+	{ .compatible = "qca,ar7240-mdio" },
+	{ .compatible = "qca,ar9340-mdio" },
+	{ .compatible = "qca,ath79-mdio" },
+	{}
+};
+
+static struct platform_driver ag71xx_mdio_driver = {
+	.probe		= ag71xx_mdio_probe,
+	.remove		= ag71xx_mdio_remove,
+	.driver = {
+		.name	 = "ag71xx-mdio",
+		.of_match_table = ag71xx_mdio_match,
+	}
+};
+
+module_platform_driver(ag71xx_mdio_driver);
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Current ag71xx is a mixed driver of mac/mdio/switch, which should be independent parts:
Although QCA mixed mdio registers with gmac ones, mdio and gmac work independently. And we need them to work independently because we always need to use mdio1 for gmac0 on SoCs with builtin switch. (Edit: This is only true for ar7241 and later SoCs.)
The builtin switch is a separated IP (AR8216 on ar933x and earlier and AR8229 on ar934x and later) and has nothing to do with gmac. We don't need to reset and reconfigure the switch everytime we bring gmac1 up.
Current mdio driver for mdio1 isn't the one in gmac1 at all. ar7240sw_phy_read/write functions are used to operate mdio in builtin switch using mdio in gmac1. I think we shouldn't make a gmac driver which is supposed to operate gmac mdio operating the mdio in the switch because it's misleading.

This PR did the following things:
1. Make mdio a separated platform device registered before ag71xx-eth so that we can get both mdio ready before initializing gmac0/gmac1.
2. Register the builtin switch as a standard mdio device.
3. Register a separated mdio bus in switch driver.