### PR TITLE
ipq40xx: uboot envtools fix for GL.iNet GL-B1300 board

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -31,6 +31,7 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+glinet,gl-b1300 |\
 openmesh,a42 |\
 openmesh,a62)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
This pull request makes the uboot env partition readable on the GL.iNet GL-B1300 board.