### PR TITLE
ramips: add TP-Link TL-WR802N-v4 support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -152,6 +152,7 @@ ramips_setup_interfaces()
 	mzk-ex750np|\
 	na930|\
 	pbr-d1|\
+  tl-wr802n-v4|\
 	ravpower,wd03|\
 	tama,w06|\
 	tplink,tl-mr3020-v3|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -487,6 +487,9 @@ ramips_board_detect() {
 	*"Timecloud")
 		name="timecloud"
 		;;
+	*"TL-WR802N v4")
+		name="tl-wr802n-v4"
+		;;
 	*"TL-WR840N v4")
 		name="tl-wr840n-v4"
 		;;

--- a/target/linux/ramips/dts/TL-WR802NV4.dts
+++ b/target/linux/ramips/dts/TL-WR802NV4.dts
@@ -1,0 +1,52 @@
+/dts-v1/;
+
+#include "TPLINK-8M.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr802n-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR802N v4";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tl-wr802n-v4:green:power";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p2led_an", "perst";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,portmap = "l";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -172,6 +172,19 @@ define Device/tplink_tl-wa801nd-v5
 endef
 TARGET_DEVICES += tplink_tl-wa801nd-v5
 
+define Device/tl-wr802n-v4
+  $(Device/tplink)
+  DTS := TL-WR802NV4
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link TL-WR802N v4
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08020004
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x4
+  TPLINK_HVERSION := 3
+endef
+TARGET_DEVICES += tl-wr802n-v4
+
 define Device/tl-wr840n-v4
   $(Device/tplink)
   DTS := TL-WR840NV4


### PR DESCRIPTION
This patch adds support for the TP-Link TL-WR802N-v4.
https://wiki.openwrt.org/toh/tp-link/tl-wr802n