### PR TITLE
kernel: autoload phy-broadcom module

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -169,7 +169,7 @@ define KernelPackage/phy-broadcom
    KCONFIG:=CONFIG_BROADCOM_PHY
    DEPENDS:=+kmod-libphy +kmod-phylib-broadcom
    FILES:=$(LINUX_DIR)/drivers/net/phy/broadcom.ko
-   AUTOLOAD:=$(call AutoLoad,18,broadcom)
+   AUTOLOAD:=$(call AutoLoad,18,broadcom,1)
 endef
 
 define KernelPackage/phy-broadcom/description


### PR DESCRIPTION
Some HP Thin clients use the broadcom nextreme chip as integrated NIC. It is connected via PCI express and will only be found automatically if phy-broadcom is loaded before tg3. This small change makes the thin client usable for Freifunk with gluon out of the box.