### PR TITLE
utils/curl: Disable libpsl

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.61.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
@@ -113,6 +113,7 @@ CONFIGURE_ARGS += \
 	--without-librtmp \
 	--without-libidn \
 	--without-ca-path \
+	--without-libpsl \
 	--with-ca-bundle=/etc/ssl/certs/ca-certificates.crt \
 	\
 	$(call autoconf_bool,CONFIG_IPV6,ipv6) \


### PR DESCRIPTION
Disabled libpsl to fix build issue reported by buildbots

```
Package libcurl is missing dependencies for the following libraries:
libpsl.so.5
```

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>