### PR TITLE
comgt: increase timeout on runcommands

### DIFF
--- a/package/network/utils/comgt/files/runcommand.gcom
+++ b/package/network/utils/comgt/files/runcommand.gcom
@@ -10,7 +10,7 @@ opengt
  send $env("COMMAND")
  send "^m"
 
- waitfor 15 "OK","ERR","ERROR","COMMAND NOT SUPPORT"
+ waitfor 25 "OK","ERR","ERROR","COMMAND NOT SUPPORT"
  if % = 0 goto continue
  if % = 1 goto error
  if % = 2 goto error


### PR DESCRIPTION
Some combination of modem/wireless operator requires more time to
execute the commands.
Tested on DWR-512 embedded wwan modem and italian operator iliad (new
virtual operator).

Signed-off-by: Giuseppe Lippolis <giu.lippolis@gmail.com>