### PR TITLE
ppp: fix pptp compilation (missing fPIC)

### DIFF
--- a/package/network/services/ppp/patches/500-add-pptp-plugin.patch
+++ b/package/network/services/ppp/patches/500-add-pptp-plugin.patch
@@ -45,7 +45,7 @@
 +	$(CC) $(CFLAGS) -c -o $@ $<
 +
 +pptp.so: dirutil.o orckit_quirks.o pptp.o pptp_callmgr.o pptp_ctrl.o pptp_quirks.o util.o vector.o
-+	$(CC) -o pptp.so -shared dirutil.o orckit_quirks.o pptp.o pptp_callmgr.o pptp_ctrl.o pptp_quirks.o util.o vector.o
++	$(CC) -o pptp.so -fPIC -shared dirutil.o orckit_quirks.o pptp.o pptp_callmgr.o pptp_ctrl.o pptp_quirks.o util.o vector.o
 +
 +install: all
 +	$(INSTALL) -d -m 755 $(LIBDIR)


### PR DESCRIPTION
Some targets like ar71xx have failed to compile pptp in ppp since the LTO changes in e7397eef by @nbd168 a few days ago.

Add missing -fPIC to fix the build error. Similar fix as in 888a15ff

I encountered the problem on my own WNDR3700 build, and buildbot also runs into it:
http://downloads.lede-project.org/snapshots/faillogs/mips_24kc/base/ppp/default/compile.txt
```
mips-openwrt-linux-musl-gcc -o pptp.so -shared dirutil.o orckit_quirks.o pptp.o pptp_callmgr.o pptp_ctrl.o pptp_quirks.o util.o vector.o
/data/bowl-builder/mips_24kc/build/sdk/staging_dir/toolchain-mips_24kc_gcc-7.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/7.3.0/../../../../mips-openwrt-linux-musl/bin/ld: /data/bowl-builder/mips_24kc/build/sdk/tmp/cceNbwrz.ltrans0.ltrans.o: relocation R_MIPS16_26 against `close' can not be used when making a shared object; recompile with -fPIC
/data/bowl-builder/mips_24kc/build/sdk/staging_dir/toolchain-mips_24kc_gcc-7.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/7.3.0/../../../../mips-openwrt-linux-musl/bin/ld: non-dynamic relocations refer to dynamic symbol close
/data/bowl-builder/mips_24kc/build/sdk/staging_dir/toolchain-mips_24kc_gcc-7.3.0_musl/bin/../lib/gcc/mips-openwrt-linux-musl/7.3.0/../../../../mips-openwrt-linux-musl/bin/ld: failed to set dynamic section sizes: Bad value
collect2: error: ld returned 1 exit status
Makefile:23: recipe for target 'pptp.so' failed
make[6]: *** [pptp.so] Error 1
```

Compile-tested with ar71xx/WNDR3700
