### PR TITLE
openvpn: re-add option comp_lzo

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/package/network/services/openvpn/files/openvpn.options
+++ b/package/network/services/openvpn/files/openvpn.options
@@ -14,6 +14,7 @@ cipher
 client_config_dir
 client_connect
 client_disconnect
+comp_lzo
 compress
 connect_freq
 connect_retry


### PR DESCRIPTION
This option is not deprecated any more (see [0]) and needed in some
situations.

[0] https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--comp-lzo

When this PR got accepted, I'll also re-add the luci support for this option.