### PR TITLE
base-files: drop relevant sections & options except when ipv6 is on

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=193
+PKG_RELEASE:=194
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -15,10 +15,14 @@ generate_static_network() {
 		set network.loopback.proto='static'
 		set network.loopback.ipaddr='127.0.0.1'
 		set network.loopback.netmask='255.0.0.0'
-		delete network.globals
-		set network.globals='globals'
-		set network.globals.ula_prefix='auto'
 	EOF
+		[ -e /proc/sys/net/ipv6 ] && {
+			uci -q batch <<-EOF
+				delete network.globals
+				set network.globals='globals'
+				set network.globals.ula_prefix='auto'
+			EOF
+		}
 
 	if json_is_a dsl object; then
 		json_select dsl
@@ -102,21 +106,23 @@ generate_network() {
 				set network.$1.proto='static'
 				set network.$1.ipaddr='$ipad'
 				set network.$1.netmask='$netm'
-				set network.$1.ip6assign='60'
 			EOF
+			[ -e /proc/sys/net/ipv6 ] && uci set network.$1.ip6assign='60'
 		;;
 
 		dhcp)
 			# fixup IPv6 slave interface if parent is a bridge
 			[ "$type" = "bridge" ] && ifname="br-$1"
 
-			uci -q batch <<-EOF
-				set network.$1.proto='dhcp'
-				delete network.${1}6
-				set network.${1}6='interface'
-				set network.${1}6.ifname='$ifname'
-				set network.${1}6.proto='dhcpv6'
-			EOF
+			uci set network.$1.proto='dhcp'
+			[ -e /proc/sys/net/ipv6 ] && {
+				uci -q batch <<-EOF
+					delete network.${1}6
+					set network.${1}6='interface'
+					set network.${1}6.ifname='$ifname'
+					set network.${1}6.proto='dhcpv6'
+				EOF
+			}
 		;;
 
 		pppoe)
@@ -124,12 +130,16 @@ generate_network() {
 				set network.$1.proto='pppoe'
 				set network.$1.username='username'
 				set network.$1.password='password'
-				set network.$1.ipv6='1'
-				delete network.${1}6
-				set network.${1}6='interface'
-				set network.${1}6.ifname='@${1}'
-				set network.${1}6.proto='dhcpv6'
 			EOF
+			[ -e /proc/sys/net/ipv6 ] && {
+				uci -q batch <<-EOF
+					set network.$1.ipv6='1'
+					delete network.${1}6
+					set network.${1}6='interface'
+					set network.${1}6.ifname='@${1}'
+					set network.${1}6.proto='dhcpv6'
+				EOF
+			}
 		;;
 	esac
 }


### PR DESCRIPTION
Enable IPv6 relevant configurations only when the system is support.

Signed-off-by: Rosy Song <rosysong@rosinson.com>