### PR TITLE
[backport][17.01] base-files: fix postinstall uci-defaults removal

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -243,10 +243,9 @@ default_postinst() {
 	if [ -z "$root" ] && grep -q -s "^/etc/uci-defaults/" "/usr/lib/opkg/info/${pkgname}.list"; then
 		. /lib/functions/system.sh
 		[ -d /tmp/.uci ] || mkdir -p /tmp/.uci
-		for i in $(sed -ne 's!^/etc/uci-defaults/!!p' "/usr/lib/opkg/info/${pkgname}.list"); do (
-			cd /etc/uci-defaults
-			[ -f "$i" ] && . ./"$i" && rm -f "$i"
-		) done
+		for i in $(grep -s "^/etc/uci-defaults/" "/usr/lib/opkg/info/${pkgname}.list"); do
+			( [ -f "$i" ] && cd "$(dirname $i)" && . "$i" ) && rm -f "$i"
+		done
 		uci commit
 	fi
 


### PR DESCRIPTION
**Target**: the [upcoming maintenance release announced](http://lists.infradead.org/pipermail/openwrt-adm/2018-December/000973.html) by @jow- 
**Compile and run-tested**: DIR-835 (ar71xx/mips24kc), LEDE-17.01.4 &  OpenWrt-18.06.1

This change (#778) is present in master and 18.06 (backport) but is missing from 17.01 where it was first developed and tested. The related commit 8806da86f5da3b1b1e4d24259d168e2219c01a26 (#779) is already present in master and back-ported to both 18.06 and 17.01.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
(backported from 4097ab6a975902b170dd7f7ac6c8025e5f32ef8d)
