### PR TITLE
iptables: add ip[6]tables-compat + libxtables-compat packages

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -106,6 +106,21 @@ IP firewall administration tool.
 
 endef
 
+define Package/iptables-compat
+$(call Package/iptables/Default)
+  TITLE:=IP firewall administration tool compat
+  DEPENDS:=iptables @IPTABLES_NFTABLES +libxtables-compat
+endef
+
+define Package/iptables-compat/description
+Extra iptables nftables compat binaries.
+  iptables-compat
+  iptables-compat-restore
+  iptables-compat-save
+  iptables-translate
+  iptables-restore-translate
+endef
+
 define Package/iptables-mod-conntrack-extra
 $(call Package/iptables/Module, +kmod-ipt-conntrack-extra)
   TITLE:=Extra connection tracking extensions
@@ -438,6 +453,20 @@ $(call Package/iptables/Default)
   MENU:=1
 endef
 
+define Package/ip6tables-compat
+$(call Package/iptables/Default)
+  DEPENDS:=ip6tables @IPTABLES_NFTABLES +libxtables-compat
+  TITLE:=IP firewall administration tool compat
+endef
+
+define Package/ip6tables-compat/description
+Extra ip6tables nftables compat binaries.
+  iptables-compat
+  iptables-compat-restore
+  iptables-compat-save
+  iptables-translate
+  iptables-restore-translate
+endef
 
 define Package/ip6tables-extra
 $(call Package/iptables/Default)
@@ -495,6 +524,15 @@ define Package/libxtables
  DEPENDS:= \
 	+IPTABLES_CONNLABEL:libnetfilter-conntrack \
 	+IPTABLES_NFTABLES:libnftnl
+endef
+
+define Package/libxtables-compat
+ $(call Package/iptables/Default)
+ SECTION:=libs
+ CATEGORY:=Libraries
+ TITLE:=IPv4/IPv6 firewall - shared xtables compat library
+ ABI_VERSION:=$(PKG_VERSION)
+ DEPENDS:=libxtables
 endef
 
 TARGET_CPPFLAGS := \
@@ -574,9 +612,22 @@ define Package/iptables/install
 	$(INSTALL_DIR) $(1)/usr/lib/iptables
 endef
 
+define Package/iptables-compat/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/xtables-compat-multi $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables-compat{,-restore,-save} $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/iptables{,-restore}-translate $(1)/usr/sbin/
+endef
+
 define Package/ip6tables/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ip6tables{,-restore,-save} $(1)/usr/sbin/
+endef
+
+define Package/ip6tables-compat/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ip6tables-compat{,-restore,-save} $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/ip6tables{,-restore}-translate $(1)/usr/sbin/
 endef
 
 define Package/libiptc/install
@@ -602,6 +653,11 @@ define Package/libxtables/install
 	$(CP) $(PKG_BUILD_DIR)/extensions/libiptext.so $(1)/usr/lib/
 endef
 
+define Package/libxtables-compat/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_BUILD_DIR)/extensions/libiptext_*.so $(1)/usr/lib/
+endef
+
 define BuildPlugin
   define Package/$(1)/install
 	$(INSTALL_DIR) $$(1)/usr/lib/iptables
@@ -617,6 +673,7 @@ define BuildPlugin
 endef
 
 $(eval $(call BuildPackage,iptables))
+$(eval $(call BuildPackage,iptables-compat))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-extra,$(IPT_CONNTRACK_EXTRA-m)))
 $(eval $(call BuildPlugin,iptables-mod-conntrack-label,$(IPT_CONNTRACK_LABEL-m)))
 $(eval $(call BuildPlugin,iptables-mod-extra,$(IPT_EXTRA-m)))
@@ -640,9 +697,11 @@ $(eval $(call BuildPlugin,iptables-mod-trace,$(IPT_DEBUG-m)))
 $(eval $(call BuildPlugin,iptables-mod-nfqueue,$(IPT_NFQUEUE-m)))
 $(eval $(call BuildPlugin,iptables-mod-checksum,$(IPT_CHECKSUM-m)))
 $(eval $(call BuildPackage,ip6tables))
+$(eval $(call BuildPackage,ip6tables-compat))
 $(eval $(call BuildPlugin,ip6tables-extra,$(IPT_IPV6_EXTRA-m)))
 $(eval $(call BuildPlugin,ip6tables-mod-nat,$(IPT_NAT6-m)))
 $(eval $(call BuildPackage,libiptc))
 $(eval $(call BuildPackage,libip4tc))
 $(eval $(call BuildPackage,libip6tc))
 $(eval $(call BuildPackage,libxtables))
+$(eval $(call BuildPackage,libxtables-compat))


### PR DESCRIPTION
depends on IPTABLES_NFTABLES to build xtables-compat-multi binary.

add ip[6]tables-compat to use nft packet filtering system via iptables-syntax
add ip[6]tables-translate
  input: iptables-commands e.g. iptables-translate -A INPUT -s 127.0.0.1 -j ACCEPT
  output:nft commands e.g. nft add rule ip filter INPUT ip saddr 127.0.0.1 counter accept
Also included: ip[6]tables-compat-{save,restore}

I'm not sure about libxtables-compat package.
xtables-compat-multi needs /usr/lib/libiptext_arpt.so and /usr/lib/libiptext_ebt.so
These files are included in iptables-dev, which creates a conflict.
Should these files be included in libtxables? Additional filesize on my architecture is 20KB.

Signed-off-by: Martin Strobel <arctus@crza.de>