### PR TITLE
ramips: add support for I-O DATA WN-AC1167GR

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -188,6 +188,10 @@ ht-tm02)
 	ucidef_set_led_netdev "eth" "Ethernet" "$boardname:green:lan" "eth0"
 	set_wifi_led "$boardname:blue:wlan"
 	;;
+iodata,wn-ac1167gr)
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$boardname:green:wlan5g" "phy0radio"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$boardname:green:wlan2g" "phy1radio"
+	;;
 kimax,u35wf)
 	set_wifi_led "$boardname:blue:wifi"
 	ucidef_set_led_netdev "eth" "ETH" "$boardname:green:eth" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -317,6 +317,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
 		;;
+	iodata,wn-ac1167gr)
+		ucidef_add_switch "switch1" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
+		;;
 	kn_rf)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6@eth0"
@@ -522,6 +526,9 @@ ramips_setup_macs()
 		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	iodata,wn-ac1167gr)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary Factory 4)" -1)
 		;;
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)

--- a/target/linux/ramips/dts/WN-AC1167GR.dts
+++ b/target/linux/ramips/dts/WN-AC1167GR.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-ac1167gr", "ralink,mt7620a-soc";
+	model = "I-O DATA WN-AC1167GR";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "wn-ac1167gr:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "wn-ac1167gr:green:wlan2g";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		notification {
+			label = "wn-ac1167gr:green:notification";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "wn-ac1167gr:green:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			Factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x8000>;
+				read-only;
+			};
+
+			iNIC_rf: partition@48000 {
+				label = "iNIC_rf";
+				reg = <0x48000 0x8000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "NoUsed";
+				reg = <0x50000 0x20000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0x6b4000>;
+			};
+
+			partition@724000 {
+				label = "manufacture";
+				reg = <0x724000 0x8c000>;
+				read-only;
+			};
+
+			partition@7b0000 {
+				label = "backup";
+				reg = <0x7b0000 0x10000>;
+				read-only;
+			};
+
+			partition@7c0000 {
+				label = "storage";
+				reg = <0x7c0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+	mtd-mac-address = <&Factory 0x4>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1 {
+			reg = <1>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@2 {
+			reg = <2>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@3 {
+			reg = <3>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1f {
+			reg = <0x1f>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&Factory 0x0>;
+};


### PR DESCRIPTION
I-O DATA WN-AC1167GR is a 2.4/5 GHz band 11ac router, based on
MediaTek MT7620A.

Specification:

- SoC     : MediaTek MT7620A
- RAM     : DDR2 64 MB
- Flash   : SPI-NOR 8MB
- WLAN    : 2.4/5 GHz, 2T2R
  - 2.4 GHz: MT7620A (SoC)
  - 5 GHz  : MT7612E
- Ethernet: 10/100/1000 Mbps (ext. MT7530)
- LED/key : 4x/3x (2x buttons, 1x slide-switch)
- UART    : through-hole on PCB
  - J2: TX, GND, RX, Vcc from SoC side
  - 115200n8

Flash instruction using factory image:

1. Boot WN-AC1167GR normaly
2. Access to "http://192.168.0.1/" and open firmware update page
("ファームウェア")
3. Select the OpenWrt factory image and click update ("更新") button
to perform firmware update
4. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>