### PR TITLE
Port CR3000 to ath79 and fix errata in ar71xx

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1486,7 +1486,7 @@ config ATH79_MACH_CAP4200AG
 	select ATH79_DEV_WMAC
 
 config ATH79_MACH_CR3000
-	bool "PowerCloud CR3000 support"
+	bool "PowerCloud Systems CR3000 support"
 	select SOC_AR934X
 	select ATH79_DEV_AP9X_PCI if PCI
 	select ATH79_DEV_ETH

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr3000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr3000.c
@@ -157,5 +157,5 @@ static void __init cr3000_setup(void)
 	ath79_register_eth(0);
 }
 
-MIPS_MACHINE(ATH79_MACH_CR3000, "CR3000", "PowerCloud CR3000",
+MIPS_MACHINE(ATH79_MACH_CR3000, "CR3000", "PowerCloud Systems CR3000",
 	     cr3000_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cr3000.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cr3000.c
@@ -21,7 +21,6 @@
  */
 
 #include <linux/gpio.h>
-#include <linux/pci.h>
 #include <linux/phy.h>
 #include <linux/platform_device.h>
 #include <linux/ath9k_platform.h>
@@ -31,7 +30,6 @@
 #include <asm/mach-ath79/ath79.h>
 
 #include "common.h"
-#include "dev-ap9x-pci.h"
 #include "dev-eth.h"
 #include "dev-gpio-buttons.h"
 #include "dev-leds-gpio.h"
@@ -58,7 +56,6 @@
 #define CR3000_MAC1_OFFSET		6
 #define CR3000_WMAC_CALDATA_OFFSET	0x1000
 #define CR3000_WMAC_MAC_OFFSET	        0x1002
-#define CR3000_PCIE_CALDATA_OFFSET	0x5000
 
 static struct gpio_led cr3000_leds_gpio[] __initdata = {
 	{
@@ -132,27 +129,37 @@ static void __init cr3000_setup(void)
 
 	/* WLAN 2GHz onboard */
 	ath79_register_wmac(art + CR3000_WMAC_CALDATA_OFFSET, art + CR3000_WMAC_MAC_OFFSET);
-	
-	ath79_register_mdio(1, 0x0);
-	ath79_register_mdio(0, 0x0);
 
+	/* FE Lan on first 4-ports of internal switch and attached to GMAC1
+	 * WAN Fast Ethernet interface attached to GMAC0
+	 * Could be configured as a 5-port switch, but we use
+	 * the SoC capabilities to attach port 5 to a separate PHY/MAC
+	 * theoretically this leaves future possibility of using SoC
+	 * acceleration/offloading.
+	 */
 	ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_SW_PHY_SWAP);
 
-	/* Lan 4-port switch attached to GMAC1 internal switch */
-	ath79_init_mac(ath79_eth1_data.mac_addr, art + CR3000_MAC0_OFFSET, 0);
+	/* GMAC0 attached to PHY4 (port 5 of the internal switch) */
+	ath79_switch_data.phy4_mii_en = 1;
+	/* For switch carrier ignore port 5 (wan) */
+	ath79_switch_data.phy_poll_mask = 0x1;
 
+	/* Register MII bus */
+	ath79_register_mdio(1, 0x0);
+
+	/* GMAC0 attached to PHY4 (port 5 of the internal switch) */
+	ath79_switch_data.phy4_mii_en = 1;
+	ath79_switch_data.phy_poll_mask = 0x1;
+
+	/* LAN */
+	ath79_init_mac(ath79_eth1_data.mac_addr, art + CR3000_MAC0_OFFSET, 0);
 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
-	ath79_eth1_data.speed = SPEED_1000;
-	ath79_eth1_data.duplex = DUPLEX_FULL;
 	ath79_register_eth(1);
 
-	ath79_init_mac(ath79_eth0_data.mac_addr, art + CR3000_MAC1_OFFSET, 0);
-
-	/* WAN Fast Ethernet interface attached to GMAC0 */
-	ath79_switch_data.phy4_mii_en = 1;
-	ath79_switch_data.phy_poll_mask = BIT(0);
-	ath79_eth0_data.phy_mask = BIT(0);
+	/* Wan */
+	ath79_init_mac(ath79_eth0_data.mac_addr, art + CR3000_MAC0_OFFSET, 1);
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
+	ath79_eth0_data.phy_mask = BIT(0);
 	ath79_eth0_data.mii_bus_dev = &ath79_mdio1_device.dev;
 	ath79_register_eth(0);
 }

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -80,7 +80,7 @@ enum ath79_mach_type {
 	ATH79_MACH_CPE510,			/* TP-LINK CPE510 */
 	ATH79_MACH_CPE830,			/* YunCore CPE830 */
 	ATH79_MACH_CPE870,			/* YunCore CPE870 */
-	ATH79_MACH_CR3000,			/* PowerCloud CR3000 */
+	ATH79_MACH_CR3000,			/* PowerCloud Systems CR3000 */
 	ATH79_MACH_CR5000,			/* PowerCloud Systems CR5000 */
 	ATH79_MACH_DAP_1330_A1,			/* D-Link DAP-1330 rev. A1 */
 	ATH79_MACH_DAP_2695_A1,			/* D-Link DAP-2695 rev. A1 */

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -695,22 +695,13 @@ endef
 TARGET_DEVICES += cap324
 
 define Device/cr3000
-  DEVICE_TITLE := PowerCloud CR3000 Cloud Router
-  BOARDNAME := CR3000
-  DEVICE_PROFILE := CR3000
-  IMAGE_SIZE := 7104k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7104k(firmware),640k(certs),64k(nvram),64k(art)ro
-endef
-TARGET_DEVICES += cr3000
-
-define Device/cr3000-nocloud
-  DEVICE_TITLE := PowerCloud CR3000 (No-Cloud)
+  DEVICE_TITLE := PowerCloud Systems CR3000
   BOARDNAME := CR3000
   DEVICE_PROFILE := CR3000
   IMAGE_SIZE := 7808k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,7808k(firmware),64k(art)ro
 endef
-TARGET_DEVICES += cr3000-nocloud
+TARGET_DEVICES += cr3000
 
 define Device/cr5000
   DEVICE_TITLE := PowerCloud Systems CR5000

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -28,15 +28,19 @@ case "$board" in
 	ucidef_set_led_switch "lan1" "LAN1" "netgear:green:lan1" "switch0" "0x02" "0x0f"
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
-
 "pcs,cap324")
 	ucidef_set_led_netdev "lan" "LAN" "pcs:lan:green" "eth0"
 	;;
-
+"pcs,cr3000")
+	ucidef_set_led_netdev "wan" "WAN" "pcs:blue:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "pcs:blue:lan1" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "LAN2" "pcs:blue:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "pcs:blue:lan3" "switch0" "0x10"
+	ucidef_set_led_switch "lan4" "LAN4" "pcs:blue:lan4" "switch0" "0x02"
+	;;
 "pcs,cr5000")
 	ucidef_set_led_usbdev "usb" "USB" "pcs:white:wps" "1-1"
 	;;
-
 "tplink,re450-v2")
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -44,6 +44,12 @@ ath79_setup_interfaces()
 		"0@eth1" "1:lan" "2:lan" "3:lan:3" "4:lan:4"
 		;;
 
+	"pcs,cr3000")
+		ucidef_add_switch "switch0" \
+			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+		ucidef_set_interface_wan "eth0"
+		;;
+
 	"pcs,cr5000")
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	model = "PowerCloud Systems CR3000";
+	compatible = "pcs,cr3000", "qca,ar9341";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &status;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-names = "default";
+                pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status: power {
+			label = "pcs:amber:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "pcs:blue:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan {
+			label = "pcs:blue:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1 {
+			label = "pcs:blue:lan1";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2 {
+			label = "pcs:blue:lan2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan3 {
+			label = "pcs:blue:lan3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan4 {
+			label = "pcs:blue:lan4";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x07a0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&art 0x0>;
+	phy-mode = "gmii";
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -75,6 +75,15 @@ define Device/pcs_cap324
 endef
 TARGET_DEVICES += pcs_cap324
 
+define Device/pcs_cr3000
+  ATH_SOC := ar9341
+  DEVICE_TITLE := PowerCloud Systems CR3000
+  IMAGE_SIZE := 7808k
+  IMAGES := sysupgrade.bin
+  SUPPORTED_DEVICES += cr3000
+endef
+
+TARGET_DEVICES += pcs_cr3000
 define Device/pcs_cr5000
   ATH_SOC := ar9344
   DEVICE_TITLE := PowerCloud Systems CR5000


### PR DESCRIPTION
This patch series add ath79 arch support for the PowerCloud Systems CR3000, and fixes some errata in the ar71xx version of the same.
