### PR TITLE
[RFC] multiple things on ath79 and ar71xx

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -41,7 +41,6 @@ ar71xx_setup_interfaces()
 	tew-712br|\
 	tew-732br|\
 	tl-mr3220|\
-	tl-mr3220-v2|\
 	tl-mr3420|\
 	tl-wdr3320-v2|\
 	tl-wdr3500|\
@@ -520,6 +519,7 @@ ar71xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
+	tl-mr3220-v2|\
 	tl-wr741nd-v4)
 		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -46,7 +46,6 @@ ar71xx_setup_interfaces()
 	tl-wdr3320-v2|\
 	tl-wdr3500|\
 	tl-wr740n-v6|\
-	tl-wr741nd-v4|\
 	tl-wr840n-v2|\
 	tl-wr840n-v3|\
 	tl-wr841n-v11|\
@@ -520,6 +519,11 @@ ar71xx_setup_interfaces()
 	tl-wr2543n)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
+		;;
+	tl-wr741nd-v4)
+		ucidef_set_interfaces_lan_wan "eth0.1" "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	tl-wr841n-v1|\
 	tl-wr941nd)

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -52,7 +52,7 @@ etactica,eg200)
 	;;
 glinet,gl-ar150)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
+	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x02"
 	;;
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -117,7 +117,7 @@ tplink,tl-wr941-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
 	;;
-tplink,tl-wr740nd-v4|\
+tplink,tl-wr740n-v4|\
 tplink,tl-wr741nd-v4|\
 tplink,tl-wr841-v8|\
 tplink,tl-wr842n-v2)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -122,10 +122,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch_port_attr "switch0" 5 led 2
 		;;
 	netgear,wnr612-v2|\
-	on,n150r)
+	on,n150r|\
+	tplink,tl-wr841-v7)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \
-		"0@eth1" "1:lan" "2:lan" "3:lan:3" "4:lan:4"
+		"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
 	phicomm,k2t)
 		ucidef_add_switch "switch0" \
@@ -144,7 +145,6 @@ ath79_setup_interfaces()
 	buffalo,whr-g301n|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
-	tplink,tl-wr841-v7|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v11|\
 	ubnt,airrouter)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -188,7 +188,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
-	tplink,tl-wr740nd-v4|\
+	tplink,tl-wr740n-v4|\
 	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v8|\
 	tplink,tl-wr842n-v1|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -144,7 +144,6 @@ ath79_setup_interfaces()
 	buffalo,whr-g301n|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
-	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v7|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v11|\
@@ -190,6 +189,7 @@ ath79_setup_interfaces()
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
 	tplink,tl-wr740nd-v4|\
+	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v8|\
 	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v2)

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr841-v7.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr841-v7.dts
@@ -5,7 +5,7 @@
 
 / {
 	compatible = "tplink,tl-wr841-v7", "qca,ar7241";
-	model = "TP-LINK TL-WR841N/ND v7";
+	model = "TP-Link TL-WR841N/ND v7";
 
 	ath9k-leds {
 		compatible = "gpio-leds";

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "tplink,tl-wr2543-v1", "qca,ar7242";
-	model = "TP-LINK TL-WR2543N/ND";
+	model = "TP-Link TL-WR2543N/ND";
 
 	aliases {
 		led-boot = &system;

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr740n-v4.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr740n-v4.dts
@@ -4,6 +4,6 @@
 #include "ar9331_tplink_tl-wr741nd-v4.dtsi"
 
 / {
-	model = "TP-Link TL-WR740N/ND v4";
-	compatible = "tplink,tl-wr740nd-v4", "qca,ar9331";
+	model = "TP-Link TL-WR740N v4";
+	compatible = "tplink,tl-wr740n-v4", "qca,ar9331";
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "tplink,archer-c58-v1", "qca,qca9560";
-	model = "TP-LINK Archer C58 v1";
+	model = "TP-Link Archer C58 v1";
 
 	aliases {
 		led-boot = &power;

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "tplink,archer-c59-v1", "qca,qca9560";
-	model = "TP-LINK Archer C59 v1";
+	model = "TP-Link Archer C59 v1";
 
 	aliases {
 		led-boot = &power;

--- a/target/linux/ath79/image/common-tp-link.mk
+++ b/target/linux/ath79/image/common-tp-link.mk
@@ -86,7 +86,7 @@ define Device/tplink-8m
 endef
 
 define Device/tplink-8mlzma
-$(Device/tplink)
+  $(Device/tplink)
   TPLINK_FLASHLAYOUT := 8Mlzma
   IMAGE_SIZE := 7936k
 endef

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -4,7 +4,7 @@ define Device/tplink_archer-a7-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
   IMAGE_SIZE := 15104k
-  DEVICE_TITLE := TP-LINK Archer A7 v5
+  DEVICE_TITLE := TP-Link Archer A7 v5
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_BOARD_ID := ARCHER-A7-V5
   BOARDNAME := ARCHER-A7-V5
@@ -16,7 +16,7 @@ define Device/tplink_archer-c58-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
   IMAGE_SIZE := 7936k
-  DEVICE_TITLE := TP-LINK Archer C58 v1
+  DEVICE_TITLE := TP-Link Archer C58 v1
   TPLINK_BOARD_ID := ARCHER-C58-V1
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
   SUPPORTED_DEVICES += archer-c58-v1
@@ -27,7 +27,7 @@ define Device/tplink_archer-c59-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
   IMAGE_SIZE := 14528k
-  DEVICE_TITLE := TP-LINK Archer C59 v1
+  DEVICE_TITLE := TP-Link Archer C59 v1
   TPLINK_BOARD_ID := ARCHER-C59-V1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca9888-ct
   SUPPORTED_DEVICES += archer-c59-v1
@@ -38,7 +38,7 @@ define Device/tplink_archer-c6-v2
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
   IMAGE_SIZE := 7808k
-  DEVICE_TITLE := TP-LINK Archer C6 v2
+  DEVICE_TITLE := TP-Link Archer C6 v2
   TPLINK_BOARD_ID := ARCHER-C6-V2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
@@ -47,7 +47,7 @@ TARGET_DEVICES += tplink_archer-c6-v2
 define Device/tplink_archer-c7-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558
-  DEVICE_TITLE := TP-LINK Archer C7 v1
+  DEVICE_TITLE := TP-Link Archer C7 v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_HWID := 0x75000001
 endef
@@ -56,7 +56,7 @@ TARGET_DEVICES += tplink_archer-c7-v1
 define Device/tplink_archer-c7-v2
   $(Device/tplink-16mlzma)
   ATH_SOC := qca9558
-  DEVICE_TITLE := TP-LINK Archer C7 v2
+  DEVICE_TITLE := TP-Link Archer C7 v2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_HWID := 0xc7000002
   IMAGES += factory-us.bin factory-eu.bin
@@ -69,7 +69,7 @@ define Device/tplink_archer-c7-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
   IMAGE_SIZE := 15360k
-  DEVICE_TITLE := TP-LINK Archer C7 v5
+  DEVICE_TITLE := TP-Link Archer C7 v5
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_BOARD_ID := ARCHER-C7-V5
   BOARDNAME := ARCHER-C7-V5
@@ -81,7 +81,7 @@ define Device/tplink_re450-v2
   $(Device/tplink)
   ATH_SOC := qca9563
   IMAGE_SIZE := 6016k
-  DEVICE_TITLE := TP-LINK RE450 v2
+  DEVICE_TITLE := TP-Link RE450 v2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_HWID := 0x0
   TPLINK_HWREV := 0
@@ -97,7 +97,7 @@ TARGET_DEVICES += tplink_re450-v2
 define Device/tplink_tl-wdr3600
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9344
-  DEVICE_TITLE := TP-LINK TL-WDR3600
+  DEVICE_TITLE := TP-Link TL-WDR3600
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x36000001
   SUPPORTED_DEVICES += tl-wdr3600
@@ -107,7 +107,7 @@ TARGET_DEVICES += tplink_tl-wdr3600
 define Device/tplink_tl-wdr4300
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9344
-  DEVICE_TITLE := TP-LINK TL-WDR4300
+  DEVICE_TITLE := TP-Link TL-WDR4300
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x43000001
   SUPPORTED_DEVICES += tl-wdr4300
@@ -117,7 +117,7 @@ TARGET_DEVICES += tplink_tl-wdr4300
 define Device/tplink_tl-wdr4900-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558
-  DEVICE_TITLE := TP-LINK TL-WDR4900 v2
+  DEVICE_TITLE := TP-Link TL-WDR4900 v2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x49000002
 endef
@@ -126,7 +126,7 @@ TARGET_DEVICES += tplink_tl-wdr4900-v2
 define Device/tplink_tl-wr1043nd-v1
   $(Device/tplink-8m)
   ATH_SOC := ar9132
-  DEVICE_TITLE := TP-LINK TL-WR1043N/ND v1
+  DEVICE_TITLE := TP-Link TL-WR1043N/ND v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430001
   SUPPORTED_DEVICES += tl-wr1043nd
@@ -136,7 +136,7 @@ TARGET_DEVICES += tplink_tl-wr1043nd-v1
 define Device/tplink_tl-wr810n-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9531
-  DEVICE_TITLE := TP-LINK TL-WR810N v1
+  DEVICE_TITLE := TP-Link TL-WR810N v1
   TPLINK_HWID := 0x8100001
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
 endef
@@ -145,7 +145,7 @@ TARGET_DEVICES += tplink_tl-wr810n-v1
 define Device/tplink_tl-wr810n-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9533
-  DEVICE_TITLE := TP-LINK TL-WR810N v2
+  DEVICE_TITLE := TP-Link TL-WR810N v2
   TPLINK_HWID := 0x8100002
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
@@ -153,7 +153,7 @@ TARGET_DEVICES += tplink_tl-wr810n-v2
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   ATH_SOC := ar7241
-  DEVICE_TITLE := TP-LINK TL-WR842N/ND v1
+  DEVICE_TITLE := TP-Link TL-WR842N/ND v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420001
 endef
@@ -162,7 +162,7 @@ TARGET_DEVICES += tplink_tl-wr842n-v1
 define Device/tplink_tl-wr842n-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9341
-  DEVICE_TITLE := TP-LINK TL-WR842N/ND v2
+  DEVICE_TITLE := TP-Link TL-WR842N/ND v2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x8420002
   SUPPORTED_DEVICES += tl-wr842n-v2
@@ -172,7 +172,7 @@ TARGET_DEVICES += tplink_tl-wr842n-v2
 define Device/tplink_tl-wr1043nd-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558
-  DEVICE_TITLE := TP-LINK TL-WR1043N/ND v2
+  DEVICE_TITLE := TP-Link TL-WR1043N/ND v2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430002
   SUPPORTED_DEVICES += tl-wr1043nd-v2
@@ -182,7 +182,7 @@ TARGET_DEVICES += tplink_tl-wr1043nd-v2
 define Device/tplink_tl-wr1043nd-v3
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558
-  DEVICE_TITLE := TP-LINK TL-WR1043N/ND v3
+  DEVICE_TITLE := TP-Link TL-WR1043N/ND v3
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430003
   SUPPORTED_DEVICES += tl-wr1043nd-v3
@@ -193,7 +193,7 @@ define Device/tplink_tl-wr1043nd-v4
   $(Device/tplink)
   ATH_SOC := qca9563
   IMAGE_SIZE := 15552k
-  DEVICE_TITLE := TP-LINK TL-WR1043N/ND v4
+  DEVICE_TITLE := TP-Link TL-WR1043N/ND v4
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x10430004
   TPLINK_BOARD_ID := TLWR1043NDV4
@@ -208,7 +208,7 @@ TARGET_DEVICES += tplink_tl-wr1043nd-v4
 define Device/tplink_tl-wr2543-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar7242
-  DEVICE_TITLE := TP-LINK TL-WR2543N/ND v1
+  DEVICE_TITLE := TP-Link TL-WR2543N/ND v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x25430001
   IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade -v 3.13.99 | \

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -14,7 +14,7 @@ TARGET_DEVICES += tplink_tl-mr10u
 define Device/tplink_tl-mr3020-v1
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
-  DEVICE_TITLE := TP-LINK TL-MR3020 v1
+  DEVICE_TITLE := TP-Link TL-MR3020 v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x30200001
   SUPPORTED_DEVICES += tl-mr3020
@@ -24,7 +24,7 @@ TARGET_DEVICES += tplink_tl-mr3020-v1
 define Device/tplink_tl-mr3040-v2
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
-  DEVICE_TITLE := TP-LINK TL-MR3040 v2
+  DEVICE_TITLE := TP-Link TL-MR3040 v2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x30400002
   SUPPORTED_DEVICES += tl-mr3040-v2
@@ -88,7 +88,7 @@ TARGET_DEVICES += tplink_tl-wr740n-v3
 define Device/tplink_tl-wr740n-v4
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
-  DEVICE_TITLE := TP-LINK TL-WR740N v4
+  DEVICE_TITLE := TP-Link TL-WR740N v4
   TPLINK_HWID := 0x07400004
   SUPPORTED_DEVICES += tl-wr740n-v4
 endef
@@ -105,7 +105,7 @@ TARGET_DEVICES += tplink_tl-wr741-v1
 define Device/tplink_tl-wr741nd-v4
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
-  DEVICE_TITLE := TP-LINK TL-WR741N/ND v4
+  DEVICE_TITLE := TP-Link TL-WR741N/ND v4
   TPLINK_HWID := 0x07410004
   SUPPORTED_DEVICES += tl-wr741n-v4
 endef
@@ -130,7 +130,7 @@ TARGET_DEVICES += tplink_tl-wr841-v5
 define Device/tplink_tl-wr841-v7
   $(Device/tplink-4m)
   ATH_SOC := ar7241
-  DEVICE_TITLE := TP-LINK TL-WR841N/ND v7
+  DEVICE_TITLE := TP-Link TL-WR841N/ND v7
   TPLINK_HWID := 0x08410007
   SUPPORTED_DEVICES += tl-wr841-v7
 endef
@@ -139,7 +139,7 @@ TARGET_DEVICES += tplink_tl-wr841-v7
 define Device/tplink_tl-wr841-v8
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9341
-  DEVICE_TITLE := TP-LINK TL-WR841N/ND v8
+  DEVICE_TITLE := TP-Link TL-WR841N/ND v8
   TPLINK_HWID := 0x08410008
   SUPPORTED_DEVICES += tl-wr841n-v8
 endef
@@ -148,7 +148,7 @@ TARGET_DEVICES += tplink_tl-wr841-v8
 define Device/tplink_tl-wr841-v9
   $(Device/tplink-4mlzma)
   ATH_SOC := qca9533
-  DEVICE_TITLE := TP-LINK TL-WR841N/ND v9
+  DEVICE_TITLE := TP-Link TL-WR841N/ND v9
   TPLINK_HWID := 0x08410009
 endef
 TARGET_DEVICES += tplink_tl-wr841-v9
@@ -156,7 +156,7 @@ TARGET_DEVICES += tplink_tl-wr841-v9
 define Device/tplink_tl-wr841-v11
   $(Device/tplink-4mlzma)
   ATH_SOC := qca9533
-  DEVICE_TITLE := TP-LINK TL-WR841N/ND v11
+  DEVICE_TITLE := TP-Link TL-WR841N/ND v11
   TPLINK_HWID := 0x08410011
   IMAGES += factory-us.bin factory-eu.bin
   IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -85,14 +85,14 @@ define Device/tplink_tl-wr740n-v3
 endef
 TARGET_DEVICES += tplink_tl-wr740n-v3
 
-define Device/tplink_tl-wr740nd-v4
+define Device/tplink_tl-wr740n-v4
   $(Device/tplink-4mlzma)
   ATH_SOC := ar9331
-  DEVICE_TITLE := TP-LINK TL-WR740N/ND v4
+  DEVICE_TITLE := TP-LINK TL-WR740N v4
   TPLINK_HWID := 0x07400004
   SUPPORTED_DEVICES += tl-wr740n-v4
 endef
-TARGET_DEVICES += tplink_tl-wr740nd-v4
+TARGET_DEVICES += tplink_tl-wr740n-v4
 
 define Device/tplink_tl-wr741-v1
   $(Device/tplink-4m)


### PR DESCRIPTION
Multiple commits to discuss, everything's RFC!

- fix TL-WR741ND-v4 switch port order:
Just installed ath79 on that device and noticed, the ports in `board.json` were not as expected.
Set port order to the same as in WR740N-v4 (also the LED trigger bitmasks for these two devices were already equivalent, i.e. the switch layout is the same)

- ath79: rename TL-WR740ND-v4 to TL-WR740N-v4
On ar71xx, the board was called tl-wr740n-v4. Versions v1 and v3 are also called "tl-wr740n-v_".
If you google for the device, I can only find **offical** tp-link.com sites for WR740N, which is not
the case for e.g. WR841N/ND. For this device(s), tp-link.com actually has different product pages.
The OpenWrt wiki at https://oldwiki.archive.openwrt.org/toh/tp-link/tl-wr740n doesn't even mention WR740ND. (I know, it's the page tl-wr740n, but there's no page tl-wr740nd)

- While we're at it:
Compare ar71xx and ath79 for wr841:
`grep wr841 target/linux/ar71xx/base-files/etc/board.d/02_network`:
```
	tl-wr841n-v11|\
	tl-wr841n-v9|\
	tl-wr841n-v8|\
	tl-wr841n-v1|\
	tl-wr841n-v7)
```
`grep wr841 target/linux/ath79/base-files/etc/board.d/02_network`:
```
	tplink,tl-wr841-v7|\
	tplink,tl-wr841-v9|\
	tplink,tl-wr841-v11|\
	tplink,tl-wr841-v5|\
	tplink,tl-wr841-v8|\
```

- fix TL-WR741ND-v4 switch port order on ar71xx too
I could not believe, that this has been (undetected) in ar71xx for so many years,
I 'downgraded' to ar71xx and installed Luci just to confirm.
The LED trigger pattern on ar71xx already reflected the correct switch layout.

- While doing this on ar71xx, another thing 'popped up':
the MR3220-v2 has exactly the same LED trigger pattern for the switch as 741ND-v4.
Shouldn't it then also have the same swconfig?

- Finally, during `make menuconfig` I came across the 'issue' that TP-Link
devices are (not) in alphabetical order. Some are called 'TP-LINK ...', others 'TP-Link ...'.
Remove the inconsistencies and use the vendors name 'TP-Link'

- change ledtrig on GL.iNet AR150
Due to the reasons discussed in #1704 :
On ar71xx we could have netdev triggers for devices that had a single **switch**port routed to a RJ45 jack. Here, we have to use the switch trigger instead.
Does this change in behaviour (ar71xx vs ath79) have relevant effects on the hotplug system?
Back then, `eth_` really went up and down in kernel, probably triggering a DHCP renew for WAN, etc. 



I could only run-test on TL-WR741ND-v4 and GL-AR150, this is RFC!
// EDIT:
BTW: WR741ND-v4 also needs #1700 (same chip)
