### PR TITLE
ramips: add D-Link DIR-506L support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -114,6 +114,9 @@ dlink,dwr-116-a1|\
 mzk-ex300np)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+dlink,dir-506l)
+	ucidef_set_led_gpio "lo_bat" "Low battery" "$boardname:red:status" "10" "0"
+	;;
 dlink,dwr-118-a1)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1f"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x20"

--- a/target/linux/ramips/dts/DIR-506L.dts
+++ b/target/linux/ramips/dts/DIR-506L.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-506l", "ralink,rt5350-soc";
+	model = "D-Link DIR-506L";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "dir-506l:green:usb";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "dir-506l:green:status";
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "dir-506l:red:status";
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "dir-506l:green:internet";
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		low_battery {
+			label = "low_battery";
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+		};
+
+		charging {
+			label = "charging";
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_1>;
+		};
+
+		on_battery {
+			label = "on_battery";
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_2>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "amit,jimage";
+				label = "firmware";
+				reg = <0x10000 0x7e0000>;
+			};
+
+			config: partition@7f0000 {
+				label = "config";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "uartf", "led";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0xe084>;
+	mtd-mac-address-increment = <(1)>;
+};
+
+&esw {
+	mediatek,portmap = <0x1>;
+	mediatek,portdisable = <0x3e>;
+	mediatek,led_polarity = <1>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&config 0xe090>;
+	ralink,led-polarity = <1>;
+	mtd-mac-address = <&config 0xe084>;
+	mtd-mac-address-increment = <(1)>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1,6 +1,9 @@
 #
 # RT305X Profiles
 #
+
+DEVICE_VARS += DLINK_ROM_ID DLINK_FAMILY_MEMBER DLINK_FIRMWARE_SIZE DLINK_IMAGE_OFFSET
+
 define Build/buffalo-tftp-header
   ( \
     echo -n -e "# Airstation FirmWare\nrun u_fw\nreset\n\n" | \
@@ -249,6 +252,21 @@ define Device/dir-320-b1
   DEVICE_TITLE := D-Link DIR-320 B1
 endef
 TARGET_DEVICES += dir-320-b1
+
+define Device/dlink_dir-506l
+  DTS := DIR-506L
+  DEVICE_TITLE := D-Link DIR-506L
+  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-core \
+		kmod-ledtrig-gpio kmod-ledtrig-netdev kmod-ledtrig-timer
+  DLINK_ROM_ID := DLK6E2114001
+  DLINK_FAMILY_MEMBER := 0x6E21
+  DLINK_FIRMWARE_SIZE := 0x7E0000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+endef
+TARGET_DEVICES += dlink_dir-506l
 
 define Device/dir-600-b1
   DTS := DIR-600-B1


### PR DESCRIPTION
Specifications:
 - Ralink RT5350 id:1 rev:3 (360 MHz)
 - 32 MB RAM
 - 8 MB Flash
 - 802.11bgn 1T1R
 - 1x internal, non-detachable antenna
 - 1x 10/100 Mbps Ethernet
 - 1x USB 2.0 (Type-A)
 - 5 leds
 - 2 buttons
 - UART header on PCB (57600 8n1)
 - JBOOT bootloader
 - 1700 - 2200 mAh battery (Fujifilm NP-120 / Pentax D-Li7, D-L17, DB-43)

Features:
 - upgrade from stock fw via web gui
 - all leds avaible
 - all buttons work
 - battery/charger gpio events added
 - USB power on by default
 - keep jboot recovery

Installation:
Apply factory image via http web-gui or JBOOT recovery page

How to revert to OEM firmware:
 - push the reset button and turn on the power. Wait until LED start blinking (~10sec.)
 - upload original factory image via JBOOT http (IP: 192.168.123.254)
If http doesn't work, it can be done with curl command:
curl -F FN=@XXXXX.bin http://192.168.123.254/upg
where XXXXX.bin is name of firmware file.

Signed-off-by: rim <rozhuk.im@gmail.com>