### PR TITLE
ath79: Remove source-only flag

### DIFF
--- a/target/linux/ath79/Makefile
+++ b/target/linux/ath79/Makefile
@@ -6,7 +6,7 @@ BOARDNAME:=Atheros ATH79 (DTS)
 CPU_TYPE:=24kc
 SUBTARGETS:=generic nand tiny
 
-FEATURES:=ramdisk source-only
+FEATURES:=ramdisk
 
 KERNEL_PATCHVER:=4.14
 


### PR DESCRIPTION
Remove the source-only flag from ath79, its supposed to replace ar71xx after next stable release but buildbots are not currently generating images for it.
So in order to expand testing as much as possible and prepare for moving to ath79 let's enable the buildbots to actually build the target.

Signed-off-by: Robert Marko <robimarko@gmail.com>
