### PR TITLE
ath79: specify "firmware" partition format for WNDR3700 and v2

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dts
@@ -24,6 +24,7 @@
 	partition@70000 {
 		label = "firmware";
 		reg = <0x070000 0x780000>;
+		compatible = "netgear,uimage";
 	};
 
 	art: partition@7f0000 {

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700v2.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700v2.dts
@@ -24,6 +24,7 @@
 	partition@70000 {
 		label = "firmware";
 		reg = <0x070000 0xf80000>;
+		compatible = "netgear,uimage";
 	};
 
 	art: partition@ff0000 {


### PR DESCRIPTION
@rmilecki 
Here is the PR for 3700 and 3700v2 that you requested

Specify the new "firmware" partition format for Netgear WNDR3700 and WNDR3700v2 similarly as ffd082aa did for WNDR3800, the third device in the family.

Tested with WNDR3700v2, but will work also on v1 as the only difference is flash size.

```
DISTRIB_REVISION='r8491-f995e143ba'
DISTRIB_TARGET='ath79/generic'
DISTRIB_ARCH='mips_24kc'
DISTRIB_DESCRIPTION='OpenWrt SNAPSHOT r8491-f995e143ba'
```
```
[    0.649347] m25p80 spi0.0: mx25l12805d (16384 Kbytes)
[    0.654489] 4 fixed-partitions partitions found on MTD device spi0.0
[    0.660821] Creating 4 MTD partitions on "spi0.0":
[    0.665622] 0x000000000000-0x000000050000 : "u-boot"
[    0.671247] 0x000000050000-0x000000070000 : "u-boot-env"
[    0.677206] 0x000000070000-0x000000ff0000 : "firmware"
[    0.685170] 2 netgear-fw partitions found on MTD device firmware
[    0.691172] Creating 2 MTD partitions on "firmware":
[    0.696177] 0x000000000000-0x00000018e440 : "kernel"
[    0.701759] 0x00000018e440-0x000000f80000 : "rootfs"
[    0.707325] mtd: device 4 (rootfs) set to be root filesystem
[    0.713005] 1 squashfs-split partitions found on MTD device rootfs
[    0.719218] 0x000000720000-0x000000f80000 : "rootfs_data"
[    0.725207] 0x000000ff0000-0x000001000000 : "art"
```
```
root@router2:~# df -h
Filesystem                Size      Used Available Use% Mounted on
/dev/root                 5.8M      5.8M         0 100% /rom
tmpfs                    29.0M    936.0K     28.1M   3% /tmp
/dev/mtdblock5            8.4M    528.0K      7.9M   6% /overlay
overlayfs:/overlay        8.4M    528.0K      7.9M   6% /
tmpfs                   512.0K         0    512.0K   0% /dev

root@router2:~# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00050000 00010000 "u-boot"
mtd1: 00020000 00010000 "u-boot-env"
mtd2: 00f80000 00010000 "firmware"
mtd3: 0018e440 00010000 "kernel"
mtd4: 00df1bc0 00010000 "rootfs"
mtd5: 00860000 00010000 "rootfs_data"
mtd6: 00010000 00010000 "art"

```