### PR TITLE
apm821xx: Add cpu model support to cpuinfo

### DIFF
--- a/target/linux/apm821xx/patches-4.14/303-cpuinfo-add-arch-for-luci.patch
+++ b/target/linux/apm821xx/patches-4.14/303-cpuinfo-add-arch-for-luci.patch
@@ -1,0 +1,13 @@
+--- a/arch/powerpc/kernel/setup-common.c
++++ b/arch/powerpc/kernel/setup-common.c
+@@ -265,6 +265,10 @@
+
+ 	seq_printf(m, "\n");
+
++#ifdef CONFIG_APM821xx
++	seq_printf(m, "model name\t: apm821xx\n");
++#endif /* CONFIG_APM821xx */
++
+ #ifdef CONFIG_TAU
+ 	if (cur_cpu_spec->cpu_features & CPU_FTR_TAU) {
+ #ifdef CONFIG_TAU_AVERAGE


### PR DESCRIPTION
This addition is to address the change at https://github.com/openwrt/luci/commit/b8f32b6da7accc672c5887e894a861de3f806cf5 which adds architecture info into LuCI.

**Without this patch:**
![screenshot at 2018-08-19 06-45-20](https://user-images.githubusercontent.com/4700774/44315446-cc97ad80-a3e9-11e8-8ebc-c001240a8105.png)

**With this patch:**
![screenshot from 2018-08-19 19 40 21](https://user-images.githubusercontent.com/4700774/44315448-d28d8e80-a3e9-11e8-8aa1-fc4885e5609d.png)