### PR TITLE
ath79: Add GL.iNet AR150 LED triggers

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -33,6 +33,10 @@ etactica,eg200)
 	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"
 	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
 	;;
+glinet,gl-ar150)
+        ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+        ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
+        ;;
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -88,8 +88,8 @@ ath79_setup_interfaces()
 	etactica,eg200)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
-	glinet,ar150|\
 	glinet,ar300m|\
+	glinet,gl-ar150|\
 	glinet,gl-x750)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;

--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "GL.iNet GL-AR150";
-	compatible = "glinet,ar150", "qca,ar9330";
+	compatible = "glinet,gl-ar150", "qca,ar9330";
 
 	aliases {
 		serial0 = &uart;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -219,14 +219,14 @@ define Device/etactica_eg200
 endef
 TARGET_DEVICES += etactica_eg200
 
-define Device/glinet_ar150
+define Device/glinet_gl-ar150
   ATH_SOC := ar9330
   DEVICE_TITLE := GL.iNet GL-AR150
   DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar150
 endef
-TARGET_DEVICES += glinet_ar150
+TARGET_DEVICES += glinet_gl-ar150
 
 define Device/glinet_ar300m-nor
   ATH_SOC := qca9531


### PR DESCRIPTION
The default LED triggers for netdev LAN and WAN got lost when switching
to ath79.

A general question for ar71xx->ath79: the boardname of this device has changed.
It was `gl-ar150` on ar71xx. On ath79 it is `glinet,ar150`. The 01_leds script breaks this
down to just `ar150`, the LEDs however are still called `gl-ar150`.
When I compare to the TP-Link devices: some are called `tplink,tl-xxx` and others
are just `tplink,xxx`. Should the vendor prefix be given in the second part of the boardname
or not?
