### PR TITLE
ath79: fix support for Buffalo WZR-HP-G450H and add support for BHR-4GRV

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -27,11 +27,7 @@ ath79_setup_interfaces()
 	wd,mynet-wifi-rangeextender)
 		ucidef_set_interface_lan "eth0"
 		;;
-	buffalo,wzr-hp-ag300h)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
-		;;
+	buffalo,bhr-4grv|\
 	buffalo,wzr-hp-g450h)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
@@ -39,6 +35,11 @@ ath79_setup_interfaces()
 	buffalo,bhr-4grv2)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
+		;;
+	buffalo,wzr-hp-ag300h)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -120,6 +120,9 @@ case "$FIRMWARE" in
 	tplink,tl-wr941-v4)
 		ath9k_eeprom_extract "art" 4096 3768
 		;;
+	buffalo,wzr-hp-g450h)
+		ath9k_eeprom_extract "ART" 4096 1088
+		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300|\

--- a/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7242_buffalo_wzr-bhr.dtsi"
+
+/ {
+	compatible = "buffalo,bhr-4grv", "qca,ar7242";
+	model = "Buffalo BHR-4GRV";
+};
+
+&sec_vpn {
+	label = "buffalo:orange:vpn";
+};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7242.dtsi"
+
+/ {
+	aliases {
+		led-boot = &diag;
+		led-failsafe = &diag;
+		led-upgrade = &diag;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		usb {
+			label = "usb";
+			linux,code = <BTN_2>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		sec_vpn: sec_vpn {
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		diag: diag {
+			label = "buffalo:red:diag";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		usb {
+			label = "buffalo:green:usb";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "buffalo:usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&flash0 &flash1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x40000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x10000>;
+				label = "u-boot-env";
+			};
+
+			ART: partition@50000 {
+				reg = <0x50000 0x10000>;
+				label = "ART";
+				read-only;
+			};
+
+			partition@60000 {
+				reg = <0x60000 0x1f80000>;
+				label = "firmware";
+			};
+
+			partition@1fe0000 {
+				reg = <0x1fe0000 0x20000>;
+				label = "user_property";
+				read-only;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	cs-gpios = <0>, <0>;
+	num-cs = <2>;
+
+	flash0: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+	};
+
+	flash1: flash@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&ART 0x1002>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -4,111 +4,74 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
-#include "ar7242.dtsi"
+#include "ar7242_buffalo_wzr-bhr.dtsi"
 
 / {
 	compatible = "buffalo,wzr-hp-g450h", "qca,ar7242";
-	model = "Buffalo WZR-HP-G450H";
+	model = "Buffalo WZR-HP-G450H/WZR-450HP";
 
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		usb {
-			linux,code = <BTN_2>;
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		movie_engine {
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-
-		aoss {
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		router_off {
-			linux,code = <BTN_5>;
-			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
+	ath9k-leds {
 		compatible = "gpio-leds";
-		security {
-			label = "buffalo:orange:security";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+
+		led_movie_engine {
+			label = "buffalo:blue:movie_engine";
+			gpios = <&ath9k 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
 		};
 
-		diag {
-			label = "buffalo:red:diag";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		router {
+			label = "buffalo:green:router";
+			gpios = <&ath9k 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
 		};
-	};
 
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		gpio_usb_power {
-			gpio-export,name = "wzr-hp-g450h:usb-power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		wireless {
+			label = "buffalo:green:wireless";
+			gpios = <&ath9k 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };
 
-&mdio0 {
-	status = "okay";
-	phy-mask = <0x1>;
+&keys {
+	movie_engine {
+		label = "movie_engine";
+		linux,code = <BTN_6>;
+		linux,input-type = <EV_SW>;
+		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		debounce-interval = <60>;
+	};
 
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "rgmii";
+	aoss {
+		label = "aoss";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+
+	router_off {
+		label = "router_off";
+		linux,code = <BTN_5>;
+		linux,input-type = <EV_SW>;
+		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		debounce-interval = <60>;
 	};
 };
 
-&eth0 {
-	status = "okay";
-
-	phy-mode = "rgmii";
-	pll-data = <0x62000000 0 0>;
-
-	fixed-link {
-		speed = <1000>;
-		full-duplex;
-	};
-};
-
-&uart {
-	status = "okay";
-};
-
-&usb_phy {
-	status = "okay";
-};
-
-&usb {
-	status = "okay";
+&sec_vpn {
+	label = "buffalo:orange:security";
 };
 
 &pcie {
 	status = "okay";
 
-	wifi@0,0 {
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&ART 0x1002>;
 		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
 	};
 };

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -69,6 +69,19 @@ define Device/avm_fritz4020
 endef
 TARGET_DEVICES += avm_fritz4020
 
+define Device/buffalo_bhr-4grv
+  ATH_SOC := ar7242
+  DEVICE_TITLE := Buffalo BHR-4GRV
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  IMAGE_SIZE := 32256k
+  IMAGES += factory.bin tftp.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | buffalo-tag BHR-4GRV
+  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
+  SUPPORTED_DEVICES += wzr-hp-g450h
+endef
+TARGET_DEVICES += buffalo_bhr-4grv
+
 define Device/buffalo_wzr-hp-ag300h
   ATH_SOC := ar7161
   DEVICE_TITLE := Buffalo WZR-HP-AG300H

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -84,9 +84,13 @@ TARGET_DEVICES += buffalo_wzr-hp-ag300h
 
 define Device/buffalo_wzr-hp-g450h
   ATH_SOC := ar7242
-  DEVICE_TITLE := Buffalo WZR-HP-G450H
+  DEVICE_TITLE := Buffalo WZR-HP-G450H/WZR-450HP
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 32256k
+  IMAGES += factory.bin tftp.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | buffalo-tag WZR-HP-G450H
+  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g450h


### PR DESCRIPTION
This PR includes following changes:
- Fix support for Buffalo WZR-HP-G450H
  - add defines for spi and virtual (concatenated) flash
  - fix ethernet configurations
  - split to dts/dtsi
  - change the device name to "WZR-HP-G450H/WZR-450HP"

- Add support for Buffalo BHR-4GRV
  - same hardware as WZR-HP-G450H

Tested:
- WZR-HP-G450H
  - Boot from flash, Ethernet, WLAN, factory image

- BHR-4GRV
  - Boot from flash, Ethernet, factory image