### PR TITLE
ath79: modify mtd partitions for Buffalo BHR-4GRV2

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -62,14 +62,6 @@ define Build/zyxel-ras-image
 		&& mv $@.new $@
 endef
 
-define Build/mkbuffaloimg
-	$(STAGING_DIR_HOST)/bin/mkbuffaloimg -B $(BOARDNAME) \
-		-R $$(($(subst k, * 1024,$(ROOTFS_SIZE)))) \
-		-K $$(($(subst k, * 1024,$(KERNEL_SIZE)))) \
-		-i $@ -o $@.new
-	mv $@.new $@
-endef
-
 define Build/netgear-chk
 	$(STAGING_DIR_HOST)/bin/mkchkimg \
 		-o $@.new \

--- a/target/linux/ar71xx/image/tiny.mk
+++ b/target/linux/ar71xx/image/tiny.mk
@@ -1,3 +1,12 @@
+define Build/mkbuffaloimg
+	$(STAGING_DIR_HOST)/bin/mkbuffaloimg -B $(BOARDNAME) \
+		-R $$(($(subst k, * 1024,$(ROOTFS_SIZE)))) \
+		-K $$(($(subst k, * 1024,$(KERNEL_SIZE)))) \
+		-i $@ -o $@.new
+	mv $@.new $@
+endef
+
+
 define Device/bhr-4grv2
   DEVICE_TITLE := Buffalo BHR-4GRV2
   BOARDNAME := BHR-4GRV2

--- a/target/linux/ath79/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/base-files/lib/upgrade/platform.sh
@@ -22,10 +22,6 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-	buffalo,bhr-4grv2)
-		PART_NAME="rootfs:kernel"
-		default_do_upgrade "$ARGV"
-		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)
 		routerstation_do_upgrade "$ARGV"

--- a/target/linux/ath79/dts/qca9557_buffalo_bhr-4grv2.dts
+++ b/target/linux/ath79/dts/qca9557_buffalo_bhr-4grv2.dts
@@ -93,17 +93,12 @@
 			partition@40000 {
 				label = "u-boot-env";
 				reg = <0x040000 0x010000>;
-				read-only;
 			};
 
 			partition@50000 {
-				label = "rootfs";
-				reg = <0x050000 0xe30000>;
-			};
-
-			partition@e80000 {
-				label = "kernel";
-				reg = <0xe80000 0x170000>;
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
 			};
 
 			art: partition@ff0000 {

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -82,6 +82,13 @@ define Device/buffalo_bhr-4grv
 endef
 TARGET_DEVICES += buffalo_bhr-4grv
 
+define Device/buffalo_bhr-4grv2
+  ATH_SOC := qca9557
+  DEVICE_TITLE := Buffalo BHR-4GRV2
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += buffalo_bhr-4grv2
+
 define Device/buffalo_wzr-hp-ag300h
   ATH_SOC := ar7161
   DEVICE_TITLE := Buffalo WZR-HP-AG300H

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,24 +1,5 @@
 include ./common-buffalo.mk
 
-DEVICE_VARS += ROOTFS_SIZE
-
-define Device/buffalo_bhr-4grv2
-  ATH_SOC := qca9558
-  DEVICE_TITLE := Buffalo BHR-4GRV2
-  BOARDNAME := BHR-4GRV2
-  ROOTFS_SIZE := 14528k
-  KERNEL_SIZE := 1472k
-  IMAGE_SIZE := 16000k
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := \
-    append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | \
-    append-kernel | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := append-kernel | \
-    pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | mkbuffaloimg
-  SUPPORTED_DEVICES += bhr-4grv2
-endef
-TARGET_DEVICES += buffalo_bhr-4grv2
-
 define Device/buffalo_whr-g301n
   ATH_SOC := ar7240
   DEVICE_TITLE := Buffalo WHR-G301N


### PR DESCRIPTION
This commit modifies mtd partitions define for Buffalo BHR-4GRV2 and
move it to generic subtarget.

In Buffalo BHR-4GRV2, "kernel" partition is located behined "rootfs"
partition in the stock firmware. This causes the size of the kernel
to be limited by the fixed value.

After ar71xx was updated to Kernel 4.14, the kernel size of BHR-4GRV2
exceeded the limit, and it breaks builds on official buildbot.
Since this issue was also confirmed in ath79, I modified the mtd
partitions to get rid of that limitation.

However, this commit breaks compatibility with ar71xx firmware, so I
dropped "SUPPORTED_DEVICES += bhr-4grv2".

This commit requires new flash instruction instead of the old one.

Flash instruction using initramfs image:

1. Connect the computer to the LAN port of BHR-4GRV2
2. Set the IP address of the computer to 192.168.12.10
3. Rename the OpenWrt initramfs image to
"bhr4grv2-uImage-initramfs-gzip.bin" and place it into the TFTP
directory
4. Start the tftp server on the computer
5. While holding down the "ECO" button, connect power cable to
BHR-4GRV2 and turn on it
6. Flashing (orange) diag LED and release the finger from the button,
BHR-4GRV2 downloads the intiramfs image from TFTP server and boot
with it
7. On the initramfs image, create "/etc/fw_env.config" file with
following contents
  /dev/mtd1 0x0 0x10000 0x10000
8. Execute following commands to add environment variables for
u-boot
  fw_setenv ipaddr 192.168.12.1
  fw_setenv serverip 192.168.12.10
  fw_setenv ethaddr 00:aa:bb:cc:dd:ee
  fw_setenv bootcmd "bootm 0x9f050000 || bootm 0x9fe80000"
9. Perform sysupgrade with squashfs-sysupgrade image
10. Wait ~150 seconds to complete flashing

And this commit includes small fix; BHR-4GRV2 has QCA9557 as a SoC,
not QCA9558.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
