### PR TITLE
sdk: find kernel modules when KDIR is a symlink

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -83,7 +83,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 	mkdir -p $(SDK_BUILD_DIR)/dl $(SDK_BUILD_DIR)/package
 	$(CP) -L $(INCLUDE_DIR) $(SCRIPT_DIR) $(SDK_BUILD_DIR)/
 	$(TAR) -cf - -C $(TOPDIR) \
-		`cd $(TOPDIR); find $(KDIR_BASE) -name \*.ko` \
+		`cd $(TOPDIR); find $(KDIR_BASE)/ -name \*.ko` \
 		`cd $(TOPDIR); find $(KDIR_BASE)/firmware/ -newer $(KDIR_BASE)/firmware/Makefile \
 			-type f -name '*.bin' -or -name '*.cis' -or -name '*.csp' -or -name '*.dsp' -or -name '*.fw'` \
 		$(foreach exclude,$(EXCLUDE_DIRS),--exclude="$(exclude)") \


### PR DESCRIPTION
The find statement would not return any results if the KDIR_BASE pointed to a
symlink. Ran into this issue due to a custom Kernel/Prepare that was installing
a symlink to the kernel directory.

The extra slash at the end fixes this scenario and does no harm for targets that
have a proper KDIR.
