### PR TITLE
18.06: ar71xx/ipq40xx: Fix sysupgrade for Allnet and OpenMesh devices

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -137,6 +137,7 @@ add_overlayfiles() {
 
 # hooks
 sysupgrade_image_check="fwtool_check_image platform_check_image"
+sysupgrade_pre_upgrade=""
 
 if [ $SAVE_OVERLAY = 1 ]; then
 	[ ! -d /overlay/upper/etc ] && {
@@ -262,6 +263,8 @@ if [ $SAVE_PARTITIONS -eq 0 ]; then
 else
 	rm -f /tmp/sysupgrade.always.overwrite.bootdisk.partmap
 fi
+
+run_hooks "" $sysupgrade_pre_upgrade
 
 install_bin /sbin/upgraded
 v "Commencing upgrade. Closing all shell sessions."

--- a/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
@@ -6,7 +6,7 @@
 # make sure we got uboot-envtools and fw_env.config copied over to the ramfs
 # create /var/lock for the lock "fw_setenv.lock" of fw_setenv
 platform_add_ramfs_ubootenv() {
-	[ -e /usr/sbin/fw_printenv ] && install_bin /usr/sbin/fw_printenv /usr/sbin/fw_setenv
+	[ -e /usr/sbin/fw_setenv ] && install_bin /usr/sbin/fw_setenv
 	[ -e /etc/fw_env.config ] && install_file /etc/fw_env.config
 	mkdir -p $RAM_ROOT/var/lock
 }
@@ -71,8 +71,8 @@ platform_get_offset() {
 }
 
 platform_check_image_allnet() {
-	local fw_printenv=/usr/sbin/fw_printenv
-	[ ! -n "$fw_printenv" -o ! -x "$fw_printenv" ] && {
+	local fw_setenv=/usr/sbin/fw_setenv
+	[ ! -n "$fw_setenv" -o ! -x "$fw_setenv" ] && {
 		echo "Please install uboot-envtools!"
 		return 1
 	}

--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
@@ -30,7 +30,7 @@ cfg_value_get()
 # create /var/lock for the lock "fw_setenv.lock" of fw_setenv
 platform_add_ramfs_ubootenv()
 {
-	[ -e /usr/sbin/fw_printenv ] && install_bin /usr/sbin/fw_printenv /usr/sbin/fw_setenv
+	[ -e /usr/sbin/fw_setenv ] && install_bin /usr/sbin/fw_setenv
 	[ -e /etc/fw_env.config ] && install_file /etc/fw_env.config
 	mkdir -p $RAM_ROOT/var/lock
 }
@@ -100,7 +100,7 @@ platform_check_image_openmesh()
 {
 	local img_magic=$1
 	local img_path=$2
-	local fw_printenv=/usr/sbin/fw_printenv
+	local fw_setenv=/usr/sbin/fw_setenv
 	local img_board_target= img_num_files= i=0
 	local cfg_name= kernel_name= rootfs_name=
 
@@ -144,7 +144,7 @@ platform_check_image_openmesh()
 		return 1
 	}
 
-	[ ! -x "$fw_printenv" ] && {
+	[ ! -x "$fw_setenv" ] && {
 		echo "Please install uboot-envtools!"
 		return 1
 	}


### PR DESCRIPTION
There are still upgrade scripts which use the hook sysupgrade_pre_upgrade to prepare the ramdisk for the use of fw_setenv and fw_printenv:

* target/linux/ar71xx/base-files/lib/upgrade/allnet.sh
* target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
* target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh

But this hook was removed without any replacement in 6a27c2f4b1a4 ("base-files: drop fwtool_pre_upgrade"). Not running the hooks can either prevent a successful upgrade or brick the device.

And the behavior of install_bin was also changed in 438dcbfe74a6 ("base-files: automatically handle paths and symlinks for RAMFS_COPY_BIN") to ignore the second parameter. This then resulted in a not created fw_setenv (which is called by these scripts.

----

@NeoRaider This is the OpenWrt 18.06 PR mentioned in #1421.