### PR TITLE
ath10k: fix kernel panic while reading tpc_stats

### DIFF
--- a/package/kernel/mac80211/patches/083-ath10k-fix-kernel-panic-while-reading-tpc_stats.patch
+++ b/package/kernel/mac80211/patches/083-ath10k-fix-kernel-panic-while-reading-tpc_stats.patch
@@ -1,0 +1,120 @@
+From 4b190675ad06f5a6ecbeef0b01890c5fb372e3eb Mon Sep 17 00:00:00 2001
+From: Tamizh Chelvam <tamizhr@codeaurora.org>
+Date: Wed, 25 Apr 2018 11:36:44 +0300
+Subject: [PATCH] ath10k: fix kernel panic while reading tpc_stats
+
+When attempt to read tpc_stats for the chipsets which support
+more than 3 tx chain will trigger kernel panic(kernel stack is corrupted)
+due to writing values on rate_code array out of range.
+This patch changes the array size depends on the WMI_TPC_TX_N_CHAIN and
+added check to avoid write values on the array if the num tx chain
+get in tpc config event is greater than WMI_TPC_TX_N_CHAIN.
+
+Tested on QCA9984 with firmware-5.bin_10.4-3.5.3-00057
+
+Kernel panic log :
+
+[  323.510944] Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: bf90c654
+[  323.510944]
+[  323.524390] CPU: 0 PID: 1908 Comm: cat Not tainted 3.14.77 #31
+[  323.530224] [<c021db48>] (unwind_backtrace) from [<c021ac08>] (show_stack+0x10/0x14)
+[  323.537941] [<c021ac08>] (show_stack) from [<c03c53c0>] (dump_stack+0x80/0xa0)
+[  323.545146] [<c03c53c0>] (dump_stack) from [<c022e4ac>] (panic+0x84/0x1e4)
+[  323.552000] [<c022e4ac>] (panic) from [<c022e61c>] (__stack_chk_fail+0x10/0x14)
+[  323.559350] [<c022e61c>] (__stack_chk_fail) from [<bf90c654>] (ath10k_wmi_event_pdev_tpc_config+0x424/0x438 [ath10k_core])
+[  323.570471] [<bf90c654>] (ath10k_wmi_event_pdev_tpc_config [ath10k_core]) from [<bf90d800>] (ath10k_wmi_10_4_op_rx+0x2f0/0x39c [ath10k_core])
+[  323.583047] [<bf90d800>] (ath10k_wmi_10_4_op_rx [ath10k_core]) from [<bf8fcc18>] (ath10k_htc_rx_completion_handler+0x170/0x1a0 [ath10k_core])
+[  323.595702] [<bf8fcc18>] (ath10k_htc_rx_completion_handler [ath10k_core]) from [<bf961f44>] (ath10k_pci_hif_send_complete_check+0x1f0/0x220 [ath10k_pci])
+[  323.609421] [<bf961f44>] (ath10k_pci_hif_send_complete_check [ath10k_pci]) from [<bf96562c>] (ath10k_ce_per_engine_service+0x74/0xc4 [ath10k_pci])
+[  323.622490] [<bf96562c>] (ath10k_ce_per_engine_service [ath10k_pci]) from [<bf9656f0>] (ath10k_ce_per_engine_service_any+0x74/0x80 [ath10k_pci])
+[  323.635423] [<bf9656f0>] (ath10k_ce_per_engine_service_any [ath10k_pci]) from [<bf96365c>] (ath10k_pci_napi_poll+0x44/0xe8 [ath10k_pci])
+[  323.647665] [<bf96365c>] (ath10k_pci_napi_poll [ath10k_pci]) from [<c0599994>] (net_rx_action+0xac/0x160)
+[  323.657208] [<c0599994>] (net_rx_action) from [<c02324a4>] (__do_softirq+0x104/0x294)
+[  323.665017] [<c02324a4>] (__do_softirq) from [<c0232920>] (irq_exit+0x9c/0x11c)
+[  323.672314] [<c0232920>] (irq_exit) from [<c0217fc0>] (handle_IRQ+0x6c/0x90)
+[  323.679341] [<c0217fc0>] (handle_IRQ) from [<c02084e0>] (gic_handle_irq+0x3c/0x60)
+[  323.686893] [<c02084e0>] (gic_handle_irq) from [<c02095c0>] (__irq_svc+0x40/0x70)
+[  323.694349] Exception stack(0xdd489c58 to 0xdd489ca0)
+[  323.699384] 9c40:                                                       00000000 a0000013
+[  323.707547] 9c60: 00000000 dc4bce40 60000013 ddc1d800 dd488000 00000990 00000000 c085c800
+[  323.715707] 9c80: 00000000 dd489d44 0000092d dd489ca0 c026e664 c026e668 60000013 ffffffff
+[  323.723877] [<c02095c0>] (__irq_svc) from [<c026e668>] (rcu_note_context_switch+0x170/0x184)
+[  323.732298] [<c026e668>] (rcu_note_context_switch) from [<c020e928>] (__schedule+0x50/0x4d4)
+[  323.740716] [<c020e928>] (__schedule) from [<c020e490>] (schedule_timeout+0x148/0x178)
+[  323.748611] [<c020e490>] (schedule_timeout) from [<c020f804>] (wait_for_common+0x114/0x154)
+[  323.756972] [<c020f804>] (wait_for_common) from [<bf8f6ef0>] (ath10k_tpc_stats_open+0xc8/0x340 [ath10k_core])
+[  323.766873] [<bf8f6ef0>] (ath10k_tpc_stats_open [ath10k_core]) from [<c02bb598>] (do_dentry_open+0x1ac/0x274)
+[  323.776741] [<c02bb598>] (do_dentry_open) from [<c02c838c>] (do_last+0x8c0/0xb08)
+[  323.784201] [<c02c838c>] (do_last) from [<c02c87e4>] (path_openat+0x210/0x598)
+[  323.791408] [<c02c87e4>] (path_openat) from [<c02c9d1c>] (do_filp_open+0x2c/0x78)
+[  323.798873] [<c02c9d1c>] (do_filp_open) from [<c02bc85c>] (do_sys_open+0x114/0x1b4)
+[  323.806509] [<c02bc85c>] (do_sys_open) from [<c0208c80>] (ret_fast_syscall+0x0/0x44)
+[  323.814241] CPU1: stopping
+[  323.816927] CPU: 1 PID: 0 Comm: swapper/1 Not tainted 3.14.77 #31
+[  323.823008] [<c021db48>] (unwind_backtrace) from [<c021ac08>] (show_stack+0x10/0x14)
+[  323.830731] [<c021ac08>] (show_stack) from [<c03c53c0>] (dump_stack+0x80/0xa0)
+[  323.837934] [<c03c53c0>] (dump_stack) from [<c021cfac>] (handle_IPI+0xb8/0x140)
+[  323.845224] [<c021cfac>] (handle_IPI) from [<c02084fc>] (gic_handle_irq+0x58/0x60)
+[  323.852774] [<c02084fc>] (gic_handle_irq) from [<c02095c0>] (__irq_svc+0x40/0x70)
+[  323.860233] Exception stack(0xdd499fa0 to 0xdd499fe8)
+[  323.865273] 9fa0: ffffffed 00000000 1d3c9000 00000000 dd498000 dd498030 10c0387d c08b62c8
+[  323.873432] 9fc0: 4220406a 512f04d0 00000000 00000000 00000001 dd499fe8 c021838c c0218390
+[  323.881588] 9fe0: 60000013 ffffffff
+[  323.885070] [<c02095c0>] (__irq_svc) from [<c0218390>] (arch_cpu_idle+0x30/0x50)
+[  323.892454] [<c0218390>] (arch_cpu_idle) from [<c026500c>] (cpu_startup_entry+0xa4/0x108)
+[  323.900690] [<c026500c>] (cpu_startup_entry) from [<422085a4>] (0x422085a4)
+
+Signed-off-by: Tamizh chelvam <tamizhr@codeaurora.org>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+[slh: backport to wt-2017-11-01-0-gfe248fc2c180/ v4.14-rc2-1-31-g86cf0e5d]
+Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>
+---
+ drivers/net/wireless/ath/ath10k/debug.c | 8 +++++++-
+ drivers/net/wireless/ath/ath10k/wmi.c   | 6 ++++++
+ drivers/net/wireless/ath/ath10k/wmi.h   | 2 +-
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/debug.c
++++ b/drivers/net/wireless/ath/ath10k/debug.c
+@@ -1763,7 +1763,13 @@ static void ath10k_tpc_stats_print(struc
+ 	*len += scnprintf(buf + *len, buf_len - *len,
+ 			  "********************************\n");
+ 	*len += scnprintf(buf + *len, buf_len - *len,
+-			  "No.  Preamble Rate_code tpc_value1 tpc_value2 tpc_value3\n");
++			  "No.  Preamble Rate_code ");
++
++	for (i = 0; i < WMI_TPC_TX_N_CHAIN; i++)
++		*len += scnprintf(buf + *len, buf_len - *len,
++				  "tpc_value%d ", i);
++
++	*len += scnprintf(buf + *len, buf_len - *len, "\n");
+ 
+ 	for (i = 0; i < tpc_stats->rate_max; i++) {
+ 		*len += scnprintf(buf + *len, buf_len - *len,
+--- a/drivers/net/wireless/ath/ath10k/wmi.c
++++ b/drivers/net/wireless/ath/ath10k/wmi.c
+@@ -4350,6 +4350,12 @@ void ath10k_wmi_event_pdev_tpc_config(st
+ 
+ 	num_tx_chain = __le32_to_cpu(ev->num_tx_chain);
+ 
++	if (num_tx_chain > WMI_TPC_TX_N_CHAIN) {
++		ath10k_warn(ar, "number of tx chain is %d greater than TPC configured tx chain %d\n",
++			    num_tx_chain, WMI_TPC_TX_N_CHAIN);
++		return;
++	}
++
+ 	/* Fill HT20 rate code */
+ 	for (i = 0; i < num_tx_chain; i++) {
+ 		for (j = 0; j < 8; j++) {
+--- a/drivers/net/wireless/ath/ath10k/wmi.h
++++ b/drivers/net/wireless/ath/ath10k/wmi.h
+@@ -3985,8 +3985,8 @@ struct wmi_pdev_get_tpc_config_cmd {
+ } __packed;
+ 
+ #define WMI_TPC_CONFIG_PARAM		1
+-#define WMI_TPC_RATE_MAX		160
+ #define WMI_TPC_TX_N_CHAIN		4
++#define WMI_TPC_RATE_MAX		(WMI_TPC_TX_N_CHAIN * 65)
+ #define WMI_TPC_PREAM_TABLE_MAX		10
+ #define WMI_TPC_FLAG			3
+ #define WMI_TPC_BUF_SIZE		10


### PR DESCRIPTION
Merge upstream patch from Tamizh chelvam <tamizhr@codeaurora.org>
for OpenWrt's backports package:
https://patchwork.kernel.org/patch/10356157/
Commit-ID: 4b190675ad06f5a6ecbeef0b01890c5fb372e3eb

> When attempt to read tpc_stats for the chipsets which support
> more than 3 tx chain will trigger kernel panic(kernel stack is corrupted)
> due to writing values on rate_code array out of range.
> This patch changes the array size depends on the WMI_TPC_TX_N_CHAIN and
> added check to avoid write values on the array if the num tx chain
> get in tpc config event is greater than WMI_TPC_TX_N_CHAIN.
> 
> Tested on QCA9984 with firmware-5.bin_10.4-3.5.3-00057
> 
> Kernel panic log :
> 
> [  323.510944] Kernel panic - not syncing: stack-protector: Kernel stack is corrupted in: bf90c654
> [  323.510944]
> [  323.524390] CPU: 0 PID: 1908 Comm: cat Not tainted 3.14.77 #31
> [  323.530224] [<c021db48>] (unwind_backtrace) from [<c021ac08>] (show_stack+0x10/0x14)
> [  323.537941] [<c021ac08>] (show_stack) from [<c03c53c0>] (dump_stack+0x80/0xa0)
> [  323.545146] [<c03c53c0>] (dump_stack) from [<c022e4ac>] (panic+0x84/0x1e4)
> [  323.552000] [<c022e4ac>] (panic) from [<c022e61c>] (__stack_chk_fail+0x10/0x14)
> [  323.559350] [<c022e61c>] (__stack_chk_fail) from [<bf90c654>] (ath10k_wmi_event_pdev_tpc_config+0x424/0x438 [ath10k_core])
> [  323.570471] [<bf90c654>] (ath10k_wmi_event_pdev_tpc_config [ath10k_core]) from [<bf90d800>] (ath10k_wmi_10_4_op_rx+0x2f0/0x39c [ath10k_core])
> [  323.583047] [<bf90d800>] (ath10k_wmi_10_4_op_rx [ath10k_core]) from [<bf8fcc18>] (ath10k_htc_rx_completion_handler+0x170/0x1a0 [ath10k_core])
> [  323.595702] [<bf8fcc18>] (ath10k_htc_rx_completion_handler [ath10k_core]) from [<bf961f44>] (ath10k_pci_hif_send_complete_check+0x1f0/0x220 [ath10k_pci])
> [  323.609421] [<bf961f44>] (ath10k_pci_hif_send_complete_check [ath10k_pci]) from [<bf96562c>] (ath10k_ce_per_engine_service+0x74/0xc4 [ath10k_pci])
> [  323.622490] [<bf96562c>] (ath10k_ce_per_engine_service [ath10k_pci]) from [<bf9656f0>] (ath10k_ce_per_engine_service_any+0x74/0x80 [ath10k_pci])
> [  323.635423] [<bf9656f0>] (ath10k_ce_per_engine_service_any [ath10k_pci]) from [<bf96365c>] (ath10k_pci_napi_poll+0x44/0xe8 [ath10k_pci])
> [  323.647665] [<bf96365c>] (ath10k_pci_napi_poll [ath10k_pci]) from [<c0599994>] (net_rx_action+0xac/0x160)
> [  323.657208] [<c0599994>] (net_rx_action) from [<c02324a4>] (__do_softirq+0x104/0x294)
> [  323.665017] [<c02324a4>] (__do_softirq) from [<c0232920>] (irq_exit+0x9c/0x11c)
> [  323.672314] [<c0232920>] (irq_exit) from [<c0217fc0>] (handle_IRQ+0x6c/0x90)
> [  323.679341] [<c0217fc0>] (handle_IRQ) from [<c02084e0>] (gic_handle_irq+0x3c/0x60)
> [  323.686893] [<c02084e0>] (gic_handle_irq) from [<c02095c0>] (__irq_svc+0x40/0x70)
> [  323.694349] Exception stack(0xdd489c58 to 0xdd489ca0)
> [  323.699384] 9c40:                                                       00000000 a0000013
> [  323.707547] 9c60: 00000000 dc4bce40 60000013 ddc1d800 dd488000 00000990 00000000 c085c800
> [  323.715707] 9c80: 00000000 dd489d44 0000092d dd489ca0 c026e664 c026e668 60000013 ffffffff
> [  323.723877] [<c02095c0>] (__irq_svc) from [<c026e668>] (rcu_note_context_switch+0x170/0x184)
> [  323.732298] [<c026e668>] (rcu_note_context_switch) from [<c020e928>] (__schedule+0x50/0x4d4)
> [  323.740716] [<c020e928>] (__schedule) from [<c020e490>] (schedule_timeout+0x148/0x178)
> [  323.748611] [<c020e490>] (schedule_timeout) from [<c020f804>] (wait_for_common+0x114/0x154)
> [  323.756972] [<c020f804>] (wait_for_common) from [<bf8f6ef0>] (ath10k_tpc_stats_open+0xc8/0x340 [ath10k_core])
> [  323.766873] [<bf8f6ef0>] (ath10k_tpc_stats_open [ath10k_core]) from [<c02bb598>] (do_dentry_open+0x1ac/0x274)
> [  323.776741] [<c02bb598>] (do_dentry_open) from [<c02c838c>] (do_last+0x8c0/0xb08)
> [  323.784201] [<c02c838c>] (do_last) from [<c02c87e4>] (path_openat+0x210/0x598)
> [  323.791408] [<c02c87e4>] (path_openat) from [<c02c9d1c>] (do_filp_open+0x2c/0x78)
> [  323.798873] [<c02c9d1c>] (do_filp_open) from [<c02bc85c>] (do_sys_open+0x114/0x1b4)
> [  323.806509] [<c02bc85c>] (do_sys_open) from [<c0208c80>] (ret_fast_syscall+0x0/0x44)
> [  323.814241] CPU1: stopping
> [  323.816927] CPU: 1 PID: 0 Comm: swapper/1 Not tainted 3.14.77 #31
> [  323.823008] [<c021db48>] (unwind_backtrace) from [<c021ac08>] (show_stack+0x10/0x14)
> [  323.830731] [<c021ac08>] (show_stack) from [<c03c53c0>] (dump_stack+0x80/0xa0)
> [  323.837934] [<c03c53c0>] (dump_stack) from [<c021cfac>] (handle_IPI+0xb8/0x140)
> [  323.845224] [<c021cfac>] (handle_IPI) from [<c02084fc>] (gic_handle_irq+0x58/0x60)
> [  323.852774] [<c02084fc>] (gic_handle_irq) from [<c02095c0>] (__irq_svc+0x40/0x70)
> [  323.860233] Exception stack(0xdd499fa0 to 0xdd499fe8)
> [  323.865273] 9fa0: ffffffed 00000000 1d3c9000 00000000 dd498000 dd498030 10c0387d c08b62c8
> [  323.873432] 9fc0: 4220406a 512f04d0 00000000 00000000 00000001 dd499fe8 c021838c c0218390
> [  323.881588] 9fe0: 60000013 ffffffff
> [  323.885070] [<c02095c0>] (__irq_svc) from [<c0218390>] (arch_cpu_idle+0x30/0x50)
> [  323.892454] [<c0218390>] (arch_cpu_idle) from [<c026500c>] (cpu_startup_entry+0xa4/0x108)
> [  323.900690] [<c026500c>] (cpu_startup_entry) from [<422085a4>] (0x422085a4)
> 
> Signed-off-by: Tamizh chelvam <tamizhr@codeaurora.org>
> Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
> [slh: backport to wt-2017-11-01-0-gfe248fc2c180/ v4.14-rc2-1-31-g86cf0e5d]
> Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>

-- 

This fixes OpenWrt crashing/ rebooting when accessing /sys/kernel/debug/ieee80211/phy1/ath10k/tpc_stats - as reported by @Ansuel in https://forum.lede-project.org/t/netgear-r7800-exploration-ipq8065-qca9984/285/1306 

The patch has been accepted to mainline linux with 4b190675ad06f5a6ecbeef0b01890c5fb372e3eb and might be cherry-picked to openwrt-18.06 as well. While I'd suggest to do that, I don't see anything accessing tpc_stats in an automated fashion, which would make this less critical for 18.06.0.

@Ansuel please follow up with success confirmation to http://lists.infradead.org/pipermail/ath10k/2018-July/011739.html I'm not subscribed to the ath10k list and don't have the message-id to follow up the thread.

runtime-tested on a ZyXEL NBG6817, ipq8065/ QCA9984.
build-tested on ath79, ar71xx and lantiq.
```
# cat /sys/kernel/debug/ieee80211/phy1/ath10k/tpc_stats 

*************************************
TPC config for channel 2472 mode 5
*************************************
CTL             =  0x30 Reg. Domain             = 55
Antenna Gain    =  1 Reg. Max Antenna Gain      =   0
Power Limit     = 40 Reg. Max Power             = 40
Num tx chains   =  4 Num supported rates        = 241
********************************
******************* CDD POWER TABLE ****************
********************************
[...]
***********************************
TXBF not supported
***************************
```
