### PR TITLE
openvpn: use hotplug.d

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \
@@ -102,6 +102,7 @@ endef
 
 define Package/openvpn-$(BUILD_VARIANT)/conffiles
 /etc/config/openvpn
+/etc/openvpn.user
 endef
 
 define Package/openvpn-$(BUILD_VARIANT)/install
@@ -111,7 +112,9 @@ define Package/openvpn-$(BUILD_VARIANT)/install
 		$(1)/etc/init.d \
 		$(1)/etc/config \
 		$(1)/etc/openvpn \
-		$(1)/lib/upgrade/keep.d
+		$(1)/lib/upgrade/keep.d \
+		$(1)/usr/lib/openvpn \
+		$(1)/etc/hotplug.d/openvpn
 
 	$(INSTALL_BIN) \
 		$(PKG_INSTALL_DIR)/usr/sbin/openvpn \
@@ -120,6 +123,19 @@ define Package/openvpn-$(BUILD_VARIANT)/install
 	$(INSTALL_BIN) \
 		files/openvpn.init \
 		$(1)/etc/init.d/openvpn
+
+	$(INSTALL_BIN) \
+		files/usr/lib/openvpn/openvpn-hotplug \
+		$(1)/usr/lib/openvpn/openvpn-hotplug
+
+	$(INSTALL_DATA) \
+		files/etc/hotplug.d/openvpn/01-user \
+		$(1)/etc/hotplug.d/openvpn/01-user
+
+	$(INSTALL_DATA) \
+		files/etc/openvpn.user \
+		$(1)/etc/openvpn.user
+
 	$(INSTALL_DATA) \
 		files/openvpn.options \
 		$(1)/usr/share/openvpn/openvpn.options

--- a/package/network/services/openvpn/files/etc/hotplug.d/openvpn/01-user
+++ b/package/network/services/openvpn/files/etc/hotplug.d/openvpn/01-user
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+get_option() {
+	local variable="$1"
+	local option="$2"
+
+	local value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+(([^ \t\\]|\\.)+)[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+'"'([^']+)'"'[ \t]*$/\1/p' "$config" | tail -n1)"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+"(([^"\\]|\\.)+)"[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
+	[ -n "$value" ] || return 1
+
+	export -n "$variable=$value"
+	return 0
+}
+
+[ -e "/etc/openvpn.user" ] && {
+	env -i ACTION="$ACTION" INSTANCE="$INSTANCE" \
+		/bin/sh \
+		/etc/openvpn.user \
+		$*
+}
+
+# Wrap user defined scripts on up/down events
+case "$ACTION" in
+	up|down)
+		if get_option command "$ACTION"; then
+			exec /bin/sh -c "$command $ACTION $INSTANCE $*"
+		fi
+	;;
+esac
+
+exit 0

--- a/package/network/services/openvpn/files/etc/openvpn.user
+++ b/package/network/services/openvpn/files/etc/openvpn.user
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This file is interpreted as shell script.
+# Put your custom openvpn action here, they will
+# be executed with each opevnp event.
+#
+# $ACTION
+#      <down>    down action is generated after the TUN/TAP device is closed
+#      <up>      up action is generated after the TUN/TAP device is opened
+# $INSTANCE  Name of the openvpn instance which went up or down
+

--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -73,13 +73,17 @@ openvpn_add_instance() {
 	local name="$1"
 	local dir="$2"
 	local conf="$3"
+	local security="$4"
 
 	procd_open_instance "$name"
 	procd_set_param command "$PROG"	\
 		--syslog "openvpn($name)" \
 		--status "/var/run/openvpn.$name.status" \
 		--cd "$dir" \
-		--config "$conf"
+		--config "$conf" \
+		--up "/usr/lib/openvpn/openvpn-hotplug up $name" \
+		--down "/usr/lib/openvpn/openvpn-hotplug down $name" \
+		--script-security "${security:-2}"
 	procd_set_param file "$dir/$conf"
 	procd_set_param term_timeout 15
 	procd_set_param respawn
@@ -100,11 +104,14 @@ start_instance() {
 		return 1
 	}
 
+	local script_security
+	config_get script_security "$s" script_security
+
 	[ ! -d "/var/run" ] && mkdir -p "/var/run"
 
 	if [ ! -z "$config" ]; then
 		append UCI_STARTED "$config" "$LIST_SEP"
-		openvpn_add_instance "$s" "${config%/*}" "$config"
+		openvpn_add_instance "$s" "${config%/*}" "$config" "$script_security"
 		return
 	fi
 
@@ -115,7 +122,7 @@ start_instance() {
 	append_params "$s" $OPENVPN_PARAMS
 	append_list "$s" $OPENVPN_LIST
 
-	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf"
+	openvpn_add_instance "$s" "/var/etc" "openvpn-$s.conf" "$script_security"
 }
 
 start_service() {

--- a/package/network/services/openvpn/files/openvpn.options
+++ b/package/network/services/openvpn/files/openvpn.options
@@ -25,7 +25,6 @@ dev
 dev_node
 dev_type
 dh
-down
 ecdh_curve
 echo
 engine
@@ -103,7 +102,6 @@ route_metric
 route_pre_down
 route_up
 rport
-script_security
 secret
 server
 server_bridge
@@ -127,7 +125,6 @@ tran_window
 tun_mtu
 tun_mtu_extra
 txqueuelen
-up
 user
 verb
 verify_client_cert

--- a/package/network/services/openvpn/files/usr/lib/openvpn/openvpn-hotplug
+++ b/package/network/services/openvpn/files/usr/lib/openvpn/openvpn-hotplug
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+ACTION=$1
+shift
+INSTANCE=$1
+shift
+
+export ACTION=$ACTION
+export INSTANCE=$INSTANCE
+exec /sbin/hotplug-call openvpn "$@"


### PR DESCRIPTION
Add to openvpn the good old openwrt hotplug mechanism.
There are also the following config option which could also use **hotplug.d**.
- route-up
- ipchange
- tls-verify
- client-connect
- learn-address
- auth-user-pass