### PR TITLE
procd: Add wrapper for uci_validate_section()

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -6,7 +6,7 @@ USE_PROCD=1
 
 validate_system_section()
 {
-	uci_validate_section system system "${1}" \
+	uci_load_validate system system "$1" "$2" \
 		'hostname:string:OpenWrt' \
 		'conloglevel:uinteger' \
 		'buffersize:uinteger' \
@@ -15,11 +15,7 @@ validate_system_section()
 }
 
 system_config() {
-	local cfg="$1"
-
-	local hostname conloglevel buffersize timezone zonename
-
-	validate_system_section "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -36,7 +32,7 @@ system_config() {
 
 reload_service() {
 	config_load system
-	config_foreach system_config system
+	config_foreach validate_system_section system system_config
 }
 
 service_triggers()

--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -29,7 +29,7 @@ append_ports()
 
 validate_section_dropbear()
 {
-	uci_validate_section dropbear dropbear "${1}" \
+	uci_load_validate dropbear dropbear "$1" "$2" \
 		'PasswordAuth:bool:1' \
 		'enable:bool:1' \
 		'Interface:string' \
@@ -48,12 +48,9 @@ validate_section_dropbear()
 
 dropbear_instance()
 {
-	local PasswordAuth enable Interface GatewayPorts \
-		RootPasswordAuth RootLogin rsakeyfile \
-		BannerFile Port SSHKeepAlive IdleTimeout \
-		MaxAuthTries RecvWindowSize mdns ipaddrs
+	local ipaddrs
 
-	validate_section_dropbear "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -135,7 +132,7 @@ start_service()
 	. /lib/functions/network.sh
 
 	config_load "${NAME}"
-	config_foreach dropbear_instance dropbear
+	config_foreach validate_section_dropbear dropbear dropbear_instance
 }
 
 service_triggers()

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -486,6 +486,23 @@ uci_validate_section()
 	return $_error
 }
 
+uci_load_validate() {
+	local _package="$1"
+	local _type="$2"
+	local _name="$3"
+	local _function="$4"
+	local _option
+	local _result
+	shift; shift; shift; shift
+	for _option in "$@"; do
+		eval "local ${_option%%:*}"
+	done
+	uci_validate_section "$_package" "$_type" "$_name" "$@"
+	_result=$?
+	[ -n "$_function" ] || return $_result
+	eval "$_function \"\$_name\" \"\$_result\""
+}
+
 _procd_wrapper \
 	procd_open_service \
 	procd_close_service \

--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -11,7 +11,7 @@ PROG=/sbin/logread
 
 validate_log_section()
 {
-	uci_validate_section system system "${1}" \
+	uci_load_validate system system "$1" "$2" \
 		'log_file:string' \
 		'log_size:uinteger' \
 		'log_hostname:string' \
@@ -25,15 +25,13 @@ validate_log_section()
 
 validate_log_daemon()
 {
-	uci_validate_section system system "${1}" \
+	uci_load_validate system system "$1" "$2" \
 		'log_size:uinteger:0' \
 		'log_buffer_size:uinteger:0'
 }
 
 start_service_daemon()
 {
-	local log_buffer_size log_size
-	validate_log_daemon "${1}"
 	[ $log_buffer_size -eq 0 -a $log_size -gt 0 ] && log_buffer_size=$log_size
 	[ $log_buffer_size -eq 0 ] && log_buffer_size=64
 	procd_open_instance
@@ -47,9 +45,8 @@ start_service_file()
 {
 	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
 	local pid_file="/var/run/logread.${PIDCOUNT}.pid"
-	local log_file log_size
 
-	validate_log_section "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -67,9 +64,8 @@ start_service_remote()
 {
 	PIDCOUNT="$(( ${PIDCOUNT} + 1))"
 	local pid_file="/var/run/logread.${PIDCOUNT}.pid"
-	local log_ip log_port log_proto log_prefix log_remote log_trailer_null log_hostname
 
-	validate_log_section "${1}" || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -96,7 +92,7 @@ service_triggers()
 start_service()
 {
 	config_load system
-	config_foreach start_service_daemon system
-	config_foreach start_service_file system
-	config_foreach start_service_remote system
+	config_foreach validate_log_daemon system start_service_daemon
+	config_foreach validate_log_section system start_service_file
+	config_foreach validate_log_section system start_service_remote
 }

--- a/package/utils/busybox/files/sysntpd
+++ b/package/utils/busybox/files/sysntpd
@@ -29,14 +29,14 @@ get_dhcp_ntp_servers() {
 }
 
 validate_ntp_section() {
-	uci_validate_section system timeserver "${1}" \
+	uci_load_validate system timeserver "$1" "$2" \
 		'server:list(host)' 'enabled:bool:1' 'enable_server:bool:0' 'use_dhcp:bool:1' 'dhcp_interface:list(string)'
 }
 
-start_service() {
-	local server enabled enable_server use_dhcp dhcp_interface peer
+start_ntpd_instance() {
+	local peer
 
-	validate_ntp_section ntp || {
+	[ "$2" = 0 ] || {
 		echo "validation failed"
 		return 1
 	}
@@ -56,6 +56,10 @@ start_service() {
 	done
 	procd_set_param respawn
 	procd_close_instance
+}
+
+start_service() {
+	validate_ntp_section ntp start_ntpd_instance
 }
 
 service_triggers() {


### PR DESCRIPTION
This adds a wrapper (`uci_validate_load`) for `uci_validate_section()` that allows callers (through a callback function) to access the values set by `uci_validate_section()`, without having to manually declare a (potentially long) list of local variables.

The callback function receives two arguments when called, the config section name and the return value of `uci_validate_section()`.

If no callback function is given, then the wrapper exits with the value returned by `uci_validate_section()`.

This also updates several init scripts to use the new wrapper function.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>