### PR TITLE
mt7620: gsw: make IntPHY and ExtPHY share mdio addr 4 possible

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
@@ -168,6 +168,12 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
 		_mt7620_mii_write(gsw, 4, 16, 0x1313);
 		_mt7620_mii_write(gsw, 4, 0, 0x3100);
 		pr_info("gsw: setting port4 to ephy mode\n");
+	} else {
+		u32 val = rt_sysc_r32(SYSC_REG_CFG1);
+
+		val &= ~(3 << 14);
+		rt_sysc_w32(val, SYSC_REG_CFG1);
+		pr_info("gsw: setting port4 to gmac mode\n");
 	}
 }
 


### PR DESCRIPTION
To share mdio addr for IntPHY and ExtPHY,
as described in the documentation (MT7620_ProgrammingGuide.pdf).
(refer: http://download.villagetelco.org/hardware/MT7620/MT7620_ProgrammingGuide.pdf)

when port4 setup to work as gmac mode, dts like:

&gsw {
    mediatek,port4 = "gmac";
};

we should set SYSCFG1.GE2_MODE==0x0 (RGMII).
but SYSCFG1.GE2_MODE may have been set to 3(RJ-45) by uboot/default
so we need to re-set it to 0x0

before this changes:
gsw: 4FE + 2GE may not work correctly and MDIO addr 4 cannot be used by ExtPHY

after this changes:
gsw: 4FE + 2GE works and MDIO addr 4 can be used by ExtPHY
