### PR TITLE
mac80211: mwl8k: Add non-DFS 5G upper channels (149-165) besides existed 4 lower channels

### DIFF
--- a/package/kernel/mac80211/patches/941-mwl8k-add-non-DFS-5G-upper-channels.patch
+++ b/package/kernel/mac80211/patches/941-mwl8k-add-non-DFS-5G-upper-channels.patch
@@ -1,0 +1,39 @@
+From 4628257bf3006c18e0037459922624f02a138aed Mon Sep 17 00:00:00 2001
+From: Weixiao Zhang <waveletboy@gmail.com>
+Date: Thu, 16 Nov 2017 01:59:55 -0600
+Subject: [PATCH] mwl8k: Expand non-DFS 5G channels
+
+Add non-DFS 5G upper channels (149-165) besides existed 4 lower channels
+(36, 40, 44, 48).
+
+Signed-off-by: Weixiao Zhang <waveletboy@gmail.com>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+---
+ drivers/net/wireless/marvell/mwl8k.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/marvell/mwl8k.c b/drivers/net/wireless/marvell/mwl8k.c
+index e813b2ca740c2..8e4e9b6919e02 100644
+--- a/drivers/net/wireless/marvell/mwl8k.c
++++ b/drivers/net/wireless/marvell/mwl8k.c
+@@ -199,7 +199,7 @@ struct mwl8k_priv {
+ 	struct ieee80211_channel channels_24[14];
+ 	struct ieee80211_rate rates_24[13];
+ 	struct ieee80211_supported_band band_50;
+-	struct ieee80211_channel channels_50[4];
++	struct ieee80211_channel channels_50[9];
+ 	struct ieee80211_rate rates_50[8];
+ 	u32 ap_macids_supported;
+ 	u32 sta_macids_supported;
+@@ -383,6 +383,11 @@ static const struct ieee80211_channel mwl8k_channels_50[] = {
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5200, .hw_value = 40, },
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5220, .hw_value = 44, },
+ 	{ .band = NL80211_BAND_5GHZ, .center_freq = 5240, .hw_value = 48, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5745, .hw_value = 149, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5765, .hw_value = 153, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5785, .hw_value = 157, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5805, .hw_value = 161, },
++	{ .band = NL80211_BAND_5GHZ, .center_freq = 5825, .hw_value = 165, },
+ };
+ 
+ static const struct ieee80211_rate mwl8k_rates_50[] = {


### PR DESCRIPTION
Add non-DFS 5G upper channels (149-165) besides existed 4 lower channels (36, 40, 44, 48).

This is a backport of https://github.com/torvalds/linux/commit/4628257bf3006c18e0037459922624f02a138aed

In my opinion can be considere safe also for 18.06.x cycle

Signed-off-by: Antonio Silverio <menion@gmail.com>
