### PR TITLE
[RFC] ath79: dts LEDs default triggers

### DIFF
--- a/package/base-files/files/etc/diag.sh
+++ b/package/base-files/files/etc/diag.sh
@@ -37,10 +37,13 @@ set_led_state() {
 		;;
 	done)
 		status_led_off
-		[ -n "$running" ] && {
+		if [ -n "$running" ]; then
 			status_led="$running"
 			status_led_on
-		}
+		else
+			trigger="$(get_dt_default_trigger boot)"
+			[ -n "$trigger" ] && led_set_attr "$status_led" "trigger" "$trigger"
+		fi
 		;;
 	esac
 }

--- a/package/base-files/files/lib/functions/leds.sh
+++ b/package/base-files/files/lib/functions/leds.sh
@@ -15,6 +15,19 @@ get_dt_led() {
 	echo "$label"
 }
 
+get_dt_default_trigger() {
+	local trigger
+	local ledpath
+	local basepath="/proc/device-tree"
+	local nodepath="$basepath/aliases/led-$1"
+
+	[ -f "$nodepath" ] && ledpath=$(cat "$nodepath")
+	[ -n "$ledpath" ] && \
+		trigger=$(cat "$basepath$ledpath/linux,default-trigger" 2>/dev/null)
+
+	echo "$trigger"
+}
+
 led_set_attr() {
 	[ -f "/sys/class/leds/$1/$2" ] && echo "$3" > "/sys/class/leds/$1/$2"
 }


### PR DESCRIPTION
On GL.iNet AR150 I came to the scenario, that the wifi LED was/is used as system status
indicator
https://github.com/openwrt/openwrt/blob/ab12913676b05c069f36eda827043c6b83e51dbe/target/linux/ath79/dts/ar9330_glinet_ar150.dts#L15-L17
and at the same time was assigned a default-trigger phy0:
https://github.com/openwrt/openwrt/blob/ab12913676b05c069f36eda827043c6b83e51dbe/target/linux/ath79/dts/ar9330_glinet_ar150.dts#L23-L26

After bootup, the LED is left with trigger = `none` in the sysfs, so although it is indicating bootup,
it does not show Wifi status later on.

First commit / question:
Do LEDs that are assigned as system status indicators additionally need a `default-state` or `default-trigger`? (From my observation on gl-ar150 the LED ends up with trigger `none` anyway)

Second commit:
To have this shared functionality (system status/bootup AND wifi), the trigger phy0tpt is added
in `/etc/config/system`for these two affected devices.
