### PR TITLE
busybox: keep syslog.conf during sysupgrade

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.29.3
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -69,6 +69,12 @@ endef
 define Package/busybox/config
 	source "$(SOURCE)/Config.in"
 endef
+
+ifdef CONFIG_BUSYBOX_CONFIG_FEATURE_SYSLOG
+define Package/busybox/conffiles
+/etc/syslog.conf
+endef
+endif
 
 # don't create a version string containing the actual timestamp
 export KCONFIG_NOTIMESTAMP=1


### PR DESCRIPTION
If a user finds that logd is too barebone for their needs and wishes
to have more control over syslog, the user presently has an option
to enable CONFIG_BUSYBOX_CONFIG_FEATURE_SYSLOG
and configure syslog with settings in /etc/syslog.conf.

Presently /etc/syslog.conf silently disappears on sysupgrade. This
patch prevents such unwanted behaviour if busybox syslog is enabled
via CONFIG_BUSYBOX_CONFIG_FEATURE_SYSLOG.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>
