### PR TITLE
ath79: specify "firmware" partition format for ELECOM and I-O DATA devices

### DIFF
--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -72,6 +72,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x780000>;
 			};

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -137,6 +137,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x040000 0xe50000>;
 			};

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
@@ -104,6 +104,7 @@
 			};
 
 			partition@70000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x070000 0x770000>;
 			};


### PR DESCRIPTION
Specify firmware partition format (denx,uimage) by compatible string
for ELECOM and I-O DATA devices.

affected devices (&run tested):
- ELECOM
  - WRC-300GHBK2-I

- I-O DATA
  - WN-AC1167DGR
  - WN-AC1600DGR2