### PR TITLE
ath79: ag71xx: remove PHY reset

### DIFF
--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -180,8 +180,8 @@
 	pll-handle = <&pll>;
 	phy-mode = "rgmii";
 
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "phy", "mac";
+	resets = <&rst 9>;
+	reset-names = "mac";
 };
 
 &mdio1 {
@@ -199,6 +199,6 @@
 
 	phy-mode = "rgmii";
 
-	resets = <&rst 12>, <&rst 13>;
-	reset-names = "phy", "mac";
+	resets = <&rst 13>;
+	reset-names = "mac";
 };

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -205,8 +205,5 @@
 
 	mtd-mac-address = <&art 0x06>;
 
-	resets = <&rst 13>;
-	reset-names = "mac";
-
 	phy-handle = <&phy4>;
 };

--- a/target/linux/ath79/dts/ar9132.dtsi
+++ b/target/linux/ath79/dts/ar9132.dtsi
@@ -191,6 +191,6 @@
 	pll-data = <0x1a000000 0x13000a44 0x00441099>;
 	pll-reg = <0x4 0x10 17>;
 	pll-handle = <&pll>;
-	resets = <&rst 8>, <&rst 9>;
-	reset-names = "phy", "mac";
+	resets = <&rst 9>;
+	reset-names = "mac";
 };

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -142,9 +142,6 @@
 	phy-mode = "rgmii";
 	mtd-mac-address = <&uboot 0x1fc00>;
 
-	resets = <&rst 9>;
-	reset-names = "mac";
-
 	fixed-link {
 		speed = <1000>;
 		full-duplex;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -186,7 +186,6 @@ struct ag71xx {
 	struct timer_list	oom_timer;
 
 	struct reset_control *mac_reset;
-	struct reset_control *phy_reset;
 
 	u32			fifodata[3];
 	u32			plldata[3];

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -423,13 +423,6 @@ static void ag71xx_hw_init(struct ag71xx *ag)
 {
 	ag71xx_hw_stop(ag);
 
-	if (ag->phy_reset) {
-		reset_control_assert(ag->phy_reset);
-		msleep(50);
-		reset_control_deassert(ag->phy_reset);
-		msleep(200);
-	}
-
 	ag71xx_sb(ag, AG71XX_REG_MAC_CFG1, MAC_CFG1_SR);
 	udelay(20);
 
@@ -1312,8 +1305,6 @@ static int ag71xx_probe(struct platform_device *pdev)
 		err = PTR_ERR(ag->mac_reset);
 		goto err_free;
 	}
-
-	ag->phy_reset = devm_reset_control_get_optional(&pdev->dev, "phy");
 
 	if (of_property_read_u32_array(np, "fifo-data", ag->fifodata, 3)) {
 		if (of_device_is_compatible(np, "qca,ar9130-eth") ||


### PR DESCRIPTION
Bit 8/12 of reset controller which is marked as PHY_RESET/SWITCH_RESET in datasheets will trigger either a reset for builtin switch or assert an external ETH0_RESET_L/ETH1_RESET_L pin, which are usually connected to the reset pin of external PHY/switch. None of them should be triggered every time an interface is brought up in ethernet driver.
This PR removes PHY reset support from ag71xx and definition for them in dtsi. If we need a reset for PHY/Switch we should patch their drivers to do this job instead of triggering unwanted resets in ag71xx.

PS:
What atheros u-boot did for these resets:
 Atheros seemed to have written a combined driver of ethernet/mdio/switch/phy and GE0/1_MAC/PHY_RESET are asserted one time before initializing other things.
Here are code taken from U-boot of ar913x:
```c
    mask = (AR7100_RESET_GE0_MAC | AR7100_RESET_GE0_PHY |
            AR7100_RESET_GE1_MAC | AR7100_RESET_GE1_PHY);

    ar7100_reg_rmw_set(AR7100_RESET, mask);
    udelay(1000 * 100);

    ar7100_reg_rmw_clear(AR7100_RESET, mask);
    udelay(1000 * 100);
```

What ar71xx did:
ag71xx trigger all the defined resets (phy/mac/mdio) one time in ag71xx_hw_init. This function is called only once in ag71xx_probe. In ar71xx, PHY reset is defined for ar724x only. Since the builtin switch is started after ag71xx_hw_init, it doesn't cause troubles.

What ath79 did:
ag71xx trigger all the defined resets (phy/mac) one time in ag71xx_hw_init. But this function is called in ag71xx_start, which means that these reset will be triggered every time this interface is brought up. As the builtin switch is now started before gmacs, an unwanted reset always breaks ethernet connections and that's the reason why I removed them for ar724x/ar934x in the previous PR.

