### PR TITLE
Change redboot DT parser compatible property to something more suitable

### DIFF
--- a/target/linux/brcm63xx/dts/livebox-blue-5g.dts
+++ b/target/linux/brcm63xx/dts/livebox-blue-5g.dts
@@ -70,7 +70,7 @@
 	status = "ok";
 
 	partitions {
-		compatible = "redhat,redboot-partitions";
+		compatible = "ecoscentric,redboot-fis-partitions";
 	};
 };
 

--- a/target/linux/generic/pending-4.14/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
+++ b/target/linux/generic/pending-4.14/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
@@ -17,7 +17,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  }
  
 +static const struct of_device_id redboot_parser_of_match_table[] = {
-+	{ .compatible = "redhat,redboot-partitions" },
++	{ .compatible = "ecoscentric,redboot-fis-partitions" },
 +	{},
 +};
 +MODULE_DEVICE_TABLE(of, redboot_parser_of_match_table);

--- a/target/linux/generic/pending-4.9/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
+++ b/target/linux/generic/pending-4.9/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
@@ -12,12 +12,20 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 
 --- a/drivers/mtd/redboot.c
 +++ b/drivers/mtd/redboot.c
-@@ -289,9 +289,16 @@ static int parse_redboot_partitions(stru
+@@ -29,6 +29,7 @@
+ #include <linux/mtd/mtd.h>
+ #include <linux/mtd/partitions.h>
+ #include <linux/module.h>
++#include <linux/mod_devicetable.h>
+ 
+ struct fis_image_desc {
+     unsigned char name[16];      // Null terminated name
+@@ -289,9 +290,16 @@ static int parse_redboot_partitions(stru
  	return ret;
  }
  
 +static const struct of_device_id redboot_parser_of_match_table[] = {
-+	{ .compatible = "redhat,redboot-partitions" },
++	{ .compatible = "ecoscentric,redboot-fis-partitions" },
 +	{},
 +};
 +MODULE_DEVICE_TABLE(of, redboot_parser_of_match_table);


### PR DESCRIPTION
The following two commits change the redboot DT parser compatible property from "redhat,redboot-partitions" to "ecoscentric,redboot-fis-partitions" and fix the build error seen on 4.9.x kernels caused by a missing header. 

This makes more sense taking into consideration RedHat hasn't had anything to do with RedBoot since 2002 or so, and provides a more descriptive property that references the FIS (Flash Information System) to distinguish it from traditional e.g. MBR partitioning schemes.

The one current user of this DT binding, livebox-blue-5g.dts, has been modified to use the new compatible property.