### PR TITLE
ath79: add support for I-O DATA WN-AC1167DGR

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ath79_setup_interfaces()
 	glinet,ar300m)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2|\
 	pcs,cr5000)
 		ucidef_add_switch "switch0" \
@@ -159,6 +160,7 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text "caldata" 65440)
 		wan_mac=$(mtd_get_mac_text "caldata" 65460)
 		;;
+	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -97,6 +97,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 2

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,6 +87,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "iodata:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		copy {
+			label = "iodata:green:copy";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		eco {
+			label = "iodata:green:eco";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wlan5g {
+			label = "iodata:green:wlan5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g {
+			label = "iodata:green:wlan2g";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+
+		notification {
+			label = "iodata:amber:notification";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		button_eco {
+			label = "eco";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+
+		button_copy {
+			label = "copy";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0xe50000>;
+			};
+
+			partition@e90000 {
+				label = "manufacture";
+				reg = <0xe90000 0x100000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "backup";
+				reg = <0xf90000 0x010000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "storage";
+				reg = <0xfa0000 0x050000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x87600000 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+	phy-handle = <&phy0>;
+};
+
+&pcie1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac1167dgr.dts
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac1167dgr.dts
@@ -7,6 +7,6 @@
 #include "qca9557_iodata_wn-ac-dgr.dtsi"
 
 / {
-	compatible = "iodata,wn-ac1600dgr2", "qca,qca9557";
-	model = "I-O DATA WN-AC1600DGR2";
+	compatible = "iodata,wn-ac1167dgr", "qca,qca9557";
+	model = "I-O DATA WN-AC1167DGR";
 };

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -67,6 +67,18 @@ define Device/glinet_ar300m_nor
 endef
 TARGET_DEVICES += glinet_ar300m_nor
 
+define Device/iodata_wn-ac1167dgr
+  ATH_SOC := qca9557
+  DEVICE_TITLE := I-O DATA WN-AC1167DGR
+  IMAGE_SIZE := 14656k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    senao-header -r 0x30a -p 0x61 -t 2
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k ath10k-firmware-qca988x
+endef
+TARGET_DEVICES += iodata_wn-ac1167dgr
+
 define Device/iodata_wn-ac1600dgr2
   ATH_SOC := qca9557
   DEVICE_TITLE := I-O DATA WN-AC1600DGR2


### PR DESCRIPTION
I-O DATA WN-AC1167DGR is a 2.4/5 GHz band 11ac router, based on
Qualcomm Atheros QCA9557.

Specification:

- Qualcomm Atheros QCA9557
- 128 MB of RAM (DDR2)
- 16 MB of Flash (SPI)
- 2T2R 2.4/5 GHz wifi
  - 2.4 GHz: SoC internal
  - 5 GHz: QCA988x
- 5x 10/100/1000 Mbps Ethernet
- 6x LEDs, 6x keys (4x buttons, 1x slide switch)
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Flash instruction using factory image:

1. Connect the computer to the LAN port of WN-AC1167DGR
2. Connect power cable to WN-AC1167DGR and turn on it
3. Access to "http://192.168.0.1/" and open firmware update page
("ファームウェア")
4. Select the OpenWrt factory image and click update ("更新") button
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
