### PR TITLE
ath79:  add support for the TP-Link TL-WR841N/ND v8 router

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -93,6 +93,7 @@ tplink,tl-wr941-v4)
 	;;
 tplink,tl-wr740nd-v4|\
 tplink,tl-wr741nd-v4|\
+tplink,tl-wr841-v8|\
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -175,6 +175,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	tplink,tl-wr841-v8|\
 	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth0"

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -130,6 +130,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3d0000>;
 			};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	model = "TP-Link TL-WR841N/ND v8";
+	compatible = "tplink,tl-wr841-v8", "qca,ar9341";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+	};
+
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -136,6 +136,14 @@ define Device/tplink_tl-wr841-v7
 endef
 TARGET_DEVICES += tplink_tl-wr841-v7
 
+define Device/tplink_tl-wr841-v8
+  $(Device/tplink-4mlzma)
+  ATH_SOC := ar9341
+  DEVICE_TITLE := TP-LINK TL-WR841N/ND v8
+  TPLINK_HWID := 0x08410008
+endef
+TARGET_DEVICES += tplink_tl-wr841-v8
+
 define Device/tplink_tl-wr841-v9
   $(Device/tplink-4mlzma)
   ATH_SOC := qca9533


### PR DESCRIPTION
This commit adds support for TP-Link TL-WR841N/ND v8 router, in ath79 Tiny targets.

CPU: Atheros AR9341 535MHz
RAM: 32MB
FLASH: 4MiB
PORTS: 4 Port 100/10 Switch, 1 Port 100/10 Wan
WiFi: Atheros AR9341 2x2:2 bgn
LED: Power (static on), LAN (controlled by Switch), WAN, SYS, WiFi, RFKill
BTN: WPS, WiFi, Reset

Installation:
Upload the factory image via the vendor-GUI or sysupgrade, use -F (force)
if upgrading from ar71xx targets.
