### PR TITLE
firmware-utils/mksercommfw: fix build with clang/macOS

### DIFF
--- a/tools/firmware-utils/src/mksercommfw.c
+++ b/tools/firmware-utils/src/mksercommfw.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
 		bufferFile(&myfile, 0);
 		char chksum = getCheckSum(myfile.file_data, myfile.file_size);
 		printf("Checksum for File: %X.\n", chksum);
-		return;
+		return 0;
 	}
 
 	if (argc != 6) {


### PR DESCRIPTION
fixes error: non-void function 'main' should return a value

Signed-off-by: Ryan Mounce <ryan@mounce.com.au>
