### PR TITLE
Fix switch ports mapping for newifi d2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ramips_setup_interfaces()
 
 	case $board in
 	11acnas|\
+	d-team,newifi-d2|\
 	w2914nsv2|\
 	zbt-we2026)
 		ucidef_add_switch "switch0" \
@@ -103,7 +104,6 @@ ramips_setup_interfaces()
 	mt7628|\
 	mzk-750dhp|\
 	mzk-w300nh2|\
-	d-team,newifi-d2|\
 	netgear,r6120|\
 	nixcore-x1-8M|\
 	nixcore-x1-16M|\


### PR DESCRIPTION
Fix switch ports mapping for newifi d2

The sequence of switch ports is LAN4, LAN3, LAN2, LAN1, WAN.
This patch correct the switch ports mapping for this device.