### PR TITLE
firmware-utils/mksercommfw: fix musl build

### DIFF
--- a/tools/firmware-utils/src/mksercommfw.c
+++ b/tools/firmware-utils/src/mksercommfw.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 /* #define DEBUG 1 */
 


### PR DESCRIPTION
* add missing <sys/types.h> for musl
