### PR TITLE
ath79: ubnt-xw: Set firmware partition format to denx,uimage

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -84,6 +84,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x760000>;
 			};


### PR DESCRIPTION
Specify firmware partition format to denx,uimage in compatible DTS property.

 2 uimage-fw partitions found on MTD device firmware
 Creating 2 MTD partitions on "firmware":
 0x000000000000-0x000000190000 : "kernel"
 0x000000190000-0x000000760000 : "rootfs"