### PR TITLE
kernel: Revert sit: reload iphdr in ipip6_rcv

### DIFF
--- a/target/linux/generic/patches-4.4/001-Revert-sit-reload-iphdr-in-ipip6_rcv.patch
+++ b/target/linux/generic/patches-4.4/001-Revert-sit-reload-iphdr-in-ipip6_rcv.patch
@@ -1,0 +1,26 @@
+From e0d66d877da5a03ed32023a6896e32334eb60445 Mon Sep 17 00:00:00 2001
+From: Dmitry Tunin <hanipouspilot@gmail.com>
+Date: Fri, 13 Jul 2018 00:57:48 +0300
+Subject: [PATCH] Revert sit: reload iphdr in ipip6_rcv [
+ 466d844cc205ff3b97c202ec9fb57632080811ab ]
+
+It has been reverted upstream.
+---
+ net/ipv6/sit.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/net/ipv6/sit.c b/net/ipv6/sit.c
+index dec4e7b..11282ff 100644
+--- a/net/ipv6/sit.c
++++ b/net/ipv6/sit.c
+@@ -692,7 +692,6 @@ static int ipip6_rcv(struct sk_buff *skb)
+ 
+ 		if (iptunnel_pull_header(skb, 0, htons(ETH_P_IPV6)))
+ 			goto out;
+-		iph = ip_hdr(skb);
+ 
+ 		err = IP_ECN_decapsulate(iph, skb);
+ 		if (unlikely(err)) {
+-- 
+2.7.4
+


### PR DESCRIPTION
This fixes FS#1541

Initially the commit was made upstream with CC to stable,
then reverted upstream, but without the CC.

This has been fixed in other distros like Ubuntu.
This needs to be backported to lede-17.01.

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>
