### PR TITLE
ath79: fix ethernet configurations for I-O DATA ETG3-R

### DIFF
--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -46,6 +46,10 @@
 	};
 };
 
+&ref {
+	clock-frequency = <40000000>;
+};
+
 &spi {
 	num-cs = <1>;
 	status = "okay";
@@ -119,10 +123,18 @@
 &eth0 {
 	status = "okay";
 
-	pll-data = <0x06000000 0x00000101 0x00001616>;
+	pll-data = <0x0e000000 0x00000101 0x00001616>;
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		rgmii-gmac0 = <1>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
 };
 
 &uart {


### PR DESCRIPTION
This commit fixes several issues in eth0 on ETG3-R, and solve slowdown
in NA(P)T speed.

- add gmac-config with correct configurations
- fix pll-data value

And I added ref clock-frequency.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>