### PR TITLE
odhcpd-ipv6only: fix dependency for IPV6

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=1.11
 
 PKG_SOURCE_PROTO:=git
@@ -72,6 +72,7 @@ endef
 define Package/odhcpd-ipv6only
   $(call Package/odhcpd/default)
   VARIANT:=ipv6only
+  DEPENDS+= @IPV6
 endef
 
 Package/odhcpd-ipv6only/config=$(call Package/odhcpd/default/config,odhcpd-ipv6only,ipv6only)


### PR DESCRIPTION
Odhcpd should not depends on **IPV6** as it will drop the ipv4 server functionality as well, but may be odhcpd-ipv6only should. @jow- @dedeckeh 

Signed-off-by: Rosy Song <rosysong@rosinson.com>

