### PR TITLE
ramips: add support for ELECOM WRC-733GHBK

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -44,6 +44,21 @@ define Build/buffalo-dhp-image
 	mv $@.new $@
 endef
 
+define Build/edimax-initramfs-factory
+	$(eval edimax_model=$(word 1,$(1)))
+	$(eval flash=$(word 2,$(1)))
+	$(eval start=$(word 3,$(1)))
+	$(eval factory_bin=$(word 4,$(1)))
+	if [ -e $(factory_bin) ]; then \
+		$(STAGING_DIR_HOST)/bin/mkedimaximg \
+			$(if $(CONFIG_BIG_ENDIAN),-b,) \
+			-s CSYS -m $(edimax_model) \
+			-f $(flash) -S $(start) \
+			-i $(factory_bin) -o $(factory_bin).new; \
+		mv $(factory_bin).new $(factory_bin); \
+	fi
+endef
+
 define Build/eva-image
 	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
 	mv $@.new $@

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -221,6 +221,20 @@ define Build/append-uboot
 	dd if=$(UBOOT_PATH) >> $@
 endef
 
+define Build/bin-cp
+	$(CP) $(1) $(BIN_DIR)/ || true
+endef
+
+define Build/initramfs-factory-common
+	$(eval fw_size=$(word 1,$(1)))
+	$(eval factory_bin=$(word 2,$(1)))
+	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(fw_size)" ]; then \
+		$(CP) $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) $(factory_bin); \
+	else \
+		echo "WARNING: initramfs kernel image too big, cannot generate factory image" >&2; \
+	fi
+endef
+
 define Build/pad-to
 	dd if=$@ of=$@.new bs=$(1) conv=sync
 	mv $@.new $@

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -18,21 +18,6 @@ define Build/addpattern
 	-mv "$@.new" "$@"
 endef
 
-define Build/edimax-initramfs-factory
-	$(eval edimax_model=$(word 1,$(1)))
-	$(eval flash=$(word 2,$(1)))
-	$(eval start=$(word 3,$(1)))
-	$(eval factory_bin=$(word 4,$(1)))
-	if [ -e $(factory_bin) ]; then \
-		$(STAGING_DIR_HOST)/bin/mkedimaximg \
-			$(if $(CONFIG_BIG_ENDIAN),-b,) \
-			-s CSYS -m $(edimax_model) \
-			-f $(flash) -S $(start) \
-			-i $(factory_bin) -o $(factory_bin).new; \
-		mv $(factory_bin).new $(factory_bin); \
-	fi
-endef
-
 define Build/elecom-header
 	$(eval product=$(word 1,$(1)))
 	$(eval factory_bin=$(word 2,$(1)))

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -124,6 +124,9 @@ dir-860l-b1)
 edimax,br-6478ac-v2)
 	set_wifi_led "$boardname:blue:wlan"
 	;;
+elecom,wrc-733ghbk)
+	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:blue:wlan2g" "wlan0"
+	;;
 ex2700|\
 wn3000rpv3)
 	set_wifi_led "$boardname:green:router"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -247,6 +247,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
+	elecom,wrc-733ghbk)
+		ucidef_add_switch "switch1" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
+		;;
 	gnubee,gb-pc1|\
 	gnubee,gb-pc2)
 		ucidef_add_switch "switch0" \
@@ -486,6 +490,10 @@ ramips_setup_macs()
 	elecom,wrc-1900gst|\
 	sk-wb8)
 		wan_mac=$(mtd_get_mac_binary factory 57350)
+		;;
+	elecom,wrc-733ghbk)
+		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
+		wan_mac=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
 		;;
 	gl-mt300n-v2|\
 	whr-g300n)

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -62,6 +62,11 @@ case "$FIRMWARE" in
 		jboot_eeprom_extract "config" 0xE000
 		rt2x00_eeprom_set_macaddr $wifi_mac
 		;;
+	elecom,wrc-733ghbk)
+		wifi_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.2G.0.MAC.Address)
+		rt2x00_eeprom_extract "Factory" 0 512
+		rt2x00_eeprom_set_macaddr $wifi_mac
+		;;
 	tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
 		rt2x00_eeprom_extract "factory" 0 512

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -57,6 +57,7 @@ platform_check_image() {
 	elecom,wrc-1167ghbk2-s|\
 	elecom,wrc-2533gst|\
 	elecom,wrc-1900gst|\
+	elecom,wrc-733ghbk|\
 	esr-9753|\
 	ew1200|\
 	ex2700|\

--- a/target/linux/ramips/dts/WRC-733GHBK.dts
+++ b/target/linux/ramips/dts/WRC-733GHBK.dts
@@ -1,0 +1,167 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "elecom,wrc-733ghbk", "ralink,mt7620a-soc";
+	model = "ELECOM WRC-733GHBK";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "wrc-733ghbk:red:wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "wrc-733ghbk:blue:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "wrc-733ghbk:blue:wlan2g";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "wrc-733ghbk:blue:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		rtl8367rb_power {
+			gpio-export,name = "rtl8367rb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		gpio-sda = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			Factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "nvram";
+				reg = <0x50000 0x20000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "firmware";
+				reg = <0x70000 0x780000>;
+			};
+
+			partition@7f0000 {
+				label = "hwconfig";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+};
+
+&pcie {
+	status = "okay";
+	/*
+	 * WRC-733GHBK has MT7610E for 5 GHz wifi,
+	 * but it's not supported in OpenWrt.
+	 */
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -211,6 +211,19 @@ define Device/e1700
 endef
 TARGET_DEVICES += e1700
 
+define Device/elecom_wrc-733ghbk
+  DTS := WRC-733GHBK
+  DEVICE_TITLE := ELECOM WRC-733GHBK
+  IMAGE_SIZE := 7680k
+  FACTORY := $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
+  KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
+    initramfs-factory-common 7864298 $$(FACTORY) | \
+    edimax-initramfs-factory RN62 0x70000 0x01100000 $$(FACTORY) | \
+    bin-cp $$(FACTORY)
+  DEVICE_PACKAGES := kmod-switch-rtl8366-smi kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += elecom_wrc-733ghbk
+
 define Device/ex2700
   NETGEAR_HW_ID := 29764623+4+0+32+2x2+0
   NETGEAR_BOARD_ID := EX2700

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -30,21 +30,17 @@ define Build/elecom-wrc-factory
   mv $@.new $@
 endef
 
-define Build/iodata-factory
-  $(eval fw_size=$(word 1,$(1)))
-  $(eval fw_type=$(word 2,$(1)))
-  $(eval product=$(word 3,$(1)))
+define Build/senao-initramfs-factory
+  $(eval vendor=$(word 1,$(1)))
+  $(eval product=$(word 2,$(1)))
+  $(eval fw_type=$(word 3,$(1)))
   $(eval factory_bin=$(word 4,$(1)))
-  if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(fw_size)" ]; then \
-    $(CP) $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) $(factory_bin); \
+  if [ -e $(factory_bin) ]; then \
     $(STAGING_DIR_HOST)/bin/mksenaofw \
-      -r 0x30a -p $(product) -t $(fw_type) \
+      -r $(vendor) -p $(product) -t $(fw_type) \
       -e $(factory_bin) -o $(factory_bin).new; \
     mv $(factory_bin).new $(factory_bin); \
-    $(CP) $(factory_bin) $(BIN_DIR)/; \
-	else \
-		echo "WARNING: initramfs kernel image too big, cannot generate factory image" >&2; \
-	fi
+  fi
 endef
 
 define Build/ubnt-erx-factory-image
@@ -190,8 +186,10 @@ TARGET_DEVICES += hc5962
 define Device/iodata_wn-ax1167gr
   DTS := WN-AX1167GR
   IMAGE_SIZE := 15552k
+  FACTORY := $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
   KERNEL_INITRAMFS := $$(KERNEL) | \
-    iodata-factory 7864320 4 0x1055 $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
+    initramfs-factory-common 7864320 $$(FACTORY) | \
+    senao-initramfs-factory 0x30a 0x1055 4 $$(FACTORY) | bin-cp $$(FACTORY)
   DEVICE_TITLE := I-O DATA WN-AX1167GR
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-mini
 endef


### PR DESCRIPTION
ELECOM WRC-733GHBK is a 11ac router, based on MediaTek MT7620A.

Specification:

- MediaTek MT7620A
- 64 MB of RAM (DDR2)
- 8 MB of RAM (SPI-NOR)
- 2.4/5 GHz wifi
  - 2.4 GHz: 2T2R (SoC internal)
  - 5 GHz: 1T1R (MT7610E)
- 5x 10/100/1000 Mbps Ethernet
  - Realtek RTL8367RB switch
- 4x LEDs, 3x keys (2x buttons, 1x slide switch)
- UART through-hole on PCB
  - TX, GND, RX, Vcc from ethernet port side
  - 57600n8

Flash instruction using factory image:

1. Boot the WRC-733GHBK normaly and connect the computer to its LAN
port
2. Access to "http://192.168.2.1/" and open firmware update page
("ファームウェア更新 手動更新（アップデート）")
3. Select the OpenWrt factory image and click apply ("適用") button
to perform firmware update
4. On the (initramfs) factory image, execute sysupgrade with
squashfs-sysupgrade image for WRC-733GHBK
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>