### PR TITLE
kirkwood: add support for Iomega Storcenter ix2-200

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -15,6 +15,7 @@ board=$(board_name)
 case "$board" in
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
+iom,ix2-200|\
 linksys,viper|\
 raidsonic,ib-nas62x0|\
 seagate,dockstar|\

--- a/target/linux/kirkwood/base-files/etc/board.d/01_leds
+++ b/target/linux/kirkwood/base-files/etc/board.d/01_leds
@@ -14,6 +14,9 @@ case "$board" in
 	ucidef_set_led_default "health" "health" "pogo_e02:green:health" "1"
 	ucidef_set_led_default "fault" "fault" "pogo_e02:orange:fault" "1"
 	;;
+"iom,ix2-200")
+	ucidef_set_led_timer "health" "health" "status:white:rebuild_led" "200" "800"
+	;;
 "linksys,audi")
 	ucidef_set_led_default "power" "power" "audi:green:power" "1"
 	;;

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ case "$board" in
 "cloudengines,pogoe02"|\
 "cloudengines,pogoplugv4"|\
 "iom,iconnect-1.1"|\
+"iom,ix2-200"|\
 "raidsonic,ib-nas62x0"|\
 "seagate,dockstar"|\
 "seagate,goflexhome"|\

--- a/target/linux/kirkwood/base-files/etc/diag.sh
+++ b/target/linux/kirkwood/base-files/etc/diag.sh
@@ -15,6 +15,9 @@ get_status_led() {
 	cloudengines,pogoplugv4)
 		status_led="pogoplugv4:green:health"
 		;;
+	iom,ix2-200)
+		status_led="status:white:power_led"
+		;;
 	linksys,audi)
 		status_led="audi:green:power"
 		;;

--- a/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
+++ b/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
@@ -4,17 +4,20 @@ START=98
 boot() {
 . /lib/functions.sh
 
-#configuring lm85 onboard temp/fan controller to run the fan on its own
+#configuring (lm85/lm63) onboard temp/fan controller to run the fan on its own
 #for more information, please read https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
 
-path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
-
 case $(board_name) in
-	zyxel,nsa310b)
+zyxel,nsa310b)
+	path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
 	echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1
 	echo 1 > "$path_to_hwmon/pwm1_auto_channels" # temp1 is the only one that changes
 	echo 23000 > "$path_to_hwmon/temp1_auto_temp_min"
 	echo 43000 > "$path_to_hwmon/temp1_auto_temp_max" # next step is 49600 millicelsius, or 50 celsius, 43 celsius is better
-		;;
+	;;
+iom,ix2-200)
+	path_to_hwmon='/sys/class/hwmon/hwmon0'
+	echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1
+	;;
 esac
 }

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -62,6 +62,22 @@ define Device/iom_iconnect-1.1
 endef
 TARGET_DEVICES += iom_iconnect-1.1
 
+define Device/iom_ix2_200
+  DEVICE_TITLE := Iomega StorCenter ix2-200
+  DEVICE_DTS := kirkwood-iomega_ix2_200
+  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-i2c-mv64xxx kmod-hwmon-lm63
+  DEVICE_TYPE:=nas
+  PAGESIZE := 512
+  SUBPAGESIZE := 256
+  BLOCKSIZE := 16KiB
+  KERNEL_SIZE := 3072k
+  KERNEL_IN_UBI := 0
+  UBINIZE_OPTS := -E 5  
+  IMAGE_SIZE := 32505856
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += iom_ix2_200
+
 define Device/linksys_audi
   DEVICE_TITLE := Linksys EA3500 (Audi)
   DEVICE_PACKAGES := kmod-mwl8k swconfig wpad-mini kmod-gpio-button-hotplug

--- a/target/linux/kirkwood/patches-4.14/103-iomega-ix2-200.patch
+++ b/target/linux/kirkwood/patches-4.14/103-iomega-ix2-200.patch
@@ -1,0 +1,33 @@
+--- a/arch/arm/boot/dts/kirkwood-iomega_ix2_200.dts
++++ b/arch/arm/boot/dts/kirkwood-iomega_ix2_200.dts
+@@ -185,18 +185,18 @@
+ 	};
+ 
+ 	partition@a0000 {
+-		label = "env";
++		label = "u-boot environment";
+ 		reg = <0xa0000 0x20000>;
+ 		read-only;
+ 	};
+ 
+ 	partition@100000 {
+-		label = "uImage";
++		label = "kernel";
+ 		reg = <0x100000 0x300000>;
+ 	};
+ 
+ 	partition@400000 {
+-		label = "rootfs";
++		label = "ubi";
+ 		reg = <0x400000 0x1C00000>;
+ 	};
+ };
+@@ -210,7 +210,7 @@
+ };
+ 
+ &eth0 {
+-	status = "okay";
++	status = "disabled";
+ 	ethernet0-port@0 {
+ 		speed = <1000>;
+ 		duplex = <1>;

--- a/target/linux/kirkwood/patches-4.9/103-iomega-ix2-200.patch
+++ b/target/linux/kirkwood/patches-4.9/103-iomega-ix2-200.patch
@@ -1,0 +1,33 @@
+--- a/arch/arm/boot/dts/kirkwood-iomega_ix2_200.dts
++++ b/arch/arm/boot/dts/kirkwood-iomega_ix2_200.dts
+@@ -185,18 +185,18 @@
+ 	};
+ 
+ 	partition@a0000 {
+-		label = "env";
++		label = "u-boot environment";
+ 		reg = <0xa0000 0x20000>;
+ 		read-only;
+ 	};
+ 
+ 	partition@100000 {
+-		label = "uImage";
++		label = "kernel";
+ 		reg = <0x100000 0x300000>;
+ 	};
+ 
+ 	partition@400000 {
+-		label = "rootfs";
++		label = "ubi";
+ 		reg = <0x400000 0x1C00000>;
+ 	};
+ };
+@@ -210,7 +210,7 @@
+ };
+ 
+ &eth0 {
+-	status = "okay";
++	status = "disabled";
+ 	ethernet0-port@0 {
+ 		speed = <1000>;
+ 		duplex = <1>;


### PR DESCRIPTION
Iomega Storcenter ix2-200 is a dual SATA NAS powered by a Marvell
 Kirkwood SoC clocked at 1GHz. It has 256MB of RAM and 32MB of 
 flash memory, 3x USB 2.0 and 1x 1Gbit/s NIC

Specification:
- SoC: Marvell Kirkwood 88F6281
- CPU/Speed: 1000Mhz
- Flash-Chip: Hynix NAND 
- Flash size: 32 MiB,erase size:16 KiB,page size:512,OOB size:16
- RAM: 256MB
- LAN: 1x 1000 Mbps Ethernet
- WiFi: none
- 3x USB 2.0
- UART: for serial console

#### Installation instructions - easy steps:
1. download factory.bin and copy into tftp server
2. access uboot environment with serial cable and run
    ```
    setenv mainlineLinux yes
    setenv arcNumber 1682 
    setenv console 'console=ttyS0,115200n8'
    setenv mtdparts 'mtdparts=orion_nand:0x100000@0x000000(u-boot)ro,0x20000@0xA0000(u-boot environment)ro,0x300000@0x100000(kernel),0x1C00000@0x400000(ubi)'
    setenv bootargs_root 'root='
    setenv bootcmd 'setenv bootargs ${console} ${mtdparts} ${bootargs_root}; nand read.e 0x800000 0x100000 0x300000; bootm 0x00800000'   
    saveenv
    setenv serverip 192.168.1.1
    setenv ipaddr 192.168.1.13
    tftpboot 0x00800000 factory.bin
    nand erase 0x100000 $(filesize)
    nand write 0x00800000 0x100000 $(filesize)
    run bootcmd
    ```
3. access openwrt by dhcp ip address assigned by your router (p.ex: 192.168.1.13)


#### Installation steps nand bad blocks proof:
1. download initramfs-uImage and copy into usb ext2 partition
    ```
    mkfs.ext2 -L ext2 /dev/sdh1
    mount -t ext2 /dev/sdh1 /mnt
    cp initramfs-uImage /mnt/initramfs.bin
    umount /mnt
    ```
2. access uboot environment with serial cable and run
    ```
    setenv mainlineLinux yes
    setenv arcNumber 1682 
    setenv console 'console=ttyS0,115200n8'
    setenv mtdparts 'mtdparts=orion_nand:0x100000@0x000000(u-boot)ro,0x20000@0xA0000(u-boot environment)ro,0x300000@0x100000(kernel),0x1C00000@0x400000(ubi)'
    setenv bootargs_root 'root='
    setenv bootcmd 'setenv bootargs ${console} ${mtdparts} ${bootargs_root}; nand read.e 0x800000 0x100000 0x300000; bootm 0x00800000'   
    saveenv
    usb reset; ext2load usb 0:1 0x00800000 /initramfs.bin; bootm 0x00800000
    ```
3. log into openwrt and sysupgrade to install into flash
    ```
    sysupgrade -n /tmp/sysupgrade.bin 
    ```
4. access openwrt by dhcp ip address assigned by your router (p.ex: 192.168.1.13)

Signed-off-by: Ademar Arvati Filho <arvati@hotmail.com>