### PR TITLE
odhcpd: enable ipv6 server mode only when it is supported

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_VERSION:=1.11
 
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/odhcpd/files/odhcpd.defaults
+++ b/package/network/services/odhcpd/files/odhcpd.defaults
@@ -13,7 +13,7 @@ json_select ..
 
 case "$protocol" in
 # only enable server mode on statically addressed lan ports
-"static") MODE=server ;;
+"static") [ -d /proc/sys/net/ipv6 ] && MODE=server || MODE=disabled ;;
 *) MODE=disabled ;;
 esac
 


### PR DESCRIPTION

Signed-off-by: Rosy Song <rosysong@rosinson.com>
