### PR TITLE
ath79: Add support for Ubiquiti NanoBeam AC

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -145,6 +145,7 @@ ubnt,rocket-m)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link3" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100"
 	;;
+ubnt,nanobeam-ac|\
 ubnt,nanostation-ac)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:blue:rssi0" "wlan0" "1" "100"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ath79_setup_interfaces()
 	ubnt,bullet-m|\
 	ubnt,bullet-m-xw|\
 	ubnt,lap-120|\
+	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -138,6 +138,7 @@ case "$FIRMWARE" in
 	ubnt,unifiac-mesh|\
 	ubnt,unifiac-mesh-pro|\
 	ubnt,lap-120|\
+	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)

--- a/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,nanobeam-ac", "ubnt,wa", "qca,ar9342";
+	model = "Ubiquiti NanoBeam AC (WA)";
+
+	leds {
+		compatible = "gpio-leds";
+
+		rssi0 {
+			label = "ubnt:blue:rssi0";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "ubnt:blue:rssi1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "ubnt:blue:rssi2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi3 {
+			label = "ubnt:blue:rssi3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "rgmii";
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -122,6 +122,15 @@ define Device/ubnt_lap-120
 endef
 TARGET_DEVICES += ubnt_lap-120
 
+define Device/ubnt_nanobeam-ac
+  $(Device/ubnt-wa)
+  DEVICE_TITLE := Ubiquiti NanoBeam AC
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15744k
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
+endef
+TARGET_DEVICES += ubnt_nanobeam-ac
+
 define Device/ubnt_nanostation-ac
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti Nanostation AC


### PR DESCRIPTION
# Overview

The NanoBeam is a small AR9342 based directional 5 GHz AC CPE with hardware
almost identical to the Ubiquiti NanoStation AC loco. Over the NanoStation
AC loco it has 5 additional LEDs. Four of those LEDs are used as rssi
indicators, the fifth LED is used as an ethernet link/activity indicator.

# Specs

CPU:   Atheros AR9342 SoC
RAM:   64 MB DDR2
Flash: 16 MB NOR SPI
WLAN:  QCA988X
Ports: 1x GbE

# Flashing

Flashing procedure is identical to the NanoStation AC loco and can be performed
either via serial or the factory firmware upgrade.

## Flashing through factory firmware:

1. Ensure firmware version v8.5.0.36727 is installed. Up/downgrade to this exact version.
2. Patch fwupdate.real binary using `hexdump -Cv /bin/ubntbox | sed 's/14 40 fe fe/00 00 00 00/g' | hexdump -R > /tmp/fwupdate.real`
3. Make the patched fwupdate.real binary executable using `chmod +x /tmp/fwupdate.real`
4. Copy the squashfs factory image to /tmp on the device
5. Flash OpenWRT using `/tmp/fwupdate.real -m <squashfs-factory image>`
6. Wait for the device to reboot

## Serial flashing

1. Connect to serial header on device (8N1 115200)
2. Power on device and enter uboot console
3. Set up tftp server serving an openwrt initramfs build
4. Load initramfs build using the command tftpboot in the uboot cli
5. Boot the loaded image using the command bootm
6. Copy squashfs openwrt sysupgrade build to the booted device
7. Use mtd to write sysupgrade to partition "firmware"
8. Reboot and enjoy

# Credits

Thanks to @cybermaus for testing!

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>