### PR TITLE
busybox: prevent compile hang with bzip2 enabled

### DIFF
--- a/package/utils/busybox/config/archival/Config.in
+++ b/package/utils/busybox/config/archival/Config.in
@@ -170,6 +170,15 @@ config BUSYBOX_CONFIG_BZIP2
 	  Unless you have a specific application which requires bzip2, you
 	  should probably say N here.
 
+config BUSYBOX_CONFIG_BZIP2_SMALL
+	int "Trade size for speed 0:fast 9:slow"
+	default BUSYBOX_DEFAULT_BZIP2_SMALL
+	range 0 9
+	depends on BUSYBOX_CONFIG_BZIP2
+	help
+	  0 is faster but larger
+	  9 is smaller but slower
+
 config BUSYBOX_CONFIG_FEATURE_BZIP2_DECOMPRESS
 	bool "Enable decompression"
 	default BUSYBOX_DEFAULT_FEATURE_BZIP2_DECOMPRESS


### PR DESCRIPTION
The BZIP2_SMALL option was not being exposed via Config.in which
caused the build to fail as 'yes' is piped to the config during
build.  As it's expecting a number, it gets stuck in a loop.

Signed-off-by: Rob Mosher <nyt-openwrt@countercultured.net>

