### PR TITLE
ath79: Fix system LED on TP-Link WR740/741 v4

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -69,7 +69,7 @@
 
 		system: system {
 			label = "tp-link:green:system";
-			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {


### PR DESCRIPTION
The system LED on these devices is ACTIVE_LOW, change back to what
it is on ar71xx.

Reference: https://github.com/openwrt/openwrt/blob/213c0e78fa57bbb52745b8dae6efaf5506378ebf/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr741nd-v4.c#L77-L79