### PR TITLE
base-files: sysctl '-e' must go before files

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=192
+PKG_RELEASE:=193
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -39,6 +39,6 @@ apply_defaults() {
 start() {
 	apply_defaults
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf; do
-		[ -f "$CONF" ] && sysctl -p "$CONF" -e >&-
+		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
 	done
 }


### PR DESCRIPTION
Tested on trunk r7516-ac10975 (x86). Affects all targets.
Please, backport to 18.06 too.

Restarting service sysctl echos multiple errors like:

  sysctl: -e: No such file or directory

After the first filename, all remaining arguments are treated
as files.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
