### PR TITLE
igmpproxy: drop SSDP packets

### DIFF
--- a/0001-igmpproxy-drop-SSDP-packets.patch
+++ b/0001-igmpproxy-drop-SSDP-packets.patch
@@ -1,0 +1,53 @@
+From 55dd9551005d48fd40a1fc97652bf2ca5059cd44 Mon Sep 17 00:00:00 2001
+From: Dmitry Tunin <hanipouspilot@gmail.com>
+Date: Sat, 28 Jul 2018 17:48:42 +0300
+Subject: [PATCH]     igmpproxy: drop SSDP packets
+
+    It is insecure to let this type of packets inside
+    They can e.g. open ports on some other routers with UPnP, etc
+
+Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>
+---
+ package/network/services/igmpproxy/Makefile             |  2 +-
+ package/network/services/igmpproxy/files/igmpproxy.init | 12 ++++++++++++
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/package/network/services/igmpproxy/Makefile b/package/network/services/igmpproxy/Makefile
+index 6ac4172..488de66 100644
+--- a/package/network/services/igmpproxy/Makefile
++++ b/package/network/services/igmpproxy/Makefile
+@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=igmpproxy
+ PKG_VERSION:=0.2.1
+-PKG_RELEASE:=2
++PKG_RELEASE:=4
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/
+diff --git a/package/network/services/igmpproxy/files/igmpproxy.init b/package/network/services/igmpproxy/files/igmpproxy.init
+index 0c30895..55c5f36 100644
+--- a/package/network/services/igmpproxy/files/igmpproxy.init
++++ b/package/network/services/igmpproxy/files/igmpproxy.init
+@@ -67,6 +67,18 @@ igmp_add_firewall_routing() {
+ 
+ 	[[ "$direction" = "downstream" && ! -z "$zone" ]] || return 0
+ 
++# First drop SSDP packets then accept all other multicast
++
++	json_add_object ""
++	json_add_string type rule
++	json_add_string src "$upstream"
++	json_add_string dest "$zone"
++	json_add_string family ipv4
++	json_add_string proto udp
++	json_add_string dest_ip "239.255.255.250"
++	json_add_string target DROP
++	json_close_object
++
+ 	json_add_object ""
+ 	json_add_string type rule
+ 	json_add_string src "$upstream"
+-- 
+2.7.4
+

--- a/package/network/services/igmpproxy/Makefile
+++ b/package/network/services/igmpproxy/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=igmpproxy
 PKG_VERSION:=0.2.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/pali/igmpproxy/releases/download/${PKG_VERSION}/

--- a/package/network/services/igmpproxy/files/igmpproxy.init
+++ b/package/network/services/igmpproxy/files/igmpproxy.init
@@ -68,6 +68,18 @@ igmp_add_firewall_routing() {
 
 	[[ "$direction" = "downstream" && ! -z "$zone" ]] || return 0
 
+# First drop SSDP packets then accept all other multicast
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$upstream"
+	json_add_string dest "$zone"
+	json_add_string family ipv4
+	json_add_string proto udp
+	json_add_string dest_ip "239.255.255.250"
+	json_add_string target DROP
+	json_close_object
+
 	json_add_object ""
 	json_add_string type rule
 	json_add_string src "$upstream"


### PR DESCRIPTION
It is insecure to let this type of packets inside
They can e.g. open ports on some other routers with UPnP, etc

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>
