### PR TITLE
uhttpd: drop relevant options if ipv6 is not supported

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -153,6 +153,7 @@ start_instance()
 
 	config_get http "$cfg" listen_http
 	for listen in $http; do
+		 [ "${listen%:*}" = "[::]" -a ! -e /proc/sys/net/ipv6 ] && continue
 		 procd_append_param command -p "$listen"
 	done
 
@@ -180,6 +181,7 @@ start_instance()
 			append_arg "$cfg" key  "-K"
 
 			for listen in $https; do
+				[ "${listen%:*}" = "[::]" -a ! -e /proc/sys/net/ipv6 ] && continue
 				procd_append_param command -s "$listen"
 			done
 		}


### PR DESCRIPTION
Signed-off-by: Rosy Song <rosysong@rosinson.com>
