### PR TITLE
base-files: fix preinit ip ineffective

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=196
+PKG_RELEASE:=197
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -95,6 +95,11 @@ generate_network() {
 	case "$protocol" in
 		static)
 			local ipad
+			# Use preseted ip (except from 192.168.1.1) if it exist,
+			# The priority of ipaddr follows below list :
+			# /lib/preinit/00_preinit.conf -> /etc/config/network -> 192.168.1.1
+			. /lib/preinit/00_preinit.conf
+			[ -n "$pi_ip" -a ! "$pi_ip" = "192.168.1.1" ] && ipaddr=$pi_ip
 			case "$1" in
 				lan) ipad=${ipaddr:-"192.168.1.1"} ;;
 				*) ipad=${ipaddr:-"192.168.$((addr_offset++)).1"} ;;


### PR DESCRIPTION
I found an issue that user change the preinit ipaddr to another address(not 192.168.1.1) is ineffective when system boot. This patch can fix the issue when we custom our preinit ip in **"make menuconfig"**

Signed-off-by: Rosy Song <rosysong@rosinson.com>
