### PR TITLE
[WIP/RFC] elfutils: install library files for pkg-config

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.174
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
@@ -71,6 +71,9 @@ define Build/InstallDev
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libasm*.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libdw*.{a,so*} $(1)/usr/lib/
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libelf*.{a,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libelf.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libdw.pc $(1)/usr/lib/pkgconfig/
 endef
 
 define Package/libasm/install


### PR DESCRIPTION
Maintainer: @luizluca 
Compile tested: mips32-be-malta, openwrt-18.06 & master branch
Run tested: mips32-be-malta, openwrt-18.06 & master branch
Dev tested: building `iproute2` with `libelf` detection using `pkg-config`
Dependent PR: https://github.com/openwrt/openwrt/pull/1627 (iproute2)

Description:
Support other packages using pkg-config to query existence and details of
libelf and libdw libraries at build time. This PR is also needed by https://github.com/openwrt/openwrt/pull/1627.
