### PR TITLE
ath79: add support for Winchannel WB2000

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -28,7 +28,8 @@ ath79_setup_interfaces()
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
 	ubnt,unifi|\
-	wd,mynet-wifi-rangeextender)
+	wd,mynet-wifi-rangeextender|\
+	winchannel,wb2000)
 		ucidef_set_interface_lan "eth0"
 		;;
 	avm,fritz4020)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -127,7 +127,8 @@ case "$FIRMWARE" in
 	ocedo,raccoon|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300|\
-	tplink,tl-wdr4900-v2)
+	tplink,tl-wdr4900-v2|\
+	winchannel,wb2000)
 		ath9k_eeprom_extract "art" 20480 1088
 		;;
 	netgear,wnr612-v2|\

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "Winchannel WB2000";
+	compatible = "winchannel,wb2000", "qca,ar9344";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	i2c@0 {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 17 GPIO_ACTIVE_HIGH
+			 &gpio 16 GPIO_ACTIVE_HIGH
+			>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rtc@68 {
+			compatible = "dallas,ds1339";
+			reg = <0x68>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "wb2000:green:2g";
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "wb2000:green:usb";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			trigger-sources = <&hub_port1>, <&hub_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		led_system: system {
+			label = "wb2000:green:system";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <50>;
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fd0000 {
+				label = "nvram";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			art: partition@fe0000 {
+				label = "art";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			addr: partition@ff0000 {
+				label = "addr";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "wb2000:green:5g";
+			gpios = <&ath9k 6 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&addr 0x0>;
+		mtd-mac-address-increment = <0x10>;
+		gpio-controller;
+	};
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	port@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <1>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+
+		hub_port2: port@2 {
+			reg = <2>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&addr 0x0>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x10>;
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xe000000 0x04000101 0x04001313>;
+
+	mtd-mac-address = <&addr 0x0>;
+	mtd-mac-address-increment = <0x21>;
+
+	phy-mode = "rgmii-rxid";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxd-delay = <1>;
+		rxdv-delay = <1>;
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -341,3 +341,11 @@ define Device/wd_mynet-wifi-rangeextender
   SUPPORTED_DEVICES += mynet-rext
 endef
 TARGET_DEVICES += wd_mynet-wifi-rangeextender
+
+define Device/winchannel_wb2000
+  ATH_SOC := ar9344
+  DEVICE_TITLE := Winchannel WB2000
+  IMAGE_SIZE := 15872k
+  DEVICE_PACKAGES := kmod-i2c-core kmod-i2c-gpio kmod-rtc-ds1307 kmod-usb2 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += winchannel_wb2000


### PR DESCRIPTION
WB2000 is a dual-band 11N AP using AR9344.
The factory firmware used the original DB120 partition table
with a small kernel partition at the end of firmware and the
kernel will easily get oversized in the future. Since it has
to be flashed using UART I also swapped kernel/rootfs and
changed the default load address.

Specification:

- SoC: Atheros AR9344
- RAM: 128 MB
- Flash: 16 MB
- Ethernet: 10/100/1000 Mbps (Atheros AR8035)
- 2x USB 2.0
- WIFI: AR9344(2G) + AR9382(5G)
- RTC: DS1338

Known issue:
5G ath9k led doesn't work due to commit ccab68f.

Flash instruction:
Set up a TFTP server on your computer and configure static IP.
Connect UART (J11 TX/GND/RX) and press any key to enter U-boot
shell.
1. Change the default boot command:
   setenv bootcmd 'bootm 0x9f050000 || bootm 0x9fd50000'
   saveenv
2. Set your router ipaddr and server ipaddr. e.g.:
   setenv ipaddr 192.168.1.1
   setenv serverip 192.168.1.50
3. Load and flash the firmware:
   tftp 0x80060000 fw.bin
   erase 0x9f050000 +$filesize
   cp.b $fileaddr 0x9f050000 $filesize
4. Reset your router:
   reset

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
