### PR TITLE
ar71xx: switch TP-LINK RE450 v1 to dynamic partitioning 

### DIFF
--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -254,6 +254,8 @@ define Device/re450-v1
   DEVICE_PROFILE := RE450
   TPLINK_HWID := 0x0
   TPLINK_HWREV := 0
+  KERNEL := kernel-bin | patch-cmdline | lzma | tplink-v1-header -O
+  KERNEL_INITRAMFS := kernel-bin | patch-cmdline | lzma | tplink-v1-header
 endef
 TARGET_DEVICES += re450-v1
 

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1103,15 +1103,10 @@ static struct device_info boards[] = {
 		.support_trail = '\x00',
 		.soft_ver = NULL,
 
-		/**
-		   The flash partition table for RE450;
-		   it is almost the same as the one used by the stock images,
-		   576KB were moved from file-system to os-image.
-		*/
+		/** We're using a dynamic kernel/rootfs split here */
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},
-			{"os-image", 0x20000, 0x180000},
-			{"file-system", 0x1a0000, 0x460000},
+			{"firmware", 0x20000, 0x5e0000},
 			{"partition-table", 0x600000, 0x02000},
 			{"default-mac", 0x610000, 0x00020},
 			{"pin", 0x610100, 0x00020},


### PR DESCRIPTION
**Version 2**

As mentioned in commit 5f24933 recent changes on ar71xx (switch to 4.14,
memory compaction, ...) cause an increase in kernel size, making it too
big for RE450.

RE450 images were not build due to the following error message:
os-image partition too big (more than 1572864 bytes): Success

Tested on RE450, device boots and was used to send this patch.

NOTE: switch to dynamic partitioning instead of switching RE450 to target
      tiny was suggested by David Bauer <mail@david-bauer.net>

Reported-by: Enrico Mioso mrkiko.rs@gmail.com
Signed-off-by: Radek Dostál rd@radekdostal.com

---
**Version 1**

As mentioned in commit 5f249333090741ecba190855b13c87fd93ca2520 recent
changes on ar71xx (switch to 4.14, memory compaction, ...) cause
an increase in kernel size, making it too big for RE450.

Its images are not build due to the following error message:
os-image partition too big (more than 1572864 bytes): Success

Tested on RE450, device boots and was used to send this patch.

Reported-by: Enrico Mioso <mrkiko.rs@gmail.com>
Signed-off-by: Radek Dostál <rd@radekdostal.com>

----
**NOTE: It may be worth to check other devices. Unfortunately I am only in possession of RE450.**
