### PR TITLE
wireguard: Add wg- prefix

### DIFF
--- a/package/network/services/wireguard/Makefile
+++ b/package/network/services/wireguard/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard
 
 PKG_VERSION:=0.0.20181119
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=WireGuard-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/WireGuard/snapshot/


### PR DESCRIPTION
Without a prefix it's hard to tell the type of the interface just from
its name, which is the case for luci to detect virtual interfaces.

Signed-off-by: David Yang <mmyangfl@gmail.com>