### PR TITLE
ramips: mt7621-spi: backport v4.19 staging driver and drop broken SPI modes

### DIFF
--- a/target/linux/ramips/dts/AP-MT7621A-V60.dts
+++ b/target/linux/ramips/dts/AP-MT7621A-V60.dts
@@ -85,7 +85,6 @@
 		compatible = "mx25l6405d","jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/AWUSFREE1.dts
+++ b/target/linux/ramips/dts/AWUSFREE1.dts
@@ -129,7 +129,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/DIR-860L-B1.dts
+++ b/target/linux/ramips/dts/DIR-860L-B1.dts
@@ -74,7 +74,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/DUZUN-DM06.dts
+++ b/target/linux/ramips/dts/DUZUN-DM06.dts
@@ -110,7 +110,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <60000000>;
-		m25p,chunked-io = <32>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ramips/dts/EW1200.dts
+++ b/target/linux/ramips/dts/EW1200.dts
@@ -70,7 +70,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/FIREWRT.dts
+++ b/target/linux/ramips/dts/FIREWRT.dts
@@ -63,7 +63,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/GB-PC1.dts
+++ b/target/linux/ramips/dts/GB-PC1.dts
@@ -72,7 +72,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/GB-PC2.dts
+++ b/target/linux/ramips/dts/GB-PC2.dts
@@ -82,7 +82,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
+++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
@@ -105,7 +105,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -71,7 +71,6 @@
 		reg = <0>;
 		linux,modalias = "m25p80", "w25q128";
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/HC5861B.dts
+++ b/target/linux/ramips/dts/HC5861B.dts
@@ -66,7 +66,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/K2P.dts
+++ b/target/linux/ramips/dts/K2P.dts
@@ -63,7 +63,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/LINKIT7688.dts
+++ b/target/linux/ramips/dts/LINKIT7688.dts
@@ -104,7 +104,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
-		m25p,chunked-io = <31>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/MAC1200RV2.dts
+++ b/target/linux/ramips/dts/MAC1200RV2.dts
@@ -41,7 +41,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/MIWIFI-NANO.dts
+++ b/target/linux/ramips/dts/MIWIFI-NANO.dts
@@ -79,7 +79,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/MT7628.dts
+++ b/target/linux/ramips/dts/MT7628.dts
@@ -32,7 +32,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/Newifi-D1.dts
+++ b/target/linux/ramips/dts/Newifi-D1.dts
@@ -87,7 +87,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/Newifi-D2.dts
+++ b/target/linux/ramips/dts/Newifi-D2.dts
@@ -102,7 +102,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/OMEGA2.dtsi
+++ b/target/linux/ramips/dts/OMEGA2.dtsi
@@ -109,7 +109,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
-		m25p,chunked-io = <31>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/PBR-D1.dts
+++ b/target/linux/ramips/dts/PBR-D1.dts
@@ -106,7 +106,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
-		m25p,chunked-io = <31>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/PBR-M1.dts
+++ b/target/linux/ramips/dts/PBR-M1.dts
@@ -118,7 +118,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/R6120.dts
+++ b/target/linux/ramips/dts/R6120.dts
@@ -84,7 +84,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -81,7 +81,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/RE350.dts
+++ b/target/linux/ramips/dts/RE350.dts
@@ -101,7 +101,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/RE6500.dts
+++ b/target/linux/ramips/dts/RE6500.dts
@@ -64,7 +64,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/SAP-G3200U3.dts
+++ b/target/linux/ramips/dts/SAP-G3200U3.dts
@@ -54,7 +54,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/SK-WB8.dts
+++ b/target/linux/ramips/dts/SK-WB8.dts
@@ -63,7 +63,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/TL-MR3020V3.dts
+++ b/target/linux/ramips/dts/TL-MR3020V3.dts
@@ -88,7 +88,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/TL-WR840NV5.dts
+++ b/target/linux/ramips/dts/TL-WR840NV5.dts
@@ -58,7 +58,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/TPLINK-8M.dtsi
+++ b/target/linux/ramips/dts/TPLINK-8M.dtsi
@@ -18,7 +18,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/Timecloud.dts
+++ b/target/linux/ramips/dts/Timecloud.dts
@@ -68,7 +68,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/U7621-06-256M-16M.dts
+++ b/target/linux/ramips/dts/U7621-06-256M-16M.dts
@@ -56,7 +56,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <14000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/U7628-01-128M-16M.dts
+++ b/target/linux/ramips/dts/U7628-01-128M-16M.dts
@@ -53,7 +53,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <12000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/UBNT-ER-e50.dtsi
+++ b/target/linux/ramips/dts/UBNT-ER-e50.dtsi
@@ -95,7 +95,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <1>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/VOCORE2.dts
+++ b/target/linux/ramips/dts/VOCORE2.dts
@@ -32,7 +32,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/VOCORE2LITE.dts
+++ b/target/linux/ramips/dts/VOCORE2LITE.dts
@@ -32,7 +32,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/VR500.dts
+++ b/target/linux/ramips/dts/VR500.dts
@@ -53,7 +53,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/W06.dts
+++ b/target/linux/ramips/dts/W06.dts
@@ -73,7 +73,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/W2914NSV2.dtsi
+++ b/target/linux/ramips/dts/W2914NSV2.dtsi
@@ -39,7 +39,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WCR-1166DS.dts
+++ b/target/linux/ramips/dts/WCR-1166DS.dts
@@ -126,7 +126,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WIDORA-NEO-16M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-16M.dts
@@ -17,7 +17,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
-		m25p,chunked-io = <31>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WIDORA-NEO-32M.dts
+++ b/target/linux/ramips/dts/WIDORA-NEO-32M.dts
@@ -17,7 +17,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
-		m25p,chunked-io = <31>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WITI.dtsi
+++ b/target/linux/ramips/dts/WITI.dtsi
@@ -47,7 +47,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WL-WN575A3.dts
+++ b/target/linux/ramips/dts/WL-WN575A3.dts
@@ -87,7 +87,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WN-AX1167GR.dts
+++ b/target/linux/ramips/dts/WN-AX1167GR.dts
@@ -78,7 +78,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WN-GX300GR.dts
+++ b/target/linux/ramips/dts/WN-GX300GR.dts
@@ -78,7 +78,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WNDR3700V5.dts
+++ b/target/linux/ramips/dts/WNDR3700V5.dts
@@ -81,7 +81,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WR1200JS.dts
+++ b/target/linux/ramips/dts/WR1200JS.dts
@@ -75,7 +75,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
+++ b/target/linux/ramips/dts/WRC-1167GHBK2-S.dts
@@ -88,7 +88,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WRTNODE2.dtsi
+++ b/target/linux/ramips/dts/WRTNODE2.dtsi
@@ -29,7 +29,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WSR-1166.dts
+++ b/target/linux/ramips/dts/WSR-1166.dts
@@ -126,7 +126,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/WSR-600.dts
+++ b/target/linux/ramips/dts/WSR-600.dts
@@ -126,7 +126,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ZBT-WE1226.dts
+++ b/target/linux/ramips/dts/ZBT-WE1226.dts
@@ -76,7 +76,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ZBT-WE1326.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326.dts
@@ -46,7 +46,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ZBT-WE3526.dts
+++ b/target/linux/ramips/dts/ZBT-WE3526.dts
@@ -47,7 +47,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ZBT-WG2626.dts
+++ b/target/linux/ramips/dts/ZBT-WG2626.dts
@@ -63,7 +63,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ZBT-WG3526.dtsi
+++ b/target/linux/ramips/dts/ZBT-WG3526.dtsi
@@ -60,7 +60,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/elecom_wrc-gst.dtsi
@@ -103,7 +103,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/ki_rb.dts
+++ b/target/linux/ramips/dts/ki_rb.dts
@@ -94,7 +94,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/patches-4.14/0043-1-spi-add-mt7621-support.patch
+++ b/target/linux/ramips/patches-4.14/0043-1-spi-add-mt7621-support.patch
@@ -5,6 +5,8 @@ Subject: [PATCH 43/53] spi: add mt7621 support
 
 Signed-off-by: John Crispin <blogic@openwrt.org>
 ---
+Note: This patch contains upstream staging mt7621-spi at 9c562d8411a54f6731cdc587c29968d9e8610c85
+
  drivers/spi/Kconfig      |    6 +
  drivers/spi/Makefile     |    1 +
  drivers/spi/spi-mt7621.c |  480 ++++++++++++++++++++++++++++++++++++++++++++++
@@ -38,7 +40,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_SPI_OC_TINY)		+= spi-oc-tiny.o
 --- /dev/null
 +++ b/drivers/spi/spi-mt7621.c
-@@ -0,0 +1,494 @@
+@@ -0,0 +1,515 @@
 +/*
 + * spi-mt7621.c -- MediaTek MT7621 SPI controller driver
 + *
@@ -96,7 +98,8 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define MT7621_CPOL		BIT(4)
 +#define MT7621_LSB_FIRST	BIT(3)
 +
-+#define RT2880_SPI_MODE_BITS	(SPI_CPOL | SPI_CPHA | SPI_LSB_FIRST | SPI_CS_HIGH)
++#define RT2880_SPI_MODE_BITS	(SPI_CPOL | SPI_CPHA |		\
++				 SPI_LSB_FIRST | SPI_CS_HIGH)
 +
 +struct mt7621_spi;
 +
@@ -106,6 +109,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	unsigned int		sys_freq;
 +	unsigned int		speed;
 +	struct clk		*clk;
++	int			pending_write;
 +
 +	struct mt7621_spi_ops	*ops;
 +};
@@ -131,14 +135,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +	master |= 7 << 29;
 +	master |= 1 << 2;
-+#ifdef CONFIG_SOC_MT7620
 +	if (duplex)
 +		master |= 1 << 10;
 +	else
-+#endif
 +		master &= ~(1 << 10);
 +
 +	mt7621_spi_write(rs, MT7621_SPI_MASTER, master);
++	rs->pending_write = 0;
 +}
 +
 +static void mt7621_spi_set_cs(struct spi_device *spi, int enable)
@@ -147,7 +150,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	int cs = spi->chip_select;
 +	u32 polar = 0;
 +
-+        mt7621_spi_reset(rs, cs);
++	mt7621_spi_reset(rs, cs);
 +	if (enable)
 +		polar = BIT(cs);
 +	mt7621_spi_write(rs, MT7621_SPI_POLAR, polar);
@@ -180,41 +183,125 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		reg |= MT7621_LSB_FIRST;
 +
 +	reg &= ~(MT7621_CPHA | MT7621_CPOL);
-+	switch(spi->mode & (SPI_CPOL | SPI_CPHA)) {
-+		case SPI_MODE_0:
-+			break;
-+		case SPI_MODE_1:
-+			reg |= MT7621_CPHA;
-+			break;
-+		case SPI_MODE_2:
-+			reg |= MT7621_CPOL;
-+			break;
-+		case SPI_MODE_3:
-+			reg |= MT7621_CPOL | MT7621_CPHA;
-+			break;
++	switch (spi->mode & (SPI_CPOL | SPI_CPHA)) {
++	case SPI_MODE_0:
++		break;
++	case SPI_MODE_1:
++		reg |= MT7621_CPHA;
++		break;
++	case SPI_MODE_2:
++		reg |= MT7621_CPOL;
++		break;
++	case SPI_MODE_3:
++		reg |= MT7621_CPOL | MT7621_CPHA;
++		break;
 +	}
 +	mt7621_spi_write(rs, MT7621_SPI_MASTER, reg);
 +
 +	return 0;
 +}
 +
-+static inline int mt7621_spi_wait_till_ready(struct spi_device *spi)
++static inline int mt7621_spi_wait_till_ready(struct mt7621_spi *rs)
 +{
-+	struct mt7621_spi *rs = spidev_to_mt7621_spi(spi);
 +	int i;
 +
 +	for (i = 0; i < RALINK_SPI_WAIT_MAX_LOOP; i++) {
 +		u32 status;
 +
 +		status = mt7621_spi_read(rs, MT7621_SPI_TRANS);
-+		if ((status & SPITRANS_BUSY) == 0) {
++		if ((status & SPITRANS_BUSY) == 0)
 +			return 0;
-+		}
 +		cpu_relax();
 +		udelay(1);
 +	}
 +
 +	return -ETIMEDOUT;
++}
++
++static void mt7621_spi_read_half_duplex(struct mt7621_spi *rs,
++					int rx_len, u8 *buf)
++{
++	/* Combine with any pending write, and perform one or
++	 * more half-duplex transactions reading 'len' bytes.
++	 * Data to be written is already in MT7621_SPI_DATA*
++	 */
++	int tx_len = rs->pending_write;
++
++	rs->pending_write = 0;
++
++	while (rx_len || tx_len) {
++		int i;
++		u32 val = (min(tx_len, 4) * 8) << 24;
++		int rx = min(rx_len, 32);
++
++		if (tx_len > 4)
++			val |= (tx_len - 4) * 8;
++		val |= (rx * 8) << 12;
++		mt7621_spi_write(rs, MT7621_SPI_MOREBUF, val);
++
++		tx_len = 0;
++
++		val = mt7621_spi_read(rs, MT7621_SPI_TRANS);
++		val |= SPI_CTL_START;
++		mt7621_spi_write(rs, MT7621_SPI_TRANS, val);
++
++		mt7621_spi_wait_till_ready(rs);
++
++		for (i = 0; i < rx; i++) {
++			if ((i % 4) == 0)
++				val = mt7621_spi_read(rs, MT7621_SPI_DATA0 + i);
++			*buf++ = val & 0xff;
++			val >>= 8;
++		}
++		rx_len -= i;
++	}
++}
++
++static inline void mt7621_spi_flush(struct mt7621_spi *rs)
++{
++	mt7621_spi_read_half_duplex(rs, 0, NULL);
++}
++
++static void mt7621_spi_write_half_duplex(struct mt7621_spi *rs,
++					 int tx_len, const u8 *buf)
++{
++	int val = 0;
++	int len = rs->pending_write;
++
++	if (len & 3) {
++		val = mt7621_spi_read(rs, MT7621_SPI_OPCODE + (len & ~3));
++		if (len < 4) {
++			val <<= (4 - len) * 8;
++			val = swab32(val);
++		}
++	}
++
++	while (tx_len > 0) {
++		if (len >= 36) {
++			rs->pending_write = len;
++			mt7621_spi_flush(rs);
++			len = 0;
++		}
++
++		val |= *buf++ << (8 * (len & 3));
++		len++;
++		if ((len & 3) == 0) {
++			if (len == 4)
++				/* The byte-order of the opcode is weird! */
++				val = swab32(val);
++			mt7621_spi_write(rs, MT7621_SPI_OPCODE + len - 4, val);
++			val = 0;
++		}
++		tx_len -= 1;
++	}
++	if (len & 3) {
++		if (len < 4) {
++			val = swab32(val);
++			val >>= (4 - len) * 8;
++		}
++		mt7621_spi_write(rs, MT7621_SPI_OPCODE + (len & ~3), val);
++	}
++	rs->pending_write = len;
 +}
 +
 +static int mt7621_spi_transfer_half_duplex(struct spi_master *master,
@@ -225,84 +312,30 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	unsigned int speed = spi->max_speed_hz;
 +	struct spi_transfer *t = NULL;
 +	int status = 0;
-+	int i, len = 0;
-+	int rx_len = 0;
-+	u32 data[9] = { 0 };
-+	u32 val;
 +
-+	mt7621_spi_wait_till_ready(spi);
++	mt7621_spi_wait_till_ready(rs);
 +
-+	list_for_each_entry(t, &m->transfers, transfer_list) {
-+		const u8 *buf = t->tx_buf;
-+
-+		if (t->rx_buf)
-+			rx_len += t->len;
-+
-+		if (!buf)
-+			continue;
-+
++	list_for_each_entry(t, &m->transfers, transfer_list)
 +		if (t->speed_hz < speed)
 +			speed = t->speed_hz;
-+
-+		/*
-+		 * m25p80 might attempt to write more data than we can handle.
-+		 * truncate the message to what we can fit into the registers
-+		 */
-+		if (len + t->len > 36)
-+			t->len = 36 - len;
-+
-+		for (i = 0; i < t->len; i++, len++)
-+			data[len / 4] |= buf[i] << (8 * (len & 3));
-+	}
-+
-+	if (WARN_ON(rx_len > 32)) {
-+		status = -EIO;
-+		goto msg_done;
-+	}
 +
 +	if (mt7621_spi_prepare(spi, speed)) {
 +		status = -EIO;
 +		goto msg_done;
 +	}
-+	data[0] = swab32(data[0]);
-+	if (len < 4)
-+		data[0] >>= (4 - len) * 8;
-+
-+	for (i = 0; i < len; i += 4)
-+		mt7621_spi_write(rs, MT7621_SPI_OPCODE + i, data[i / 4]);
-+
-+	val = (min_t(int, len, 4) * 8) << 24;
-+	if (len > 4)
-+		val |= (len - 4) * 8;
-+	val |= (rx_len * 8) << 12;
-+	mt7621_spi_write(rs, MT7621_SPI_MOREBUF, val);
 +
 +	mt7621_spi_set_cs(spi, 1);
-+
-+	val = mt7621_spi_read(rs, MT7621_SPI_TRANS);
-+	val |= SPI_CTL_START;
-+	mt7621_spi_write(rs, MT7621_SPI_TRANS, val);
-+
-+	mt7621_spi_wait_till_ready(spi);
++	m->actual_length = 0;
++	list_for_each_entry(t, &m->transfers, transfer_list) {
++		if (t->rx_buf)
++			mt7621_spi_read_half_duplex(rs, t->len, t->rx_buf);
++		else if (t->tx_buf)
++			mt7621_spi_write_half_duplex(rs, t->len, t->tx_buf);
++		m->actual_length += t->len;
++	}
++	mt7621_spi_flush(rs);
 +
 +	mt7621_spi_set_cs(spi, 0);
-+
-+	for (i = 0; i < rx_len; i += 4)
-+		data[i / 4] = mt7621_spi_read(rs, MT7621_SPI_DATA0 + i);
-+
-+	m->actual_length = len + rx_len;
-+
-+	len = 0;
-+	list_for_each_entry(t, &m->transfers, transfer_list) {
-+		u8 *buf = t->rx_buf;
-+
-+		if (!buf)
-+			continue;
-+
-+		for (i = 0; i < t->len; i++, len++)
-+			buf[i] = data[len / 4] >> (8 * (len & 3));
-+	}
-+
 +msg_done:
 +	m->status = status;
 +	spi_finalize_current_message(master);
@@ -310,7 +343,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	return 0;
 +}
 +
-+#ifdef CONFIG_SOC_MT7620
 +static int mt7621_spi_transfer_full_duplex(struct spi_master *master,
 +					   struct spi_message *m)
 +{
@@ -324,7 +356,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	u32 data[9] = { 0 };
 +	u32 val = 0;
 +
-+	mt7621_spi_wait_till_ready(spi);
++	mt7621_spi_wait_till_ready(rs);
 +
 +	list_for_each_entry(t, &m->transfers, transfer_list) {
 +		const u8 *buf = t->tx_buf;
@@ -369,7 +401,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	val |= SPI_CTL_START;
 +	mt7621_spi_write(rs, MT7621_SPI_TRANS, val);
 +
-+	mt7621_spi_wait_till_ready(spi);
++	mt7621_spi_wait_till_ready(rs);
 +
 +	mt7621_spi_set_cs(spi, 0);
 +
@@ -395,18 +427,15 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +	return 0;
 +}
-+#endif
 +
 +static int mt7621_spi_transfer_one_message(struct spi_master *master,
 +					   struct spi_message *m)
 +{
 +	struct spi_device *spi = m->spi;
-+#ifdef CONFIG_SOC_MT7620
 +	int cs = spi->chip_select;
 +
 +	if (cs)
 +		return mt7621_spi_transfer_full_duplex(master, m);
-+#endif
 +	return mt7621_spi_transfer_half_duplex(master, m);
 +}
 +
@@ -432,11 +461,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	{},
 +};
 +MODULE_DEVICE_TABLE(of, mt7621_spi_match);
-+
-+static size_t mt7621_max_transfer_size(struct spi_device *spi)
-+{
-+	return 32;
-+}
 +
 +static int mt7621_spi_probe(struct platform_device *pdev)
 +{
@@ -483,7 +507,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	master->bits_per_word_mask = SPI_BPW_MASK(8);
 +	master->dev.of_node = pdev->dev.of_node;
 +	master->num_chipselect = 2;
-+	master->max_transfer_size = mt7621_max_transfer_size;
 +
 +	dev_set_drvdata(&pdev->dev, master);
 +
@@ -493,6 +516,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	rs->master = master;
 +	rs->sys_freq = clk_get_rate(rs->clk);
 +	rs->ops = ops;
++	rs->pending_write = 0;
 +	dev_info(&pdev->dev, "sys_freq: %u\n", rs->sys_freq);
 +
 +	device_reset(&pdev->dev);
@@ -521,7 +545,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static struct platform_driver mt7621_spi_driver = {
 +	.driver = {
 +		.name = DRIVER_NAME,
-+		.owner = THIS_MODULE,
 +		.of_match_table = mt7621_spi_match,
 +	},
 +	.probe = mt7621_spi_probe,

--- a/target/linux/ramips/patches-4.14/0043-2-spi-spi-mt7621-drop-the-broken-full-duplex-mode.patch
+++ b/target/linux/ramips/patches-4.14/0043-2-spi-spi-mt7621-drop-the-broken-full-duplex-mode.patch
@@ -1,0 +1,212 @@
+From 108d9dd51363e52de92019aa2107885493ddb5f3 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Thu, 6 Dec 2018 21:15:08 +0800
+Subject: [PATCH] staging: mt7621-spi: drop the broken full-duplex mode
+
+According to John Crispin (aka blogic) on IRC on Nov 26 2018:
+  so basically i made cs1 work for MTK/labs when i built
+  the linkit smart for them. the req-sheet said that cs1 should be proper
+  duplex spi. however ....
+   1) the core will always send 1 byte before any transfer, this is the
+      m25p80 command.
+   2) mode 3 is broken and bit reversed (?)
+   3) some bit are incorrectly wired in hw for mode2/3
+  we wrote a test script and test for [0-0xffff] on all modes and certain
+  bits are swizzled under certain conditions and it was not possible to
+  fix this even using a hack.
+  we then decided to use spi-gpio and i never removed the errornous code
+  basically the spi is fecked for anything but half duplex spi mode0
+  running a sflash on it
+
+The controller will always send some data from OPCODE register under half
+duplex mode before starting a full-duplex transfer, so the full-duplex
+mode is broken.
+This piece of code also make CS1 unavailable since it forces the
+broken full-duplex mode to be used on CS1.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+Reviewed-by: NeilBrown <neil@brown.name>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/staging/mt7621-spi/spi-mt7621.c | 123 ++++--------------------
+ 1 file changed, 17 insertions(+), 106 deletions(-)
+
+diff --git a/drivers/staging/mt7621-spi/spi-mt7621.c b/drivers/staging/mt7621-spi/spi-mt7621.c
+index d045b5568e0f..a69293d43281 100644
+--- a/drivers/spi/spi-mt7621.c
++++ b/drivers/spi/spi-mt7621.c
+@@ -86,16 +86,13 @@ static inline void mt7621_spi_write(struct mt7621_spi *rs, u32 reg, u32 val)
+ 	iowrite32(val, rs->base + reg);
+ }
+ 
+-static void mt7621_spi_reset(struct mt7621_spi *rs, int duplex)
++static void mt7621_spi_reset(struct mt7621_spi *rs)
+ {
+ 	u32 master = mt7621_spi_read(rs, MT7621_SPI_MASTER);
+ 
+ 	master |= 7 << 29;
+ 	master |= 1 << 2;
+-	if (duplex)
+-		master |= 1 << 10;
+-	else
+-		master &= ~(1 << 10);
++	master &= ~(1 << 10);
+ 
+ 	mt7621_spi_write(rs, MT7621_SPI_MASTER, master);
+ 	rs->pending_write = 0;
+@@ -107,7 +104,7 @@ static void mt7621_spi_set_cs(struct spi_device *spi, int enable)
+ 	int cs = spi->chip_select;
+ 	u32 polar = 0;
+ 
+-	mt7621_spi_reset(rs, cs);
++	mt7621_spi_reset(rs);
+ 	if (enable)
+ 		polar = BIT(cs);
+ 	mt7621_spi_write(rs, MT7621_SPI_POLAR, polar);
+@@ -261,7 +258,7 @@ static void mt7621_spi_write_half_duplex(struct mt7621_spi *rs,
+ 	rs->pending_write = len;
+ }
+ 
+-static int mt7621_spi_transfer_half_duplex(struct spi_master *master,
++static int mt7621_spi_transfer_one_message(struct spi_master *master,
+ 					   struct spi_message *m)
+ {
+ 	struct mt7621_spi *rs = spi_master_get_devdata(master);
+@@ -284,10 +281,20 @@ static int mt7621_spi_transfer_half_duplex(struct spi_master *master,
+ 	mt7621_spi_set_cs(spi, 1);
+ 	m->actual_length = 0;
+ 	list_for_each_entry(t, &m->transfers, transfer_list) {
+-		if (t->rx_buf)
++		if ((t->rx_buf) && (t->tx_buf)) {
++			/* This controller will shift some extra data out
++			 * of spi_opcode if (mosi_bit_cnt > 0) &&
++			 * (cmd_bit_cnt == 0). So the claimed full-duplex
++			 * support is broken since we have no way to read
++			 * the MISO value during that bit.
++			 */
++			status = -EIO;
++			goto msg_done;
++		} else if (t->rx_buf) {
+ 			mt7621_spi_read_half_duplex(rs, t->len, t->rx_buf);
+-		else if (t->tx_buf)
++		} else if (t->tx_buf) {
+ 			mt7621_spi_write_half_duplex(rs, t->len, t->tx_buf);
++		}
+ 		m->actual_length += t->len;
+ 	}
+ 	mt7621_spi_flush(rs);
+@@ -300,102 +307,6 @@ static int mt7621_spi_transfer_half_duplex(struct spi_master *master,
+ 	return 0;
+ }
+ 
+-static int mt7621_spi_transfer_full_duplex(struct spi_master *master,
+-					   struct spi_message *m)
+-{
+-	struct mt7621_spi *rs = spi_master_get_devdata(master);
+-	struct spi_device *spi = m->spi;
+-	unsigned int speed = spi->max_speed_hz;
+-	struct spi_transfer *t = NULL;
+-	int status = 0;
+-	int i, len = 0;
+-	int rx_len = 0;
+-	u32 data[9] = { 0 };
+-	u32 val = 0;
+-
+-	mt7621_spi_wait_till_ready(rs);
+-
+-	list_for_each_entry(t, &m->transfers, transfer_list) {
+-		const u8 *buf = t->tx_buf;
+-
+-		if (t->rx_buf)
+-			rx_len += t->len;
+-
+-		if (!buf)
+-			continue;
+-
+-		if (WARN_ON(len + t->len > 16)) {
+-			status = -EIO;
+-			goto msg_done;
+-		}
+-
+-		for (i = 0; i < t->len; i++, len++)
+-			data[len / 4] |= buf[i] << (8 * (len & 3));
+-		if (speed > t->speed_hz)
+-			speed = t->speed_hz;
+-	}
+-
+-	if (WARN_ON(rx_len > 16)) {
+-		status = -EIO;
+-		goto msg_done;
+-	}
+-
+-	if (mt7621_spi_prepare(spi, speed)) {
+-		status = -EIO;
+-		goto msg_done;
+-	}
+-
+-	for (i = 0; i < len; i += 4)
+-		mt7621_spi_write(rs, MT7621_SPI_DATA0 + i, data[i / 4]);
+-
+-	val |= len * 8;
+-	val |= (rx_len * 8) << 12;
+-	mt7621_spi_write(rs, MT7621_SPI_MOREBUF, val);
+-
+-	mt7621_spi_set_cs(spi, 1);
+-
+-	val = mt7621_spi_read(rs, MT7621_SPI_TRANS);
+-	val |= SPI_CTL_START;
+-	mt7621_spi_write(rs, MT7621_SPI_TRANS, val);
+-
+-	mt7621_spi_wait_till_ready(rs);
+-
+-	mt7621_spi_set_cs(spi, 0);
+-
+-	for (i = 0; i < rx_len; i += 4)
+-		data[i / 4] = mt7621_spi_read(rs, MT7621_SPI_DATA4 + i);
+-
+-	m->actual_length = rx_len;
+-
+-	len = 0;
+-	list_for_each_entry(t, &m->transfers, transfer_list) {
+-		u8 *buf = t->rx_buf;
+-
+-		if (!buf)
+-			continue;
+-
+-		for (i = 0; i < t->len; i++, len++)
+-			buf[i] = data[len / 4] >> (8 * (len & 3));
+-	}
+-
+-msg_done:
+-	m->status = status;
+-	spi_finalize_current_message(master);
+-
+-	return 0;
+-}
+-
+-static int mt7621_spi_transfer_one_message(struct spi_master *master,
+-					   struct spi_message *m)
+-{
+-	struct spi_device *spi = m->spi;
+-	int cs = spi->chip_select;
+-
+-	if (cs)
+-		return mt7621_spi_transfer_full_duplex(master, m);
+-	return mt7621_spi_transfer_half_duplex(master, m);
+-}
+-
+ static int mt7621_spi_setup(struct spi_device *spi)
+ {
+ 	struct mt7621_spi *rs = spidev_to_mt7621_spi(spi);
+@@ -478,7 +389,7 @@ static int mt7621_spi_probe(struct platform_device *pdev)
+ 
+ 	device_reset(&pdev->dev);
+ 
+-	mt7621_spi_reset(rs, 0);
++	mt7621_spi_reset(rs);
+ 
+ 	return spi_register_master(master);
+ }
+-- 
+2.19.2
+

--- a/target/linux/ramips/patches-4.14/0043-3-spi-spi-mt7621-drop-support-for-SPI-mode-1-2-3.patch
+++ b/target/linux/ramips/patches-4.14/0043-3-spi-spi-mt7621-drop-support-for-SPI-mode-1-2-3.patch
@@ -1,0 +1,75 @@
+From 354ea2ee6d2bc08d2f73b67096e67760089887cb Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Thu, 6 Dec 2018 21:15:09 +0800
+Subject: [PATCH] staging: mt7621-spi: drop support for SPI mode 1/2/3
+
+As explained in previous patch, this SPI controller seems to be
+tested on SPI flash only before mass production and some bits are
+swizzled under other SPI modes probably due to incorrect wiring
+inside the silicon. Drop implementation of SPI mode 1/2/3 since
+they are broken.
+
+Also drop RT2880_SPI_MODE_BITS macro because we now have only
+SPI_LSB_FIRST implemented and the mode_bits is so short that we
+don't need a macro there.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+Reviewed-by: NeilBrown <neil@brown.name>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/staging/mt7621-spi/spi-mt7621.c | 24 +++++++-----------------
+ 1 file changed, 7 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/staging/mt7621-spi/spi-mt7621.c b/drivers/staging/mt7621-spi/spi-mt7621.c
+index a69293d43281..513b6e79b985 100644
+--- a/drivers/spi/spi-mt7621.c
++++ b/drivers/spi/spi-mt7621.c
+@@ -55,9 +55,6 @@
+ #define MT7621_CPOL		BIT(4)
+ #define MT7621_LSB_FIRST	BIT(3)
+ 
+-#define RT2880_SPI_MODE_BITS	(SPI_CPOL | SPI_CPHA |		\
+-				 SPI_LSB_FIRST | SPI_CS_HIGH)
+-
+ struct mt7621_spi;
+ 
+ struct mt7621_spi {
+@@ -136,20 +133,13 @@ static int mt7621_spi_prepare(struct spi_device *spi, unsigned int speed)
+ 	if (spi->mode & SPI_LSB_FIRST)
+ 		reg |= MT7621_LSB_FIRST;
+ 
++	/* This SPI controller seems to be tested on SPI flash only
++	 * and some bits are swizzled under other SPI modes probably
++	 * due to incorrect wiring inside the silicon. Only mode 0
++	 * works correctly.
++	 */
+ 	reg &= ~(MT7621_CPHA | MT7621_CPOL);
+-	switch (spi->mode & (SPI_CPOL | SPI_CPHA)) {
+-	case SPI_MODE_0:
+-		break;
+-	case SPI_MODE_1:
+-		reg |= MT7621_CPHA;
+-		break;
+-	case SPI_MODE_2:
+-		reg |= MT7621_CPOL;
+-		break;
+-	case SPI_MODE_3:
+-		reg |= MT7621_CPOL | MT7621_CPHA;
+-		break;
+-	}
++
+ 	mt7621_spi_write(rs, MT7621_SPI_MASTER, reg);
+ 
+ 	return 0;
+@@ -368,7 +358,7 @@ static int mt7621_spi_probe(struct platform_device *pdev)
+ 		return -ENOMEM;
+ 	}
+ 
+-	master->mode_bits = RT2880_SPI_MODE_BITS;
++	master->mode_bits = SPI_LSB_FIRST;
+ 
+ 	master->setup = mt7621_spi_setup;
+ 	master->transfer_one_message = mt7621_spi_transfer_one_message;
+-- 
+2.19.2
+


### PR DESCRIPTION
The first commit backported the upstream driver. That driver is more efficient thanks to the refactor of spi reading operation.
The second one dropped broken SPI modes.

Performance test on MT7628:
Tested with the following command:
time dd if=/dev/mtdblock3 of=/dev/null bs=64k
mtdblock3 is firmware partition and its size is 15808k.
This patch increases reading speed from 737KB/s to 1047KB/s.

I didn't squash patches together to make it easier to track changes when bumping to 4.19.

