### PR TITLE
kernel: switch compatible property for RedBoot DT binding

### DIFF
--- a/target/linux/brcm63xx/dts/livebox-blue-5g.dts
+++ b/target/linux/brcm63xx/dts/livebox-blue-5g.dts
@@ -70,7 +70,7 @@
 	status = "ok";
 
 	partitions {
-		compatible = "redhat,redboot-partitions";
+		compatible = "ecoscentric,redboot-fis-partitions";
 	};
 };
 

--- a/target/linux/generic/pending-4.14/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
+++ b/target/linux/generic/pending-4.14/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
@@ -17,7 +17,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  }
  
 +static const struct of_device_id redboot_parser_of_match_table[] = {
-+	{ .compatible = "redhat,redboot-partitions" },
++	{ .compatible = "ecoscentric,redboot-fis-partitions" },
 +	{},
 +};
 +MODULE_DEVICE_TABLE(of, redboot_parser_of_match_table);

--- a/target/linux/generic/pending-4.9/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
+++ b/target/linux/generic/pending-4.9/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
@@ -25,7 +25,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  }
  
 +static const struct of_device_id redboot_parser_of_match_table[] = {
-+	{ .compatible = "redhat,redboot-partitions" },
++	{ .compatible = "ecoscentric,redboot-fis-partitions" },
 +	{},
 +};
 +MODULE_DEVICE_TABLE(of, redboot_parser_of_match_table);


### PR DESCRIPTION
This changes the DT binding's compatible property to
"ecoscentric,redboot-fis-partitions", removing the existing reference to
Red Hat.

Per the documentation hosted at eCosCentric's website, eCosCentric is
RedBoot's sole commercial maintainer since 2002, and the project has
been under the stewardship of the Free Software Foundation since 2008.

This also updates the property in the Inventel Livebox 1 .dts, the
binding's only current user.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>