### PR TITLE
ramips: fix TP-Link Archer C20 v1 sysupgrade

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -516,7 +516,7 @@ TARGET_DEVICES += tplink_c2-v1
 define Device/tplink_c20-v1
   $(Device/Archer)
   DTS := ArcherC20v1
-  SUPPORTED_DEVICES := c20v1
+  SUPPORTED_DEVICES := tplink,c20-v1 
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc2000001
   TPLINK_HWREV := 0x44


### PR DESCRIPTION
The sysupgrade image failed the check due to the wrong string in the supported devices. This patch provides the correct name.

Signed-off-by: Steffen Förster <steffen@chemnitz.freifunk.net>