### PR TITLE
lantiq: add support for AVM FRITZ!Box 7362 SL

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -158,6 +158,14 @@ avm,fritz7360sl)
 		"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
 	;;
 
+avm,fritz7362sl)
+	annex="b"
+	lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
+	wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
+	ucidef_add_switch "switch0" \
+		"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
+	;;
+
 siemens,gigaset-sx76x)
 	annex="b"
 	ucidef_add_switch "switch0" \

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -157,7 +157,8 @@ case "$FIRMWARE" in
 				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 524
 				;;
 			avm,fritz3370-rev2-hynix|\
-			avm,fritz3370-rev2-micron)
+			avm,fritz3370-rev2-micron|\
+			avm,fritz7362sl)
 				ath9k_eeprom_extract_reverse "urlader" 5441 1088
 				;;
 			avm,fritz7312|avm,fritz7320|avm,fritz7360sl)

--- a/target/linux/lantiq/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/base-files/lib/upgrade/platform.sh
@@ -11,6 +11,7 @@ platform_do_upgrade() {
 	case "$board" in
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz7362sl|\
 	bt,homehub-v2b|\
 	bt,homehub-v3a|\
 	bt,homehub-v5a|\

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7360SL.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7360SL.dts
@@ -1,171 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "vr9.dtsi"
+#include "FRITZ736X.dtsi"
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/mips/lantiq_rcu_gphy.h>
 
 / {
-	compatible = "avm,fritz7360sl", "lantiq,xway", "lantiq,vr9";
+	compatible = "avm,fritz7360sl", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
 	model = "AVM FRITZ!Box 7360 SL";
-
-	chosen {
-		bootargs = "console=ttyLTQ0,115200";
-	};
-
-	aliases {
-		led-boot = &power_green;
-		led-failsafe = &power_red;
-		led-running = &power_green;
-		led-upgrade = &power_green;
-
-		led-dsl = &info_green;
-		led-wifi = &wifi;
-	};
-
-	memory@0 {
-		reg = <0x0 0x8000000>;
-	};
-
-	gpio-keys-polled {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <100>;
-		dect {
-			label = "dect";
-			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_PHONE>;
-		};
-		wifi {
-			label = "wifi";
-			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
-		};
-	};
-
-	gpio-leds {
-		compatible = "gpio-leds";
-
-		power_green: power {
-			label = "fritz7360sl:green:power";
-			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
-			default-state = "keep";
-		};
-		power_red: power2 {
-			label = "fritz7360sl:red:power";
-			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
-		};
-		info_red {
-			label = "fritz7360sl:red:info";
-			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
-		};
-		info_green: info_green {
-			label = "fritz7360sl:green:info";
-			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
-		};
-		wifi: wifi {
-			label = "fritz7360sl:green:wlan";
-			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
-		};
-		dect {
-			label = "fritz7360sl:green:dect";
-			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
-		};
-	};
 };
 
-&eth0 {
-	lan: interface@0 {
-		compatible = "lantiq,xrx200-pdi";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0>;
-		mtd-mac-address = <&urlader 0xa91>;
-		mtd-mac-address-increment = <(-2)>;
-		lantiq,switch;
-
-		ethernet@0 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <0>;
-			phy-mode = "rmii";
-			phy-handle = <&phy0>;
-		};
-		ethernet@1 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <1>;
-			phy-mode = "rmii";
-			phy-handle = <&phy1>;
-		};
-		ethernet@2 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <2>;
-			phy-mode = "gmii";
-			phy-handle = <&phy11>;
-		};
-		ethernet@3 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <4>;
-			phy-mode = "gmii";
-			phy-handle = <&phy13>;
-		};
-	};
-
-	mdio@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "lantiq,xrx200-mdio";
-		reg = <0>;
-
-		phy0: ethernet-phy@0 {
-			reg = <0x00>;
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
-		};
-		phy1: ethernet-phy@1 {
-			reg = <0x01>;
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
-		};
-		phy11: ethernet-phy@11 {
-			reg = <0x11>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-		phy13: ethernet-phy@13 {
-			reg = <0x13>;
-			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
-		};
-	};
+&power_green {
+	label = "fritz7360sl:green:power";
 };
 
-&gphy0 {
-	lantiq,gphy-mode = <GPHY_MODE_GE>;
+&power_red {
+	label = "fritz7360sl:red:power";
 };
 
-&gphy1 {
-	lantiq,gphy-mode = <GPHY_MODE_GE>;
+&info_green {
+	label = "fritz7360sl:green:info";
 };
 
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
+&wifi {
+	label = "fritz7360sl:green:wlan";
+};
 
-	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-		phy-rst {
-			lantiq,pins = "io37", "io44";
-			lantiq,pull = <0>;
-			lantiq,open-drain;
-			lantiq,output = <1>;
-		};
-		pcie-rst {
-			lantiq,pins = "io38";
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
+&info_red {
+	label = "fritz7360sl:red:info";
+};
+
+&dect {
+	label = "fritz7360sl:green:dect";
+};
+
+&state_default {
+	pcie-rst {
+		lantiq,pins = "io38";
+		lantiq,pull = <0>;
+		lantiq,output = <1>;
 	};
 };
 
@@ -205,36 +79,4 @@
 			};
 		};
 	};
-};
-
-&pcie0 {
-	pcie@0 {
-		reg = <0 0 0 0 0>;
-		#interrupt-cells = <1>;
-		#size-cells = <2>;
-		#address-cells = <3>;
-		device_type = "pci";
-
-		wifi@168c,002e {
-			compatible = "pci168c,002e";
-			reg = <0 0 0 0 0>;
-			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
-		};
-	};
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb_phy1 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
-};
-
-&usb1 {
-	status = "okay";
 };

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7362SL.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ7362SL.dts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "FRITZ736X.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7362sl", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7362 SL";
+};
+
+&power_green {
+	label = "fritz7362sl:green:power";
+};
+
+&power_red {
+	label = "fritz7362sl:red:power";
+};
+
+&info_green {
+	label = "fritz7362sl:green:info";
+};
+
+&wifi {
+	label = "fritz7362sl:green:wlan";
+};
+
+&info_red {
+	label = "fritz7362sl:red:info";
+};
+
+&dect {
+	label = "fritz7362sl:green:dect";
+};
+
+&gpio {
+	pins_spi_default: pins_spi_default {
+		spi_in {
+			lantiq,groups = "spi_di";
+			lantiq,function = "spi";
+		};
+
+		spi_out {
+			lantiq,groups = "spi_do", "spi_clk",
+				"spi_cs4";
+			lantiq,function = "spi";
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&state_default {
+	nand {
+		lantiq,groups = "nand ale", "nand cle",
+				"nand cs1", "nand rd", "nand rdy";
+		lantiq,function = "ebu";
+	};
+
+	pcie-rst {
+		lantiq,pins = "io21";
+		lantiq,open-drain = <1>;
+		lantiq,output = <1>;
+	};
+};
+
+&spi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_spi_default>;
+
+	flash@4 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <4 0>;
+		spi-max-frequency = <1000000>;
+
+		urlader: partition@0 {
+			reg = <0x0 0x40000>;
+			label = "urlader";
+			read-only;
+		};
+
+		partition@40000 {
+			reg = <0x40000 0x60000>;
+			label = "tffs (1)";
+			read-only;
+		};
+
+		partition@A0000 {
+			reg = <0xA0000 0x60000>;
+			label = "tffs (2)";
+			read-only;
+		};
+	};
+};
+
+&localbus {
+	nand@1 {
+		compatible = "lantiq,nand-xway";
+		lantiq,cs1 = <1>;
+		bank-width = <1>;
+		reg = <1 0x0 0x2000000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		nand-ecc-mode = "on-die";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		#size-cells = <1>;
+		#address-cells = <2>;
+	};
+};

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ736X.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ736X.dtsi
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+		led-dsl = &info_green;
+		led-wifi = &wifi;
+	};
+
+	memory@0 {
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		dect {
+			label = "dect";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_PHONE>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WLAN>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		power_green: power {
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		power_red: power2 {
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+
+		info_green: info_green {
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi: wifi {
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		info_red: info_red {
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		dect: dect {
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	lan: interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		mtd-mac-address = <&urlader 0xa91>;
+		mtd-mac-address-increment = <(-2)>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rmii";
+			phy-handle = <&phy0>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rmii";
+			phy-handle = <&phy1>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+		reg = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0x00>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x01>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		mdio {
+			lantiq,groups = "mdio";
+			lantiq,function = "mdio";
+		};
+
+		phy-rst {
+			lantiq,pins = "io37", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+};
+
+&pcie0 {
+	status = "okay";
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <1>;
+		#address-cells = <2>;
+		device_type = "pci";
+
+		wifi@168c,002e {
+			compatible = "pci168c,002e";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -664,6 +664,17 @@ define Device/avm_fritz7360sl
 endef
 TARGET_DEVICES += avm_fritz7360sl
 
+define Device/avm_fritz7362sl
+  $(Device/AVM)
+  $(Device/NAND)
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_DTS := FRITZ7362SL
+  DEVICE_TITLE := AVM FRITZ!Box 7362 SL
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic kmod-usb-dwc2 fritz-tffs
+endef
+TARGET_DEVICES += avm_fritz7362sl
+
 define Device/arcadyan_vg3503j
   IMAGE_SIZE := 8000k
   DEVICE_DTS := VG3503J


### PR DESCRIPTION
[1/2] lantiq: add support for AVM FRITZ!Box 7362 SL
Hardware:
- SoC: Lantiq VRX288
- RAM: Winbond W971GG6JB 128 MiB
- Flash:
  - SPI: 8 Mb (1 MiB) for bootloader and tffs
  - NAND: 1Gb (128 MiB) for OS
- xDSL: Lantiq VRX208
- WLAN: Atheros AR9381
- DECT: Dialog Semiconductors SC14441

Everything except FXS/DECT works
(no drivers for AVM's FXS implementation with SC14441).

Installation via FTP:
1. Use scripts/flashing/eva_ramboot.py to send initramfs-kernel.bin
to the device when powering on.
Standard AVM procedures with finding the correct IP address and
the right moment to open FTP apply here (approx. 4 seconds on 7362SL).
IMPORTANT: set lzma compression in ramdisk options, bootloader stalls
when receiving uncompressed images.

2. Transfer sysupgrade.bin image with scp to /tmp directory
and run sysupgrade

3. First boot might take a bit longer if linux_fs_start was set to 1,
in that case the device will reboot twice, first time it will fail to load
second kernel (overwritten by ubifs), set linux_fs_start to 0 and reboot.

OpenWrt uses the entire NAND flash. Kernel uses 4 MiB and rootfs uses
the rest of 124 MiB, overwriting everything related to FRITZ!OS - both
OS images, config and answering machine/media server data.

[2/2] lantiq: unify FRITZ736X device trees
FRITZ!Box 7360 and FRITZ!Box 7362 share similar configuration,
unify it in FRITZ736X.dtsi.
