### PR TITLE
brcm47xx: Enable USB power on WNDR3400v3

### DIFF
--- a/target/linux/brcm47xx/patches-4.14/161-MIPS-BCM47XX-Enable-USB-power-on-Netgear-WNDR3400v3.patch
+++ b/target/linux/brcm47xx/patches-4.14/161-MIPS-BCM47XX-Enable-USB-power-on-Netgear-WNDR3400v3.patch
@@ -1,0 +1,44 @@
+From 17cb62255ef8f6b6ac270024204a8fa65537b333 Mon Sep 17 00:00:00 2001
+From: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>
+Date: Sun, 19 Aug 2018 21:23:14 +0300
+Subject: [PATCH] MIPS: BCM47XX: Enable USB power on Netgear WNDR3400v3
+
+Setting GPIO 21 high seems to be required to enable power to USB ports
+on the WNDR3400v3. As there is already similar code for WNR3500L,
+make the existing USB power GPIO code generic and use that.
+
+Signed-off-by: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>
+---
+ arch/mips/bcm47xx/workarounds.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/arch/mips/bcm47xx/workarounds.c b/arch/mips/bcm47xx/workarounds.c
+index 1a8a07e7a563..46eddbec8d9f 100644
+--- a/arch/mips/bcm47xx/workarounds.c
++++ b/arch/mips/bcm47xx/workarounds.c
+@@ -5,9 +5,8 @@
+ #include <bcm47xx_board.h>
+ #include <bcm47xx.h>
+ 
+-static void __init bcm47xx_workarounds_netgear_wnr3500l(void)
++static void __init bcm47xx_workarounds_enable_usb_power(int usb_power)
+ {
+-	const int usb_power = 12;
+ 	int err;
+ 
+ 	err = gpio_request_one(usb_power, GPIOF_OUT_INIT_HIGH, "usb_power");
+@@ -23,7 +22,10 @@ void __init bcm47xx_workarounds(void)
+ 
+ 	switch (board) {
+ 	case BCM47XX_BOARD_NETGEAR_WNR3500L:
+-		bcm47xx_workarounds_netgear_wnr3500l();
++		bcm47xx_workarounds_enable_usb_power(12);
++		break;
++	case BCM47XX_BOARD_NETGEAR_WNDR3400_V3:
++		bcm47xx_workarounds_enable_usb_power(21);
+ 		break;
+ 	default:
+ 		/* No workaround(s) needed */
+-- 
+2.16.3
+


### PR DESCRIPTION
WNDR3400v3 needs GPIO 21 pulled high to enable power to USB ports. Add a
kernel patch to do that.

Signed-off-by: Tuomas Tynkkynen <tuomas.tynkkynen@iki.fi>