### PR TITLE
grub2: fix packed-not-aligned error on GCC 8

### DIFF
--- a/package/boot/grub2/patches/0008-Fix-packed-not-aligned-error-on-GCC-8.patch
+++ b/package/boot/grub2/patches/0008-Fix-packed-not-aligned-error-on-GCC-8.patch
@@ -1,0 +1,71 @@
+From 563b1da6e6ae7af46cc8354cadb5dab416989f0a Mon Sep 17 00:00:00 2001
+From: Michael Chang <mchang@suse.com>
+Date: Mon, 26 Mar 2018 16:52:34 +0800
+Subject: Fix packed-not-aligned error on GCC 8
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When building with GCC 8, there are several errors regarding packed-not-aligned.
+
+./include/grub/gpt_partition.h:79:1: error: alignment 1 of ‘struct grub_gpt_partentry’ is less than 8 [-Werror=packed-not-aligned]
+
+This patch fixes the build error by cleaning up the ambiguity of placing
+aligned structure in a packed one. In "struct grub_btrfs_time" and "struct
+grub_gpt_part_type", the aligned attribute seems to be superfluous, and also
+has to be packed, to ensure the structure is bit-to-bit mapped to the format
+laid on disk. I think we could blame to copy and paste error here for the
+mistake. In "struct efi_variable", we have to use grub_efi_packed_guid_t, as
+the name suggests. :)
+
+Signed-off-by: Michael Chang <mchang@suse.com>
+Tested-by: Michael Chang <mchang@suse.com>
+Tested-by: Paul Menzel <paulepanter@users.sourceforge.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/fs/btrfs.c          | 2 +-
+ include/grub/efiemu/runtime.h | 2 +-
+ include/grub/gpt_partition.h  | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/fs/btrfs.c b/grub-core/fs/btrfs.c
+index 4849c1ceb..be195448d 100644
+--- a/grub-core/fs/btrfs.c
++++ b/grub-core/fs/btrfs.c
+@@ -175,7 +175,7 @@ struct grub_btrfs_time
+ {
+   grub_int64_t sec;
+   grub_uint32_t nanosec;
+-} __attribute__ ((aligned (4)));
++} GRUB_PACKED;
+ 
+ struct grub_btrfs_inode
+ {
+diff --git a/include/grub/efiemu/runtime.h b/include/grub/efiemu/runtime.h
+index 9b6b729f4..36d2dedf4 100644
+--- a/include/grub/efiemu/runtime.h
++++ b/include/grub/efiemu/runtime.h
+@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
+ 
+ struct efi_variable
+ {
+-  grub_efi_guid_t guid;
++  grub_efi_packed_guid_t guid;
+   grub_uint32_t namelen;
+   grub_uint32_t size;
+   grub_efi_uint32_t attributes;
+diff --git a/include/grub/gpt_partition.h b/include/grub/gpt_partition.h
+index 1b32f6725..9668a68c3 100644
+--- a/include/grub/gpt_partition.h
++++ b/include/grub/gpt_partition.h
+@@ -28,7 +28,7 @@ struct grub_gpt_part_type
+   grub_uint16_t data2;
+   grub_uint16_t data3;
+   grub_uint8_t data4[8];
+-} __attribute__ ((aligned(8)));
++} GRUB_PACKED;
+ typedef struct grub_gpt_part_type grub_gpt_part_type_t;
+ 
+ #define GRUB_GPT_PARTITION_TYPE_EMPTY \
+-- 
+cgit v1.1-33-g03f6


### PR DESCRIPTION
Fix the compile error "packed-not-aligned" when using GCC 8. 

patch from: https://aur.archlinux.org/cgit/aur.git/tree/0008-Fix-packed-not-aligned-error-on-GCC-8.patch?h=grub-linux-default

Signed-off-by: Edi Turn <yyxstter@gmail.com>