### PR TITLE
zram-swap: dependency fix, stats info output

### DIFF
--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/zram-swap
   SECTION:=utils
   CATEGORY:=Base system
-  DEPENDS:=+kmod-zram +!BUSYBOX_CONFIG_MKSWAP:swap-utils +!BUSYBOX_CONFIG_SWAPONOFF:block-mount
+  DEPENDS:=+kmod-zram +!(BUSYBOX_DEFAULT_MKSWAP||BUSYBOX_CONFIG_MKSWAP):swap-utils +!((BUSYBOX_DEFAULT_SWAPON||BUSYBOX_CONFIG_SWAPON)&&(BUSYBOX_DEFAULT_SWAPOFF||BUSYBOX_CONFIG_SWAPOFF)):block-mount
   TITLE:=ZRAM swap scripts
   PKGARCH:=all
 endef

--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zram-swap
 PKG_VERSION:=1.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -2,17 +2,21 @@
 
 START=15
 
-ram_size()
+EXTRA_COMMANDS="compact status"
+EXTRA_HELP="        compact trigger compaction for all Z-RAM swap dev's
+        status  print out status information & statistics about Z-RAM swap devices"
+
+ram_getsize()
 {
 	local line
 
 	while read line; do case "$line" in MemTotal:*) set $line; echo "$2"; break ;; esac; done </proc/meminfo
 }
 
-zram_size()	# in megabytes
+zram_getsize()	# in megabytes
 {
 	local zram_size="$( uci -q get system.@system[0].zram_size_mb )"
-	local ram_size="$( ram_size )"
+	local ram_size="$( ram_getsize )"
 
 	if [ -z "$zram_size" ]; then
 		# e.g. 6mb for 16mb-routers or 61mb for 128mb-routers
@@ -106,9 +110,9 @@ zram_comp_streams()
 	fi
 }
 
+#print various stats info about zram swap device
 zram_stats()
 {
-	#print various stats info about zram swap device
 	local zdev="/sys/block/$( basename "$1" )"
 
 	printf "\nGathering stats info for zram device \"$( basename "$1" )\"\n\n"
@@ -124,7 +128,7 @@ zram_stats()
 		print "\nDATA\n----" }
 		{ printf fmt, "Original data size", $1/1024/1024, "Mb"
 		printf fmt, "Compressed data size", $2/1024/1024, "Mb"
-		printf fmt, "Compress ratio", $1/$2
+		printf fmt, "Compress ratio", $1/$2, ""
 		print "\nMEMORY\n------"
 		printf fmt, "Memory used, total", $3/1024/1024, "Mb"
 		printf fmt, "Allocator overhead", ($3-$2)/1024/1024, "Mb"
@@ -143,12 +147,16 @@ zram_compact()
 	# compact zram device (reduce memory allocation overhead)
 	local zdev="/sys/block/$( basename "$1" )"
 
-	old_mem_used=`awk '{print $3}' <$zdev/mm_stat`
-	old_overhead=`awk '{print $3-$2}' <$zdev/mm_stat`
+	local old_mem_used=`awk '{print $3}' <$zdev/mm_stat`
+	local old_overhead=`awk '{print $3-$2}' <$zdev/mm_stat`
+
+	echo 1 > $zdev/compact
+
+	# If not running interactively, than just return
+	[ -z "$PS1" ] && return 0
 
 	echo ""
-	echo "Compacting zram device..."
-	echo 1 > $zdev/compact
+	echo "Compacting zram device $zdev"
 	awk -v old_mem="$old_mem_used" -v ovr="$old_overhead" 'BEGIN { fmt = "%-25s - %.1f %s\n" }
 		{ printf fmt, "Memory usage reduced by ", (old_mem-$3)/1024/1024, "Mb"
 		printf fmt, "Overhead reduced by", (ovr-($3-$2))/ovr*100, "%" }' <$zdev/mm_stat
@@ -156,23 +164,13 @@ zram_compact()
 
 start()
 {
-	local zram_size="$( zram_size )"
-	local zram_dev
-
 	if [ $( grep -cs zram /proc/swaps ) -ne 0 ]; then
 		logger -s -t zram_start -p daemon.notice "[OK] zram swap is already mounted"
-		# If not running interactively, than just quit
-		[ -z "$PS1" ] && return 1
-
-		# show memory stats and compact all zram swaps
-		for zram_dev in $( grep zram /proc/swaps |awk '{print $1}' ); do {
-			zram_compact "$zram_dev"
-			zram_stats "$zram_dev"
-		} done
-		return
+		return 1
 	fi
 
-	zram_dev="$( zram_getdev )"
+	local zram_size="$( zram_getsize )"
+	local zram_dev="$( zram_getdev )"
 	zram_applicable "$zram_dev" || return 1
 
 	logger -s -t zram_start -p daemon.debug "activating '$zram_dev' for swapping ($zram_size MegaBytes)"
@@ -200,3 +198,18 @@ stop()
 	} done
 }
 
+# show memory stats for all zram swaps
+status()
+{
+	for zram_dev in $( grep zram /proc/swaps |awk '{print $1}' ); do {
+		zram_stats "$zram_dev"
+	} done
+}
+
+# trigger compaction for all zram swaps
+compact()
+{
+	for zram_dev in $( grep zram /proc/swaps |awk '{print $1}' ); do {
+		zram_compact "$zram_dev"
+	} done
+}

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -106,6 +106,54 @@ zram_comp_streams()
 	fi
 }
 
+zram_stats()
+{
+	#print various stats info about zram swap device
+	local zdev="/sys/block/$( basename "$1" )"
+
+	printf "\nGathering stats info for zram device \"$( basename "$1" )\"\n\n"
+
+	printf "Z-RAM\n-----\n"
+	printf "%-25s - %s\n" "Block device" $zdev
+	awk '{ printf "%-25s - %d Mb\n", "Device size", $1/1024/1024 }' <$zdev/disksize
+	printf "%-25s - %s\n" "Compression algo" "$(cat $zdev/comp_algorithm)"
+	printf "%-25s - %s\n" "Compression streams" "$( cat $zdev/max_comp_streams)"
+
+	awk 'BEGIN { fmt = "%-25s - %.2f %s\n"
+		fmt2 = "%-25s - %d\n"
+		print "\nDATA\n----" }
+		{ printf fmt, "Original data size", $1/1024/1024, "Mb"
+		printf fmt, "Compressed data size", $2/1024/1024, "Mb"
+		printf fmt, "Compress ratio", $1/$2
+		print "\nMEMORY\n------"
+		printf fmt, "Memory used, total", $3/1024/1024, "Mb"
+		printf fmt, "Allocator overhead", ($3-$2)/1024/1024, "Mb"
+		printf fmt, "Allocator efficiency", $2/$3*100, "%"
+		printf fmt, "Maximum memory ever used", $5/1024/1024, "Mb"
+		printf fmt, "Memory limit", $4/1024/1024, "Mb"
+		print "\nPAGES\n-----"
+		printf fmt2, "Same pages count", $6
+		printf fmt2, "Pages compacted", $7 }' <$zdev/mm_stat
+
+	awk '{ printf "%-25s - %d\n", "Free pages discarded", $4 }' <$zdev/io_stat
+}
+
+zram_compact()
+{
+	# compact zram device (reduce memory allocation overhead)
+	local zdev="/sys/block/$( basename "$1" )"
+
+	old_mem_used=`awk '{print $3}' <$zdev/mm_stat`
+	old_overhead=`awk '{print $3-$2}' <$zdev/mm_stat`
+
+	echo ""
+	echo "Compacting zram device..."
+	echo 1 > $zdev/compact
+	awk -v old_mem="$old_mem_used" -v ovr="$old_overhead" 'BEGIN { fmt = "%-25s - %.1f %s\n" }
+		{ printf fmt, "Memory usage reduced by ", (old_mem-$3)/1024/1024, "Mb"
+		printf fmt, "Overhead reduced by", (ovr-($3-$2))/ovr*100, "%" }' <$zdev/mm_stat
+}
+
 start()
 {
 	local zram_size="$( zram_size )"
@@ -113,7 +161,15 @@ start()
 
 	if [ $( grep -cs zram /proc/swaps ) -ne 0 ]; then
 		logger -s -t zram_start -p daemon.notice "[OK] zram swap is already mounted"
-		return 1
+		# If not running interactively, than just quit
+		[ -z "$PS1" ] && return 1
+
+		# show memory stats and compact all zram swaps
+		for zram_dev in $( grep zram /proc/swaps |awk '{print $1}' ); do {
+			zram_compact "$zram_dev"
+			zram_stats "$zram_dev"
+		} done
+		return
 	fi
 
 	zram_dev="$( zram_getdev )"

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1728,16 +1728,16 @@ config BUSYBOX_DEFAULT_SETSID
 	default n
 config BUSYBOX_DEFAULT_SWAPON
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SWAPON_DISCARD
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SWAPON_PRI
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_SWAPOFF
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_SWAPONOFF_LABEL
 	bool
 	default n


### PR DESCRIPTION
**zram-swap:**
- fix dependency on BUSYBOX_CONFIG_SWAPONOFF (removed in 84da2a6)
- add busybox defaults checking (fix zram-swap always installs swap-utils and libblkid as dependency, even if busybox includes mkswap by default)
- Add zram compaction and statistics info output
    Executing '/etc/init.d/zram start' during runtime (with a swap being already mounted) triggers zram device compaction and prints out nice stats info about zram memory usage

**busybox:**
- enable swapon/off by default to make it consistent with mkswap
      No size increase on busybox binary.
      Since busybox mkswap is already enabled by default it seems reasonable to enable swapon/off too. For ex. this obsoletes installing block-mount dependency for zram-swap.

build/run tested on ramips/ar71

Stats info example


```
Compacting zram device...
Memory usage reduced by   - 0.8 Mb
Overhead reduced by       - 37.7 %
Gathering stats info for zram device "zram0"

Z-RAM
-----
Block device              - /sys/block/zram0
Device size               - 64 Mb
Compression algo          - lzo [lz4] deflate 
Compression streams       - 4

DATA
----
Original data size        - 40.55 Mb
Compressed data size      - 16.60 Mb
Compress ratio            - 2.44 

MEMORY
------
Memory used, total        - 17.89 Mb
Allocator overhead        - 1.29 Mb
Allocator efficiency      - 92.80 %
Maximum memory ever used  - 28.73 Mb
Memory limit              - 0.00 Mb

PAGES
-----
Same pages count          - 198
Pages compacted           - 200
Free pages discarded      - 22779
```
