### PR TITLE
ath79: add support for WNDR3700 and WNDR3700v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -51,6 +51,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
+	netgear,wndr3700|\
+	netgear,wndr3700v2|\
 	netgear,wndr3800)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7161_netgear_wndr3700.dtsi"
+
+/ {
+	compatible = "netgear,wndr3700", "qca,ar7161";
+	model = "Netgear WNDR3700";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x050000>;
+		read-only;
+	};
+
+	partition@50000 {
+		label = "u-boot-env";
+		reg = <0x050000 0x020000>;
+		read-only;
+	};
+
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0x780000>;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};
+

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7100.dtsi"
+
+/ {
+	aliases {
+		led-status = &power_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	reset-leds {
+		compatible = "reset-leds";
+
+		usb_led {
+			label = "netgear:green:usb";
+			resets = <&rst 12>;
+			trigger-sources = <&usb_ochi_port>, <&usb_echi_port>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "netgear:orange:wps";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		power_green: power_green {
+			label = "netgear:green:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		power_orange {
+			label = "netgear:orange:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wps_green {
+			label = "netgear:green:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan_green {
+			label = "netgear:green:wan";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtl8366s {
+		compatible = "realtek,rtl8366s";
+		gpio-sda = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio 7 GPIO_ACTIVE_HIGH>;
+
+		mdio-bus {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			phy-mask = <0x10>;
+
+			phy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "rgmii";
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_ochi_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_echi_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
+	mtd-mac-address = <&art 0x00>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
+	mtd-mac-address = <&art 0x06>;
+
+	phy-handle = <&phy4>;
+};

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700v2.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700v2.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7161_netgear_wndr3700.dtsi"
+
+/ {
+	compatible = "netgear,wndr3700v2", "qca,ar7161";
+	model = "Netgear WNDR3700v2";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x050000>;
+		read-only;
+	};
+
+	partition@50000 {
+		label = "u-boot-env";
+		reg = <0x050000 0x020000>;
+		read-only;
+	};
+
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0xf80000>;
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};
+

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3800.dts
@@ -1,211 +1,35 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "ar7100.dtsi"
+#include "ar7161_netgear_wndr3700.dtsi"
 
 / {
 	compatible = "netgear,wndr3800", "qca,ar7161";
 	model = "Netgear WNDR3800";
+};
 
-	aliases {
-		led-status = &power_green;
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x050000>;
+		read-only;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,115200";
+	partition@50000 {
+		label = "u-boot-env";
+		reg = <0x050000 0x020000>;
+		read-only;
 	};
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0xf80000>;
 	};
 
-	reset-leds {
-		compatible = "reset-leds";
-
-		usb_led {
-			label = "netgear:green:usb";
-			resets = <&rst 12>;
-			trigger-sources = <&usb_ochi_port>, <&usb_echi_port>;
-			linux,default-trigger = "usbport";
-		};
-	};
-
-	gpio-leds {
-		compatible = "gpio-leds";
-
-		wps {
-			label = "netgear:orange:wps";
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		power_green: power_green {
-			label = "netgear:green:power";
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		power_orange {
-			label = "netgear:orange:power";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		wps_green {
-			label = "netgear:green:wps";
-			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-
-		wan_green {
-			label = "netgear:green:wan";
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-			default-state = "off";
-		};
-	};
-
-	gpio-keys-polled {
-		compatible = "gpio-keys-polled";
-		poll-interval = <100>;
-
-		wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		rfkill {
-			label = "rfkill";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	rtl8366s {
-		compatible = "realtek,rtl8366s";
-		gpio-sda = <&gpio 5 GPIO_ACTIVE_HIGH>;
-		gpio-sck = <&gpio 7 GPIO_ACTIVE_HIGH>;
-
-		mdio-bus {
-			#address-cells = <1>;
-			#size-cells = <0>;
-			status = "okay";
-
-			phy-mask = <0x10>;
-
-			phy4: ethernet-phy@4 {
-				reg = <4>;
-				phy-mode = "rgmii";
-			};
-		};
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
 	};
 };
 
-&usb_phy {
-	status = "okay";
-};
-
-&usb1 {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	status = "okay";
-
-	usb_ochi_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
-};
-
-&usb2 {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	status = "okay";
-
-	usb_echi_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
-};
-
-&pcie0 {
-	status = "okay";
-};
-
-&uart {
-	status = "okay";
-};
-
-&spi {
-	status = "okay";
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x050000>;
-				read-only;
-			};
-
-			partition@1 {
-				label = "u-boot-env";
-				reg = <0x050000 0x020000>;
-				read-only;
-			};
-
-			partition@2 {
-				label = "firmware";
-				reg = <0x070000 0xf80000>;
-			};
-
-			art: partition@3 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	pll-data = <0x11110000 0x00001099 0x00991099>;
-
-	mtd-mac-address = <&art 0x00>;
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
-};
-
-&eth1 {
-	status = "okay";
-
-	pll-data = <0x11110000 0x00001099 0x00991099>;
-
-	mtd-mac-address = <&art 0x06>;
-
-	phy-handle = <&phy4>;
-};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -144,6 +144,29 @@ define Device/netgear_wndr3x00
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset
 endef
 
+define Device/netgear_wndr3700
+  $(Device/netgear_wndr3x00)
+  DEVICE_TITLE := NETGEAR WNDR3700
+  NETGEAR_KERNEL_MAGIC := 0x33373030
+  NETGEAR_BOARD_ID := WNDR3700
+  IMAGE_SIZE := 7680k
+  IMAGES += factory-NA.img
+  IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size $$$$(IMAGE_SIZE)
+  SUPPORTED_DEVICES += wndr3700
+endef
+TARGET_DEVICES += netgear_wndr3700
+
+define Device/netgear_wndr3700v2
+  $(Device/netgear_wndr3x00)
+  DEVICE_TITLE := NETGEAR WNDR3700v2
+  NETGEAR_KERNEL_MAGIC := 0x33373031
+  NETGEAR_BOARD_ID := WNDR3700v2
+  NETGEAR_HW_ID := 29763654+16+64
+  IMAGE_SIZE := 15872k
+  SUPPORTED_DEVICES += wndr3700v2
+endef
+TARGET_DEVICES += netgear_wndr3700v2
+
 define Device/netgear_wndr3800
   $(Device/netgear_wndr3x00)
   DEVICE_TITLE := NETGEAR WNDR3800

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -134,20 +134,23 @@ define Device/pcs_cr5000
 endef
 TARGET_DEVICES += pcs_cr5000
 
-define Device/netgear_wndr3800
+define Device/netgear_wndr3x00
   ATH_SOC := ar7161
-  DEVICE_TITLE := NETGEAR WNDR3800
-  NETGEAR_KERNEL_MAGIC := 0x33373031
   KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  NETGEAR_BOARD_ID := WNDR3800
-  NETGEAR_HW_ID := 29763654+16+128
-  IMAGE_SIZE := 15872k
   IMAGES := sysupgrade.bin factory.img
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset
+endef
+
+define Device/netgear_wndr3800
+  $(Device/netgear_wndr3x00)
+  DEVICE_TITLE := NETGEAR WNDR3800
+  NETGEAR_KERNEL_MAGIC := 0x33373031
+  NETGEAR_BOARD_ID := WNDR3800
+  NETGEAR_HW_ID := 29763654+16+128
+  IMAGE_SIZE := 15872k
   SUPPORTED_DEVICES += wndr3800
 endef
 TARGET_DEVICES += netgear_wndr3800


### PR DESCRIPTION
@mkresin 
Thanks for advice regarding the .dtsi / .dts formulation. I left only the partitions in the .dts

Add support for WNDR3700 and WNDR3700v2

The three routers are identical except
  * device IDs
  * WNDR3700 (v1) has only 8 MB flash, while others have 16 MB. Partition structure needs to be defined for each device.
  * (Additionally, WNDR3800 has 128 MB RAM, but RAM size is not in DTS)

Commits:
* separate the common parts from old wndr3800.dts into wndr3700.dtsi and leave just the device-specific things into wndr3800.dts
* add definitions for WNDR3700 and WNDR3700v2

Note: wifi related things have been left out of this PR to keep this simple.

Tested with WDNR3800 and WNDR3700v2

