### PR TITLE
base-files: fix several bashisms

### DIFF
--- a/package/base-files/files/lib/preinit/30_failsafe_wait
+++ b/package/base-files/files/lib/preinit/30_failsafe_wait
@@ -82,7 +82,7 @@ fs_wait_for_key () {
 
 failsafe_wait() {
 	FAILSAFE=
-	[ "$pi_preinit_no_failsafe" == "y" ] && {
+	[ "$pi_preinit_no_failsafe" = "y" ] && {
 		fs_wait_for_key "" "" $fs_failsafe_wait_timeout
 		return
 	}

--- a/package/base-files/files/lib/preinit/81_urandom_seed
+++ b/package/base-files/files/lib/preinit/81_urandom_seed
@@ -18,7 +18,7 @@ do_urandom_seed() {
     _do_urandom_seed "/etc/urandom.seed"
 
     SEED="$(uci -q get system.@system[0].urandom_seed)"
-    [ "${SEED:0:1}" == "/" -a "$SEED" != "/etc/urandom.seed" ] && _do_urandom_seed "$SEED"
+    [ "${SEED:0:1}" = "/" -a "$SEED" != "/etc/urandom.seed" ] && _do_urandom_seed "$SEED"
 }
 
 boot_hook_add preinit_main do_urandom_seed

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -164,7 +164,7 @@ export_partdevice() {
 }
 
 hex_le32_to_cpu() {
-	[ "$(echo 01 | hexdump -v -n 2 -e '/2 "%x"')" == "3031" ] && {
+	[ "$(echo 01 | hexdump -v -n 2 -e '/2 "%x"')" = "3031" ] && {
 		echo "${1:0:2}${1:8:2}${1:6:2}${1:4:2}${1:2:2}"
 		return
 	}

--- a/package/base-files/files/sbin/urandom_seed
+++ b/package/base-files/files/sbin/urandom_seed
@@ -13,7 +13,7 @@ save() {
 }
 
 SEED="$(uci -q get system.@system[0].urandom_seed || true)"
-[ "${SEED:0:1}" == "/" ] && save "$SEED"
+[ "${SEED:0:1}" = "/" ] && save "$SEED"
 
 SEED=/etc/urandom.seed
 [ ! -f $SEED ] && save "$SEED"

--- a/package/base-files/files/usr/libexec/login.sh
+++ b/package/base-files/files/usr/libexec/login.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-[ "$(uci -q get system.@system[0].ttylogin)" == 1 ] || exec /bin/ash --login
+[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/ash --login
 
 exec /bin/login


### PR DESCRIPTION
For equality test a simple = is sufficient, the == is
usually disregardes as bashism.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>
