### PR TITLE
musl: Make hack to disable crypto functions optional

### DIFF
--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -293,6 +293,13 @@ config USE_EXTERNAL_LIBC
 	bool
 	default y if EXTERNAL_TOOLCHAIN || NATIVE_TOOLCHAIN
 
+config CRYPTO_SIZE_HACK
+	bool
+	prompt "Strip other hash functions than DES from musl" if TOOLCHAINOPTS
+	default y
+	help
+	  Enable if you want to silently replace all hash function in crypt by DES and get extra space
+
 source "toolchain/binutils/Config.version"
 source "toolchain/gcc/Config.version"
 

--- a/toolchain/musl/Makefile
+++ b/toolchain/musl/Makefile
@@ -11,6 +11,10 @@ MUSL_MAKEOPTS = -C $(HOST_BUILD_DIR) \
 	DESTDIR="$(TOOLCHAIN_DIR)/" \
 	LIBCC="$(subst libgcc.a,libgcc_initial.a,$(shell $(TARGET_CC) -print-libgcc-file-name))"
 
+ifeq ($(CRYPTO_SIZE_HACK),y)
+TARGET_CFLAGS += -DSIZE_HACK
+endif
+
 define Host/SetToolchainInfo
 	$(SED) 's,^\(LIBC_TYPE\)=.*,\1=$(PKG_NAME),' $(TOOLCHAIN_DIR)/info.mk
 	$(SED) 's,^\(LIBC_URL\)=.*,\1=http://www.musl-libc.org/,' $(TOOLCHAIN_DIR)/info.mk

--- a/toolchain/musl/patches/901-crypt_size_hack.patch
+++ b/toolchain/musl/patches/901-crypt_size_hack.patch
@@ -1,15 +1,17 @@
 --- a/src/crypt/crypt_r.c
 +++ b/src/crypt/crypt_r.c
-@@ -19,12 +19,6 @@ char *__crypt_r(const char *key, const c
+@@ -19,12 +19,14 @@ char *__crypt_r(const char *key, const c
  	if (salt[0] == '$' && salt[1] && salt[2]) {
  		if (salt[1] == '1' && salt[2] == '$')
  			return __crypt_md5(key, salt, output);
--		if (salt[1] == '2' && salt[3] == '$')
--			return __crypt_blowfish(key, salt, output);
--		if (salt[1] == '5' && salt[2] == '$')
--			return __crypt_sha256(key, salt, output);
--		if (salt[1] == '6' && salt[2] == '$')
--			return __crypt_sha512(key, salt, output);
++#ifndef SIZE_HACK
+ 		if (salt[1] == '2' && salt[3] == '$')
+ 			return __crypt_blowfish(key, salt, output);
+ 		if (salt[1] == '5' && salt[2] == '$')
+ 			return __crypt_sha256(key, salt, output);
+ 		if (salt[1] == '6' && salt[2] == '$')
+ 			return __crypt_sha512(key, salt, output);
++#endif
  	}
  	return __crypt_des(key, salt, output);
  }
@@ -19,7 +21,7 @@
  #include <stdio.h>
  #include <string.h>
  #include <stdint.h>
-+#if 0
++#ifndef SIZE_HACK
  
  /* public domain sha512 implementation based on fips180-3 */
  /* >=2^64 bits messages are not supported (about 2000 peta bytes) */
@@ -34,7 +36,7 @@
  #include <string.h>
  #include <stdint.h>
  
-+#if 0
++#ifndef SIZE_HACK
  typedef uint32_t BF_word;
  typedef int32_t BF_word_signed;
  
@@ -49,7 +51,7 @@
  #include <string.h>
  #include <stdint.h>
  
-+#if 0
++#ifndef SIZE_HACK
  /* public domain sha256 implementation based on fips180-3 */
  
  struct sha256 {


### PR DESCRIPTION
Some devices have enough space to handle strong cryptography.

Signed-off-by: Michal Hrusecky <Michal@Hrusecky.net>