### PR TITLE
kernel: add kmod-frame-vector

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -146,6 +146,15 @@ define KernelPackage/dma-buf
 endef
 $(eval $(call KernelPackage,dma-buf))
 
+define KernelPackage/frame-vector
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Frame vector support
+  HIDDEN:=1
+  KCONFIG:=CONFIG_FRAME_VECTOR
+  FILES:=$(LINUX_DIR)/mm/frame_vector.ko
+  AUTOLOAD:=$(call AutoLoad,20,frame_vector)
+endef
+$(eval $(call KernelPackage,frame-vector))
 
 define KernelPackage/nvmem
   SUBMENU:=$(OTHER_MENU)

--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -307,7 +307,7 @@ endef
 
 define KernelPackage/video-videobuf2
   TITLE:=videobuf2 lib
-  DEPENDS:=+kmod-dma-buf
+  DEPENDS:=+kmod-dma-buf +kmod-frame-vector
   KCONFIG:= \
 	CONFIG_VIDEOBUF2_CORE \
 	CONFIG_VIDEOBUF2_MEMOPS \

--- a/target/linux/generic/hack-4.14/920-unconditional-debloated-frame-vector.patch
+++ b/target/linux/generic/hack-4.14/920-unconditional-debloated-frame-vector.patch
@@ -1,0 +1,11 @@
+--- a/mm/Kconfig.orig	2018-08-15 18:13:02.000000000 +0200
++++ b/mm/Kconfig	2018-11-02 19:01:53.946274973 +0100
+@@ -743,7 +743,7 @@
+ 	  the CPU
+ 
+ config FRAME_VECTOR
+-	bool
++	tristate "Frame vector support"
+ 
+ config ARCH_USES_HIGH_VMA_FLAGS
+ 	bool


### PR DESCRIPTION
This is essential for feeds which provide bleeding edge drivers for V4L/DVB devices based on LinuxTV dot org.

I mean if the feed is unable to set this dependency, the build will fail unless something else enabled CONFIG_FRAME_VECTOR in the kernel somehow. So we should provide this option.