### PR TITLE
ath79: dts: Use PowerCloud CAP324 bicolor status LED

### DIFF
--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -14,7 +14,7 @@
 		serial0 = &uart;
 		led-boot = &status;
 		led-failsafe = &status;
-		led-running = &status;
+		led-running = &running;
 		led-upgrade = &status;
 	};
 
@@ -36,13 +36,13 @@
 	leds {
 		compatible = "gpio-leds";
 
-		power_amber {
+		status: power_amber {
 			label = "pcs:amber:power";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 		};
 
-		status: power_green {
+		running: power_green {
 			label = "pcs:green:power";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			default-state = "on";


### PR DESCRIPTION
PowerCloud Systems CAP324 has a bicolor power LED and OpenWrt DTS files /
base files support using both colours to better inform user of state
and to better match stock firmware, so use green power to indicate
normal operation.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

@mkresin Is this the right way to do bicolor LED status?