### PR TITLE
ramips: ex2700: actually remove kmod-mt76*

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -221,7 +221,7 @@ define Device/ex2700
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | append-uImage-fakehdr filesystem
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	netgear-dni
-  DEVICE_PACKAGES := -kmod-mt76
+  DEVICE_PACKAGES := -kmod-mt76 -kmod-mt7603 -kmod-mt76x2 -kmod-mt76-core
   DEVICE_TITLE := Netgear EX2700
 endef
 TARGET_DEVICES += ex2700


### PR DESCRIPTION
Explicitly exclude all 3 mt76 packages, plus the metapackage.
Otherwise, these modules will be included in the build, wasting
a few hundred kilobytes.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>