### PR TITLE
Fixed compilation under gcc 8.x

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -78,10 +78,6 @@ define Package/uhttpd/conffiles
 /etc/uhttpd.key
 endef
 
-ifneq ($(CONFIG_USE_GLIBC),)
-  TARGET_CFLAGS += -D_DEFAULT_SOURCE
-endif
-
 TARGET_LDFLAGS += -lcrypt
 
 CMAKE_OPTIONS = -DTLS_SUPPORT=on

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -105,6 +105,7 @@ ifdef CONFIG_PACKAGE_rdma
 endif
 
 define Build/Configure
+	$(SED) 's,$$$$CC\s\+-I,$$$$CC $$$$CFLAGS -I,' $(PKG_BUILD_DIR)/configure
 	$(SED) "s,-I/usr/include/db3,," $(PKG_BUILD_DIR)/Makefile
 	$(SED) "s,^KERNEL_INCLUDE.*,KERNEL_INCLUDE=$(LINUX_DIR)/include," \
 		$(PKG_BUILD_DIR)/Makefile

--- a/rules.mk
+++ b/rules.mk
@@ -239,6 +239,8 @@ else
   endif
 endif
 
+TARGET_CPPFLAGS+= $(filter -m%,$(TARGET_CFLAGS))
+
 export PATH:=$(TARGET_PATH)
 export STAGING_DIR STAGING_DIR_HOST STAGING_DIR_HOSTPKG
 export SH_FUNC:=. $(INCLUDE_DIR)/shell.sh;

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -174,13 +174,6 @@ ifneq ($(GCC_ARCH),)
   GCC_CONFIGURE+= --with-arch=$(GCC_ARCH)
 endif
 
-ifneq ($(CONFIG_SOFT_FLOAT),y)
-  ifeq ($(CONFIG_arm),y)
-    GCC_CONFIGURE+= \
-		--with-float=hard
-  endif
-endif
-
 ifeq ($(CONFIG_TARGET_x86)$(CONFIG_USE_GLIBC)$(CONFIG_INSTALL_GCCGO),yyy)
   TARGET_CFLAGS+=-fno-split-stack
 endif

--- a/toolchain/glibc/common.mk
+++ b/toolchain/glibc/common.mk
@@ -48,6 +48,7 @@ GLIBC_CONFIGURE:= \
 	BUILD_CC="$(HOSTCC)" \
 	$(TARGET_CONFIGURE_OPTS) \
 	CFLAGS="-O2 $(filter-out -Os,$(call qstrip,$(TARGET_CFLAGS)))" \
+	CPPFLAGS="$(TARGET_CPPFLAGS)" \
 	libc_cv_slibdir="/lib" \
 	use_ldconfig=no \
 	$(HOST_BUILD_DIR)/$(GLIBC_PATH)configure \


### PR DESCRIPTION
This  resolves few issues preventing project compiling under GCC 8.x. 
The description/explanation of the solution below:

Revert commit 8e4f0ec38de04617c2433d0c038baef700b59805
and resolve the problem it was solving in a different manner
that does not result in kernel compilation failure under GCC 8

In addition iproute2 configure script is fixed and
uhttd compilation under glibc

If one would like to integrate this into local build he needs make sure that all compiled code is removed (make dirclean) before compiling this patch.