### PR TITLE
ncurses: use default host install

### DIFF
--- a/package/libs/ncurses/Makefile
+++ b/package/libs/ncurses/Makefile
@@ -162,12 +162,6 @@ define Host/Compile
 	$(MAKE) -C $(HOST_BUILD_DIR)/progs tic
 endef
 
-define Host/Install
-	$(INSTALL_BIN) $(HOST_BUILD_DIR)/progs/tic $(STAGING_DIR_HOST)/bin/tic
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib/
-	$(INSTALL_DATA) $(HOST_BUILD_DIR)/lib/libncurses.a $(STAGING_DIR_HOSTPKG)/lib/
-endef
-
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,terminfo))
 $(eval $(call BuildPackage,libncurses))


### PR DESCRIPTION
The custom Host/build already cherry-picks what needs to-be build for host, so just install everything it build via host/default/install. This way we also get correctly installed/generated libs and headers for the host.

As example openwrt/packages#6577 expects working libs and headers on host.