### PR TITLE
brcm2708: Add feature flag rootfs-part

### DIFF
--- a/target/linux/brcm2708/Makefile
+++ b/target/linux/brcm2708/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=brcm2708
 BOARDNAME:=Broadcom BCM27xx
-FEATURES:=ext4 audio usb usbgadget display gpio fpu squashfs
+FEATURES:=ext4 audio usb usbgadget display gpio fpu squashfs rootfs-part
 MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 SUBTARGETS:=bcm2708 bcm2709 bcm2710
 


### PR DESCRIPTION
Even with squashfs brcm2708 requires ROOTFS_PART_SIZE because the overlay
exists as a loopback device on the space not used by squashfs in the root
partition.  Also for ext4 (the other fs option) ROOTFS_PART_SIZE is required,
so always enable ROOTFS_PART_SIZE for brcm2708.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>
