### PR TITLE
 ath79: Add support for Ubiquiti LiteAP ac

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -21,6 +21,7 @@ ath79_setup_interfaces()
 	tplink,tl-wa901nd-v2|\
 	tplink,tl-wr703n|\
 	ubnt,bullet-m|\
+	ubnt,liteap-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,7 @@ case "$FIRMWARE" in
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\
+	ubnt,liteap-ac|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)

--- a/target/linux/ath79/dts/ar9342_ubnt_liteap-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_liteap-ac.dts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,liteap-ac", "ubnt,wa";
+	model = "Ubiquiti LiteAP ac (WA)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "rgmii";
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};
+
+&wmac {
+	status = "disabled";
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -84,6 +84,16 @@ define Device/ubnt_nano-m
 endef
 TARGET_DEVICES += ubnt_nano-m
 
+define Device/ubnt_liteap-ac
+  $(Device/ubnt-wa)
+  DEVICE_TITLE := Ubiquiti LiteAP ac
+  DEVICE_PACKAGES += kmod-ath10k ath10k-firmware-qca988x
+  IMAGE_SIZE := 15744k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
+endef
+TARGET_DEVICES += ubnt_liteap-ac
+
 define Device/ubnt_nanostation-ac
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti Nanostation AC


### PR DESCRIPTION
### Summary
This pull request adds support for the **Ubiquiti LiteAP ac**, an outdoor 5 GHz AC access point with an integrated 120º 16 dBi antenna. The device was previously known as LiteBeam AP ac (LBE-5AC-16-120) but was later rebranded.

### Specs
CPU:    Atheros AR9342 SoC
RAM:    64 MB DDR2
Flash:  16 MB NOR SPI
Ports:  1 GbE port (PoE in)
WLAN:   5 GHz QCA899X (PCI)

The integrated QCA899X is a Ubiquiti branded part with modified vendor
and product id (0777:11ac9). It is very similar to the NanoStation loco
AC, except for the 2.4 GHz management radio (missing here).

### Support
The device is fully supported: identification, network, wireless and reset button.

### Installation
Installation procedure is the same as the NanoStation [loco] AC:

1. Connect to serial header on device
2. Power on device and enter uboot console
3. Set up tftp server serving an openwrt initramfs build
4. Load initramfs build using the command tftpboot in the uboot cli
5. Boot the loaded image using the command bootm
6. Copy squashfs openwrt sysupgrade build to the booted device
7. Use mtd to write sysupgrade to partition "firmware"
8. Reboot and enjoy

### Acknowledgments
@TobleMiner, for his great work on the UBNT WA boards support, on which this commit is based.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>