### PR TITLE
ramips: Add RB750Gr3 native support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -217,9 +217,9 @@ ramips_setup_interfaces()
 	jhr-n805r|\
 	jhr-n825r|\
 	jhr-n926r|\
+	mikrotik,rb750gr3|\
 	mikrotik,rbm33g|\
 	mzk-wdpr|\
-	rb750gr3|\
 	rt-n14u|\
 	skylab,skw92a|\
 	tplink,c20-v4|\

--- a/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
@@ -7,6 +7,9 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+mikrotik,rb750gr3)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "17"
+	;;
 ubnt-erx)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "0"
 	;;

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -415,9 +415,6 @@ ramips_board_detect() {
 	*"R6220")
 		name="r6220"
 		;;
-	*"RB750Gr3")
-		name="rb750gr3"
-		;;
 	*"RE350 v1")
 		name="re350-v1"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -13,6 +13,7 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	mikrotik,rb750gr3|\
 	mikrotik,rbm11g|\
 	mikrotik,rbm33g)
 		[ -z "$(rootfs_type)" ] && mtd erase firmware

--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -7,13 +7,13 @@
 
 / {
 	compatible = "mikrotik,rb750gr3", "mediatek,mt7621-soc";
-	model = "MikroTik RB750Gr3";
+	model = "MikroTik RouterBOARD 750Gr3";
 
 	aliases {
-		led-boot = &led_pwr;
-		led-failsafe = &led_pwr;
-		led-running = &led_pwr;
-		led-upgrade = &led_pwr;
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-running = &led_usr;
+		led-upgrade = &led_usr;
 	};
 
 	memory@0 {
@@ -22,18 +22,19 @@
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,57600";
+		bootargs = "console=ttyS0,115200";
 	};
 
-	gpio-leds {
+	leds {
 		compatible = "gpio-leds";
 
-		led_pwr: pwr {
+		pwr {
 			label = "rb750gr3:blue:pwr";
 			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
 		};
 
-		usr {
+		led_usr: usr {
 			label = "rb750gr3:green:usr";
 			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
 		};
@@ -46,7 +47,7 @@
 		mode {
 			label = "mode";
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RFKILL>;
+			linux,code = <BTN_0>;
 		};
 
 		res {
@@ -67,9 +68,9 @@
 		};
 
 		usb {
-			gpio-export,name = "usb";
+			gpio-export,name = "usb_power_off";
 			gpio-export,output = <1>;
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -77,11 +78,10 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
+		spi-max-frequency = <20000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -89,41 +89,61 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
 				read-only;
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0xf000>;
+					read-only;
+				};
+
+				hard_config: partition@f000 {
+					label = "hard_config";
+					reg = <0xf000 0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0xf000>;
+					read-only;
+				};
+
+				partition@20000 {
+					label = "soft_config";
+					reg = <0x20000 0x1000>;
+				};
+
+				partition@30000 {
+					label = "bios";
+					reg = <0x30000 0x1000>;
+					read-only;
+				};
 			};
 
-			partition@30000 {
-				label = "u-boot-env";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
+			partition@40000 {
+				compatible = "mikrotik,minor";
 				label = "firmware";
-				reg = <0x50000 0xfb0000>;
+				reg = <0x040000 0xfc0000>;
 			};
 		};
 	};
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0xe000>;
+	mtd-mac-address = <&hard_config 0x0010>;
 	mtd-mac-address-increment = <1>;
 };
 
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2c", "uart2", "uart3", "pcie", "rgmii2", "jtag";
+			ralink,group = "uart2", "uart3", "jtag", "wdt";
 			ralink,function = "gpio";
 		};
 	};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -324,14 +324,6 @@ define Device/netgear_r6350
 endef
 TARGET_DEVICES += netgear_r6350
 
-define Device/rb750gr3
-  DTS := RB750Gr3
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
-  DEVICE_TITLE := MikroTik RB750Gr3
-  DEVICE_PACKAGES := kmod-usb3 uboot-envtools
-endef
-TARGET_DEVICES += rb750gr3
-
 define Device/MikroTik
   BLOCKSIZE := 64k
   IMAGE_SIZE := 16128k
@@ -342,6 +334,13 @@ define Device/MikroTik
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
+
+define Device/mikrotik_rb750gr3
+  $(Device/MikroTik)
+  DTS := RB750Gr3
+  DEVICE_TITLE := MikroTik RouterBOARD RB750Gr3
+endef
+TARGET_DEVICES += mikrotik_rb750gr3
 
 define Device/mikrotik_rbm33g
   $(Device/MikroTik)


### PR DESCRIPTION
This patch adds support of MikroTik RouterBOARD 750Gr3. It does not
require reflashing the bootloader.

Installation through RouterBoot follows the usual MikroTik method
https://openwrt.org/toh/mikrotik/common

This patch is the rebase of Thibaut's original RFC attempt
https://patchwork.ozlabs.org/patch/953454/ with tiny fixups.

Tested as much as I could.

Signed-off-by: Thibaut VARÈNE <hacks@slashdirt.org>
Signed-off-by: Anton Arapov <arapov@gmail.com>