### PR TITLE
ath79: add support for ELECOM WRC-1750GHBK2-I/C

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
+	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
@@ -244,6 +245,7 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
 		;;
+	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary ART 4098)" -2)
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -96,6 +96,9 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
+	elecom,wrc-1750ghbk2-i)
+		ath10kcal_extract "ART" 20480 2116
+		;;
 	glinet,ar750s|\
 	tplink,re450-v2)
 		ath10kcal_extract "art" 20480 2116

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
@@ -7,20 +7,26 @@
 #include "qca9563_elecom_wrc-ghbk2-i.dtsi"
 
 / {
-	model = "ELECOM WRC-300GHBK2-I";
-	compatible = "elecom,wrc-300ghbk2-i", "qca,qca9563";
+	model = "ELECOM WRC-1750GHBK2-I/C";
+	compatible = "elecom,wrc-1750ghbk2-i", "qca,qca9563";
 };
 
 &leds {
 	power: power {
-		label = "elecom:white:power";
+		label = "elecom:blue:power";
 		gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
 		default-state = "on";
 	};
 
 	wlan2g {
-		label = "elecom:white:wlan2g";
+		label = "elecom:blue:wlan2g";
 		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		linux,default-trigger = "phy1tpt";
+	};
+
+	wlan5g {
+		label = "elecom:blue:wlan5g";
+		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		linux,default-trigger = "phy0tpt";
 	};
 };
@@ -29,18 +35,22 @@
 	partition@70000 {
 		compatible = "denx,uimage";
 		label = "firmware";
-		reg = <0x070000 0x770000>;
+		reg = <0x070000 0xf70000>;
 	};
 
-	partition@7e0000 {
+	partition@fe0000 {
 		label = "hwconfig";
-		reg = <0x7e0000 0x010000>;
+		reg = <0xfe0000 0x010000>;
 		read-only;
 	};
 
-	ART: partition@7f0000 {
+	ART: partition@ff0000 {
 		label = "ART";
-		reg = <0x7f0000 0x010000>;
+		reg = <0xff0000 0x010000>;
 		read-only;
 	};
+};
+
+&pcie {
+	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "elecom:red:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		button_wps {
+			label = "wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		ap {
+			label = "ap";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "nvram";
+				reg = <0x050000 0x020000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x50 0xcf37cf37 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	mtd-mac-address = <&ART 0x1002>;
+	mtd-mac-address-increment = <(-1)>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&ART 0x1000>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -221,6 +221,17 @@ define Device/dlink_dir-859-a1
 endef
 TARGET_DEVICES += dlink_dir-859-a1
 
+define Device/elecom_wrc-1750ghbk2-i
+  ATH_SOC := qca9563
+  DEVICE_TITLE := ELECOM WRC-1750GHBK2-I/C
+  IMAGE_SIZE := 15808k
+  KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
+    elecom-header 16187314 RN68 WRC-1750GHBK2 \
+      $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += elecom_wrc-1750ghbk2-i
+
 define Device/elecom_wrc-300ghbk2-i
   ATH_SOC := qca9563
   DEVICE_TITLE := ELECOM WRC-300GHBK2-I


### PR DESCRIPTION
ELECOM WRC-1750GHBK2-I/WRC-1750GHBK2-C are 2.4/5 GHz band 11ac
routers, based on Qualcomm Atheros QCA9563.

This commit also includes small fix; use "0x0x03000101" as pll_1000
instead of "0x03000000".

Specification:

- SoC:      Qualcom Atheros QCA9563
- RAM:      128 MB (DDR2)
- Flash:    16 MB (SPI-NOR)
- WLAN:     2.4/5 GHz
  - 2.4 GHz: 2T2R (SoC internal)
  - 5 GHz:   3T3R (QCA9880)
- Ethernet: 10/100/1000 Mbps
- LED/key:  4x/3x (2x buttons, 1x slide-switch)
- UART:     through-hole on PCB
  - Vcc, RX, GND, TX from switch (QCA8337N) side
  - 115200n8

Flash instruction using factory image:

1. Boot WRC-1750GHBK2-I/C normaly
2. Access to "http://192.168.2.1/" and open firmware upgrade page
("ファームウェア更新 手動更新（アップデート）")
3. Select the OpenWrt factory image and click apply ("適用") button
to perform firmware update
4. On the (initramfs) factory image, perform sysupgrade with
squashfs-sysupgrade image
5. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>