### PR TITLE
ath10k-ct: Update to 2018-12-20

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -1,16 +1,16 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct
-PKG_RELEASE=3
+PKG_RELEASE=1
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=
 
 PKG_SOURCE_URL:=https://github.com/greearb/ath10k-ct.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2018-12-11
-PKG_SOURCE_VERSION:=812d90c08ca8ce8dcbd1b2281e89ff562c7096e1
-PKG_MIRROR_HASH:=986feafd27a828801be96ce4177886204998beea305cda40aafe92a9636db852
+PKG_SOURCE_DATE:=2018-12-20
+PKG_SOURCE_VERSION:=118e16da8e82f2e028654f86e47f4c8e5bddccc8
+PKG_MIRROR_HASH:=f84616d5c6c3f6c0aded40b821d9b54fd88b78737f534b37a6ed0c51db16ed06
 
 # Build the 4.19 ath10k-ct driver version.  Other options are "-4.16", or
 # leave un-defined for 4.7 kernel.  Probably this should match as closely as

--- a/package/kernel/ath10k-ct/patches/100-kernel_compat.patch
+++ b/package/kernel/ath10k-ct/patches/100-kernel_compat.patch
@@ -108,7 +108,7 @@
  		return;
 --- a/ath10k-4.16/wmi.c
 +++ b/ath10k-4.16/wmi.c
-@@ -4063,7 +4063,7 @@ static void ath10k_dfs_radar_report(stru
+@@ -4065,7 +4065,7 @@ static void ath10k_dfs_radar_report(stru
  
  	ATH10K_DFS_STAT_INC(ar, pulses_detected);
  

--- a/package/kernel/ath10k-ct/patches/201-ath10k-4.16_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/ath10k-ct/patches/201-ath10k-4.16_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -455,7 +455,7 @@ v13:
  static const struct wmi_peer_flags_map wmi_tlv_peer_flags_map = {
 --- a/ath10k-4.16/wmi.c
 +++ b/ath10k-4.16/wmi.c
-@@ -7323,6 +7323,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
+@@ -7325,6 +7325,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
  	return skb;
  }
  
@@ -505,7 +505,7 @@ v13:
  static struct sk_buff *
  ath10k_wmi_op_gen_set_psmode(struct ath10k *ar, u32 vdev_id,
  			     enum wmi_sta_ps_mode psmode)
-@@ -8938,6 +8981,9 @@ static const struct wmi_ops wmi_ops = {
+@@ -8940,6 +8983,9 @@ static const struct wmi_ops wmi_ops = {
  	.fw_stats_fill = ath10k_wmi_main_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
  	.gen_echo = ath10k_wmi_op_gen_echo,
@@ -515,7 +515,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9008,6 +9054,8 @@ static const struct wmi_ops wmi_10_1_ops
+@@ -9010,6 +9056,8 @@ static const struct wmi_ops wmi_10_1_ops
  	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
  	.gen_echo = ath10k_wmi_op_gen_echo,
@@ -524,7 +524,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9085,6 +9133,8 @@ static const struct wmi_ops wmi_10_2_ops
+@@ -9087,6 +9135,8 @@ static const struct wmi_ops wmi_10_2_ops
  	.gen_delba_send = ath10k_wmi_op_gen_delba_send,
  	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
@@ -533,7 +533,7 @@ v13:
  	/* .gen_pdev_enable_adaptive_cca not implemented */
  };
  
-@@ -9155,6 +9205,8 @@ static const struct wmi_ops wmi_10_2_4_o
+@@ -9157,6 +9207,8 @@ static const struct wmi_ops wmi_10_2_4_o
  	.gen_pdev_enable_adaptive_cca =
  		ath10k_wmi_op_gen_pdev_enable_adaptive_cca,
  	.get_vdev_subtype = ath10k_wmi_10_2_4_op_get_vdev_subtype,
@@ -542,7 +542,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9231,6 +9283,8 @@ static const struct wmi_ops wmi_10_4_ops
+@@ -9233,6 +9285,8 @@ static const struct wmi_ops wmi_10_4_ops
  	.gen_pdev_bss_chan_info_req = ath10k_wmi_10_2_op_gen_pdev_bss_chan_info,
  	.gen_echo = ath10k_wmi_op_gen_echo,
  	.gen_pdev_get_tpc_config = ath10k_wmi_10_2_4_op_gen_pdev_get_tpc_config,
@@ -674,7 +674,7 @@ v13:
  		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
-@@ -3097,6 +3103,10 @@ int ath10k_core_start(struct ath10k *ar,
+@@ -3102,6 +3108,10 @@ int ath10k_core_start(struct ath10k *ar,
  						   ar->eeprom_overrides.rc_txbf_probe);
  	}
  
@@ -685,7 +685,7 @@ v13:
  	return 0;
  
  err_hif_stop:
-@@ -3351,9 +3361,18 @@ static void ath10k_core_register_work(st
+@@ -3356,9 +3366,18 @@ static void ath10k_core_register_work(st
  		goto err_spectral_destroy;
  	}
  
@@ -704,7 +704,7 @@ v13:
  err_spectral_destroy:
  	ath10k_spectral_destroy(ar);
  err_debug_destroy:
-@@ -3411,6 +3430,8 @@ void ath10k_core_unregister(struct ath10
+@@ -3416,6 +3435,8 @@ void ath10k_core_unregister(struct ath10
  	if (!test_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags))
  		return;
  
@@ -977,7 +977,7 @@ v13:
  static const struct wmi_peer_flags_map wmi_tlv_peer_flags_map = {
 --- a/ath10k-4.19/wmi.c
 +++ b/ath10k-4.19/wmi.c
-@@ -7843,6 +7843,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
+@@ -7844,6 +7844,49 @@ ath10k_wmi_op_gen_peer_set_param(struct
  	return skb;
  }
  
@@ -1027,7 +1027,7 @@ v13:
  static struct sk_buff *
  ath10k_wmi_op_gen_set_psmode(struct ath10k *ar, u32 vdev_id,
  			     enum wmi_sta_ps_mode psmode)
-@@ -9567,6 +9610,9 @@ static const struct wmi_ops wmi_ops = {
+@@ -9568,6 +9611,9 @@ static const struct wmi_ops wmi_ops = {
  	.fw_stats_fill = ath10k_wmi_main_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
  	.gen_echo = ath10k_wmi_op_gen_echo,
@@ -1037,7 +1037,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9637,6 +9683,8 @@ static const struct wmi_ops wmi_10_1_ops
+@@ -9638,6 +9684,8 @@ static const struct wmi_ops wmi_10_1_ops
  	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
  	.gen_echo = ath10k_wmi_op_gen_echo,
@@ -1046,7 +1046,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9714,6 +9762,8 @@ static const struct wmi_ops wmi_10_2_ops
+@@ -9715,6 +9763,8 @@ static const struct wmi_ops wmi_10_2_ops
  	.gen_delba_send = ath10k_wmi_op_gen_delba_send,
  	.fw_stats_fill = ath10k_wmi_10x_op_fw_stats_fill,
  	.get_vdev_subtype = ath10k_wmi_op_get_vdev_subtype,
@@ -1055,7 +1055,7 @@ v13:
  	/* .gen_pdev_enable_adaptive_cca not implemented */
  };
  
-@@ -9784,6 +9834,8 @@ static const struct wmi_ops wmi_10_2_4_o
+@@ -9785,6 +9835,8 @@ static const struct wmi_ops wmi_10_2_4_o
  	.gen_pdev_enable_adaptive_cca =
  		ath10k_wmi_op_gen_pdev_enable_adaptive_cca,
  	.get_vdev_subtype = ath10k_wmi_10_2_4_op_get_vdev_subtype,
@@ -1064,7 +1064,7 @@ v13:
  	/* .gen_bcn_tmpl not implemented */
  	/* .gen_prb_tmpl not implemented */
  	/* .gen_p2p_go_bcn_ie not implemented */
-@@ -9864,6 +9916,8 @@ static const struct wmi_ops wmi_10_4_ops
+@@ -9865,6 +9917,8 @@ static const struct wmi_ops wmi_10_4_ops
  	.gen_pdev_bss_chan_info_req = ath10k_wmi_10_2_op_gen_pdev_bss_chan_info,
  	.gen_echo = ath10k_wmi_op_gen_echo,
  	.gen_pdev_get_tpc_config = ath10k_wmi_10_2_4_op_gen_pdev_get_tpc_config,

--- a/package/kernel/ath10k-ct/patches/202-ath10k-4.16-use-tpt-trigger-by-default.patch
+++ b/package/kernel/ath10k-ct/patches/202-ath10k-4.16-use-tpt-trigger-by-default.patch
@@ -79,7 +79,7 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
  	if (ret)
 --- a/ath10k-4.19/mac.c
 +++ b/ath10k-4.19/mac.c
-@@ -9768,7 +9768,7 @@ int ath10k_mac_register(struct ath10k *a
+@@ -9775,7 +9775,7 @@ int ath10k_mac_register(struct ath10k *a
  	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_CQM_RSSI_LIST);
  
  #ifdef CPTCFG_MAC80211_LEDS


### PR DESCRIPTION
This version removes a lot of unusefull warnings that would quickly overflow the dmesg.
Warnings like this:
ath10k_ahb a800000.wifi: Invalid legacy rate 26 peer stats
ath10k_ahb a000000.wifi: Invalid VHT mcs 15 peer stats
On this version I only had 2 warnings at all.
Tested on 8devices Jalapeno.

Signed-off-by: Robert Marko <robimarko@gmail.com>