### PR TITLE
brcm47xx: cosmetic fix in model detection

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -39,7 +39,7 @@ configure_by_vlanports() {
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "5@eth0"
 
 	else
-		logger -t "01_detect" "Unable to determine network configuration"
+		logger -t "01_network" "Unable to determine network configuration"
 		ucidef_set_interface_lan "eth0"
 	fi
 }


### PR DESCRIPTION
@jow- 

In d7d10f2c1e8511fe07c9760e85f2272a85168f8d, the file was renamed to 01_network.
This PR updates the warning message to reference the new filename (leftover)
