### PR TITLE
ath79: add support for I-O DATA WN-AG300DGR

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -81,6 +81,7 @@ ath79_setup_interfaces()
 	iodata,etg3-r|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2|\
+	iodata,wn-ag300dgr|\
 	pcs,cr5000)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
@@ -221,7 +222,8 @@ ath79_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" -1)
 		;;
 	iodata,wn-ac1167dgr|\
-	iodata,wn-ac1600dgr2)
+	iodata,wn-ac1600dgr2|\
+	iodata,wn-ag300dgr)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -101,7 +101,8 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract_reverse "urlader" 5441 1088
 		;;
 	iodata,wn-ac1167dgr|\
-	iodata,wn-ac1600dgr2)
+	iodata,wn-ac1600dgr2|\
+	iodata,wn-ag300dgr)
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 2
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -13,6 +13,10 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	iodata,wn-ag300dgr)
+		[ "$PHYNBR" -eq 1 ] && \
+			echo $(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1) > /sys${DEVPATH}/macaddress
+		;;
 	phicomm,k2t)
 		# The K2T factory firmware does use LAN mac address as the 2.4G wifi mac address
 		[ "$PHYNBR" -eq 1 ] && \

--- a/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
+++ b/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "iodata,wn-ag300dgr", "qca,ar9344";
+	model = "I-O DATA WN-AG300DGR";
+
+	aliases {
+		led-boot = &router;
+		led-failsafe = &router;
+		led-running = &router;
+		led-upgrade = &router;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		router: router {
+			label = "wn-ag300dgr:green:router";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		children {
+			label = "wn-ag300dgr:green:children";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		eco {
+			label = "wn-ag300dgr:green:eco";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		notification {
+			label = "wn-ag300dgr:amber:notification";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wlan2g {
+			label = "wn-ag300dgr:green:wlan2g";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "wn-ag300dgr:green:wlan5g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		eco {
+			label = "eco";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		children {
+			label = "children";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&spi {
+	num-cs = <1>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xf10000>;
+			};
+
+			partition@f50000 {
+				label = "manufacture";
+				reg = <0xf50000 0x40000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "backup";
+				reg = <0xf90000 0x10000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "storage";
+				reg = <0xfa0000 0x50000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07a00000 /* PORT0 PAD MODE CTRL */
+			0x7c 0x000000fe /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -222,6 +222,18 @@ define Device/iodata_wn-ac1600dgr2
 endef
 TARGET_DEVICES += iodata_wn-ac1600dgr2
 
+define Device/iodata_wn-ag300dgr
+  ATH_SOC := ar1022
+  DEVICE_TITLE := I-O DATA WN-AG300DGR
+  IMAGE_SIZE := 15424k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    senao-header -r 0x30a -p 0x47 -t 2
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
+endef
+TARGET_DEVICES += iodata_wn-ag300dgr
+
 define Device/ocedo_koala
   ATH_SOC := qca9558
   DEVICE_TITLE := OCEDO Koala


### PR DESCRIPTION
I-O DATA WN-AG300DGR is a 2T2R 2.4/5 GHz 11n router, based on Atheros
AR1022.

WN-AG300DGR does not have an LED to indicates power or system status,
I set "router" LED as OpenWrt status LED.

There is no eeprom data for 5 GHz wlan in "art" partition.

Specification:

- Atheros AR1022
- 64 MB of RAM (DDR2)
- 8 MB of Flash (SPI-NOR)
- 2T2R 2.4/5GHz wifi
  - 2.4 GHz: SoC internal
  - 5 GHz: Atheros AR93x2
- 5x 10/100/1000 Mbps Ethernet
- 6x LEDs, 6x keys (4x buttons, 1x slide switch)
- 1x USB 2.0 Type-A
- UART through-hole on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Flash instruction using factory image:

1. Connect the computer to the LAN port on WN-AG300DGR
2. Connect power cable to WN-AG300DGR and turn it
3. Access to "http://192.168.0.1/" and open firmware update page
("ファームウェア")
4. Select the OpenWrt factory image and click update ("更新") button
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>