### PR TITLE
brcm2708: Get RPi 3B+ ethernet activity LED working

### DIFF
--- a/target/linux/brcm2708/patches-4.9/033-4.18-lan78xx-read-led-states-from-dt.patch
+++ b/target/linux/brcm2708/patches-4.9/033-4.18-lan78xx-read-led-states-from-dt.patch
@@ -1,0 +1,190 @@
+From 8876bb8d6b19a5e330e27aaee77447700e8f4dd9 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 5 Sep 2018 11:41:24 +0200
+Subject: [PATCH] lan78xx: Read LED states from Device Tree
+
+Add support for DT property "microchip,led-modes", a vector of zero
+to four cells (u32s) in the range 0-15, each of which sets the mode
+for one of the LEDs. Some possible values are:
+
+    0=link/activity          1=link1000/activity
+    2=link100/activity       3=link10/activity
+    4=link100/1000/activity  5=link10/1000/activity
+    6=link10/100/activity    14=off    15=on
+
+These values are given symbolic constants in a dt-bindings header.
+
+Also use the presence of the DT property to indicate that the
+LEDs should be enabled - necessary in the event that no valid OTP
+or EEPROM is available.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ MAINTAINERS                                 |  1 +
+ drivers/net/phy/microchip.c                 | 25 +++++++++++++++
+ drivers/net/usb/lan78xx.c                   | 34 ++++++++++++++++++++-
+ include/dt-bindings/net/microchip-lan78xx.h | 21 +++++++++++++
+ include/linux/microchipphy.h                |  3 ++
+ 5 files changed, 83 insertions(+), 1 deletion(-)
+ create mode 100644 include/dt-bindings/net/microchip-lan78xx.h
+
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -12510,6 +12510,7 @@ M:	Microchip Linux Driver Support <UNGLi
+ L:	netdev@vger.kernel.org
+ S:	Maintained
+ F:	drivers/net/usb/lan78xx.*
++F:	include/dt-bindings/net/microchip-lan78xx.h
+ 
+ USB MASS STORAGE DRIVER
+ M:	Alan Stern <stern@rowland.harvard.edu>
+--- a/drivers/net/phy/microchip.c
++++ b/drivers/net/phy/microchip.c
+@@ -20,6 +20,8 @@
+ #include <linux/ethtool.h>
+ #include <linux/phy.h>
+ #include <linux/microchipphy.h>
++#include <linux/of.h>
++#include <dt-bindings/net/microchip-lan78xx.h>
+ 
+ #define DRIVER_AUTHOR	"WOOJUNG HUH <woojung.huh@microchip.com>"
+ #define DRIVER_DESC	"Microchip LAN88XX PHY driver"
+@@ -70,6 +72,8 @@ static int lan88xx_probe(struct phy_devi
+ {
+ 	struct device *dev = &phydev->mdio.dev;
+ 	struct lan88xx_priv *priv;
++	u32 led_modes[4];
++	int len;
+ 
+ 	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+ 	if (!priv)
+@@ -77,6 +81,27 @@ static int lan88xx_probe(struct phy_devi
+ 
+ 	priv->wolopts = 0;
+ 
++	len = of_property_read_variable_u32_array(dev->of_node,
++						  "microchip,led-modes",
++						  led_modes,
++						  0,
++						  ARRAY_SIZE(led_modes));
++	if (len >= 0) {
++		u32 reg = 0;
++		int i;
++
++		for (i = 0; i < len; i++) {
++			if (led_modes[i] > 15)
++				return -EINVAL;
++			reg |= led_modes[i] << (i * 4);
++		}
++		for (; i < ARRAY_SIZE(led_modes); i++)
++			reg |= LAN78XX_FORCE_LED_OFF << (i * 4);
++		(void)phy_write(phydev, LAN78XX_PHY_LED_MODE_SELECT, reg);
++	} else if (len == -EOVERFLOW) {
++		return -EINVAL;
++	}
++
+ 	/* these values can be used to identify internal PHY */
+ 	priv->chip_id = phy_read_mmd_indirect(phydev, LAN88XX_MMD3_CHIP_ID, 3);
+ 	priv->chip_rev = phy_read_mmd_indirect(phydev, LAN88XX_MMD3_CHIP_REV,
+--- a/drivers/net/usb/lan78xx.c
++++ b/drivers/net/usb/lan78xx.c
+@@ -31,6 +31,9 @@
+ #include <linux/mdio.h>
+ #include <net/ip6_checksum.h>
+ #include <linux/microchipphy.h>
++#include <linux/phy.h>
++#include <linux/of_mdio.h>
++#include <linux/of_net.h>
+ #include "lan78xx.h"
+ 
+ #define DRIVER_AUTHOR	"WOOJUNG HUH <woojung.huh@microchip.com>"
+@@ -1762,6 +1765,7 @@ done:
+ 
+ static int lan78xx_mdio_init(struct lan78xx_net *dev)
+ {
++	struct device_node *node;
+ 	int ret;
+ 
+ 	dev->mdiobus = mdiobus_alloc();
+@@ -1786,7 +1790,13 @@ static int lan78xx_mdio_init(struct lan7
+ 		break;
+ 	}
+ 
+-	ret = mdiobus_register(dev->mdiobus);
++	node = of_get_child_by_name(dev->udev->dev.of_node, "mdio");
++	if (node) {
++		ret = of_mdiobus_register(dev->mdiobus, node);
++		of_node_put(node);
++	} else {
++		ret = mdiobus_register(dev->mdiobus);
++	}
+ 	if (ret) {
+ 		netdev_err(dev->net, "can't register MDIO bus\n");
+ 		goto exit1;
+@@ -1880,6 +1890,28 @@ static int lan78xx_phy_init(struct lan78
+ 	mii_adv = (u32)mii_advertise_flowctrl(dev->fc_request_control);
+ 	phydev->advertising |= mii_adv_to_ethtool_adv_t(mii_adv);
+ 
++	if (phydev->mdio.dev.of_node) {
++		u32 reg;
++		int len;
++
++		len = of_property_count_elems_of_size(phydev->mdio.dev.of_node,
++						      "microchip,led-modes",
++						      sizeof(u32));
++		if (len >= 0) {
++			/* Ensure the appropriate LEDs are enabled */
++			lan78xx_read_reg(dev, HW_CFG, &reg);
++			reg &= ~(HW_CFG_LED0_EN_ |
++				 HW_CFG_LED1_EN_ |
++				 HW_CFG_LED2_EN_ |
++				 HW_CFG_LED3_EN_);
++			reg |= (len > 0) * HW_CFG_LED0_EN_ |
++				(len > 1) * HW_CFG_LED1_EN_ |
++				(len > 2) * HW_CFG_LED2_EN_ |
++				(len > 3) * HW_CFG_LED3_EN_;
++			lan78xx_write_reg(dev, HW_CFG, reg);
++		}
++	}
++
+ 	genphy_config_aneg(phydev);
+ 
+ 	dev->fc_autoneg = phydev->autoneg;
+--- /dev/null
++++ b/include/dt-bindings/net/microchip-lan78xx.h
+@@ -0,0 +1,21 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _DT_BINDINGS_MICROCHIP_LAN78XX_H
++#define _DT_BINDINGS_MICROCHIP_LAN78XX_H
++
++/* LED modes for LAN7800/LAN7850 embedded PHY */
++
++#define LAN78XX_LINK_ACTIVITY           0
++#define LAN78XX_LINK_1000_ACTIVITY      1
++#define LAN78XX_LINK_100_ACTIVITY       2
++#define LAN78XX_LINK_10_ACTIVITY        3
++#define LAN78XX_LINK_100_1000_ACTIVITY  4
++#define LAN78XX_LINK_10_1000_ACTIVITY   5
++#define LAN78XX_LINK_10_100_ACTIVITY    6
++#define LAN78XX_DUPLEX_COLLISION        8
++#define LAN78XX_COLLISION               9
++#define LAN78XX_ACTIVITY                10
++#define LAN78XX_AUTONEG_FAULT           12
++#define LAN78XX_FORCE_LED_OFF           14
++#define LAN78XX_FORCE_LED_ON            15
++
++#endif
+--- a/include/linux/microchipphy.h
++++ b/include/linux/microchipphy.h
+@@ -70,4 +70,7 @@
+ #define	LAN88XX_MMD3_CHIP_ID			(32877)
+ #define	LAN88XX_MMD3_CHIP_REV			(32878)
+ 
++/* Registers specific to the LAN7800/LAN7850 embedded phy */
++#define LAN78XX_PHY_LED_MODE_SELECT		(0x1D)
++
+ #endif /* _MICROCHIPPHY_H */

--- a/target/linux/brcm2708/patches-4.9/951-rpi-3b-plus-Enable-ethernet-LEDs.patch
+++ b/target/linux/brcm2708/patches-4.9/951-rpi-3b-plus-Enable-ethernet-LEDs.patch
@@ -1,0 +1,48 @@
+From 51324698a88520c835cf94b77723f7c4792f0e04 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 5 Sep 2018 12:01:23 +0200
+Subject: [PATCH] rpi-3b-plus: Enable ethernet LEDs
+
+Enable the ethernet LEDs on Pi 3B+ to work since driver support
+was backported from 4.18 previously
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ arch/arm/boot/dts/bcm283x-rpi-lan7515.dtsi | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/arm/boot/dts/bcm283x-rpi-lan7515.dtsi b/arch/arm/boot/dts/bcm283x-rpi-lan7515.dtsi
+index 146ef801..30e47251 100644
+--- a/arch/arm/boot/dts/bcm283x-rpi-lan7515.dtsi
++++ b/arch/arm/boot/dts/bcm283x-rpi-lan7515.dtsi
+@@ -1,3 +1,5 @@
++#include <dt-bindings/net/microchip-lan78xx.h>
++
+ / {
+       aliases {
+               ethernet = &ethernet;
+@@ -20,8 +22,21 @@
+                       ethernet: usbether@1 {
+                               compatible = "usb424,7800";
+                               reg = <1>;
++
+                               microchip,eee-enabled;
+                               microchip,tx-lpi-timer = <600>; /* non-aggressive*/
++
++                              mdio {
++                                      #address-cells = <0x1>;
++                                      #size-cells = <0x0>;
++                                      eth_phy: ethernet-phy@1 {
++                                              reg = <1>;
++                                              microchip,led-modes = <
++                                                      LAN78XX_LINK_1000_ACTIVITY
++                                                      LAN78XX_LINK_10_100_ACTIVITY
++                                              >;
++                                      };
++                              };
+                       };
+               };
+       };
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR introduces the support needed to get the ethernet activity LED on Pi 3B+ working.
It backports the needed feature to lan78xx driver from 4.18 and adds the needed node to DTSi adapted from a pending patch to upstream by Stefan Wahren.
https://patchwork.kernel.org/patch/10584887/

Further details in each commit message.

Runtime tested under bcm2710 on Pi 3B+.
Signed-off-by: Robert Marko <robimarko@gmail.com>