### PR TITLE
build: fix umask detection bashism

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -24,7 +24,7 @@ $(eval $(call TestHostCommand,case-sensitive-fs, \
 
 $(eval $(call TestHostCommand,proper-umask, \
 	Please build with umask 022 - other values produce broken packages, \
-	umask | grep -xE 00[012][012]))
+	umask | grep -xE 0?0[012][012]))
 
 $(eval $(call SetupHostCommand,gcc, \
 	Please install the GNU C Compiler (gcc) 4.8 or later, \


### PR DESCRIPTION
the leading 0 is optional and not emitted by some shells

Signed-off-by: Thorsten Glaser <tg@mirbsd.org>