### PR TITLE
Fix model naming according to market titles

### DIFF
--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -7,14 +7,17 @@ do_sysinfo_octeon() {
 	case "$machine" in
 	"UBNT_E100"*)
 		name="erlite"
+		machine="Ubiquiti EdgeRouter Lite"
 		;;
 
 	"UBNT_E200"*)
 		name="er"
+		machine="Ubiquiti EdgeRouter"
 		;;
 
 	"UBNT_E220"*)
 		name="erpro"
+		machine="Ubiquiti EdgeRouter Pro"
 		;;
 
 	*)


### PR DESCRIPTION
Grepping from '/proc/cpuinfo' leads to ugly model names, like "UBNT_E100 (CN5020p1.1-500-SCP)" for the 'EdgeRouter Lite' model. I propose to override this with fixed string of their common market titles to make it more eye-candy. Other device types have their nice model names in '/tmp/sysinfo/model'.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
