### PR TITLE
bcm53xx: added basic dts for linksys ea6500v2

### DIFF
--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -224,12 +224,17 @@ endef
 TARGET_DEVICES += dlink-dir-885l
 
 # Linksys devices are disabled due to problem with 2 TRX partitions
-
 define Device/linksys-ea6300-v1
   DEVICE_TITLE := Linksys EA6300 V1
   DEVICE_PACKAGES := $(B43) $(USB3_PACKAGES)
 endef
 # TARGET_DEVICES += linksys-ea6300-v1
+
+define Device/linksys-ea6500-v2
+  DEVICE_TITLE := Linksys EA6500 V2
+  DEVICE_PACKAGES := $(B43) $(USB3_PACKAGES)
+endef
+TARGET_DEVICES += linksys-ea6500-v2
 
 define Device/linksys-ea9200
   DEVICE_TITLE := Linksys EA9200 V1

--- a/target/linux/bcm53xx/patches-4.14/315-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA6500-V2.patch
+++ b/target/linux/bcm53xx/patches-4.14/315-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA6500-V2.patch
@@ -1,0 +1,61 @@
+---
+ arch/arm/boot/dts/Makefile                      |  1 +
+ arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts | 41 +++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -65,6 +65,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4708-asus-rt-ac68u.dtb \
+ 	bcm4708-buffalo-wzr-1750dhp.dtb \
+	bcm4708-linksys-ea6300-v1.dtb \
++	bcm4708-linksys-ea6500-v2.dtb \
+ 	bcm4708-luxul-xap-1510.dtb \
+ 	bcm4708-luxul-xwc-1000.dtb \
+ 	bcm4708-netgear-r6250.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
+@@ -0,0 +1,42 @@
++/*
++ * Copyright (C) 2017 Rafał Miłecki <rafal@milecki.pl>
++ * Copyright (C) 2017 Rene Kjellerup <rk.katana.steel@gmail.com>
++ *
++ * Licensed under the ISC license.
++ */
++
++/dts-v1/;
++
++#include "bcm4708.dtsi"
++#include "bcm5301x-nand-cs0-bch8.dtsi"
++
++/ {
++	compatible = "linksys,ea6500-v2", "brcm,bcm4708";
++	model = "Linksys EA6500 V2";
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	memory {
++		reg = <0x00000000 0x08000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++		};
++
++		restart {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++	};
++};

--- a/target/linux/bcm53xx/patches-4.14/315-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA6500-V2.patch
+++ b/target/linux/bcm53xx/patches-4.14/315-ARM-dts-BCM5301X-Add-basic-DT-for-Linksys-EA6500-V2.patch
@@ -16,12 +16,12 @@
  	bcm4708-netgear-r6250.dtb \
 --- /dev/null
 +++ b/arch/arm/boot/dts/bcm4708-linksys-ea6500-v2.dts
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,45 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 +/*
 + * Copyright (C) 2017 Rafał Miłecki <rafal@milecki.pl>
-+ * Copyright (C) 2017 Rene Kjellerup <rk.katana.steel@gmail.com>
++ * Copyright (C) 2018 Rene Kjellerup <rk.katana.steel@gmail.com>
 + *
-+ * Licensed under the ISC license.
 + */
 +
 +/dts-v1/;
@@ -59,3 +59,7 @@
 +		};
 +	};
 +};
++&usb3_phy {
++	status = "okay";
++};
+


### PR DESCRIPTION
only thing not working is the b43 5GHz wifi band as upstream kernel
doesn't support the 0x4360 chip so far

Signed-off-by: Rene Kjellerup <rk.katana.steel@gmail.com>
