### PR TITLE
toolchain: nasm: fix build error with gcc 8

### DIFF
--- a/toolchain/nasm/patches/0001-Remove-invalid-pure_func-qualifiers.patch
+++ b/toolchain/nasm/patches/0001-Remove-invalid-pure_func-qualifiers.patch
@@ -1,0 +1,31 @@
+From 2287973815790428bdce58baab6ba39a6794f1ca Mon Sep 17 00:00:00 2001
+From: Michael Simacek <msimacek@redhat.com>
+Date: Thu, 8 Feb 2018 14:47:08 +0100
+Subject: [PATCH] Remove invalid pure_func qualifiers
+
+Remove pure attribute from seg_init and seg_alloc functions which are
+not pure.
+
+Signed-off-by: Michael Simacek <msimacek@redhat.com>
+---
+ include/nasmlib.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/nasmlib.h b/include/nasmlib.h
+index 78bb1e48..1675ca28 100644
+--- a/include/nasmlib.h
++++ b/include/nasmlib.h
+@@ -192,8 +192,8 @@ int64_t readstrnum(char *str, int length, bool *warn);
+  * seg_init: Initialise the segment-number allocator.
+  * seg_alloc: allocate a hitherto unused segment number.
+  */
+-void pure_func seg_init(void);
+-int32_t pure_func seg_alloc(void);
++void seg_init(void);
++int32_t seg_alloc(void);
+ 
+ /*
+  * Add/replace or remove an extension to the end of a filename
+-- 
+2.14.3
+


### PR DESCRIPTION
Fix a build error with gcc 8. 

> ./include/nasmlib.h:194:1: error: 'pure' attribute on function returning 'void' [-Werror=attributes]
 void pure_func seg_init(void);

Detail & patch at https://bugzilla.nasm.us/show_bug.cgi?id=3392461

Signed-off-by: Edi Turn <yyxstter@gmail.com>