### PR TITLE
ipq40xx: fix openmesh sysupgrade with tar content out of order

### DIFF
--- a/target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/openmesh.sh
@@ -76,9 +76,9 @@ platform_do_upgrade_openmesh() {
 	# take care of restoring a saved config
 	[ "$SAVE_CONFIG" -eq 1 ] && restore_backup="${MTD_CONFIG_ARGS} -j ${CONF_TAR}"
 
-	# write concatinated kernel + rootfs to flash
-	tar xf $tar_file ${board_dir}/kernel ${board_dir}/root -O | \
-		mtd $restore_backup write - $PART_NAME
+	mtd -q erase inactive
+	tar xf $tar_file ${board_dir}/root -O | mtd -n -p $kernel_length $restore_backup write - $PART_NAME
+	tar xf $tar_file ${board_dir}/kernel -O | mtd -n write - $PART_NAME
 
 	# prepare new u-boot env
 	if [ "$next_boot_part" = "1" ]; then


### PR DESCRIPTION
The tar extraction depends on the order in which the files
are added to the tar file. Since the order is not guaranteed
and depends on the host system, the combined mtd write fails
with sysupgrade images built on some systems.
Fix by changing to tar file order independent mtd write.

Fixes: 86e18f6706e1 ("ipq806x: add support for OpenMesh A42")