### PR TITLE
build: fix STAGING_DIR cleaning for packages

### DIFF
--- a/include/package.mk
+++ b/include/package.mk
@@ -81,9 +81,10 @@ STAGING_FILES_LIST:=$(PKG_DIR_NAME)$(if $(BUILD_VARIANT),.$(BUILD_VARIANT),).lis
 define CleanStaging
 	rm -f $(STAMP_INSTALLED)
 	@-(\
-		cd "$(STAGING_DIR)"; \
-		if [ -f packages/$(STAGING_FILES_LIST) ]; then \
-			cat packages/$(STAGING_FILES_LIST) | xargs -r rm -f 2>/dev/null; \
+		if [ -f $(STAGING_DIR)/packages/$(STAGING_FILES_LIST) ]; then \
+			$(SCRIPT_DIR)/clean-package.sh \
+				"$(STAGING_DIR)/packages/$(STAGING_FILES_LIST)" \
+				"$(STAGING_DIR)"; \
 		fi; \
 	)
 endef

--- a/scripts/clean-package.sh
+++ b/scripts/clean-package.sh
@@ -14,7 +14,7 @@ cat "$1" | (
 		[ -f "$entry" ] && rm -f $entry
 	done
 )
-cat "$1" | (
+sort -r "$1" | (
 	cd "$2"
 	while read entry; do
 		[ -n "$entry" ] || break


### PR DESCRIPTION
This fixes two issues with cleaning package files from STAGING_DIR:

* `CleanStaging` currently can only remove files and not directories. This changes `CleanStaging` to use clean-package.sh, which does remove directories.

* Because of the way directories are ordered in the staging files list, clean-package.sh currently tries (and fails) to remove parent directories before removing subdirectories. This changes clean-package.sh to process the staging files list in reverse, so that subdirectories are removed first.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>