### PR TITLE
base-files: /etc/services: add missing 'rpcbind' alias

### DIFF
--- a/package/base-files/files/etc/services
+++ b/package/base-files/files/etc/services
@@ -29,8 +29,8 @@ kerberos	88/tcp		kerberos5 krb5 kerberos-sec
 kerberos	88/udp		kerberos5 krb5 kerberos-sec
 pop3		110/tcp
 pop3		110/udp
-sunrpc		111/tcp
-sunrpc		111/udp
+sunrpc		111/tcp		rpcbind
+sunrpc		111/udp		rpcbind
 auth		113/tcp		ident
 sftp		115/tcp
 nntp		119/tcp


### PR DESCRIPTION
Add the `rpcbind` alias to the services list, this is the default behavior on many distros and allows rpcbind to open its ports. Without it rpcbind is not reachable via lan, which should not interfere with nfs-server itself, but is a unexpected behavior.

PS: I got 3 cases where users could not mount there nfs shares, without this change. This should not happen, but after the change they reported the issue as fixed.

fixes openwrt/packages#6871