### PR TITLE
ramips: add support for ELECOM WRC-2533GST

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -232,6 +232,7 @@ ramips_setup_interfaces()
 		;;
 	dir-860l-b1|\
 	elecom,wrc-1167ghbk2-s|\
+	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)
 		ucidef_add_switch "switch0" \
@@ -466,6 +467,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii config WAN_MAC_ADDR)
 		;;
 	elecom,wrc-1167ghbk2-s|\
+	elecom,wrc-2533gst|\
 	sk-wb8)
 		wan_mac=$(mtd_get_mac_binary factory 57350)
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -55,6 +55,7 @@ platform_check_image() {
 	duzun-dm06|\
 	e1700|\
 	elecom,wrc-1167ghbk2-s|\
+	elecom,wrc-2533gst|\
 	esr-9753|\
 	ew1200|\
 	ex2700|\

--- a/target/linux/ramips/dts/WRC-2533GST.dts
+++ b/target/linux/ramips/dts/WRC-2533GST.dts
@@ -1,0 +1,178 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "elecom,wrc-2533gst", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-2533GST";
+
+	aliases {
+		led-status = &led_power_green;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "wrc-2533gst:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_blue {
+			label = "wrc-2533gst:blue:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "wrc-2533gst:red:wps";
+			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_red {
+			label = "wrc-2533gst:red:power";
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		client {
+			label = "client";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		ap {
+			label = "ap";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		extender {
+			label = "extender";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+			read-only;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0xb00000>;
+		};
+
+		partition@b50000 {
+			label = "tm_pattern";
+			reg = <0xb50000 0x380000>;
+			read-only;
+		};
+
+		partition@ed0000 {
+			label = "tm_key";
+			reg = <0xed0000 0x80000>;
+			read-only;
+		};
+
+		partition@f50000 {
+			label = "art_block";
+			reg = <0xf50000 0x30000>;
+			read-only;
+		};
+
+		partition@f80000 {
+			label = "user_data";
+			reg = <0xf80000 0x80000>;
+			read-only;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "jtag", "wdt", "sdhci";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+	// WRC-2533GST has MT7615 for 2.4/5 GHz wifi,
+	// but it's not supported in OpenWrt.
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -4,6 +4,19 @@
 
 DEVICE_VARS += TPLINK_BOARD_ID TPLINK_HEADER_VERSION TPLINK_HWID TPLINK_HWREV
 
+define Build/elecom-gst-factory
+  $(eval product=$(word 1,$(1)))
+  $(eval version=$(word 2,$(1)))
+  ( $(STAGING_DIR_HOST)/bin/mkhash md5 $@ | tr -d '\n' ) >> $@
+  ( \
+    echo -n "ELECOM $(product) v$(version)" | \
+      dd bs=32 count=1 conv=sync; \
+    dd if=$@; \
+  ) > $@.new
+  mv $@.new $@
+  echo -n "MT7621_ELECOM_$(product)" >> $@
+endef
+
 define Build/elecom-wrc-factory
   $(eval product=$(word 1,$(1)))
   $(eval version=$(word 2,$(1)))
@@ -103,6 +116,16 @@ define Device/elecom_wrc-1167ghbk2-s
     elecom-wrc-factory WRC-1167GHBK2-S 0.00
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
+
+define Device/elecom_wrc-2533gst
+  DTS := WRC-2533GST
+  IMAGE_SIZE := 11264k
+  DEVICE_TITLE := ELECOM WRC-2533GST
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) |\
+    elecom-gst-factory WRC-2533GST 0.00
+endef
+TARGET_DEVICES += elecom_wrc-2533gst
 
 define Device/ew1200
   DTS := EW1200


### PR DESCRIPTION
ELECOM WRC-2533GST is a 2.4/5 GHz band 11ac rotuer, based on
MediaTek MT7621A.

Specification:

- MT7621A (2-Core, 4-Threads)
- 128 MB of RAM (DDR3)
- 16 MB of Flash (SPI)
- 4T4R 2.4/5 GHz wifi
  - MediaTek MT7615
- 5x 10/100/1000 Mbps Ethernet
- 4x LEDs, 6 keys (2x buttons, 1x slide switch)
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - baudrate: 57600 bps

Flash instruction using factory image:

1. Connect the computer to the LAN port of WRC-2533GST
2. Connect power cable to WRC-2533GST and turn on it
3. Access to "https://192.168.2.1/" and open firmware update
page ("ファームウェア更新")
4. Select the OpenWrt factory image and click apply ("適用")
button
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
