### PR TITLE
ath79: Add support for TP-Link Archer C6 v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -65,6 +65,12 @@ tplink,archer-c59-v1)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
 	;;
+tplink,archer-c6-v2)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
+	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
+	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:green:wlan5g" "phy0tpt"
+	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -144,6 +144,7 @@ ath79_setup_interfaces()
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c7-v5|\
+	tplink,archer-c6-v2|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -146,10 +146,17 @@ case "$FIRMWARE" in
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
 	tplink,archer-c58-v1|\
-	tplink,archer-c59-v1)
+	tplink,archer-c59-v1|\
+	tplink,archer-c6-v2)
 		ath10kcal_extract "art" 20480 12064
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+
+		case "$board" in
+		tplink,archer-c6-v2)
+			ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
+			;;
+		esac
 		;;
 	esac
 	;;

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_archer-x6-v2.dtsi"
+
+/ {
+	compatible = "tplink,archer-c6-v2", "qca,qca9563";
+	model = "TP-Link Archer C6 v2";
+};

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "tp-link:amber:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			mac: partition@20000 {
+				label = "mac";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0x7a0000>;
+			};
+
+			partition@7d0000 {
+				label = "tplink";
+				reg = <0x7d0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	mtd-mac-address = <&mac 0x8>;
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&mac 0x8>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -34,6 +34,17 @@ define Device/tplink_archer-c59-v1
 endef
 TARGET_DEVICES += tplink_archer-c59-v1
 
+define Device/tplink_archer-c6-v2
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-LINK Archer C6 v2
+  TPLINK_BOARD_ID := ARCHER-C6-V2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SUPPORTED_DEVICES += archer-c6-v2
+endef
+TARGET_DEVICES += tplink_archer-c6-v2
+
 define Device/tplink_archer-c7-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -548,6 +548,42 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the C6v2 */
+	{
+		.id	= "ARCHER-C6-V2",
+		.vendor	= "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:Archer C6,product_ver:2.0.0,special_id:45550000}\r\n"
+			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
+			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.0.0\n",
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00200},
+			{"pin", 0x20200, 0x00100},
+			{"product-info", 0x20300, 0x00200},
+			{"device-id", 0x20500, 0x0fb00},
+			{"firmware", 0x30000, 0x7a9400},
+			{"soft-version", 0x7d9400, 0x00100},
+			{"extra-para", 0x7d9500, 0x00100},
+			{"support-list", 0x7d9600, 0x00200},
+			{"profile", 0x7d9800, 0x03000},
+			{"default-config", 0x7dc800, 0x03000},
+			{"partition-table", 0x7df800, 0x00800},
+			{"user-config", 0x7e0000, 0x0c000},
+			{"certificate", 0x7ec000, 0x04000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
+
 	/** Firmware layout for the C60v1 */
 	{
 		.id	= "ARCHER-C60-V1",
@@ -1623,6 +1659,9 @@ static void build_image(const char *output,
 		parts[5] = put_data("extra-para", mdat, 11);
 	} else if (strcasecmp(info->id, "ARCHER-A7-V5") == 0 || strcasecmp(info->id, "ARCHER-C7-V4") == 0 || strcasecmp(info->id, "ARCHER-C7-V5") == 0) {
 		const char mdat[11] = {0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0xca, 0x00, 0x01, 0x00, 0x00};
+		parts[5] = put_data("extra-para", mdat, 11);
+	} else if (strcasecmp(info->id, "ARCHER-C6-V2") == 0) {
+		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
 	}
 


### PR DESCRIPTION
This patch adds support for TP-Link Archer C6 v2 (EU)

Hardware specification:
- SOC: Qualcomm QCA9563 @ 775MHz
- Flash: GigaDevice GD25Q64CSIG (8MiB)
- RAM: Zentel A3R1GE40JBF (128 MiB DDR2)
- Ethernet: Qualcomm QCA8337N: 4x 1Gbps LAN + 1x 1Gbps WAN
- Wireless:
  - 2.4GHz (bgn) QCA9563 integrated (3x3)
  - 5GHz (ac) Qualcomm QCA9886 (2x2)
- Button: 1x power, 1x reset, 1x wps
- LED: 6x LEDs: power, wlan2g, wlan5g, lan, wan, wps
- UART: There's no UART header on the board

Flash instructions:

Upload
openwrt-ath79-generic-tplink_archer-c6-v2-squashfs-factory.bin
via the router Web interface.

Flash instruction using tftp recovery:

1. Connect the computer to one of the LAN ports of the router
2. Set the computer IP to 192.168.0.66
3. Start a tftp server with the OpenWrt factory image in the
   tftp root directory renamed to ArcherC6v2_tp_recovery.bin.
4. Connect power cable to router, press and hold the reset
   button and turn the router on
5. Keep the reset button pressed until the WPS LED lights up
6. Wait ~150 seconds to complete flashing

GPL source code:
https://static.tp-link.com/resources/gpl/c6v2_gpl_new.tar.gz

According to the GPL source the non-EU variant has different
GPIOs assigned to some of the LEDs and buttons. The flash
layout might be different as well. The wikidevi entry for
Archer A6/C6 assumes they are identical.

Signed-off-by: Georgi Vlaev <georgi.vlaev@gmail.com>
