### PR TITLE
ramips: mt7621: r6220: add support for additional flash layouts

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -337,6 +337,8 @@ px-4885-8M)
 	set_wifi_led "px-4885:orange:wifi"
 	set_usb_led "px-4885:blue:storage"
 	;;
+r6220a|\
+r6220b|\
 r6220)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:wan" eth0.2
 	set_wifi_led "$boardname:green:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -106,6 +106,8 @@ ramips_setup_interfaces()
 	pbr-m1|\
 	psg1208|\
 	psg1218a|\
+	r6220b|\
+	r6220a|\
 	r6220|\
 	rt-n12p|\
 	sap-g3200u3|\
@@ -516,6 +518,8 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory 40)
 		wan_mac=$(mtd_get_mac_binary factory 46)
 		;;
+	r6220b|\
+	r6220a|\
 	r6220)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -39,6 +39,8 @@ get_status_led() {
 	nbg-419n|\
 	nbg-419n2|\
 	pwh2004|\
+	r6220b|\
+	r6220a|\
 	r6220|\
 	tplink,c20-v4|\
 	tplink,c50-v3|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -415,6 +415,12 @@ ramips_board_detect() {
 	*"Q7")
 		name="zte-q7"
 		;;
+	*"R6220B")
+		name="r6220b"
+		;;
+	*"R6220A")
+		name="r6220a"
+		;;
 	*"R6220")
 		name="r6220"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -290,6 +290,8 @@ platform_check_image() {
 		;;
 	hc5962|\
 	mir3g|\
+	r6220b|\
+	r6220a|\	
 	r6220|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
@@ -345,6 +347,8 @@ platform_do_upgrade() {
 	case "$board" in
 	hc5962|\
 	mir3g|\
+	r6220b|\
+	r6220a|\
 	r6220|\
 	ubnt-erx|\
 	ubnt-erx-sfp)

--- a/target/linux/ramips/dts/R6220A.dts
+++ b/target/linux/ramips/dts/R6220A.dts
@@ -1,0 +1,158 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6220a", "mediatek,mt7621-soc";
+	model = "Netgear R6220A";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "r6220a:green:power";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "r6220a:green:usb";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "r6220a:green:wan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "r6220a:green:wifi";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "r6220a:green:wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0 0x100000>;
+		read-only;
+	};
+
+	partition@100000 {
+		label = "SC PID";
+		reg = <0x100000 0x100000>;
+		read-only;
+	};
+
+	partition@200000 {
+		label = "kernel";
+		reg = <0x200000 0x400000>;
+	};
+
+	partition@600000 {
+		label = "ubi";
+		reg = <0x600000 0x1c00000>;
+	};
+
+	factory: partition@2de0000 {
+		label = "factory";
+		reg = <0x2de0000 0x100000>;
+		read-only;
+	};
+
+	partition@4200000 {
+		label = "reserved";
+		reg = <0x4200000 0x3c00000>;
+		read-only;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x00000004>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/dts/R6220B.dts
+++ b/target/linux/ramips/dts/R6220B.dts
@@ -1,0 +1,158 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6220b", "mediatek,mt7621-soc";
+	model = "Netgear R6220B";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "r6220b:green:power";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "r6220b:green:usb";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "r6220b:green:wan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "r6220b:green:wifi";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "r6220b:green:wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0 0x100000>;
+		read-only;
+	};
+
+	partition@100000 {
+		label = "SC PID";
+		reg = <0x100000 0x100000>;
+		read-only;
+	};
+
+	partition@200000 {
+		label = "kernel";
+		reg = <0x200000 0x400000>;
+	};
+
+	partition@600000 {
+		label = "ubi";
+		reg = <0x600000 0x1c00000>;
+	};
+
+	factory: partition@2da0000 {
+		label = "factory";
+		reg = <0x2da0000 0x100000>;
+		read-only;
+	};
+
+	partition@4200000 {
+		label = "reserved";
+		reg = <0x4200000 0x3c00000>;
+		read-only;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	pcie0 {
+		mt76@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x8000>;
+			ieee80211-freq-limit = <5000000 6000000>;
+		};
+	};
+
+	pcie1 {
+		mt76@1,0 {
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			ieee80211-freq-limit = <2400000 2500000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x00000004>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -207,6 +207,38 @@ define Device/pbr-m1
 endef
 TARGET_DEVICES += pbr-m1
 
+define Device/r6220b
+  DTS := R6220B
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 28672k
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.tar kernel.bin rootfs.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/kernel.bin := append-kernel
+  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := Netgear R6220B
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini
+endef
+define Device/r6220a
+  DTS := R6220A
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 28672k
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.tar kernel.bin rootfs.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/kernel.bin := append-kernel
+  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := Netgear R6220A
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini
+endef
 define Device/r6220
   DTS := R6220
   BLOCKSIZE := 128k
@@ -223,7 +255,7 @@ define Device/r6220
   DEVICE_PACKAGES := \
 	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini
 endef
-TARGET_DEVICES += r6220
+TARGET_DEVICES += r6220b r6220a r6220
 
 define Device/rb750gr3
   DTS := RB750Gr3


### PR DESCRIPTION
This patch is based on work from ptpt52. It supports two new flash layouts of the R6220.

The original flash layout is:
        factory: partition@2e00000 {
                label = "factory";
                reg = <0x2e00000 0x100000>;
                read-only;
        };

This patch adds the following flash layouts as R6220A and R6220B.

R6220A:
        factory: partition@2de0000 {
                label = "factory";
                reg = <0x2de0000 0x100000>;
                read-only;
        };

R6220B:
        factory: partition@2da0000 {
                label = "factory";
                reg = <0x2da0000 0x100000>;
                read-only;
        };

Those additional flash layouts are required for WiFi to work reliably on 2.4G.
Without these flash layouts for the factory mtd the MAC address cannot be found.

Signed-off-by: Rene Sterz <rene.sterz@gmx.de>