### PR TITLE
ath79: fix base configuration for Ubiquiti XM series

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -92,6 +92,13 @@ tplink,tl-wr841-v11)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+ubnt,bullet-m|\
+ubnt,nano-m|\
+ubnt,rocket-m)
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100"
 esac
 
 board_config_flush

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -19,6 +19,8 @@ ath79_setup_interfaces()
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\
 	tplink,tl-wr703n|\
+	ubnt,bullet-m|\
+	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifi)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -137,6 +137,11 @@ case "$FIRMWARE" in
 	tplink,tl-wr741-v1|\
 	tplink,tl-wr743nd-v1|\
 	tplink,tl-wr841-v7|\
+	ubnt,bullet-m|\
+	ubnt,nano-m|\
+	ubnt,rocket-m)
+		ath9k_eeprom_extract "art" 4096 4096
+		;;
 	ubnt,unifi)
 		ath9k_eeprom_extract "art" 4096 2048
 		;;

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -9,6 +9,11 @@
 	compatible = "ubnt,xm", "qca,ar7241";
 	model = "Ubiquiti Networks XM (rev 1.0) board";
 
+	aliases {
+		led-boot = &link4;
+		led-failsafe = &link4;
+	};
+
 /*	extosc: ref {
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
@@ -42,7 +47,7 @@
 			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		};
 
-		link4 {
+		link4: link4 {
 			label = "ubnt:green:link4";
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};


### PR DESCRIPTION
This series of patches brings the Ubiquiti XM series (Bullet-M, Nano-M, Rocket-M) to their default configuration based on information from ar71xx target.

The first patch allows EEPROM image loading for ath9k module from ART partition. This is crucial for wireless interface to operate. Result is correct MAC and correct SSID broadcast by onboard radio.
Second patch fixes default network configuration to create LAN interface only (only for Bullet-M and Rocket-M), as these two are single-port devices. Nano-M is kept as is.
Third patch adds back support for system status LED by updating device tree aliases.
Last patch makes the four RSSI LEDs present on board usable with "rssileds" package by creating default configuration.

The series was runtime and functionally tested on Ubiquiti Nanobridge M5 unit, using target bullet-m.
