### PR TITLE
ar71xx: TP-Link Archer C7 v4 correct mac address for wan interface

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -603,6 +603,10 @@ ar71xx_setup_macs()
 	fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
+	archer-c7-v4)
+		base_mac=$(mtd_get_mac_binary config 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	tl-wr1043n-v5|\
 	tl-wr1043nd-v4)
 		lan_mac=$(mtd_get_mac_binary product-info 8)


### PR DESCRIPTION
The correct MAC address for this device is lan_mac +1, there is no
need to set lan_mac so use base_mac variable instead lan_mac.

Based on this PR for ath79:
https://github.com/openwrt/openwrt/pull/1726

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>