### PR TITLE
ath79: WNDR3800: add wifi

### DIFF
--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -78,4 +78,24 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"ath9k-eeprom-pci-0000:00:11.0.bin")
+	case $board in
+	netgear,wndr3800)
+		ath9k_eeprom_extract "art" 4096 3768
+		;;
+	*)
+		ath9k_eeprom_die "board $board is not supported yet"
+		;;
+	esac
+	;;
+"ath9k-eeprom-pci-0000:00:12.0.bin")
+	case $board in
+	netgear,wndr3800)
+		ath9k_eeprom_extract "art" 20480 3768
+		;;
+	*)
+		ath9k_eeprom_die "board $board is not supported yet"
+		;;
+	esac
+	;;
 esac

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -70,6 +70,22 @@
 		};
 	};
 
+	ath9k-leds {
+		compatible = "gpio-leds";
+		wlan2g {
+			label = "netgear:green:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+		wlan5g {
+			label = "netgear:blue:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		poll-interval = <100>;
@@ -141,6 +157,24 @@
 
 &pcie0 {
 	status = "okay";
+
+	ath9k0: wifi@0,11 {
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0x10000>;
+		mtd-mac-address = <&art 0x0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 {
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0x10000>;
+		mtd-mac-address = <&art 0xc>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
 };
 
 &uart {
@@ -193,6 +227,10 @@
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
 	mtd-mac-address = <&art 0x00>;
+	mtd-mac-address-local-admin;
+
+	resets = <&rst 9>;
+	reset-names = "mac";
 
 	fixed-link {
 		speed = <1000>;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -115,7 +115,7 @@ define Device/netgear_wndr3800
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += wndr3800
 endef
 TARGET_DEVICES += netgear_wndr3800


### PR DESCRIPTION
@mkresin 
(note: requires PR #1257 )

Add wifi functionality to WNDR3800:
* include kmod-owl-loader in device packages
* read EEPROM contents from art into firmware files
* define ath9k wifi nodes in DTS
* defines wifi LEDs

(* additionally, phy reset removed from eth0)

Note: unique eth0/wlan0 MACs requires mtd-mac-address-local-admin support in DTS. Support implemented in PR #1257

Known issues / work-to-do:

* wifi does not get enabled at the boot after flash.
  It starts ok at subsequent reboots.
  Hypothesis: firmware file creation is tried too early,   before jffs2 is ready in the first boot.
* antenna group adjustment has not been done
* wlan0 and wlan1 get swapped. Contrary to ar71xx, pci0000:00/0000:00:11.0 seems to lead to 5GHz radio
