### PR TITLE
linux-firmware: Update linux-firmware to 2018-10-18

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -11,10 +11,10 @@ PKG_NAME:=linux-firmware
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2018-08-03
-PKG_SOURCE_VERSION:=7b5835fd37630d18ac0c755329172f6a17c1af29
-PKG_MIRROR_HASH:=fd631e7d024b0da78ad930a64503f816be19f49b15bbd454e83d41fd8dfde793
-PKG_SOURCE_URL:=git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+PKG_SOURCE_DATE:=2018-10-18
+PKG_SOURCE_VERSION:=d87753369b82c5f362250c197d04a1e1ef5bf698
+PKG_MIRROR_HASH:=6f3b1d10544609d285a9a47b5bd578bdceb59d86e5d99347e8fa52cd6f3ed66c
+PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Kalles ath10k PR was finally merged so update linux-firmware to
include those changes.

This is needed since disabling ath10k-firmware a lot of custom BDF-s
in board-2.bin-s are not available in previously outdated linux-firmware
board-2.bin-s.
This also includes support for boards currently using ipq-wifi and other
WIP ones.

As ath10k-ct is default firmware updating ath10k-firmware is also needed
to get rid of ipq-wifi, but that will be another PR.

Runtime tested on 8devices Jalapeno.

Signed-off-by: Robert Marko <robimarko@gmail.com>