### PR TITLE
binutils: Use 2.31.1 by default

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_30 if !arc
+	default BINUTILS_USE_VERSION_2_31_1 if !arc
 	default BINUTILS_USE_VERSION_2_29_ARC if arc
 	help
 	  Select the version of binutils you wish to use.

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -6,10 +6,10 @@ config BINUTILS_VERSION_2_29_1
 	bool
 
 config BINUTILS_VERSION_2_30
-	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_31_1
+	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION


### PR DESCRIPTION
Set binutils 2.23.1 as default

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>