### PR TITLE
openvpn: add list element parsing

### DIFF
--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -49,6 +49,18 @@ append_params() {
 	done
 }
 
+list_cb_append() {
+	printf "${1}:"
+}
+
+append_list() {
+	local p; local v; local s="$1"; shift
+	for p in $*; do
+		v=$(config_list_foreach "$s" "$p" list_cb_append)
+	done
+	[ -n "$v" ] && append_param "$s" "$p" && echo " ${v%*:}" >> "/var/etc/openvpn-$s.conf"
+}
+
 section_enabled() {
 	config_get_bool enable  "$1" 'enable'  0
 	config_get_bool enabled "$1" 'enabled' 0
@@ -99,6 +111,7 @@ start_instance() {
 
 	append_bools "$s" $OPENVPN_BOOLS
 	append_params "$s" $OPENVPN_PARAMS
+	append_list "$s" $OPENVPN_LIST
 
 	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf"
 }

--- a/package/network/services/openvpn/files/openvpn.options
+++ b/package/network/services/openvpn/files/openvpn.options
@@ -68,7 +68,6 @@ mode
 mssfix
 mtu_disc
 mute
-ncp_ciphers
 nice
 ns_cert_type
 ping
@@ -117,7 +116,6 @@ status_version
 syslog
 tcp_queue_limit
 tls_auth
-tls_cipher
 tls_crypt
 tls_timeout
 tls_verify
@@ -189,4 +187,9 @@ tls_server
 up_delay
 up_restart
 username_as_common_name
+'
+
+OPENVPN_LIST='
+tls_cipher
+ncp_ciphers
 '


### PR DESCRIPTION
For the parameters tls-cipher and ncp-ciphers more than one option can
be used in the OpenVPN configuration, separated by a colon, which should
be implemented as a list in order to configure it more clearly. By
adding the new OPENVPN_LIST option to the openvpn.options file with the
tls-cipher and ncp-cipher parameters, uci can now add this option as a
"list" and the init script will generate the appropriate OpenVPN
configuration from it.
