### PR TITLE
lantiq/xrx200: Add support for Fritzbox 7360v2.

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -158,6 +158,14 @@ avm,fritz7360sl)
 		"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
 	;;
 
+avm,fritz7360v2)
+        annex="b"
+        wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2705)" 1)
+        ucidef_add_switch "switch0" \
+                "0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
+        ;;
+
+
 siemens,gigaset-sx76x)
 	annex="b"
 	ucidef_add_switch "switch0" \

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -160,7 +160,7 @@ case "$FIRMWARE" in
 			avm,fritz3370-rev2-micron)
 				ath9k_eeprom_extract_reverse "urlader" 5441 1088
 				;;
-			avm,fritz7312|avm,fritz7320|avm,fritz7360sl)
+			avm,fritz7312|avm,fritz7320|avm,fritz7360sl|avm,fritz7360v2)
 				ath9k_eeprom_extract "urlader" 2437 0
 				;;
 			tplink,tdw8970|tplink,tdw8980)

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7360V2.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7360V2.dts
@@ -1,0 +1,240 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7360v2", "lantiq,xway", "lantiq,vr9";
+	model = "AVM Fritzbox 7360v2";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+
+		led-dsl = &info_green;
+		led-wifi = &wifi;
+	};
+
+	memory@0 {
+		reg = <0x0 0x8000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <100>;
+		dect {
+			label = "dect";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_PHONE>;
+		};
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WLAN>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power_green: power {
+			label = "fritz7360v2:green:power";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+		power_red: power2 {
+			label = "fritz7360v2:red:power";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+		info_red {
+			label = "fritz7360v2:red:info";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+		info_green: info_green {
+			label = "fritz7360v2:green:info";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+		wifi: wifi {
+			label = "fritz7360v2:green:wlan";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+		dect {
+			label = "fritz7360v2:green:dect";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		mtd-mac-address = <&urlader 0xa91>;
+		mtd-mac-address-increment = <(-2)>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rmii";
+			phy-handle = <&phy0>;
+		};
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rmii";
+			phy-handle = <&phy1>;
+		};
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		reg = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0x00>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+		phy1: ethernet-phy@1 {
+			reg = <0x01>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		mdio {
+			lantiq,groups = "mdio";
+			lantiq,function = "mdio";
+		};
+		phy-rst {
+			lantiq,pins = "io37", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+		pcie-rst {
+			lantiq,pins = "io38";
+			lantiq,pull = <0>;
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&localbus {
+	nor@0 {
+		compatible = "lantiq,nor";
+		bank-width = <2>;
+		reg = <0 0x0 0x2000000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			urlader: partition@0 {
+				label = "urlader";
+				reg = <0x00000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x20000 0x1f60000>;
+			};
+
+			partition@1f80000 {
+				label = "tffs (1)";
+				reg = <0x1f80000 0x40000>;
+				read-only;
+			};
+
+			partition@1fc0000 {
+				label = "tffs (2)";
+				reg = <0x1fc0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <2>;
+		#address-cells = <3>;
+		device_type = "pci";
+
+		wifi@168c,002e {
+			compatible = "pci168c,002e";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -664,6 +664,17 @@ define Device/avm_fritz7360sl
 endef
 TARGET_DEVICES += avm_fritz7360sl
 
+define Device/avm_fritz7360v2
+  $(Device/AVM)
+  IMAGE_SIZE := 32128k
+  DEVICE_DTS := FRITZ7360V2
+  DEVICE_TITLE := AVM Fritzbox 7360v2 - FRITZ7360V2
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic kmod-usb-dwc2
+  SUPPORTED_DEVICES += FRITZ7360V2
+endef
+TARGET_DEVICES += avm_fritz7360v2
+
+
 define Device/arcadyan_vg3503j
   IMAGE_SIZE := 8000k
   DEVICE_DTS := VG3503J


### PR DESCRIPTION
This commit adds support for the Fritzbox 7360v2.

CPU: VR9 500MHz Cores: 2
RAM: 128 MB
NOR-Flash: 32 MB
WLAN: AR9287-BL1A

DECT is not working.

Thanks Sebastian Ortwein for adding 7360SL from which I derived this patch.

Flash instruction:

Set your client IP to 192.168.178.2
Connect to your Fritzbox at 192.168.178.1 via ftp in the first 5 seconds after powering on the device.

login with adam2/adam2

type into ftp prompt: 

```
passive
binary
debug 1
quote MEDIA FLSH             // (not FLASH)

put openwrt-lantiq-xrx200-avm_fritz7360v2-squashfs-sysupgrade.bin mtd1
```

wait till red light flashing turns off. 
reboot



Getting one warning at bootup:

```
[   11.316127] ------------[ cut here ]------------
[   11.319460] WARNING: CPU: 0 PID: 3 at backports-4.19-rc5-1/net/wireless/reg.c:1021 regulatory_hint_user+0x6b0/0x768 [cfg80211]
[   11.330785] Modules linked in: ath9k ath9k_common ath9k_hw ath pppoe nf_conntrack_ipv6 mac80211 iptable_nat ipt_REJECT ipt_MASQUERADE cfg80211 xt_time xt_tc$
[   11.399102] CPU: 0 PID: 3 Comm: kworker/0:0 Not tainted 4.14.82 #0
[   11.405187] Workqueue: events request_firmware_work_func
[   11.410456] Stack : 805be528 87c4bd3c 80630000 87c22680 805be5bc 87089a9c 00000009 000003fd
[   11.418793]         00000000 8007b4f0 87c38fac 80638687 80630000 00000001 87c4bd00 74ab3c4f
[   11.427148]         00000000 00000000 00000000 00004810 00000000 00000000 00000007 00000000
[   11.435504]         000000e5 80640000 000000e4 00000000 00000000 80650000 00000000 87089a9c
[   11.443860]         00000009 000003fd 00000000 00010000 00000003 00000000 00000000 80790000
[   11.452216]         ...
[   11.454653] Call Trace:
[   11.457117] [<80011404>] show_stack+0x58/0x100
[   11.461564] [<804b2714>] dump_stack+0xe4/0x120
[   11.466005] [<80032b20>] __warn+0xe0/0x114
[   11.470087] [<80032be4>] warn_slowpath_null+0x1c/0x28
[   11.475209] [<87089a9c>] regulatory_hint_user+0x6b0/0x768 [cfg80211]
[   11.481539] [<802d4ac0>] request_firmware_work_func+0x40/0x70
[   11.487237] [<8004c130>] process_one_work+0x2f0/0x4e0
[   11.492280] [<8004c744>] worker_thread+0x424/0x704
[   11.497076] [<80052b18>] kthread+0x168/0x17c
[   11.501341] [<8000b418>] ret_from_kernel_thread+0x14/0x1c
[   11.506807] ---[ end trace dabf4e7e4d04b93b ]---

```

edit: fixed by manually invoking:

`dd if=/dev/mtd0 of=/lib/firmware/ath9k-eeprom-pci-0000:01:00.0.bin bs=1 skip=2437 count=4096`

Signed-off-by: Yushi Nishida <kyro2man@gmx.net> 