### PR TITLE
ar71xx: add led configuration for TP-Link Archer C7 v5

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -155,6 +155,16 @@ archer-c7-v4)
 	ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
 	ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
 	;;
+archer-c7-v5)
+	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
+	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
+	ucidef_set_led_switch "lan1" "LAN1" "$board:green:lan4" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan2" "switch0" "0x10"
+	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan1" "switch0" "0x20"
+	ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+	;;
 arduino-yun)
 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
 	ucidef_set_led_usbdev "usb" "USB" "arduino:white:usb" "1-1.1"


### PR DESCRIPTION
This adds the LED configuration for the TP-Link Archer C7 v5.
It is slightly different than the v4, as it only has one USB.

Signed-off-by: Daniel Muñoz <danyable@gmail.com>