### PR TITLE
 ramips: fix GELAN port in D-Link DWR-118-A2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -130,7 +130,7 @@ dlink,dwr-118-a1)
 	set_wifi_led "$boardname:green:wlan2g" "wlan1"
 	;;
 dlink,dwr-118-a2)
-	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0e"
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	set_wifi_led "$boardname:green:wlan2g" "wlan1"
 	;;

--- a/target/linux/ramips/dts/DWR-118-A2.dts
+++ b/target/linux/ramips/dts/DWR-118-A2.dts
@@ -157,25 +157,27 @@
 
 &ethernet {
 	status = "okay";
+	mediatek,portmap = "wllll";
 	pinctrl-names = "default";
 	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
 
 	port@4 {
 		status = "okay";
-		phy-handle = <&phy4>;
+		phy-handle = <&phy0>;
 		phy-mode = "rgmii";
 	};
 
 	mdio-bus {
 		status = "okay";
 
-		phy4: ethernet-phy@4 {
-			reg = <4>;
-			phy-mode = "rgmii";
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii-rxid";
 		};
 	};
 };
 
 &gsw {
 	mediatek,port4 = "gmac";
+	mediatek,ephy-base-address = /bits/ 16 < 2 >;
 };

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
@@ -116,73 +116,82 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw, int mdio_mode)
 
 		mt7530_mdio_w32(gsw, 0x7a78, 0x855);
 	} else {
+
+		if (gsw->ephy_base) {
+			/* set phy base addr to ephy_base */
+			mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_GPC1) |
+				(gsw->ephy_base << 16),
+				GSW_REG_GPC1);
+			fe_reset(BIT(24)); /* Resets the Ethernet PHY block. */
+		}
+
 		/* global page 4 */
-		_mt7620_mii_write(gsw, 1, 31, 0x4000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0x4000);
 
-		_mt7620_mii_write(gsw, 1, 17, 0x7444);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 17, 0x7444);
 		if (is_BGA)
-			_mt7620_mii_write(gsw, 1, 19, 0x0114);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 19, 0x0114);
 		else
-			_mt7620_mii_write(gsw, 1, 19, 0x0117);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 19, 0x0117);
 
-		_mt7620_mii_write(gsw, 1, 22, 0x10cf);
-		_mt7620_mii_write(gsw, 1, 25, 0x6212);
-		_mt7620_mii_write(gsw, 1, 26, 0x0777);
-		_mt7620_mii_write(gsw, 1, 29, 0x4000);
-		_mt7620_mii_write(gsw, 1, 28, 0xc077);
-		_mt7620_mii_write(gsw, 1, 24, 0x0000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 22, 0x10cf);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 25, 0x6212);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 26, 0x0777);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 29, 0x4000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 28, 0xc077);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 24, 0x0000);
 
 		/* global page 3 */
-		_mt7620_mii_write(gsw, 1, 31, 0x3000);
-		_mt7620_mii_write(gsw, 1, 17, 0x4838);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0x3000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 17, 0x4838);
 
 		/* global page 2 */
-		_mt7620_mii_write(gsw, 1, 31, 0x2000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0x2000);
 		if (is_BGA) {
-			_mt7620_mii_write(gsw, 1, 21, 0x0515);
-			_mt7620_mii_write(gsw, 1, 22, 0x0053);
-			_mt7620_mii_write(gsw, 1, 23, 0x00bf);
-			_mt7620_mii_write(gsw, 1, 24, 0x0aaf);
-			_mt7620_mii_write(gsw, 1, 25, 0x0fad);
-			_mt7620_mii_write(gsw, 1, 26, 0x0fc1);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 21, 0x0515);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 22, 0x0053);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 23, 0x00bf);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 24, 0x0aaf);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 25, 0x0fad);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 26, 0x0fc1);
 		} else {
-			_mt7620_mii_write(gsw, 1, 21, 0x0517);
-			_mt7620_mii_write(gsw, 1, 22, 0x0fd2);
-			_mt7620_mii_write(gsw, 1, 23, 0x00bf);
-			_mt7620_mii_write(gsw, 1, 24, 0x0aab);
-			_mt7620_mii_write(gsw, 1, 25, 0x00ae);
-			_mt7620_mii_write(gsw, 1, 26, 0x0fff);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 21, 0x0517);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 22, 0x0fd2);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 23, 0x00bf);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 24, 0x0aab);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 25, 0x00ae);
+			_mt7620_mii_write(gsw, gsw->ephy_base + 1, 26, 0x0fff);
 		}
 		/* global page 1 */
-		_mt7620_mii_write(gsw, 1, 31, 0x1000);
-		_mt7620_mii_write(gsw, 1, 17, 0xe7f8);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0x1000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 1, 17, 0xe7f8);
 
 		/* turn on all PHYs */
 		for (i = 0; i <= 4; i++) {
-			val = _mt7620_mii_read(gsw, i, 0);
+			val = _mt7620_mii_read(gsw, gsw->ephy_base + i, 0);
 			val &= ~BIT(11);
-			_mt7620_mii_write(gsw, i, 0, val);
+			_mt7620_mii_write(gsw, gsw->ephy_base + i, 0, val);
 		}
 	}
 
 	/* global page 0 */
-	_mt7620_mii_write(gsw, 1, 31, 0x8000);
-	_mt7620_mii_write(gsw, 0, 30, 0xa000);
-	_mt7620_mii_write(gsw, 1, 30, 0xa000);
-	_mt7620_mii_write(gsw, 2, 30, 0xa000);
-	_mt7620_mii_write(gsw, 3, 30, 0xa000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0x8000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 0, 30, 0xa000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 1, 30, 0xa000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 2, 30, 0xa000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 3, 30, 0xa000);
 
-	_mt7620_mii_write(gsw, 0, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 1, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 2, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 3, 4, 0x05e1);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 0, 4, 0x05e1);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 1, 4, 0x05e1);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 2, 4, 0x05e1);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 3, 4, 0x05e1);
 
 	/* global page 2 */
-	_mt7620_mii_write(gsw, 1, 31, 0xa000);
-	_mt7620_mii_write(gsw, 0, 16, 0x1111);
-	_mt7620_mii_write(gsw, 1, 16, 0x1010);
-	_mt7620_mii_write(gsw, 2, 16, 0x1515);
-	_mt7620_mii_write(gsw, 3, 16, 0x0f0f);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 1, 31, 0xa000);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 0, 16, 0x1111);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 1, 16, 0x1010);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 2, 16, 0x1515);
+	_mt7620_mii_write(gsw, gsw->ephy_base + 3, 16, 0x0f0f);
 
 	/* CPU Port6 Force Link 1G, FC ON */
 	mtk_switch_w32(gsw, 0x5e33b, GSW_REG_PORT_PMCR(6));
@@ -196,9 +205,9 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw, int mdio_mode)
 
 		val |= 3 << 14;
 		rt_sysc_w32(val, SYSC_REG_CFG1);
-		_mt7620_mii_write(gsw, 4, 30, 0xa000);
-		_mt7620_mii_write(gsw, 4, 4, 0x05e1);
-		_mt7620_mii_write(gsw, 4, 16, 0x1313);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 4, 30, 0xa000);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 4, 4, 0x05e1);
+		_mt7620_mii_write(gsw, gsw->ephy_base + 4, 16, 0x1313);
 		pr_info("gsw: setting port4 to ephy mode\n");
 	} else if (!mdio_mode) {
 		u32 val = rt_sysc_r32(SYSC_REG_CFG1);
@@ -247,6 +256,7 @@ static int mt7620_gsw_probe(struct platform_device *pdev)
 	const char *port4 = NULL;
 	struct mt7620_gsw *gsw;
 	struct device_node *np = pdev->dev.of_node;
+	u16 val;
 
 	gsw = devm_kzalloc(&pdev->dev, sizeof(struct mt7620_gsw), GFP_KERNEL);
 	if (!gsw)
@@ -265,6 +275,11 @@ static int mt7620_gsw_probe(struct platform_device *pdev)
 		gsw->port4 = PORT4_EXT;
 	else
 		gsw->port4 = PORT4_EPHY;
+
+	if (of_property_read_u16(np, "mediatek,ephy-base-address", &val) == 0)
+		gsw->ephy_base = val;
+	else
+		gsw->ephy_base = 0;
 
 	gsw->irq = platform_get_irq(pdev, 0);
 

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.h
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.h
@@ -103,6 +103,7 @@ struct mt7620_gsw {
 	int			irq;
 	int			port4;
 	unsigned long int	autopoll;
+	u16 ephy_base;
 };
 
 void mtk_switch_w32(struct mt7620_gsw *gsw, u32 val, unsigned reg);

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.c
@@ -60,19 +60,19 @@ static void fe_phy_link_adjust(struct net_device *dev)
 	spin_unlock_irqrestore(&priv->phy->lock, flags);
 }
 
-int fe_connect_phy_node(struct fe_priv *priv, struct device_node *phy_node)
+int fe_connect_phy_node(struct fe_priv *priv, struct device_node *phy_node, int port)
 {
-	const __be32 *_port = NULL;
+	const __be32 *_phy_addr = NULL;
 	struct phy_device *phydev;
-	int phy_mode, port;
+	int phy_mode;
 
-	_port = of_get_property(phy_node, "reg", NULL);
+	_phy_addr = of_get_property(phy_node, "reg", NULL);
 
-	if (!_port || (be32_to_cpu(*_port) >= 0x20)) {
-		pr_err("%s: invalid port id\n", phy_node->name);
+	if (!_phy_addr || (be32_to_cpu(*_phy_addr) >= 0x20)) {
+		pr_err("%s: invalid phy id\n", phy_node->name);
 		return -EINVAL;
 	}
-	port = be32_to_cpu(*_port);
+
 	phy_mode = of_get_phy_mode(phy_node);
 	if (phy_mode < 0) {
 		dev_err(priv->dev, "incorrect phy-mode %d\n", phy_mode);

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.c
@@ -127,8 +127,14 @@ static int fe_phy_connect(struct fe_priv *priv)
 				priv->phy_dev = priv->phy->phy[i];
 				priv->phy_flags = FE_PHY_FLAG_PORT;
 			}
-		} else if (priv->mii_bus && mdiobus_get_phy(priv->mii_bus, i)) {
-			phy_init(priv, mdiobus_get_phy(priv->mii_bus, i));
+		} else if (priv->mii_bus) {
+			struct phy_device *phydev;
+
+			phydev = mdiobus_get_phy(priv->mii_bus, i);
+			if (!phydev || phydev->attached_dev)
+				continue;
+
+			phy_init(priv, phydev);
 			if (!priv->phy_dev) {
 				priv->phy_dev = mdiobus_get_phy(priv->mii_bus, i);
 				priv->phy_flags = FE_PHY_FLAG_ATTACH;

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.h
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio.h
@@ -19,7 +19,8 @@
 int fe_mdio_init(struct fe_priv *priv);
 void fe_mdio_cleanup(struct fe_priv *priv);
 int fe_connect_phy_node(struct fe_priv *priv,
-			struct device_node *phy_node);
+			struct device_node *phy_node,
+			int port);
 #else
 static inline int fe_mdio_init(struct fe_priv *priv) { return 0; }
 static inline void fe_mdio_cleanup(struct fe_priv *priv) {}

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio_rt2880.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mdio_rt2880.c
@@ -218,5 +218,5 @@ void rt2880_port_init(struct fe_priv *priv, struct device_node *np)
 	}
 
 	if (priv->phy->phy_node[0] && mdiobus_get_phy(priv->mii_bus, 0))
-		fe_connect_phy_node(priv, priv->phy->phy_node[0]);
+		fe_connect_phy_node(priv, priv->phy->phy_node[0], 0);
 }

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
@@ -140,6 +140,7 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 {
 	struct mt7620_gsw *gsw = (struct mt7620_gsw *)priv->soc->swpriv;
 	const __be32 *_id = of_get_property(np, "reg", NULL);
+	const __be32 *phy_addr;
 	int phy_mode, size, id;
 	int shift = 12;
 	u32 val, mask = 0;
@@ -234,12 +235,13 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 		return;
 	}
 
-	if (priv->phy->phy_node[id] && mdiobus_get_phy(priv->mii_bus, id)) {
+	phy_addr = of_get_property(priv->phy->phy_node[id], "reg", NULL);
+	if (phy_addr && mdiobus_get_phy(priv->mii_bus, be32_to_cpup(phy_addr))) {
 		u32 val = PMCR_BACKPRES | PMCR_BACKOFF | PMCR_RX_EN |
 			PMCR_TX_EN |  PMCR_MAC_MODE | PMCR_IPG;
 
 		mtk_switch_w32(gsw, val, GSW_REG_PORT_PMCR(id));
-		fe_connect_phy_node(priv, priv->phy->phy_node[id]);
+		fe_connect_phy_node(priv, priv->phy->phy_node[id], id);
 		gsw->autopoll |= BIT(id);
 		mt7620_auto_poll(gsw);
 		return;

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
@@ -118,7 +118,7 @@ static void mt7620_set_mac(struct fe_priv *priv, unsigned char *mac)
 	spin_unlock_irqrestore(&priv->page_lock, flags);
 }
 
-static void mt7620_auto_poll(struct mt7620_gsw *gsw)
+static void mt7620_auto_poll(struct mt7620_gsw *gsw, int port)
 {
 	int phy;
 	int lsb = -1, msb = 0;
@@ -129,7 +129,9 @@ static void mt7620_auto_poll(struct mt7620_gsw *gsw)
 		msb = phy;
 	}
 
-	if (lsb == msb)
+	if (lsb == msb && port ==  4)
+		msb++;
+	else if (lsb == msb && port ==  5)
 		lsb--;
 
 	mtk_switch_w32(gsw, PHY_AN_EN | PHY_PRE_EN | PMY_MDC_CONF(5) |
@@ -242,8 +244,8 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 
 		mtk_switch_w32(gsw, val, GSW_REG_PORT_PMCR(id));
 		fe_connect_phy_node(priv, priv->phy->phy_node[id], id);
-		gsw->autopoll |= BIT(id);
-		mt7620_auto_poll(gsw);
+		gsw->autopoll |= BIT(be32_to_cpup(phy_addr));
+		mt7620_auto_poll(gsw,id);
 		return;
 	}
 }


### PR DESCRIPTION
This patch fix and enable GELAN port in D-LINK DWR-118-A2.

This changes allow to use PHY with mdio address different than
port number.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
