### PR TITLE
ath79: fix irq assignment for pci-ar71xx driver

### DIFF
--- a/target/linux/ath79/patches-4.14/0020-MIPS-ath79-turn-pci-ar71xx-driver-into-a-pure-OF-dri.patch
+++ b/target/linux/ath79/patches-4.14/0020-MIPS-ath79-turn-pci-ar71xx-driver-into-a-pure-OF-dri.patch
@@ -175,15 +175,19 @@ Signed-off-by: John Crispin <john@phrozen.org>
  	ar71xx_pci_reset();
  
  	/* setup COMMAND register */
-@@ -380,9 +376,11 @@ static int ar71xx_pci_probe(struct platf
+@@ -378,11 +374,13 @@ static int ar71xx_pci_probe(struct platf
+ 	/* clear bus errors */
+ 	ar71xx_pci_check_error(apc, 1);
  
- 	ar71xx_pci_irq_init(apc);
- 
+-	ar71xx_pci_irq_init(apc);
+-
 +	apc->np = pdev->dev.of_node;
  	apc->pci_ctrl.pci_ops = &ar71xx_pci_ops;
  	apc->pci_ctrl.mem_resource = &apc->mem_res;
  	apc->pci_ctrl.io_resource = &apc->io_res;
 +	pci_load_of_ranges(&apc->pci_ctrl, pdev->dev.of_node);
++
++	ar71xx_pci_irq_init(apc);
  
  	register_pci_controller(&apc->pci_ctrl);
  


### PR DESCRIPTION
In the new DT-based pci-ar71xx driver, ar71xx_pci_irq_init() was being
called before populating the PCI controller's device_node struct member.
This led to no IRQ being assigned to connected PCI devices (e.g. ath9k
cards) and caused them to be non-functional aside from simply being
detected.

The previous errors encountered in dmesg were: "irq: no irq domain found
for /ahb/apb/pcie-controller@180c0000 !". /proc/interrupts listed an IRQ
of 0 for the cards.

While this has been only been tested on a yet-to-be-merged RouterStation
Pro target, it should also fix the broken wifi people have reported for
the ath79 WNDR3800 target.