### PR TITLE
ramips: mt7620: add DIR-810L's mt7610e 5 GHz radio

### DIFF
--- a/target/linux/ramips/dts/DIR-810L.dts
+++ b/target/linux/ramips/dts/DIR-810L.dts
@@ -143,3 +143,11 @@
 &wmac {
 	ralink,mtd-eeprom = <&factory 0>;
 };
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -145,8 +145,9 @@ TARGET_DEVICES += dch-m225
 
 define Device/dir-810l
   DTS := DIR-810L
-  IMAGE_SIZE := 6720k
+  DEVICE_PACKAGES := kmod-mt76x0e
   DEVICE_TITLE := D-Link DIR-810L
+  IMAGE_SIZE := 6720k
 endef
 TARGET_DEVICES += dir-810l
 


### PR DESCRIPTION
This PR enables the 5 GHz radio of D-Link DIR-810L devices, which use the MT7610E chip that has recently received support in OpenWrt.

It has been tested on the actual device as AP and client, TCP throughput is ~90 Mbps U/D.