### PR TITLE
ltq-atm/ltq-ptm: re-enable/fix reset_ppe() functionality for VR9

### DIFF
--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
@@ -40,6 +40,7 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
 #include <asm/delay.h>
 
 /*
@@ -80,7 +81,7 @@
  */
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_ema(void);
 static inline void init_mailbox(void);
 static inline void init_atm_tc(void);
@@ -136,7 +137,7 @@ static inline void uninit_pmu(void)
     //PPE_TOP_PMU_SETUP(IFX_PMU_DISABLE);*/
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 #if 0 //MODULE
     unsigned int etop_cfg;
@@ -262,11 +263,11 @@ extern void ase_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ase_init(void)
+void ase_init(struct platform_device *pdev)
 {
     init_pmu();
 
-    reset_ppe();
+    reset_ppe(pdev);
 
     init_ema();
 

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
@@ -40,6 +40,7 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
 #include <asm/delay.h>
 
 /*
@@ -83,7 +84,7 @@
  */
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_ema(void);
 static inline void init_mailbox(void);
 static inline void clear_share_buffer(void);
@@ -125,7 +126,7 @@ static inline void uninit_pmu(void)
 {
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 #ifdef MODULE
     //  reset PPE
@@ -193,10 +194,10 @@ void ar9_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ar9_init(void)
+void ar9_init(struct platform_device *pdev)
 {
 	init_pmu();
-	reset_ppe();
+	reset_ppe(pdev);
 	init_ema();
 	init_mailbox();
 	clear_share_buffer();

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_core.h
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_core.h
@@ -34,7 +34,7 @@
 #define SET_BITS(x, msb, lsb, value)    (((x) & ~(((1 << ((msb) + 1)) - 1) ^ ((1 << (lsb)) - 1))) | (((value) & ((1 << (1 + (msb) - (lsb))) - 1)) << (lsb)))
 
 struct ltq_atm_ops {
-	void (*init)(void);
+	void (*init)(struct platform_device *pdev);
 	void (*shutdown)(void);
 
 	int (*start)(int pp32);

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
@@ -40,6 +40,7 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
 #include <linux/delay.h>
 
 /*
@@ -61,7 +62,7 @@
 #define EMA_WRITE_BURST      0x2
 #define EMA_READ_BURST       0x2
 
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 
 #define IFX_PMU_MODULE_PPE_SLL01  BIT(19)
 #define IFX_PMU_MODULE_PPE_TC     BIT(21)
@@ -70,7 +71,7 @@ static inline void reset_ppe(void);
 #define IFX_PMU_MODULE_TPE       BIT(13)
 #define IFX_PMU_MODULE_DSL_DFE    BIT(9)
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 /*#ifdef MODULE
     unsigned int etop_cfg;
@@ -140,7 +141,7 @@ static void danube_fw_ver(unsigned int *major, unsigned int *minor)
 	*minor = FW_VER_ID->minor;
 }
 
-static void danube_init(void)
+static void danube_init(struct platform_device *pdev)
 {
             volatile u32 *p = SB_RAM0_ADDR(0);
     unsigned int i;
@@ -152,7 +153,7 @@ static void danube_init(void)
 		IFX_PMU_MODULE_TPE |
 		IFX_PMU_MODULE_DSL_DFE);
 
-	reset_ppe();
+	reset_ppe(pdev);
 
     /* init ema */
         IFX_REG_W32((EMA_CMD_BUF_LEN << 16) | (EMA_CMD_BASE_ADDR >> 2), EMA_CMDCFG);

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
@@ -40,6 +40,8 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <asm/delay.h>
 
 #include "ifxmips_atm_core.h"
@@ -56,21 +58,46 @@
 #define IFX_PMU_MODULE_AHBS       BIT(13)
 #define IFX_PMU_MODULE_DSL_DFE    BIT(9)
 
-static inline void vr9_reset_ppe(void)
+static inline void vr9_reset_ppe(struct platform_device *pdev)
 {
-/*#ifdef MODULE
-	//  reset PPE
-	ifx_rcu_rst(IFX_RCU_DOMAIN_DSLDFE, IFX_RCU_MODULE_ATM);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	struct device *dev = &pdev->dev;
+	struct reset_control *dsp;
+	struct reset_control *dfe;
+	struct reset_control *tc;
+
+	dsp = devm_reset_control_get(dev, "dsp");
+	if (IS_ERR(dsp)) {
+		if (PTR_ERR(dsp) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup dsp reset\n");
+// 		return PTR_ERR(dsp);
+	}
+
+	dfe = devm_reset_control_get(dev, "dfe");
+	if (IS_ERR(dfe)) {
+		if (PTR_ERR(dfe) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup dfe reset\n");
+// 		return PTR_ERR(dfe);
+	}
+
+	tc = devm_reset_control_get(dev, "tc");
+	if (IS_ERR(tc)) {
+		if (PTR_ERR(tc) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup tc reset\n");
+// 		return PTR_ERR(tc);
+	}
+
+	reset_control_assert(dsp);
 	udelay(1000);
-	ifx_rcu_rst(IFX_RCU_DOMAIN_DSLTC, IFX_RCU_MODULE_ATM);
+	reset_control_assert(dfe);
 	udelay(1000);
-	ifx_rcu_rst(IFX_RCU_DOMAIN_PPE, IFX_RCU_MODULE_ATM);
+	reset_control_assert(tc);
 	udelay(1000);
 	*PP32_SRST &= ~0x000303CF;
 	udelay(1000);
 	*PP32_SRST |= 0x000303CF;
 	udelay(1000);
-#endif*/
+#endif
 }
 
 static inline int vr9_pp32_download_code(int pp32, u32 *code_src, unsigned int code_dword_len, u32 *data_src, unsigned int data_dword_len)
@@ -107,7 +134,7 @@ static void vr9_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-static void vr9_init(void)
+static void vr9_init(struct platform_device *pdev)
 {
 	volatile u32 *p;
 	unsigned int i;
@@ -120,7 +147,7 @@ static void vr9_init(void)
 		IFX_PMU_MODULE_AHBS |
 		IFX_PMU_MODULE_DSL_DFE);
 
-	vr9_reset_ppe();
+	vr9_reset_ppe(pdev);
 
 	/* pdma init */
 	IFX_REG_W32(0x08,       PDMA_CFG);

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1777,7 +1777,7 @@ static int ltq_atm_probe(struct platform_device *pdev)
 		goto INIT_PRIV_DATA_FAIL;
 	}
 
-	ops->init();
+	ops->init(pdev);
 	init_rx_tables();
 	init_tx_tables();
 

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.h
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.h
@@ -122,7 +122,7 @@ extern unsigned int ifx_ptm_dbg_enable;
 
 extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor);
 
-extern void ifx_ptm_init_chip(void);
+extern void ifx_ptm_init_chip(struct platform_device *pdev);
 extern void ifx_ptm_uninit_chip(void);
 
 extern int ifx_pp32_start(int pp32);

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_amazon_se.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_amazon_se.c
@@ -40,6 +40,8 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <asm/delay.h>
 
 /*
@@ -84,7 +86,7 @@
  */
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_ema(void);
 static inline void init_mailbox(void);
 static inline void init_atm_tc(void);
@@ -129,7 +131,7 @@ static inline void uninit_pmu(void)
     //PPE_TOP_PMU_SETUP(IFX_PMU_DISABLE);
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 #ifdef MODULE
     unsigned int etop_cfg;
@@ -260,11 +262,11 @@ extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ifx_ptm_init_chip(void)
+void ifx_ptm_init_chip(struct platform_device *pdev)
 {
     init_pmu();
 
-    reset_ppe();
+    reset_ppe(pdev);
 
     init_ema();
 

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_ar9.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_ar9.c
@@ -40,6 +40,8 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <asm/delay.h>
 
 /*
@@ -80,7 +82,7 @@
  */
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_ema(void);
 static inline void init_mailbox(void);
 static inline void init_atm_tc(void);
@@ -130,7 +132,7 @@ static inline void uninit_pmu(void)
 
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 #ifdef MODULE
     //  reset PPE
@@ -283,11 +285,11 @@ void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ifx_ptm_init_chip(void)
+void ifx_ptm_init_chip(struct platform_device *pdev)
 {
     init_pmu();
 
-    reset_ppe();
+    reset_ppe(pdev);
 
     init_ema();
 

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_danube.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_danube.c
@@ -40,6 +40,8 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <linux/delay.h>
 
 /*
@@ -79,7 +81,7 @@
  */
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_ema(void);
 static inline void init_mailbox(void);
 static inline void init_atm_tc(void);
@@ -125,7 +127,7 @@ static inline void uninit_pmu(void)
 		IFX_PMU_MODULE_DSL_DFE);
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
 #ifdef MODULE
     /*unsigned int etop_cfg;
@@ -255,11 +257,11 @@ extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ifx_ptm_init_chip(void)
+void ifx_ptm_init_chip(struct platform_device *pdev)
 {
     init_pmu();
 
-    reset_ppe();
+    reset_ppe(pdev);
 
     init_ema();
 

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -33,6 +33,8 @@
 #include <linux/etherdevice.h>
 #include <linux/interrupt.h>
 #include <linux/netdevice.h>
+#include <linux/platform_device.h>
+#include <linux/of_device.h>
 
 #include "ifxmips_ptm_vdsl.h"
 #include <lantiq_soc.h>
@@ -971,9 +973,21 @@ static int ptm_showtime_exit(void)
 	return 0;
 }
 
+static const struct of_device_id ltq_ptm_match[] = {
+#ifdef CONFIG_DANUBE
+	{ .compatible = "lantiq,ppe-danube", .data = NULL },
+#elif defined CONFIG_AMAZON_SE
+	{ .compatible = "lantiq,ppe-ase", .data = NULL },
+#elif defined CONFIG_AR9
+	{ .compatible = "lantiq,ppe-arx100", .data = NULL },
+#elif defined CONFIG_VR9
+	{ .compatible = "lantiq,ppe-xrx200", .data = NULL },
+#endif
+	{},
+};
+MODULE_DEVICE_TABLE(of, ltq_ptm_match);
 
-
-static int ifx_ptm_init(void)
+static int ltq_ptm_probe(struct platform_device *pdev)
 {
     int ret;
     int i;
@@ -986,7 +1000,7 @@ static int ifx_ptm_init(void)
         goto INIT_PRIV_DATA_FAIL;
     }
 
-    ifx_ptm_init_chip();
+    ifx_ptm_init_chip(pdev);
     ret = init_tables();
     if ( ret != 0 ) {
         err("INIT_TABLES_FAIL");
@@ -1068,7 +1082,7 @@ INIT_PRIV_DATA_FAIL:
     return ret;
 }
 
-static void __exit ifx_ptm_exit(void)
+static int ltq_ptm_remove(struct platform_device *pdev)
 {
     int i;
 	ifx_mei_atm_showtime_enter = NULL;
@@ -1092,6 +1106,8 @@ static void __exit ifx_ptm_exit(void)
     ifx_ptm_uninit_chip();
 
     clear_priv_data();
+
+    return 0;
 }
 
 #ifndef MODULE
@@ -1120,8 +1136,17 @@ static int __init queue_gamma_map_setup(char *line)
     return 0;
 }
 #endif
-module_init(ifx_ptm_init);
-module_exit(ifx_ptm_exit);
+static struct platform_driver ltq_ptm_driver = {
+	.probe = ltq_ptm_probe,
+	.remove = ltq_ptm_remove,
+	.driver = {
+		.name = "ptm",
+		.owner = THIS_MODULE,
+		.of_match_table = ltq_ptm_match,
+	},
+};
+
+module_platform_driver(ltq_ptm_driver);
 #ifndef MODULE
   __setup("wanqos_en=", wanqos_en_setup);
   __setup("queue_gamma_map=", queue_gamma_map_setup);

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.h
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.h
@@ -113,7 +113,7 @@ extern unsigned int ifx_ptm_dbg_enable;
 
 extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor);
 
-extern void ifx_ptm_init_chip(void);
+extern void ifx_ptm_init_chip(struct platform_device *pdev);
 extern void ifx_ptm_uninit_chip(void);
 
 extern int ifx_pp32_start(int pp32);

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vr9.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vr9.c
@@ -40,6 +40,8 @@
 #include <linux/proc_fs.h>
 #include <linux/init.h>
 #include <linux/ioctl.h>
+#include <linux/platform_device.h>
+#include <linux/reset.h>
 #include <asm/delay.h>
 
 /*
@@ -52,7 +54,7 @@
 
 static inline void init_pmu(void);
 static inline void uninit_pmu(void);
-static inline void reset_ppe(void);
+static inline void reset_ppe(struct platform_device *pdev);
 static inline void init_pdma(void);
 static inline void init_mailbox(void);
 static inline void init_atm_tc(void);
@@ -80,21 +82,46 @@ static inline void uninit_pmu(void)
 {
 }
 
-static inline void reset_ppe(void)
+static inline void reset_ppe(struct platform_device *pdev)
 {
-/*#ifdef MODULE
-    //  reset PPE
-    ifx_rcu_rst(IFX_RCU_DOMAIN_DSLDFE, IFX_RCU_MODULE_PTM);
-    udelay(1000);
-    ifx_rcu_rst(IFX_RCU_DOMAIN_DSLTC, IFX_RCU_MODULE_PTM);
-    udelay(1000);
-    ifx_rcu_rst(IFX_RCU_DOMAIN_PPE, IFX_RCU_MODULE_PTM);
-    udelay(1000);
-    *PP32_SRST &= ~0x000303CF;
-    udelay(1000);
-    *PP32_SRST |= 0x000303CF;
-    udelay(1000);
-#endif*/
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+	struct device *dev = &pdev->dev;
+	struct reset_control *dsp;
+	struct reset_control *dfe;
+	struct reset_control *tc;
+
+	dsp = devm_reset_control_get(dev, "dsp");
+	if (IS_ERR(dsp)) {
+		if (PTR_ERR(dsp) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup dsp reset\n");
+// 		return PTR_ERR(dsp);
+	}
+
+	dfe = devm_reset_control_get(dev, "dfe");
+	if (IS_ERR(dfe)) {
+		if (PTR_ERR(dfe) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup dfe reset\n");
+// 		return PTR_ERR(dfe);
+	}
+
+	tc = devm_reset_control_get(dev, "tc");
+	if (IS_ERR(tc)) {
+		if (PTR_ERR(tc) != -EPROBE_DEFER)
+			dev_err(dev, "Failed to lookup tc reset\n");
+// 		return PTR_ERR(tc);
+	}
+
+	reset_control_assert(dsp);
+	udelay(1000);
+	reset_control_assert(dfe);
+	udelay(1000);
+	reset_control_assert(tc);
+	udelay(1000);
+	*PP32_SRST &= ~0x000303CF;
+	udelay(1000);
+	*PP32_SRST |= 0x000303CF;
+	udelay(1000);
+#endif
 }
 
 static inline void init_pdma(void)
@@ -230,11 +257,11 @@ extern void ifx_ptm_get_fw_ver(unsigned int *major, unsigned int *minor)
     *minor = FW_VER_ID->minor;
 }
 
-void ifx_ptm_init_chip(void)
+void ifx_ptm_init_chip(struct platform_device *pdev)
 {
     init_pmu();
 
-    reset_ppe();
+    reset_ppe(pdev);
 
     init_pdma();
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
@@ -297,6 +297,8 @@
 			compatible = "lantiq,ppe-xrx200";
 			interrupt-parent = <&icu0>;
 			interrupts = <96>;
+			resets = <&reset0 3 3>, <&reset0 11 11>, <&reset0 23 23>;
+			reset-names = "dsp", "dfe", "tc";
 		};
 
 		pcie0: pcie@d900000 {


### PR DESCRIPTION
This patch re-enables the reset_ppe() functionality for VR9 targets by using
the new lantiq rcu subsystem. The reset sequence in the reset_ppe() function
was taken from the ppa datapath driver of lantiq UGW 7.4.1.

Additionally it adds the required reset definitions to the vr9 dtsi file.

It also prepares the reset_ppe() function calls for the other lantiq targets.

This feature is needed to be able to switch between ltq-atm/ltq-ptm driver
in ATM/PTM Auto-Mode at runtime.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
