### PR TITLE
ath79: Fix UBNT Unifi AC LEDs

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -15,13 +15,13 @@
 
 		wifi_ac {
 			label = "ubnt:white:dome";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		wifi_n {
 			label = "ubnt:blue:dome";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy1tpt";
 		};
 


### PR DESCRIPTION
Both LEDs on these devices are ACTIVE_HIGH, change back to what
it is on ar71xx.

Reference: https://github.com/openwrt/openwrt/blob/213c0e78fa57bbb52745b8dae6efaf5506378ebf/target/linux/ar71xx/files/arch/mips/ath79/mach-ubnt-unifiac.c#L57-L63