### PR TITLE
ipq806x: fix and cleanup dts for NEC WG2600HP

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
@@ -26,7 +26,7 @@
 		mdio-gpio0 = &mdio0;
 
 		led-boot = &power_green;
-		led-failsafe = &power_green;
+		led-failsafe = &power_red;
 		led-running = &power_green;
 		led-upgrade = &power_green;
 	};
@@ -36,256 +36,6 @@
 	};
 
 	soc {
-		pinmux@800000 {
-			button_pins: button_pins {
-				mux {
-					pins = "gpio16", "gpio54", "gpio24", "gpio25";
-					function = "gpio";
-					drive-strength = <2>;
-					bias-pull-up;
-				};
-			};
-
-			i2c4_pins: i2c4_pinmux {
-				mux {
-					pins = "gpio12", "gpio13";
-					function = "gsbi4";
-					drive-strength = <12>;
-					bias-disable;
-				};
-			};
-
-			led_pins: led_pins {
-				mux {
-					pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio14",
-						"gpio15", "gpio55", "gpio56", "gpio57", "gpio58",
-						"gpio64", "gpio65";
-					function = "gpio";
-					drive-strength = <2>;
-					bias-pull-down;
-				};
-			};
-
-			spi_pins: spi_pins {
-				mux {
-					pins = "gpio18", "gpio19", "gpio21";
-					function = "gsbi5";
-					bias-pull-down;
-				};
-
-				data {
-					pins = "gpio18", "gpio19";
-					drive-strength = <10>;
-				};
-
-				cs {
-					pins = "gpio20";
-					drive-strength = <10>;
-					bias-pull-up;
-				};
-
-				clk {
-					pins = "gpio21";
-					drive-strength = <12>;
-				};
-			};
-
-			mdio0_pins: mdio0_pins {
-				mux {
-					pins = "gpio0", "gpio1";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
-			rgmii2_pins: rgmii2_pins {
-				mux {
-					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-					function = "rgmii2";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
-			usb_pwr_en_pins: usb_pwr_en_pins {
-				mux {
-					pins = "gpio22";
-					function = "gpio";
-					drive-strength = <2>;
-					bias-pull-down;
-					output-high;
-				};
-			};
-		};
-
-		gsbi@16300000 {
-			qcom,mode = <GSBI_PROT_I2C_UART>;
-			status = "ok";
-			serial@16340000 {
-				status = "ok";
-			};
-			/*
-			 * The i2c device on gsbi4 should not be enabled.
-			 * On ipq806x designs gsbi4 i2c is meant for exclusive
-			 * RPM usage. Turning this on in kernel manifests as
-			 * i2c failure for the RPM.
-			 */
-		};
-
-		gsbi5: gsbi@1a200000 {
-			qcom,mode = <GSBI_PROT_SPI>;
-			status = "ok";
-
-			spi4: spi@1a280000 {
-				status = "ok";
-
-				pinctrl-0 = <&spi_pins>;
-				pinctrl-names = "default";
-
-				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
-
-				flash: m25p80@0 {
-					compatible = "jedec,spi-nor";
-					#address-cells = <1>;
-					#size-cells = <1>;
-					spi-max-frequency = <50000000>;
-					reg = <0>;
-
-					SBL1@0 {
-						label = "SBL1";
-						reg = <0x0 0x20000>;
-						read-only;
-					};
-
-					MIBIB@20000 {
-						label = "MIBIB";
-						reg = <0x20000 0x20000>;
-						read-only;
-					};
-
-					SBL2@40000 {
-						label = "SBL2";
-						reg = <0x40000 0x40000>;
-						read-only;
-					};
-
-					SBL3@80000 {
-						label = "SBL3";
-						reg = <0x80000 0x80000>;
-						read-only;
-					};
-
-					DDRCONFIG@100000 {
-						label = "DDRCONFIG";
-						reg = <0x100000 0x10000>;
-						read-only;
-					};
-
-					SSD@110000 {
-						label = "SSD";
-						reg = <0x110000 0x10000>;
-						read-only;
-					};
-
-					TZ@120000 {
-						label = "TZ";
-						reg = <0x120000 0x80000>;
-						read-only;
-					};
-
-					RPM@1a0000 {
-						label = "RPM";
-						reg = <0x1a0000 0x80000>;
-						read-only;
-					};
-
-					APPSBL@220000 {
-						label = "APPSBL";
-						reg = <0x220000 0x80000>;
-						read-only;
-					};
-
-					APPSBLENV@2a0000 {
-						label = "APPSBLENV";
-						reg = <0x2a0000 0x10000>;
-					};
-
-					PRODUCTDATA: PRODUCTDATA@2b0000 {
-						label = "PRODUCTDATA";
-						reg = <0x2b0000 0x30000>;
-						read-only;
-					};
-
-					ART@2e0000 {
-						label = "ART";
-						reg = <0x2e0000 0x40000>;
-						read-only;
-					};
-
-					TP@320000 {
-						label = "TP";
-						reg = <0x320000 0x40000>;
-						read-only;
-					};
-
-					TINY@360000 {
-						label = "TINY";
-						reg = <0x360000 0x500000>;
-						read-only;
-					};
-
-					firmware@860000 {
-						label = "firmware";
-						reg = <0x860000 0x17a0000>;
-					};
-				};
-			};
-		};
-
-		phy@100f8800 {		/* USB3 port 1 HS phy */
-			status = "ok";
-		};
-
-		phy@100f8830 {		/* USB3 port 1 SS phy */
-			status = "ok";
-		};
-
-		phy@110f8800 {		/* USB3 port 0 HS phy */
-			status = "ok";
-		};
-
-		phy@110f8830 {		/* USB3 port 0 SS phy */
-			status = "ok";
-		};
-
-		usb30@0 {
-			status = "ok";
-
-			pinctrl-0 = <&usb_pwr_en_pins>;
-			pinctrl-names = "default";
-		};
-
-		usb30@1 {
-			status = "ok";
-		};
-
-		pcie0: pci@1b500000 {
-			status = "ok";
-			reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
-			pinctrl-0 = <&pcie0_pins>;
-			pinctrl-names = "default";
-		};
-
-		pcie1: pci@1b700000 {
-			status = "ok";
-			reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
-			pinctrl-0 = <&pcie1_pins>;
-			pinctrl-names = "default";
-			force_gen1 = <1>;
-		};
-
 		mdio0: mdio {
 			compatible = "virtual,mdio-gpio";
 			#address-cells = <1>;
@@ -294,50 +44,20 @@
 			pinctrl-0 = <&mdio0_pins>;
 			pinctrl-names = "default";
 
-			phy0: ethernet-phy@0 {
+			ethernet-phy@0 {
 				reg = <0>;
 				qca,ar8327-initvals = <
-					0x00004 0x7600000   /* PAD0_MODE */
-					0x00008 0x1000000   /* PAD5_MODE */
-					0x0000c 0x80        /* PAD6_MODE */
-					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x00004 0x06000000  /* PAD0_MODE */
+					0x0000c 0x00080080  /* PAD6_MODE */
+					0x000e4 0x0006a545  /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
-					0x0007c 0x4e        /* PORT0_STATUS */
-					0x00094 0x4e        /* PORT6_STATUS */
+					0x0007c 0x0000004e  /* PORT0_STATUS */
+					0x00094 0x0000004e  /* PORT6_STATUS */
 					>;
 			};
 
-			phy4: ethernet-phy@4 {
+			ethernet-phy@4 {
 				reg = <4>;
-			};
-		};
-
-		gmac1: ethernet@37200000 {
-			status = "ok";
-			phy-mode = "rgmii";
-			qcom,id = <1>;
-
-			pinctrl-0 = <&rgmii2_pins>;
-			pinctrl-names = "default";
-
-			mtd-mac-address = <&PRODUCTDATA 6>;
-
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
-
-		gmac2: ethernet@37400000 {
-			status = "ok";
-			phy-mode = "sgmii";
-			qcom,id = <2>;
-
-			mtd-mac-address = <&PRODUCTDATA 0>;
-
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
 			};
 		};
 	};
@@ -384,7 +104,7 @@
 			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_HIGH>;
 		};
 
-		power_red {
+		power_red: power_red {
 			label = "wg2600hp:red:power";
 			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
 		};
@@ -442,5 +162,281 @@
 };
 
 &adm_dma {
-	status = "ok";
+	status = "okay";
+};
+
+&gmac1 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	mtd-mac-address = <&PRODUCTDATA 6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+
+	mtd-mac-address = <&PRODUCTDATA 0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gsbi4 {
+	status = "okay";
+	qcom,mode = <GSBI_PROT_I2C_UART>;
+};
+
+&gsbi4_serial {
+	status = "okay";
+};
+
+&gsbi5 {
+	status = "okay";
+
+	qcom,mode = <GSBI_PROT_SPI>;
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "jedec,spi-nor";
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				SBL1@0 {
+					label = "SBL1";
+					reg = <0x0 0x20000>;
+					read-only;
+				};
+
+				MIBIB@20000 {
+					label = "MIBIB";
+					reg = <0x20000 0x20000>;
+					read-only;
+				};
+
+				SBL2@40000 {
+					label = "SBL2";
+					reg = <0x40000 0x40000>;
+					read-only;
+				};
+
+				SBL3@80000 {
+					label = "SBL3";
+					reg = <0x80000 0x80000>;
+					read-only;
+				};
+
+				DDRCONFIG@100000 {
+					label = "DDRCONFIG";
+					reg = <0x100000 0x10000>;
+					read-only;
+				};
+
+				SSD@110000 {
+					label = "SSD";
+					reg = <0x110000 0x10000>;
+					read-only;
+				};
+
+				TZ@120000 {
+					label = "TZ";
+					reg = <0x120000 0x80000>;
+					read-only;
+				};
+
+				RPM@1a0000 {
+					label = "RPM";
+					reg = <0x1a0000 0x80000>;
+					read-only;
+				};
+
+				APPSBL@220000 {
+					label = "APPSBL";
+					reg = <0x220000 0x80000>;
+					read-only;
+				};
+
+				APPSBLENV@2a0000 {
+					label = "APPSBLENV";
+					reg = <0x2a0000 0x10000>;
+				};
+
+				PRODUCTDATA: PRODUCTDATA@2b0000 {
+					label = "PRODUCTDATA";
+					reg = <0x2b0000 0x30000>;
+					read-only;
+				};
+
+				ART@2e0000 {
+					label = "ART";
+					reg = <0x2e0000 0x40000>;
+					read-only;
+				};
+
+				TP@320000 {
+					label = "TP";
+					reg = <0x320000 0x40000>;
+					read-only;
+				};
+
+				TINY@360000 {
+					label = "TINY";
+					reg = <0x360000 0x500000>;
+					read-only;
+				};
+
+				firmware@860000 {
+					compatible = "denx,uimage";
+					label = "firmware";
+					reg = <0x860000 0x17a0000>;
+				};
+			};
+		};
+	};
+};
+
+&hs_phy_0 {		/* USB3 port 0 HS phy */
+	status = "okay";
+};
+
+&ss_phy_0 {		/* USB3 port 0 SS phy */
+	status = "okay";
+};
+
+&hs_phy_1 {		/* USB3 port 1 HS phy */
+	status = "okay";
+};
+
+&ss_phy_1 {		/* USB3 port 1 SS phy */
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+
+	pinctrl-0 = <&usb_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&usb3_1 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+	force_gen1 = <1>;
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio16", "gpio54", "gpio24", "gpio25";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	i2c4_pins: i2c4_pinmux {
+		mux {
+			pins = "gpio12", "gpio13";
+			function = "gsbi4";
+			drive-strength = <12>;
+			bias-disable;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio14",
+				"gpio15", "gpio55", "gpio56", "gpio57", "gpio58",
+				"gpio64", "gpio65";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			bias-pull-down;
+		};
+
+		data {
+			pins = "gpio18", "gpio19";
+			drive-strength = <10>;
+		};
+
+		cs {
+			pins = "gpio20";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+
+		clk {
+			pins = "gpio21";
+			drive-strength = <12>;
+		};
+	};
+
+	mdio0_pins: mdio0_pins {
+		mux {
+			pins = "gpio0", "gpio1";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		mux {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+			       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+			function = "rgmii2";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	usb_pwr_en_pins: usb_pwr_en_pins {
+		mux {
+			pins = "gpio22";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-high;
+		};
+	};
 };


### PR DESCRIPTION
This commit fixes and cleanups qcom-ipq8064-wg2600hp.dts to improve the
support for WG2600HP.

- Use dt label in qcom-ipq8064.dtsi:

  - gmac1
  - gmac2
  - gsbi4
    - gsbi4_serial
  - gsbi5
  - hs_phy_0
  - ss_phy_0
  - usb3_0
  - usb3_1
  - pcie0
  - pcie1
  - qcom_pinmux

- Fix wrong pcie reset (perst) gpios

  - drop reset-gpio and use perst-gpios in qcom-ipq8064.dtsi

- Remove unnecessary dt label from device dts

  - flash
  - phy0, phy4

- Fix qca,ar8327-initvals

  - use oem settings

    - fix: PAD0_MODE, PAD6_MODE
    - drop PAD5_MODE (unnecessary)

- Move mtd partitions under partitions (fixed-partitions) node

- Specify "firmware" partition format

  - WG2600HP uses uImage format (denx,uimage)

- Change failsafe status LED to power_red

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>