### PR TITLE
ramips: add TP-Link TL-WR802N-v4 support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -155,6 +155,7 @@ ramips_setup_interfaces()
 	ravpower,wd03|\
 	tama,w06|\
 	tplink,tl-mr3020-v3|\
+	tplink,tl-wr802n-v4|\
 	u25awf-h1|\
 	wli-tx4-ag300n|\
 	wmdr-143n|\

--- a/target/linux/ramips/dts/TL-WR802NV4.dts
+++ b/target/linux/ramips/dts/TL-WR802NV4.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "TPLINK-8M.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr802n-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR802N v4";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tl-wr802n-v4:green:power";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "refclk", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xf100>;
+	mediatek,portmap = "l";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -172,6 +172,19 @@ define Device/tplink_tl-wa801nd-v5
 endef
 TARGET_DEVICES += tplink_tl-wa801nd-v5
 
+define Device/tplink_tl-wr802n-v4
+  $(Device/tplink)
+  DTS := TL-WR802NV4
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link TL-WR802N v4
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08020004
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x4
+  TPLINK_HVERSION := 3
+endef
+TARGET_DEVICES += tplink_tl-wr802n-v4
+
 define Device/tl-wr840n-v4
   $(Device/tplink)
   DTS := TL-WR840NV4


### PR DESCRIPTION
This patch adds support for the TP-Link TL-WR802N-v4.
https://openwrt.org/toh/tp-link/tl-wr802n

Specification:
- MT7628N (580 MHz)
- 64 MB RAM
- 8 MB FLASH
- 2T2R 2.4 GHz
- 1x 10/100 Mbps Ethernet
- 1x LED

Flash instruction:

The only way to flash the image in TL-WR802N v4 is to use
tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.0.225/24 and tftp server.
2. Rename "openwrt-ramips-mt76x8-tplink_tl-wr802n-v4-squashfs-tftp-recovery.bin"
   to "tp_recovery.bin" and place it in tftp server directory.
3. Connect PC with the LAN port, press the reset button, power up
   the router and keep button pressed for around 10 seconds, until
   device starts downloading the file.
4. Router will download file from server, write it to flash and reboot.
