### PR TITLE
base-files: create /etc/ethers by default

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -49,6 +49,7 @@ define Package/base-files/conffiles
 /etc/config/system
 /etc/crontabs/
 /etc/dropbear/
+/etc/ethers
 /etc/group
 /etc/hosts
 /etc/inittab


### PR DESCRIPTION
/etc/ethers is missing on /rom but always created when dnsmasq
runs. It is better to have it in place and avoid an extra change
in flash after firstboot.

It will generate an extra /etc/ethers-opkg when it has changed.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

I did not bumped release as this commit does not change a running system, only .bin file