### PR TITLE
ramips: rb750gr3: License DTS as GPL-2.0-or-later OR MIT

### DIFF
--- a/target/linux/ramips/dts/RB750Gr3.dts
+++ b/target/linux/ramips/dts/RB750Gr3.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include "mt7621.dtsi"


### PR DESCRIPTION
Adding license in order to fully satisfy dts checklist: https://openwrt.org/submitting-patches#dts_checklist

Original mails in mbox: [rb750gr3_dts_license_acks.mbox.zip](https://github.com/openwrt/openwrt/files/2763183/rb750gr3_dts_license_acks.mbox.zip)

Signed-off-by: Anton Arapov <arapov@gmail.com>
Signed-off-by: Mathias Kresin <dev@kresin.me>
Acked-by: Thibaut <hacks@slashdirt.org>
Acked-by: INAGAKI Hiroshi <musashino.open@gmail.com>
Acked-by: Chuanhong Guo <gch981213@gmail.com>
Acked-by: Andrew Yong <me@ndoo.sg>
Acked-by: Alex Maclean <monkeh@monkeh.net>