### PR TITLE
ath79: add support for TP-Link Archer C7 v5

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -52,7 +52,8 @@ pcs,cr3000)
 	ucidef_set_led_switch "lan3" "LAN3" "pcs:blue:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "pcs:blue:lan4" "switch0" "0x02"
 	;;
-tplink,archer-a7-v5)
+tplink,archer-a7-v5|\
+tplink,archer-c7-v5)
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -135,6 +135,7 @@ ath79_setup_interfaces()
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
 	tplink,archer-a7-v5|\
+	tplink,archer-c7-v5|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -109,6 +109,10 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
+	tplink,archer-c7-v5)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
+		;;
 	tplink,re450-v2)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_archer-x7-v5.dtsi"
+
+/ {
+	compatible = "tplink,archer-c7-v5", "qca,qca9563";
+	model = "TP-Link Archer C7 v5";
+};
+
+&mtdparts {
+	partition@0 {
+		label = "factory-uboot";
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	partition@20000 {
+		label = "u-boot";
+		reg = <0x020000 0x020000>;
+		read-only;
+	};
+
+	partition@40000 {
+		label = "partition-table";
+		reg = <0x040000 0x010000>;
+	};
+
+	art: partition@50000 {
+		label = "art";
+		reg = <0x050000 0x010000>;
+		read-only;
+	};
+
+	info: partition@60000 {
+		label = "info";
+		reg = <0x060000 0x020000>;
+	};
+
+	partition@80000 {
+		label = "user-config";
+		reg = <0x080000 0x040000>;
+	};
+
+	partition@c0000 {
+		label = "firmware";
+		reg = <0x0c0000 0xf00000>;
+		compatible = "denx,uimage";
+	};
+
+	partition@ff0000 {
+		label = "default-config";
+		reg = <0xff0000 0x010000>;
+	};
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -55,6 +55,18 @@ define Device/tplink_archer-c7-v2
 endef
 TARGET_DEVICES += tplink_archer-c7-v2
 
+define Device/tplink_archer-c7-v5
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 15360k
+  DEVICE_TITLE := TP-LINK Archer C7 v5
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  TPLINK_BOARD_ID := ARCHER-C7-V5
+  BOARDNAME := ARCHER-C7-V5
+  SUPPORTED_DEVICES += archer-c7-v5
+endef
+TARGET_DEVICES += tplink_archer-c7-v5
+
 define Device/tplink_re450-v2
   $(Device/tplink)
   ATH_SOC := qca9563


### PR DESCRIPTION
This commit adds support for TP-Link Archer C7 v5, leveraging most effort from commit ea9baee and 1e4ee63. Archer C7 v5 is identical to Archer A7 v5 but with a different flash layout.

Specification:
-   QCA9563 SoC (750 MHz)
-   128 MiB of RAM (DDR2)
-   16 MiB of flash (SPI)
-   5x 1 Gbps Ethernet (1x WAN + 4x LAN)
-   2.4GHz (bgn) SoC internal + 5GHz (ac) QCA9880
-   10x LED, 2x button
-   UART header on PCB

Flash instructions:
1.  Upload openwrt-ath79-generic-tplink_archer-c7-v5-squashfs-factory.bin via web interface.

Flash instructions using TFTP recovery:
1.  Plug PC to one of the LAN ports
2.  Set PC to fixed IP address 192.168.0.66
3.  Rename the factory image to ArcherC7v5_tp_recovery.bin and place it in TFTP root directory
4.  Turn on the router with the reset button pressed for about 15 secs
5.  Release the button and wait about 150 secs to complete flashing