### PR TITLE
libevent: update to 2.1.8

### DIFF
--- a/package/libs/libevent2/Makefile
+++ b/package/libs/libevent2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libevent2
-PKG_VERSION:=2.0.22
+PKG_VERSION:=2.1.8
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/libevent-$(PKG_VERSION)-stable
-PKG_SOURCE:=libevent-$(PKG_VERSION)-stable.tar.gz
-PKG_SOURCE_URL:=@SF/levent
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/libevent/libevent.git
+PKG_SOURCE_VERSION:=release-$(PKG_VERSION)-stable
 PKG_HASH:=71c2c49f0adadacfdbe6332a372c38cf9c8b7895bb73dabeaa53cdcc1d4e1fa3
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=BSD-3-Clause
@@ -46,7 +46,7 @@ endef
 
 define Package/libevent2
   $(call Package/libevent2/Default)
-  TITLE+= library (version 2.0)
+  TITLE+= library (version 2.1)
 endef
 
 define Package/libevent2/description
@@ -58,7 +58,7 @@ endef
 
 define Package/libevent2-core
   $(call Package/libevent2/Default)
-  TITLE+= core library (version 2.0)
+  TITLE+= core library (version 2.1)
 endef
 
 define Package/libevent2-core/description
@@ -70,7 +70,7 @@ endef
 
 define Package/libevent2-extra
   $(call Package/libevent2/Default)
-  TITLE+= extra library (version 2.0)
+  TITLE+= extra library (version 2.1)
 endef
 
 define Package/libevent2-extra/description
@@ -82,7 +82,7 @@ endef
 
 define Package/libevent2-openssl
   $(call Package/libevent2/Default)
-  TITLE+= OpenSSL library (version 2.0)
+  TITLE+= OpenSSL library (version 2.1)
   DEPENDS+=+libopenssl
 endef
 
@@ -95,7 +95,7 @@ endef
 
 define Package/libevent2-pthreads
   $(call Package/libevent2/Default)
-  TITLE+= Pthreads library (version 2.0)
+  TITLE+= Pthreads library (version 2.1)
   DEPENDS+=+libpthread
 endef
 
@@ -121,34 +121,34 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/* $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*.{la,a,so} $(1)/usr/lib/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.0.so* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent*-2.1.so* $(1)/usr/lib/
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libevent*.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libevent2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-core/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_core-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-extra/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_extra-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-openssl/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_openssl-2.1.so.* $(1)/usr/lib/
 endef
 
 define Package/libevent2-pthreads/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.0.so.* $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libevent_pthreads-2.1.so.* $(1)/usr/lib/
 endef
 
 $(eval $(call BuildPackage,libevent2))

--- a/package/libs/libevent2/patches/0001-Do-not-check-for-ERR_remove_thread_state-do-not-link.patch
+++ b/package/libs/libevent2/patches/0001-Do-not-check-for-ERR_remove_thread_state-do-not-link.patch
@@ -1,0 +1,87 @@
+From f519e0f30a00393b949c4e20868952726a9c6d2e Mon Sep 17 00:00:00 2001
+From: Pierce Lopez <pierce.lopez@gmail.com>
+Date: Thu, 2 Mar 2017 21:09:32 -0500
+Subject: [PATCH] Do not check for ERR_remove_thread_state() (do not link ssl
+ into every library)
+
+This reverts commit c4e9d9bd662de7f575f2172c160795d452ebe709
+("sample/https-client: check for ERR_remove_thread_state() existence").
+
+Calling AC_SEARCH_LIBS() modifies LIBS - -lcrypto incorrectly
+ends up in LIBS, and thus linked to by libevent_core.so.
+
+Checking for ERR_remove_thread_state should no longer be needed
+because it was introduced in openssl 1.0.0, and the previous line
+0.9.8 had support discontinued at the end of 2015.
+
+Fixes: #473
+---
+ CMakeLists.txt        | 4 ----
+ configure.ac          | 4 ----
+ event-config.h.cmake  | 3 ---
+ sample/https-client.c | 4 ----
+ 4 files changed, 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b4a34f3d..28d6c22c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -877,10 +877,6 @@ if (NOT EVENT__DISABLE_SAMPLES)
+         time-test)
+ 
+     if (NOT EVENT__DISABLE_OPENSSL AND OPENSSL_LIBRARIES)
+-        set(CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES})
+-        CHECK_FUNCTION_EXISTS_EX(ERR_remove_thread_state EVENT__HAVE_ERR_REMOVE_THREAD_STATE)
+-        set(CMAKE_REQUIRED_LIBRARIES "")
+-
+         # Special sample with more than one file.
+         add_executable(https-client
+             sample/https-client.c
+diff --git a/configure.ac b/configure.ac
+index 7528d37e..3f137277 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -791,10 +791,6 @@ fi
+ 
+ # check if we have and should use openssl
+ AM_CONDITIONAL(OPENSSL, [test "$enable_openssl" != "no" && test "$have_openssl" = "yes"])
+-if test "x$enable_openssl" = "xyes"; then
+-	AC_SEARCH_LIBS([ERR_remove_thread_state], [crypto eay32],
+-		[AC_DEFINE(HAVE_ERR_REMOVE_THREAD_STATE, 1, [Define to 1 if you have ERR_remove_thread_stat().])])
+-fi
+ 
+ # Add some more warnings which we use in development but not in the
+ # released versions.  (Some relevant gcc versions can't handle these.)
+diff --git a/event-config.h.cmake b/event-config.h.cmake
+index c1355be9..cb363be8 100644
+--- a/event-config.h.cmake
++++ b/event-config.h.cmake
+@@ -523,9 +523,6 @@
+ 
+ #cmakedefine EVENT__NEED_DLLIMPORT
+ 
+-/* Define to 1 if you have ERR_remove_thread_stat(). */
+-#cmakedefine EVENT__HAVE_ERR_REMOVE_THREAD_STATE
+-
+ /* Define if waitpid() supports WNOWAIT */
+ #cmakedefine EVENT__HAVE_WAITPID_WITH_WNOWAIT
+ 
+diff --git a/sample/https-client.c b/sample/https-client.c
+index 74839565..2ed6fb74 100644
+--- a/sample/https-client.c
++++ b/sample/https-client.c
+@@ -484,11 +484,7 @@ cleanup:
+ 	EVP_cleanup();
+ 	ERR_free_strings();
+ 
+-#ifdef EVENT__HAVE_ERR_REMOVE_THREAD_STATE
+ 	ERR_remove_thread_state(NULL);
+-#else
+-	ERR_remove_state(0);
+-#endif
+ 	CRYPTO_cleanup_all_ex_data();
+ 
+ 	sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
+-- 
+2.17.0
+


### PR DESCRIPTION
The already back ported commit fe90d14880ad80e5cbc0eba036f8f9f83fa77396 relies on this one, so either it goes into openwrt-18.06 as well or fe90d14880ad80e5cbc0eba036f8f9f83fa77396 should be reverted.