### PR TITLE
ramips: add support for Wavlink WL-WN570HA1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -368,6 +368,14 @@ we1026-5g-16m)
 	ucidef_set_led_netdev "lan" "LAN" "we1026-5g:green:lan" "eth0"
 	set_wifi_led "we1026-5g:green:wifi"
 	;;
+wl-wn570ha1)
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "wifi-low" "wifi-low" "$boardname:green:wifi-low" "wlan0" "1" "49"
+	ucidef_set_led_rssi "wifi-med" "wifi-med" "$boardname:green:wifi-med" "wlan0" "50" "84"
+	ucidef_set_led_rssi "wifi-high" "wifi-high" "$boardname:green:wifi-high" "wlan0" "85" "100"
+	set_wifi_led "$boardname:green:wifi"
+	;;
 wl-wn575a3)
 	ucidef_set_rssimon "wlan1" "200000" "1"
 	ucidef_set_led_rssi "wifi-low" "wifi-low" "$boardname:green:wifi-low" "wlan1" "1" "49"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -121,6 +121,7 @@ ramips_setup_interfaces()
 	whr-g300n|\
 	mqmaker,witi-256m|\
 	mqmaker,witi-512m|\
+	wl-wn570ha1|\
 	wl-wn575a3|\
 	wndr3700v5|\
 	youku-yk1|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -595,6 +595,9 @@ ramips_board_detect() {
 	*"WL-351 v1 002")
 		name="wl-351"
 		;;
+	*"WL-WN570HA1")
+		name="wl-wn570ha1"
+		;;
 	*"WL-WN575A3")
 		name="wl-wn575a3"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -190,6 +190,7 @@ platform_check_image() {
 	wl-330n3g|\
 	wl-341v3|\
 	wl-351|\
+	wl-wn570ha1|\
 	wl-wn575a3|\
 	wli-tx4-ag300n|\
 	wlr-6000|\

--- a/target/linux/ramips/dts/WL-WN570HA1.dts
+++ b/target/linux/ramips/dts/WL-WN570HA1.dts
@@ -1,0 +1,135 @@
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn570ha1", "mediatek,mt7628an-soc";
+	model = "Wavlink WL-WN570HA1";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "wl-wn570ha1:green:power";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		wan {
+			label = "wl-wn570ha1:green:wan";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-high {
+			label = "wl-wn570ha1:green:wifi-high";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-med {
+			label = "wl-wn570ha1:green:wifi-med";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "wl-wn570ha1:green:wifi-low";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "wl-wn570ha1:green:wifi";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wled_an", "p0led_an", "wdt", "refclk";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x2e>;
+	mediatek,portmap = "llllw";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -329,6 +329,14 @@ define Device/wcr-1166ds
 endef
 TARGET_DEVICES += wcr-1166ds
 
+define Device/wl-wn570ha1
+  DTS := WL-WN570HA1
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  DEVICE_TITLE := Wavlink WL-WN570HA1
+  DEVICE_PACKAGES := kmod-mt76x0e
+endef
+TARGET_DEVICES += wl-wn570ha1
+
 define Device/wl-wn575a3
   DTS := WL-WN575A3
   IMAGE_SIZE := $(ralink_default_fw_size_8M)


### PR DESCRIPTION
This commit adds support for the Wavlink WL-WN570HA1, a dual-band PoE
wireless router with the following specifications:

 - CPU: MediaTek MT7688AN 580MHz
 - Flash: 8MB
 - RAM: 64MB
 - Ethernet: 1x 10/100Mbps
 - 2.4 GHz: 802.11b/g/n SoC, 1T1R, 27 dBm
 - 5 GHz: 802.11a/n/ac MT7610E, 1T1R, 25 dBm
 - Antennas: 2x external (1 per radio), detachable
 - LEDs: 3 programmable + Wi-Fi, WAN/LAN, Power
 - Buttons: Reset

Flashing instructions:

Factory U-boot launches a TFTP client if reset button is pressed during power-on.
Rename the sysupgrade file and configure TFTP as follows:

 - Client (WL-WN570HA1) IP: 192.168.10.101
 - Server IP: 192.168.10.100
 - Filename: firmware.bin

Signed-off-by: Thomas Vincent-Cross <me@tvc.id.au>