### PR TITLE
ath79: allow asserting mdio/mac reset together

### DIFF
--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -192,19 +192,16 @@
 
 &mdio0 {
 	compatible = "qca,ar9340-mdio";
-	resets = <&rst 22>;
-	reset-names = "mdio";
 };
 
 &eth0 {
-	compatible = "qca,ar9340-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar9340-eth", "syscon";
 
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	pll-reg = <0x4 0x2c 17>;
 	pll-handle = <&pll>;
-
-	resets = <&rst 9>;
-	reset-names = "mac";
+	resets = <&rst 9>, <&rst 22>;
+	reset-names = "mac", "mdio";
 };
 
 &mdio1 {

--- a/target/linux/ath79/dts/qca9557.dtsi
+++ b/target/linux/ath79/dts/qca9557.dtsi
@@ -289,12 +289,11 @@
 };
 
 &mdio0 {
-	resets = <&rst 22>;
-	reset-names = "mdio";
+	compatible = "qca,ar9340-mdio";
 };
 
 &eth0 {
-	compatible = "qca,qca9550-eth", "syscon", "simple-mfd";
+	compatible = "qca,qca9550-eth", "syscon";
 
 	pll-reg = <0 0x28 0>;
 	pll-handle = <&pll>;
@@ -302,17 +301,16 @@
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	phy-mode = "rgmii";
 
-	resets = <&rst 9>;
-	reset-names = "mac";
+	resets = <&rst 9>, <&rst 22>;
+	reset-names = "mac", "mdio";
 };
 
 &mdio1 {
-	resets = <&rst 23>;
-	reset-names = "mdio";
+	compatible = "qca,ar9340-mdio";
 };
 
 &eth1 {
-	compatible = "qca,qca9550-eth", "syscon", "simple-mfd";
+	compatible = "qca,qca9550-eth", "syscon";
 
 	pll-reg = <0 0x48 0>;
 	pll-handle = <&pll>;
@@ -320,6 +318,6 @@
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	phy-mode = "sgmii";
 
-	resets = <&rst 13>;
-	reset-names = "mac";
+	resets = <&rst 13>, <&rst 23>;
+	reset-names = "mac", "mdio";
 };

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -188,6 +188,7 @@ struct ag71xx {
 	struct timer_list	oom_timer;
 
 	struct reset_control *mac_reset;
+	struct reset_control *mdio_reset;
 
 	u32			fifodata[3];
 	u32			plldata[3];

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1309,26 +1309,6 @@ static const struct net_device_ops ag71xx_netdev_ops = {
 #endif
 };
 
-static const char *ag71xx_get_phy_if_mode_name(phy_interface_t mode)
-{
-	switch (mode) {
-	case PHY_INTERFACE_MODE_MII:
-		return "MII";
-	case PHY_INTERFACE_MODE_GMII:
-		return "GMII";
-	case PHY_INTERFACE_MODE_RMII:
-		return "RMII";
-	case PHY_INTERFACE_MODE_RGMII:
-		return "RGMII";
-	case PHY_INTERFACE_MODE_SGMII:
-		return "SGMII";
-	default:
-		break;
-	}
-
-	return "unknown";
-}
-
 static int ag71xx_probe(struct platform_device *pdev)
 {
 	struct device_node *np = pdev->dev.of_node;
@@ -1540,9 +1520,9 @@ static int ag71xx_probe(struct platform_device *pdev)
 		goto err_phy_disconnect;
 	}
 
-	pr_info("%s: Atheros AG71xx at 0x%08lx, irq %d, mode:%s\n",
+	pr_info("%s: Atheros AG71xx at 0x%08lx, irq %d, mode: %s\n",
 		dev->name, (unsigned long) ag->mac_base, dev->irq,
-		ag71xx_get_phy_if_mode_name(ag->phy_if_mode));
+		phy_modes(ag->phy_if_mode));
 
 	return 0;
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_mdio.c
@@ -190,7 +190,7 @@ static int ag71xx_mdio_probe(struct platform_device *pdev)
 	if (!mii_bus)
 		return -ENOMEM;
 
-	am->mdio_reset = of_reset_control_get_exclusive(np, "mdio");
+	am->mdio_reset = devm_reset_control_get_exclusive(amdev, "mdio");
 	builtin_switch = of_property_read_bool(np, "builtin-switch");
 
 	mii_bus->name = "ag71xx_mdio";


### PR DESCRIPTION
On ar933x and later chips, there are separated mac/mdio resets, but resetting the entire gmac block with register values requires both mac_reset and mdio_reset to be asserted together.
Add support for optional mdio reset so that we can do a full reset if needed.

This PR also include several cleanups for ag71xx, check commit message for details.

Tested on:
Winchannel WB2000 (AR9344)
TP-Link TL-WDR4900 v2 (QCA9558)

For other chips, the code should behave the same as before if dts is unchanged.