### PR TITLE
ath79: Add support for Ubiquiti Nanostation AC loco

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr3040-v2|\
 	tplink,tl-wr703n|\
 	ubnt,bullet-m|\
+	ubnt,nanostation-ac-loco|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,7 @@ case "$FIRMWARE" in
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\
+	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-ac-loco", "ubnt,wa";
+	model = "Ubiquiti Nanostation AC loco (WA)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "rgmii";
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "ubnt,wa", "qca,ar9344";
+	model = "Ubiquiti Networks WA board";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			eeprom: partition@ff0000 {
+				label = "EEPROM";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,disable-5ghz;
+	mtd-cal-data = <&eeprom 0x1000>;
+	mtd-mac-address = <&eeprom 0x1002>;
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -1,4 +1,4 @@
-DEVICE_VARS += UBNT_BOARD UBNT_CHIP UBNT_TYPE
+DEVICE_VARS += UBNT_BOARD UBNT_CHIP UBNT_TYPE UBNT_VERSION
 
 # mkubntimage is using the kernel image direct
 # routerboard creates partitions out of the ubnt header
@@ -10,14 +10,14 @@ define Build/mkubntimage
 		-o $@
 endef
 
-# all UBNT XM device expect the kernel image to have 1024k while flash, when
+# all UBNT XM/WA devices expect the kernel image to have 1024k while flash, when
 # booting the image, the size doesn't matter.
 define Build/mkubntimage-split
 	-[ -f $@ ] && ( \
 	dd if=$@ of=$@.old1 bs=1024k count=1; \
 	dd if=$@ of=$@.old2 bs=1024k skip=1; \
 	$(STAGING_DIR_HOST)/bin/mkfwimage \
-		-B $(UBNT_BOARD) -v $(UBNT_TYPE).$(UBNT_CHIP).v6.0.0-$(VERSION_DIST)-$(REVISION) \
+		-B $(UBNT_BOARD) -v $(UBNT_TYPE).$(UBNT_CHIP).v$(UBNT_VERSION)-$(VERSION_DIST)-$(REVISION) \
 		-k $@.old1 \
 		-r $@.old2 \
 		-o $@; \
@@ -27,10 +27,12 @@ endef
 # UBNT_BOARD e.g. one of (XS2, XS5, RS, XM)
 # UBNT_TYPE e.g. one of (BZ, XM, XW)
 # UBNT_CHIP e.g. one of (ar7240, ar933x, ar934x)
+# UBNT_VERSION e.g. one of (6.0.0, 8.5.0)
 define Device/ubnt
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
   IMAGE_SIZE := 7552k
   UBNT_BOARD := XM
+  UBNT_VERSION := 6.0.0
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | mkubntimage-split
@@ -50,6 +52,15 @@ define Device/ubnt-bz
   UBNT_TYPE := BZ
   UBNT_CHIP := ar7240
   ATH_SOC := ar7241
+endef
+
+define Device/ubnt-wa
+  $(Device/ubnt)
+  UBNT_TYPE := WA
+  UBNT_CHIP := ar934x
+  UBNT_BOARD := WA
+  UBNT_VERSION := 8.5.0
+  ATH_SOC := ar9342
 endef
 
 define Device/ubnt_bullet-m
@@ -72,6 +83,16 @@ define Device/ubnt_nano-m
   SUPPORTED_DEVICES += nano-m
 endef
 TARGET_DEVICES += ubnt_nano-m
+
+define Device/ubnt_nanostation-ac-loco
+  $(Device/ubnt-wa)
+  DEVICE_TITLE := Ubiquiti Nanostation AC loco
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x
+  IMAGE_SIZE := 15744k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
+endef
+TARGET_DEVICES += ubnt_nanostation-ac-loco
 
 define Device/ubnt_unifi
   $(Device/ubnt-bz)

--- a/tools/firmware-utils/src/fw.h
+++ b/tools/firmware-utils/src/fw.h
@@ -24,6 +24,7 @@
 #define MAGIC_HEADER	"OPEN"
 #define MAGIC_PART	"PART"
 #define MAGIC_END	"END."
+#define MAGIC_ENDS	"ENDS"
 
 #define MAGIC_LENGTH	4
 
@@ -56,6 +57,13 @@ typedef struct signature {
 	u_int32_t crc;
 	u_int32_t pad;
 } __attribute__ ((packed)) signature_t;
+
+typedef struct signature_rsa {
+	char magic[MAGIC_LENGTH];
+//	u_int32_t crc;
+	unsigned char rsa_signature[256];
+	u_int32_t pad;
+} __attribute__ ((packed)) signature_rsa_t;
 
 #define VERSION "1.2"
 

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -29,65 +29,106 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <stdbool.h>
 #include "fw.h"
 
 typedef struct fw_layout_data {
-	char		name[PATH_MAX];
 	u_int32_t	kern_start;
 	u_int32_t	kern_entry;
 	u_int32_t	firmware_max_length;
 } fw_layout_t;
 
-fw_layout_t fw_layout_data[] = {
+struct fw_info {
+	char			name[PATH_MAX];
+	struct fw_layout_data	fw_layout;
+	bool			sign;
+};
+
+struct fw_info fw_info[] = {
 	{
-		.name		=	"XS2",
-		.kern_start	=	0xbfc30000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x00390000,
+		.name = "XS2",
+		.fw_layout = {
+			.kern_start	=	0xbfc30000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x00390000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"XS5",
-		.kern_start	=	0xbe030000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x00390000,
+		.name = "XS5",
+		.fw_layout = {
+			.kern_start	=	0xbe030000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x00390000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"RS",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00B00000,
+		.name = "RS",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00B00000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"RSPRO",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00F00000,
+		.name = "RSPRO",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00F00000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"LS-SR71",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00640000,
+		.name = "LS-SR71",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00640000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"XS2-8",
-		.kern_start	=	0xa8030000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x006C0000,
+		.name = "XS2-8",
+		.fw_layout = {
+			.kern_start	=	0xa8030000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x006C0000,
+		},
+		.sign = false,
+		
 	},
 	{
-		.name		=	"XM",
-		.kern_start	=	0x9f050000,
-		.kern_entry	=	0x80002000,
-		.firmware_max_length=	0x00760000,
+		.name = "XM",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00760000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"UBDEV01",
-		.kern_start	=	0x9f050000,
-		.kern_entry	=	0x80002000,
-		.firmware_max_length=	0x006A0000,
+		.name = "UBDEV01",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x006A0000,
+		},
+		.sign = false,
 	},
-	{	.name		=	"",
+	{
+		.name = "WA",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00F60000,
+		},
+		.sign = true,
+	},
+	{
+		.name = "",
 	},
 };
 
@@ -116,7 +157,19 @@ typedef struct image_info {
 	char outputfile[PATH_MAX];
 	u_int32_t	part_count;
 	part_data_t parts[MAX_SECTIONS];
+	struct fw_info* fwinfo;
 } image_info_t;
+
+static struct fw_info* get_fwinfo(char* board_name) {
+	struct fw_info *fwinfo = fw_info;
+	while(strlen(fwinfo->name)) {
+		if(strcmp(fwinfo->name, board_name) == 0) {
+			return fwinfo;
+		}
+		fwinfo++;
+	}
+	return NULL;
+}
 
 static void write_header(void* mem, const char *magic, const char* version)
 {
@@ -139,6 +192,17 @@ static void write_signature(void* mem, u_int32_t sig_offset)
 
 	memcpy(sign->magic, MAGIC_END, MAGIC_LENGTH);
 	sign->crc = htonl(crc32(0L,(unsigned char *)mem, sig_offset));
+	sign->pad = 0L;
+}
+
+static void write_signature_rsa(void* mem, u_int32_t sig_offset)
+{
+	/* write signature */
+	signature_rsa_t* sign = (signature_rsa_t*)(mem + sig_offset);
+	memset(sign, 0, sizeof(signature_rsa_t));
+
+	memcpy(sign->magic, MAGIC_ENDS, MAGIC_LENGTH);
+//	sign->crc = htonl(crc32(0L,(unsigned char *)mem, sig_offset));
 	sign->pad = 0L;
 }
 
@@ -237,17 +301,9 @@ static int create_image_layout(const char* kernelfile, const char* rootfsfile, c
 	part_data_t* kernel = &im->parts[0];
 	part_data_t* rootfs = &im->parts[1];
 
-	fw_layout_t* p;
+	fw_layout_t* p = &im->fwinfo->fw_layout;
 
-	p = &fw_layout_data[0];
-	while (*p->name && (strcmp(p->name, board_name) != 0))
-		p++;
-	if (!*p->name) {
-		printf("BUG! Unable to find default fw layout!\n");
-		exit(-1);
-	}
-
-	printf("board = %s\n", p->name);
+	printf("board = %s\n", im->fwinfo->name);
 	strcpy(kernel->partition_name, "kernel");
 	kernel->partition_index = 1;
 	kernel->partition_baseaddr = p->kern_start;
@@ -330,7 +386,12 @@ static int build_image(image_info_t* im)
 	int i;
 
 	// build in-memory buffer
-	mem_size = sizeof(header_t) + sizeof(signature_t);
+	mem_size = sizeof(header_t);
+	if(im->fwinfo->sign) {
+		mem_size += sizeof(signature_rsa_t);
+	} else {
+		mem_size += sizeof(signature_t);
+	}
 	for (i = 0; i < im->part_count; ++i)
 	{
 		part_data_t* d = &im->parts[i];
@@ -359,7 +420,11 @@ static int build_image(image_info_t* im)
 		ptr += sizeof(part_t) + d->stats.st_size + sizeof(part_crc_t);
 	}
 	// write signature
-	write_signature(mem, mem_size - sizeof(signature_t));
+	if(im->fwinfo->sign) {
+		write_signature_rsa(mem, mem_size - sizeof(signature_rsa_t));
+	} else {
+		write_signature(mem, mem_size - sizeof(signature_t));
+	}
 
 	// write in-memory buffer into file
 	if ((f = fopen(im->outputfile, "w")) == NULL)
@@ -388,6 +453,7 @@ int main(int argc, char* argv[])
 	char board_name[PATH_MAX];
 	int o, rc;
 	image_info_t im;
+	struct fw_info *fwinfo;
 
 	memset(&im, 0, sizeof(im));
 	memset(kernelfile, 0, sizeof(kernelfile));
@@ -446,6 +512,14 @@ int main(int argc, char* argv[])
 		usage(argv[0]);
 		return -2;
 	}
+
+	if ((fwinfo = get_fwinfo(board_name)) == NULL) {
+		ERROR("Invalid baord name '%s'\n", board_name);
+		usage(argv[0]);
+		return -2;		
+	}
+
+	im.fwinfo = fwinfo;
 
 	if ((rc = create_image_layout(kernelfile, rootfsfile, board_name, &im)) != 0)
 	{


### PR DESCRIPTION
# Overview

The Ubiquiti NanoStation AC loco is the sucessor to the NanoStation M5 loco.
It features both a 5 GHz AC and a 2.4 GHz radio.

## Specs

CPU: Atheros AR9342 @ 535 MHz
Flash: 128 Mbit nor flash, Macronix MX25L12805D
RAM: 64 MB
Ethernet: 1x 1000 Mbit/s (AR8035 PHY)
WLAN: AR9342 & QCA988X

It's worthy of note though that the 5 GHz radio is a custom Ubiquiti branded part with the pci id 0777:11ac and a Ubiquiti part number. Apart from the pci id it seems to be an absolutely normal QCA988X rev 2.

# Obtaining firmware
Either build it yourself or get it from https://github.com/TobleMiner/openwrt-prereleases-bin

# Installation
The firmware for this ubiquiti device is signed. But since there are no mtd utilities available on the device the original  fwupdate.real binary must be used.
Please make sure you have got firmware version ```v8.5.0.36727``` installed. The instructions probably won't work for other versions.
To install unsigned firmware the fwupdate.real binary (which is in fact just a symlink to ubntbox) must be patched:
```
hexdump -Cv /bin/ubntbox | sed 's/14 40 fe fe/00 00 00 00/g' | hexdump -R > /tmp/fwupdate.real
chmod +x /tmp/fwupdate.real
```
After that the factory image can be installed using the patched binary:
```
/tmp/fwupdate.real -m /tmp/openwrt-ath79-generic-ubnt_nanostation-ac-loco-squashfs-factory.bin
```
## Problems installing?

The above instructions were only verified using firmware version ```v8.5.0.36727```.

It will most likely work for any firmware version where
```
md5sum /bin/fwupdate.real
```
outputs
```
3584df67dd90aeedf4bee71c08292233
```
I've not had a look at any other firmware versions yet but up/downgrading to version ```v8.5.0.36727``` should always work.

If you do not have any luck with the non-invasive installation and are not afraid of opening your device and have a USB to serial adapter at hand you can always follow the instructions below.


# Alternate Installation Instructions
There seem to be some additional checks in the tftp rescue and I was unable to install any of my firmware binaries that way.

It may be possible to dd the firmware onto the flash directly from AirOS but I used the tftpboot functionality of u-boot to first load an initramfs image and then persistently flash a squashfs image from inside openWrt:

1. Connect to serial header on device (8N1 115200, see [photo of serial header](https://wiki.openwrt.org/_detail/media/ubiquiti/nanostation_ac_loco_serial.jpg?id=inbox%3Aubiquiti%3Aubiquiti_nanostation_ac_loco))
2. Power on device and enter u-boot console
3. Set up tftp server serving an openwrt initramfs build
4. Load initramfs build using the command tftpboot in the uboot cli
5. Boot the loaded image using the command bootm
6. Copy squashfs openwrt sysupgrade build to the booted device
7. Use mtd to write sysupgrade to partition "firmware"
8. Reboot and enjoy

# Performance
Performance is great. I'm seeing upwards of 350 Mbit/s throughput on 5 GHz and around 40 Mbit/s on 2.4 GHz. The latter is to be expected since the 2.4 GHz radio is only used as a management and servicing radio by the Ubiquiti firmware.

# Issues
I've not come across any compatibility issues yet, everything seems to work perfectly.

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>
