### PR TITLE
uboot-envtools: add device support for Buffalo WZR-HP-AG300H and BHR-4GRV2 for ath79

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -16,6 +16,7 @@ case "$board" in
 buffalo,wzr-hp-ag300h)
         ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
         ;;
+buffalo,bhr-4grv2|\
 glinet,ar300m|\
 ocedo,koala|\
 ocedo,raccoon|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -13,6 +13,9 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+buffalo,wzr-hp-ag300h)
+        ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
+        ;;
 glinet,ar300m|\
 ocedo,koala|\
 ocedo,raccoon|\


### PR DESCRIPTION
This pull request extends out-of-the-box support for the Buffalo BHR-4GRV2 as introduced to ath79 in https://github.com/openwrt/openwrt/pull/1527 by making sure that it (and the Buffalo WZR-HP-AG300H) are supported by uboot-envtools and preinstalled for the initramfs image necessary for repartitioning.

@musashino205 the Buffalo BHR-4GRV2 specific parts have been adapted from your commit message, but not actually tested on a real device.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>