### PR TITLE
kernel/modules: TI ADS1015 kernel module support enabled.

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -29,6 +29,20 @@ define AddDepends/hwmon
   DEPENDS:=kmod-hwmon-core $(1)
 endef
 
+define KernelPackage/hwmon-ads1015
+  TITLE:=Texas Instruments ADS1015
+  KCONFIG:= CONFIG_SENSORS_ADS1015
+  FILES:= $(LINUX_DIR)/drivers/hwmon/ads1015.ko
+  AUTOLOAD:=$(call AutoLoad,60,ads1015)
+  $(call AddDepends/hwmon,+kmod-i2c-core)
+endef
+
+define KernelPackage/hwmon-ads1015/description
+ Kernel module for Texas Instruments ADS1015 Analog-to-Digital converter
+endef
+
+$(eval $(call KernelPackage,hwmon-ads1015))
+
 define KernelPackage/hwmon-adt7410
   TITLE:=ADT7410 monitoring support
   KCONFIG:= \


### PR DESCRIPTION
Signed-off-by: Roman Bazalevsky <rvb@rvb.name>

Enable support for TI ADS1015/ADS1115 analog-to-digital converters (I2C interface).
Tested on Nano Pi NEO (Allwinner) and LinkIt Smart 7688 (MTK MIPS).
