### PR TITLE
ath79: Define firmware partition format to all boards where applicable

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -209,6 +209,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x610000>;
 			};

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -86,6 +86,7 @@
 			};
 
 			partition@50000 {
+				compatible = "netgear,uimage";
 				reg = <0x50000 0x3a0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
@@ -106,6 +106,7 @@
 			};
 
 			firmware: partition@20000 {
+				compatible = "tplink,firmware";
 				reg = <0x20000 0x3d0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -68,6 +68,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				reg = <0x20000 0x3d0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -81,6 +81,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x750000>;
 			};

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -60,6 +60,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x750000>;
 			};

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -115,6 +115,7 @@
 			};
 
 			partition@20000 {
+				compatible = "avm,eva-firmware";
 				reg = <0x20000 0xee0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -125,6 +125,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7d0000>;
 			};

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -93,6 +93,7 @@
 			};
 
 			partition@1 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3D0000>;
 			};

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -124,6 +124,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7D0000>;
 			};

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
@@ -131,6 +131,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3d0000>;
 			};

--- a/target/linux/ath79/dts/ar9330_glinet_ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_ar150.dts
@@ -108,6 +108,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0xfa0000>;
 			};

--- a/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
+++ b/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
@@ -109,6 +109,7 @@
 			};
 
 			partition@70000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x070000 0x780000>;
 			};

--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
@@ -89,6 +89,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0xfa0000>;
 			};

--- a/target/linux/ath79/dts/ar9331_etactica_eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica_eg200.dts
@@ -112,6 +112,7 @@
 			};
 
 			firmware@50000 {
+				compatible = "denx,uimage";
 				reg = <0x50000 0xfa0000>;
 			};
 

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -70,6 +70,7 @@
 			};
 
 			firmware: partition@20000 {
+				compatible = "tplink,firmware";
 				reg = <0x20000 0x7d0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -137,6 +137,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3c0000>;
 			};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -128,6 +128,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3d0000>;
 			};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
@@ -67,6 +67,7 @@
 			};
 
 			firmware: partition@20000 {
+				compatible = "tplink,firmware";
 				reg = <0x20000 0x3d0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -107,6 +107,7 @@
 			};
 
 			firmware: partition@20000 {
+				compatible = "tplink,firmware";
 				reg = <0x20000 0x3d0000>;
 				label = "firmware";
 			};

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -128,6 +128,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x07a0000>;
 			};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -146,6 +146,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7d0000>;
 			};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
@@ -64,6 +64,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0xf60000>;
 			};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -84,6 +84,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x760000>;
 			};

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -116,6 +116,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x0fa0000>;
 			};

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -105,6 +105,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0x07a0000>;
 			};

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -147,6 +147,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7d0000>;
 			};

--- a/target/linux/ath79/dts/qca9533_glinet_ar300m_nor.dts
+++ b/target/linux/ath79/dts/qca9533_glinet_ar300m_nor.dts
@@ -31,6 +31,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0xfa0000>;
 			};

--- a/target/linux/ath79/dts/qca9533_glinet_gl-x750.dts
+++ b/target/linux/ath79/dts/qca9533_glinet_gl-x750.dts
@@ -113,6 +113,7 @@
 			};
 
 			partition@60000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x060000 0xfa0000>;
 			};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -102,6 +102,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x3d0000>;
 			};

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -121,6 +121,7 @@
 			};
 
 			partition@2 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x850000 0x7a0000>;
 			};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
@@ -36,6 +36,7 @@
 	};
 
 	firmware@20000 {
+		compatible = "tplink,firmware";
 		reg = <0x020000 0x7d0000>;
 	};
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -168,6 +168,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7d0000>;
 			};

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -123,6 +123,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x7d0000>;
 			};

--- a/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
+++ b/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
@@ -136,6 +136,7 @@
 			};
 
 			partition@1 {
+				compatible = "avm,eva-firmware";
 				label = "firmware";
 				reg = <0x020000 0xee0000>;
 			};

--- a/target/linux/ath79/dts/qca9563_phicomm_k2t.dts
+++ b/target/linux/ath79/dts/qca9563_phicomm_k2t.dts
@@ -101,6 +101,7 @@
 			};
 
 			partition@90000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x090000 0xf60000>;
 			};

--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -84,6 +84,7 @@
 			};
 
 			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x050000 0xf80000>;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
@@ -150,6 +150,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0x5e0000>;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
@@ -136,6 +136,7 @@
 			};
 
 			partition@20000 {
+				compatible = "tplink,firmware";
 				label = "firmware";
 				reg = <0x020000 0xf30000>;
 			};


### PR DESCRIPTION
Parsing "firmware" partition (to create kernel + rootfs) was implemented
using OpenWrt downstream code enabled by CONFIG_MTD_SPLIT_FIRMWARE. With
recent upstream mtd changes we can do it in a more clean way for DTS
targets. It just requires adding a proper "compatible" string to the
"firmware" partition node.

### Used firmware partition formats in ath79 targets

* n/a (missing partitions definitions etc.)
* avm,eva-firmware (dts)
* cybertan,trx (dts)
* denx,uimage (dts)
* ecoscentric,redboot-fis-partitions (dts)
* netgear,uimage (dts)
* tplink,firmware (dts)

### Enabled partition splitters in kernel:

```
 CONFIG_MTD_SPLIT_FIRMWARE=y
 CONFIG_MTD_SPLIT_LZMA_FW=y
 CONFIG_MTD_SPLIT_SEAMA_FW=y (not used? can be disabled?)
 CONFIG_MTD_SPLIT_TPLINK_FW=y
 CONFIG_MTD_SPLIT_UIMAGE_FW=y
 CONFIG_MTD_SPLIT_WRGG_FW=y (not used? can be disabled?)
 CONFIG_MTD_SPLIT_EVA_FW=y
```

### List of partition formats in dts/dtsi files

```
avm,eva-firmware		ar7242_avm_fritz300e.dts
avm,eva-firmware	        qca9561_avm_fritz4020.dts
cybertan,trx			ar9344_wd_mynet-wifi-rangeextender.dts
denx,uimage			ar7161_buffalo_wzr-hp-ag300h.dts
denx,uimage			ar7161_dlink_dir-825-b1.dts
denx,uimage			ar7240_buffalo_whr-g301n.dts
denx,uimage			ar7241_ubnt_unifi.dts
denx,uimage			ar7241_ubnt_xm.dtsi
denx,uimage			ar7242_buffalo_wzr-bhr.dtsi
denx,uimage			ar7242_buffalo_wzr-hp-g302h-a1a0.dts
denx,uimage			ar9330_glinet_ar150.dts
denx,uimage			ar9330_pqi_air-pen.dts
denx,uimage			ar9331_embeddedwireless_dorin.dts
denx,uimage			ar9331_etactica_eg200.dts
denx,uimage			ar9341_pcs_cr3000.dts
denx,uimage			ar9342_iodata_etg3-r.dts
denx,uimage			ar9342_ubnt_wa.dtsi
denx,uimage			ar9342_ubnt_xw.dtsi
denx,uimage			ar9344_ocedo_raccoon.dts
denx,uimage			ar9344_pcs_cap324.dts
denx,uimage			ar9344_pcs_cr5000.dts
denx,uimage			qca9533_glinet_ar300m_nor.dts
denx,uimage			qca9533_glinet_gl-x750.dts
denx,uimage			qca9557_buffalo_bhr-4grv2.dts
denx,uimage			qca9557_iodata_wn-ac-dgr.dtsi
denx,uimage			qca9558_ocedo_koala.dts
denx,uimage			qca9558_openmesh_om5p-ac-v2.dts
denx,uimage			qca9561_tplink_archer-c58-v1.dts
denx,uimage			qca9561_tplink_archer-c59-v1.dts
denx,uimage			qca9563_elecom_wrc-300ghbk2-i.dts
denx,uimage			qca9563_phicomm_k2t.dts
denx,uimage			qca9563_rosinson_wr818.dts
denx,uimage			qca9563_ubnt_unifiac.dtsi
ecoscentric,redboot-fis-partitions ar7161_ubnt_routerstation.dtsi
n/a				        ar7161_netgear_wndr3700.dtsi
n/a				        qca9533_glinet_ar300m_nand.dts
n/a				        qca9558_tplink_archer-c7.dtsi
netgear,uimage		ar7161_netgear_wndr3700.dts
netgear,uimage		ar7161_netgear_wndr3700v2.dts
netgear,uimage		ar7161_netgear_wndr3800.dts
netgear,uimage		ar7240_netgear_wnr612-v2.dtsi
tplink,firmware			ar7240_tplink_tl-wr74xn-v1.dtsi
tplink,firmware			ar7241_tplink.dtsi
tplink,firmware			ar7242_tplink_tl-wr2543-v1.dts
tplink,firmware			ar9132_tplink_tl-wa901nd-v2.dts
tplink,firmware			ar9132_tplink_tl-wr1043nd-v1.dts
tplink,firmware			ar9132_tplink_tl-wr941-v2.dts
tplink,firmware			ar9331_pisen_wmm003n.dts
tplink,firmware			ar9331_tplink_tl-mr3020-v1.dts
tplink,firmware			ar9331_tplink_tl-mr3040-v2.dts
tplink,firmware			ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
tplink,firmware			ar9331_tplink_tl-wr741nd-v4.dtsi
tplink,firmware			ar9341_tplink_tl-wr842n-v2.dts
tplink,firmware			ar9344_tplink_tl-wdr4300.dtsi
tplink,firmware			qca9533_tplink_tl-wr841.dtsi
tplink,firmware			qca9558_tplink_tl-wdr4900-v2.dts
tplink,firmware			qca9558_tplink_tl-wr1043nd.dtsi
tplink,firmware			qca9563_tplink_re450-v2.dts
tplink,firmware			qca9563_tplink_tl-wr1043n.dtsi
```