### PR TITLE
kernel: modules: 4.19: fix kmod-rtc-ds1307

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -476,7 +476,7 @@ define KernelPackage/rtc-ds1307
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Dallas/Maxim DS1307 (and compatible) RTC support
   DEFAULT:=m if ALL_KMODS && RTC_SUPPORT
-  DEPENDS:=+kmod-i2c-core +LINUX_4_14:kmod-regmap
+  DEPENDS:=+kmod-i2c-core +!(LINUX_3_18||LINUX_4_9):kmod-regmap +!(LINUX_3_18||LINUX_4_9||LINUX_4_14):kmod-hwmon-core
   KCONFIG:=CONFIG_RTC_DRV_DS1307 \
 	CONFIG_RTC_CLASS=y
   FILES:=$(LINUX_DIR)/drivers/rtc/rtc-ds1307.ko


### PR DESCRIPTION
Upstream commit "rtc: ds1307: simplify hwmon config"
6b583a64fd1e019fd01626b46892ebf2361951c5 add hwmon
to module dependency.

Also kmod-regmap dependency need to be reworked for 4.19.

This patch fix that issues.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>

