### PR TITLE
layerscape: fix Ethernet/DPAA/FMAN on Traverse boards after DTS refresh

### DIFF
--- a/target/linux/layerscape/patches-4.9/303-dts-layerscape-add-traverse-ls1043.patch
+++ b/target/linux/layerscape/patches-4.9/303-dts-layerscape-add-traverse-ls1043.patch
@@ -9,8 +9,10 @@ Signed-off-by: Mathew McBride <matt@traverse.com.au>
  1 file changed, 4 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
 
---- a/arch/arm64/boot/dts/freescale/Makefile
-+++ b/arch/arm64/boot/dts/freescale/Makefile
+Index: linux-4.9.128/arch/arm64/boot/dts/freescale/Makefile
+===================================================================
+--- linux-4.9.128.orig/arch/arm64/boot/dts/freescale/Makefile
++++ linux-4.9.128/arch/arm64/boot/dts/freescale/Makefile
 @@ -21,7 +21,10 @@ dtb-$(CONFIG_ARCH_LAYERSCAPE) += fsl-ls2
  dtb-$(CONFIG_ARCH_LAYERSCAPE) += fsl-ls2080a-simu.dtb
  dtb-$(CONFIG_ARCH_LAYERSCAPE) += fsl-ls2088a-qds.dtb
@@ -23,9 +25,11 @@ Signed-off-by: Mathew McBride <matt@traverse.com.au>
  always		:= $(dtb-y)
  subdir-y	:= $(dts-dirs)
  clean-files	:= *.dtb
---- a/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
-+++ b/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
-@@ -330,3 +330,29 @@
+Index: linux-4.9.128/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
+===================================================================
+--- linux-4.9.128.orig/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
++++ linux-4.9.128/arch/arm64/boot/dts/freescale/traverse-ls1043s.dts
+@@ -330,3 +330,32 @@
  &sata {
  	status = "disabled";
  };
@@ -33,6 +37,9 @@ Signed-off-by: Mathew McBride <matt@traverse.com.au>
 +/* Additions for Layerscape SDK (4.4/4.9) Kernel only
 + * These kernels need additional setup for FMan/QMan DMA shared memory
 + */
++
++#include "qoriq-qman-portals-sdk.dtsi"
++#include "qoriq-bman-portals-sdk.dtsi"
 +
 +&bman_fbpr {
 +	compatible = "fsl,bman-fbpr";
@@ -55,9 +62,11 @@ Signed-off-by: Mathew McBride <matt@traverse.com.au>
 +&fman0 {
 +	compatible = "fsl,fman", "simple-bus";
 +};
---- a/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
-+++ b/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
-@@ -251,3 +251,29 @@
+Index: linux-4.9.128/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
+===================================================================
+--- linux-4.9.128.orig/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
++++ linux-4.9.128/arch/arm64/boot/dts/freescale/traverse-ls1043v.dts
+@@ -251,3 +251,32 @@
  &sata {
  	status = "disabled";
  };
@@ -65,6 +74,9 @@ Signed-off-by: Mathew McBride <matt@traverse.com.au>
 +/* Additions for Layerscape SDK (4.4/4.9) Kernel only
 + * These kernels need additional setup for FMan/QMan DMA shared memory
 + */
++
++#include "qoriq-qman-portals-sdk.dtsi"
++#include "qoriq-bman-portals-sdk.dtsi"
 +
 +&bman_fbpr {
 +	compatible = "fsl,bman-fbpr";


### PR DESCRIPTION
Patch 303 is required for Traverse LS1043 targets when using the NXP DPAA1 driver.
The recent refresh of 4.9 patches on layerscape changed how FMan/BMan memory regions
were defined and meant Ethernet stopped working on these boards.

(Note that these definitions are only required for NXP's Ethernet driver, the new
upstream driver in >=4.15 works using the DTS provided in files/)

Signed-off-by: Mathew McBride <matt@traverse.com.au>