### PR TITLE
ramips: bdcom-wap2100: Fixes and improvements

### DIFF
--- a/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
+++ b/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
@@ -130,6 +130,18 @@
 	ralink,mtd-eeprom = <&factory 0>;
 };
 
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+       wifi@0,0 {
+               reg = <0x0000 0 0 0 0>;
+               mediatek,mtd-eeprom = <&factory 0x8000>;
+               ieee80211-freq-limit = <5000000 6000000>;
+       };
+};
+
 &pinctrl {
 	state_default: pinctrl0 {
 		default {

--- a/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
+++ b/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf70000>;
 			};

--- a/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
+++ b/target/linux/ramips/dts/BDCOM-WAP2100-SK.dts
@@ -66,6 +66,7 @@
 		spi-max-frequency = <10000000>;
 
 		partitions {
+			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
 

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -84,7 +84,7 @@ define Device/bdcom_wap2100-sk
   DTS := BDCOM-WAP2100-SK
   IMAGE_SIZE := 15808k
   DEVICE_TITLE := BDCOM WAP2100-SK (ZTE ZXECS EBG3130)
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76 kmod-mt76x0e kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += bdcom_wap2100-sk
 


### PR DESCRIPTION
Hi @mkresin,

thank you for your board support improvements, unfortunately it has rendered the board unbootable due to the missing `compatible` property in the `partitions` node. So this PR fixes that boot failure, and while touching that device again, I'm adding back SUPPORTED_DEVICES variable which you've (accidentally?) removed during your improvements session also. I've also added proper partition format to the `firmware` partition and enabled 5GHz radio.

Cheers, Petr