### PR TITLE
Relocates input parameters to pkg-config to after the default parameters

### DIFF
--- a/tools/pkg-config/files/pkg-config
+++ b/tools/pkg-config/files/pkg-config
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-pkg-config.real $@ --define-variable=prefix=${STAGING_PREFIX} --define-variable=exec_prefix=${STAGING_PREFIX}
+pkg-config.real --define-variable=prefix=${STAGING_PREFIX} --define-variable=exec_prefix=${STAGING_PREFIX} $@


### PR DESCRIPTION
Relocates input parameters to pkg-config to after the default parameters

As pkg-config.real parses a '--' parameter to signify the end of options and treats
subsequent parameters as libraries. An error along the lines of
"Package --define-variable=prefix=/foo was not found in the pkg-config search path."
occurs when parsing in a '--' to pkg-config

I stumbled across this while making a runc package for OpenWRT, golang seems to pass in `--cflags -- libseccomp libseccomp` which obviously breaks.

Error output:
```
go build -buildmode=pie  -ldflags "-X main.gitCommit="3cd75e780b0907d12c1a8dff4ba30cf562dd04ac" -X main.version=1.0.0-rc6+dev " -tags "seccomp apparmor selinux" -o runc .
# /home/gerard/openwrt/openwrt/staging_dir/host/bin/pkg-config --cflags libseccomp libseccomp
Package -- was not found in the pkg-config search path.
Perhaps you should add the directory containing `--.pc'
to the PKG_CONFIG_PATH environment variable
No package '--' found
Package --define-variable=prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr was not found in the pkg-config search path.
Perhaps you should add the directory containing `--define-variable=prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr.pc'
to the PKG_CONFIG_PATH environment variable
No package '--define-variable=prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr' found
Package --define-variable=exec_prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr was not found in the pkg-config search path.
Perhaps you should add the directory containing `--define-variable=exec_prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr.pc'
to the PKG_CONFIG_PATH environment variable
No package '--define-variable=exec_prefix=/home/gerard/openwrt/openwrt/staging_dir/target-x86_64_musl/usr' found
/home/gerard/openwrt/openwrt/staging_dir/host/bin/pkg-config: exit status 1
```

Signed-off-by: Gerard Ryan <openwrt@gerard-ryan.com>