### PR TITLE
ramips: fix RBMxxG name and partitionning

### DIFF
--- a/target/linux/ramips/dts/RBM11G.dts
+++ b/target/linux/ramips/dts/RBM11G.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "mikrotik,rbm11g", "mediatek,mt7621-soc";
-	model = "MikroTik RBM11G";
+	model = "MikroTik RouterBOARD M11G";
 
 	aliases {
 		led-status = &led_usr;
@@ -90,29 +90,54 @@
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
+		// XXX empiric value to obtain actual 10MHz SCK at the chip
 		spi-max-frequency = <3125000>;
 
-		partition@0 {
-			label = "routerboot";
-			reg = <0x000000 0x00F000>;
-			read-only;
-		};
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		factory: partition@f000 {
-			label = "factory";
-			reg = <0x00F000 0x031000>;
-			read-only;
-		};
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
 
-		partition@40000 {
-			label = "firmware";
-			reg = <0x040000 0xFC0000>;
+			routerboot@0 {
+				reg = <0x0 0xf000>;
+				read-only;
+			};
+
+			hard_config: hard_config@f000 {
+				reg = <0xf000 0x1000>;
+				read-only;
+			};
+
+			routerboot2@10000 {
+				reg = <0x10000 0xf000>;
+				read-only;
+			};
+
+			soft_config@20000 {
+				reg = <0x20000 0x1000>;
+			};
+
+			// valid data only extends up to 0x4f but make it 0x1000 to match ar71xx
+			bios@30000 {
+				reg = <0x30000 0x1000>;
+				read-only;
+			};
+
+			firmware@40000 {
+				reg = <0x040000 0xFC0000>;
+			};
 		};
 	};
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x0010>;
+	mtd-mac-address = <&hard_config 0x0010>;
 	mtd-mac-address-increment = <1>;
 };
 
@@ -133,3 +158,6 @@
 &pcie {
 	status = "okay";
 };
+
+// XXX this device has hardware crypto
+//&crypto {};

--- a/target/linux/ramips/dts/RBM33G.dts
+++ b/target/linux/ramips/dts/RBM33G.dts
@@ -7,7 +7,7 @@
 
 / {
 	compatible = "mikrotik,rbm33g", "mediatek,mt7621-soc";
-	model = "MikroTik RBM33G";
+	model = "MikroTik RouterBOARD M33G";
 
 	aliases {
 		led-status = &led_usr;
@@ -39,7 +39,7 @@
 		poll-interval = <20>;
 
 		res {
-			label = "res";
+			label = "reset";
 			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
@@ -69,6 +69,7 @@
 		regulator-always-on;
 	};
 
+	// not defined in OEM source, this controls the M.2 slot
 	pcie2_vcc_reg {
 		compatible = "regulator-fixed";
 		regulator-name = "pcie2_vcc";
@@ -104,18 +105,42 @@
 		reg = <0>;
 		spi-max-frequency = <3125000>;
 
-		partition@0 {
-			label = "routerboot";
-			reg = <0x0 0xf000>;
-			read-only;
-		};
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-		factory: partition@f000 {
-			label = "factory";
-			reg = <0xf000 0x71000>;
-			read-only;
-		};
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
 
+			routerboot@0 {
+				reg = <0x0 0xf000>;
+				read-only;
+			};
+
+			hard_config: hard_config@f000 {
+				reg = <0xf000 0x1000>;
+				read-only;
+			};
+
+			routerboot2@10000 {
+				reg = <0x10000 0xf000>;
+				read-only;
+			};
+
+			soft_config@20000 {
+				reg = <0x20000 0x1000>;
+			};
+
+			// valid data only extends up to 0x4f but make it 0x1000 to match ar71xx
+			bios@30000 {
+				reg = <0x30000 0x1000>;
+				read-only;
+			};
+		};
 	};
 
 	w25q128@0 {
@@ -123,7 +148,15 @@
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <1>;
+		// XXX empiric value to obtain actual 10MHz SCK at the chip 
 		spi-max-frequency = <3125000>;
+
+		// this contains no data but is defined in OEM source
+		partition@0 {
+			label = "RouterBootFake";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
 
 		partition@40000 {
 			label = "firmware";
@@ -133,7 +166,7 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x0010>;
+	mtd-mac-address = <&hard_config 0x0010>;
 	mtd-mac-address-increment = <1>;
 };
 
@@ -158,3 +191,6 @@
 &pcie {
 	status = "okay";
 };
+
+// XXX this device has hardware crypto
+//&crypto {};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -260,11 +260,9 @@ define Device/rb750gr3
 endef
 TARGET_DEVICES += rb750gr3
 
-define Device/mikrotik_rbm33g
-  DTS := RBM33G
+define Device/MikroTik
   BLOCKSIZE := 64k
   IMAGE_SIZE := 16128k
-  DEVICE_TITLE := MikroTik RBM33G
   DEVICE_PACKAGES := kmod-usb3
   LOADER_TYPE := elf
   PLATFORM := mt7621
@@ -272,18 +270,18 @@ define Device/mikrotik_rbm33g
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
+
+define Device/mikrotik_rbm33g
+  $(Device/MikroTik)
+  DTS := RBM33G
+  DEVICE_TITLE := MikroTik RouterBOARD M33G
+endef
 TARGET_DEVICES += mikrotik_rbm33g
 
 define Device/mikrotik_rbm11g
+  $(Device/MikroTik)
   DTS := RBM11G
-  BLOCKSIZE := 64k
-  IMAGE_SIZE := 16128k
-  DEVICE_TITLE := MikroTik RBM11G
-  LOADER_TYPE := elf
-  PLATFORM := mt7621
-  KERNEL := kernel-bin | patch-dtb | lzma | loader-kernel
-  IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := MikroTik RouterBOARD M11G
 endef
 TARGET_DEVICES += mikrotik_rbm11g
 


### PR DESCRIPTION
This patch series sets the correct partition scheme for the RouterBoot section of the flash on these devices.

This section is subdivided in several segments, as they are on ar71xx
RB devices, albeit with different offsets and sizes.

The device name is corrected to match the hardware-stored (in hard_config)
device name.

**the RBM33G is already included in 18.06, the corresponding patch should be cherry-picked.**