### PR TITLE
base-files: provide more tolerant xterm detection

### DIFF
--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -14,7 +14,11 @@ export HOME=$(grep -e "^${USER:-root}:" /etc/passwd | cut -d ":" -f 6)
 export HOME=${HOME:-/root}
 export PS1='\u@\h:\w\$ '
 
-[ "$TERM" = "xterm" ] && export PS1='\[\e]0;\u@\h: \w\a\]'$PS1
+case "$TERM" in
+	xterm*|rxvt*)
+		export PS1='\[\e]0;\u@\h: \w\a\]'$PS1
+		;;
+esac
 
 [ -x /bin/more ] || alias more=less
 [ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi


### PR DESCRIPTION
In d742e1b5137d63175f4c41a4cb357cbe358112ef `PS1` got exported to set the window title of the terminal, if xterm is detected.
Since, there's not only "xterm", but also different flavours of if (e.g. "xterm-256color", "xterm-color", "xterm-16color"), use the same detection mechanism that Debian / Ubuntu is using here.