### PR TITLE
ramips: fix wd03 platform to mt7620a . I2C should work now with RavPower WD03

### DIFF
--- a/target/linux/ramips/dts/WD03.dts
+++ b/target/linux/ramips/dts/WD03.dts
@@ -1,6 +1,6 @@
 /dts-v1/;
 
-#include "mt7620a.dtsi"
+#include "mt7620n.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
I made a mistake in the original PR https://github.com/openwrt/openwrt/pull/974 . It prevents i2c to work on the WD03. the correct chipset is indeed mt7620a and not mt7620n.

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>
