### PR TITLE
ath9k: don't unconditionally mask AH_USE_EEPROM

### DIFF
--- a/target/linux/ath79/dts/ar9342_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9342_pcs_cr5000.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "PowerCloud Systems CR5000";
-	compatible = "pcs,cr5000", "qca,ar9344";
+	compatible = "pcs,cr5000", "qca,ar9342";
 
 	aliases {
 		serial0 = &uart;
@@ -18,7 +18,7 @@
 		led-upgrade = &status;
 	};
 
-	keys {
+	gpio-keys-polled {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
@@ -40,7 +40,7 @@
 		};
 	};
 
-	leds {
+	gpio-leds {
 		compatible = "gpio-leds";
 
 		status: power {
@@ -124,7 +124,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	hub_port1: port@1 {
+	hub_port: port@1 {
 		reg = <1>;
 		#trigger-source-cells = <0>;
 	};
@@ -138,11 +138,7 @@
 	status = "okay";
 
 	ath9k: wifi@0,0 {
-		compatible = "pci168c,0030";
-		reg = <0x0000 0 0 0 0>;
 		mtd-mac-address = <&art 0x5002>;
-		#gpio-cells = <2>;
-		gpio-controller;
 	};
 };
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -278,7 +278,7 @@ endef
 TARGET_DEVICES += pcs_cr3000
 
 define Device/pcs_cr5000
-  ATH_SOC := ar9344
+  ATH_SOC := ar9342
   DEVICE_TITLE := PowerCloud Systems CR5000
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-core
   IMAGE_SIZE := 7808k


### PR DESCRIPTION
* The PowerCloud CR5000 uses AR1022 SoC (detects as AR9342) not
  an AR9344.
* Fix PCIe to use the same settings as ap94_pci_init for ar71xx.
* Some DTS renaming (e.g. to gpio-keys-polls from keys)


Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>

@mkresin (or anyone else): Any idea why ``mtd-mac-address`` is not being used for the PCIe ath9k wireless?  The mac address from the PCI EEPROM is being used instead (which is not the OEM's MAC address which is at art + 0x5002 on the flash).

Also, while this gets 5GHz wireless working again on the CR5000, I'm not sure the wifi@0,12 and reg = <0x9000 0 0 0 0x10000> are actually right, and am wondering how to determine (for certain) the correct values.