### PR TITLE
ath79: ubnt-xm: add out-of-box support for RSSI LEDs

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -95,6 +95,7 @@ tplink,tl-wr841-v11)
 ubnt,bullet-m|\
 ubnt,nano-m|\
 ubnt,rocket-m)
+	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100"
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100"

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -38,7 +38,7 @@ endef
 
 define Device/ubnt-xm
   $(Device/ubnt)
-  DEVICE_PACKAGES += kmod-usb-ohci
+  DEVICE_PACKAGES += kmod-usb-ohci rssileds
   UBNT_TYPE := XM
   UBNT_CHIP := ar7240
   ATH_SOC := ar7241


### PR DESCRIPTION
This patchset aims to provide RSSI monitor functionality "out of box" for Ubiquiti XM series devices (namely, Bullet-M, Nanostation-M, Rocket-M), just as it is available in stock firmware.

RSSI refresh period is set to reasonable 200ms, especially given the fact the LEDs on XM boards do not support PWM.

This is mainly meant for easy first-time setups, especially when doing a setup without internet access to install additional packages or edit the configuration files.
The previous pull request adding LED support for Ubiquiti XM series omitted these changes by mistake.

Runtime tested on Ubiquiti Nanobridge M5.

Also, I think that similar change might be backported to ar71xx target as well, in which LEDs are defined (with coefficients for PWM), but without monitor mapping and without the rssileds package. But let's focus on ath79 for now.