### PR TITLE
ath79: add support for TP-Link TL-WA901ND v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\
+	tplink,tl-wa901nd-v2|\
 	tplink,tl-wr703n|\
 	ubnt,bullet-m|\
 	ubnt,rocket-m|\

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9132.dtsi"
+
+/ {
+	compatible = "tplink,tl-wa901nd-v2", "qca,ar9132";
+	model = "TP-Link TL-WA901ND v2";
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		qss {
+			label = "qss";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@1 {
+				label = "firmware";
+				reg = <0x020000 0x3D0000>;
+			};
+
+			art: partition@2 {
+				label = "art";
+				reg = <0x3F0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0c {
+		reg = <0x0c>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -51,6 +51,14 @@ define Device/tplink_tl-mr3420-v1
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v1
 
+define Device/tplink_tl-wa901nd-v2
+  $(Device/tplink-4m)
+  ATH_SOC := ar9132
+  DEVICE_TITLE := TP-Link TL-WA901ND v2
+  TPLINK_HWID := 0x09010002
+endef
+TARGET_DEVICES += tplink_tl-wa901nd-v2
+
 define Device/tplink_tl-wr703n
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331


### PR DESCRIPTION
This commit adds support for the TP-Link TL-WR901ND v2 access point.

CPU:    Atheros AR9132 400MHz
RAM:    32MB
FLASH: 4MiB
WiFi:   Atheros AR9103 3x3:2 bgn
LED:   Power (static on)
           LAN (controlled by PHY)
           SYS, WiFi, QSS toggleable
BTN:   Reset, QSS

Installation:
Upload the factory image via the vendor-GUI.
