### PR TITLE
ath79: add support for TP-Link TL-WR842N/ND v1 router

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -172,6 +172,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -143,6 +143,7 @@ case "$FIRMWARE" in
 	tplink,tl-wr741-v1|\
 	tplink,tl-wr743nd-v1|\
 	tplink,tl-wr841-v7|\
+	tplink,tl-wr842n-v1|\
 	ubnt,airrouter|\
 	ubnt,bullet-m|\
 	ubnt,nano-m|\

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7241.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr842n-v1", "qca,ar7241";
+	model = "TP-Link TL-WR842N/ND v1";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		rfkill {
+			label = "rfkill";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led3g {
+			label = "tp-link:green:3g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "tp-link:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002e";
+		reg = <0x0000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+		qca,no-eeprom;
+		mtd-mac-address = <&uboot 0x1fc00>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -99,6 +99,15 @@ define Device/tplink_tl-wr1043nd-v1
 endef
 TARGET_DEVICES += tplink_tl-wr1043nd-v1
 
+define Device/tplink_tl-wr842n-v1
+  $(Device/tplink-8m)
+  ATH_SOC := ar7241
+  DEVICE_TITLE := TP-LINK TL-WR842N/ND v1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x8420001
+endef
+TARGET_DEVICES += tplink_tl-wr842n-v1
+
 define Device/tplink_tl-wr842n-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9341


### PR DESCRIPTION
This ports support for TP-Link TL-WR842N/ND v1 from ar71xx.

CPU: Atheros AR7241 400 MHz
RAM: 32 MiB
FLASH: 8 MiB
PORTS: 4 Port 100/10 Switch, 1 Port 100/10 WAN
WiFi: Atheros AR9287
LED: SYS, WiFi, LAN, WAN, 3G, QSS
BTN: WiFi, Reset/WPS

AR71xx target used "tl-mr3420" as board id so force flag is needed if upgrading from old target.

This device is somewhat odd device combining old chipset with fairly decent flash. As a result DTS shares many entries with `ar7241_tplink_tl-mr3x20.dtsi` and `ar7241_tplink.dtsi` but there are also some differences at various levels (for instance partition layout is different due to larger flash size). Reusing them would be reasonable but that would require either deleting/overriding DTSI tree entries or further splitting them to exclude parts that are model-dependent (like mentioned partition layout burried deep in `ar7241_tplink.dtsi`). On the other hand most devices don't use such complex DTSI hierarchy and AR724x chipsets seem to be an exception rather than a rule.

There's also some inconsistency with TP-Link N/ND models target naming. There are three different approaches: with `nd` suffix (like `tl-wr1043nd-v3`), with `n` suffix (like `tl-wr740n-v4`) and without a suffix (like `tl-wr941-v4`). TP-Link TL-WR741N/ND is inconsistent even with itself (`tl-wr741-v1` vs `tl-wr741n-v4`). Here I follow TP-Link TL-WR842 N/ND v2 convention thus naming the target `tl-wr842n-v1` but this lack of consistency is very misleading when working with userland files leading to mistakes that are not obvious on a first glance.

In my view we need a clear guideline on how to consistently name `ath79` targets.



