### PR TITLE
 ath79: add syscon compatible property to ar7100 ethernet nodes

### DIFF
--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -182,7 +182,7 @@
 };
 
 &eth0 {
-	compatible = "qca,ar7100-eth";
+	compatible = "qca,ar7100-eth", "syscon";
 	reg = <0x19000000 0x200
 		0x18070000 0x4>;
 
@@ -201,7 +201,7 @@
 };
 
 &eth1 {
-	compatible = "qca,ar7100-eth";
+	compatible = "qca,ar7100-eth", "syscon";
 	reg = <0x1a000000 0x200
 		0x18070004 0x4>;
 

--- a/target/linux/ath79/dts/ar7161_ubnt_routerstation-pro.dts
+++ b/target/linux/ath79/dts/ar7161_ubnt_routerstation-pro.dts
@@ -21,13 +21,11 @@
 };
 
 &eth0 {
-	compatible = "qca,ar7100-eth", "syscon";
 	phy-mode = "rgmii";
 	phy-handle = <&phy4>;
 };
 
 &eth1 {
-	compatible = "qca,ar7100-eth", "syscon";
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
 };

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
@@ -183,8 +183,8 @@ static int ag71xx_mdio_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	am->mii_regmap = syscon_regmap_lookup_by_phandle(np, "regmap");
-	if (!am->mii_regmap)
-		return -ENOENT;
+	if (IS_ERR(am->mii_regmap))
+		return PTR_ERR(am->mii_regmap);
 
 	mii_bus = devm_mdiobus_alloc(amdev);
 	if (!mii_bus)


### PR DESCRIPTION
This adds "syscon" to the compatible properties for the eth0/eth1 nodes
in ar7100.dtsi.

Without this, a kernel panic is encountered on boot with some ar7100
boards. This for some reason wasn't an issue for the WNDR3800, which
uses a Realtek switch chipset, but the panic was encountered on the
RouterStation Pro (using an AR8216 switch) and some other boards that
haven't yet been merged.

The panic message mentions an unaligned access and happens in
ag71xx_mdio_probe in drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c.

Even if the unaligned access is fixed, the ag71xx_mdio probe still fails
without the "syscon" property.

This was already being worked around in
ar7161_ubnt_routerstation-pro.dts by overriding the compatible property,
so this commit removes that as well.

All of the other ath79 .dtsi already have this property, so no changes
are needed elsewhere.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>