### PR TITLE
ath79: Add support for TP-Link WDR7800 v1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -76,6 +76,13 @@ tplink,tl-wr941-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
 	;;
+tplink,tl-wdr7800-v1)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
+	;;
 tplink,tl-wr740nd-v4|\
 tplink,tl-wr741nd-v4|\
 tplink,tl-wr842n-v2)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -166,6 +166,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
+  tplink,tl-wdr7800-v1)
+    ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
+    ucidef_add_switch "switch0" \
+      "0@eth1" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
+		;;
 	tplink,tl-wr941-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -104,6 +104,10 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
+	tplink,wdr7800-v1)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+		;;
 	tplink,re450-v2)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)

--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr7800-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr7800-v1.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9561_tplink_tl-wdr7800.dtsi"
+
+/ {
+  compatible = "tplink,tl-wdr7800-v1", "qca,qca9561";
+  model = "TP-Link TL-WDR7800 Version 1";
+};
+
+&mtdparts {
+  uboot: u-boot@0 {
+    reg = <0x000000 0x010000>;
+    read-only;
+  };
+
+  firmware@10000 {
+    reg = <0x030000 0x7e0000>;
+  };
+
+  art: art@7f0000 {
+    reg = <0x7f0000 0x010000>;
+    read-only;
+  };
+};
+
+&gpio_leds {
+  system: system {
+    label = "tp-link:green:system";
+    gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+    linux,default-trigger = "heartbeat";
+  };
+
+  wan {
+    label = "tp-link:green:wan";
+    gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+    default-state = "off";
+  };
+
+  lan1 {
+    label = "tp-link:green:lan1";
+    gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+  };
+
+  lan2 {
+    label = "tp-link:green:lan2";
+    gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+  };
+
+  lan3 {
+    label = "tp-link:green:lan3";
+    gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+  };
+
+  lan4 {
+    label = "tp-link:green:lan4";
+    gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+  };
+};
+
+&gpio_keys {
+  reset {
+    label = "Reset button";
+    linux,code = <KEY_RESTART>;
+    gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+    debounce-interval = <60>;
+  };
+};

--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr7800.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr7800.dtsi
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+	};
+
+  gpio_keys: keys {
+		compatible = "gpio-keys";
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+  status = "okay";
+  num-cs = <1>;
+
+  flash@0 {
+    compatible = "jedec,spi-nor";
+    reg = <0>;
+    spi-max-frequency = <25000000>;
+
+    mtdparts: partitions {
+      compatible = "fixed-partitions";
+      #address-cells = <1>;
+      #size-cells = <1>;
+    };
+  };
+};
+
+&mdio0 {
+  status = "okay";
+
+  phy0: ethernet-phy@0 {
+    reg = <0>;
+
+    qca,ar8327-initvals = <
+      0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+      0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+      0x50 0xc737c737 /* LED_CTRL0 */
+      0x54 0x00000000 /* LED_CTRL1 */
+      0x58 0x00000000 /* LED_CTRL2 */
+      0x5c 0x0030c300 /* LED_CTRL3 */
+      0x7c 0x0000007e /* PORT0_STATUS */
+      0x94 0x0000007e /* PORT6 STATUS */
+      >;
+  };
+};
+
+&eth0 {
+  status = "okay";
+
+  mtd-mac-address = <&uboot 0x1fc00>;
+  mtd-mac-address-increment = <1>;
+  phy-handle = <&phy0>;
+  pll-data = <0x56000000 0x00000101 0x00001616>;
+
+  gmac-config {
+    device = <&gmac>;
+    rgmii-enabled = <1>;
+  };
+};
+
+&eth1 {
+  status = "okay";
+
+  mtd-mac-address = <&uboot 0x1fc00>;
+  pll-data = <0x03000101 0x00000101 0x00001616>;
+
+  fixed-link {
+    speed = <1000>;
+    full-duplex;
+  };
+};
+
+&wmac {
+  status = "okay";
+  mtd-cal-data = <&art 0x1000>;
+  mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -135,3 +135,12 @@ define Device/tplink_tl-wr2543-v1
   SUPPORTED_DEVICES += tl-wr2543-v1
 endef
 TARGET_DEVICES += tplink_tl-wr2543-v1
+
+define Device/tplink_tl-wdr7800-v1
+  $(Device/tplink-8mlzma)
+  ATH_SOC := qca9561
+  DEVICE_TITLE := TP-LINK TL-WDR7800 v1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  TPLINK_HWID := 0x78000001
+endef
+TARGET_DEVICES += tplink_tl-wdr7800-v1


### PR DESCRIPTION
TP-Link WDR7800 v1 is a dual band router
based on Qualcomm/Atheros QCA9561 + QCA9880.
The model solution is similar to WDR6500, WDR7400.

Specification:
 - 750 MHz CPU
 - 64 MB of RAM (DDR 650MHz)
 - AHB 250MHz
 - Ref 25MHz
 - 8 MB of FLASH (various like GD25Q64)
 - SoC integrated 3T3R 2.4 GHz Wi-Fi 450Mbps
 - QCA9880 with 3T3R 5 GHz Wi-Fi 1300Mbps
 - Switch: Atheros AR8228/AR8229 rev 1
 - 4x 10/100 Mbps LAN (v1)
 - 1x 10/100 Mbps WAN
 - External PA and LNA
 - Only one Reset button

Flash instruction:
  <https://www.youtube.com/watch?v=_sqcEedKhJE>
  Only via UART is possible.
  TTL pins (positioning LAN on TOP): tx, rx, gnd, vcc3.3v
  Soldering: R9, R10 left side
  Command to enter uboot: slp

Other Known GPIOs:
  18 - Rx
  20 - Tx
  22 - Unknown (Direction out)
  23 - Unknown (Direction out)

For futher information on the device, visit:
<https://www.tp-link.com.cn/product_493.html>

Signed-off-by: Joey Jiao <joeyjiaojg@163.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
