### PR TITLE
kernel: Set -march=armv7-a for ARMv7 CPUs to fix builds with GCC 8

### DIFF
--- a/target/linux/generic/hack-4.14/379-arm-set-march-armv7-a-instead-of-armv5t-on-armv7-cpus.patch
+++ b/target/linux/generic/hack-4.14/379-arm-set-march-armv7-a-instead-of-armv5t-on-armv7-cpus.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm/Makefile b/arch/arm/Makefile
+index 36ae445..9bb3fab 100644
+--- a/arch/arm/Makefile
++++ b/arch/arm/Makefile
+@@ -67,7 +67,7 @@ KBUILD_CFLAGS	+= $(call cc-option,-fno-ipa-sra)
+ # macro, but instead defines a whole series of macros which makes
+ # testing for a specific architecture or later rather impossible.
+ arch-$(CONFIG_CPU_32v7M)	=-D__LINUX_ARM_ARCH__=7 -march=armv7-m -Wa,-march=armv7-m
+-arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 $(call cc-option,-march=armv7-a,-march=armv5t -Wa$(comma)-march=armv7-a)
++arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 $(call cc-option,-march=armv7-a,-march=armv7-a -Wa$(comma)-march=armv7-a)
+ arch-$(CONFIG_CPU_32v6)		=-D__LINUX_ARM_ARCH__=6 $(call cc-option,-march=armv6,-march=armv5t -Wa$(comma)-march=armv6)
+ # Only override the compiler option if ARMv6. The ARMv6K extensions are
+ # always available in ARMv7


### PR DESCRIPTION
The kernel sets -march=armv5t -Wa,-march=armv7-a for ARMv7 CPUs and as GCC uses the lowest common denominator it fails like below.
Changing -march=armv5t to -march=armv7-a fixes these compilation errors.

Also reported here:
https://lists.openwrt.org/pipermail/openwrt-devel/2018-July/013348.html

```
.../openwrt/tmp/ccQBODmW.s: Assembler messages:
.../openwrt/tmp/ccQBODmW.s:138: Error: selected processor does not support `dmb ish' in ARM mode
.../openwrt/tmp/ccQBODmW.s:153: Error: selected processor does not support `dsb ishst' in ARM mode
.../openwrt/tmp/ccQBODmW.s:157: Error: selected processor does not support `sev' in ARM mode
.../openwrt/tmp/ccQBODmW.s:303: Error: selected processor does not support `dmb ish' in ARM mode
.../openwrt/tmp/ccQBODmW.s:318: Error: selected processor does not support `dsb ishst' in ARM mode
.../openwrt/tmp/ccQBODmW.s:322: Error: selected processor does not support `sev' in ARM mode
scripts/Makefile.build:328: recipe for target 'crypto/jitterentropy-kcapi.o' failed
make[6]: *** [crypto/jitterentropy-kcapi.o] Error 1
```

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>