### PR TITLE
lantiq/led_dsl: Fix netdev led trigger

### DIFF
--- a/target/linux/lantiq/base-files/etc/hotplug.d/dsl/led_dsl.sh
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/dsl/led_dsl.sh
@@ -10,7 +10,9 @@ led_dsl_up() {
 	"netdev")
 		led_set_attr $1 "trigger" "netdev"
 		led_set_attr $1 "device_name" "$(config_get led_dsl dev)"
-		led_set_attr $1 "mode" "$(config_get led_dsl mode)"
+		for m in $(config_get led_dsl mode); do
+			led_set_attr $1 "$m" "1"
+		done
 		;;
 	*)
 		led_on $1


### PR DESCRIPTION
In the upstream netdev led trigger the one mode file was replaced by 3
files named rx, tx and link. Fix the netdev trigger configuration code
to use the modified API.

This fix is based on 201058b35ce ("base-files: Fix netdev led trigger")

Fixes: aa3b6a08c56 ("kernel: Replace ledtrig-netdev with upstream backport")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
