### PR TITLE
build: fix passing -specs to gcc not ld

### DIFF
--- a/include/hardening.mk
+++ b/include/hardening.mk
@@ -18,8 +18,8 @@ ifdef CONFIG_PKG_CHECK_FORMAT_SECURITY
 endif
 ifdef CONFIG_PKG_ASLR_PIE
   ifeq ($(strip $(PKG_ASLR_PIE)),1)
-    TARGET_CFLAGS += $(FPIC)
-    TARGET_LDFLAGS += $(FPIC) -specs=$(INCLUDE_DIR)/hardened-ld-pie.specs
+    TARGET_CFLAGS += $(FPIC) -specs=$(INCLUDE_DIR)/hardened-ld-pie.specs
+    TARGET_LDFLAGS += -pie
   endif
 endif
 ifdef CONFIG_PKG_CC_STACKPROTECTOR_REGULAR


### PR DESCRIPTION
Per the gcc(1) and ld(1) man pages, `-specs=file` applies only to `gcc`.