### PR TITLE
build: fix ASLR for LTO packages

### DIFF
--- a/include/hardening.mk
+++ b/include/hardening.mk
@@ -19,7 +19,7 @@ endif
 ifdef CONFIG_PKG_ASLR_PIE
   ifeq ($(strip $(PKG_ASLR_PIE)),1)
     TARGET_CFLAGS += $(FPIC)
-    TARGET_LDFLAGS += -specs=$(INCLUDE_DIR)/hardened-ld-pie.specs
+    TARGET_LDFLAGS += $(FPIC) -specs=$(INCLUDE_DIR)/hardened-ld-pie.specs
   endif
 endif
 ifdef CONFIG_PKG_CC_STACKPROTECTOR_REGULAR


### PR DESCRIPTION
Fix building packages with LTO when CONFIG_PKG_ASLR_PIE is enabled.

Despite comment of PR lto/80838, it seems that GCC needs -fPIC on linker
command line, even if all objects are -fPIC. This may change as PR
lto/80838 is merged into 8.1

compile-tested: ar71xx, ath79

Fix commits:
6dac92a42e052f89971762173daabb7fd84742ef
8c11133c9de632dca69c8464f911d8e2716effe2
07940acc341ee9bb2887359f193625e48f36207e
e7397eef69a20fc630148d0e597523e139d21c0c
ef16a394d2b24a363b50b5b4720cb23fe156c9da
ef96d1e34a990871c912938c336f51a510b1e32f
47b42137ce1e931ae5871952b1f98438396f5e07
73fc67b61480a3430d31de33478a1c0c2c364b9c
154c0c4006daf41e2cbb6c8b7ad5557f83dfea3e
804c51e1e661819c5a7532e66fb8a12166eef9a9

Signed-off-by: Julien Dusser <julien.dusser@free.fr>