### PR TITLE
ar71xx: ag71xx minor fixes that help debugging

### DIFF
--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
@@ -76,9 +76,23 @@ void ag71xx_phy_stop(struct ag71xx *ag)
 
 static int ag71xx_phy_connect_fixed(struct ag71xx *ag)
 {
-	struct device *dev = &ag->pdev->dev;
+	struct platform_device *pdev = ag->pdev;
+	struct device *dev = NULL;
 	struct ag71xx_platform_data *pdata = ag71xx_get_pdata(ag);
 	int ret = 0;
+
+	if (!pdev)
+		return -ENODEV;
+
+	dev = &pdev->dev;
+
+	if (!dev)
+		return -ENODEV;
+
+	if (!ag->phy_dev) {
+		pr_err("Missing PHY for %s", dev_name(dev));
+		return -ENODEV;
+	}
 
 	/* use fixed settings */
 	switch (pdata->speed) {

--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
@@ -119,7 +119,8 @@ static int ag71xx_phy_connect_multi(struct ag71xx *ag)
 		DBG("%s: PHY found at %s, uid=%08x\n",
 			dev_name(dev),
 			dev_name(&ag->mii_bus->phy_map[phy_addr]->dev),
-			ag->mii_bus->phy_map[phy_addr]->phy_id);
+			&ag->mii_bus->phy_map[phy_addr]->phy_id),
+			&ag->mii_bus->phy_map[phy_addr]->phy_id : 0);
 
 		if (phydev == NULL)
 			phydev = ag->mii_bus->phy_map[phy_addr];
@@ -130,7 +131,8 @@ static int ag71xx_phy_connect_multi(struct ag71xx *ag)
 		DBG("%s: PHY found at %s, uid=%08x\n",
 			dev_name(dev),
 			dev_name(&ag->mii_bus->mdio_map[phy_addr]->dev),
-			ag->mii_bus->mdio_map[phy_addr]->phy_id);
+			mdiobus_get_phy(ag->mii_bus, phy_addr) ?
+			mdiobus_get_phy(ag->mii_bus, phy_addr)->phy_id : 0);
 
 		if (phydev == NULL)
 			phydev = mdiobus_get_phy(ag->mii_bus, phy_addr);

--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
@@ -97,6 +97,17 @@ static int ag71xx_phy_connect_fixed(struct ag71xx *ag)
 	ag->duplex = pdata->duplex;
 	ag->speed = pdata->speed;
 
+	if (!ret) {
+		dev_info(dev, "connected to fixed PHY at %s [uid=%08x, driver=%s]\n",
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,5,0)
+			    dev_name(&ag->phy_dev->dev),
+#else
+			    phydev_name(ag->phy_dev),
+#endif
+			    ag->phy_dev->phy_id, ag->phy_dev->drv->name);
+	} else {
+		pr_err("Failed to connect to fixed PHY\n");
+	}
 	return ret;
 }
 


### PR DESCRIPTION
This is a trio of minor fixes/tweaks for ar71xx version of ag71xx that help debugging when working with the driver and/or modifying board definitions for ag71xx boards.
