### PR TITLE
ramips: Fix mmc for MT76x8

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/mt6575_sd.h
+++ b/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/mt6575_sd.h
@@ -237,6 +237,7 @@ enum {
 #define MSDC_IOCON_DDLSEL       (0x1  << 3)     /* RW */
 #define MSDC_IOCON_DDR50CKD     (0x1  << 4)     /* RW */
 #define MSDC_IOCON_DSPLSEL      (0x1  << 5)     /* RW */
+#define MSDC_IOCON_WDSPL        (0x1  << 8)     /* RW */
 #define MSDC_IOCON_D0SPL        (0x1  << 16)    /* RW */
 #define MSDC_IOCON_D1SPL        (0x1  << 17)    /* RW */
 #define MSDC_IOCON_D2SPL        (0x1  << 18)    /* RW */

--- a/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files-4.14/drivers/mmc/host/mtk-mmc/sd.c
@@ -1796,6 +1796,9 @@ static void msdc_ops_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
 				      MSDC_SMPL_FALLING);
 			sdr_set_field(MSDC_IOCON, MSDC_IOCON_DSPL,
 				      MSDC_SMPL_FALLING);
+      if (ralink_soc != MT762X_SOC_MT7620A)
+		    sdr_set_field(MSDC_IOCON, MSDC_IOCON_WDSPL,
+				        MSDC_SMPL_FALLING);
 			//} /* for tuning debug */
 		} else { /* default value */
 			sdr_write32(MSDC_IOCON,      0x00000000);
@@ -2205,16 +2208,6 @@ static int msdc_drv_probe(struct platform_device *pdev)
 	struct msdc_host *host;
 	struct msdc_hw *hw;
 	int ret;
-	u32 reg;
-
-	//FIXME: this should be done by pinconf and not by the sd driver
-	if (ralink_soc == MT762X_SOC_MT7688 ||
-	    ralink_soc == MT762X_SOC_MT7628AN) {
-		/* set EPHY pads to digital mode */
-		reg = sdr_read32((void __iomem *)(RALINK_SYSCTL_BASE + 0x3c));
-		reg |= 0x1e << 16;
-		sdr_write32((void __iomem *)(RALINK_SYSCTL_BASE + 0x3c), reg);
-	}
 
 	hw = &msdc0_hw;
 


### PR DESCRIPTION
- Set sample crc by clock falling edge (lost for 7621/7628).
- Don't set `EPHY_GPIO_AIO_EN` because it will cause some Ethernet ports
block in some devices with 5 ports, for instance, HC5661A. (see
d48cc5e0).

The sample crc part is from [padavan](https://bitbucket.org/padavan/rt-n56u/commits/a2b3cfb71c5c9d862518b2862e5c4d75bf58a5ed) and I have tested it on HC5661A.

As for `EPHY_GPIO_AIO_EN` part, there is no document saying `EPHY_GPIO_AIO_EN` has to be set on 76x8 when sdcard is enabled. And for HC5661A, if it is set, 1 WAN and 3 LAN will be blocked (see d48cc5e0). After unsetting it, it works well now.
