### PR TITLE
ath79: Fix wrong switch port order on LuCI for TL-WR740N v4

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -167,7 +167,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
-	tplink,tl-wr740nd-v4|\
 	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v11)
@@ -175,6 +174,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	tplink,tl-wr740nd-v4|\
 	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth0"


### PR DESCRIPTION
This commit fix bug report https://bugs.openwrt.org/index.php?do=details&task_id=1469 on ath79 port

Signed-off-by: Eduardo Barros <geadas@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
