### PR TITLE
buildsystem: add CPE information to ipkg packages and manifest files

### DIFF
--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -165,6 +165,7 @@ $$(call addfield,Depends,$$(Package/$(1)/DEPENDS)
 )$$(call addfield,LicenseFiles,$(LICENSE_FILES)
 )$$(call addfield,Section,$(SECTION)
 )$$(call addfield,Require-User,$(USERID)
+)$(if $(PKG_CPE_ID),CPE-ID: $(PKG_CPE_ID)
 )$(if $(filter hold,$(PKG_FLAGS)),Status: unknown hold not-installed
 )$(if $(filter essential,$(PKG_FLAGS)),Essential: yes
 )$(if $(MAINTAINER),Maintainer: $(MAINTAINER)


### PR DESCRIPTION
Common Platform Enumeration (CPE) is a structured naming scheme for
information technology systems, software, and packages.

This information already exists in some makefiles. In order for the
information to be processed further, it should also be added to the
manifest file and the control file of ipkg packages. This could be used
to get Common Vulnerabilities and Exposures (CVE) from a database
(for example https://cve.mitre.org/find/).
