### PR TITLE
ramips: mt7620: add dir-810l network config

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ramips_setup_interfaces()
 	dir-320-b1|\
 	dir-610-a1|\
 	dir-615-h1|\
+	dir-810l|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-921-c1|\
 	ew1200|\


### PR DESCRIPTION
This commit adds the dir-810l device to the /etc/board.d/02_network file, from where it was missing, so that the network is now properly configured on boot.

Tested on the actual device.
