### PR TITLE
include: drop relevant default packages when ipv6 is not support

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -17,7 +17,11 @@ DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fs
 # For nas targets
 DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm
 # For router targets
+ifneq ($(CONFIG_IPV6),)
 DEFAULT_PACKAGES.router:=dnsmasq iptables ip6tables ppp ppp-mod-pppoe firewall odhcpd-ipv6only odhcp6c kmod-ipt-offload
+else
+DEFAULT_PACKAGES.router:=dnsmasq iptables ppp ppp-mod-pppoe firewall kmod-ipt-offload
+endif
 DEFAULT_PACKAGES.bootloader:=
 
 ifneq ($(DUMP),)


### PR DESCRIPTION

Signed-off-by: Rosy Song <rosysong@rosinson.com>
