### PR TITLE
ath79 + ramips: fix spaces/tabs

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -37,9 +37,9 @@ etactica,eg200)
 	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
 	;;
 glinet,gl-ar150)
-        ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
-        ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
-        ;;
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
+	;;
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	;;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -244,7 +244,7 @@
 			interrupts = <4>;
 
 			status = "disabled";
-                };
+		};
 
 		gdma: gdma@2800 {
 			compatible = "ralink,rt3883-gdma";


### PR DESCRIPTION
@mkresin 
Sorry to bother you with my dumb mistake here.
In the previous change to ath79 / 01_leds, I've copy pasted some spaces instead
of tabs. Since the last push is your's anyway, would you correct my mistake and
then force-push? Or merge this commit? (Which also fixes something similar in
a ramips' DTS)

EDIT: Hmmm... force-pushing probably is not an option anyway