### PR TITLE
ipq806x: drop kernel/ rootfs partition images for the ZyXEL NBG6817

### DIFF
--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -67,11 +67,9 @@ define Device/ZyXELImage
 	KERNEL_SUFFIX := -uImage
 	KERNEL = kernel-bin | append-dtb | uImage none | pad-to $${KERNEL_SIZE}
 	KERNEL_NAME := zImage
-	IMAGES := factory.bin sysupgrade.bin mmcblk0p5-rootfs.bin mmcblk0p4-kernel.bin
+	IMAGES := factory.bin sysupgrade.bin
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to $$$$(BLOCKSIZE) | zyxel-ras-image separate-kernel
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$${BLOCKSIZE} | sysupgrade-tar rootfs=$$$$@ | append-metadata
-	IMAGE/mmcblk0p5-rootfs.bin := append-rootfs | pad-rootfs | pad-to $$$${BLOCKSIZE}
-	IMAGE/mmcblk0p4-kernel.bin := append-kernel
 endef
 
 define Device/compex_wpq864


### PR DESCRIPTION
Since commit 8e9a59a6b924469c0061d4bd945ae0c6dbfdecfe (build: add
mkrasimage) a proper factory image can be provided for the ZyXEL
NBG6817, which can be flashed from the OEM firmware or used for
tftp based push-button recovery, therefore the previously used
partition images for mmcblk0p5-rootfs.bin and mmcblk0p4-kernel.bin
are no longer required (and using them properly has always been
slightly difficult and risky) and can now be dropped from the image
generation code.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>