### PR TITLE
ramips: add support to Strong 1200

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -236,6 +236,9 @@ mr200)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "usb0"
 	set_wifi_led "$boardname:white:wlan"
 	;;
+mtc,wr1201)
+	ucidef_set_led_switch "eth_link" "LAN link" "$boardname:green:eth_link" "switch0" "0x0f"
+	;;
 mzk-ex750np)
 	set_wifi_led "$boardname:red:wifi"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -102,6 +102,7 @@ ramips_setup_interfaces()
 	miwifi-nano|\
 	mt7621|\
 	mt7628|\
+	mtc,wr1201|\
 	mzk-750dhp|\
 	mzk-w300nh2|\
 	netgear,r6120|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -110,6 +110,7 @@ platform_check_image() {
 	mpr-a2|\
 	mr-102n|\
 	mt7628|\
+	mtc,wr1201|\
 	mzk-750dhp|\
 	mzk-dp150n|\
 	mzk-ex300np|\

--- a/target/linux/ramips/dts/WR1201.dts
+++ b/target/linux/ramips/dts/WR1201.dts
@@ -1,0 +1,159 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "mtc,wr1201", "mediatek,mt7621-soc";
+	model = "MTC Wireless Router WR1201";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "wr1201:green:power";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "wr1201:green:usb";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		eth_link {
+			label = "wr1201:green:eth_link";
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wr1201:green:wps";
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "Second_Config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "rgmii2";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -98,6 +98,19 @@ define Build/umedia-header
 	fix-u-media-header -T 0x46 -B $(1) -i $@ -o $@.new && mv $@.new $@
 endef
 
+# The OEM webinterface expects an kernel with initramfs which has the uImage
+# header field ih_name.
+# We don't wan't to set the header name field for the kernel include in the
+# sysupgrade image as well, as this image shouldn't be accepted by the OEM
+# webinterface. It will soft-brick the board.
+define Build/mtc-factory-header
+	mkimage -A $(LINUX_KARCH) \
+	-O linux -T kernel \
+	-C lzma -a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+	-n 'WR1201_8_128' -d $@ $@.new
+	mv $@.new $@
+endef
+
 define Build/edimax-header
 	$(STAGING_DIR_HOST)/bin/mkedimaximg -i $@ -o $@.new $(1)
 	@mv $@.new $@

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -319,6 +319,16 @@ define Device/mikrotik_rbm11g
 endef
 TARGET_DEVICES += mikrotik_rbm11g
 
+define Device/mtc_wr1201
+	DTS := WR1201
+	IMAGE_SIZE := 16000k
+	DEVICE_TITLE := MTC Wireless Router WR1201
+	KERNEL_INITRAMFS := $(KERNEL_DTB) | mtc-factory-header
+	DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 \
+		kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += mtc_wr1201
+
 define Device/re350-v1
   DTS := RE350
   DEVICE_TITLE := TP-LINK RE350 v1


### PR DESCRIPTION
Support for Strong 1200

[https://forum.openwrt.org/t/support-for-strong-1200/22768](https://forum.openwrt.org/t/support-for-strong-1200/22768)

Specification:
- SoC: MediaTek MT7621A (880 MHz)
- Flash: 16 MiB
- RAM: 128 MiB
- Wireless: 2.4Ghz(MT7602EN) and 5Ghz (MT7612EN)
- Ethernet speed: 10/100/1000
- Ethernet ports: 4+1
- 1x USB 3.0
- 1x microSD reader
- Serial baud rate of Bootloader and factory firmware: 57600

To flash via webinterface use first initramfs.bin and after (from the OpenWrt) the sysupgrade.bin

Some notes:
- some microSD not work (kernel bug?):

```
[  173.767665] mtk-sd 1e130000.sdhci: no support for card's volts
[  173.779318] mmc0: error -22 whilst initialising SDIO card
[  173.791941] mtk-sd 1e130000.sdhci: no support for card's volts
[  173.803598] mmc0: error -22 whilst initialising MMC card
[  173.877989] mtk-sd 1e130000.sdhci: no support for card's volts
[  173.889610] mmc0: error -22 whilst initialising SDIO card
[  173.902535] mtk-sd 1e130000.sdhci: card claims to support voltages below defined range
[  173.918337] mtk-sd 1e130000.sdhci: no support for card's volts
[  173.929975] mmc0: error -22 whilst initialising MMC card
[  173.998351] mtk-sd 1e130000.sdhci: no support for card's volts
[  174.009972] mmc0: error -22 whilst initialising SDIO card
[  174.023202] mtk-sd 1e130000.sdhci: no support for card's volts
[  174.034820] mmc0: error -22 whilst initialising MMC card
```

- Wifi LED (2.4 and 5) not available
