### PR TITLE
ath79: specify "firmware" partition format for Buffalo devices

### DIFF
--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dts
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dts
@@ -167,6 +167,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x0060000 0x1f90000>;
 			};

--- a/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
+++ b/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
@@ -136,6 +136,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				reg = <0x40000 0x3a0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -99,6 +99,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				reg = <0x60000 0x1f80000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -155,6 +155,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				reg = <0x60000 0x1f60000>;
 				label = "firmware";
 			};


### PR DESCRIPTION
Specify firmware partition format (denx,uimage) by compatible string
for Buffalo devices.

affected devices (&run tested):
- BHR-4GRV
- WHR-G301N
- WZR-HP-AG300H
- WZR-HP-G302H A1A0
- WZR-HP-G450H (WZR-450HP)

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>