### PR TITLE
uqmi: wait for the control device too

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -44,6 +44,8 @@ proto_qmi_setup() {
 		return 1
 	}
 
+	[ -n "$delay" ] && sleep "$delay"
+
 	device="$(readlink -f $device)"
 	[ -c "$device" ] || {
 		echo "The specified control device does not exist"
@@ -61,8 +63,6 @@ proto_qmi_setup() {
 		proto_set_available "$interface" 0
 		return 1
 	}
-
-	[ -n "$delay" ] && sleep "$delay"
 
 	while uqmi -s -d "$device" --get-pin-status | grep '"UIM uninitialized"' > /dev/null; do
 		[ -e "$device" ] || return 1


### PR DESCRIPTION
The control device /dev/cdc-wdm0 is not available immediately on the
D-Link DWR-921 Rev.C3, therefore the wwan interface fails to start at
boot with a "The specified control device does not exist" error.

This patch alters /lib/netifd/proto/qmi.sh to wait for
network.wwan.delay earlier, before checking for the control device,
instead of just before interacting with the modem.

One still has to use network.wwan.proto='qmi', as the "wwan" proto
performs that sort of check before any delay is possible, failing with a
"No valid device was found" error.

Signed-off-by: Thomas Equeter <tequeter@users.noreply.github.com>