### PR TITLE
ramips: specify "firmware" partition format

### DIFF
--- a/target/linux/ramips/dts/3G-6200N.dts
+++ b/target/linux/ramips/dts/3G-6200N.dts
@@ -52,6 +52,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x390000>;
 			};

--- a/target/linux/ramips/dts/3G-6200NL.dts
+++ b/target/linux/ramips/dts/3G-6200NL.dts
@@ -52,6 +52,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x390000>;
 			};

--- a/target/linux/ramips/dts/3G150B.dts
+++ b/target/linux/ramips/dts/3G150B.dts
@@ -87,6 +87,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/3G300M.dts
+++ b/target/linux/ramips/dts/3G300M.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/A5-V11.dts
+++ b/target/linux/ramips/dts/A5-V11.dts
@@ -91,6 +91,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/AC1200RM.dts
+++ b/target/linux/ramips/dts/AC1200RM.dts
@@ -170,6 +170,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/AI-BR100.dts
+++ b/target/linux/ramips/dts/AI-BR100.dts
@@ -82,6 +82,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x7c0000>;
 			};

--- a/target/linux/ramips/dts/AIR3GII.dts
+++ b/target/linux/ramips/dts/AIR3GII.dts
@@ -73,6 +73,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/ALL0239-3G.dts
+++ b/target/linux/ramips/dts/ALL0239-3G.dts
@@ -47,6 +47,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ALL0256N-4M.dts
+++ b/target/linux/ramips/dts/ALL0256N-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3c8000>;
 			};

--- a/target/linux/ramips/dts/ALL0256N-8M.dts
+++ b/target/linux/ramips/dts/ALL0256N-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ALL5002.dts
+++ b/target/linux/ramips/dts/ALL5002.dts
@@ -81,6 +81,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/ALL5003.dts
+++ b/target/linux/ramips/dts/ALL5003.dts
@@ -81,6 +81,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/AP-MT7621A-V60.dts
+++ b/target/linux/ramips/dts/AP-MT7621A-V60.dts
@@ -111,6 +111,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/AR670W.dts
+++ b/target/linux/ramips/dts/AR670W.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				reg = <0x40000 0x3c0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/AR725W.dts
+++ b/target/linux/ramips/dts/AR725W.dts
@@ -44,6 +44,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x50000 0x3B0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/ASL26555-16M.dts
+++ b/target/linux/ramips/dts/ASL26555-16M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/ASL26555-8M.dts
+++ b/target/linux/ramips/dts/ASL26555-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x790000>;
 			};

--- a/target/linux/ramips/dts/ATP-52B.dts
+++ b/target/linux/ramips/dts/ATP-52B.dts
@@ -44,6 +44,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/AWAPN2403.dts
+++ b/target/linux/ramips/dts/AWAPN2403.dts
@@ -70,6 +70,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/AWM002-EVB-4M.dts
+++ b/target/linux/ramips/dts/AWM002-EVB-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/AWM002-EVB-8M.dts
+++ b/target/linux/ramips/dts/AWM002-EVB-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/AWUSFREE1.dts
+++ b/target/linux/ramips/dts/AWUSFREE1.dts
@@ -160,6 +160,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ArcherC2-v1.dts
+++ b/target/linux/ramips/dts/ArcherC2-v1.dts
@@ -104,6 +104,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/ArcherC20i.dts
+++ b/target/linux/ramips/dts/ArcherC20i.dts
@@ -87,6 +87,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/ArcherC20v1.dts
+++ b/target/linux/ramips/dts/ArcherC20v1.dts
@@ -117,6 +117,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/ArcherC50.dts
+++ b/target/linux/ramips/dts/ArcherC50.dts
@@ -116,6 +116,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/ArcherMR200.dts
+++ b/target/linux/ramips/dts/ArcherMR200.dts
@@ -134,6 +134,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/BC2.dts
+++ b/target/linux/ramips/dts/BC2.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
+++ b/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
@@ -88,6 +88,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf70000>;
 			};

--- a/target/linux/ramips/dts/BOCCO.dts
+++ b/target/linux/ramips/dts/BOCCO.dts
@@ -124,6 +124,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/BR-6475ND.dts
+++ b/target/linux/ramips/dts/BR-6475ND.dts
@@ -88,6 +88,7 @@
 			};
 
 			partition@70000 {
+				compatible = "denx,uimage";
 				reg = <0x00070000 0x00790000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/BR-6478AC-V2.dts
+++ b/target/linux/ramips/dts/BR-6478AC-V2.dts
@@ -122,6 +122,7 @@
 			};
 
 			partition@70000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x00070000 0x00790000>;
 			};

--- a/target/linux/ramips/dts/BROADWAY.dts
+++ b/target/linux/ramips/dts/BROADWAY.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x790000>;
 			};

--- a/target/linux/ramips/dts/C108.dts
+++ b/target/linux/ramips/dts/C108.dts
@@ -145,6 +145,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/CARAMBOLA.dts
+++ b/target/linux/ramips/dts/CARAMBOLA.dts
@@ -43,6 +43,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/CF-WR800N.dts
+++ b/target/linux/ramips/dts/CF-WR800N.dts
@@ -99,6 +99,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/CS-QR10.dts
+++ b/target/linux/ramips/dts/CS-QR10.dts
@@ -101,6 +101,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/CY-SWR1100.dts
+++ b/target/linux/ramips/dts/CY-SWR1100.dts
@@ -54,6 +54,7 @@
 			};
 
 			partition@50000 {
+				compatible = "seama";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/D105.dts
+++ b/target/linux/ramips/dts/D105.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/D240.dts
+++ b/target/linux/ramips/dts/D240.dts
@@ -147,6 +147,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/DAP-1350.dts
+++ b/target/linux/ramips/dts/DAP-1350.dts
@@ -56,6 +56,7 @@
 			};
 
 			partition@b0000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0xb0000 0x750000>;
 			};

--- a/target/linux/ramips/dts/DAP-1522-A1.dts
+++ b/target/linux/ramips/dts/DAP-1522-A1.dts
@@ -40,6 +40,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x3a0000>;
 			};

--- a/target/linux/ramips/dts/DB-WRT01.dts
+++ b/target/linux/ramips/dts/DB-WRT01.dts
@@ -73,6 +73,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DCH-M225.dts
+++ b/target/linux/ramips/dts/DCH-M225.dts
@@ -151,6 +151,7 @@
 			};
 
 			partition@150000 {
+				compatible = "seama";
 				label = "firmware";
 				reg = <0x150000 0x6b0000>;
 			};

--- a/target/linux/ramips/dts/DCS-930.dts
+++ b/target/linux/ramips/dts/DCS-930.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DCS-930L-B1.dts
+++ b/target/linux/ramips/dts/DCS-930L-B1.dts
@@ -80,6 +80,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-300-B1.dts
+++ b/target/linux/ramips/dts/DIR-300-B1.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-300-B7.dts
+++ b/target/linux/ramips/dts/DIR-300-B7.dts
@@ -80,6 +80,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-320-B1.dts
+++ b/target/linux/ramips/dts/DIR-320-B1.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-600-B1.dts
+++ b/target/linux/ramips/dts/DIR-600-B1.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-610-A1.dts
+++ b/target/linux/ramips/dts/DIR-610-A1.dts
@@ -80,6 +80,7 @@
 			};
 
 			partition@50000 {
+				compatible = "seama";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-615-D.dts
+++ b/target/linux/ramips/dts/DIR-615-D.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-615-H1.dts
+++ b/target/linux/ramips/dts/DIR-615-H1.dts
@@ -97,6 +97,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-620-A1.dts
+++ b/target/linux/ramips/dts/DIR-620-A1.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-620-D1.dts
+++ b/target/linux/ramips/dts/DIR-620-D1.dts
@@ -74,6 +74,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-645.dts
+++ b/target/linux/ramips/dts/DIR-645.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@50000 {
+				compatible = "seama";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/DIR-810L.dts
+++ b/target/linux/ramips/dts/DIR-810L.dts
@@ -109,6 +109,7 @@
 			};
 
 			partition@170000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x170000 0x690000>;
 			};

--- a/target/linux/ramips/dts/DIR-860L-B1.dts
+++ b/target/linux/ramips/dts/DIR-860L-B1.dts
@@ -112,6 +112,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/DUZUN-DM06.dts
+++ b/target/linux/ramips/dts/DUZUN-DM06.dts
@@ -137,6 +137,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/E1700.dts
+++ b/target/linux/ramips/dts/E1700.dts
@@ -90,6 +90,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ESR-9753.dts
+++ b/target/linux/ramips/dts/ESR-9753.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/EW1200.dts
+++ b/target/linux/ramips/dts/EW1200.dts
@@ -96,6 +96,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/EX2700.dts
+++ b/target/linux/ramips/dts/EX2700.dts
@@ -122,6 +122,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/EX3700.dts
+++ b/target/linux/ramips/dts/EX3700.dts
@@ -121,6 +121,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x790000>;
 			};

--- a/target/linux/ramips/dts/F5D8235_V1.dts
+++ b/target/linux/ramips/dts/F5D8235_V1.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/F5D8235_V2.dts
+++ b/target/linux/ramips/dts/F5D8235_V2.dts
@@ -34,6 +34,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x790000>;
 			};

--- a/target/linux/ramips/dts/F7C027.dts
+++ b/target/linux/ramips/dts/F7C027.dts
@@ -96,6 +96,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x770000>;
 			};

--- a/target/linux/ramips/dts/FIREWRT.dts
+++ b/target/linux/ramips/dts/FIREWRT.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/FONERA20N.dts
+++ b/target/linux/ramips/dts/FONERA20N.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/FREESTATION5.dts
+++ b/target/linux/ramips/dts/FREESTATION5.dts
@@ -43,6 +43,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/GB-PC1.dts
+++ b/target/linux/ramips/dts/GB-PC1.dts
@@ -98,6 +98,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/GB-PC2.dts
+++ b/target/linux/ramips/dts/GB-PC2.dts
@@ -108,6 +108,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/GL-MT300A.dts
+++ b/target/linux/ramips/dts/GL-MT300A.dts
@@ -107,6 +107,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
+++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
@@ -131,6 +131,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/GL-MT300N.dts
+++ b/target/linux/ramips/dts/GL-MT300N.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/GL-MT750.dts
+++ b/target/linux/ramips/dts/GL-MT750.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -101,6 +101,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf70000>;
 			};

--- a/target/linux/ramips/dts/HC5861B.dts
+++ b/target/linux/ramips/dts/HC5861B.dts
@@ -92,6 +92,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf70000>;
 			};

--- a/target/linux/ramips/dts/HC5X61.dtsi
+++ b/target/linux/ramips/dts/HC5X61.dtsi
@@ -81,6 +81,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/HG255D.dts
+++ b/target/linux/ramips/dts/HG255D.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@80000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x80000 0xf60000>;
 			};

--- a/target/linux/ramips/dts/HLKRM04.dts
+++ b/target/linux/ramips/dts/HLKRM04.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/HPM.dts
+++ b/target/linux/ramips/dts/HPM.dts
@@ -118,6 +118,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x00050000 0x00fb0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/HT-TM02.dts
+++ b/target/linux/ramips/dts/HT-TM02.dts
@@ -85,6 +85,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/HW550-3G.dts
+++ b/target/linux/ramips/dts/HW550-3G.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/IP2202.dts
+++ b/target/linux/ramips/dts/IP2202.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/JHR-N805R.dts
+++ b/target/linux/ramips/dts/JHR-N805R.dts
@@ -78,6 +78,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/JHR-N825R.dts
+++ b/target/linux/ramips/dts/JHR-N825R.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/JHR-N926R.dts
+++ b/target/linux/ramips/dts/JHR-N926R.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/K2G.dts
+++ b/target/linux/ramips/dts/K2G.dts
@@ -86,6 +86,7 @@
 			};
 
 			partition@a0000 {
+				compatible = "denx,uimage";
 				reg = <0xa0000 0x760000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/K2P.dts
+++ b/target/linux/ramips/dts/K2P.dts
@@ -95,6 +95,7 @@
 			};
 
 			partition@a0000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0xa0000 0xf60000>;
 			};

--- a/target/linux/ramips/dts/LINKIT7688.dts
+++ b/target/linux/ramips/dts/LINKIT7688.dts
@@ -129,6 +129,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/M2M.dts
+++ b/target/linux/ramips/dts/M2M.dts
@@ -84,6 +84,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/M3.dts
+++ b/target/linux/ramips/dts/M3.dts
@@ -76,6 +76,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/M4-4M.dts
+++ b/target/linux/ramips/dts/M4-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/M4-8M.dts
+++ b/target/linux/ramips/dts/M4-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MAC1200RV2.dts
+++ b/target/linux/ramips/dts/MAC1200RV2.dts
@@ -76,6 +76,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x7c0000>;
 			};

--- a/target/linux/ramips/dts/MINIEMBPLUG.dts
+++ b/target/linux/ramips/dts/MINIEMBPLUG.dts
@@ -100,6 +100,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MINIEMBWIFI.dts
+++ b/target/linux/ramips/dts/MINIEMBWIFI.dts
@@ -71,6 +71,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MIWIFI-MINI.dts
+++ b/target/linux/ramips/dts/MIWIFI-MINI.dts
@@ -97,6 +97,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/MIWIFI-NANO.dts
+++ b/target/linux/ramips/dts/MIWIFI-NANO.dts
@@ -105,6 +105,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/MLW221.dts
+++ b/target/linux/ramips/dts/MLW221.dts
@@ -92,6 +92,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf60000>;
 			};

--- a/target/linux/ramips/dts/MLWG2.dts
+++ b/target/linux/ramips/dts/MLWG2.dts
@@ -92,6 +92,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf60000>;
 			};

--- a/target/linux/ramips/dts/MOFI3500-3GN.dts
+++ b/target/linux/ramips/dts/MOFI3500-3GN.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MPRA1.dts
+++ b/target/linux/ramips/dts/MPRA1.dts
@@ -91,6 +91,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/MPRA2.dts
+++ b/target/linux/ramips/dts/MPRA2.dts
@@ -91,6 +91,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MR-102N.dts
+++ b/target/linux/ramips/dts/MR-102N.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x790000>;
 			};

--- a/target/linux/ramips/dts/MT7620a.dts
+++ b/target/linux/ramips/dts/MT7620a.dts
@@ -59,6 +59,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MT7620a_MT7530.dts
+++ b/target/linux/ramips/dts/MT7620a_MT7530.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MT7620a_MT7610e.dts
+++ b/target/linux/ramips/dts/MT7620a_MT7610e.dts
@@ -63,6 +63,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MT7620a_V22SG.dts
+++ b/target/linux/ramips/dts/MT7620a_V22SG.dts
@@ -53,6 +53,7 @@
 			};
 
 			partition@80000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x80000 0x7f80000>;
 			};

--- a/target/linux/ramips/dts/MT7628.dts
+++ b/target/linux/ramips/dts/MT7628.dts
@@ -58,6 +58,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MZK-750DHP.dts
+++ b/target/linux/ramips/dts/MZK-750DHP.dts
@@ -93,6 +93,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/MZK-DP150N.dts
+++ b/target/linux/ramips/dts/MZK-DP150N.dts
@@ -73,6 +73,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/MZK-EX300NP.dts
+++ b/target/linux/ramips/dts/MZK-EX300NP.dts
@@ -108,6 +108,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x730000>;
 			};

--- a/target/linux/ramips/dts/MZK-EX750NP.dts
+++ b/target/linux/ramips/dts/MZK-EX750NP.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x730000>;
 			};

--- a/target/linux/ramips/dts/MZK-W300NH2.dts
+++ b/target/linux/ramips/dts/MZK-W300NH2.dts
@@ -52,6 +52,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x390000>;
 			};

--- a/target/linux/ramips/dts/MZK-WDPR.dts
+++ b/target/linux/ramips/dts/MZK-WDPR.dts
@@ -49,6 +49,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x680000>;
 			};

--- a/target/linux/ramips/dts/MicroWRT.dts
+++ b/target/linux/ramips/dts/MicroWRT.dts
@@ -71,6 +71,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0xfc0000>;
 			};

--- a/target/linux/ramips/dts/NA930.dts
+++ b/target/linux/ramips/dts/NA930.dts
@@ -47,6 +47,7 @@
 			};
 
 			partition@640000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x640000 0x1400000>;
 			};

--- a/target/linux/ramips/dts/NBG-419N.dts
+++ b/target/linux/ramips/dts/NBG-419N.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/NBG-419N2.dts
+++ b/target/linux/ramips/dts/NBG-419N2.dts
@@ -48,6 +48,7 @@
 					};
 
 					partition@50000 {
+						compatible = "denx,uimage";
 						label = "firmware";
 						reg = <0x50000 0x7b0000>;
 					};

--- a/target/linux/ramips/dts/NCS601W.dts
+++ b/target/linux/ramips/dts/NCS601W.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/NIXCORE-16M.dts
+++ b/target/linux/ramips/dts/NIXCORE-16M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/NIXCORE-8M.dts
+++ b/target/linux/ramips/dts/NIXCORE-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/NW718.dts
+++ b/target/linux/ramips/dts/NW718.dts
@@ -87,6 +87,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x60000 0x3a0000>;
 			};

--- a/target/linux/ramips/dts/Newifi-D1.dts
+++ b/target/linux/ramips/dts/Newifi-D1.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/Newifi-D2.dts
+++ b/target/linux/ramips/dts/Newifi-D2.dts
@@ -128,6 +128,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/OMEGA2.dtsi
+++ b/target/linux/ramips/dts/OMEGA2.dtsi
@@ -135,6 +135,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 			};
 		};

--- a/target/linux/ramips/dts/OY-0001.dts
+++ b/target/linux/ramips/dts/OY-0001.dts
@@ -86,6 +86,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/PBR-D1.dts
+++ b/target/linux/ramips/dts/PBR-D1.dts
@@ -131,6 +131,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x0fb0000>;
 			};

--- a/target/linux/ramips/dts/PBR-M1.dts
+++ b/target/linux/ramips/dts/PBR-M1.dts
@@ -144,6 +144,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/PSG1208.dts
+++ b/target/linux/ramips/dts/PSG1208.dts
@@ -82,6 +82,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/PSG1218.dtsi
+++ b/target/linux/ramips/dts/PSG1218.dtsi
@@ -54,6 +54,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/PSR-680W.dts
+++ b/target/linux/ramips/dts/PSR-680W.dts
@@ -50,6 +50,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/PWH2004.dts
+++ b/target/linux/ramips/dts/PWH2004.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/PX-4885-4M.dts
+++ b/target/linux/ramips/dts/PX-4885-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/PX-4885-8M.dts
+++ b/target/linux/ramips/dts/PX-4885-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/R6120.dts
+++ b/target/linux/ramips/dts/R6120.dts
@@ -110,6 +110,7 @@
 			};
 
 			partition@90000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x90000 0xf60000>;
 			};

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -107,6 +107,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/RE350.dts
+++ b/target/linux/ramips/dts/RE350.dts
@@ -115,6 +115,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x5e0000>;
 			};

--- a/target/linux/ramips/dts/RE6500.dts
+++ b/target/linux/ramips/dts/RE6500.dts
@@ -90,6 +90,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/RP-N53.dts
+++ b/target/linux/ramips/dts/RP-N53.dts
@@ -129,6 +129,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/RT-AC51U.dts
+++ b/target/linux/ramips/dts/RT-AC51U.dts
@@ -98,6 +98,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/RT-G32-B1.dts
+++ b/target/linux/ramips/dts/RT-G32-B1.dts
@@ -59,6 +59,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/RT-N10-PLUS.dts
+++ b/target/linux/ramips/dts/RT-N10-PLUS.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/RT-N12-PLUS.dts
+++ b/target/linux/ramips/dts/RT-N12-PLUS.dts
@@ -100,6 +100,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/RT-N13U.dts
+++ b/target/linux/ramips/dts/RT-N13U.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/RT-N14U.dts
+++ b/target/linux/ramips/dts/RT-N14U.dts
@@ -105,6 +105,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/RT-N15.dts
+++ b/target/linux/ramips/dts/RT-N15.dts
@@ -48,6 +48,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/RT-N56U.dts
+++ b/target/linux/ramips/dts/RT-N56U.dts
@@ -45,6 +45,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x00050000 0x007b0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/RT5350F-OLINUXINO.dtsi
+++ b/target/linux/ramips/dts/RT5350F-OLINUXINO.dtsi
@@ -42,6 +42,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/RUT5XX.dts
+++ b/target/linux/ramips/dts/RUT5XX.dts
@@ -69,6 +69,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/SAP-G3200U3.dts
+++ b/target/linux/ramips/dts/SAP-G3200U3.dts
@@ -86,6 +86,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/SK-WB8.dts
+++ b/target/linux/ramips/dts/SK-WB8.dts
@@ -88,6 +88,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/SL-R7205.dts
+++ b/target/linux/ramips/dts/SL-R7205.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/TEW-638APB-V2.dts
+++ b/target/linux/ramips/dts/TEW-638APB-V2.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/TEW-691GR.dts
+++ b/target/linux/ramips/dts/TEW-691GR.dts
@@ -45,6 +45,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x00050000 0x007b0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/TEW-692GR.dts
+++ b/target/linux/ramips/dts/TEW-692GR.dts
@@ -45,6 +45,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x00050000 0x007b0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/TEW-714TRU.dts
+++ b/target/linux/ramips/dts/TEW-714TRU.dts
@@ -90,6 +90,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/TINY-AC.dts
+++ b/target/linux/ramips/dts/TINY-AC.dts
@@ -96,6 +96,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/TL-MR3020V3.dts
+++ b/target/linux/ramips/dts/TL-MR3020V3.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/TL-WR840NV5.dts
+++ b/target/linux/ramips/dts/TL-WR840NV5.dts
@@ -72,6 +72,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x3d0000>;
 			};

--- a/target/linux/ramips/dts/TPLINK-8M.dtsi
+++ b/target/linux/ramips/dts/TPLINK-8M.dtsi
@@ -32,6 +32,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x20000 0x7a0000>;
 			};

--- a/target/linux/ramips/dts/Timecloud.dts
+++ b/target/linux/ramips/dts/Timecloud.dts
@@ -94,6 +94,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/U25AWF-H1.dts
+++ b/target/linux/ramips/dts/U25AWF-H1.dts
@@ -82,6 +82,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/U35WF.dts
+++ b/target/linux/ramips/dts/U35WF.dts
@@ -82,6 +82,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/U7621-06-256M-16M.dts
+++ b/target/linux/ramips/dts/U7621-06-256M-16M.dts
@@ -82,6 +82,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/U7628-01-128M-16M.dts
+++ b/target/linux/ramips/dts/U7628-01-128M-16M.dts
@@ -79,6 +79,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/UR-326N4G.dts
+++ b/target/linux/ramips/dts/UR-326N4G.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/UR-336UN.dts
+++ b/target/linux/ramips/dts/UR-336UN.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/V11STFE.dts
+++ b/target/linux/ramips/dts/V11STFE.dts
@@ -45,6 +45,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				reg = <0x00050000 0x003b0000>;
 				label = "firmware";
 			};

--- a/target/linux/ramips/dts/V22RW-2X2.dts
+++ b/target/linux/ramips/dts/V22RW-2X2.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/VAR11N-300.dts
+++ b/target/linux/ramips/dts/VAR11N-300.dts
@@ -73,6 +73,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/VOCORE-16M.dts
+++ b/target/linux/ramips/dts/VOCORE-16M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/VOCORE-8M.dts
+++ b/target/linux/ramips/dts/VOCORE-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -58,6 +58,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/VOCORE2LITE.dts
+++ b/target/linux/ramips/dts/VOCORE2LITE.dts
@@ -58,6 +58,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/VR500.dts
+++ b/target/linux/ramips/dts/VR500.dts
@@ -79,6 +79,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3fb0000>;
 			};

--- a/target/linux/ramips/dts/W06.dts
+++ b/target/linux/ramips/dts/W06.dts
@@ -99,6 +99,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xeb0000>;
 			};

--- a/target/linux/ramips/dts/W150M.dts
+++ b/target/linux/ramips/dts/W150M.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3c8000>;
 			};

--- a/target/linux/ramips/dts/W2914NSV2.dtsi
+++ b/target/linux/ramips/dts/W2914NSV2.dtsi
@@ -65,6 +65,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/W306R_V20.dts
+++ b/target/linux/ramips/dts/W306R_V20.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/W502U.dts
+++ b/target/linux/ramips/dts/W502U.dts
@@ -50,6 +50,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WCR150GN.dts
+++ b/target/linux/ramips/dts/WCR150GN.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WD03.dts
+++ b/target/linux/ramips/dts/WD03.dts
@@ -84,6 +84,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WE1026-5G-16M.dts
+++ b/target/linux/ramips/dts/WE1026-5G-16M.dts
@@ -72,6 +72,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WHR-1166D.dts
+++ b/target/linux/ramips/dts/WHR-1166D.dts
@@ -123,6 +123,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WHR-300HP2.dts
+++ b/target/linux/ramips/dts/WHR-300HP2.dts
@@ -123,6 +123,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WHR-600D.dts
+++ b/target/linux/ramips/dts/WHR-600D.dts
@@ -123,6 +123,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WHR-G300N.dts
+++ b/target/linux/ramips/dts/WHR-G300N.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3a0000>;
 			};

--- a/target/linux/ramips/dts/WIDORA-NEO-16M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-16M.dts
@@ -42,6 +42,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x0fb0000>;
 			};

--- a/target/linux/ramips/dts/WIDORA-NEO-32M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-32M.dts
@@ -42,6 +42,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/WITI.dtsi
+++ b/target/linux/ramips/dts/WITI.dtsi
@@ -72,6 +72,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WIZARD8800.dts
+++ b/target/linux/ramips/dts/WIZARD8800.dts
@@ -47,6 +47,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WIZFI630A.dts
+++ b/target/linux/ramips/dts/WIZFI630A.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				#size-cells = <1>;
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;

--- a/target/linux/ramips/dts/WL-330N.dts
+++ b/target/linux/ramips/dts/WL-330N.dts
@@ -80,6 +80,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WL-330N3G.dts
+++ b/target/linux/ramips/dts/WL-330N3G.dts
@@ -85,6 +85,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WL-341V3.dts
+++ b/target/linux/ramips/dts/WL-341V3.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WL-351.dts
+++ b/target/linux/ramips/dts/WL-351.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WL-WN575A3.dts
+++ b/target/linux/ramips/dts/WL-WN575A3.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WLI-TX4-AG300N.dts
+++ b/target/linux/ramips/dts/WLI-TX4-AG300N.dts
@@ -48,6 +48,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WLR-6000.dts
+++ b/target/linux/ramips/dts/WLR-6000.dts
@@ -131,6 +131,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x713000>;
 			};

--- a/target/linux/ramips/dts/WMDR-143N.dts
+++ b/target/linux/ramips/dts/WMDR-143N.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WMR-300.dts
+++ b/target/linux/ramips/dts/WMR-300.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WN-AX1167GR.dts
+++ b/target/linux/ramips/dts/WN-AX1167GR.dts
@@ -110,6 +110,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x60000 0xf30000>;
 			};

--- a/target/linux/ramips/dts/WN-GX300GR.dts
+++ b/target/linux/ramips/dts/WN-GX300GR.dts
@@ -110,6 +110,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x60000 0x770000>;
 			};

--- a/target/linux/ramips/dts/WN3000RPV3.dts
+++ b/target/linux/ramips/dts/WN3000RPV3.dts
@@ -120,6 +120,7 @@
 			};
 
 			partition@40000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x40000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WNCE2001.dts
+++ b/target/linux/ramips/dts/WNCE2001.dts
@@ -123,6 +123,7 @@
 			};
 
 			partition@b0000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0xb0000 0x350000>;
 			};

--- a/target/linux/ramips/dts/WNDR3700V5.dts
+++ b/target/linux/ramips/dts/WNDR3700V5.dts
@@ -107,6 +107,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xee0000>;
 			};

--- a/target/linux/ramips/dts/WR1200JS.dts
+++ b/target/linux/ramips/dts/WR1200JS.dts
@@ -101,6 +101,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WR512-3GN-4M.dts
+++ b/target/linux/ramips/dts/WR512-3GN-4M.dts
@@ -36,6 +36,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3c8000>;
 			};

--- a/target/linux/ramips/dts/WR512-3GN-8M.dts
+++ b/target/linux/ramips/dts/WR512-3GN-8M.dts
@@ -36,6 +36,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WR6202.dts
+++ b/target/linux/ramips/dts/WR6202.dts
@@ -74,6 +74,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
+++ b/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
@@ -114,6 +114,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf20000>;
 			};

--- a/target/linux/ramips/dts/WRH-300CR.dts
+++ b/target/linux/ramips/dts/WRH-300CR.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@210000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x210000 0xdf0000>;
 			};

--- a/target/linux/ramips/dts/WRTNODE.dts
+++ b/target/linux/ramips/dts/WRTNODE.dts
@@ -69,6 +69,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WRTNODE2.dtsi
+++ b/target/linux/ramips/dts/WRTNODE2.dtsi
@@ -55,6 +55,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/WSR-600.dts
+++ b/target/linux/ramips/dts/WSR-600.dts
@@ -152,6 +152,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/WT1520-4M.dts
+++ b/target/linux/ramips/dts/WT1520-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WT1520-8M.dts
+++ b/target/linux/ramips/dts/WT1520-8M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WT3020-4M.dts
+++ b/target/linux/ramips/dts/WT3020-4M.dts
@@ -39,6 +39,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/WT3020-8M.dts
+++ b/target/linux/ramips/dts/WT3020-8M.dts
@@ -47,6 +47,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/WZR-AGL300NH.dts
+++ b/target/linux/ramips/dts/WZR-AGL300NH.dts
@@ -48,6 +48,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/X5.dts
+++ b/target/linux/ramips/dts/X5.dts
@@ -108,6 +108,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/X8.dts
+++ b/target/linux/ramips/dts/X8.dts
@@ -69,6 +69,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/XDXRN502J.dts
+++ b/target/linux/ramips/dts/XDXRN502J.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/Y1.dtsi
+++ b/target/linux/ramips/dts/Y1.dtsi
@@ -66,6 +66,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/YOUKU-YK1.dts
+++ b/target/linux/ramips/dts/YOUKU-YK1.dts
@@ -97,6 +97,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-APE522II.dts
+++ b/target/linux/ramips/dts/ZBT-APE522II.dts
@@ -101,6 +101,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
 			};

--- a/target/linux/ramips/dts/ZBT-CPE102.dts
+++ b/target/linux/ramips/dts/ZBT-CPE102.dts
@@ -94,6 +94,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x760000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WA05.dts
+++ b/target/linux/ramips/dts/ZBT-WA05.dts
@@ -97,6 +97,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x760000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE1226.dts
+++ b/target/linux/ramips/dts/ZBT-WE1226.dts
@@ -102,6 +102,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE1326.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326.dts
@@ -72,6 +72,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE2026.dts
+++ b/target/linux/ramips/dts/ZBT-WE2026.dts
@@ -86,6 +86,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x760000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE3526.dts
+++ b/target/linux/ramips/dts/ZBT-WE3526.dts
@@ -73,6 +73,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE826-16M.dts
+++ b/target/linux/ramips/dts/ZBT-WE826-16M.dts
@@ -39,6 +39,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WE826-32M.dts
+++ b/target/linux/ramips/dts/ZBT-WE826-32M.dts
@@ -39,6 +39,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x1fb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WG2626.dts
+++ b/target/linux/ramips/dts/ZBT-WG2626.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};

--- a/target/linux/ramips/dts/ZBT-WG3526.dtsi
+++ b/target/linux/ramips/dts/ZBT-WG3526.dtsi
@@ -86,6 +86,7 @@
 			};
 
 			firmware: partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 			};
 		};

--- a/target/linux/ramips/dts/ZBT-WR8305RT.dts
+++ b/target/linux/ramips/dts/ZBT-WR8305RT.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ZL5900V2.dts
+++ b/target/linux/ramips/dts/ZL5900V2.dts
@@ -74,6 +74,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/ZTE-Q7.dts
+++ b/target/linux/ramips/dts/ZTE-Q7.dts
@@ -82,6 +82,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/elecom_wrc-gst.dtsi
@@ -129,6 +129,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xb00000>;
 			};

--- a/target/linux/ramips/dts/ki_rb.dts
+++ b/target/linux/ramips/dts/ki_rb.dts
@@ -120,6 +120,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xe90000>;
 			};

--- a/target/linux/ramips/dts/kn.dts
+++ b/target/linux/ramips/dts/kn.dts
@@ -46,6 +46,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x3b0000>;
 			};

--- a/target/linux/ramips/dts/kn_rc.dts
+++ b/target/linux/ramips/dts/kn_rc.dts
@@ -117,6 +117,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/kn_rf.dts
+++ b/target/linux/ramips/dts/kn_rf.dts
@@ -117,6 +117,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0x7b0000>;
 			};

--- a/target/linux/ramips/dts/kng_rc.dts
+++ b/target/linux/ramips/dts/kng_rc.dts
@@ -121,6 +121,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
 			};


### PR DESCRIPTION
Specify firmware partition format for ramips devices.

formats in ramips:

- denx,uimage
- tplink,firmware
- seama