### PR TITLE
netifd: do not validate relevant section when ipv6 is not supported

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -133,9 +133,9 @@ service_triggers()
 	procd_open_validate
 	validate_atm_bridge_section
 	validate_route_section
-	validate_route6_section
+	[ -e /proc/sys/net/ipv6 ] && validate_route6_section
 	validate_rule_section
-	validate_rule6_section
+	[ -e /proc/sys/net/ipv6 ] && validate_rule6_section
 	validate_switch_section
 	validate_switch_vlan
 	procd_close_validate


### PR DESCRIPTION

Signed-off-by: Rosy Song <rosysong@rosinson.com>