### PR TITLE
firewall: drop SSDP packets from wan zone

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -53,6 +53,16 @@ config rule
 	option family		ipv4
 	option target		ACCEPT
 
+#Drop SSDP requests from wan zone
+config rule
+	option name		Drop-SSDP-on-wan
+	option src		wan
+	option proto		udp
+	option family		ipv4
+	option dest		*
+	option dest_ip		239.255.255.250
+	option target		DROP
+
 # Allow DHCPv6 replies
 # see https://dev.openwrt.org/ticket/10381
 config rule


### PR DESCRIPTION
If multicast is allowed from wan, e.g. by igmpproxy.init, we allow SSDP packets
to be forwarded to lan, that is not good for security reasons.
Also it causes log spam by igmpproxy

The source address 100.109.217.212 for group 239.255.255.250, is not in any valid net for upstream VIF.

We don't need SSDP packets from wan anyway. So this rule just drops them.

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>

