### PR TITLE
ramips: Fix early memory calculation for certain MIPS platforms

### DIFF
--- a/target/linux/ramips/patches-4.14/0003-MIPS-Fix-memory-reservation-in-bootmem_init-for-cert.patch
+++ b/target/linux/ramips/patches-4.14/0003-MIPS-Fix-memory-reservation-in-bootmem_init-for-cert.patch
@@ -1,0 +1,45 @@
+From: Tobias Wolf <dev-NTEO@vplace.de>
+Subject: [v2] MIPS: Fix memory reservation in bootmem_init for certain non-usermem setups
+
+Commit 67a3ba25aa95 ("MIPS: Fix incorrect mem=X@Y handling") introduced a new
+issue for rt288x where "PHYS_OFFSET" is 0x0 but the calculated "ramstart" is
+not. As the prerequisite of custom memory map has been removed, this results
+in the full memory range of 0x0 - 0x8000000 to be marked as reserved for this
+platform.
+
+v2: Correctly compare that usermem is not null.
+
+This patch adds the originally intended prerequisite again.
+
+Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>
+---
+
+--- a/arch/mips/kernel/setup.c        2018-08-18 19:07:07.142066706 +0200
++++ b/arch/mips/kernel/setup.c        2018-08-18 19:10:17.827918423 +0200
+@@ -369,6 +369,8 @@ static unsigned long __init bootmap_byte
+ 	return ALIGN(bytes, sizeof(long));
+ }
+ 
++static int usermem __initdata;
++
+ static void __init bootmem_init(void)
+ {
+ 	unsigned long reserved_end;
+@@ -442,7 +444,7 @@ static void __init bootmem_init(void)
+ 	/*
+ 	 * Reserve any memory between the start of RAM and PHYS_OFFSET
+ 	 */
+-	if (ramstart > PHYS_OFFSET)
++	if (usermem && ramstart > PHYS_OFFSET)
+ 		add_memory_region(PHYS_OFFSET, ramstart - PHYS_OFFSET,
+ 				  BOOT_MEM_RESERVED);
+ 
+@@ -652,8 +654,6 @@ static void __init bootmem_init(void)
+  * initialization hook for anything else was introduced.
+  */
+ 
+-static int usermem __initdata;
+-
+ static int __init early_parse_mem(char *p)
+ {
+ 	phys_addr_t start, size;


### PR DESCRIPTION
Kernel upstream commit 67a3ba25aa95 ("MIPS: Fix incorrect mem=X@Y handling") introduced a new issue for rt288x where "PHYS_OFFSET" is 0x0 but the calculated "ramstart" is not. As the prerequisite of custom memory map has been removed, this results in the full memory range of 0x0 - 0x8000000 to be marked as reserved
for this platform.

This patch adds the originally intended prerequisite again.

Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
