### PR TITLE
kernel: Enable support for AM2315/AM2320 humidity sensor

### DIFF
--- a/package/kernel/linux/modules/iio.mk
+++ b/package/kernel/linux/modules/iio.mk
@@ -52,6 +52,19 @@ endef
 
 $(eval $(call KernelPackage,iio-ad799x))
 
+define KernelPackage/iio-am2315
+  SUBMENU:=$(IIO_MENU)
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core
+  TITLE:=Asong AM2315 humidity/temperature sensor
+  KCONFIG:= CONFIG_AM2315
+  FILES:=$(LINUX_DIR)/drivers/iio/humidity/am2315.ko
+  AUTOLOAD:=$(call AutoLoad,56,am2315)
+endef
+define KernelPackage/iio-am2315/description
+  Aosong AM2315 humidity/temperature sensor (I2C bus)
+endef
+$(eval $(call KernelPackage,iio-am2315))
+
 define KernelPackage/iio-mxs-lradc
   SUBMENU:=$(IIO_MENU)
   DEPENDS:=@TARGET_mxs +kmod-iio-core


### PR DESCRIPTION
Enable support for Aosong AM2315 humidity/temperature i2c sensor. Already in mainline kernel, tested with Onion Omega 2+ and Orange Pi Zero boards. Creates kmod-iio-am2315 package. Works with AM2320 sensor too.