### PR TITLE
x86: enable kmod-bnx2 on 64-bit by default

### DIFF
--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,6 +1,6 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
-DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb
+DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb kmod-bnx2
 
 define Target/Description
         Build images for 64 bit systems including virtualized guests.


### PR DESCRIPTION
Gigabit ethernet adapters using BCM5706/5708/5709/5716 chipset are 
common on servers and as easy/cheap to get as Intel based ones.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>