### PR TITLE
ath79: add support for OCEDO Raccoon

### DIFF
--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -50,6 +50,7 @@ case "$FIRMWARE" in
 	"avm,fritz300e")
 		ath9k_eeprom_extract_reverse "urloader" 5441 1088
 		;;
+	"ocedo,raccoon"|\
 	"tplink,tl-wdr3600"|\
 	"tplink,tl-wdr4300")
 		ath9k_eeprom_extract "art" 20480 1088

--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "OCEDO Raccoon";
+	compatible = "ocedo,raccoon", "qca,ar9344";
+
+	aliases {
+		led-status = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "raccoon:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "raccoon:yellow:wlan24";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		system: system {
+			label = "raccoon:blue:sys";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "raccoon:red:wlan5";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x740000>;
+			};
+
+			partition@790000 {
+				label = "vendor";
+				reg = <0x790000 0x740000>;
+				read-only;
+			};
+
+			partition@ed0000 {
+				label = "data";
+				reg = <0xed0000 0x110000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "id";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@168c,0030 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&art 0xc>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x6>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -49,6 +49,15 @@ define Device/glinet_ar300m_nor
 endef
 TARGET_DEVICES += glinet_ar300m_nor
 
+define Device/ocedo_raccoon
+  ATH_SOC := ar9344
+  DEVICE_TITLE := OCEDO Raccoon
+  IMAGE_SIZE := 7424k
+  SUPPORTED_DEVICES += raccoon
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += ocedo_raccoon
+
 define Device/openmesh_om5p-ac-v2
   ATH_SOC := qca9558
   DEVICE_TITLE := OpenMesh OM5P-AC v2


### PR DESCRIPTION
This commit adds support for the OCEDO Raccoon

SOC:	Atheros AR9344
RAM:    128MB
FLASH:  16MiB
WLAN1:  AR9344 2.4 GHz 802.11bgn 2x2
WLAN2:  AR9382 5 GHz 802.11an 2x2
INPUT:  RESET button
LED:    Power, LAN, WiFi 2.4, WiFi 5
Serial: Header Next to Black metal shield
        Pinout is 3.3V - GND - TX - RX (Arrow Pad is 3.3V)
        The Serial setting is 115200-8-N-1.

	NOTE: The U-Boot won't boot with the serial attached.
	Boot the device without serial attached and attach it
	after 3 seconds.

Tested and working:
 - Ethernet
 - 2.4 GHz WiFi
 - 5 GHz WiFi
 - TFTP boot from ramdisk image
 - Installation via ramdisk image
 - OpenWRT sysupgrade
 - Buttons
 - LEDs

Installation seems to be possible only through booting an OpenWRT
ramdisk image.

Hold down the reset button while powering on the device. It will load a
ramdisk image named 'raccoon-uImage-initramfs-lzma.bin' from 192.168.100.8.

Note: depending on the present software, the device might also try to
pull a file called 'raccoon-uimage-factory'. Only the name differs, it
is still used as a ramdisk image.

Wait for the ramdisk image to boot. OpenWRT can be written to the flash
via sysupgrade or mtd.

Due to the flip-flop bootloader which we not (yet) support, you need to
set the partition the bootloader is selecting. It is possible from the
initramfs image with

 > fw_setenv bootcmd run bootcmd_1

Afterwards you can reboot the device.

Signed-off-by: David Bauer <mail@david-bauer.net>
