### PR TITLE
ramips: clear depends on mt76xx drivers

### DIFF
--- a/target/linux/ramips/dts/HC5761.dts
+++ b/target/linux/ramips/dts/HC5761.dts
@@ -37,3 +37,11 @@
 		};
 	};
 };
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/dts/HC5861.dts
+++ b/target/linux/ramips/dts/HC5861.dts
@@ -97,3 +97,11 @@
 &gsw {
 	mediatek,port4 = "gmac";
 };
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/dts/TINY-AC.dts
+++ b/target/linux/ramips/dts/TINY-AC.dts
@@ -161,3 +161,11 @@
 		};
 	};
 };
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -28,7 +28,7 @@ define Device/alfa-network_ac1200rm
   DTS := AC1200RM
   IMAGE_SIZE := 16064k
   DEVICE_TITLE := ALFA Network AC1200RM
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci uboot-envtools
 endef
 TARGET_DEVICES += alfa-network_ac1200rm
 
@@ -51,6 +51,7 @@ define Device/ArcherC20i
   IMAGES += factory.bin
   DEVICE_PACKAGES := kmod-mt76x0e
   DEVICE_TITLE := TP-Link ArcherC20i
+  DEVICE_PACKAGES := kmod-mt76x0e
 endef
 TARGET_DEVICES += ArcherC20i
 
@@ -65,6 +66,7 @@ define Device/ArcherC50v1
   IMAGE/factory-us.bin := tplink-v2-image -e -w 0
   IMAGE/factory-eu.bin := tplink-v2-image -e -w 2
   DEVICE_TITLE := TP-Link ArcherC50v1
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += ArcherC50v1
 
@@ -75,7 +77,7 @@ define Device/ArcherMR200
   TPLINK_FLASHLAYOUT := 8MLmtk
   TPLINK_HWID := 0xd7500001
   TPLINK_HWREV := 0x4a
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-net kmod-usb-net-rndis kmod-usb-serial kmod-usb-serial-option adb-enablemodem
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-net kmod-usb-net-rndis kmod-usb-serial kmod-usb-serial-option adb-enablemodem
   DEVICE_TITLE := TP-Link ArcherMR200
 endef
 TARGET_DEVICES += ArcherMR200
@@ -122,7 +124,7 @@ define Device/d240
   DTS := D240
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Sanlinking Technologies D240
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76-core kmod-mt76x2 kmod-sdhci-mt7620
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += d240
 
@@ -148,7 +150,7 @@ define Device/dch-m225
 	seama-seal -m "signature=wapn22_dlink.2013gui_dap1320b" | \
 	check-size $$$$(IMAGE_SIZE)
   DEVICE_TITLE := D-Link DCH-M225
-  DEVICE_PACKAGES := kmod-mt76 kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
+  DEVICE_PACKAGES := kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
 endef
 TARGET_DEVICES += dch-m225
 
@@ -177,7 +179,7 @@ TARGET_DEVICES += dlink_dwr-116-a1
 define Device/dlink_dwr-118-a2
   DTS := DWR-118-A2
   DEVICE_TITLE := D-Link DWR-118 A2
-  DEVICE_PACKAGES := kmod-usb2 jboot-tools kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 jboot-tools
   DLINK_ROM_ID := DLK6E3814001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0xFE0000
@@ -231,7 +233,6 @@ define Device/ex2700
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | append-uImage-fakehdr filesystem
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	netgear-dni
-  DEVICE_PACKAGES := -kmod-mt76 -kmod-mt7603 -kmod-mt76x2 -kmod-mt76-core
   DEVICE_TITLE := Netgear EX2700
 endef
 TARGET_DEVICES += ex2700
@@ -243,7 +244,7 @@ define Device/ex3700-ex3800
   IMAGE_SIZE := 7744k
   IMAGES += factory.chk
   IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
-  DEVICE_PACKAGES := -kmod-mt76 kmod-mt76x2
+  DEVICE_PACKAGES := mod-mt76x2
   DEVICE_TITLE := Netgear EX3700/EX3800
   SUPPORTED_DEVICES := ex3700
 endef
@@ -253,7 +254,7 @@ define Device/gl-mt300a
   DTS := GL-MT300A
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := GL-Inet GL-MT300A
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += gl-mt300a
 
@@ -268,7 +269,7 @@ define Device/gl-mt300n
   DTS := GL-MT300N
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := GL-Inet GL-MT300N
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += gl-mt300n
 
@@ -276,7 +277,7 @@ define Device/gl-mt750
   DTS := GL-MT750
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := GL-Inet GL-MT750
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += gl-mt750
 
@@ -292,7 +293,7 @@ define Device/hc5761
   DTS := HC5761
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5761
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5761
 
@@ -300,7 +301,7 @@ define Device/hc5861
   DTS := HC5861
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5861
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5861
 
@@ -362,8 +363,7 @@ define Device/lava_lr-25g001
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
   IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
-  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-mt76 kmod-mt76x0-common \
-					kmod-mt76x0e
+  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-mt76x0e
 endef
 TARGET_DEVICES += lava_lr-25g001
 
@@ -371,7 +371,7 @@ define Device/miwifi-mini
   DTS := MIWIFI-MINI
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Xiaomi MiWiFi Mini
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += miwifi-mini
 
@@ -419,7 +419,7 @@ TARGET_DEVICES += mt7620a_v22sg
 define Device/mzk-750dhp
   DTS := MZK-750DHP
   DEVICE_TITLE := Planex MZK-750DHP
-  DEVICE_PACKAGES := kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x0e
 endef
 TARGET_DEVICES += mzk-750dhp
 
@@ -432,7 +432,7 @@ TARGET_DEVICES += mzk-ex300np
 define Device/mzk-ex750np
   DTS := MZK-EX750NP
   DEVICE_TITLE := Planex MZK-EX750NP
-  DEVICE_PACKAGES := kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += mzk-ex750np
 
@@ -453,7 +453,7 @@ TARGET_DEVICES += oy-0001
 define Device/psg1208
   DTS := PSG1208
   DEVICE_TITLE := Phicomm PSG1208
-  DEVICE_PACKAGES := kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += psg1208
 
@@ -503,14 +503,14 @@ define Device/rt-ac51u
   DTS := RT-AC51U
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Asus RT-AC51U
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb-core kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += rt-ac51u
 
 define Device/tiny-ac
   DTS := TINY-AC
   DEVICE_TITLE := Dovado Tiny AC
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += tiny-ac
 
@@ -522,7 +522,7 @@ define Device/edimax_br-6478ac-v2
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN68 -f 0x70000 -S 0x01100000 | pad-rootfs | \
 	append-metadata | check-size $$$$(IMAGE_SIZE)
-  DEVICE_PACKAGES := kmod-mt76 kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += edimax_br-6478ac-v2
 
@@ -534,7 +534,7 @@ define Device/tplink_c2-v1
   TPLINK_HWREV := 50
   IMAGES += factory.bin
   DEVICE_TITLE := TP-Link Archer C2 v1
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b
 endef
 TARGET_DEVICES += tplink_c2-v1
 
@@ -547,7 +547,7 @@ define Device/tplink_c20-v1
   TPLINK_HWREVADD := 0x1
   IMAGES += factory.bin
   DEVICE_TITLE := TP-Link ArcherC20 v1
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += tplink_c20-v1
 
@@ -563,7 +563,7 @@ define Device/ravpower_wd03
   DTS := WD03
   IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_TITLE := Ravpower WD03
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-usb-ehci
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ehci
 endef
 TARGET_DEVICES += ravpower_wd03
 
@@ -571,6 +571,7 @@ define Device/whr-1166d
   DTS := WHR-1166D
   IMAGE_SIZE := 15040k
   DEVICE_TITLE := Buffalo WHR-1166D
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += whr-1166d
 
@@ -652,6 +653,7 @@ define Device/y1
   DTS := Y1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Lenovo Y1
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += y1
 
@@ -659,6 +661,7 @@ define Device/y1s
   DTS := Y1S
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Lenovo Y1S
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += y1s
 
@@ -675,14 +678,14 @@ define Device/we1026-5g-16m
   IMAGE_SIZE := 16777216
   SUPPORTED_DEVICES += we1026-5g-16m
   DEVICE_TITLE := Zbtlink ZBT-WE1026-5G (16M)
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-sdhci-mt7620
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += we1026-5g-16m
 
 define Device/zbt-ape522ii
   DTS := ZBT-APE522II
   DEVICE_TITLE := Zbtlink ZBT-APE522II
-  DEVICE_PACKAGES := kmod-mt76
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += zbt-ape522ii
 
@@ -710,7 +713,7 @@ define Device/zbt-we826-16M
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   SUPPORTED_DEVICES += zbt-we826
   DEVICE_TITLE := Zbtlink ZBT-WE826 (16M)
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-sdhci-mt7620 
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += zbt-we826-16M
 
@@ -718,7 +721,7 @@ define Device/zbt-we826-32M
   DTS := ZBT-WE826-32M
   IMAGE_SIZE := $(ralink_default_fw_size_32M)
   DEVICE_TITLE := Zbtlink ZBT-WE826 (32M)
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-sdhci-mt7620
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += zbt-we826-32M
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -73,6 +73,7 @@ define Device/hiwifi_hc5861b
   DTS := HC5861B
   IMAGE_SIZE := 15808k
   DEVICE_TITLE := HiWiFi HC5861B
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += hiwifi_hc5861b
 
@@ -89,6 +90,7 @@ define Device/mac1200r-v2
   DTS := MAC1200RV2
   DEVICE_TITLE := Mercury MAC1200R v2.0
   SUPPORTED_DEVICES := mac1200rv2
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += mac1200r-v2
 
@@ -114,7 +116,7 @@ define Device/netgear_r6120
   BLOCKSIZE := 64k
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := Netgear AC1200 R6120
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
   SERCOMM_KERNEL_OFFSET := 0x90000
   SERCOMM_HWID := CGQ
   SERCOMM_HWVER := A001
@@ -223,6 +225,7 @@ define Device/tplink_c20-v4
   TPLINK_HWREV := 0x1
   TPLINK_HWREVADD := 0x4
   TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-mt76x0e
 endef
 TARGET_DEVICES += tplink_c20-v4
 
@@ -236,6 +239,7 @@ define Device/tplink_c50-v3
   TPLINK_HWREV := 0x79
   TPLINK_HWREVADD := 0x1
   TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += tplink_c50-v3
 
@@ -342,6 +346,7 @@ define Device/wcr-1166ds
 	buffalo-tag-dhp WCR-1166DS JP JP | buffalo-enc-tag -l | \
 	buffalo-dhp-image
   DEVICE_TITLE := Buffalo WCR-1166DS
+  DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += wcr-1166ds
 
@@ -397,7 +402,7 @@ define Device/zyxel_keenetic-extra-ii
   IMAGE_SIZE := 14912k
   BLOCKSIZE := 64k
   DEVICE_TITLE := ZyXEL Keenetic Extra II
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
 	check-size $$$$(IMAGE_SIZE) | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"

--- a/target/linux/ramips/mt7620/target.mk
+++ b/target/linux/ramips/mt7620/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT7620 based boards
 FEATURES+=usb
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc kmod-mt76 wpad-basic
+DEFAULT_PACKAGES += kmod-rt2800-pci kmod-rt2800-soc wpad-basic
 
 define Target/Description
 	Build firmware images for Ralink MT7620 based boards.

--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT76x8 based boards
 FEATURES+=usb
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt76 wpad-basic
+DEFAULT_PACKAGES += wpad-basic
 
 define Target/Description
 	Build firmware images for Ralink MT76x8 based boards.


### PR DESCRIPTION
 - drop depends on kmod-mt76 by default
 - each device individually selects the required mt76xx
 - some devices do not need drivers for the mt76xx series at all
 - since mt7610e is now supported, early devices added mt76x0e dependencies

 we can find the hardware specifies and determine the dependencies on these sites:
  https://wikidevi.com/wiki/
  https://openwrt.org/toh/hwdata/

 The following devices use mt76x0e:
  dir-810l
  tiny-ac
  mzk-750dhp
  tplink_c2-v1
  tplink_c20-v1
  ArcherC20i
  ArcherMR200
  tplink_c20-v4
  tplink_tl-wr902ac-v3
  rt-ac51u
  gl-mt750
  hc5761
  hc5861 (not sure)