### PR TITLE
ramips: add DT binding support to the jimage parser and specify "firmware" partition format in JBOOT devices

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_jimage.c
@@ -19,6 +19,7 @@
 #include <linux/vmalloc.h>
 #include <linux/mtd/mtd.h>
 #include <linux/mtd/partitions.h>
+#include <linux/version.h>
 #include <linux/byteorder/generic.h>
 
 #include "mtdsplit.h"
@@ -256,9 +257,19 @@ mtdsplit_jimage_parse_generic(struct mtd_info *master,
 				      jimage_verify_default);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+static const struct of_device_id mtdsplit_jimage_of_match_table[] = {
+	{ .compatible = "amit,jimage" },
+	{},
+};
+#endif
+
 static struct mtd_part_parser jimage_generic_parser = {
 	.owner = THIS_MODULE,
 	.name = "jimage-fw",
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+	.of_match_table = mtdsplit_jimage_of_match_table,
+#endif
 	.parse_fn = mtdsplit_jimage_parse_generic,
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };

--- a/target/linux/ramips/dts/DWR-116-A1.dts
+++ b/target/linux/ramips/dts/DWR-116-A1.dts
@@ -59,7 +59,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
@@ -76,6 +76,7 @@
 			};
 
 			partition@10000 {
+				compatible = "amit,jimage";
 				label = "firmware";
 				reg = <0x10000 0x7e0000>;
 			};

--- a/target/linux/ramips/dts/DWR-118-A2.dts
+++ b/target/linux/ramips/dts/DWR-118-A2.dts
@@ -106,6 +106,7 @@
 			};
 
 			partition@10000 {
+				compatible = "amit,jimage";
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/DWR-512-B.dts
+++ b/target/linux/ramips/dts/DWR-512-B.dts
@@ -81,7 +81,7 @@
 &spi0 {
 	status = "okay";
 
-	mx25l6405d@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <30000000>;
@@ -99,6 +99,7 @@
 			};
 
 			partition@10000 {
+				compatible = "amit,jimage";
 				label = "firmware";
 				reg = <0x10000 0x7e0000>;
 			};

--- a/target/linux/ramips/dts/DWR-921-C1.dts
+++ b/target/linux/ramips/dts/DWR-921-C1.dts
@@ -97,7 +97,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
@@ -114,6 +114,7 @@
 			};
 
 			partition@10000 {
+				compatible = "amit,jimage";
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/LR-25G001.dts
+++ b/target/linux/ramips/dts/LR-25G001.dts
@@ -88,6 +88,7 @@
 			};
 
 			partition@10000 {
+				compatible = "amit,jimage";
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};


### PR DESCRIPTION
This PR add DT binding in jimage mtd parser. 

Second commit add support in dts.

List of devices:
-DWR-116-A1 (tested)
-DWR-118-A2
-DWR-512-B
-DWR-921-C1
-LR-25G001 (tested)
