### PR TITLE
lantiq/basefiles: use shutdown instead of stop when the system goes down

### DIFF
--- a/target/linux/lantiq/base-files/etc/inittab
+++ b/target/linux/lantiq/base-files/etc/inittab
@@ -1,3 +1,3 @@
 ::sysinit:/etc/init.d/rcS S boot
-::shutdown:/etc/init.d/rcS K stop
+::shutdown:/etc/init.d/rcS K shutdown
 ttyLTQ0::askfirst:/usr/libexec/login.sh


### PR DESCRIPTION
I can't see any reason why we shouldn't use shutdown for lantiq as well.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
