### PR TITLE
ramips: add support for D-Link DWR-118 A1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -114,6 +114,11 @@ dlink,dwr-116-a1|\
 mzk-ex300np)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+dlink,dwr-118-a1)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1f"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x20"
+	set_wifi_led "$boardname:green:wlan2g" "wlan1"
+	;;
 dlink,dwr-118-a2)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -162,6 +162,10 @@ ramips_setup_interfaces()
 	wrh-300cr)
 		ucidef_set_interface_lan "eth0"
 		;;
+	dlink,dwr-118-a1)
+		ucidef_add_switch "switch0" \
+			"1:lan:2" "2:lan:3" "3:lan:1" "4:lan:0" "5:wan" "6@eth0"
+		;;
 	dlink,dwr-118-a2)
 		ucidef_add_switch "switch0" \
 			"1:lan:2" "2:lan:1" "3:lan:3" "4:lan" "0:wan" "6@eth0"
@@ -475,6 +479,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
 		;;
 	dlink,dwr-116-a1|\
+	dlink,dwr-118-a1|\
 	dlink,dwr-118-a2|\
 	dlink,dwr-921-c1|\
 	lava,lr-25g001)

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -55,6 +55,7 @@ case "$FIRMWARE" in
 "soc_wmac.eeprom")
 	case $board in
 	dlink,dwr-116-a1|\
+	dlink,dwr-118-a1|\
 	dlink,dwr-118-a2|\
 	dlink,dwr-921-c1|\
 	lava,lr-25g001)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -296,6 +296,7 @@ platform_check_image() {
 		return 0
 		;;
 	dlink,dwr-116-a1|\
+	dlink,dwr-118-a1|\
 	dlink,dwr-118-a2|\
 	dlink,dwr-921-c1|\
 	dwr-512-b|\

--- a/target/linux/ramips/dts/DWR-118-A1.dts
+++ b/target/linux/ramips/dts/DWR-118-A1.dts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dwr-118-a1", "ralink,mt7620a-soc";
+	model = "D-Link DWR-118 A1";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-upgrade = &led_internet;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "dwr-118-a1:green:wan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet: internet {
+			label = "dwr-118-a1:green:internet";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "dwr-118-a1:green:lan";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "dwr-118-a1:green:wlan2g";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "dwr-118-a1:green:usb";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb {
+			gpio-export,name = "usb";
+			gpio-export,output = <0>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "amit,jimage";
+				label = "firmware";
+				reg = <0x10000 0xfe0000>;
+			};
+
+			config: partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "ephy", "uartf", "spi refclk", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&config 0xe496>;
+		mtd-mac-address-increment = <(2)>;
+		mediatek,mtd-eeprom = <&config 0xe083>;
+	};
+};
+
+&ethernet {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	port@4 {
+		status = "okay";
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+	};
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii-rxid";
+		};
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii-rxid";
+		};
+	};
+};
+
+&gsw {
+	mediatek,port4 = "gmac";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -174,6 +174,20 @@ define Device/dlink_dwr-116-a1
 endef
 TARGET_DEVICES += dlink_dwr-116-a1
 
+define Device/dlink_dwr-118-a1
+  DTS := DWR-118-A1
+  DEVICE_TITLE := D-Link DWR-118 A1
+  DEVICE_PACKAGES := kmod-usb2 jboot-tools kmod-mt76x0e
+  DLINK_ROM_ID := DLK6E3811001
+  DLINK_FAMILY_MEMBER := 0x6E38
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+endef
+TARGET_DEVICES += dlink_dwr-118-a1
+
 define Device/dlink_dwr-118-a2
   DTS := DWR-118-A2
   DEVICE_TITLE := D-Link DWR-118 A2


### PR DESCRIPTION
The DWR-118-A1 Wireless Router is based on the MT7620A SoC.

Specification:

- MediaTek MT7620A (580 Mhz)
- 64 MB of RAM
- 16 MB of FLASH
- 1x 802.11bgn radio
- 1x 802.11ac radio (MT7610EN)
- 3x 10/100 Mbps Ethernet (3 LAN)
- 2x 10/100/1000 Mbps ICPlus IP1001 Ethernet PHY (1 WAN AND 1 LAN)
- 1x internal, non-detachable antenna
- 2x external, non-detachable antennas
- 1x USB 2.0
- UART (J1) header on PCB (57600 8n1)
- 7x LED (5x GPIO-controlled), 2x button
- JBOOT bootloader

Known issues:
- WIFI 5G LED not working
- flash is very slow

The status led has been assigned to the dwr-118-a1:green:internet led.
At the end of the boot it is switched off and is available for other
operation. Work correctly also during sysupgrade operation.

Installation:
Apply factory image via http web-gui or JBOOT recovery page

How to revert to OEM firmware:
- push the reset button and turn on the power. Wait until LED start
  blinking (~10sec.)
- upload original factory image via JBOOT http (IP: 192.168.123.254)

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
