### PR TITLE
tools/expat: fix docbook2man error on some systems

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -19,6 +19,9 @@ HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
+HOST_CONFIGURE_ARGS += \
+	--without-docbook
+
 define Host/Install
 	$(MAKE) -C $(HOST_BUILD_DIR) install
 endef


### PR DESCRIPTION
On some systems (Gentoo) configure stage fails because of docbook2man
working with SGML rather than with XML. We don't need xmlwf man pages so
we disable this.

@diizzyy

Signed-off-by: Marko Ratkaj <marko.ratkaj@sartura.hr>