### PR TITLE
ramips: add support for GeHua GHL-R-001

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -251,6 +251,7 @@ netgear,r6120)
 oy-0001)
 	set_wifi_led "$boardname:green:wifi"
 	;;
+gehua,ghl-r-001|\
 pbr-m1)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -140,6 +140,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	gehua,ghl-r-001)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "4:wan" "6@eth0"
+		;;
 	alfa-network,awusfree1|\
 	cs-qr10|\
 	d105|\

--- a/target/linux/ramips/dts/GHL-R-001.dts
+++ b/target/linux/ramips/dts/GHL-R-001.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "gehua,ghl-r-001", "mediatek,mt7621-soc";
+	model = "GeHua GHL-R-001";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		internet {
+			label = "ghl-r-001:blue:internet";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "ghl-r-001:blue:usb";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&uartlite3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "jtag", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -169,6 +169,15 @@ define Device/firewrt
 endef
 TARGET_DEVICES += firewrt
 
+define Device/gehua_ghl-r-001
+  DTS := GHL-R-001
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := GeHua GHL-R-001
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += gehua_ghl-r-001
+
 define Device/gnubee_gb-pc1
   DTS := GB-PC1
   DEVICE_TITLE := GnuBee Personal Cloud One


### PR DESCRIPTION
This PR depends on #1681 

Specs
- 	SoC: MT7621AT
- 	RAM: 512MiB
- 	Flash: 32MiB MX25L25635F SPI NOR
- 	2.4G: MT7603EN
- 	5G: MT7612EN
- 	Ethernet: 4x GE ports (1x WAN, 3x LAN) with link status LEDs
- 	USB 3.0
- 	LEDs: POWER, 5G WIFI, 2.4G WIFI, USB, Internet.
	The last two ones are controlled by GPIO
- 	UART: There are 2 UARTs (UARTLITE1/ttyS0 and UARTLITE3/ttyS1) on board.
	UARTLITE1 is close to LEDs, and UARTLITE3 is close to flash chip.
	The stock u-boot uses UARTLITE1 by default. Baud rate is 57600

Flash instruction
1. `telnet 192.168.9.1 2317`, username is "root" and password is "admin"
One can alternatively use UART to log in
2. Put OpenWrt firmware in a FAT32 USB drive, and connect it to the router
One can alternatively download the firmware via `wget` through Internet
3. `mtd write /path/to/openwrt.bin firmware`
4. reboot