### PR TITLE
ramips: add support for UniElec U7621-06-512M-64M variant

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -116,6 +116,7 @@ ramips_setup_interfaces()
 	sap-g3200u3|\
 	sk-wb8|\
 	u7621-06-256M-16M|\
+	u7621-06-512M-64M|\
 	vr500|\
 	wf-2881|\
 	whr-g300n|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -505,6 +505,9 @@ ramips_board_detect() {
 	*"U7621-06 (256M RAM/16M flash)")
 		name="u7621-06-256M-16M"
 		;;
+	*"U7621-06 (512M RAM/64M flash)")
+		name="u7621-06-512M-64M"
+		;;
 	*"U7628-01 (128M RAM/16M flash)")
 		name="u7628-01-128M-16M"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -161,6 +161,7 @@ platform_check_image() {
 	tiny-ac|\
 	u25awf-h1|\
 	u7621-06-256M-16M|\
+	u7621-06-512M-64M|\
 	u7628-01-128M-16M|\
 	ur-326n4g|\
 	ur-336un|\

--- a/target/linux/ramips/dts/U7621-06-512M-64M.dts
+++ b/target/linux/ramips/dts/U7621-06-512M-64M.dts
@@ -1,0 +1,91 @@
+/*
+ *  BSD LICENSE
+ *
+ *  Copyright(c) 2017 Kristian Evensen <kristian.evensen@gmail.com>.
+ *  Copyright(c) 2017 Piotr Dymacz <pepe2k@gmail.com>.
+ *  Copyright(c) 2018 Nishant Sharma <codemarauder@gmail.com>.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in
+ *      the documentation and/or other materials provided with the
+ *      distribution.
+ *    * Neither the name of Broadcom Corporation nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/dts-v1/;
+
+#include "U7621-06.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "unielec,u7621-06-512m-64m", "unielec,u7621-06", "mediatek,mt7621-soc";
+	model = "UniElec U7621-06 (512M RAM/64M flash)";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0x3f60000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -374,6 +374,14 @@ define Device/u7621-06-256M-16M
 endef
 TARGET_DEVICES += u7621-06-256M-16M
 
+define Device/u7621-06-512M-64M
+  DTS := U7621-06-512M-64M
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := UniElec U7621-06 (512M RAM/64M flash)
+  DEVICE_PACKAGES := kmod-ata-core kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3
+endef
+TARGET_DEVICES += u7621-06-512M-64M
+
 define Device/ubnt-erx
   DTS := UBNT-ERX
   FILESYSTEMS := squashfs

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -376,7 +376,7 @@ TARGET_DEVICES += u7621-06-256M-16M
 
 define Device/u7621-06-512M-64M
   DTS := U7621-06-512M-64M
-  IMAGE_SIZE := 16064k
+  IMAGE_SIZE := 6645304
   DEVICE_TITLE := UniElec U7621-06 (512M RAM/64M flash)
   DEVICE_PACKAGES := kmod-ata-core kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3
 endef


### PR DESCRIPTION
This commit adds support for UniElec U7621-06 variant with 512MB RAM and 64MB flash.
The board with 256MB RAM and 16MB flash is already supported. Additional specs are below:

CPU: MT7621 (880Mhz)
Flash: 64MB (Macronix MX66L51235F (by U-Boot) / MX66L51235L (by kernel) (65536 Kbytes))
RAM: 512MB

Rest of the details as per commit:

https://github.com/openwrt/openwrt/commit/46ab81e405d238e95071d7d56a0f07bb51fc8cb3 by @pepe2k

Signed-off-by: Nishant Sharma <codemarauder@gmail.com>
