### PR TITLE
ath79: Fix led nodes for TL-WR740N v2 and add its clones

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -56,12 +56,17 @@ tplink,tl-wr1043nd-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
-tplink,tl-wr740n-v2)
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
-	ucidef_set_led_switch "lan1" "LAN1" "$boardname:green:lan1" "switch0" "0x02"
-	ucidef_set_led_switch "lan2" "LAN2" "$boardname:green:lan2" "switch0" "0x04"
-	ucidef_set_led_switch "lan3" "LAN3" "$boardname:green:lan3" "switch0" "0x08"
-	ucidef_set_led_switch "lan4" "LAN4" "$boardname:green:lan4" "switch0" "0x10"
+tplink,tl-wr740n-v1|\
+tplink,tl-wr740n-v3|\
+tplink,tl-wr741-v1|\
+tplink,tl-wr743nd-v1|\
+tplink,tl-wr841-v5|\
+tplink,tl-wr941-v4)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
 	;;
 tplink,tl-wr740nd-v4|\
 tplink,tl-wr741nd-v4)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -97,7 +97,12 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
-	tplink,tl-wr740n-v2)
+	tplink,tl-wr740n-v1|\
+	tplink,tl-wr740n-v3|\
+	tplink,tl-wr741-v1|\
+	tplink,tl-wr743nd-v1|\
+	tplink,tl-wr841-v5|\
+	tplink,tl-wr941-v4)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -61,10 +61,17 @@ case "$FIRMWARE" in
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
 	tplink,tl-wr2543-v1|\
-	tplink,tl-wr740n-v2|\
+	tplink,tl-wr740n-v1|\
+	tplink,tl-wr740n-v3|\
+	tplink,tl-wr741-v1|\
+	tplink,tl-wr743nd-v1|\
 	tplink,tl-wr841-v7|\
 	ubnt,unifi)
 		ath9k_eeprom_extract "art" 4096 2048
+		;;
+	tplink,tl-wr841-v5|\
+	tplink,tl-wr941-v4)
+		ath9k_eeprom_extract "art" 4096 3768
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR740N v1/v2";
+	compatible = "tplink,tl-wr740n-v1";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v3.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v3.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR740N v3";
+	compatible = "tplink,tl-wr740n-v3";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr741-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr741-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR741N/ND v1/v2";
+	compatible = "tplink,tl-wr741-v1";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr743nd-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr743nd-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR743ND v1";
+	compatible = "tplink,tl-wr743nd-v1";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
-/dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -7,9 +6,6 @@
 #include "ar7240.dtsi"
 
 / {
-	compatible = "tplink,tl-wr740n-v2", "qca,ar7240";
-	model = "TP-Link TL-WR740N v2";
-
 	aliases {
 		led-status = &led_system;
 	};
@@ -41,45 +37,49 @@
 		pinctrl-0 = <&switch_led_pins>;
 
 		led_system: system {
-			label = "tl-wr740n-v2:green:system";
+			label = "tp-link:green:system";
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 		};
 
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
 		lan1 {
-			label = "tl-wr740n-v2:green:lan1";
+			label = "tp-link:green:lan1";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		lan2 {
-			label = "tl-wr740n-v2:green:lan2";
+			label = "tp-link:green:lan2";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		lan3 {
-			label = "tl-wr740n-v2:green:lan3";
+			label = "tp-link:green:lan3";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		lan4 {
-			label = "tl-wr740n-v2:green:lan4";
+			label = "tp-link:green:lan4";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "tl-wr740n-v2:green:wan";
+			label = "tp-link:green:wan";
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
 
 		wlan {
-			label = "tl-wr740n-v2:green:wlan";
+			label = "tp-link:green:wlan";
 			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 			linux,default-trigger = "phy0tpt";
-		};
-
-		wps {
-			label = "tl-wr740n-v2:green:wps";
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR841N/ND v5/v6";
+	compatible = "tplink,tl-wr841-v5";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr941-v4.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr941-v4.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wr74xn-v1.dtsi"
+
+/ {
+	model = "TP-Link TL-WR941N/ND v4";
+	compatible = "tplink,tl-wr941-v4";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -51,14 +51,21 @@ define Device/tplink_tl-wr703n
 endef
 TARGET_DEVICES += tplink_tl-wr703n
 
-define Device/tplink_tl-wr740n-v2
+define Device/tplink_tl-wr740n-v1
   $(Device/tplink-4m)
   ATH_SOC := ar7240
-  DEVICE_TITLE := TP-Link TL-WR740N/ND v2
+  DEVICE_TITLE := TP-Link TL-WR740N v1/v2
   TPLINK_HWID := 0x07400001
-  SUPPORTED_DEVICES += tl-wr740n-v2
 endef
-TARGET_DEVICES += tplink_tl-wr740n-v2
+TARGET_DEVICES += tplink_tl-wr740n-v1
+
+define Device/tplink_tl-wr740n-v3
+  $(Device/tplink-4m)
+  ATH_SOC := ar7240
+  DEVICE_TITLE := TP-Link TL-WR740N v3
+  TPLINK_HWID := 0x07400003
+endef
+TARGET_DEVICES += tplink_tl-wr740n-v3
 
 define Device/tplink_tl-wr740nd-v4
   $(Device/tplink-4mlzma)
@@ -69,6 +76,14 @@ define Device/tplink_tl-wr740nd-v4
 endef
 TARGET_DEVICES += tplink_tl-wr740nd-v4
 
+define Device/tplink_tl-wr741-v1
+  $(Device/tplink-4m)
+  ATH_SOC := ar7240
+  DEVICE_TITLE := TP-Link TL-WR741N/ND v1/v2
+  TPLINK_HWID := 0x07410001
+endef
+TARGET_DEVICES += tplink_tl-wr741-v1
+
 define Device/tplink_tl-wr741nd-v4
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
@@ -77,6 +92,22 @@ define Device/tplink_tl-wr741nd-v4
   SUPPORTED_DEVICES += tl-wr741n-v4
 endef
 TARGET_DEVICES += tplink_tl-wr741nd-v4
+
+define Device/tplink_tl-wr743nd-v1
+  $(Device/tplink-4m)
+  ATH_SOC := ar7240
+  DEVICE_TITLE := TP-Link TL-WR743ND v1
+  TPLINK_HWID := 0x07430001
+endef
+TARGET_DEVICES += tplink_tl-wr743nd-v1
+
+define Device/tplink_tl-wr841-v5
+  $(Device/tplink-4m)
+  ATH_SOC := ar7240
+  DEVICE_TITLE := TP-Link TL-WR841N/ND v5/v6
+  TPLINK_HWID := 0x08410005
+endef
+TARGET_DEVICES += tplink_tl-wr841-v5
 
 define Device/tplink_tl-wr841-v7
   $(Device/tplink-4m)
@@ -95,3 +126,11 @@ define Device/tplink_tl-wr841-v9
   SUPPORTED_DEVICES += tl-wr841n-v9
 endef
 TARGET_DEVICES += tplink_tl-wr841-v9
+
+define Device/tplink_tl-wr941-v4
+  $(Device/tplink-4m)
+  ATH_SOC := ar7240
+  DEVICE_TITLE := TP-Link TL-WR941N/ND v4
+  TPLINK_HWID := 0x09410004
+endef
+TARGET_DEVICES += tplink_tl-wr941-v4


### PR DESCRIPTION
This patch did the following things:
1. Separate ath9k-leds out of gpio leds so that all other leds will work
   before ath9k loded (e.g. during preinit/init stage).
2. Rename wps led to qss since that's how TP-Link mark it.
3. Rename LED prefix to tp-link because that dts is shared by many devices.
4. Rename to wr740n-v1 because v1 is the first and v2 just use the fw of v1.
   (This will require a forced sysupgrade if you comes from
   the previous wr740n v2 image.)
5. Remove SUPPORTED_DEVICES.
   (tl-wr740n-v2 doesn't exist anywhere so it's useless.)
6. Add all WR741ND v1 clones found in ar71xx.

Tested on TL-WR940N v1 (which is a clone of TL-WR941N v4)