### PR TITLE
scripts: support the $ORIGIN only without back slash to specify rpath

### DIFF
--- a/scripts/rstrip.sh
+++ b/scripts/rstrip.sh
@@ -34,7 +34,7 @@ find $TARGETS -type f -a -exec file {} \; | \
 			old_rpath="$($PATCHELF --print-rpath $F)"; new_rpath=""
 			for path in $old_rpath; do
 				case "$path" in
-					/lib/[^/]*|/usr/lib/[^/]*|\$ORIGIN/*) new_rpath="${new_rpath:+$new_rpath:}$path" ;;
+					/lib/[^/]*|/usr/lib/[^/]*|\$ORIGIN/*|\$ORIGIN) new_rpath="${new_rpath:+$new_rpath:}$path" ;;
 					*) echo "$SELF: $F: removing rpath $path" ;;
 				esac
 			done


### PR DESCRIPTION
2efe776 introduces the bad rpaths check with the following description:

> Remove all rpath entries which do not point to a location below /lib or
> /usr/lib and which do not begin with '$ORIGIN'.

However the implementation are "begin with '$ORIGIN/'", somehow we need
to support `$ORIGIN` without back slash, too.

/cc @jow- 