### PR TITLE
ramips: Convert gpio-export to platform driver.

### DIFF
--- a/target/linux/ramips/patches-4.14/0024-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/ramips/patches-4.14/0024-GPIO-add-named-gpio-exports.patch
@@ -22,7 +22,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  
-@@ -506,3 +508,71 @@ void of_gpiochip_remove(struct gpio_chip
+@@ -506,3 +508,68 @@ void of_gpiochip_remove(struct gpio_chip
  	gpiochip_remove_pin_ranges(chip);
  	of_node_put(chip->of_node);
  }
@@ -32,7 +32,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	{ /* sentinel */ }
 +};
 +
-+static int __init of_gpio_export_probe(struct platform_device *pdev)
++static int of_gpio_export_probe(struct platform_device *pdev)
 +{
 +	struct device_node *np = pdev->dev.of_node;
 +	struct device_node *cnp;
@@ -87,13 +87,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		.owner	= THIS_MODULE,
 +		.of_match_table	= of_match_ptr(gpio_export_ids),
 +	},
++	.probe		= of_gpio_export_probe,
 +};
 +
-+static int __init of_gpio_export_init(void)
-+{
-+	return platform_driver_probe(&gpio_export_driver, of_gpio_export_probe);
-+}
-+device_initcall(of_gpio_export_init);
++module_platform_driver(gpio_export_driver);
 --- a/drivers/gpio/gpiolib-sysfs.c
 +++ b/drivers/gpio/gpiolib-sysfs.c
 @@ -553,7 +553,7 @@ static struct class gpio_class = {


### PR DESCRIPTION
Needed to export i2c expander gpio.

Signed-off-by: René van Dorst <opensource@vdorst.com>

