### PR TITLE
ramips: mt7628: add TP-Link Archer C20 V4  mt7610e 5 GHz radio

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -223,6 +223,7 @@ define Device/tplink_c20-v4
   TPLINK_HWREV := 0x1
   TPLINK_HWREVADD := 0x4
   TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-mt76x0e
 endef
 TARGET_DEVICES += tplink_c20-v4
 


### PR DESCRIPTION
The 5 GHz radio of this device uses an mt7610e pci-e chip.
mt76 driver now supports this chip.
