### PR TITLE
ramips: add support for TP-Link TL-MR3020 v3

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -404,6 +404,11 @@ tplink,tl-wa801nd-v5)
 	ucidef_set_led_wlan "wlan" "wlan" "$boardname:green:wlan" "phy0tpt"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
 	;;
+tplink,tl-mr3020-v3)
+	set_usb_led "$boardname:green:3g"
+	set_wifi_led "$boardname:green:wlan"
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	;;
 tplink,tl-mr3420-v5|\
 tplink,tl-wr842n-v5)
 	set_usb_led "$boardname:green:usb"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -150,6 +150,7 @@ ramips_setup_interfaces()
 	pbr-d1|\
 	ravpower,wd03|\
 	tama,w06|\
+	tplink,tl-mr3020-v3|\
 	u25awf-h1|\
 	wli-tx4-ag300n|\
 	wmdr-143n|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -265,6 +265,7 @@ platform_check_image() {
 	tplink,c20-v1|\
 	tplink,c20-v4|\
 	tplink,c50-v3|\
+	tplink,tl-mr3020-v3|\
 	tplink,tl-mr3420-v5|\
 	tplink,tl-wa801nd-v5|\
 	tplink,tl-wr842n-v5|\

--- a/target/linux/ramips/dts/TL-MR3020V3.dts
+++ b/target/linux/ramips/dts/TL-MR3020V3.dts
@@ -1,0 +1,144 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-mr3020-v3", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-MR3020 v3";
+
+	aliases {
+		led-status = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		modec1 {
+			label = "sw1";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		modec2 {
+			label = "sw2";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tl-mr3020-v3:green:power";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan {
+			label = "tl-mr3020-v3:green:3g";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-mr3020-v3:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tl-mr3020-v3:green:wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tl-mr3020-v3:green:lan";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x20000 0x7a0000>;
+			};
+
+			partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@7d0000 {
+				label = "factory";
+				reg = <0x7d0000 0x30000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2s", "refclk", "wdt", "p2led_an", "p1led_an", "p0led_an", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,mtd-eeprom = <&factory 0x20000>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xf100>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -231,6 +231,20 @@ define Device/tplink_c50-v3
 endef
 TARGET_DEVICES += tplink_c50-v3
 
+define Device/tplink_tl-mr3020-v3
+  $(Device/tplink)
+  DTS := TL-MR3020V3
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link TL-MR3020 v3
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x30200003
+  TPLINK_HWREV := 0x3
+  TPLINK_HWREVADD := 0x3
+  TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += tplink_tl-mr3020-v3
+
 define Device/tplink_tl-mr3420-v5
   $(Device/tplink)
   DTS := TL-MR3420V5


### PR DESCRIPTION
TP-Link TL-MR3020 v3 is a pocket-size router based on MediaTek MT7628N.

This PR is based on the work of @meyergru[1], with his permission.

Specification:
- MediaTek MT7628N/N (575 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz
- 1x 10/100 Mbps Ethernet 

Flash instruction:

The only way to flash the image in TL-MR3020 v3 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.0.225/24 and tftp server.
2. Rename "openwrt-ramips-mt76x8-tplink_tl-mr3020-v3-squashfs-tftp-recovery.bin"
   to "tp_recovery.bin" and place it in tftp server directory.
3. Connect PC with the LAN port, press the reset button, power up
   the router and keep button pressed for around 6-7 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and reboot.

[1] https://github.com/meyergru/lede-source/commits/TL-MR3020-V3

Signed-off-by: Carlo Nel <carlojnel@gmail.com>