### PR TITLE
kernel: mtd: add support for EN25QH64 in spi-nor.c

### DIFF
--- a/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
+++ b/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
@@ -1,0 +1,10 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -956,6 +956,7 @@ static const struct flash_info spi_nor_i
+ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
+ 	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },
++	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,   128, 0) },
+ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
+ 	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },

--- a/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-eon-en25qh64.patch
+++ b/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-eon-en25qh64.patch
@@ -1,0 +1,10 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -956,6 +956,7 @@ static const struct flash_info spi_nor_i
+ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
+ 	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },
++	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,   128, 0) },
+ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
+ 	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },


### PR DESCRIPTION
The Eon EN25QH64 is a 64 Mbit SPI NOR flash memory chip. Its 32, 128 and 256 Mbits siblings are supported upstream but this particular size wasn't.
This commit includes patches for kernels 4.14 and 4.19.

Tested on a COMFAST CF-E120A v3 (ath79).