### PR TITLE
package: mac80211: ath9k: add support for reading eeprom from mtd

### DIFF
--- a/package/kernel/mac80211/patches/553-ath9k-mtd-eeprom.patch
+++ b/package/kernel/mac80211/patches/553-ath9k-mtd-eeprom.patch
@@ -1,0 +1,118 @@
+--- a/drivers/net/wireless/ath/ath9k/eeprom.c
++++ b/drivers/net/wireless/ath/ath9k/eeprom.c
+@@ -135,6 +135,16 @@ static bool ath9k_hw_nvram_read_firmware
+ 					 offset, data);
+ }
+ 
++static bool ath9k_hw_nvram_read_mtd(struct ath_hw *ah,
++					 off_t offset, u16 *data)
++{
++	size_t retlen;
++	int ret;
++	ret = mtd_read(ah->eeprom_mtd, ah->eeprom_mtd_offset + offset * sizeof(u16),
++			sizeof(u16), &retlen, (u8*)data);
++	return ((!ret) && (retlen == sizeof(u16)));
++}
++
+ bool ath9k_hw_nvram_read(struct ath_hw *ah, u32 off, u16 *data)
+ {
+ 	struct ath_common *common = ath9k_hw_common(ah);
+@@ -143,6 +153,8 @@ bool ath9k_hw_nvram_read(struct ath_hw *
+ 
+ 	if (ah->eeprom_blob)
+ 		ret = ath9k_hw_nvram_read_firmware(ah->eeprom_blob, off, data);
++	else if (ah->eeprom_mtd)
++		ret = ath9k_hw_nvram_read_mtd(ah, off, data);
+ 	else if (pdata && !pdata->use_eeprom)
+ 		ret = ath9k_hw_nvram_read_pdata(pdata, off, data);
+ 	else
+--- a/drivers/net/wireless/ath/ath9k/hw.h
++++ b/drivers/net/wireless/ath/ath9k/hw.h
+@@ -21,6 +21,7 @@
+ #include <linux/delay.h>
+ #include <linux/io.h>
+ #include <linux/firmware.h>
++#include <linux/mtd/mtd.h>
+ 
+ #include "mac.h"
+ #include "ani.h"
+@@ -982,6 +983,8 @@ struct ath_hw {
+ 	bool disable_5ghz;
+ 
+ 	const struct firmware *eeprom_blob;
++	struct mtd_info *eeprom_mtd;
++	loff_t eeprom_mtd_offset;
+ 
+ 	struct ath_dynack dynack;
+ 
+--- a/drivers/net/wireless/ath/ath9k/init.c
++++ b/drivers/net/wireless/ath/ath9k/init.c
+@@ -513,6 +513,51 @@ static void ath9k_eeprom_release(struct
+ 	release_firmware(sc->sc_ah->eeprom_blob);
+ }
+ 
++static int ath9k_mtd_eeprom_get(struct ath_softc *sc, struct device_node *np)
++{
++#ifdef CONFIG_MTD
++	struct ath_hw *ah = sc->sc_ah;
++	struct device_node *mtd_np = NULL;
++	int size;
++	struct mtd_info *mtd;
++	const char *part;
++	const __be32 *list;
++	phandle phandle;
++
++	list = of_get_property(np, "qca,mtd-eeprom", &size);
++	if (!list)
++		return 0;
++
++	if (size != (2 * sizeof(*list)))
++		return -EINVAL;
++
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
++		return -EINVAL;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return -EINVAL;
++	ah->eeprom_mtd = mtd;
++	ah->eeprom_mtd_offset = be32_to_cpup(list);
++	of_node_put(mtd_np);
++#endif
++	return 0;
++}
++
++static void ath9k_mtd_eeprom_put(struct ath_softc *sc)
++{
++	if (sc->sc_ah->eeprom_mtd)
++		put_mtd_device(sc->sc_ah->eeprom_mtd);
++}
++
+ static int ath9k_init_platform(struct ath_softc *sc)
+ {
+ 	struct ath9k_platform_data *pdata = sc->dev->platform_data;
+@@ -588,6 +632,8 @@ static int ath9k_of_init(struct ath_soft
+ 			return ret;
+ 	}
+ 
++	ath9k_mtd_eeprom_get(sc, np);
++
+ 	mac = of_get_mac_address(np);
+ 	if (mac)
+ 		ether_addr_copy(common->macaddr, mac);
+@@ -1081,6 +1127,7 @@ static void ath9k_deinit_softc(struct at
+ 		sc->dfs_detector->exit(sc->dfs_detector);
+ 
+ 	ath9k_eeprom_release(sc);
++	ath9k_mtd_eeprom_put(sc);
+ }
+ 
+ void ath9k_deinit_device(struct ath_softc *sc)


### PR DESCRIPTION
This patch is made for ath79 target.
Currently there are only support to read eeprom from mtd for ahb devices. (And I guess the dts support for ahb devices is a temporary solution.) This patch add a qca,mtd-eeprom that works for both pci and ahb devices which could help reducing the size of 10-ath9k-eeprom a lot.
Tested on TP-Link TL-WR841N v9 and TL-WR941N v4.

I didn't convert ath79 target to use this patch because there are 6 PRs and 1 patch on mailing list to add new device support for ath79. If this PR can be merged, I'll create another one to convert ath79 target and remove mtd-cal-data from 552-ahb_of.patch in mac80211 after the pending ath79 patches.