### PR TITLE
iptables: add missing upstream patch

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.8.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.netfilter.org/iptables

--- a/package/network/utils/iptables/patches/003-ebtables-vlan-fix_userspace_kernel_headers_collision.patch
+++ b/package/network/utils/iptables/patches/003-ebtables-vlan-fix_userspace_kernel_headers_collision.patch
@@ -1,0 +1,46 @@
+From 51d374ba41ae4f1bb851228c06b030b83dd2092f Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Tue, 13 Nov 2018 19:22:08 +0200
+Subject: ebtables: vlan: fix userspace/kernel headers collision
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Build with musl libc fails because of conflicting struct ethhdr
+definitions:
+
+In file included from .../sysroot/usr/include/net/ethernet.h:10:0,
+                 from ../iptables/nft-bridge.h:8,
+                 from libebt_vlan.c:18:
+.../sysroot/usr/include/netinet/if_ether.h:107:8: error: redefinition of ‘struct ethhdr’
+ struct ethhdr {
+        ^~~~~~
+In file included from libebt_vlan.c:16:0:
+.../sysroot/usr/include/linux/if_ether.h:160:8: note: originally defined here
+ struct ethhdr {
+        ^~~~~~
+
+Include the userspace header first for the definition suppression logic
+to do the right thing.
+
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ extensions/libebt_vlan.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/extensions/libebt_vlan.c b/extensions/libebt_vlan.c
+index 4a2eb712..be269c6c 100644
+--- a/extensions/libebt_vlan.c
++++ b/extensions/libebt_vlan.c
+@@ -12,6 +12,7 @@
+ #include <getopt.h>
+ #include <ctype.h>
+ #include <xtables.h>
++#include <netinet/if_ether.h>
+ #include <linux/netfilter_bridge/ebt_vlan.h>
+ #include <linux/if_ether.h>
+ #include "iptables/nft.h"
+-- 
+cgit v1.2.1
+


### PR DESCRIPTION
This fix some compilation error with ebtables by adding an upstream patch.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>