### PR TITLE
ath79: add support for TP-Link Archer C2 V3 (AC900)

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -57,6 +57,7 @@ tplink,tl-mr3020-v1|\
 tplink,tl-mr3040-v2)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
+tplink,archer-c2-v3|\
 tplink,tl-wr1043nd-v4)
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x20"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -133,6 +133,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "6@eth0"
 		;;
+	tplink,archer-c2-v3|\
 	tplink,tl-wr1043nd-v4)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -108,6 +108,10 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
+	tplink,archer-c2-v3)
+		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
+		;;
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c2-v3", "qca,qca9563";
+	model = "TP-Link Archer C2 Version 3";
+	
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+	
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "heartbeat";
+		};
+
+		wifi2g {
+			label = "tp-link:green:wifi2g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		wifi5g {
+			label = "tp-link:green:wifi5g";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan_fail {
+			label = "tp-link:orange:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "uboot";
+				reg = <0x020000 0x10000>;
+			};
+			
+			partition@30000 {
+				label = "firmware";
+				reg = <0x030000 0x7A0000>;
+			};
+			
+			info: partition@7e0000 {
+				label = "product-info";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "ART";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gpio {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x8>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};
+
+

--- a/target/linux/ath79/image/common-tp-link.mk
+++ b/target/linux/ath79/image/common-tp-link.mk
@@ -39,6 +39,14 @@ define Build/mktplinkfw-combined
 	@mv $@.new $@
 endef
 
+define Build/uImageArcher
+	mkimage -A $(LINUX_KARCH) \
+		-O linux -T kernel \
+		-C $(1) -a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+		-n '$(call toupper,$(LINUX_KARCH)) OpenWrt Linux-$(LINUX_VERSION)' -d $@ $@.new
+	@mv $@.new $@
+endef
+
 define Device/tplink
   TPLINK_HWREV := 0x1
   TPLINK_HEADER_VERSION := 1

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -1,5 +1,20 @@
 include ./common-tp-link.mk
 
+define Device/tplink_archer-c2-v3
+  $(Device/tplink)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-LINK Archer C2 v3
+  TPLINK_BOARD_ID := ARCHER-C2-V3
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  TPLINK_HWID := 0x00020003
+  KERNEL := kernel-bin | append-dtb | lzma | uImageArcher lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImageArcher lzma
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | append-metadata
+  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+endef
+TARGET_DEVICES += tplink_archer-c2-v3
+
 define Device/tplink_archer-c7-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -398,6 +398,48 @@ static struct device_info boards[] = {
 		.first_sysupgrade_partition = "os-image",
 		.last_sysupgrade_partition = "file-system",
 	},
+	
+	/** Firmware layout for the C2v3 */
+	{
+		.id = "ARCHER-C2-V3",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:ArcherC2,product_ver:3.0.0,special_id:00000000}\n"
+			"{product_name:ArcherC2,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:ArcherC2,product_ver:3.0.0,special_id:45550000}\n",
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:3.0.1\n",
+
+		/**
+		    We use a bigger os-image partition than the stock images (and thus
+		    smaller file-system), as our kernel doesn't fit in the stock firmware's
+		    1MB os-image.
+		*/
+		.partitions = {
+			{"factory-boot", 0x00000, 0x20000},
+			{"fs-uboot", 0x20000, 0x10000},
+			{"os-image", 0x30000, 0x200000},	/* Stock: base 0x30000 size 0x100000 */
+			{"file-system", 0x230000, 0x5A0000},	/* Stock: base 0x130000 size 0x6a0000 */
+			{"user-config", 0x7d0000, 0x04000},
+			{"default-mac", 0x7e0000, 0x00100},
+			{"device-id", 0x7e0100, 0x00100},
+			{"extra-para", 0x7e0200, 0x00100},
+			{"pin", 0x7e0300, 0x00100},
+			{"support-list", 0x7e0400, 0x00400},
+			{"soft-version", 0x7e0800, 0x00400},
+			{"product-info", 0x7e0c00, 0x01400},
+			{"partition-table", 0x7e2000, 0x01000},
+			{"profile", 0x7e3000, 0x01000},
+			{"default-config", 0x7e4000, 0x04000},
+			{"merge-config", 0x7ec000, 0x02000},
+			{"qos-db", 0x7ee000, 0x02000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
 
 	/** Firmware layout for the C58v1 */
 	{

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -410,16 +410,12 @@ static struct device_info boards[] = {
 		.support_trail = '\x00',
 		.soft_ver = "soft_ver:3.0.1\n",
 
-		/**
-		    We use a bigger os-image partition than the stock images (and thus
-		    smaller file-system), as our kernel doesn't fit in the stock firmware's
-		    1MB os-image.
-		*/
+		/** We're using a dynamic kernel/rootfs split here */
+
 		.partitions = {
 			{"factory-boot", 0x00000, 0x20000},
 			{"fs-uboot", 0x20000, 0x10000},
-			{"os-image", 0x30000, 0x200000},	/* Stock: base 0x30000 size 0x100000 */
-			{"file-system", 0x230000, 0x5A0000},	/* Stock: base 0x130000 size 0x6a0000 */
+			{"firmware", 0x30000, 0x7a0000},
 			{"user-config", 0x7d0000, 0x04000},
 			{"default-mac", 0x7e0000, 0x00100},
 			{"device-id", 0x7e0100, 0x00100},

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1640,6 +1640,7 @@ static void build_image(const char *output,
 	if (strcasecmp(info->id, "ARCHER-C25-V1") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C59-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V2") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C2-V3") == 0 || 
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);


### PR DESCRIPTION
This commit adds support for TP-link Archer C2 V3 (AC900)

CPU: QCA9563 750Mhz
Ram: 64MB (DDR2)
Flash: 8MB (SPI NOR)
Ethernet: 5x 10/100/1000
Wifi: QCA9563 bgn + QCA9887 an+ac
9x Leds, 2x buttons

Signed-off-by: Skirmantas Lauzikas <skirmantas.lauzikas@blackraven.lt>