### PR TITLE
ath79: Add support for TP-Link WR810N

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -90,7 +90,9 @@ ath79_setup_interfaces()
 		;;
 	glinet,ar150|\
 	glinet,ar300m|\
-	glinet,gl-x750)
+	glinet,gl-x750|\
+	tplink,tl-wr810n-v1|\
+	tplink,tl-wr810n-v2)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	nec,wg800hp)

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x_tplink_tl-wr810n.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr810n-v1", "qca,qca9531";
+	model = "TP-Link TL-WR810N v1";
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	vbus-supply = <&reg_usb_vbus>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr810n-v2.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr810n-v2.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x_tplink_tl-wr810n.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr810n-v2", "qca,qca9533";
+	model = "TP-Link TL-WR810N v2";
+};

--- a/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
+++ b/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:blue:system";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		switch_b0 {
+			label = "switch_b0";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		switch_b1 {
+			label = "switch_b1";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_1>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -123,6 +123,23 @@ define Device/tplink_tl-wr1043nd-v1
 endef
 TARGET_DEVICES += tplink_tl-wr1043nd-v1
 
+define Device/tplink_tl-wr810n-v1
+  $(Device/tplink-8mlzma)
+  ATH_SOC := qca9531
+  DEVICE_TITLE := TP-LINK TL-WR810N v1
+  TPLINK_HWID := 0x8100001
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += tplink_tl-wr810n-v1
+
+define Device/tplink_tl-wr810n-v2
+  $(Device/tplink-8mlzma)
+  ATH_SOC := qca9533
+  DEVICE_TITLE := TP-LINK TL-WR810N v2
+  TPLINK_HWID := 0x8100002
+endef
+TARGET_DEVICES += tplink_tl-wr810n-v2
+
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   ATH_SOC := ar7241


### PR DESCRIPTION
This commit adds support for TP-Link WR810N v2 (and v1).

Since I don't own a v1-device, I could only test version 2.

As the only difference is the USB port in v1 which is not there
any more on v2, the devices share a common dtsi.
The dts for v1 then configures that USB port (not tested, but to the
best of my knowledge)

Again, I'm not sure about the board name of v1:
in ar71xx this was just `tl-wr810n`. Here, I added `-v1`.
Should -v1 devices be kept without an explicit version identifier?
The v2 was and is called `tl-wr810n-v2`

For reference, the mach file on ar71xx: [1]

[1]: https://github.com/openwrt/openwrt/blob/213c0e78fa57bbb52745b8dae6efaf5506378ebf/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr810n.c