### PR TITLE
kernel: generic: Fix nftables inet table breakage

### DIFF
--- a/target/linux/generic/backport-4.14/290-v4.16-netfilter-core-make-nf_unregister_net_hooks-simple-w.patch
+++ b/target/linux/generic/backport-4.14/290-v4.16-netfilter-core-make-nf_unregister_net_hooks-simple-w.patch
@@ -1,0 +1,96 @@
+From 406b0b99580448ee0818629e45d6d2fb39217f78 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Fri, 1 Dec 2017 00:21:02 +0100
+Subject: [PATCH 02/11] netfilter: core: make nf_unregister_net_hooks simple
+ wrapper again
+
+This reverts commit d3ad2c17b4047
+("netfilter: core: batch nf_unregister_net_hooks synchronize_net calls").
+
+Nothing wrong with it.  However, followup patch will delay freeing of hooks
+with call_rcu, so all synchronize_net() calls become obsolete and there
+is no need anymore for this batching.
+
+This revert causes a temporary performance degradation when destroying
+network namespace, but its resolved with the upcoming call_rcu conversion.
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/core.c | 59 +++-------------------------------------------------
+ 1 file changed, 3 insertions(+), 56 deletions(-)
+
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 0e22e406e9db..4ff77d8227bf 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -378,63 +378,10 @@ EXPORT_SYMBOL(nf_register_net_hooks);
+ void nf_unregister_net_hooks(struct net *net, const struct nf_hook_ops *reg,
+ 			     unsigned int hookcount)
+ {
+-	struct nf_hook_entries *to_free[16], *p;
+-	struct nf_hook_entries __rcu **pp;
+-	unsigned int i, j, n;
+-
+-	mutex_lock(&nf_hook_mutex);
+-	for (i = 0; i < hookcount; i++) {
+-		pp = nf_hook_entry_head(net, &reg[i]);
+-		if (!pp)
+-			continue;
+-
+-		p = nf_entry_dereference(*pp);
+-		if (WARN_ON_ONCE(!p))
+-			continue;
+-		__nf_unregister_net_hook(p, &reg[i]);
+-	}
+-	mutex_unlock(&nf_hook_mutex);
+-
+-	do {
+-		n = min_t(unsigned int, hookcount, ARRAY_SIZE(to_free));
+-
+-		mutex_lock(&nf_hook_mutex);
+-
+-		for (i = 0, j = 0; i < hookcount && j < n; i++) {
+-			pp = nf_hook_entry_head(net, &reg[i]);
+-			if (!pp)
+-				continue;
+-
+-			p = nf_entry_dereference(*pp);
+-			if (!p)
+-				continue;
+-
+-			to_free[j] = __nf_hook_entries_try_shrink(pp);
+-			if (to_free[j])
+-				++j;
+-		}
+-
+-		mutex_unlock(&nf_hook_mutex);
+-
+-		if (j) {
+-			unsigned int nfq;
+-
+-			synchronize_net();
+-
+-			/* need 2nd synchronize_net() if nfqueue is used, skb
+-			 * can get reinjected right before nf_queue_hook_drop()
+-			 */
+-			nfq = nf_queue_nf_hook_drop(net);
+-			if (nfq)
+-				synchronize_net();
+-
+-			for (i = 0; i < j; i++)
+-				kvfree(to_free[i]);
+-		}
++	unsigned int i;
+ 
+-		reg += n;
+-		hookcount -= n;
+-	} while (hookcount > 0);
++	for (i = 0; i < hookcount; i++)
++		nf_unregister_net_hook(net, &reg[i]);
+ }
+ EXPORT_SYMBOL(nf_unregister_net_hooks);
+ 
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/291-v4.16-netfilter-core-remove-synchronize_net-call-if-nfqueu.patch
+++ b/target/linux/generic/backport-4.14/291-v4.16-netfilter-core-remove-synchronize_net-call-if-nfqueu.patch
@@ -1,0 +1,129 @@
+From 57b32e3483d76a6ef11670c969b69b5d1f98b229 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Fri, 1 Dec 2017 00:21:03 +0100
+Subject: [PATCH 03/11] netfilter: core: remove synchronize_net call if nfqueue
+ is used
+
+since commit 960632ece6949b ("netfilter: convert hook list to an array")
+nfqueue no longer stores a pointer to the hook that caused the packet
+to be queued.  Therefore no extra synchronize_net() call is needed after
+dropping the packets enqueued by the old rule blob.
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/net/netfilter/nf_queue.h | 2 +-
+ net/netfilter/core.c             | 6 +-----
+ net/netfilter/nf_internals.h     | 2 +-
+ net/netfilter/nf_queue.c         | 7 ++-----
+ net/netfilter/nfnetlink_queue.c  | 9 ++-------
+ 5 files changed, 7 insertions(+), 19 deletions(-)
+
+diff --git a/include/net/netfilter/nf_queue.h b/include/net/netfilter/nf_queue.h
+index 814058d0f167..a50a69f5334c 100644
+--- a/include/net/netfilter/nf_queue.h
++++ b/include/net/netfilter/nf_queue.h
+@@ -25,7 +25,7 @@ struct nf_queue_entry {
+ struct nf_queue_handler {
+ 	int		(*outfn)(struct nf_queue_entry *entry,
+ 				 unsigned int queuenum);
+-	unsigned int	(*nf_hook_drop)(struct net *net);
++	void		(*nf_hook_drop)(struct net *net);
+ };
+ 
+ void nf_register_queue_handler(struct net *net, const struct nf_queue_handler *qh);
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 4ff77d8227bf..cc26f9a729f3 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -324,7 +324,6 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ {
+ 	struct nf_hook_entries __rcu **pp;
+ 	struct nf_hook_entries *p;
+-	unsigned int nfq;
+ 
+ 	pp = nf_hook_entry_head(net, reg);
+ 	if (!pp)
+@@ -347,10 +346,7 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 
+ 	synchronize_net();
+ 
+-	/* other cpu might still process nfqueue verdict that used reg */
+-	nfq = nf_queue_nf_hook_drop(net);
+-	if (nfq)
+-		synchronize_net();
++	nf_queue_nf_hook_drop(net);
+ 	kvfree(p);
+ }
+ EXPORT_SYMBOL(nf_unregister_net_hook);
+diff --git a/net/netfilter/nf_internals.h b/net/netfilter/nf_internals.h
+index 44284cd2528d..18f6d7ae995b 100644
+--- a/net/netfilter/nf_internals.h
++++ b/net/netfilter/nf_internals.h
+@@ -10,7 +10,7 @@
+ int nf_queue(struct sk_buff *skb, struct nf_hook_state *state,
+ 	     const struct nf_hook_entries *entries, unsigned int index,
+ 	     unsigned int verdict);
+-unsigned int nf_queue_nf_hook_drop(struct net *net);
++void nf_queue_nf_hook_drop(struct net *net);
+ 
+ /* nf_log.c */
+ int __init netfilter_log_init(void);
+diff --git a/net/netfilter/nf_queue.c b/net/netfilter/nf_queue.c
+index ada7289998f4..1b679db077a0 100644
+--- a/net/netfilter/nf_queue.c
++++ b/net/netfilter/nf_queue.c
+@@ -98,18 +98,15 @@ void nf_queue_entry_get_refs(struct nf_queue_entry *entry)
+ }
+ EXPORT_SYMBOL_GPL(nf_queue_entry_get_refs);
+ 
+-unsigned int nf_queue_nf_hook_drop(struct net *net)
++void nf_queue_nf_hook_drop(struct net *net)
+ {
+ 	const struct nf_queue_handler *qh;
+-	unsigned int count = 0;
+ 
+ 	rcu_read_lock();
+ 	qh = rcu_dereference(net->nf.queue_handler);
+ 	if (qh)
+-		count = qh->nf_hook_drop(net);
++		qh->nf_hook_drop(net);
+ 	rcu_read_unlock();
+-
+-	return count;
+ }
+ EXPORT_SYMBOL_GPL(nf_queue_nf_hook_drop);
+ 
+diff --git a/net/netfilter/nfnetlink_queue.c b/net/netfilter/nfnetlink_queue.c
+index d83c9d1ce631..d51db35ca5be 100644
+--- a/net/netfilter/nfnetlink_queue.c
++++ b/net/netfilter/nfnetlink_queue.c
+@@ -941,23 +941,18 @@ static struct notifier_block nfqnl_dev_notifier = {
+ 	.notifier_call	= nfqnl_rcv_dev_event,
+ };
+ 
+-static unsigned int nfqnl_nf_hook_drop(struct net *net)
++static void nfqnl_nf_hook_drop(struct net *net)
+ {
+ 	struct nfnl_queue_net *q = nfnl_queue_pernet(net);
+-	unsigned int instances = 0;
+ 	int i;
+ 
+ 	for (i = 0; i < INSTANCE_BUCKETS; i++) {
+ 		struct nfqnl_instance *inst;
+ 		struct hlist_head *head = &q->instance_table[i];
+ 
+-		hlist_for_each_entry_rcu(inst, head, hlist) {
++		hlist_for_each_entry_rcu(inst, head, hlist)
+ 			nfqnl_flush(inst, NULL, 0);
+-			instances++;
+-		}
+ 	}
+-
+-	return instances;
+ }
+ 
+ static int
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/292-v4.16-netfilter-core-free-hooks-with-call_rcu.patch
+++ b/target/linux/generic/backport-4.14/292-v4.16-netfilter-core-free-hooks-with-call_rcu.patch
@@ -1,0 +1,139 @@
+From bc44598233d543f1b5acd1697b017c93ee4711be Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Fri, 1 Dec 2017 00:21:04 +0100
+Subject: [PATCH 04/11] netfilter: core: free hooks with call_rcu
+
+Giuseppe Scrivano says:
+  "SELinux, if enabled, registers for each new network namespace 6
+    netfilter hooks."
+
+Cost for this is high.  With synchronize_net() removed:
+   "The net benefit on an SMP machine with two cores is that creating a
+   new network namespace takes -40% of the original time."
+
+This patch replaces synchronize_net+kvfree with call_rcu().
+We store rcu_head at the tail of a structure that has no fixed layout,
+i.e. we cannot use offsetof() to compute the start of the original
+allocation.  Thus store this information right after the rcu head.
+
+We could simplify this by just placing the rcu_head at the start
+of struct nf_hook_entries.  However, this structure is used in
+packet processing hotpath, so only place what is needed for that
+at the beginning of the struct.
+
+Reported-by: Giuseppe Scrivano <gscrivan@redhat.com>
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/linux/netfilter.h | 19 +++++++++++++++----
+ net/netfilter/core.c      | 34 ++++++++++++++++++++++++++++------
+ 2 files changed, 43 insertions(+), 10 deletions(-)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 1aed7c6f2a1d..9b16dee7f9e2 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -78,17 +78,28 @@ struct nf_hook_entry {
+ 	void				*priv;
+ };
+ 
++struct nf_hook_entries_rcu_head {
++	struct rcu_head head;
++	void	*allocation;
++};
++
+ struct nf_hook_entries {
+ 	u16				num_hook_entries;
+ 	/* padding */
+ 	struct nf_hook_entry		hooks[];
+ 
+-	/* trailer: pointers to original orig_ops of each hook.
+-	 *
+-	 * This is not part of struct nf_hook_entry since its only
+-	 * needed in slow path (hook register/unregister).
++	/* trailer: pointers to original orig_ops of each hook,
++	 * followed by rcu_head and scratch space used for freeing
++	 * the structure via call_rcu.
+ 	 *
++	 *   This is not part of struct nf_hook_entry since its only
++	 *   needed in slow path (hook register/unregister):
+ 	 * const struct nf_hook_ops     *orig_ops[]
++	 *
++	 *   For the same reason, we store this at end -- its
++	 *   only needed when a hook is deleted, not during
++	 *   packet path processing:
++	 * struct nf_hook_entries_rcu_head     head
+ 	 */
+ };
+ 
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index cc26f9a729f3..6962eb600b3f 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -51,7 +51,8 @@ static struct nf_hook_entries *allocate_hook_entries_size(u16 num)
+ 	struct nf_hook_entries *e;
+ 	size_t alloc = sizeof(*e) +
+ 		       sizeof(struct nf_hook_entry) * num +
+-		       sizeof(struct nf_hook_ops *) * num;
++		       sizeof(struct nf_hook_ops *) * num +
++		       sizeof(struct nf_hook_entries_rcu_head);
+ 
+ 	if (num == 0)
+ 		return NULL;
+@@ -62,6 +63,30 @@ static struct nf_hook_entries *allocate_hook_entries_size(u16 num)
+ 	return e;
+ }
+ 
++static void __nf_hook_entries_free(struct rcu_head *h)
++{
++	struct nf_hook_entries_rcu_head *head;
++
++	head = container_of(h, struct nf_hook_entries_rcu_head, head);
++	kvfree(head->allocation);
++}
++
++static void nf_hook_entries_free(struct nf_hook_entries *e)
++{
++	struct nf_hook_entries_rcu_head *head;
++	struct nf_hook_ops **ops;
++	unsigned int num;
++
++	if (!e)
++		return;
++
++	num = e->num_hook_entries;
++	ops = nf_hook_entries_get_hook_ops(e);
++	head = (void *)&ops[num];
++	head->allocation = e;
++	call_rcu(&head->head, __nf_hook_entries_free);
++}
++
+ static unsigned int accept_all(void *priv,
+ 			       struct sk_buff *skb,
+ 			       const struct nf_hook_state *state)
+@@ -274,9 +299,8 @@ int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ #ifdef HAVE_JUMP_LABEL
+ 	static_key_slow_inc(&nf_hooks_needed[reg->pf][reg->hooknum]);
+ #endif
+-	synchronize_net();
+ 	BUG_ON(p == new_hooks);
+-	kvfree(p);
++	nf_hook_entries_free(p);
+ 	return 0;
+ }
+ EXPORT_SYMBOL(nf_register_net_hook);
+@@ -344,10 +368,8 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 	if (!p)
+ 		return;
+ 
+-	synchronize_net();
+-
+ 	nf_queue_nf_hook_drop(net);
+-	kvfree(p);
++	nf_hook_entries_free(p);
+ }
+ EXPORT_SYMBOL(nf_unregister_net_hook);
+ 
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/293-v4.16-netfilter-reduce-size-of-hook-entry-point-locations.patch
+++ b/target/linux/generic/backport-4.14/293-v4.16-netfilter-reduce-size-of-hook-entry-point-locations.patch
@@ -1,0 +1,213 @@
+From ab24412595d0976c898d7bd14720b1eda31822e0 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Sun, 3 Dec 2017 00:58:47 +0100
+Subject: [PATCH 05/11] netfilter: reduce size of hook entry point locations
+
+struct net contains:
+
+struct nf_hook_entries __rcu *hooks[NFPROTO_NUMPROTO][NF_MAX_HOOKS];
+
+which store the hook entry point locations for the various protocol
+families and the hooks.
+
+Using array results in compact c code when doing accesses, i.e.
+  x = rcu_dereference(net->nf.hooks[pf][hook]);
+
+but its also wasting a lot of memory, as most families are
+not used.
+
+So split the array into those families that are used, which
+are only 5 (instead of 13).  In most cases, the 'pf' argument is
+constant, i.e. gcc removes switch statement.
+
+struct net before:
+ /* size: 5184, cachelines: 81, members: 46 */
+after:
+ /* size: 4672, cachelines: 73, members: 46 */
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/linux/netfilter.h       | 24 ++++++++++++++++++++++--
+ include/net/netns/netfilter.h   |  6 +++++-
+ net/bridge/br_netfilter_hooks.c |  2 +-
+ net/netfilter/core.c            | 38 ++++++++++++++++++++++++++++++--------
+ net/netfilter/nf_queue.c        | 21 +++++++++++++++++++--
+ 5 files changed, 77 insertions(+), 14 deletions(-)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 9b16dee7f9e2..44908cc09752 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -196,7 +196,7 @@ static inline int nf_hook(u_int8_t pf, unsigned int hook, struct net *net,
+ 			  struct net_device *indev, struct net_device *outdev,
+ 			  int (*okfn)(struct net *, struct sock *, struct sk_buff *))
+ {
+-	struct nf_hook_entries *hook_head;
++	struct nf_hook_entries *hook_head = NULL;
+ 	int ret = 1;
+ 
+ #ifdef HAVE_JUMP_LABEL
+@@ -207,7 +207,27 @@ static inline int nf_hook(u_int8_t pf, unsigned int hook, struct net *net,
+ #endif
+ 
+ 	rcu_read_lock();
+-	hook_head = rcu_dereference(net->nf.hooks[pf][hook]);
++	switch (pf) {
++	case NFPROTO_IPV4:
++		hook_head = rcu_dereference(net->nf.hooks_ipv4[hook]);
++		break;
++	case NFPROTO_IPV6:
++		hook_head = rcu_dereference(net->nf.hooks_ipv6[hook]);
++		break;
++	case NFPROTO_ARP:
++		hook_head = rcu_dereference(net->nf.hooks_arp[hook]);
++		break;
++	case NFPROTO_BRIDGE:
++		hook_head = rcu_dereference(net->nf.hooks_bridge[hook]);
++		break;
++	case NFPROTO_DECNET:
++		hook_head = rcu_dereference(net->nf.hooks_decnet[hook]);
++		break;
++	default:
++		WARN_ON_ONCE(1);
++		break;
++	}
++
+ 	if (hook_head) {
+ 		struct nf_hook_state state;
+ 
+diff --git a/include/net/netns/netfilter.h b/include/net/netns/netfilter.h
+index cc00af2ac2d7..b39c563c2fce 100644
+--- a/include/net/netns/netfilter.h
++++ b/include/net/netns/netfilter.h
+@@ -17,7 +17,11 @@ struct netns_nf {
+ #ifdef CONFIG_SYSCTL
+ 	struct ctl_table_header *nf_log_dir_header;
+ #endif
+-	struct nf_hook_entries __rcu *hooks[NFPROTO_NUMPROTO][NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_ipv4[NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_ipv6[NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_arp[NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_bridge[NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_decnet[NF_MAX_HOOKS];
+ #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV4)
+ 	bool			defrag_ipv4;
+ #endif
+diff --git a/net/bridge/br_netfilter_hooks.c b/net/bridge/br_netfilter_hooks.c
+index c2eea1b8737a..27f1d4f2114a 100644
+--- a/net/bridge/br_netfilter_hooks.c
++++ b/net/bridge/br_netfilter_hooks.c
+@@ -991,7 +991,7 @@ int br_nf_hook_thresh(unsigned int hook, struct net *net,
+ 	unsigned int i;
+ 	int ret;
+ 
+-	e = rcu_dereference(net->nf.hooks[NFPROTO_BRIDGE][hook]);
++	e = rcu_dereference(net->nf.hooks_bridge[hook]);
+ 	if (!e)
+ 		return okfn(net, sk, skb);
+ 
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 6962eb600b3f..f6547459024d 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -247,8 +247,23 @@ static void *__nf_hook_entries_try_shrink(struct nf_hook_entries __rcu **pp)
+ 
+ static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const struct nf_hook_ops *reg)
+ {
+-	if (reg->pf != NFPROTO_NETDEV)
+-		return net->nf.hooks[reg->pf]+reg->hooknum;
++	switch (reg->pf) {
++	case NFPROTO_NETDEV:
++		break;
++	case NFPROTO_ARP:
++		return net->nf.hooks_arp + reg->hooknum;
++	case NFPROTO_BRIDGE:
++		return net->nf.hooks_bridge + reg->hooknum;
++	case NFPROTO_IPV4:
++		return net->nf.hooks_ipv4 + reg->hooknum;
++	case NFPROTO_IPV6:
++		return net->nf.hooks_ipv6 + reg->hooknum;
++	case NFPROTO_DECNET:
++		return net->nf.hooks_decnet + reg->hooknum;
++	default:
++		WARN_ON_ONCE(1);
++		return NULL;
++	}
+ 
+ #ifdef CONFIG_NETFILTER_INGRESS
+ 	if (reg->hooknum == NF_NETDEV_INGRESS) {
+@@ -517,14 +532,21 @@ void (*nf_nat_decode_session_hook)(struct sk_buff *, struct flowi *);
+ EXPORT_SYMBOL(nf_nat_decode_session_hook);
+ #endif
+ 
+-static int __net_init netfilter_net_init(struct net *net)
++static void __net_init __netfilter_net_init(struct nf_hook_entries *e[NF_MAX_HOOKS])
+ {
+-	int i, h;
++	int h;
+ 
+-	for (i = 0; i < ARRAY_SIZE(net->nf.hooks); i++) {
+-		for (h = 0; h < NF_MAX_HOOKS; h++)
+-			RCU_INIT_POINTER(net->nf.hooks[i][h], NULL);
+-	}
++	for (h = 0; h < NF_MAX_HOOKS; h++)
++		RCU_INIT_POINTER(e[h], NULL);
++}
++
++static int __net_init netfilter_net_init(struct net *net)
++{
++	__netfilter_net_init(net->nf.hooks_ipv4);
++	__netfilter_net_init(net->nf.hooks_ipv6);
++	__netfilter_net_init(net->nf.hooks_arp);
++	__netfilter_net_init(net->nf.hooks_bridge);
++	__netfilter_net_init(net->nf.hooks_decnet);
+ 
+ #ifdef CONFIG_PROC_FS
+ 	net->nf.proc_netfilter = proc_net_mkdir(net, "netfilter",
+diff --git a/net/netfilter/nf_queue.c b/net/netfilter/nf_queue.c
+index 1b679db077a0..00643badcf21 100644
+--- a/net/netfilter/nf_queue.c
++++ b/net/netfilter/nf_queue.c
+@@ -249,6 +249,23 @@ static unsigned int nf_iterate(struct sk_buff *skb,
+ 	return NF_ACCEPT;
+ }
+ 
++static struct nf_hook_entries *nf_hook_entries_head(const struct net *net, u8 pf, u8 hooknum)
++{
++	switch (pf) {
++	case NFPROTO_BRIDGE:
++		return rcu_dereference(net->nf.hooks_bridge[hooknum]);
++	case NFPROTO_IPV4:
++		return rcu_dereference(net->nf.hooks_ipv4[hooknum]);
++	case NFPROTO_IPV6:
++		return rcu_dereference(net->nf.hooks_ipv6[hooknum]);
++	default:
++		WARN_ON_ONCE(1);
++		return NULL;
++	}
++
++	return NULL;
++}
++
+ /* Caller must hold rcu read-side lock */
+ void nf_reinject(struct nf_queue_entry *entry, unsigned int verdict)
+ {
+@@ -263,12 +280,12 @@ void nf_reinject(struct nf_queue_entry *entry, unsigned int verdict)
+ 	net = entry->state.net;
+ 	pf = entry->state.pf;
+ 
+-	hooks = rcu_dereference(net->nf.hooks[pf][entry->state.hook]);
++	hooks = nf_hook_entries_head(net, pf, entry->state.hook);
+ 
+ 	nf_queue_entry_release_refs(entry);
+ 
+ 	i = entry->hook_index;
+-	if (WARN_ON_ONCE(i >= hooks->num_hook_entries)) {
++	if (WARN_ON_ONCE(!hooks || i >= hooks->num_hook_entries)) {
+ 		kfree_skb(skb);
+ 		kfree(entry);
+ 		return;
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/294-v4.16-netfilter-reduce-hook-array-sizes-to-what-is-needed.patch
+++ b/target/linux/generic/backport-4.14/294-v4.16-netfilter-reduce-hook-array-sizes-to-what-is-needed.patch
@@ -1,0 +1,102 @@
+From 6ca9b83933cd3ae254adef76d9a10dae99864d7c Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 7 Dec 2017 16:28:24 +0100
+Subject: [PATCH 06/11] netfilter: reduce hook array sizes to what is needed
+
+Not all families share the same hook count, adjust sizes to what is
+needed.
+
+struct net before:
+/* size: 6592, cachelines: 103, members: 46 */
+after:
+/* size: 5952, cachelines: 93, members: 46 */
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/net/netns/netfilter.h | 10 +++++-----
+ net/netfilter/core.c          | 24 +++++++++++++++++-------
+ 2 files changed, 22 insertions(+), 12 deletions(-)
+
+diff --git a/include/net/netns/netfilter.h b/include/net/netns/netfilter.h
+index b39c563c2fce..8f756a4b9205 100644
+--- a/include/net/netns/netfilter.h
++++ b/include/net/netns/netfilter.h
+@@ -17,11 +17,11 @@ struct netns_nf {
+ #ifdef CONFIG_SYSCTL
+ 	struct ctl_table_header *nf_log_dir_header;
+ #endif
+-	struct nf_hook_entries __rcu *hooks_ipv4[NF_MAX_HOOKS];
+-	struct nf_hook_entries __rcu *hooks_ipv6[NF_MAX_HOOKS];
+-	struct nf_hook_entries __rcu *hooks_arp[NF_MAX_HOOKS];
+-	struct nf_hook_entries __rcu *hooks_bridge[NF_MAX_HOOKS];
+-	struct nf_hook_entries __rcu *hooks_decnet[NF_MAX_HOOKS];
++	struct nf_hook_entries __rcu *hooks_ipv4[NF_INET_NUMHOOKS];
++	struct nf_hook_entries __rcu *hooks_ipv6[NF_INET_NUMHOOKS];
++	struct nf_hook_entries __rcu *hooks_arp[NF_ARP_NUMHOOKS];
++	struct nf_hook_entries __rcu *hooks_bridge[NF_INET_NUMHOOKS];
++	struct nf_hook_entries __rcu *hooks_decnet[NF_DN_NUMHOOKS];
+ #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV4)
+ 	bool			defrag_ipv4;
+ #endif
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index f6547459024d..75497fad3482 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -251,14 +251,24 @@ static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const
+ 	case NFPROTO_NETDEV:
+ 		break;
+ 	case NFPROTO_ARP:
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_arp) <= reg->hooknum))
++			return NULL;
+ 		return net->nf.hooks_arp + reg->hooknum;
+ 	case NFPROTO_BRIDGE:
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_bridge) <= reg->hooknum))
++			return NULL;
+ 		return net->nf.hooks_bridge + reg->hooknum;
+ 	case NFPROTO_IPV4:
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv4) <= reg->hooknum))
++			return NULL;
+ 		return net->nf.hooks_ipv4 + reg->hooknum;
+ 	case NFPROTO_IPV6:
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv6) <= reg->hooknum))
++			return NULL;
+ 		return net->nf.hooks_ipv6 + reg->hooknum;
+ 	case NFPROTO_DECNET:
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_decnet) <= reg->hooknum))
++			return NULL;
+ 		return net->nf.hooks_decnet + reg->hooknum;
+ 	default:
+ 		WARN_ON_ONCE(1);
+@@ -532,21 +542,21 @@ void (*nf_nat_decode_session_hook)(struct sk_buff *, struct flowi *);
+ EXPORT_SYMBOL(nf_nat_decode_session_hook);
+ #endif
+ 
+-static void __net_init __netfilter_net_init(struct nf_hook_entries *e[NF_MAX_HOOKS])
++static void __net_init __netfilter_net_init(struct nf_hook_entries **e, int max)
+ {
+ 	int h;
+ 
+-	for (h = 0; h < NF_MAX_HOOKS; h++)
++	for (h = 0; h < max; h++)
+ 		RCU_INIT_POINTER(e[h], NULL);
+ }
+ 
+ static int __net_init netfilter_net_init(struct net *net)
+ {
+-	__netfilter_net_init(net->nf.hooks_ipv4);
+-	__netfilter_net_init(net->nf.hooks_ipv6);
+-	__netfilter_net_init(net->nf.hooks_arp);
+-	__netfilter_net_init(net->nf.hooks_bridge);
+-	__netfilter_net_init(net->nf.hooks_decnet);
++	__netfilter_net_init(net->nf.hooks_ipv4, ARRAY_SIZE(net->nf.hooks_ipv4));
++	__netfilter_net_init(net->nf.hooks_ipv6, ARRAY_SIZE(net->nf.hooks_ipv6));
++	__netfilter_net_init(net->nf.hooks_arp, ARRAY_SIZE(net->nf.hooks_arp));
++	__netfilter_net_init(net->nf.hooks_bridge, ARRAY_SIZE(net->nf.hooks_bridge));
++	__netfilter_net_init(net->nf.hooks_decnet, ARRAY_SIZE(net->nf.hooks_decnet));
+ 
+ #ifdef CONFIG_PROC_FS
+ 	net->nf.proc_netfilter = proc_net_mkdir(net, "netfilter",
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/295-v4.16-netfilter-don-t-allocate-space-for-decnet-hooks-unle.patch
+++ b/target/linux/generic/backport-4.14/295-v4.16-netfilter-don-t-allocate-space-for-decnet-hooks-unle.patch
@@ -1,0 +1,76 @@
+From 2c9d4c4bea5d92884ce6116b7e416eec305ec961 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 7 Dec 2017 16:28:25 +0100
+Subject: [PATCH 07/11] netfilter: don't allocate space for decnet hooks unless
+ needed
+
+no need to define hook points if the family isn't supported.
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/linux/netfilter.h     | 2 ++
+ include/net/netns/netfilter.h | 2 ++
+ net/netfilter/core.c          | 4 ++++
+ 3 files changed, 8 insertions(+)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 44908cc09752..39e8c2fbb83d 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -220,9 +220,11 @@ static inline int nf_hook(u_int8_t pf, unsigned int hook, struct net *net,
+ 	case NFPROTO_BRIDGE:
+ 		hook_head = rcu_dereference(net->nf.hooks_bridge[hook]);
+ 		break;
++#if IS_ENABLED(CONFIG_DECNET)
+ 	case NFPROTO_DECNET:
+ 		hook_head = rcu_dereference(net->nf.hooks_decnet[hook]);
+ 		break;
++#endif
+ 	default:
+ 		WARN_ON_ONCE(1);
+ 		break;
+diff --git a/include/net/netns/netfilter.h b/include/net/netns/netfilter.h
+index 8f756a4b9205..432609fd9899 100644
+--- a/include/net/netns/netfilter.h
++++ b/include/net/netns/netfilter.h
+@@ -21,7 +21,9 @@ struct netns_nf {
+ 	struct nf_hook_entries __rcu *hooks_ipv6[NF_INET_NUMHOOKS];
+ 	struct nf_hook_entries __rcu *hooks_arp[NF_ARP_NUMHOOKS];
+ 	struct nf_hook_entries __rcu *hooks_bridge[NF_INET_NUMHOOKS];
++#if IS_ENABLED(CONFIG_DECNET)
+ 	struct nf_hook_entries __rcu *hooks_decnet[NF_DN_NUMHOOKS];
++#endif
+ #if IS_ENABLED(CONFIG_NF_DEFRAG_IPV4)
+ 	bool			defrag_ipv4;
+ #endif
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 75497fad3482..e33c430f52c0 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -266,10 +266,12 @@ static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const
+ 		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv6) <= reg->hooknum))
+ 			return NULL;
+ 		return net->nf.hooks_ipv6 + reg->hooknum;
++#if IS_ENABLED(CONFIG_DECNET)
+ 	case NFPROTO_DECNET:
+ 		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_decnet) <= reg->hooknum))
+ 			return NULL;
+ 		return net->nf.hooks_decnet + reg->hooknum;
++#endif
+ 	default:
+ 		WARN_ON_ONCE(1);
+ 		return NULL;
+@@ -556,7 +558,9 @@ static int __net_init netfilter_net_init(struct net *net)
+ 	__netfilter_net_init(net->nf.hooks_ipv6, ARRAY_SIZE(net->nf.hooks_ipv6));
+ 	__netfilter_net_init(net->nf.hooks_arp, ARRAY_SIZE(net->nf.hooks_arp));
+ 	__netfilter_net_init(net->nf.hooks_bridge, ARRAY_SIZE(net->nf.hooks_bridge));
++#if IS_ENABLED(CONFIG_DECNET)
+ 	__netfilter_net_init(net->nf.hooks_decnet, ARRAY_SIZE(net->nf.hooks_decnet));
++#endif
+ 
+ #ifdef CONFIG_PROC_FS
+ 	net->nf.proc_netfilter = proc_net_mkdir(net, "netfilter",
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/296-v4.16-netfilter-don-t-allocate-space-for-arp-bridge-hooks-.patch
+++ b/target/linux/generic/backport-4.14/296-v4.16-netfilter-don-t-allocate-space-for-arp-bridge-hooks-.patch
@@ -1,0 +1,184 @@
+From 49eb7b6e232f9487c01f0af3aeaf169e56987e33 Mon Sep 17 00:00:00 2001
+From: Florian Westphal <fw@strlen.de>
+Date: Thu, 7 Dec 2017 16:28:26 +0100
+Subject: [PATCH 08/11] netfilter: don't allocate space for arp/bridge hooks
+ unless needed
+
+no need to define hook points if the family isn't supported.
+Because we need these hooks for either nftables, arp/ebtables
+or the 'call-iptables' hack we have in the bridge layer add two
+new dependencies, NETFILTER_FAMILY_{ARP,BRIDGE}, and have the
+users select them.
+
+Signed-off-by: Florian Westphal <fw@strlen.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/linux/netfilter.h     | 4 ++++
+ include/net/netns/netfilter.h | 4 ++++
+ net/Kconfig                   | 1 +
+ net/bridge/netfilter/Kconfig  | 2 ++
+ net/ipv4/netfilter/Kconfig    | 2 ++
+ net/netfilter/Kconfig         | 6 ++++++
+ net/netfilter/core.c          | 8 ++++++++
+ net/netfilter/nf_queue.c      | 2 ++
+ 8 files changed, 29 insertions(+)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 39e8c2fbb83d..85a1a0b32c66 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -215,10 +215,14 @@ static inline int nf_hook(u_int8_t pf, unsigned int hook, struct net *net,
+ 		hook_head = rcu_dereference(net->nf.hooks_ipv6[hook]);
+ 		break;
+ 	case NFPROTO_ARP:
++#ifdef CONFIG_NETFILTER_FAMILY_ARP
+ 		hook_head = rcu_dereference(net->nf.hooks_arp[hook]);
++#endif
+ 		break;
+ 	case NFPROTO_BRIDGE:
++#ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 		hook_head = rcu_dereference(net->nf.hooks_bridge[hook]);
++#endif
+ 		break;
+ #if IS_ENABLED(CONFIG_DECNET)
+ 	case NFPROTO_DECNET:
+diff --git a/include/net/netns/netfilter.h b/include/net/netns/netfilter.h
+index 432609fd9899..ca043342c0eb 100644
+--- a/include/net/netns/netfilter.h
++++ b/include/net/netns/netfilter.h
+@@ -19,8 +19,12 @@ struct netns_nf {
+ #endif
+ 	struct nf_hook_entries __rcu *hooks_ipv4[NF_INET_NUMHOOKS];
+ 	struct nf_hook_entries __rcu *hooks_ipv6[NF_INET_NUMHOOKS];
++#ifdef CONFIG_NETFILTER_FAMILY_ARP
+ 	struct nf_hook_entries __rcu *hooks_arp[NF_ARP_NUMHOOKS];
++#endif
++#ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 	struct nf_hook_entries __rcu *hooks_bridge[NF_INET_NUMHOOKS];
++#endif
+ #if IS_ENABLED(CONFIG_DECNET)
+ 	struct nf_hook_entries __rcu *hooks_decnet[NF_DN_NUMHOOKS];
+ #endif
+diff --git a/net/Kconfig b/net/Kconfig
+index bb42ba33a1ee..ead4e0e0a94e 100644
+--- a/net/Kconfig
++++ b/net/Kconfig
+@@ -191,6 +191,7 @@ config BRIDGE_NETFILTER
+ 	depends on BRIDGE
+ 	depends on NETFILTER && INET
+ 	depends on NETFILTER_ADVANCED
++	select NETFILTER_FAMILY_BRIDGE
+ 	default m
+ 	---help---
+ 	  Enabling this option will let arptables resp. iptables see bridged
+diff --git a/net/bridge/netfilter/Kconfig b/net/bridge/netfilter/Kconfig
+index e7ef1a1ef3a6..225d1668dfdd 100644
+--- a/net/bridge/netfilter/Kconfig
++++ b/net/bridge/netfilter/Kconfig
+@@ -4,6 +4,7 @@
+ #
+ menuconfig NF_TABLES_BRIDGE
+ 	depends on BRIDGE && NETFILTER && NF_TABLES
++	select NETFILTER_FAMILY_BRIDGE
+ 	tristate "Ethernet Bridge nf_tables support"
+ 
+ if NF_TABLES_BRIDGE
+@@ -29,6 +30,7 @@ endif # NF_TABLES_BRIDGE
+ menuconfig BRIDGE_NF_EBTABLES
+ 	tristate "Ethernet Bridge tables (ebtables) support"
+ 	depends on BRIDGE && NETFILTER && NETFILTER_XTABLES
++	select NETFILTER_FAMILY_BRIDGE
+ 	help
+ 	  ebtables is a general, extensible frame/packet identification
+ 	  framework. Say 'Y' or 'M' here if you want to do Ethernet
+diff --git a/net/ipv4/netfilter/Kconfig b/net/ipv4/netfilter/Kconfig
+index ca14244dd517..042ee677877e 100644
+--- a/net/ipv4/netfilter/Kconfig
++++ b/net/ipv4/netfilter/Kconfig
+@@ -72,6 +72,7 @@ endif # NF_TABLES_IPV4
+ 
+ config NF_TABLES_ARP
+ 	tristate "ARP nf_tables support"
++	select NETFILTER_FAMILY_ARP
+ 	help
+ 	  This option enables the ARP support for nf_tables.
+ 
+@@ -400,6 +401,7 @@ endif # IP_NF_IPTABLES
+ config IP_NF_ARPTABLES
+ 	tristate "ARP tables support"
+ 	select NETFILTER_XTABLES
++	select NETFILTER_FAMILY_ARP
+ 	depends on NETFILTER_ADVANCED
+ 	help
+ 	  arptables is a general, extensible packet identification framework.
+diff --git a/net/netfilter/Kconfig b/net/netfilter/Kconfig
+index e5edd146a6ef..1aeafa4d2680 100644
+--- a/net/netfilter/Kconfig
++++ b/net/netfilter/Kconfig
+@@ -12,6 +12,12 @@ config NETFILTER_INGRESS
+ config NETFILTER_NETLINK
+ 	tristate "Netfilter NFNETLINK interface"
+ 
++config NETFILTER_FAMILY_BRIDGE
++	bool
++
++config NETFILTER_FAMILY_ARP
++	bool
++
+ config NETFILTER_NETLINK_ACCT
+ tristate "Netfilter NFACCT over NFNETLINK interface"
+ 	depends on NETFILTER_ADVANCED
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index e33c430f52c0..5ad10b8c3192 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -250,14 +250,18 @@ static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const
+ 	switch (reg->pf) {
+ 	case NFPROTO_NETDEV:
+ 		break;
++#ifdef CONFIG_NETFILTER_FAMILY_ARP
+ 	case NFPROTO_ARP:
+ 		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_arp) <= reg->hooknum))
+ 			return NULL;
+ 		return net->nf.hooks_arp + reg->hooknum;
++#endif
++#ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 	case NFPROTO_BRIDGE:
+ 		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_bridge) <= reg->hooknum))
+ 			return NULL;
+ 		return net->nf.hooks_bridge + reg->hooknum;
++#endif
+ 	case NFPROTO_IPV4:
+ 		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv4) <= reg->hooknum))
+ 			return NULL;
+@@ -556,8 +560,12 @@ static int __net_init netfilter_net_init(struct net *net)
+ {
+ 	__netfilter_net_init(net->nf.hooks_ipv4, ARRAY_SIZE(net->nf.hooks_ipv4));
+ 	__netfilter_net_init(net->nf.hooks_ipv6, ARRAY_SIZE(net->nf.hooks_ipv6));
++#ifdef CONFIG_NETFILTER_FAMILY_ARP
+ 	__netfilter_net_init(net->nf.hooks_arp, ARRAY_SIZE(net->nf.hooks_arp));
++#endif
++#ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 	__netfilter_net_init(net->nf.hooks_bridge, ARRAY_SIZE(net->nf.hooks_bridge));
++#endif
+ #if IS_ENABLED(CONFIG_DECNET)
+ 	__netfilter_net_init(net->nf.hooks_decnet, ARRAY_SIZE(net->nf.hooks_decnet));
+ #endif
+diff --git a/net/netfilter/nf_queue.c b/net/netfilter/nf_queue.c
+index 00643badcf21..d67a96a25a68 100644
+--- a/net/netfilter/nf_queue.c
++++ b/net/netfilter/nf_queue.c
+@@ -252,8 +252,10 @@ static unsigned int nf_iterate(struct sk_buff *skb,
+ static struct nf_hook_entries *nf_hook_entries_head(const struct net *net, u8 pf, u8 hooknum)
+ {
+ 	switch (pf) {
++#ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 	case NFPROTO_BRIDGE:
+ 		return rcu_dereference(net->nf.hooks_bridge[hooknum]);
++#endif
+ 	case NFPROTO_IPV4:
+ 		return rcu_dereference(net->nf.hooks_ipv4[hooknum]);
+ 	case NFPROTO_IPV6:
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/297-v4.16-netfilter-core-pass-hook-number-family-and-device-to.patch
+++ b/target/linux/generic/backport-4.14/297-v4.16-netfilter-core-pass-hook-number-family-and-device-to.patch
@@ -1,0 +1,103 @@
+From 255348ea0495b1929d9c5915d89c295d54ac48ce Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Sat, 9 Dec 2017 15:23:51 +0100
+Subject: [PATCH 09/11] netfilter: core: pass hook number, family and device to
+ nf_find_hook_list()
+
+Instead of passing struct nf_hook_ops, this is needed by follow up
+patches to handle NFPROTO_INET from the core.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/core.c | 36 +++++++++++++++++++-----------------
+ 1 file changed, 19 insertions(+), 17 deletions(-)
+
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 5ad10b8c3192..b9038b20b556 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -245,36 +245,38 @@ static void *__nf_hook_entries_try_shrink(struct nf_hook_entries __rcu **pp)
+ 	return old;
+ }
+ 
+-static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const struct nf_hook_ops *reg)
++static struct nf_hook_entries __rcu **
++nf_hook_entry_head(struct net *net, int pf, unsigned int hooknum,
++		   struct net_device *dev)
+ {
+-	switch (reg->pf) {
++	switch (pf) {
+ 	case NFPROTO_NETDEV:
+ 		break;
+ #ifdef CONFIG_NETFILTER_FAMILY_ARP
+ 	case NFPROTO_ARP:
+-		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_arp) <= reg->hooknum))
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_arp) <= hooknum))
+ 			return NULL;
+-		return net->nf.hooks_arp + reg->hooknum;
++		return net->nf.hooks_arp + hooknum;
+ #endif
+ #ifdef CONFIG_NETFILTER_FAMILY_BRIDGE
+ 	case NFPROTO_BRIDGE:
+-		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_bridge) <= reg->hooknum))
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_bridge) <= hooknum))
+ 			return NULL;
+-		return net->nf.hooks_bridge + reg->hooknum;
++		return net->nf.hooks_bridge + hooknum;
+ #endif
+ 	case NFPROTO_IPV4:
+-		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv4) <= reg->hooknum))
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv4) <= hooknum))
+ 			return NULL;
+-		return net->nf.hooks_ipv4 + reg->hooknum;
++		return net->nf.hooks_ipv4 + hooknum;
+ 	case NFPROTO_IPV6:
+-		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv6) <= reg->hooknum))
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_ipv6) <= hooknum))
+ 			return NULL;
+-		return net->nf.hooks_ipv6 + reg->hooknum;
++		return net->nf.hooks_ipv6 + hooknum;
+ #if IS_ENABLED(CONFIG_DECNET)
+ 	case NFPROTO_DECNET:
+-		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_decnet) <= reg->hooknum))
++		if (WARN_ON_ONCE(ARRAY_SIZE(net->nf.hooks_decnet) <= hooknum))
+ 			return NULL;
+-		return net->nf.hooks_decnet + reg->hooknum;
++		return net->nf.hooks_decnet + hooknum;
+ #endif
+ 	default:
+ 		WARN_ON_ONCE(1);
+@@ -282,9 +284,9 @@ static struct nf_hook_entries __rcu **nf_hook_entry_head(struct net *net, const
+ 	}
+ 
+ #ifdef CONFIG_NETFILTER_INGRESS
+-	if (reg->hooknum == NF_NETDEV_INGRESS) {
+-		if (reg->dev && dev_net(reg->dev) == net)
+-			return &reg->dev->nf_hooks_ingress;
++	if (hooknum == NF_NETDEV_INGRESS) {
++		if (dev && dev_net(dev) == net)
++			return &dev->nf_hooks_ingress;
+ 	}
+ #endif
+ 	WARN_ON_ONCE(1);
+@@ -306,7 +308,7 @@ int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 			return -EINVAL;
+ 	}
+ 
+-	pp = nf_hook_entry_head(net, reg);
++	pp = nf_hook_entry_head(net, reg->pf, reg->hooknum, reg->dev);
+ 	if (!pp)
+ 		return -EINVAL;
+ 
+@@ -380,7 +382,7 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 	struct nf_hook_entries __rcu **pp;
+ 	struct nf_hook_entries *p;
+ 
+-	pp = nf_hook_entry_head(net, reg);
++	pp = nf_hook_entry_head(net, reg->pf, reg->hooknum, reg->dev);
+ 	if (!pp)
+ 		return;
+ 
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/298-v4.16-netfilter-core-add-nf_remove_net_hook.patch
+++ b/target/linux/generic/backport-4.14/298-v4.16-netfilter-core-add-nf_remove_net_hook.patch
@@ -1,0 +1,49 @@
+From 3d2e96bbd5d65cd5f5dfed9b66065136cfa90272 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Sat, 9 Dec 2017 15:19:14 +0100
+Subject: [PATCH 01/11] netfilter: core: add nf_remove_net_hook
+
+Just a cleanup, __nf_unregister_net_hook() is used by a follow up patch
+when handling NFPROTO_INET as a real family from the core.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/core.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 40846cd54063..0e22e406e9db 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -282,7 +282,7 @@ int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ EXPORT_SYMBOL(nf_register_net_hook);
+ 
+ /*
+- * __nf_unregister_net_hook - remove a hook from blob
++ * nf_remove_net_hook - remove a hook from blob
+  *
+  * @oldp: current address of hook blob
+  * @unreg: hook to unregister
+@@ -290,8 +290,8 @@ EXPORT_SYMBOL(nf_register_net_hook);
+  * This cannot fail, hook unregistration must always succeed.
+  * Therefore replace the to-be-removed hook with a dummy hook.
+  */
+-static void __nf_unregister_net_hook(struct nf_hook_entries *old,
+-				     const struct nf_hook_ops *unreg)
++static void nf_remove_net_hook(struct nf_hook_entries *old,
++			       const struct nf_hook_ops *unreg)
+ {
+ 	struct nf_hook_ops **orig_ops;
+ 	bool found = false;
+@@ -338,7 +338,7 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 		return;
+ 	}
+ 
+-	__nf_unregister_net_hook(p, reg);
++	nf_remove_net_hook(p, reg);
+ 
+ 	p = __nf_hook_entries_try_shrink(pp);
+ 	mutex_unlock(&nf_hook_mutex);
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/298-v4.16-netfilter-core-pass-family-as-parameter-to-nf_remove.patch
+++ b/target/linux/generic/backport-4.14/298-v4.16-netfilter-core-pass-family-as-parameter-to-nf_remove.patch
@@ -1,0 +1,56 @@
+From 85512044511adcfaf991eba76304d7877b952562 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Sat, 9 Dec 2017 15:26:37 +0100
+Subject: [PATCH 10/11] netfilter: core: pass family as parameter to
+ nf_remove_net_hook()
+
+So static_key_slow_dec applies to the family behind NFPROTO_INET.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/core.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index b9038b20b556..800c125eb82e 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -348,7 +348,7 @@ EXPORT_SYMBOL(nf_register_net_hook);
+  * Therefore replace the to-be-removed hook with a dummy hook.
+  */
+ static void nf_remove_net_hook(struct nf_hook_entries *old,
+-			       const struct nf_hook_ops *unreg)
++			       const struct nf_hook_ops *unreg, int pf)
+ {
+ 	struct nf_hook_ops **orig_ops;
+ 	bool found = false;
+@@ -366,14 +366,14 @@ static void nf_remove_net_hook(struct nf_hook_entries *old,
+ 
+ 	if (found) {
+ #ifdef CONFIG_NETFILTER_INGRESS
+-		if (unreg->pf == NFPROTO_NETDEV && unreg->hooknum == NF_NETDEV_INGRESS)
++		if (pf == NFPROTO_NETDEV && unreg->hooknum == NF_NETDEV_INGRESS)
+ 			net_dec_ingress_queue();
+ #endif
+ #ifdef HAVE_JUMP_LABEL
+-		static_key_slow_dec(&nf_hooks_needed[unreg->pf][unreg->hooknum]);
++		static_key_slow_dec(&nf_hooks_needed[pf][unreg->hooknum]);
+ #endif
+ 	} else {
+-		WARN_ONCE(1, "hook not found, pf %d num %d", unreg->pf, unreg->hooknum);
++		WARN_ONCE(1, "hook not found, pf %d num %d", pf, unreg->hooknum);
+ 	}
+ }
+ 
+@@ -394,7 +394,7 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 		return;
+ 	}
+ 
+-	nf_remove_net_hook(p, reg);
++	nf_remove_net_hook(p, reg, reg->pf);
+ 
+ 	p = __nf_hook_entries_try_shrink(pp);
+ 	mutex_unlock(&nf_hook_mutex);
+-- 
+2.11.0
+

--- a/target/linux/generic/backport-4.14/299-v4.16-netfilter-core-support-for-NFPROTO_INET-hook-registr.patch
+++ b/target/linux/generic/backport-4.14/299-v4.16-netfilter-core-support-for-NFPROTO_INET-hook-registr.patch
@@ -1,0 +1,134 @@
+From 16f449560dab3b88c3c2fda886808d7bdffa5623 Mon Sep 17 00:00:00 2001
+From: Pablo Neira Ayuso <pablo@netfilter.org>
+Date: Sat, 9 Dec 2017 15:30:26 +0100
+Subject: [PATCH 11/11] netfilter: core: support for NFPROTO_INET hook
+ registration
+
+Expand NFPROTO_INET in two hook registrations, one for NFPROTO_IPV4 and
+another for NFPROTO_IPV6. Hence, we handle NFPROTO_INET from the core.
+
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/netfilter/core.c | 53 +++++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 44 insertions(+), 9 deletions(-)
+
+diff --git a/net/netfilter/core.c b/net/netfilter/core.c
+index 800c125eb82e..997dd387d259 100644
+--- a/net/netfilter/core.c
++++ b/net/netfilter/core.c
+@@ -293,12 +293,13 @@ nf_hook_entry_head(struct net *net, int pf, unsigned int hooknum,
+ 	return NULL;
+ }
+ 
+-int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
++static int __nf_register_net_hook(struct net *net, int pf,
++				  const struct nf_hook_ops *reg)
+ {
+ 	struct nf_hook_entries *p, *new_hooks;
+ 	struct nf_hook_entries __rcu **pp;
+ 
+-	if (reg->pf == NFPROTO_NETDEV) {
++	if (pf == NFPROTO_NETDEV) {
+ #ifndef CONFIG_NETFILTER_INGRESS
+ 		if (reg->hooknum == NF_NETDEV_INGRESS)
+ 			return -EOPNOTSUPP;
+@@ -308,7 +309,7 @@ int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 			return -EINVAL;
+ 	}
+ 
+-	pp = nf_hook_entry_head(net, reg->pf, reg->hooknum, reg->dev);
++	pp = nf_hook_entry_head(net, pf, reg->hooknum, reg->dev);
+ 	if (!pp)
+ 		return -EINVAL;
+ 
+@@ -326,17 +327,16 @@ int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 
+ 	hooks_validate(new_hooks);
+ #ifdef CONFIG_NETFILTER_INGRESS
+-	if (reg->pf == NFPROTO_NETDEV && reg->hooknum == NF_NETDEV_INGRESS)
++	if (pf == NFPROTO_NETDEV && reg->hooknum == NF_NETDEV_INGRESS)
+ 		net_inc_ingress_queue();
+ #endif
+ #ifdef HAVE_JUMP_LABEL
+-	static_key_slow_inc(&nf_hooks_needed[reg->pf][reg->hooknum]);
++	static_key_slow_inc(&nf_hooks_needed[pf][reg->hooknum]);
+ #endif
+ 	BUG_ON(p == new_hooks);
+ 	nf_hook_entries_free(p);
+ 	return 0;
+ }
+-EXPORT_SYMBOL(nf_register_net_hook);
+ 
+ /*
+  * nf_remove_net_hook - remove a hook from blob
+@@ -377,12 +377,13 @@ static void nf_remove_net_hook(struct nf_hook_entries *old,
+ 	}
+ }
+ 
+-void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
++void __nf_unregister_net_hook(struct net *net, int pf,
++			      const struct nf_hook_ops *reg)
+ {
+ 	struct nf_hook_entries __rcu **pp;
+ 	struct nf_hook_entries *p;
+ 
+-	pp = nf_hook_entry_head(net, reg->pf, reg->hooknum, reg->dev);
++	pp = nf_hook_entry_head(net, pf, reg->hooknum, reg->dev);
+ 	if (!pp)
+ 		return;
+ 
+@@ -394,7 +395,7 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 		return;
+ 	}
+ 
+-	nf_remove_net_hook(p, reg, reg->pf);
++	nf_remove_net_hook(p, reg, pf);
+ 
+ 	p = __nf_hook_entries_try_shrink(pp);
+ 	mutex_unlock(&nf_hook_mutex);
+@@ -404,8 +405,42 @@ void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
+ 	nf_queue_nf_hook_drop(net);
+ 	nf_hook_entries_free(p);
+ }
++
++void nf_unregister_net_hook(struct net *net, const struct nf_hook_ops *reg)
++{
++	if (reg->pf == NFPROTO_INET) {
++		__nf_unregister_net_hook(net, NFPROTO_IPV4, reg);
++		__nf_unregister_net_hook(net, NFPROTO_IPV6, reg);
++	} else {
++		__nf_unregister_net_hook(net, reg->pf, reg);
++	}
++}
+ EXPORT_SYMBOL(nf_unregister_net_hook);
+ 
++int nf_register_net_hook(struct net *net, const struct nf_hook_ops *reg)
++{
++	int err;
++
++	if (reg->pf == NFPROTO_INET) {
++		err = __nf_register_net_hook(net, NFPROTO_IPV4, reg);
++		if (err < 0)
++			return err;
++
++		err = __nf_register_net_hook(net, NFPROTO_IPV6, reg);
++		if (err < 0) {
++			__nf_unregister_net_hook(net, NFPROTO_IPV4, reg);
++			return err;
++		}
++	} else {
++		err = __nf_register_net_hook(net, reg->pf, reg);
++		if (err < 0)
++			return err;
++	}
++
++	return 0;
++}
++EXPORT_SYMBOL(nf_register_net_hook);
++
+ int nf_register_net_hooks(struct net *net, const struct nf_hook_ops *reg,
+ 			  unsigned int n)
+ {
+-- 
+2.11.0
+


### PR DESCRIPTION
Commit b7265c59ab7d ("kernel: backport a series of netfilter cleanup
patches to 4.14") added patch 302-netfilter-nf_tables_inet-don-t-use-
multihook-infrast.patch.  That patch switches the netfilter core in the
kernel to use the new native NFPROTO_INET support.  Unfortunately, the
new native NFPROTO_INET support does not exist in 4.14 and was not
backported along with this patchset.  As such, nftables inet tables never
see any traffic.

As an example the following nft counter rule should increment for every
packet coming into the box, but never will:

nft add table inet foo
nft add chain inet foo bar { type filter hook input priority 0\; }
nft add rule inet foo bar counter

This commit pulls in the required backport patches to add the new
native NFPROTO_INET support, and thus restore nftables inet table
functionality.

Tested on Turris Omnia (mvebu)

Fixes: b7265c59ab7d ("kernel: backport a series of netfilter cleanup ...")
Signed-off-by: Brett Mastbergen <bmastbergen@untangle.com>