### PR TITLE
ar71xx: ubnt-(xm,xw): support RSSI LEDs out-of-box

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -184,10 +184,11 @@ nanostation-m|\
 nanostation-m-xw|\
 rocket-m|\
 rocket-m-xw)
-	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100" "0" "13"
-	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100" "-25" "13"
-	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100" "-50" "13"
-	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100" "-75" "13"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:orange:link2" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100"
 	;;
 bxu2000n-2-a1)
 	ucidef_set_led_wlan "wlan" "WLAN" "bhu:green:wlan" "phy0tpt"

--- a/target/linux/ar71xx/image/generic-ubnt.mk
+++ b/target/linux/ar71xx/image/generic-ubnt.mk
@@ -49,7 +49,7 @@ endef
 
 define Device/ubnt-xm
   $(Device/ubnt)
-  DEVICE_PACKAGES += kmod-usb-ohci
+  DEVICE_PACKAGES += kmod-usb-ohci rssileds
   UBNT_TYPE := XM
   UBNT_CHIP := ar7240
   KERNEL := kernel-bin | patch-cmdline | relocate-kernel | lzma | uImage lzma
@@ -57,6 +57,7 @@ endef
 
 define Device/ubnt-xw
   $(Device/ubnt)
+  DEVICE_PACKAGES += rssileds
   UBNT_TYPE := XW
   UBNT_CHIP := ar934x
 endef


### PR DESCRIPTION
Since RSSI monitor mapping for Ubiquiti XM and XW boards was missing also from ar71xx target, backport the mapping from ath79 target and enable rssileds package for ubnt-xm and ubnt-xw devices in ar71xx target as well.

While at it, drop coefficients for PWM from default LED definitions, since XM and XW boards don't support them.

Please note that since "ubnt:green:link4" LED is hijacked as status LED, instead of staying on after bootup, startup of rssileds will turn it off until wireless connection is established. Bootup and failsafe function is unaffected.

Runtime tested on Ubiquiti Nanobridge M5 (XM) and on Ubiquiti Bullet M2HP (XW -Thanks to @ynezz)
