### PR TITLE
ipq40xx: Limit usable channels for OpenMesh A62 PHYs

### DIFF
--- a/package/kernel/mac80211/patches/976-ath10k-Limit-available-channels-via-DT-ieee80211-fre.patch
+++ b/package/kernel/mac80211/patches/976-ath10k-Limit-available-channels-via-DT-ieee80211-fre.patch
@@ -1,0 +1,44 @@
+From bbf0a8af2261bc7ae39b227ff6a1e9f45a008c27 Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven.eckelmann@openmesh.com>
+Date: Mon, 30 Jul 2018 17:31:41 +0200
+Subject: [PATCH] ath10k: Limit available channels via DT ieee80211-freq-limit
+
+Tri-band devices (1x 2.4GHz + 2x 5GHz) often incorporate special filters in
+the RX and TX path. These filtered channel can in theory still be used by
+the hardware but the signal strength is reduced so much that it makes no
+sense.
+
+There is already a DT property to limit the available channels but ath10k
+has to manually call this functionality to limit the currrently set wiphy
+channels further.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@openmesh.com>
+
+Forwarded: https://patchwork.kernel.org/patch/10549245/
+---
+ drivers/net/wireless/ath/ath10k/mac.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/net/wireless/ath/ath10k/mac.c b/drivers/net/wireless/ath/ath10k/mac.c
+index 95243b48a179..8ed37ffd320f 100644
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -18,6 +18,7 @@
+ 
+ #include "mac.h"
+ 
++#include <net/cfg80211.h>
+ #include <net/mac80211.h>
+ #include <linux/etherdevice.h>
+ #include <linux/acpi.h>
+@@ -8306,6 +8307,7 @@ int ath10k_mac_register(struct ath10k *ar)
+ 		ar->hw->wiphy->bands[NL80211_BAND_5GHZ] = band;
+ 	}
+ 
++	wiphy_read_of_freq_limits(ar->hw->wiphy);
+ 	ath10k_mac_setup_ht_vht_cap(ar);
+ 
+ 	ar->hw->wiphy->interface_modes =
+-- 
+2.11.0
+

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-a62.dts
@@ -222,6 +222,7 @@
 			status = "okay";
 			reg = <0x00010000 0 0 0 0>;
 			qcom,ath10k-calibration-variant = "OM-A62";
+			ieee80211-freq-limit = <5170000 5350000>;
 		};
 	};
 };
@@ -234,4 +235,5 @@
 &wifi1 {
 	status = "okay";
 	qcom,ath10k-calibration-variant = "OM-A62";
+	ieee80211-freq-limit = <5470000 5875000>;
 };


### PR DESCRIPTION
The OpenMesh A62 is a tri-band device (1x 2.4GHz, 2x 5GHz) with special filters in front of the RX+TX paths to the 5GHz PHYs. These filtered channel can in theory still be used by the hardware but the signal strength is reduced so much that it makes no sense.

The signal on an (uncalibrated) receiver looks like

![2018-03-27_5ghz_txpower](https://user-images.githubusercontent.com/1094579/43408660-3294cdde-9422-11e8-9be9-f8a02edf340c.png)

And the rx signal on the A62

![2018-03-27_5ghz_sensitivity](https://user-images.githubusercontent.com/1094579/43408716-51c9a7f6-9422-11e8-8b38-41262c75dfc5.png)

The ath10k patch was forwarded to https://patchwork.kernel.org/patch/10549245/