### PR TITLE
apm821xx: load kernel and dtb from SATA 0:1 first on the MBL

### DIFF
--- a/target/linux/apm821xx/image/mbl_boot.scr
+++ b/target/linux/apm821xx/image/mbl_boot.scr
@@ -1,6 +1,6 @@
 setenv boot_args 'setenv bootargs root=/dev/sda2 rw rootfstype=squashfs,ext4'
-setenv load_part1 'sata init; ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
-setenv load_part2 'sata init; ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_part1 'sata init; ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_part2 'sata init; ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
 setenv load_sata 'if run load_part1; then echo Loaded part 1; elif run load_part2; then echo Loaded part 2; fi'
 setenv boot_sata 'run load_sata; run boot_args addtty; bootm ${kernel_addr_r} - ${fdt_addr_r}'
 run boot_sata


### PR DESCRIPTION
This remedies an issue with the My Book Live Duo where, if two drives are inserted, each with OpenWrt, the boot script would first attempt to load kernel and dtb from a different disk (1:1) than what later goes on to be the system disk (0:1). This mix&match obviously only works if both drives contain the same version of OpenWrt, and especially fails after the system drive has been sysupgrade'd.

For compatibility with the MBL Single that only uses 1:1, the subsequent attempt to load kernel&dtb from 1:1 needs to stay in.