### PR TITLE
ag71xx: preserve port mirror flags during swconfig apply.

### DIFF
--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -730,6 +730,10 @@ static void ar7240sw_setup_port(struct ar7240sw *as, unsigned port, u8 portmask)
 			portmask = ar7240sw_port_mask(as, AR7240_PORT_CPU);
 	}
 
+	/* preserve mirror rx&tx flags */
+	ctrl |= ar7240sw_reg_read(mii, AR7240_REG_PORT_CTRL(port)) & 
+		(AR7240_PORT_CTRL_MIRROR_RX | AR7240_PORT_CTRL_MIRROR_TX);
+
 	/* allow the port to talk to all other ports, but exclude its
 	 * own ID to prevent frames from being reflected back to the
 	 * port that they came from */

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -742,6 +742,10 @@ static void ar7240sw_setup_port(struct ar7240sw *as, unsigned port, u8 portmask)
 			portmask = ar7240sw_port_mask(as, AR7240_PORT_CPU);
 	}
 
+	/* preserve mirror rx&tx flags */
+	ctrl |= ar7240sw_reg_read(mii, AR7240_REG_PORT_CTRL(port)) &
+		(AR7240_PORT_CTRL_MIRROR_RX | AR7240_PORT_CTRL_MIRROR_TX);
+
 	/* allow the port to talk to all other ports, but exclude its
 	 * own ID to prevent frames from being reflected back to the
 	 * port that they came from */


### PR DESCRIPTION
As discussed in https://forum.openwrt.org/t/swconfig-versus-etc-config-network/25310/29 port mirroring does not work via 'swconfig dev eth0 load network'.

The swconfig load operation always triggers 'apply' function which in this driver currently clears port mirroring flags effectively undoing port mirroring configuration.

This fix preserves port mirroring flags during apply.

Signed-off-by: Milan Krstic <milan.krstic@gmail.com>