### PR TITLE
ath79: Add support for LigoWawe DLB 5 Propeller

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -14,6 +14,7 @@ board=$(board_name)
 
 case "$board" in
 glinet,ar300m|\
+ligowawe,dlb5-propeller|\
 ocedo,raccoon|\
 openmesh,om5p-ac-v2)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -22,6 +22,14 @@ etactica,eg200)
 	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"
 	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
 	;;
+ligowawe,dlb5-propeller)
+	ucidef_set_led_netdev "lan0" "LAN0" "ligowawe:green:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "ligowawe:yellow:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "ligowawe:yellow:link2" "wlan0" "25" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ligowawe:yellow:link3" "wlan0" "50" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ligowawe:yellow:link4" "wlan0" "75" "100"
+	;;
 netgear,wnr612-v2|\
 on,n150r)
 	ucidef_set_led_netdev "wan" "WAN" "netgear:green:wan" "eth0"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ ath79_setup_interfaces()
 
 	case "$board" in
 	avm,fritz300e|\
+	ligowawe,dlb5-propeller|\
 	ocedo,raccoon|\
 	pcs,cap324|\
 	tplink,re450-v2|\

--- a/target/linux/ath79/base-files/etc/diag.sh
+++ b/target/linux/ath79/base-files/etc/diag.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
+. /lib/functions.sh
 . /lib/functions/leds.sh
+
+board=$(board_name)
 
 status_led="$(get_dt_led status)"
 
@@ -17,6 +20,12 @@ set_state() {
 		;;
 	done)
 		status_led_on
+		case "$board" in
+		ligowawe,dlb5-propeller)
+			active_fw=$(fw_printenv -n active)
+                	fw_setenv linux_fail${active_fw}=0
+		;;
+		esac
 		;;
 	esac
 }

--- a/target/linux/ath79/dts/ar9342_ligowawe_dlb5_propeller.dts
+++ b/target/linux/ath79/dts/ar9342_ligowawe_dlb5_propeller.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "LigoWawe DLB 5 Propeller";
+	compatible = "ligowawe,dlb5-propeller", "qca,ar9344";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &status;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-names = "default";
+                pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status: power {
+			label = "ligowawe:green:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		lan {
+			label = "ligowawe:green:lan";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		link1 {
+			label = "ligowawe:yellow:link1";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		link2 {
+			label = "ligowawe:yellow:link2";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		link3 {
+			label = "ligowawe:yellow:link3";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		link4 {
+			label = "ligowawe:yellow:link4";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+			};
+			
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0x780000>;
+			};
+
+			partition@f40000 {
+				label = "data";
+				reg = <0xf40000 0x090000>;
+				read-only;
+			};
+
+			cfg: partition@fd0000 {
+				label = "cfg";
+				reg = <0xfd0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+	
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "mii";
+	phy-handle = <&phy0>;
+	
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -57,6 +57,15 @@ define Device/glinet_ar300m_nor
 endef
 TARGET_DEVICES += glinet_ar300m_nor
 
+define Device/ligowawe_dlb5_propeller
+  ATH_SOC := ar9342
+  DEVICE_TITLE := LigoWawe DLB 5 Propeller
+  DEVICE_PACKAGES := rssileds uboot-envtools
+  SUPPORTED_DEVICES += ligowawe,dlb5-propeller dlb5-propeller
+  IMAGE_SIZE := 7680k
+endef
+TARGET_DEVICES += ligowawe_dlb5_propeller
+
 define Device/ocedo_raccoon
   ATH_SOC := ar9344
   DEVICE_TITLE := OCEDO Raccoon


### PR DESCRIPTION
LigoDLB Propeller 5 is 5 GHz AP based on Qualcomm AR9342 rev 2.
https://www.ligowave.com/products/ligodlb-propeller-5
Specifications:

560/450/225/40 MHz (CPU/DDR/AHB/REF)
64MB of RAM
16 MB of FLASH (8 MB usable because of dual image)
1x 10/100 Mbps Ethernet with 24V POE IN
6x LED, 1x button
UART header on PCB
JTAG header on PCB

Currently not working:

Update from official web interface
LigoWawe uses they custom app to flash images and therefore flashing OpenWRT images does not work.

Flash instruction:

Set PC to fixed IP address 192.168.2.254
Download openwrt-ath79-generic-ligowawe_dlb5_propeller-squashfs-sysupgrade.bin and rename it to fwupdate.bin
Start a TFTP server with the file fwupdate.bin in its root directory
Turn off the router
Press and hold Reset button
Turn on router with the reset button pressed and wait 6 or more seconds
LED-s will start flashing and after it is done device should boot into OpenWRT.

Device specifics:
The bootloader has Netconsole built it, you can access it by holding the reset button while powering on for at least 3 seconds and less than 6 seconds.
It can be useful for recovery as serial pads are on PCB and device is not meant to be opened at all.

8 MB of 16 MB of SPI flash is usable.
That is due to LigoWawe using dual firmware bootloader.
So if after 3 boots boot counter is not reset bootloader will boot the other firmware image.
Due to that at boot counter for used firmware image is reset to 0.

Signed-off-by: Robert Marko robimarko@gmail.com
