### PR TITLE
ar71xx: add support for MikroTik RB931-2nD

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -626,6 +626,7 @@ rb-911-2hn|\
 rb-911-5hn)
 	ucidef_set_led_netdev "eth" "ETH" "rb:green:eth" "eth0"
 	;;
+rb-931-2nd|\
 rb-941-2nd)
 	ucidef_set_led_timer "user" "USR/ACT" "rb:green:user" "1000" "1000"
 	;;

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -315,6 +315,10 @@ ar71xx_setup_interfaces()
 	dap-2695-a1)
 		ucidef_add_switch "switch0" "0@eth0" "2:lan" "3:wan" "6@eth1"
 		;;
+	rb-931-2nd)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:3" "2:lan:2" "3:wan:1"
+	;;
 	rb-941-2nd)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:wan:1"

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -368,6 +368,7 @@ get_status_led() {
 	rb-911g-2hpnd|\
 	rb-911g-5hpacd|\
 	rb-911g-5hpnd|\
+	rb-931-2nd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1061,6 +1061,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 921GS-5HPacD r2")
 		name="rb-921gs-5hpacd-r2"
 		;;
+	*"RouterBOARD 931-2nD")
+		name="rb-931-2nd"
+		;;
 	*"RouterBOARD 941-2nD")
 		name="rb-941-2nd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -704,6 +704,7 @@ platform_check_image() {
 	rb-750up-r2|\
 	rb-911-2hn|\
 	rb-911-5hn|\
+	rb-931-2nd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\
@@ -731,6 +732,7 @@ platform_pre_upgrade() {
 	rb-750up-r2|\
 	rb-911-2hn|\
 	rb-911-5hn|\
+	rb-931-2nd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
 	rb-952ui-5ac2nd|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1133,6 +1133,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik ROuterBOARD 911-5Hn (911 Lite5)
 	  MikroTik RouterBOARD mAP
 	  MikroTik RouterBOARD mAP lite
+	  MikroTik RouterBOARD hAP mini
 	  MikroTik RouterBOARD hAP lite
 	  MikroTik RouterBOARD hAP
 	  MikroTik RouterBOARD hAP ac

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -211,6 +211,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_751G,			/* Mikrotik RouterBOARD 751G */
 	ATH79_MACH_RB_911L,			/* Mikrotik RouterBOARD 911-2Hn/911-5Hn boards */
 	ATH79_MACH_RB_922GS,			/* Mikrotik RouterBOARD 911/922GS boards */
+	ATH79_MACH_RB_931,			/* MikroTik RouterBOARD 931-2nD */
 	ATH79_MACH_RB_941,			/* MikroTik RouterBOARD 941-2nD */
 	ATH79_MACH_RB_951G,			/* Mikrotik RouterBOARD 951G */
 	ATH79_MACH_RB_951U,			/* Mikrotik RouterBOARD 951Ui-2HnD */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -46,7 +46,7 @@ define Device/rb-nor-flash-16M
   DEVICE_PACKAGES := rbcfg rssileds -nand-utils kmod-ledtrig-gpio
   IMAGE_SIZE := 16000k
   KERNEL_INSTALL := 1
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef


### PR DESCRIPTION
This patch adds support for the MikroTik RB931-2nD (hAP mini):
https://mikrotik.com/product/RB931-2nD

Everything works: switch ports are correctly numbered in Luci, LED and buttons work and their GPIO levels are confirmed correct.

Specifications:
  * SoC: Qualcomm QCA9533 (650MHz)
  * RAM: 32MiB
  * Storage: 16MiB SPI NOR flash
  * Ethernet: 3x100M
  * Wireless: QCA9533 built-in, dual-chain 802.11b/g/n

Installation:

1. Setup a DHCP/BOOTP Server with the following parameters:
   * DHCP-Option 66 (TFTP server name): pointing to a local TFTP
     server within the same subnet of the DHCP range
   * DHCP-Option 67 (Bootfile-Name): matching the initramfs filename
     of the to be booted image. The usable intramfs files are:
       - openwrt-ar71xx-mikrotik-vmlinux-initramfs.elf
       - openwrt-ar71xx-mikrotik-vmlinux-initramfs-lzma.elf
       - openwrt-ar71xx-mikrotik-rb-nor-flash-16M-initramfs-kernel.bin

2. Press the reset button on the board and keep that pressed.

3. Connect the board to your local network via its Internet port.

4. Release the button after the LEDs on the board are turned off.
   Now the board should load and start the initramfs image from
   the TFTP server.

5. Now connect the board via either of its LAN ports (2 or 3).

6. Upload the sysupgrade image to the board with scp:
     $ scp openwrt-ar71xx-mikrotik-rb-nor-flash-16M-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/fw.bin

7. Log in to the running system listening on 192.168.1.1 via ssh
   as root (without password):
     $ ssh root@192.168.1.1

8. Flash the uploaded firmware file from the ssh session via the
   sysupgrade command:
     root@OpenWrt:~# sysupgrade /tmp/fw.bin

Signed-off-by: Thibaut VARÈNE <hacks@slashdirt.org>