### PR TITLE
build: ar71xx remove packages from archer-c7-v1

### DIFF
--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -87,7 +87,7 @@ TARGET_DEVICES += archer-c5-v1
 define Device/archer-c7-v1
   $(Device/tplink-8mlzma)
   DEVICE_TITLE := TP-LINK Archer C7 v1
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca988x
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   BOARDNAME := ARCHER-C7
   DEVICE_PROFILE := ARCHERC7
   TPLINK_HWID := 0x75000001


### PR DESCRIPTION
  removed ath10k because the 5 GHz hardware,
  QCA9880-AR1A, is unsupported and boot loops
  kmod-ath10k ath10k-firmware-qca988x
  5 GHz radio decommissioned, but router works.

Signed-off-by: Aubrey McIntosh, PhD <aubrey.mcintosh@utexas.edu>
