### PR TITLE
ncurses: install lib on host build

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -164,6 +164,8 @@ endef
 
 define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/progs/tic $(STAGING_DIR_HOST)/bin/tic
+	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/
+	$(INSTALL_DATA) $(HOST_BUILD_DIR)/lib/libncurses.a $(STAGING_DIR_HOSTPKG)/lib/
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
Install libncurses.a on host build, so host packages can find/consume as needed.

Signed-off-by: Andy Walsh <andy.walsh44+github@gmail.com>