### PR TITLE
[backport][17.01] base-files: install missing /etc/iproute2/ematch_map

### DIFF
--- a/package/base-files/files/etc/iproute2/ematch_map
+++ b/package/base-files/files/etc/iproute2/ematch_map
@@ -1,0 +1,8 @@
+# lookup table for ematch kinds
+1	cmp
+2	nbyte
+3	u32
+4	meta
+7	canid
+8	ipset
+9	ipt


### PR DESCRIPTION
This file is needed to properly use the tc ematch modules present in
kmod-sched-core and kmod-sched. It is a read-only index file of ematch
methods used by tc.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
[cherry picked from commit 10a2ccb7fceef3a6dea4ece14e6141a807292d5f]

**Target**: the [upcoming maintenance release announced](http://lists.infradead.org/pipermail/openwrt-adm/2018-December/000973.html) by @jow- 
**Compile and run-tested**: DIR-835 (ar71xx/mips24kc), LEDE-17.01.5 &  OpenWrt-18.06.1
