### PR TITLE
ar71xx: several fixes for mach-rbspi.c / correct support for wAP R

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -680,6 +680,9 @@ rb-wap-2nd)
 	ucidef_set_led_timer "user" "USER" "rb:green:user" "1000" "1000"
 	ucidef_set_led_wlan "wlan" "WLAN" "rb:green:wlan" "phy0tpt"
 	;;
+rb-wapr-2nd)
+	ucidef_set_led_wlan "wlan" "WLAN" "rb:green:user" "phy0tpt"
+	;;
 re355|\
 re450)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "$board:green:lan_data" "eth0" "tx rx"

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -384,7 +384,8 @@ get_status_led() {
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
 	rb-sxt2n|\
-	rb-sxt5n)
+	rb-sxt5n|\
+	rb-wapg-5hact2hnd)
 		status_led="rb:green:power"
 		;;
 	re355|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -376,7 +376,8 @@ get_status_led() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
-	rb-wap-2nd)
+	rb-wap-2nd|\
+	rb-wapr-2nd)
 		status_led="rb:green:user"
 		;;
 	rb-951ui-2hnd)

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -375,7 +375,8 @@ get_status_led() {
 	rb-962uigs-5hact2hnt|\
 	rb-lhg-5nd|\
 	rb-map-2nd|\
-	rb-mapl-2nd)
+	rb-mapl-2nd|\
+	rb-wap-2nd)
 		status_led="rb:green:user"
 		;;
 	rb-951ui-2hnd)

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -255,6 +255,8 @@ static struct gpio_led rb952_leds[] __initdata = {
 
 
 /* RB 962UiGS-5HacT2HnT gpios */
+#define RB962_WIFI_LED_1	1
+#define RB962_WIFI_LED_2	2
 #define RB962_GPIO_POE_STATUS	2
 #define RB962_GPIO_POE_POWER	3
 #define RB962_GPIO_LED_USER	12
@@ -520,7 +522,7 @@ static struct platform_device rbwapgsc_phy_device = {
 #define RB911L_GPIO_LED_ETH	20
 #define RB911L_GPIO_LED_POWER	11
 #define RB911L_GPIO_LED_USER	3
-#define RB911L_GPIO_PIN_HOLE	14 /* for reference */
+#define RB911L_GPIO_PIN_HOLE	14 /* for reference, active low */
 
 static struct gpio_led rb911l_leds[] __initdata = {
 	{
@@ -551,6 +553,7 @@ static struct gpio_led rb911l_leds[] __initdata = {
 		.name = "rb:green:power",
 		.gpio = RB911L_GPIO_LED_POWER,
 		.default_state = LEDS_GPIO_DEFSTATE_ON,
+		.active_low = 1,
 		.open_drain = 1,
 	}, {
 		.name = "rb:green:user",

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -478,10 +478,10 @@ static struct gpio_led rblhg_leds[] __initdata = {
 };
 
 /* RB w APG-5HacT2HnD (wAP AC) gpios*/
-#define RBWAPGSC_LED1		1
-#define RBWAPGSC_LED2		8
-#define RBWAPGSC_LED3		9
-#define RBWAPGSC_POWERLED		16
+#define RBWAPGSC_WIFI_LED_1		1
+#define RBWAPGSC_WIFI_LED_2		8
+#define RBWAPGSC_WIFI_LED_3		9
+#define RBWAPGSC_GPIO_LED_POWER		16
 #define RBWAPGSC_GPIO_BTN_RESET		1
 #define RBWAPGSC_GPIO_MDIO_MDC		12
 #define RBWAPGSC_GPIO_MDIO_DATA		11
@@ -489,13 +489,10 @@ static struct gpio_led rblhg_leds[] __initdata = {
 
 static struct gpio_led rbwapgsc_leds[] __initdata = {
 	{
-		.name = "rb:green:led1",
-		.gpio = RBWAPGSC_LED1,
+		.name = "rb:green:power",
+		.gpio = RBWAPGSC_GPIO_LED_POWER,
 		.active_low = 1,
-	},{
-		.name = "rb:blue:power",
-		.gpio = RBWAPGSC_POWERLED,
-		.active_low = 1,
+		.default_state = LEDS_GPIO_DEFSTATE_ON,
 	},
 };
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rbspi.c
@@ -213,7 +213,7 @@ static struct gpio_led rbhapl_leds[] __initdata = {
 #define RB952_GPIO_POE_POWER	14
 #define RB952_GPIO_POE_STATUS	12
 #define RB952_GPIO_BTN_RESET	16
-#define RB952_GPIO_USB_POWER	RBSPI_SSR_GPIO(RB952_SSR_BIT_USB_POWER)
+#define RB952_GPIO_USB_PWROFF	RBSPI_SSR_GPIO(RB952_SSR_BIT_USB_POWER)
 #define RB952_GPIO_LED_LAN1	RBSPI_SSR_GPIO(RB952_SSR_BIT_LED_LAN1)
 #define RB952_GPIO_LED_LAN2	RBSPI_SSR_GPIO(RB952_SSR_BIT_LED_LAN2)
 #define RB952_GPIO_LED_LAN3	RBSPI_SSR_GPIO(RB952_SSR_BIT_LED_LAN3)
@@ -258,7 +258,7 @@ static struct gpio_led rb952_leds[] __initdata = {
 #define RB962_GPIO_POE_STATUS	2
 #define RB962_GPIO_POE_POWER	3
 #define RB962_GPIO_LED_USER	12
-#define RB962_GPIO_USB_POWER	13
+#define RB962_GPIO_USB_PWROFF	13
 #define RB962_GPIO_BTN_RESET	20
 
 static struct gpio_led rb962_leds_gpio[] __initdata = {
@@ -388,7 +388,7 @@ static struct gpio_led rbcap_leds[] __initdata = {
 #define RBMAP_GPIO_LED_POWER	4
 #define RBMAP_GPIO_POE_POWER	14
 #define RBMAP_GPIO_POE_STATUS	12
-#define RBMAP_GPIO_USB_POWER	RBSPI_SSR_GPIO(RBMAP_SSR_BIT_USB_POWER)
+#define RBMAP_GPIO_USB_PWROFF	RBSPI_SSR_GPIO(RBMAP_SSR_BIT_USB_POWER)
 #define RBMAP_GPIO_LED_LAN1	RBSPI_SSR_GPIO(RBMAP_SSR_BIT_LED_LAN1)
 #define RBMAP_GPIO_LED_LAN2	RBSPI_SSR_GPIO(RBMAP_SSR_BIT_LED_LAN2)
 #define RBMAP_GPIO_LED_POEO	RBSPI_SSR_GPIO(RBMAP_SSR_BIT_LED_POEO)
@@ -828,9 +828,9 @@ static void __init rbspi_952_750r2_setup(u32 flags)
 	rbspi_network_setup(flags, 1, 5, 6);
 
 	if (flags & RBSPI_HAS_USB)
-		gpio_request_one(RB952_GPIO_USB_POWER,
+		gpio_request_one(RB952_GPIO_USB_PWROFF, GPIOF_ACTIVE_LOW |
 				GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
-				"USB power");
+				"USB power off");
 
 	if (flags & RBSPI_HAS_POE)
 		gpio_request_one(RB952_GPIO_POE_POWER,
@@ -938,9 +938,9 @@ static void __init rb962_setup(void)
 	rbspi_wlan_init(1, 7);
 
 	if (flags & RBSPI_HAS_USB)
-		gpio_request_one(RB962_GPIO_USB_POWER,
+		gpio_request_one(RB962_GPIO_USB_PWROFF, GPIOF_ACTIVE_LOW |
 				GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
-				"USB power");
+				"USB power off");
 
 	/* PoE output GPIO is inverted, set GPIOF_ACTIVE_LOW for consistency */
 	if (flags & RBSPI_HAS_POE)
@@ -1047,12 +1047,11 @@ static void __init rbmap_setup(void)
 				GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
 				"POE power");
 
-	/* USB power GPIO is inverted, set GPIOF_ACTIVE_LOW for consistency */
 	if (flags & RBSPI_HAS_USB)
-		gpio_request_one(RBMAP_GPIO_USB_POWER,
+		gpio_request_one(RBMAP_GPIO_USB_PWROFF,
 				GPIOF_OUT_INIT_HIGH | GPIOF_ACTIVE_LOW |
 					GPIOF_EXPORT_DIR_FIXED,
-				"USB power");
+				"USB power off");
 
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(rbmap_leds), rbmap_leds);
 

--- a/target/linux/generic/pending-4.9/481-mtd-spi-nor-add-w25q128jv.patch
+++ b/target/linux/generic/pending-4.9/481-mtd-spi-nor-add-w25q128jv.patch
@@ -1,0 +1,39 @@
+From b3b0dd8da363308355c0d7fcd3270962c05bd6d2 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Sat, 23 Jun 2018 12:08:27 +0200
+Subject: [PATCH] mtd: spi-nor: Add Winbond w25q128jv support
+
+mtd: spi-nor: Add Winbond w25q128jv support
+
+Datasheet:
+http://www.winbond.com/resource-files/w25q128jv%20revf%2003272018%20plus.pdf
+
+Testing done on Mikrotik Routerboard wAP R board which does not support
+Dual or Quad modes.
+
+This patch has been submitted upstream:
+https://patchwork.ozlabs.org/patch/934181/
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+[description message edited]
+Signed-off-by: Thibaut VARÈNE <hacks@slashdirt.org>
+---
+ spi-nor.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
+index 9a6a6a8..d4983e0 100644
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1149,6 +1149,11 @@ static const struct flash_info spi_nor_ids[] = {
+ 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
+ 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 	},
++	{ 
++		"w25q128jv", INFO(0xef7018, 0, 64 * 1024, 256,
++			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++	},
+ 	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },


### PR DESCRIPTION
This patch series contains several fixes for MikroTik SPI-NOR RouterBOARD devices.

**The following patches should be cherry-picked for 18.06:**
- `ar71xx: rbspi: clarify USB power gpios action`
- `ar71xx: rbspi: fix RB wAP AC gpio conflict and LED`
- `ar71xx: rbspi: mark rb911L user led as active low`
- `ar71xx: add missing diag LED support for RB wAP 2nD`

(The wAP R support code is currently not in 18.06)

Hope this helps