### PR TITLE
ramips: add support for WIZnet WizFi630S board

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -416,6 +416,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:wan" "6@eth0"
 		;;
+	wiznet,wizfi630s)
+		ucidef_add_switch "switch0" \
+			"0:wan" "3:lan" "4:lan" "6@eth0"
+		;;
 	wt3020-4M|\
 	wt3020-8M)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/dts/WIZFI630S.dts
+++ b/target/linux/ramips/dts/WIZFI630S.dts
@@ -1,0 +1,193 @@
+//SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wiznet,wizfi630s", "mediatek,mt7628an-soc";
+	model = "WIZnet WizFi630S";
+
+	chosen {
+		bootargs = "console=ttyS1,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	aliases {
+		led-boot = &led_run;
+		led-failsafe = &led_run;
+		led-running = &led_run;
+		led-upgrade = &led_run;
+		serial0 = &uart1;
+		serial1 = &uartlite;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		
+		led_run: run {
+			label = "wizfi630s:green:run";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		ledwps {
+			label = "wizfi630s:green:wps";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>; 
+		};
+
+		leduart1 {
+			label = "wizfi630s:green:uart1";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+
+		leduart2 {
+			label = "wizfi630s:green:uart2";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		scm1 {
+			label = "SCM1";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		scm2 {
+			label = "SCM2";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_2>;
+		};
+
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio";
+			ralink,function = "gpio";
+		};
+
+		i2s {
+			ralink,group = "i2s";
+			ralink,function = "gpio";
+		};
+
+		wdt {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+
+
+		i2c {
+			ralink,group = "i2c";
+			ralink,function = "gpio";
+		};
+
+		refclk {
+			ralink,group = "refclk";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		m25p,chunked-io = <31>;
+	
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&sdhci {
+	status = "okay";
+	mediatek,cd-high;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -374,6 +374,13 @@ define Device/widora_neo-32m
 endef
 TARGET_DEVICES += widora_neo-32m
 
+define Device/wizfi630s
+  DTS := WIZFI630S
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := WIZnet WizFi630S
+endef
+TARGET_DEVICES += wizfi630s
+
 define Device/wrtnode2p
   DTS := WRTNODE2P
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
The WIZnet WizFi63S board is in the miniPCIe form factor.

SoC: Mediatek MT7688AN
RAM: 128MB
Flash: 32Mb
WiFi: 2.4GHz
Ethernet: 3x 100Mbit
USB: 1 (USB 2.0)
serial ports: 2 (1x full, 1xlite)

Signed-off-by: Tobias Welz <tw@wiznet.eu>