### PR TITLE
ar71xx:  add support for TP-Link Archer A7 v5

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -144,7 +144,9 @@ archer-c60-v2)
 		;;
 	esac
 	;;
-archer-c7-v4)
+archer-c7-v4|\
+archer-c7-v5|\
+archer-a7-v5)
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
 	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
@@ -153,7 +155,11 @@ archer-c7-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan2" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan1" "switch0" "0x20"
 	ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
+	case "$board" in
+	archer-c7-v4)
+￼		ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
+￼		;;
+	esac
 	;;
 arduino-yun)
 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -504,6 +504,7 @@ ar71xx_setup_interfaces()
 		;;
 	archer-c7-v4|\
 	archer-c7-v5|\
+	archer-a7-v5|\
 	tl-wdr4300|\
 	tl-wr1041n-v2)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -71,6 +71,7 @@ get_status_led() {
 	archer-c60-v2|\
 	archer-c7-v4|\
 	archer-c7-v5|\
+	archer-a7-v5|\
 	fritz300e|\
 	fritz4020|\
 	fritz450e|\

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -66,7 +66,8 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
 	archer-c7-v4|\
-	archer-c7-v5)
+	archer-c7-v5|\
+	archer-a7-v5)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -487,6 +487,9 @@ ar71xx_board_detect() {
 	*"Archer C7 v5")
 		name="archer-c7-v5"
 		;;
+	*"Archer A7 v5")
+		name="archer-a7-v5"
+		;;
 	*"Archer C58 v1")
 		name="archer-c58-v1"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -217,6 +217,7 @@ platform_check_image() {
 	archer-c60-v2|\
 	archer-c7-v4|\
 	archer-c7-v5|\
+	archer-a7-v5|\
 	bullet-m|\
 	c-55|\
 	carambola2|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v5.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v5.c
@@ -161,11 +161,8 @@ static struct mdio_board_info archer_c7_v5_mdio0_info[] = {
 };
 
 
-static void __init archer_c7_v5_setup(void)
+static void archer_c7_v5_setup_common(u8 *art, u8 * mac)
 {
-	u8 *art = (u8 *) KSEG1ADDR(0x1f050000);
-	u8 *mac = (u8 *) KSEG1ADDR(0x1f060008);
-
 	ath79_register_m25p80(NULL);
 
 
@@ -203,5 +200,24 @@ static void __init archer_c7_v5_setup(void)
 	ath79_register_eth(0);
 }
 
+static void __init archer_c7_v5_setup(void)
+{
+	u8 *art = (u8 *) KSEG1ADDR(0x1f050000);
+	u8 *mac = (u8 *) KSEG1ADDR(0x1f060008);
+
+    archer_c7_v5_setup_common(art, mac);
+}
+
+static void __init archer_a7_v5_setup(void)
+{
+	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+	u8 *mac = (u8 *) KSEG1ADDR(0x1ff40008);
+
+    archer_c7_v5_setup_common(art, mac);
+}
+
 MIPS_MACHINE(ATH79_MACH_ARCHER_C7_V5, "ARCHER-C7-V5", "TP-LINK Archer C7 v5",
 	     archer_c7_v5_setup);
+
+MIPS_MACHINE(ATH79_MACH_ARCHER_A7_V5, "ARCHER-A7-V5", "TP-LINK Archer A7 v5",
+	     archer_a7_v5_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -54,6 +54,7 @@ enum ath79_mach_type {
 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
 	ATH79_MACH_ARCHER_C7_V4,		/* TP-LINK Archer C7 V4 board */
 	ATH79_MACH_ARCHER_C7_V5,		/* TP-LINK Archer C7 V5 board */
+	ATH79_MACH_ARCHER_A7_V5,		/* TP-LINK Archer A7 V5 board */
 	ATH79_MACH_ARDUINO_YUN,			/* Yun */
 	ATH79_MACH_AW_NR580,			/* AzureWave AW-NR580 */
 	ATH79_MACH_BHR_4GRV2,			/* Buffalo BHR-4GRV2 */

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -159,6 +159,17 @@ define Device/archer-c7-v5
 endef
 TARGET_DEVICES += archer-c7-v5
 
+define Device/archer-a7-v5
+  $(Device/archer-c7-v5)
+  DEVICE_TITLE := TP-LINK Archer A7 v5
+  BOARDNAME := ARCHER-A7-V5
+  TPLINK_BOARD_ID := ARCHER-A7-V5
+  IMAGE_SIZE := 15104k
+  MTDPARTS := spi0.0:128k(factory-uboot),128k(u-boot),1536k(kernel),13824k(rootfs),64k@0xff0000(art),15360k@0x40000(firmware)
+  SUPPORTED_DEVICES := archer-a7-v5
+endef
+TARGET_DEVICES += archer-a7-v5
+
 define Device/cpe510-520-v1
   DEVICE_TITLE := TP-LINK CPE510/520 v1
   BOARDNAME := CPE510

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -716,6 +716,53 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the A7 v5*/
+	{
+		.id = "ARCHER-A7-V5",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:45550000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:55530000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:43410000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:4A500000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:54570000}\n",
+
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.0.0\n",
+
+		/**
+		  We use a bigger os-image partition than the stock images (and thus
+		  smaller file-system), as our kernel doesn't fit in the stock firmware's
+		  1MB os-image.
+		  */
+		.partitions = {
+			{"factory-boot",    0x00000,  0x20000},
+			{"fs-uboot",        0x20000,  0x20000},
+
+			{"os-image",        0x40000,  0x180000}, /* Stock: base 0x40000  size 0x120000 */
+			{"file-system",     0x1c0000, 0xd80000}, /* Stock: base 0x160000 size 0xde0000 */
+
+			{"default-mac",     0xf40000 , 0x00200},
+			{"pin",             0xf40200 , 0x00200},
+			{"device-id",       0xf40400 , 0x00100},
+			{"product-info",    0xf40500 , 0x0fb00},
+			{"soft-version",    0xf50000 , 0x01000},
+			{"extra-para",      0xf51000 , 0x01000},
+			{"support-list",    0xf52000 , 0x0a000},
+			{"profile",         0xf5c000 , 0x04000},
+			{"default-config",  0xf60000 , 0x10000},
+			{"user-config",     0xf70000 , 0x40000},
+			{"certificate",     0xfb0000 , 0x10000},
+			{"partition-table", 0xfc0000 , 0x10000},
+			{"log",             0xfd0000 , 0x20000},
+			{"radio",           0xff0000 , 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the C9 */
 	{
 		.id = "ARCHERC9",
@@ -1605,7 +1652,9 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
-	} else if (strcasecmp(info->id, "ARCHER-C7-V4") == 0 || strcasecmp(info->id, "ARCHER-C7-V5") == 0) {
+	} else if (strcasecmp(info->id, "ARCHER-C7-V4") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C7-V5") == 0 ||
+	    strcasecmp(info->id, "ARCHER-A7-V5") == 0) {
 		const char mdat[11] = {0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0xca, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
 	}


### PR DESCRIPTION
this is identital to Archer C7, but with a different flash layout

TP-Link Archer C7 v5 is a dual-band AC1750 router, based on Qualcomm/Atheros
QCA9563+QCA9880.

Specification:

750/400/250 MHz (CPU/DDR/AHB
128 MB of RAM (DDR2)
16 MB of FLASH (SPI NOR)
3T3R 2.4 GHz
3T3R 5 GHz
5x 10/100/1000 Mbps Ethernet
10x LED, 2x button
UART header on PCB
Flash instruction:

Upload lede-ar71xx-generic-archer-c7-v5-squashfs-factory.bin via Web interface
Flash instruction using TFTP recovery:

Set PC to fixed ip address 192.168.0.66
Download lede-ar71xx-generic-archer-c7-v5-squashfs-factory.bin
and rename it to ArcherC7v5_tp_recovery.bin
Start a tftp server with the file tp_recovery.bin in its root directory
Turn off the router
Press and hold Reset button
Turn on router with the reset button pressed and wait ~15 seconds
Release the reset button and after a short time
the firmware should be transferred from the tftp server
Wait ~30 second to complete recovery.

With help from: Michael Hilgenstock
Signed-off-by: Arvid E. Picciani <aep@exys.org>