### PR TITLE
ath79: fix pinmux for ar933x devices

### DIFF
--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -75,7 +75,7 @@
 				};
 
 				switch_led_pins: pinmux_switch_led_pins {
-					pinctrl-single,bits = <0x0 0x1f 0xf8>;
+					pinctrl-single,bits = <0x0 0x0 0xf8>;
 				};
 			};
 

--- a/target/linux/ath79/dts/ar9331_dragino_ms14.dts
+++ b/target/linux/ath79/dts/ar9331_dragino_ms14.dts
@@ -16,6 +16,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_pins>;
 
 		wlan {
 			label = "dragino2:red:wlan";

--- a/target/linux/ath79/dts/ar9331_etactica_eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica_eg200.dts
@@ -26,6 +26,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_pins>;
 
 		modbus {
 			label = "eg200:red:modbus";

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -17,6 +17,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_pins>;
 
 		wlan {
 			label = "tp-link:green:wlan";


### PR DESCRIPTION
On ar71xx, some ar933x devices called `ath79_gpio_function_disable`
to disable the SoC's internal switch LEDs and gain full control over
some GPIOs. The pinmux register 0x18040028 was not set to the correct
value, therefore LAN1 and WAN on e.g. TL-WR740-v4 were stuck at "1".

This commit fixes the value for disabling this GPIO/pinmux function and
further adds `pinctrl-0 = <&switch_led_pins>` to those devices, that had called
the function back in ar71xx to achieve similar results.

Run-tested only for TL-WR740-v4