### PR TITLE
build: suppress error output in feeds.mk

### DIFF
--- a/include/feeds.mk
+++ b/include/feeds.mk
@@ -9,7 +9,7 @@
 -include $(TMP_DIR)/.packagesubdirs
 
 FEEDS_INSTALLED:=$(notdir $(wildcard $(TOPDIR)/package/feeds/*))
-FEEDS_AVAILABLE:=$(sort $(FEEDS_INSTALLED) $(shell $(SCRIPT_DIR)/feeds list -n))
+FEEDS_AVAILABLE:=$(sort $(FEEDS_INSTALLED) $(shell $(SCRIPT_DIR)/feeds list -n 2>/dev/null))
 
 PACKAGE_SUBDIRS=$(PACKAGE_DIR)
 ifneq ($(CONFIG_PER_FEED_REPO),)


### PR DESCRIPTION
If no feed.conf or feeds.conf.default is found on image generation
with the imagebuilder we always get the following message
"Unable to open feeds configuration at \<dir\>/scripts/feeds line 48."
on std error.

To get rid off this needless warning on image generation with the imagebuilder
supress the output in feeds.mk.
