### PR TITLE
base-files: fix unkillable processes after restart

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -23,6 +23,7 @@ reload() {
 restart() {
 	trap '' TERM
 	stop "$@"
+	trap - TERM
 	start "$@"
 }
 


### PR DESCRIPTION
When restart is run on an init script, the script traps SIGTERM. This is
done as a workaround for scripts named the same name as the program they
start. In that case, the init script process will have the same name as
the program process, and so when the init script runs killall, it will
kill itself. So SIGTERM is trapped to make the init script unkillable.

However, the trap is retained when the init script runs start, and thus
processes started by restart will not respond to SIGTERM, and will thus
be unkillable unless you use SIGKILL. This fixes that by removing the
trap before running start.

Signed-off-by: Linus Kardell <linus@telliq.com>