### PR TITLE
ath79: use irq-ath79-misc for PCIE irq handling

### DIFF
--- a/target/linux/ath79/dts/ar724x.dtsi
+++ b/target/linux/ath79/dts/ar724x.dtsi
@@ -114,20 +114,28 @@
 				#size-cells = <2>;
 				bus-range = <0x0 0x0>;
 				reg = <0x180c0000 0x1000>, /* CRP */
-				      <0x180f0000 0x100>,  /* CTRL */
+				      <0x180f0000 0x4c>,  /* CTRL */
 				      <0x14000000 0x1000>; /* CFG */
 				reg-names = "crp_base", "ctrl_base", "cfg_base";
 				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+
+				#interrupt-cells = <1>;
+				interrupt-map-mask = <0 0 0 7>;
+				interrupt-map = <0 0 0 1 &pcie0_intc 14
+						 0 0 0 2 &pcie0_intc 15
+						 0 0 0 3 &pcie0_intc 16
+						 0 0 0 4 &pcie0_intc 17>;
+				status = "disabled";
+			};
+
+			pcie0_intc: interrupt-controller@180f004c {
+				compatible = "qca,ar7100-misc-intc";
+				reg = <0x180f004c 0x8>;
 				interrupt-parent = <&cpuintc>;
 				interrupts = <2>;
-
 				interrupt-controller;
 				#interrupt-cells = <1>;
-
-				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie 0>;
-				status = "disabled";
 			};
 		};
 

--- a/target/linux/ath79/dts/ar9344.dtsi
+++ b/target/linux/ath79/dts/ar9344.dtsi
@@ -38,21 +38,28 @@
 		#size-cells = <2>;
 		bus-range = <0x0 0x0>;
 		reg = <0x180c0000 0x1000>, /* CRP */
-				<0x180f0000 0x100>, /* CTRL */
+				<0x180f0000 0x4c>, /* CTRL */
 				<0x14000000 0x1000>; /* CFG */
 		reg-names = "crp_base", "ctrl_base", "cfg_base";
 		ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000 /* pci memory */
 				0x1000000 0 0x00000000 0x0000000 0 0x000001>; /* io space */
+
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0 0 0 7>;
+		interrupt-map = <0 0 0 1 &pcie0_intc 14
+				 0 0 0 2 &pcie0_intc 15
+				 0 0 0 3 &pcie0_intc 16
+				 0 0 0 4 &pcie0_intc 17>;
+		status = "disabled";
+	};
+
+	pcie0_intc: interrupt-controller@180f004c {
+		compatible = "qca,ar7100-misc-intc";
+		reg = <0x180f004c 0x8>;
 		interrupt-parent = <&intc2>;
 		interrupts = <1>;
-
 		interrupt-controller;
 		#interrupt-cells = <1>;
-
-		interrupt-map-mask = <0 0 0 1>;
-		interrupt-map = <0 0 0 0 &pcie 0>;
-
-		status = "disabled";
 	};
 };
 

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -150,20 +150,28 @@
 				#size-cells = <2>;
 				bus-range = <0x0 0x0>;
 				reg = <0x180c0000 0x1000>, /* CRP */
-				      <0x180f0000 0x100>,  /* CTRL */
+				      <0x180f0000 0x4c>,  /* CTRL */
 				      <0x14000000 0x1000>; /* CFG */
 				reg-names = "crp_base", "ctrl_base", "cfg_base";
 				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+
+				#interrupt-cells = <1>;
+				interrupt-map-mask = <0 0 0 7>;
+				interrupt-map = <0 0 0 1 &pcie0_intc 14
+						 0 0 0 2 &pcie0_intc 15
+						 0 0 0 3 &pcie0_intc 16
+						 0 0 0 4 &pcie0_intc 17>;
+				status = "disabled";
+			};
+
+			pcie0_intc: interrupt-controller@180f004c {
+				compatible = "qca,ar7100-misc-intc";
+				reg = <0x180f004c 0x8>;
 				interrupt-parent = <&intc2>;
 				interrupts = <1>;
-
 				interrupt-controller;
 				#interrupt-cells = <1>;
-
-				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie0 0>;
-				status = "disabled";
 			};
 
 			gmac: gmac@18070000 {

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -182,20 +182,28 @@
 				#size-cells = <2>;
 				bus-range = <0x0 0x0>;
 				reg = <0x180c0000 0x1000>, /* CRP */
-				      <0x180f0000 0x100>,  /* CTRL */
+				      <0x180f0000 0x4c>,  /* CTRL */
 				      <0x14000000 0x1000>; /* CFG */
 				reg-names = "crp_base", "ctrl_base", "cfg_base";
 				ranges = <0x2000000 0 0x10000000 0x10000000 0 0x04000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+
+				#interrupt-cells = <1>;
+				interrupt-map-mask = <0 0 0 7>;
+				interrupt-map = <0 0 0 1 &pcie0_intc 14
+						 0 0 0 2 &pcie0_intc 15
+						 0 0 0 3 &pcie0_intc 16
+						 0 0 0 4 &pcie0_intc 17>;
+				status = "disabled";
+			};
+
+			pcie0_intc: interrupt-controller@180f004c {
+				compatible = "qca,ar7100-misc-intc";
+				reg = <0x180f004c 0x8>;
 				interrupt-parent = <&intc2>;
 				interrupts = <1>;
-
 				interrupt-controller;
 				#interrupt-cells = <1>;
-
-				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie0 0>;
-				status = "disabled";
 			};
 
 			pcie1: pcie-controller@18250000 {
@@ -204,20 +212,28 @@
 				#size-cells = <2>;
 				bus-range = <0x0 0x0>;
 				reg = <0x18250000 0x1000>, /* CRP */
-				      <0x18280000 0x100>,  /* CTRL */
+				      <0x18280000 0x4c>,  /* CTRL */
 				      <0x16000000 0x1000>; /* CFG */
 				reg-names = "crp_base", "ctrl_base", "cfg_base";
 				ranges = <0x2000000 0 0x12000000 0x12000000 0 0x02000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+
+				#interrupt-cells = <1>;
+				interrupt-map-mask = <0 0 0 7>;
+				interrupt-map = <0 0 0 1 &pcie1_intc 14
+						 0 0 0 2 &pcie1_intc 15
+						 0 0 0 3 &pcie1_intc 16
+						 0 0 0 4 &pcie1_intc 17>;
+				status = "disabled";
+			};
+
+			pcie1_intc: interrupt-controller@1828004c {
+				compatible = "qca,ar7100-misc-intc";
+				reg = <0x1828004c 0x8>;
 				interrupt-parent = <&intc3>;
 				interrupts = <0>;
-
 				interrupt-controller;
 				#interrupt-cells = <1>;
-
-				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie1 0>;
-				status = "disabled";
 			};
 
 			gmac: gmac@18070000 {

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -155,20 +155,28 @@
 				#size-cells = <2>;
 				bus-range = <0x0 0x0>;
 				reg = <0x18250000 0x1000>, /* CRP */
-				      <0x18280000 0x100>,  /* CTRL */
+				      <0x18280000 0x4c>,  /* CTRL */
 				      <0x16000000 0x1000>; /* CFG */
 				reg-names = "crp_base", "ctrl_base", "cfg_base";
 				ranges = <0x2000000 0 0x12000000 0x12000000 0 0x02000000	/* pci memory */
 					  0x1000000 0 0x00000000 0x0000000 0 0x000001>;		/* io space */
+
+				#interrupt-cells = <1>;
+				interrupt-map-mask = <0 0 0 7>;
+				interrupt-map = <0 0 0 1 &pcie0_intc 14
+						 0 0 0 2 &pcie0_intc 15
+						 0 0 0 3 &pcie0_intc 16
+						 0 0 0 4 &pcie0_intc 17>;
+				status = "disabled";
+			};
+
+			pcie0_intc: interrupt-controller@1828004c {
+				compatible = "qca,ar7100-misc-intc";
+				reg = <0x1828004c 0x8>;
 				interrupt-parent = <&intc3>;
 				interrupts = <0>;
-
 				interrupt-controller;
 				#interrupt-cells = <1>;
-
-				interrupt-map-mask = <0 0 0 1>;
-				interrupt-map = <0 0 0 0 &pcie 0>;
-				status = "disabled";
 			};
 		};
 

--- a/target/linux/ath79/patches-4.14/0040-irqchip-ath79-misc-split-ath79_misc_irq_chip-into-tw.patch
+++ b/target/linux/ath79/patches-4.14/0040-irqchip-ath79-misc-split-ath79_misc_irq_chip-into-tw.patch
@@ -1,0 +1,134 @@
+From 97c1b677e5f04a559413a25644dc4c92e42d5347 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Thu, 4 Oct 2018 15:42:25 +0800
+Subject: [PATCH 1/2] irqchip: ath79-misc: split ath79_misc_irq_chip into two
+ structs
+
+The original code use one irq_chip for two different irq handling
+behaviors, meaning that we can't use both qca,ar7100-misc-intc and
+qca,ar7240-misc-intc on the same device. (The difference between
+them is whether it needs a write to clear the INT_STATUS register)
+This driver is also suitable for handling PCI interrupts and to use
+this for ar724x and later devices we need to use both behaviors at
+the same time. (misc_intc needs an ack but pcie_intc doesn't)
+
+This patch defines separated irq_chip and irq_domain_ops for two
+types of misc_intc to solve this problem.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ drivers/irqchip/irq-ath79-misc.c | 51 +++++++++++++++++++++-----------
+ 1 file changed, 33 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/irqchip/irq-ath79-misc.c b/drivers/irqchip/irq-ath79-misc.c
+index aa729078..5ee471d2 100644
+--- a/drivers/irqchip/irq-ath79-misc.c
++++ b/drivers/irqchip/irq-ath79-misc.c
+@@ -90,22 +90,43 @@ static void ar724x_misc_irq_ack(struct irq_data *d)
+ 	__raw_readl(base + AR71XX_RESET_REG_MISC_INT_STATUS);
+ }
+ 
+-static struct irq_chip ath79_misc_irq_chip = {
+-	.name		= "MISC",
++static struct irq_chip ar71xx_misc_irq_chip = {
++	.name			= "AR7100_MISC",
++	.irq_unmask		= ar71xx_misc_irq_unmask,
++	.irq_mask		= ar71xx_misc_irq_mask,
++	.irq_mask_ack	= ar71xx_misc_irq_mask,
++};
++
++static int ar71xx_misc_map(struct irq_domain *d, unsigned int irq, irq_hw_number_t hw)
++{
++	irq_set_chip_and_handler(irq, &ar71xx_misc_irq_chip, handle_level_irq);
++	irq_set_chip_data(irq, d->host_data);
++	return 0;
++}
++
++static const struct irq_domain_ops ar71xx_misc_irq_domain_ops = {
++	.xlate = irq_domain_xlate_onecell,
++	.map = ar71xx_misc_map,
++};
++
++
++static struct irq_chip ar724x_misc_irq_chip = {
++	.name		= "AR724X_MISC",
+ 	.irq_unmask	= ar71xx_misc_irq_unmask,
+ 	.irq_mask	= ar71xx_misc_irq_mask,
++	.irq_ack	= ar724x_misc_irq_ack,
+ };
+ 
+-static int misc_map(struct irq_domain *d, unsigned int irq, irq_hw_number_t hw)
++static int ar724x_misc_map(struct irq_domain *d, unsigned int irq, irq_hw_number_t hw)
+ {
+-	irq_set_chip_and_handler(irq, &ath79_misc_irq_chip, handle_level_irq);
++	irq_set_chip_and_handler(irq, &ar724x_misc_irq_chip, handle_level_irq);
+ 	irq_set_chip_data(irq, d->host_data);
+ 	return 0;
+ }
+ 
+-static const struct irq_domain_ops misc_irq_domain_ops = {
++static const struct irq_domain_ops ar724x_misc_irq_domain_ops = {
+ 	.xlate = irq_domain_xlate_onecell,
+-	.map = misc_map,
++	.map = ar724x_misc_map,
+ };
+ 
+ static void __init ath79_misc_intc_domain_init(
+@@ -121,7 +142,8 @@ static void __init ath79_misc_intc_domain_init(
+ }
+ 
+ static int __init ath79_misc_intc_of_init(
+-	struct device_node *node, struct device_node *parent)
++	struct device_node *node, struct device_node *parent,
++	const struct irq_domain_ops *misc_irq_domain_ops)
+ {
+ 	struct irq_domain *domain;
+ 	void __iomem *base;
+@@ -140,7 +162,7 @@ static int __init ath79_misc_intc_of_init(
+ 	}
+ 
+ 	domain = irq_domain_add_linear(node, ATH79_MISC_IRQ_COUNT,
+-				&misc_irq_domain_ops, base);
++				misc_irq_domain_ops, base);
+ 	if (!domain) {
+ 		pr_err("Failed to add MISC irqdomain\n");
+ 		return -EINVAL;
+@@ -153,8 +175,7 @@ static int __init ath79_misc_intc_of_init(
+ static int __init ar7100_misc_intc_of_init(
+ 	struct device_node *node, struct device_node *parent)
+ {
+-	ath79_misc_irq_chip.irq_mask_ack = ar71xx_misc_irq_mask;
+-	return ath79_misc_intc_of_init(node, parent);
++	return ath79_misc_intc_of_init(node, parent, &ar71xx_misc_irq_domain_ops);
+ }
+ 
+ IRQCHIP_DECLARE(ar7100_misc_intc, "qca,ar7100-misc-intc",
+@@ -163,8 +184,7 @@ IRQCHIP_DECLARE(ar7100_misc_intc, "qca,ar7100-misc-intc",
+ static int __init ar7240_misc_intc_of_init(
+ 	struct device_node *node, struct device_node *parent)
+ {
+-	ath79_misc_irq_chip.irq_ack = ar724x_misc_irq_ack;
+-	return ath79_misc_intc_of_init(node, parent);
++	return ath79_misc_intc_of_init(node, parent, &ar724x_misc_irq_domain_ops);
+ }
+ 
+ IRQCHIP_DECLARE(ar7240_misc_intc, "qca,ar7240-misc-intc",
+@@ -175,13 +195,9 @@ void __init ath79_misc_irq_init(void __iomem *regs, int irq,
+ {
+ 	struct irq_domain *domain;
+ 
+-	if (is_ar71xx)
+-		ath79_misc_irq_chip.irq_mask_ack = ar71xx_misc_irq_mask;
+-	else
+-		ath79_misc_irq_chip.irq_ack = ar724x_misc_irq_ack;
+-
+ 	domain = irq_domain_add_legacy(NULL, ATH79_MISC_IRQ_COUNT,
+-			irq_base, 0, &misc_irq_domain_ops, regs);
++			irq_base, 0, is_ar71xx ? &ar71xx_misc_irq_domain_ops
++			: &ar724x_misc_irq_domain_ops, regs);
+ 	if (!domain)
+ 		panic("Failed to create MISC irqdomain");
+ 
+-- 
+2.17.1
+

--- a/target/linux/ath79/patches-4.14/0041-MIPS-pci-ar724x-remove-irq-handling-code.patch
+++ b/target/linux/ath79/patches-4.14/0041-MIPS-pci-ar724x-remove-irq-handling-code.patch
@@ -1,0 +1,196 @@
+From 12d941b9836a91d44ecd576916d212d1319e9d0a Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Thu, 4 Oct 2018 15:52:56 +0800
+Subject: [PATCH] MIPS: pci-ar724x: remove irq handling code
+
+They can be completedly replaced by qca,ar7100-misc-intc.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ arch/mips/pci/pci-ar724x.c | 111 -------------------------------------
+ 1 file changed, 111 deletions(-)
+
+--- a/arch/mips/pci/pci-ar724x.c
++++ b/arch/mips/pci/pci-ar724x.c
+@@ -9,30 +9,21 @@
+  *  by the Free Software Foundation.
+  */
+ 
+-#include <linux/irq.h>
+ #include <linux/pci.h>
+ #include <linux/init.h>
+ #include <linux/delay.h>
+ #include <linux/platform_device.h>
+-#include <linux/irqchip/chained_irq.h>
+ #include <asm/mach-ath79/ath79.h>
+ #include <asm/mach-ath79/ar71xx_regs.h>
+-#include <linux/of_irq.h>
+ #include <linux/of_pci.h>
+ 
+ #define AR724X_PCI_REG_APP		0x00
+ #define AR724X_PCI_REG_RESET		0x18
+-#define AR724X_PCI_REG_INT_STATUS	0x4c
+-#define AR724X_PCI_REG_INT_MASK		0x50
+ 
+ #define AR724X_PCI_APP_LTSSM_ENABLE	BIT(0)
+ 
+ #define AR724X_PCI_RESET_LINK_UP	BIT(0)
+ 
+-#define AR724X_PCI_INT_DEV0		BIT(14)
+-
+-#define AR724X_PCI_IRQ_COUNT		1
+-
+ #define AR7240_BAR0_WAR_VALUE	0xffff
+ 
+ #define AR724X_PCI_CMD_INIT	(PCI_COMMAND_MEMORY |		\
+@@ -47,21 +38,16 @@ struct ar724x_pci_controller {
+ 	void __iomem *ctrl_base;
+ 	void __iomem *crp_base;
+ 
+-	int irq;
+-
+ 	bool link_up;
+ 	bool bar0_is_cached;
+ 	u32  bar0_value;
+ 
+ 	struct device_node *np;
+ 	struct pci_controller pci_controller;
+-	struct irq_domain *domain;
+ 	struct resource io_res;
+ 	struct resource mem_res;
+ };
+ 
+-static struct irq_chip ar724x_pci_irq_chip;
+-
+ static inline bool ar724x_pci_check_link(struct ar724x_pci_controller *apc)
+ {
+ 	u32 reset;
+@@ -235,108 +221,6 @@ static struct pci_ops ar724x_pci_ops = {
+ 	.write	= ar724x_pci_write,
+ };
+ 
+-static void ar724x_pci_irq_handler(struct irq_desc *desc)
+-{
+-	struct irq_chip *chip = irq_desc_get_chip(desc);
+-	struct ar724x_pci_controller *apc = irq_desc_get_handler_data(desc);
+-	u32 pending;
+-
+-	chained_irq_enter(chip, desc);
+-	pending = __raw_readl(apc->ctrl_base + AR724X_PCI_REG_INT_STATUS) &
+-		  __raw_readl(apc->ctrl_base + AR724X_PCI_REG_INT_MASK);
+-
+-	if (pending & AR724X_PCI_INT_DEV0)
+-		generic_handle_irq(irq_linear_revmap(apc->domain, 1));
+-	else
+-		spurious_interrupt();
+-	chained_irq_exit(chip, desc);
+-}
+-
+-static void ar724x_pci_irq_unmask(struct irq_data *d)
+-{
+-	struct ar724x_pci_controller *apc;
+-	void __iomem *base;
+-	u32 t;
+-
+-	apc = irq_data_get_irq_chip_data(d);
+-	base = apc->ctrl_base;
+-
+-	switch (irq_linear_revmap(apc->domain, d->irq)) {
+-	case 0:
+-		t = __raw_readl(base + AR724X_PCI_REG_INT_MASK);
+-		__raw_writel(t | AR724X_PCI_INT_DEV0,
+-			     base + AR724X_PCI_REG_INT_MASK);
+-		/* flush write */
+-		__raw_readl(base + AR724X_PCI_REG_INT_MASK);
+-	}
+-}
+-
+-static void ar724x_pci_irq_mask(struct irq_data *d)
+-{
+-	struct ar724x_pci_controller *apc;
+-	void __iomem *base;
+-	u32 t;
+-
+-	apc = irq_data_get_irq_chip_data(d);
+-	base = apc->ctrl_base;
+-
+-	switch (irq_linear_revmap(apc->domain, d->irq)) {
+-	case 0:
+-		t = __raw_readl(base + AR724X_PCI_REG_INT_MASK);
+-		__raw_writel(t & ~AR724X_PCI_INT_DEV0,
+-			     base + AR724X_PCI_REG_INT_MASK);
+-
+-		/* flush write */
+-		__raw_readl(base + AR724X_PCI_REG_INT_MASK);
+-
+-		t = __raw_readl(base + AR724X_PCI_REG_INT_STATUS);
+-		__raw_writel(t | AR724X_PCI_INT_DEV0,
+-			     base + AR724X_PCI_REG_INT_STATUS);
+-
+-		/* flush write */
+-		__raw_readl(base + AR724X_PCI_REG_INT_STATUS);
+-	}
+-}
+-
+-static struct irq_chip ar724x_pci_irq_chip = {
+-	.name		= "AR724X PCI ",
+-	.irq_mask	= ar724x_pci_irq_mask,
+-	.irq_unmask	= ar724x_pci_irq_unmask,
+-	.irq_mask_ack	= ar724x_pci_irq_mask,
+-};
+-
+-static int ar724x_pci_irq_map(struct irq_domain *d,
+-			      unsigned int irq, irq_hw_number_t hw)
+-{
+-	struct ar724x_pci_controller *apc = d->host_data;
+-
+-	irq_set_chip_and_handler(irq, &ar724x_pci_irq_chip, handle_level_irq);
+-	irq_set_chip_data(irq, apc);
+-
+-	return 0;
+-}
+-
+-static const struct irq_domain_ops ar724x_pci_domain_ops = {
+-	.xlate = irq_domain_xlate_onecell,
+-	.map = ar724x_pci_irq_map,
+-};
+-
+-static void ar724x_pci_irq_init(struct ar724x_pci_controller *apc,
+-				int id)
+-{
+-	void __iomem *base;
+-
+-	base = apc->ctrl_base;
+-
+-	__raw_writel(0, base + AR724X_PCI_REG_INT_MASK);
+-	__raw_writel(0, base + AR724X_PCI_REG_INT_STATUS);
+-
+-	apc->domain = irq_domain_add_linear(apc->np, 2,
+-					    &ar724x_pci_domain_ops, apc);
+-	irq_set_chained_handler_and_data(apc->irq, ar724x_pci_irq_handler,
+-					 apc);
+-}
+-
+ static void ar724x_pci_hw_init(struct ar724x_pci_controller *apc)
+ {
+ 	u32 ppl, app;
+@@ -398,10 +282,6 @@ static int ar724x_pci_probe(struct platf
+ 	if (IS_ERR(apc->crp_base))
+ 		return PTR_ERR(apc->crp_base);
+ 
+-	apc->irq = platform_get_irq(pdev, 0);
+-	if (apc->irq < 0)
+-		return -EINVAL;
+-
+ 	apc->np = pdev->dev.of_node;
+ 	apc->pci_controller.pci_ops = &ar724x_pci_ops;
+ 	apc->pci_controller.io_resource = &apc->io_res;
+@@ -419,8 +299,6 @@ static int ar724x_pci_probe(struct platf
+ 	if (!apc->link_up)
+ 		dev_warn(&pdev->dev, "PCIe link is down\n");
+ 
+-	ar724x_pci_irq_init(apc, id);
+-
+ 	ar724x_pci_local_write(apc, PCI_COMMAND, 4, AR724X_PCI_CMD_INIT);
+ 
+ 	register_pci_controller(&apc->pci_controller);


### PR DESCRIPTION
This helps reducing code duplication and removes the incorrect (but coincidentally work) IRQ handling code in PCIE driver.
Patches aren't sent upstream because I don't know which list I should send it to and how to test the patches with mainline kernel.
Tested on TL-WR940N v1(AR7240+AR9280) and TL-WDR4900 v2(QCA9558+AR9580)