### PR TITLE
ath79: fix MAC address for Buffalo BHR-4GRV

### DIFF
--- a/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
@@ -8,6 +8,10 @@
 	model = "Buffalo BHR-4GRV";
 };
 
+&eth0 {
+	mtd-mac-address = <&ART 0x0>;
+};
+
 &sec_vpn {
 	label = "buffalo:orange:vpn";
 };

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -144,8 +144,6 @@
 &eth0 {
 	status = "okay";
 
-	mtd-mac-address = <&ART 0x1002>;
-
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
 };

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -59,6 +59,10 @@
 	};
 };
 
+&eth0 {
+	mtd-mac-address = <&ART 0x1002>;
+};
+
 &sec_vpn {
 	label = "buffalo:orange:security";
 };


### PR DESCRIPTION
I added mtd-mac-address for WZR-HP-G450H and BHR-4GRV in
1df1ea4d7e8b6ae3351780ed58800ccd9edd4c27, but that address in ART is
incorrect for BHR-4GRV.

WZR-HP-G450H has wlan eeprom and MAC address in ART, but BHR-4GRV
has only MAC address in ART.

- WZR-HP-G450H
  - eeprom: 0x1000
  - MAC:    0x1002

- BHR-4GRV
  - MAC:    0x0

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>

It was overlooked when checking the operation on the devices, sorry...