### PR TITLE
kernel: backport rtc ds1308 support to 4.9

### DIFF
--- a/target/linux/generic/backport-4.9/095-v4.13-0001-rtc-ds1307-add-ds1308-variant.patch
+++ b/target/linux/generic/backport-4.9/095-v4.13-0001-rtc-ds1307-add-ds1308-variant.patch
@@ -1,0 +1,51 @@
+From 300a7735becf55f7fd18f8cd3dc3b945a0cab712 Mon Sep 17 00:00:00 2001
+From: Sean Nyekjaer <sean.nyekjaer@prevas.dk>
+Date: Thu, 8 Jun 2017 12:36:54 +0200
+Subject: rtc: ds1307: add ds1308 variant
+
+The ds1308 variant is very similar to the already supported ds1338
+variant, it have more debug registers and a square wave clock output.
+
+Signed-off-by: Sean Nyekjaer <sean.nyekjaer@prevas.dk>
+Signed-off-by: Alexandre Belloni <alexandre.belloni@free-electrons.com>
+---
+ drivers/rtc/rtc-ds1307.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+--- a/drivers/rtc/rtc-ds1307.c
++++ b/drivers/rtc/rtc-ds1307.c
+@@ -31,6 +31,7 @@
+  */
+ enum ds_type {
+ 	ds_1307,
++	ds_1308,
+ 	ds_1337,
+ 	ds_1338,
+ 	ds_1339,
+@@ -144,6 +145,10 @@ static struct chip_desc chips[last_ds_ty
+ 		.nvram_offset	= 8,
+ 		.nvram_size	= 56,
+ 	},
++	[ds_1308] = {
++		.nvram_offset	= 8,
++		.nvram_size	= 56,
++	},
+ 	[ds_1337] = {
+ 		.alarm		= 1,
+ 	},
+@@ -175,6 +180,7 @@ static struct chip_desc chips[last_ds_ty
+ 
+ static const struct i2c_device_id ds1307_id[] = {
+ 	{ "ds1307", ds_1307 },
++	{ "ds1308", ds_1308 },
+ 	{ "ds1337", ds_1337 },
+ 	{ "ds1338", ds_1338 },
+ 	{ "ds1339", ds_1339 },
+@@ -1488,6 +1494,7 @@ read_rtc:
+ 			goto read_rtc;
+ 		}
+ 		break;
++	case ds_1308:
+ 	case ds_1338:
+ 		/* clock halted?  turn it on, so clock can tick. */
+ 		if (tmp & DS1307_BIT_CH)


### PR DESCRIPTION
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
