### PR TITLE
Rename hostname and ssid with EUI of mac address

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -2,6 +2,7 @@
 
 CFG=/etc/board.json
 
+. /lib/functions/system.sh
 . /usr/share/libubox/jshn.sh
 
 [ -s $CFG ] || /bin/board_detect || exit 1
@@ -237,7 +238,6 @@ generate_static_system() {
 	uci -q batch <<-EOF
 		delete system.@system[0]
 		add system system
-		set system.@system[-1].hostname='OpenWrt'
 		set system.@system[-1].timezone='UTC'
 		set system.@system[-1].ttylogin='0'
 		set system.@system[-1].log_size='64'
@@ -253,6 +253,12 @@ generate_static_system() {
 		add_list system.ntp.server='3.openwrt.pool.ntp.org'
 	EOF
 
+	local labelmac=$(get_mac_label)
+	if [ -n "$labelmac" ]; then
+		uci set system.@system[-1].hostname="OpenWrt-$(macaddr_geteui $labelmac)"
+	else
+		uci set system.@system[-1].hostname=OpenWrt
+	fi
 	if json_is_a system object; then
 		json_select system
 			local hostname

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -115,6 +115,13 @@ macaddr_add() {
 	echo $oui:$nic
 }
 
+macaddr_geteui() {
+	local mac=$1
+	local sep=$2
+
+	echo ${mac:9:2}$sep${mac:12:2}$sep${mac:15:2}
+}
+
 macaddr_setbit_la() {
 	local mac=$1
 

--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 append DRIVERS "mac80211"
 
+. /lib/functions/system.sh
+
 lookup_phy() {
 	[ -n "$phy" ] && {
 		[ -d /sys/class/ieee80211/$phy ] && return
@@ -106,6 +108,10 @@ detect_mac80211() {
 			dev_id="set wireless.radio${devidx}.macaddr=$(cat /sys/class/ieee80211/${dev}/macaddress)"
 		fi
 
+		local ssid=OpenWrt
+		local labelmac=$(get_mac_label)
+		[ -n "$labelmac" ] && ssid="${ssid}_$(macaddr_geteui $labelmac)"
+
 		uci -q batch <<-EOF
 			set wireless.radio${devidx}=wifi-device
 			set wireless.radio${devidx}.type=mac80211
@@ -119,7 +125,7 @@ detect_mac80211() {
 			set wireless.default_radio${devidx}.device=radio${devidx}
 			set wireless.default_radio${devidx}.network=lan
 			set wireless.default_radio${devidx}.mode=ap
-			set wireless.default_radio${devidx}.ssid=OpenWrt
+			set wireless.default_radio${devidx}.ssid=${ssid}
 			set wireless.default_radio${devidx}.encryption=none
 EOF
 		uci -q commit wireless


### PR DESCRIPTION
This commit can meet the need of users who has more than 1 routers running with OpenWrt,
so that they can better distinguish between routers running OpenWrt without renaming the hostname and wifi ssid one by one.