### PR TITLE
ramips: add support for Apexera NetBot and WiBot

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -44,6 +44,8 @@ ramips_setup_interfaces()
 	all0256n-8M|\
 	all5002|\
 	all5003|\
+	apexera,netbot|\
+	apexera,wibot|\
 	bocco|\
 	broadway|\
 	dcs-930|\

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -24,6 +24,8 @@ platform_check_image() {
 	all5002|\
 	all5003|\
 	mediatek,ap-mt7621a-v60|\
+	apexera,netbot|\
+	apexera,wibot|\
 	ar725w|\
 	asl26555-8M|\
 	asl26555-16M|\

--- a/target/linux/ramips/dts/ApexeraNetBot.dts
+++ b/target/linux/ramips/dts/ApexeraNetBot.dts
@@ -1,0 +1,180 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "apexera,netbot", "ralink,mt7620a-soc";
+	model = "Apexera NetBot";
+
+	chosen {
+		bootargs = "console=ttyS1,57600";
+	};
+
+	aliases {
+		led-boot = &led_wifi;
+		led-failsafe = &led_wifi;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_wifi: wifi {
+			label = "netbot:led:wifi";
+			gpios = <&gpio2 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "netbot:led:wan";
+			gpios = <&gpio2 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb2g {
+			label = "netbot:green:usb2";
+			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb2r {
+			label = "netbot:red:usb2";
+			gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb4g {
+			label = "netbot:green:usb4";
+			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb4r {
+			label = "netbot:red:usb4";
+			gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb1g {
+			label = "netbot:green:usb1";
+			gpios = <&gpio2 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb1r {
+			label = "netbot:red:usb1";
+			gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb3g {
+			label = "netbot:green:usb3";
+			gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb3r {
+			label = "netbot:red:usb3";
+			gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&i2s {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+
+	pcf8563: rtc@51 {
+		status = "okay";
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+	};
+
+	wm8978: wm8978@1a {
+		compatible = "wm8978";
+		reg = <0x1a>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x10>;
+	ralink,port-map = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "rgmii2", "mdio", "ephy";
+			ralink,function = "gpio";
+		};
+
+		i2s_uartf {
+			ralink,group = "uartf";
+			ralink,function = "i2s uartf";
+		};
+	};
+};

--- a/target/linux/ramips/dts/ApexeraWiBot.dts
+++ b/target/linux/ramips/dts/ApexeraWiBot.dts
@@ -1,0 +1,172 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "apexera,wibot", "ralink,mt7620a-soc";
+	model = "Apexera WiBot";
+
+	chosen {
+		bootargs = "console=ttyS1,57600";
+	};
+
+	aliases {
+		led-boot = &led_boot;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "wibot:blue:wan";
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "wibot:blue:wifi";
+			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status: status {
+			label = "wibot:blue:status";
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_boot: boot {
+			label = "wibot:blue:boot";
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		reset {
+			label = "wibot:blue:reset";
+			gpios = <&gpio2 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		ctrl3g {
+			label = "wibot:blue:ctrl3g";
+			gpios = <&gpio2 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb0 {
+			label = "wibot:blue:usb0";
+			gpios = <&gpio2 20 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb1 {
+			label = "wibot:blue:usb1";
+			gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+
+	pcf8563: rtc@51 {
+		status = "okay";
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x10>;
+	ralink,port-map = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "rgmii1", "rgmii2";
+			ralink,function = "gpio";
+		};
+
+		uartf_gpio {
+			ralink,group = "uartf";
+			ralink,function = "gpio uartf";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -32,6 +32,29 @@ define Device/alfa-network_ac1200rm
 endef
 TARGET_DEVICES += alfa-network_ac1200rm
 
+define Device/apexera_netbot
+  DTS := ApexeraNetBot
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := Apexera NetBot
+  DEVICE_PACKAGES := kmod-i2c-ralink \
+	kmod-rtc-pcf8563 kmod-sound-core \
+	kmod-sound-mt7620 kmod-usb2 kmod-usb3 \
+	kmod-usb-ohci kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += apexera_netbot
+
+define Device/apexera_wibot
+  DTS := ApexeraWiBot
+  IMAGE_SIZE := 16064k
+  DEVICE_TITLE := Apexera WiBot
+  DEVICE_PACKAGES :=	kmod-i2c-ralink \
+	kmod-rtc-pcf8563 kmod-sound-core \
+	kmod-sound-mt7620 kmod-usb2 \
+	kmod-usb-ohci kmod-sdhci-mt7620 \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += apexera_wibot
+
 define Device/Archer
   TPLINK_HWREVADD := 0
   TPLINK_HVERSION := 3


### PR DESCRIPTION
Apexera WiBot Specification:

* CPU: MT7620A
* DRAM: 256 MiB
* NOR: 16 MiB
* Wireless: 2.4Ghz
* Ethernet speed: 10/100
* Ethernet ports: 1
* 1x USB Hub (with 3 ports exported)
  * 1x USB Converted PCIe Slot (for 4G Adapter)
  * 1x USB 3.0 
  * 1x USB Power Output: DC 5V Max 1A
* 1x Micro USB Power Input: 5V Max 2.5A
* 1x microSD reader
* Debug Serial: 57600,8N1
* Battery: 6000mAh/3.8V
* Reset Button
* LED: In Charge lEDs(4 streaming LED), Power, Wifi, 4G available.
* STM32: stm32f030f4p6 for battery&power manage
  * 1x uart(i2c) (connected to uart1 and i2c of MT7620A, for stm32 firmware update and charging manage, protocol unknown)
  * 4x led (PA3/PA4/PA5/PA6 for charging state)
  * 1x ADC (PA1 for battery adc)
  * Power Button (PA0)

Apexera NetBot Specification:

* CPU: MT7620A
* DRAM: 256 MiB
* NOR: 16 MiB
* Wireless: 2.4Ghz
* Ethernet speed: 10/100
* Ethernet ports: 1
* 4x USB 2.0 
* 1x Micro USB Power Input: 5V Max 2.5A
* 1x microSD reader
* Debug Serial: 57600,8N1
* Reset Button
* I2S Output
* LED: wifi, usb, ethernet

Signed-off-by: Han Pengfei <pengphei@foxmail.com>