### PR TITLE
valgrind: fix mips revision detection, enable LTO

### DIFF
--- a/package/devel/valgrind/Makefile
+++ b/package/devel/valgrind/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=valgrind
 PKG_VERSION:=3.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://sourceware.org/pub/valgrind/
@@ -105,6 +105,7 @@ CONFIGURE_ARGS += \
 	--disable-valgrindtk \
 	--without-included-gettext \
 	--with-pagesize=4 \
+	--enable-lto
 
 define Package/valgrind/install	
 	$(INSTALL_DIR) $(1)/usr/bin

--- a/package/devel/valgrind/patches/140-mips_if_revision_is_specified_use_it_for_compilation.patch
+++ b/package/devel/valgrind/patches/140-mips_if_revision_is_specified_use_it_for_compilation.patch
@@ -1,0 +1,183 @@
+From e61d13087096139024788393218367572751b4b6 Mon Sep 17 00:00:00 2001
+From: Petar Jovanovic <mips32r2@gmail.com>
+Date: Mon, 25 Mar 2019 17:39:38 +0000
+Subject: [PATCH] mips: if revision is specified, use it for compilation
+
+If user has specified a particular MIPS revision in configure line,
+do not interfere with this (i.e. skip setting FLAG_M32/FLAG_M64).
+
+Related KDE issues #402123 and #400975.
+
+Patch by Stefan Maksimovic.
+
+diff --git a/configure.ac b/configure.ac
+old mode 100644
+new mode 100755
+index 912dec3a9..3c92f7152
+--- a/configure.ac
++++ b/configure.ac
+@@ -1748,44 +1748,47 @@ AM_CONDITIONAL(HAVE_NR_MEMBARRIER, [test x$ac_have_nr_membarrier = xyes])
+ 
+ case "${host_cpu}" in
+     mips*)
+-        # does this compiler support -march=mips32 (mips32 default) ?
+-        AC_MSG_CHECKING([if gcc accepts -march=mips32 -mabi=32])
+-
+-        safe_CFLAGS=$CFLAGS
+-        CFLAGS="$CFLAGS -mips32 -mabi=32 -Werror"
+-
+-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
+-          return 0;
+-        ]])], [
+-        FLAG_M32="-mips32 -mabi=32"
+-        AC_MSG_RESULT([yes])
+-        ], [
+-        FLAG_M32=""
+-        AC_MSG_RESULT([no])
+-        ])
+-        CFLAGS=$safe_CFLAGS
+-
+-        AC_SUBST(FLAG_M32)
+-
+-
+-        # does this compiler support -march=mips64r2 (mips64r2 default) ?
+-        AC_MSG_CHECKING([if gcc accepts -march=mips64r2 -mabi=64])
+-
+-        safe_CFLAGS=$CFLAGS
+-        CFLAGS="$CFLAGS -march=mips64r2 -mabi=64 -Werror"
+-
+-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
+-          return 0;
+-        ]])], [
+-        FLAG_M64="-march=mips64r2 -mabi=64"
+-        AC_MSG_RESULT([yes])
+-        ], [
+-        FLAG_M64=""
+-        AC_MSG_RESULT([no])
+-        ])
+-        CFLAGS=$safe_CFLAGS
+-
+-        AC_SUBST(FLAG_M64)
++        ARCH=$(echo "$CFLAGS" | grep -E -e '-march=@<:@^ @:>@+' -e '-mips@<:@^ +@:>@')
++        if test -z "$ARCH"; then
++          # does this compiler support -march=mips32 (mips32 default) ?
++          AC_MSG_CHECKING([if gcc accepts -march=mips32 -mabi=32])
++
++          safe_CFLAGS=$CFLAGS
++          CFLAGS="$CFLAGS -mips32 -mabi=32 -Werror"
++
++          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
++            return 0;
++          ]])], [
++          FLAG_M32="-mips32 -mabi=32"
++          AC_MSG_RESULT([yes])
++          ], [
++          FLAG_M32=""
++          AC_MSG_RESULT([no])
++          ])
++          CFLAGS=$safe_CFLAGS
++
++          AC_SUBST(FLAG_M32)
++
++
++          # does this compiler support -march=mips64r2 (mips64r2 default) ?
++          AC_MSG_CHECKING([if gcc accepts -march=mips64r2 -mabi=64])
++
++          safe_CFLAGS=$CFLAGS
++          CFLAGS="$CFLAGS -march=mips64r2 -mabi=64 -Werror"
++
++          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
++            return 0;
++          ]])], [
++          FLAG_M64="-march=mips64r2 -mabi=64"
++          AC_MSG_RESULT([yes])
++          ], [
++          FLAG_M64=""
++          AC_MSG_RESULT([no])
++          ])
++          CFLAGS=$safe_CFLAGS
++
++          AC_SUBST(FLAG_M64)
++        fi
+         ;;
+     *)
+         # does this compiler support -m32 ?
+@@ -1829,44 +1832,48 @@ case "${host_cpu}" in
+         ;;
+ esac
+ 
+-# does this compiler support -march=octeon (Cavium OCTEON I Specific) ?
+-AC_MSG_CHECKING([if gcc accepts -march=octeon])
+ 
+-safe_CFLAGS=$CFLAGS
+-CFLAGS="$CFLAGS $FLAG_M64 -march=octeon -Werror"
++ARCH=$(echo "$CFLAGS" | grep -E -e '-march=@<:@^ @:>@+' -e '-mips@<:@^ +@:>@')
++if test -z "$ARCH"; then
++  # does this compiler support -march=octeon (Cavium OCTEON I Specific) ?
++  AC_MSG_CHECKING([if gcc accepts -march=octeon])
+ 
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
+-  return 0;
+-]])], [
+-FLAG_OCTEON="-march=octeon"
+-AC_MSG_RESULT([yes])
+-], [
+-FLAG_OCTEON=""
+-AC_MSG_RESULT([no])
+-])
+-CFLAGS=$safe_CFLAGS
++  safe_CFLAGS=$CFLAGS
++  CFLAGS="$CFLAGS $FLAG_M64 -march=octeon -Werror"
+ 
+-AC_SUBST(FLAG_OCTEON)
++  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
++    return 0;
++  ]])], [
++  FLAG_OCTEON="-march=octeon"
++  AC_MSG_RESULT([yes])
++  ], [
++  FLAG_OCTEON=""
++  AC_MSG_RESULT([no])
++  ])
++  CFLAGS=$safe_CFLAGS
+ 
++  AC_SUBST(FLAG_OCTEON)
+ 
+-# does this compiler support -march=octeon2 (Cavium OCTEON II Specific) ?
+-AC_MSG_CHECKING([if gcc accepts -march=octeon2])
+ 
+-safe_CFLAGS=$CFLAGS
+-CFLAGS="$CFLAGS $FLAG_M64 -march=octeon2 -Werror"
++  # does this compiler support -march=octeon2 (Cavium OCTEON II Specific) ?
++  AC_MSG_CHECKING([if gcc accepts -march=octeon2])
+ 
+-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
+-  return 0;
+-]])], [
+-FLAG_OCTEON2="-march=octeon2"
+-AC_MSG_RESULT([yes])
+-], [
+-FLAG_OCTEON2=""
+-AC_MSG_RESULT([no])
+-])
+-CFLAGS=$safe_CFLAGS
++  safe_CFLAGS=$CFLAGS
++  CFLAGS="$CFLAGS $FLAG_M64 -march=octeon2 -Werror"
++
++  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
++    return 0;
++  ]])], [
++  FLAG_OCTEON2="-march=octeon2"
++  AC_MSG_RESULT([yes])
++  ], [
++  FLAG_OCTEON2=""
++  AC_MSG_RESULT([no])
++  ])
++  CFLAGS=$safe_CFLAGS
+ 
+-AC_SUBST(FLAG_OCTEON2)
++  AC_SUBST(FLAG_OCTEON2)
++fi
+ 
+ 
+ # does this compiler support -mmsa (MIPS MSA ASE) ?


### PR DESCRIPTION
Maintainer: @nbd168 
Compile & Run-tested: Asus RT-N56U, ramips, mipsel_74kc, openwrt master

Valgrind is failing with LTO enabled on mips32r2 platforms with errors like: 
```
{standard input}: Assembler messages:
{standard input}:92627: Error: `fp=64' used with a 32-bit fpu
{standard input}:92927: Error: opcode not supported on this processor:
mips32 (mips32) `ceil.l.s $f24,$f24'
```
I've opened a bug report upstream at https://bugs.kde.org/show_bug.cgi?id=402123
They have fixed it, with this patch, so I have reenabled LTO.

This was edited to reflect the proper fix.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>