### PR TITLE
dnsmasq: allow dnsmasq variants to be included in image

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -53,6 +53,7 @@ $(call Package/dnsmasq/Default)
   TITLE += (with DHCPv6 support)
   DEPENDS+=@IPV6
   VARIANT:=dhcpv6
+  PROVIDES:=dnsmasq
 endef
 
 define Package/dnsmasq-full
@@ -62,6 +63,7 @@ $(call Package/dnsmasq/Default)
 	+PACKAGE_dnsmasq_full_ipset:kmod-ipt-ipset \
 	+PACKAGE_dnsmasq_full_conntrack:libnetfilter-conntrack
   VARIANT:=full
+  PROVIDES:=dnsmasq
 endef
 
 define Package/dnsmasq/description


### PR DESCRIPTION
The dnsmasq variants should provide dnsmasq, otherwise it is impossible
to include them in the image.

This change allows one to have CONFIG_PACKAGE_dnsmasq=m and
CONFIG_PACKAGE_dnsmasq-full=y, e.g. because you want DNSSEC support, or
IPSETs suport on your 3000-devices fleet ;-)

This is a minimal fix.  A more complete one would be to have the default
in target.mk accept any of the dnsmasq variants, so that one could set
CONFIG_PACKAGE_dnsmasq=n if one will only use one of the variants.  But
that has a lot more potential impact for little gain, so it would be
harder to backport to 18.06.

Signed-off-by: Henrique de Moraes Holschuh <hmh@hmh.eng.br>