### PR TITLE
ath79:add support for COMFAST CF-E5/E7

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -47,6 +47,14 @@ comfast,cf-e120a-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "76" "100"
 	;;
+comfast,cf-e5)
+	ucidef_set_led_switch "lan" "LAN" "$boardname:blue:lan" "switch0" "0x02"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:wan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:blue:rssi0" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
+	;;
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -64,6 +64,17 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
+	comfast,cf-e5|\
+	glinet,gl-ar150|\
+	glinet,gl-ar300m-nand|\
+	glinet,gl-ar300m-nor|\
+	glinet,gl-x750|\
+	tplink,tl-wr810n-v1|\
+	tplink,tl-wr810n-v2|\
+	ubnt,routerstation|\
+	yuncore,a770)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	devolo,dvl1200e|\
 	devolo,dvl1750e)
 		ucidef_set_interface_lan "eth0 eth1"
@@ -96,16 +107,6 @@ ath79_setup_interfaces()
 		;;
 	etactica,eg200)
 		ucidef_set_interface_lan "eth0" "dhcp"
-		;;
-	glinet,gl-ar150|\
-	glinet,gl-ar300m-nand|\
-	glinet,gl-ar300m-nor|\
-	glinet,gl-x750|\
-	tplink,tl-wr810n-v1|\
-	tplink,tl-wr810n-v2|\
-	ubnt,routerstation|\
-	yuncore,a770)
-		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	glinet,gl-ar750s)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -10,6 +10,12 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+comfast,cf-e5)
+	ucidef_add_gpio_switch "lte_power" "LTE Power" "14" "1"
+	ucidef_add_gpio_switch "lte_wakeup" "LTE Wakeup" "11" "1"
+	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
+	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
+	;;
 dlink,dir-825-c1|\
 dlink,dir-835-a1)
 	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "comfast,cf-e5", "qca,qca9531";
+	model = "COMFAST CF-E5/E7";
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &led_wan_pin>;
+
+		wan {
+			label = "cf-e5:blue:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "cf-e5:blue:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "cf-e5:blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssi0 {
+			label = "cf-e5:blue:rssi0";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "cf-e5:blue:rssi1";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "cf-e5:blue:rssi2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	mtd-mac-address = <&art 0x6>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pinmux {
+	led_wan_pin: pinmux_led_wan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -171,6 +171,15 @@ define Device/comfast_cf-e120a-v3
 endef
 TARGET_DEVICES += comfast_cf-e120a-v3
 
+define Device/comfast_cf-e5
+  ATH_SOC := qca9531
+  DEVICE_TITLE := COMFAST CF-E5/E7
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio kmod-usb-core kmod-usb2 kmod-usb-net \
+	kmod-usb-net-qmi-wwan -swconfig -uboot-envtools
+  IMAGE_SIZE := 16192k
+endef
+TARGET_DEVICES += comfast_cf-e5
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_TITLE := devolo WiFi pro 1200e


### PR DESCRIPTION
COMFAST CF-E5/E7 is a outdoor 4G LTE AP with PoE support, based on
Qualcomm/Atheros QCA9531.

Short specification:

    2x 10/100 Mbps Ethernet, with 24v PoE support
    64 MB of RAM (DDR2)
    16 MB of FLASH (SPI)
    2T2R 2.4 GHz, 802.11b/g/n
    built-in 1x 3 dBi antennas
    output power (max): 80 mW (19 dBm)
    Qucetel EC20 LTE MODULE(1x external detachable antenna)

Flash instruction:

Original firmware is based on OpenWrt.
Use sysupgrade image directly in vendor GUI.

Signed-off-by: Ding Tengfei <dtf@comfast.cn>