### PR TITLE
ipq40xx:add support qxwlan e2600ac-c1/c2

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -44,18 +44,6 @@ define Build/buffalo-dhp-image
 	mv $@.new $@
 endef
 
-# blow up binary to given size and put a given string at its end:
-# cameo-factory <size[k]> <string>
-define Build/cameo-factory
-	factory_stamp=$(word 2,$(1)); \
-	((reduced_size=$(subst k,*1024,$(word 1,$(1)))-$${#factory_stamp})); \
-	( \
-		dd if=$@ bs=$$reduced_size conv=sync; \
-		echo -n $$factory_stamp; \
-	) > $@.new && \
-	mv $@.new $@
-endef
-
 define Build/eva-image
 	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
 	mv $@.new $@

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -146,7 +146,8 @@ define Device/dlink_dir-825-c1
   IMAGE_SIZE := 15936k
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/factory.bin := $$(IMAGE/default) | cameo-factory $$$$(IMAGE_SIZE) 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
+	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 TARGET_DEVICES += dlink_dir-825-c1
@@ -159,7 +160,8 @@ define Device/dlink_dir-835-a1
   IMAGE_SIZE := 15936k
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/factory.bin := $$(IMAGE/default) | cameo-factory $$$$(IMAGE_SIZE) 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
+	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 TARGET_DEVICES += dlink_dir-835-a1


### PR DESCRIPTION
Qxwlan E2600AC C1 based on IPQ4019

Specifications:
SOC:	Qualcomm IPQ4019
DRAM:	256 MiB
FLASH:	32 MiB Winbond W25Q256
ETH:	Qualcomm QCA8075
WLAN:	5G + 5G/2.4G
INPUT:  Reset buutton
LED:	1x Power ,6 driver by gpio
SERIAL: UART (J5)
UUSB:	USB3.0
POWER:	1x DC jack for main power input (9-24 V)
SLOT:	Pcie (J25), sim card (J11), SD card (J51)

Flash instruction (using U-Boot CLI and tftp server):

 - Configure PC with static IP 192.168.1.10 and tftp server.
 - Rename "sysupgrade" filename to "firmware.bin" and place it in tftp
   server directory.
 - Connect PC with one of RJ45 ports, power up the board and press
   "enter" key to access U-Boot CLI.
 - Use the following command to update the device to OpenWrt: "run lfw".

Flash instruction (using U-Boot web-based recovery):

 - Configure PC with static IP 192.168.1.xxx(2-254)/24.
 - Connect PC with one of RJ45 ports, press the reset button, power up
   the board and keep button pressed for around 6-7 seconds, until LEDs
   start flashing.
 - Open your browser and enter 192.168.1.1, select "sysupgrade" image
   and click the upgrade button.

Qxwlan E2600AC C2 based on IPQ4019

Specifications:
SOC:	Qualcomm IPQ4019
DRAM:	256 MiB
NOR:	16 MiB Winbond W25Q128
NAND:	128MiB Micron MT29F1G08ABAEAWP
ETH:	Qualcomm QCA8075
WLAN:	5G + 5G/2.4G
INPUT:  Reset buutton
LED:	1x Power ,6 driver by gpio
SERIAL: UART (J5)
USB:	USB3.0
POWER:	1x DC jack for main power input (9-24 V)
SLOT:	Pcie (J25), sim card (J11), SD card (J51)

Flash instruction (using U-Boot CLI and tftp server):

 - Configure PC with static IP 192.168.1.10 and tftp server.
 - Rename "ubi" filename to "ubi-firmware.bin" and place it in tftp
   server directory.
 - Connect PC with one of RJ45 ports, power up the board and press
   "enter" key to access U-Boot CLI.
 - Use the following command to update the device to OpenWrt: "run lfw".

Flash instruction (using U-Boot web-based recovery):

 - Configure PC with static IP 192.168.1.xxx(2-254)/24.
 - Connect PC with one of RJ45 ports, press the reset button, power up
   the board and keep button pressed for around 6-7 seconds, until LEDs
   start flashing.
 - Open your browser and enter 192.168.1.1, select "ubi" image
   and click the upgrade button.

Signed-off-by: 张鹏 <sd20@qxwlan.com>