### PR TITLE
ramips: several fixes for HC5x61

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -167,15 +167,11 @@ hc5661a)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
 	set_wifi_led "$boardname:blue:wlan2g"
 	;;
-hc5761)
-	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
-	set_wifi_led "$boardname:blue:wlan2g"
-	ucidef_set_led_netdev "wifi5g" "wifi5g" "$boardname:blue:wlan5g" "rai0"
-	;;
+hc5761|\
 hc5861)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
-	set_wifi_led "$boardname:blue:wlan2g"
-	ucidef_set_led_netdev "wifi5g" "wifi5g" "$boardname:blue:wlan5g" "rai0"
+	ucidef_set_led_netdev "wifi5g" "wifi5g" "$boardname:blue:wlan5g" "wlan0"
+	ucidef_set_led_netdev "wifi2g" "wifi2g" "$boardname:blue:wlan2g" "wlan1"
 	;;
 hg255d)
 	set_wifi_led "$boardname:green:wlan"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -304,7 +304,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
-	hc5*61|\
+	hc5661|\
+	hc5861|\
 	y1s)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
@@ -326,6 +327,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
 		ucidef_set_interface_wan "usb0"
+		;;
+	hc5761)
+		ucidef_add_switch "switch0" \
+			"1:lan" "4:lan" "0:wan" "6@eth0"
 		;;
 	mzk-dp150n|\
 	vocore-8M|\

--- a/target/linux/ramips/dts/HC5761.dts
+++ b/target/linux/ramips/dts/HC5761.dts
@@ -38,6 +38,18 @@
 	};
 };
 
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
 &pcie0 {
 	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;

--- a/target/linux/ramips/dts/HC5861.dts
+++ b/target/linux/ramips/dts/HC5861.dts
@@ -60,6 +60,14 @@
 	};
 };
 
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
 &ethernet {
 	status = "okay";
 	mtd-mac-address = <&factory 0x4>;
@@ -96,6 +104,10 @@
 
 &gsw {
 	mediatek,port4 = "gmac";
+};
+
+&pcie {
+	status = "okay";
 };
 
 &pcie0 {

--- a/target/linux/ramips/dts/HC5X61.dtsi
+++ b/target/linux/ramips/dts/HC5X61.dtsi
@@ -67,6 +67,7 @@
 			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x30000>;
+				read-only;
 			};
 
 			partition@30000 {
@@ -78,6 +79,7 @@
 			factory: partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
+				read-only;
 			};
 
 			partition@50000 {
@@ -89,27 +91,22 @@
 			partition@fd0000 {
 				label = "hwf_config";
 				reg = <0xfd0000 0x10000>;
+				read-only;
 			};
 
 			bdinfo: partition@fe0000 {
 				label = "bdinfo";
 				reg = <0xfe0000 0x10000>;
+				read-only;
 			};
 
 			partition@ff0000 {
 				label = "backup";
 				reg = <0xff0000 0x10000>;
+				read-only;
 			};
 		};
 	};
-};
-
-&ehci {
-	status = "okay";
-};
-
-&ohci {
-	status = "okay";
 };
 
 &ethernet {
@@ -127,10 +124,6 @@
 	ralink,mtd-eeprom = <&factory 0>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pa_pins>;
-};
-
-&pcie {
-	status = "okay";
 };
 
 &pinctrl {

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -297,15 +297,15 @@ TARGET_DEVICES += gl-mt750
 
 define Device/hc5661
   DTS := HC5661
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_TITLE := HiWiFi HC5661
-  DEVICE_PACKAGES := kmod-usb2 kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-sdhci-mt7620
 endef
 TARGET_DEVICES += hc5661
 
 define Device/hc5761
   DTS := HC5761
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_TITLE := HiWiFi HC5761
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
@@ -313,9 +313,9 @@ TARGET_DEVICES += hc5761
 
 define Device/hc5861
   DTS := HC5861
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_TITLE := HiWiFi HC5861
-  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += hc5861
 


### PR DESCRIPTION
 - Mark other partitions as read-only for HC5x61

 - Only enable USB and PCIe for HC5761/HC5861
   HC5661 doesn't have a USB port, and there is nothing attached to its PCIe.

 - Fix HC5761 switch ports
   HC5761 has only 3 ethernet ports (1x WAN + 2x LAN). Remove unused ports.

 - Fix HC5861 5GHz radio
   HC5861 has MT7612EN 5GHz WiFi chip, not MT7610EN.

 - Fix HC5761/HC5861 WiFi LEDs
   After 5GHz is enabled, it becomes wlan0. And 2.4GHz would be wlan1.

 - Fix HC5x61 image size
   It should be 15872k (0xf80000)