### PR TITLE
ramips: add support for ZyXEL Keenetic Start

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -468,6 +468,9 @@ zyxel,keenetic-extra-ii)
 	set_wifi_led "$boardname:green:wifi"
 	ucidef_set_led_switch "internet" "internet" "$boardname:green:internet" "switch0" "0x01"
 	;;
+zyxel,keenetic-start)
+	set_wifi_led "rt2800pci-phy0::radio"
+	;;
 youku-yk1)
 	set_wifi_led "$boardname:blue:air"
 	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x10"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -446,6 +446,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"
 		;;
+	zyxel,keenetic-start)
+		ucidef_add_switch "switch0" \
+			"0:lan:3" "1:lan:2" "2:lan:1" "3:lan:0" "4:wan" "6@eth0"
+		;;
 	*)
 		RT3X5X=`cat /proc/cpuinfo | egrep "(RT3.5|RT5350)"`
 		if [ -n "${RT3X5X}" ]; then
@@ -652,6 +656,9 @@ ramips_setup_macs()
 	xiaomi,mir3g|\
 	xiaomi,mir3p)
 		lan_mac=$(mtd_get_mac_binary Factory 0xe006)
+		;;
+	zyxel,keenetic-start)
+		wan_mac=$(mtd_get_mac_binary factory 40)
 		;;
 	*)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/dts/kn_st.dts
+++ b/target/linux/ramips/dts/kn_st.dts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,keenetic-start", "ralink,rt5350-soc";
+	model = "ZyXEL Keenetic Start";
+	
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};	
+	
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: power {
+			label = "zyxel:green:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "zyxel:green:internet";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x3b0000>;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,led_polarity = <0x17>;
+};
+
+&wmac {
+	status = "okay";
+	ralink,led-polarity = <1>;
+	ralink,mtd-eeprom = <&factory 0>;
+};
+

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -910,6 +910,13 @@ define Device/kn
 endef
 TARGET_DEVICES += kn
 
+define Device/zyxel_keenetic-start
+  DTS := kn_st
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  DEVICE_TITLE := ZyXEL Keenetic Start
+endef
+TARGET_DEVICES += zyxel_keenetic-start
+
 define Device/zorlik_zl5900v2
   DTS := ZL5900V2
   DEVICE_TITLE := Zorlik ZL5900V2


### PR DESCRIPTION
Device specification:
- SoC: RT5350F
- CPU Frequency: 360 MHz
- Flash Chip: Winbond 25Q32 (4096 KiB)
- RAM: 32768 KiB
- 5x 10/100 Mbps Ethernet (4x LAN, 1x WAN)
- 1x external, non-detachable antenna
- UART (J1) header on PCB (57800 8n1)
- Wireless: SoC-intergated: 2.4GHz 802.11bgn
- USB: None
- 3x LED, 2x button

Flash instruction:
1. Configure PC with static IP 192.168.1.2/24 and start TFTP server.
2. Rename "openwrt-ramips-rt305x-kn_st-squashfs-sysupgrade.bin"
   to "kstart_recovery.bin" and place it in TFTP server directory.
3. Connect PC with one of LAN ports, press the reset button, power up
   the router and keep button pressed until power LED start blinking.
4. Router will download file from TFTP server, write it to flash and reboot.

Signed-off-by: Vladimir Kot <<snmetamorph.adc@gmail.com>>
