### PR TITLE
ipq806x: add support for Buffalo WXR-2533DHP

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -11,6 +11,10 @@ board=$(board_name)
 boardname="${board##*,}"
 
 case "$board" in
+buffalo,wxr-2533dhp)
+	ucidef_set_led_wlan "wlan" "WLAN" "${boardname}:white:wireless" "phy0tpt"
+	ucidef_set_led_switch "wan" "WAN" "${boardname}:white:internet" "switch0" "0x20"
+	;;
 compex,wpq864)
 	ucidef_set_led_usbport "usb" "USB" "wpq864:green:usb" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "pcie-usb" "PCIe USB" "wpq864:green:usb-pcie" "usb3-port1"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+buffalo,wxr-2533dhp |\
 compex,wpq864 |\
 netgear,d7800 |\
 netgear,r7500 |\

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -79,6 +79,10 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
+	buffalo,wxr-2533dhp)
+		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 30)
+		;;
 	linksys,ea8500)
 		ath10kcal_extract "art" 4096 12064
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +1)
@@ -109,6 +113,10 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
+	buffalo,wxr-2533dhp)
+		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 24)
+		;;
 	linksys,ea8500)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +2)

--- a/target/linux/ipq806x/base-files/lib/upgrade/buffalo.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/buffalo.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Copyright (C) 2018 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+# The mtd partition 'ubi' and 'rootfs_1' on NAND flash are os-image
+# partitions. These partitions are called as "Bank1/Bank2" in U-Boot
+# on WXR-2533DHP, and they are checked conditions when booting.
+# Then, U-Boot checks kernel and rootfs volumes in ubi, but U-Boot
+# needs "ubi_rootfs" as rootfs volume name. And, U-Boot checks the
+# checksum at the end of rootfs (ubi_rootfs).
+# When U-Boot writes os-image into the Bank, only kernel, rootfs
+# (ubi_rootfs) and rootfs_data (ubi_rootfs_data) volumes are wrote
+# into the Bank. (not full ubi image)
+#
+# == U-Boot Behaviors ==
+# - Bank1/Bank2 images are good, images are different
+#   -> writes os-image to Bank1 from Bank2
+#      (this behavior is used to firmware upgrade in stock firmware)
+# - Bank1 image is broken (or checksum error)
+#   -> writes os-image to Bank1 from Bank2
+# - Bank2 image is broken (or checksum error)
+#   -> writes os-image to Bank2 from Bank1
+# - Bank1/Bank2 images are broken (or checksum error)
+#   -> start tftp
+
+buffalo_upgrade_prepare_ubi() {
+	local ubidev="$( nand_find_ubi ubi )"
+	local mtdnum2="$( find_mtd_index rootfs_1 )"
+
+	if [ ! "$mtdnum2" ]; then
+		echo "cannot find second ubi mtd partition rootfs_1"
+		return 1
+	fi
+
+	local ubidev2="$( nand_find_ubi rootfs_1 )"
+	if [ ! "$ubidev2" ] && [ -n "$mtdnum2" ]; then
+		ubiattach -m "$mtdnum2"
+		ubidev2="$( nand_find_ubi rootfs_1 )"
+	fi
+
+	ubirmvol /dev/$ubidev -N ubi_rootfs_data &> /dev/null || true
+	ubirmvol /dev/$ubidev2 -N kernel &> /dev/null || true
+}

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -10,6 +10,11 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	buffalo,wxr-2533dhp)
+		buffalo_upgrade_prepare_ubi
+		CI_ROOTPART="ubi_rootfs"
+		nand_do_upgrade "$ARGV"
+		;;
 	compex,wpq864|\
 	netgear,d7800 |\
 	netgear,r7500 |\

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "qcom-ipq8064-v2.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Buffalo WXR-2533DHP";
+	compatible = "buffalo,wxr-2533dhp", "qcom,ipq8064";
+
+	memory@42000000 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+
+		led-boot = &power;
+		led-failsafe = &diag;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	chosen {
+		/* use "ubi_rootfs" volume in "ubi" partition as rootfs */
+		bootargs = "ubi.block=0,1 root=/dev/ubiblock0_1 rootfstype=squashfs";
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		nand@1ac00000 {
+			status = "okay";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs@0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					ubi@0 {
+						label = "ubi";
+						reg = <0x0000000 0x4000000>;
+					};
+
+					rootfs_1@4000000 {
+						label = "rootfs_1";
+						reg = <0x4000000 0x4000000>;
+					};
+				};
+			};
+		};
+
+		mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH>,
+				<&qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			ethernet-phy@0 {
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x07600000  /* PAD0_MODE */
+					0x00008 0x01000000  /* PAD5_MODE */
+					0x0000c 0x00000080  /* PAD6_MODE */
+					0x00050 0xcc35cc35  /* LED_CTRL0 */
+					0x00054 0xca35ca35  /* LED_CTRL1 */
+					0x00058 0xc935c935  /* LED_CTRL2 */
+					0x0005c 0x03ffff00  /* LED_CTRL3 */
+					0x000e4 0x0006a545  /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x0000007e  /* PORT0_STATUS */
+					0x00094 0x0000007e  /* PORT6_STATUS */
+					>;
+			};
+
+			ethernet-phy@4 {
+				reg = <4>;
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		usb {
+			label = "wxr-2533dhp:green:usb";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port0 &hub_port1>;
+		};
+
+		guestport {
+			label = "wxr-2533dhp:green:guestport";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		diag: diag {
+			label = "wxr-2533dhp:orange:diag";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet_orange {
+			label = "wxr-2533dhp:orange:internet";
+			gpios = <&qcom_pinmux 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet_white {
+			label = "wxr-2533dhp:white:internet";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		wireless_orange {
+			label = "wxr-2533dhp:orange:wireless";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		wireless_white {
+			label = "wxr-2533dhp:white:wireless";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		router_orange {
+			label = "wxr-2533dhp:orange:router";
+			gpios = <&qcom_pinmux 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		router_white {
+			label = "wxr-2533dhp:white:router";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+		};
+
+		power: power {
+			label = "wxr-2533dhp:white:power";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		power {
+			label = "power";
+			gpios = <&qcom_pinmux 58 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_POWER>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		eject {
+			label = "eject";
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_EJECTCD>;
+		};
+
+		guest {
+			label = "guest";
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		ap {
+			label = "ap";
+			gpios = <&qcom_pinmux 55 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&qcom_pinmux 56 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&qcom_pinmux 57 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&gmac1 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	mtd-mac-address = <&ART 6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "ok";
+
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+
+	mtd-mac-address = <&ART 0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gsbi4 {
+	status = "okay";
+	qcom,mode = <GSBI_PROT_I2C_UART>;
+};
+
+&gsbi4_serial {
+	status = "okay";
+
+	pinctrl-0 = <&uart0_pins>;
+	pinctrl-names = "default";
+};
+
+&gsbi5 {
+	status = "okay";
+	qcom,mode = <GSBI_PROT_SPI>;
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "jedec,spi-nor";
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				SBL1@0 {
+					label = "SBL1";
+					reg = <0x0 0x10000>;
+					read-only;
+				};
+
+				MIBIB@10000 {
+					label = "MIBIB";
+					reg = <0x10000 0x20000>;
+					read-only;
+				};
+
+				SBL2@30000 {
+					label = "SBL2";
+					reg = <0x30000 0x30000>;
+					read-only;
+				};
+
+				SBL3@60000 {
+					label = "SBL3";
+					reg = <0x60000 0x30000>;
+					read-only;
+				};
+
+				DDRCONFIG@90000 {
+					label = "DDRCONFIG";
+					reg = <0x90000 0x10000>;
+					read-only;
+				};
+
+				SSD@a0000 {
+					label = "SSD";
+					reg = <0xa0000 0x10000>;
+					read-only;
+				};
+
+				TZ@b0000 {
+					label = "TZ";
+					reg = <0xb0000 0x30000>;
+					read-only;
+				};
+
+				RPM@e0000 {
+					label = "RPM";
+					reg = <0xe0000 0x20000>;
+					read-only;
+				};
+
+				APPSBL@100000 {
+					label = "APPSBL";
+					reg = <0x100000 0x70000>;
+					read-only;
+				};
+
+				APPSBLENV@170000 {
+					label = "APPSBLENV";
+					reg = <0x170000 0x10000>;
+					read-only;
+				};
+
+				ART: ART@180000 {
+					label = "ART";
+					reg = <0x180000 0x40000>;
+					read-only;
+				};
+
+				BOOTCONFIG@1c0000 {
+					label = "BOOTCONFIG";
+					reg = <0x1c0000 0x10000>;
+					read-only;
+				};
+
+				APPSBL_1@1d0000 {
+					label = "APPSBL_1";
+					reg = <0x1d0000 0x70000>;
+					read-only;
+				};
+			};
+		};
+	};
+};
+
+&hs_phy_0 {		/* USB3 port 0 HS phy */
+	status = "okay";
+};
+
+&ss_phy_0 {		/* USB3 port 0 SS phy */
+	status = "okay";
+};
+
+&hs_phy_1 {		/* USB3 port 1 HS phy */
+	status = "okay";
+};
+
+&ss_phy_1 {		/* USB3 port 1 SS phy */
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+
+	pinctrl-0 = <&usb_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&usb3_1 {
+	status = "okay";
+};
+
+&dwc3_0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&dwc3_1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+	force_gen1 = <1>;
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio6", "gpio54", "gpio55", "gpio56", "gpio57",
+				"gpio58", "gpio64", "gpio65";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio22",
+				"gpio23", "gpio24", "gpio25", "gpio26", "gpio53";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	uart0_pins: uart0_pins {
+		mux {
+			pins = "gpio10", "gpio11";
+			function = "gsbi4";
+			drive-strength = <12>;
+			bias-disable;
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			bias-pull-down;
+		};
+
+		data {
+			pins = "gpio18", "gpio19";
+			drive-strength = <10>;
+		};
+
+		cs{
+			pins = "gpio20";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+
+		clk {
+			pins = "gpio21";
+			drive-strength = <12>;
+		};
+	};
+
+	mdio0_pins: mdio0_pins {
+		mux {
+			pins = "gpio0", "gpio1";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	nand_pins: nand_pins {
+		mux {
+			pins = "gpio34", "gpio35", "gpio36",
+			       "gpio37", "gpio38", "gpio39",
+			       "gpio40", "gpio41", "gpio42",
+			       "gpio43", "gpio44", "gpio45",
+			       "gpio46", "gpio47";
+			function = "nand";
+			drive-strength = <10>;
+			bias-disable;
+		};
+
+		pullups {
+			pins = "gpio39";
+			bias-pull-up;
+		};
+
+		hold {
+			pins = "gpio40", "gpio41", "gpio42",
+			       "gpio43", "gpio44", "gpio45",
+			       "gpio46", "gpio47";
+			bias-bus-hold;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		mux {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+			       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+			function = "rgmii2";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	usb_pwr_en_pins: usb_pwr_en_pins {
+		mux{
+			pins = "gpio68";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+			output-high;
+		};
+	};
+};

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -972,7 +972,7 @@
 
 			status = "disabled";
 
-			dwc3@11000000 {
+			dwc3_0: dwc3@11000000 {
 				compatible = "snps,dwc3";
 				reg = <0x11000000 0xcd00>;
 				interrupts = <0 110 0x4>;
@@ -997,7 +997,7 @@
 
 			status = "disabled";
 
-			dwc3@10000000 {
+			dwc3_1: dwc3@10000000 {
 				compatible = "snps,dwc3";
 				reg = <0x10000000 0xcd00>;
 				interrupts = <0 205 0x4>;

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -3,6 +3,13 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+define Build/buffalo-rootfs-cksum
+	( \
+		echo -ne "\x$$(od -A n -t u1 $@ | tr -s ' ' '\n' | \
+			$(STAGING_DIR_HOST)/bin/awk '{s+=$$0}END{printf "%x", 255-s%256}')"; \
+	) >> $@
+endef
+
 define Device/Default
 	PROFILES := Default
 	KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
@@ -71,6 +78,21 @@ define Device/ZyXELImage
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to $$$$(BLOCKSIZE) | zyxel-ras-image separate-kernel
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$${BLOCKSIZE} | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
+
+define Device/buffalo_wxr-2533dhp
+	$(call Device/LegacyImage)
+	DEVICE_DTS := qcom-ipq8064-wxr-2533dhp
+	DEVICE_TITLE := Buffalo WXR-2533DHP
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 65536k
+	KERNEL_IN_UBI := 1
+	IMAGES := sysupgrade.bin
+	IMAGE/sysupgrade.bin := append-rootfs | buffalo-rootfs-cksum | \
+		sysupgrade-tar rootfs=$$$$@ | append-metadata
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+endef
+TARGET_DEVICES += buffalo_wxr-2533dhp
 
 define Device/compex_wpq864
 	$(call Device/FitImage)

--- a/target/linux/ipq806x/patches-4.14/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-4.14/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -699,6 +699,17 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -699,6 +699,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8084-mtp.dtb \
  	qcom-ipq4019-ap.dk01.1-c1.dtb \
  	qcom-ipq8064-ap148.dtb \
@@ -23,6 +23,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-r7500v2.dtb \
 +	qcom-ipq8064-wg2600hp.dtb \
 +	qcom-ipq8064-wpq864.dtb \
++	qcom-ipq8064-wxr-2533dhp.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
  	qcom-msm8660-surf.dtb \


### PR DESCRIPTION
Buffalo WXR-2533DHP is a 2.4/5 GHz band 11ac router, based on Qualcomm
IPQ8064.

The U-Boot on WXR-2533DHP behaves slightly complicated according to
the conditions of os-images. See the notes in buffalo.sh for details.

specifications:

- Qualcomm IPQ8064 (384 - 1,400 MHz, 2C2T)
- 512 MB of RAM (DDR3)
- 256 MB of Flash (NAND)
- 4T4R 2.4/5 GHz Wlan (QCA9980)
- 5x 10/100/1000 Mbps Ethernet
- 10x LEDs, 8x keys (6x buttons, 2x slide-switches)
- 2x USB 3.0 Type-A
- 12VDC/4A AC Adapter
- UART through-hole on PCB
  - J3: Vcc, GND, TX, RX from USB port side
  - 115200n8

Flash instruction using initramfs image:

1. Prepare the TFTP server with initramfs image renamed to
"wxr2300dhp-initramfs.uImage" and IP address "192.168.11.10"
2. Push power button on WXR-2533DHP with holding the "AOSS" button
and turn on WXR-2533DHP
3. Flash "Wireless" LED and release finger from AOSS button,
WXR-2533DHP downloads renamed initramfs image from TFTP server and
boot with it
4. On the initramfs image, perform sysupgrade with squashfs-sysupgrade
image
5. Wait ~120 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>