### PR TITLE
ar71xx: update Trendnet TEW-823DRU MAC address fix

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -19,6 +19,9 @@ case "$board" in
 	archer-c60-v2)
 		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+	tew-823dru)
+	        echo $(mtd_get_mac_text mac 24) > /sys${DEVPATH}/macaddress
+		;;
 	*)
 		;;
 esac

--- a/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
+++ b/target/linux/ar71xx/base-files/lib/preinit/82_patch_ath10k
@@ -21,8 +21,7 @@ do_patch_ath10k_firmware() {
 	# we have to patch the default mac in the firmware because we cannot change
 	# the otp.
 	case $(board_name) in
-	dgl-5500-a1|\
-	tew-823dru)
+	dgl-5500-a1)
 		local mac
 		mac=$(mtd_get_mac_ascii nvram wlan1_mac)
 
@@ -40,8 +39,7 @@ do_patch_ath10k_firmware() {
 
 check_patch_ath10k_firmware() {
 	case $(board_name) in
-	dgl-5500-a1|\
-	tew-823dru)
+	dgl-5500-a1)
 		do_patch_ath10k_firmware
 		;;
 	esac


### PR DESCRIPTION
Remove not working Trendnet TEW-823DRU mac address fix from preinit/82_patch_ath10k script. Add fix to etc/hotplug.d/ieee80211/10_fix_wifi_mac by reading LAN ethernet mac address from mtd mac partition, incrementing by 1 and writing it to ath10k interface mac address.

Signed-off-by: Pramod Pancha <pancha@vill.com>
