### PR TITLE
target.mk: Remove obsolete octeon CPU_CFLAGS

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -174,7 +174,6 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_mips64 = -mips64 -mtune=mips64 -mabi=64
     CPU_CFLAGS_24kc = -mips32r2 -mtune=24kc
     CPU_CFLAGS_74kc = -mips32r2 -mtune=74kc
-    CPU_CFLAGS_octeon = -march=octeon -mabi=64
     CPU_CFLAGS_octeonplus = -march=octeon+ -mabi=64
   endif
   ifeq ($(ARCH),i386)


### PR DESCRIPTION
As of https://github.com/openwrt/openwrt/commit/c6e02b49f65cb4eff624a0831d3db265b3fadd2a
octeon target uses octeonplus instead of octeon

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>