### PR TITLE
treewide: fix some cosmetic glitches in dts files

### DIFF
--- a/target/linux/apm821xx/dts/meraki-mr24.dts
+++ b/target/linux/apm821xx/dts/meraki-mr24.dts
@@ -29,7 +29,6 @@
 	chosen {
 		linux,stdout-path = "/plb/opb/serial@ef600400";
 	};
-
 };
 
 

--- a/target/linux/apm821xx/dts/meraki-mx60.dts
+++ b/target/linux/apm821xx/dts/meraki-mx60.dts
@@ -29,7 +29,6 @@
 	chosen {
 		linux,stdout-path = "/plb/opb/serial@ef600400";
 	};
-
 };
 
 &CRYPTO {

--- a/target/linux/at91/files/arch/arm/boot/dts/at91-q5xr5.dts
+++ b/target/linux/at91/files/arch/arm/boot/dts/at91-q5xr5.dts
@@ -106,7 +106,7 @@
 			watchdog@fffffd40 {
 				status = "okay";
 			};
- 
+
 			spi0: spi@fffc8000 {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -124,7 +124,7 @@
 					reg = <0>;
 					#address-cells = <1>;
 					#size-cells = <1>;
- 
+
 					at91boot@0 {
 						label = "at91boot";
 						reg = <0x0 0x4000>;
@@ -167,7 +167,7 @@
 				};
 			};
 		};
-		
+
 		usb0: ohci@500000 {
 			num-ports = <2>;
 			status = "okay";

--- a/target/linux/at91/files/arch/arm/boot/dts/lmu5000.dts
+++ b/target/linux/at91/files/arch/arm/boot/dts/lmu5000.dts
@@ -39,7 +39,6 @@
 						atmel,pins =
 							<2 1 0x2 0x0>;	/* PC1 periph B */
 					};
-
 				};
 			};
 

--- a/target/linux/at91/files/arch/arm/boot/dts/wb50n.dts
+++ b/target/linux/at91/files/arch/arm/boot/dts/wb50n.dts
@@ -48,11 +48,11 @@
 			spi1: spi@f8008000 {
 				status = "okay";
 
-			        spidev@0 {
-				          compatible = "spidev";
-				          reg = <0>;
-				          spi-max-frequency = <8000000>;
-			         };
+				spidev@0 {
+					compatible = "spidev";
+					reg = <0>;
+					spi-max-frequency = <8000000>;
+				};
 			};
 
 			watchdog@fffffe40 {
@@ -71,7 +71,6 @@
 		usb2: ehci@00700000 {
 			status = "okay";
 		};
-
 	};
 
 	gpio_keys {
@@ -93,25 +92,25 @@
 		};
 	};
 
-    leds {
-        compatible = "gpio-leds";
+	leds {
+		compatible = "gpio-leds";
 
-        led0 {
-            label = "wb50n:blue:led0";
-            gpios = <&pioA 12 GPIO_ACTIVE_LOW>;
-            default-state = "off";
-        };
+		led0 {
+			label = "wb50n:blue:led0";
+			gpios = <&pioA 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
 
-        led1 {
-            label = "wb50n:green:led1";
-            gpios = <&pioA 24 GPIO_ACTIVE_LOW>;
-            default-state = "off";
-        };
+		led1 {
+			label = "wb50n:green:led1";
+			gpios = <&pioA 24 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
 
-        led2 {
-            label = "wb50n:red:led2";
-            gpios = <&pioA 26 GPIO_ACTIVE_LOW>;
-            default-state = "off";
-        };
-    };
+		led2 {
+			label = "wb50n:red:led2";
+			gpios = <&pioA 26 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
 };

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -85,7 +85,6 @@
 			default-state = "off";
 			linux,default-trigger = "phy1tpt";
 		};
-
 	};
 
 	keys {
@@ -125,7 +124,6 @@
 				phy-mode = "rgmii";
 			};
 		};
-	
 	};
 };
 
@@ -181,7 +179,7 @@
 };
 
 &pll {
-    clocks = <&extosc>;
+	clocks = <&extosc>;
 };
 
 &spi {
@@ -239,7 +237,6 @@
 		speed = <1000>;
 		full-duplex;
 	};
-
 };
 
 &eth1 {
@@ -247,5 +244,4 @@
 	pll-data = <0x11110000 0x00001099 0x00991099>;
 
 	phy-handle = <&phy4>;
-
 };

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -43,7 +43,6 @@
 			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 			debounce-interval = <60>;
 		};
-
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -80,7 +80,6 @@
 			default-state = "off";
 			linux,default-trigger = "phy0tpt";
 		};
-
 	};
 
 	rtl8367 {

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -47,7 +47,6 @@
 		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
-
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -154,7 +154,6 @@
 	phy-handle = <&swphy0>;
 	mtd-mac-address = <&art 0x0>;
 	mtd-mac-address-increment = <1>;
-
 };
 
 &eth1 {

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -74,7 +74,6 @@
 			default-state = "off";
 		};
 	};
-
 };
 
 &ref {

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -63,7 +63,6 @@
 			default-state = "off";
 		};
 	};
-
 };
 
 &ref {
@@ -218,7 +217,6 @@
 		swconfig,segment = "wan";
 		swconfig,portmap = <5 5>;
 	};
-
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -96,7 +96,6 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 };
 

--- a/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
+++ b/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
@@ -45,7 +45,6 @@
 				output-high;
 				line-name = "gpio-latch-bit";
 			};
-
 		};
 	};
 

--- a/target/linux/brcm63xx/dts/ad1018-nor.dts
+++ b/target/linux/brcm63xx/dts/ad1018-nor.dts
@@ -36,7 +36,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
 };
 
 &pinctrl {

--- a/target/linux/brcm63xx/dts/bcm96318ref.dts
+++ b/target/linux/brcm63xx/dts/bcm96318ref.dts
@@ -31,7 +31,7 @@
 			gpios = <&pinctrl 34 1>;
 			linux,code = <KEY_RESTART>;
 		};
-        };
+	};
 
 	gpio-leds {
 		compatible = "gpio-leds";

--- a/target/linux/brcm63xx/dts/bcm96318ref_p300.dts
+++ b/target/linux/brcm63xx/dts/bcm96318ref_p300.dts
@@ -31,7 +31,7 @@
 			gpios = <&pinctrl 34 1>;
 			linux,code = <KEY_RESTART>;
 		};
-        };
+	};
 
 	gpio-leds {
 		compatible = "gpio-leds";

--- a/target/linux/brcm63xx/dts/bcm963268bu_p300.dts
+++ b/target/linux/brcm63xx/dts/bcm963268bu_p300.dts
@@ -31,7 +31,7 @@
 			gpios = <&pinctrl 33 0>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
-        };
+	};
 };
 
 &hsspi {

--- a/target/linux/brcm63xx/dts/bcm963269bhr.dts
+++ b/target/linux/brcm63xx/dts/bcm963269bhr.dts
@@ -25,7 +25,7 @@
 			gpios = <&pinctrl 32 0>;
 			linux,code = <KEY_RESTART>;
 		};
-        };
+	};
 
 	gpio-leds {
 		compatible = "gpio-leds";

--- a/target/linux/brcm63xx/dts/dgnd3700v1.dts
+++ b/target/linux/brcm63xx/dts/dgnd3700v1.dts
@@ -119,7 +119,7 @@
 			reg = <0x1fe0000 0x20000>;
 		};
 	};
-}; 
+};
 
 &pinctrl {
 	pinctrl-names = "default";

--- a/target/linux/brcm63xx/dts/r5010unv2.dts
+++ b/target/linux/brcm63xx/dts/r5010unv2.dts
@@ -13,7 +13,7 @@
 		stdout-path = "serial0:115200n8";
 	};
 
-	
+
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/brcm63xx/dts/rta770bw.dts
+++ b/target/linux/brcm63xx/dts/rta770bw.dts
@@ -25,7 +25,7 @@
 			gpios = <&gpio0 13 1>;
 			linux,code = <KEY_RESTART>;
 		};
-        };
+	};
 
 	gpio-leds {
 		compatible = "gpio-leds";

--- a/target/linux/brcm63xx/dts/rta770w.dts
+++ b/target/linux/brcm63xx/dts/rta770w.dts
@@ -25,7 +25,7 @@
 			gpios = <&gpio0 13 1>;
 			linux,code = <KEY_RESTART>;
 		};
-        };
+	};
 
 	gpio-leds {
 		compatible = "gpio-leds";

--- a/target/linux/brcm63xx/dts/vg50.dts
+++ b/target/linux/brcm63xx/dts/vg50.dts
@@ -31,7 +31,7 @@
 			gpios = <&pinctrl 34 0>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
-        };
+	};
 };
 
 &hsspi {

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-nbg6617.dts
@@ -183,7 +183,7 @@
 			output-low;
 		};
 	};
-	led_pins: led_pinmux  {
+	led_pins: led_pinmux {
 		mux {
 			pins = "gpio0", "gpio1", "gpio3", "gpio5", "gpio58";
 			drive-strength = <0x8>;

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -410,4 +410,4 @@
 
 /delete-node/ &pcie2_pins;
 /delete-node/ &pcie2;
- 
+

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -57,7 +57,7 @@
 	};
 
 	soc {
-		rpm@108000  {
+		rpm@108000 {
 			pinctrl-0 = <&rpm_pins>;
 			pinctrl-names = "default";
 		};
@@ -443,7 +443,7 @@
 
 	led_pins: led_pins {
 		mux {
-			pins = "gpio7", "gpio8", "gpio9",  "gpio22",
+			pins = "gpio7", "gpio8", "gpio9", "gpio22",
 			       "gpio23", "gpio24", "gpio25", "gpio53";
 			function = "gpio";
 			drive-strength = <2>;

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ALL0333CJ.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ALL0333CJ.dts
@@ -18,7 +18,6 @@
 			led-dsl = &dsl;
 			led-internet = &online_green;
 		};
-
 	};
 
 	memory@0 {

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV4519PW.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV4519PW.dts
@@ -181,7 +181,7 @@
 	};
 };
 
-&pci0  {
+&pci0 {
 	status = "okay";
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ASL56026.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ASL56026.dts
@@ -93,7 +93,6 @@
 			phy-mode = "mii";
 			phy-handle = <&phy14>;
 		};
-
 	};
 
 	mdio@0 {
@@ -111,7 +110,6 @@
 			reg = <0x14>;
 			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
 		};
-
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY88388.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY88388.dts
@@ -28,7 +28,7 @@
 
 	pinctrl {
 		led_pins: led-pins {
-			lantiq,pins = "io34", "io35", "io36", "io37", "io38", 
+			lantiq,pins = "io34", "io35", "io36", "io37", "io38",
 					"io39", "io40", "io41";
 			lantiq,function = "gpio";
 		};
@@ -100,7 +100,6 @@
 			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
-
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY88444.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY88444.dts
@@ -14,7 +14,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x4000000>;  // 64M at 0x0
+		reg = <0x0 0x4000000>;	// 64M at 0x0
 	};
 
 	gpio-keys {
@@ -74,7 +74,6 @@
 			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 		};
-
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY98021.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/EASY98021.dts
@@ -15,7 +15,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x4000000>;  // 64M at 0x0
+		reg = <0x0 0x4000000>;	// 64M at 0x0
 	};
 
 	gpio-keys {
@@ -31,12 +31,12 @@
 		/* Place-holder for SIM-Card connector,
 		   to list the used GPIOs, no official binding */
 		compatible = "gpio-mmc";
-		gpios =  <&gpio0 3 GPIO_ACTIVE_HIGH>,
-			 <&gpio0 3 GPIO_ACTIVE_HIGH>,
-			 <&gpio0 2 GPIO_ACTIVE_HIGH>,
-			 <0>; /* no CS */
+		gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>,
+			<&gpio0 3 GPIO_ACTIVE_HIGH>,
+			<&gpio0 2 GPIO_ACTIVE_HIGH>,
+			<0>; /* no CS */
 		gpio-names = "di", "do", "clk", "cs";
-		reset-gpio =  <&gpio3 24 GPIO_ACTIVE_HIGH>;
+		reset-gpio = <&gpio3 24 GPIO_ACTIVE_HIGH>;
 	};
 
 	pinctrl {

--- a/target/linux/layerscape/files/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
+++ b/target/linux/layerscape/files/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
@@ -109,7 +109,7 @@
 			gpios = <&gpio4 1 GPIO_ACTIVE_LOW>;
 		};
 	};
-	
+
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;

--- a/target/linux/layerscape/files/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
+++ b/target/linux/layerscape/files/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
@@ -94,7 +94,7 @@
 			gpios = <&pca9555 6 GPIO_ACTIVE_HIGH>;
 		};
 	};
-	
+
 	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;
@@ -249,5 +249,5 @@
 
 /* No SATA/AHCI on this board */
 &sata {
-       status = "disabled";
+	status = "disabled";
 };

--- a/target/linux/mvebu/files-4.14/arch/arm/boot/dts/armada-385-linksys-venom.dts
+++ b/target/linux/mvebu/files-4.14/arch/arm/boot/dts/armada-385-linksys-venom.dts
@@ -121,51 +121,51 @@
 			/* Spansion S34ML02G2 256MiB, OEM Layout */
 			partition@0 {
 				label = "u-boot";
-				reg = <0x0000000 0x200000>;  /* 2MB */
+				reg = <0x0000000 0x200000>;	/* 2MB */
 				read-only;
 			};
 
 			partition@200000 {
 				label = "u_env";
-				reg = <0x200000 0x20000>;    /* 128KB */
+				reg = <0x200000 0x20000>;	/* 128KB */
 			};
 
 			partition@220000 {
 				label = "s_env";
-				reg = <0x220000 0x40000>;    /* 256KB */
+				reg = <0x220000 0x40000>;	/* 256KB */
 			};
 
 			partition@180000 {
 				label = "unused_area";
-				reg = <0x260000 0x5c0000>;   /* 5.75MB */
+				reg = <0x260000 0x5c0000>;	/* 5.75MB */
 			};
 
 			partition@7e0000 {
 				label = "devinfo";
-				reg = <0x7e0000 0x40000>;   /* 256KB */
+				reg = <0x7e0000 0x40000>;	/* 256KB */
 				read-only;
 			};
 
 			/* kernel1 overlaps with rootfs1 by design */
 			partition@900000 {
 				label = "kernel1";
-				reg = <0x900000 0x7b00000>;  /* 123MB */
+				reg = <0x900000 0x7b00000>;	/* 123MB */
 			};
 
 			partition@c00000 {
 				label = "rootfs1";
-				reg = <0xc00000 0x7800000>;  /* 120MB */
+				reg = <0xc00000 0x7800000>;	/* 120MB */
 			};
 
 			/* kernel2 overlaps with rootfs2 by design */
 			partition@8400000 {
 				label = "kernel2";
-				reg = <0x8400000 0x7b00000>; /* 123MB */
+				reg = <0x8400000 0x7b00000>;	/* 123MB */
 			};
 
 			partition@8700000 {
 				label = "rootfs2";
-				reg = <0x8700000 0x7800000>;  /* 120MB */
+				reg = <0x8700000 0x7800000>;	/* 120MB */
 			};
 
 			/* last MB is for the BBT, not writable */

--- a/target/linux/oxnas/files/arch/arm/boot/dts/ox820-mitrastar-stg212.dts
+++ b/target/linux/oxnas/files/arch/arm/boot/dts/ox820-mitrastar-stg212.dts
@@ -64,7 +64,6 @@
 		gpios = <&gpio1 9 0 &gpio1 10 0>;
 		i2c-gpio,delay-us = <10>;
 	};
-
 };
 
 &uart0 {

--- a/target/linux/ramips/dts/ArcherMR200.dts
+++ b/target/linux/ramips/dts/ArcherMR200.dts
@@ -97,7 +97,6 @@
 			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/D240.dts
+++ b/target/linux/ramips/dts/D240.dts
@@ -65,7 +65,6 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 	gpio-leds {

--- a/target/linux/ramips/dts/DWR-118-A2.dts
+++ b/target/linux/ramips/dts/DWR-118-A2.dts
@@ -57,8 +57,6 @@
 			label = "dwr-118-a2:green:usb";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
-
-
 	};
 
 	gpio_export {
@@ -69,8 +67,8 @@
 			gpio-export,name = "usb";
 			gpio-export,output = <1>;
 			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
 	};
-    };
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/GB-PC2.dts
+++ b/target/linux/ramips/dts/GB-PC2.dts
@@ -65,7 +65,6 @@
 			label = "gb-pc2:green:lan3";
 			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 };
 

--- a/target/linux/ramips/dts/GL-MT300A.dts
+++ b/target/linux/ramips/dts/GL-MT300A.dts
@@ -35,7 +35,6 @@
 			label = "gl-mt300a:usb";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -58,7 +57,7 @@
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
- 	};
+	};
 };
 
 &gpio0 {

--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
+++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
@@ -75,7 +75,6 @@
 			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
 };
 
 &pinctrl {

--- a/target/linux/ramips/dts/GL-MT300N.dts
+++ b/target/linux/ramips/dts/GL-MT300N.dts
@@ -30,7 +30,6 @@
 			label = "gl-mt300n:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/ramips/dts/GL-MT750.dts
+++ b/target/linux/ramips/dts/GL-MT750.dts
@@ -30,7 +30,6 @@
 			label = "gl-mt750:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -53,7 +52,7 @@
 			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
 		};
- 	};
+	};
 };
 
 &gpio0 {

--- a/target/linux/ramips/dts/MIR3G.dts
+++ b/target/linux/ramips/dts/MIR3G.dts
@@ -54,7 +54,6 @@
 			label = "mir3g:amber:lan2";
 			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -76,7 +75,6 @@
 		gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
-
 };
 
 &xhci {

--- a/target/linux/ramips/dts/NBG-419N2.dts
+++ b/target/linux/ramips/dts/NBG-419N2.dts
@@ -92,7 +92,6 @@
 			linux,code = <KEY_RFKILL>;
 		};
 	};
-
 };
 
 &pinctrl {

--- a/target/linux/ramips/dts/RBM33G.dts
+++ b/target/linux/ramips/dts/RBM33G.dts
@@ -29,7 +29,6 @@
 			label = "rbm33g:green:usr";
 			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/ramips/dts/TINY-AC.dts
+++ b/target/linux/ramips/dts/TINY-AC.dts
@@ -25,7 +25,6 @@
 			label = "tiny-ac:orange:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	gpio-keys-polled {
@@ -37,7 +36,6 @@
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
-
 	};
 
 	gpio_export {

--- a/target/linux/ramips/dts/Timecloud.dts
+++ b/target/linux/ramips/dts/Timecloud.dts
@@ -34,7 +34,6 @@
 			label = "timecloud:orange:status";
 			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 	gpio-keys-polled {

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -162,7 +162,7 @@
 		mc: mc@1fbf8000 {
 			compatible = "mtk,mt7621-mc";
 			reg = <0x1fbf8000 0x8000>;
- 		};
+		};
 
 		uartlite: uartlite@c00 {
 			compatible = "ns16550a";

--- a/target/linux/samsung/dts/TQ210.dts
+++ b/target/linux/samsung/dts/TQ210.dts
@@ -15,56 +15,55 @@
 #include "s5pv210.dtsi"
 
 / {
-    model = "Embedsky TQ210 based on S5PV210";
-    compatible = "embedsky,tq210", "samsung,s5pv210";
+	model = "Embedsky TQ210 based on S5PV210";
+	compatible = "embedsky,tq210", "samsung,s5pv210";
 
-    chosen {
-        bootargs = "console=ttySAC0,115200n8";
-    };
+	chosen {
+		bootargs = "console=ttySAC0,115200n8";
+	};
 
-    memory@20000000 {
-        device_type = "memory";
-        reg = <0x20000000 0x40000000>;
-    };
+	memory@20000000 {
+		device_type = "memory";
+		reg = <0x20000000 0x40000000>;
+	};
 
-    ethernet@88000000 {
-        compatible = "davicom,dm9000";
-        reg = <0x88000000 0x2 0x88000004 0x2>;
-        interrupt-parent = <&gph1>;
-        interrupts = <2 IRQ_TYPE_LEVEL_HIGH>;
-        local-mac-address = [00 00 de ad be ef];
-        davicom,no-eeprom;
-        clocks = <&clocks CLK_SROMC>;
-        clock-names = "sromc";
-    };
+	ethernet@88000000 {
+		compatible = "davicom,dm9000";
+		reg = <0x88000000 0x2 0x88000004 0x2>;
+		interrupt-parent = <&gph1>;
+		interrupts = <2 IRQ_TYPE_LEVEL_HIGH>;
+		local-mac-address = [00 00 de ad be ef];
+		davicom,no-eeprom;
+		clocks = <&clocks CLK_SROMC>;
+		clock-names = "sromc";
+	};
 };
 
 &xxti {
-    clock-frequency = <24000000>;
+	clock-frequency = <24000000>;
 };
 
 &uart0 {
-    status = "okay";
+	status = "okay";
 };
 
 &nand {
-    status = "okay";
-    nand-ecc-mode = "soft";
+	status = "okay";
+	nand-ecc-mode = "soft";
 
-    partition@0 {
-        label = "boot";
-        reg = <0x0 0x40000>;        /* 246KB */
-        read-only;
-    };
-    
-    partition@40000 {
-        label = "kernel";
-        reg = <0x40000 0x300000>;   /* 3MB */
-    };
+	partition@0 {
+		label = "boot";
+		reg = <0x0 0x40000>;		/* 246KB */
+		read-only;
+	};
 
-    partition@340000 {
-        label = "rootfs";
-        reg = <0x340000 0x3fcc0000>; /* 1020MB */
-    };
+	partition@40000 {
+		label = "kernel";
+		reg = <0x40000 0x300000>;	/* 3MB */
+	};
 
+	partition@340000 {
+		label = "rootfs";
+		reg = <0x340000 0x3fcc0000>;	/* 1020MB */
+	};
 };


### PR DESCRIPTION
- remove single spaces hidden by a tab
- replace indentation with spaces by tabs
- make empty lines empty
