### PR TITLE
iptables: fix dependency for libip6tc on IPV6

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -492,7 +492,7 @@ define Package/libiptc
 $(call Package/iptables/Default)
   SECTION:=libs
   CATEGORY:=Libraries
-  DEPENDS:=+libip4tc +libip6tc +libxtables
+  DEPENDS:=+libip4tc +IPV6:libip6tc +libxtables
   ABI_VERSION:=$(PKG_VERSION)
   TITLE:=IPv4/IPv6 firewall - shared libiptc library (compatibility stub)
 endef
@@ -512,7 +512,7 @@ $(call Package/iptables/Default)
   CATEGORY:=Libraries
   TITLE:=IPv6 firewall - shared libiptc library
   ABI_VERSION:=$(PKG_VERSION)
-  DEPENDS:=+libxtables
+  DEPENDS:=@IPV6 +libxtables
 endef
 
 define Package/libxtables


### PR DESCRIPTION

Signed-off-by: Rosy Song <rosysong@rosinson.com>