### PR TITLE
gettext-full: host compile with -fpic

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -77,6 +77,8 @@ HOST_CONFIGURE_VARS += \
 	am_cv_func_iconv=no \
 	ac_cv_header_iconv_h=no \
 
+HOST_CFLAGS += $(HOST_FPIC)
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/libintl-full/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libintl.h $(1)/usr/lib/libintl-full/include/


### PR DESCRIPTION
@jow- I got this trying to compile `glib2/host` under Alpine:
```
Entering directory '/workdir/sdk-snapshots-mvebu-cortexa9/build_dir/hostpkg/glib-2.56.1/glib'
  CCLD     libglib-2.0.la
/usr/lib/gcc/x86_64-alpine-linux-musl/6.4.0/../../../../x86_64-alpine-linux-musl/bin/ld: /workdir/sdk-snapshots-mvebu-cortexa9/staging_dir/hostpkg/lib/libintl.a(bindtextdom.o): relocation R_X86_64_PC32 against symbol `_nl_msg_cat_cntr' can not be used when making a shared object; recompile with -fPIC
/usr/lib/gcc/x86_64-alpine-linux-musl/6.4.0/../../../../x86_64-alpine-linux-musl/bin/ld: final link failed: Bad value
```
Adding `fpic` similar to `libiconv/host` solved the problem, i also noticed `libffi/host` might miss this too?