### PR TITLE
build: add PKG_SOURCE_URL_FILE support

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -288,6 +288,7 @@ endef
 define Download/default
   FILE:=$(PKG_SOURCE)
   URL:=$(PKG_SOURCE_URL)
+  URL_FILE:=$(PKG_SOURCE_URL_FILE)
   SUBDIR:=$(PKG_SOURCE_SUBDIR)
   PROTO:=$(PKG_SOURCE_PROTO)
   $(if $(PKG_SOURCE_MIRROR),MIRROR:=$(filter 1,$(PKG_MIRROR)))


### PR DESCRIPTION
It seems that there is a missing PKG_SOURCE_URL_FILE support.
This little fix adds the support for packages to change the name of the
downloaded file.

Sometimes it is desirable to change the downloaded archive file name, like
for mitigating name conflicts for different packages (some files on the server
could be named like, e.g. 2018-01-01.tar.gz) or for the cases that there is
no name for the file in the URL (e.g. http://someserver.com/download).

Signed-off-by: Kamil Wcislo <kamil.wcislo@lpnplant.io>