### PR TITLE
ath79: add support for TP-Link WR841v11

### DIFF
--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v11.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9533_tplink_tl-wr841.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr841-v11", "qca,qca9533";
+	model = "TP-Link TL-WR841N/ND Version 11";
+
+	aliases {
+		led-status = &system_led;
+	};
+};
+
+&gpio_leds {
+	system_led: system {
+		label = "tp-link:green:system";
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		default-state = "off";
+	};
+
+	wan_orange {
+		label = "tp-link:orange:wan";
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		default-state = "off";
+	};
+};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9.dts
@@ -7,6 +7,6 @@
 #include "qca9533_tplink_tl-wr841.dtsi"
 
 / {
-	compatible = "tplink,tl-wr841n-v9", "qca,qca9533";
+	compatible = "tplink,tl-wr841-v9", "qca,qca9533";
 	model = "TP-Link TL-WR841N/ND Version 9";
 };

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841-v9.dts
@@ -9,4 +9,8 @@
 / {
 	compatible = "tplink,tl-wr841-v9", "qca,qca9533";
 	model = "TP-Link TL-WR841N/ND Version 9";
+
+	aliases {
+		led-status = &qss_led;
+	};
 };

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -11,7 +11,7 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
-	leds {
+	gpio_leds: leds {
 		compatible = "gpio-leds";
 
 		wifi {

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -11,10 +11,6 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
-	aliases {
-		led-status = &system;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -25,7 +21,7 @@
 			linux,default-trigger = "phy0tpt";
 		};
 
-		system: wifi_qss {
+		qss_led: qss {
 			label = "tp-link:green:qss";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			default-state = "off";

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -126,6 +126,17 @@ define Device/tplink_tl-wr841-v9
 endef
 TARGET_DEVICES += tplink_tl-wr841-v9
 
+define Device/tplink_tl-wr841-v11
+  $(Device/tplink-4mlzma)
+  ATH_SOC := qca9533
+  DEVICE_TITLE := TP-LINK TL-WR841N/ND v11
+  TPLINK_HWID := 0x08410011
+  IMAGES += factory-us.bin factory-eu.bin
+  IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
+  IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+endef
+TARGET_DEVICES += tplink_tl-wr841-v11
+
 define Device/tplink_tl-wr941-v4
   $(Device/tplink-4m)
   ATH_SOC := ar7240

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -123,7 +123,6 @@ define Device/tplink_tl-wr841-v9
   ATH_SOC := qca9533
   DEVICE_TITLE := TP-LINK TL-WR841N/ND v9
   TPLINK_HWID := 0x08410009
-  SUPPORTED_DEVICES += tl-wr841n-v9
 endef
 TARGET_DEVICES += tplink_tl-wr841-v9
 


### PR DESCRIPTION
This device is apart from two additional led´s the same as TP-Link WR841v9.

Also remove SUPPORTED_DEVICES from wr841-v9 because it´s not needed and
for consistency rename everything to tl-wr841-v9.

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>