### PR TITLE
mac80211: Use @KERNEL alias instead of hardlink

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=mac80211
 
 PKG_VERSION:=4.19-rc5-1
 PKG_RELEASE:=1
-PKG_SOURCE_URL:=https://mirrors.edge.kernel.org/pub/linux/kernel/projects/backports/stable/v4.19-rc5/
+PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v4.19-rc5/
 PKG_HASH:=5b61e64ea79d22bbac9e8612d5d5485974f223de00d4ec250b0faf4b7baf9957
 
 PKG_SOURCE:=backports-$(PKG_VERSION).tar.xz


### PR DESCRIPTION
Use @KERNEL alias provided by toolchain instead of relying on a specific site.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>