### PR TITLE
ramips : add SPDX license identifier into dts,dtsi for R6350 and WRC-1900GST

### DIFF
--- a/target/linux/ramips/dts/R6350.dts
+++ b/target/linux/ramips/dts/R6350.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /dts-v1/;
 
 #include "mt7621.dtsi"

--- a/target/linux/ramips/dts/WRC-1900GST.dts
+++ b/target/linux/ramips/dts/WRC-1900GST.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /dts-v1/;
 
 #include "elecom_wrc-gst.dtsi"

--- a/target/linux/ramips/dts/elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/elecom_wrc-gst.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /dts-v1/;
 
 #include "mt7621.dtsi"


### PR DESCRIPTION
add SPDX license identifier into dts,dtsi for R6350 and WRC-1900GST

Signed-off-by: NOGUCHI Hiroshi <drvlabo@gmail.com>