### PR TITLE
uhttpd: allow users to configure share document root for files

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -15,6 +15,9 @@ config uhttpd main
 	# Server document root
 	option home		/www
 
+	# Share document root
+	option share		/tmp
+
 	# Reject requests from RFC1918 IP addresses
 	# directed to the servers public IP(s).
 	# This is a DNS rebinding countermeasure.

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -191,6 +191,13 @@ start_instance()
 		[ -s "$file" ] && procd_append_param command -H "$file"
 	done
 
+	config_get home_dir "$cfg" home
+	config_get share_dir "$cfg" share
+	[ -n "$home_dir" -a -n "$share_dir" ] && {
+		rm -f $home_dir/share
+		ln -s $share_dir $home_dir/share
+	}
+
 	procd_close_instance
 }
 


### PR DESCRIPTION
This commit allows users to configure share document root for files.
Below is the screenshot, See https://github.com/openwrt/luci/pull/2404 for more details.

![share-document-root](https://user-images.githubusercontent.com/37688994/50533186-5eb17e80-0b5f-11e9-8d73-40a4bbffb482.gif)


Signed-off-by: Rosy Song <rosysong@rosinson.com>
