### PR TITLE
lantiq: enable FXS ports on VR200v

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -195,7 +195,7 @@ arcadyan,vg3503j)
 		"2:lan:2" "4:lan:1" "6t@eth0"
 	;;
 
-tplink,vr200v)
+tplink,vr200|tplink,vr200v)
 	wan_mac=$(macaddr_add "$(mtd_get_mac_binary romfile 61696)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan" "2:lan" "4:lan" "5:lan" "6t@eth0"

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200.dts
@@ -1,0 +1,94 @@
+/dts-v1/;
+
+#include "VR200.dtsi"
+
+/ {
+	compatible = "tplink,vr200", "lantiq,xway", "lantiq,vr9";
+	model = "TP-LINK Archer VR200";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+
+		led-dsl = &dsl;
+		led-internet = &internet;
+		led-wifi = &wlan5g;
+
+		led-usb = &led_usb;
+		led-usb2 = &led_usb;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+		reset {
+			label = "reset";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		led {
+			label = "led";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		power: power {
+			label = "vr200:blue:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+		dsl: dsl {
+			label = "vr200:blue:dsl";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+		internet: internet {
+			label = "vr200:blue:internet";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+		led_usb: usb {
+			label = "vr200:blue:usb";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+		eth {
+			label = "vr200:blue:lan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+		wlan {
+			label = "vr200:blue:wlan";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+		wlan5g: wifi {
+			label = "vr200:blue:wlan5g";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+		led_wps {
+			label = "vr200:blue:wps";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};	
+};

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200.dtsi
@@ -1,0 +1,219 @@
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	memory@0 {
+		reg = <0x0 0x7f00000>;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		mtd-mac-address = <&romfile 0xf100>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
+			// gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy5>;
+		};
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		reg = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy5: ethernet-phy@5 {
+			reg = <0x5>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		mdio {
+			lantiq,groups = "mdio";
+			lantiq,function = "mdio";
+		};
+		gphy-leds {
+			lantiq,groups = "gphy0 led1", "gphy1 led1";
+			lantiq,function = "gphy";
+			lantiq,pull = <2>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		phy-rst {
+			lantiq,pins = "io42";
+			lantiq,pull = <0>;
+			lantiq,open-drain = <0>;
+			lantiq,output = <1>;
+		};
+		pcie-rst {
+			lantiq,pins = "io38";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+	};
+	pins_spi_default: pins_spi_default {
+		spi_in {
+			lantiq,groups = "spi_di";
+			lantiq,function = "spi";
+		};
+		spi_out {
+			lantiq,groups = "spi_do", "spi_clk",
+				"spi_cs4";
+			lantiq,function = "spi";
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&pci0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
+};
+
+&spi {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_spi_default>;
+
+	m25p80@4 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <4 0>;
+		spi-max-frequency = <33250000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0xf90000>;
+				label = "firmware";
+			};
+
+			partition@fb0000 {
+				reg = <0xfb0000 0x10000>;
+				label = "radioDECT";
+				read-only;
+			};
+
+			partition@fc0000 {
+				reg = <0xfc0000 0x10000>;
+				label = "config";
+				read-only;
+			};
+
+			romfile: partition@fd0000 {
+				reg = <0xfd0000 0x10000>;
+				label = "romfile";
+				read-only;
+			};
+
+			partition@fe0000 {
+				reg = <0xfe0000 0x10000>;
+				label = "rom";
+				read-only;
+			};
+
+			partition@ff0000 {
+				reg = <0xff0000 0x10000>;
+				label = "radio";
+				read-only;
+			};
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200v.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/VR200v.dts
@@ -1,30 +1,27 @@
 /dts-v1/;
 
-#include "vr9.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+#include "VR200.dtsi"
 
 / {
 	compatible = "tplink,vr200v", "lantiq,xway", "lantiq,vr9";
 	model = "TP-LINK Archer VR200v";
 
 	chosen {
-		bootargs = "console=ttyLTQ0,115200";
+		bootargs = "console=ttyLTQ0,115200 mem=126M vpe1_load_addr=0x87e00000 vpe1_mem=2M maxvpes=1 maxtcs=1 nosmp";
 	};
 
 	aliases {
 		led-boot = &power;
 		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
 
 		led-dsl = &dsl;
 		led-internet = &internet;
+		led-wifi = &wlan5g;
+
 		led-usb = &led_usb;
 		led-usb2 = &led_usb;
-	};
-
-	memory@0 {
-		reg = <0x0 0x7f00000>;
 	};
 
 	gpio-keys-polled {
@@ -63,6 +60,7 @@
 		power: power {
 			label = "vr200v:blue:power";
 			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
 		};
 		dsl: dsl {
 			label = "vr200v:blue:dsl";
@@ -84,7 +82,7 @@
 			label = "vr200v:blue:wlan";
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
 		};
-		wlan5g {
+		wlan5g: wifi {
 			label = "vr200v:blue:wlan5g";
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
@@ -92,214 +90,12 @@
 			label = "vr200v:blue:phone";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 33 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
+	};	
 };
 
-&eth0 {
-	lan: interface@0 {
-		compatible = "lantiq,xrx200-pdi";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0>;
-		mtd-mac-address = <&romfile 0xf100>;
-		lantiq,switch;
-
-		ethernet@0 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <0>;
-			phy-mode = "rgmii";
-			phy-handle = <&phy0>;
-			// gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
-		};
-		ethernet@5 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <5>;
-			phy-mode = "rgmii";
-			phy-handle = <&phy5>;
-		};
-		ethernet@2 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <2>;
-			phy-mode = "gmii";
-			phy-handle = <&phy11>;
-		};
-		ethernet@3 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <4>;
-			phy-mode = "gmii";
-			phy-handle = <&phy13>;
-		};
-	};
-
-	mdio@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "lantiq,xrx200-mdio";
-		reg = <0>;
-
-		phy0: ethernet-phy@0 {
-			reg = <0x0>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-		phy5: ethernet-phy@5 {
-			reg = <0x5>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-		phy11: ethernet-phy@11 {
-			reg = <0x11>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-		phy13: ethernet-phy@13 {
-			reg = <0x13>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-	};
-};
-
-&gphy0 {
-	lantiq,gphy-mode = <GPHY_MODE_GE>;
-};
-
-&gphy1 {
-	lantiq,gphy-mode = <GPHY_MODE_GE>;
-};
-
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-		gphy-leds {
-			lantiq,groups = "gphy0 led1", "gphy1 led1";
-			lantiq,function = "gphy";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
-		phy-rst {
-			lantiq,pins = "io42";
-			lantiq,pull = <0>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
-		pcie-rst {
-			lantiq,pins = "io38";
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
-	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
-};
-
-&pci0 {
+&vmmc {
 	status = "okay";
-	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
-};
-
-&spi {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
-
-	m25p80@4 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "jedec,spi-nor";
-		reg = <4 0>;
-		spi-max-frequency = <33250000>;
-		m25p,fast-read;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				reg = <0x0 0x20000>;
-				label = "u-boot";
-				read-only;
-			};
-
-			partition@20000 {
-				reg = <0x20000 0xf90000>;
-				label = "firmware";
-			};
-
-			partition@fb0000 {
-				reg = <0xfb0000 0x10000>;
-				label = "radioDECT";
-				read-only;
-			};
-
-			partition@fc0000 {
-				reg = <0xfc0000 0x10000>;
-				label = "config";
-				read-only;
-			};
-
-			romfile: partition@fd0000 {
-				reg = <0xfd0000 0x10000>;
-				label = "romfile";
-				read-only;
-			};
-
-			partition@fe0000 {
-				reg = <0xfe0000 0x10000>;
-				label = "rom";
-				read-only;
-			};
-
-			partition@ff0000 {
-				reg = <0xff0000 0x10000>;
-				label = "radio";
-				read-only;
-			};
-		};
-	};
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb_phy1 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-	vbus-supply = <&usb_vbus>;
-};
-
-&usb1 {
-	status = "okay";
-	vbus-supply = <&usb_vbus>;
+	gpios = <&gpio 30 GPIO_ACTIVE_HIGH  //fxs relay
+			 &gpio 31 GPIO_ACTIVE_HIGH  //still unknown
+			 &gpio 3  GPIO_ACTIVE_HIGH>; //reset_slic?
 };

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -37,16 +37,28 @@ define Device/tplink_tdw8980
 endef
 TARGET_DEVICES += tplink_tdw8980
 
+define Device/tplink_vr200
+  $(Device/lantiqTpLink)
+  DEVICE_DTS := VR200
+  TPLINK_FLASHLAYOUT := 16Mltq
+  TPLINK_HWID := 0x63e64801
+  TPLINK_HWREV := 0x53
+  IMAGE_SIZE := 15808k
+  DEVICE_TITLE := TP-LINK Archer VR200
+  DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += VR200
+endef
+TARGET_DEVICES += tplink_vr200
+
 define Device/tplink_vr200v
   $(Device/lantiqTpLink)
   DEVICE_DTS := VR200v
-  TPLINK_BOARD_ID := ArcherVR200V
   TPLINK_FLASHLAYOUT := 16Mltq
   TPLINK_HWID := 0x73b70801
   TPLINK_HWREV := 0x2f
   IMAGE_SIZE := 15808k
   DEVICE_TITLE := TP-LINK Archer VR200v
-  DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VR200v
 endef
 TARGET_DEVICES += tplink_vr200v


### PR DESCRIPTION
Disables SMP support.
Add VR200 target to keep SMP on FXS-less device variant.

Signed-off-by: Kevin Schmidt <kevin.patrick.schmidt@googlemail.com>
