### PR TITLE
bzip2: Replace main site with mirrors

### DIFF
--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0.6
 PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.bzip.org/$(PKG_VERSION)
+PKG_SOURCE_URL:=http://distfiles.gentoo.org/distfiles/ http://distcache.freebsd.org/ports-distfiles/
 PKG_HASH:=a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
 PKG_MAINTAINER:=Steven Barth <cyrus@openwrt.org>
 


### PR DESCRIPTION
Use Gentoo and FreeBSDs distfile caches as mirrors because
main site/domain is abandoned.
Source: https://lwn.net/Articles/762264/

Fixes FS#1913

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>