### PR TITLE
ath79: add support for TP-Link CPE610-v1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -155,6 +155,9 @@ tplink,cpe210-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
 	;;
+tplink,cpe610-v1)
+	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
+	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ath79_setup_interfaces()
 	pqi,air-pen|\
 	tplink,cpe210-v2|\
 	tplink,cpe210-v3|\
+	tplink,cpe610-v1|\
 	tplink,re350k-v1|\
 	tplink,re450-v2|\
 	tplink,tl-mr10u|\

--- a/target/linux/ath79/dts/ar9344_tplink_cpe610-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe610-v1.dts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "TP-Link CPE610 v1";
+	compatible = "tplink,cpe610-v1", "qca,ar9344";
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "partition-table";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			info: partition@30000 {
+				label = "info";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0x780000>;
+
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "kernel";
+					reg = <0x000000 0x1c0000>;
+				};
+
+				partition@1c0000 {
+					label = "rootfs";
+					reg = <0x1c0000 0x5c0000>;
+				};
+			};
+
+			partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x030000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x08>;
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x08>;
+
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -146,6 +146,17 @@ define Device/tplink_cpe210-v3
 endef
 TARGET_DEVICES += tplink_cpe210-v3
 
+define Device/tplink_cpe610-v1
+  $(Device/tplink-safeloader)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_TITLE := TP-Link CPE610 v1
+  TPLINK_BOARD_ID := CPE610V1
+  LOADER_TYPE := elf
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel
+endef
+TARGET_DEVICES += tplink_cpe610-v1
+
 define Device/tplink_archer-d50-v1
   ATH_SOC := qca9531
   DEVICE_TITLE := TP-Link Archer D50 v1

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -278,6 +278,45 @@ static struct device_info boards[] = {
 		.first_sysupgrade_partition = "os-image",
 		.last_sysupgrade_partition = "support-list",
 	},
+	/** Firmware layout for the CPE610V1 */
+	{
+		.id     = "CPE610V1",
+		.vendor = "CPE610(TP-LINK|UN|N300-5|00000000):1.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"CPE610(TP-LINK|EU|N300-5|00000000):1.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5|45550000):1.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5|55530000):1.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|00000000):1.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|45550000):1.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|55530000):1.0\r\n"
+			"CPE610(TP-LINK|US|N300-5|55530000):1.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5):1.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5):1.0\r\n"
+			"CPE610(TP-LINK|US|N300-5):1.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x1c0000},
+			{"file-system", 0x200000, 0x5b0000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
 
 	{
 		.id	= "WBS210",


### PR DESCRIPTION
TP-Link CPE610-v1 is an outdoor wireless CPE for 5 GHz with
one Ethernet port based on Atheros AR9344

Specifications:
 - Based on the same underlying hardware as the TP-Link CPE510
 - Power, LAN0, WLAN green LEDs
 - 23dBi high-gain directional 2×2 MIMO antenna and a dedicated metal reflector

Flashing instructions:
 Flash factory image through stock firmware WEB UI
 or through TFTP
 To get to TFTP recovery just hold reset button while powering on for
 around 4-5 seconds and release.
 Rename factory image to recovery.bin
 Stock TFTP server IP:192.168.0.100
 Stock device TFTP adress:192.168.0.254

Signed-off-by: Andrew Cameron <apcameron@softhome.net>
