### PR TITLE
base-files: sysupgrade: abort if config backup fails

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=193
+PKG_RELEASE:=194
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -165,6 +165,11 @@ do_save_conffiles() {
 	v "Saving config files..."
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
 	tar c${TAR_V}zf "$conf_tar" -T "$CONFFILES" 2>/dev/null
+	if [ "$?" -ne 0 ]; then
+		echo "Failed to create the configuration backup."
+		rm -f "$conf_tar"
+		exit 1
+	fi
 
 	rm -f "$CONFFILES"
 }


### PR DESCRIPTION
Sysupgrade shouldn't proceed, if the backup of the configuration
fails because tar (or gzip) exit with a non-zero code.

Signed-off-by: Andreas Ziegler <dev@andreas-ziegler.de>

we experienced  a bug which was caused by uclient (and fixed in master  e44162ffca448d024fe023944df702c9d3f6b586 and 18.06 8be3af93b433bf79a8fee4d41d84a796b5708121 already, lede-17.01 not yet) - together with the missing exit code check in sysupgrade, it killed quite a few devices' configs.
related downstream issue: https://github.com/freifunk-gluon/gluon/issues/1496