### PR TITLE
fstools: filter unknown action in mount.hotplug script

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fstools
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=$(PROJECT_GIT)/project/fstools.git

--- a/package/system/fstools/files/mount.hotplug
+++ b/package/system/fstools/files/mount.hotplug
@@ -1,1 +1,1 @@
-/sbin/block hotplug
+[ "$ACTION" = "add" -o "$ACTION" = "remove" ] && /sbin/block hotplug


### PR DESCRIPTION
Since block program does not handle that action "change", why not filter it in hotplug script ? :-)
And this can avoid the "block: unknown action change" message in logread.

Signed-off-by: Rosy Song <rosysong@rosinson.com>
