### PR TITLE
linux-generic: backport upstream firmware_loader

### DIFF
--- a/package/kernel/mac80211/patches/979-ath10k-use-firmware_request_nowarn()-to-load-firmware.patch
+++ b/package/kernel/mac80211/patches/979-ath10k-use-firmware_request_nowarn()-to-load-firmware.patch
@@ -1,0 +1,20 @@
+This reduces the unnecessary spew when trying to load optional firmware:
+"Direct firmware load for ... failed with error -2"
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -550,7 +550,7 @@ static const struct firmware *ath10k_fet
+ 		dir = ".";
+ 
+ 	snprintf(filename, sizeof(filename), "%s/%s", dir, file);
+-	ret = request_firmware(&fw, filename, ar->dev);
++	ret = firmware_request_nowarn(&fw, filename, ar->dev);
+ 	ath10k_dbg(ar, ATH10K_DBG_BOOT, "boot fw request '%s': %d\n",
+ 		   filename, ret);
+ 

--- a/package/kernel/mac80211/patches/980-ath10k-re-enable-the-firmware-fallback-mechanism-for-testmode.patch
+++ b/package/kernel/mac80211/patches/980-ath10k-re-enable-the-firmware-fallback-mechanism-for-testmode.patch
@@ -1,0 +1,23 @@
+The ath10k testmode uses request_firmware_direct() in order to avoid
+producing firmware load warnings. Disabling the fallback mechanism was a
+side effect of disabling warnings.
+
+We now have a new API that allows us to avoid warnings while keeping the
+fallback mechanism enabled. So use that instead.
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+--- a/drivers/net/wireless/ath/ath10k/testmode.c
++++ b/drivers/net/wireless/ath/ath10k/testmode.c
+@@ -157,7 +157,7 @@ static int ath10k_tm_fetch_utf_firmware_
+ 		 ar->hw_params.fw.dir, ATH10K_FW_UTF_FILE);
+ 
+ 	/* load utf firmware image */
+-	ret = request_firmware_direct(&fw_file->firmware, filename, ar->dev);
++	ret = firmware_request_nowarn(&fw_file->firmware, filename, ar->dev);
+ 	ath10k_dbg(ar, ATH10K_DBG_TESTMODE, "testmode fw request '%s': %d\n",
+ 		   filename, ret);
+ 

--- a/target/linux/generic/backport-4.14/081-0001-firmware-bump-to-7dec-version.patch
+++ b/target/linux/generic/backport-4.14/081-0001-firmware-bump-to-7dec-version.patch
@@ -1,0 +1,1607 @@
+--- a/drivers/base/firmware_class.c
++++ b/drivers/base/firmware_class.c
+@@ -1,3 +1,4 @@
++// SPDX-License-Identifier: GPL-2.0
+ /*
+  * firmware_class.c - Multi purpose firmware loading support
+  *
+@@ -41,6 +42,96 @@
+ MODULE_DESCRIPTION("Multi purpose firmware loading support");
+ MODULE_LICENSE("GPL");
+ 
++enum fw_status {
++	FW_STATUS_UNKNOWN,
++	FW_STATUS_LOADING,
++	FW_STATUS_DONE,
++	FW_STATUS_ABORTED,
++};
++
++/*
++ * Concurrent request_firmware() for the same firmware need to be
++ * serialized.  struct fw_state is simple state machine which hold the
++ * state of the firmware loading.
++ */
++struct fw_state {
++	struct completion completion;
++	enum fw_status status;
++};
++
++/* firmware behavior options */
++#define FW_OPT_UEVENT	(1U << 0)
++#define FW_OPT_NOWAIT	(1U << 1)
++#define FW_OPT_USERHELPER	(1U << 2)
++#define FW_OPT_NO_WARN	(1U << 3)
++#define FW_OPT_NOCACHE	(1U << 4)
++#define FW_OPT_NOFALLBACK (1U << 5)
++
++struct firmware_cache {
++	/* firmware_buf instance will be added into the below list */
++	spinlock_t lock;
++	struct list_head head;
++	int state;
++
++#ifdef CONFIG_PM_SLEEP
++	/*
++	 * Names of firmware images which have been cached successfully
++	 * will be added into the below list so that device uncache
++	 * helper can trace which firmware images have been cached
++	 * before.
++	 */
++	spinlock_t name_lock;
++	struct list_head fw_names;
++
++	struct delayed_work work;
++
++	struct notifier_block   pm_notify;
++#endif
++};
++
++struct fw_priv {
++	struct kref ref;
++	struct list_head list;
++	struct firmware_cache *fwc;
++	struct fw_state fw_st;
++	void *data;
++	size_t size;
++	size_t allocated_size;
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++	bool is_paged_buf;
++	bool need_uevent;
++	struct page **pages;
++	int nr_pages;
++	int page_array_size;
++	struct list_head pending_list;
++#endif
++	const char *fw_name;
++};
++
++struct fw_cache_entry {
++	struct list_head list;
++	const char *name;
++};
++
++struct fw_name_devm {
++	unsigned long magic;
++	const char *name;
++};
++
++static inline struct fw_priv *to_fw_priv(struct kref *ref)
++{
++	return container_of(ref, struct fw_priv, ref);
++}
++
++#define	FW_LOADER_NO_CACHE	0
++#define	FW_LOADER_START_CACHE	1
++
++/* fw_lock could be moved to 'struct fw_sysfs' but since it is just
++ * guarding for corner cases a global lock should be OK */
++static DEFINE_MUTEX(fw_lock);
++
++static struct firmware_cache fw_cache;
++
+ /* Builtin firmware support */
+ 
+ #ifdef CONFIG_FW_LOADER
+@@ -48,6 +139,14 @@
+ extern struct builtin_fw __start_builtin_fw[];
+ extern struct builtin_fw __end_builtin_fw[];
+ 
++static void fw_copy_to_prealloc_buf(struct firmware *fw,
++				    void *buf, size_t size)
++{
++	if (!buf || size < fw->size)
++		return;
++	memcpy(buf, fw->data, fw->size);
++}
++
+ static bool fw_get_builtin_firmware(struct firmware *fw, const char *name,
+ 				    void *buf, size_t size)
+ {
+@@ -57,9 +156,10 @@
+ 		if (strcmp(name, b_fw->name) == 0) {
+ 			fw->size = b_fw->size;
+ 			fw->data = b_fw->data;
++			fw_copy_to_prealloc_buf(fw, buf, size);
+ 
+-			if (buf && fw->size <= size)
+-				memcpy(buf, fw->data, fw->size);
++							   
++									
+ 			return true;
+ 		}
+ 	}
+@@ -93,12 +193,12 @@
+ }
+ #endif
+ 
+-enum fw_status {
+-	FW_STATUS_UNKNOWN,
+-	FW_STATUS_LOADING,
+-	FW_STATUS_DONE,
+-	FW_STATUS_ABORTED,
+-};
++				
++				   
++				   
++				
++				   
++  
+ 
+ static int loading_timeout = 60;	/* In seconds */
+ 
+@@ -107,29 +207,32 @@
+ 	return loading_timeout > 0 ? loading_timeout * HZ : MAX_JIFFY_OFFSET;
+ }
+ 
+-/*
+- * Concurrent request_firmware() for the same firmware need to be
+- * serialized.  struct fw_state is simple state machine which hold the
+- * state of the firmware loading.
+- */
+-struct fw_state {
+-	struct completion completion;
+-	enum fw_status status;
+-};
++  
++																 
++																	  
++								 
++   
++				 
++							  
++					   
++  
+ 
+-static void fw_state_init(struct fw_state *fw_st)
++static void fw_state_init(struct fw_priv *fw_priv)
+ {
++	struct fw_state *fw_st = &fw_priv->fw_st;
++
+ 	init_completion(&fw_st->completion);
+ 	fw_st->status = FW_STATUS_UNKNOWN;
+ }
+ 
+-static inline bool __fw_state_is_done(enum fw_status status)
+-{
+-	return status == FW_STATUS_DONE || status == FW_STATUS_ABORTED;
+-}
++															
++ 
++																
++ 
+ 
+-static int __fw_state_wait_common(struct fw_state *fw_st, long timeout)
++static int __fw_state_wait_common(struct fw_priv *fw_priv, long timeout)
+ {
++	struct fw_state *fw_st = &fw_priv->fw_st;
+ 	long ret;
+ 
+ 	ret = wait_for_completion_killable_timeout(&fw_st->completion, timeout);
+@@ -141,226 +244,236 @@
+ 	return ret < 0 ? ret : 0;
+ }
+ 
+-static void __fw_state_set(struct fw_state *fw_st,
++static void __fw_state_set(struct fw_priv *fw_priv,
+ 			   enum fw_status status)
+ {
++	struct fw_state *fw_st = &fw_priv->fw_st;
++
+ 	WRITE_ONCE(fw_st->status, status);
+ 
+ 	if (status == FW_STATUS_DONE || status == FW_STATUS_ABORTED)
+ 		complete_all(&fw_st->completion);
+ }
+ 
+-#define fw_state_start(fw_st)					\
+-	__fw_state_set(fw_st, FW_STATUS_LOADING)
+-#define fw_state_done(fw_st)					\
+-	__fw_state_set(fw_st, FW_STATUS_DONE)
+-#define fw_state_aborted(fw_st)					\
+-	__fw_state_set(fw_st, FW_STATUS_ABORTED)
+-#define fw_state_wait(fw_st)					\
+-	__fw_state_wait_common(fw_st, MAX_SCHEDULE_TIMEOUT)
++static inline void fw_state_start(struct fw_priv *fw_priv)
++										 
++								  
++									  
++									 
++										 
++								  
++													
+ 
+-static int __fw_state_check(struct fw_state *fw_st, enum fw_status status)
++																		  
+ {
+-	return fw_st->status == status;
++	__fw_state_set(fw_priv, FW_STATUS_LOADING);
+ }
+ 
+-#define fw_state_is_aborted(fw_st)				\
+-	__fw_state_check(fw_st, FW_STATUS_ABORTED)
++									   
++										   
+ 
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
++								   
+ 
+-#define fw_state_aborted(fw_st)					\
+-	__fw_state_set(fw_st, FW_STATUS_ABORTED)
+-#define fw_state_is_done(fw_st)					\
+-	__fw_state_check(fw_st, FW_STATUS_DONE)
+-#define fw_state_is_loading(fw_st)				\
+-	__fw_state_check(fw_st, FW_STATUS_LOADING)
+-#define fw_state_wait_timeout(fw_st, timeout)			\
+-	__fw_state_wait_common(fw_st, timeout)
++									 
++										 
++									 
++										
++									   
++										   
++												 
++									   
+ 
+-#endif /* CONFIG_FW_LOADER_USER_HELPER */
++static inline void fw_state_done(struct fw_priv *fw_priv)
++{
++	__fw_state_set(fw_priv, FW_STATUS_DONE);
++}
+ 
+-/* firmware behavior options */
+-#define FW_OPT_UEVENT	(1U << 0)
+-#define FW_OPT_NOWAIT	(1U << 1)
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-#define FW_OPT_USERHELPER	(1U << 2)
+-#else
+-#define FW_OPT_USERHELPER	0
+-#endif
+-#ifdef CONFIG_FW_LOADER_USER_HELPER_FALLBACK
+-#define FW_OPT_FALLBACK		FW_OPT_USERHELPER
+-#else
+-#define FW_OPT_FALLBACK		0
+-#endif
+-#define FW_OPT_NO_WARN	(1U << 3)
+-#define FW_OPT_NOCACHE	(1U << 4)
++static inline void fw_state_aborted(struct fw_priv *fw_priv)
++{
++	__fw_state_set(fw_priv, FW_STATUS_ABORTED);
++}
++								   
++	 
++						   
++	  
++											
++										  
++	 
++						  
++	  
++								
++								
+ 
+-struct firmware_cache {
+-	/* firmware_buf instance will be added into the below list */
+-	spinlock_t lock;
+-	struct list_head head;
+-	int state;
++static inline int fw_state_wait(struct fw_priv *fw_priv)
++{
++	return __fw_state_wait_common(fw_priv, MAX_SCHEDULE_TIMEOUT);
++}
++		   
+ 
+-#ifdef CONFIG_PM_SLEEP
+-	/*
+-	 * Names of firmware images which have been cached successfully
+-	 * will be added into the below list so that device uncache
+-	 * helper can trace which firmware images have been cached
+-	 * before.
+-	 */
+-	spinlock_t name_lock;
+-	struct list_head fw_names;
++static bool __fw_state_check(struct fw_priv *fw_priv,
++			     enum fw_status status)
++{
++	struct fw_state *fw_st = &fw_priv->fw_st;
++														   
++		   
++	
++					  
++						   
+ 
+-	struct delayed_work work;
++	return fw_st->status == status;
++}
+ 
+-	struct notifier_block   pm_notify;
+-#endif
+-};
++static inline bool fw_state_is_aborted(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_ABORTED);
++}
+ 
+-struct firmware_buf {
+-	struct kref ref;
+-	struct list_head list;
+-	struct firmware_cache *fwc;
+-	struct fw_state fw_st;
+-	void *data;
+-	size_t size;
+-	size_t allocated_size;
++					 
++				 
++					   
++							
++					   
++			
++			 
++					   
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-	bool is_paged_buf;
+-	bool need_uevent;
+-	struct page **pages;
+-	int nr_pages;
+-	int page_array_size;
+-	struct list_head pending_list;
+-#endif
+-	const char *fw_id;
+-};
++				   
++				  
++					 
++			  
++					 
++							   
++	  
++				   
++  
+ 
+-struct fw_cache_entry {
+-	struct list_head list;
+-	const char *name;
+-};
++static inline bool fw_sysfs_done(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_DONE);
++}
+ 
+-struct fw_name_devm {
+-	unsigned long magic;
+-	const char *name;
+-};
++static inline bool fw_sysfs_loading(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_LOADING);
++}
+ 
+-#define to_fwbuf(d) container_of(d, struct firmware_buf, ref)
++static inline int fw_sysfs_wait_timeout(struct fw_priv *fw_priv,  long timeout)
++{
++	return __fw_state_wait_common(fw_priv, timeout);
++}
+ 
+-#define	FW_LOADER_NO_CACHE	0
+-#define	FW_LOADER_START_CACHE	1
++#endif /* CONFIG_FW_LOADER_USER_HELPER */
++							   
+ 
+ static int fw_cache_piggyback_on_request(const char *name);
+ 
+-/* fw_lock could be moved to 'struct firmware_priv' but since it is just
+- * guarding for corner cases a global lock should be OK */
+-static DEFINE_MUTEX(fw_lock);
++																		
++														  
++							 
+ 
+-static struct firmware_cache fw_cache;
++									  
+ 
+-static struct firmware_buf *__allocate_fw_buf(const char *fw_name,
+-					      struct firmware_cache *fwc,
+-					      void *dbuf, size_t size)
++static struct fw_priv *__allocate_fw_priv(const char *fw_name,
++					  struct firmware_cache *fwc,
++					  void *dbuf, size_t size)
+ {
+-	struct firmware_buf *buf;
++	struct fw_priv *fw_priv;
+ 
+-	buf = kzalloc(sizeof(*buf), GFP_ATOMIC);
+-	if (!buf)
++	fw_priv = kzalloc(sizeof(*fw_priv), GFP_ATOMIC);
++	if (!fw_priv)
+ 		return NULL;
+ 
+-	buf->fw_id = kstrdup_const(fw_name, GFP_ATOMIC);
+-	if (!buf->fw_id) {
+-		kfree(buf);
++	fw_priv->fw_name = kstrdup_const(fw_name, GFP_ATOMIC);
++	if (!fw_priv->fw_name) {
++		kfree(fw_priv);
+ 		return NULL;
+ 	}
+ 
+-	kref_init(&buf->ref);
+-	buf->fwc = fwc;
+-	buf->data = dbuf;
+-	buf->allocated_size = size;
+-	fw_state_init(&buf->fw_st);
++	kref_init(&fw_priv->ref);
++	fw_priv->fwc = fwc;
++	fw_priv->data = dbuf;
++	fw_priv->allocated_size = size;
++	fw_state_init(fw_priv);
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-	INIT_LIST_HEAD(&buf->pending_list);
++	INIT_LIST_HEAD(&fw_priv->pending_list);
+ #endif
+ 
+-	pr_debug("%s: fw-%s buf=%p\n", __func__, fw_name, buf);
++	pr_debug("%s: fw-%s fw_priv=%p\n", __func__, fw_name, fw_priv);
+ 
+-	return buf;
++	return fw_priv;
+ }
+ 
+-static struct firmware_buf *__fw_lookup_buf(const char *fw_name)
++static struct fw_priv *__lookup_fw_priv(const char *fw_name)
+ {
+-	struct firmware_buf *tmp;
++	struct fw_priv *tmp;
+ 	struct firmware_cache *fwc = &fw_cache;
+ 
+ 	list_for_each_entry(tmp, &fwc->head, list)
+-		if (!strcmp(tmp->fw_id, fw_name))
++		if (!strcmp(tmp->fw_name, fw_name))
+ 			return tmp;
+ 	return NULL;
+ }
+ 
+ /* Returns 1 for batching firmware requests with the same name */
+-static int fw_lookup_and_allocate_buf(const char *fw_name,
+-				      struct firmware_cache *fwc,
+-				      struct firmware_buf **buf, void *dbuf,
+-				      size_t size)
++static int alloc_lookup_fw_priv(const char *fw_name,
++				struct firmware_cache *fwc,
++				struct fw_priv **fw_priv, void *dbuf,
++				size_t size)
+ {
+-	struct firmware_buf *tmp;
++	struct fw_priv *tmp;
+ 
+ 	spin_lock(&fwc->lock);
+-	tmp = __fw_lookup_buf(fw_name);
++	tmp = __lookup_fw_priv(fw_name);
+ 	if (tmp) {
+ 		kref_get(&tmp->ref);
+ 		spin_unlock(&fwc->lock);
+-		*buf = tmp;
+-		pr_debug("batched request - sharing the same struct firmware_buf and lookup for multiple requests\n");
++		*fw_priv = tmp;
++		pr_debug("batched request - sharing the same struct fw_priv and lookup for multiple requests\n");
+ 		return 1;
+ 	}
+-	tmp = __allocate_fw_buf(fw_name, fwc, dbuf, size);
++	tmp = __allocate_fw_priv(fw_name, fwc, dbuf, size);
+ 	if (tmp)
+ 		list_add(&tmp->list, &fwc->head);
+ 	spin_unlock(&fwc->lock);
+ 
+-	*buf = tmp;
++	*fw_priv = tmp;
+ 
+ 	return tmp ? 0 : -ENOMEM;
+ }
+ 
+-static void __fw_free_buf(struct kref *ref)
++static void __free_fw_priv(struct kref *ref)
+ 	__releases(&fwc->lock)
+ {
+-	struct firmware_buf *buf = to_fwbuf(ref);
+-	struct firmware_cache *fwc = buf->fwc;
++	struct fw_priv *fw_priv = to_fw_priv(ref);
++	struct firmware_cache *fwc = fw_priv->fwc;
+ 
+-	pr_debug("%s: fw-%s buf=%p data=%p size=%u\n",
+-		 __func__, buf->fw_id, buf, buf->data,
+-		 (unsigned int)buf->size);
++	pr_debug("%s: fw-%s fw_priv=%p data=%p size=%u\n",
++		 __func__, fw_priv->fw_name, fw_priv, fw_priv->data,
++		 (unsigned int)fw_priv->size);
+ 
+-	list_del(&buf->list);
++	list_del(&fw_priv->list);
+ 	spin_unlock(&fwc->lock);
+ 
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-	if (buf->is_paged_buf) {
++	if (fw_priv->is_paged_buf) {
+ 		int i;
+-		vunmap(buf->data);
+-		for (i = 0; i < buf->nr_pages; i++)
+-			__free_page(buf->pages[i]);
+-		vfree(buf->pages);
++		vunmap(fw_priv->data);
++		for (i = 0; i < fw_priv->nr_pages; i++)
++			__free_page(fw_priv->pages[i]);
++		vfree(fw_priv->pages);
+ 	} else
+ #endif
+-	if (!buf->allocated_size)
+-		vfree(buf->data);
+-	kfree_const(buf->fw_id);
+-	kfree(buf);
++	if (!fw_priv->allocated_size)
++		vfree(fw_priv->data);
++	kfree_const(fw_priv->fw_name);
++	kfree(fw_priv);
+ }
+ 
+-static void fw_free_buf(struct firmware_buf *buf)
++static void free_fw_priv(struct fw_priv *fw_priv)
+ {
+-	struct firmware_cache *fwc = buf->fwc;
++	struct firmware_cache *fwc = fw_priv->fwc;
+ 	spin_lock(&fwc->lock);
+-	if (!kref_put(&buf->ref, __fw_free_buf))
++	if (!kref_put(&fw_priv->ref, __free_fw_priv))
+ 		spin_unlock(&fwc->lock);
+ }
+ 
+@@ -383,7 +496,7 @@
+ MODULE_PARM_DESC(path, "customized firmware image search path with a higher priority than default path");
+ 
+ static int
+-fw_get_filesystem_firmware(struct device *device, struct firmware_buf *buf)
++fw_get_filesystem_firmware(struct device *device, struct fw_priv *fw_priv)
+ {
+ 	loff_t size;
+ 	int i, len;
+@@ -393,9 +506,9 @@
+ 	size_t msize = INT_MAX;
+ 
+ 	/* Already populated data member means we're loading into a buffer */
+-	if (buf->data) {
++	if (fw_priv->data) {
+ 		id = READING_FIRMWARE_PREALLOC_BUFFER;
+-		msize = buf->allocated_size;
++		msize = fw_priv->allocated_size;
+ 	}
+ 
+ 	path = __getname();
+@@ -408,15 +521,15 @@
+ 			continue;
+ 
+ 		len = snprintf(path, PATH_MAX, "%s/%s",
+-			       fw_path[i], buf->fw_id);
++			       fw_path[i], fw_priv->fw_name);
+ 		if (len >= PATH_MAX) {
+ 			rc = -ENAMETOOLONG;
+ 			break;
+ 		}
+ 
+-		buf->size = 0;
+-		rc = kernel_read_file_from_path(path, &buf->data, &size, msize,
+-						id);
++		fw_priv->size = 0;
++		rc = kernel_read_file_from_path(path, &fw_priv->data, &size,
++						msize, id);
+ 		if (rc) {
+ 			if (rc == -ENOENT)
+ 				dev_dbg(device, "loading %s failed with error %d\n",
+@@ -426,9 +539,9 @@
+ 					 path, rc);
+ 			continue;
+ 		}
+-		dev_dbg(device, "direct-loading %s\n", buf->fw_id);
+-		buf->size = size;
+-		fw_state_done(&buf->fw_st);
++		dev_dbg(device, "direct-loading %s\n", fw_priv->fw_name);
++		fw_priv->size = size;
++		fw_state_done(fw_priv);
+ 		break;
+ 	}
+ 	__putname(path);
+@@ -444,22 +557,22 @@
+ 		vfree(fw->data);
+ 		return;
+ 	}
+-	fw_free_buf(fw->priv);
++	free_fw_priv(fw->priv);
+ }
+ 
+ /* store the pages buffer info firmware from buf */
+-static void fw_set_page_data(struct firmware_buf *buf, struct firmware *fw)
++static void fw_set_page_data(struct fw_priv *fw_priv, struct firmware *fw)
+ {
+-	fw->priv = buf;
++	fw->priv = fw_priv;
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-	fw->pages = buf->pages;
++	fw->pages = fw_priv->pages;
+ #endif
+-	fw->size = buf->size;
+-	fw->data = buf->data;
++	fw->size = fw_priv->size;
++	fw->data = fw_priv->data;
+ 
+-	pr_debug("%s: fw-%s buf=%p data=%p size=%u\n",
+-		 __func__, buf->fw_id, buf, buf->data,
+-		 (unsigned int)buf->size);
++	pr_debug("%s: fw-%s fw_priv=%p data=%p size=%u\n",
++		 __func__, fw_priv->fw_name, fw_priv, fw_priv->data,
++		 (unsigned int)fw_priv->size);
+ }
+ 
+ #ifdef CONFIG_PM_SLEEP
+@@ -523,13 +636,13 @@
+ }
+ #endif
+ 
+-static int assign_firmware_buf(struct firmware *fw, struct device *device,
+-			       unsigned int opt_flags)
++static int assign_fw(struct firmware *fw, struct device *device,
++		     unsigned int opt_flags)
+ {
+-	struct firmware_buf *buf = fw->priv;
++	struct fw_priv *fw_priv = fw->priv;
+ 
+ 	mutex_lock(&fw_lock);
+-	if (!buf->size || fw_state_is_aborted(&buf->fw_st)) {
++	if (!fw_priv->size || fw_state_is_aborted(fw_priv)) {
+ 		mutex_unlock(&fw_lock);
+ 		return -ENOENT;
+ 	}
+@@ -544,20 +657,20 @@
+ 	/* don't cache firmware handled without uevent */
+ 	if (device && (opt_flags & FW_OPT_UEVENT) &&
+ 	    !(opt_flags & FW_OPT_NOCACHE))
+-		fw_add_devm_name(device, buf->fw_id);
++		fw_add_devm_name(device, fw_priv->fw_name);
+ 
+ 	/*
+ 	 * After caching firmware image is started, let it piggyback
+ 	 * on request firmware.
+ 	 */
+ 	if (!(opt_flags & FW_OPT_NOCACHE) &&
+-	    buf->fwc->state == FW_LOADER_START_CACHE) {
+-		if (fw_cache_piggyback_on_request(buf->fw_id))
+-			kref_get(&buf->ref);
++	    fw_priv->fwc->state == FW_LOADER_START_CACHE) {
++		if (fw_cache_piggyback_on_request(fw_priv->fw_name))
++			kref_get(&fw_priv->ref);
+ 	}
+ 
+ 	/* pass the pages buffer to driver at the last minute */
+-	fw_set_page_data(buf, fw);
++	fw_set_page_data(fw_priv, fw);
+ 	mutex_unlock(&fw_lock);
+ 	return 0;
+ }
+@@ -566,49 +679,50 @@
+  * user-mode helper code
+  */
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-struct firmware_priv {
++struct fw_sysfs {
+ 	bool nowait;
+ 	struct device dev;
+-	struct firmware_buf *buf;
++	struct fw_priv *fw_priv;
+ 	struct firmware *fw;
+ };
+ 
+-static struct firmware_priv *to_firmware_priv(struct device *dev)
++static struct fw_sysfs *to_fw_sysfs(struct device *dev)
+ {
+-	return container_of(dev, struct firmware_priv, dev);
++	return container_of(dev, struct fw_sysfs, dev);
+ }
+ 
+-static void __fw_load_abort(struct firmware_buf *buf)
++static void __fw_load_abort(struct fw_priv *fw_priv)
+ {
+ 	/*
+ 	 * There is a small window in which user can write to 'loading'
+ 	 * between loading done and disappearance of 'loading'
+ 	 */
+-	if (fw_state_is_done(&buf->fw_st))
++	if (fw_sysfs_done(fw_priv))
+ 		return;
+ 
+-	list_del_init(&buf->pending_list);
+-	fw_state_aborted(&buf->fw_st);
++	list_del_init(&fw_priv->pending_list);
++	fw_state_aborted(fw_priv);
+ }
+ 
+-static void fw_load_abort(struct firmware_priv *fw_priv)
++static void fw_load_abort(struct fw_sysfs *fw_sysfs)
+ {
+-	struct firmware_buf *buf = fw_priv->buf;
++	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
+ 
+-	__fw_load_abort(buf);
++	__fw_load_abort(fw_priv);
+ }
+ 
+ static LIST_HEAD(pending_fw_head);
+ 
+ static void kill_pending_fw_fallback_reqs(bool only_kill_custom)
+ {
+-	struct firmware_buf *buf;
+-	struct firmware_buf *next;
++	struct fw_priv *fw_priv;
++	struct fw_priv *next;
+ 
+ 	mutex_lock(&fw_lock);
+-	list_for_each_entry_safe(buf, next, &pending_fw_head, pending_list) {
+-		if (!buf->need_uevent || !only_kill_custom)
+-			 __fw_load_abort(buf);
++	list_for_each_entry_safe(fw_priv, next, &pending_fw_head,
++				 pending_list) {
++		if (!fw_priv->need_uevent || !only_kill_custom)
++			 __fw_load_abort(fw_priv);
+ 	}
+ 	mutex_unlock(&fw_lock);
+ }
+@@ -651,18 +765,18 @@
+ 
+ static void fw_dev_release(struct device *dev)
+ {
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+ 
+-	kfree(fw_priv);
++	kfree(fw_sysfs);
+ }
+ 
+-static int do_firmware_uevent(struct firmware_priv *fw_priv, struct kobj_uevent_env *env)
++static int do_firmware_uevent(struct fw_sysfs *fw_sysfs, struct kobj_uevent_env *env)
+ {
+-	if (add_uevent_var(env, "FIRMWARE=%s", fw_priv->buf->fw_id))
++	if (add_uevent_var(env, "FIRMWARE=%s", fw_sysfs->fw_priv->fw_name))
+ 		return -ENOMEM;
+ 	if (add_uevent_var(env, "TIMEOUT=%i", loading_timeout))
+ 		return -ENOMEM;
+-	if (add_uevent_var(env, "ASYNC=%d", fw_priv->nowait))
++	if (add_uevent_var(env, "ASYNC=%d", fw_sysfs->nowait))
+ 		return -ENOMEM;
+ 
+ 	return 0;
+@@ -670,12 +784,12 @@
+ 
+ static int firmware_uevent(struct device *dev, struct kobj_uevent_env *env)
+ {
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+ 	int err = 0;
+ 
+ 	mutex_lock(&fw_lock);
+-	if (fw_priv->buf)
+-		err = do_firmware_uevent(fw_priv, env);
++	if (fw_sysfs->fw_priv)
++		err = do_firmware_uevent(fw_sysfs, env);
+ 	mutex_unlock(&fw_lock);
+ 	return err;
+ }
+@@ -687,15 +801,25 @@
+ 	.dev_release	= fw_dev_release,
+ };
+ 
++static inline int register_sysfs_loader(void)
++{
++	return class_register(&firmware_class);
++}
++
++static inline void unregister_sysfs_loader(void)
++{
++	class_unregister(&firmware_class);
++}
++
+ static ssize_t firmware_loading_show(struct device *dev,
+ 				     struct device_attribute *attr, char *buf)
+ {
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+ 	int loading = 0;
+ 
+ 	mutex_lock(&fw_lock);
+-	if (fw_priv->buf)
+-		loading = fw_state_is_loading(&fw_priv->buf->fw_st);
++	if (fw_sysfs->fw_priv)
++		loading = fw_sysfs_loading(fw_sysfs->fw_priv);
+ 	mutex_unlock(&fw_lock);
+ 
+ 	return sprintf(buf, "%d\n", loading);
+@@ -707,14 +831,15 @@
+ #endif
+ 
+ /* one pages buffer should be mapped/unmapped only once */
+-static int fw_map_pages_buf(struct firmware_buf *buf)
++static int map_fw_priv_pages(struct fw_priv *fw_priv)
+ {
+-	if (!buf->is_paged_buf)
++	if (!fw_priv->is_paged_buf)
+ 		return 0;
+ 
+-	vunmap(buf->data);
+-	buf->data = vmap(buf->pages, buf->nr_pages, 0, PAGE_KERNEL_RO);
+-	if (!buf->data)
++	vunmap(fw_priv->data);
++	fw_priv->data = vmap(fw_priv->pages, fw_priv->nr_pages, 0,
++			     PAGE_KERNEL_RO);
++	if (!fw_priv->data)
+ 		return -ENOMEM;
+ 	return 0;
+ }
+@@ -736,32 +861,32 @@
+ 				      struct device_attribute *attr,
+ 				      const char *buf, size_t count)
+ {
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
+-	struct firmware_buf *fw_buf;
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
+ 	ssize_t written = count;
+ 	int loading = simple_strtol(buf, NULL, 10);
+ 	int i;
+ 
+ 	mutex_lock(&fw_lock);
+-	fw_buf = fw_priv->buf;
+-	if (fw_state_is_aborted(&fw_buf->fw_st))
++	fw_priv = fw_sysfs->fw_priv;
++	if (fw_state_is_aborted(fw_priv))
+ 		goto out;
+ 
+ 	switch (loading) {
+ 	case 1:
+ 		/* discarding any previous partial load */
+-		if (!fw_state_is_done(&fw_buf->fw_st)) {
+-			for (i = 0; i < fw_buf->nr_pages; i++)
+-				__free_page(fw_buf->pages[i]);
+-			vfree(fw_buf->pages);
+-			fw_buf->pages = NULL;
+-			fw_buf->page_array_size = 0;
+-			fw_buf->nr_pages = 0;
+-			fw_state_start(&fw_buf->fw_st);
++		if (!fw_sysfs_done(fw_priv)) {
++			for (i = 0; i < fw_priv->nr_pages; i++)
++				__free_page(fw_priv->pages[i]);
++			vfree(fw_priv->pages);
++			fw_priv->pages = NULL;
++			fw_priv->page_array_size = 0;
++			fw_priv->nr_pages = 0;
++			fw_state_start(fw_priv);
+ 		}
+ 		break;
+ 	case 0:
+-		if (fw_state_is_loading(&fw_buf->fw_st)) {
++		if (fw_sysfs_loading(fw_priv)) {
+ 			int rc;
+ 
+ 			/*
+@@ -770,25 +895,25 @@
+ 			 * see the mapped 'buf->data' once the loading
+ 			 * is completed.
+ 			 * */
+-			rc = fw_map_pages_buf(fw_buf);
++			rc = map_fw_priv_pages(fw_priv);
+ 			if (rc)
+ 				dev_err(dev, "%s: map pages failed\n",
+ 					__func__);
+ 			else
+ 				rc = security_kernel_post_read_file(NULL,
+-						fw_buf->data, fw_buf->size,
++						fw_priv->data, fw_priv->size,
+ 						READING_FIRMWARE);
+ 
+ 			/*
+ 			 * Same logic as fw_load_abort, only the DONE bit
+ 			 * is ignored and we set ABORT only on failure.
+ 			 */
+-			list_del_init(&fw_buf->pending_list);
++			list_del_init(&fw_priv->pending_list);
+ 			if (rc) {
+-				fw_state_aborted(&fw_buf->fw_st);
++				fw_state_aborted(fw_priv);
+ 				written = rc;
+ 			} else {
+-				fw_state_done(&fw_buf->fw_st);
++				fw_state_done(fw_priv);
+ 			}
+ 			break;
+ 		}
+@@ -797,7 +922,7 @@
+ 		dev_err(dev, "%s: unexpected value (%d)\n", __func__, loading);
+ 		/* fallthrough */
+ 	case -1:
+-		fw_load_abort(fw_priv);
++		fw_load_abort(fw_sysfs);
+ 		break;
+ 	}
+ out:
+@@ -807,16 +932,16 @@
+ 
+ static DEVICE_ATTR(loading, 0644, firmware_loading_show, firmware_loading_store);
+ 
+-static void firmware_rw_buf(struct firmware_buf *buf, char *buffer,
++static void firmware_rw_data(struct fw_priv *fw_priv, char *buffer,
+ 			   loff_t offset, size_t count, bool read)
+ {
+ 	if (read)
+-		memcpy(buffer, buf->data + offset, count);
++		memcpy(buffer, fw_priv->data + offset, count);
+ 	else
+-		memcpy(buf->data + offset, buffer, count);
++		memcpy(fw_priv->data + offset, buffer, count);
+ }
+ 
+-static void firmware_rw(struct firmware_buf *buf, char *buffer,
++static void firmware_rw(struct fw_priv *fw_priv, char *buffer,
+ 			loff_t offset, size_t count, bool read)
+ {
+ 	while (count) {
+@@ -825,14 +950,14 @@
+ 		int page_ofs = offset & (PAGE_SIZE-1);
+ 		int page_cnt = min_t(size_t, PAGE_SIZE - page_ofs, count);
+ 
+-		page_data = kmap(buf->pages[page_nr]);
++		page_data = kmap(fw_priv->pages[page_nr]);
+ 
+ 		if (read)
+ 			memcpy(buffer, page_data + page_ofs, page_cnt);
+ 		else
+ 			memcpy(page_data + page_ofs, buffer, page_cnt);
+ 
+-		kunmap(buf->pages[page_nr]);
++		kunmap(fw_priv->pages[page_nr]);
+ 		buffer += page_cnt;
+ 		offset += page_cnt;
+ 		count -= page_cnt;
+@@ -844,69 +969,69 @@
+ 				  char *buffer, loff_t offset, size_t count)
+ {
+ 	struct device *dev = kobj_to_dev(kobj);
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
+-	struct firmware_buf *buf;
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
+ 	ssize_t ret_count;
+ 
+ 	mutex_lock(&fw_lock);
+-	buf = fw_priv->buf;
+-	if (!buf || fw_state_is_done(&buf->fw_st)) {
++	fw_priv = fw_sysfs->fw_priv;
++	if (!fw_priv || fw_sysfs_done(fw_priv)) {
+ 		ret_count = -ENODEV;
+ 		goto out;
+ 	}
+-	if (offset > buf->size) {
++	if (offset > fw_priv->size) {
+ 		ret_count = 0;
+ 		goto out;
+ 	}
+-	if (count > buf->size - offset)
+-		count = buf->size - offset;
++	if (count > fw_priv->size - offset)
++		count = fw_priv->size - offset;
+ 
+ 	ret_count = count;
+ 
+-	if (buf->data)
+-		firmware_rw_buf(buf, buffer, offset, count, true);
++	if (fw_priv->data)
++		firmware_rw_data(fw_priv, buffer, offset, count, true);
+ 	else
+-		firmware_rw(buf, buffer, offset, count, true);
++		firmware_rw(fw_priv, buffer, offset, count, true);
+ 
+ out:
+ 	mutex_unlock(&fw_lock);
+ 	return ret_count;
+ }
+ 
+-static int fw_realloc_buffer(struct firmware_priv *fw_priv, int min_size)
++static int fw_realloc_pages(struct fw_sysfs *fw_sysfs, int min_size)
+ {
+-	struct firmware_buf *buf = fw_priv->buf;
++	struct fw_priv *fw_priv= fw_sysfs->fw_priv;
+ 	int pages_needed = PAGE_ALIGN(min_size) >> PAGE_SHIFT;
+ 
+ 	/* If the array of pages is too small, grow it... */
+-	if (buf->page_array_size < pages_needed) {
++	if (fw_priv->page_array_size < pages_needed) {
+ 		int new_array_size = max(pages_needed,
+-					 buf->page_array_size * 2);
++					 fw_priv->page_array_size * 2);
+ 		struct page **new_pages;
+ 
+ 		new_pages = vmalloc(new_array_size * sizeof(void *));
+ 		if (!new_pages) {
+-			fw_load_abort(fw_priv);
++			fw_load_abort(fw_sysfs);
+ 			return -ENOMEM;
+ 		}
+-		memcpy(new_pages, buf->pages,
+-		       buf->page_array_size * sizeof(void *));
+-		memset(&new_pages[buf->page_array_size], 0, sizeof(void *) *
+-		       (new_array_size - buf->page_array_size));
+-		vfree(buf->pages);
+-		buf->pages = new_pages;
+-		buf->page_array_size = new_array_size;
++		memcpy(new_pages, fw_priv->pages,
++		       fw_priv->page_array_size * sizeof(void *));
++		memset(&new_pages[fw_priv->page_array_size], 0, sizeof(void *) *
++		       (new_array_size - fw_priv->page_array_size));
++		vfree(fw_priv->pages);
++		fw_priv->pages = new_pages;
++		fw_priv->page_array_size = new_array_size;
+ 	}
+ 
+-	while (buf->nr_pages < pages_needed) {
+-		buf->pages[buf->nr_pages] =
++	while (fw_priv->nr_pages < pages_needed) {
++		fw_priv->pages[fw_priv->nr_pages] =
+ 			alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
+ 
+-		if (!buf->pages[buf->nr_pages]) {
+-			fw_load_abort(fw_priv);
++		if (!fw_priv->pages[fw_priv->nr_pages]) {
++			fw_load_abort(fw_sysfs);
+ 			return -ENOMEM;
+ 		}
+-		buf->nr_pages++;
++		fw_priv->nr_pages++;
+ 	}
+ 	return 0;
+ }
+@@ -928,37 +1053,37 @@
+ 				   char *buffer, loff_t offset, size_t count)
+ {
+ 	struct device *dev = kobj_to_dev(kobj);
+-	struct firmware_priv *fw_priv = to_firmware_priv(dev);
+-	struct firmware_buf *buf;
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
+ 	ssize_t retval;
+ 
+ 	if (!capable(CAP_SYS_RAWIO))
+ 		return -EPERM;
+ 
+ 	mutex_lock(&fw_lock);
+-	buf = fw_priv->buf;
+-	if (!buf || fw_state_is_done(&buf->fw_st)) {
++	fw_priv = fw_sysfs->fw_priv;
++	if (!fw_priv || fw_sysfs_done(fw_priv)) {
+ 		retval = -ENODEV;
+ 		goto out;
+ 	}
+ 
+-	if (buf->data) {
+-		if (offset + count > buf->allocated_size) {
++	if (fw_priv->data) {
++		if (offset + count > fw_priv->allocated_size) {
+ 			retval = -ENOMEM;
+ 			goto out;
+ 		}
+-		firmware_rw_buf(buf, buffer, offset, count, false);
++		firmware_rw_data(fw_priv, buffer, offset, count, false);
+ 		retval = count;
+ 	} else {
+-		retval = fw_realloc_buffer(fw_priv, offset + count);
++		retval = fw_realloc_pages(fw_sysfs, offset + count);
+ 		if (retval)
+ 			goto out;
+ 
+ 		retval = count;
+-		firmware_rw(buf, buffer, offset, count, false);
++		firmware_rw(fw_priv, buffer, offset, count, false);
+ 	}
+ 
+-	buf->size = max_t(size_t, offset + count, buf->size);
++	fw_priv->size = max_t(size_t, offset + count, fw_priv->size);
+ out:
+ 	mutex_unlock(&fw_lock);
+ 	return retval;
+@@ -991,22 +1116,22 @@
+ 	NULL
+ };
+ 
+-static struct firmware_priv *
++static struct fw_sysfs *
+ fw_create_instance(struct firmware *firmware, const char *fw_name,
+ 		   struct device *device, unsigned int opt_flags)
+ {
+-	struct firmware_priv *fw_priv;
++	struct fw_sysfs *fw_sysfs;
+ 	struct device *f_dev;
+ 
+-	fw_priv = kzalloc(sizeof(*fw_priv), GFP_KERNEL);
+-	if (!fw_priv) {
+-		fw_priv = ERR_PTR(-ENOMEM);
++	fw_sysfs = kzalloc(sizeof(*fw_sysfs), GFP_KERNEL);
++	if (!fw_sysfs) {
++		fw_sysfs = ERR_PTR(-ENOMEM);
+ 		goto exit;
+ 	}
+ 
+-	fw_priv->nowait = !!(opt_flags & FW_OPT_NOWAIT);
+-	fw_priv->fw = firmware;
+-	f_dev = &fw_priv->dev;
++	fw_sysfs->nowait = !!(opt_flags & FW_OPT_NOWAIT);
++	fw_sysfs->fw = firmware;
++	f_dev = &fw_sysfs->dev;
+ 
+ 	device_initialize(f_dev);
+ 	dev_set_name(f_dev, "%s", fw_name);
+@@ -1014,20 +1139,20 @@
+ 	f_dev->class = &firmware_class;
+ 	f_dev->groups = fw_dev_attr_groups;
+ exit:
+-	return fw_priv;
++	return fw_sysfs;
+ }
+ 
+ /* load a firmware via user helper */
+-static int _request_firmware_load(struct firmware_priv *fw_priv,
++static int _request_firmware_load(struct fw_sysfs *fw_sysfs,
+ 				  unsigned int opt_flags, long timeout)
+ {
+ 	int retval = 0;
+-	struct device *f_dev = &fw_priv->dev;
+-	struct firmware_buf *buf = fw_priv->buf;
++	struct device *f_dev = &fw_sysfs->dev;
++	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
+ 
+ 	/* fall back on userspace loading */
+-	if (!buf->data)
+-		buf->is_paged_buf = true;
++	if (!fw_priv->data)
++		fw_priv->is_paged_buf = true;
+ 
+ 	dev_set_uevent_suppress(f_dev, true);
+ 
+@@ -1038,31 +1163,31 @@
+ 	}
+ 
+ 	mutex_lock(&fw_lock);
+-	list_add(&buf->pending_list, &pending_fw_head);
++	list_add(&fw_priv->pending_list, &pending_fw_head);
+ 	mutex_unlock(&fw_lock);
+ 
+ 	if (opt_flags & FW_OPT_UEVENT) {
+-		buf->need_uevent = true;
++		fw_priv->need_uevent = true;
+ 		dev_set_uevent_suppress(f_dev, false);
+-		dev_dbg(f_dev, "firmware: requesting %s\n", buf->fw_id);
+-		kobject_uevent(&fw_priv->dev.kobj, KOBJ_ADD);
++		dev_dbg(f_dev, "firmware: requesting %s\n", fw_priv->fw_name);
++		kobject_uevent(&fw_sysfs->dev.kobj, KOBJ_ADD);
+ 	} else {
+ 		timeout = MAX_JIFFY_OFFSET;
+ 	}
+ 
+-	retval = fw_state_wait_timeout(&buf->fw_st, timeout);
++	retval = fw_sysfs_wait_timeout(fw_priv, timeout);
+ 	if (retval < 0) {
+ 		mutex_lock(&fw_lock);
+-		fw_load_abort(fw_priv);
++		fw_load_abort(fw_sysfs);
+ 		mutex_unlock(&fw_lock);
+ 	}
+ 
+-	if (fw_state_is_aborted(&buf->fw_st)) {
++	if (fw_state_is_aborted(fw_priv)) {
+ 		if (retval == -ERESTARTSYS)
+ 			retval = -EINTR;
+ 		else
+ 			retval = -EAGAIN;
+-	} else if (buf->is_paged_buf && !buf->data)
++	} else if (fw_priv->is_paged_buf && !fw_priv->data)
+ 		retval = -ENOMEM;
+ 
+ 	device_del(f_dev);
+@@ -1075,7 +1200,7 @@
+ 				    const char *name, struct device *device,
+ 				    unsigned int opt_flags)
+ {
+-	struct firmware_priv *fw_priv;
++	struct fw_sysfs *fw_sysfs;
+ 	long timeout;
+ 	int ret;
+ 
+@@ -1096,17 +1221,17 @@
+ 		}
+ 	}
+ 
+-	fw_priv = fw_create_instance(firmware, name, device, opt_flags);
+-	if (IS_ERR(fw_priv)) {
+-		ret = PTR_ERR(fw_priv);
++	fw_sysfs = fw_create_instance(firmware, name, device, opt_flags);
++	if (IS_ERR(fw_sysfs)) {
++		ret = PTR_ERR(fw_sysfs);
+ 		goto out_unlock;
+ 	}
+ 
+-	fw_priv->buf = firmware->priv;
+-	ret = _request_firmware_load(fw_priv, opt_flags, timeout);
++	fw_sysfs->fw_priv = firmware->priv;
++	ret = _request_firmware_load(fw_sysfs, opt_flags, timeout);
+ 
+ 	if (!ret)
+-		ret = assign_firmware_buf(firmware, device, opt_flags);
++		ret = assign_fw(firmware, device, opt_flags);
+ 
+ out_unlock:
+ 	usermodehelper_read_unlock();
+@@ -1114,16 +1239,61 @@
+ 	return ret;
+ }
+ 
++#ifdef CONFIG_FW_LOADER_USER_HELPER_FALLBACK
++static bool fw_force_sysfs_fallback(unsigned int opt_flags)
++{
++	return true;
++}
++#else
++static bool fw_force_sysfs_fallback(unsigned int opt_flags)
++{
++	if (!(opt_flags & FW_OPT_USERHELPER))
++		return false;
++	return true;
++}
++#endif
++
++static bool fw_run_sysfs_fallback(unsigned int opt_flags)
++{
++	if ((opt_flags & FW_OPT_NOFALLBACK))
++		return false;
++
++	return fw_force_sysfs_fallback(opt_flags);
++}
++
++static int fw_sysfs_fallback(struct firmware *fw, const char *name,
++			    struct device *device,
++			    unsigned int opt_flags,
++			    int ret)
++{
++	if (!fw_run_sysfs_fallback(opt_flags))
++		return ret;
++
++	dev_warn(device, "Falling back to user helper\n");
++	return fw_load_from_user_helper(fw, name, device, opt_flags);
++}
+ #else /* CONFIG_FW_LOADER_USER_HELPER */
+-static inline int
+-fw_load_from_user_helper(struct firmware *firmware, const char *name,
+-			 struct device *device, unsigned int opt_flags)
++static int fw_sysfs_fallback(struct firmware *fw, const char *name,
++																	 
++			     struct device *device,
++			     unsigned int opt_flags,
++			     int ret)
+ {
+-	return -ENOENT;
++	/* Keep carrying over the same error */
++	return ret;
+ }
+ 
+ static inline void kill_pending_fw_fallback_reqs(bool only_kill_custom) { }
+ 
++static inline int register_sysfs_loader(void)
++{
++	return 0;
++}
++
++static inline void unregister_sysfs_loader(void)
++{
++}
++
+ #endif /* CONFIG_FW_LOADER_USER_HELPER */
+ 
+ /* prepare firmware and firmware_buf structs;
+@@ -1135,7 +1305,7 @@
+ 			  struct device *device, void *dbuf, size_t size)
+ {
+ 	struct firmware *firmware;
+-	struct firmware_buf *buf;
++	struct fw_priv *fw_priv;
+ 	int ret;
+ 
+ 	*firmware_p = firmware = kzalloc(sizeof(*firmware), GFP_KERNEL);
+@@ -1150,18 +1320,18 @@
+ 		return 0; /* assigned */
+ 	}
+ 
+-	ret = fw_lookup_and_allocate_buf(name, &fw_cache, &buf, dbuf, size);
++	ret = alloc_lookup_fw_priv(name, &fw_cache, &fw_priv, dbuf, size);
+ 
+ 	/*
+-	 * bind with 'buf' now to avoid warning in failure path
++	 * bind with 'priv' now to avoid warning in failure path
+ 	 * of requesting firmware.
+ 	 */
+-	firmware->priv = buf;
++	firmware->priv = fw_priv;
+ 
+ 	if (ret > 0) {
+-		ret = fw_state_wait(&buf->fw_st);
++		ret = fw_state_wait(fw_priv);
+ 		if (!ret) {
+-			fw_set_page_data(buf, firmware);
++			fw_set_page_data(fw_priv, firmware);
+ 			return 0; /* assigned */
+ 		}
+ 	}
+@@ -1177,20 +1347,20 @@
+  * released until the last user calls release_firmware().
+  *
+  * Failed batched requests are possible as well, in such cases we just share
+- * the struct firmware_buf and won't release it until all requests are woken
++ * the struct fw_priv and won't release it until all requests are woken
+  * and have gone through this same path.
+  */
+ static void fw_abort_batch_reqs(struct firmware *fw)
+ {
+-	struct firmware_buf *buf;
++	struct fw_priv *fw_priv;
+ 
+ 	/* Loaded directly? */
+ 	if (!fw || !fw->priv)
+ 		return;
+ 
+-	buf = fw->priv;
+-	if (!fw_state_is_aborted(&buf->fw_st))
+-		fw_state_aborted(&buf->fw_st);
++	fw_priv = fw->priv;
++	if (!fw_state_is_aborted(fw_priv))
++		fw_state_aborted(fw_priv);
+ }
+ 
+ /* called from request_firmware() and request_firmware_work_func() */
+@@ -1220,13 +1390,13 @@
+ 			dev_warn(device,
+ 				 "Direct firmware load for %s failed with error %d\n",
+ 				 name, ret);
+-		if (opt_flags & FW_OPT_USERHELPER) {
+-			dev_warn(device, "Falling back to user helper\n");
+-			ret = fw_load_from_user_helper(fw, name, device,
+-						       opt_flags);
+-		}
++									  
++													 
++		ret = fw_sysfs_fallback(fw, name, device, opt_flags, ret);
++						
++   
+ 	} else
+-		ret = assign_firmware_buf(fw, device, opt_flags);
++		ret = assign_fw(fw, device, opt_flags);
+ 
+  out:
+ 	if (ret < 0) {
+@@ -1268,7 +1438,7 @@
+ 	/* Need to pin this module until return */
+ 	__module_get(THIS_MODULE);
+ 	ret = _request_firmware(firmware_p, name, device, NULL, 0,
+-				FW_OPT_UEVENT | FW_OPT_FALLBACK);
++				FW_OPT_UEVENT);
+ 	module_put(THIS_MODULE);
+ 	return ret;
+ }
+@@ -1292,7 +1462,8 @@
+ 
+ 	__module_get(THIS_MODULE);
+ 	ret = _request_firmware(firmware_p, name, device, NULL, 0,
+-				FW_OPT_UEVENT | FW_OPT_NO_WARN);
++				FW_OPT_UEVENT | FW_OPT_NO_WARN |
++				FW_OPT_NOFALLBACK);
+ 	module_put(THIS_MODULE);
+ 	return ret;
+ }
+@@ -1321,8 +1492,8 @@
+ 
+ 	__module_get(THIS_MODULE);
+ 	ret = _request_firmware(firmware_p, name, device, buf, size,
+-				FW_OPT_UEVENT | FW_OPT_FALLBACK |
+-				FW_OPT_NOCACHE);
++				FW_OPT_UEVENT | FW_OPT_NOCACHE);
++					
+ 	module_put(THIS_MODULE);
+ 	return ret;
+ }
+@@ -1414,7 +1585,7 @@
+ 	fw_work->device = device;
+ 	fw_work->context = context;
+ 	fw_work->cont = cont;
+-	fw_work->opt_flags = FW_OPT_NOWAIT | FW_OPT_FALLBACK |
++	fw_work->opt_flags = FW_OPT_NOWAIT |
+ 		(uevent ? FW_OPT_UEVENT : FW_OPT_USERHELPER);
+ 
+ 	if (!try_module_get(module)) {
+@@ -1463,13 +1634,13 @@
+ 	return ret;
+ }
+ 
+-static struct firmware_buf *fw_lookup_buf(const char *fw_name)
++static struct fw_priv *lookup_fw_priv(const char *fw_name)
+ {
+-	struct firmware_buf *tmp;
++	struct fw_priv *tmp;
+ 	struct firmware_cache *fwc = &fw_cache;
+ 
+ 	spin_lock(&fwc->lock);
+-	tmp = __fw_lookup_buf(fw_name);
++	tmp = __lookup_fw_priv(fw_name);
+ 	spin_unlock(&fwc->lock);
+ 
+ 	return tmp;
+@@ -1488,7 +1659,7 @@
+  */
+ static int uncache_firmware(const char *fw_name)
+ {
+-	struct firmware_buf *buf;
++	struct fw_priv *fw_priv;
+ 	struct firmware fw;
+ 
+ 	pr_debug("%s: %s\n", __func__, fw_name);
+@@ -1496,9 +1667,9 @@
+ 	if (fw_get_builtin_firmware(&fw, fw_name, NULL, 0))
+ 		return 0;
+ 
+-	buf = fw_lookup_buf(fw_name);
+-	if (buf) {
+-		fw_free_buf(buf);
++	fw_priv = lookup_fw_priv(fw_name);
++	if (fw_priv) {
++		free_fw_priv(fw_priv);
+ 		return 0;
+ 	}
+ 
+@@ -1767,20 +1938,20 @@
+ static struct syscore_ops fw_syscore_ops = {
+ 	.suspend = fw_suspend,
+ };
+-#else
+-static int fw_cache_piggyback_on_request(const char *name)
+-{
+-	return 0;
+-}
+-#endif
++	 
++														  
++ 
++		  
++ 
++	  
+ 
+-static void __init fw_cache_init(void)
++static int __init register_fw_pm_ops(void)
+ {
+-	spin_lock_init(&fw_cache.lock);
+-	INIT_LIST_HEAD(&fw_cache.head);
+-	fw_cache.state = FW_LOADER_NO_CACHE;
++	int ret;
++								
++									 
+ 
+-#ifdef CONFIG_PM_SLEEP
++					  
+ 	spin_lock_init(&fw_cache.name_lock);
+ 	INIT_LIST_HEAD(&fw_cache.fw_names);
+ 
+@@ -1788,10 +1959,39 @@
+ 			  device_uncache_fw_images_work);
+ 
+ 	fw_cache.pm_notify.notifier_call = fw_pm_notify;
+-	register_pm_notifier(&fw_cache.pm_notify);
++	ret = register_pm_notifier(&fw_cache.pm_notify);
++	if (ret)
++		return ret;
+ 
+ 	register_syscore_ops(&fw_syscore_ops);
++
++	return ret;
++}
++
++static inline void unregister_fw_pm_ops(void)
++{
++	unregister_syscore_ops(&fw_syscore_ops);
++	unregister_pm_notifier(&fw_cache.pm_notify);
++}
++#else
++static int fw_cache_piggyback_on_request(const char *name)
++{
++	return 0;
++}
++static inline int register_fw_pm_ops(void)
++{
++	return 0;
++}
++static inline void unregister_fw_pm_ops(void)
++{
++}
+ #endif
++
++static void __init fw_cache_init(void)
++{
++	spin_lock_init(&fw_cache.lock);
++	INIT_LIST_HEAD(&fw_cache.head);
++	fw_cache.state = FW_LOADER_NO_CACHE;
+ }
+ 
+ static int fw_shutdown_notify(struct notifier_block *unused1,
+@@ -1812,25 +2012,37 @@
+ 
+ static int __init firmware_class_init(void)
+ {
++	int ret;
++
++	/* No need to unfold these on exit */
+ 	fw_cache_init();
+-	register_reboot_notifier(&fw_shutdown_nb);
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-	return class_register(&firmware_class);
+-#else
+-	return 0;
+-#endif
++
++	ret = register_fw_pm_ops();
++	if (ret)
++		return ret;
++
++	ret = register_reboot_notifier(&fw_shutdown_nb);
++	if (ret)
++		goto out;
++
++	return register_sysfs_loader();
++
++out:
++	unregister_fw_pm_ops();
++	return ret;
++	  
+ }
+ 
+ static void __exit firmware_class_exit(void)
+ {
+-#ifdef CONFIG_PM_SLEEP
+-	unregister_syscore_ops(&fw_syscore_ops);
+-	unregister_pm_notifier(&fw_cache.pm_notify);
+-#endif
++	unregister_fw_pm_ops();
++										 
++											 
++	  
+ 	unregister_reboot_notifier(&fw_shutdown_nb);
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-	class_unregister(&firmware_class);
+-#endif
++	unregister_sysfs_loader();
++								   
++	  
+ }
+ 
+ fs_initcall(firmware_class_init);

--- a/target/linux/generic/backport-4.14/081-0002-firmware-enable-to-split-firmware_class-into-separate-target-files.patch
+++ b/target/linux/generic/backport-4.14/081-0002-firmware-enable-to-split-firmware_class-into-separate-target-files.patch
@@ -1,0 +1,50 @@
+From ad4365f138363cc9c2271d4181bc35e3f06551de Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:45 -0800
+Subject: [PATCH] firmware: enable to split firmware_class into separate target
+ files
+
+The firmware loader code has grown quite a bit over the years.
+The practice of stuffing everything we need into one file makes
+the code hard to follow.
+
+In order to split the firmware loader code into different components
+we must pick a module name and a first object target file. We must
+keep the firmware_class name to remain compatible with scripts which
+have been relying on the sysfs loader path for years, so the old module
+name stays. We can however rename the C file without affecting the
+module name.
+
+The firmware_class used to represent the idea that the code was a simple
+sysfs firmware loader, provided by the struct class firmware_class.
+The sysfs firmware loader used to be the default, today its only the
+fallback mechanism.
+
+This only renames the target code then to make emphasis of what the code
+does these days. With this change new features can also use a new object
+files.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/Makefile                                | 1 +
+ drivers/base/{firmware_class.c => firmware_loader.c} | 0
+ 2 files changed, 1 insertion(+)
+ rename drivers/base/{firmware_class.c => firmware_loader.c} (100%)
+
+diff --git a/drivers/base/Makefile b/drivers/base/Makefile
+index e32a52490051d..f261143fafbf9 100644
+--- a/drivers/base/Makefile
++++ b/drivers/base/Makefile
+@@ -13,6 +13,7 @@ obj-$(CONFIG_HAS_DMA)	+= dma-mapping.o
+ obj-$(CONFIG_HAVE_GENERIC_DMA_COHERENT) += dma-coherent.o
+ obj-$(CONFIG_ISA_BUS_API)	+= isa.o
+ obj-$(CONFIG_FW_LOADER)	+= firmware_class.o
++firmware_class-objs := firmware_loader.o
+ obj-$(CONFIG_NUMA)	+= node.o
+ obj-$(CONFIG_MEMORY_HOTPLUG_SPARSE) += memory.o
+ ifeq ($(CONFIG_SYSFS),y)
+diff --git a/drivers/base/firmware_class.c b/drivers/base/firmware_loader.c
+similarity index 100%
+rename from drivers/base/firmware_class.c
+rename to drivers/base/firmware_loader.c

--- a/target/linux/generic/backport-4.14/081-0003-firmware-bump-to-20mar-version.patch
+++ b/target/linux/generic/backport-4.14/081-0003-firmware-bump-to-20mar-version.patch
@@ -1,0 +1,393 @@
+--- a/drivers/base/firmware_loader.c
++++ b/drivers/base/firmware_loader.c
+@@ -158,8 +158,6 @@
+ 			fw->data = b_fw->data;
+ 			fw_copy_to_prealloc_buf(fw, buf, size);
+ 
+-							   
+-									
+ 			return true;
+ 		}
+ 	}
+@@ -193,30 +191,6 @@
+ }
+ #endif
+ 
+-				
+-				   
+-				   
+-				
+-				   
+-  
+-
+-static int loading_timeout = 60;	/* In seconds */
+-
+-static inline long firmware_loading_timeout(void)
+-{
+-	return loading_timeout > 0 ? loading_timeout * HZ : MAX_JIFFY_OFFSET;
+-}
+-
+-  
+-																 
+-																	  
+-								 
+-   
+-				 
+-							  
+-					   
+-  
+-
+ static void fw_state_init(struct fw_priv *fw_priv)
+ {
+ 	struct fw_state *fw_st = &fw_priv->fw_st;
+@@ -225,11 +199,6 @@
+ 	fw_st->status = FW_STATUS_UNKNOWN;
+ }
+ 
+-															
+- 
+-																
+- 
+-
+ static int __fw_state_wait_common(struct fw_priv *fw_priv, long timeout)
+ {
+ 	struct fw_state *fw_st = &fw_priv->fw_st;
+@@ -256,33 +225,10 @@
+ }
+ 
+ static inline void fw_state_start(struct fw_priv *fw_priv)
+-										 
+-								  
+-									  
+-									 
+-										 
+-								  
+-													
+-
+-																		  
+ {
+ 	__fw_state_set(fw_priv, FW_STATUS_LOADING);
+ }
+ 
+-									   
+-										   
+-
+-								   
+-
+-									 
+-										 
+-									 
+-										
+-									   
+-										   
+-												 
+-									   
+-
+ static inline void fw_state_done(struct fw_priv *fw_priv)
+ {
+ 	__fw_state_set(fw_priv, FW_STATUS_DONE);
+@@ -292,33 +238,16 @@
+ {
+ 	__fw_state_set(fw_priv, FW_STATUS_ABORTED);
+ }
+-								   
+-	 
+-						   
+-	  
+-											
+-										  
+-	 
+-						  
+-	  
+-								
+-								
+ 
+ static inline int fw_state_wait(struct fw_priv *fw_priv)
+ {
+ 	return __fw_state_wait_common(fw_priv, MAX_SCHEDULE_TIMEOUT);
+ }
+-		   
+ 
+ static bool __fw_state_check(struct fw_priv *fw_priv,
+ 			     enum fw_status status)
+ {
+ 	struct fw_state *fw_st = &fw_priv->fw_st;
+-														   
+-		   
+-	
+-					  
+-						   
+ 
+ 	return fw_st->status == status;
+ }
+@@ -328,24 +257,66 @@
+ 	return __fw_state_check(fw_priv, FW_STATUS_ABORTED);
+ }
+ 
+-					 
+-				 
+-					   
+-							
+-					   
+-			
+-			 
+-					   
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-				   
+-				  
+-					 
+-			  
+-					 
+-							   
+-	  
+-				   
+-  
++
++/**
++ * struct firmware_fallback_config - firmware fallback configuratioon settings
++ *
++ * Helps describe and fine tune the fallback mechanism.
++ *
++ * @force_sysfs_fallback: force the sysfs fallback mechanism to be used
++ * 	as if one had enabled CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y.
++ * @old_timeout: for internal use
++ * @loading_timeout: the timeout to wait for the fallback mechanism before
++ * 	giving up, in seconds.
++ */
++struct firmware_fallback_config {
++	const bool force_sysfs_fallback;
++	int old_timeout;
++	int loading_timeout;
++};
++
++static struct firmware_fallback_config fw_fallback_config = {
++	.force_sysfs_fallback = IS_ENABLED(CONFIG_FW_LOADER_USER_HELPER_FALLBACK),
++	.loading_timeout = 60,
++	.old_timeout = 60,
++};
++
++/* These getters are vetted to use int properly */
++static inline int __firmware_loading_timeout(void)
++{
++	return fw_fallback_config.loading_timeout;
++}
++
++/* These setters are vetted to use int properly */
++static void __fw_fallback_set_timeout(int timeout)
++{
++	fw_fallback_config.loading_timeout = timeout;
++}
++
++static inline long firmware_loading_timeout(void)
++{
++	return __firmware_loading_timeout() > 0 ?
++		__firmware_loading_timeout() * HZ : MAX_JIFFY_OFFSET;
++}
++
++/*
++ * use small loading timeout for caching devices' firmware because all these
++ * firmware images have been loaded successfully at lease once, also system is
++ * ready for completing firmware loading now. The maximum size of firmware in
++ * current distributions is about 2M bytes, so 10 secs should be enough.
++ */
++static void fw_fallback_set_cache_timeout(void)
++{
++	fw_fallback_config.old_timeout = __firmware_loading_timeout();
++	__fw_fallback_set_timeout(10);
++}
++
++/* Restores the timeout to the value last configured during normal operation */
++static void fw_fallback_set_default_timeout(void)
++{
++	__fw_fallback_set_timeout(fw_fallback_config.old_timeout);
++}
+ 
+ static inline bool fw_sysfs_done(struct fw_priv *fw_priv)
+ {
+@@ -363,16 +334,9 @@
+ }
+ 
+ #endif /* CONFIG_FW_LOADER_USER_HELPER */
+-							   
+ 
+ static int fw_cache_piggyback_on_request(const char *name);
+ 
+-																		
+-														  
+-							 
+-
+-									  
+-
+ static struct fw_priv *__allocate_fw_priv(const char *fw_name,
+ 					  struct firmware_cache *fwc,
+ 					  void *dbuf, size_t size)
+@@ -730,7 +694,7 @@
+ static ssize_t timeout_show(struct class *class, struct class_attribute *attr,
+ 			    char *buf)
+ {
+-	return sprintf(buf, "%d\n", loading_timeout);
++	return sprintf(buf, "%d\n", __firmware_loading_timeout());
+ }
+ 
+ /**
+@@ -749,9 +713,12 @@
+ static ssize_t timeout_store(struct class *class, struct class_attribute *attr,
+ 			     const char *buf, size_t count)
+ {
+-	loading_timeout = simple_strtol(buf, NULL, 10);
+-	if (loading_timeout < 0)
+-		loading_timeout = 0;
++	int tmp_loading_timeout = simple_strtol(buf, NULL, 10);
++
++	if (tmp_loading_timeout < 0)
++		tmp_loading_timeout = 0;
++
++	__fw_fallback_set_timeout(tmp_loading_timeout);
+ 
+ 	return count;
+ }
+@@ -774,7 +741,7 @@
+ {
+ 	if (add_uevent_var(env, "FIRMWARE=%s", fw_sysfs->fw_priv->fw_name))
+ 		return -ENOMEM;
+-	if (add_uevent_var(env, "TIMEOUT=%i", loading_timeout))
++	if (add_uevent_var(env, "TIMEOUT=%i", __firmware_loading_timeout()))
+ 		return -ENOMEM;
+ 	if (add_uevent_var(env, "ASYNC=%d", fw_sysfs->nowait))
+ 		return -ENOMEM;
+@@ -1239,19 +1206,14 @@
+ 	return ret;
+ }
+ 
+-#ifdef CONFIG_FW_LOADER_USER_HELPER_FALLBACK
+-static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+-{
+-	return true;
+-}
+-#else
+ static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+ {
++	if (fw_fallback_config.force_sysfs_fallback)
++		return true;
+ 	if (!(opt_flags & FW_OPT_USERHELPER))
+ 		return false;
+ 	return true;
+ }
+-#endif
+ 
+ static bool fw_run_sysfs_fallback(unsigned int opt_flags)
+ {
+@@ -1274,7 +1236,6 @@
+ }
+ #else /* CONFIG_FW_LOADER_USER_HELPER */
+ static int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-																	 
+ 			     struct device *device,
+ 			     unsigned int opt_flags,
+ 			     int ret)
+@@ -1284,6 +1245,8 @@
+ }
+ 
+ static inline void kill_pending_fw_fallback_reqs(bool only_kill_custom) { }
++static inline void fw_fallback_set_cache_timeout(void) { }
++static inline void fw_fallback_set_default_timeout(void) { }
+ 
+ static inline int register_sysfs_loader(void)
+ {
+@@ -1390,11 +1353,7 @@
+ 			dev_warn(device,
+ 				 "Direct firmware load for %s failed with error %d\n",
+ 				 name, ret);
+-									  
+-													 
+ 		ret = fw_sysfs_fallback(fw, name, device, opt_flags, ret);
+-						
+-   
+ 	} else
+ 		ret = assign_fw(fw, device, opt_flags);
+ 
+@@ -1493,7 +1452,6 @@
+ 	__module_get(THIS_MODULE);
+ 	ret = _request_firmware(firmware_p, name, device, buf, size,
+ 				FW_OPT_UEVENT | FW_OPT_NOCACHE);
+-					
+ 	module_put(THIS_MODULE);
+ 	return ret;
+ }
+@@ -1835,7 +1793,6 @@
+ static void device_cache_fw_images(void)
+ {
+ 	struct firmware_cache *fwc = &fw_cache;
+-	int old_timeout;
+ 	DEFINE_WAIT(wait);
+ 
+ 	pr_debug("%s\n", __func__);
+@@ -1843,16 +1800,7 @@
+ 	/* cancel uncache work */
+ 	cancel_delayed_work_sync(&fwc->work);
+ 
+-	/*
+-	 * use small loading timeout for caching devices' firmware
+-	 * because all these firmware images have been loaded
+-	 * successfully at lease once, also system is ready for
+-	 * completing firmware loading now. The maximum size of
+-	 * firmware in current distributions is about 2M bytes,
+-	 * so 10 secs should be enough.
+-	 */
+-	old_timeout = loading_timeout;
+-	loading_timeout = 10;
++	fw_fallback_set_cache_timeout();
+ 
+ 	mutex_lock(&fw_lock);
+ 	fwc->state = FW_LOADER_START_CACHE;
+@@ -1862,7 +1810,7 @@
+ 	/* wait for completion of caching firmware for all devices */
+ 	async_synchronize_full_domain(&fw_cache_domain);
+ 
+-	loading_timeout = old_timeout;
++	fw_fallback_set_default_timeout();
+ }
+ 
+ /**
+@@ -1938,20 +1886,11 @@
+ static struct syscore_ops fw_syscore_ops = {
+ 	.suspend = fw_suspend,
+ };
+-	 
+-														  
+- 
+-		  
+- 
+-	  
+ 
+ static int __init register_fw_pm_ops(void)
+ {
+ 	int ret;
+-								
+-									 
+ 
+-					  
+ 	spin_lock_init(&fw_cache.name_lock);
+ 	INIT_LIST_HEAD(&fw_cache.fw_names);
+ 
+@@ -2030,19 +1969,13 @@
+ out:
+ 	unregister_fw_pm_ops();
+ 	return ret;
+-	  
+ }
+ 
+ static void __exit firmware_class_exit(void)
+ {
+ 	unregister_fw_pm_ops();
+-										 
+-											 
+-	  
+ 	unregister_reboot_notifier(&fw_shutdown_nb);
+ 	unregister_sysfs_loader();
+-								   
+-	  
+ }
+ 
+ fs_initcall(firmware_class_init);
+

--- a/target/linux/generic/backport-4.14/081-0004-firmware-split-firmware-fallback-functionality-into-its-own-file.patch
+++ b/target/linux/generic/backport-4.14/081-0004-firmware-split-firmware-fallback-functionality-into-its-own-file.patch
@@ -1,0 +1,1804 @@
+From d73f821c7aea16ad4f501fb87c8b5373a025e7f4 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:49 -0800
+Subject: [PATCH] firmware: split firmware fallback functionality into its own
+ file
+
+The firmware fallback code is optional. Split that code out to help
+distinguish the fallback functionlity from othere core firmware loader
+features. This should make it easier to maintain and review code
+changes.
+
+The reason for keeping the configuration onto a table which is built-in
+if you enable firmware loading is so that we can later enable the kernel
+after subsequent patches to tweak this configuration, even if the
+firmware loader is modular.
+
+This introduces no functional changes.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/Makefile                  |   4 +-
+ drivers/base/firmware_fallback.c       | 661 +++++++++++++++++++++++++++
+ drivers/base/firmware_fallback.h       |  61 +++
+ drivers/base/firmware_fallback_table.c |  29 ++
+ drivers/base/firmware_loader.c         | 803 +--------------------------------
+ drivers/base/firmware_loader.h         | 115 +++++
+ 6 files changed, 874 insertions(+), 799 deletions(-)
+ create mode 100644 drivers/base/firmware_fallback.c
+ create mode 100644 drivers/base/firmware_fallback.h
+ create mode 100644 drivers/base/firmware_fallback_table.c
+ create mode 100644 drivers/base/firmware_loader.h
+
+diff --git a/drivers/base/Makefile b/drivers/base/Makefile
+index f261143fafbf9..b946a408256d1 100644
+--- a/drivers/base/Makefile
++++ b/drivers/base/Makefile
+@@ -5,7 +5,8 @@ obj-y			:= component.o core.o bus.o dd.o syscore.o \
+ 			   driver.o class.o platform.o \
+ 			   cpu.o firmware.o init.o map.o devres.o \
+ 			   attribute_container.o transport_class.o \
+-			   topology.o container.o property.o cacheinfo.o
++			   topology.o container.o property.o cacheinfo.o \
++			   firmware_fallback_table.o
+ obj-$(CONFIG_DEVTMPFS)	+= devtmpfs.o
+ obj-$(CONFIG_DMA_CMA) += dma-contiguous.o
+ obj-y			+= power/
+@@ -14,6 +15,7 @@ obj-$(CONFIG_HAVE_GENERIC_DMA_COHERENT) += dma-coherent.o
+ obj-$(CONFIG_ISA_BUS_API)	+= isa.o
+ obj-$(CONFIG_FW_LOADER)	+= firmware_class.o
+ firmware_class-objs := firmware_loader.o
++firmware_class-$(CONFIG_FW_LOADER_USER_HELPER) += firmware_fallback.o
+ obj-$(CONFIG_NUMA)	+= node.o
+ obj-$(CONFIG_MEMORY_HOTPLUG_SPARSE) += memory.o
+ ifeq ($(CONFIG_SYSFS),y)
+diff --git a/drivers/base/firmware_fallback.c b/drivers/base/firmware_fallback.c
+new file mode 100644
+index 0000000000000..47690207e0ee9
+--- /dev/null
++++ b/drivers/base/firmware_fallback.c
+@@ -0,0 +1,661 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/types.h>
++#include <linux/kconfig.h>
++#include <linux/list.h>
++#include <linux/slab.h>
++#include <linux/security.h>
++#include <linux/highmem.h>
++#include <linux/umh.h>
++
++#include "firmware_fallback.h"
++#include "firmware_loader.h"
++
++/*
++ * firmware fallback mechanism
++ */
++
++extern struct firmware_fallback_config fw_fallback_config;
++
++/* These getters are vetted to use int properly */
++static inline int __firmware_loading_timeout(void)
++{
++	return fw_fallback_config.loading_timeout;
++}
++
++/* These setters are vetted to use int properly */
++static void __fw_fallback_set_timeout(int timeout)
++{
++	fw_fallback_config.loading_timeout = timeout;
++}
++
++/*
++ * use small loading timeout for caching devices' firmware because all these
++ * firmware images have been loaded successfully at lease once, also system is
++ * ready for completing firmware loading now. The maximum size of firmware in
++ * current distributions is about 2M bytes, so 10 secs should be enough.
++ */
++void fw_fallback_set_cache_timeout(void)
++{
++	fw_fallback_config.old_timeout = __firmware_loading_timeout();
++	__fw_fallback_set_timeout(10);
++}
++
++/* Restores the timeout to the value last configured during normal operation */
++void fw_fallback_set_default_timeout(void)
++{
++	__fw_fallback_set_timeout(fw_fallback_config.old_timeout);
++}
++
++static long firmware_loading_timeout(void)
++{
++	return __firmware_loading_timeout() > 0 ?
++		__firmware_loading_timeout() * HZ : MAX_JIFFY_OFFSET;
++}
++
++static inline bool fw_sysfs_done(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_DONE);
++}
++
++static inline bool fw_sysfs_loading(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_LOADING);
++}
++
++static inline int fw_sysfs_wait_timeout(struct fw_priv *fw_priv,  long timeout)
++{
++	return __fw_state_wait_common(fw_priv, timeout);
++}
++
++struct fw_sysfs {
++	bool nowait;
++	struct device dev;
++	struct fw_priv *fw_priv;
++	struct firmware *fw;
++};
++
++static struct fw_sysfs *to_fw_sysfs(struct device *dev)
++{
++	return container_of(dev, struct fw_sysfs, dev);
++}
++
++static void __fw_load_abort(struct fw_priv *fw_priv)
++{
++	/*
++	 * There is a small window in which user can write to 'loading'
++	 * between loading done and disappearance of 'loading'
++	 */
++	if (fw_sysfs_done(fw_priv))
++		return;
++
++	list_del_init(&fw_priv->pending_list);
++	fw_state_aborted(fw_priv);
++}
++
++static void fw_load_abort(struct fw_sysfs *fw_sysfs)
++{
++	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
++
++	__fw_load_abort(fw_priv);
++}
++
++static LIST_HEAD(pending_fw_head);
++
++void kill_pending_fw_fallback_reqs(bool only_kill_custom)
++{
++	struct fw_priv *fw_priv;
++	struct fw_priv *next;
++
++	mutex_lock(&fw_lock);
++	list_for_each_entry_safe(fw_priv, next, &pending_fw_head,
++				 pending_list) {
++		if (!fw_priv->need_uevent || !only_kill_custom)
++			 __fw_load_abort(fw_priv);
++	}
++	mutex_unlock(&fw_lock);
++}
++
++static ssize_t timeout_show(struct class *class, struct class_attribute *attr,
++			    char *buf)
++{
++	return sprintf(buf, "%d\n", __firmware_loading_timeout());
++}
++
++/**
++ * firmware_timeout_store - set number of seconds to wait for firmware
++ * @class: device class pointer
++ * @attr: device attribute pointer
++ * @buf: buffer to scan for timeout value
++ * @count: number of bytes in @buf
++ *
++ *	Sets the number of seconds to wait for the firmware.  Once
++ *	this expires an error will be returned to the driver and no
++ *	firmware will be provided.
++ *
++ *	Note: zero means 'wait forever'.
++ **/
++static ssize_t timeout_store(struct class *class, struct class_attribute *attr,
++			     const char *buf, size_t count)
++{
++	int tmp_loading_timeout = simple_strtol(buf, NULL, 10);
++
++	if (tmp_loading_timeout < 0)
++		tmp_loading_timeout = 0;
++
++	__fw_fallback_set_timeout(tmp_loading_timeout);
++
++	return count;
++}
++static CLASS_ATTR_RW(timeout);
++
++static struct attribute *firmware_class_attrs[] = {
++	&class_attr_timeout.attr,
++	NULL,
++};
++ATTRIBUTE_GROUPS(firmware_class);
++
++static void fw_dev_release(struct device *dev)
++{
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++
++	kfree(fw_sysfs);
++}
++
++static int do_firmware_uevent(struct fw_sysfs *fw_sysfs, struct kobj_uevent_env *env)
++{
++	if (add_uevent_var(env, "FIRMWARE=%s", fw_sysfs->fw_priv->fw_name))
++		return -ENOMEM;
++	if (add_uevent_var(env, "TIMEOUT=%i", __firmware_loading_timeout()))
++		return -ENOMEM;
++	if (add_uevent_var(env, "ASYNC=%d", fw_sysfs->nowait))
++		return -ENOMEM;
++
++	return 0;
++}
++
++static int firmware_uevent(struct device *dev, struct kobj_uevent_env *env)
++{
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	int err = 0;
++
++	mutex_lock(&fw_lock);
++	if (fw_sysfs->fw_priv)
++		err = do_firmware_uevent(fw_sysfs, env);
++	mutex_unlock(&fw_lock);
++	return err;
++}
++
++static struct class firmware_class = {
++	.name		= "firmware",
++	.class_groups	= firmware_class_groups,
++	.dev_uevent	= firmware_uevent,
++	.dev_release	= fw_dev_release,
++};
++
++int register_sysfs_loader(void)
++{
++	return class_register(&firmware_class);
++}
++
++void unregister_sysfs_loader(void)
++{
++	class_unregister(&firmware_class);
++}
++
++static ssize_t firmware_loading_show(struct device *dev,
++				     struct device_attribute *attr, char *buf)
++{
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	int loading = 0;
++
++	mutex_lock(&fw_lock);
++	if (fw_sysfs->fw_priv)
++		loading = fw_sysfs_loading(fw_sysfs->fw_priv);
++	mutex_unlock(&fw_lock);
++
++	return sprintf(buf, "%d\n", loading);
++}
++
++/* Some architectures don't have PAGE_KERNEL_RO */
++#ifndef PAGE_KERNEL_RO
++#define PAGE_KERNEL_RO PAGE_KERNEL
++#endif
++
++/* one pages buffer should be mapped/unmapped only once */
++static int map_fw_priv_pages(struct fw_priv *fw_priv)
++{
++	if (!fw_priv->is_paged_buf)
++		return 0;
++
++	vunmap(fw_priv->data);
++	fw_priv->data = vmap(fw_priv->pages, fw_priv->nr_pages, 0,
++			     PAGE_KERNEL_RO);
++	if (!fw_priv->data)
++		return -ENOMEM;
++	return 0;
++}
++
++/**
++ * firmware_loading_store - set value in the 'loading' control file
++ * @dev: device pointer
++ * @attr: device attribute pointer
++ * @buf: buffer to scan for loading control value
++ * @count: number of bytes in @buf
++ *
++ *	The relevant values are:
++ *
++ *	 1: Start a load, discarding any previous partial load.
++ *	 0: Conclude the load and hand the data to the driver code.
++ *	-1: Conclude the load with an error and discard any written data.
++ **/
++static ssize_t firmware_loading_store(struct device *dev,
++				      struct device_attribute *attr,
++				      const char *buf, size_t count)
++{
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
++	ssize_t written = count;
++	int loading = simple_strtol(buf, NULL, 10);
++	int i;
++
++	mutex_lock(&fw_lock);
++	fw_priv = fw_sysfs->fw_priv;
++	if (fw_state_is_aborted(fw_priv))
++		goto out;
++
++	switch (loading) {
++	case 1:
++		/* discarding any previous partial load */
++		if (!fw_sysfs_done(fw_priv)) {
++			for (i = 0; i < fw_priv->nr_pages; i++)
++				__free_page(fw_priv->pages[i]);
++			vfree(fw_priv->pages);
++			fw_priv->pages = NULL;
++			fw_priv->page_array_size = 0;
++			fw_priv->nr_pages = 0;
++			fw_state_start(fw_priv);
++		}
++		break;
++	case 0:
++		if (fw_sysfs_loading(fw_priv)) {
++			int rc;
++
++			/*
++			 * Several loading requests may be pending on
++			 * one same firmware buf, so let all requests
++			 * see the mapped 'buf->data' once the loading
++			 * is completed.
++			 * */
++			rc = map_fw_priv_pages(fw_priv);
++			if (rc)
++				dev_err(dev, "%s: map pages failed\n",
++					__func__);
++			else
++				rc = security_kernel_post_read_file(NULL,
++						fw_priv->data, fw_priv->size,
++						READING_FIRMWARE);
++
++			/*
++			 * Same logic as fw_load_abort, only the DONE bit
++			 * is ignored and we set ABORT only on failure.
++			 */
++			list_del_init(&fw_priv->pending_list);
++			if (rc) {
++				fw_state_aborted(fw_priv);
++				written = rc;
++			} else {
++				fw_state_done(fw_priv);
++			}
++			break;
++		}
++		/* fallthrough */
++	default:
++		dev_err(dev, "%s: unexpected value (%d)\n", __func__, loading);
++		/* fallthrough */
++	case -1:
++		fw_load_abort(fw_sysfs);
++		break;
++	}
++out:
++	mutex_unlock(&fw_lock);
++	return written;
++}
++
++static DEVICE_ATTR(loading, 0644, firmware_loading_show, firmware_loading_store);
++
++static void firmware_rw_data(struct fw_priv *fw_priv, char *buffer,
++			   loff_t offset, size_t count, bool read)
++{
++	if (read)
++		memcpy(buffer, fw_priv->data + offset, count);
++	else
++		memcpy(fw_priv->data + offset, buffer, count);
++}
++
++static void firmware_rw(struct fw_priv *fw_priv, char *buffer,
++			loff_t offset, size_t count, bool read)
++{
++	while (count) {
++		void *page_data;
++		int page_nr = offset >> PAGE_SHIFT;
++		int page_ofs = offset & (PAGE_SIZE-1);
++		int page_cnt = min_t(size_t, PAGE_SIZE - page_ofs, count);
++
++		page_data = kmap(fw_priv->pages[page_nr]);
++
++		if (read)
++			memcpy(buffer, page_data + page_ofs, page_cnt);
++		else
++			memcpy(page_data + page_ofs, buffer, page_cnt);
++
++		kunmap(fw_priv->pages[page_nr]);
++		buffer += page_cnt;
++		offset += page_cnt;
++		count -= page_cnt;
++	}
++}
++
++static ssize_t firmware_data_read(struct file *filp, struct kobject *kobj,
++				  struct bin_attribute *bin_attr,
++				  char *buffer, loff_t offset, size_t count)
++{
++	struct device *dev = kobj_to_dev(kobj);
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
++	ssize_t ret_count;
++
++	mutex_lock(&fw_lock);
++	fw_priv = fw_sysfs->fw_priv;
++	if (!fw_priv || fw_sysfs_done(fw_priv)) {
++		ret_count = -ENODEV;
++		goto out;
++	}
++	if (offset > fw_priv->size) {
++		ret_count = 0;
++		goto out;
++	}
++	if (count > fw_priv->size - offset)
++		count = fw_priv->size - offset;
++
++	ret_count = count;
++
++	if (fw_priv->data)
++		firmware_rw_data(fw_priv, buffer, offset, count, true);
++	else
++		firmware_rw(fw_priv, buffer, offset, count, true);
++
++out:
++	mutex_unlock(&fw_lock);
++	return ret_count;
++}
++
++static int fw_realloc_pages(struct fw_sysfs *fw_sysfs, int min_size)
++{
++	struct fw_priv *fw_priv= fw_sysfs->fw_priv;
++	int pages_needed = PAGE_ALIGN(min_size) >> PAGE_SHIFT;
++
++	/* If the array of pages is too small, grow it... */
++	if (fw_priv->page_array_size < pages_needed) {
++		int new_array_size = max(pages_needed,
++					 fw_priv->page_array_size * 2);
++		struct page **new_pages;
++
++		new_pages = vmalloc(new_array_size * sizeof(void *));
++		if (!new_pages) {
++			fw_load_abort(fw_sysfs);
++			return -ENOMEM;
++		}
++		memcpy(new_pages, fw_priv->pages,
++		       fw_priv->page_array_size * sizeof(void *));
++		memset(&new_pages[fw_priv->page_array_size], 0, sizeof(void *) *
++		       (new_array_size - fw_priv->page_array_size));
++		vfree(fw_priv->pages);
++		fw_priv->pages = new_pages;
++		fw_priv->page_array_size = new_array_size;
++	}
++
++	while (fw_priv->nr_pages < pages_needed) {
++		fw_priv->pages[fw_priv->nr_pages] =
++			alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
++
++		if (!fw_priv->pages[fw_priv->nr_pages]) {
++			fw_load_abort(fw_sysfs);
++			return -ENOMEM;
++		}
++		fw_priv->nr_pages++;
++	}
++	return 0;
++}
++
++/**
++ * firmware_data_write - write method for firmware
++ * @filp: open sysfs file
++ * @kobj: kobject for the device
++ * @bin_attr: bin_attr structure
++ * @buffer: buffer being written
++ * @offset: buffer offset for write in total data store area
++ * @count: buffer size
++ *
++ *	Data written to the 'data' attribute will be later handed to
++ *	the driver as a firmware image.
++ **/
++static ssize_t firmware_data_write(struct file *filp, struct kobject *kobj,
++				   struct bin_attribute *bin_attr,
++				   char *buffer, loff_t offset, size_t count)
++{
++	struct device *dev = kobj_to_dev(kobj);
++	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
++	struct fw_priv *fw_priv;
++	ssize_t retval;
++
++	if (!capable(CAP_SYS_RAWIO))
++		return -EPERM;
++
++	mutex_lock(&fw_lock);
++	fw_priv = fw_sysfs->fw_priv;
++	if (!fw_priv || fw_sysfs_done(fw_priv)) {
++		retval = -ENODEV;
++		goto out;
++	}
++
++	if (fw_priv->data) {
++		if (offset + count > fw_priv->allocated_size) {
++			retval = -ENOMEM;
++			goto out;
++		}
++		firmware_rw_data(fw_priv, buffer, offset, count, false);
++		retval = count;
++	} else {
++		retval = fw_realloc_pages(fw_sysfs, offset + count);
++		if (retval)
++			goto out;
++
++		retval = count;
++		firmware_rw(fw_priv, buffer, offset, count, false);
++	}
++
++	fw_priv->size = max_t(size_t, offset + count, fw_priv->size);
++out:
++	mutex_unlock(&fw_lock);
++	return retval;
++}
++
++static struct bin_attribute firmware_attr_data = {
++	.attr = { .name = "data", .mode = 0644 },
++	.size = 0,
++	.read = firmware_data_read,
++	.write = firmware_data_write,
++};
++
++static struct attribute *fw_dev_attrs[] = {
++	&dev_attr_loading.attr,
++	NULL
++};
++
++static struct bin_attribute *fw_dev_bin_attrs[] = {
++	&firmware_attr_data,
++	NULL
++};
++
++static const struct attribute_group fw_dev_attr_group = {
++	.attrs = fw_dev_attrs,
++	.bin_attrs = fw_dev_bin_attrs,
++};
++
++static const struct attribute_group *fw_dev_attr_groups[] = {
++	&fw_dev_attr_group,
++	NULL
++};
++
++static struct fw_sysfs *
++fw_create_instance(struct firmware *firmware, const char *fw_name,
++		   struct device *device, unsigned int opt_flags)
++{
++	struct fw_sysfs *fw_sysfs;
++	struct device *f_dev;
++
++	fw_sysfs = kzalloc(sizeof(*fw_sysfs), GFP_KERNEL);
++	if (!fw_sysfs) {
++		fw_sysfs = ERR_PTR(-ENOMEM);
++		goto exit;
++	}
++
++	fw_sysfs->nowait = !!(opt_flags & FW_OPT_NOWAIT);
++	fw_sysfs->fw = firmware;
++	f_dev = &fw_sysfs->dev;
++
++	device_initialize(f_dev);
++	dev_set_name(f_dev, "%s", fw_name);
++	f_dev->parent = device;
++	f_dev->class = &firmware_class;
++	f_dev->groups = fw_dev_attr_groups;
++exit:
++	return fw_sysfs;
++}
++
++/* load a firmware via user helper */
++static int _request_firmware_load(struct fw_sysfs *fw_sysfs,
++				  unsigned int opt_flags, long timeout)
++{
++	int retval = 0;
++	struct device *f_dev = &fw_sysfs->dev;
++	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
++
++	/* fall back on userspace loading */
++	if (!fw_priv->data)
++		fw_priv->is_paged_buf = true;
++
++	dev_set_uevent_suppress(f_dev, true);
++
++	retval = device_add(f_dev);
++	if (retval) {
++		dev_err(f_dev, "%s: device_register failed\n", __func__);
++		goto err_put_dev;
++	}
++
++	mutex_lock(&fw_lock);
++	list_add(&fw_priv->pending_list, &pending_fw_head);
++	mutex_unlock(&fw_lock);
++
++	if (opt_flags & FW_OPT_UEVENT) {
++		fw_priv->need_uevent = true;
++		dev_set_uevent_suppress(f_dev, false);
++		dev_dbg(f_dev, "firmware: requesting %s\n", fw_priv->fw_name);
++		kobject_uevent(&fw_sysfs->dev.kobj, KOBJ_ADD);
++	} else {
++		timeout = MAX_JIFFY_OFFSET;
++	}
++
++	retval = fw_sysfs_wait_timeout(fw_priv, timeout);
++	if (retval < 0) {
++		mutex_lock(&fw_lock);
++		fw_load_abort(fw_sysfs);
++		mutex_unlock(&fw_lock);
++	}
++
++	if (fw_state_is_aborted(fw_priv)) {
++		if (retval == -ERESTARTSYS)
++			retval = -EINTR;
++		else
++			retval = -EAGAIN;
++	} else if (fw_priv->is_paged_buf && !fw_priv->data)
++		retval = -ENOMEM;
++
++	device_del(f_dev);
++err_put_dev:
++	put_device(f_dev);
++	return retval;
++}
++
++static int fw_load_from_user_helper(struct firmware *firmware,
++				    const char *name, struct device *device,
++				    unsigned int opt_flags)
++{
++	struct fw_sysfs *fw_sysfs;
++	long timeout;
++	int ret;
++
++	timeout = firmware_loading_timeout();
++	if (opt_flags & FW_OPT_NOWAIT) {
++		timeout = usermodehelper_read_lock_wait(timeout);
++		if (!timeout) {
++			dev_dbg(device, "firmware: %s loading timed out\n",
++				name);
++			return -EBUSY;
++		}
++	} else {
++		ret = usermodehelper_read_trylock();
++		if (WARN_ON(ret)) {
++			dev_err(device, "firmware: %s will not be loaded\n",
++				name);
++			return ret;
++		}
++	}
++
++	fw_sysfs = fw_create_instance(firmware, name, device, opt_flags);
++	if (IS_ERR(fw_sysfs)) {
++		ret = PTR_ERR(fw_sysfs);
++		goto out_unlock;
++	}
++
++	fw_sysfs->fw_priv = firmware->priv;
++	ret = _request_firmware_load(fw_sysfs, opt_flags, timeout);
++
++	if (!ret)
++		ret = assign_fw(firmware, device, opt_flags);
++
++out_unlock:
++	usermodehelper_read_unlock();
++
++	return ret;
++}
++
++static bool fw_force_sysfs_fallback(unsigned int opt_flags)
++{
++	if (fw_fallback_config.force_sysfs_fallback)
++		return true;
++	if (!(opt_flags & FW_OPT_USERHELPER))
++		return false;
++	return true;
++}
++
++static bool fw_run_sysfs_fallback(unsigned int opt_flags)
++{
++	if ((opt_flags & FW_OPT_NOFALLBACK))
++		return false;
++
++	return fw_force_sysfs_fallback(opt_flags);
++}
++
++int fw_sysfs_fallback(struct firmware *fw, const char *name,
++		      struct device *device,
++		      unsigned int opt_flags,
++		      int ret)
++{
++	if (!fw_run_sysfs_fallback(opt_flags))
++		return ret;
++
++	dev_warn(device, "Falling back to user helper\n");
++	return fw_load_from_user_helper(fw, name, device, opt_flags);
++}
+diff --git a/drivers/base/firmware_fallback.h b/drivers/base/firmware_fallback.h
+new file mode 100644
+index 0000000000000..550498c7fa4c6
+--- /dev/null
++++ b/drivers/base/firmware_fallback.h
+@@ -0,0 +1,61 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __FIRMWARE_FALLBACK_H
++#define __FIRMWARE_FALLBACK_H
++
++#include <linux/firmware.h>
++#include <linux/device.h>
++
++/**
++ * struct firmware_fallback_config - firmware fallback configuratioon settings
++ *
++ * Helps describe and fine tune the fallback mechanism.
++ *
++ * @force_sysfs_fallback: force the sysfs fallback mechanism to be used
++ * 	as if one had enabled CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y.
++ * @old_timeout: for internal use
++ * @loading_timeout: the timeout to wait for the fallback mechanism before
++ * 	giving up, in seconds.
++ */
++struct firmware_fallback_config {
++	const bool force_sysfs_fallback;
++	int old_timeout;
++	int loading_timeout;
++};
++
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++int fw_sysfs_fallback(struct firmware *fw, const char *name,
++		      struct device *device,
++		      unsigned int opt_flags,
++		      int ret);
++void kill_pending_fw_fallback_reqs(bool only_kill_custom);
++
++void fw_fallback_set_cache_timeout(void);
++void fw_fallback_set_default_timeout(void);
++
++int register_sysfs_loader(void);
++void unregister_sysfs_loader(void);
++#else /* CONFIG_FW_LOADER_USER_HELPER */
++static inline int fw_sysfs_fallback(struct firmware *fw, const char *name,
++				    struct device *device,
++				    unsigned int opt_flags,
++				    int ret)
++{
++	/* Keep carrying over the same error */
++	return ret;
++}
++
++static inline void kill_pending_fw_fallback_reqs(bool only_kill_custom) { }
++static inline void fw_fallback_set_cache_timeout(void) { }
++static inline void fw_fallback_set_default_timeout(void) { }
++
++static inline int register_sysfs_loader(void)
++{
++	return 0;
++}
++
++static inline void unregister_sysfs_loader(void)
++{
++}
++#endif /* CONFIG_FW_LOADER_USER_HELPER */
++
++#endif /* __FIRMWARE_FALLBACK_H */
+diff --git a/drivers/base/firmware_fallback_table.c b/drivers/base/firmware_fallback_table.c
+new file mode 100644
+index 0000000000000..53cc4e4925206
+--- /dev/null
++++ b/drivers/base/firmware_fallback_table.c
+@@ -0,0 +1,29 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/types.h>
++#include <linux/kconfig.h>
++#include <linux/list.h>
++#include <linux/slab.h>
++#include <linux/security.h>
++#include <linux/highmem.h>
++#include <linux/umh.h>
++#include <linux/sysctl.h>
++
++#include "firmware_fallback.h"
++#include "firmware_loader.h"
++
++/*
++ * firmware fallback configuration table
++ */
++
++/* Module or buit-in */
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++
++struct firmware_fallback_config fw_fallback_config = {
++	.force_sysfs_fallback = IS_ENABLED(CONFIG_FW_LOADER_USER_HELPER_FALLBACK),
++	.loading_timeout = 60,
++	.old_timeout = 60,
++};
++EXPORT_SYMBOL_GPL(fw_fallback_config);
++
++#endif
+diff --git a/drivers/base/firmware_loader.c b/drivers/base/firmware_loader.c
+index 9757f9fff01e2..21dd31ef08ae3 100644
+--- a/drivers/base/firmware_loader.c
++++ b/drivers/base/firmware_loader.c
+@@ -37,36 +37,13 @@
+ #include <generated/utsrelease.h>
+ 
+ #include "base.h"
++#include "firmware_loader.h"
++#include "firmware_fallback.h"
+ 
+ MODULE_AUTHOR("Manuel Estrada Sainz");
+ MODULE_DESCRIPTION("Multi purpose firmware loading support");
+ MODULE_LICENSE("GPL");
+ 
+-enum fw_status {
+-	FW_STATUS_UNKNOWN,
+-	FW_STATUS_LOADING,
+-	FW_STATUS_DONE,
+-	FW_STATUS_ABORTED,
+-};
+-
+-/*
+- * Concurrent request_firmware() for the same firmware need to be
+- * serialized.  struct fw_state is simple state machine which hold the
+- * state of the firmware loading.
+- */
+-struct fw_state {
+-	struct completion completion;
+-	enum fw_status status;
+-};
+-
+-/* firmware behavior options */
+-#define FW_OPT_UEVENT	(1U << 0)
+-#define FW_OPT_NOWAIT	(1U << 1)
+-#define FW_OPT_USERHELPER	(1U << 2)
+-#define FW_OPT_NO_WARN	(1U << 3)
+-#define FW_OPT_NOCACHE	(1U << 4)
+-#define FW_OPT_NOFALLBACK (1U << 5)
+-
+ struct firmware_cache {
+ 	/* firmware_buf instance will be added into the below list */
+ 	spinlock_t lock;
+@@ -89,25 +66,6 @@ struct firmware_cache {
+ #endif
+ };
+ 
+-struct fw_priv {
+-	struct kref ref;
+-	struct list_head list;
+-	struct firmware_cache *fwc;
+-	struct fw_state fw_st;
+-	void *data;
+-	size_t size;
+-	size_t allocated_size;
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-	bool is_paged_buf;
+-	bool need_uevent;
+-	struct page **pages;
+-	int nr_pages;
+-	int page_array_size;
+-	struct list_head pending_list;
+-#endif
+-	const char *fw_name;
+-};
+-
+ struct fw_cache_entry {
+ 	struct list_head list;
+ 	const char *name;
+@@ -128,7 +86,7 @@ static inline struct fw_priv *to_fw_priv(struct kref *ref)
+ 
+ /* fw_lock could be moved to 'struct fw_sysfs' but since it is just
+  * guarding for corner cases a global lock should be OK */
+-static DEFINE_MUTEX(fw_lock);
++DEFINE_MUTEX(fw_lock);
+ 
+ static struct firmware_cache fw_cache;
+ 
+@@ -199,142 +157,11 @@ static void fw_state_init(struct fw_priv *fw_priv)
+ 	fw_st->status = FW_STATUS_UNKNOWN;
+ }
+ 
+-static int __fw_state_wait_common(struct fw_priv *fw_priv, long timeout)
+-{
+-	struct fw_state *fw_st = &fw_priv->fw_st;
+-	long ret;
+-
+-	ret = wait_for_completion_killable_timeout(&fw_st->completion, timeout);
+-	if (ret != 0 && fw_st->status == FW_STATUS_ABORTED)
+-		return -ENOENT;
+-	if (!ret)
+-		return -ETIMEDOUT;
+-
+-	return ret < 0 ? ret : 0;
+-}
+-
+-static void __fw_state_set(struct fw_priv *fw_priv,
+-			   enum fw_status status)
+-{
+-	struct fw_state *fw_st = &fw_priv->fw_st;
+-
+-	WRITE_ONCE(fw_st->status, status);
+-
+-	if (status == FW_STATUS_DONE || status == FW_STATUS_ABORTED)
+-		complete_all(&fw_st->completion);
+-}
+-
+-static inline void fw_state_start(struct fw_priv *fw_priv)
+-{
+-	__fw_state_set(fw_priv, FW_STATUS_LOADING);
+-}
+-
+-static inline void fw_state_done(struct fw_priv *fw_priv)
+-{
+-	__fw_state_set(fw_priv, FW_STATUS_DONE);
+-}
+-
+-static inline void fw_state_aborted(struct fw_priv *fw_priv)
+-{
+-	__fw_state_set(fw_priv, FW_STATUS_ABORTED);
+-}
+-
+ static inline int fw_state_wait(struct fw_priv *fw_priv)
+ {
+ 	return __fw_state_wait_common(fw_priv, MAX_SCHEDULE_TIMEOUT);
+ }
+ 
+-static bool __fw_state_check(struct fw_priv *fw_priv,
+-			     enum fw_status status)
+-{
+-	struct fw_state *fw_st = &fw_priv->fw_st;
+-
+-	return fw_st->status == status;
+-}
+-
+-static inline bool fw_state_is_aborted(struct fw_priv *fw_priv)
+-{
+-	return __fw_state_check(fw_priv, FW_STATUS_ABORTED);
+-}
+-
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-
+-/**
+- * struct firmware_fallback_config - firmware fallback configuratioon settings
+- *
+- * Helps describe and fine tune the fallback mechanism.
+- *
+- * @force_sysfs_fallback: force the sysfs fallback mechanism to be used
+- * 	as if one had enabled CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y.
+- * @old_timeout: for internal use
+- * @loading_timeout: the timeout to wait for the fallback mechanism before
+- * 	giving up, in seconds.
+- */
+-struct firmware_fallback_config {
+-	const bool force_sysfs_fallback;
+-	int old_timeout;
+-	int loading_timeout;
+-};
+-
+-static struct firmware_fallback_config fw_fallback_config = {
+-	.force_sysfs_fallback = IS_ENABLED(CONFIG_FW_LOADER_USER_HELPER_FALLBACK),
+-	.loading_timeout = 60,
+-	.old_timeout = 60,
+-};
+-
+-/* These getters are vetted to use int properly */
+-static inline int __firmware_loading_timeout(void)
+-{
+-	return fw_fallback_config.loading_timeout;
+-}
+-
+-/* These setters are vetted to use int properly */
+-static void __fw_fallback_set_timeout(int timeout)
+-{
+-	fw_fallback_config.loading_timeout = timeout;
+-}
+-
+-static inline long firmware_loading_timeout(void)
+-{
+-	return __firmware_loading_timeout() > 0 ?
+-		__firmware_loading_timeout() * HZ : MAX_JIFFY_OFFSET;
+-}
+-
+-/*
+- * use small loading timeout for caching devices' firmware because all these
+- * firmware images have been loaded successfully at lease once, also system is
+- * ready for completing firmware loading now. The maximum size of firmware in
+- * current distributions is about 2M bytes, so 10 secs should be enough.
+- */
+-static void fw_fallback_set_cache_timeout(void)
+-{
+-	fw_fallback_config.old_timeout = __firmware_loading_timeout();
+-	__fw_fallback_set_timeout(10);
+-}
+-
+-/* Restores the timeout to the value last configured during normal operation */
+-static void fw_fallback_set_default_timeout(void)
+-{
+-	__fw_fallback_set_timeout(fw_fallback_config.old_timeout);
+-}
+-
+-static inline bool fw_sysfs_done(struct fw_priv *fw_priv)
+-{
+-	return __fw_state_check(fw_priv, FW_STATUS_DONE);
+-}
+-
+-static inline bool fw_sysfs_loading(struct fw_priv *fw_priv)
+-{
+-	return __fw_state_check(fw_priv, FW_STATUS_LOADING);
+-}
+-
+-static inline int fw_sysfs_wait_timeout(struct fw_priv *fw_priv,  long timeout)
+-{
+-	return __fw_state_wait_common(fw_priv, timeout);
+-}
+-
+-#endif /* CONFIG_FW_LOADER_USER_HELPER */
+-
+ static int fw_cache_piggyback_on_request(const char *name);
+ 
+ static struct fw_priv *__allocate_fw_priv(const char *fw_name,
+@@ -600,8 +427,8 @@ static int fw_add_devm_name(struct device *dev, const char *name)
+ }
+ #endif
+ 
+-static int assign_fw(struct firmware *fw, struct device *device,
+-		     unsigned int opt_flags)
++int assign_fw(struct firmware *fw, struct device *device,
++	      unsigned int opt_flags)
+ {
+ 	struct fw_priv *fw_priv = fw->priv;
+ 
+@@ -639,626 +466,6 @@ static int assign_fw(struct firmware *fw, struct device *device,
+ 	return 0;
+ }
+ 
+-/*
+- * user-mode helper code
+- */
+-#ifdef CONFIG_FW_LOADER_USER_HELPER
+-struct fw_sysfs {
+-	bool nowait;
+-	struct device dev;
+-	struct fw_priv *fw_priv;
+-	struct firmware *fw;
+-};
+-
+-static struct fw_sysfs *to_fw_sysfs(struct device *dev)
+-{
+-	return container_of(dev, struct fw_sysfs, dev);
+-}
+-
+-static void __fw_load_abort(struct fw_priv *fw_priv)
+-{
+-	/*
+-	 * There is a small window in which user can write to 'loading'
+-	 * between loading done and disappearance of 'loading'
+-	 */
+-	if (fw_sysfs_done(fw_priv))
+-		return;
+-
+-	list_del_init(&fw_priv->pending_list);
+-	fw_state_aborted(fw_priv);
+-}
+-
+-static void fw_load_abort(struct fw_sysfs *fw_sysfs)
+-{
+-	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
+-
+-	__fw_load_abort(fw_priv);
+-}
+-
+-static LIST_HEAD(pending_fw_head);
+-
+-static void kill_pending_fw_fallback_reqs(bool only_kill_custom)
+-{
+-	struct fw_priv *fw_priv;
+-	struct fw_priv *next;
+-
+-	mutex_lock(&fw_lock);
+-	list_for_each_entry_safe(fw_priv, next, &pending_fw_head,
+-				 pending_list) {
+-		if (!fw_priv->need_uevent || !only_kill_custom)
+-			 __fw_load_abort(fw_priv);
+-	}
+-	mutex_unlock(&fw_lock);
+-}
+-
+-static ssize_t timeout_show(struct class *class, struct class_attribute *attr,
+-			    char *buf)
+-{
+-	return sprintf(buf, "%d\n", __firmware_loading_timeout());
+-}
+-
+-/**
+- * firmware_timeout_store - set number of seconds to wait for firmware
+- * @class: device class pointer
+- * @attr: device attribute pointer
+- * @buf: buffer to scan for timeout value
+- * @count: number of bytes in @buf
+- *
+- *	Sets the number of seconds to wait for the firmware.  Once
+- *	this expires an error will be returned to the driver and no
+- *	firmware will be provided.
+- *
+- *	Note: zero means 'wait forever'.
+- **/
+-static ssize_t timeout_store(struct class *class, struct class_attribute *attr,
+-			     const char *buf, size_t count)
+-{
+-	int tmp_loading_timeout = simple_strtol(buf, NULL, 10);
+-
+-	if (tmp_loading_timeout < 0)
+-		tmp_loading_timeout = 0;
+-
+-	__fw_fallback_set_timeout(tmp_loading_timeout);
+-
+-	return count;
+-}
+-static CLASS_ATTR_RW(timeout);
+-
+-static struct attribute *firmware_class_attrs[] = {
+-	&class_attr_timeout.attr,
+-	NULL,
+-};
+-ATTRIBUTE_GROUPS(firmware_class);
+-
+-static void fw_dev_release(struct device *dev)
+-{
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-
+-	kfree(fw_sysfs);
+-}
+-
+-static int do_firmware_uevent(struct fw_sysfs *fw_sysfs, struct kobj_uevent_env *env)
+-{
+-	if (add_uevent_var(env, "FIRMWARE=%s", fw_sysfs->fw_priv->fw_name))
+-		return -ENOMEM;
+-	if (add_uevent_var(env, "TIMEOUT=%i", __firmware_loading_timeout()))
+-		return -ENOMEM;
+-	if (add_uevent_var(env, "ASYNC=%d", fw_sysfs->nowait))
+-		return -ENOMEM;
+-
+-	return 0;
+-}
+-
+-static int firmware_uevent(struct device *dev, struct kobj_uevent_env *env)
+-{
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-	int err = 0;
+-
+-	mutex_lock(&fw_lock);
+-	if (fw_sysfs->fw_priv)
+-		err = do_firmware_uevent(fw_sysfs, env);
+-	mutex_unlock(&fw_lock);
+-	return err;
+-}
+-
+-static struct class firmware_class = {
+-	.name		= "firmware",
+-	.class_groups	= firmware_class_groups,
+-	.dev_uevent	= firmware_uevent,
+-	.dev_release	= fw_dev_release,
+-};
+-
+-static inline int register_sysfs_loader(void)
+-{
+-	return class_register(&firmware_class);
+-}
+-
+-static inline void unregister_sysfs_loader(void)
+-{
+-	class_unregister(&firmware_class);
+-}
+-
+-static ssize_t firmware_loading_show(struct device *dev,
+-				     struct device_attribute *attr, char *buf)
+-{
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-	int loading = 0;
+-
+-	mutex_lock(&fw_lock);
+-	if (fw_sysfs->fw_priv)
+-		loading = fw_sysfs_loading(fw_sysfs->fw_priv);
+-	mutex_unlock(&fw_lock);
+-
+-	return sprintf(buf, "%d\n", loading);
+-}
+-
+-/* Some architectures don't have PAGE_KERNEL_RO */
+-#ifndef PAGE_KERNEL_RO
+-#define PAGE_KERNEL_RO PAGE_KERNEL
+-#endif
+-
+-/* one pages buffer should be mapped/unmapped only once */
+-static int map_fw_priv_pages(struct fw_priv *fw_priv)
+-{
+-	if (!fw_priv->is_paged_buf)
+-		return 0;
+-
+-	vunmap(fw_priv->data);
+-	fw_priv->data = vmap(fw_priv->pages, fw_priv->nr_pages, 0,
+-			     PAGE_KERNEL_RO);
+-	if (!fw_priv->data)
+-		return -ENOMEM;
+-	return 0;
+-}
+-
+-/**
+- * firmware_loading_store - set value in the 'loading' control file
+- * @dev: device pointer
+- * @attr: device attribute pointer
+- * @buf: buffer to scan for loading control value
+- * @count: number of bytes in @buf
+- *
+- *	The relevant values are:
+- *
+- *	 1: Start a load, discarding any previous partial load.
+- *	 0: Conclude the load and hand the data to the driver code.
+- *	-1: Conclude the load with an error and discard any written data.
+- **/
+-static ssize_t firmware_loading_store(struct device *dev,
+-				      struct device_attribute *attr,
+-				      const char *buf, size_t count)
+-{
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-	struct fw_priv *fw_priv;
+-	ssize_t written = count;
+-	int loading = simple_strtol(buf, NULL, 10);
+-	int i;
+-
+-	mutex_lock(&fw_lock);
+-	fw_priv = fw_sysfs->fw_priv;
+-	if (fw_state_is_aborted(fw_priv))
+-		goto out;
+-
+-	switch (loading) {
+-	case 1:
+-		/* discarding any previous partial load */
+-		if (!fw_sysfs_done(fw_priv)) {
+-			for (i = 0; i < fw_priv->nr_pages; i++)
+-				__free_page(fw_priv->pages[i]);
+-			vfree(fw_priv->pages);
+-			fw_priv->pages = NULL;
+-			fw_priv->page_array_size = 0;
+-			fw_priv->nr_pages = 0;
+-			fw_state_start(fw_priv);
+-		}
+-		break;
+-	case 0:
+-		if (fw_sysfs_loading(fw_priv)) {
+-			int rc;
+-
+-			/*
+-			 * Several loading requests may be pending on
+-			 * one same firmware buf, so let all requests
+-			 * see the mapped 'buf->data' once the loading
+-			 * is completed.
+-			 * */
+-			rc = map_fw_priv_pages(fw_priv);
+-			if (rc)
+-				dev_err(dev, "%s: map pages failed\n",
+-					__func__);
+-			else
+-				rc = security_kernel_post_read_file(NULL,
+-						fw_priv->data, fw_priv->size,
+-						READING_FIRMWARE);
+-
+-			/*
+-			 * Same logic as fw_load_abort, only the DONE bit
+-			 * is ignored and we set ABORT only on failure.
+-			 */
+-			list_del_init(&fw_priv->pending_list);
+-			if (rc) {
+-				fw_state_aborted(fw_priv);
+-				written = rc;
+-			} else {
+-				fw_state_done(fw_priv);
+-			}
+-			break;
+-		}
+-		/* fallthrough */
+-	default:
+-		dev_err(dev, "%s: unexpected value (%d)\n", __func__, loading);
+-		/* fallthrough */
+-	case -1:
+-		fw_load_abort(fw_sysfs);
+-		break;
+-	}
+-out:
+-	mutex_unlock(&fw_lock);
+-	return written;
+-}
+-
+-static DEVICE_ATTR(loading, 0644, firmware_loading_show, firmware_loading_store);
+-
+-static void firmware_rw_data(struct fw_priv *fw_priv, char *buffer,
+-			   loff_t offset, size_t count, bool read)
+-{
+-	if (read)
+-		memcpy(buffer, fw_priv->data + offset, count);
+-	else
+-		memcpy(fw_priv->data + offset, buffer, count);
+-}
+-
+-static void firmware_rw(struct fw_priv *fw_priv, char *buffer,
+-			loff_t offset, size_t count, bool read)
+-{
+-	while (count) {
+-		void *page_data;
+-		int page_nr = offset >> PAGE_SHIFT;
+-		int page_ofs = offset & (PAGE_SIZE-1);
+-		int page_cnt = min_t(size_t, PAGE_SIZE - page_ofs, count);
+-
+-		page_data = kmap(fw_priv->pages[page_nr]);
+-
+-		if (read)
+-			memcpy(buffer, page_data + page_ofs, page_cnt);
+-		else
+-			memcpy(page_data + page_ofs, buffer, page_cnt);
+-
+-		kunmap(fw_priv->pages[page_nr]);
+-		buffer += page_cnt;
+-		offset += page_cnt;
+-		count -= page_cnt;
+-	}
+-}
+-
+-static ssize_t firmware_data_read(struct file *filp, struct kobject *kobj,
+-				  struct bin_attribute *bin_attr,
+-				  char *buffer, loff_t offset, size_t count)
+-{
+-	struct device *dev = kobj_to_dev(kobj);
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-	struct fw_priv *fw_priv;
+-	ssize_t ret_count;
+-
+-	mutex_lock(&fw_lock);
+-	fw_priv = fw_sysfs->fw_priv;
+-	if (!fw_priv || fw_sysfs_done(fw_priv)) {
+-		ret_count = -ENODEV;
+-		goto out;
+-	}
+-	if (offset > fw_priv->size) {
+-		ret_count = 0;
+-		goto out;
+-	}
+-	if (count > fw_priv->size - offset)
+-		count = fw_priv->size - offset;
+-
+-	ret_count = count;
+-
+-	if (fw_priv->data)
+-		firmware_rw_data(fw_priv, buffer, offset, count, true);
+-	else
+-		firmware_rw(fw_priv, buffer, offset, count, true);
+-
+-out:
+-	mutex_unlock(&fw_lock);
+-	return ret_count;
+-}
+-
+-static int fw_realloc_pages(struct fw_sysfs *fw_sysfs, int min_size)
+-{
+-	struct fw_priv *fw_priv= fw_sysfs->fw_priv;
+-	int pages_needed = PAGE_ALIGN(min_size) >> PAGE_SHIFT;
+-
+-	/* If the array of pages is too small, grow it... */
+-	if (fw_priv->page_array_size < pages_needed) {
+-		int new_array_size = max(pages_needed,
+-					 fw_priv->page_array_size * 2);
+-		struct page **new_pages;
+-
+-		new_pages = vmalloc(new_array_size * sizeof(void *));
+-		if (!new_pages) {
+-			fw_load_abort(fw_sysfs);
+-			return -ENOMEM;
+-		}
+-		memcpy(new_pages, fw_priv->pages,
+-		       fw_priv->page_array_size * sizeof(void *));
+-		memset(&new_pages[fw_priv->page_array_size], 0, sizeof(void *) *
+-		       (new_array_size - fw_priv->page_array_size));
+-		vfree(fw_priv->pages);
+-		fw_priv->pages = new_pages;
+-		fw_priv->page_array_size = new_array_size;
+-	}
+-
+-	while (fw_priv->nr_pages < pages_needed) {
+-		fw_priv->pages[fw_priv->nr_pages] =
+-			alloc_page(GFP_KERNEL | __GFP_HIGHMEM);
+-
+-		if (!fw_priv->pages[fw_priv->nr_pages]) {
+-			fw_load_abort(fw_sysfs);
+-			return -ENOMEM;
+-		}
+-		fw_priv->nr_pages++;
+-	}
+-	return 0;
+-}
+-
+-/**
+- * firmware_data_write - write method for firmware
+- * @filp: open sysfs file
+- * @kobj: kobject for the device
+- * @bin_attr: bin_attr structure
+- * @buffer: buffer being written
+- * @offset: buffer offset for write in total data store area
+- * @count: buffer size
+- *
+- *	Data written to the 'data' attribute will be later handed to
+- *	the driver as a firmware image.
+- **/
+-static ssize_t firmware_data_write(struct file *filp, struct kobject *kobj,
+-				   struct bin_attribute *bin_attr,
+-				   char *buffer, loff_t offset, size_t count)
+-{
+-	struct device *dev = kobj_to_dev(kobj);
+-	struct fw_sysfs *fw_sysfs = to_fw_sysfs(dev);
+-	struct fw_priv *fw_priv;
+-	ssize_t retval;
+-
+-	if (!capable(CAP_SYS_RAWIO))
+-		return -EPERM;
+-
+-	mutex_lock(&fw_lock);
+-	fw_priv = fw_sysfs->fw_priv;
+-	if (!fw_priv || fw_sysfs_done(fw_priv)) {
+-		retval = -ENODEV;
+-		goto out;
+-	}
+-
+-	if (fw_priv->data) {
+-		if (offset + count > fw_priv->allocated_size) {
+-			retval = -ENOMEM;
+-			goto out;
+-		}
+-		firmware_rw_data(fw_priv, buffer, offset, count, false);
+-		retval = count;
+-	} else {
+-		retval = fw_realloc_pages(fw_sysfs, offset + count);
+-		if (retval)
+-			goto out;
+-
+-		retval = count;
+-		firmware_rw(fw_priv, buffer, offset, count, false);
+-	}
+-
+-	fw_priv->size = max_t(size_t, offset + count, fw_priv->size);
+-out:
+-	mutex_unlock(&fw_lock);
+-	return retval;
+-}
+-
+-static struct bin_attribute firmware_attr_data = {
+-	.attr = { .name = "data", .mode = 0644 },
+-	.size = 0,
+-	.read = firmware_data_read,
+-	.write = firmware_data_write,
+-};
+-
+-static struct attribute *fw_dev_attrs[] = {
+-	&dev_attr_loading.attr,
+-	NULL
+-};
+-
+-static struct bin_attribute *fw_dev_bin_attrs[] = {
+-	&firmware_attr_data,
+-	NULL
+-};
+-
+-static const struct attribute_group fw_dev_attr_group = {
+-	.attrs = fw_dev_attrs,
+-	.bin_attrs = fw_dev_bin_attrs,
+-};
+-
+-static const struct attribute_group *fw_dev_attr_groups[] = {
+-	&fw_dev_attr_group,
+-	NULL
+-};
+-
+-static struct fw_sysfs *
+-fw_create_instance(struct firmware *firmware, const char *fw_name,
+-		   struct device *device, unsigned int opt_flags)
+-{
+-	struct fw_sysfs *fw_sysfs;
+-	struct device *f_dev;
+-
+-	fw_sysfs = kzalloc(sizeof(*fw_sysfs), GFP_KERNEL);
+-	if (!fw_sysfs) {
+-		fw_sysfs = ERR_PTR(-ENOMEM);
+-		goto exit;
+-	}
+-
+-	fw_sysfs->nowait = !!(opt_flags & FW_OPT_NOWAIT);
+-	fw_sysfs->fw = firmware;
+-	f_dev = &fw_sysfs->dev;
+-
+-	device_initialize(f_dev);
+-	dev_set_name(f_dev, "%s", fw_name);
+-	f_dev->parent = device;
+-	f_dev->class = &firmware_class;
+-	f_dev->groups = fw_dev_attr_groups;
+-exit:
+-	return fw_sysfs;
+-}
+-
+-/* load a firmware via user helper */
+-static int _request_firmware_load(struct fw_sysfs *fw_sysfs,
+-				  unsigned int opt_flags, long timeout)
+-{
+-	int retval = 0;
+-	struct device *f_dev = &fw_sysfs->dev;
+-	struct fw_priv *fw_priv = fw_sysfs->fw_priv;
+-
+-	/* fall back on userspace loading */
+-	if (!fw_priv->data)
+-		fw_priv->is_paged_buf = true;
+-
+-	dev_set_uevent_suppress(f_dev, true);
+-
+-	retval = device_add(f_dev);
+-	if (retval) {
+-		dev_err(f_dev, "%s: device_register failed\n", __func__);
+-		goto err_put_dev;
+-	}
+-
+-	mutex_lock(&fw_lock);
+-	list_add(&fw_priv->pending_list, &pending_fw_head);
+-	mutex_unlock(&fw_lock);
+-
+-	if (opt_flags & FW_OPT_UEVENT) {
+-		fw_priv->need_uevent = true;
+-		dev_set_uevent_suppress(f_dev, false);
+-		dev_dbg(f_dev, "firmware: requesting %s\n", fw_priv->fw_name);
+-		kobject_uevent(&fw_sysfs->dev.kobj, KOBJ_ADD);
+-	} else {
+-		timeout = MAX_JIFFY_OFFSET;
+-	}
+-
+-	retval = fw_sysfs_wait_timeout(fw_priv, timeout);
+-	if (retval < 0) {
+-		mutex_lock(&fw_lock);
+-		fw_load_abort(fw_sysfs);
+-		mutex_unlock(&fw_lock);
+-	}
+-
+-	if (fw_state_is_aborted(fw_priv)) {
+-		if (retval == -ERESTARTSYS)
+-			retval = -EINTR;
+-		else
+-			retval = -EAGAIN;
+-	} else if (fw_priv->is_paged_buf && !fw_priv->data)
+-		retval = -ENOMEM;
+-
+-	device_del(f_dev);
+-err_put_dev:
+-	put_device(f_dev);
+-	return retval;
+-}
+-
+-static int fw_load_from_user_helper(struct firmware *firmware,
+-				    const char *name, struct device *device,
+-				    unsigned int opt_flags)
+-{
+-	struct fw_sysfs *fw_sysfs;
+-	long timeout;
+-	int ret;
+-
+-	timeout = firmware_loading_timeout();
+-	if (opt_flags & FW_OPT_NOWAIT) {
+-		timeout = usermodehelper_read_lock_wait(timeout);
+-		if (!timeout) {
+-			dev_dbg(device, "firmware: %s loading timed out\n",
+-				name);
+-			return -EBUSY;
+-		}
+-	} else {
+-		ret = usermodehelper_read_trylock();
+-		if (WARN_ON(ret)) {
+-			dev_err(device, "firmware: %s will not be loaded\n",
+-				name);
+-			return ret;
+-		}
+-	}
+-
+-	fw_sysfs = fw_create_instance(firmware, name, device, opt_flags);
+-	if (IS_ERR(fw_sysfs)) {
+-		ret = PTR_ERR(fw_sysfs);
+-		goto out_unlock;
+-	}
+-
+-	fw_sysfs->fw_priv = firmware->priv;
+-	ret = _request_firmware_load(fw_sysfs, opt_flags, timeout);
+-
+-	if (!ret)
+-		ret = assign_fw(firmware, device, opt_flags);
+-
+-out_unlock:
+-	usermodehelper_read_unlock();
+-
+-	return ret;
+-}
+-
+-static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+-{
+-	if (fw_fallback_config.force_sysfs_fallback)
+-		return true;
+-	if (!(opt_flags & FW_OPT_USERHELPER))
+-		return false;
+-	return true;
+-}
+-
+-static bool fw_run_sysfs_fallback(unsigned int opt_flags)
+-{
+-	if ((opt_flags & FW_OPT_NOFALLBACK))
+-		return false;
+-
+-	return fw_force_sysfs_fallback(opt_flags);
+-}
+-
+-static int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-			    struct device *device,
+-			    unsigned int opt_flags,
+-			    int ret)
+-{
+-	if (!fw_run_sysfs_fallback(opt_flags))
+-		return ret;
+-
+-	dev_warn(device, "Falling back to user helper\n");
+-	return fw_load_from_user_helper(fw, name, device, opt_flags);
+-}
+-#else /* CONFIG_FW_LOADER_USER_HELPER */
+-static int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-			     struct device *device,
+-			     unsigned int opt_flags,
+-			     int ret)
+-{
+-	/* Keep carrying over the same error */
+-	return ret;
+-}
+-
+-static inline void kill_pending_fw_fallback_reqs(bool only_kill_custom) { }
+-static inline void fw_fallback_set_cache_timeout(void) { }
+-static inline void fw_fallback_set_default_timeout(void) { }
+-
+-static inline int register_sysfs_loader(void)
+-{
+-	return 0;
+-}
+-
+-static inline void unregister_sysfs_loader(void)
+-{
+-}
+-
+-#endif /* CONFIG_FW_LOADER_USER_HELPER */
+-
+ /* prepare firmware and firmware_buf structs;
+  * return 0 if a firmware is already assigned, 1 if need to load one,
+  * or a negative error code
+diff --git a/drivers/base/firmware_loader.h b/drivers/base/firmware_loader.h
+new file mode 100644
+index 0000000000000..64acbb1a392c7
+--- /dev/null
++++ b/drivers/base/firmware_loader.h
+@@ -0,0 +1,115 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __FIRMWARE_LOADER_H
++#define __FIRMWARE_LOADER_H
++
++#include <linux/firmware.h>
++#include <linux/types.h>
++#include <linux/kref.h>
++#include <linux/list.h>
++#include <linux/completion.h>
++
++#include <generated/utsrelease.h>
++
++/* firmware behavior options */
++#define FW_OPT_UEVENT			(1U << 0)
++#define FW_OPT_NOWAIT			(1U << 1)
++#define FW_OPT_USERHELPER		(1U << 2)
++#define FW_OPT_NO_WARN			(1U << 3)
++#define FW_OPT_NOCACHE			(1U << 4)
++#define FW_OPT_NOFALLBACK		(1U << 5)
++
++enum fw_status {
++	FW_STATUS_UNKNOWN,
++	FW_STATUS_LOADING,
++	FW_STATUS_DONE,
++	FW_STATUS_ABORTED,
++};
++
++/*
++ * Concurrent request_firmware() for the same firmware need to be
++ * serialized.  struct fw_state is simple state machine which hold the
++ * state of the firmware loading.
++ */
++struct fw_state {
++	struct completion completion;
++	enum fw_status status;
++};
++
++struct fw_priv {
++	struct kref ref;
++	struct list_head list;
++	struct firmware_cache *fwc;
++	struct fw_state fw_st;
++	void *data;
++	size_t size;
++	size_t allocated_size;
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++	bool is_paged_buf;
++	bool need_uevent;
++	struct page **pages;
++	int nr_pages;
++	int page_array_size;
++	struct list_head pending_list;
++#endif
++	const char *fw_name;
++};
++
++extern struct mutex fw_lock;
++
++static inline bool __fw_state_check(struct fw_priv *fw_priv,
++				    enum fw_status status)
++{
++	struct fw_state *fw_st = &fw_priv->fw_st;
++
++	return fw_st->status == status;
++}
++
++static inline int __fw_state_wait_common(struct fw_priv *fw_priv, long timeout)
++{
++	struct fw_state *fw_st = &fw_priv->fw_st;
++	long ret;
++
++	ret = wait_for_completion_killable_timeout(&fw_st->completion, timeout);
++	if (ret != 0 && fw_st->status == FW_STATUS_ABORTED)
++		return -ENOENT;
++	if (!ret)
++		return -ETIMEDOUT;
++
++	return ret < 0 ? ret : 0;
++}
++
++static inline void __fw_state_set(struct fw_priv *fw_priv,
++				  enum fw_status status)
++{
++	struct fw_state *fw_st = &fw_priv->fw_st;
++
++	WRITE_ONCE(fw_st->status, status);
++
++	if (status == FW_STATUS_DONE || status == FW_STATUS_ABORTED)
++		complete_all(&fw_st->completion);
++}
++
++static inline void fw_state_aborted(struct fw_priv *fw_priv)
++{
++	__fw_state_set(fw_priv, FW_STATUS_ABORTED);
++}
++
++static inline bool fw_state_is_aborted(struct fw_priv *fw_priv)
++{
++	return __fw_state_check(fw_priv, FW_STATUS_ABORTED);
++}
++
++static inline void fw_state_start(struct fw_priv *fw_priv)
++{
++	__fw_state_set(fw_priv, FW_STATUS_LOADING);
++}
++
++static inline void fw_state_done(struct fw_priv *fw_priv)
++{
++	__fw_state_set(fw_priv, FW_STATUS_DONE);
++}
++
++int assign_fw(struct firmware *fw, struct device *device,
++	      unsigned int opt_flags);
++
++#endif /* __FIRMWARE_LOADER_H */

--- a/target/linux/generic/backport-4.14/081-0005-firmware-move-firmware-loader-into-its-own-directory.patch
+++ b/target/linux/generic/backport-4.14/081-0005-firmware-move-firmware-loader-into-its-own-directory.patch
@@ -1,0 +1,151 @@
+From 5d6d1ddd27301dc85b13b794262c8bcececf88f1 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:50 -0800
+Subject: [PATCH] firmware: move firmware loader into its own directory
+
+This will make it much easier to manage as we manage to
+keep trimming componnents down into their own files to more
+easily manage and maintain this codebase.
+
+Suggested-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ MAINTAINERS                                                       | 2 +-
+ drivers/base/Makefile                                             | 7 ++-----
+ drivers/base/firmware_loader/Makefile                             | 7 +++++++
+ drivers/base/{firmware_fallback.c => firmware_loader/fallback.c}  | 4 ++--
+ drivers/base/{firmware_fallback.h => firmware_loader/fallback.h}  | 0
+ .../fallback_table.c}                                             | 4 ++--
+ drivers/base/{firmware_loader.h => firmware_loader/firmware.h}    | 0
+ drivers/base/{firmware_loader.c => firmware_loader/main.c}        | 8 ++++----
+ 8 files changed, 18 insertions(+), 14 deletions(-)
+ create mode 100644 drivers/base/firmware_loader/Makefile
+ rename drivers/base/{firmware_fallback.c => firmware_loader/fallback.c} (99%)
+ rename drivers/base/{firmware_fallback.h => firmware_loader/fallback.h} (100%)
+ rename drivers/base/{firmware_fallback_table.c => firmware_loader/fallback_table.c} (90%)
+ rename drivers/base/{firmware_loader.h => firmware_loader/firmware.h} (100%)
+ rename drivers/base/{firmware_loader.c => firmware_loader/main.c} (99%)
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 4623caf8d72d8..44c6ea94d7271 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -5552,7 +5552,7 @@ M:	Luis R. Rodriguez <mcgrof@kernel.org>
+ L:	linux-kernel@vger.kernel.org
+ S:	Maintained
+ F:	Documentation/firmware_class/
+-F:	drivers/base/firmware*.c
++F:	drivers/base/firmware_loader/
+ F:	include/linux/firmware.h
+ 
+ FLASH ADAPTER DRIVER (IBM Flash Adapter 900GB Full Height PCI Flash Card)
+diff --git a/drivers/base/Makefile b/drivers/base/Makefile
+index b946a408256d1..b9539abec675f 100644
+--- a/drivers/base/Makefile
++++ b/drivers/base/Makefile
+@@ -5,17 +5,14 @@ obj-y			:= component.o core.o bus.o dd.o syscore.o \
+ 			   driver.o class.o platform.o \
+ 			   cpu.o firmware.o init.o map.o devres.o \
+ 			   attribute_container.o transport_class.o \
+-			   topology.o container.o property.o cacheinfo.o \
+-			   firmware_fallback_table.o
++			   topology.o container.o property.o cacheinfo.o
+ obj-$(CONFIG_DEVTMPFS)	+= devtmpfs.o
+ obj-$(CONFIG_DMA_CMA) += dma-contiguous.o
+ obj-y			+= power/
+ obj-$(CONFIG_HAS_DMA)	+= dma-mapping.o
+ obj-$(CONFIG_HAVE_GENERIC_DMA_COHERENT) += dma-coherent.o
+ obj-$(CONFIG_ISA_BUS_API)	+= isa.o
+-obj-$(CONFIG_FW_LOADER)	+= firmware_class.o
+-firmware_class-objs := firmware_loader.o
+-firmware_class-$(CONFIG_FW_LOADER_USER_HELPER) += firmware_fallback.o
++obj-y				+= firmware_loader/
+ obj-$(CONFIG_NUMA)	+= node.o
+ obj-$(CONFIG_MEMORY_HOTPLUG_SPARSE) += memory.o
+ ifeq ($(CONFIG_SYSFS),y)
+diff --git a/drivers/base/firmware_loader/Makefile b/drivers/base/firmware_loader/Makefile
+new file mode 100644
+index 0000000000000..a97eeb0be1d8e
+--- /dev/null
++++ b/drivers/base/firmware_loader/Makefile
+@@ -0,0 +1,7 @@
++# SPDX-License-Identifier: GPL-2.0
++# Makefile for the Linux firmware loader
++
++obj-y			:= fallback_table.o
++obj-$(CONFIG_FW_LOADER)	+= firmware_class.o
++firmware_class-objs := main.o
++firmware_class-$(CONFIG_FW_LOADER_USER_HELPER) += fallback.o
+diff --git a/drivers/base/firmware_fallback.c b/drivers/base/firmware_loader/fallback.c
+similarity index 99%
+rename from drivers/base/firmware_fallback.c
+rename to drivers/base/firmware_loader/fallback.c
+index 47690207e0ee9..9b65837256d6f 100644
+--- a/drivers/base/firmware_fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -8,8 +8,8 @@
+ #include <linux/highmem.h>
+ #include <linux/umh.h>
+ 
+-#include "firmware_fallback.h"
+-#include "firmware_loader.h"
++#include "fallback.h"
++#include "firmware.h"
+ 
+ /*
+  * firmware fallback mechanism
+diff --git a/drivers/base/firmware_fallback.h b/drivers/base/firmware_loader/fallback.h
+similarity index 100%
+rename from drivers/base/firmware_fallback.h
+rename to drivers/base/firmware_loader/fallback.h
+diff --git a/drivers/base/firmware_fallback_table.c b/drivers/base/firmware_loader/fallback_table.c
+similarity index 90%
+rename from drivers/base/firmware_fallback_table.c
+rename to drivers/base/firmware_loader/fallback_table.c
+index 53cc4e4925206..981419044c7ec 100644
+--- a/drivers/base/firmware_fallback_table.c
++++ b/drivers/base/firmware_loader/fallback_table.c
+@@ -9,8 +9,8 @@
+ #include <linux/umh.h>
+ #include <linux/sysctl.h>
+ 
+-#include "firmware_fallback.h"
+-#include "firmware_loader.h"
++#include "fallback.h"
++#include "firmware.h"
+ 
+ /*
+  * firmware fallback configuration table
+diff --git a/drivers/base/firmware_loader.h b/drivers/base/firmware_loader/firmware.h
+similarity index 100%
+rename from drivers/base/firmware_loader.h
+rename to drivers/base/firmware_loader/firmware.h
+diff --git a/drivers/base/firmware_loader.c b/drivers/base/firmware_loader/main.c
+similarity index 99%
+rename from drivers/base/firmware_loader.c
+rename to drivers/base/firmware_loader/main.c
+index 21dd31ef08ae3..c8966c84bd441 100644
+--- a/drivers/base/firmware_loader.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -1,6 +1,6 @@
+ // SPDX-License-Identifier: GPL-2.0
+ /*
+- * firmware_class.c - Multi purpose firmware loading support
++ * main.c - Multi purpose firmware loading support
+  *
+  * Copyright (c) 2003 Manuel Estrada Sainz
+  *
+@@ -36,9 +36,9 @@
+ 
+ #include <generated/utsrelease.h>
+ 
+-#include "base.h"
+-#include "firmware_loader.h"
+-#include "firmware_fallback.h"
++#include "../base.h"
++#include "firmware.h"
++#include "fallback.h"
+ 
+ MODULE_AUTHOR("Manuel Estrada Sainz");
+ MODULE_DESCRIPTION("Multi purpose firmware loading support");

--- a/target/linux/generic/backport-4.14/081-0006-firmware-enable-run-time-change-of-forcing-fallback-loader.patch
+++ b/target/linux/generic/backport-4.14/081-0006-firmware-enable-run-time-change-of-forcing-fallback-loader.patch
@@ -1,0 +1,133 @@
+From ceb18132248d95b2c68e30c3df78e69175c4452f Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:51 -0800
+Subject: [PATCH] firmware: enable run time change of forcing fallback loader
+
+Currently one requires to test four kernel configurations to test the
+firmware API completely:
+
+0)
+  CONFIG_FW_LOADER=y
+
+1)
+  o CONFIG_FW_LOADER=y
+  o CONFIG_FW_LOADER_USER_HELPER=y
+
+2)
+  o CONFIG_FW_LOADER=y
+  o CONFIG_FW_LOADER_USER_HELPER=y
+  o CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y
+
+3) When CONFIG_FW_LOADER=m the built-in stuff is disabled, we have
+   no current tests for this.
+
+We can reduce the requirements to three kernel configurations by making
+fw_config.force_sysfs_fallback a proc knob we flip on off. For kernels that
+disable CONFIG_IKCONFIG_PROC this can also enable one to inspect if
+CONFIG_FW_LOADER_USER_HELPER_FALLBACK was enabled at build time by checking
+the proc value at boot time.
+
+Acked-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c       |  1 +
+ drivers/base/firmware_loader/fallback.h       |  4 +++-
+ drivers/base/firmware_loader/fallback_table.c | 17 +++++++++++++++++
+ kernel/sysctl.c                               | 11 +++++++++++
+ 4 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 9b65837256d6f..45cc40933a47b 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -7,6 +7,7 @@
+ #include <linux/security.h>
+ #include <linux/highmem.h>
+ #include <linux/umh.h>
++#include <linux/sysctl.h>
+ 
+ #include "fallback.h"
+ #include "firmware.h"
+diff --git a/drivers/base/firmware_loader/fallback.h b/drivers/base/firmware_loader/fallback.h
+index 550498c7fa4c6..ca7e69a8417bb 100644
+--- a/drivers/base/firmware_loader/fallback.h
++++ b/drivers/base/firmware_loader/fallback.h
+@@ -12,12 +12,14 @@
+  *
+  * @force_sysfs_fallback: force the sysfs fallback mechanism to be used
+  * 	as if one had enabled CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y.
++ * 	Useful to help debug a CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y
++ * 	functionality on a kernel where that config entry has been disabled.
+  * @old_timeout: for internal use
+  * @loading_timeout: the timeout to wait for the fallback mechanism before
+  * 	giving up, in seconds.
+  */
+ struct firmware_fallback_config {
+-	const bool force_sysfs_fallback;
++	unsigned int force_sysfs_fallback;
+ 	int old_timeout;
+ 	int loading_timeout;
+ };
+diff --git a/drivers/base/firmware_loader/fallback_table.c b/drivers/base/firmware_loader/fallback_table.c
+index 981419044c7ec..92365e053e309 100644
+--- a/drivers/base/firmware_loader/fallback_table.c
++++ b/drivers/base/firmware_loader/fallback_table.c
+@@ -19,6 +19,9 @@
+ /* Module or buit-in */
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+ 
++static unsigned int zero;
++static unsigned int one = 1;
++
+ struct firmware_fallback_config fw_fallback_config = {
+ 	.force_sysfs_fallback = IS_ENABLED(CONFIG_FW_LOADER_USER_HELPER_FALLBACK),
+ 	.loading_timeout = 60,
+@@ -26,4 +29,18 @@ struct firmware_fallback_config fw_fallback_config = {
+ };
+ EXPORT_SYMBOL_GPL(fw_fallback_config);
+ 
++struct ctl_table firmware_config_table[] = {
++	{
++		.procname	= "force_sysfs_fallback",
++		.data		= &fw_fallback_config.force_sysfs_fallback,
++		.maxlen         = sizeof(unsigned int),
++		.mode           = 0644,
++		.proc_handler   = proc_douintvec_minmax,
++		.extra1		= &zero,
++		.extra2		= &one,
++	},
++	{ }
++};
++EXPORT_SYMBOL_GPL(firmware_config_table);
++
+ #endif
+diff --git a/kernel/sysctl.c b/kernel/sysctl.c
+index f98f28c12020f..bdf7090b106da 100644
+--- a/kernel/sysctl.c
++++ b/kernel/sysctl.c
+@@ -253,6 +253,10 @@ extern struct ctl_table random_table[];
+ extern struct ctl_table epoll_table[];
+ #endif
+ 
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++extern struct ctl_table firmware_config_table[];
++#endif
++
+ #ifdef HAVE_ARCH_PICK_MMAP_LAYOUT
+ int sysctl_legacy_va_layout;
+ #endif
+@@ -748,6 +752,13 @@ static struct ctl_table kern_table[] = {
+ 		.mode		= 0555,
+ 		.child		= usermodehelper_table,
+ 	},
++#ifdef CONFIG_FW_LOADER_USER_HELPER
++	{
++		.procname	= "firmware_config",
++		.mode		= 0555,
++		.child		= firmware_config_table,
++	},
++#endif
+ 	{
+ 		.procname	= "overflowuid",
+ 		.data		= &overflowuid,

--- a/target/linux/generic/backport-4.14/081-0007-firmware-enable-to-force-disable-the-fallback-mechanism-at-run-time.patch
+++ b/target/linux/generic/backport-4.14/081-0007-firmware-enable-to-force-disable-the-fallback-mechanism-at-run-time.patch
@@ -1,0 +1,77 @@
+From 2cd7a1c6dcd33e7c1a82b254871230f29866d4e9 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:52 -0800
+Subject: [PATCH] firmware: enable to force disable the fallback mechanism at
+ run time
+
+You currently need four different kernel builds to test the firmware
+API fully. By adding a proc knob to force disable the fallback mechanism
+completely we are able to reduce the amount of kernels you need built
+to test the firmware API down to two.
+
+Acked-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c       | 5 +++++
+ drivers/base/firmware_loader/fallback.h       | 4 ++++
+ drivers/base/firmware_loader/fallback_table.c | 9 +++++++++
+ 3 files changed, 18 insertions(+)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 45cc40933a47b..d6838e7ec00c8 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -643,6 +643,11 @@ static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+ 
+ static bool fw_run_sysfs_fallback(unsigned int opt_flags)
+ {
++	if (fw_fallback_config.ignore_sysfs_fallback) {
++		pr_info_once("Ignoring firmware sysfs fallback due to debugfs knob\n");
++		return false;
++	}
++
+ 	if ((opt_flags & FW_OPT_NOFALLBACK))
+ 		return false;
+ 
+diff --git a/drivers/base/firmware_loader/fallback.h b/drivers/base/firmware_loader/fallback.h
+index ca7e69a8417bb..dfebc644ed35a 100644
+--- a/drivers/base/firmware_loader/fallback.h
++++ b/drivers/base/firmware_loader/fallback.h
+@@ -14,12 +14,16 @@
+  * 	as if one had enabled CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y.
+  * 	Useful to help debug a CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y
+  * 	functionality on a kernel where that config entry has been disabled.
++ * @ignore_sysfs_fallback: force to disable the sysfs fallback mechanism.
++ * 	This emulates the behaviour as if we had set the kernel
++ * 	config CONFIG_FW_LOADER_USER_HELPER=n.
+  * @old_timeout: for internal use
+  * @loading_timeout: the timeout to wait for the fallback mechanism before
+  * 	giving up, in seconds.
+  */
+ struct firmware_fallback_config {
+ 	unsigned int force_sysfs_fallback;
++	unsigned int ignore_sysfs_fallback;
+ 	int old_timeout;
+ 	int loading_timeout;
+ };
+diff --git a/drivers/base/firmware_loader/fallback_table.c b/drivers/base/firmware_loader/fallback_table.c
+index 92365e053e309..7428659d8df94 100644
+--- a/drivers/base/firmware_loader/fallback_table.c
++++ b/drivers/base/firmware_loader/fallback_table.c
+@@ -39,6 +39,15 @@ struct ctl_table firmware_config_table[] = {
+ 		.extra1		= &zero,
+ 		.extra2		= &one,
+ 	},
++	{
++		.procname	= "ignore_sysfs_fallback",
++		.data		= &fw_fallback_config.ignore_sysfs_fallback,
++		.maxlen         = sizeof(unsigned int),
++		.mode           = 0644,
++		.proc_handler   = proc_douintvec_minmax,
++		.extra1		= &zero,
++		.extra2		= &one,
++	},
+ 	{ }
+ };
+ EXPORT_SYMBOL_GPL(firmware_config_table);

--- a/target/linux/generic/backport-4.14/081-0008-firmware-rename-_request_firmware_load()-fw_load_sysfs_fallback().patch
+++ b/target/linux/generic/backport-4.14/081-0008-firmware-rename-_request_firmware_load()-fw_load_sysfs_fallback().patch
@@ -1,0 +1,59 @@
+From 60fa74263cbeae1704908c403aba2bfd62c798e8 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:55 -0800
+Subject: [PATCH] rename: _request_firmware_load() fw_load_sysfs_fallback()
+
+This reflects much clearer what is being done.
+While at it, kdoc'ify it.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ Documentation/driver-api/firmware/fallback-mechanisms.rst |  2 +-
+ drivers/base/firmware_loader/fallback.c                   | 13 ++++++++++---
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/Documentation/driver-api/firmware/fallback-mechanisms.rst b/Documentation/driver-api/firmware/fallback-mechanisms.rst
+index 4055ac76b288c..f353783ae0be5 100644
+--- a/Documentation/driver-api/firmware/fallback-mechanisms.rst
++++ b/Documentation/driver-api/firmware/fallback-mechanisms.rst
+@@ -112,7 +112,7 @@ Since a device is created for the sysfs interface to help load firmware as a
+ fallback mechanism userspace can be informed of the addition of the device by
+ relying on kobject uevents. The addition of the device into the device
+ hierarchy means the fallback mechanism for firmware loading has been initiated.
+-For details of implementation refer to _request_firmware_load(), in particular
++For details of implementation refer to fw_load_sysfs_fallback(), in particular
+ on the use of dev_set_uevent_suppress() and kobject_uevent().
+ 
+ The kernel's kobject uevent mechanism is implemented in lib/kobject_uevent.c,
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index d6838e7ec00c8..0a8ec7fec5857 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -535,8 +535,15 @@ fw_create_instance(struct firmware *firmware, const char *fw_name,
+ 	return fw_sysfs;
+ }
+ 
+-/* load a firmware via user helper */
+-static int _request_firmware_load(struct fw_sysfs *fw_sysfs,
++/**
++ * fw_load_sysfs_fallback - load a firmware via the syfs fallback mechanism
++ * @fw_sysfs: firmware syfs information for the firmware to load
++ * @opt_flags: flags of options, FW_OPT_*
++ * @timeout: timeout to wait for the load
++ *
++ * In charge of constructing a sysfs fallback interface for firmware loading.
++ **/
++static int fw_load_sysfs_fallback(struct fw_sysfs *fw_sysfs,
+ 				  unsigned int opt_flags, long timeout)
+ {
+ 	int retval = 0;
+@@ -621,7 +628,7 @@ static int fw_load_from_user_helper(struct firmware *firmware,
+ 	}
+ 
+ 	fw_sysfs->fw_priv = firmware->priv;
+-	ret = _request_firmware_load(fw_sysfs, opt_flags, timeout);
++	ret = fw_load_sysfs_fallback(fw_sysfs, opt_flags, timeout);
+ 
+ 	if (!ret)
+ 		ret = assign_fw(firmware, device, opt_flags);

--- a/target/linux/generic/backport-4.14/081-0009-firmware-fix-checking-for-return-values-for-fw_add_devm_name().patch
+++ b/target/linux/generic/backport-4.14/081-0009-firmware-fix-checking-for-return-values-for-fw_add_devm_name().patch
@@ -1,0 +1,66 @@
+From d15d7311550983be97dca44ad68cbc2ca001297b Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:56 -0800
+Subject: [PATCH] firmware: fix checking for return values for
+ fw_add_devm_name()
+
+Currently fw_add_devm_name() returns 1 if the firmware cache
+was already set. This makes it complicated for us to check for
+correctness. It is actually non-fatal if the firmware cache
+is already setup, so just return 0, and simplify the checkers.
+
+fw_add_devm_name() adds device's name onto the devres for the
+device so that prior to suspend we cache the firmware onto memory,
+so that on resume the firmware is reliably available. We never
+were checking for success for this call though, meaning in some
+really rare cases we my have never setup the firmware cache for
+a device, which could in turn make resume fail.
+
+This is all theoretical, no known issues have been reported.
+This small issue has been present way since the addition of the
+devres firmware cache names on v3.7.
+
+Fixes: f531f05ae9437 ("firmware loader: store firmware name into devres list")
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/main.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index c8966c84bd441..f5046887e3625 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -403,7 +403,7 @@ static int fw_add_devm_name(struct device *dev, const char *name)
+ 
+ 	fwn = fw_find_devm_name(dev, name);
+ 	if (fwn)
+-		return 1;
++		return 0;
+ 
+ 	fwn = devres_alloc(fw_name_devm_release, sizeof(struct fw_name_devm),
+ 			   GFP_KERNEL);
+@@ -431,6 +431,7 @@ int assign_fw(struct firmware *fw, struct device *device,
+ 	      unsigned int opt_flags)
+ {
+ 	struct fw_priv *fw_priv = fw->priv;
++	int ret;
+ 
+ 	mutex_lock(&fw_lock);
+ 	if (!fw_priv->size || fw_state_is_aborted(fw_priv)) {
+@@ -447,8 +448,13 @@ int assign_fw(struct firmware *fw, struct device *device,
+ 	 */
+ 	/* don't cache firmware handled without uevent */
+ 	if (device && (opt_flags & FW_OPT_UEVENT) &&
+-	    !(opt_flags & FW_OPT_NOCACHE))
+-		fw_add_devm_name(device, fw_priv->fw_name);
++	    !(opt_flags & FW_OPT_NOCACHE)) {
++		ret = fw_add_devm_name(device, fw_priv->fw_name);
++		if (ret) {
++			mutex_unlock(&fw_lock);
++			return ret;
++		}
++	}
+ 
+ 	/*
+ 	 * After caching firmware image is started, let it piggyback

--- a/target/linux/generic/backport-4.14/081-0010-firmware-add-helper-to-check-to-see-if-fw-cache-is-setup.patch
+++ b/target/linux/generic/backport-4.14/081-0010-firmware-add-helper-to-check-to-see-if-fw-cache-is-setup.patch
@@ -1,0 +1,44 @@
+From 3194d06a7e41d31ea4d8771b1ff3d93445e27403 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:57 -0800
+Subject: [PATCH] firmware: add helper to check to see if fw cache is setup
+
+Add a helper to check if the firmware cache is already setup for a device.
+This will be used later.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/main.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index f5046887e3625..b569d8a093926 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -396,13 +396,23 @@ static struct fw_name_devm *fw_find_devm_name(struct device *dev,
+ 	return fwn;
+ }
+ 
+-/* add firmware name into devres list */
+-static int fw_add_devm_name(struct device *dev, const char *name)
++static bool fw_cache_is_setup(struct device *dev, const char *name)
+ {
+ 	struct fw_name_devm *fwn;
+ 
+ 	fwn = fw_find_devm_name(dev, name);
+ 	if (fwn)
++		return true;
++
++	return false;
++}
++
++/* add firmware name into devres list */
++static int fw_add_devm_name(struct device *dev, const char *name)
++{
++	struct fw_name_devm *fwn;
++
++	if (fw_cache_is_setup(dev, name))
+ 		return 0;
+ 
+ 	fwn = devres_alloc(fw_name_devm_release, sizeof(struct fw_name_devm),

--- a/target/linux/generic/backport-4.14/081-0011-firmware-ensure-the-081-0006-firmware-cache-is-not-used-on-incompatible-calls.patch
+++ b/target/linux/generic/backport-4.14/081-0011-firmware-ensure-the-081-0006-firmware-cache-is-not-used-on-incompatible-calls.patch
@@ -1,0 +1,61 @@
+From 995e8695f65db7a8b465b5c27887b32e8e5bb66e Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Sat, 10 Mar 2018 06:14:59 -0800
+Subject: [PATCH] firmware: ensure the firmware cache is not used on
+ incompatible calls
+
+request_firmware_into_buf() explicitly disables the firmware cache,
+meanwhile the firmware cache cannot be used when request_firmware_nowait()
+is used without the uevent. Enforce a sanity check for this to avoid future
+issues undocumented behaviours should misuses of the firmware cache
+happen later.
+
+One of the reasons we want to enforce this is the firmware cache is
+used for helping with suspend/resume, and if incompatible calls use it
+they can stall suspend.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/main.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index b569d8a093926..2913bb0e5e7b0 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -431,6 +431,11 @@ static int fw_add_devm_name(struct device *dev, const char *name)
+ 	return 0;
+ }
+ #else
++static bool fw_cache_is_setup(struct device *dev, const char *name)
++{
++	return false;
++}
++
+ static int fw_add_devm_name(struct device *dev, const char *name)
+ {
+ 	return 0;
+@@ -672,6 +677,9 @@ request_firmware_into_buf(const struct firmware **firmware_p, const char *name,
+ {
+ 	int ret;
+ 
++	if (fw_cache_is_setup(device, name))
++		return -EOPNOTSUPP;
++
+ 	__module_get(THIS_MODULE);
+ 	ret = _request_firmware(firmware_p, name, device, buf, size,
+ 				FW_OPT_UEVENT | FW_OPT_NOCACHE);
+@@ -769,6 +777,12 @@ request_firmware_nowait(
+ 	fw_work->opt_flags = FW_OPT_NOWAIT |
+ 		(uevent ? FW_OPT_UEVENT : FW_OPT_USERHELPER);
+ 
++	if (!uevent && fw_cache_is_setup(device, name)) {
++		kfree_const(fw_work->name);
++		kfree(fw_work);
++		return -EOPNOTSUPP;
++	}
++
+ 	if (!try_module_get(module)) {
+ 		kfree_const(fw_work->name);
+ 		kfree(fw_work);

--- a/target/linux/generic/backport-4.14/081-0012-firmware-explicitly-include-vmalloc.h.patch
+++ b/target/linux/generic/backport-4.14/081-0012-firmware-explicitly-include-vmalloc.h.patch
@@ -1,0 +1,51 @@
+From ccce305bd411f1c3a15eb8ca3b3cf827e38bd47c Mon Sep 17 00:00:00 2001
+From: Stephen Rothwell <sfr@canb.auug.org.au>
+Date: Wed, 21 Mar 2018 19:06:35 +1100
+Subject: [PATCH] firmware: explicitly include vmalloc.h
+
+After some other include file changes, fixes:
+
+drivers/base/firmware_loader/fallback.c: In function 'map_fw_priv_pages':
+drivers/base/firmware_loader/fallback.c:232:2: error: implicit declaration of function 'vunmap'; did you mean 'kunmap'? [-Werror=implicit-function-declaration]
+  vunmap(fw_priv->data);
+  ^~~~~~
+  kunmap
+drivers/base/firmware_loader/fallback.c:233:18: error: implicit declaration of function 'vmap'; did you mean 'kmap'? [-Werror=implicit-function-declaration]
+  fw_priv->data = vmap(fw_priv->pages, fw_priv->nr_pages, 0,
+                  ^~~~
+                  kmap
+drivers/base/firmware_loader/fallback.c:233:16: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+  fw_priv->data = vmap(fw_priv->pages, fw_priv->nr_pages, 0,
+                ^
+drivers/base/firmware_loader/fallback.c: In function 'firmware_loading_store':
+drivers/base/firmware_loader/fallback.c:274:4: error: implicit declaration of function 'vfree'; did you mean 'kvfree'? [-Werror=implicit-function-declaration]
+    vfree(fw_priv->pages);
+    ^~~~~
+    kvfree
+drivers/base/firmware_loader/fallback.c: In function 'fw_realloc_pages':
+drivers/base/firmware_loader/fallback.c:405:15: error: implicit declaration of function 'vmalloc'; did you mean 'kvmalloc'? [-Werror=implicit-function-declaration]
+   new_pages = vmalloc(new_array_size * sizeof(void *));
+               ^~~~~~~
+               kvmalloc
+drivers/base/firmware_loader/fallback.c:405:13: warning: assignment makes pointer from integer without a cast [-Wint-conversion]
+   new_pages = vmalloc(new_array_size * sizeof(void *));
+             ^
+
+Signed-off-by: Stephen Rothwell <sfr@canb.auug.org.au>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 0a8ec7fec5857..d231bbcb95d7a 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -8,6 +8,7 @@
+ #include <linux/highmem.h>
+ #include <linux/umh.h>
+ #include <linux/sysctl.h>
++#include <linux/vmalloc.h>
+ 
+ #include "fallback.h"
+ #include "firmware.h"

--- a/target/linux/generic/backport-4.14/081-0013-firmware-fix-typo-on-pr_info_once()-when-ignore_sysfs_fallback-is-used.patch
+++ b/target/linux/generic/backport-4.14/081-0013-firmware-fix-typo-on-pr_info_once()-when-ignore_sysfs_fallback-is-used.patch
@@ -1,0 +1,29 @@
+From c6263a48459934c9d07153e6d7f0fa43462d8dd2 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Wed, 21 Mar 2018 15:34:28 -0700
+Subject: [PATCH] firmware: fix typo on pr_info_once() when
+ ignore_sysfs_fallback is used
+
+When the sysctl knob is used ignore the fallback mechanism we pr_info_once()
+to ensure its noted the knob was used. The print incorrectly states its a
+debugfs knob, its a sysctl knob, so correct this typo.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index d231bbcb95d7a..31b5015b59fec 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -652,7 +652,7 @@ static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+ static bool fw_run_sysfs_fallback(unsigned int opt_flags)
+ {
+ 	if (fw_fallback_config.ignore_sysfs_fallback) {
+-		pr_info_once("Ignoring firmware sysfs fallback due to debugfs knob\n");
++		pr_info_once("Ignoring firmware sysfs fallback due to sysctl knob\n");
+ 		return false;
+ 	}
+ 

--- a/target/linux/generic/backport-4.14/081-0014-firmware-add-firmware_request_cache()-to-help-with-cache-on-reboot.patch
+++ b/target/linux/generic/backport-4.14/081-0014-firmware-add-firmware_request_cache()-to-help-with-cache-on-reboot.patch
@@ -1,0 +1,96 @@
+From 5d42c96e1cf98bdfea18e7d32e5f6cf75aac93b9 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Wed, 21 Mar 2018 15:34:29 -0700
+Subject: [PATCH] firmware: add firmware_request_cache() to help with cache on
+ reboot
+
+Some devices have an optimization in place to enable the firmware to
+be retaineed during a system reboot, so after reboot the device can skip
+requesting and loading the firmware. This can save up to 1s in load
+time. The mt7601u 802.11 device happens to be such a device.
+
+When these devices retain the firmware on a reboot and then suspend
+they can miss looking for the firmware on resume. To help with this we
+need a way to cache the firmware when such an optimization has taken
+place.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ .../driver-api/firmware/request_firmware.rst       | 14 +++++++++++++
+ drivers/base/firmware_loader/main.c                | 24 ++++++++++++++++++++++
+ include/linux/firmware.h                           |  3 +++
+ 3 files changed, 41 insertions(+)
+
+diff --git a/Documentation/driver-api/firmware/request_firmware.rst b/Documentation/driver-api/firmware/request_firmware.rst
+index cc0aea8808244..cf4516dfbf964 100644
+--- a/Documentation/driver-api/firmware/request_firmware.rst
++++ b/Documentation/driver-api/firmware/request_firmware.rst
+@@ -44,6 +44,20 @@ request_firmware_nowait
+ .. kernel-doc:: drivers/base/firmware_class.c
+    :functions: request_firmware_nowait
+ 
++Special optimizations on reboot
++===============================
++
++Some devices have an optimization in place to enable the firmware to be
++retained during system reboot. When such optimizations are used the driver
++author must ensure the firmware is still available on resume from suspend,
++this can be done with firmware_request_cache() insted of requesting for the
++firmare to be loaded.
++
++firmware_request_cache()
++-----------------------
++.. kernel-doc:: drivers/base/firmware_class.c
++   :functions: firmware_request_cache
++
+ request firmware API expected driver use
+ ========================================
+ 
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index 2913bb0e5e7b0..eb34089e42995 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -656,6 +656,30 @@ int request_firmware_direct(const struct firmware **firmware_p,
+ }
+ EXPORT_SYMBOL_GPL(request_firmware_direct);
+ 
++/**
++ * firmware_request_cache: - cache firmware for suspend so resume can use it
++ * @name: name of firmware file
++ * @device: device for which firmware should be cached for
++ *
++ * There are some devices with an optimization that enables the device to not
++ * require loading firmware on system reboot. This optimization may still
++ * require the firmware present on resume from suspend. This routine can be
++ * used to ensure the firmware is present on resume from suspend in these
++ * situations. This helper is not compatible with drivers which use
++ * request_firmware_into_buf() or request_firmware_nowait() with no uevent set.
++ **/
++int firmware_request_cache(struct device *device, const char *name)
++{
++	int ret;
++
++	mutex_lock(&fw_lock);
++	ret = fw_add_devm_name(device, name);
++	mutex_unlock(&fw_lock);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(firmware_request_cache);
++
+ /**
+  * request_firmware_into_buf - load firmware into a previously allocated buffer
+  * @firmware_p: pointer to firmware image
+diff --git a/include/linux/firmware.h b/include/linux/firmware.h
+index d4508080348d3..41050417cafb7 100644
+--- a/include/linux/firmware.h
++++ b/include/linux/firmware.h
+@@ -85,4 +85,7 @@ static inline int request_firmware_into_buf(const struct firmware **firmware_p,
+ }
+ 
+ #endif
++
++int firmware_request_cache(struct device *device, const char *name);
++
+ #endif

--- a/target/linux/generic/backport-4.14/081-0015-firmware-some-documentation-fixes.patch
+++ b/target/linux/generic/backport-4.14/081-0015-firmware-some-documentation-fixes.patch
@@ -1,0 +1,46 @@
+From b93815d0f37e7c4a056a143e6d782abc084ea56b Mon Sep 17 00:00:00 2001
+From: Andres Rodriguez <andresx7@gmail.com>
+Date: Wed, 25 Apr 2018 12:25:39 -0400
+Subject: [PATCH] firmware: some documentation fixes
+
+Including:
+ - Fixup outdated kernel-doc paths
+ - Slightly too short title underline
+ - Some typos
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ Documentation/driver-api/firmware/request_firmware.rst | 6 +++---
+ drivers/base/firmware_loader/fallback.c                | 4 ++--
+ drivers/base/firmware_loader/fallback.h                | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 31b5015b59fec..358354148decc 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -537,8 +537,8 @@ fw_create_instance(struct firmware *firmware, const char *fw_name,
+ }
+ 
+ /**
+- * fw_load_sysfs_fallback - load a firmware via the syfs fallback mechanism
+- * @fw_sysfs: firmware syfs information for the firmware to load
++ * fw_load_sysfs_fallback - load a firmware via the sysfs fallback mechanism
++ * @fw_sysfs: firmware sysfs information for the firmware to load
+  * @opt_flags: flags of options, FW_OPT_*
+  * @timeout: timeout to wait for the load
+  *
+diff --git a/drivers/base/firmware_loader/fallback.h b/drivers/base/firmware_loader/fallback.h
+index dfebc644ed35a..f8255670a6635 100644
+--- a/drivers/base/firmware_loader/fallback.h
++++ b/drivers/base/firmware_loader/fallback.h
+@@ -6,7 +6,7 @@
+ #include <linux/device.h>
+ 
+ /**
+- * struct firmware_fallback_config - firmware fallback configuratioon settings
++ * struct firmware_fallback_config - firmware fallback configuration settings
+  *
+  * Helps describe and fine tune the fallback mechanism.
+  *

--- a/target/linux/generic/backport-4.14/081-0016-firmware-wrap-FW_OPT_-into-an-enum.patch
+++ b/target/linux/generic/backport-4.14/081-0016-firmware-wrap-FW_OPT_-into-an-enum.patch
@@ -1,0 +1,202 @@
+From eb33eb04926e40331750f538a58d93cde87afaa4 Mon Sep 17 00:00:00 2001
+From: Andres Rodriguez <andresx7@gmail.com>
+Date: Thu, 10 May 2018 13:08:37 -0700
+Subject: [PATCH] firmware: wrap FW_OPT_* into an enum
+
+This should let us associate enum kdoc to these values.
+While at it, kdocify the fw_opt.
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: coding style fixes, merge kdoc with enum move]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c | 12 +++++------
+ drivers/base/firmware_loader/fallback.h |  6 ++++--
+ drivers/base/firmware_loader/firmware.h | 37 ++++++++++++++++++++++++++-------
+ drivers/base/firmware_loader/main.c     |  6 +++---
+ 4 files changed, 42 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 358354148decc..b57a7b3b4122f 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -512,7 +512,7 @@ static const struct attribute_group *fw_dev_attr_groups[] = {
+ 
+ static struct fw_sysfs *
+ fw_create_instance(struct firmware *firmware, const char *fw_name,
+-		   struct device *device, unsigned int opt_flags)
++		   struct device *device, enum fw_opt opt_flags)
+ {
+ 	struct fw_sysfs *fw_sysfs;
+ 	struct device *f_dev;
+@@ -545,7 +545,7 @@ fw_create_instance(struct firmware *firmware, const char *fw_name,
+  * In charge of constructing a sysfs fallback interface for firmware loading.
+  **/
+ static int fw_load_sysfs_fallback(struct fw_sysfs *fw_sysfs,
+-				  unsigned int opt_flags, long timeout)
++				  enum fw_opt opt_flags, long timeout)
+ {
+ 	int retval = 0;
+ 	struct device *f_dev = &fw_sysfs->dev;
+@@ -599,7 +599,7 @@ static int fw_load_sysfs_fallback(struct fw_sysfs *fw_sysfs,
+ 
+ static int fw_load_from_user_helper(struct firmware *firmware,
+ 				    const char *name, struct device *device,
+-				    unsigned int opt_flags)
++				    enum fw_opt opt_flags)
+ {
+ 	struct fw_sysfs *fw_sysfs;
+ 	long timeout;
+@@ -640,7 +640,7 @@ static int fw_load_from_user_helper(struct firmware *firmware,
+ 	return ret;
+ }
+ 
+-static bool fw_force_sysfs_fallback(unsigned int opt_flags)
++static bool fw_force_sysfs_fallback(enum fw_opt opt_flags)
+ {
+ 	if (fw_fallback_config.force_sysfs_fallback)
+ 		return true;
+@@ -649,7 +649,7 @@ static bool fw_force_sysfs_fallback(unsigned int opt_flags)
+ 	return true;
+ }
+ 
+-static bool fw_run_sysfs_fallback(unsigned int opt_flags)
++static bool fw_run_sysfs_fallback(enum fw_opt opt_flags)
+ {
+ 	if (fw_fallback_config.ignore_sysfs_fallback) {
+ 		pr_info_once("Ignoring firmware sysfs fallback due to sysctl knob\n");
+@@ -664,7 +664,7 @@ static bool fw_run_sysfs_fallback(unsigned int opt_flags)
+ 
+ int fw_sysfs_fallback(struct firmware *fw, const char *name,
+ 		      struct device *device,
+-		      unsigned int opt_flags,
++		      enum fw_opt opt_flags,
+ 		      int ret)
+ {
+ 	if (!fw_run_sysfs_fallback(opt_flags))
+diff --git a/drivers/base/firmware_loader/fallback.h b/drivers/base/firmware_loader/fallback.h
+index f8255670a6635..a3b73a09db6c9 100644
+--- a/drivers/base/firmware_loader/fallback.h
++++ b/drivers/base/firmware_loader/fallback.h
+@@ -5,6 +5,8 @@
+ #include <linux/firmware.h>
+ #include <linux/device.h>
+ 
++#include "firmware.h"
++
+ /**
+  * struct firmware_fallback_config - firmware fallback configuration settings
+  *
+@@ -31,7 +33,7 @@ struct firmware_fallback_config {
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+ int fw_sysfs_fallback(struct firmware *fw, const char *name,
+ 		      struct device *device,
+-		      unsigned int opt_flags,
++		      enum fw_opt opt_flags,
+ 		      int ret);
+ void kill_pending_fw_fallback_reqs(bool only_kill_custom);
+ 
+@@ -43,7 +45,7 @@ void unregister_sysfs_loader(void);
+ #else /* CONFIG_FW_LOADER_USER_HELPER */
+ static inline int fw_sysfs_fallback(struct firmware *fw, const char *name,
+ 				    struct device *device,
+-				    unsigned int opt_flags,
++				    enum fw_opt opt_flags,
+ 				    int ret)
+ {
+ 	/* Keep carrying over the same error */
+diff --git a/drivers/base/firmware_loader/firmware.h b/drivers/base/firmware_loader/firmware.h
+index 64acbb1a392c7..4f433b447367e 100644
+--- a/drivers/base/firmware_loader/firmware.h
++++ b/drivers/base/firmware_loader/firmware.h
+@@ -2,6 +2,7 @@
+ #ifndef __FIRMWARE_LOADER_H
+ #define __FIRMWARE_LOADER_H
+ 
++#include <linux/bitops.h>
+ #include <linux/firmware.h>
+ #include <linux/types.h>
+ #include <linux/kref.h>
+@@ -10,13 +11,33 @@
+ 
+ #include <generated/utsrelease.h>
+ 
+-/* firmware behavior options */
+-#define FW_OPT_UEVENT			(1U << 0)
+-#define FW_OPT_NOWAIT			(1U << 1)
+-#define FW_OPT_USERHELPER		(1U << 2)
+-#define FW_OPT_NO_WARN			(1U << 3)
+-#define FW_OPT_NOCACHE			(1U << 4)
+-#define FW_OPT_NOFALLBACK		(1U << 5)
++/**
++ * enum fw_opt - options to control firmware loading behaviour
++ *
++ * @FW_OPT_UEVENT: Enables the fallback mechanism to send a kobject uevent
++ *	when the firmware is not found. Userspace is in charge to load the
++ *	firmware using the sysfs loading facility.
++ * @FW_OPT_NOWAIT: Used to describe the firmware request is asynchronous.
++ * @FW_OPT_USERHELPER: Enable the fallback mechanism, in case the direct
++ *	filesystem lookup fails at finding the firmware.  For details refer to
++ *	fw_sysfs_fallback().
++ * @FW_OPT_NO_WARN: Quiet, avoid printing warning messages.
++ * @FW_OPT_NOCACHE: Disables firmware caching. Firmware caching is used to
++ *	cache the firmware upon suspend, so that upon resume races against the
++ *	firmware file lookup on storage is avoided. Used for calls where the
++ *	file may be too big, or where the driver takes charge of its own
++ *	firmware caching mechanism.
++ * @FW_OPT_NOFALLBACK: Disable the fallback mechanism. Takes precedence over
++ *	&FW_OPT_UEVENT and &FW_OPT_USERHELPER.
++ */
++enum fw_opt {
++	FW_OPT_UEVENT =         BIT(0),
++	FW_OPT_NOWAIT =         BIT(1),
++	FW_OPT_USERHELPER =     BIT(2),
++	FW_OPT_NO_WARN =        BIT(3),
++	FW_OPT_NOCACHE =        BIT(4),
++	FW_OPT_NOFALLBACK =     BIT(5),
++};
+ 
+ enum fw_status {
+ 	FW_STATUS_UNKNOWN,
+@@ -110,6 +131,6 @@ static inline void fw_state_done(struct fw_priv *fw_priv)
+ }
+ 
+ int assign_fw(struct firmware *fw, struct device *device,
+-	      unsigned int opt_flags);
++	      enum fw_opt opt_flags);
+ 
+ #endif /* __FIRMWARE_LOADER_H */
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index eb34089e42995..9919f0e6a7ccf 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -443,7 +443,7 @@ static int fw_add_devm_name(struct device *dev, const char *name)
+ #endif
+ 
+ int assign_fw(struct firmware *fw, struct device *device,
+-	      unsigned int opt_flags)
++	      enum fw_opt opt_flags)
+ {
+ 	struct fw_priv *fw_priv = fw->priv;
+ 	int ret;
+@@ -558,7 +558,7 @@ static void fw_abort_batch_reqs(struct firmware *fw)
+ static int
+ _request_firmware(const struct firmware **firmware_p, const char *name,
+ 		  struct device *device, void *buf, size_t size,
+-		  unsigned int opt_flags)
++		  enum fw_opt opt_flags)
+ {
+ 	struct firmware *fw = NULL;
+ 	int ret;
+@@ -734,7 +734,7 @@ struct firmware_work {
+ 	struct device *device;
+ 	void *context;
+ 	void (*cont)(const struct firmware *fw, void *context);
+-	unsigned int opt_flags;
++	enum fw_opt opt_flags;
+ };
+ 
+ static void request_firmware_work_func(struct work_struct *work)

--- a/target/linux/generic/backport-4.14/081-0017-firmware-use-()-to-terminate-kernel-doc-function-names.patch
+++ b/target/linux/generic/backport-4.14/081-0017-firmware-use-()-to-terminate-kernel-doc-function-names.patch
@@ -1,0 +1,162 @@
+From c35f9cbb1df8f17d398112173024a76964b5154d Mon Sep 17 00:00:00 2001
+From: Andres Rodriguez <andresx7@gmail.com>
+Date: Thu, 10 May 2018 13:08:38 -0700
+Subject: [PATCH] firmware: use () to terminate kernel-doc function names
+
+The kernel-doc spec dictates a function name ends in ().
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Randy Dunlap <rdunlap@infradead.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: adjust since the wide API rename is not yet merged]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c |  8 ++++----
+ drivers/base/firmware_loader/main.c     | 22 +++++++++++-----------
+ 2 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index b57a7b3b4122f..529f7013616f8 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -125,7 +125,7 @@ static ssize_t timeout_show(struct class *class, struct class_attribute *attr,
+ }
+ 
+ /**
+- * firmware_timeout_store - set number of seconds to wait for firmware
++ * firmware_timeout_store() - set number of seconds to wait for firmware
+  * @class: device class pointer
+  * @attr: device attribute pointer
+  * @buf: buffer to scan for timeout value
+@@ -239,7 +239,7 @@ static int map_fw_priv_pages(struct fw_priv *fw_priv)
+ }
+ 
+ /**
+- * firmware_loading_store - set value in the 'loading' control file
++ * firmware_loading_store() - set value in the 'loading' control file
+  * @dev: device pointer
+  * @attr: device attribute pointer
+  * @buf: buffer to scan for loading control value
+@@ -431,7 +431,7 @@ static int fw_realloc_pages(struct fw_sysfs *fw_sysfs, int min_size)
+ }
+ 
+ /**
+- * firmware_data_write - write method for firmware
++ * firmware_data_write() - write method for firmware
+  * @filp: open sysfs file
+  * @kobj: kobject for the device
+  * @bin_attr: bin_attr structure
+@@ -537,7 +537,7 @@ fw_create_instance(struct firmware *firmware, const char *fw_name,
+ }
+ 
+ /**
+- * fw_load_sysfs_fallback - load a firmware via the sysfs fallback mechanism
++ * fw_load_sysfs_fallback() - load a firmware via the sysfs fallback mechanism
+  * @fw_sysfs: firmware sysfs information for the firmware to load
+  * @opt_flags: flags of options, FW_OPT_*
+  * @timeout: timeout to wait for the load
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index 9919f0e6a7ccf..4d11efadb3a41 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -597,7 +597,7 @@ _request_firmware(const struct firmware **firmware_p, const char *name,
+ }
+ 
+ /**
+- * request_firmware: - send firmware request and wait for it
++ * request_firmware() - send firmware request and wait for it
+  * @firmware_p: pointer to firmware image
+  * @name: name of firmware file
+  * @device: device for which firmware is being loaded
+@@ -632,7 +632,7 @@ request_firmware(const struct firmware **firmware_p, const char *name,
+ EXPORT_SYMBOL(request_firmware);
+ 
+ /**
+- * request_firmware_direct: - load firmware directly without usermode helper
++ * request_firmware_direct() - load firmware directly without usermode helper
+  * @firmware_p: pointer to firmware image
+  * @name: name of firmware file
+  * @device: device for which firmware is being loaded
+@@ -657,7 +657,7 @@ int request_firmware_direct(const struct firmware **firmware_p,
+ EXPORT_SYMBOL_GPL(request_firmware_direct);
+ 
+ /**
+- * firmware_request_cache: - cache firmware for suspend so resume can use it
++ * firmware_request_cache() - cache firmware for suspend so resume can use it
+  * @name: name of firmware file
+  * @device: device for which firmware should be cached for
+  *
+@@ -681,7 +681,7 @@ int firmware_request_cache(struct device *device, const char *name)
+ EXPORT_SYMBOL_GPL(firmware_request_cache);
+ 
+ /**
+- * request_firmware_into_buf - load firmware into a previously allocated buffer
++ * request_firmware_into_buf() - load firmware into a previously allocated buffer
+  * @firmware_p: pointer to firmware image
+  * @name: name of firmware file
+  * @device: device for which firmware is being loaded and DMA region allocated
+@@ -713,7 +713,7 @@ request_firmware_into_buf(const struct firmware **firmware_p, const char *name,
+ EXPORT_SYMBOL(request_firmware_into_buf);
+ 
+ /**
+- * release_firmware: - release the resource associated with a firmware image
++ * release_firmware() - release the resource associated with a firmware image
+  * @fw: firmware resource to release
+  **/
+ void release_firmware(const struct firmware *fw)
+@@ -755,7 +755,7 @@ static void request_firmware_work_func(struct work_struct *work)
+ }
+ 
+ /**
+- * request_firmware_nowait - asynchronous version of request_firmware
++ * request_firmware_nowait() - asynchronous version of request_firmware
+  * @module: module requesting the firmware
+  * @uevent: sends uevent to copy the firmware image if this flag
+  *	is non-zero else the firmware copy must be done manually.
+@@ -824,7 +824,7 @@ EXPORT_SYMBOL(request_firmware_nowait);
+ static ASYNC_DOMAIN_EXCLUSIVE(fw_cache_domain);
+ 
+ /**
+- * cache_firmware - cache one firmware image in kernel memory space
++ * cache_firmware() - cache one firmware image in kernel memory space
+  * @fw_name: the firmware image name
+  *
+  * Cache firmware in kernel memory so that drivers can use it when
+@@ -866,7 +866,7 @@ static struct fw_priv *lookup_fw_priv(const char *fw_name)
+ }
+ 
+ /**
+- * uncache_firmware - remove one cached firmware image
++ * uncache_firmware() - remove one cached firmware image
+  * @fw_name: the firmware image name
+  *
+  * Uncache one firmware image which has been cached successfully
+@@ -1042,7 +1042,7 @@ static void __device_uncache_fw_images(void)
+ }
+ 
+ /**
+- * device_cache_fw_images - cache devices' firmware
++ * device_cache_fw_images() - cache devices' firmware
+  *
+  * If one device called request_firmware or its nowait version
+  * successfully before, the firmware names are recored into the
+@@ -1075,7 +1075,7 @@ static void device_cache_fw_images(void)
+ }
+ 
+ /**
+- * device_uncache_fw_images - uncache devices' firmware
++ * device_uncache_fw_images() - uncache devices' firmware
+  *
+  * uncache all firmwares which have been cached successfully
+  * by device_uncache_fw_images earlier
+@@ -1092,7 +1092,7 @@ static void device_uncache_fw_images_work(struct work_struct *work)
+ }
+ 
+ /**
+- * device_uncache_fw_images_delay - uncache devices firmwares
++ * device_uncache_fw_images_delay() - uncache devices firmwares
+  * @delay: number of milliseconds to delay uncache device firmwares
+  *
+  * uncache all devices's firmwares which has been cached successfully

--- a/target/linux/generic/backport-4.14/081-0018-firmware-rename-fw_sysfs_fallback-to-firmware_fallback_sysfs().patch
+++ b/target/linux/generic/backport-4.14/081-0018-firmware-rename-fw_sysfs_fallback-to-firmware_fallback_sysfs().patch
@@ -1,0 +1,102 @@
+From cf1cde7cd6e42aa65aa7a80e4980afe6d1a1330e Mon Sep 17 00:00:00 2001
+From: Andres Rodriguez <andresx7@gmail.com>
+Date: Thu, 10 May 2018 13:08:39 -0700
+Subject: [PATCH] firmware: rename fw_sysfs_fallback to
+ firmware_fallback_sysfs()
+
+This is done since this call is now exposed through kernel-doc,
+and since this also paves the way for different future types of
+fallback mechanims.
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: small coding style changes]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c |  8 ++++----
+ drivers/base/firmware_loader/fallback.h | 16 ++++++++--------
+ drivers/base/firmware_loader/firmware.h |  2 +-
+ drivers/base/firmware_loader/main.c     |  2 +-
+ 4 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 529f7013616f8..3db9e0f225acc 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -662,10 +662,10 @@ static bool fw_run_sysfs_fallback(enum fw_opt opt_flags)
+ 	return fw_force_sysfs_fallback(opt_flags);
+ }
+ 
+-int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-		      struct device *device,
+-		      enum fw_opt opt_flags,
+-		      int ret)
++int firmware_fallback_sysfs(struct firmware *fw, const char *name,
++			    struct device *device,
++			    enum fw_opt opt_flags,
++			    int ret)
+ {
+ 	if (!fw_run_sysfs_fallback(opt_flags))
+ 		return ret;
+diff --git a/drivers/base/firmware_loader/fallback.h b/drivers/base/firmware_loader/fallback.h
+index a3b73a09db6c9..21063503e4ea1 100644
+--- a/drivers/base/firmware_loader/fallback.h
++++ b/drivers/base/firmware_loader/fallback.h
+@@ -31,10 +31,10 @@ struct firmware_fallback_config {
+ };
+ 
+ #ifdef CONFIG_FW_LOADER_USER_HELPER
+-int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-		      struct device *device,
+-		      enum fw_opt opt_flags,
+-		      int ret);
++int firmware_fallback_sysfs(struct firmware *fw, const char *name,
++			    struct device *device,
++			    enum fw_opt opt_flags,
++			    int ret);
+ void kill_pending_fw_fallback_reqs(bool only_kill_custom);
+ 
+ void fw_fallback_set_cache_timeout(void);
+@@ -43,10 +43,10 @@ void fw_fallback_set_default_timeout(void);
+ int register_sysfs_loader(void);
+ void unregister_sysfs_loader(void);
+ #else /* CONFIG_FW_LOADER_USER_HELPER */
+-static inline int fw_sysfs_fallback(struct firmware *fw, const char *name,
+-				    struct device *device,
+-				    enum fw_opt opt_flags,
+-				    int ret)
++static inline int firmware_fallback_sysfs(struct firmware *fw, const char *name,
++					  struct device *device,
++					  enum fw_opt opt_flags,
++					  int ret)
+ {
+ 	/* Keep carrying over the same error */
+ 	return ret;
+diff --git a/drivers/base/firmware_loader/firmware.h b/drivers/base/firmware_loader/firmware.h
+index 4f433b447367e..4c1395f8e7ed2 100644
+--- a/drivers/base/firmware_loader/firmware.h
++++ b/drivers/base/firmware_loader/firmware.h
+@@ -20,7 +20,7 @@
+  * @FW_OPT_NOWAIT: Used to describe the firmware request is asynchronous.
+  * @FW_OPT_USERHELPER: Enable the fallback mechanism, in case the direct
+  *	filesystem lookup fails at finding the firmware.  For details refer to
+- *	fw_sysfs_fallback().
++ *	firmware_fallback_sysfs().
+  * @FW_OPT_NO_WARN: Quiet, avoid printing warning messages.
+  * @FW_OPT_NOCACHE: Disables firmware caching. Firmware caching is used to
+  *	cache the firmware upon suspend, so that upon resume races against the
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index 4d11efadb3a41..abdc4e4d55f1b 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -581,7 +581,7 @@ _request_firmware(const struct firmware **firmware_p, const char *name,
+ 			dev_warn(device,
+ 				 "Direct firmware load for %s failed with error %d\n",
+ 				 name, ret);
+-		ret = fw_sysfs_fallback(fw, name, device, opt_flags, ret);
++		ret = firmware_fallback_sysfs(fw, name, device, opt_flags, ret);
+ 	} else
+ 		ret = assign_fw(fw, device, opt_flags);
+ 

--- a/target/linux/generic/backport-4.14/081-0019-firmware_loader-document-firmware_sysfs_fallback().patch
+++ b/target/linux/generic/backport-4.14/081-0019-firmware_loader-document-firmware_sysfs_fallback().patch
@@ -1,0 +1,46 @@
+From 84b5c4fec73353a8946fe3f2d43e407d7a53a050 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Thu, 10 May 2018 13:08:40 -0700
+Subject: [PATCH] firmware_loader: document firmware_sysfs_fallback()
+
+This also sets the expecations for future fallback interfaces, even
+if they are not exported.
+
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 3db9e0f225acc..9169e7b9800c8 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -662,6 +662,26 @@ static bool fw_run_sysfs_fallback(enum fw_opt opt_flags)
+ 	return fw_force_sysfs_fallback(opt_flags);
+ }
+ 
++/**
++ * firmware_fallback_sysfs() - use the fallback mechanism to find firmware
++ * @fw: pointer to firmware image
++ * @name: name of firmware file to look for
++ * @device: device for which firmware is being loaded
++ * @opt_flags: options to control firmware loading behaviour
++ * @ret: return value from direct lookup which triggered the fallback mechanism
++ *
++ * This function is called if direct lookup for the firmware failed, it enables
++ * a fallback mechanism through userspace by exposing a sysfs loading
++ * interface. Userspace is in charge of loading the firmware through the syfs
++ * loading interface. This syfs fallback mechanism may be disabled completely
++ * on a system by setting the proc sysctl value ignore_sysfs_fallback to true.
++ * If this false we check if the internal API caller set the @FW_OPT_NOFALLBACK
++ * flag, if so it would also disable the fallback mechanism. A system may want
++ * to enfoce the sysfs fallback mechanism at all times, it can do this by
++ * setting ignore_sysfs_fallback to false and force_sysfs_fallback to true.
++ * Enabling force_sysfs_fallback is functionally equivalent to build a kernel
++ * with CONFIG_FW_LOADER_USER_HELPER_FALLBACK.
++ **/
+ int firmware_fallback_sysfs(struct firmware *fw, const char *name,
+ 			    struct device *device,
+ 			    enum fw_opt opt_flags,

--- a/target/linux/generic/backport-4.14/081-0020-firmware-Drop-FIRMWARE_IN_KERNEL-Kconfig-option.patch
+++ b/target/linux/generic/backport-4.14/081-0020-firmware-Drop-FIRMWARE_IN_KERNEL-Kconfig-option.patch
@@ -1,0 +1,749 @@
+From 7f55c733b6607d6bfc16057641f18280e587cca8 Mon Sep 17 00:00:00 2001
+From: Benjamin Gilbert <benjamin.gilbert@coreos.com>
+Date: Tue, 23 Jan 2018 18:06:31 -0800
+Subject: [PATCH] firmware: Drop FIRMWARE_IN_KERNEL Kconfig option
+
+It doesn't actually do anything.  Merge its help text into
+EXTRA_FIRMWARE.
+
+Fixes: 5620a0d1aacd ("firmware: delete in-kernel firmware")
+Fixes: 0946b2fb38fd ("firmware: cleanup FIRMWARE_IN_KERNEL message")
+Signed-off-by: Benjamin Gilbert <benjamin.gilbert@coreos.com>
+Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ arch/arc/configs/axs101_defconfig          |  1 -
+ arch/arc/configs/axs103_defconfig          |  1 -
+ arch/arc/configs/axs103_smp_defconfig      |  1 -
+ arch/arc/configs/haps_hs_defconfig         |  1 -
+ arch/arc/configs/haps_hs_smp_defconfig     |  1 -
+ arch/arc/configs/hsdk_defconfig            |  1 -
+ arch/arc/configs/nsim_700_defconfig        |  1 -
+ arch/arc/configs/nsim_hs_defconfig         |  1 -
+ arch/arc/configs/nsim_hs_smp_defconfig     |  1 -
+ arch/arc/configs/nsimosci_defconfig        |  1 -
+ arch/arc/configs/nsimosci_hs_defconfig     |  1 -
+ arch/arc/configs/nsimosci_hs_smp_defconfig |  1 -
+ arch/arc/configs/tb10x_defconfig           |  1 -
+ arch/arc/configs/vdk_hs38_defconfig        |  1 -
+ arch/arc/configs/vdk_hs38_smp_defconfig    |  1 -
+ arch/arm/configs/cns3420vb_defconfig       |  1 -
+ arch/arm/configs/magician_defconfig        |  1 -
+ arch/arm/configs/mini2440_defconfig        |  1 -
+ arch/arm/configs/mv78xx0_defconfig         |  1 -
+ arch/arm/configs/mxs_defconfig             |  1 -
+ arch/arm/configs/orion5x_defconfig         |  1 -
+ arch/arm/configs/tegra_defconfig           |  1 -
+ arch/arm/configs/vf610m4_defconfig         |  1 -
+ arch/m68k/configs/amiga_defconfig          |  1 -
+ arch/m68k/configs/apollo_defconfig         |  1 -
+ arch/m68k/configs/atari_defconfig          |  1 -
+ arch/m68k/configs/bvme6000_defconfig       |  1 -
+ arch/m68k/configs/hp300_defconfig          |  1 -
+ arch/m68k/configs/mac_defconfig            |  1 -
+ arch/m68k/configs/multi_defconfig          |  1 -
+ arch/m68k/configs/mvme147_defconfig        |  1 -
+ arch/m68k/configs/mvme16x_defconfig        |  1 -
+ arch/m68k/configs/q40_defconfig            |  1 -
+ arch/m68k/configs/sun3_defconfig           |  1 -
+ arch/m68k/configs/sun3x_defconfig          |  1 -
+ arch/mips/configs/ar7_defconfig            |  1 -
+ arch/mips/configs/ath25_defconfig          |  1 -
+ arch/mips/configs/ath79_defconfig          |  1 -
+ arch/mips/configs/pic32mzda_defconfig      |  1 -
+ arch/mips/configs/qi_lb60_defconfig        |  1 -
+ arch/mips/configs/rt305x_defconfig         |  1 -
+ arch/mips/configs/xway_defconfig           |  1 -
+ arch/mn10300/configs/asb2364_defconfig     |  1 -
+ arch/powerpc/configs/44x/warp_defconfig    |  1 -
+ arch/powerpc/configs/mpc512x_defconfig     |  1 -
+ arch/powerpc/configs/ppc6xx_defconfig      |  1 -
+ arch/powerpc/configs/ps3_defconfig         |  1 -
+ arch/powerpc/configs/wii_defconfig         |  1 -
+ arch/s390/configs/zfcpdump_defconfig       |  1 -
+ arch/sh/configs/polaris_defconfig          |  1 -
+ arch/tile/configs/tilegx_defconfig         |  1 -
+ arch/tile/configs/tilepro_defconfig        |  1 -
+ drivers/base/Kconfig                       | 28 +++++-----------------------
+ 53 files changed, 5 insertions(+), 75 deletions(-)
+
+diff --git a/arch/arc/configs/axs101_defconfig b/arch/arc/configs/axs101_defconfig
+index ec7c849a5c8e9..09f85154c5a4b 100644
+--- a/arch/arc/configs/axs101_defconfig
++++ b/arch/arc/configs/axs101_defconfig
+@@ -44,7 +44,6 @@ CONFIG_IP_PNP_RARP=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_SCSI=y
+ CONFIG_BLK_DEV_SD=y
+ CONFIG_NETDEVICES=y
+diff --git a/arch/arc/configs/axs103_defconfig b/arch/arc/configs/axs103_defconfig
+index 63d3cf69e0b02..09fed3ef22b6a 100644
+--- a/arch/arc/configs/axs103_defconfig
++++ b/arch/arc/configs/axs103_defconfig
+@@ -44,7 +44,6 @@ CONFIG_IP_PNP_RARP=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_SCSI=y
+ CONFIG_BLK_DEV_SD=y
+diff --git a/arch/arc/configs/axs103_smp_defconfig b/arch/arc/configs/axs103_smp_defconfig
+index f613ecac14a75..ea2f6d817d1ae 100644
+--- a/arch/arc/configs/axs103_smp_defconfig
++++ b/arch/arc/configs/axs103_smp_defconfig
+@@ -45,7 +45,6 @@ CONFIG_IP_PNP_RARP=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_SCSI=y
+ CONFIG_BLK_DEV_SD=y
+diff --git a/arch/arc/configs/haps_hs_defconfig b/arch/arc/configs/haps_hs_defconfig
+index db04ea4dd2d97..ab231c040efe5 100644
+--- a/arch/arc/configs/haps_hs_defconfig
++++ b/arch/arc/configs/haps_hs_defconfig
+@@ -40,7 +40,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ # CONFIG_NET_VENDOR_ARC is not set
+diff --git a/arch/arc/configs/haps_hs_smp_defconfig b/arch/arc/configs/haps_hs_smp_defconfig
+index 3507be2af6fe3..cf449cbf440df 100644
+--- a/arch/arc/configs/haps_hs_smp_defconfig
++++ b/arch/arc/configs/haps_hs_smp_defconfig
+@@ -43,7 +43,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ # CONFIG_NET_VENDOR_ARC is not set
+diff --git a/arch/arc/configs/hsdk_defconfig b/arch/arc/configs/hsdk_defconfig
+index 7b8f8faf8a243..128d615d1ca75 100644
+--- a/arch/arc/configs/hsdk_defconfig
++++ b/arch/arc/configs/hsdk_defconfig
+@@ -32,7 +32,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_SCSI=y
+ CONFIG_BLK_DEV_SD=y
+ CONFIG_NETDEVICES=y
+diff --git a/arch/arc/configs/nsim_700_defconfig b/arch/arc/configs/nsim_700_defconfig
+index 6dff83a238b85..31c2c70b34a17 100644
+--- a/arch/arc/configs/nsim_700_defconfig
++++ b/arch/arc/configs/nsim_700_defconfig
+@@ -36,7 +36,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ CONFIG_ARC_EMAC=y
+diff --git a/arch/arc/configs/nsim_hs_defconfig b/arch/arc/configs/nsim_hs_defconfig
+index 31ee51b987e7c..a578c721d50fb 100644
+--- a/arch/arc/configs/nsim_hs_defconfig
++++ b/arch/arc/configs/nsim_hs_defconfig
+@@ -40,7 +40,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ # CONFIG_INPUT_MOUSEDEV_PSAUX is not set
+ # CONFIG_INPUT_KEYBOARD is not set
+diff --git a/arch/arc/configs/nsim_hs_smp_defconfig b/arch/arc/configs/nsim_hs_smp_defconfig
+index 8d3b1f67cae42..37d7395f3272a 100644
+--- a/arch/arc/configs/nsim_hs_smp_defconfig
++++ b/arch/arc/configs/nsim_hs_smp_defconfig
+@@ -39,7 +39,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ # CONFIG_INPUT_MOUSEDEV_PSAUX is not set
+ # CONFIG_INPUT_KEYBOARD is not set
+diff --git a/arch/arc/configs/nsimosci_defconfig b/arch/arc/configs/nsimosci_defconfig
+index 6168ce2ac2efd..1e1470e2a7f00 100644
+--- a/arch/arc/configs/nsimosci_defconfig
++++ b/arch/arc/configs/nsimosci_defconfig
+@@ -35,7 +35,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ CONFIG_EZCHIP_NPS_MANAGEMENT_ENET=y
+diff --git a/arch/arc/configs/nsimosci_hs_defconfig b/arch/arc/configs/nsimosci_hs_defconfig
+index a70bdeb2b3fd0..084a6e42685bf 100644
+--- a/arch/arc/configs/nsimosci_hs_defconfig
++++ b/arch/arc/configs/nsimosci_hs_defconfig
+@@ -36,7 +36,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ CONFIG_EZCHIP_NPS_MANAGEMENT_ENET=y
+diff --git a/arch/arc/configs/nsimosci_hs_smp_defconfig b/arch/arc/configs/nsimosci_hs_smp_defconfig
+index ef96406c446e8..f36d479904152 100644
+--- a/arch/arc/configs/nsimosci_hs_smp_defconfig
++++ b/arch/arc/configs/nsimosci_hs_smp_defconfig
+@@ -39,7 +39,6 @@ CONFIG_INET=y
+ CONFIG_DEVTMPFS=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_BLK_DEV is not set
+ CONFIG_NETDEVICES=y
+ # CONFIG_NET_VENDOR_ARC is not set
+diff --git a/arch/arc/configs/tb10x_defconfig b/arch/arc/configs/tb10x_defconfig
+index f301825493950..1aca2e8fd1ba2 100644
+--- a/arch/arc/configs/tb10x_defconfig
++++ b/arch/arc/configs/tb10x_defconfig
+@@ -42,7 +42,6 @@ CONFIG_IP_MULTICAST=y
+ # CONFIG_IPV6 is not set
+ # CONFIG_WIRELESS is not set
+ CONFIG_DEVTMPFS=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_NETDEVICES=y
+ # CONFIG_NET_CADENCE is not set
+ # CONFIG_NET_VENDOR_BROADCOM is not set
+diff --git a/arch/arc/configs/vdk_hs38_defconfig b/arch/arc/configs/vdk_hs38_defconfig
+index 4fcf4f2503f61..f629493929ea6 100644
+--- a/arch/arc/configs/vdk_hs38_defconfig
++++ b/arch/arc/configs/vdk_hs38_defconfig
+@@ -31,7 +31,6 @@ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arc/configs/vdk_hs38_smp_defconfig b/arch/arc/configs/vdk_hs38_smp_defconfig
+index 7b71464f6c2f2..21f0ca26a05d5 100644
+--- a/arch/arc/configs/vdk_hs38_smp_defconfig
++++ b/arch/arc/configs/vdk_hs38_smp_defconfig
+@@ -34,7 +34,6 @@ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/cns3420vb_defconfig b/arch/arm/configs/cns3420vb_defconfig
+index 63a953d855a67..c6dcd6e4f4e6c 100644
+--- a/arch/arm/configs/cns3420vb_defconfig
++++ b/arch/arm/configs/cns3420vb_defconfig
+@@ -28,7 +28,6 @@ CONFIG_ZBOOT_ROM_TEXT=0x0
+ CONFIG_ZBOOT_ROM_BSS=0x0
+ CONFIG_CMDLINE="console=ttyS0,38400 mem=128M root=/dev/mmcblk0p1 ro rootwait"
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/magician_defconfig b/arch/arm/configs/magician_defconfig
+index ec5674c229a3c..de5be2fc7306a 100644
+--- a/arch/arm/configs/magician_defconfig
++++ b/arch/arm/configs/magician_defconfig
+@@ -54,7 +54,6 @@ CONFIG_BT_BNEP_PROTO_FILTER=y
+ CONFIG_BT_HIDP=m
+ CONFIG_BT_HCIBTUSB=m
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/mini2440_defconfig b/arch/arm/configs/mini2440_defconfig
+index cf7dcb2c86e69..88ea02e7ba19b 100644
+--- a/arch/arm/configs/mini2440_defconfig
++++ b/arch/arm/configs/mini2440_defconfig
+@@ -77,7 +77,6 @@ CONFIG_MAC80211=m
+ CONFIG_MAC80211_MESH=y
+ CONFIG_MAC80211_LEDS=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_CONNECTOR=m
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+diff --git a/arch/arm/configs/mv78xx0_defconfig b/arch/arm/configs/mv78xx0_defconfig
+index 752e2e74de5b7..0448bd8075acd 100644
+--- a/arch/arm/configs/mv78xx0_defconfig
++++ b/arch/arm/configs/mv78xx0_defconfig
+@@ -37,7 +37,6 @@ CONFIG_IP_PNP_BOOTP=y
+ # CONFIG_IPV6 is not set
+ CONFIG_NET_PKTGEN=m
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/mxs_defconfig b/arch/arm/configs/mxs_defconfig
+index e5822ab01b7de..bbfb6759447b2 100644
+--- a/arch/arm/configs/mxs_defconfig
++++ b/arch/arm/configs/mxs_defconfig
+@@ -46,7 +46,6 @@ CONFIG_CAN_FLEXCAN=m
+ # CONFIG_WIRELESS is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/orion5x_defconfig b/arch/arm/configs/orion5x_defconfig
+index b831baddae026..bf9046331f6ef 100644
+--- a/arch/arm/configs/orion5x_defconfig
++++ b/arch/arm/configs/orion5x_defconfig
+@@ -60,7 +60,6 @@ CONFIG_IP_PNP_BOOTP=y
+ CONFIG_NET_DSA=y
+ CONFIG_NET_PKTGEN=m
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/arm/configs/tegra_defconfig b/arch/arm/configs/tegra_defconfig
+index 6678f2929356e..9dccd305132b3 100644
+--- a/arch/arm/configs/tegra_defconfig
++++ b/arch/arm/configs/tegra_defconfig
+@@ -76,7 +76,6 @@ CONFIG_RFKILL_INPUT=y
+ CONFIG_RFKILL_GPIO=y
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_DMA_CMA=y
+ CONFIG_CMA_SIZE_MBYTES=64
+ CONFIG_TEGRA_GMI=y
+diff --git a/arch/arm/configs/vf610m4_defconfig b/arch/arm/configs/vf610m4_defconfig
+index b7ecb83a95b6a..a89f035c3b01b 100644
+--- a/arch/arm/configs/vf610m4_defconfig
++++ b/arch/arm/configs/vf610m4_defconfig
+@@ -23,7 +23,6 @@ CONFIG_BINFMT_SHARED_FLAT=y
+ # CONFIG_UEVENT_HELPER is not set
+ # CONFIG_STANDALONE is not set
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_ALLOW_DEV_COREDUMP is not set
+ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_COUNT=4
+diff --git a/arch/m68k/configs/amiga_defconfig b/arch/m68k/configs/amiga_defconfig
+index 5b5fa9831b4d1..c911adf52b53f 100644
+--- a/arch/m68k/configs/amiga_defconfig
++++ b/arch/m68k/configs/amiga_defconfig
+@@ -313,7 +313,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_PARPORT=m
+diff --git a/arch/m68k/configs/apollo_defconfig b/arch/m68k/configs/apollo_defconfig
+index 72a7764b74edf..0e32b85661797 100644
+--- a/arch/m68k/configs/apollo_defconfig
++++ b/arch/m68k/configs/apollo_defconfig
+@@ -311,7 +311,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/atari_defconfig b/arch/m68k/configs/atari_defconfig
+index 884b43a2f0d92..e873c6f97f008 100644
+--- a/arch/m68k/configs/atari_defconfig
++++ b/arch/m68k/configs/atari_defconfig
+@@ -311,7 +311,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_PARPORT=m
+diff --git a/arch/m68k/configs/bvme6000_defconfig b/arch/m68k/configs/bvme6000_defconfig
+index fcfa60d31499b..7b42cc1c2e613 100644
+--- a/arch/m68k/configs/bvme6000_defconfig
++++ b/arch/m68k/configs/bvme6000_defconfig
+@@ -309,7 +309,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/hp300_defconfig b/arch/m68k/configs/hp300_defconfig
+index 9d597bbbbbfe6..9f4b83541c31d 100644
+--- a/arch/m68k/configs/hp300_defconfig
++++ b/arch/m68k/configs/hp300_defconfig
+@@ -311,7 +311,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/mac_defconfig b/arch/m68k/configs/mac_defconfig
+index 45da20d1286ce..64094bf74822c 100644
+--- a/arch/m68k/configs/mac_defconfig
++++ b/arch/m68k/configs/mac_defconfig
+@@ -313,7 +313,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_SWIM=m
+diff --git a/arch/m68k/configs/multi_defconfig b/arch/m68k/configs/multi_defconfig
+index fda880c108615..9ae1f91ea690b 100644
+--- a/arch/m68k/configs/multi_defconfig
++++ b/arch/m68k/configs/multi_defconfig
+@@ -323,7 +323,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_PARPORT=m
+diff --git a/arch/m68k/configs/mvme147_defconfig b/arch/m68k/configs/mvme147_defconfig
+index 7d5e4863efec0..31586b2f852e3 100644
+--- a/arch/m68k/configs/mvme147_defconfig
++++ b/arch/m68k/configs/mvme147_defconfig
+@@ -308,7 +308,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/mvme16x_defconfig b/arch/m68k/configs/mvme16x_defconfig
+index 7763b71a9c497..7fd5e2de8a508 100644
+--- a/arch/m68k/configs/mvme16x_defconfig
++++ b/arch/m68k/configs/mvme16x_defconfig
+@@ -309,7 +309,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/q40_defconfig b/arch/m68k/configs/q40_defconfig
+index 17eaebfa3e198..0339309b51751 100644
+--- a/arch/m68k/configs/q40_defconfig
++++ b/arch/m68k/configs/q40_defconfig
+@@ -309,7 +309,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_PARPORT=m
+diff --git a/arch/m68k/configs/sun3_defconfig b/arch/m68k/configs/sun3_defconfig
+index d1cb7a04ae1d3..5aef62938f326 100644
+--- a/arch/m68k/configs/sun3_defconfig
++++ b/arch/m68k/configs/sun3_defconfig
+@@ -306,7 +306,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/m68k/configs/sun3x_defconfig b/arch/m68k/configs/sun3x_defconfig
+index ea3a331c62d5b..45df9a6559e58 100644
+--- a/arch/m68k/configs/sun3x_defconfig
++++ b/arch/m68k/configs/sun3x_defconfig
+@@ -306,7 +306,6 @@ CONFIG_NET_DEVLINK=m
+ # CONFIG_UEVENT_HELPER is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_TEST_ASYNC_DRIVER_PROBE=m
+ CONFIG_CONNECTOR=m
+ CONFIG_BLK_DEV_LOOP=y
+diff --git a/arch/mips/configs/ar7_defconfig b/arch/mips/configs/ar7_defconfig
+index 92fca3c42eac3..5651f4d8f45c4 100644
+--- a/arch/mips/configs/ar7_defconfig
++++ b/arch/mips/configs/ar7_defconfig
+@@ -82,7 +82,6 @@ CONFIG_MAC80211=m
+ CONFIG_MAC80211_RC_PID=y
+ CONFIG_MAC80211_RC_DEFAULT_PID=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_BLOCK=y
+ CONFIG_MTD_CFI=y
+diff --git a/arch/mips/configs/ath25_defconfig b/arch/mips/configs/ath25_defconfig
+index 2c829950be17d..b8d48038e74f5 100644
+--- a/arch/mips/configs/ath25_defconfig
++++ b/arch/mips/configs/ath25_defconfig
+@@ -38,7 +38,6 @@ CONFIG_CFG80211=m
+ CONFIG_MAC80211=m
+ CONFIG_MAC80211_DEBUGFS=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_REDBOOT_PARTS=y
+ CONFIG_MTD_REDBOOT_DIRECTORY_BLOCK=-2
+diff --git a/arch/mips/configs/ath79_defconfig b/arch/mips/configs/ath79_defconfig
+index 25ed914933e5c..951c4231bdb85 100644
+--- a/arch/mips/configs/ath79_defconfig
++++ b/arch/mips/configs/ath79_defconfig
+@@ -39,7 +39,6 @@ CONFIG_CFG80211=m
+ CONFIG_MAC80211=m
+ CONFIG_MAC80211_DEBUGFS=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_REDBOOT_PARTS=y
+ CONFIG_MTD_REDBOOT_DIRECTORY_BLOCK=-2
+diff --git a/arch/mips/configs/pic32mzda_defconfig b/arch/mips/configs/pic32mzda_defconfig
+index 52192c632ae8d..41190c2036e60 100644
+--- a/arch/mips/configs/pic32mzda_defconfig
++++ b/arch/mips/configs/pic32mzda_defconfig
+@@ -26,7 +26,6 @@ CONFIG_BINFMT_MISC=m
+ # CONFIG_SUSPEND is not set
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ # CONFIG_ALLOW_DEV_COREDUMP is not set
+ CONFIG_BLK_DEV_LOOP=m
+ CONFIG_SCSI=y
+diff --git a/arch/mips/configs/qi_lb60_defconfig b/arch/mips/configs/qi_lb60_defconfig
+index 3f13335174057..3b02ff9a7c64f 100644
+--- a/arch/mips/configs/qi_lb60_defconfig
++++ b/arch/mips/configs/qi_lb60_defconfig
+@@ -42,7 +42,6 @@ CONFIG_TCP_CONG_WESTWOOD=y
+ # CONFIG_TCP_CONG_HTCP is not set
+ # CONFIG_IPV6 is not set
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_BLOCK=y
+ CONFIG_MTD_NAND=y
+diff --git a/arch/mips/configs/rt305x_defconfig b/arch/mips/configs/rt305x_defconfig
+index c695b7b1c4ae8..dbe6a4639d051 100644
+--- a/arch/mips/configs/rt305x_defconfig
++++ b/arch/mips/configs/rt305x_defconfig
+@@ -76,7 +76,6 @@ CONFIG_VLAN_8021Q=y
+ CONFIG_NET_SCHED=y
+ CONFIG_HAMRADIO=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/mips/configs/xway_defconfig b/arch/mips/configs/xway_defconfig
+index 4365108bef776..fa750d501c112 100644
+--- a/arch/mips/configs/xway_defconfig
++++ b/arch/mips/configs/xway_defconfig
+@@ -75,7 +75,6 @@ CONFIG_VLAN_8021Q=y
+ CONFIG_NET_SCHED=y
+ CONFIG_HAMRADIO=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/mn10300/configs/asb2364_defconfig b/arch/mn10300/configs/asb2364_defconfig
+index b1d80cee97eef..a84c3153f22a5 100644
+--- a/arch/mn10300/configs/asb2364_defconfig
++++ b/arch/mn10300/configs/asb2364_defconfig
+@@ -44,7 +44,6 @@ CONFIG_IPV6=y
+ # CONFIG_INET6_XFRM_MODE_TRANSPORT is not set
+ # CONFIG_INET6_XFRM_MODE_TUNNEL is not set
+ # CONFIG_INET6_XFRM_MODE_BEET is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_CONNECTOR=y
+ CONFIG_MTD=y
+ CONFIG_MTD_DEBUG=y
+diff --git a/arch/powerpc/configs/44x/warp_defconfig b/arch/powerpc/configs/44x/warp_defconfig
+index b5c866073efda..6c02f53271cdc 100644
+--- a/arch/powerpc/configs/44x/warp_defconfig
++++ b/arch/powerpc/configs/44x/warp_defconfig
+@@ -28,7 +28,6 @@ CONFIG_NETFILTER=y
+ CONFIG_VLAN_8021Q=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ # CONFIG_STANDALONE is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/powerpc/configs/mpc512x_defconfig b/arch/powerpc/configs/mpc512x_defconfig
+index 10be5773ad5dc..c2b1c44046837 100644
+--- a/arch/powerpc/configs/mpc512x_defconfig
++++ b/arch/powerpc/configs/mpc512x_defconfig
+@@ -39,7 +39,6 @@ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+ # CONFIG_PREVENT_FIRMWARE_BUILD is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/powerpc/configs/ppc6xx_defconfig b/arch/powerpc/configs/ppc6xx_defconfig
+index da0e8d535eb88..7ee736f207740 100644
+--- a/arch/powerpc/configs/ppc6xx_defconfig
++++ b/arch/powerpc/configs/ppc6xx_defconfig
+@@ -347,7 +347,6 @@ CONFIG_MAC80211_DEBUGFS=y
+ CONFIG_NET_9P=m
+ CONFIG_NET_9P_VIRTIO=m
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_DEBUG_DEVRES=y
+ CONFIG_CONNECTOR=y
+ CONFIG_PARPORT=m
+diff --git a/arch/powerpc/configs/ps3_defconfig b/arch/powerpc/configs/ps3_defconfig
+index 2efa025bf4836..187e2f7c12c83 100644
+--- a/arch/powerpc/configs/ps3_defconfig
++++ b/arch/powerpc/configs/ps3_defconfig
+@@ -64,7 +64,6 @@ CONFIG_CFG80211_WEXT=y
+ CONFIG_MAC80211=m
+ # CONFIG_MAC80211_RC_MINSTREL is not set
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_SIZE=65535
+diff --git a/arch/powerpc/configs/wii_defconfig b/arch/powerpc/configs/wii_defconfig
+index 9c7400a19e9df..0b0f78823a1bf 100644
+--- a/arch/powerpc/configs/wii_defconfig
++++ b/arch/powerpc/configs/wii_defconfig
+@@ -43,7 +43,6 @@ CONFIG_CFG80211=y
+ CONFIG_MAC80211=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ # CONFIG_STANDALONE is not set
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_COUNT=2
+diff --git a/arch/s390/configs/zfcpdump_defconfig b/arch/s390/configs/zfcpdump_defconfig
+index 04e042edbab76..7dc7f58c42877 100644
+--- a/arch/s390/configs/zfcpdump_defconfig
++++ b/arch/s390/configs/zfcpdump_defconfig
+@@ -26,7 +26,6 @@ CONFIG_NET=y
+ # CONFIG_IUCV is not set
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ CONFIG_DEVTMPFS=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_BLK_DEV_RAM=y
+ # CONFIG_BLK_DEV_XPRAM is not set
+ # CONFIG_DCSSBLK is not set
+diff --git a/arch/sh/configs/polaris_defconfig b/arch/sh/configs/polaris_defconfig
+index 0a432b5f50e74..87641b7d6c4e7 100644
+--- a/arch/sh/configs/polaris_defconfig
++++ b/arch/sh/configs/polaris_defconfig
+@@ -38,7 +38,6 @@ CONFIG_IP_MULTICAST=y
+ # CONFIG_INET_XFRM_MODE_BEET is not set
+ # CONFIG_IPV6 is not set
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_MTD=y
+ CONFIG_MTD_CMDLINE_PARTS=y
+ CONFIG_MTD_BLOCK=y
+diff --git a/arch/tile/configs/tilegx_defconfig b/arch/tile/configs/tilegx_defconfig
+index 9f94435cc44f4..357a4c271ad46 100644
+--- a/arch/tile/configs/tilegx_defconfig
++++ b/arch/tile/configs/tilegx_defconfig
+@@ -159,7 +159,6 @@ CONFIG_DNS_RESOLVER=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_CONNECTOR=y
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_BLK_DEV_CRYPTOLOOP=m
+diff --git a/arch/tile/configs/tilepro_defconfig b/arch/tile/configs/tilepro_defconfig
+index 1c5bd4f8ffca3..da2858755fa1e 100644
+--- a/arch/tile/configs/tilepro_defconfig
++++ b/arch/tile/configs/tilepro_defconfig
+@@ -289,7 +289,6 @@ CONFIG_DNS_RESOLVER=y
+ CONFIG_UEVENT_HELPER_PATH="/sbin/hotplug"
+ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+-# CONFIG_FIRMWARE_IN_KERNEL is not set
+ CONFIG_CONNECTOR=y
+ CONFIG_BLK_DEV_LOOP=y
+ CONFIG_BLK_DEV_CRYPTOLOOP=m
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index bdc87907d6a1b..698db8549686e 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -86,10 +86,9 @@ config FW_LOADER
+ 	  require userspace firmware loading support, but a module built
+ 	  out-of-tree does.
+ 
+-config FIRMWARE_IN_KERNEL
+-	bool "Include in-kernel firmware blobs in kernel binary"
++config EXTRA_FIRMWARE
++	string "External firmware blobs to build into the kernel binary"
+ 	depends on FW_LOADER
+-	default y
+ 	help
+ 	  Various drivers in the kernel source tree may require firmware,
+ 	  which is generally available in your distribution's linux-firmware
+@@ -99,23 +98,6 @@ config FIRMWARE_IN_KERNEL
+ 	  /lib/firmware/ on your system, so they can be loaded by userspace
+ 	  helpers on request.
+ 
+-	  Enabling this option will build each required firmware blob
+-	  specified by EXTRA_FIRMWARE into the kernel directly, where
+-	  request_firmware() will find them without having to call out to
+-	  userspace. This may be useful if your root file system requires a
+-	  device that uses such firmware and you do not wish to use an
+-	  initrd.
+-
+-	  This single option controls the inclusion of firmware for
+-	  every driver that uses request_firmware(), which avoids a
+-	  proliferation of 'Include firmware for xxx device' options.
+-
+-	  Say 'N' and let firmware be loaded from userspace.
+-
+-config EXTRA_FIRMWARE
+-	string "External firmware blobs to build into the kernel binary"
+-	depends on FW_LOADER
+-	help
+ 	  This option allows firmware to be built into the kernel for the case
+ 	  where the user either cannot or doesn't want to provide it from
+ 	  userspace at runtime (for example, when the firmware in question is
+@@ -126,11 +108,11 @@ config EXTRA_FIRMWARE
+ 	  firmware files -- the same names that appear in MODULE_FIRMWARE()
+ 	  and request_firmware() in the source. These files should exist under
+ 	  the directory specified by the EXTRA_FIRMWARE_DIR option, which is
+-	  by default the firmware subdirectory of the kernel source tree.
++	  /lib/firmware by default.
+ 
+ 	  For example, you might set CONFIG_EXTRA_FIRMWARE="usb8388.bin", copy
+-	  the usb8388.bin file into the firmware directory, and build the kernel.
+-	  Then any request_firmware("usb8388.bin") will be satisfied internally
++	  the usb8388.bin file into /lib/firmware, and build the kernel. Then
++	  any request_firmware("usb8388.bin") will be satisfied internally
+ 	  without needing to call out to userspace.
+ 
+ 	  WARNING: If you include additional firmware files into your binary

--- a/target/linux/generic/backport-4.14/081-0021-firmware_loader-enhance-Kconfig-documentation-over-FW_LOADER.patch
+++ b/target/linux/generic/backport-4.14/081-0021-firmware_loader-enhance-Kconfig-documentation-over-FW_LOADER.patch
@@ -1,0 +1,236 @@
+From 02c399306826412562ec68712eada97e8e355f35 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Thu, 10 May 2018 13:08:41 -0700
+Subject: [PATCH] firmware_loader: enhance Kconfig documentation over FW_LOADER
+
+If you try to read FW_LOADER today it speaks of old riddles and
+unless you have been following development closely you will lose
+track of what is what. Even the documentation for PREVENT_FIRMWARE_BUILD
+is a bit fuzzy and how it fits into this big picture.
+
+Give the FW_LOADER kconfig documentation some love with more up to
+date developments and recommendations. While at it, wrap the FW_LOADER
+code into its own menu to compartmentalize and make it clearer which
+components really are part of the FW_LOADER. This should also make
+it easier to later move these kconfig entries into the firmware_loader/
+directory later.
+
+This also now recommends using firmwared [0] for folks left needing a
+uevent handler in userspace for the sysfs firmware fallback mechanis
+given udev's uevent firmware mechanism was ripped out a while ago.
+
+[0] https://github.com/teg/firmwared
+
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/Kconfig | 165 ++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 131 insertions(+), 34 deletions(-)
+
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index 29b0eb452b3a6..db2bbe483927a 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -70,39 +70,64 @@ config STANDALONE
+ 	  If unsure, say Y.
+ 
+ config PREVENT_FIRMWARE_BUILD
+-	bool "Prevent firmware from being built"
++	bool "Disable drivers features which enable custom firmware building"
+ 	default y
+ 	help
+-	  Say yes to avoid building firmware. Firmware is usually shipped
+-	  with the driver and only when updating the firmware should a
+-	  rebuild be made.
+-	  If unsure, say Y here.
++	  Say yes to disable driver features which enable building a custom
++	  driver firmware at kernel build time. These drivers do not use the
++	  kernel firmware API to load firmware (CONFIG_FW_LOADER), instead they
++	  use their own custom loading mechanism. The required firmware is
++	  usually shipped with the driver, building the driver firmware
++	  should only be needed if you have an updated firmware source.
++
++	  Firmware should not be being built as part of kernel, these days
++	  you should always prevent this and say Y here. There are only two
++	  old drivers which enable building of its firmware at kernel build
++	  time:
++
++	    o CONFIG_WANXL through CONFIG_WANXL_BUILD_FIRMWARE
++	    o CONFIG_SCSI_AIC79XX through CONFIG_AIC79XX_BUILD_FIRMWARE
++
++menu "Firmware loader"
+ 
+ config FW_LOADER
+-	tristate "Userspace firmware loading support" if EXPERT
++	tristate "Firmware loading facility" if EXPERT
+ 	default y
+ 	---help---
+-	  This option is provided for the case where none of the in-tree modules
+-	  require userspace firmware loading support, but a module built
+-	  out-of-tree does.
++	  This enables the firmware loading facility in the kernel. The kernel
++	  will first look for built-in firmware, if it has any. Next, it will
++	  look for the requested firmware in a series of filesystem paths:
++
++		o firmware_class path module parameter or kernel boot param
++		o /lib/firmware/updates/UTS_RELEASE
++		o /lib/firmware/updates
++		o /lib/firmware/UTS_RELEASE
++		o /lib/firmware
++
++	  Enabling this feature only increases your kernel image by about
++	  828 bytes, enable this option unless you are certain you don't
++	  need firmware.
++
++	  You typically want this built-in (=y) but you can also enable this
++	  as a module, in which case the firmware_class module will be built.
++	  You also want to be sure to enable this built-in if you are going to
++	  enable built-in firmware (CONFIG_EXTRA_FIRMWARE).
++
++if FW_LOADER
+ 
+ config EXTRA_FIRMWARE
+-	string "External firmware blobs to build into the kernel binary"
+-	depends on FW_LOADER
++	string "Build named firmware blobs into the kernel binary"
+ 	help
+-	  Various drivers in the kernel source tree may require firmware,
+-	  which is generally available in your distribution's linux-firmware
+-	  package.
++	  Device drivers which require firmware can typically deal with
++	  having the kernel load firmware from the various supported
++	  /lib/firmware/ paths. This option enables you to build into the
++	  kernel firmware files. Built-in firmware searches are preceded
++	  over firmware lookups using your filesystem over the supported
++	  /lib/firmware paths documented on CONFIG_FW_LOADER.
+ 
+-	  The linux-firmware package should install firmware into
+-	  /lib/firmware/ on your system, so they can be loaded by userspace
+-	  helpers on request.
+-
+-	  This option allows firmware to be built into the kernel for the case
+-	  where the user either cannot or doesn't want to provide it from
+-	  userspace at runtime (for example, when the firmware in question is
+-	  required for accessing the boot device, and the user doesn't want to
+-	  use an initrd).
++	  This may be useful for testing or if the firmware is required early on
++	  in boot and cannot rely on the firmware being placed in an initrd or
++	  initramfs.
+ 
+ 	  This option is a string and takes the (space-separated) names of the
+ 	  firmware files -- the same names that appear in MODULE_FIRMWARE()
+@@ -113,7 +138,7 @@ config EXTRA_FIRMWARE
+ 	  For example, you might set CONFIG_EXTRA_FIRMWARE="usb8388.bin", copy
+ 	  the usb8388.bin file into /lib/firmware, and build the kernel. Then
+ 	  any request_firmware("usb8388.bin") will be satisfied internally
+-	  without needing to call out to userspace.
++	  inside the kernel without ever looking at your filesystem at runtime.
+ 
+ 	  WARNING: If you include additional firmware files into your binary
+ 	  kernel image that are not available under the terms of the GPL,
+@@ -130,22 +155,94 @@ config EXTRA_FIRMWARE_DIR
+ 	  looks for the firmware files listed in the EXTRA_FIRMWARE option.
+ 
+ config FW_LOADER_USER_HELPER
+-	bool
++	bool "Enable the firmware sysfs fallback mechanism"
++	help
++	  This option enables a sysfs loading facility to enable firmware
++	  loading to the kernel through userspace as a fallback mechanism
++	  if and only if the kernel's direct filesystem lookup for the
++	  firmware failed using the different /lib/firmware/ paths, or the
++	  path specified in the firmware_class path module parameter, or the
++	  firmware_class path kernel boot parameter if the firmware_class is
++	  built-in. For details on how to work with the sysfs fallback mechanism
++	  refer to Documentation/driver-api/firmware/fallback-mechanisms.rst.
++
++	  The direct filesystem lookup for firmware is always used first now.
++
++	  If the kernel's direct filesystem lookup for firmware fails to find
++	  the requested firmware a sysfs fallback loading facility is made
++	  available and userspace is informed about this through uevents.
++	  The uevent can be suppressed if the driver explicitly requested it,
++	  this is known as the driver using the custom fallback mechanism.
++	  If the custom fallback mechanism is used userspace must always
++	  acknowledge failure to find firmware as the timeout for the fallback
++	  mechanism is disabled, and failed requests will linger forever.
++
++	  This used to be the default firmware loading facility, and udev used
++	  to listen for uvents to load firmware for the kernel. The firmware
++	  loading facility functionality in udev has been removed, as such it
++	  can no longer be relied upon as a fallback mechanism. Linux no longer
++	  relies on or uses a fallback mechanism in userspace. If you need to
++	  rely on one refer to the permissively licensed firmwared:
++
++	  https://github.com/teg/firmwared
++
++	  Since this was the default firmware loading facility at one point,
++	  old userspace may exist which relies upon it, and as such this
++	  mechanism can never be removed from the kernel.
++
++	  You should only enable this functionality if you are certain you
++	  require a fallback mechanism and have a userspace mechanism ready to
++	  load firmware in case it is not found. One main reason for this may
++	  be if you have drivers which require firmware built-in and for
++	  whatever reason cannot place the required firmware in initramfs.
++	  Another reason kernels may have this feature enabled is to support a
++	  driver which explicitly relies on this fallback mechanism. Only two
++	  drivers need this today:
++
++	    o CONFIG_LEDS_LP55XX_COMMON
++	    o CONFIG_DELL_RBU
++
++	  Outside of supporting the above drivers, another reason for needing
++	  this may be that your firmware resides outside of the paths the kernel
++	  looks for and cannot possibly be specified using the firmware_class
++	  path module parameter or kernel firmware_class path boot parameter
++	  if firmware_class is built-in.
++
++	  A modern use case may be to temporarily mount a custom partition
++	  during provisioning which is only accessible to userspace, and then
++	  to use it to look for and fetch the required firmware. Such type of
++	  driver functionality may not even ever be desirable upstream by
++	  vendors, and as such is only required to be supported as an interface
++	  for provisioning. Since udev's firmware loading facility has been
++	  removed you can use firmwared or a fork of it to customize how you
++	  want to load firmware based on uevents issued.
++
++	  Enabling this option will increase your kernel image size by about
++	  13436 bytes.
++
++	  If you are unsure about this, say N here, unless you are Linux
++	  distribution and need to support the above two drivers, or you are
++	  certain you need to support some really custom firmware loading
++	  facility in userspace.
+ 
+ config FW_LOADER_USER_HELPER_FALLBACK
+-	bool "Fallback user-helper invocation for firmware loading"
+-	depends on FW_LOADER
+-	select FW_LOADER_USER_HELPER
++	bool "Force the firmware sysfs fallback mechanism when possible"
++	depends on FW_LOADER_USER_HELPER
+ 	help
+-	  This option enables / disables the invocation of user-helper
+-	  (e.g. udev) for loading firmware files as a fallback after the
+-	  direct file loading in kernel fails.  The user-mode helper is
+-	  no longer required unless you have a special firmware file that
+-	  resides in a non-standard path. Moreover, the udev support has
+-	  been deprecated upstream.
++	  Enabling this option forces a sysfs userspace fallback mechanism
++	  to be used for all firmware requests which explicitly do not disable a
++	  a fallback mechanism. Firmware calls which do prohibit a fallback
++	  mechanism is request_firmware_direct(). This option is kept for
++          backward compatibility purposes given this precise mechanism can also
++	  be enabled by setting the proc sysctl value to true:
++
++	       /proc/sys/kernel/firmware_config/force_sysfs_fallback
+ 
+ 	  If you are unsure about this, say N here.
+ 
++endif # FW_LOADER
++endmenu
++
+ config WANT_DEV_COREDUMP
+ 	bool
+ 	help

--- a/target/linux/generic/backport-4.14/081-0022-firmware_loader-replace----help----with-help.patch
+++ b/target/linux/generic/backport-4.14/081-0022-firmware_loader-replace----help----with-help.patch
@@ -1,0 +1,26 @@
+From 367d09824193e5a9aea98490ae0506cec8abe9c4 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Thu, 10 May 2018 13:08:42 -0700
+Subject: [PATCH] firmware_loader: replace ---help--- with help
+
+As per checkpatch using help is preferred over ---help---.
+
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index db2bbe483927a..0c38df32c7fe4 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -93,7 +93,7 @@ menu "Firmware loader"
+ config FW_LOADER
+ 	tristate "Firmware loading facility" if EXPERT
+ 	default y
+-	---help---
++	help
+ 	  This enables the firmware loading facility in the kernel. The kernel
+ 	  will first look for built-in firmware, if it has any. Next, it will
+ 	  look for the requested firmware in a series of filesystem paths:

--- a/target/linux/generic/backport-4.14/081-0023-firmware_loader-move-kconfig-FW_LOADER-entries-to-its-own-file.patch
+++ b/target/linux/generic/backport-4.14/081-0023-firmware_loader-move-kconfig-FW_LOADER-entries-to-its-own-file.patch
@@ -1,0 +1,346 @@
+From 06bfd3c8ab1dbf0031022d056a90ace682f6a94c Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Thu, 10 May 2018 13:08:43 -0700
+Subject: [PATCH] firmware_loader: move kconfig FW_LOADER entries to its own
+ file
+
+This will make it easier to track and easier to understand
+what components and features are part of the FW_LOADER. There
+are some components related to firmware which have *nothing* to
+do with the FW_LOADER, souch as PREVENT_FIRMWARE_BUILD.
+
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/Kconfig                 | 155 +----------------------------------
+ drivers/base/firmware_loader/Kconfig | 154 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 155 insertions(+), 154 deletions(-)
+ create mode 100644 drivers/base/firmware_loader/Kconfig
+
+diff --git a/drivers/base/Kconfig b/drivers/base/Kconfig
+index 0c38df32c7fe4..3e63a900b330e 100644
+--- a/drivers/base/Kconfig
++++ b/drivers/base/Kconfig
+@@ -88,160 +88,7 @@ config PREVENT_FIRMWARE_BUILD
+ 	    o CONFIG_WANXL through CONFIG_WANXL_BUILD_FIRMWARE
+ 	    o CONFIG_SCSI_AIC79XX through CONFIG_AIC79XX_BUILD_FIRMWARE
+ 
+-menu "Firmware loader"
+-
+-config FW_LOADER
+-	tristate "Firmware loading facility" if EXPERT
+-	default y
+-	help
+-	  This enables the firmware loading facility in the kernel. The kernel
+-	  will first look for built-in firmware, if it has any. Next, it will
+-	  look for the requested firmware in a series of filesystem paths:
+-
+-		o firmware_class path module parameter or kernel boot param
+-		o /lib/firmware/updates/UTS_RELEASE
+-		o /lib/firmware/updates
+-		o /lib/firmware/UTS_RELEASE
+-		o /lib/firmware
+-
+-	  Enabling this feature only increases your kernel image by about
+-	  828 bytes, enable this option unless you are certain you don't
+-	  need firmware.
+-
+-	  You typically want this built-in (=y) but you can also enable this
+-	  as a module, in which case the firmware_class module will be built.
+-	  You also want to be sure to enable this built-in if you are going to
+-	  enable built-in firmware (CONFIG_EXTRA_FIRMWARE).
+-
+-if FW_LOADER
+-
+-config EXTRA_FIRMWARE
+-	string "Build named firmware blobs into the kernel binary"
+-	help
+-	  Device drivers which require firmware can typically deal with
+-	  having the kernel load firmware from the various supported
+-	  /lib/firmware/ paths. This option enables you to build into the
+-	  kernel firmware files. Built-in firmware searches are preceded
+-	  over firmware lookups using your filesystem over the supported
+-	  /lib/firmware paths documented on CONFIG_FW_LOADER.
+-
+-	  This may be useful for testing or if the firmware is required early on
+-	  in boot and cannot rely on the firmware being placed in an initrd or
+-	  initramfs.
+-
+-	  This option is a string and takes the (space-separated) names of the
+-	  firmware files -- the same names that appear in MODULE_FIRMWARE()
+-	  and request_firmware() in the source. These files should exist under
+-	  the directory specified by the EXTRA_FIRMWARE_DIR option, which is
+-	  /lib/firmware by default.
+-
+-	  For example, you might set CONFIG_EXTRA_FIRMWARE="usb8388.bin", copy
+-	  the usb8388.bin file into /lib/firmware, and build the kernel. Then
+-	  any request_firmware("usb8388.bin") will be satisfied internally
+-	  inside the kernel without ever looking at your filesystem at runtime.
+-
+-	  WARNING: If you include additional firmware files into your binary
+-	  kernel image that are not available under the terms of the GPL,
+-	  then it may be a violation of the GPL to distribute the resulting
+-	  image since it combines both GPL and non-GPL work. You should
+-	  consult a lawyer of your own before distributing such an image.
+-
+-config EXTRA_FIRMWARE_DIR
+-	string "Firmware blobs root directory"
+-	depends on EXTRA_FIRMWARE != ""
+-	default "/lib/firmware"
+-	help
+-	  This option controls the directory in which the kernel build system
+-	  looks for the firmware files listed in the EXTRA_FIRMWARE option.
+-
+-config FW_LOADER_USER_HELPER
+-	bool "Enable the firmware sysfs fallback mechanism"
+-	help
+-	  This option enables a sysfs loading facility to enable firmware
+-	  loading to the kernel through userspace as a fallback mechanism
+-	  if and only if the kernel's direct filesystem lookup for the
+-	  firmware failed using the different /lib/firmware/ paths, or the
+-	  path specified in the firmware_class path module parameter, or the
+-	  firmware_class path kernel boot parameter if the firmware_class is
+-	  built-in. For details on how to work with the sysfs fallback mechanism
+-	  refer to Documentation/driver-api/firmware/fallback-mechanisms.rst.
+-
+-	  The direct filesystem lookup for firmware is always used first now.
+-
+-	  If the kernel's direct filesystem lookup for firmware fails to find
+-	  the requested firmware a sysfs fallback loading facility is made
+-	  available and userspace is informed about this through uevents.
+-	  The uevent can be suppressed if the driver explicitly requested it,
+-	  this is known as the driver using the custom fallback mechanism.
+-	  If the custom fallback mechanism is used userspace must always
+-	  acknowledge failure to find firmware as the timeout for the fallback
+-	  mechanism is disabled, and failed requests will linger forever.
+-
+-	  This used to be the default firmware loading facility, and udev used
+-	  to listen for uvents to load firmware for the kernel. The firmware
+-	  loading facility functionality in udev has been removed, as such it
+-	  can no longer be relied upon as a fallback mechanism. Linux no longer
+-	  relies on or uses a fallback mechanism in userspace. If you need to
+-	  rely on one refer to the permissively licensed firmwared:
+-
+-	  https://github.com/teg/firmwared
+-
+-	  Since this was the default firmware loading facility at one point,
+-	  old userspace may exist which relies upon it, and as such this
+-	  mechanism can never be removed from the kernel.
+-
+-	  You should only enable this functionality if you are certain you
+-	  require a fallback mechanism and have a userspace mechanism ready to
+-	  load firmware in case it is not found. One main reason for this may
+-	  be if you have drivers which require firmware built-in and for
+-	  whatever reason cannot place the required firmware in initramfs.
+-	  Another reason kernels may have this feature enabled is to support a
+-	  driver which explicitly relies on this fallback mechanism. Only two
+-	  drivers need this today:
+-
+-	    o CONFIG_LEDS_LP55XX_COMMON
+-	    o CONFIG_DELL_RBU
+-
+-	  Outside of supporting the above drivers, another reason for needing
+-	  this may be that your firmware resides outside of the paths the kernel
+-	  looks for and cannot possibly be specified using the firmware_class
+-	  path module parameter or kernel firmware_class path boot parameter
+-	  if firmware_class is built-in.
+-
+-	  A modern use case may be to temporarily mount a custom partition
+-	  during provisioning which is only accessible to userspace, and then
+-	  to use it to look for and fetch the required firmware. Such type of
+-	  driver functionality may not even ever be desirable upstream by
+-	  vendors, and as such is only required to be supported as an interface
+-	  for provisioning. Since udev's firmware loading facility has been
+-	  removed you can use firmwared or a fork of it to customize how you
+-	  want to load firmware based on uevents issued.
+-
+-	  Enabling this option will increase your kernel image size by about
+-	  13436 bytes.
+-
+-	  If you are unsure about this, say N here, unless you are Linux
+-	  distribution and need to support the above two drivers, or you are
+-	  certain you need to support some really custom firmware loading
+-	  facility in userspace.
+-
+-config FW_LOADER_USER_HELPER_FALLBACK
+-	bool "Force the firmware sysfs fallback mechanism when possible"
+-	depends on FW_LOADER_USER_HELPER
+-	help
+-	  Enabling this option forces a sysfs userspace fallback mechanism
+-	  to be used for all firmware requests which explicitly do not disable a
+-	  a fallback mechanism. Firmware calls which do prohibit a fallback
+-	  mechanism is request_firmware_direct(). This option is kept for
+-          backward compatibility purposes given this precise mechanism can also
+-	  be enabled by setting the proc sysctl value to true:
+-
+-	       /proc/sys/kernel/firmware_config/force_sysfs_fallback
+-
+-	  If you are unsure about this, say N here.
+-
+-endif # FW_LOADER
+-endmenu
++source "drivers/base/firmware_loader/Kconfig"
+ 
+ config WANT_DEV_COREDUMP
+ 	bool
+diff --git a/drivers/base/firmware_loader/Kconfig b/drivers/base/firmware_loader/Kconfig
+new file mode 100644
+index 0000000000000..eb15d976a9ea2
+--- /dev/null
++++ b/drivers/base/firmware_loader/Kconfig
+@@ -0,0 +1,154 @@
++menu "Firmware loader"
++
++config FW_LOADER
++	tristate "Firmware loading facility" if EXPERT
++	default y
++	help
++	  This enables the firmware loading facility in the kernel. The kernel
++	  will first look for built-in firmware, if it has any. Next, it will
++	  look for the requested firmware in a series of filesystem paths:
++
++		o firmware_class path module parameter or kernel boot param
++		o /lib/firmware/updates/UTS_RELEASE
++		o /lib/firmware/updates
++		o /lib/firmware/UTS_RELEASE
++		o /lib/firmware
++
++	  Enabling this feature only increases your kernel image by about
++	  828 bytes, enable this option unless you are certain you don't
++	  need firmware.
++
++	  You typically want this built-in (=y) but you can also enable this
++	  as a module, in which case the firmware_class module will be built.
++	  You also want to be sure to enable this built-in if you are going to
++	  enable built-in firmware (CONFIG_EXTRA_FIRMWARE).
++
++if FW_LOADER
++
++config EXTRA_FIRMWARE
++	string "Build named firmware blobs into the kernel binary"
++	help
++	  Device drivers which require firmware can typically deal with
++	  having the kernel load firmware from the various supported
++	  /lib/firmware/ paths. This option enables you to build into the
++	  kernel firmware files. Built-in firmware searches are preceded
++	  over firmware lookups using your filesystem over the supported
++	  /lib/firmware paths documented on CONFIG_FW_LOADER.
++
++	  This may be useful for testing or if the firmware is required early on
++	  in boot and cannot rely on the firmware being placed in an initrd or
++	  initramfs.
++
++	  This option is a string and takes the (space-separated) names of the
++	  firmware files -- the same names that appear in MODULE_FIRMWARE()
++	  and request_firmware() in the source. These files should exist under
++	  the directory specified by the EXTRA_FIRMWARE_DIR option, which is
++	  /lib/firmware by default.
++
++	  For example, you might set CONFIG_EXTRA_FIRMWARE="usb8388.bin", copy
++	  the usb8388.bin file into /lib/firmware, and build the kernel. Then
++	  any request_firmware("usb8388.bin") will be satisfied internally
++	  inside the kernel without ever looking at your filesystem at runtime.
++
++	  WARNING: If you include additional firmware files into your binary
++	  kernel image that are not available under the terms of the GPL,
++	  then it may be a violation of the GPL to distribute the resulting
++	  image since it combines both GPL and non-GPL work. You should
++	  consult a lawyer of your own before distributing such an image.
++
++config EXTRA_FIRMWARE_DIR
++	string "Firmware blobs root directory"
++	depends on EXTRA_FIRMWARE != ""
++	default "/lib/firmware"
++	help
++	  This option controls the directory in which the kernel build system
++	  looks for the firmware files listed in the EXTRA_FIRMWARE option.
++
++config FW_LOADER_USER_HELPER
++	bool "Enable the firmware sysfs fallback mechanism"
++	help
++	  This option enables a sysfs loading facility to enable firmware
++	  loading to the kernel through userspace as a fallback mechanism
++	  if and only if the kernel's direct filesystem lookup for the
++	  firmware failed using the different /lib/firmware/ paths, or the
++	  path specified in the firmware_class path module parameter, or the
++	  firmware_class path kernel boot parameter if the firmware_class is
++	  built-in. For details on how to work with the sysfs fallback mechanism
++	  refer to Documentation/driver-api/firmware/fallback-mechanisms.rst.
++
++	  The direct filesystem lookup for firmware is always used first now.
++
++	  If the kernel's direct filesystem lookup for firmware fails to find
++	  the requested firmware a sysfs fallback loading facility is made
++	  available and userspace is informed about this through uevents.
++	  The uevent can be suppressed if the driver explicitly requested it,
++	  this is known as the driver using the custom fallback mechanism.
++	  If the custom fallback mechanism is used userspace must always
++	  acknowledge failure to find firmware as the timeout for the fallback
++	  mechanism is disabled, and failed requests will linger forever.
++
++	  This used to be the default firmware loading facility, and udev used
++	  to listen for uvents to load firmware for the kernel. The firmware
++	  loading facility functionality in udev has been removed, as such it
++	  can no longer be relied upon as a fallback mechanism. Linux no longer
++	  relies on or uses a fallback mechanism in userspace. If you need to
++	  rely on one refer to the permissively licensed firmwared:
++
++	  https://github.com/teg/firmwared
++
++	  Since this was the default firmware loading facility at one point,
++	  old userspace may exist which relies upon it, and as such this
++	  mechanism can never be removed from the kernel.
++
++	  You should only enable this functionality if you are certain you
++	  require a fallback mechanism and have a userspace mechanism ready to
++	  load firmware in case it is not found. One main reason for this may
++	  be if you have drivers which require firmware built-in and for
++	  whatever reason cannot place the required firmware in initramfs.
++	  Another reason kernels may have this feature enabled is to support a
++	  driver which explicitly relies on this fallback mechanism. Only two
++	  drivers need this today:
++
++	    o CONFIG_LEDS_LP55XX_COMMON
++	    o CONFIG_DELL_RBU
++
++	  Outside of supporting the above drivers, another reason for needing
++	  this may be that your firmware resides outside of the paths the kernel
++	  looks for and cannot possibly be specified using the firmware_class
++	  path module parameter or kernel firmware_class path boot parameter
++	  if firmware_class is built-in.
++
++	  A modern use case may be to temporarily mount a custom partition
++	  during provisioning which is only accessible to userspace, and then
++	  to use it to look for and fetch the required firmware. Such type of
++	  driver functionality may not even ever be desirable upstream by
++	  vendors, and as such is only required to be supported as an interface
++	  for provisioning. Since udev's firmware loading facility has been
++	  removed you can use firmwared or a fork of it to customize how you
++	  want to load firmware based on uevents issued.
++
++	  Enabling this option will increase your kernel image size by about
++	  13436 bytes.
++
++	  If you are unsure about this, say N here, unless you are Linux
++	  distribution and need to support the above two drivers, or you are
++	  certain you need to support some really custom firmware loading
++	  facility in userspace.
++
++config FW_LOADER_USER_HELPER_FALLBACK
++	bool "Force the firmware sysfs fallback mechanism when possible"
++	depends on FW_LOADER_USER_HELPER
++	help
++	  Enabling this option forces a sysfs userspace fallback mechanism
++	  to be used for all firmware requests which explicitly do not disable a
++	  a fallback mechanism. Firmware calls which do prohibit a fallback
++	  mechanism is request_firmware_direct(). This option is kept for
++          backward compatibility purposes given this precise mechanism can also
++	  be enabled by setting the proc sysctl value to true:
++
++	       /proc/sys/kernel/firmware_config/force_sysfs_fallback
++
++	  If you are unsure about this, say N here.
++
++endif # FW_LOADER
++endmenu

--- a/target/linux/generic/backport-4.14/081-0024-firmware_loader-make-firmware_fallback_sysfs()-print-more-useful.patch
+++ b/target/linux/generic/backport-4.14/081-0024-firmware_loader-make-firmware_fallback_sysfs()-print-more-useful.patch
@@ -1,0 +1,43 @@
+From 27d5d7dc9aafd6db3d7aeb49cdbfe578fc1b8663 Mon Sep 17 00:00:00 2001
+From: "Luis R. Rodriguez" <mcgrof@kernel.org>
+Date: Thu, 10 May 2018 13:08:44 -0700
+Subject: [PATCH] firmware_loader: make firmware_fallback_sysfs() print more
+ useful
+
+If we resort to using the sysfs fallback mechanism we don't print
+the filename. This can be deceiving given we could have a series of
+callers intertwined and it'd be unclear exactly for what firmware
+this was meant for.
+
+Additionally, although we don't currently use FW_OPT_NO_WARN when
+dealing with the fallback mechanism, we will soon, so just respect
+its use consistently.
+
+And even if you *don't* want to print always on failure, you may
+want to print when debugging so enable dynamic debug print when
+FW_OPT_NO_WARN is used.
+
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/base/firmware_loader/fallback.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/base/firmware_loader/fallback.c b/drivers/base/firmware_loader/fallback.c
+index 9169e7b9800c8..b676a99c469c2 100644
+--- a/drivers/base/firmware_loader/fallback.c
++++ b/drivers/base/firmware_loader/fallback.c
+@@ -690,6 +690,11 @@ int firmware_fallback_sysfs(struct firmware *fw, const char *name,
+ 	if (!fw_run_sysfs_fallback(opt_flags))
+ 		return ret;
+ 
+-	dev_warn(device, "Falling back to user helper\n");
++	if (!(opt_flags & FW_OPT_NO_WARN))
++		dev_warn(device, "Falling back to syfs fallback for: %s\n",
++				 name);
++	else
++		dev_dbg(device, "Falling back to sysfs fallback for: %s\n",
++				name);
+ 	return fw_load_from_user_helper(fw, name, device, opt_flags);
+ }

--- a/target/linux/generic/backport-4.14/081-0025-firmware-add-firmware_request_nowarn().patch
+++ b/target/linux/generic/backport-4.14/081-0025-firmware-add-firmware_request_nowarn().patch
@@ -1,0 +1,113 @@
+From 7dcc01343e483efda0882456f8361f061a5f416d Mon Sep 17 00:00:00 2001
+From: Andres Rodriguez <andresx7@gmail.com>
+Date: Thu, 10 May 2018 13:08:45 -0700
+Subject: [PATCH] firmware: add firmware_request_nowarn() - load firmware
+ without warnings
+
+Currently the firmware loader only exposes one silent path for querying
+optional firmware, and that is firmware_request_direct(). This function
+also disables the sysfs fallback mechanism, which might not always be the
+desired behaviour [0].
+
+This patch introduces a variations of request_firmware() that enable the
+caller to disable the undesired warning messages but enables the sysfs
+fallback mechanism. This is equivalent to adding FW_OPT_NO_WARN to the
+old behaviour.
+
+[0]: https://git.kernel.org/linus/c0cc00f250e1
+
+Signed-off-by: Andres Rodriguez <andresx7@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Acked-by: Luis R. Rodriguez <mcgrof@kernel.org>
+[mcgrof: used the old API calls as the full rename is not done yet, and
+ add the caller for when FW_LOADER is disabled, enhance documentation ]
+Signed-off-by: Luis R. Rodriguez <mcgrof@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ .../driver-api/firmware/request_firmware.rst       |  5 ++++
+ drivers/base/firmware_loader/main.c                | 27 ++++++++++++++++++++++
+ include/linux/firmware.h                           | 10 ++++++++
+ 3 files changed, 42 insertions(+)
+
+diff --git a/Documentation/driver-api/firmware/request_firmware.rst b/Documentation/driver-api/firmware/request_firmware.rst
+index d5ec95a7195bf..f62bdcbfed5b5 100644
+--- a/Documentation/driver-api/firmware/request_firmware.rst
++++ b/Documentation/driver-api/firmware/request_firmware.rst
+@@ -20,6 +20,11 @@ request_firmware
+ .. kernel-doc:: drivers/base/firmware_loader/main.c
+    :functions: request_firmware
+ 
++firmware_request_nowarn
++-----------------------
++.. kernel-doc:: drivers/base/firmware_loader/main.c
++   :functions: firmware_request_nowarn
++
+ request_firmware_direct
+ -----------------------
+ .. kernel-doc:: drivers/base/firmware_loader/main.c
+diff --git a/drivers/base/firmware_loader/main.c b/drivers/base/firmware_loader/main.c
+index abdc4e4d55f1b..0943e7065e0ea 100644
+--- a/drivers/base/firmware_loader/main.c
++++ b/drivers/base/firmware_loader/main.c
+@@ -631,6 +631,33 @@ request_firmware(const struct firmware **firmware_p, const char *name,
+ }
+ EXPORT_SYMBOL(request_firmware);
+ 
++/**
++ * firmware_request_nowarn() - request for an optional fw module
++ * @firmware: pointer to firmware image
++ * @name: name of firmware file
++ * @device: device for which firmware is being loaded
++ *
++ * This function is similar in behaviour to request_firmware(), except
++ * it doesn't produce warning messages when the file is not found.
++ * The sysfs fallback mechanism is enabled if direct filesystem lookup fails,
++ * however, however failures to find the firmware file with it are still
++ * suppressed. It is therefore up to the driver to check for the return value
++ * of this call and to decide when to inform the users of errors.
++ **/
++int firmware_request_nowarn(const struct firmware **firmware, const char *name,
++			    struct device *device)
++{
++	int ret;
++
++	/* Need to pin this module until return */
++	__module_get(THIS_MODULE);
++	ret = _request_firmware(firmware, name, device, NULL, 0,
++				FW_OPT_UEVENT | FW_OPT_NO_WARN);
++	module_put(THIS_MODULE);
++	return ret;
++}
++EXPORT_SYMBOL_GPL(firmware_request_nowarn);
++
+ /**
+  * request_firmware_direct() - load firmware directly without usermode helper
+  * @firmware_p: pointer to firmware image
+diff --git a/include/linux/firmware.h b/include/linux/firmware.h
+index 41050417cafb7..2dd566c91d448 100644
+--- a/include/linux/firmware.h
++++ b/include/linux/firmware.h
+@@ -42,6 +42,8 @@ struct builtin_fw {
+ #if defined(CONFIG_FW_LOADER) || (defined(CONFIG_FW_LOADER_MODULE) && defined(MODULE))
+ int request_firmware(const struct firmware **fw, const char *name,
+ 		     struct device *device);
++int firmware_request_nowarn(const struct firmware **fw, const char *name,
++			    struct device *device);
+ int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,
+@@ -59,6 +61,14 @@ static inline int request_firmware(const struct firmware **fw,
+ {
+ 	return -EINVAL;
+ }
++
++static inline int firmware_request_nowarn(const struct firmware **fw,
++					  const char *name,
++					  struct device *device)
++{
++	return -EINVAL;
++}
++
+ static inline int request_firmware_nowait(
+ 	struct module *module, bool uevent,
+ 	const char *name, struct device *device, gfp_t gfp, void *context,


### PR DESCRIPTION
This backport firmware_loader changes to this kernel. This push support for firmware_nowarn function to fix error with ath10k wireless firmware load.

Compiled and tested on r7800

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>