### PR TITLE
odhcp6c: add client fqdn and reconfigure options

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -17,6 +17,8 @@ proto_dhcpv6_init_config() {
 	proto_config_add_string 'extendprefix:bool'
 	proto_config_add_string 'norelease:bool'
 	proto_config_add_string 'noserverunicast:bool'
+	proto_config_add_string 'noclientfqdn:bool'
+	proto_config_add_string 'noacceptreconfigure:bool'
 	proto_config_add_array 'ip6prefix:list(ip6addr)'
 	proto_config_add_string iface_dslite
 	proto_config_add_string zone_dslite
@@ -51,8 +53,8 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast ip6prefix ip6prefixes iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
-	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
+	local reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfigure ip6prefix ip6prefixes iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
+	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfigure iface_dslite iface_map iface_464xlat ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff
 	json_for_each_item proto_dhcpv6_add_prefix ip6prefix ip6prefixes
 
 	# Configure
@@ -73,6 +75,10 @@ proto_dhcpv6_setup() {
 	[ "$norelease" = "1" ] && append opts "-k"
 
 	[ "$noserverunicast" = "1" ] && append opts "-U"
+
+	[ "$noclientfqdn" = "1" ] && append opts "-f"
+
+	[ "$noacceptreconfigure" = "1" ] && append opts "-a"
 
 	[ -n "$ifaceid" ] && append opts "-i$ifaceid"
 


### PR DESCRIPTION
Allowing DHCPV6_CLIENT_FQDN and DHCPV6_ACCEPT_RECONFIGURE to be turned off.
Defaulting to false, former behavior remains unchanged.

Signed-off-by: pacien \<pacien.trangirard@pacien.net\>

CC: package maintainer @dedeckeh

The [wiki page](https://openwrt.org/docs/guide-user/network/ipv6/start) and the package info in the Makefile may need to be updated as well.