### PR TITLE
[RFC] lantiq: add support for VGV953 (Speedport W 921V)

### DIFF
--- a/package/boot/uboot-lantiq/Makefile
+++ b/package/boot/uboot-lantiq/Makefile
@@ -332,6 +332,14 @@ define U-Boot/vgv7519_ram
   DDR_SETTINGS:=board/arcadyan/vgv7519/ddr_settings.h
 endef
 
+define U-Boot/vgv953akw22_ram
+  NAME:=Speedport W 921V (RAM)
+  BUILD_SUBTARGET:=xrx200
+  BUILD_DEVICES:=arcadyan_vgv953akw22
+#  DDR_SETTINGS:=board/arcadyan/vgv953akw22/ddr_settings.h
+  DDR_SETTINGS:=board/bt/bthomehubv5a/ddr_settings.h
+endef
+
 UBOOT_TARGETS:= \
 	arv4519pw_ram arv4519pw_nor arv4519pw_brn \
 	arv7506pw11_ram arv7506pw11_nor arv7506pw11_brn \
@@ -349,7 +357,8 @@ UBOOT_TARGETS:= \
 	fb3370_eva fb3370_ram fb3370_sfspl \
 	p2812hnufx_ram p2812hnufx_nandspl \
 	vgv7510kw22_brn vgv7510kw22_nor vgv7510kw22_ram \
-	vgv7519_brn vgv7519_nor vgv7519_ram
+	vgv7519_brn vgv7519_nor vgv7519_ram \
+	vgv953akw22_ram
 
 define CompressVR9Firmware
 	$(STAGING_DIR_HOST)/bin/lzma e \

--- a/package/boot/uboot-lantiq/patches/0117-MIPS-add-board-support-for-Arcadyan-VGV953.patch
+++ b/package/boot/uboot-lantiq/patches/0117-MIPS-add-board-support-for-Arcadyan-VGV953.patch
@@ -1,0 +1,300 @@
+--- /dev/null
++++ b/board/arcadyan/vgv953akw22/Makefile
+@@ -0,0 +1,27 @@
++#
++# Copyright (C) 2000-2011 Wolfgang Denk, DENX Software Engineering, wd@denx.de
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++include $(TOPDIR)/config.mk
++
++LIB	= $(obj)lib$(BOARD).o
++
++COBJS	= $(BOARD).o
++
++SRCS	:= $(SOBJS:.o=.S) $(COBJS:.o=.c)
++OBJS	:= $(addprefix $(obj),$(COBJS))
++SOBJS	:= $(addprefix $(obj),$(SOBJS))
++
++$(LIB):	$(obj).depend $(OBJS) $(SOBJS)
++	$(call cmd_link_o_target, $(OBJS) $(SOBJS))
++
++#########################################################################
++
++# defines $(obj).depend target
++include $(SRCTREE)/rules.mk
++
++sinclude $(obj).depend
++
++#########################################################################
+--- /dev/null
++++ b/board/arcadyan/vgv953akw22/vgv953akw22.c
+@@ -0,0 +1,97 @@
++/*
++ * Copyright (C) 2018 Stefan Grau, stefangrau85@gmail.com
++ * Based on p2812hnufx.c: (C) 2013 Luka Perkov <luka@openwrt.org>
++ *
++ * SPDX-License-Identifier:	GPL-2.0+
++ */
++
++#include <common.h>
++#include <asm/gpio.h>
++#include <asm/lantiq/eth.h>
++#include <asm/lantiq/chipid.h>
++#include <asm/lantiq/cpu.h>
++#include <asm/arch/gphy.h>
++
++#if defined(CONFIG_SPL_BUILD)
++#define do_gpio_init	1
++#define do_pll_init	1
++#define do_dcdc_init	0
++#elif defined(CONFIG_SYS_BOOT_RAM)
++#define do_gpio_init	1
++#define do_pll_init	0
++#define do_dcdc_init	1
++#else
++#define do_gpio_init	0
++#define do_pll_init	0
++#define do_dcdc_init	1
++#endif
++
++static void gpio_init(void)
++{
++	/* EBU.FL_CS1 as output for NAND CE */
++	gpio_set_altfunc(23, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* EBU.FL_A23 as output for NAND CLE */
++	gpio_set_altfunc(24, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* EBU.FL_A24 as output for NAND ALE */
++	gpio_set_altfunc(13, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++	/* GPIO 3.0 as input for NAND Ready Busy */
++	gpio_set_altfunc(48, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_IN);
++	/* GPIO 3.1 as output for NAND Read */
++	gpio_set_altfunc(49, GPIO_ALTSEL_SET, GPIO_ALTSEL_CLR, GPIO_DIR_OUT);
++}
++
++int board_early_init_f(void)
++{
++	if (do_gpio_init)
++		gpio_init();
++
++	if (do_pll_init)
++		ltq_pll_init();
++
++	if (do_dcdc_init)
++		ltq_dcdc_init(0x7F);
++
++	return 0;
++}
++
++int checkboard(void)
++{
++	puts("Board: " CONFIG_BOARD_NAME "\n");
++	ltq_chip_print_info();
++
++	return 0;
++}
++
++static const struct ltq_eth_port_config eth_port_config[] = {
++	/* GMAC0: external Lantiq PEF7071 10/100/1000 PHY for LAN port 0 */
++	{ 0, 0x0, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_RGMII },
++	/* GMAC1: external Lantiq PEF7071 10/100/1000 PHY for LAN port 1 */
++	{ 1, 0x1, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_RGMII },
++	/* GMAC2: internal GPHY0 with 10/100/1000 firmware for LAN port 2 */
++	{ 2, 0x11, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_GMII },
++	/* GMAC3: unused */
++	{ 3, 0x0, LTQ_ETH_PORT_NONE, PHY_INTERFACE_MODE_NONE },
++	/* GMAC4: internal GPHY1 with 10/100/1000 firmware for LAN port 3 */
++	{ 4, 0x13, LTQ_ETH_PORT_PHY, PHY_INTERFACE_MODE_GMII },
++	/* GMAC5: unused */
++};
++
++static const struct ltq_eth_board_config eth_board_config = {
++	.ports = eth_port_config,
++	.num_ports = ARRAY_SIZE(eth_port_config),
++};
++
++int board_eth_init(bd_t * bis)
++{
++	const enum ltq_gphy_clk clk = LTQ_GPHY_CLK_25MHZ_PLL0;
++	const ulong fw_addr = 0x80FF0000;
++
++	ltq_gphy_phy11g_a1x_load(fw_addr);
++
++	ltq_cgu_gphy_clk_src(clk);
++
++	ltq_rcu_gphy_boot(0, fw_addr);
++	ltq_rcu_gphy_boot(1, fw_addr);
++
++	return ltq_eth_initialize(&eth_board_config);
++}
+--- /dev/null
++++ b/board/arcadyan/vgv953akw22/config.mk
+@@ -0,0 +1,7 @@
++#
++# Copyright (C) 2012-2013 Daniel Schwierzeck, daniel.schwierzeck@gmail.com
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++PLATFORM_CPPFLAGS += -I$(TOPDIR)/board/$(BOARDDIR)
+--- /dev/null
++++ b/board/arcadyan/vgv953akw22/ddr_settings.h
+@@ -0,0 +1,70 @@
++/*
++ * Copyright (C) 2018 Stefan Grau, stefangrau85@gmail.com
++ *
++ * The values have been taken from the FIXME
++ *
++ * SPDX-License-Identifier:	GPL-2.0+
++ */
++
++#define	MC_CCR00_VALUE	0x101
++#define	MC_CCR01_VALUE	0x1000100
++#define	MC_CCR02_VALUE	0x1010000
++#define	MC_CCR03_VALUE	0x101
++#define	MC_CCR04_VALUE	0x1000000
++#define	MC_CCR05_VALUE	0x1000101
++#define	MC_CCR06_VALUE	0x1000100
++#define	MC_CCR07_VALUE	0x1010000
++#define	MC_CCR08_VALUE	0x1000101
++#define	MC_CCR09_VALUE	0x0
++#define	MC_CCR10_VALUE	0x2000100
++#define	MC_CCR11_VALUE	0x2000300
++#define	MC_CCR12_VALUE	0x30000
++#define	MC_CCR13_VALUE	0x202
++#define	MC_CCR14_VALUE	0x7080A0F
++#define	MC_CCR15_VALUE	0x2040F
++#define	MC_CCR16_VALUE	0x40000
++#define	MC_CCR17_VALUE	0x70102
++#define	MC_CCR18_VALUE	0x4020002
++#define	MC_CCR19_VALUE	0x30302
++#define	MC_CCR20_VALUE	0x8000700
++#define	MC_CCR21_VALUE	0x40F020A
++#define	MC_CCR22_VALUE	0x0
++#define	MC_CCR23_VALUE	0xC020000
++#define	MC_CCR24_VALUE	0x4401B04
++#define	MC_CCR25_VALUE	0x0
++#define	MC_CCR26_VALUE	0x0
++#define	MC_CCR27_VALUE	0x6420000
++#define	MC_CCR28_VALUE	0x0
++#define	MC_CCR29_VALUE	0x0
++#define	MC_CCR30_VALUE	0x798
++#define	MC_CCR31_VALUE	0x0
++#define	MC_CCR32_VALUE	0x0
++#define	MC_CCR33_VALUE	0x650000
++#define	MC_CCR34_VALUE	0x200C8
++#define	MC_CCR35_VALUE	0x1D445D
++#define	MC_CCR36_VALUE	0xC8
++#define	MC_CCR37_VALUE	0xC351
++#define	MC_CCR38_VALUE	0x0
++#define	MC_CCR39_VALUE	0x141F04
++#define	MC_CCR40_VALUE	0x142704
++#define	MC_CCR41_VALUE	0x141B42
++#define	MC_CCR42_VALUE	0x141B42
++#define	MC_CCR43_VALUE	0x566504
++#define	MC_CCR44_VALUE	0x566504
++#define	MC_CCR45_VALUE	0x565F17
++#define	MC_CCR46_VALUE	0x565F17
++#define	MC_CCR47_VALUE	0x0
++#define	MC_CCR48_VALUE	0x0
++#define	MC_CCR49_VALUE	0x0
++#define	MC_CCR50_VALUE	0x0
++#define	MC_CCR51_VALUE	0x0
++#define	MC_CCR52_VALUE	0x133
++#define	MC_CCR53_VALUE	0xF3014B27
++#define	MC_CCR54_VALUE	0xF3014B27
++#define	MC_CCR55_VALUE	0xF3014B27
++#define	MC_CCR56_VALUE	0xF3014B27
++#define	MC_CCR57_VALUE	0x7800301
++#define	MC_CCR58_VALUE	0x7800301
++#define	MC_CCR59_VALUE	0x7800301
++#define	MC_CCR60_VALUE	0x7800301
++#define	MC_CCR61_VALUE	0x4
+--- a/boards.cfg
++++ b/boards.cfg
+@@ -540,6 +540,8 @@ Active  mips        mips32         incai
+ Active  mips        mips32         vrx200      arcadyan        vgv7510kw22         vgv7510kw22_brn                      vgv7510kw22:SYS_BOOT_BRN                                                                                                           Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+ Active  mips        mips32         vrx200      arcadyan        vgv7510kw22         vgv7510kw22_nor                      vgv7510kw22:SYS_BOOT_NOR                                                                                                           Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+ Active  mips        mips32         vrx200      arcadyan        vgv7510kw22         vgv7510kw22_ram                      vgv7510kw22:SYS_BOOT_RAM                                                                                                           Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++Active  mips        mips32         vrx200      arcadyan        vgv953akw22         vgv953akw22_nandspl                  vgv953akw22:SYS_BOOT_NANDSPL                                                                                                            Stefan Grau <tbd@tbd.de>
++Active  mips        mips32         vrx200      arcadyan        vgv953akw22         vgv953akw22_ram                      vgv953akw22:SYS_BOOT_RAM                                                                                                                Stefan Grau <tbd@tbd.de>
+ Active  mips        mips32         vrx200      arcadyan        vgv7519             vgv7519_brn                          vgv7519:SYS_BOOT_BRN                                                                                                              Mathias Kresin <dev@kresin.me>
+ Active  mips        mips32         vrx200      arcadyan        vgv7519             vgv7519_nor                          vgv7519:SYS_BOOT_NOR                                                                                                              Eddi De Pieri <eddi@depieri.net>
+ Active  mips        mips32         vrx200      arcadyan        vgv7519             vgv7519_ram                          vgv7519:SYS_BOOT_RAM                                                                                                              Eddi De Pieri <eddi@depieri.net>
+--- /dev/null
++++ b/include/configs/vgv953akw22.h
+@@ -0,0 +1,73 @@
++/*
++ * Copyright (C) 2018 Stefan Grau, stefangrau85@gmail.com
++ *
++ * SPDX-License-Identifier:	GPL-2.0+
++ */
++
++#ifndef __CONFIG_H
++#define __CONFIG_H
++
++#define CONFIG_MACH_TYPE	"VGV953AKW22"
++#define CONFIG_IDENT_STRING	" "CONFIG_MACH_TYPE
++#define CONFIG_BOARD_NAME	"Arcadyan VGV953AKW22"
++
++/* Configure SoC */
++#define CONFIG_LTQ_SUPPORT_UART			/* Enable ASC and UART */
++
++#define CONFIG_LTQ_SUPPORT_ETHERNET		/* Enable ethernet */
++
++#define CONFIG_LTQ_SUPPORT_NAND_FLASH		/* Have a NAND256W3A NAND flash */
++
++#define CONFIG_LTQ_SUPPORT_SPL_NAND_FLASH	/* Build NAND flash SPL */
++#define CONFIG_SYS_NAND_PAGE_COUNT	64
++#define CONFIG_SYS_NAND_PAGE_SIZE	512
++#define CONFIG_SYS_NAND_OOBSIZE	16
++#define CONFIG_SYS_NAND_BLOCK_SIZE	(16 * 2048)
++#define CONFIG_SYS_NAND_U_BOOT_OFFS	0x4000
++
++#define CONFIG_LTQ_SPL_COMP_LZO			/* Compress SPL with LZO */
++#define CONFIG_LTQ_SPL_CONSOLE			/* Enable SPL console */
++
++#define CONFIG_SYS_DRAM_PROBE
++
++#define CONFIG_SYS_BOOTM_LEN          0x1000000       /* 16 MB */
++
++/* Environment */
++#if defined(CONFIG_SYS_BOOT_NANDSPL)
++
++#define CONFIG_ENV_IS_IN_NAND
++#define CONFIG_ENV_OVERWRITE
++#define CONFIG_ENV_OFFSET		(256 * 1024)
++#define CONFIG_ENV_SECT_SIZE		(128 * 1024)
++#else
++#define CONFIG_ENV_IS_NOWHERE
++#endif
++
++#define CONFIG_ENV_SIZE			(8 * 1024)
++
++#define CONFIG_LOADADDR			CONFIG_SYS_LOAD_ADDR
++
++/* Console */
++#define CONFIG_LTQ_ADVANCED_CONSOLE
++#define CONFIG_BAUDRATE			115200
++#define CONFIG_CONSOLE_ASC		1
++#define CONFIG_CONSOLE_DEV		"ttyLTQ1"
++
++/* Pull in default board configs for Lantiq XWAY VRX200 */
++#include <asm/lantiq/config.h>
++#include <asm/arch/config.h>
++
++/* Pull in default OpenWrt configs for Lantiq SoC */
++#include "openwrt-lantiq-common.h"
++
++#define CONFIG_ENV_UPDATE_UBOOT_NAND \
++	"load-uboot-nandtpl-lzo=tftpboot u-boot.ltq.lzo.nandtpl\0"	\
++	"update-uboot=run load-uboot-nandtpl-lzo write-uboot-nand\0"	\
++	"backup=nand read $loadaddr 0 0x2000000 tftpput $loadaddr 0x2000000 vgv953akw22.nand.dump\0"	\
++	"restore=tftpboot vgv953akw22.nand.dump && nand write $loadaddr 0 0x2000000\0"
++
++#define CONFIG_EXTRA_ENV_SETTINGS	\
++	CONFIG_ENV_LANTIQ_DEFAULTS	\
++	CONFIG_ENV_UPDATE_UBOOT_NAND	\
++
++#endif /* __CONFIG_H */

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -211,6 +211,7 @@
 			compatible = "lantiq,xrx200-pinctrl";
 			#gpio-cells = <2>;
 			gpio-controller;
+			gpio-ranges = <&gpio 0 0 56>;
 			reg = <0xe100b10 0xa0>;
 
 			gphy0_led0_pins: gphy0-led0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
@@ -205,6 +205,17 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
+		exin3 {
+			lantiq,groups = "exin3";
+			lantiq,function = "exin";
+		};
+		stp {
+			lantiq,groups = "stp";
+			lantiq,function = "stp";
+			lantiq,pull = <2>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,output = <1>;
@@ -247,11 +258,11 @@
 			};
 			partition@60000 {
 				label = "kernel";
-				reg = <0x60000 0x200000>;
+				reg = <0x60000 0x400000>;
 			};
-			partition@260000 {
+			partition@460000 {
 				label = "ubi";
-				reg = <0x260000 0x1da0000>;
+				reg = <0x460000 0x1ba0000>;
 			};
 		};
 	};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
@@ -104,17 +104,6 @@
 		};
 	};
 
-	usb0_vbus: regulator-usb0-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB0_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 	usb1_vbus: regulator-usb1-vbus {
 		compatible = "regulator-fixed";
 
@@ -234,6 +223,12 @@
 			lantiq,output = <1>;
 		};
 	};
+	ifxhcd-rst-dev {
+		gpio-hog;
+		line-name = "ifxhcd-rst-dev";
+		gpios = <32 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
 };
 
 &localbus {
@@ -262,8 +257,11 @@
 			};
 			partition@460000 {
 				label = "ubi";
-				reg = <0x460000 0x1ba0000>;
+				reg = <0x460000 0x1B98000>;
 			};
+			/*
+			 * last 32 KiB are for the bad block table, not writable
+			 */
 		};
 	};
 };
@@ -293,17 +291,8 @@
 	lantiq,phy2 = <0x0>;
 };
 
-&usb_phy0 {
-	status = "okay";
-};
-
 &usb_phy1 {
 	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-	vbus-supply = <&usb0_vbus>;
 };
 
 &usb1 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "arcadyan,vgv953akw22", "lantiq,xway", "lantiq,vr9";
+	model = "Speedport W 921V";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power_white;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_white;
+		led-upgrade = &led_waiting;
+
+		led-dsl = &led_dsl;
+		led-internet = &led_internet;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		dect_paging {
+			label = "dect_paging";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+
+		dect_pairing {
+			label = "dect";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_CONFIG>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_waiting: waiting {
+			label = "vgv953:yellow:waiting";
+			gpios = <&stp 16 GPIO_ACTIVE_LOW>;
+		};
+		led_service: service {
+			label = "vgv953:yellow:sevice";
+			gpios = <&stp 17 GPIO_ACTIVE_LOW>;
+		};
+		led_phone: phone {
+			label = "vgv953:white:phone";
+			gpios = <&stp 18 GPIO_ACTIVE_LOW>;
+		};
+		led_wifi: wifi {
+			label = "vgv953:white:wifi";
+			gpios = <&stp 19 GPIO_ACTIVE_LOW>;
+		};
+		led_internet: internet {
+			label = "vgv953:white:internet";
+			gpios = <&stp 20 GPIO_ACTIVE_LOW>;
+		};
+		led_dsl: dsl {
+			label = "vgv953:white:dsl";
+			gpios = <&stp 21 GPIO_ACTIVE_LOW>;
+		};
+		led_power_red: power_red {
+			label = "vgv953:red:power";
+			gpios = <&stp 22 GPIO_ACTIVE_LOW>;
+		};
+		led_power_white: power_white {
+			label = "vgv953:white:power";
+			gpios = <&stp 23 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+	usb1_vbus: regulator-usb1-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB1_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy1>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pci_rst {
+			lantiq,pins = "io21";
+			lantiq,output = <1>;
+			lantiq,open-drain = <0>;
+			lantiq,pull = <2>;
+		};
+		pcie-rst {
+			lantiq,pins = "io38";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+		ifxhcd-rst {
+			lantiq,pins = "io33";
+			lantiq,pull = <0>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nand-xway";
+		lantiq,cs = <1>;
+		bank-width = <2>;
+		reg = <0x0 0x0 0x2000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x00000 0x40000>;
+			};
+			partition@40000 {
+				label = "uboot-env";
+				reg = <0x40000 0x20000>;
+			};
+			partition@60000 {
+				label = "kernel";
+				reg = <0x60000 0x200000>;
+			};
+			partition@260000 {
+				label = "ubi";
+				reg = <0x260000 0x1da0000>;
+			};
+		};
+	};
+};
+
+&pci0 {
+	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+
+/*	wifi@1a30,0700*/
+};
+
+&pcie0 {
+	status = "disabled";
+	gpio-reset = <&gpio 38 GPIO_ACTIVE_HIGH>;
+};
+&stp {
+	status = "okay";
+
+	lantiq,shadow = <0xffffff>;
+	lantiq,groups = <0x7>;
+	lantiq,dsl = <0x0>;
+	lantiq,phy1 = <0x0>;
+	lantiq,phy2 = <0x0>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb1_vbus>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv953akw22.dts
@@ -70,35 +70,35 @@
 		compatible = "gpio-leds";
 
 		led_waiting: waiting {
-			label = "vgv953:yellow:waiting";
+			label = "vgv953akw22:yellow:waiting";
 			gpios = <&stp 16 GPIO_ACTIVE_LOW>;
 		};
 		led_service: service {
-			label = "vgv953:yellow:sevice";
+			label = "vgv953akw22:yellow:sevice";
 			gpios = <&stp 17 GPIO_ACTIVE_LOW>;
 		};
 		led_phone: phone {
-			label = "vgv953:white:phone";
+			label = "vgv953akw22:white:phone";
 			gpios = <&stp 18 GPIO_ACTIVE_LOW>;
 		};
 		led_wifi: wifi {
-			label = "vgv953:white:wifi";
+			label = "vgv953akw22:white:wifi";
 			gpios = <&stp 19 GPIO_ACTIVE_LOW>;
 		};
 		led_internet: internet {
-			label = "vgv953:white:internet";
+			label = "vgv953akw22:white:internet";
 			gpios = <&stp 20 GPIO_ACTIVE_LOW>;
 		};
 		led_dsl: dsl {
-			label = "vgv953:white:dsl";
+			label = "vgv953akw22:white:dsl";
 			gpios = <&stp 21 GPIO_ACTIVE_LOW>;
 		};
 		led_power_red: power_red {
-			label = "vgv953:red:power";
+			label = "vgv953akw22:red:power";
 			gpios = <&stp 22 GPIO_ACTIVE_LOW>;
 		};
 		led_power_white: power_white {
-			label = "vgv953:white:power";
+			label = "vgv953akw22:white:power";
 			gpios = <&stp 23 GPIO_ACTIVE_LOW>;
 			default-state = "keep";
 		};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -89,6 +89,20 @@ define Device/arcadyan_vgv7519-nor
 endef
 TARGET_DEVICES += arcadyan_vgv7519-nor
 
+define Device/arcadyan_vgv953akw22
+  $(Device/NAND)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := VGV953AKW22
+  DEVICE_VARIANT := NAND
+  DEVICE_ALT0_VENDOR := Telekom
+  DEVICE_ALT0_MODEL := Speedport W 921V
+  BOARD_NAME := VGV953AKW22
+  SOC := vr9
+  DEVICE_PACKAGES := kmod-usb-dwc2
+  SUPPORTED_DEVICES += VGV953AKW22
+endef
+TARGET_DEVICES += arcadyan_vgv953
+
 define Device/avm_fritz3370
   $(Device/AVM)
   $(Device/NAND)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -101,7 +101,7 @@ define Device/arcadyan_vgv953akw22
   DEVICE_PACKAGES := kmod-usb-dwc2
   SUPPORTED_DEVICES += VGV953AKW22
 endef
-TARGET_DEVICES += arcadyan_vgv953
+TARGET_DEVICES += arcadyan_vgv953akw22
 
 define Device/avm_fritz3370
   $(Device/AVM)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -36,6 +36,10 @@ lantiq_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "4:lan:1" "5:wan:5" "6t@eth0"
 		;;
+	arcadyan,vgv953akw22)
+		ucidef_add_switch "switch0" \
+		"0:lan:4" "1:lan:3" "2:lan:2" "4:lan:1" "6t@eth0"
+		;;
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7360sl|\
@@ -110,7 +114,8 @@ lantiq_setup_macs()
 	lantiq,easy80920-nand|\
 	lantiq,easy80920-nor|\
 	zyxel,p-2812hnu-f1|\
-	zyxel,p-2812hnu-f3)
+	zyxel,p-2812hnu-f3|\
+	arcadyan,vgv953akw22)
 		lan_mac=$(mtd_get_mac_ascii uboot-env ethaddr)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	arcadyan,vgv953akw22|\
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7362sl|\


### PR DESCRIPTION
Create VGV953.dts
Update platform.sh, Makefile and 02_network

there is no wifi module for XWAVE300
possible bugs with nand and usb when checking dmesg
USB works and I did not had any issues with the partitions yet
LEDs and Network Ports are all mapped
2nd kernel line present in dts file with sram commented out
Old Install instruction is still valid
https://openwrt.org/toh/t-com/spw921v
known u-boot size limitation for initramfs image
usb power with gpio 32 high so assume dummy voltage regulator

Signed-off-by: Stefan Grau <stefan_grau@t-online.de>