### PR TITLE
ath79: tweak the position of factory partition for wr818

### DIFF
--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -83,16 +83,16 @@
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x050000 0xf80000>;
+			info: partition@50000 {
+				label = "factory";
+				reg = <0x050000 0x010000>;
+				read-only;
 			};
 
-			info: partition@fd0000 {
-				label = "factory";
-				reg = <0xfd0000 0x010000>;
-				read-only;
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xf80000>;
 			};
 
 			art: partition@ff0000 {


### PR DESCRIPTION

This commit change the position of 'factory' pattition for WR818,
we move it to 0x50000-0x60000.

Signed-off-by: Rosy Song <rosysong@rosinson.com>
