### PR TITLE
ramips: add hlk-7688a module support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -145,6 +145,9 @@ dir-320-b1|\
 dir-610-a1|\
 esr-9753|\
 hlk-rm04|\
+hlk-7688a)
+	ucidef_set_led_wlan "wifi" "wifi" "hlk-7688a:green:wifi" "phy0radio"
+	;;
 sl-r7205|\
 v11st-fe|\
 w306r-v20|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -90,6 +90,12 @@ ramips_setup_interfaces()
 	hc5661a|\
 	hc5962|\
 	hlk-rm04|\
+	hlk-7688a)
+		ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"
+		ucidef_add_switch "switch0" "1" "1"
+		ucidef_add_switch_vlan "switch0" "1" "1 6t"
+		ucidef_add_switch_vlan "switch0" "2" "0 6t"
+		;;
 	k2p|\
 	kn|\
 	kn_rc|\
@@ -424,6 +430,7 @@ ramips_setup_macs()
 	esr-9753|\
 	freestation5|\
 	hlk-rm04|\
+	hlk-7688a|\
 	mpr-a1|\
 	psr-680w|\
 	sl-r7205|\

--- a/target/linux/ramips/base-files/etc/diag.sh
+++ b/target/linux/ramips/base-files/etc/diag.sh
@@ -65,6 +65,9 @@ get_status_led() {
 	d105|\
 	dcs-930l-b1|\
 	hlk-rm04|\
+	hlk-7688a)
+		status_led="hlk-7688a:green:wifi"
+		;;
 	jhr-n825r|\
 	mpr-a1|\
 	mpr-a2|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -238,6 +238,9 @@ ramips_board_detect() {
 	*"HLK-RM04")
 		name="hlk-rm04"
 		;;
+	*"HLK-7688A")
+		name="hlk-7688a"
+		;;
 	*"HPM")
 		name="hpm"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -73,6 +73,7 @@ platform_check_image() {
 	hc5661a|\
 	hg255d|\
 	hlk-rm04|\
+	hlk-7688a|\
 	hpm|\
 	ht-tm02|\
 	hw550-3g|\

--- a/target/linux/ramips/dts/HLK7688A.dts
+++ b/target/linux/ramips/dts/HLK7688A.dts
@@ -1,0 +1,153 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hilink,hlk-7688a", "mediatek,mt7628an-soc";
+	model = "Hi-Link HLK-7688A";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	bootstrap {
+		compatible = "hilink,hlk-7688a";
+
+		status = "okay";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "hlk-7688a:green:wifi";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		spis {
+			ralink,group = "spis";
+			ralink,function = "gpio";
+		};
+
+		wled_an {
+			ralink,group = "wled_an";
+			ralink,function = "gpio";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	m25p80@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x30000>;
+			read-only;
+		};
+
+		partition@30000 {
+			label = "u-boot-env";
+			reg = <0x30000 0x10000>;
+		};
+
+		factory: partition@40000 {
+			label = "factory";
+			reg = <0x40000 0x10000>;
+			read-only;
+		};
+
+		partition@50000 {
+			label = "firmware";
+			reg = <0x50000 0x1fb0000>;
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-high;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -57,6 +57,15 @@ define Device/hc5661a
 endef
 TARGET_DEVICES += hc5661a
 
+define Device/hlk-7688a
+  DTS := HLK7688A
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  SUPPORTED_DEVICES := hlk-7688a
+  DEVICE_TITLE := Hi-Link HLK-7688A
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
+endef
+TARGET_DEVICES += hlk-7688a
+
 define Device/LinkIt7688
   DTS := LINKIT7688
   IMAGE_SIZE := $(ralink_default_fw_size_32M)


### PR DESCRIPTION
The default compiled firmware may have some network problems. Because it is based on the LinkItSmart7688 development board, some gpio pins have functional definitions that differ from the hlk-7688a module. Unfinished