### PR TITLE
ath79: Add support for Ubiquiti LiteAP ac

### DIFF
--- a/package/kernel/mac80211/patches/083-add-missing-pci-id-for-ubiquiti-branded-qca988x.patch
+++ b/package/kernel/mac80211/patches/083-add-missing-pci-id-for-ubiquiti-branded-qca988x.patch
@@ -1,0 +1,92 @@
+Author: Tobias Schramm <tobleminer@gmail.com>
+Date:   Tue Jan 30 14:06:05 2018 +0200
+ath10k: add support for Ubiquiti rebranded QCA988X v2
+
+Some modern Ubiquiti devices contain a rebranded QCA988X rev2 with
+a custom Ubiquiti vendor and device id. This patch adds support for
+those devices, treating them as a QCA988X v2.
+
+Signed-off-by: Tobias Schramm <tobleminer@gmail.com>
+[kvalo@codeaurora.org: rebase, add missing fields in hw_params, fix a long line in pci.c:61]
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -54,6 +54,30 @@ MODULE_PARM_DESC(rawmode, "Use raw 802.1
+ static const struct ath10k_hw_params ath10k_hw_params_list[] = {
+ 	{
+ 		.id = QCA988X_HW_2_0_VERSION,
++		.dev_id = QCA988X_2_0_DEVICE_ID_UBNT,
++		.name = "qca988x hw2.0",
++		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
++		.uart_pin = 7,
++		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_ALL,
++		.otp_exe_param = 0,
++		.channel_counters_freq_hz = 88000,
++		.max_probe_resp_desc_thres = 0,
++		.cal_data_len = 2116,
++		.fw = {
++			.dir = QCA988X_HW_2_0_FW_DIR,
++			.board = QCA988X_HW_2_0_BOARD_DATA_FILE,
++			.board_size = QCA988X_BOARD_DATA_SZ,
++			.board_ext_size = QCA988X_BOARD_EXT_DATA_SZ,
++		},
++		.hw_ops = &qca988x_ops,
++		.decap_align_bytes = 4,
++		.spectral_bin_discard = 0,
++		.vht160_mcs_rx_highest = 0,
++		.vht160_mcs_tx_highest = 0,
++		.n_cipher_suites = 8,
++	},
++	{
++		.id = QCA988X_HW_2_0_VERSION,
+ 		.dev_id = QCA988X_2_0_DEVICE_ID,
+ 		.name = "qca988x hw2.0",
+ 		.patch_load_addr = QCA988X_HW_2_0_PATCH_LOAD_ADDR,
+--- a/drivers/net/wireless/ath/ath10k/hw.h
++++ b/drivers/net/wireless/ath/ath10k/hw.h
+@@ -22,6 +22,7 @@
+ 
+ #define ATH10K_FW_DIR			"ath10k"
+ 
++#define QCA988X_2_0_DEVICE_ID_UBNT   (0x11ac)
+ #define QCA988X_2_0_DEVICE_ID   (0x003c)
+ #define QCA6164_2_1_DEVICE_ID   (0x0041)
+ #define QCA6174_2_1_DEVICE_ID   (0x003e)
+--- a/drivers/net/wireless/ath/ath10k/pci.c
++++ b/drivers/net/wireless/ath/ath10k/pci.c
+@@ -51,7 +51,10 @@ MODULE_PARM_DESC(reset_mode, "0: auto, 1
+ #define ATH10K_PCI_TARGET_WAIT 3000
+ #define ATH10K_PCI_NUM_WARM_RESET_ATTEMPTS 3
+ 
++#define PCI_VENDOR_ID_UBNT 0x0777
++
+ static const struct pci_device_id ath10k_pci_id_table[] = {
++	{ PCI_VDEVICE(UBNT, QCA988X_2_0_DEVICE_ID_UBNT) }, /* PCI-E QCA988X V2 */
+ 	{ PCI_VDEVICE(ATHEROS, QCA988X_2_0_DEVICE_ID) }, /* PCI-E QCA988X V2 */
+ 	{ PCI_VDEVICE(ATHEROS, QCA6164_2_1_DEVICE_ID) }, /* PCI-E QCA6164 V2.1 */
+ 	{ PCI_VDEVICE(ATHEROS, QCA6174_2_1_DEVICE_ID) }, /* PCI-E QCA6174 V2.1 */
+@@ -68,6 +71,7 @@ static const struct ath10k_pci_supp_chip
+ 	 * hacks. ath10k doesn't have them and these devices crash horribly
+ 	 * because of that.
+ 	 */
++	{ QCA988X_2_0_DEVICE_ID_UBNT, QCA988X_HW_2_0_CHIP_ID_REV },
+ 	{ QCA988X_2_0_DEVICE_ID, QCA988X_HW_2_0_CHIP_ID_REV },
+ 
+ 	{ QCA6164_2_1_DEVICE_ID, QCA6174_HW_2_1_CHIP_ID_REV },
+@@ -1976,6 +1980,7 @@ static int ath10k_pci_get_num_banks(stru
+ 	struct ath10k_pci *ar_pci = ath10k_pci_priv(ar);
+ 
+ 	switch (ar_pci->pdev->device) {
++	case QCA988X_2_0_DEVICE_ID_UBNT:
+ 	case QCA988X_2_0_DEVICE_ID:
+ 	case QCA99X0_2_0_DEVICE_ID:
+ 	case QCA9888_2_0_DEVICE_ID:
+@@ -3208,6 +3213,7 @@ static int ath10k_pci_probe(struct pci_d
+ 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
+ 
+ 	switch (pci_dev->device) {
++	case QCA988X_2_0_DEVICE_ID_UBNT:
+ 	case QCA988X_2_0_DEVICE_ID:
+ 		hw_rev = ATH10K_HW_QCA988X;
+ 		pci_ps = false;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr3040-v2|\
 	tplink,tl-wr703n|\
 	ubnt,bullet-m|\
+	ubnt,nanostation-ac-loco|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr3040-v2|\
 	tplink,tl-wr703n|\
 	ubnt,bullet-m|\
+	ubnt,liteap-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,7 @@ case "$FIRMWARE" in
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\
+	ubnt,liteap-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,7 @@ case "$FIRMWARE" in
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\
+	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116
 		;;

--- a/target/linux/ath79/dts/ar9342_ubnt_liteap-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_liteap-ac.dts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,liteap-ac", "ubnt,wa";
+	model = "Ubiquiti LiteAP ac (WA)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "rgmii";
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};
+
+&wmac {
+	status = "disabled";
+	};

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-ac-loco", "ubnt,wa";
+	model = "Ubiquiti Nanostation AC loco (WA)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "rgmii";
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "ubnt,wa", "qca,ar9344";
+	model = "Ubiquiti Networks WA board";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			eeprom: partition@ff0000 {
+				label = "EEPROM";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,disable-5ghz;
+	mtd-cal-data = <&eeprom 0x1000>;
+	mtd-mac-address = <&eeprom 0x1002>;
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -83,6 +83,16 @@ define Device/ubnt_nano-m
 endef
 TARGET_DEVICES += ubnt_nano-m
 
+define Device/ubnt_liteap-ac
+  $(Device/ubnt-wa)
+  DEVICE_TITLE := Ubiquiti LiteAP ac
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x
+  IMAGE_SIZE := 15744k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
+endef
+TARGET_DEVICES += ubnt_liteap-ac
+
 define Device/ubnt_nanostation-ac-loco
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti Nanostation AC loco

--- a/tools/firmware-utils/src/fw.h
+++ b/tools/firmware-utils/src/fw.h
@@ -24,6 +24,7 @@
 #define MAGIC_HEADER	"OPEN"
 #define MAGIC_PART	"PART"
 #define MAGIC_END	"END."
+#define MAGIC_ENDS	"ENDS"
 
 #define MAGIC_LENGTH	4
 
@@ -56,6 +57,13 @@ typedef struct signature {
 	u_int32_t crc;
 	u_int32_t pad;
 } __attribute__ ((packed)) signature_t;
+
+typedef struct signature_rsa {
+	char magic[MAGIC_LENGTH];
+//	u_int32_t crc;
+	unsigned char rsa_signature[256];
+	u_int32_t pad;
+} __attribute__ ((packed)) signature_rsa_t;
 
 #define VERSION "1.2"
 

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -29,65 +29,106 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <stdbool.h>
 #include "fw.h"
 
 typedef struct fw_layout_data {
-	char		name[PATH_MAX];
 	u_int32_t	kern_start;
 	u_int32_t	kern_entry;
 	u_int32_t	firmware_max_length;
 } fw_layout_t;
 
-fw_layout_t fw_layout_data[] = {
+struct fw_info {
+	char			name[PATH_MAX];
+	struct fw_layout_data	fw_layout;
+	bool			sign;
+};
+
+struct fw_info fw_info[] = {
 	{
-		.name		=	"XS2",
-		.kern_start	=	0xbfc30000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x00390000,
+		.name = "XS2",
+		.fw_layout = {
+			.kern_start	=	0xbfc30000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x00390000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"XS5",
-		.kern_start	=	0xbe030000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x00390000,
+		.name = "XS5",
+		.fw_layout = {
+			.kern_start	=	0xbe030000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x00390000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"RS",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00B00000,
+		.name = "RS",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00B00000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"RSPRO",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00F00000,
+		.name = "RSPRO",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00F00000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"LS-SR71",
-		.kern_start	=	0xbf030000,
-		.kern_entry	=	0x80060000,
-		.firmware_max_length=	0x00640000,
+		.name = "LS-SR71",
+		.fw_layout = {
+			.kern_start	=	0xbf030000,
+			.kern_entry	=	0x80060000,
+			.firmware_max_length=	0x00640000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"XS2-8",
-		.kern_start	=	0xa8030000,
-		.kern_entry	=	0x80041000,
-		.firmware_max_length=	0x006C0000,
+		.name = "XS2-8",
+		.fw_layout = {
+			.kern_start	=	0xa8030000,
+			.kern_entry	=	0x80041000,
+			.firmware_max_length=	0x006C0000,
+		},
+		.sign = false,
+		
 	},
 	{
-		.name		=	"XM",
-		.kern_start	=	0x9f050000,
-		.kern_entry	=	0x80002000,
-		.firmware_max_length=	0x00760000,
+		.name = "XM",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00760000,
+		},
+		.sign = false,
 	},
 	{
-		.name		=	"UBDEV01",
-		.kern_start	=	0x9f050000,
-		.kern_entry	=	0x80002000,
-		.firmware_max_length=	0x006A0000,
+		.name = "UBDEV01",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x006A0000,
+		},
+		.sign = false,
 	},
-	{	.name		=	"",
+	{
+		.name = "WA",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00F60000,
+		},
+		.sign = true,
+	},
+	{
+		.name = "",
 	},
 };
 
@@ -116,7 +157,19 @@ typedef struct image_info {
 	char outputfile[PATH_MAX];
 	u_int32_t	part_count;
 	part_data_t parts[MAX_SECTIONS];
+	struct fw_info* fwinfo;
 } image_info_t;
+
+static struct fw_info* get_fwinfo(char* board_name) {
+	struct fw_info *fwinfo = fw_info;
+	while(strlen(fwinfo->name)) {
+		if(strcmp(fwinfo->name, board_name) == 0) {
+			return fwinfo;
+		}
+		fwinfo++;
+	}
+	return NULL;
+}
 
 static void write_header(void* mem, const char *magic, const char* version)
 {
@@ -139,6 +192,17 @@ static void write_signature(void* mem, u_int32_t sig_offset)
 
 	memcpy(sign->magic, MAGIC_END, MAGIC_LENGTH);
 	sign->crc = htonl(crc32(0L,(unsigned char *)mem, sig_offset));
+	sign->pad = 0L;
+}
+
+static void write_signature_rsa(void* mem, u_int32_t sig_offset)
+{
+	/* write signature */
+	signature_rsa_t* sign = (signature_rsa_t*)(mem + sig_offset);
+	memset(sign, 0, sizeof(signature_rsa_t));
+
+	memcpy(sign->magic, MAGIC_ENDS, MAGIC_LENGTH);
+//	sign->crc = htonl(crc32(0L,(unsigned char *)mem, sig_offset));
 	sign->pad = 0L;
 }
 
@@ -237,17 +301,9 @@ static int create_image_layout(const char* kernelfile, const char* rootfsfile, c
 	part_data_t* kernel = &im->parts[0];
 	part_data_t* rootfs = &im->parts[1];
 
-	fw_layout_t* p;
+	fw_layout_t* p = &im->fwinfo->fw_layout;
 
-	p = &fw_layout_data[0];
-	while (*p->name && (strcmp(p->name, board_name) != 0))
-		p++;
-	if (!*p->name) {
-		printf("BUG! Unable to find default fw layout!\n");
-		exit(-1);
-	}
-
-	printf("board = %s\n", p->name);
+	printf("board = %s\n", im->fwinfo->name);
 	strcpy(kernel->partition_name, "kernel");
 	kernel->partition_index = 1;
 	kernel->partition_baseaddr = p->kern_start;
@@ -330,7 +386,12 @@ static int build_image(image_info_t* im)
 	int i;
 
 	// build in-memory buffer
-	mem_size = sizeof(header_t) + sizeof(signature_t);
+	mem_size = sizeof(header_t);
+	if(im->fwinfo->sign) {
+		mem_size += sizeof(signature_rsa_t);
+	} else {
+		mem_size += sizeof(signature_t);
+	}
 	for (i = 0; i < im->part_count; ++i)
 	{
 		part_data_t* d = &im->parts[i];
@@ -359,7 +420,11 @@ static int build_image(image_info_t* im)
 		ptr += sizeof(part_t) + d->stats.st_size + sizeof(part_crc_t);
 	}
 	// write signature
-	write_signature(mem, mem_size - sizeof(signature_t));
+	if(im->fwinfo->sign) {
+		write_signature_rsa(mem, mem_size - sizeof(signature_rsa_t));
+	} else {
+		write_signature(mem, mem_size - sizeof(signature_t));
+	}
 
 	// write in-memory buffer into file
 	if ((f = fopen(im->outputfile, "w")) == NULL)
@@ -388,6 +453,7 @@ int main(int argc, char* argv[])
 	char board_name[PATH_MAX];
 	int o, rc;
 	image_info_t im;
+	struct fw_info *fwinfo;
 
 	memset(&im, 0, sizeof(im));
 	memset(kernelfile, 0, sizeof(kernelfile));
@@ -446,6 +512,14 @@ int main(int argc, char* argv[])
 		usage(argv[0]);
 		return -2;
 	}
+
+	if ((fwinfo = get_fwinfo(board_name)) == NULL) {
+		ERROR("Invalid baord name '%s'\n", board_name);
+		usage(argv[0]);
+		return -2;		
+	}
+
+	im.fwinfo = fwinfo;
 
 	if ((rc = create_image_layout(kernelfile, rootfsfile, board_name, &im)) != 0)
 	{


### PR DESCRIPTION
### Summary
This pull request adds support for the **Ubiquiti LiteAP ac**, an outdoor 5 GHz AC access point with an integrated 120º 16 dBi antenna. The device was previously known as LiteBeam AP ac (LBE-5AC-16-120) but was later rebranded.

### Specs
CPU:    Atheros AR9342 SoC
RAM:    64 MB DDR2
Flash:  16 MB NOR SPI
Ports:  1 GbE port (PoE in)
WLAN:   5 GHz QCA899X (PCI)

The integrated QCA899X is a Ubiquiti branded part with modified vendor
and product id (0777:11ac9). It is very similar to the NanoStation loco
AC, except for the 2.4 GHz management radio (missing here).

### Support
The device is fully supported: identification, network, wireless and reset button.

### Installation
Installation procedure is the same as the NanoStation [loco] AC:

1. Connect to serial header on device
2. Power on device and enter uboot console
3. Set up tftp server serving an openwrt initramfs build
4. Load initramfs build using the command tftpboot in the uboot cli
5. Boot the loaded image using the command bootm
6. Copy squashfs openwrt sysupgrade build to the booted device
7. Use mtd to write sysupgrade to partition "firmware"
8. Reboot and enjoy

### Acknowledgments
@TobleMiner, for his great work on the UBNT WA boards support, on which this commit is based.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>