### PR TITLE
ath79: ubnt-m-xw and ubnt-bullet-m-xw improvements

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -24,8 +24,6 @@
 &eth0 {
 	status = "okay";
 
-	mtd-mac-address = <&eeprom 0x0>;
-
 	phy-mode = "rgmii";
 	phy-handle = <&phy4>;
 

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -24,7 +24,6 @@
 &eth0 {
 	status = "okay";
 
-	pll-data = <0x06000000 0x00000101 0x00001313>;
 	mtd-mac-address = <&eeprom 0x0>;
 
 	phy-mode = "rgmii";

--- a/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_bullet-m-xw.dts
@@ -33,7 +33,3 @@
 		rxdv-delay = <3>;
 	};
 };
-
-&eth1 {
-	status = "disabled";
-};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -9,6 +9,13 @@
 	compatible = "ubnt,xw", "qca,ar9342";
 	model = "Ubiquiti Networks XW board";
 
+	aliases {
+		led-boot = &system;
+		led-running = &system;
+		led-upgrade = &system;
+		led-failsafe = &system;
+	};
+
 	gpio-leds {
 		compatible = "gpio-leds";
 
@@ -27,7 +34,7 @@
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		link4 {
+		system: link4 {
 			label = "ubnt:green:link4";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -117,3 +117,7 @@
 	mtd-cal-data = <&eeprom 0x1000>;
 	mtd-mac-address = <&eeprom 0x1002>;
 };
+
+&eth0 {
+	mtd-mac-address = <&eeprom 0x0>;
+};


### PR DESCRIPTION
This is part of my previous pull request [`ath79: Add support for Ubiquiti Nanostation M (XW)`](https://github.com/openwrt/openwrt/pull/1632) which I've closed since we first need to properly fix the MAC/MDIO reset in the `ath79/ag71xx` in order to proceed with adding support for Nanostation M (XW), but this is going to take some time, so I've now taken out patches which are making `ubnt-m-xw` and `ubnt-bullet-m-xw` DTS files cleaner and add LED aliases for diag.sh support which is currently missing.