### PR TITLE
ramips: add support for TP-Link TL-WR841n v14

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -335,6 +335,10 @@ tl-wr841n-v13)
 	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
+tplink,tl-wr841n-v14)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	;;
 tplink,c2-v1)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch1" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch1" "0x01"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -239,6 +239,7 @@ ramips_setup_interfaces()
 	tl-wr840n-v4|\
 	tl-wr840n-v5|\
 	tl-wr841n-v13|\
+	tplink,tl-wr841n-v14|\
 	u7628-01-128M-16M|\
 	ubnt-erx|\
 	ubnt-erx-sfp|\

--- a/target/linux/ramips/dts/TL-WR841NV14.dts
+++ b/target/linux/ramips/dts/TL-WR841NV14.dts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr841n-v14", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR841N v14";
+
+	aliases {
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x2000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tl-wr841n-v14:green:lan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_green {
+			label = "tl-wr841n-v14:green:wan";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan: wlan {
+			label = "tl-wr841n-v14:green:wlan";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_orange {
+			label = "tl-wr841n-v14:orange:wan";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		wifi_led_en {
+			gpio-export,name = "wifi_led_en";
+			gpio-export,output = <1>;
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x10000 0x3e0000>;
+			};
+
+			factory: partition@3f0000 {
+				label = "factory";
+				reg = <0x3f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,mtd-eeprom = <&factory 0x10000>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,portmap = "wllll";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -238,6 +238,20 @@ define Device/tl-wr841n-v13
 endef
 TARGET_DEVICES += tl-wr841n-v13
 
+define Device/tplink_tl-wr841n-v14
+  $(Device/tplink)
+  DTS := TL-WR841NV14
+  IMAGE_SIZE := 3968k
+  DEVICE_TITLE := TP-Link TL-WR841N v14
+  TPLINK_FLASHLAYOUT := 4Mmtk
+  TPLINK_HWID := 0x08410014
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x14
+  TPLINK_HVERSION := 3
+  IMAGE/tftp-recovery.bin := pad-extra 64k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_tl-wr841n-v14
+
 define Device/tplink_c20-v4
   $(Device/tplink)
   DTS := ArcherC20v4


### PR DESCRIPTION
TP-Link TL-WR841n v14 is a router based on MediaTek MT7628N.

- MediaTek MT7628NN
- 32 MB of RAM
- 4 MB of FLASH
- 2T2R 2.4 GHz
- 5x 10/100 Mbps Ethernet

Installation:
- copy the
  'openwrt-ramips-mt76x8-tl-wr841n-v14-squashfs-tftp-recovery.bin'
  file to your tftp server root and rename it to 'tp_recovery.bin'.
- configure your PC running the TFTP server with the static IP address
  192.168.0.66/24
- push the reset button and plug in the power connector. Wait until
  the orange led starts blinking (~6sec)
