### PR TITLE
ath79 add missing "" "" to seperate eth0 and eth1 on devolo's 1200e

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -63,7 +63,7 @@ ath79_setup_interfaces()
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
 	devolo,dvl1200e)
-		ucidef_set_interface_lan "eth0 eth1"
+		ucidef_set_interface_lan "eth0" "eth1"
 		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"


### PR DESCRIPTION
Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
