### PR TITLE
add support for Mikrotik RouterBOARD SXT Lite 2 with NOR flash

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -113,6 +113,7 @@ ar71xx_setup_interfaces()
 	rb-mapl-2nd|\
 	rb-sxt2n|\
 	rb-sxt5n|\
+	rb-sxt-2nd-r3|\
 	rb-wap-2nd|\
 	rb-wapr-2nd|\
 	rb-wapg-5hact2hnd|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -380,6 +380,7 @@ get_status_led() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
+	rb-sxt-2nd-r3|\
 	rb-wap-2nd|\
 	rb-wapr-2nd)
 		status_led="rb:green:user"

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1110,6 +1110,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD mAP L-2nD")
 		name="rb-mapl-2nd"
 		;;
+	*"RouterBOARD SXT 2nD r3")
+		name="rb-sxt-2nd-r3"
+		;;
 	*"RouterBOARD SXT Lite2")
 		name="rb-sxt2n"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -729,6 +729,7 @@ platform_check_image() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
+	rb-sxt-2nd-r3|\
 	rb-wap-2nd|\
 	rb-wapg-5hact2hnd|\
 	rb-wapr-2nd)
@@ -757,6 +758,7 @@ platform_pre_upgrade() {
 	rb-lhg-5nd|\
 	rb-map-2nd|\
 	rb-mapl-2nd|\
+	rb-sxt-2nd-r3|\
 	rb-wap-2nd|\
 	rb-wapg-5hact2hnd|\
 	rb-wapr-2nd)

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1176,11 +1176,12 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD Powerbox
 	  MikroTik RouterBOARD LHG 5
 	  MikroTik RouterBOARD cAP (EXPERIMENTAL)
+	  MikroTik RouterBOARD SXT Lite 2 r3
 	  MikroTik RouterBOARD wAP
 	  MikroTik RouterBOARD wAP R-2nD
 
 config ATH79_MACH_RBSXTLITE
-	bool "MikroTik RouterBOARD SXT Lite"
+	bool "MikroTik RouterBOARD SXT Lite (NAND flash versions)"
 	select SOC_AR934X
 	select ATH79_DEV_ETH
 	select ATH79_DEV_NFC

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -46,7 +46,7 @@ define Device/rb-nor-flash-16M
   DEVICE_PACKAGES := rbcfg rssileds -nand-utils kmod-ledtrig-gpio
   IMAGE_SIZE := 16000k
   KERNEL_INSTALL := 1
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd rb-sxt-2nd-r3
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef


### PR DESCRIPTION
The Mikrotik RouterBOARD SXT Lite 2 with NOR flash (SXT 2nD r3) works when using the forced update mode of sysupgrade.
This patch adds the device to the white list.
