### PR TITLE
ath10k-firmware: Update QCA9984 firmware version

### DIFF
--- a/package/firmware/ath10k-firmware/Makefile
+++ b/package/firmware/ath10k-firmware/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-firmware
-PKG_SOURCE_DATE:=2018-05-12
-PKG_SOURCE_VERSION:=952afa4949cb34193040cd4e7441e1aee50ac731
-PKG_MIRROR_HASH:=dd300f3f28b8f8c07c93065fd9dc1c9785ebda8f15398b4d2d33f9418adcaf46
+PKG_SOURCE_DATE:=2018-09-06
+PKG_SOURCE_VERSION:=327ee47ed67e58deb2c76c822221440c36ed952f
+PKG_MIRROR_HASH:=e52e1e8ceaf6dc2679a7bd974df22113687fd18059efb0417e95f1583310bbc8
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -473,7 +473,7 @@ define Package/ath10k-firmware-qca9984/install
 		$(PKG_BUILD_DIR)/QCA9984/hw1.0/board-2.bin \
 		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/board-2.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/QCA9984/hw1.0/3.5.3/firmware-5.bin_10.4-3.5.3-00053 \
+		$(PKG_BUILD_DIR)/QCA9984/hw1.0/3.6.0.1/firmware-5.bin_10.4-3.6.0.1-00003 \
 		$(1)/lib/firmware/ath10k/QCA9984/hw1.0/firmware-5.bin
 endef
 


### PR DESCRIPTION
This appears to fix some fairly frequent 5GHz connection dropouts on a
Netgear R7800.

Signed-off-by: Robert Hancock <hancockrwd@gmail.com>
