### PR TITLE
ramips: fix support for MX25L25635F flash

### DIFF
--- a/target/linux/ramips/dts/GHL-R-001.dts
+++ b/target/linux/ramips/dts/GHL-R-001.dts
@@ -55,9 +55,10 @@
 	status = "okay";
 
 	flash@0 {
-		compatible = "jedec,spi-nor";
+		compatible = "mx25l25635f", "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/Newifi-D1.dts
+++ b/target/linux/ramips/dts/Newifi-D1.dts
@@ -82,10 +82,10 @@
 	status = "okay";
 
 	m25p80@0 {
-		compatible = "jedec,spi-nor";
+		compatible = "mx25l25635f", "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
-		m25p,chunked-io = <32>;
+		spi-max-frequency = <25000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/YOUKU-YK1.dts
+++ b/target/linux/ramips/dts/YOUKU-YK1.dts
@@ -69,9 +69,10 @@
 	status = "okay";
 
 	m25p80@0 {
-		compatible = "jedec,spi-nor";
+		compatible = "mx25l25635f", "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <25000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/patches-4.14/304-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
+++ b/target/linux/ramips/patches-4.14/304-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
@@ -1,0 +1,62 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1098,6 +1098,7 @@ static const struct flash_info spi_nor_i
+ 	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
+ 	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },
+ 	{ "mx25l25635e", INFO(0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "mx25l25635f", INFO(0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | SPI_NOR_4B_OPCODES) },
+ 	{ "mx25u25635f", INFO(0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },
+ 	{ "mx25l25655e", INFO(0xc22619, 0, 64 * 1024, 512, 0) },
+ 	{ "mx66l51235l", INFO(0xc2201a, 0, 64 * 1024, 1024, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | SPI_NOR_4B_OPCODES) },
+@@ -1267,11 +1268,12 @@ static const struct flash_info spi_nor_i
+ 	{ },
+ };
+ 
+-static const struct flash_info *spi_nor_read_id(struct spi_nor *nor)
++static const struct flash_info *spi_nor_read_id(struct spi_nor *nor,
++						const char *name)
+ {
+ 	int			tmp;
+ 	u8			id[SPI_NOR_MAX_ID_LEN];
+-	const struct flash_info	*info;
++	const struct flash_info	*info, *first_match = NULL;
+ 
+ 	tmp = nor->read_reg(nor, SPINOR_OP_RDID, id, SPI_NOR_MAX_ID_LEN);
+ 	if (tmp < 0) {
+@@ -1282,10 +1284,16 @@ static const struct flash_info *spi_nor_
+ 	for (tmp = 0; tmp < ARRAY_SIZE(spi_nor_ids) - 1; tmp++) {
+ 		info = &spi_nor_ids[tmp];
+ 		if (info->id_len) {
+-			if (!memcmp(info->id, id, info->id_len))
+-				return &spi_nor_ids[tmp];
++			if (!memcmp(info->id, id, info->id_len)) {
++				if (!name || !strcmp(name, info->name))
++					return info;
++				if (!first_match)
++					first_match = info;
++			}
+ 		}
+ 	}
++	if (first_match)
++		return first_match;
+ 	dev_err(nor->dev, "unrecognized JEDEC id bytes: %02x, %02x, %02x\n",
+ 		id[0], id[1], id[2]);
+ 	return ERR_PTR(-ENODEV);
+@@ -2765,7 +2773,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 		info = spi_nor_match_id(name);
+ 	/* Try to auto-detect if chip name wasn't specified or not found */
+ 	if (!info)
+-		info = spi_nor_read_id(nor);
++		info = spi_nor_read_id(nor, NULL);
+ 	if (IS_ERR_OR_NULL(info))
+ 		return -ENOENT;
+ 
+@@ -2776,7 +2784,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	if (name && info->id_len) {
+ 		const struct flash_info *jinfo;
+ 
+-		jinfo = spi_nor_read_id(nor);
++		jinfo = spi_nor_read_id(nor, name);
+ 		if (IS_ERR(jinfo)) {
+ 			return PTR_ERR(jinfo);
+ 		} else if (jinfo != info) {


### PR DESCRIPTION
Patch picked from commit 82618062cf7ed6b40d2c52c6f6b96364888ffda6 (Author @chunkeey)

This enables 4B opcodes for MX25L25635F, to fix the reboot crash issue (FS#1120)
At least 3 devices are using this flash
- GeHua GHL-R-001
- Youku YK1
- Newifi D1

Now the MX25L25635F can be correctly detected without breaking MX25L25635E
```
[ 3.034324] spi-mt7621 1e000b00.spi: sys_freq: 220000000
[ 3.045962] m25p80 spi0.0: mx25l25635f (32768 Kbytes)
[ 3.056098] 4 fixed-partitions partitions found on MTD device spi0.0
[ 3.068748] Creating 4 MTD partitions on "spi0.0":
```