### PR TITLE
ramips: fix switch port order for HuaWei HG255D

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -204,7 +204,6 @@ ramips_setup_interfaces()
 	gl-mt300a|\
 	gl-mt300n|\
 	gl-mt750|\
-	hg255d|\
 	hiwifi,hc5861b|\
 	jhr-n805r|\
 	jhr-n825r|\
@@ -242,6 +241,7 @@ ramips_setup_interfaces()
 	elecom,wrc-1167ghbk2-s|\
 	elecom,wrc-2533gst|\
 	elecom,wrc-1900gst|\
+	hg255d|\
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
The order of port marks and LEDs is reversed according to the board.

Signed-off-by: David Yang <mmyangfl@gmail.com>