### PR TITLE
ath79: fix leds and network for TP-Link TL-WR841 v9/v11

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -76,7 +76,8 @@ tplink,tl-wr741nd-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
-tplink,tl-wr841n-v9)
+tplink,tl-wr841-v9|\
+tplink,tl-wr841-v11)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -128,7 +128,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
-	tplink,tl-wr841n-v9)
+	tplink,tl-wr841-v9|\
+	tplink,tl-wr841-v11)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \
 		"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"


### PR DESCRIPTION
Adding tl-wr841-v11 and the rename of tl-wr841n-v9 to tl-wr841-v9 in 01_leds
and 02_network script files are missing in commits cc35c91 and 8db6522.

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>

This changes got lost while splitting the single commit into more atomic one on PR https://github.com/openwrt/openwrt/pull/1268.
Sorry for my mistake.