### PR TITLE
ath79: add support for Netgear EX6400 and EX7300

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -20,6 +20,8 @@ buffalo,bhr-4grv2|\
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor|\
 librerouter,librerouter-v1|\
+netgear,ex6400|\
+netgear,ex7300|\
 ocedo,koala|\
 ocedo,raccoon|\
 openmesh,om5p-ac-v2|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -14,6 +14,8 @@ ath79_setup_interfaces()
 	devolo,dvl1750c|\
 	devolo,dvl1750i|\
 	glinet,ar300m-lite|\
+	netgear,ex6400|\
+	netgear,ex7300|\
 	ocedo,koala|\
 	ocedo,raccoon|\
 	pcs,cap324|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -169,6 +169,11 @@ case "$FIRMWARE" in
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
+	netgear,ex6400|\
+	netgear,ex7300)
+		ath10kcal_extract "caldata" 20480 12064
+		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 12)
+		;;
 	phicomm,k2t)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(k2t_get_mac "5g_mac")

--- a/target/linux/ath79/dts/qca9558_netgear_ex6400.dts
+++ b/target/linux/ath79/dts/qca9558_netgear_ex6400.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_netgear_ex7300.dtsi"
+
+/ {
+	model = "Netgear EX6400";
+	compatible = "netgear,ex6400", "qca,qca9558";
+};

--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dts
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_netgear_ex7300.dtsi"
+
+/ {
+	model = "Netgear EX7300";
+	compatible = "netgear,ex7300", "qca,qca9558";
+};

--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_amber;
+		led-running = &power_green;
+		led-upgrade = &power_amber;
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-sck = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "nxp,74lvc594";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			lines-initial-states = /bits/ 8 <0xff>;
+			spi-max-frequency = <500000>;
+
+			gpio_latch_bit {
+				gpio-hog;
+				gpios = <4 GPIO_ACTIVE_HIGH>;
+				output-high;
+				line-name = "gpio-latch-bit";
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_green: power_green {
+			label = "netgear:green:power";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		power_amber: power_amber {
+			label = "netgear:amber:power";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		left_blue {
+			label = "netgear:blue:left";
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		right_blue {
+			label = "netgear:blue:right";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_green {
+			label = "netgear:green:wps";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		client_red {
+			label = "netgear:red:client";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		client_green {
+			label = "netgear:green:client";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		router_red {
+			label = "netgear:red:router";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		router_green {
+			label = "netgear:green:router";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		extender_apmode {
+			label = "EXTENDER/APMODE switch";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			caldata: partition@50000 {
+				label = "caldata";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "caldata-backup";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "config";
+				reg = <0x070000 0x010000>;
+			};
+
+			partition@80000 {
+				label = "pot";
+				reg = <0x080000 0x010000>;
+			};
+
+			partition@90000 {
+				label = "firmware";
+				reg = <0x090000 0xf30000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fc0000 {
+				label = "language";
+				reg = <0xfc0000 0x040000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&caldata 0x1000>;
+	mtd-mac-address = <&caldata 0x06>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&caldata 0x00>;
+
+	phy-handle = <&phy4>;
+	phy-mode = "rgmii";
+
+	pll-data = <0x83000000 0x80000101 0x80001313>;
+};

--- a/target/linux/ath79/image/common-netgear.mk
+++ b/target/linux/ath79/image/common-netgear.mk
@@ -19,6 +19,16 @@ define Build/netgear-squashfs
 	rm -rf $@.squashfs $@.fs
 endef
 
+define Build/netgear-rootfs
+	mkimage \
+		-A mips -O linux -T filesystem -C none \
+		-M $(NETGEAR_KERNEL_MAGIC) \
+		-n '$(VERSION_DIST) filesystem' \
+		-d $(IMAGE_ROOTFS) $@.fs
+	cat $@.fs >> $@
+	rm -rf $@.fs
+endef
+
 define Build/netgear-uImage
 	$(call Build/uImage,$(1) -M $(NETGEAR_KERNEL_MAGIC))
 endef

--- a/target/linux/ath79/image/common-netgear.mk
+++ b/target/linux/ath79/image/common-netgear.mk
@@ -22,3 +22,11 @@ endef
 define Build/netgear-uImage
 	$(call Build/uImage,$(1) -M $(NETGEAR_KERNEL_MAGIC))
 endef
+
+define Device/netgear_ath79
+  KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
+  IMAGES += factory.img
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
+endef
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -542,6 +542,29 @@ define Device/netgear_wndr3x00
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
 endef
 
+define Device/netgear_ex7300_ex6400
+  ATH_SOC := qca9558
+  IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | netgear-rootfs | pad-rootfs
+  $(Device/netgear_ath79)
+  NETGEAR_KERNEL_MAGIC := 0x27051956
+  NETGEAR_BOARD_ID := EX7300series
+  NETGEAR_HW_ID := 29765104+16+0+128
+  IMAGE_SIZE := 15552k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca99x0-ct
+endef
+
+define Device/netgear_ex6400
+  $(Device/netgear_ex7300_ex6400)
+  DEVICE_TITLE := NETGEAR EX6400
+endef
+TARGET_DEVICES += netgear_ex6400
+
+define Device/netgear_ex7300
+  $(Device/netgear_ex7300_ex6400)
+  DEVICE_TITLE := NETGEAR EX7300
+endef
+TARGET_DEVICES += netgear_ex7300
+
 define Device/netgear_wndr3700
   $(Device/netgear_wndr3x00)
   DEVICE_TITLE := NETGEAR WNDR3700

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -537,11 +537,8 @@ TARGET_DEVICES += pcs_cr5000
 
 define Device/netgear_wndr3x00
   ATH_SOC := ar7161
-  KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  IMAGES += factory.img
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
+  $(Device/netgear_ath79)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
 endef
 

--- a/target/linux/ath79/image/tiny-netgear.mk
+++ b/target/linux/ath79/image/tiny-netgear.mk
@@ -1,35 +1,27 @@
 include ./common-netgear.mk
 
+define Device/netgear_ar7240
+  ATH_SOC := ar7240
+  NETGEAR_KERNEL_MAGIC := 0x32303631
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
+  IMAGE_SIZE := 3904k
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
+  $(Device/netgear_ath79)
+endef
 
 define Device/netgear_wnr612-v2
-  ATH_SOC := ar7240
+  $(Device/netgear_ar7240)
   DEVICE_TITLE := Netgear WNR612v2
   DEVICE_DTS := ar7240_netgear_wnr612-v2
-  NETGEAR_KERNEL_MAGIC := 0x32303631
-  KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
   NETGEAR_BOARD_ID := REALWNR612V2
-  IMAGE_SIZE := 3904k
-  IMAGES += factory.img
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
   SUPPORTED_DEVICES += wnr612-v2
 endef
 TARGET_DEVICES += netgear_wnr612-v2
 
 define Device/on_n150r
-  ATH_SOC := ar7240
+  $(Device/netgear_ar7240)
   DEVICE_TITLE := ON Network N150R
-  NETGEAR_KERNEL_MAGIC := 0x32303631
-  KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
   NETGEAR_BOARD_ID := N150R
-  IMAGE_SIZE := 3904k
-  IMAGES += factory.img
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
   SUPPORTED_DEVICES += n150r
 endef
 TARGET_DEVICES += on_n150r


### PR DESCRIPTION
This is sold as a dual-band 802.11ac range extender. It has a sliding
switch for Extender mode or Access Point mode, a WPS button, a recessed
Reset button, a hard-power button, and a multitude of LED's, some
multiplexed via an NXP 74AHC164D chip. The internal serial header pinout is
Vcc, Tx, Rx, GND, with GND closest to the corner of the board. You may
connect at 115200 bps, 8 data bits, no parity, 1 stop bit.

Specification:
- System-On-Chip: QCA9558
- CPU/Speed: 720 MHz
- Flash-Chip: Winbond 25Q128FVSG
- Flash size: 16 MiB
- RAM: 128 MiB
- Wireless No1: QCA9558 on-chip 2.4GHz 802.11bgn, 3x3
- Wireless No2: QCA99x0 chip 5GHz 802.11an+ac, 4x4
- PHY: Atheros AR8035-A

Installation:
If you can get to the stock firmware's firmware upgrade option, just feed
it the factory.img and boot as usual. As an alternative, TFTP the
factory.img to the bootloader.

Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>