### PR TITLE
Add D-Link DIR-506L support:

### DIFF
--- a/target/linux/ramips/dts/DIR-506L.dts
+++ b/target/linux/ramips/dts/DIR-506L.dts
@@ -1,0 +1,159 @@
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-506l", "ralink,rt5350-soc";
+	model = "D-Link DIR-506L";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "dir-506l:green:usb";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "dir-506l:green:status";
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "dir-506l:red:status";
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "dir-506l:green:internet";
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		ext_power {
+			label = "charging";
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+		};
+
+		bat_power {
+			label = "bat";
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_1>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				label = "recovery";
+				reg = <0x10000 0x140000>;
+				read-only;
+			};
+
+			partition@150000 {
+				label = "firmware";
+				reg = <0x150000 0x6a0000>;
+			};
+
+			config: partition@7f0000 {
+				label = "config";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "uartf", "led";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0xe084>;
+};
+
+&esw {
+	mediatek,portmap = <0x1>;
+	mediatek,portdisable = <0x3e>;
+	mediatek,led_polarity = <1>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&config 0xe08a>;
+	ralink,led-polarity = <1>;
+	mtd-mac-address = <&config 0xe084>;
+	mtd-mac-address-increment = <(1)>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1,6 +1,9 @@
 #
 # RT305X Profiles
 #
+
+DEVICE_VARS += DLINK_ROM_ID DLINK_FAMILY_MEMBER DLINK_FIRMWARE_SIZE
+
 define Build/buffalo-tftp-header
   ( \
     echo -n -e "# Airstation FirmWare\nrun u_fw\nreset\n\n" | \
@@ -233,6 +236,22 @@ define Device/dir-320-b1
   DEVICE_TITLE := D-Link DIR-320 B1
 endef
 TARGET_DEVICES += dir-320-b1
+
+define Device/dir-506l
+  DTS := DIR-506L
+  DEVICE_TITLE := D-Link DIR-506L
+  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-core kmod-usb-ohci \
+		kmod-ledtrig-gpio kmod-ledtrig-oneshot kmod-ledtrig-netdev \
+		kmod-ledtrig-timer kmod-usb-ledtrig-usbport
+  DLINK_ROM_ID := DLK6E2114001
+  DLINK_FAMILY_MEMBER := 0x6E21
+  DLINK_FIRMWARE_SIZE := 0x7E0000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+endef
+TARGET_DEVICES += dir-506l
 
 define Device/dir-600-b1
   DTS := DIR-600-B1


### PR DESCRIPTION
- upgrade from stock fw via web gui
- all leds avaible
- all buttons work
- battery/charger gpio events added
- USB power on by default

Signed-off-by: rim <rozhuk.im@gmail.com>


I'm not sure about:
 - DEVICE_PACKAGES - may be something not needed/duplicated, like kmod-usb-ohci
 - `ralink,mtd-eeprom = <&config 0xe08a>;`  - it from D-Link DWR-512 B. Some dlink devices store eprom before mac, some after. I try both (0xe08a and 0xe080) and it both work fine.


