### PR TITLE
mvebu: add support for SolidRun Clearfog GT 8K

### DIFF
--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -64,6 +64,10 @@ solidrun,clearfog*a1)
 		ucidef_add_switch "switch0" \
 			"0:lan:5" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5u@eth1" "6:lan:6"
 	;;
+solidrun,clearfog-gt-8k)
+	ucidef_set_interface_wan "eth0"
+	ucidef_set_interface_lan "lan1 lan2 lan3 lan4 sfp0"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
+++ b/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
@@ -40,6 +40,18 @@ preinit_set_mac_address() {
 			;;
 		esac
 		;;
+	solidrun,clearfog-gt-8k)
+		case "$(readlink /sys/class/net/eth0)" in
+			*f2000000*)
+				ip link set eth0 name sfp0
+			;;
+		esac
+		case "$(readlink /sys/class/net/eth1)" in
+			*f4000000*)
+				ip link set eth1 name eth0
+				ip link set eth2 name cpu
+			;;
+		esac
 	esac
 }
 

--- a/target/linux/mvebu/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/platform.sh
@@ -25,7 +25,7 @@ platform_do_upgrade() {
 		platform_do_upgrade_linksys "$ARGV"
 		;;
 	cznic,turris-omnia|globalscale,espressobin|globalscale,espressobin-emmc|globalscale,espressobin-v7|globalscale,espressobin-v7-emmc|\
-	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
+	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1|solidrun,clearfog-gt-8k)
 		platform_do_upgrade_sdcard "$ARGV"
 		;;
 	*)
@@ -39,7 +39,7 @@ platform_copy_config() {
 		platform_copy_config_linksys
 		;;
 	cznic,turris-omnia|globalscale,espressobin|globalscale,espressobin-emmc|globalscale,espressobin-v7|globalscale,espressobin-v7-emmc|\
-	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
+	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1|solidrun,clearfog-gt-8k)
 		platform_copy_config_sdcard "$ARGV"
 		;;
 	esac

--- a/target/linux/mvebu/image/cortex-a72.mk
+++ b/target/linux/mvebu/image/cortex-a72.mk
@@ -25,4 +25,17 @@ define Device/marvell_armada7040-db
 endef
 TARGET_DEVICES += marvell_armada7040-db
 
+define Device/solidrun-clearfog-gt-8k
+  KERNEL_NAME := Image
+  KERNEL := kernel-bin
+  DEVICE_TITLE := SolidRun ClearFog GT 8K
+  DEVICE_PACKAGES := e2fsprogs ethtool mkf2fs kmod-fs-vfat kmod-mmc
+  IMAGES := sdcard.img.gz
+  IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
+  DEVICE_DTS := armada-8040-clearfog-gt-8k
+  DTS_DIR := $(DTS_DIR)/marvell
+  SUPPORTED_DEVICES := solidrun,clearfog-gt-8k
+endef
+TARGET_DEVICES += solidrun-clearfog-gt-8k
+
 endif

--- a/target/linux/mvebu/image/solidrun-clearfog-gt-8k.bootscript
+++ b/target/linux/mvebu/image/solidrun-clearfog-gt-8k.bootscript
@@ -1,0 +1,10 @@
+setenv bootargs "root=PARTUUID=@ROOT@-02 rw rootwait"
+
+if test -n "${console}"; then
+	setenv bootargs "${bootargs} ${console}"
+fi
+
+load mmc 1:1 ${fdt_addr_r} armada-8040-clearfog-gt-8k.dtb
+load mmc 1:1 ${kernel_addr_r} Image
+
+booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/target/linux/mvebu/patches-4.19/301-PCI-armada8k-add-support-for-gpio-controlled-reset-signal.patch
+++ b/target/linux/mvebu/patches-4.19/301-PCI-armada8k-add-support-for-gpio-controlled-reset-signal.patch
@@ -1,0 +1,48 @@
+diff --git a/drivers/pci/controller/dwc/pcie-armada8k.c b/drivers/pci/controller/dwc/pcie-armada8k.c
+index 0c389a30ef5d..b171b6bc15c8 100644
+--- a/drivers/pci/controller/dwc/pcie-armada8k.c
++++ b/drivers/pci/controller/dwc/pcie-armada8k.c
+@@ -22,6 +22,7 @@
+ #include <linux/resource.h>
+ #include <linux/of_pci.h>
+ #include <linux/of_irq.h>
++#include <linux/gpio/consumer.h>
+ 
+ #include "pcie-designware.h"
+ 
+@@ -29,6 +30,7 @@ struct armada8k_pcie {
+ 	struct dw_pcie *pci;
+ 	struct clk *clk;
+ 	struct clk *clk_reg;
++	struct gpio_desc *reset_gpio;
+ };
+ 
+ #define PCIE_VENDOR_REGS_OFFSET		0x8000
+@@ -137,6 +139,12 @@ static int armada8k_pcie_host_init(struct pcie_port *pp)
+ 	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
+ 	struct armada8k_pcie *pcie = to_armada8k_pcie(pci);
+ 
++	if (pcie->reset_gpio) {
++		/* assert and then deassert the reset signal */
++		gpiod_set_value_cansleep(pcie->reset_gpio, 1);
++		msleep(100);
++		gpiod_set_value_cansleep(pcie->reset_gpio, 0);
++	}
+ 	dw_pcie_setup_rc(pp);
+ 	armada8k_pcie_establish_link(pcie);
+ 
+@@ -249,6 +257,14 @@ static int armada8k_pcie_probe(struct platform_device *pdev)
+ 		goto fail_clkreg;
+ 	}
+ 
++	/* Get reset gpio signal and hold asserted (logically high) */
++	pcie->reset_gpio = devm_gpiod_get_optional(dev, "reset",
++						   GPIOD_OUT_HIGH);
++	if (IS_ERR(pcie->reset_gpio)) {
++		ret = PTR_ERR(pcie->reset_gpio);
++		goto fail_clkreg;
++	}
++
+ 	platform_set_drvdata(pdev, pcie);
+ 
+ 	ret = armada8k_add_pcie_port(pcie, pdev);

--- a/target/linux/mvebu/patches-4.19/302-Armada-8040-clearfog-gt-8k.dts.patch
+++ b/target/linux/mvebu/patches-4.19/302-Armada-8040-clearfog-gt-8k.dts.patch
@@ -1,0 +1,475 @@
+diff --git a/arch/arm64/boot/dts/marvell/Makefile b/arch/arm64/boot/dts/marvell/Makefile
+index ea9d49f2a911..eca8bac6303a 100644
+--- a/arch/arm64/boot/dts/marvell/Makefile
++++ b/arch/arm64/boot/dts/marvell/Makefile
+@@ -3,6 +3,7 @@
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-espressobin.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-7040-db.dtb
++dtb-$(CONFIG_ARCH_MVEBU) += armada-8040-clearfog-gt-8k.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-8040-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-8040-mcbin.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-8080-db.dtb
+diff --git a/arch/arm64/boot/dts/marvell/armada-8040-clearfog-gt-8k.dts b/arch/arm64/boot/dts/marvell/armada-8040-clearfog-gt-8k.dts
+new file mode 100644
+index 000000000000..2e06d82bec58
+--- /dev/null
++++ b/arch/arm64/boot/dts/marvell/armada-8040-clearfog-gt-8k.dts
+@@ -0,0 +1,457 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2018 SolidRun ltd.
++ * Based on Marvell MACCHIATOBin board
++ *
++ * Device Tree file for SolidRun's ClearFog GT 8K
++ */
++
++#include "armada-8040.dtsi"
++
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "SolidRun ClearFog GT 8K";
++	compatible = "solidrun,clearfog-gt-8k", "marvell,armada8040",
++			"marvell,armada-ap806-quad", "marvell,armada-ap806";
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@00000000 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x80000000>;
++	};
++
++	aliases {
++		ethernet0 = &cp1_eth1;
++		ethernet1 = &cp0_eth0;
++		ethernet2 = &cp1_eth2;
++	};
++
++	v_3_3: regulator-3-3v {
++		compatible = "regulator-fixed";
++		regulator-name = "v_3_3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++		status = "okay";
++	};
++
++	v_5v0_usb3_hst_vbus: regulator-usb3-vbus0 {
++		compatible = "regulator-fixed";
++		gpio = <&cp0_gpio2 15 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cp0_xhci_vbus_pins>;
++		regulator-name = "v_5v0_usb3_hst_vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		status = "okay";
++	};
++
++	usb3h0_phy: usb3_phy0 {
++		compatible = "usb-nop-xceiv";
++		vcc-supply = <&v_5v0_usb3_hst_vbus>;
++	};
++
++	sfp_cp0_eth0: sfp-cp0-eth0 {
++		compatible = "sff,sfp";
++		i2c-bus = <&cp0_i2c1>;
++		mod-def0-gpio = <&cp0_gpio2 17 GPIO_ACTIVE_LOW>;
++		tx-disable-gpio = <&cp1_gpio1 29 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cp0_sfp_present_pins &cp1_sfp_tx_disable_pins>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = <&cp0_led0_pins
++			     &cp0_led1_pins>;
++		pinctrl-names = "default";
++		/* No designated function for these LEDs at the moment */
++		led0 {
++			label = "clearfog-gt-8k:green:led0";
++			gpios = <&cp0_gpio2 8 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++		led1 {
++			label = "clearfog-gt-8k:green:led1";
++			gpios = <&cp0_gpio2 9 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++	};
++
++	keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&cp0_gpio_reset_pins &cp1_wps_button_pins>;
++		pinctrl-names = "default";
++
++		button_0 {
++			/* The rear button */
++			label = "Rear Button";
++			gpios = <&cp0_gpio2 7 GPIO_ACTIVE_LOW>;
++			linux,can-disable;
++			linux,code = <BTN_0>;
++		};
++
++		button_1 {
++			/* The wps button */
++			label = "WPS Button";
++			gpios = <&cp1_gpio1 30 GPIO_ACTIVE_LOW>;
++			linux,can-disable;
++			linux,code = <KEY_WPS_BUTTON>;
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++	pinctrl-0 = <&uart0_pins>;
++	pinctrl-names = "default";
++};
++
++&ap_sdhci0 {
++	bus-width = <8>;
++	no-1-8-v;
++	no-sd;
++	no-sdio;
++	non-removable;
++	status = "okay";
++	vqmmc-supply = <&v_3_3>;
++};
++
++&cp0_i2c0 {
++	clock-frequency = <100000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_i2c0_pins>;
++	status = "okay";
++};
++
++&cp0_i2c1 {
++	clock-frequency = <100000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_i2c1_pins>;
++	status = "okay";
++};
++
++&cp0_pinctrl {
++	/*
++	* MPP Bus:
++	* [0-31] = 0xff: Keep default CP0_shared_pins:
++	* [11] CLKOUT_MPP_11 (out)
++	* [23] LINK_RD_IN_CP2CP (in)
++	* [25] CLKOUT_MPP_25 (out)
++	* [29] AVS_FB_IN_CP2CP (in)
++	* [32, 33, 34] pci0/1/2 reset
++	* [35-38] CP0 I2C1 and I2C0
++	* [39] GPIO reset button
++	* [40,41] LED0 and LED1
++	* [43] 1512 phy reset
++	* [47] USB VBUS EN (active low)
++	* [48] FAN PWM
++	* [49] SFP+ present signal
++	* [50] TPM interrupt
++	* [51] WLAN0 disable
++	* [52] WLAN1 disable
++	* [53] LTE disable
++	* [54] NFC reset
++	* [55] Micro SD card detect
++	* [56-61] Micro SD
++	*/
++
++	cp0_pci0_reset_pins: pci0-reset-pins {
++		marvell,pins = "mpp32";
++		marvell,function = "gpio";
++	};
++
++	cp0_pci1_reset_pins: pci1-reset-pins {
++		marvell,pins = "mpp33";
++		marvell,function = "gpio";
++	};
++
++	cp0_pci2_reset_pins: pci2-reset-pins {
++		marvell,pins = "mpp34";
++		marvell,function = "gpio";
++	};
++
++	cp0_i2c1_pins: i2c1-pins {
++		marvell,pins = "mpp35", "mpp36";
++		marvell,function = "i2c1";
++	};
++
++	cp0_i2c0_pins: i2c0-pins {
++		marvell,pins = "mpp37", "mpp38";
++		marvell,function = "i2c0";
++	};
++
++	cp0_gpio_reset_pins: gpio-reset-pins {
++		marvell,pins = "mpp39";
++		marvell,function = "gpio";
++	};
++
++	cp0_led0_pins: led0-pins {
++		marvell,pins = "mpp40";
++		marvell,function = "gpio";
++	};
++
++	cp0_led1_pins: led1-pins {
++		marvell,pins = "mpp41";
++		marvell,function = "gpio";
++	};
++
++	cp0_copper_eth_phy_reset: copper-eth-phy-reset {
++		marvell,pins = "mpp43";
++		marvell,function = "gpio";
++	};
++
++	cp0_xhci_vbus_pins: xhci0-vbus-pins {
++		marvell,pins = "mpp47";
++		marvell,function = "gpio";
++	};
++
++	cp0_fan_pwm_pins: fan-pwm-pins {
++		marvell,pins = "mpp48";
++		marvell,function = "gpio";
++	};
++
++	cp0_sfp_present_pins: sfp-present-pins {
++		marvell,pins = "mpp49";
++		marvell,function = "gpio";
++	};
++
++	cp0_tpm_irq_pins: tpm-irq-pins {
++		marvell,pins = "mpp50";
++		marvell,function = "gpio";
++	};
++
++	cp0_sdhci_pins: sdhci-pins {
++		marvell,pins = "mpp55", "mpp56", "mpp57", "mpp58", "mpp59",
++			       "mpp60", "mpp61";
++		marvell,function = "sdio";
++	};
++};
++
++&cp0_pcie0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_pci0_reset_pins>;
++	reset-gpios = <&cp0_gpio2 0 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&cp0_gpio2 {
++	sata_reset {
++		gpio-hog;
++		gpios = <1 GPIO_ACTIVE_HIGH>;
++		output-high;
++	};
++
++	lte_reset {
++		gpio-hog;
++		gpios = <2 GPIO_ACTIVE_LOW>;
++		output-low;
++	};
++
++	lte_disable {
++		gpio-hog;
++		gpios = <21 GPIO_ACTIVE_LOW>;
++		output-low;
++	};
++};
++
++&cp0_ethernet {
++	status = "okay";
++};
++
++/* SFP */
++&cp0_eth0 {
++	status = "okay";
++	phy-mode = "10gbase-kr";
++	managed = "in-band-status";
++	phys = <&cp0_comphy2 0>;
++	sfp = <&sfp_cp0_eth0>;
++};
++
++&cp0_sdhci0 {
++	broken-cd;
++	bus-width = <4>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp0_sdhci_pins>;
++	status = "okay";
++	vqmmc-supply = <&v_3_3>;
++};
++
++&cp1_pinctrl {
++	/*
++	 * MPP Bus:
++	 * [0-5] TDM
++	 * [6]   VHV Enable
++	 * [7]   CP1 SPI0 CSn1 (FXS)
++	 * [8]   CP1 SPI0 CSn0 (TPM)
++	 * [9.11]CP1 SPI0 MOSI/MISO/CLK
++	 * [13]  CP1 SPI1 MISO (TDM and SPI ROM shared)
++	 * [14]  CP1 SPI1 CS0n (64Mb SPI ROM)
++	 * [15]  CP1 SPI1 MOSI (TDM and SPI ROM shared)
++	 * [16]  CP1 SPI1 CLK (TDM and SPI ROM shared)
++	 * [24]  Topaz switch reset
++	 * [26]  Buzzer
++	 * [27]  CP1 SMI MDIO
++	 * [28]  CP1 SMI MDC
++	 * [29]  CP0 10G SFP TX Disable
++	 * [30]  WPS button
++	 * [31]  Front panel button
++	 */
++
++	cp1_spi1_pins: spi1-pins {
++		marvell,pins = "mpp13", "mpp14", "mpp15", "mpp16";
++		marvell,function = "spi1";
++	};
++
++	cp1_switch_reset_pins: switch-reset-pins {
++		marvell,pins = "mpp24";
++		marvell,function = "gpio";
++	};
++
++	cp1_ge_mdio_pins: ge-mdio-pins {
++		marvell,pins = "mpp27", "mpp28";
++		marvell,function = "ge";
++	};
++
++	cp1_sfp_tx_disable_pins: sfp-tx-disable-pins {
++		marvell,pins = "mpp29";
++		marvell,function = "gpio";
++	};
++
++	cp1_wps_button_pins: wps-button-pins {
++		marvell,pins = "mpp30";
++		marvell,function = "gpio";
++	};
++};
++
++&cp1_sata0 {
++	pinctrl-0 = <&cp0_pci1_reset_pins>;
++	status = "okay";
++};
++
++&cp1_mdio {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp1_ge_mdio_pins>;
++	status = "okay";
++
++	ge_phy: ethernet-phy@0 {
++		/* LED0 - GB link
++		 * LED1 - on: link, blink: activity
++		 */
++		marvell,reg-init = <3 16 0 0x1017>;
++		reg = <0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cp0_copper_eth_phy_reset>;
++		reset-gpios = <&cp1_gpio1 11 GPIO_ACTIVE_LOW>;
++		reset-assert-us = <10000>;
++	};
++
++	switch0: switch0@4 {
++		compatible = "marvell,mv88e6085";
++		reg = <4>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cp1_switch_reset_pins>;
++		reset-gpios = <&cp1_gpio1 24 GPIO_ACTIVE_LOW>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@1 {
++				reg = <1>;
++				label = "lan2";
++				phy-handle = <&switch0phy0>;
++			};
++
++			port@2 {
++				reg = <2>;
++				label = "lan1";
++				phy-handle = <&switch0phy1>;
++			};
++
++			port@3 {
++				reg = <3>;
++				label = "lan4";
++				phy-handle = <&switch0phy2>;
++			};
++
++			port@4 {
++				reg = <4>;
++				label = "lan3";
++				phy-handle = <&switch0phy3>;
++			};
++
++			port@5 {
++				reg = <5>;
++				label = "cpu";
++				ethernet = <&cp1_eth2>;
++			};
++		};
++
++		mdio {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			switch0phy0: switch0phy0@11 {
++				reg = <0x11>;
++			};
++
++			switch0phy1: switch0phy1@12 {
++				reg = <0x12>;
++			};
++
++			switch0phy2: switch0phy2@13 {
++				reg = <0x13>;
++			};
++
++			switch0phy3: switch0phy3@14 {
++				reg = <0x14>;
++			};
++		};
++	};
++};
++
++&cp1_ethernet {
++	status = "okay";
++};
++
++/* 1G copper */
++&cp1_eth1 {
++	status = "okay";
++	phy-mode = "sgmii";
++	phy = <&ge_phy>;
++	phys = <&cp1_comphy3 1>;
++};
++
++/* Switch uplink */
++&cp1_eth2 {
++	status = "okay";
++	phy-mode = "2500base-x";
++	phys = <&cp1_comphy5 2>;
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&cp1_spi1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&cp1_spi1_pins>;
++	status = "okay";
++
++	spi-flash@0 {
++		compatible = "st,w25q32";
++		spi-max-frequency = <50000000>;
++		reg = <0>;
++	};
++};
++
++&cp1_usb3_0 {
++	usb-phy = <&usb3h0_phy>;
++	status = "okay";
++};


### PR DESCRIPTION
Bump mvebu kernel to 4.19 (work from @ratkaj https://github.com/openwrt/openwrt/pull/1386)
Add SolidRun ClearFog-GT-8K platform support
