### PR TITLE
ath79: Add support for Ubiquiti Nanostation M (XW)

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -138,6 +138,7 @@ tplink,tl-wr841-v11)
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
 ubnt,nano-m|\
+ubnt,nanostation-m-xw|\
 ubnt,rocket-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:red:link1" "wlan0" "1" "100"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -207,6 +207,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	ubnt,nanostation-m-xw)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "5:lan" "1:wan"
+		;;
 	ubnt,nanostation-ac|\
 	ubnt,unifiac-mesh-pro|\
 	ubnt,unifiac-pro)

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-m-xw.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_xw.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-m-xw", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti Nanostation M (XW)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4-mii-enable;
+	phy-mask = <0x23>;
+
+	phy4: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		mii-gmac0 = <1>;
+		mii-gmac0-slave = <1>;
+	};
+};

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
@@ -53,6 +53,7 @@ static void ag71xx_setup_gmac_934x(struct device_node *np, void __iomem *base)
 
 	ag71xx_of_bit(np, "rgmii-gmac0", &val, AR934X_ETH_CFG_RGMII_GMAC0);
 	ag71xx_of_bit(np, "mii-gmac0", &val, AR934X_ETH_CFG_MII_GMAC0);
+	ag71xx_of_bit(np, "mii-gmac0-slave", &val, AR934X_ETH_CFG_MII_GMAC0_SLAVE);
 	ag71xx_of_bit(np, "gmii-gmac0", &val, AR934X_ETH_CFG_GMII_GMAC0);
 	ag71xx_of_bit(np, "switch-phy-swap", &val, AR934X_ETH_CFG_SW_PHY_SWAP);
 	ag71xx_of_bit(np, "switch-only-mode", &val,

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -113,6 +113,12 @@ define Device/ubnt_nano-m
 endef
 TARGET_DEVICES += ubnt_nano-m
 
+define Device/ubnt_nanostation-m-xw
+  $(Device/ubnt-xw)
+  DEVICE_TITLE := Ubiquiti Nanostation M (XW)
+endef
+TARGET_DEVICES += ubnt_nanostation-m-xw
+
 define Device/ubnt_lap-120
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti LiteAP ac (LAP-120)


### PR DESCRIPTION
This my 3rd attempt, so `Version 3`. `Version 1` of this patchset was sent for review through [mailing list](http://lists.infradead.org/pipermail/openwrt-devel/2018-December/015092.html). `Version 2` of this patchset was done through #1632.

This PR adds DTS with support for Ubiquiti Nanostation M (XW) and support for `mii-gmac0-slave` parser which is needed on Nanostation, since both ethernet ports accesible through `GMAC0` are connected through `AR8236` switch which is providing both `TX` and `RX` clocks to `GMAC0` so `GMAC0` acts as slave.

This PR depends on #1735 which seems to be the proper way of fixing `GMAC0` reset issues, where currently the `GMAC0` reset is working properly on `ar71xx`, but isn't being reset at all in `ath79`. In `ar71xx` we assert both `mdio` and `mac` reset bits, but in `ath79` we currently just assert the `mac` reset bit, which is not enough to put the `GMAC0` in the reset state.

More details on the `GMAC0` reset issue could be found at [previous attempt to fix this issue](https://github.com/openwrt/openwrt/pull/1632/commits/9d8f7d52072352dd3ecb4a3c5067307903c48346) and at [Pending ath79 issues on ar9342 and 4.14/4.19 kernels](http://lists.infradead.org/pipermail/openwrt-devel/2019-January/015387.html) mailing list thread.

This `GMAC0` reset issue seems to cause problems only on Nanostation M (XW) so far.

`Version 3` was run-tested by me on Bullet M2 (XW) and by @ae6xe on his Nanostation M5 (XW).