### PR TITLE
base-files: install missing /etc/iproute2/ematch_map

### DIFF
--- a/package/base-files/files/etc/iproute2/ematch_map
+++ b/package/base-files/files/etc/iproute2/ematch_map
@@ -1,0 +1,8 @@
+# lookup table for ematch kinds
+1	cmp
+2	nbyte
+3	u32
+4	meta
+7	canid
+8	ipset
+9	ipt


### PR DESCRIPTION
**Compile tested**: mips32-be-malta, openwrt-18.06 & master branch
**Run tested**: mips32-be-malta, lede-17.01, openwrt-18.06 & master branch
**Related PRs**: #1627 
**Distribution**: @ldir-EDB0 , @jow- 

**Description**:
This file is needed to properly use the tc ematch modules present in
kmod-sched-core and kmod-sched. It is a read-only index file of ematch
methods and used only by tc.

Locating this file within `base-files` along side `/etc/iproute2/rt_protos`
and `/etc/iproute2/rt_tables`. Note this file isn't marked as a conffile as
there's no expectation of user editing.

Best regards