### PR TITLE
tools/pkg-config: pass arguments at the end

### DIFF
--- a/tools/pkg-config/files/pkg-config
+++ b/tools/pkg-config/files/pkg-config
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pkg-config.real $@ --define-variable=prefix=${STAGING_PREFIX} --define-variable=exec_prefix=${STAGING_PREFIX}
+pkg-config.real --define-variable=prefix=${STAGING_PREFIX} --define-variable=exec_prefix=${STAGING_PREFIX} $@


### PR DESCRIPTION
Go for openwrt passes pkg-config arguments in the format of

        pkg-config --cflags -- pkg-name 

which in turn will be passed down to the real pkg-config as something
like

        pkg-config.real --cflags -- pkg-name --define...

and causes the real pkg-config implementation to missinterpret the given
argument list.

This also helps to fix https://github.com/golang/go/issues/27940
