### PR TITLE
ramips: add support for Netgear R6350

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -370,7 +370,7 @@ px-4885-8M)
 	set_usb_led "px-4885:blue:storage"
 	;;
 r6220|\
-r6350)
+netgear,r6350)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:wan" eth0.2
 	set_wifi_led "$boardname:green:wifi"
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -369,7 +369,8 @@ px-4885-8M)
 	set_wifi_led "px-4885:orange:wifi"
 	set_usb_led "px-4885:blue:storage"
 	;;
-r6220)
+r6220|\
+r6350)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:wan" eth0.2
 	set_wifi_led "$boardname:green:wifi"
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -112,6 +112,7 @@ ramips_setup_interfaces()
 	psg1208|\
 	psg1218a|\
 	r6220|\
+	r6350|\
 	rt-n12p|\
 	sap-g3200u3|\
 	sk-wb8|\
@@ -544,7 +545,8 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory 40)
 		wan_mac=$(mtd_get_mac_binary factory 46)
 		;;
-	r6220)
+	r6220|\
+	r6350)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -112,7 +112,7 @@ ramips_setup_interfaces()
 	psg1208|\
 	psg1218a|\
 	r6220|\
-	r6350|\
+	netgear,r6350|\
 	rt-n12p|\
 	sap-g3200u3|\
 	sk-wb8|\
@@ -546,7 +546,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 46)
 		;;
 	r6220|\
-	r6350)
+	netgear,r6350)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -418,9 +418,6 @@ ramips_board_detect() {
 	*"R6220")
 		name="r6220"
 		;;
-	*"R6350")
-		name="r6350"
-		;;
 	*"RB750Gr3")
 		name="rb750gr3"
 		;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -418,6 +418,9 @@ ramips_board_detect() {
 	*"R6220")
 		name="r6220"
 		;;
+	*"R6350")
+		name="r6350"
+		;;
 	*"RB750Gr3")
 		name="rb750gr3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -302,6 +302,7 @@ platform_check_image() {
 	hc5962|\
 	mir3g|\
 	r6220|\
+	r6350|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
 		nand_do_platform_check "$board" "$1"
@@ -359,6 +360,7 @@ platform_do_upgrade() {
 	hc5962|\
 	mir3g|\
 	r6220|\
+	r6350|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
 		nand_do_upgrade "$ARGV"

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -302,7 +302,7 @@ platform_check_image() {
 	hc5962|\
 	mir3g|\
 	r6220|\
-	r6350|\
+	netgear,r6350|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
 		nand_do_platform_check "$board" "$1"
@@ -360,7 +360,7 @@ platform_do_upgrade() {
 	hc5962|\
 	mir3g|\
 	r6220|\
-	r6350|\
+	netgear,r6350|\
 	ubnt-erx|\
 	ubnt-erx-sfp)
 		nand_do_upgrade "$ARGV"

--- a/target/linux/ramips/dts/R6350.dts
+++ b/target/linux/ramips/dts/R6350.dts
@@ -1,0 +1,143 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6350", "mediatek,mt7621-soc";
+	model = "Netgear R6350";
+
+	aliases {
+		led-status = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "r6350:green:power";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "r6350:green:usb";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "r6350:green:wan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "r6350:green:wifi";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "SC PART_MAP";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x2800000>;
+		};
+
+		/* +0x02E00000 - +0x04600000 : reserved */
+
+		factory: partition@4600000 {
+			label = "factory";
+			reg = <0x4600000 0x200000>;
+			read-only;
+		};
+
+		/* +0x04800000 - +0x08000000 : reserved */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x00000004>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "uart2", "jtag", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -285,6 +285,24 @@ define Device/r6220
 endef
 TARGET_DEVICES += r6220
 
+define Device/r6350
+  DTS := R6350
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 40960k
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.tar kernel.bin rootfs.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/kernel.bin := append-kernel
+  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_TITLE := Netgear R6350
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-mini
+endef
+TARGET_DEVICES += r6350
+
 define Device/rb750gr3
   DTS := RB750Gr3
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Netgear R6350 is a wireless router, aka Netgear AC1750.

Specification:
- SoC: Mediatek MT7621AT (2 CPU cores, 4 threads)
- RAM: 128MiB (Nanya NT5CC64M16GP-DI)
- ROM: 128MiB NAND Flash (Macronix MX30LF1G18AC-TI)
- Wireless:
   for 11b/g/n (upto 300Mbps): MT7603
   for 11a/ac  (upto 1450Mbps) : MT7615, is not avaliable now
- Ethernet LAN speed: up to 1000Mbps
- Ethernet LAN ports: 4
- Ethernet WAN speed: up to 1000Mbps
- Ethernet WAN ports: 1
- USB ports: 1 (USB 2.0)
- LEDs: 4 (all can be controlled by SoC's GPIO)
- buttons: 2
- serial ports: unknown

Installation through telnet:
  - Copy kernel.bin and rootfs.bin to a USB flash disk,
    plug to usb port on the router.
  - Enable telnet with link: http://192.168.1.1/setup.cgi?todo=debug
    (login if required, default: admin password)
  - You will see "Debug Enabled!"
  - Telnet 192.168.1.1 and login with "root"
  - ls /mnt/shares/ to find out path of your USB disk.
    'myUdisk' for example.
  - cd /mnt/shares/myUdisk
  - mtd_write write rootfs.bin Rootfs
  - mtd_write write kernel.bin Kernel
  - reboot

recovery when bricked:
  nmrpflash can be used to recover to the netgear firmware
  if a broken image was flashed.

Signed-off-by: NOGUCHI Hiroshi <drvlabo@gmail.com>