### PR TITLE
brcm63xx: Add support for D-Link DSL-2750u rev C1

### DIFF
--- a/target/linux/brcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/brcm63xx/base-files/etc/board.d/01_leds
@@ -35,6 +35,9 @@ dgnd3700v1_dgnd3800b)
 	ucidef_set_led_usbdev "usb1" "USB1" "DGND3700v1_3800B:green:usb-back" "1-1"
 	ucidef_set_led_usbdev "usb2" "USB2" "DGND3700v1_3800B:green:usb-front" "1-2"
 	;;
+dsl-2750u-c1)
+	ucidef_set_led_usbdev "usb" "USB" "dsl-2750u-c1:green:usb" "1-1"
+	;;
 evg2000)
 	ucidef_set_led_netdev "lan" "LAN" "EVG2000:green:lan" "eth0"
 	ucidef_set_led_netdev "wan" "WAN" "EVG2000:green:wan" "eth1"

--- a/target/linux/brcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/brcm63xx/base-files/etc/board.d/02_network
@@ -84,6 +84,7 @@ bcm963281tan |\
 bcm96328avng |\
 bcm96368mvngr |\
 dsl-274xb-f |\
+dsl-2750u-c1 |\
 dsl-275xb-d |\
 fast2504n |\
 fast2704v2 |\

--- a/target/linux/brcm63xx/base-files/etc/diag.sh
+++ b/target/linux/brcm63xx/base-files/etc/diag.sh
@@ -64,6 +64,9 @@ set_state() {
 	dsl-274xb-f)
 		status_led="dsl-274xb:green:power"
 		;;
+	dsl-2750u-c1)
+		status_led="dsl-2750u-c1:green:power"
+		;;
 	dsl-275xb-d)
 		status_led="dsl-275xb:green:power"
 		;;

--- a/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
+++ b/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
@@ -138,6 +138,9 @@ brcm63xx_dt_detect() {
 	"D-Link DSL-2750B/DSL-2751 rev D1")
 		board_name="dsl-275xb-d"
 		;;
+	"D-Link DSL-2750U rev C1")
+		board_name="dsl-2750u-c1"
+		;;
 	"D-Link DVA-G3810BN/TL")
 		board_name="dva-g3810bn"
 		;;

--- a/target/linux/brcm63xx/dts/dsl-2750u-c1.dts
+++ b/target/linux/brcm63xx/dts/dsl-2750u-c1.dts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "D-Link DSL-2750U rev C1";
+	compatible = "d-link,dsl-2750u-c1", "brcm,bcm6328";
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wifi {
+			label = "wifi";
+			gpios = <&pinctrl 12 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		inet_green {
+			label = "dsl-2750u-c1:green:inet";
+			gpios = <&pinctrl 1 1>;
+		};
+
+		power_green {
+			label = "dsl-2750u-c1:green:power";
+			gpios = <&pinctrl 4 1>;
+			default-state = "on";
+		};
+
+		inet_red {
+			label = "dsl-2750u-c1:red:inet";
+			gpios = <&pinctrl 7 1>;
+		};
+
+		power_red {
+			label = "dsl-2750u-c1:red:power";
+			gpios = <&pinctrl 8 1>;
+		};
+
+		wps_green {
+			label = "dsl-2750u-c1:green:wps";
+			gpios = <&pinctrl 9 1>;
+		};
+
+		usb_green {
+			label = "dsl-2750u-c1:green:usb";
+			gpios = <&pinctrl 10 1>;
+		};
+
+		dsl_green {
+			label = "dsl-2750u-c1:green:dsl";
+			gpios = <&pinctrl 11 1>;
+		};
+	};
+};
+
+&hsspi {
+	status = "ok";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			linux@10000 {
+				reg = <0x010000 0x7e0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			nvram@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "ok";
+};

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -549,6 +549,19 @@ define Device/DSL274XB-F1
 endef
 TARGET_DEVICES += DSL274XB-F1
 
+define Device/DSL2750U-C1
+  $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
+  DEVICE_TITLE := D-Link DSL-2750U rev C1
+  DEVICE_DTS := dsl-2750u-c1
+  CFE_BOARD_ID := 963281TAVNG
+  CFE_CHIP_ID := 6328
+  FLASH_MB := 8
+  DEVICE_PACKAGES := \
+    $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += DSL2750U-C1
+
 define Device/DSL275XB-D1
   $(Device/bcm63xx)
   DEVICE_TITLE := D-Link DSL-2750B/DSL-2751 rev D1

--- a/target/linux/brcm63xx/patches-4.14/599-board_dsl-2750u-c1.patch
+++ b/target/linux/brcm63xx/patches-4.14/599-board_dsl-2750u-c1.patch
@@ -1,0 +1,68 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -715,6 +715,49 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct board_info __initdata board_dsl_2750u_c1 = {
++	.name				= "963281TAVNG",
++	.expected_cpu_id		= 0x6328,
++
++	.has_pci			= 1,
++	.use_fallback_sprom		= 1,
++	.has_ohci0			= 1,
++	.has_ehci0			= 1,
++	.num_usbh_ports			= 1,
++	.has_enetsw			= 1,
++
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used	= 1,
++				.phy_id	= 1,
++				.name	= "Port 1",
++			},
++			[1] = {
++				.used	= 1,
++				.phy_id	= 2,
++				.name	= "Port 2",
++			},
++			[2] = {
++				.used	= 1,
++				.phy_id	= 3,
++				.name	= "Port 3",
++			},
++			[3] = {
++				.used	= 1,
++				.phy_id	= 4,
++				.name	= "Port 4",
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type 				= SPROM_BCM43225,
++		.pci_bus			= 1,
++		.pci_dev			= 0,
++	},
++};
++
+ static struct board_info __initdata board_FAST2704V2 = {
+ 	.name				= "F@ST2704V2",
+ 	.expected_cpu_id		= 0x6328,
+@@ -2724,6 +2767,7 @@ static const struct board_info __initcon
+ 	&board_A4001N,
+ 	&board_A4001N1,
+ 	&board_dsl_274xb_f1,
++	&board_dsl_2750u_c1,
+ 	&board_FAST2704V2,
+ 	&board_R5010UNV2,
+ #endif
+@@ -2831,6 +2875,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },
+ 	{ .compatible = "comtrend,ar-5387un", .data = &board_AR5387un, },
+ 	{ .compatible = "d-link,dsl-274xb-f", .data = &board_dsl_274xb_f1, },
++	{ .compatible = "d-link,dsl-2750u-c1", .data = &board_dsl_2750u_c1, },
+ 	{ .compatible = "nucom,r5010unv2", .data = &board_R5010UNV2, },
+ 	{ .compatible = "sagem,f@st2704v2", .data = &board_FAST2704V2, },
+ 	{ .compatible = "sercomm,ad1018-nor", .data = &board_AD1018, },


### PR DESCRIPTION
This adds support for the D-Link DSL-2750u rev C1.
(https://wikidevi.com/wiki/D-Link_DSL-2750U_rev_C1)

It uses the same hardware as ADB P.DG A4001N.
CPU:   Broadcom BCM63281 (320 MHz)
RAM:   324M
FLASH: 8M

Flash instructions:

1.  Assign static IP 192.168.1.100 to PC
2.  Unplug the power source
3.  Press the RESET button at the router, don't release it yet!
4.  Plug the power source.Wait some seconds
5.  Release the RESET button
6.  Browse to http://192.168.1.1
7.  Send the openwrt-brcm63xx-generic-DSL2750U-C1-squashfs-cfe.bin and
    wait some minutes until the firmware upgrade finish.

Signed-off-by: Ahmed Naseef <naseefkm@gmail.com>

