### PR TITLE
ramips: add audio support for Vocore2

### DIFF
--- a/target/linux/generic/hack-4.14/252-asoc-es8328-allow-no-clk.patch
+++ b/target/linux/generic/hack-4.14/252-asoc-es8328-allow-no-clk.patch
@@ -1,0 +1,52 @@
+--- a/sound/soc/codecs/es8328.c	2018-09-20 05:43:49.000000000 +0900
++++ b/sound/soc/codecs/es8328.c	2018-09-29 15:35:05.967572228 +0900
+@@ -728,7 +728,8 @@ static int es8328_suspend(struct snd_soc
+ 
+ 	es8328 = snd_soc_codec_get_drvdata(codec);
+ 
+-	clk_disable_unprepare(es8328->clk);
++	if (es8328->clk)
++		clk_disable_unprepare(es8328->clk);
+ 
+ 	ret = regulator_bulk_disable(ARRAY_SIZE(es8328->supplies),
+ 			es8328->supplies);
+@@ -747,10 +748,12 @@ static int es8328_resume(struct snd_soc_
+ 
+ 	es8328 = snd_soc_codec_get_drvdata(codec);
+ 
+-	ret = clk_prepare_enable(es8328->clk);
+-	if (ret) {
+-		dev_err(codec->dev, "unable to enable clock\n");
+-		return ret;
++	if (es8328->clk) {
++		ret = clk_prepare_enable(es8328->clk);
++		if (ret) {
++			dev_err(codec->dev, "unable to enable clock\n");
++			return ret;
++		}
+ 	}
+ 
+ 	ret = regulator_bulk_enable(ARRAY_SIZE(es8328->supplies),
+@@ -787,15 +790,14 @@ static int es8328_codec_probe(struct snd
+ 	/* Setup clocks */
+ 	es8328->clk = devm_clk_get(codec->dev, NULL);
+ 	if (IS_ERR(es8328->clk)) {
++		es8328->clk = NULL;
+ 		dev_err(codec->dev, "codec clock missing or invalid\n");
+-		ret = PTR_ERR(es8328->clk);
+-		goto clk_fail;
+-	}
+-
+-	ret = clk_prepare_enable(es8328->clk);
+-	if (ret) {
+-		dev_err(codec->dev, "unable to prepare codec clk\n");
+-		goto clk_fail;
++	} else {
++		ret = clk_prepare_enable(es8328->clk);
++		if (ret) {
++			dev_err(codec->dev, "unable to prepare codec clk\n");
++			goto clk_fail;
++		}
+ 	}
+ 
+ 	return 0;

--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -20,6 +20,46 @@
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	i2c_gpio: i2c-gpio {
+		compatible = "i2c-gpio";
+
+		gpios = <&gpio0 5 0
+			 &gpio0 4 0>;
+		i2c-gpio,delay-us = <5>;
+
+		codec: es8388@10 {
+			compatible = "everest,es8388";
+			reg = <0x10>;
+
+			#sound-dai-cells = <0>;
+
+			status = "okay";
+		};
+	};
+
+	sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "audio_i2s";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,bitclock-master = <&dailink_master>;
+		simple-audio-card,frame-master = <&dailink_master>;
+		simple-audio-card,widgets =
+			"Headphone", "Headphones",
+			"Microphone", "Mic";
+		simple-audio-card,routing =
+			"Headphones", "LOUT1",
+			"Headphones", "ROUT1",
+			"LINPUT1", "Mic";
+
+		dailink_master: simple-audio-card,cpu {
+			sound-dai = <&i2s>;
+		};
+
+		simple-audio-card,codec {
+			sound-dai = <&codec>;
+		};
+	};
 };
 
 &spi0 {
@@ -60,4 +100,22 @@
 			};
 		};
 	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&i2s {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s_pins>, <&gpio_refclk_pins>;
+
+	#sound-dai-cells = <0>;
+
+	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -364,6 +364,19 @@
 				ralink,function = "refclk";
 			};
 		};
+
+		gpio_pins: gpio {
+			gpio {
+				ralink,group = "gpio";
+				ralink,function = "gpio";
+			};
+		};
+		gpio_refclk_pins: gpio_refclk {
+			gpio {
+				ralink,group = "gpio";
+				ralink,function = "refclk";
+			};
+		};
 	};
 
 	rstctrl: rstctrl {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -82,7 +82,7 @@ TARGET_DEVICES += ArcherMR200
 define Device/bocco
   DTS := BOCCO
   DEVICE_TITLE := YUKAI Engineering BOCCO
-  DEVICE_PACKAGES := kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
+  DEVICE_PACKAGES := kmod-sound-core kmod-sound-ralink-i2s kmod-sound-soc-wm8960 kmod-sound-soc-simple-card kmod-i2c-ralink
 endef
 TARGET_DEVICES += bocco
 
@@ -104,7 +104,7 @@ define Device/cs-qr10
   DTS := CS-QR10
   DEVICE_TITLE := Planex CS-QR10
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci \
-	kmod-sound-core kmod-sound-mt7620 \
+	kmod-sound-core kmod-sound-ralink-i2s kmod-sound-soc-wm8960 kmod-sound-soc-simple-card \
 	kmod-i2c-ralink kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += cs-qr10
@@ -139,7 +139,7 @@ define Device/dch-m225
 	seama-seal -m "signature=wapn22_dlink.2013gui_dap1320b" | \
 	check-size $$$$(IMAGE_SIZE)
   DEVICE_TITLE := D-Link DCH-M225
-  DEVICE_PACKAGES := kmod-mt76 kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
+  DEVICE_PACKAGES := kmod-mt76 kmod-sound-core kmod-sound-ralink-i2s kmod-sound-soc-wm8960 kmod-sound-soc-simple-card kmod-i2c-ralink
 endef
 TARGET_DEVICES += dch-m225
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -104,7 +104,7 @@ define Device/mediatek_ap-mt7621a-v60
   DTS := AP-MT7621A-V60
   IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_TITLE := Mediatek AP-MT7621A-V60 EVB
-  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620
+  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-ralink-i2s kmod-sound-soc-wm8960 kmod-sound-soc-simple-card
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -300,7 +300,9 @@ define Device/vocore2
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := VoCore VoCore2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
-    kmod-sdhci-mt7620
+    kmod-sdhci-mt7620 \
+    kmod-sound-core kmod-sound-ralink-i2s kmod-sound-soc-simple-card \
+    kmod-sound-codec-es8328-i2c kmod-i2c-gpio
 endef
 TARGET_DEVICES += vocore2
 

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -114,25 +114,73 @@ endef
 
 $(eval $(call KernelPackage,hsdma-mtk))
 
-define KernelPackage/sound-mt7620
-  TITLE:=MT7620 PCM/I2S Alsa Driver
+define KernelPackage/sound-ralink-i2s
+  TITLE:=Ralink SoC PCM/I2S Alsa Driver
   DEPENDS:=@TARGET_ramips +kmod-sound-soc-core +kmod-regmap +kmod-dma-ralink @!TARGET_ramips_rt288x
   KCONFIG:= \
-	CONFIG_SND_RALINK_SOC_I2S \
-	CONFIG_SND_SIMPLE_CARD \
-	CONFIG_SND_SIMPLE_CARD_UTILS \
-	CONFIG_SND_SOC_WM8960
+	CONFIG_SND_RALINK_SOC_I2S
   FILES:= \
-	$(LINUX_DIR)/sound/soc/ralink/snd-soc-ralink-i2s.ko \
-	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card.ko \
-	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card-utils.ko \
-	$(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8960.ko
-  AUTOLOAD:=$(call AutoLoad,90,snd-soc-wm8960 snd-soc-ralink-i2s snd-soc-simple-card)
+	$(LINUX_DIR)/sound/soc/ralink/snd-soc-ralink-i2s.ko
+  AUTOLOAD:=$(call AutoLoad,90,snd-soc-ralink-i2s)
   $(call AddDepends/sound)
 endef
 
-define KernelPackage/sound-mt7620/description
+define KernelPackage/sound-ralink-i2s/description
  Alsa modules for ralink i2s controller.
 endef
 
-$(eval $(call KernelPackage,sound-mt7620))
+$(eval $(call KernelPackage,sound-ralink-i2s))
+
+define KernelPackage/sound-soc-wm8960
+  TITLE:=ALSA driver for Wolfson Micro WM8960 I2S CODEC
+  DEPENDS:=+kmod-sound-soc-core +kmod-regmap
+  KCONFIG:= \
+	CONFIG_SND_SOC_WM8960
+  FILES:= \
+	$(LINUX_DIR)/sound/soc/codecs/snd-soc-wm8960.ko
+  AUTOLOAD:=$(call AutoLoad,90,snd-soc-wm8960)
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-soc-wm8960/description
+  ALSA modules for Wolfson Micro WM8960 I2S CODEC
+endef
+
+$(eval $(call KernelPackage,sound-soc-wm8960))
+
+define KernelPackage/sound-soc-es8328-i2c
+  TITLE:=ALSA Driver for Everest ES8328/ES8388 I2S CODEC via I2C
+  DEPENDS:=+kmod-sound-soc-core +kmod-regmap
+  KCONFIG:= \
+	CONFIG_SND_SOC_ES8328_I2C
+  FILES:= \
+	$(LINUX_DIR)/sound/soc/codecs/snd-soc-es8328.ko \
+	$(LINUX_DIR)/sound/soc/codecs/snd-soc-es8328-i2c.ko
+  AUTOLOAD:=$(call AutoLoad,90,snd-soc-es8328 snd-soc-es8328-i2c)
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-soc-es8328-i2c/description
+ Alsa modules for Everest ES8328/ES8388 I2S CODEC via I2C
+endef
+
+$(eval $(call KernelPackage,sound-soc-es8328-i2c))
+
+define KernelPackage/sound-soc-simple-card
+  TITLE:=ALSA Driver for simple card
+  DEPENDS:=+kmod-sound-soc-core
+  KCONFIG:= \
+	CONFIG_SND_SIMPLE_CARD \
+	CONFIG_SND_SIMPLE_CARD_UTILS
+  FILES:= \
+	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card.ko \
+	$(LINUX_DIR)/sound/soc/generic/snd-soc-simple-card-utils.ko
+  AUTOLOAD:=$(call AutoLoad,91,snd-soc-simple-card)
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-soc-simple-card/description
+ ALSA modules for simple card
+endef
+
+$(eval $(call KernelPackage,sound-soc-simple-card))

--- a/target/linux/ramips/patches-4.14/0048-asoc-add-mt7620-support.patch
+++ b/target/linux/ramips/patches-4.14/0048-asoc-add-mt7620-support.patch
@@ -1007,7 +1007,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	if (ret)
 +		goto err_debugfs;
 +
-+	dev_info(i2s->dev, "mclk %luKHz\n", clk_get_rate(i2s->clk) / 1000000);
++	dev_info(i2s->dev, "mclk %luMHz\n", clk_get_rate(i2s->clk) / 1000000);
 +
 +	return 0;
 +

--- a/target/linux/ramips/patches-4.14/111-pinctrl-ralink-configure-funcs-belong-multiple-groups.patch
+++ b/target/linux/ramips/patches-4.14/111-pinctrl-ralink-configure-funcs-belong-multiple-groups.patch
@@ -1,0 +1,250 @@
+diff -Nurp a/arch/mips/include/asm/mach-ralink/pinmux.h b/arch/mips/include/asm/mach-ralink/pinmux.h
+--- a/arch/mips/include/asm/mach-ralink/pinmux.h	2018-09-20 05:43:49.000000000 +0900
++++ b/arch/mips/include/asm/mach-ralink/pinmux.h	2018-10-07 08:44:33.052701808 +0900
+@@ -32,8 +32,7 @@ struct rt2880_pmx_func {
+ 	int pin_count;
+ 	int *pins;
+ 
+-	int *groups;
+-	int group_count;
++	int group_idx;
+ 
+ 	int enabled;
+ };
+--- a/drivers/pinctrl/pinctrl-rt2880.c	2018-10-07 08:56:18.671330903 +0900
++++ b/drivers/pinctrl/pinctrl-rt2880.c	2018-10-07 08:27:17.976210887 +0900
+@@ -29,6 +29,12 @@
+ #define SYSC_REG_GPIO_MODE	0x60
+ #define SYSC_REG_GPIO_MODE2	0x64
+ 
++struct rt2880_func_group_map {
++	const char *func_name;
++	const char **group_names;
++	int num_groups;
++};
++
+ struct rt2880_priv {
+ 	struct device *dev;
+ 
+@@ -42,6 +48,10 @@ struct rt2880_priv {
+ 	const char **group_names;
+ 	int group_count;
+ 
++	struct rt2880_func_group_map *func_to_group_map;
++	int16_t *group_to_func_map;
++	int func_to_group_count;
++
+ 	uint8_t *gpio;
+ 	int max_pins;
+ };
+@@ -169,7 +179,7 @@ static int rt2880_pmx_func_count(struct
+ {
+ 	struct rt2880_priv *p = pinctrl_dev_get_drvdata(pctrldev);
+ 
+-	return p->func_count;
++	return p->func_to_group_count;
+ }
+ 
+ static const char *rt2880_pmx_func_name(struct pinctrl_dev *pctrldev,
+@@ -177,7 +187,7 @@ static const char *rt2880_pmx_func_name(
+ {
+ 	struct rt2880_priv *p = pinctrl_dev_get_drvdata(pctrldev);
+ 
+-	return p->func[func]->name;
++	return p->func_to_group_map[func].func_name;
+ }
+ 
+ static int rt2880_pmx_group_get_groups(struct pinctrl_dev *pctrldev,
+@@ -187,12 +197,8 @@ static int rt2880_pmx_group_get_groups(s
+ {
+ 	struct rt2880_priv *p = pinctrl_dev_get_drvdata(pctrldev);
+ 
+-	if (p->func[func]->group_count == 1)
+-		*groups = &p->group_names[p->func[func]->groups[0]];
+-	else
+-		*groups = p->group_names;
+-
+-	*num_groups = p->func[func]->group_count;
++	*groups = p->func_to_group_map[func].group_names;
++	*num_groups = p->func_to_group_map[func].num_groups;
+ 
+ 	return 0;
+ }
+@@ -206,6 +212,7 @@ static int rt2880_pmx_group_enable(struc
+ 	u32 reg = SYSC_REG_GPIO_MODE;
+ 	int i;
+ 	int shift;
++	int func_in_grp;
+ 
+ 	/* dont allow double use */
+ 	if (p->groups[group].enabled) {
+@@ -213,8 +220,12 @@ static int rt2880_pmx_group_enable(struc
+ 		return -EBUSY;
+ 	}
+ 
++	func_in_grp = p->group_to_func_map[(group * p->func_to_group_count) + func];
++	if (func_in_grp < 0)
++		return -EINVAL;
++
+ 	p->groups[group].enabled = 1;
+-	p->func[func]->enabled = 1;
++	p->func[func_in_grp]->enabled = 1;
+ 
+ 	shift = p->groups[group].shift;
+ 	if (shift >= 32) {
+@@ -232,9 +243,9 @@ static int rt2880_pmx_group_enable(struc
+ 	if (func == 0) {
+ 		mode |= p->groups[group].gpio << shift;
+ 	} else {
+-		for (i = 0; i < p->func[func]->pin_count; i++)
+-			p->gpio[p->func[func]->pins[i]] = 0;
+-		mode |= p->func[func]->value << shift;
++		for (i = 0; i < p->func[func_in_grp]->pin_count; i++)
++			p->gpio[p->func[func_in_grp]->pins[i]] = 0;
++		mode |= p->func[func_in_grp]->value << shift;
+ 	}
+ 	rt_sysc_w32(mode, reg);
+ 
+@@ -274,6 +285,105 @@ static struct rt2880_pmx_func gpio_func
+ 	.name = "gpio",
+ };
+ 
++static int rt2880_build_internal_map(struct rt2880_priv *p)
++{
++	int i, j;
++	struct rt2880_func_group_map *f_g;
++	struct rt2880_func_group_map *f_g_tmp;
++	int16_t *g_f;
++	int c = 0;
++	int ret = 0;
++
++	/* func_to_group_map[0] is used for gpio */
++	f_g = devm_kzalloc(p->dev, sizeof(f_g[0]) * 1, GFP_KERNEL);
++	if (!f_g) {
++		ret = -ENOMEM;
++		goto l_exit;
++	}
++	f_g[0].func_name = p->func[0]->name;
++	f_g[0].group_names = p->group_names;
++	f_g[0].num_groups = p->group_count;
++	c = 1;
++
++	/* parse function list which has entries with same function name */
++	/* (skip the "gpio" function entry) */
++	for (i = 1; i < p->func_count; i++) {
++		if (!strcmp(p->func[i]->name, "gpio"))
++			continue;
++
++		for (j = 1; j < c; j++)
++			if (!strcmp(f_g[j].func_name, p->func[i]->name))
++				break;
++		if (j < c) {
++			int n;
++			const char** names_tmp;
++
++			n = f_g[j].num_groups;
++			names_tmp = devm_kzalloc(p->dev, sizeof(char *) * (n + 1), GFP_KERNEL);
++			if (!names_tmp) {
++				ret = -ENOMEM;
++				goto l_exit;
++			}
++			memcpy(names_tmp, f_g[j].group_names, sizeof(char *) * n);
++			devm_kfree(p->dev, f_g[j].group_names);
++			f_g[j].group_names = names_tmp;
++
++			f_g[j].group_names[n] = p->group_names[p->func[i]->group_idx];
++			f_g[j].num_groups++;
++		} else{
++			/* add a new entry */
++			f_g_tmp = f_g;
++			f_g = devm_kzalloc(p->dev, sizeof(f_g[0]) * (c + 1), GFP_KERNEL);
++			if (!f_g) {
++				ret = -ENOMEM;
++				goto l_exit;
++			}
++			memcpy(f_g, f_g_tmp, sizeof(f_g[0]) * c);
++			devm_kfree(p->dev, f_g_tmp);
++
++			f_g[c].group_names = devm_kzalloc(p->dev, sizeof(char *) * 1, GFP_KERNEL);
++			if (!f_g[c].group_names) {
++				ret = -ENOMEM;
++				goto l_exit;
++			}
++
++			f_g[c].func_name = p->func[i]->name;
++			f_g[c].group_names[0] = p->group_names[p->func[i]->group_idx];
++			f_g[c].num_groups = 1;
++
++			c++;
++		}
++	}
++
++	g_f = devm_kzalloc(p->dev, sizeof(int16_t) * p->group_count * c, GFP_KERNEL);
++	if (!g_f) {
++		ret = -ENOMEM;
++		goto l_exit;
++	}
++	for (i = 0; i < p->group_count; i++) {
++		g_f[(i * c) + 0] = 0;	/* always map as "gpio" */
++
++		for (j = 1; j < c; j++) {
++			g_f[(i * c) + j] = -1;
++		}
++	}
++
++	for (i = 1 ; i < p->func_count; i++) {
++		for (j = 1; j < c; j++)
++			if(!strcmp(f_g[j].func_name, p->func[i]->name))
++				break;
++		if (j < c)
++			g_f[(p->func[i]->group_idx * c) + j] = i;
++	}
++
++	p->group_to_func_map = g_f;
++	p->func_to_group_map = f_g;
++	p->func_to_group_count = c;
++
++  l_exit:;
++	return ret;
++}
++
+ static int rt2880_pinmux_index(struct rt2880_priv *p)
+ {
+ 	struct rt2880_pmx_func **f;
+@@ -300,16 +410,11 @@ static int rt2880_pinmux_index(struct rt
+ 	p->func_count++;
+ 
+ 	/* allocate our function and group mapping index buffers */
+-	f = p->func = devm_kzalloc(p->dev, sizeof(struct rt2880_pmx_func) * p->func_count, GFP_KERNEL);
+-	gpio_func.groups = devm_kzalloc(p->dev, sizeof(int) * p->group_count, GFP_KERNEL);
+-	if (!f || !gpio_func.groups)
++	f = p->func = devm_kzalloc(p->dev, sizeof(struct rt2880_pmx_func *) * p->func_count,
++					GFP_KERNEL);
++	if (!f)
+ 		return -1;
+ 
+-	/* add a backpointer to the function so it knows its group */
+-	gpio_func.group_count = p->group_count;
+-	for (i = 0; i < gpio_func.group_count; i++)
+-		gpio_func.groups[i] = i;
+-
+ 	f[c] = &gpio_func;
+ 	c++;
+ 
+@@ -317,13 +422,12 @@ static int rt2880_pinmux_index(struct rt
+ 	for (i = 0; i < p->group_count; i++) {
+ 		for (j = 0; j < p->groups[i].func_count; j++) {
+ 			f[c] = &p->groups[i].func[j];
+-			f[c]->groups = devm_kzalloc(p->dev, sizeof(int), GFP_KERNEL);
+-			f[c]->groups[0] = i;
+-			f[c]->group_count = 1;
++			f[c]->group_idx = i;
+ 			c++;
+ 		}
+ 	}
+-	return 0;
++
++	return rt2880_build_internal_map(p);
+ }
+ 
+ static int rt2880_pinmux_pins(struct rt2880_priv *p)


### PR DESCRIPTION
Vocore2's ultimate dock has ES8388 I2S codec.
This modifications supports ES8388 codec audio with es8328 driver and ASoC simple card by DT bindings.

This also includes the modifications of pinctrl-ralink driver, to use 'gpio' group PINMUX as 'refclk' function.