### PR TITLE
sunxi: build image/uboot for the NanoPi NEO2

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -182,6 +182,14 @@ define U-Boot/nanopi_neo_plus2
   UENV:=a64
 endef
 
+define U-Boot/nanopi_neo2
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=NanoPi NEO2 (H5)
+  BUILD_DEVICES:=sun50i-h5-nanopi-neo2
+  DEPENDS:=+PACKAGE_u-boot-nanopi_neo2:arm-trusted-firmware-sunxi
+  UENV:=a64
+endef
+
 define U-Boot/pine64_plus
   BUILD_SUBTARGET:=cortexa53
   NAME:=Pine64 Plus A64
@@ -237,6 +245,7 @@ UBOOT_TARGETS := \
 	nanopi_m1_plus \
 	nanopi_neo \
 	nanopi_neo_plus2 \
+	nanopi_neo2 \
 	orangepi_r1 \
 	orangepi_pc \
 	orangepi_plus \

--- a/target/linux/sunxi/image/cortex-a53.mk
+++ b/target/linux/sunxi/image/cortex-a53.mk
@@ -17,6 +17,16 @@ endef
 
 TARGET_DEVICES += sun50i-h5-nanopi-neo-plus2
 
+define Device/sun50i-h5-nanopi-neo2
+  DEVICE_TITLE:=Nanopi NEO2 (H5)
+  SUPPORTED_DEVICES:=nanopi-neo2
+  SUNXI_DTS:=allwinner/sun50i-h5-nanopi-neo2
+  KERNEL_NAME := Image
+  KERNEL := kernel-bin
+endef
+
+TARGET_DEVICES += sun50i-h5-nanopi-neo2
+
 define Device/sun50i-a64-pine64-plus
   DEVICE_TITLE:=Pine64 Plus A64
   SUPPORTED_DEVICES:=pine64,pine64-plus


### PR DESCRIPTION
The NanoPi NEO2 is a small Allwinner H5 based board available with
different DRAM configurations.
This board is very similar to the NanoPi NEO PLUS2

**Compiled and Tested on a NanoPi NEO2 1GB Ram**

Signed-off-by: Jasper Scholte <NightNL@outlook.com>