### PR TITLE
kernel: Include kernel magic in all kmods

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -196,7 +196,7 @@ define KernelPackage
     CATEGORY:=Kernel modules
     DESCRIPTION:=$(DESCRIPTION)
     EXTRA_DEPENDS:=kernel (=$(LINUX_VERSION)-$(LINUX_RELEASE)-$(LINUX_VERMAGIC))
-    VERSION:=$(LINUX_VERSION)$(if $(PKG_VERSION),+$(PKG_VERSION))-$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))
+    VERSION:=$(LINUX_VERSION)$(if $(PKG_VERSION),+$(PKG_VERSION))-$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))-$(LINUX_VERMAGIC)
     PKGFLAGS:=$(PKGFLAGS)
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))


### PR DESCRIPTION
Kernel modules can greatly depend on configuration of the kernel and might not
work with different kernel, so always put kernel magic as part of the package
version.

Signed-off-by: Michal Hrusecky <Michal@Hrusecky.net>