### PR TITLE
fix compilation on an x32 (amd64ilp32) host system again

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -20,7 +20,7 @@ export SOURCE_DATE_EPOCH
 export GIT_CONFIG_PARAMETERS='core.autocrlf=false'
 export GIT_ASKPASS:=/bin/true
 export MAKE_JOBSERVER=$(filter --jobserver%,$(MAKEFLAGS))
-export GNU_HOST_NAME:=$(shell $(TOPDIR)/scripts/config.guess)
+export GNU_HOST_NAME:=$(shell $(TOPDIR)/scripts/get-gnu-host-name.sh)
 export HOST_OS:=$(shell uname)
 export HOST_ARCH:=$(shell uname -m)
 

--- a/scripts/get-gnu-host-name.sh
+++ b/scripts/get-gnu-host-name.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+case $(uname) in
+(Darwin)
+	# force config.guess run
+	GNU_HOST_NAME=
+	;;
+(*)
+	GNU_HOST_NAME=$(gcc -dumpmachine)
+	;;
+esac
+test -n "$GNU_HOST_NAME" || \
+    GNU_HOST_NAME=$("$(dirname "$0")/config.guess")
+printf '%s\n' "$GNU_HOST_NAME"


### PR DESCRIPTION
- fix libressl build for x32 by disabling assembly code there; x32 is mis-detected as amd64, so it uses wrong asm code
- unbreak content of the GNU_HOST_NAME variable that got broken during some refactoring; `config.guess` also mis-detects x32 as amd64 (because the maintainers deliberately do _not_ want to call the host compiler to check whether it’s x32 or not)