### PR TITLE
[backport][18.06] ar71xx: Archer C7 v4 fix wan mac, add usb modules

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -590,6 +590,10 @@ ar71xx_setup_macs()
 	fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
+	archer-c7-v4)
+		base_mac=$(mtd_get_mac_binary config 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	tl-wr1043n-v5|\
 	tl-wr1043nd-v4)
 		lan_mac=$(mtd_get_mac_binary product-info 8)

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -131,7 +131,7 @@ TARGET_DEVICES += tl-wdr7500-v3
 define Device/archer-c7-v4
   $(Device/archer-cxx)
   DEVICE_TITLE := TP-LINK Archer C7 v4
-  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca988x
   BOARDNAME := ARCHER-C7-V4
   TPLINK_BOARD_ID := ARCHER-C7-V4
   IMAGE_SIZE := 15104k


### PR DESCRIPTION
Correct wan mac address and add pertinent usb modules.
USB modules change is in master and the mac one is proposed.
Tested that router usbs works in 18.06.1

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>