### PR TITLE
grub2: fix regression caused by binutils-2.31.1

### DIFF
--- a/package/boot/grub2/patches/400-R_X86_64_PLT32.patch
+++ b/package/boot/grub2/patches/400-R_X86_64_PLT32.patch
@@ -1,0 +1,75 @@
+From 02702bdfe14d8a04643a45b03715f734ae34dbac Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Sat, 17 Feb 2018 06:47:28 -0800
+Subject: x86-64: Treat R_X86_64_PLT32 as R_X86_64_PC32
+
+Starting from binutils commit bd7ab16b4537788ad53521c45469a1bdae84ad4a:
+
+https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=bd7ab16b4537788ad53521c45469a1bdae84ad4a
+
+x86-64 assembler generates R_X86_64_PLT32, instead of R_X86_64_PC32, for
+32-bit PC-relative branches.  Grub2 should treat R_X86_64_PLT32 as
+R_X86_64_PC32.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+
+Origin: upstream, https://git.savannah.gnu.org/cgit/grub.git/commit/?id=842c390469e2c2e10b5aa36700324cd3bde25875
+Last-Update: 2018-07-30
+
+Patch-Name: R_X86_64_PLT32.patch
+---
+ grub-core/efiemu/i386/loadcore64.c | 1 +
+ grub-core/kern/x86_64/dl.c         | 1 +
+ util/grub-mkimagexx.c              | 1 +
+ util/grub-module-verifier.c        | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/grub-core/efiemu/i386/loadcore64.c b/grub-core/efiemu/i386/loadcore64.c
+index e49d0b6ff..18facf47f 100644
+--- a/grub-core/efiemu/i386/loadcore64.c
++++ b/grub-core/efiemu/i386/loadcore64.c
+@@ -98,6 +98,7 @@ grub_arch_efiemu_relocate_symbols64 (grub_efiemu_segment_t segs,
+ 		    break;
+ 
+ 		  case R_X86_64_PC32:
++		  case R_X86_64_PLT32:
+ 		    err = grub_efiemu_write_value (addr,
+ 						   *addr32 + rel->r_addend
+ 						   + sym.off
+diff --git a/grub-core/kern/x86_64/dl.c b/grub-core/kern/x86_64/dl.c
+index 440690673..3a73e6e6c 100644
+--- a/grub-core/kern/x86_64/dl.c
++++ b/grub-core/kern/x86_64/dl.c
+@@ -70,6 +70,7 @@ grub_arch_dl_relocate_symbols (grub_dl_t mod, void *ehdr,
+ 	  break;
+ 
+ 	case R_X86_64_PC32:
++	case R_X86_64_PLT32:
+ 	  {
+ 	    grub_int64_t value;
+ 	    value = ((grub_int32_t) *addr32) + rel->r_addend + sym->st_value -
+diff --git a/util/grub-mkimagexx.c b/util/grub-mkimagexx.c
+index e63f148e4..f20255a28 100644
+--- a/util/grub-mkimagexx.c
++++ b/util/grub-mkimagexx.c
+@@ -832,6 +832,7 @@ SUFFIX (relocate_addresses) (Elf_Ehdr *e, Elf_Shdr *sections,
+ 		  break;
+ 
+ 		case R_X86_64_PC32:
++		case R_X86_64_PLT32:
+ 		  {
+ 		    grub_uint32_t *t32 = (grub_uint32_t *) target;
+ 		    *t32 = grub_host_to_target64 (grub_target_to_host32 (*t32)
+diff --git a/util/grub-module-verifier.c b/util/grub-module-verifier.c
+index 9179285a5..a79271f66 100644
+--- a/util/grub-module-verifier.c
++++ b/util/grub-module-verifier.c
+@@ -19,6 +19,7 @@ struct grub_module_verifier_arch archs[] = {
+       -1
+     }, (int[]){
+       R_X86_64_PC32,
++      R_X86_64_PLT32,
+       -1
+     }
+   },


### PR DESCRIPTION
grub-efi no longer works:

`grub-mkimage: error: relocation 0x4 is not implemented yet.`

See:

http://git.savannah.gnu.org/cgit/grub.git/commit/util?id=842c390469e2c2e10b5aa36700324cd3bde25875

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
