### PR TITLE
18.06 - dnsmasq: use the user defined dhcp-script directly when available

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -872,8 +872,10 @@ dnsmasq_start()
 	fi
 
 	config_get user_dhcpscript $cfg dhcpscript
-	if has_handler || [ -n "$user_dhcpscript" ]; then
+	if has_handler ; then
 		xappend "--dhcp-script=$DHCPSCRIPT"
+	elif [ -n "$user_dhcpscript" ] ; then
+		xappend "--dhcp-script=$user_dhcpscript"
 	fi
 
 	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"
@@ -1024,7 +1026,7 @@ dnsmasq_start()
 	procd_open_instance $cfg
 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
 	procd_set_param file $CONFIGFILE
-	[ -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
+	[ has_handler -a -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
 	procd_set_param respawn
 
 	procd_add_jail dnsmasq ubus log


### PR DESCRIPTION
The introduction of hotplug scripts handling means that user defined scripts are not called directly when defined in config but sourced from dhcp-script.sh. This causes an issue when the dhcp script is not source-able (not an ash script). I added the user defined script in second position so that if both hotplug scripts and a user defined script exist, the current behaviour is maintained (I suspect there was a reason to source the file in the current version).

Signed-off-by: Vincent Riou <vincent@invizbox.com>