### PR TITLE
[RFC] gre: add static ip on setup

### DIFF
--- a/package/network/config/gre/Makefile
+++ b/package/network/config/gre/Makefile
@@ -22,7 +22,7 @@ define Package/gre
   CATEGORY:=Network
   MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
   TITLE:=Generic Routing Encapsulation config support
-  DEPENDS:=+kmod-gre +IPV6:kmod-gre6 +resolveip
+  DEPENDS:=+kmod-gre +IPV6:kmod-gre6 +resolveip +kmod-nf-nathelper-extra
   PROVIDES:=grev4 grev6
 endef
 

--- a/package/network/config/gre/files/gre.sh
+++ b/package/network/config/gre/files/gre.sh
@@ -16,7 +16,6 @@ gre_generic_setup() {
 	local mtu ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
 	json_get_vars mtu ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
 
-	[ -z "$zone" ] && zone="wan"
 	[ -z "$multicast" ] && multicast=1
 
 	proto_init_update "$link" 1

--- a/package/network/config/iptunnel/Makefile
+++ b/package/network/config/iptunnel/Makefile
@@ -1,0 +1,44 @@
+#
+# Copyright (C) 2018 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See https://www.gnu.org/licenses/gpl-2.0.txt for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=iptunnel
+PKG_VERSION:=1
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/iptunnel/Default
+endef
+
+define Package/iptunnel
+  SECTION:=net
+  CATEGORY:=Network
+  MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
+  TITLE:=Protocol wrapper for ip tunnel protocols (gre)
+  DEPENDS:=+gre
+endef
+
+define Package/iptunnel/description
+ Protocol wrapper for ip tunnel protocols.
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/iptunnel/install
+	$(INSTALL_DIR) $(1)/lib/netifd/proto
+	$(INSTALL_BIN) ./files/lib/netifd/proto/iptunnel.sh \
+		$(1)/lib/netifd/proto/iptunnel.sh
+endef
+
+$(eval $(call BuildPackage,iptunnel))

--- a/package/network/config/iptunnel/files/lib/netifd/proto/iptunnel.sh
+++ b/package/network/config/iptunnel/files/lib/netifd/proto/iptunnel.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. /lib/functions/network.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
+
+proto_gre_setup() { echo "iptunnel[$$] gre proto missing";}
+
+[ -f ./gre.sh ] && . ./gre.sh
+
+proto_iptunnel_setup() {
+	local cfg="$1"
+
+	local localaddr netmask
+	json_get_vars localaddr netmask
+
+	proto_gre_setup $@
+
+	[ -n "$localaddr" ] && {
+		local prefix
+		[ -n "$netmask" ] && {
+			local prefix
+			eval "$(ipcalc.sh "$localaddr" "$netmask")"
+			prefix="$PREFIX"
+		}
+
+		if [ -z "$prefix" ]; then
+			echo "Assign IPv4 address $localaddr to device gre4-$cfg"
+		else
+			echo "Assign IPv4 transfer net ${localaddr}/${prefix:-32} to device gre4-$cfg"
+		fi
+
+		proto_init_update "gre4-$cfg" 1
+		proto_set_keep 1
+		proto_add_ipv4_address "$localaddr" "${prefix:-32}"
+		proto_send_update "$cfg"
+	}
+}
+
+proto_iptunnel_teardown() {
+	local cfg="$1"
+
+	proto_gre_teardown $@
+}
+
+iptunnel_generic_init_config() {
+	no_device=1
+	available=1
+
+	proto_config_add_int "mtu"
+	proto_config_add_int "ttl"
+	proto_config_add_string "tos"
+	proto_config_add_string "tunlink"
+	proto_config_add_string "zone"
+	proto_config_add_int "ikey"
+	proto_config_add_int "okey"
+	proto_config_add_boolean "icsum"
+	proto_config_add_boolean "ocsum"
+	proto_config_add_boolean "iseqno"
+	proto_config_add_boolean "oseqno"
+	proto_config_add_boolean "multicast"
+}
+
+proto_iptunnel_init_config() {
+	gre_generic_init_config
+	proto_config_add_string "ipaddr"
+	proto_config_add_string "peeraddr"
+	proto_config_add_boolean "df"
+	proto_config_add_string "localaddr"
+	proto_config_add_string "netmask"
+}
+
+[ -n "$INCLUDE_ONLY" ] || {
+	add_protocol iptunnel
+}


### PR DESCRIPTION
@dedeckeh 
Normaly the gre proto handler will only setup the tunnel configuration
params. If you want to send traffic over this interface you need also
set an address to this interface. This is normaly done with a ralated
interface with the openwrt "@" syntax on an additonal configuration step.

To simplify the configuration setps add the possibility setting up the static
ip for this gre interface in the proto handler during setup step. So you
do mot need an additonal configuration section in the network config.

If the params iface_ipaddr and/or iface_netmask is specified in the
interface config section then the gre interface will also get a static
ip or network assigned.
