### PR TITLE
ath79: add support for Buffalo WHR-G301N

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -17,6 +17,13 @@ avm,fritz300e)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssi3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssi4" "wlan0" "80" "100"
 	;;
+buffalo,whr-g301n)
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_switch "lan1" "LAN1" "$boardname:green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "$boardname:green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "$boardname:green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "$boardname:green:lan4" "switch0" "0x10"
+	;;
 etactica,eg200)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:red:eth0" "eth0"
 	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -83,6 +83,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
 		;;
+	buffalo,whr-g301n|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
 	tplink,tl-wr841-v7)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -111,6 +111,11 @@ case "$FIRMWARE" in
 	avm,fritz300e)
 		ath9k_eeprom_extract_reverse "urloader" 5441 1088
 		;;
+	buffalo,whr-g301n|\
+	tplink,tl-wr841-v5|\
+	tplink,tl-wr941-v4)
+		ath9k_eeprom_extract "art" 4096 3768
+		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300|\
@@ -130,10 +135,6 @@ case "$FIRMWARE" in
 	tplink,tl-wr841-v7|\
 	ubnt,unifi)
 		ath9k_eeprom_extract "art" 4096 2048
-		;;
-	tplink,tl-wr841-v5|\
-	tplink,tl-wr941-v4)
-		ath9k_eeprom_extract "art" 4096 3768
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
+++ b/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7240.dtsi"
+
+/ {
+	compatible = "buffalo,whr-g301n", "qca,ar7240";
+	model = "Buffalo WHR-G301N";
+
+	aliases {
+		led-boot = &diag;
+		led-failsafe = &diag;
+		led-upgrade = &diag;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		router_on {
+			label = "router_on";
+			linux,code = <BTN_2>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_off {
+			label = "router_off";
+			linux,code = <BTN_3>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_pins>;
+
+		security {
+			label = "whr-g301n:orange:security";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		diag: diag {
+			label = "whr-g301n:red:diag";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		router {
+			label = "whr-g301n:green:router";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "whr-g301n:green:lan1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "whr-g301n:green:lan2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "whr-g301n:green:lan3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "whr-g301n:green:lan4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "whr-g301n:green:wan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "whr-g301n:green:wlan";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x3e000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@3e000 {
+				reg = <0x3e000 0x2000>;
+				label = "u-boot-env";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x3a0000>;
+				label = "firmware";
+			};
+
+			partition@3e0000 {
+				reg = <0x3e0000 0x10000>;
+				label = "user_property";
+				read-only;
+			};
+
+			art: partition@3f0000 {
+				reg = <0x3f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x120c>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x120c>;
+	mtd-mac-address-increment = <1>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&art 0x120c>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pinmux {
+	switch_led_pins: switch_led_pins {
+		pinctrl-single,bits = <0x0 0x0 0xf8>;
+	};
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,5 +1,24 @@
 DEVICE_VARS += ROOTFS_SIZE
 
+define Build/buffalo-tftp-header
+	( \
+		echo -n -e "# Airstation Public Fmt1" | dd bs=32 count=1 conv=sync; \
+		dd if=$@; \
+	) > $@.new
+  mv $@.new $@
+endef
+
+define Build/buffalo-tag
+	$(eval product=$(word 1,$(1)))
+	$(STAGING_DIR_HOST)/bin/buffalo-tag \
+		-c 0x80041000 -d 0x801e8000 -w 3 \
+		-a ath -v 1.99 -m 1.01 -f 1 \
+		-b $(product) -p $(product) \
+		-r M_ -l mlang8 \
+		-i $@ -o $@.new
+	mv $@.new $@
+endef
+
 define Device/buffalo_bhr-4grv2
   ATH_SOC := qca9558
   DEVICE_TITLE := Buffalo BHR-4GRV2
@@ -16,3 +35,15 @@ define Device/buffalo_bhr-4grv2
   SUPPORTED_DEVICES += bhr-4grv2
 endef
 TARGET_DEVICES += buffalo_bhr-4grv2
+
+define Device/buffalo_whr-g301n
+  ATH_SOC := ar7240
+  DEVICE_TITLE := Buffalo WHR-G301N
+  IMAGE_SIZE := 3712k
+  IMAGES += factory.bin tftp.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | buffalo-tag WHR-G301N
+  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
+  SUPPORTED_DEVICES += WHRG301N
+endef
+TARGET_DEVICES += buffalo_whr-g301n


### PR DESCRIPTION
Buffalo WHR-G301N is a 2.4 GHz 11n router, based on Atheros AR7240.
Ported from ar71xx target.

Specification:

- Atheros AR7240
- 32 MB of RAM
- 4 MB of Flash
- 2.4 GHz 2T2R wifi
- 5x 10/100 Mbps Ethernet
- 9x LEDs, 4x keys
  - LED: 8x gpio-leds, 1x ath9k-leds
  - key: 2x buttons, 1x slide switch
- UART header on PCB
  - Vcc, GND, TX, RX from LEDs side
  - 115200n8

Flash instruction using factory image:

1. Connect the computer to the LAN port of WHR-G301N
2. Connect power cable to WHR-G301N and turn on it
3. Access to "http://192.168.11.1/" and open firmware update page
("ファーム更新")
4. Select the OpenWrt factory image and click execute ("実行") button
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>