### PR TITLE
ath79: fix wrong pll-data value for I-O DATA WN-AC-DGR devices

### DIFF
--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -184,7 +184,7 @@
 &eth0 {
 	status = "okay";
 
-	pll-data = <0x56000000 0x00000101 0x00001616>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
 	phy-handle = <&phy0>;
 };
 


### PR DESCRIPTION
The pll-data value "0x56000000" is wrong for I-O DATA WN-AC1600DGR2
and WN-AC1167DGR, so there was a problem of slowing down the speed of
ethernet.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>