### PR TITLE
kernel: dm: add dm-raid for LVM raid

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -239,7 +239,12 @@ define KernelPackage/dm
 	CONFIG_BLK_DEV_DM \
 	CONFIG_DM_CRYPT \
 	CONFIG_DM_MIRROR
-  FILES:=$(LINUX_DIR)/drivers/md/dm-*.ko
+  FILES:= \
+    $(LINUX_DIR)/drivers/md/dm-mod.ko \
+    $(LINUX_DIR)/drivers/md/dm-crypt.ko \
+    $(LINUX_DIR)/drivers/md/dm-log.ko \
+    $(LINUX_DIR)/drivers/md/dm-mirror.ko \
+    $(LINUX_DIR)/drivers/md/dm-region-hash.ko
   AUTOLOAD:=$(call AutoLoad,30,dm-mod dm-log dm-region-hash dm-mirror dm-crypt)
 endef
 
@@ -248,6 +253,23 @@ define KernelPackage/dm/description
 endef
 
 $(eval $(call KernelPackage,dm))
+
+define KernelPackage/dm-raid
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=LVM2 raid support
+  DEPENDS:=+kmod-dm +kmod-md-mod \
+           +kmod-md-raid0 +kmod-md-raid1 +kmod-md-raid10 +kmod-md-raid456
+  KCONFIG:= \
+	CONFIG_DM_RAID
+  FILES:=$(LINUX_DIR)/drivers/md/dm-raid.ko
+  AUTOLOAD:=$(call AutoLoad,31,dm-raid)
+endef
+
+define KernelPackage/dm-raid/description
+ Kernel module necessary for LVM2 raid support
+endef
+
+$(eval $(call KernelPackage,dm-raid))
 
 
 define KernelPackage/md-mod


### PR DESCRIPTION
This adds the dm-raid kmod, which is needed for
LVM builtin raid configurations, aka "MD-over-LVM"

Signed-off-by: Chris "Koying" Browet <cbro@semperpax.com>
