### PR TITLE
ramips: fix power LED DTB for wt3020

### DIFF
--- a/target/linux/ramips/dts/WT3020.dtsi
+++ b/target/linux/ramips/dts/WT3020.dtsi
@@ -26,7 +26,7 @@
 
 		led_power: power {
 			label = "wt3020:blue:power";
-			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};
 };


### PR DESCRIPTION
Since 43df31f power LED is no longer lights after boot-up.
Reversing gpio polarity makes it work as it should be.
Tested with all triggers including timer/netdev.

@mkresin pls, take a look into this.