### PR TITLE
ath79: add support for Buffalo BHR-4GRV2

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -62,6 +62,14 @@ define Build/make-ras
 	@mv $@.new $@
 endef
 
+define Build/mkbuffaloimg
+	$(STAGING_DIR_HOST)/bin/mkbuffaloimg -B $(BOARDNAME) \
+		-R $$(($(subst k, * 1024,$(ROOTFS_SIZE)))) \
+		-K $$(($(subst k, * 1024,$(KERNEL_SIZE)))) \
+		-i $@ -o $@.new
+	mv $@.new $@
+endef
+
 define Build/netgear-chk
 	$(STAGING_DIR_HOST)/bin/mkchkimg \
 		-o $@.new \

--- a/target/linux/ar71xx/image/tiny.mk
+++ b/target/linux/ar71xx/image/tiny.mk
@@ -1,12 +1,3 @@
-define Build/mkbuffaloimg
-	$(STAGING_DIR_HOST)/bin/mkbuffaloimg -B $(BOARDNAME) \
-		-R $$(($(subst k, * 1024,$(ROOTFS_SIZE)))) \
-		-K $$(($(subst k, * 1024,$(KERNEL_SIZE)))) \
-		-i $@ -o $@.new
-	mv $@.new $@
-endef
-
-
 define Device/bhr-4grv2
   DEVICE_TITLE := Buffalo BHR-4GRV2
   BOARDNAME := BHR-4GRV2

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -25,6 +25,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
 		;;
+	buffalo,bhr-4grv2)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
+		;;
 	embeddedwireless,dorin)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"

--- a/target/linux/ath79/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/base-files/lib/upgrade/platform.sh
@@ -13,6 +13,10 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	buffalo,bhr-4grv2)
+		PART_NAME="rootfs:kernel"
+		default_do_upgrade "$ARGV"
+		;;
 	*)
 		default_do_upgrade "$ARGV"
 		;;

--- a/target/linux/ath79/dts/qca9558_buffalo_bhr-4grv2.dts
+++ b/target/linux/ath79/dts/qca9558_buffalo_bhr-4grv2.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "buffalo,bhr-4grv2", "qca,qca9557";
+	model = "Buffalo BHR-4GRV2";
+
+	aliases {
+		led-status = &power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "bhr-4grv2:green:power";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		diag {
+			label = "bhr-4grv2:orange:diag";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		vpn_orange {
+			label = "bhr-4grv2:orange:vpn";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		vpn_green {
+			label = "bhr-4grv2:green:vpn";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		eco {
+			label = "eco";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "rootfs";
+				reg = <0x050000 0xe30000>;
+			};
+
+			partition@e80000 {
+				label = "kernel";
+				reg = <0xe80000 0x170000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+		    0x04 0x80080080 /* PORT0 PAD MODE CTRL */
+		    0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+		    0x7c 0x0000007e /* PORT0_STATUS */
+		    0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&phy0>;
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6>;
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -75,6 +75,7 @@ ifeq ($(SUBTARGET),nand)
 include ./nand.mk
 endif
 ifeq ($(SUBTARGET),tiny)
+include ./tiny.mk
 include ./tiny-netgear.mk
 include ./tiny-tp-link.mk
 endif

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,0 +1,18 @@
+DEVICE_VARS += ROOTFS_SIZE
+
+define Device/buffalo_bhr-4grv2
+  ATH_SOC := qca9558
+  DEVICE_TITLE := Buffalo BHR-4GRV2
+  BOARDNAME := BHR-4GRV2
+  ROOTFS_SIZE := 14528k
+  KERNEL_SIZE := 1472k
+  IMAGE_SIZE := 16000k
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := \
+    append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | \
+    append-kernel | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-kernel | \
+    pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | mkbuffaloimg
+  SUPPORTED_DEVICES += bhr-4grv2
+endef
+TARGET_DEVICES += buffalo_bhr-4grv2


### PR DESCRIPTION
Buffalo BHR-4GRV2 is a wired router, based on Qualcomm Atheros
QCA9558.
Ported from ar71xx target.

Specification:

- Qualcomm Atheros QCA9558
- 64 MB of RAM
- 16 MB of Flash
- 5x 10/100/1000 Ethernet
  - QCA8337N
- 4x LEDs, 2x keys
- UART header on PCB
  - Vcc, TX, RX, GND from LED side
  - 115200n8

Flash instruction using factory image:

1. Connect the computer to the LAN port of BHR-4GRV2
2. Connect power cable to BHR-4GRV2 and turn on it
3. Access to "http://192.168.12.1/" and open firmware update
page ("ファームウェア更新")
4. Select the OpenWrt factory image and click update ("更新実行")
button
5. Wait ~120 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
