### PR TITLE
ath79: Add wifi to WNDR3700, WNDR3700v2 and WNDR3800

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -159,6 +159,11 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
+	netgear,wndr3700|\
+	netgear,wndr3700v2|\
+	netgear,wndr3800)
+		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0)")
+		;;
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")
 		wan_mac=$(k2t_get_mac "wan_mac")

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -146,6 +146,11 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "caldata" 4096 3768
 		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 65440) 524
 		;;
+	netgear,wndr3700|\
+	netgear,wndr3700v2|\
+	netgear,wndr3800)
+		ath9k_eeprom_extract "art" 4096 3768
+		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
 		;;
@@ -156,6 +161,11 @@ case "$FIRMWARE" in
 	dlink,dir-825-b1)
 		ath9k_eeprom_extract "caldata" 20480 3768
 		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 65460) 1) 524
+		;;
+	netgear,wndr3700|\
+	netgear,wndr3700v2|\
+	netgear,wndr3800)
+		ath9k_eeprom_extract "art" 20480 3768
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
@@ -67,6 +67,22 @@
 		};
 	};
 
+	ath9k-leds {
+		compatible = "gpio-leds";
+		wlan2g {
+			label = "netgear:green:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+		wlan5g {
+			label = "netgear:blue:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		poll-interval = <100>;
@@ -138,6 +154,24 @@
 
 &pcie0 {
 	status = "okay";
+
+	ath9k0: wifi@8800 {
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0x10000>;
+		mtd-mac-address = <&art 0x0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@9000 {
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0x10000>;
+		mtd-mac-address = <&art 0xc>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
 };
 
 &uart {

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -141,7 +141,7 @@ define Device/netgear_wndr3x00
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
 endef
 
 define Device/netgear_wndr3700


### PR DESCRIPTION
This is the rebased wifi PR after the revamp of the WNDR3700/3800 series in ath79.

Wifi support is not quite perfect yet, see known issues below, but this can still serve as the first implementation.

I do not quite like the "adjust MAC in /etc/config/network" approach, and will look into doing that already in preinit, like it is supposed to happen in mvebu (where is apparently broken at the moment, but the intended process is still visible in source code)

-----

Add ath9k wifi capabilities to WNDR3700 family.

* use kmod-owl-loader to load firmware from "art"
* add wifi to DTS
* add wifi LEDs

Avoid using the same MAC for eth0 LAN and wlan0 by toggling the eth0 MAC into a locally administered MAC. That is currently done by in user-space in /etc/board.d/02_network by adding a uci config item into /etc/config/network
(More elegant solution might be setting it already in preinit phase.)

Known issues:

* wifi firmware file may not get created on the first boot after flashing on time to bring wifi normally up. Likely the overlay jffs2 is not yet ready for creating the firmware file. "wifi up" may still bring wifi up. Wifi will work normally at subsequent boots.

* phy0 and phy1 may get assigned mixed, so that phy0 may be the 5GHz radio instead of the normal 2.4GHz, and vice versa for phy1. Does not happen always, but may happen.


