### PR TITLE
imagebuilder: manifest function show stderr

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -119,8 +119,8 @@ _call_image: staging_dir/host/.prereq-build
 _call_manifest: FORCE
 	rm -rf $(TARGET_DIR)
 	mkdir -p $(TARGET_DIR) $(BIN_DIR) $(TMP_DIR) $(DL_DIR)
-	$(MAKE) package_reload >/dev/null 2>/dev/null
-	$(MAKE) package_install >/dev/null 2>/dev/null
+	$(MAKE) package_reload >/dev/null
+	$(MAKE) package_install >/dev/null
 	$(OPKG) list-installed
 
 package_index: FORCE


### PR DESCRIPTION
This really simplifies debugging, if a package is not found or a feed is
not reachable, a proper stderr is printed. Currently it would only say
`_call_manifest` failed.

Signed-off-by: Paul Spooren <mail@aparcar.org>