### PR TITLE
ath79: add support for ELECOM WRC-300GHBK2-I

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -39,6 +39,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
 		;;
+	elecom,wrc-300ghbk2-i)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
+		;;
 	embeddedwireless,dorin)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
@@ -175,6 +179,9 @@ ath79_setup_macs()
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 65440)
 		wan_mac=$(mtd_get_mac_text "caldata" 65460)
+		;;
+	elecom,wrc-300ghbk2-i)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary ART 4098)" -2)
 		;;
 	iodata,etg3-r)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	model = "ELECOM WRC-300GHBK2-I";
+	compatible = "elecom,wrc-300ghbk2-i", "qca,qca9563";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "wrc-300ghbk2-i:white:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "wrc-300ghbk2-i:white:wlan2g";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "wrc-300ghbk2-i:red:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		button_wps {
+			label = "wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		ap {
+			label = "ap";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "nvram";
+				reg = <0x050000 0x020000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "firmware";
+				reg = <0x070000 0x770000>;
+			};
+
+			partition@7e0000 {
+				label = "hwconfig";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			ART: partition@7f0000 {
+				label = "ART";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x50 0xcf37cf37 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&ART 0x1002>;
+	mtd-mac-address-increment = <(-1)>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&ART 0x1000>;
+};


### PR DESCRIPTION
ELECOM WRC-300GHBK2-I is a 2.4 GHz wireless router, based on Qualcomm
Atheros QCA9563.

Specification:

- Qualcomm Atheros QCA9563
- 64 MB of RAM (DDR2)
- 8 MB of Flash (SPI-NOR)
- 2T2R 2.4 GHz wifi
  - SoC internal
- 5x 10/100/1000 Mbps Ethernet
- 3x LEDs, 4x keys(connected to GPIO: 3x)
- UART header on PCB
  - TX, GND, RX, Vcc from ethernet port side
  - 115200n8

Flash instruction using factory image:

1. Boot the WRC-300GHBK2-I normaly and connect the computer to its
LAN port
2. Access to "http://192.168.2.1/" and open firmware update page
("ファームウェア更新 手動更新（アップデート）")
3. Select the OpenWrt factory image and click apply ("適用") button
to perform firmware update
4. On the (initramfs) factory image, execute "mtd erase firmware" to
erase stock firmware and execute sysupgrade with squashfs-sysupgrade
image for WRC-300GHBK2-I
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
