### PR TITLE
tools: bison: fix compilation with glibc 2.28

### DIFF
--- a/tools/bison/patches/110-glibc-change-work-around.patch
+++ b/tools/bison/patches/110-glibc-change-work-around.patch
@@ -1,0 +1,33 @@
+Subject: Workaround change in glibc
+
+Temporary workaround to compile with glibc 2.28, which
+deprecated some constants
+
+Based on the workaround made for the tools/m4 package
+
+--- a/lib/stdio-impl.h
++++ b/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -29,7 +29,7 @@
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+   fp_->_flags |= __SERR;


### PR DESCRIPTION
Temporary workaround to compile with glibc 2.28, which deprecated some
constants. Based on the workaround made for the tools/m4 package.

More details: https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html

Signed-off-by: Rado Sław <rdslw@ferusfragum.science>