### PR TITLE
ar71xx/ipq40xx: Fix sysupgrade for Allnet and OpenMesh devices

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
@@ -3,14 +3,6 @@
 # In case the check fails during boot, a failsafe-system is started to provide
 # a minimal web-interface for flashing a new firmware.
 
-# create /var/lock for the lock "fw_setenv.lock" of fw_setenv
-# the rest is copied using ar71xx's RAMFS_COPY_BIN and RAMFS_COPY_DATA
-platform_add_ramfs_ubootenv()
-{
-	mkdir -p $RAM_ROOT/var/lock
-}
-append sysupgrade_pre_upgrade platform_add_ramfs_ubootenv
-
 # determine size of the main firmware partition
 platform_get_firmware_size() {
 	local dev size erasesize name
@@ -152,6 +144,8 @@ rootfs_size $rootfs_hexsize
 rootfs_checksum $rootfs_md5
 bootcmd bootm $vmlinux_hexaddr
 EOF
+
+	mkdir -p /var/lock
 	fw_setenv -s /tmp/fw_env_upgrade || {
 		echo "failed to update U-Boot environment"
 		return 1

--- a/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
@@ -3,11 +3,10 @@
 # In case the check fails during boot, a failsafe-system is started to provide
 # a minimal web-interface for flashing a new firmware.
 
-# make sure we got uboot-envtools and fw_env.config copied over to the ramfs
 # create /var/lock for the lock "fw_setenv.lock" of fw_setenv
-platform_add_ramfs_ubootenv() {
-	[ -e /usr/sbin/fw_printenv ] && install_bin /usr/sbin/fw_printenv /usr/sbin/fw_setenv
-	[ -e /etc/fw_env.config ] && install_file /etc/fw_env.config
+# the rest is copied using ar71xx's RAMFS_COPY_BIN and RAMFS_COPY_DATA
+platform_add_ramfs_ubootenv()
+{
 	mkdir -p $RAM_ROOT/var/lock
 }
 append sysupgrade_pre_upgrade platform_add_ramfs_ubootenv

--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
@@ -26,14 +26,6 @@ cfg_value_get()
 		done
 }
 
-# create /var/lock for the lock "fw_setenv.lock" of fw_setenv
-# the rest is copied using ar71xx's RAMFS_COPY_BIN and RAMFS_COPY_DATA
-platform_add_ramfs_ubootenv()
-{
-	mkdir -p $RAM_ROOT/var/lock
-}
-append sysupgrade_pre_upgrade platform_add_ramfs_ubootenv
-
 platform_check_image_target_openmesh()
 {
 	img_board_target="$1"
@@ -232,6 +224,7 @@ platform_do_upgrade_openmesh()
 	printf "rootfs_size %s\n" $rootfs_checksize >> $uboot_env_upgrade
 	printf "rootfs_checksum %s\n" $rootfs_md5 >> $uboot_env_upgrade
 
+	mkdir -p /var/lock
 	fw_setenv -s $uboot_env_upgrade || {
 		echo "failed to update U-Boot environment"
 		return 1

--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
@@ -26,12 +26,10 @@ cfg_value_get()
 		done
 }
 
-# make sure we got uboot-envtools and fw_env.config copied over to the ramfs
 # create /var/lock for the lock "fw_setenv.lock" of fw_setenv
+# the rest is copied using ar71xx's RAMFS_COPY_BIN and RAMFS_COPY_DATA
 platform_add_ramfs_ubootenv()
 {
-	[ -e /usr/sbin/fw_printenv ] && install_bin /usr/sbin/fw_printenv /usr/sbin/fw_setenv
-	[ -e /etc/fw_env.config ] && install_file /etc/fw_env.config
 	mkdir -p $RAM_ROOT/var/lock
 }
 append sysupgrade_pre_upgrade platform_add_ramfs_ubootenv

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -6,8 +6,8 @@
 . /lib/ar71xx.sh
 
 PART_NAME=firmware
-RAMFS_COPY_DATA=/lib/ar71xx.sh
-RAMFS_COPY_BIN='nandwrite'
+RAMFS_COPY_DATA='/lib/ar71xx.sh /etc/fw_env.config /var/lock/fw_printenv.lock'
+RAMFS_COPY_BIN='nandwrite fw_printenv fw_setenv'
 
 CI_BLKSZ=65536
 CI_LDADR=0x80060000

--- a/target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh
@@ -98,16 +98,9 @@ platform_do_upgrade_openmesh() {
 	printf "rootfs_checksum %s\n" ${rootfs_md5} >> $setenv_script
 
 	# store u-boot env changes
+	mkdir -p /var/lock
 	fw_setenv -s $setenv_script || {
 		echo "failed to update U-Boot environment"
 		return 1
 	}
 }
-
-# create /var/lock for the lock "fw_setenv.lock" of fw_setenv
-# the rest is copied using ipq806x's RAMFS_COPY_BIN and RAMFS_COPY_DATA
-platform_add_ramfs_ubootenv()
-{
-	mkdir -p $RAM_ROOT/var/lock
-}
-append sysupgrade_pre_upgrade platform_add_ramfs_ubootenv


### PR DESCRIPTION
There are still upgrade scripts which use the hook sysupgrade_pre_upgrade to prepare the ramdisk for the use of fw_setenv and fw_printenv:

* target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
* target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
* target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh

But this hook was removed without any replacement in 5e1b4c57ded7 ("base-files: drop fwtool_pre_upgrade"). Not running the hooks can either prevent a successful upgrade or brick the device.

And the behavior of install_bin was also changed in 438dcbfe74a6 ("base-files: automatically handle paths and symlinks for RAMFS_COPY_BIN") to ignore the second parameter. This then resulted in a not created fw_setenv (which is called by these scripts.

----

@NeoRaider I will also propose a OpenWrt 18.06 version of the PR. You should check how you integrate this in gluon 2018.2/2019.0.