### PR TITLE
ath79: add support for TP-LINK Archer C7 v4

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -74,6 +74,7 @@ pcs,cr3000)
 	ucidef_set_led_switch "lan4" "LAN4" "pcs:blue:lan4" "switch0" "0x02"
 	;;
 tplink,archer-a7-v5|\
+tplink,archer-c7-v4|\
 tplink,archer-c7-v5)
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -157,6 +157,7 @@ ath79_setup_interfaces()
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c6-v2|\
+	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,tl-wdr3600|\
 	tplink,tl-wdr4300)
@@ -280,6 +281,10 @@ ath79_setup_macs()
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
+	tplink,archer-c7-v4)
+		base_mac=$(mtd_get_mac_binary config 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,tl-wr1043nd-v4)
 		base_mac=$(mtd_get_mac_binary product-info 8)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -130,6 +130,7 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
 	tplink,archer-a7-v5|\
+	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c7-v4", "qca,qca9563";
+	model = "TP-Link Archer C7 v4";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpio-sck = <&gpio 15 GPIO_ACTIVE_HIGH>;		// 74HC595 SRCLK (Serial Clock)
+		gpio-mosi = <&gpio 14 GPIO_ACTIVE_HIGH>;	// 74HC595 SER (Serial)
+		cs-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;		// 74HC595 RCLK (Register Clock)
+		num-chipselects = <1>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_shift_register_oe {
+			gpio-export,name = "tp-link:oe:sr";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;	// 74HC595 /OE (Output Enable)
+		};
+
+		gpio_shift_register_reset {
+			gpio-export,name = "tp-link:reset:sr";
+			gpio-export,output = <1>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;	// 74HC595 /SRCLR (Serial Clear)
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		usb1 {
+			label = "tp-link:green:usb1";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb2 {
+			label = "tp-link:green:usb2";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "tp-link:orange:wan";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0xec0000>;
+				compatible = "denx,uimage";
+			};
+
+			info: partition@f00000 {
+				label = "config";
+				reg = <0xf00000 0x0f0000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x80080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x00000200 /* PORT6_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	mtd-mac-address = <&info 0x8>;
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -65,6 +65,18 @@ define Device/tplink_archer-c7-v2
 endef
 TARGET_DEVICES += tplink_archer-c7-v2
 
+define Device/tplink_archer-c7-v4
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 15104k
+  DEVICE_TITLE := TP-LINK Archer C7 v4
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  TPLINK_BOARD_ID := ARCHER-C7-V4
+  BOARDNAME := ARCHER-C7-V4
+  SUPPORTED_DEVICES += archer-c7-v4
+endef
+TARGET_DEVICES += tplink_archer-c7-v4
+
 define Device/tplink_archer-c7-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563


### PR DESCRIPTION
TP-Link Archer C7 v4 is a dual-band AC1750 router, based on Qualcomm/Atheros
QCA9561+QCA9880.

Specification:

- 775/650/258 MHz (CPU/DDR/AHB)
- 128 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- 3T3R 2.4 GHz
- 3T3R 5 GHz
- 5x 10/100/1000 Mbps Ethernet
- 7x LED, 2x button
- UART header on PCB

Flash instruction:
1. Upload openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-factory.bin via Web interface

Flash instruction using TFTP recovery:
1. Set PC to fixed ip address 192.168.0.66
2. Download openwrt-ath79-generic-tplink_archer-c7-v4-squashfs-factory.bin
and rename it to ArcherC7v4_tp_recovery.bin
3. Start a tftp server with the file tp_recovery.bin in its root directory
4. Turn off the router
5. Press and hold Reset button
6. Turn on router with the reset button pressed and wait ~15 seconds
7. Release the reset button and after a short time
the firmware should be transferred from the tftp server
8. Wait ~30 second to complete recovery.