### PR TITLE
ath79: support ath9k firmware loading on ubnt-xm

### DIFF
--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -137,6 +137,12 @@ case "$FIRMWARE" in
 	tplink,tl-wr741-v1|\
 	tplink,tl-wr743nd-v1|\
 	tplink,tl-wr841-v7|\
+	ubnt,xm|\
+	ubnt,bullet-m|\
+	ubnt,nano-m|\
+	ubnt,rocket-m)
+		ath9k_eeprom_extract "art" 4096 4096
+		;;
 	ubnt,unifi)
 		ath9k_eeprom_extract "art" 4096 2048
 		;;


### PR DESCRIPTION
Enable ath9k EEPROM extraction on boot for Ubiquiti XM-series boards.
This is required for wireless interface to function.
Tested on Nanobridge M5.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>