### PR TITLE
ramips: add support for Netgear R6020

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -246,6 +246,11 @@ mtc,wr1201)
 mzk-ex750np)
 	set_wifi_led "$boardname:red:wifi"
 	;;
+netgear,r6020)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
+	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "$boardname:green:wlan5g" "phy1tpt"
+	;;
 netgear,r6120)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
 	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -107,6 +107,7 @@ ramips_setup_interfaces()
 	mtc,wr1201|\
 	mzk-750dhp|\
 	mzk-w300nh2|\
+	netgear,r6020|\
 	netgear,r6120|\
 	nixcore-x1-8M|\
 	nixcore-x1-16M|\

--- a/target/linux/ramips/dts/R6020.dts
+++ b/target/linux/ramips/dts/R6020.dts
@@ -1,0 +1,149 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6020", "mediatek,mt7628an-soc";
+	model = "Netgear AC750 R6020";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "r6020:green:lan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "r6020:green:power";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "r6020:green:wlan2g";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_orange {
+			label = "r6020:orange:wlan2g";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5 {
+			label = "r6020:green:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5_orange {
+			label = "r6020:orange:wlan5g";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p1led_an", "p2led_an",
+				       "p3led_an", "p4led_an", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		m25p,chunked-io = <32>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			nvram: partition@60000 {
+				label = "nvram";
+				reg = <0x60000 0x30000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0xf60000>;
+			};
+
+			partition@ff0000 {
+				label = "reserved";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&nvram 0x100b0>;
+	mediatek,mtd-eeprom = <&factory 0x20000>;
+};
+
+&ethernet {
+	mtd-mac-address = <&nvram 0x100b0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x28000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&nvram 0x100b0>;
+		mtd-mac-address-increment = <(2)>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -127,6 +127,23 @@ define Device/netgear_r6120
 endef
 TARGET_DEVICES += netgear_r6120
 
+define Device/netgear_r6020
+  DTS := R6020
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Netgear AC750 R6020
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+  SERCOMM_KERNEL_OFFSET := 0x90000
+  SERCOMM_HWID := CFR
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0040
+  IMAGES += factory.img
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.img := $$(IMAGE/default) | mksercommfw
+endef
+TARGET_DEVICES += netgear_r6020
+
 define Device/omega2
   DTS := OMEGA2
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
This patch adds support for the Netgear R6020, aka Netgear AC750.
The code is identical to the R6120 except for the identifier.

Hardware specification:
- SoC: MediaTek MT7628 (580 MHz)
- Flash: 16 MiB
- RAM: 64 MiB
- Wireless: 2.4Ghz(builtin) and 5Ghz (MT7612E)
- LAN speed: 10/100
- LAN ports: 4
- WAN speed: 10/100
- WAN ports: 1
- Serial baud rate of Bootloader and factory firmware: 57600

To flash use nmrpflash with the provided factory.img.

Signed-off-by: Chris Dotson <chris@dotson97.org>