### PR TITLE
popt: Replace dead upstream site with mirror

### DIFF
--- a/package/libs/popt/Makefile
+++ b/package/libs/popt/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.16
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://rpm5.org/files/popt/ http://distfiles.gentoo.org/distfiles/
+PKG_SOURCE_URL:=http://distfiles.gentoo.org/distfiles/ http://distcache.freebsd.org/ports-distfiles/
 PKG_HASH:=e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
 PKG_LICENSE:=MIT
 


### PR DESCRIPTION
We can safely assume by now that rpm5.org is dead and isn't coming back
so just add another mirror instead.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>