### PR TITLE
ath79: spi-ath79: add shift register mode support for ath79-spi

### DIFF
--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -109,8 +109,8 @@
 		};
 
 		spi: spi@1f000000 {
-			compatible = "qca,ar7100-spi";
-			reg = <0x1f000000 0x10>;
+			compatible = "qca,ar9330-spi", "qca,ar7100-spi";
+			reg = <0x1f000000 0x1c>;
 
 			clocks = <&pll ATH79_CLK_AHB>;
 			clock-names = "ahb";

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -165,7 +165,7 @@
 		};
 
 		spi: spi@1f000000 {
-			compatible = "qca,ar9340-spi", "qca,ar7100-spi";
+			compatible = "qca,ar9330-spi", "qca,ar7100-spi";
 			reg = <0x1f000000 0x1c>;
 
 			clocks = <&pll ATH79_CLK_AHB>;

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -201,8 +201,8 @@
 		};
 
 		spi: spi@1f000000 {
-			compatible = "qca,ar9530-spi", "qca,ar7100-spi";
-			reg = <0x1f000000 0x10>;
+			compatible = "qca,ar9330-spi", "qca,ar7100-spi";
+			reg = <0x1f000000 0x1c>;
 
 			clocks = <&pll ATH79_CLK_AHB>;
 			clock-names = "ahb";

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -273,8 +273,8 @@
 	};
 
 		spi: spi@1f000000 {
-			compatible = "qca,ar9557-spi", "qca,ar7100-spi";
-			reg = <0x1f000000 0x10>;
+			compatible = "qca,ar9330-spi", "qca,ar7100-spi";
+			reg = <0x1f000000 0x1c>;
 
 			clocks = <&pll ATH79_CLK_AHB>;
 			clock-names = "ahb";

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -211,8 +211,8 @@
 		};
 
 		spi: spi@1f000000 {
-			compatible = "qca,qca9560-spi", "qca,ar7100-spi";
-			reg = <0x1f000000 0x10>;
+			compatible = "qca,ar9330-spi", "qca,ar7100-spi";
+			reg = <0x1f000000 0x1c>;
 
 			clocks = <&pll ATH79_CLK_AHB>;
 			clock-names = "ahb";

--- a/target/linux/ath79/patches-4.14/460-1-spi-spi-ath79-add-register-definitions-from-ar71xx_r.patch
+++ b/target/linux/ath79/patches-4.14/460-1-spi-spi-ath79-add-register-definitions-from-ar71xx_r.patch
@@ -1,0 +1,51 @@
+From c0b1100ddc4299448adcf2d8f58a1bd21eb33b80 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Wed, 24 Oct 2018 22:04:03 +0800
+Subject: [PATCH 1/2] spi: spi-ath79: add register definitions from
+ ar71xx_regs.h
+
+These registers are IP-specific, not SoC/architecture specific.
+Move them into spi-ath79.c and remove the inclusion of ar71xx_regs.h.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ drivers/spi/spi-ath79.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/spi/spi-ath79.c b/drivers/spi/spi-ath79.c
+index 6eb72555..295fa402 100644
+--- a/drivers/spi/spi-ath79.c
++++ b/drivers/spi/spi-ath79.c
+@@ -25,10 +25,27 @@
+ #include <linux/clk.h>
+ #include <linux/err.h>
+ 
+-#include <asm/mach-ath79/ar71xx_regs.h>
+-
+ #define DRV_NAME	"ath79-spi"
+ 
++#define AR71XX_SPI_REG_FS	0x00	/* Function Select */
++#define AR71XX_SPI_REG_CTRL	0x04	/* SPI Control */
++#define AR71XX_SPI_REG_IOC	0x08	/* SPI I/O Control */
++#define AR71XX_SPI_REG_RDS	0x0c	/* Read Data Shift */
++
++#define AR71XX_SPI_FS_GPIO	BIT(0)	/* Enable GPIO mode */
++
++#define AR71XX_SPI_CTRL_RD	BIT(6)	/* Remap Disable */
++#define AR71XX_SPI_CTRL_DIV_MASK 0x3f
++
++#define AR71XX_SPI_IOC_DO	BIT(0)	/* Data Out pin */
++#define AR71XX_SPI_IOC_CLK	BIT(8)	/* CLK pin */
++#define AR71XX_SPI_IOC_CS(n)	BIT(16 + (n))
++#define AR71XX_SPI_IOC_CS0	AR71XX_SPI_IOC_CS(0)
++#define AR71XX_SPI_IOC_CS1	AR71XX_SPI_IOC_CS(1)
++#define AR71XX_SPI_IOC_CS2	AR71XX_SPI_IOC_CS(2)
++#define AR71XX_SPI_IOC_CS_ALL	(AR71XX_SPI_IOC_CS0 | AR71XX_SPI_IOC_CS1 | \
++				 AR71XX_SPI_IOC_CS2)
++
+ #define ATH79_SPI_RRW_DELAY_FACTOR	12000
+ #define MHZ				(1000 * 1000)
+ 
+-- 
+2.17.2
+

--- a/target/linux/ath79/patches-4.14/460-2-spi-spi-ath79-add-shift-register-mode-support-for-at.patch
+++ b/target/linux/ath79/patches-4.14/460-2-spi-spi-ath79-add-shift-register-mode-support-for-at.patch
@@ -1,0 +1,89 @@
+From 6f5a193ae08b49f775d0b7c8fd8c262077035171 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Wed, 24 Oct 2018 22:10:56 +0800
+Subject: [PATCH 2/2] spi: spi-ath79: add shift register mode support for
+ ath79-spi
+
+Since ar933x Atheros added a new hardware data shifting mode which
+allows direct programming of the data and the number of bits to shift
+and let controller finish the rest job.
+This patch added support for this feature and introduced a new
+compatible string "qca,ar9330-spi" for this new IP.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ drivers/spi/spi-ath79.c | 30 +++++++++++++++++++++++++++++-
+ 1 file changed, 29 insertions(+), 1 deletion(-)
+
+--- a/drivers/spi/spi-ath79.c
++++ b/drivers/spi/spi-ath79.c
+@@ -17,7 +17,9 @@
+ #include <linux/delay.h>
+ #include <linux/spinlock.h>
+ #include <linux/platform_device.h>
++#include <linux/of.h>
+ #include <linux/io.h>
++#include <linux/iopoll.h>
+ #include <linux/spi/spi.h>
+ #include <linux/spi/spi_bitbang.h>
+ #include <linux/bitops.h>
+@@ -46,6 +48,13 @@
+ #define AR71XX_SPI_IOC_CS_ALL	(AR71XX_SPI_IOC_CS0 | AR71XX_SPI_IOC_CS1 | \
+ 				 AR71XX_SPI_IOC_CS2)
+ 
++#define AR933X_SPI_REG_SDO	0x10	/* SPI Data to Shift Out */
++#define AR933X_SPI_REG_SCNT	0x14	/* SPI Data Shift Control */
++#define AR933X_SPI_REG_SDI	0x18	/* SPI Data to Shift In */
++
++#define AR933X_SPI_SHIFT_EN		BIT(31)			/* Enable Shifting */
++#define AR933X_SPI_SHIFT_CS(n)	BIT(28 + (n))	/* CS Enable */
++
+ #define ATH79_SPI_RRW_DELAY_FACTOR	12000
+ #define MHZ				(1000 * 1000)
+ 
+@@ -220,6 +229,25 @@ static u32 ath79_spi_txrx_mode0(struct s
+ 	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
+ }
+ 
++static u32 ath79_spi_txrx_shiftreg_mode0(struct spi_device *spi, unsigned nsecs,
++					u32 word, u8 bits)
++{
++	int reg;
++	struct ath79_spi *sp = ath79_spidev_to_sp(spi);
++
++	/* fallback to bitbang mode for GPIO CS */
++	if (gpio_is_valid(spi->cs_gpio))
++		ath79_spi_txrx_mode0(spi, nsecs, word, bits);
++
++	ath79_spi_wr(sp, AR933X_SPI_REG_SDO, word);
++	ath79_spi_wr(sp, AR933X_SPI_REG_SCNT, AR933X_SPI_SHIFT_EN |
++					     AR933X_SPI_SHIFT_CS(spi->chip_select) | bits);
++	/* TODO: timeout handling? */
++	readl_poll_timeout(sp->base + AR933X_SPI_REG_SCNT, reg,
++					     !(reg & AR933X_SPI_SHIFT_EN), 100, 10000);
++	return ath79_spi_rr(sp, AR933X_SPI_REG_SDI);
++}
++
+ static int ath79_spi_probe(struct platform_device *pdev)
+ {
+ 	struct spi_master *master;
+@@ -244,7 +272,10 @@ static int ath79_spi_probe(struct platfo
+ 
+ 	sp->bitbang.master = master;
+ 	sp->bitbang.chipselect = ath79_spi_chipselect;
+-	sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_mode0;
++	if (of_device_is_compatible(master->dev.of_node, "qca,ar9330-spi"))
++		sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_shiftreg_mode0;
++	else
++		sp->bitbang.txrx_word[SPI_MODE_0] = ath79_spi_txrx_mode0;
+ 	sp->bitbang.setup_transfer = spi_bitbang_setup_transfer;
+ 	sp->bitbang.flags = SPI_CS_HIGH;
+ 
+@@ -311,6 +342,7 @@ static void ath79_spi_shutdown(struct pl
+ 
+ static const struct of_device_id ath79_spi_of_match[] = {
+ 	{ .compatible = "qca,ar7100-spi", },
++	{ .compatible = "qca,ar9330-spi", },
+ 	{ },
+ };
+ MODULE_DEVICE_TABLE(of, ath79_spi_of_match);

--- a/target/linux/ath79/patches-4.14/461-spi-ath79-add-fast-flash-read.patch
+++ b/target/linux/ath79/patches-4.14/461-spi-ath79-add-fast-flash-read.patch
@@ -1,6 +1,6 @@
 --- a/drivers/spi/spi-ath79.c
 +++ b/drivers/spi/spi-ath79.c
-@@ -101,9 +101,6 @@ static void ath79_spi_enable(struct ath7
+@@ -126,9 +126,6 @@ static void ath79_spi_enable(struct ath7
  	/* save CTRL register */
  	sp->reg_ctrl = ath79_spi_rr(sp, AR71XX_SPI_REG_CTRL);
  	sp->ioc_base = ath79_spi_rr(sp, AR71XX_SPI_REG_IOC);
@@ -10,8 +10,8 @@
  }
  
  static void ath79_spi_disable(struct ath79_spi *sp)
-@@ -203,6 +200,38 @@ static u32 ath79_spi_txrx_mode0(struct s
- 	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
+@@ -244,6 +241,38 @@ static u32 ath79_spi_txrx_shiftreg_mode0
+ 	return ath79_spi_rr(sp, AR933X_SPI_REG_SDI);
  }
  
 +static bool ath79_spi_flash_read_supported(struct spi_device *spi)
@@ -49,7 +49,7 @@
  static int ath79_spi_probe(struct platform_device *pdev)
  {
  	struct spi_master *master;
-@@ -237,6 +266,8 @@ static int ath79_spi_probe(struct platfo
+@@ -281,6 +310,8 @@ static int ath79_spi_probe(struct platfo
  		ret = PTR_ERR(sp->base);
  		goto err_put_master;
  	}


### PR DESCRIPTION
This PR is a porting of #1000 to ath79.

Since ar934x Atheros added a new hardware data shifting mode which
allows direct programming of the data and the number of bits to shift
and let controller finish the rest job. This patch adds the support
for this feature and updated dts accordingly.

Introducing a new compatible 'qca,ar9330-spi' for these new controllers.
Update dts accordingly and dropped qca,ar9340/qca9530/qca9557/qca956x
from dts since they are exactly the same IP as ar9330-spi.
(At least on datasheets they are described exactly the same.)
Keep qca,ar7100-spi untouched because the old driver works with new IP.

Add SPI specific register definitions from ar71xx_regs.h and dropped that
inclusion at the beginning because these are IP-specific definitions, not
SoC/architecture specific ones.

Performance tests on AR9341 with Winbond W25Q64:
Tested with this command: time dd if=/dev/mtdblock1 of=/dev/null bs=64k
mtdblock1 is firmware partition and the size of it is 0x7d0000 (8000KB)
3.39s with the existing fast flash read
4.55s with spi shiftreg mode (fast flash read patch removed.)
9.94s with the original bitbang mode (spi-max-frequency modified to
40000000 to make it work at the fastest clock current bit-bang code
can achieve.)

BTW I think the mtd patch in #1000 looks a little bit hacky. I may add spi-mem support for ath79-spi to use the full 32bit shiftreg capability after this target is bumped to 4.19.
