### PR TITLE
apm821xx: on MBL load kernel/dtb from SATA 0:1 first

### DIFF
--- a/target/linux/apm821xx/image/mbl_boot.scr
+++ b/target/linux/apm821xx/image/mbl_boot.scr
@@ -1,6 +1,6 @@
 setenv boot_args 'setenv bootargs root=/dev/sda2 rw rootfstype=squashfs,ext4'
-setenv load_part1 'sata init; ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
-setenv load_part2 'sata init; ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_part1 'sata init; ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_part2 'sata init; ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
 setenv load_sata 'if run load_part1; then echo Loaded part 1; elif run load_part2; then echo Loaded part 2; fi'
 setenv boot_sata 'run load_sata; run boot_args addtty; bootm ${kernel_addr_r} - ${fdt_addr_r}'
 run boot_sata


### PR DESCRIPTION
This change remedies a problem with the MBL Duo where, if two disks
are inserted and both contain OpenWrt, kernel and dtb are loaded
from SATA 1:1 while rootfs (/dev/sda2) is on SATA 0:1.

This mix&match obviously only works out if both disks contain the
same version of OpenWrt, and it especially fails after sysupgrade
upgrades /dev/sda on SATA 0:1.

The fallback to SATA 1:1 needs to be kept for MBL Single (only has
SATA 1:1) and MBL Duo with only one disk inserted in SATA 1:1.

Signed off: Freddy Leitner <hello@square.wf>