### PR TITLE
ar71xx: Fix FS#1805 (build failure for tiny targets due to -Wpacked-not-aligned introduced by GCC 8)

### DIFF
--- a/target/linux/ar71xx/patches-4.14/910-unaligned_access_hacks.patch
+++ b/target/linux/ar71xx/patches-4.14/910-unaligned_access_hacks.patch
@@ -129,6 +129,15 @@
  struct ip_auth_hdr {
 --- a/include/uapi/linux/ipv6.h
 +++ b/include/uapi/linux/ipv6.h
+@@ -104,7 +104,7 @@ struct ipv6_destopt_hao {
+ 	__u8			type;
+ 	__u8			length;
+ 	struct in6_addr		addr;
+-} __attribute__((packed));
++} __attribute__((packed, aligned(2)));
+ 
+ /*
+  *	IPv6 fixed header
 @@ -131,7 +131,7 @@ struct ipv6hdr {
  
  	struct	in6_addr	saddr;


### PR DESCRIPTION
Fix build failure for ar71xx tiny targets by correcting alignment for struct ipv6_destopt_hao in include/uapi/linux/ipv6.h