### PR TITLE
ath79: add support for Buffalo WZR-HP-G302H A1A0

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -41,6 +41,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	buffalo,wzr-hp-g302h-a1a0)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
+		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -116,6 +116,7 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract_reverse "urloader" 5441 1088
 		;;
 	buffalo,whr-g301n|\
+	buffalo,wzr-hp-g302h-a1a0|\
 	tplink,tl-wr841-v5|\
 	tplink,tl-wr941-v4)
 		ath9k_eeprom_extract "art" 4096 3768

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7242.dtsi"
+
+/ {
+	compatible = "buffalo,wzr-hp-g302h-a1a0", "qca,ar7242";
+	model = "Buffalo WZR-HP-G302H A1A0";
+
+	aliases {
+		led-boot = &diag;
+		led-failsafe = &diag;
+		led-upgrade = &diag;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button_usb {
+			label = "usb";
+			linux,code = <BTN_2>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_on {
+			label = "router_on";
+			linux,code = <BTN_5>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		movie_engine {
+			label = "movie_engine";
+			linux,code = <BTN_3>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		diag: diag {
+			label = "buffalo:red:diag";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "buffalo:blue:usb";
+			gpios = <&ath9k 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		wireless {
+			label = "buffalo:green:wireless";
+			gpios = <&ath9k 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		security {
+			label = "buffalo:orange:security";
+			gpios = <&ath9k 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		router {
+			label = "buffalo:green:router";
+			gpios = <&ath9k 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		movie_engine_on {
+			label = "buffalo:blue:movie_engine_on";
+			gpios = <&ath9k 8 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		movie_engine_off {
+			label = "buffalo:blue:movie_engine_off";
+			gpios = <&ath9k 9 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "buffalo:usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&flash0 &flash1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x40000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x10000>;
+				label = "u-boot-env";
+			};
+
+			art: partition@50000 {
+				reg = <0x50000 0x10000>;
+				label = "art";
+				read-only;
+			};
+
+			partition@60000 {
+				reg = <0x60000 0x1f60000>;
+				label = "firmware";
+			};
+
+			partition@1fc0000 {
+				reg = <0x1fc0000 0x40000>;
+				label = "user_property";
+				read-only;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	cs-gpios = <0>, <0>;
+	num-cs = <2>;
+
+	flash0: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+	};
+
+	flash1: flash@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x1c000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x120c>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&art 0x120c>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/image/common-buffalo.mk
+++ b/target/linux/ath79/image/common-buffalo.mk
@@ -8,8 +8,9 @@ endef
 
 define Build/buffalo-tag
 	$(eval product=$(word 1,$(1)))
+	$(eval hwver=$(word 2,$(1)))
 	$(STAGING_DIR_HOST)/bin/buffalo-tag \
-		-c 0x80041000 -d 0x801e8000 -w 3 \
+		-c 0x80041000 -d 0x801e8000 -w $(hwver) \
 		-a ath -v 1.99 -m 1.01 -f 1 \
 		-b $(product) -p $(product) \
 		-r M_ -l mlang8 \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -95,6 +95,19 @@ define Device/buffalo_wzr-hp-ag300h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-ag300h
 
+define Device/buffalo_wzr-hp-g302h-a1a0
+  ATH_SOC := ar7242
+  DEVICE_TITLE := Buffalo WZR-HP-G302H A1A0
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  IMAGE_SIZE := 32128k
+  IMAGES += factory.bin tftp.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G302H 1.99 | buffalo-tag WZR-HP-G302H 4
+  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
+  SUPPORTED_DEVICES += wzr-hp-g300nh2
+endef
+TARGET_DEVICES += buffalo_wzr-hp-g302h-a1a0
+
 define Device/buffalo_wzr-hp-g450h
   ATH_SOC := ar7242
   DEVICE_TITLE := Buffalo WZR-HP-G450H/WZR-450HP

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -76,7 +76,7 @@ define Device/buffalo_bhr-4grv
   IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | buffalo-tag BHR-4GRV
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | buffalo-tag BHR-4GRV 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
 endef
@@ -88,7 +88,7 @@ define Device/buffalo_wzr-hp-ag300h
   IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-AG300H 1.99 | buffalo-tag WZR-HP-AG300H
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-AG300H 1.99 | buffalo-tag WZR-HP-AG300H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += wzr-hp-ag300h
@@ -102,7 +102,7 @@ define Device/buffalo_wzr-hp-g450h
   IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | buffalo-tag WZR-HP-G450H
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | buffalo-tag WZR-HP-G450H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
 endef

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -25,7 +25,7 @@ define Device/buffalo_whr-g301n
   IMAGE_SIZE := 3712k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | buffalo-tag WHR-G301N
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | buffalo-tag WHR-G301N 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += whr-g301n
 endef


### PR DESCRIPTION
Buffalo WZR-HP-G302H is a 2T2R 2.4 GHz 11n router, based on Atheros
AR7242.

It is Japanese market model of WZR-HP-G300NH2, but there are some
diffrences. This commit is based on WZR-HP-G300NH2 in ar71xx.
And, G302H has several hardware versions and hardware is different
dependent on the versions. This commit adds support for "A1A0"
version.

Specification:

- Atheros AR7242
- 64 MB of RAM (DDR2)
- 32 MB of Flash
  - 2x 16 MB SPI-NOR flash
- 2.4 GHz 2T2R wifi
  - Atheros AR9283
- 5x 10/100/1000 Mbps Ethernet
  - Atheros AR8316
- 7x LEDs, 5x keys
  - LED: 1x gpio-leds, 6x ath9k-leds
  - key: 3x buttons, 2x slide switches
- UART header on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Flash instruction using factory image:

1. Boot WZR-HP-G302H normaly and connect the computer to its LAN port
2. Access to "http://192.168.11.1/" and move to firmware update page
("ファーム更新")
3. Select the OpenWrt factory image and click update ("更新実行")
button to perform firmware update
4. Wait ~200 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>