### PR TITLE
 config: ext4: increase x86 rootfs size for online resize

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -274,7 +274,8 @@ menu "Target Images"
 	config TARGET_ROOTFS_PARTSIZE
 		int "Root filesystem partition size (in MB)"
 		depends on GRUB_IMAGES || USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_mvebu || TARGET_rb532 || TARGET_sunxi || TARGET_uml
-		default 256
+		default 2048 if TARGET_x86
+		default 256 if ! TARGET_x86
 		help
 		  Select the root filesystem partition size.
 


### PR DESCRIPTION
ext4 online resize on x86 rootfs fails unless the rootfs size is set to 2 GB or larger, 
this is very inconvenient because the only way to increase 
filesystem size is to do it with the filesystem unmounted.

This is an example of the error when I try to resize it when mounted from my PC
(this is the same error I get also in OpenWrt)

-------

alby@openSUSE-xeon:/> sudo resize2fs /dev/sdd2
resize2fs 1.44.4 (18-Aug-2018)
Filesystem at /dev/sdd2 is mounted on /run/media/alby/57f8f4bc-abf4-655f-bf67-946fc0f9f25b; on-line resizing required
old_desc_blocks = 1, new_desc_blocks = 1
resize2fs: Invalid argument While checking for on-line resizing support

-------

This commit restores commit dc6cc040169a3f29d0126c24d65d5e7b6c479ab8
which was reverted later in commit 4cc1f1ac1cb7fe5216792f346a85c2c119b33a04
imho (also reading the description) the revert was a mistake.
"2 GB is overkill and was only added to allow unlimited ext4 resizing,
which is a pretty rare use case. "

That commit was not about allowing unlimited resizing.
The issue here is that online resize does not work 
unless the filesystem size is 2GB or more, 
or maybe if we change the block size instead.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>

