### PR TITLE
ath79: Add support for D-Link DIR-825 B1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -25,6 +25,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
 		;;
+	dlink,dir-825-b1)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
+		;;
 	embeddedwireless,dorin)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
@@ -131,6 +136,10 @@ ath79_setup_macs()
 	case "$board" in
 	avm,fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
+		;;
+	dlink,dir-825-b1)
+		lan_mac=$(dd if=$(find_mtd_part "caldata") bs=1 skip=65440 count=17 2>/dev/null)
+		wan_mac=$(dd if=$(find_mtd_part "caldata") bs=1 skip=65460 count=17 2>/dev/null)
 		;;
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -71,4 +71,24 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"ath9k-eeprom-pci-0000:00:11.0.bin")
+	case $board in
+	dlink,dir-825-b1)
+		ath9k_eeprom_extract "caldata" 4096 3768
+		;;
+	*)
+		ath9k_eeprom_die "board $board is not supported yet"
+		;;
+	esac
+	;;
+"ath9k-eeprom-pci-0000:00:12.0.bin")
+	case $board in
+	dlink,dir-825-b1)
+		ath9k_eeprom_extract "caldata" 20480 3768
+		;;
+	*)
+		ath9k_eeprom_die "board $board is not supported yet"
+		;;
+	esac
+	;;
 esac

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -18,6 +18,15 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			echo $(k2t_get_mac "lan_mac") > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dir-825-b1)
+		[ "$PHYNBR" -eq 0 ] && \
+			mac0=$(dd if=$(find_mtd_part "caldata") bs=1 skip=65440 count=17 2>/dev/null)
+			echo $mac0 > /sys${DEVPATH}/macaddress
+
+		[ "$PHYNBR" -eq 1 ] && \
+			mac1=$(dd if=$(find_mtd_part "caldata") bs=1 skip=65460 count=17 2>/dev/null)
+			echo $(macaddr_add "$mac1" 1) > /sys${DEVPATH}/macaddress
+		;;
 	*)
 		;;
 esac

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -22,6 +22,16 @@ define Device/buffalo_wzr-hp-g450h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g450h
 
+define Device/dlink_dir-825-b1
+  ATH_SOC := ar7161
+  DEVICE_TITLE := D-LINK DIR-825 B1
+  IMAGE_SIZE := 6208k
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
+  SUPPORTED_DEVICES += dir-825-b1
+endef
+TARGET_DEVICES += dlink_dir-825-b1
+
 define Device/embeddedwireless_dorin
   ATH_SOC := ar9331
   DEVICE_TITLE := Embedded Wireless Dorin


### PR DESCRIPTION
Only sysupgrade at the moment, because factory build is a bit tricky for me.
Everything works, including switch, wifi, vlans, leds.

10-ath9k-eeprom needs to be updated, because it doesn't assume 2 PCI devices.
I am going to do it next with some more testing.

Signed-off-by: Dmitry Tunin <hanipouspilot@gmail.com>
