### PR TITLE
 apm821xx: MBL: load kernel/dtb from SATA 0:1 first

### DIFF
--- a/target/linux/apm821xx/image/mbl_boot.scr
+++ b/target/linux/apm821xx/image/mbl_boot.scr
@@ -1,6 +1,6 @@
 setenv boot_args 'setenv bootargs root=/dev/sda2 rw rootfstype=ext4'
-setenv load_part1 'sata init; ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
-setenv load_part2 'sata init; ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
-setenv load_sata 'if run load_part1; then echo Loaded part 1; elif run load_part2; then echo Loaded part 2; fi'
+setenv load_part1 'ext2load sata 0:1 ${kernel_addr_r} /boot/uImage; ext2load sata 0:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_part2 'ext2load sata 1:1 ${kernel_addr_r} /boot/uImage; ext2load sata 1:1 ${fdt_addr_r} /boot/apollo3g.dtb'
+setenv load_sata 'sata init; if run load_part1; then echo Loaded part 1; elif run load_part2; then echo Loaded part 2; fi'
 setenv boot_sata 'run load_sata; run boot_args addtty; bootm ${kernel_addr_r} - ${fdt_addr_r}'
 run boot_sata


### PR DESCRIPTION
(Backport of commit 7aa5dc46ee79c095e53f2b8e19c640cee8a58e0f)

This remedies an issue with the MBL Duo if both disks are inserted
and contain OpenWrt. kernel and dtb would be loaded from SATA 1:1
while rootfs (/dev/sda2) would be mounted on SATA 0:1.

Such a mix&match would obviously only work if both OpenWrt versions/
builds are identical, and especially fail after sysupgrade upgraded
the system disk on SATA 0:1.

The fallback to SATA 1:1 needs to be kept for MBL Single (only has
SATA 1:1) and MBL Duo with one disk inserted on SATA 1:1. To speed
up booting in those cases, the unneccesarily doubled "sata init"
will only be called once. (In theory it could be omitted completely
since the on-flash boot script already initializes SATA to load the
on-disk boot script.)

Tested on MBL Duo (all possible combination of disks) and MBL Single

Signed-off-by: Freddy Leitner <hello@square.wf>