### PR TITLE
sunxi: activated USB in dts for opi 0 expansion

### DIFF
--- a/target/linux/sunxi/patches-4.14/203-ARM-dts-sun81-active-USB-expansion-on-Orange-Pi-Zero.patch
+++ b/target/linux/sunxi/patches-4.14/203-ARM-dts-sun81-active-USB-expansion-on-Orange-Pi-Zero.patch
@@ -1,0 +1,32 @@
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -101,6 +101,14 @@
+ &ehci1 {
+ 	status = "okay";
+ };
++
++&ehci2 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
+ 
+ &mmc0 {
+ 	pinctrl-names = "default";
+@@ -137,6 +145,14 @@
+ &ohci1 {
+        status = "okay";
+ };
++
++&ohci2 {
++       status = "okay";
++};
++
++&ohci3 {
++       status = "okay";
++};
+ 
+ &spi0 {
+ 	/* Disable SPI NOR by default: it optional on Orange Pi Zero boards */


### PR DESCRIPTION
This patch updates the DTS file of the Orange Pi Zero H2+ to activate the
expansion board USB ports.  Without this change the additional ports will
not be active. Tested change on master with an Orange Pi Zero H2+
both with and without an expansion board and seemed to work fine.

Signed-off-by: Chris Morgan <macromorgan@hotmail.com>