### PR TITLE
ath79: add TP-Link TL-WR710N v1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -203,6 +203,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
+	tplink,tl-wr710n-v1)
+		ucidef_set_interface_wan "eth0"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "3:lan"
+		;;
 	tplink,tl-wr740n-v4|\
 	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v8|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/00-wmac-migration
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/00-wmac-migration
@@ -14,6 +14,10 @@ migrate_wmac_path() {
 			path="platform/ahb/ahb:apb/18100000.wmac"
 			WMAC_PATH_CHANGED=1
 		;;
+		"platform/ar933x_wmac")
+			path="platform/ahb/18100000.wmac"
+			WMAC_PATH_CHANGED=1
+		;;
 		*)
 			return 0
 		;;

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v1.dts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "TP-Link TL-WR710N v1";
+	compatible = "tplink,tl-wr710n-v1", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tl-wr710n:green:system";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			firmware: partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -198,6 +198,16 @@ define Device/tplink_tl-wr810n-v2
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
+define Device/tplink_tl-wr710n-v1
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9331
+  DEVICE_TITLE := TP-Link TL-WR710N v1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x07100001
+  SUPPORTED_DEVICES += tl-wr710n
+endef
+TARGET_DEVICES += tplink_tl-wr710n-v1
+
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   ATH_SOC := ar7241


### PR DESCRIPTION
This commit adds support for TP-Link TL-WR710N v1 router.

CPU: Atheros AR9331 400MHz
RAM: 32MB
FLASH: 8MiB
PORTS: 1 Port 100/10 LAN (connected to a switch), 1 Port 100/10 WAN
WiFi: Atheros AR9331 1x2:1 bgn
USB: ChipIdea HDRC USB2.0
LED: SYS
BTN: Reset

Sysupgrade from `ar71xx` works without glitches. Only wireless radio path needs adjustment afterwards.
Network interfaces assigned for LAN and WAN ports are `eth1` and `eth0` respectively, what's consistent with `ar71xx` target.
