### PR TITLE
ath79: Fix GL-AR300M USB trigger

### DIFF
--- a/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m.dtsi
@@ -77,7 +77,7 @@
 
 	hub_port: port@1 {
 		reg = <1>;
-		#trigger-soruce-cells = <0>;
+		#trigger-source-cells = <0>;
 	};
 };
 


### PR DESCRIPTION
Correct a typo preventing USB trigger to work on AR300M.

Signed-off-by: Robert Marko robimarko@gmail.com
