### PR TITLE
kernel: fix mv88e6060 roaming

### DIFF
--- a/target/linux/ar71xx/patches-4.9/424-net-dsa-fix-88e6060-roaming.patch
+++ b/target/linux/ar71xx/patches-4.9/424-net-dsa-fix-88e6060-roaming.patch
@@ -1,0 +1,22 @@
+--- a/drivers/net/dsa/mv88e6060.c
++++ b/drivers/net/dsa/mv88e6060.c
+@@ -114,8 +114,7 @@
+ 	/* Reset the switch. */
+ 	REG_WRITE(REG_GLOBAL, GLOBAL_ATU_CONTROL,
+ 		  GLOBAL_ATU_CONTROL_SWRESET |
+-		  GLOBAL_ATU_CONTROL_ATUSIZE_1024 |
+-		  GLOBAL_ATU_CONTROL_ATE_AGE_5MIN);
++		  GLOBAL_ATU_CONTROL_LEARNDIS);
+ 
+ 	/* Wait up to one second for reset to complete. */
+ 	timeout = jiffies + 1 * HZ;
+@@ -145,8 +144,7 @@
+ 	 * time to 5 minutes.
+ 	 */
+ 	REG_WRITE(REG_GLOBAL, GLOBAL_ATU_CONTROL,
+-		  GLOBAL_ATU_CONTROL_ATUSIZE_1024 |
+-		  GLOBAL_ATU_CONTROL_ATE_AGE_5MIN);
++		  GLOBAL_ATU_CONTROL_LEARNDIS);
+ 
+ 	return 0;
+ }


### PR DESCRIPTION
This commit disable Marvell 88E6060 hardware level mac learning and let it be handled by the kernel.

Wireless Station Roaming didn't work on TP-LINK TL-WR941ND and others with same switch because Marvell 88E6060 switch chip doesn't update its mac table when it receives a packet from a new port.
