### PR TITLE
bzip2: fix broken download url

### DIFF
--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0.6
 PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
+PKG_SOURCE_URL:=http://sources.lede-project.org
 PKG_HASH:=a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 


### PR DESCRIPTION
Hi, 

the bzip2 offical home bzip2.org is changes hands and download url is
broken. so change url to sources.lede-project.org.

Signed-off-by: lbzhung <gewalalb@gmail.com>