### PR TITLE
kernel: mac80211: reapply 70afc0bd to fix ath9k gpio leds

### DIFF
--- a/package/kernel/mac80211/patches/ath/548-ath9k_enable_gpio_chip.patch
+++ b/package/kernel/mac80211/patches/ath/548-ath9k_enable_gpio_chip.patch
@@ -45,7 +45,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #ifdef CPTCFG_ATH9K_DEBUGFS
 --- a/drivers/net/wireless/ath/ath9k/gpio.c
 +++ b/drivers/net/wireless/ath/ath9k/gpio.c
-@@ -16,13 +16,130 @@
+@@ -16,13 +16,135 @@
  
  #include "ath9k.h"
  #include <linux/ath9k_platform.h>
@@ -127,6 +127,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	snprintf(gc->label, sizeof(gc->label), "ath9k-%s",
 +		 wiphy_name(sc->hw->wiphy));
 +
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
++	gc->gchip.parent = sc->dev;
++#else
++	gc->gchip.dev = sc->dev;
++#endif
 +	gc->gchip.label = gc->label;
 +	gc->gchip.base = -1;	/* determine base automatically */
 +	gc->gchip.ngpio = ah->caps.num_gpio_pins;
@@ -178,7 +183,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static void ath_fill_led_pin(struct ath_softc *sc)
  {
  	struct ath_hw *ah = sc->sc_ah;
-@@ -80,6 +197,12 @@ static int ath_add_led(struct ath_softc
+@@ -80,6 +202,12 @@ static int ath_add_led(struct ath_softc
  	else
  		ath9k_hw_set_gpio(sc->sc_ah, gpio->gpio, gpio->active_low);
  
@@ -191,7 +196,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	return 0;
  }
  
-@@ -136,17 +259,24 @@ void ath_deinit_leds(struct ath_softc *s
+@@ -136,17 +264,24 @@ void ath_deinit_leds(struct ath_softc *s
  
  	while (!list_empty(&sc->leds)) {
  		led = list_first_entry(&sc->leds, struct ath_led, list);
@@ -216,7 +221,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	char led_name[32];
  	const char *trigger;
  	int i;
-@@ -156,6 +286,15 @@ void ath_init_leds(struct ath_softc *sc)
+@@ -156,6 +291,15 @@ void ath_init_leds(struct ath_softc *sc)
  	if (AR_SREV_9100(sc->sc_ah))
  		return;
  
@@ -232,7 +237,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ath_fill_led_pin(sc);
  
  	if (pdata && pdata->leds && pdata->num_leds)
-@@ -180,6 +319,7 @@ void ath_init_leds(struct ath_softc *sc)
+@@ -180,6 +324,7 @@ void ath_init_leds(struct ath_softc *sc)
  	ath_create_gpio_led(sc, sc->sc_ah->led_pin, led_name, trigger,
  			   !sc->sc_ah->config.led_active_high);
  }

--- a/package/kernel/mac80211/patches/ath/549-ath9k_enable_gpio_buttons.patch
+++ b/package/kernel/mac80211/patches/ath/549-ath9k_enable_gpio_buttons.patch
@@ -29,7 +29,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #ifdef CPTCFG_MAC80211_LEDS
  
-@@ -124,6 +126,67 @@ static void ath9k_unregister_gpio_chip(s
+@@ -129,6 +131,67 @@ static void ath9k_unregister_gpio_chip(s
  	sc->gpiochip = NULL;
  }
  
@@ -97,7 +97,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #else /* CONFIG_GPIOLIB */
  
  static inline void ath9k_register_gpio_chip(struct ath_softc *sc)
-@@ -134,6 +197,14 @@ static inline void ath9k_unregister_gpio
+@@ -139,6 +202,14 @@ static inline void ath9k_unregister_gpio
  {
  }
  
@@ -112,7 +112,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #endif /* CONFIG_GPIOLIB */
  
  /********************************/
-@@ -257,6 +328,7 @@ void ath_deinit_leds(struct ath_softc *s
+@@ -262,6 +333,7 @@ void ath_deinit_leds(struct ath_softc *s
  {
  	struct ath_led *led;
  
@@ -120,7 +120,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	while (!list_empty(&sc->leds)) {
  		led = list_first_entry(&sc->leds, struct ath_led, list);
  #ifdef CONFIG_GPIOLIB
-@@ -296,6 +368,7 @@ void ath_init_leds(struct ath_softc *sc)
+@@ -301,6 +373,7 @@ void ath_init_leds(struct ath_softc *sc)
  	}
  
  	ath_fill_led_pin(sc);


### PR DESCRIPTION
It seems that this commit got accidentally dropped during mac80211 bump,
breaking all ath9k leds in ath79 target.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>

