### PR TITLE
uboot-ar71xx: fix musl host build

### DIFF
--- a/package/boot/uboot-ar71xx/patches/023-musl-compat.patch
+++ b/package/boot/uboot-ar71xx/patches/023-musl-compat.patch
@@ -1,0 +1,13 @@
+--- a/include/compiler.h	2018-08-29
++++ b/include/compiler.h	2018-08-29
+@@ -46,6 +46,10 @@ extern int errno;
+ #ifdef __linux__
+ # include <endian.h>
+ # include <byteswap.h>
++#ifndef __GLIBC__
++typedef unsigned long ulong;
++typedef unsigned int  uint;
++#endif
+ #elif defined(__MACH__) || defined(__FreeBSD__)
+ # include <machine/endian.h>
+ typedef unsigned long ulong;


### PR DESCRIPTION
Fixes missing uint/ulong on musl, for the older uboot-ar71xx target.
