### PR TITLE
mpc85xx: workaround 4.14 cross compile issue

### DIFF
--- a/target/linux/mpc85xx/patches-4.14/103-powerpc-fix-build-cross32ar.patch
+++ b/target/linux/mpc85xx/patches-4.14/103-powerpc-fix-build-cross32ar.patch
@@ -1,0 +1,10 @@
+--- a/arch/powerpc/Makefile
++++ b/arch/powerpc/Makefile
+@@ -23,6 +23,7 @@ CROSS32AR		:= $(CROSS32_COMPILE)ar
+ ifeq ($(HAS_BIARCH),y)
+ ifeq ($(CROSS32_COMPILE),)
+ CROSS32CC	:= $(CC) -m32
++CROSS32AR	:= $(AR)
+ KBUILD_ARFLAGS	+= --target=elf32-powerpc
+ endif
+ endif


### PR DESCRIPTION
Regression introduced with 4.10 by 43c9127d94d62a232ed33ed2eab8a08657ce5472

Build will fail if system 'ar' does not support deterministic builds.
e.g. macOS with Xcode toolchain

Appears to be fixed upstream in 4.18 by af3901cbbd3de182aafb8ee553c825c0074df6a2

Signed-off-by: Ryan Mounce <ryan@mounce.com.au>
