### PR TITLE
ramips: add support for HiWiFi HC5861B

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -242,6 +242,9 @@ hg255d)
 	set_usb_led "$boardname:green:usb"
 	ucidef_set_led_netdev "internet" "internet" "$boardname:green:internet" "eth0.2"
 	;;
+hiwifi,hc5861b)
+	set_wifi_led "$boardname:green:wlan2g"
+	;;
 hpm)
 	ucidef_set_led_default "power" "POWER" "$boardname:orange:power" "1"
 	ucidef_set_led_netdev "eth" "ETH" "$boardname:green:eth" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -198,6 +198,7 @@ ramips_setup_interfaces()
 	gl-mt300n|\
 	gl-mt750|\
 	hg255d|\
+	hiwifi,hc5861b|\
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
@@ -482,7 +483,8 @@ ramips_setup_macs()
 		;;
 	hc5*61|\
 	hc5661a|\
-	hc5962)
+	hc5962|\
+	hiwifi,hc5861b)
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -73,6 +73,7 @@ platform_check_image() {
 	hc5*61|\
 	hc5661a|\
 	hg255d|\
+	hiwifi,hc5861b|\
 	hlk-rm04|\
 	hpm|\
 	ht-tm02|\

--- a/target/linux/ramips/dts/HC5861B.dts
+++ b/target/linux/ramips/dts/HC5861B.dts
@@ -1,0 +1,141 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hiwifi,hc5861b", "mediatek,mt7628an-soc";
+	model = "HiWiFi HC5861B";
+
+	aliases {
+		led-status = &led_system;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "hc5861b:green:system";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+		wlan2g {
+			label = "hc5861b:green:wlan2g";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "refclk", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "hw_panic";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xf70000>;
+			};
+
+			partition@fc0000 {
+				label = "oem";
+				reg = <0xfc0000 0x20000>;
+				read-only;
+			};
+
+			bdinfo: partition@fe0000 {
+				label = "bdinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "backup";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		mtd-mac-address = <&factory 0x2e>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -58,6 +58,13 @@ define Device/hc5661a
 endef
 TARGET_DEVICES += hc5661a
 
+define Device/hiwifi_hc5861b
+  DTS := HC5861B
+  IMAGE_SIZE := 15808k
+  DEVICE_TITLE := HiWiFi HC5861B
+endef
+TARGET_DEVICES += hiwifi_hc5861b
+
 define Device/LinkIt7688
   DTS := LINKIT7688
   IMAGE_SIZE := $(ralink_default_fw_size_32M)


### PR DESCRIPTION
HiWiFi "Gee Enjoy1200" HC5861B is a dual-band router based on MediaTek MT7628AN
https://www.hiwifi.com/enjoy-view

Specifications:
- MediaTek MT7628AN 580MHz
- 128 MB DDR2 RAM
- 16 MB SPI Flash
- 2.4G MT7628AN 802.11bgn 2T2R 300Mbps
- 5G MT7612EN 802.11ac 2T2R 867Mbps
- 5x 10/100 Mbps Ethernet

Flash instruction:
1. Get SSH access to the router
2. SSH to router with `ssh -p 1022 root@192.168.199.1`, The SSH password is the same as the webconfig one
3. Upload OpenWrt sysupgrade firmware into the router's `/tmp` folder with SCP
4. Run `mtd write /tmp/<filename> firmware`
5. reboot