### PR TITLE
ipq40xx: uboot-envtools configuration for GL.iNet GL-B1300

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -31,6 +31,7 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+glinet,gl-b1300 |\
 openmesh,a42 |\
 openmesh,a62)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
This commit adds the necessary settings to allow reading the uboot environment variables on the GL.iNet GL-B1300 board.

This does NOT install the uboot-envtools package by default (fw_setenv, fw_printenv) and everything remains optional. Should you wish to install uboot-envtools then correct settings will be applied.

This commit has been proposed before but was not merged in. I am trying again.

This was discussed some time ago on the openwrt dev irc channel with positive results.
There has been similar commits before that does the exact same thing for other targets.