### PR TITLE
NET: extend mtd-mac-address with mtd-mac-address-local-admin (needed for ath79 WNDR3800)

### DIFF
--- a/target/linux/generic/pending-4.14/681-NET-add-of_get_mac_address_mtd.patch
+++ b/target/linux/generic/pending-4.14/681-NET-add-of_get_mac_address_mtd.patch
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -47,6 +48,73 @@ static const void *of_get_mac_addr(struc
+@@ -47,6 +48,76 @@ static const void *of_get_mac_addr(struc
  	return NULL;
  }
  
@@ -76,6 +76,9 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	if (!of_property_read_u32(np, "mtd-mac-address-increment", &mac_inc))
 +		mac[5] += mac_inc;
 +
++	if (of_property_read_bool(np, "mtd-mac-address-local-admin"))
++		mac[0] |= 0x02;
++
 +	if (!is_valid_ether_addr(mac))
 +		return NULL;
 +
@@ -106,7 +109,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -64,11 +132,18 @@ static const void *of_get_mac_addr(struc
+@@ -64,11 +135,18 @@ static const void *of_get_mac_addr(struc
   * addresses.  Some older U-Boots only initialized 'local-mac-address'.  In
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.


### PR DESCRIPTION
@mkresin   
Reference to ath79 WNDR3800 discussion. This is a prerequisite for fixing MACs for WNDR3800 in ath79.

cc @blogic who has authored the original 681-NET-add-of_get_mac_address_mtd.patch

Extend the functionality of mtd-mac-address DTS property with an optional "mtd-mac-address-local-admin" property that indicates that the MAC address will be modified by toggling the "locally administered" bit to 1.

This enables the same MAC address from flash to be used for two different interfaces, e.g. eth0 and wlan0, so that the interfaces will have unique MAC addresses.

The functionality has earlier been implemented in ar71xx as function "ath79_init_local_mac" for some routers like WNDR3700, WNDR3800 and the transition to ath79 requires similar functionality to be implemented for DTS.

The functionality would likely be useful for other devices, where all needed MACs have not been stored on flash.

Tested with ath79 WNDR3800:

WNDR3800 has 3 MAC addresses stored to flash (eth0+wlan0, eth1, wlan1). To avoid identical MACs, the eth0 for LAN is marked as local, so that one bit will be toggled. Note that there will be no MAC collision with other devices.

DTS specs:

```
&eth0 {
	status = "okay";

	pll-data = <0x11110000 0x00001099 0x00991099>;

	mtd-mac-address = <&art 0x00>;
	mtd-mac-address-local-admin;
```

Result:
LAN interface MAC stars with modified 76, while wlan0 retains the original 74: as well as do eth1 and wlan1:
```
root@OpenWrt:/# ifconfig | grep HW
br-lan    Link encap:Ethernet  HWaddr 76:44:xx:xx:A3:E7
eth0      Link encap:Ethernet  HWaddr 76:44:xx:xx:A3:E7
eth0.1    Link encap:Ethernet  HWaddr 76:44:xx:xx:A3:E7
eth1      Link encap:Ethernet  HWaddr 74:44:xx:xx:A3:E8
wlan0     Link encap:Ethernet  HWaddr 74:44:xx:xx:A3:E9
wlan1     Link encap:Ethernet  HWaddr 74:44:xx:xx:A3:E7
```

EDIT: note that wlan0 and wlan1 are currently swapped from the intended MACs in WNDR3800, so the example is faulty on that regard. Discussion on the PR about that device.