### PR TITLE
ath79: add support for I-O DATA ETG3-R

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -49,6 +49,7 @@ ath79_setup_interfaces()
 	glinet,ar300m)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	iodata,etg3-r|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2|\
 	pcs,cr5000)
@@ -164,6 +165,10 @@ ath79_setup_macs()
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 65440)
 		wan_mac=$(mtd_get_mac_text "caldata" 65460)
+		;;
+	iodata,etg3-r)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" -1)
 		;;
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)

--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "iodata,etg3-r", "qca,ar9344";
+	model = "I-O DATA ETG3-R";
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "etg3-r:green:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		notification {
+			label = "etg3-r:green:notification";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	num-cs = <1>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0x780000>;
+			};
+
+			partition@7d0000 {
+				label = "Config";
+				reg = <0x07d0000 0x10000>;
+				read-only;
+			};
+
+			partition@7e0000 {
+				label = "Rsv";
+				reg = <0x07e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "ART";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x50 0xffb7ffb7 /* LED_CTRL0 */
+			0x54 0xffb7ffb7 /* LED_CTRL1 */
+			0x58 0xffb7ffb7 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -80,6 +80,13 @@ define Device/glinet_ar300m_nor
 endef
 TARGET_DEVICES += glinet_ar300m_nor
 
+define Device/iodata_etg3-r
+  ATH_SOC := ar9342
+  DEVICE_TITLE := I-O DATA ETG3-R
+  IMAGE_SIZE := 7680k
+endef
+TARGET_DEVICES += iodata_etg3-r
+
 define Device/iodata_wn-ac1167dgr
   ATH_SOC := qca9557
   DEVICE_TITLE := I-O DATA WN-AC1167DGR


### PR DESCRIPTION
I-O DATA ETG3-R is a wired router, based on Atheros AR9342.

Specification:

- Atheros AR9342
- 64 MB of RAM
- 8 MB of Flash
- 5x 10/100/1000 Ethernet
  - AR8327N
- 2x LEDs, 1x key
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Flash instruction using initramfs image:

1. Connect serial cable to UART header on ETG3-R
2. Rename OpenWrt initramfs image to "1500A8C0.img" and place it in
the TFTP directory
3. Set IP address of the computer to 192.168.0.10, connect to the
LAN port of ETG3-R, and start the TFTP server on the computer
4. Connect power cable to ETG3-R and turn on the router
5. Press "Enter" key when the "Hit any key to stop autoboot:" message
is displayed on the console and enter the u-boot cli
6. execute following commands to change kernel address for u-boot
  setenv bootsf 1
  setenv mtd_kernel1 "bootm 0x9f050000"
  saveenv
7. execute "tftpboot; bootm" command to download the initramfs image from
TFTP server and boot with it
8. On the initramfs image, execute "mtd erase firmware" to erase stock
firmware and execute sysupgrade with sysupgrade image for ETG3-R
9. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>