### PR TITLE
qmi: fix variable initilization for timeout handling and add logging output

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -68,6 +68,8 @@ proto_qmi_setup() {
 		return 1
 	}
 
+	echo "Waiting for SIM initialization"
+	local uninitialized_timeout=0
 	while uqmi -s -d "$device" --get-pin-status | grep '"UIM uninitialized"' > /dev/null; do
 		[ -e "$device" ] || return 1
 		if [ "$uninitialized_timeout" -lt "$timeout" ]; then


### PR DESCRIPTION
@xback This is a follow PR from https://github.com/openwrt/openwrt/pull/866
During rebase i have seen that the variable **uninitialized_timeout** is not declared local and ist not proper initialized.

I have also added a logger output that the user knows that we are waiting for SIM initialization

