### PR TITLE
ath79: add support for ROSINSON WR818 board

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -105,6 +105,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan:1" "5:lan:2" "4:wan"
 		;;
+	rosinson,wr818)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:wan"
+		;;
 	tplink,archer-c7-v1|\
 	tplink,archer-c7-v2|\
 	tplink,tl-wdr4900-v2)
@@ -223,6 +227,10 @@ ath79_setup_macs()
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")
 		wan_mac=$(k2t_get_mac "wan_mac")
+		;;
+	rosinson,wr818)
+		wan_mac=$(mtd_get_mac_binary factory 0)
+		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
 	tplink,tl-wr1043nd-v4)
 		base_mac=$(mtd_get_mac_binary product-info 8)

--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	model = "ROSINSON WR818";
+	compatible = "rosinson,wr818";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "wr818:red:system";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_2g {
+			label = "wr818:red:wifi2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xf80000>;
+			};
+
+			info: partition@fe0000 {
+				label = "factory";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x0>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -341,3 +341,12 @@ define Device/wd_mynet-wifi-rangeextender
   SUPPORTED_DEVICES += mynet-rext
 endef
 TARGET_DEVICES += wd_mynet-wifi-rangeextender
+
+define Device/rosinson_wr818
+  ATH_SOC := qca9563
+  DEVICE_TITLE := ROSINSON WR818
+  IMAGE_SIZE := 15936k
+  IMAGES := sysupgrade.bin
+  DEVICE_PACKAGES := kmod-usb2
+endef
+TARGET_DEVICES += rosinson_wr818


### PR DESCRIPTION
This commit adds support for the **ROSINSON WR818** WiFi-Router

* SoC:       Qualcomm Atheros QCA9563,
* FLASH:   Winbond W25Q128FV 16MBytes,
* WiFi:       QCA9563 b/g/n 3x3 450Mbit/s,
* USB:       1x USB 2.0 Type A, **1x USB2.0 Type C**,
* IN:           WPS/Reset button GPIO1,
* OUT:       Power LED red, Internet LED red, WLAN LED red, LAN1 LED red, LAN2 LED red, System LED red,
* UART:   RX-GPIO18, TX-GPIO22,

Tested and working:
  *  Ethernet (LAN + WAN)
  *  WiFi
  *  OpenWRT sysupgrade
  *  Button
  *  LEDs

Signed-off-by: Rosy Song <rosysong@rosinson.com>

**Official Site : www.rosinson.com**
