### PR TITLE
busybox: fix dependency issue for IPV6 (V2)

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -2124,6 +2124,7 @@ config BUSYBOX_DEFAULT_WATCHDOG
 	default n
 config BUSYBOX_DEFAULT_FEATURE_IPV6
 	bool
+	depends on IPV6
 	default y
 config BUSYBOX_DEFAULT_FEATURE_UNIX_LOCAL
 	bool

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.29.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/config/networking/Config.in
+++ b/package/utils/busybox/config/networking/Config.in
@@ -9,7 +9,6 @@ menu "Networking Utilities"
 config BUSYBOX_CONFIG_FEATURE_IPV6
 	bool "Enable IPv6 support"
 	default BUSYBOX_DEFAULT_FEATURE_IPV6
-	depends on IPV6
 	help
 	  Enable IPv6 support in busybox.
 	  This adds IPv6 support in the networking applets.


### PR DESCRIPTION
For the previous commit, I found that adding dependency in file **networking/Config.in** can not avoid install the **ping6** and **traceroute6** utilities, beacuse the PING6 and TRACEROUTE6 depends on the DEFAULT_FEATURE_IPV6 which is **y** as default. This commit can fix the issue. @jow- @dedeckeh 

Signed-off-by: Rosy Song <rosysong@rosinson.com>

