### PR TITLE
Reduce reproducibility problems of sysupgrade.tar files

### DIFF
--- a/scripts/sysupgrade-tar.sh
+++ b/scripts/sysupgrade-tar.sh
@@ -61,7 +61,7 @@ if [ -n "$SOURCE_DATE_EPOCH" ]; then
 	mtime="--mtime=@${SOURCE_DATE_EPOCH}"
 fi
 
-(cd "$tmpdir"; tar --sort=name -cvf sysupgrade.tar sysupgrade-${board} ${mtime})
+(cd "$tmpdir"; tar --sort=name --owner=0 --group=0 --numeric-owner -cvf sysupgrade.tar sysupgrade-${board} ${mtime})
 err="$?"
 if [ -e "$tmpdir/sysupgrade.tar" ]; then
 	cp "$tmpdir/sysupgrade.tar" "$outfile"

--- a/scripts/sysupgrade-tar.sh
+++ b/scripts/sysupgrade-tar.sh
@@ -61,7 +61,7 @@ if [ -n "$SOURCE_DATE_EPOCH" ]; then
 	mtime="--mtime=@${SOURCE_DATE_EPOCH}"
 fi
 
-(cd "$tmpdir"; tar cvf sysupgrade.tar sysupgrade-${board} ${mtime})
+(cd "$tmpdir"; tar --sort=name -cvf sysupgrade.tar sysupgrade-${board} ${mtime})
 err="$?"
 if [ -e "$tmpdir/sysupgrade.tar" ]; then
 	cp "$tmpdir/sysupgrade.tar" "$outfile"


### PR DESCRIPTION
@jow- here are some of the fixes (including the one requested by you in https://github.com/openwrt/openwrt/pull/1594#issuecomment-444763163) to improve the reproducible of the sysupgrade.tar files. I've tackled:

* ordering of files in sysupgrade.tar
* user/group names
* user/group IDs
* file creation modes