### PR TITLE
package/utils/f2fs-tools: Update to 1.11.0

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
-PKG_VERSION:=1.10.0
+PKG_VERSION:=1.11.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPLv2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
-PKG_HASH:=e841b086dbe02e3553b2c2ecb8c11a7990cfa9ca835c3d7aea6d600c6a543316
+PKG_HASH:=b916ac7cda902502cf18de98da94921f71edbab40fb0437d757f0716191c79e3
 
 PKG_FIXUP:=autoreconf
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Update f2fs-tools to 1.11.0

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>