### PR TITLE
omcproxy: Rework omcproxy.init to make it work again

### DIFF
--- a/package/network/services/omcproxy/files/omcproxy.init
+++ b/package/network/services/omcproxy/files/omcproxy.init
@@ -10,7 +10,7 @@ PROG=/usr/sbin/omcproxy
 PROXIES=""
 
 omcproxy_add_proxy() {
-	local proxy scope uplink downlinks device up
+	local proxy scope uplink downlinks device
 
 	config_get scope $1 scope
 	config_get uplink $1 uplink
@@ -18,14 +18,7 @@ omcproxy_add_proxy() {
 
 	[ -n "$uplink" ] || return
 
-	local status="$(ubus -S call "network.interface.$uplink" status)"
-	[ -n "$status" ] || return
-
-	json_load "$status"
-	json_get_var device l3_device
-	json_get_var up up
-
-	[ -n "$device" -a "$up" = "1" ] || {
+	network_get_device device "$uplink" || {
 		procd_append_param error "$uplink is not up"
 		return;
 	}
@@ -33,14 +26,7 @@ omcproxy_add_proxy() {
 	proxy="$device"
 
 	for downlink in $downlinks; do
-		local status="$(ubus -S call "network.interface.$downlink" status)"
-		[ -n "$status" ] || return
-
-		json_load "$status"
-		json_get_var device l3_device
-		json_get_var up up
-
-		[ -n "$device" -a "$up" = "1" ] || {
+		network_get_device device "$downlink" || {
 			procd_append_param error "$downlink is not up"
 			continue;
 		}
@@ -64,9 +50,8 @@ omcproxy_add_network_triggers() {
 	config_get uplink $1 uplink
 	config_get downlinks $1 downlink
 
-	procd_add_interface_trigger "interface.*" $uplink /etc/init.d/omcproxy reload
-	for downlink in $downlinks; do
-		procd_add_interface_trigger "interface.*" $downlink /etc/init.d/omcproxy reload
+	for link in $uplink $downlinks; do
+		procd_add_interface_trigger "interface.*" $link /etc/init.d/omcproxy reload
 	done
 }
 
@@ -134,6 +119,8 @@ service_triggers() {
 }
 
 start_service() {
+	. /lib/functions/network.sh
+
 	config_load omcproxy
 
 	config_foreach omcproxy_add_proxy proxy

--- a/package/network/services/omcproxy/files/omcproxy.init
+++ b/package/network/services/omcproxy/files/omcproxy.init
@@ -1,55 +1,80 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2010-2014 OpenWrt.org
+# Copyright (C) 2018 OpenWrt.org
 
 START=99
 USE_PROCD=1
 PROG=/usr/sbin/omcproxy
 
-# Uncomment to enable verbosity 
-#OPTIONS="-v" 
+# Uncomment to enable verbosity
+#OPTIONS="-v"
 PROXIES=""
 
-
 omcproxy_add_proxy() {
-	local uplink downlink scope proxy
-	config_get uplink $1 uplink
-	config_get downlink $1 downlink
+	local proxy scope uplink downlinks device up
+
 	config_get scope $1 scope
+	config_get uplink $1 uplink
+	config_get downlinks $1 downlink
 
-	proxy=""
+	[ -n "$uplink" ] || return
 
-	network_get_device updev $uplink
-	[ -n "$updev" ] || return 0
+	local status="$(ubus -S call "network.interface.$uplink" status)"
+	[ -n "$status" ] || return
 
-	for network in $downlink; do
-		network_get_device downdev $network
-		[ -n "$downdev" ] && proxy="$proxy,$downdev"
+	json_load "$status"
+	json_get_var device l3_device
+	json_get_var up up
 
-		# Disable in-kernel querier while ours is active
-		[ -f /sys/class/net/$downdev/bridge/multicast_querier ] && \
-			echo 0 > /sys/class/net/$downdev/bridge/multicast_querier
+	[ -n "$device" -a "$up" = "1" ] || {
+		procd_append_param error "$uplink is not up"
+		return;
+	}
+
+	proxy="$device"
+
+	for downlink in $downlinks; do
+		local status="$(ubus -S call "network.interface.$downlink" status)"
+		[ -n "$status" ] || return
+
+		json_load "$status"
+		json_get_var device l3_device
+		json_get_var up up
+
+		[ -n "$device" -a "$up" = "1" ] || {
+			procd_append_param error "$downlink is not up"
+			continue;
+		}
+
+		proxy="$proxy,$device"
+
+		# Disable in-kernel querier while ours is active, default is 1.
+		[ -f /sys/class/net/$device/bridge/multicast_querier ] && \
+			echo 0 > /sys/class/net/$device/bridge/multicast_querier
 	done
 
 	[ -n "$proxy" ] || return 0
 	[ -n "$scope" ] && proxy="$proxy,scope=$scope"
 
-	PROXIES="$PROXIES $updev$proxy"
-
+	PROXIES="$PROXIES $proxy"
 }
 
-omcproxy_add_trigger() {
-	local uplink downlink
-	config_get uplink $1 uplink
-	config_get downlink $1 downlink
+omcproxy_add_network_triggers() {
+	local uplink downlinks
 
-	for network in $uplink $downlink; do
-		procd_add_interface_trigger "interface.*" $network /etc/init.d/omcproxy restart
+	config_get uplink $1 uplink
+	config_get downlinks $1 downlink
+
+	procd_add_interface_trigger "interface.*" $uplink /etc/init.d/omcproxy reload
+	for downlink in $downlinks; do
+		procd_add_interface_trigger "interface.*" $downlink /etc/init.d/omcproxy reload
 	done
 }
 
-omcproxy_add_firewall() {
+omcproxy_add_firewall_rules() {
+	local uplink downlinks
+
 	config_get uplink $1 uplink
-	config_get downlink $1 downlink
+	config_get downlinks $1 downlink
 
 	upzone=$(fw3 -q network $uplink 2>/dev/null)
 	[ -n "$upzone" ] || return 0
@@ -57,6 +82,7 @@ omcproxy_add_firewall() {
 	json_add_object ""
 	json_add_string type rule
 	json_add_string src "$upzone"
+	json_add_string family ipv4
 	json_add_string proto igmp
 	json_add_string target ACCEPT
 	json_close_object
@@ -76,8 +102,8 @@ omcproxy_add_firewall() {
 	json_add_string target ACCEPT
 	json_close_object
 
-	for network in $downlink; do
-		downzone=$(fw3 -q network $network 2>/dev/null)
+	for downlink in $downlinks; do
+		downzone=$(fw3 -q network $downlink 2>/dev/null)
 		[ -n "$downzone" ] || continue
 
 		json_add_object ""
@@ -85,7 +111,7 @@ omcproxy_add_firewall() {
 		json_add_string src "$upzone"
 		json_add_string dest "$downzone"
 		json_add_string family ipv4
-		json_add_string proto any
+		json_add_string proto udp
 		json_add_string dest_ip "224.0.0.0/4"
 		json_add_string target ACCEPT
 		json_close_object
@@ -95,7 +121,7 @@ omcproxy_add_firewall() {
 		json_add_string src "$upzone"
 		json_add_string dest "$downzone"
 		json_add_string family ipv6
-		json_add_string proto any
+		json_add_string proto udp
 		json_add_string dest_ip "ff00::/8"
 		json_add_string target ACCEPT
 		json_close_object
@@ -104,14 +130,13 @@ omcproxy_add_firewall() {
 
 service_triggers() {
 	procd_add_reload_trigger "omcproxy"
+	config_foreach omcproxy_add_network_triggers proxy
 }
 
 start_service() {
-	include /lib/functions
-
 	config_load omcproxy
-	config_foreach omcproxy_add_proxy proxy
 
+	config_foreach omcproxy_add_proxy proxy
 	[ -n "$PROXIES" ] || return 0
 
 	procd_open_instance
@@ -120,24 +145,24 @@ start_service() {
 	procd_append_param command $PROXIES
 	procd_set_param respawn
 
-	procd_open_trigger
-	config_foreach omcproxy_add_trigger proxy
-	procd_close_trigger
-
 	procd_open_data
 
 	json_add_array firewall
-	config_foreach omcproxy_add_firewall proxy
+	config_foreach omcproxy_add_firewall_rules proxy
 	json_close_array
 
 	procd_close_data
 
 	procd_close_instance
 
-	# Increase maximum IPv4 group memberships per socket
+	# Increase maximum IPv4 group memberships per socket, default is 100.
 	echo 128 > /proc/sys/net/ipv4/igmp_max_memberships
 }
 
 service_started() {
+	procd_set_config_changed firewall
+}
+
+stop_service() {
 	procd_set_config_changed firewall
 }


### PR DESCRIPTION
Actual omcproxy,init file doesn't bring up omcproxy at boot. This version is based in igmpproxy.init but adapted to omcproxy config file structure.

Changes from the old init are:
Set up network triggers in service_triggers.
Use ubus calls to get network device from interface name.
Use ubus calls to get interface status.
Specify proper family and proto options in firewall rules.

This fixes https://bugs.openwrt.org/index.php?do=details&task_id=1972 where omcproxy will not start up at boot because triggers aren't set properly in that situation and the network interface is not up when omcproxy init file starts. This init version set ups triggers even when no interface is up for the ones defined in omcproxy's config so when interface is ready it brings up.

 Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>