### PR TITLE
uboot-lantiq: fix compile with modern host dtc

### DIFF
--- a/package/boot/uboot-lantiq/patches/200-fix-dtc-header-guard.patch
+++ b/package/boot/uboot-lantiq/patches/200-fix-dtc-header-guard.patch
@@ -1,0 +1,19 @@
+--- a/include/libfdt_env.h
++++ b/include/libfdt_env.h
+@@ -8,6 +8,7 @@
+ 
+ #ifndef _LIBFDT_ENV_H
+ #define _LIBFDT_ENV_H
++#define LIBFDT_ENV_H
+ 
+ #include "compiler.h"
+ #include "linux/types.h"
+--- a/include/libfdt.h
++++ b/include/libfdt.h
+@@ -1,5 +1,6 @@
+ #ifndef _LIBFDT_H
+ #define _LIBFDT_H
++#define LIBFDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.


### PR DESCRIPTION
In dtc version 1.4.6 the macro names in header include guards changed,
but the build relies on them matching in order to replace selected
headers. This is a horrible hack to work around this.

This was spotted on arch linux. The right solution would likely to upgrade to a newer uboot release where this is fixed, but that's a lot of work. I'm completely at peace with this being rejected if someone wants to fix this properly...

Thanks,

Tom