### PR TITLE
ar71xx: change partition layout on domywifi dw33d

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -350,7 +350,6 @@ platform_check_image() {
 	bxu2000n-2-a1|\
 	db120|\
 	dr344|\
-	dw33d|\
 	f9k1115v2|\
 	hornet-ub|\
 	mr12|\
@@ -713,6 +712,7 @@ platform_check_image() {
 		return 0;
 		;;
 	# these boards use metadata images
+	dw33d|\
 	fritz300e|\
 	fritz4020|\
 	fritz450e|\
@@ -853,6 +853,7 @@ platform_do_upgrade() {
 		platform_do_upgrade_openmesh "$ARGV"
 		;;
 	c-60|\
+	dw33d|\
 	hiveap-121|\
 	nbg6716|\
 	r6100|\

--- a/target/linux/ar71xx/image/nand.mk
+++ b/target/linux/ar71xx/image/nand.mk
@@ -33,9 +33,16 @@ define Device/domywifi-dw33d
   DEVICE_TITLE := DomyWifi DW33D
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   BOARDNAME := DW33D
-  IMAGE_SIZE := 16000k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware);ar934x-nfc:96m(rootfs_data),32m(backup)ro
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 14528k | append-kernel | check-size $$$$(IMAGE_SIZE)
+  SUPPORTED_DEVICES := dw33d
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 2048k
+  UBINIZE_OPTS := -E 5
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),14528k(rf),1472k(kl),64k(art)ro,15936k@0x50000(fw);ar934x-nfc:2048k(kernel),94m(ubi),32m(backup)ro
+  KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma
+  IMAGES := sysupgrade.tar factory.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
 endef
 TARGET_DEVICES += domywifi-dw33d
 


### PR DESCRIPTION
This commit changes the domywifi-dw33d partition layout
1.install OpenWrt on the NAND Flash(kernel+ubi)
2.reset kernel partition,support 4.14 kernel
3.add factory.bin image,change sysupgrade.bin
to sysupgrade-tar,append metadata to images,Support for installation in
oem firmware.

oem partition layout
dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00e30000 00010000 "rootfs"
mtd3: 00170000 00010000 "kernel"
mtd4: 00010000 00010000 "art"
mtd5: 00f90000 00010000 "firmware"
mtd6: 06000000 00020000 "rootfs_data"
mtd7: 02000000 00020000 "backup"

new partition layout
dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00e30000 00010000 "rf"
mtd3: 00170000 00010000 "kl"
mtd4: 00010000 00010000 "art"
mtd5: 00f90000 00010000 "fw"
mtd6: 00200000 00020000 "kernel"
mtd7: 05e00000 00020000 "ubi"
mtd8: 02000000 00020000 "backup"

oem u-boot-env
bootcmd=bootm 0x9fe80000

new u-boot-env
bootcmd=nboot 0x8050000 0;bootm

installation guide
1.Upload openwrt firmware to the device
scp openwrt-snapshot-r8703-bcb8592353-ar71xx-nand-domywifi-dw33d-\
squashfs-factory.bin root@192.168.10.1:/tmp
2.ssh login to the device, modify uboot-env
fw_setenv bootcmd 'nboot 0x8050000 0;bootm'
Run the fw_printenv command to check if the settings are correct.
3.Write openwrt firmware
mtd -r write /tmp/openwrt-snapshot-r8703-bcb8592353-ar71xx-nand-\
domywifi-dw33d-squashfs-factory.bin /dev/mtd6
The device will restart automatically and the openwrt firmware
installation is complete.

Detailed installation help please visit:
https://www.right.com.cn/forum/thread-376877-1-1.html

Signed-off-by: shanpo <jwdsccd@gmail.com>
