### PR TITLE
ath79/ar71xx: Add/update support for CR5000 and CAP324

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -71,6 +71,7 @@ ar71xx_setup_interfaces()
 	aw-nr580|\
 	bullet-m|\
 	c-55|\
+	cap324|\
 	cap4200ag|\
 	cf-e380ac-v1|\
 	cf-e380ac-v2|\
@@ -274,7 +275,6 @@ ar71xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:wan" "4:lan"
 		;;
-	cap324|\
 	rme-eg200)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1433,7 +1433,7 @@ config ATH79_MACH_RW2458N
 	select ATH79_DEV_USB
 
 config ATH79_MACH_CAP324
-	bool "PowerCloud CAP324 support"
+	bool "PowerCloud Systems CAP324 support"
 	select SOC_AR934X
 	select ATH79_DEV_AP9X_PCI if PCI
 	select ATH79_DEV_ETH

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cap324.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cap324.c
@@ -129,5 +129,5 @@ static void __init cap324_setup(void)
 	ath79_register_eth(0);
 }
 
-MIPS_MACHINE(ATH79_MACH_CAP324, "CAP324", "PowerCloud CAP324",
+MIPS_MACHINE(ATH79_MACH_CAP324, "CAP324", "PowerCloud Systems CAP324",
 	     cap324_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cap324.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cap324.c
@@ -106,11 +106,11 @@ static void __init cap324_setup(void)
 					ARRAY_SIZE(cap324_gpio_keys),
 					cap324_gpio_keys);
 
-	ath79_init_mac(mac, art + CAP324_MAC_OFFSET, -1);
+	ath79_init_mac(mac, art + CAP324_MAC_OFFSET, -2);
 	ath79_wmac_disable_2ghz();
 	ath79_register_wmac(art + CAP324_WMAC_CALDATA_OFFSET, mac);
 
-	ath79_init_mac(mac, art + CAP324_MAC_OFFSET, -2);
+	ath79_init_mac(mac, art + CAP324_MAC_OFFSET, -1);
 	ap91_pci_init(art + CAP324_PCIE_CALDATA_OFFSET, mac);
 
 	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_RGMII_GMAC0 |
@@ -119,7 +119,7 @@ static void __init cap324_setup(void)
 	ath79_register_mdio(0, 0x0);
 
 	ath79_init_mac(ath79_eth0_data.mac_addr,
-		       art + CAP324_MAC_OFFSET, -2);
+		       art + CAP324_MAC_OFFSET, 0);
 
 	/* GMAC0 is connected to an external PHY */
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
@@ -106,10 +106,10 @@ static struct ar8327_pad_cfg cr5000_ar8327_pad0_cfg = {
 };
 
 static struct ar8327_led_cfg cr5000_ar8327_led_cfg = {
-	.led_ctrl0 = 0x00000000,
-	.led_ctrl1 = 0xc737c737,
-	.led_ctrl2 = 0x00000000,
-	.led_ctrl3 = 0x00c30c00,
+	.led_ctrl0 = 0xcc35cc35,
+	.led_ctrl1 = 0xca35ca35,
+	.led_ctrl2 = 0xc935c935,
+	.led_ctrl3 = 0x03ffff00,
 	.open_drain = true,
 };
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
@@ -1,5 +1,5 @@
 /*
- * PowerCloud CR5000 support
+ * PowerCloud Systems CR5000 support
  *
  * Copyright (c) 2011 Qualcomm Atheros
  * Copyright (c) 2011-2012 Gabor Juhos <juhosg@openwrt.org>
@@ -172,5 +172,5 @@ static void __init cr5000_setup(void)
 	ath79_register_eth(0);
 }
 
-MIPS_MACHINE(ATH79_MACH_CR5000, "CR5000", "PowerCloud CR5000",
+MIPS_MACHINE(ATH79_MACH_CR5000, "CR5000", "PowerCloud Systems CR5000",
 	     cr5000_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
@@ -90,7 +90,7 @@ static struct gpio_keys_button cr5000_gpio_keys[] __initdata = {
 	{
 		.desc		= "Reset button",
 		.type		= EV_KEY,
-		.code		= KEY_WPS_BUTTON,
+		.code		= KEY_RESTART,
 		.debounce_interval = CR5000_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= CR5000_GPIO_BTN_RESET,
 		.active_low	= 1,

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr5000.c
@@ -58,7 +58,7 @@
 #define CR5000_WMAC_CALDATA_OFFSET	0x1000
 #define CR5000_WMAC_MAC_OFFSET	        0x1002
 #define CR5000_PCIE_CALDATA_OFFSET	0x5000
-#define CR5000_PCIE_MAC_OFFSET	        0x5002
+#define CR5000_PCIE_WMAC_OFFSET		0x5002
 
 static struct gpio_led cr5000_leds_gpio[] __initdata = {
 	{
@@ -153,7 +153,7 @@ static void __init cr5000_setup(void)
 					cr5000_gpio_keys);
 	ath79_register_usb();
 	ath79_register_wmac(art + CR5000_WMAC_CALDATA_OFFSET, art + CR5000_WMAC_MAC_OFFSET);
-	ap94_pci_init(NULL, NULL, NULL, art + CR5000_PCIE_MAC_OFFSET);
+	ap94_pci_init(NULL, NULL, NULL, art + CR5000_PCIE_WMAC_OFFSET);
 
         ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_RGMII_GMAC0);
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -80,7 +80,7 @@ enum ath79_mach_type {
 	ATH79_MACH_CPE830,			/* YunCore CPE830 */
 	ATH79_MACH_CPE870,			/* YunCore CPE870 */
 	ATH79_MACH_CR3000,			/* PowerCloud CR3000 */
-	ATH79_MACH_CR5000,			/* PowerCloud CR5000 */
+	ATH79_MACH_CR5000,			/* PowerCloud Systems CR5000 */
 	ATH79_MACH_DAP_1330_A1,			/* D-Link DAP-1330 rev. A1 */
 	ATH79_MACH_DAP_2695_A1,			/* D-Link DAP-2695 rev. A1 */
 	ATH79_MACH_DB120,			/* Atheros DB120 reference board */

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -60,7 +60,7 @@ enum ath79_mach_type {
 	ATH79_MACH_BSB,				/* Smart Electronics Black Swift board */
 	ATH79_MACH_C55,				/* AirTight Networks C-55 */
 	ATH79_MACH_C60,				/* AirTight Networks C-60 */
-	ATH79_MACH_CAP324,			/* PowerCloud CAP324 */
+	ATH79_MACH_CAP324,			/* PowerCloud Systems CAP324 */
 	ATH79_MACH_CAP4200AG,			/* Senao CAP4200AG */
 	ATH79_MACH_CARAMBOLA2,			/* 8devices Carambola2 */
 	ATH79_MACH_CF_E316N_V2,			/* COMFAST CF-E316N v2 */

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -629,22 +629,13 @@ endef
 TARGET_DEVICES += wndrmacv2
 
 define Device/cap324
-  DEVICE_TITLE := PowerCloud Systems CAP324 Cloud AP
-  BOARDNAME := CAP324
-  DEVICE_PROFILE := CAP324
-  IMAGE_SIZE := 15296k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,15296k(firmware),640k(certs),64k(nvram),64k(art)ro
-endef
-TARGET_DEVICES += cap324
-
-define Device/cap324-nocloud
-  DEVICE_TITLE := PowerCloud Systems CAP324 Cloud AP (No-Cloud)
+  DEVICE_TITLE := PowerCloud Systems CAP324
   BOARDNAME := CAP324
   DEVICE_PROFILE := CAP324
   IMAGE_SIZE := 16000k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
 endef
-TARGET_DEVICES += cap324-nocloud
+TARGET_DEVICES += cap324
 
 define Device/cr3000
   DEVICE_TITLE := PowerCloud CR3000 Cloud Router

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -665,24 +665,14 @@ endef
 TARGET_DEVICES += cr3000-nocloud
 
 define Device/cr5000
-  DEVICE_TITLE := PowerCloud CR5000 Cloud Router
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb-core
-  BOARDNAME := CR5000
-  DEVICE_PROFILE := CR5000
-  IMAGE_SIZE := 7104k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7104k(firmware),640k(certs),64k(nvram),64k(art)ro
-endef
-TARGET_DEVICES += cr5000
-
-define Device/cr5000-nocloud
-  DEVICE_TITLE := PowerCloud CR5000 (No-Cloud)
+  DEVICE_TITLE := PowerCloud Systems CR5000
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb-core
   BOARDNAME := CR5000
   DEVICE_PROFILE := CR5000
   IMAGE_SIZE := 7808k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7808k(firmware),64k(art)ro
 endef
-TARGET_DEVICES += cr5000-nocloud
+TARGET_DEVICES += cr5000
 
 define Device/packet-squirrel
   $(Device/tplink-16mlzma)

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -629,7 +629,7 @@ endef
 TARGET_DEVICES += wndrmacv2
 
 define Device/cap324
-  DEVICE_TITLE := PowerCloud CAP324 Cloud AP
+  DEVICE_TITLE := PowerCloud Systems CAP324 Cloud AP
   BOARDNAME := CAP324
   DEVICE_PROFILE := CAP324
   IMAGE_SIZE := 15296k
@@ -638,7 +638,7 @@ endef
 TARGET_DEVICES += cap324
 
 define Device/cap324-nocloud
-  DEVICE_TITLE := PowerCloud CAP324 Cloud AP (No-Cloud)
+  DEVICE_TITLE := PowerCloud Systems CAP324 Cloud AP (No-Cloud)
   BOARDNAME := CAP324
   DEVICE_PROFILE := CAP324
   IMAGE_SIZE := 16000k

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -29,6 +29,10 @@ case "$board" in
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
 
+"pcs,cap324")
+	ucidef_set_led_netdev "lan" "LAN" "pcs:lan:green" "eth0"
+	;;
+
 "pcs,cr5000")
 	ucidef_set_led_usbdev "usb" "USB" "pcs:white:wps" "1-1"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -28,6 +28,11 @@ case "$board" in
 	ucidef_set_led_switch "lan1" "LAN1" "netgear:green:lan1" "switch0" "0x02" "0x0f"
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
+
+"pcs,cr5000")
+	ucidef_set_led_usbdev "usb" "USB" "pcs:white:wps" "1-1"
+	;;
+
 "tplink,re450-v2")
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 		;;
 	"avm,fritz300e"|\
 	"ocedo,raccoon"|\
+	"pcs,cap324"|\
 	"tplink,re450-v2"|\
 	"tplink,tl-mr10u"|\
 	"tplink,tl-wr703n"|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -43,6 +43,11 @@ ath79_setup_interfaces()
 		"0@eth1" "1:lan" "2:lan" "3:lan:3" "4:lan:4"
 		;;
 
+	"pcs,cr5000")
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
+		;;
+
 	"tplink,tl-archer-c7-v2")
 		ucidef_set_interfaces_lan_wan "eth1.1" "eth0.2"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -57,6 +57,7 @@ case "$FIRMWARE" in
 		;;
 	"netgear,wnr612-v2"|\
 	"on,n150r"|\
+	"pcs,cap324"|\
 	"tplink,tl-mr3220-v1"|\
 	"tplink,tl-mr3420-v1"|\
 	"tplink,tl-wr740n-v2"|\

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "PowerCloud Systems CAP324";
+	compatible = "pcs,cap324", "qca,ar9344";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &status;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-names = "default";
+                pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_amber {
+			label = "pcs:amber:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		status: power_green {
+			label = "pcs:green:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan_amber {
+			label = "pcs:amber:wlan";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan_green {
+			label = "pcs:green:wlan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan_amber {
+			label = "pcs:lan:amber";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan_green {
+			label = "pcs:lan:green";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x0fa0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+        ath9k: wifi@168c,0030 {
+		compatible = "168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&art 0x0>;
+		mtd-mac-address-increment = <(-2)>;
+		mtd-cal-data = <&art 0x5000>;
+		qca,no-eeprom;
+		qca,disable-5ghz;
+		#gpio-cells = <2>;
+		gpio-controller;
+        };
+};
+
+&wmac {
+	status = "okay";
+
+	qca,disable-2ghz;
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "PowerCloud Systems CR5000";
+	compatible = "pcs,cr5000", "qca,ar9344";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &status;
+	};
+
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-names = "default";
+                pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status: power {
+			label = "pcs:amber:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>,
+				<&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "pcs:blue:wlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps_white {
+			label = "pcs:white:wps";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x07a0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&usb {
+	status = "okay";
+
+	port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
+
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+        ath9k: wifi@168c,0030 {
+		compatible = "168c,0030";
+		mtd-mac-address = <&art 0x5002>;
+		#gpio-cells = <2>;
+		gpio-controller;
+        };
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+                qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+
+	aliases {
+		ag0 = &eth1;
+	};
+
+	port@0 {
+		compatible = "swconfig,port";
+		swconfig,segment = "lan";
+		swconfig,portmap = <1 1>;
+	};
+
+	port@1 {
+		compatible = "swconfig,port";
+		swconfig,segment = "lan";
+		swconfig,portmap = <2 2>;
+	};
+
+	port@2 {
+		compatible = "swconfig,port";
+		swconfig,segment = "lan";
+		swconfig,portmap = <3 3>;
+	};
+
+	port@3 {
+		compatible = "swconfig,port";
+		swconfig,segment = "lan";
+		swconfig,portmap = <4 4>;
+	};
+
+	port@4 {
+		compatible = "swconfig,port";
+		swconfig,segment = "wan";
+		swconfig,portmap = <5 5>;
+	};
+
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -66,6 +66,16 @@ define Device/openmesh_om5p-ac-v2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
 
+define Device/pcs_cr5000
+  ATH_SOC := ar9344
+  DEVICE_TITLE := PowerCloud Systems CR5000
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-usb-core
+  IMAGE_SIZE := 7808k
+  IMAGES := sysupgrade.bin
+  SUPPORTED_DEVICES += cr5000
+endef
+TARGET_DEVICES += pcs_cr5000
+
 define Device/netgear_wndr3800
   ATH_SOC := ar7161
   DEVICE_TITLE := NETGEAR WNDR3800

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -66,6 +66,15 @@ define Device/openmesh_om5p-ac-v2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
 
+define Device/pcs_cap324
+  ATH_SOC := ar9344
+  DEVICE_TITLE := PowerCloud Systems CAP324
+  IMAGE_SIZE := 16000k
+  IMAGES := sysupgrade.bin
+  SUPPORTED_DEVICES += cap324
+endef
+TARGET_DEVICES += pcs_cap324
+
 define Device/pcs_cr5000
   ATH_SOC := ar9344
   DEVICE_TITLE := PowerCloud Systems CR5000


### PR DESCRIPTION
This series of commits adds ath79 support for CR5000 and CAP324 from PowerCloud Systems.

It also fixes some errata in the previous ar71xx CR5000 and CAP324 definitions.

It also drops support for reverting to stock firmware as the stock firmware is only relevant for a cloud service that no longer exists.

[EDIT]: Also switches CAP324 default network to a static lan instead of a DHCP client; for non-modifed openwrt this makes more sense.