### PR TITLE
ramips: add support for CreativeBox v1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -255,6 +255,10 @@ netgear,r6120)
 oy-0001)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+creativebox-v1-nor|\
+creativebox-v1-nand)
+	ucidef_set_led_netdev "internet" "internet" "creativebox-v1:blue:internet" "eth0.2"
+	;;
 pbr-m1)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -80,6 +80,8 @@ ramips_setup_interfaces()
 	ai-br100|\
 	alfa-network,ac1200rm|\
 	mediatek,ap-mt7621a-v60|\
+	creativebox-v1-nor|\
+	creativebox-v1-nand|\
 	d240|\
 	db-wrt01|\
 	dir-300-b7|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -100,6 +100,12 @@ ramips_board_detect() {
 	*"CF-WR800N")
 		name="cf-wr800n"
 		;;
+	*"CreativeBox v1 (NOR)")
+		name="creativebox-v1-nor"
+		;;
+	*"CreativeBox v1 (NAND)")
+		name="creativebox-v1-nand"
+		;;
 	*"CS-QR10")
 		name="cs-qr10"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -37,6 +37,7 @@ platform_check_image() {
 	c108|\
 	carambola|\
 	cf-wr800n|\
+	creativebox-v1-nor|\
 	cs-qr10|\
 	d105|\
 	d240|\
@@ -307,6 +308,7 @@ platform_check_image() {
 		}
 		return 0
 		;;
+	creativebox-v1-nand|\
 	hc5962|\
 	mir3g|\
 	r6220|\
@@ -364,6 +366,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	creativebox-v1-nand|\
 	hc5962|\
 	mir3g|\
 	r6220|\

--- a/target/linux/ramips/dts/CreativeBox-v1-nand.dts
+++ b/target/linux/ramips/dts/CreativeBox-v1-nand.dts
@@ -1,0 +1,69 @@
+/dts-v1/;
+
+#include "CreativeBox-v1.dtsi"
+
+/ {
+	compatible = "xzwifi,creativebox-v1-nand", "mediatek,mt7621-soc";
+	model = "CreativeBox v1 (NAND)";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "snor-firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+
+	spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x300000>;
+			};
+
+			partition@300000 {
+				label = "ubi";
+				reg = <0x300000 0xfd00000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/dts/CreativeBox-v1-nor.dts
+++ b/target/linux/ramips/dts/CreativeBox-v1-nor.dts
@@ -1,0 +1,70 @@
+/dts-v1/;
+
+#include "CreativeBox-v1.dtsi"
+
+/ {
+	compatible = "xzwifi,creativebox-v1-nor", "mediatek,mt7621-soc";
+	model = "CreativeBox v1 (NOR)";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+
+	spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "snand-kernel";
+				reg = <0x0 0x300000>;
+			};
+
+			partition@300000 {
+				label = "snand-ubi";
+				reg = <0x300000 0xfd00000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/dts/CreativeBox-v1.dtsi
+++ b/target/linux/ramips/dts/CreativeBox-v1.dtsi
@@ -1,0 +1,125 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1C000000>,
+		      <0x20000000 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "creativebox-v1:blue:power";
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_sys: sys {
+			label = "creativebox-v1:blue:sys";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "creativebox-v1:blue:internet";
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "creativebox-v1:blue:wlan2g";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "creativebox-v1:blue:wlan5g";
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power_usb2 {
+			gpio-export,name = "power_usb2";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_usb3 {
+			gpio-export,name = "power_usb3";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		power_sata {
+			gpio-export,name = "power_sata";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt", "rgmii2", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -121,6 +121,32 @@ define Device/mediatek_ap-mt7621a-v60
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
+define Device/creativebox-v1-nor
+  DTS := CreativeBox-v1-nor
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := CreativeBox v1 (NOR)
+  DEVICE_PACKAGES := \
+	kmod-ata-core kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
+	kmod-usb3 wpad-basic
+endef
+TARGET_DEVICES += creativebox-v1-nor
+
+define Device/creativebox-v1-nand
+  DTS := CreativeBox-v1-nand
+  DEVICE_TITLE := CreativeBox v1 (NAND)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 3072k
+  UBINIZE_OPTS := -E 5
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := \
+	kmod-ata-core kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
+	kmod-usb3 wpad-basic
+endef
+TARGET_DEVICES += creativebox-v1-nand
+
 define Device/elecom_wrc-1167ghbk2-s
   DTS := WRC-1167GHBK2-S
   IMAGE_SIZE := 15488k


### PR DESCRIPTION
Hardware:
SoC: MT7621
DRAM: 512MB DDR3
Flash1: 32MB SPI-NOR
Flash2: 256MB SPI-NAND
WiFi 2.4GHz: MT7603 @ PCIe0
WiFi 5.8GHz: MT7612 @ PCIe1
SATA: ASM1061 @ PCIe2 (SATA + eSATA)

Flash instructions:
Through factory bootloader or firmware web interface

Signed-off-by: Weijie Gao <hackpascal@gmail.com>