### PR TITLE
ramips: disable sdhc for HC5661A

### DIFF
--- a/target/linux/ramips/dts/HC5661A.dts
+++ b/target/linux/ramips/dts/HC5661A.dts
@@ -62,11 +62,11 @@
 		};
 	};
 };
-
+/*
 &sdhci {
 	status = "okay";
 };
-
+*/
 &spi0 {
 	status = "okay";
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -65,7 +65,6 @@ define Device/hc5661a
   DTS := HC5661A
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := HiWiFi HC5661A
-  DEVICE_PACKAGES := kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += hc5661a
 


### PR DESCRIPTION
Currently OpenWrt doesn't support switching MT7628 into AP mode
(which is done by writing some undocumented registers in MTK SDK)
Without doing so, enabling SD breaks 4 FE ports and the SD controller
doesn't work since SD pins aren't configured correctly.

Disable SDHC on HC5661A to recover the 4 FE ports.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>