### PR TITLE
mac80211: backport and update patch for ath10k 

### DIFF
--- a/package/kernel/mac80211/patches/972-ath10k_fix-crash-due-to-wrong-handling-of-peer_bw_rxnss_override-parameter.patch
+++ b/package/kernel/mac80211/patches/972-ath10k_fix-crash-due-to-wrong-handling-of-peer_bw_rxnss_override-parameter.patch
@@ -1,31 +1,26 @@
-From: Sebastian Gottschall <s.gottsch...@dd-wrt.com>
+From: Sebastian Gottschall <s.gottschall@dd-wrt.com>
 
-current handling of peer_bw_rxnss_override parameter is based on guessing the 
-VHT160/8080 capability by rx rate. this is wrong and may lead
-to a non initialized peer_bw_rxnss_override parameter which is required since 
-VHT160 operation mode only supports 2x2 chainmasks in addition the original code
+current handling of peer_bw_rxnss_override parameter is based on guessing the VHT160/8080 capability by rx rate. this is wrong and may lead
+to a non initialized peer_bw_rxnss_override parameter which is required since VHT160 operation mode only supports 2x2 chainmasks in addition the original code
 initialized the parameter with wrong masked values.
-This patch uses the peer phymode and peer nss information for correct 
-initialisation of the peer_bw_rxnss_override parameter.
-if this peer information is not available, we initialize the parameter by 
-minimum nss which is suggested by QCA as temporary workaround according
+This patch uses the peer phymode and peer nss information for correct initialisation of the peer_bw_rxnss_override parameter.
+if this peer information is not available, we initialize the parameter by minimum nss which is suggested by QCA as temporary workaround according
 to the QCA sourcecodes.
 
-Signed-off-by: Sebastian Gottschall <s.gottsch...@dd-wrt.com>
+Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
 
 v2: remove debug messages
 v3: apply some cosmetics, update documentation
-v4: fix compile warning and truncate nss to maximum of 2x2 since current 
-chipsets only support 2x2 at vht160
+v4: fix compile warning and truncate nss to maximum of 2x2 since current chipsets only support 2x2 at vht160
 v5: handle maximum nss for chipsets supportig vht160 with 1x1 only
-v7: use more simple code variant and take care about hw/sw chainmask 
-configuration
+v7: use more simple code variant and take care about hw/sw chainmask configuration
+v8: fix some code style issues
+v9: use SM/MS macros from code.h to simplify shift/mask handling
 ---
- drivers/net/wireless/ath/ath10k/mac.c | 40 +++++++++++++++------------
- drivers/net/wireless/ath/ath10k/wmi.c |  7 +----
- drivers/net/wireless/ath/ath10k/wmi.h | 14 +++++++++-
- 3 files changed, 36 insertions(+), 25 deletions(-)
-
+ drivers/net/wireless/ath/ath10k/mac.c | 54 +++++++++++++++++++--------
+ drivers/net/wireless/ath/ath10k/wmi.c |  7 +---
+ drivers/net/wireless/ath/ath10k/wmi.h | 14 ++++++-
+ 3 files changed, 52 insertions(+), 23 deletions(-)
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
 @@ -2466,7 +2466,7 @@ static void ath10k_peer_assoc_h_vht(stru
@@ -37,7 +32,7 @@ configuration
  
  	if (WARN_ON(ath10k_mac_vif_chan(vif, &def)))
  		return;
-@@ -2526,23 +2526,27 @@ static void ath10k_peer_assoc_h_vht(stru
+@@ -2526,23 +2526,45 @@ static void ath10k_peer_assoc_h_vht(stru
  		__le16_to_cpu(vht_cap->vht_mcs.tx_highest);
  	arg->peer_vht_rates.tx_mcs_set = ath10k_peer_assoc_h_vht_limit(
  		__le16_to_cpu(vht_cap->vht_mcs.tx_mcs_map), vht_mcs_mask);
@@ -46,7 +41,10 @@ configuration
  
 -	ath10k_dbg(ar, ATH10K_DBG_MAC, "mac vht peer %pM max_mpdu %d flags 0x%x\n",
 -		   sta->addr, arg->peer_max_mpdu, arg->peer_flags);
--
++	/* only local 4x4 configuration do support 2x2 for VHT160,
++	 * everything else must use 1x1 
++	 */
+ 
 -	if (arg->peer_vht_rates.rx_max_rate &&
 -	    (sta->vht_cap.cap & IEEE80211_VHT_CAP_SUPP_CHAN_WIDTH_MASK)) {
 -		switch (arg->peer_vht_rates.rx_max_rate) {
@@ -59,28 +57,42 @@ configuration
 -			arg->peer_bw_rxnss_override = 1;
 -			break;
 -		}
-+	/* only 4x4 configuration do support 2x2 for VHT160, everything else must use 1x1 */
 +	if (ar->cfg_rx_chainmask == 15)
-+		nss160 = arg->peer_num_spatial_streams <= 2 ? arg->peer_num_spatial_streams : 2;
++		nss160 = arg->peer_num_spatial_streams <= 2 ? 1 : 2;
 +
-+	/* in case if peer is connected with vht160 or vht80+80, we need to properly adjust rxnss parameters otherwise firmware will raise a assert */
-+	switch(arg->peer_phymode) {
++	/* if peer provides 1x1 nss160 information using max rate
++	 * vht information, we reduce local nss160 to 1x1.
++	 * consider that it has been observed that some client
++	 * devices provide zero here, no matter which transmission
++	 * rate is possible. in that case the local nss configuration 
++	 * will be used at maxmimum configuration possible. (see above)
++	 */
++
++	if (arg->peer_vht_rates.rx_max_rate == 780)
++		nss160 = 1;
++
++	/* in case if peer is connected with vht160 or vht80+80,
++         * we need to properly adjust rxnss parameters otherwise 
++	 * firmware will raise a assert 
++	 */
++	switch (arg->peer_phymode) {
 +	case MODE_11AC_VHT80_80:
 +		arg->peer_bw_rxnss_override = BW_NSS_FWCONF_80_80(nss160);
 +	/* fall through */
 +	case MODE_11AC_VHT160:
 +		arg->peer_bw_rxnss_override |= BW_NSS_FWCONF_160(nss160);
-+	break;
++		break;
 +	default:
-+	break;
++		break;
  	}
 +
 +	ath10k_dbg(ar, ATH10K_DBG_MAC, "mac vht peer %pM max_mpdu %d flags 0x%x peer_bw_rxnss_override 0x%x\n",
-+		   sta->addr, arg->peer_max_mpdu, arg->peer_flags, arg->peer_bw_rxnss_override);
++		   sta->addr, arg->peer_max_mpdu, arg->peer_flags, 
++		   arg->peer_bw_rxnss_override);
  }
  
  static void ath10k_peer_assoc_h_qos(struct ath10k *ar,
-@@ -2694,9 +2698,9 @@ static int ath10k_peer_assoc_prepare(str
+@@ -2694,9 +2716,9 @@ static int ath10k_peer_assoc_prepare(str
  	ath10k_peer_assoc_h_crypto(ar, vif, sta, arg);
  	ath10k_peer_assoc_h_rates(ar, vif, sta, arg);
  	ath10k_peer_assoc_h_ht(ar, vif, sta, arg);
@@ -114,19 +126,19 @@ configuration
  } __packed;
  
 -#define PEER_BW_RXNSS_OVERRIDE_OFFSET  31
-+#define BW_NSS_FWCONF_MAP_ENABLE             (1 << 31)
-+#define BW_NSS_FWCONF_MAP_160MHZ_S           (0)
-+#define BW_NSS_FWCONF_MAP_160MHZ_M           (0x00000007)
-+#define BW_NSS_FWCONF_MAP_80_80MHZ_S         (3)
-+#define BW_NSS_FWCONF_MAP_80_80MHZ_M         (0x00000038)
-+#define BW_NSS_FWCONF_MAP_M                  (0x0000003F)
++#define BW_NSS_FWCONF_MAP_ENABLE	BIT(31)
++#define BW_NSS_FWCONF_MAP_160MHZ_LSB	(0)
++#define BW_NSS_FWCONF_MAP_160MHZ_MASK	(0x00000007)
++#define BW_NSS_FWCONF_MAP_80_80MHZ_LSB	(3)
++#define BW_NSS_FWCONF_MAP_80_80MHZ_MASK (0x00000038)
++#define BW_NSS_FWCONF_MAP_MASK		(0x0000003F)
 +
-+#define GET_BW_NSS_FWCONF_160(x)             ((((x) & BW_NSS_FWCONF_MAP_160MHZ_M) >> BW_NSS_FWCONF_MAP_160MHZ_S) + 1)
-+#define GET_BW_NSS_FWCONF_80_80(x)           ((((x) & BW_NSS_FWCONF_MAP_80_80MHZ_M) >> BW_NSS_FWCONF_MAP_80_80MHZ_S) + 1)
++#define GET_BW_NSS_FWCONF_160(x)	(MS(x, BW_NSS_FWCONF_MAP_160MHZ) + 1)
++#define GET_BW_NSS_FWCONF_80_80(x)	(MS(x, BW_NSS_FWCONF_MAP_80_80MHZ) + 1)
 +
 +/* Values defined to set 160 MHz Bandwidth NSS Mapping into FW*/
-+#define BW_NSS_FWCONF_160(x)          (BW_NSS_FWCONF_MAP_ENABLE | (((x - 1) << BW_NSS_FWCONF_MAP_160MHZ_S) & BW_NSS_FWCONF_MAP_160MHZ_M))
-+#define BW_NSS_FWCONF_80_80(x)        (BW_NSS_FWCONF_MAP_ENABLE | (((x - 1) << BW_NSS_FWCONF_MAP_80_80MHZ_S) & BW_NSS_FWCONF_MAP_80_80MHZ_M))
++#define BW_NSS_FWCONF_160(x)		(BW_NSS_FWCONF_MAP_ENABLE | SM(x - 1, BW_NSS_FWCONF_MAP_160MHZ))
++#define BW_NSS_FWCONF_80_80(x)		(BW_NSS_FWCONF_MAP_ENABLE | SM(x - 1, BW_NSS_FWCONF_MAP_80_80MHZ))
  
  struct wmi_10_4_peer_assoc_complete_cmd {
  	struct wmi_10_2_peer_assoc_complete_cmd cmd;

--- a/package/kernel/mac80211/patches/973-ath10k_fix-band_center_freq-handling-for-VHT160-in-recent-firmwares.patch
+++ b/package/kernel/mac80211/patches/973-ath10k_fix-band_center_freq-handling-for-VHT160-in-recent-firmwares.patch
@@ -4,13 +4,16 @@ starting with firmware 10.4.3.4.x series QCA changed the handling of the channel
 likelly for backward compatiblity with vht80 only capable clients.
 this patch adjusts the handling to get vht160 to work again with official qca firmwares newer than 3.3
 consider that this patch will not work with older firmwares anymore. to avoid undefined behaviour this we disable vht160 capability for outdated firmwares
+Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>
+
+v2: fix trailing whitespace issue and fix some typos within the commit note
 ---
  drivers/net/wireless/ath/ath10k/mac.c |  7 -------
  drivers/net/wireless/ath/ath10k/wmi.c | 11 ++++++++---
  2 files changed, 8 insertions(+), 10 deletions(-)
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -4415,13 +4415,6 @@ static struct ieee80211_sta_vht_cap ath1
+@@ -4433,13 +4433,6 @@ static struct ieee80211_sta_vht_cap ath1
  		vht_cap.cap |= val;
  	}
  
@@ -42,7 +45,7 @@ consider that this patch will not work with older firmwares anymore. to avoid un
 +		if (arg->freq < arg->band_center_freq1)
 +			ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1 - 40);
 +		else
-+			ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1 + 40);		
++			ch->band_center_freq1 = __cpu_to_le32(arg->band_center_freq1 + 40);
 +		ch->band_center_freq2 = __cpu_to_le32(arg->band_center_freq1);
 +	}
  	ch->min_power = arg->min_power;

--- a/package/kernel/mac80211/patches/975-ath10k-use-tpt-trigger-by-default.patch
+++ b/package/kernel/mac80211/patches/975-ath10k-use-tpt-trigger-by-default.patch
@@ -42,7 +42,7 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  	if (ret)
 --- a/drivers/net/wireless/ath/ath10k/mac.c
 +++ b/drivers/net/wireless/ath/ath10k/mac.c
-@@ -8366,7 +8366,7 @@ int ath10k_mac_register(struct ath10k *a
+@@ -8384,7 +8384,7 @@ int ath10k_mac_register(struct ath10k *a
  	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_CQM_RSSI_LIST);
  
  #ifdef CPTCFG_MAC80211_LEDS

--- a/package/kernel/mac80211/patches/976-ath10k-support-use-of-channel-173.patch
+++ b/package/kernel/mac80211/patches/976-ath10k-support-use-of-channel-173.patch
@@ -1,0 +1,42 @@
+The India regulatory domain allows CH 173, so add that to the
+available channel list.  I verified basic connectivity between
+a 9880 and 9984 NIC.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -47,7 +47,8 @@
+ #define WMI_READY_TIMEOUT (5 * HZ)
+ #define ATH10K_FLUSH_TIMEOUT_HZ (5 * HZ)
+ #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
+-#define ATH10K_NUM_CHANS 40
++#define ATH10K_NUM_CHANS 41
++#define ATH10K_MAX_5G_CHAN 173
+ 
+ /* Antenna noise floor */
+ #define ATH10K_DEFAULT_NOISE_FLOOR -95
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -7743,6 +7743,9 @@ static const struct ieee80211_channel at
+ 	CHAN5G(161, 5805, 0),
+ 	CHAN5G(165, 5825, 0),
+ 	CHAN5G(169, 5845, 0),
++	CHAN5G(173, 5865, 0),
++	/* If you add more, you may need to change ATH10K_MAX_5G_CHAN */
++	/* And you will definitely need to change ATH10K_NUM_CHANS in core.h */
+ };
+ 
+ struct ath10k *ath10k_mac_create(size_t priv_size)
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -2356,7 +2356,7 @@ int ath10k_wmi_event_mgmt_rx(struct ath1
+ 	 */
+ 	if (channel >= 1 && channel <= 14) {
+ 		status->band = NL80211_BAND_2GHZ;
+-	} else if (channel >= 36 && channel <= 169) {
++	} else if (channel >= 36 && channel <= ATH10K_MAX_5G_CHAN) {
+ 		status->band = NL80211_BAND_5GHZ;
+ 	} else {
+ 		/* Shouldn't happen unless list of advertised channels to

--- a/package/kernel/mac80211/patches/977-ath10k-fix-spectral-scan-for-QCA9984-and-QC-9888-chipsets.patch
+++ b/package/kernel/mac80211/patches/977-ath10k-fix-spectral-scan-for-QCA9984-and-QC-9888-chipsets.patch
@@ -1,0 +1,145 @@
+The spectral scan has been always broken on QCA9984 and QCA9888.
+
+Introduce a hardware parameter 'spectral_bin_offset' to resolve this issue for
+QCA9984 and QCA9888 chipsets. For other chipsets, the hardware parameter
+'spectral_bin_offset' is zero so that existing behaviour is retained as it is.
+
+In QCA9984 and QCA9888 chipsets, hardware param value 'spectral_bin_discard'
+is 12 bytes. This 12 bytes is derived as the sum of segment index (4 bytes),
+extra bins before the actual data (4 bytes) and extra bins after the actual
+data (4 bytes). Always discarding (12 bytes) happens at end of the samples and
+incorrect samples got dumped, so that user can find incorrect arrangement
+samples in spectral scan dump.
+
+To fix this issue, we have to discard first 8 bytes and last 4 bytes in every
+samples, so totally 12 bytes are discarded. In every sample we need to consider
+the offset while taking the actual spectral data. For QCA9984, QCA9888 the
+offset is 8 bytes (segment index + extra bins before actual data).
+
+Hardware tested: QCA9984 and QCA9888
+Firmware tested: 10.4-3.5.3-00053
+
+Signed-off-by: Karthikeyan Periyasamy <periyasa@codeaurora.org>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -74,6 +74,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -99,6 +100,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -122,6 +124,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -145,6 +148,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -168,6 +172,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -194,6 +199,7 @@ static const struct ath10k_hw_params ath
+ 		.target_cpu_freq = 176000000,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -224,6 +230,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
+ 		.spectral_bin_discard = 4,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 11,
+@@ -255,6 +262,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
+ 		.spectral_bin_discard = 12,
++		.spectral_bin_offset = 8,
+ 
+ 		/* Can do only 2x2 VHT160 or 80+80. 1560Mbps is 4x4 80Mhz
+ 		 * or 2x2 160Mhz, long-guard-interval.
+@@ -289,6 +297,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
+ 		.spectral_bin_discard = 12,
++		.spectral_bin_offset = 8,
+ 
+ 		/* Can do only 1x1 VHT160 or 80+80. 780Mbps is 2x2 80Mhz or
+ 		 * 1x1 160Mhz, long-guard-interval.
+@@ -316,6 +325,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca988x_ops,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -341,6 +351,7 @@ static const struct ath10k_hw_params ath
+ 		.target_cpu_freq = 176000000,
+ 		.decap_align_bytes = 4,
+ 		.spectral_bin_discard = 0,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 8,
+@@ -371,6 +382,7 @@ static const struct ath10k_hw_params ath
+ 		.hw_ops = &qca99x0_ops,
+ 		.decap_align_bytes = 1,
+ 		.spectral_bin_discard = 4,
++		.spectral_bin_offset = 0,
+ 		.vht160_mcs_rx_highest = 0,
+ 		.vht160_mcs_tx_highest = 0,
+ 		.n_cipher_suites = 11,
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -554,6 +554,9 @@ struct ath10k_hw_params {
+ 
+ 	/* Number of ciphers supported (i.e First N) in cipher_suites array */
+ 	int n_cipher_suites;
++
++	/* Number of bytes to be the offset for each FFT sample */
++	int spectral_bin_offset;
+ };
+ 
+ struct htt_rx_desc;
+--- a/drivers/net/wireless/ath/ath10k/spectral.c
++++ b/drivers/net/wireless/ath/ath10k/spectral.c
+@@ -145,7 +145,7 @@ int ath10k_spectral_process_fft(struct a
+ 	fft_sample->noise = __cpu_to_be16(phyerr->nf_chains[chain_idx]);
+ 
+ 	bins = (u8 *)fftr;
+-	bins += sizeof(*fftr);
++	bins += sizeof(*fftr) + ar->hw_params.spectral_bin_offset;
+ 
+ 	fft_sample->tsf = __cpu_to_be64(tsf);
+ 

--- a/package/kernel/mac80211/patches/978-ath10k-add-support-to-configure-channel-dwell-time.patch
+++ b/package/kernel/mac80211/patches/978-ath10k-add-support-to-configure-channel-dwell-time.patch
@@ -1,0 +1,83 @@
+Configure channel dwell time from duration of the scan request
+received from mac80211 when the duration is non-zero. When the
+scan request does not have duration value, use the default ones,
+the current implementation.
+
+Corresponding flag NL80211_EXT_FEATURE_SET_SCAN_DWELL is
+advertized.
+
+Supported Chipsets:
+ -QCA988X/QCA9887 PCI
+ -QCA99X0/QCA9984/QCA9888/QCA4019 PCI
+ -QCA6174/QCA9377 PCI/USB/SDIO
+ -WCN3990 SNOC
+
+Tested on QCA9984 with firmware ver 10.4-3.6-0010
+
+Signed-off-by: Pradeep Kumar Chitrapu <pradeepc@codeaurora.org>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -44,6 +44,7 @@
+ #define WO(_f)      ((_f##_OFFSET) >> 2)
+ 
+ #define ATH10K_SCAN_ID 0
++#define ATH10K_SCAN_CHANNEL_SWITCH_WMI_EVT_OVERHEAD 10 /* msec */
+ #define WMI_READY_TIMEOUT (5 * HZ)
+ #define ATH10K_FLUSH_TIMEOUT_HZ (5 * HZ)
+ #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -5611,6 +5611,7 @@ static int ath10k_hw_scan(struct ieee802
+ 	struct wmi_start_scan_arg arg;
+ 	int ret = 0;
+ 	int i;
++	u32 scan_timeout;
+ 
+ 	mutex_lock(&ar->conf_mutex);
+ 
+@@ -5661,6 +5662,22 @@ static int ath10k_hw_scan(struct ieee802
+ 			arg.channels[i] = req->channels[i]->center_freq;
+ 	}
+ 
++	/* if duration is set, default dwell times will be overwritten */
++	if (req->duration) {
++		arg.dwell_time_active = req->duration;
++		arg.dwell_time_passive = req->duration;
++		arg.burst_duration_ms = req->duration;
++
++		scan_timeout = min_t(u32, arg.max_rest_time *
++				(arg.n_channels - 1) + (req->duration +
++				ATH10K_SCAN_CHANNEL_SWITCH_WMI_EVT_OVERHEAD) *
++				arg.n_channels, arg.max_scan_time + 200);
++
++	} else {
++		/* Add a 200ms margin to account for event/command processing */
++		scan_timeout = arg.max_scan_time + 200;
++	}
++
+ 	ret = ath10k_start_scan(ar, &arg);
+ 	if (ret) {
+ 		ath10k_warn(ar, "failed to start hw scan: %d\n", ret);
+@@ -5669,10 +5686,8 @@ static int ath10k_hw_scan(struct ieee802
+ 		spin_unlock_bh(&ar->data_lock);
+ 	}
+ 
+-	/* Add a 200ms margin to account for event/command processing */
+ 	ieee80211_queue_delayed_work(ar->hw, &ar->scan.timeout,
+-				     msecs_to_jiffies(arg.max_scan_time +
+-						      200));
++				     msecs_to_jiffies(scan_timeout));
+ 
+ exit:
+ 	mutex_unlock(&ar->conf_mutex);
+@@ -8288,6 +8303,8 @@ int ath10k_mac_register(struct ath10k *a
+ 	}
+ 
+ 	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_VHT_IBSS);
++	wiphy_ext_feature_set(ar->hw->wiphy,
++			      NL80211_EXT_FEATURE_SET_SCAN_DWELL);
+ 
+ 	/*
+ 	 * on LL hardware queues are managed entirely by the FW

--- a/package/kernel/mac80211/patches/979-ath10k-use-firmware_request_nowarn()-to-load-firmware.patch
+++ b/package/kernel/mac80211/patches/979-ath10k-use-firmware_request_nowarn()-to-load-firmware.patch
@@ -1,0 +1,20 @@
+This reduces the unnecessary spew when trying to load optional firmware:
+"Direct firmware load for ... failed with error -2"
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -550,7 +550,7 @@ static const struct firmware *ath10k_fet
+ 		dir = ".";
+ 
+ 	snprintf(filename, sizeof(filename), "%s/%s", dir, file);
+-	ret = request_firmware(&fw, filename, ar->dev);
++	ret = firmware_request_nowarn(&fw, filename, ar->dev);
+ 	ath10k_dbg(ar, ATH10K_DBG_BOOT, "boot fw request '%s': %d\n",
+ 		   filename, ret);
+ 

--- a/package/kernel/mac80211/patches/980-ath10k-re-enable-the-firmware-fallback-mechanism-for-testmode.patch
+++ b/package/kernel/mac80211/patches/980-ath10k-re-enable-the-firmware-fallback-mechanism-for-testmode.patch
@@ -1,0 +1,23 @@
+The ath10k testmode uses request_firmware_direct() in order to avoid
+producing firmware load warnings. Disabling the fallback mechanism was a
+side effect of disabling warnings.
+
+We now have a new API that allows us to avoid warnings while keeping the
+fallback mechanism enabled. So use that instead.
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+--- a/drivers/net/wireless/ath/ath10k/testmode.c
++++ b/drivers/net/wireless/ath/ath10k/testmode.c
+@@ -157,7 +157,7 @@ static int ath10k_tm_fetch_utf_firmware_
+ 		 ar->hw_params.fw.dir, ATH10K_FW_UTF_FILE);
+ 
+ 	/* load utf firmware image */
+-	ret = request_firmware_direct(&fw_file->firmware, filename, ar->dev);
++	ret = firmware_request_nowarn(&fw_file->firmware, filename, ar->dev);
+ 	ath10k_dbg(ar, ATH10K_DBG_TESTMODE, "testmode fw request '%s': %d\n",
+ 		   filename, ret);
+ 

--- a/target/linux/generic/backport-4.14/081-v4.18-firmware-add-firmware_request_nowarn().patch
+++ b/target/linux/generic/backport-4.14/081-v4.18-firmware-add-firmware_request_nowarn().patch
@@ -1,0 +1,96 @@
+Currently the firmware loader only exposes one silent path for querying
+optional firmware, and that is firmware_request_direct(). This function
+also disables the sysfs fallback mechanism, which might not always be the
+desired behaviour [0].
+
+This patch introduces a variations of request_firmware() that enable the
+caller to disable the undesired warning messages but enables the sysfs
+fallback mechanism. This is equivalent to adding FW_OPT_NO_WARN to the
+old behaviour.
+
+[0]: https://git.kernel.org/linus/c0cc00f250e1
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: used the old API calls as the full rename is not done yet, and
+ add the caller for when FW_LOADER is disabled, enhance documentation ]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+--- a/Documentation/driver-api/firmware/request_firmware.rst
++++ b/Documentation/driver-api/firmware/request_firmware.rst
+@@ -20,6 +20,11 @@ request_firmware
+ .. kernel-doc:: drivers/base/firmware_class.c
+    :functions: request_firmware
+ 
++firmware_request_nowarn
++-----------------------
++.. kernel-doc:: drivers/base/firmware_class.c
++   :functions: firmware_request_nowarn
++
+ request_firmware_direct
+ -----------------------
+ .. kernel-doc:: drivers/base/firmware_class.c
+--- a/drivers/base/firmware_class.c
++++ b/drivers/base/firmware_class.c
+@@ -1275,6 +1275,33 @@ request_firmware(const struct firmware *
+ EXPORT_SYMBOL(request_firmware);
+ 
+ /**
++ * firmware_request_nowarn() - request for an optional fw module
++ * @firmware: pointer to firmware image
++ * @name: name of firmware file
++ * @device: device for which firmware is being loaded
++ *
++ * This function is similar in behaviour to request_firmware(), except
++ * it doesn't produce warning messages when the file is not found.
++ * The sysfs fallback mechanism is enabled if direct filesystem lookup fails,
++ * however, however failures to find the firmware file with it are still
++ * suppressed. It is therefore up to the driver to check for the return value
++ * of this call and to decide when to inform the users of errors.
++ **/
++int firmware_request_nowarn(const struct firmware **firmware, const char *name,
++			    struct device *device)
++{
++	int ret;
++
++	/* Need to pin this module until return */
++	__module_get(THIS_MODULE);
++	ret = _request_firmware(firmware, name, device, NULL, 0,
++				FW_OPT_UEVENT | FW_OPT_NO_WARN);
++	module_put(THIS_MODULE);
++	return ret;
++}
++EXPORT_SYMBOL_GPL(firmware_request_nowarn);
++
++/**
+  * request_firmware_direct: - load firmware directly without usermode helper
+  * @firmware_p: pointer to firmware image
+  * @name: name of firmware file
+--- a/include/linux/firmware.h
++++ b/include/linux/firmware.h
+@@ -42,6 +42,8 @@ struct builtin_fw {
+ #if defined(CONFIG_FW_LOADER) || (defined(CONFIG_FW_LOADER_MODULE) && defined(MODULE))
+ int request_firmware(const struct firmware **fw, const char *name,
+ 		     struct device *device);
++int firmware_request_nowarn(const struct firmware **fw, const char *name,
++			    struct device *device);
+ int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,
+@@ -59,6 +61,14 @@ static inline int request_firmware(const
+ {
+ 	return -EINVAL;
+ }
++
++static inline int firmware_request_nowarn(const struct firmware **fw,
++					  const char *name,
++					  struct device *device)
++{
++	return -EINVAL;
++}
++
+ static inline int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,

--- a/target/linux/generic/backport-4.9/081-v4.18-firmware-add-firmware_request_nowarn().patch
+++ b/target/linux/generic/backport-4.9/081-v4.18-firmware-add-firmware_request_nowarn().patch
@@ -1,0 +1,102 @@
+Currently the firmware loader only exposes one silent path for querying
+optional firmware, and that is firmware_request_direct(). This function
+also disables the sysfs fallback mechanism, which might not always be the
+desired behaviour [0].
+
+This patch introduces a variations of request_firmware() that enable the
+caller to disable the undesired warning messages but enables the sysfs
+fallback mechanism. This is equivalent to adding FW_OPT_NO_WARN to the
+old behaviour.
+
+[0]: https://git.kernel.org/linus/c0cc00f250e1
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: used the old API calls as the full rename is not done yet, and
+ add the caller for when FW_LOADER is disabled, enhance documentation ]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+diff --git a/Documentation/driver-api/firmware/request_firmware.rst b/Documentation/driver-api/firmware/request_firmware.rst
+index d5ec95a..f62bdcb 100644
+--- a/Documentation/driver-api/firmware/request_firmware.rst
++++ b/Documentation/driver-api/firmware/request_firmware.rst
+@@ -20,6 +20,11 @@ request_firmware
+ .. kernel-doc:: drivers/base/firmware_class.c
+    :functions: request_firmware
+ 
++firmware_request_nowarn
++-----------------------
++.. kernel-doc:: drivers/base/firmware_class.c
++   :functions: firmware_request_nowarn
++
+ request_firmware_direct
+ -----------------------
+ .. kernel-doc:: drivers/base/firmware_class.c
+diff --git a/drivers/base/firmware_class.c b/drivers/base/firmware_class.c
+index abdc4e4..0943e70 100644
+--- a/drivers/base/firmware_class.c
++++ b/drivers/base/firmware_class.c
+@@ -1275,6 +1275,33 @@
+ EXPORT_SYMBOL(request_firmware);
+ 
+ /**
++ * firmware_request_nowarn() - request for an optional fw module
++ * @firmware: pointer to firmware image
++ * @name: name of firmware file
++ * @device: device for which firmware is being loaded
++ *
++ * This function is similar in behaviour to request_firmware(), except
++ * it doesn't produce warning messages when the file is not found.
++ * The sysfs fallback mechanism is enabled if direct filesystem lookup fails,
++ * however, however failures to find the firmware file with it are still
++ * suppressed. It is therefore up to the driver to check for the return value
++ * of this call and to decide when to inform the users of errors.
++ **/
++int firmware_request_nowarn(const struct firmware **firmware, const char *name,
++			    struct device *device)
++{
++	int ret;
++
++	/* Need to pin this module until return */
++	__module_get(THIS_MODULE);
++	ret = _request_firmware(firmware, name, device, NULL, 0,
++				FW_OPT_UEVENT | FW_OPT_NO_WARN);
++	module_put(THIS_MODULE);
++	return ret;
++}
++EXPORT_SYMBOL_GPL(firmware_request_nowarn);
++
++/**
+  * request_firmware_direct: - load firmware directly without usermode helper
+  * @firmware_p: pointer to firmware image
+  * @name: name of firmware file
+diff --git a/include/linux/firmware.h b/include/linux/firmware.h
+index 4105041..2dd566c 100644
+--- a/include/linux/firmware.h
++++ b/include/linux/firmware.h
+@@ -42,6 +42,8 @@ struct builtin_fw {
+ #if defined(CONFIG_FW_LOADER) || (defined(CONFIG_FW_LOADER_MODULE) && defined(MODULE))
+ int request_firmware(const struct firmware **fw, const char *name,
+ 		     struct device *device);
++int firmware_request_nowarn(const struct firmware **fw, const char *name,
++			    struct device *device);
+ int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,
+@@ -59,6 +61,14 @@ static inline int request_firmware(const struct firmware **fw,
+ {
+ 	return -EINVAL;
+ }
++
++static inline int firmware_request_nowarn(const struct firmware **fw,
++					  const char *name,
++					  struct device *device)
++{
++	return -EINVAL;
++}
++
+ static inline int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,


### PR DESCRIPTION
This refresh and update patch version of the 2 patches that fix 160mhz on ath10k wireless driver. Also adds some patch from ath-next pushed upstream.


Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>