### PR TITLE
ath79: add support for TP-Link TL-WR941N v7 Chinese version

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -164,7 +164,8 @@ ath79_setup_interfaces()
 	tplink,archer-c6-v2|\
 	tplink,archer-c7-v5|\
 	tplink,tl-wdr3600|\
-	tplink,tl-wdr4300)
+	tplink,tl-wdr4300|\
+	tplink,tl-wr941n-v7-cn)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
@@ -285,7 +286,8 @@ ath79_setup_macs()
 		base_mac=$(mtd_get_mac_binary product-info 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
-	tplink,tl-wr941-v2)
+	tplink,tl-wr941-v2|\
+	tplink,tl-wr941n-v7-cn)
 		base_mac=$(mtd_get_mac_binary u-boot 130048)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr941n-v7-cn", "qca,qca9558";
+	model = "TP-Link TL-WR941N v7 (CN)";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "qss";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	switch0@1f {
+		compatible = "qca,ar8236";
+		reg = <0x1f>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-mode = "mii";
+	mtd-mac-address = <&uboot 0x1fc00>;
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -180,3 +180,11 @@ define Device/tplink_tl-wr941-v4
   TPLINK_HWID := 0x09410004
 endef
 TARGET_DEVICES += tplink_tl-wr941-v4
+
+define Device/tplink_tl-wr941n-v7-cn
+  $(Device/tplink-4mlzma)
+  ATH_SOC := qca9558
+  DEVICE_TITLE := TP-Link TL-WR941N v7 (CN)
+  TPLINK_HWID := 0x09410007
+endef
+TARGET_DEVICES += tplink_tl-wr941n-v7-cn


### PR DESCRIPTION
Specification:
- SoC: Qualcomm Atheros QCA9558
- Flash: 4 MB
- RAM: 64 MB
- Ethernet: Atheros AR8236 with 5 FE ports

Flash instruction:
  Upload the generated factory firmware on web interface.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>

** This PR depends on #1739 **
Edit: I typed a wrong PR ID 2 months ago.. 
The U-boot for this device enables switch mdio master, which makes PHYs inaccessible through CPU mdio and current PHY probing isn't possible because no PHY ID could be read. A mdio-device probing is required.
