### PR TITLE
ath79: Add support for Ubiquiti Nanostation M (XW) 

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -104,6 +104,7 @@ tplink,tl-wr841-v11)
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
 ubnt,nano-m|\
+ubnt,nanostation-m-xw|\
 ubnt,rocket-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -188,6 +188,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	ubnt,nanostation-m-xw)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "5:lan" "1:wan"
+		;;
 	ubnt,nanostation-ac|\
 	ubnt,unifiac-mesh-pro|\
 	ubnt,unifiac-pro)

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -24,8 +24,6 @@
 &eth0 {
 	status = "okay";
 
-	mtd-mac-address = <&eeprom 0x0>;
-
 	phy-mode = "rgmii";
 	phy-handle = <&phy4>;
 

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -24,7 +24,6 @@
 &eth0 {
 	status = "okay";
 
-	pll-data = <0x06000000 0x00000101 0x00001313>;
 	mtd-mac-address = <&eeprom 0x0>;
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -33,7 +33,3 @@
 		rxdv-delay = <3>;
 	};
 };
-
-&eth1 {
-	status = "disabled";
-};

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_xw.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-m-xw", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti Nanostation M (XW)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4-mii-enable;
+	phy-mask = <0x23>;
+
+	phy4: ethernet-phy@4 {
+		reg = <0>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		mii-gmac0 = <1>;
+		mii-gmac0-slave = <1>;
+	};
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
@@ -17,7 +17,7 @@
 	phy4-mii-enable;
 	phy-mask = <0x23>;
 
-	phy4: ethernet-phy@4 {
+	phy4: ethernet-phy@0 {
 		reg = <0>;
 		phy-mode = "mii";
 	};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -9,6 +9,13 @@
 	compatible = "ubnt,xw", "qca,ar9342";
 	model = "Ubiquiti Networks XW board";
 
+	aliases {
+		led-boot = &system;
+		led-running = &system;
+		led-upgrade = &system;
+		led-failsafe = &system;
+	};
+
 	gpio-leds {
 		compatible = "gpio-leds";
 
@@ -27,7 +34,7 @@
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		link4 {
+		system: link4 {
 			label = "ubnt:green:link4";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -121,3 +121,7 @@
 &eth0 {
 	mtd-mac-address = <&eeprom 0x0>;
 };
+
+&eth1 {
+	status = "disabled";
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -117,3 +117,7 @@
 	mtd-cal-data = <&eeprom 0x1000>;
 	mtd-mac-address = <&eeprom 0x1002>;
 };
+
+&eth0 {
+	mtd-mac-address = <&eeprom 0x0>;
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -122,6 +122,10 @@
 	mtd-mac-address = <&eeprom 0x0>;
 };
 
+&mdio1 {
+	status = "disabled";
+};
+
 &eth1 {
 	status = "disabled";
 };

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
@@ -53,6 +53,7 @@ static void ag71xx_setup_gmac_934x(struct device_node *np, void __iomem *base)
 
 	ag71xx_of_bit(np, "rgmii-gmac0", &val, AR934X_ETH_CFG_RGMII_GMAC0);
 	ag71xx_of_bit(np, "mii-gmac0", &val, AR934X_ETH_CFG_MII_GMAC0);
+	ag71xx_of_bit(np, "mii-gmac0-slave", &val, AR934X_ETH_CFG_MII_GMAC0_SLAVE);
 	ag71xx_of_bit(np, "gmii-gmac0", &val, AR934X_ETH_CFG_GMII_GMAC0);
 	ag71xx_of_bit(np, "switch-phy-swap", &val, AR934X_ETH_CFG_SW_PHY_SWAP);
 	ag71xx_of_bit(np, "switch-only-mode", &val,

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -399,14 +399,18 @@ static void ag71xx_hw_setup(struct ag71xx *ag)
 {
 	struct device_node *np = ag->pdev->dev.of_node;
 	u32 init = MAC_CFG1_INIT;
+	u32 cfg2;
 
 	/* setup MAC configuration registers */
 	if (of_property_read_bool(np, "flow-control"))
 		init |= MAC_CFG1_TFC | MAC_CFG1_RFC;
 	ag71xx_wr(ag, AG71XX_REG_MAC_CFG1, init);
 
-	ag71xx_sb(ag, AG71XX_REG_MAC_CFG2,
-		  MAC_CFG2_PAD_CRC_EN | MAC_CFG2_LEN_CHECK);
+	/* ensure that CRC is disabled and not appended to frames */
+	cfg2 = ag71xx_rr(ag, AG71XX_REG_MAC_CFG2);
+	cfg2 &= ~(MAC_CFG2_CRC_EN);
+	cfg2 |= MAC_CFG2_PAD_CRC_EN | MAC_CFG2_LEN_CHECK;
+	ag71xx_wr(ag, AG71XX_REG_MAC_CFG2, cfg2);
 
 	/* setup max frame length to zero */
 	ag71xx_wr(ag, AG71XX_REG_MAC_MFL, 0);

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -113,6 +113,12 @@ define Device/ubnt_nano-m
 endef
 TARGET_DEVICES += ubnt_nano-m
 
+define Device/ubnt_nanostation-m-xw
+  $(Device/ubnt-xw)
+  DEVICE_TITLE := Ubiquiti Nanostation M (XW)
+endef
+TARGET_DEVICES += ubnt_nanostation-m-xw
+
 define Device/ubnt_lap-120
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti LiteAP ac (LAP-120)


### PR DESCRIPTION
This my 2nd attempt, so `Version 2`. `Version 1` of this patchset was sent for review through [mailing list](http://lists.infradead.org/pipermail/openwrt-devel/2018-December/015092.html). I'm continuing with my 2nd attempt here through GitHub PR as it's simply more faster to iterate for me here.

This PR adds support for Ubiquiti Nanostation M (XW). I've added missing mii-gmac0-slave parser, fixed bug with enabled CRC in frames which is appearing only in ath79 and once I've started final testing, I've realized, that there are quite common bits shared with Bullet M (XW) so I've moved them into the common include file. Then I've found out, that in comparison to ar71xx snapshot builds I'm missing support for status LEDs, so I've added it as well.                                                                                                                                                                                                            

In `Version 2` I've tried to fix all the review comments from @mkresin:
* use only `link4` LED to signal all the diag.sh states (the same LED is used in ar71xx)
* split `pll-data`, `mdio1`, `eth1` and `eth0` changes into separate commits so it's more transparent
* improved description in new `mii-gmac0-slave` parser commit
* renamed the board name from `nano-m-xw` to `nanostation-m-xw` as it's prefered to have the full name of a board as image filename/userspace boardname, as it makes it way easier to find the correct image
* I've added to DTS the compatible for the ar9342 SoC as well
                                                                                                                                                                                                                    
`Version 1` was tested by @ae6xe on his Nanostation M5 (XW), and by myself on                                                                                                                                             
Nanostation M5 (XW) and Bullet M2 (XW).

`Version 2` was run-tested by me on Bullet M2 (XW) and by @ae6xe on his Nanostation M5 (XW).