### PR TITLE
ath79: add D-Link DIR-825-C1 and DIR-835-A1

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -44,6 +44,18 @@ define Build/buffalo-dhp-image
 	mv $@.new $@
 endef
 
+# blow up binary to given size and put a given string at its end:
+# cameo-factory <size[k]> <string>
+define Build/cameo-factory
+	factory_stamp=$(word 2,$(1)); \
+	((reduced_size=$(subst k,*1024,$(word 1,$(1)))-$${#factory_stamp})); \
+	( \
+		dd if=$@ bs=$$reduced_size conv=sync; \
+		echo -n $$factory_stamp; \
+	) > $@.new && \
+	mv $@.new $@
+endef
+
 define Build/eva-image
 	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
 	mv $@.new $@

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -78,6 +78,8 @@ ath79_setup_interfaces()
 	glinet,gl-x750)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	dlink,dir-825-c1|\
+	dlink,dir-835-a1|\
 	iodata,etg3-r|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2|\
@@ -212,6 +214,11 @@ ath79_setup_macs()
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 65440)
 		wan_mac=$(mtd_get_mac_text "caldata" 65460)
+		;;
+	dlink,dir-825-c1|\
+	dlink,dir-835-a1)
+		lan_mac=$(mtd_get_mac_text "mac" 4)
+		wan_mac=$(mtd_get_mac_text "mac" 24)
 		;;
 	elecom,wrc-300ghbk2-i)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary ART 4098)" -2)

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -10,6 +10,10 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+dlink,dir-825-c1|\
+dlink,dir-835-a1)
+	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"
+	;;
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -100,6 +100,11 @@ case "$FIRMWARE" in
 	avm,fritz4020)
 		ath9k_eeprom_extract_reverse "urlader" 5441 1088
 		;;
+	dlink,dir-825-c1|\
+	dlink,dir-835-a1)
+		ath9k_eeprom_extract "art" 4096 1088
+		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 4) 2
+		;;
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
 		ath9k_eeprom_extract "art" 4096 1088
@@ -123,6 +128,11 @@ case "$FIRMWARE" in
 		;;
 	buffalo,wzr-hp-g450h)
 		ath9k_eeprom_extract "ART" 4096 1088
+		;;
+	dlink,dir-825-c1|\
+	dlink,dir-835-a1)
+		ath9k_eeprom_extract "art" 20480 1088
+		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 24) 1) 2
 		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3600|\

--- a/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_dlink_dir-8x5.dtsi"
+
+/ {
+	model = "D-LINK DIR-825 C1";
+	compatible = "dlink,dir-825-c1", "qca,ar9344";
+
+	aliases {
+		led-boot = &orange_power;
+		led-failsafe = &orange_power;
+		led-running = &blue_power;
+		led-upgrade = &orange_power;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_11>;
+
+		blue_power: blue_power {
+			label = "d-link:blue:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		blue_usb {
+			label = "d-link:blue:usb";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port1>;
+		};
+
+		blue_wan {
+			label = "d-link:blue:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		blue_wlan2g {
+			label = "d-link:blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		blue_wps {
+			label = "d-link:blue:wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		orange_power: orange_power {
+			label = "d-link:orange:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		orange_wan {
+			label = "d-link:orange:wan";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds-ath9k {
+		compatible = "gpio-leds";
+
+		blue_wlan5g {
+			label = "d-link:blue:wlan5g";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&pinmux {
+	enable_gpio_11: pinmux_enable_gpio_11 {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+};
+

--- a/target/linux/ath79/dts/ar9344_dlink_dir-835-a1.dts
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-835-a1.dts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_dlink_dir-8x5.dtsi"
+
+/ {
+	model = "D-LINK DIR-835 A1";
+	compatible = "dlink,dir-835-a1", "qca,ar9344";
+
+	aliases {
+		led-boot = &orange_power;
+		led-failsafe = &orange_power;
+		led-running = &green_power;
+		led-upgrade = &orange_power;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		green_power: green_power {
+			label = "d-link:green:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		green_wan {
+			label = "d-link:green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		green_wps {
+			label = "d-link:green:wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		orange_power: orange_power {
+			label = "d-link:orange:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		orange_wan {
+			label = "d-link:orange:wan";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+

--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&eth0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+		qca,ar8327-initvals = <
+			/* GPL code drop (bsp.h & athrs17_phy.c) */
+			0x10 0xc1000000 /* PWS_REG_VALUE */
+			0x04 0x07600000 /* PORT0 PAD Mode */
+			0x0c 0x01000000 /* PORT6 PAD Mode */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6_STATUS */
+		>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				label = "nvram";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0xF90000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fb0000 {
+				label = "lang";
+				reg = <0xfb0000 0x030000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "mac";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -138,6 +138,32 @@ define Device/dlink_dir-825-b1
 endef
 TARGET_DEVICES += dlink_dir-825-b1
 
+define Device/dlink_dir-825-c1
+  ATH_SOC := ar9344
+  DEVICE_TITLE := D-LINK DIR-825 C1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
+  SUPPORTED_DEVICES += dir-825-c1
+  IMAGE_SIZE := 15936k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
+  IMAGE/factory.bin := $$(IMAGE/default) | cameo-factory $$$$(IMAGE_SIZE) 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += dlink_dir-825-c1
+
+define Device/dlink_dir-835-a1
+  ATH_SOC := ar9344
+  DEVICE_TITLE := D-LINK DIR-835 A1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-leds-reset kmod-owl-loader
+  SUPPORTED_DEVICES += dir-835-a1
+  IMAGE_SIZE := 15936k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
+  IMAGE/factory.bin := $$(IMAGE/default) | cameo-factory $$$$(IMAGE_SIZE) 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += dlink_dir-835-a1
+
 define Device/elecom_wrc-300ghbk2-i
   ATH_SOC := qca9563
   DEVICE_TITLE := ELECOM WRC-300GHBK2-I


### PR DESCRIPTION
Hello all,

Here's my port of these two boards from ar71xx to ath79. I tested a lot with the first one, the second one I don't own. But they're pretty much identical.

All LEDs work. Well, technically 5GHz wifi led doesn't work. But that's due to Felix' commit ccab68f2d399d2395a18d1fb3495fe7e048fe054 and I believe the other ath79 targets that use the ath9k gpio controller have the same problem. I'm sure that will be sorted out in due time.

I kept the behavior from ar71xx regarding MAC addresses and LEDs, except that now the blue Power LED is used when running instead of the orange one. That's also how the vendor firmware does it.

Actually for dir-835-c1 I hope that I have fixed some issues with LEDs and MACs. Anyway, don't have this router as I said, so can't test.

Kind regards,
Seb