### PR TITLE
uClibc++: Support quoted argument pass-through

### DIFF
--- a/package/libs/uclibc++/Makefile
+++ b/package/libs/uclibc++/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uclibc++
 PKG_VERSION:=0.2.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=uClibc++-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://cxx.uclibc.org/src/

--- a/package/libs/uclibc++/patches/060-Bugfix-escape-arguments.patch
+++ b/package/libs/uclibc++/patches/060-Bugfix-escape-arguments.patch
@@ -1,0 +1,18 @@
+--- a/bin/Makefile	2018-12-10 13:14:47.824789823 -0700
++++ b/bin/Makefile	2018-12-10 13:16:25.602465991 -0700
+@@ -24,7 +24,7 @@
+ 	echo 'WRAPPER_INCLIB="Y"' >> $@
+ 	echo 'while [ -n "$$1" ]' >> $@
+ 	echo 'do' >> $@
+-	echo '	WRAPPER_OPTIONS="$$WRAPPER_OPTIONS $$1"' >> $@
++	echo '	WRAPPER_OPTIONS="$$WRAPPER_OPTIONS '"'"'$$1'"'"'"' >> $@
+ 	echo '	if [ "$$1" = "-c" -o "$$1" = "-E" -o "$$1" = "-S" -o "$$1" = "-MF" ]' >> $@
+ 	echo '	then' >> $@
+ 	echo '		WRAPPER_INCLIB="N"' >> $@
+@@ -45,5 +45,5 @@
+ ifeq ($(DODEBUG),y)
+ 	echo 'echo $(CXX) $(GEN_CFLAGS) $(GEN_CXXFLAGS) $(EH_CXXFLAGS) $$WRAPPER_INCLUDEDIR $$WRAPPER_OPTIONS' >> $@
+ endif
+-	echo 'exec $(CXX) $(GEN_CFLAGS) $(GEN_CXXFLAGS) $(EH_CXXFLAGS) $$WRAPPER_INCLUDEDIR $$WRAPPER_OPTIONS' >> $@
++	echo 'eval $(CXX) $(GEN_CFLAGS) $(GEN_CXXFLAGS) $(EH_CXXFLAGS) "$$WRAPPER_INCLUDEDIR" "$$WRAPPER_OPTIONS"' >> $@
+ 	chmod 755 $@


### PR DESCRIPTION
This patch permits the pass-through of command-line arguments which contain spaces and quotes.

This patch was created due to a problem reported here:
- https://gist.github.com/neheb/5f4ddcfa370952808dca4842f5bd3dc5
- https://github.com/openwrt/packages/pull/7616

Signed-off-by: Joseph Benden <joe@benden.us>