### PR TITLE
ath79: add support for Pisen WMM003N (Cloud Easy Power)

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ath79_setup_interfaces()
 	ocedo,koala|\
 	ocedo,raccoon|\
 	pcs,cap324|\
+	pisen,wmm003n|\
 	tplink,re450-v2|\
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "Pisen WMM003N";
+	compatible = "pisen,wmm003n", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+		led-status = &led_system;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "pisen:blue:system";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			firmware: partition@20000 {
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -134,6 +134,17 @@ define Device/pcs_cr5000
 endef
 TARGET_DEVICES += pcs_cr5000
 
+define Device/pisen_wmm003n
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9331
+  DEVICE_TITLE := Pisen WMM003N (Cloud Easy Power)
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-chipidea2
+  TPLINK_HWID := 0x07030101
+  SUPPORTED_DEVICES += wmm003n
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += pisen_wmm003n
+
 define Device/netgear_wndr3800
   ATH_SOC := ar7161
   DEVICE_TITLE := NETGEAR WNDR3800


### PR DESCRIPTION
Pisen WMM003N (sold under the name of Cloud Easy Power) is an
AR9331-based router and power bank combo device. The device uses a
stock firmware modified from OpenWRT for TP-Link TL-WR703N; however
some GPIO definition is different on this device with TL-WR703N. An
AXP202 PMIC (connected to a 5000mAh battery) and a SD slot are also
added, and the stock Flash/RAM configuration is 8MiB/64MiB.

The stock firmware is an old and heavily modified OpenWRT-based
firmware, which has telnetd defaultly open, and the root password is
"ifconfig" (quotation marks not included). The factory image format is
not known yet, however the stock firmware ships the OpenWRT's sysupgrade
command, and it can be used to install a newer firmware.

Due to the lack of the access to the STM8 embedded controller, the SD
slot is currently not usable (because it's muxed with the on-board USB
port) and the AXP PMIC cannot be monitored.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>

---
See also [1].

[1] http://my.piseneasy.com/product/details/2465