### PR TITLE
ath79: rename qca9533.dtsi to qca953x.dtsi

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_ar300m.dtsi
@@ -3,10 +3,10 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
-#include "qca9533.dtsi"
+#include "qca953x.dtsi"
 
 / {
-	compatible = "glinet,ar300m", "qca,qca9533";
+	compatible = "glinet,ar300m", "qca,qca9531";
 	model = "GL.iNet GL-AR300M";
 
 	keys {

--- a/target/linux/ath79/dts/qca9531_glinet_ar300m_nand.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_ar300m_nand.dts
@@ -1,13 +1,10 @@
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "qca9533_glinet_ar300m.dtsi"
+#include "qca9531_glinet_ar300m.dtsi"
 
 &spi {
 	status = "okay";
-	num-cs = <0>;
+	num-cs = <1>;
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
@@ -31,13 +28,35 @@
 			};
 
 			partition@2 {
-				label = "firmware";
+				label = "reserved";
 				reg = <0x050000 0xfa0000>;
 			};
 
 			art: partition@3 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
+			};
+		};
+	};
+
+	flash@1 {
+		compatible = "spinand,mt29f";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x000000 0x0200000>;
+			};
+
+			partition@1 {
+				label = "ubi";
+				reg = <0x200000 0x7e00000>;
 			};
 		};
 	};

--- a/target/linux/ath79/dts/qca9531_glinet_ar300m_nor.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_ar300m_nor.dts
@@ -1,10 +1,13 @@
 /dts-v1/;
 
-#include "qca9533_glinet_ar300m.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9531_glinet_ar300m.dtsi"
 
 &spi {
 	status = "okay";
-	num-cs = <1>;
+	num-cs = <0>;
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
@@ -28,35 +31,13 @@
 			};
 
 			partition@2 {
-				label = "reserved";
+				label = "firmware";
 				reg = <0x050000 0xfa0000>;
 			};
 
 			art: partition@3 {
 				label = "art";
 				reg = <0xff0000 0x010000>;
-			};
-		};
-	};
-
-	flash@1 {
-		compatible = "spinand,mt29f";
-		reg = <1>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "kernel";
-				reg = <0x000000 0x0200000>;
-			};
-
-			partition@1 {
-				label = "ubi";
-				reg = <0x200000 0x7e00000>;
 			};
 		};
 	};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -4,7 +4,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 
-#include "qca9533.dtsi"
+#include "qca953x.dtsi"
 
 / {
 	chosen {

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -3,7 +3,7 @@
 #include "ath79.dtsi"
 
 / {
-	compatible = "qca,qca9533";
+	compatible = "qca,qca9530";
 
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -168,7 +168,7 @@ endef
 TARGET_DEVICES += glinet_ar150
 
 define Device/glinet_ar300m_nor
-  ATH_SOC := qca9533
+  ATH_SOC := qca9531
   DEVICE_TITLE := GL.iNet GL-AR300M
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
   IMAGE_SIZE := 16000k

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -1,5 +1,5 @@
 define Device/glinet_ar300m_nand
-  ATH_SOC := qca9533
+  ATH_SOC := qca9531
   DEVICE_TITLE := GL-AR300M (NAND)
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-usb-ledtrig-usbport
   KERNEL_SIZE := 2048k


### PR DESCRIPTION
qca9533 is a costdown version of qca9531 which doesn't have USB and PCIE.
Rename the misleading dtsi names and fix the SoC type of gl-ar300m.

This PR has passed compile test.

Although qca9533 is a costdown version, it have all the dummy register spaces so that all qca9531 firmwares works on qca9533 (The chip identity seems the same and we never distinguish them in ar71xx). I didn't make a qca9531/qca9533 split like ar934x because I don't have any qca9531 routers with USB and/or PCIE and I can't do any tests for them. Such a simple renaming shouldn't cause more troubles when it passed compile test.

BTW I've got 3 ath79 PRs now...I'll rebase the other two if this got applied first...