### PR TITLE
imagebuilder: ability to sign created images

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -31,6 +31,8 @@ ifdef CONFIG_USE_MKLIBS
   endef
 endif
 
+usign = $(STAGING_DIR_HOST)/bin/usign
+
 # where to build (and put) .ipk packages
 opkg = \
   IPKG_NO_SCRIPT=1 \

--- a/rules.mk
+++ b/rules.mk
@@ -395,9 +395,11 @@ endef
 # Calculate sha256sum of any plain file within a given directory
 # $(1) => Input directory
 # $(2) => If set, recurse into subdirectories
+# $(3) => If set, sign sha256sums via usign
 define sha256sums
 	(cd $(1); find . $(if $(2),,-maxdepth 1) -type f -not -name 'sha256sums' -printf "%P\n" | sort | \
-		xargs -r $(STAGING_DIR_HOST)/bin/mkhash -n sha256 | sed -ne 's!^\(.*\) \(.*\)$$!\1 *\2!p' > sha256sums)
+		xargs -r $(STAGING_DIR_HOST)/bin/mkhash -n sha256 | sed -ne 's!^\(.*\) \(.*\)$$!\1 *\2!p' > sha256sums; \
+		$(if $(3),usign -S -s $(TOPDIR)/keys/key-build -m sha256sums,))
 endef
 
 # file extension

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -53,6 +53,10 @@ Print manifest:
 	make manifest PROFILE="<profilename>" # override the default target profile
 	make manifest PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
 
+Create signing keys:
+    Create keys to sign created images
+
+    make usign_setup
 endef
 $(eval $(call shexport,Helptext))
 
@@ -67,6 +71,7 @@ OPKG:=$(call opkg,$(TARGET_DIR)) \
 	-f $(TOPDIR)/repositories.conf \
 	--cache $(DL_DIR) \
 	--lists-dir $(LISTS_DIR)
+USIGN:=$(call usign,$(TARGET_DIR))
 
 include $(INCLUDE_DIR)/target.mk
 -include .profiles.mk
@@ -168,7 +173,7 @@ build_image: FORCE
 checksum: FORCE
 	@echo
 	@echo Calculating checksums...
-	@$(call sha256sums,$(BIN_DIR))
+	@$(call sha256sums,$(BIN_DIR),,$(CONFIG_SIGNED_IMAGES))
 
 clean:
 	rm -rf $(TMP_DIR) $(DL_DIR) $(TARGET_DIR) $(BIN_DIR)
@@ -203,5 +208,9 @@ manifest: FORCE
 	$(MAKE) -s _call_manifest \
 		$(if $(PROFILE),USER_PROFILE="$(PROFILE_FILTER)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)"))
+
+usign_setup:
+	mkdir -p ./keys
+	$(USIGN) -G -p ./keys/key-build.pub -s ./keys/key-build
 
 .SILENT: help info image manifest


### PR DESCRIPTION
Add config option CONFIG_SIGNED_IMAGES so the ImageBuilder would
automatically sign the created sha256sums files via usign.

This is a usefull feature to allow devices/routers verify firmware
images without the need of GPG installed.

Signed-off-by: Paul Spooren <mail@aparcar.org>