### PR TITLE
ath79: add 'compatible' attr for rosinson wr818 dts file

### DIFF
--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -86,6 +86,7 @@
 			partition@50000 {
 				label = "firmware";
 				reg = <0x050000 0xf80000>;
+				compatible = "denx,uimage";
 			};
 
 			info: partition@fd0000 {


### PR DESCRIPTION

This commit adds 'compatible' attr for rosinson wr818 dts file

Signed-off-by: Rosy Song <rosysong@rosinson.com>