### PR TITLE
ath79: add support for PQI Air Pen

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 	ocedo,raccoon|\
 	pcs,cap324|\
 	pisen,wmm003n|\
+	pqi,air-pen|\
 	tplink,re450-v2|\
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -148,6 +148,9 @@ case "$FIRMWARE" in
 	ubnt,unifi)
 		ath9k_eeprom_extract "art" 4096 2048
 		;;
+	pqi,air-pen)
+		ath9k_eeprom_extract "art" 4096 2002
+		;;
 	wd,mynet-wifi-rangeextender)
 		ath9k_eeprom_extract "art" 4096 4096
 		ath9k_patch_fw_mac_crc $(nvram get wl0_hwaddr) "$mac" 2

--- a/target/linux/ath79/dts/ar9330_pqi-air-pen.dts
+++ b/target/linux/ath79/dts/ar9330_pqi-air-pen.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9330.dtsi"
+
+/ {
+	model = "PQI Air-Pen";
+	compatible = "pqi,air-pen", "qca,ar9330";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &wlan;
+		led-failsafe = &wlan;
+		led-upgrade = &wlan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan: wlan {
+			label = "air-pen:blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "air-pen:blue:wps";
+			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <104000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "NVRAM";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "firmware";
+				reg = <0x070000 0x780000>;
+			};
+
+			partition@7f0000 {
+				label = "CONF";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x1002>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x2>;
+};

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -30,3 +30,13 @@ define Device/buffalo_whr-g301n
   SUPPORTED_DEVICES += whr-g301n
 endef
 TARGET_DEVICES += buffalo_whr-g301n
+
+define Device/pqi-air-pen
+  ATH_SOC := ar9330
+  DEVICE_TITLE := PQI Air-Pen
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
+  IMAGE_SIZE := 7680k
+  SUPPORTED_DEVICES += pqi-air-pen
+endef
+TARGET_DEVICES += pqi-air-pen
+


### PR DESCRIPTION
SoC: AR9330 (or AR9331 revision?)
Ethernet x1, Wireless 2.4G, uSD card slot x1.
USB Power, include Li-Po Battery.

Installation:
Upload the image from telnet command line.
Flash 8MiB. (factory is dual image)
write image is use half 4MiB size from factory.
rewrite 8MiB all size after write openwrt once.

Signed-off-by: YuheiOKAWA <tochiro.srchack@gmail.com>