### PR TITLE
Device support for VGV953 (Speedport W 921V)

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -226,6 +226,13 @@ buffalo,wbmr-300hpd)
 		"5:lan:2" "2:lan:3" "3:lan:4" "4:wan:1" "6t@eth0"
 	;;
 
+arcadyan,vgv953)
+	lan_mac=$(mtd_get_mac_ascii uboot-env ethaddr)
+	wan_mac=$(macaddr_add "$lan_mac" 1)
+	ucidef_add_switch "switch0" \
+		"0:lan:4" "1:lan:3" "2:lan:2" "4:lan:1" "6t@eth0"
+	;;
+
 *)
 	ucidef_set_interface_lan 'eth0'
 	;;

--- a/target/linux/lantiq/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/base-files/lib/upgrade/platform.sh
@@ -15,7 +15,8 @@ platform_do_upgrade() {
 	bt,homehub-v3a|\
 	bt,homehub-v5a|\
 	zyxel,p-2812hnu-f1|\
-	zyxel,p-2812hnu-f3)
+	zyxel,p-2812hnu-f3|\
+	arcadyan,vgv953)
 		nand_do_upgrade $1
 		;;
 	*)

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV953.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VGV953.dts
@@ -1,0 +1,323 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "arcadyan,vgv953", "lantiq,xway", "lantiq,vr9";
+	model = "Speedport W 921V";
+
+	chosen {
+/*		bootargs = "console=ttyLTQ0,115200 mem=62M vpe1_load_addr=0x83e00000 vpe1_mem=2M maxvpes=1 maxtcs=1 nosmp";*/
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-dsl = &dsl;
+		led-internet = &internet;
+	};
+
+	memory@0 {
+		reg = <0x0 0x8000000>;
+	};
+/*	sram@1F000000 {*/
+/*		vmmc@107000 {*/
+/*		status = "okay";*/
+/*		gpios = <&gpio 31 GPIO_ACTIVE_LOW>;*/
+/*		};*/
+/*	};*/
+};
+&localbus {
+	nand@0 {
+		compatible = "lantiq,nand-xway";
+		lantiq,cs = <1>;
+		bank-width = <2>;
+		reg = <0 0x0 0x2000000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			partition@0 {
+				label = "uboot";
+				reg = <0x00000 0x40000>;
+			};
+			partition@40000 {
+				label = "uboot-env";
+				reg = <0x40000 0x20000>;
+			};
+			partition@60000 {
+				label = "kernel";
+				reg = <0x60000 0x200000>;
+			};
+			partition@260000 {
+				label = "ubi";
+				reg = <0x260000 0x1da0000>;
+			};
+		};
+	};
+  
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+		reset {
+			label = "reset";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+		dect_paging {
+			label = "dect_paging";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+		dect_pairing {
+			label = "dect";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		waiting {
+			label = "vgv953:white:waiting";
+			gpios = <&stp 16 GPIO_ACTIVE_LOW>;
+		};
+		service {
+			label = "vgv953:white:sevice";
+			gpios = <&stp 17 GPIO_ACTIVE_LOW>;
+		};
+		phone {
+			label = "vgv953:white:phone";
+			gpios = <&stp 18 GPIO_ACTIVE_LOW>;
+		};
+		wlan {
+			label = "vgv953:white:wlan";
+			gpios = <&stp 19 GPIO_ACTIVE_LOW>;
+		};
+		internet: internet {
+			label = "vgv953:white:internet";
+			gpios = <&stp 20 GPIO_ACTIVE_LOW>;
+		};
+		dsl: dsl {
+			label = "vgv953:white:dsl";
+			gpios = <&stp 21 GPIO_ACTIVE_LOW>;
+		};
+		power_red: power {
+			label = "vgv953:red:power";
+			gpios = <&stp 22 GPIO_ACTIVE_LOW>;
+		};
+		power_green: power2 {
+			label = "vgv953:white:power";
+			gpios = <&stp 23 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		mac-address = [ 00 11 22 33 44 55 ];
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
+		};
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy1>;
+		};
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		reg = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		exin3 {
+			lantiq,groups = "exin3";
+			lantiq,function = "exin";
+		};
+		mdio {
+			lantiq,groups = "mdio";
+			lantiq,function = "mdio";
+		};
+		gphy-leds {
+			lantiq,groups = "gphy0 led1", "gphy1 led1",
+					"gphy0 led2", "gphy1 led2";
+			lantiq,function = "gphy";
+			lantiq,pull = <2>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		stp {
+			lantiq,groups = "stp";
+			lantiq,function = "stp";
+			lantiq,pull = <2>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		pci-in {
+			lantiq,groups = "req1";
+			lantiq,function = "pci";
+			lantiq,output = <0>;
+			lantiq,open-drain = <1>;
+			lantiq,pull = <2>;
+		};
+		pci-out {
+			lantiq,groups = "gnt1";
+			lantiq,function = "pci";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <0>;
+		};
+
+		pci_rst {
+			lantiq,pins = "io21";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <2>;
+		};
+		pcie-rst {
+			lantiq,pins = "io38";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+		ifxhcd-rst {
+			lantiq,pins = "io33";
+			lantiq,pull = <0>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		nand_out {
+			lantiq,groups = "nand cle", "nand ale";
+			lantiq,function = "ebu";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <0>;
+		};
+		nand_cs1 {
+			lantiq,groups = "nand cs1";
+			lantiq,function = "ebu";
+			lantiq,open-drain = <0>;
+			lantiq,pull = <0>;
+		};
+	};
+};
+&stp {
+	status = "okay";
+	lantiq,shadow = <0xffffff>;
+	lantiq,groups = <0x7>;
+	lantiq,dsl = <0x0>;
+	lantiq,phy1 = <0x0>;
+	lantiq,phy2 = <0x0>;
+};
+&pci0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+};
+
+&pcie0 {
+	status = "disabled";
+};
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -727,6 +727,16 @@ define Device/arcadyan_vgv7519-brn
 endef
 TARGET_DEVICES += arcadyan_vgv7519-brn
 
+define Device/arcadyan_vgv953
+  $(Device/NAND)
+  BOARD_NAME := VGV953
+  DEVICE_DTS := VGV953
+  DEVICE_TITLE := Telekom SPEEDPORT W921V
+  DEVICE_PACKAGES := kmod-rt2800-pci wpad-mini kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += VGV953
+endef
+TARGET_DEVICES += arcadyan_vgv953
+
 endif
 
 


### PR DESCRIPTION
Create VGV953.dts
Update platform.sh, Makefile and 02_network

there is no wifi module for XWAVE300
possible bugs with nand and usb when checking dmesg
USB works and I did not had any issues with the partitions yet
LEDs and Network Ports are all mapped
2nd kernel line present in dts file with sram commented out
Old Install instruction is still valid
https://wiki.openwrt.org/toh/t-com/spw921v
known u-boot size limitation for initramfs image
thanks to cornelus1978 for his work on device support

Signed-off-by: Stefan Grau stefan_grau@t-online.de