### PR TITLE
kernel: Added required dependencies for socket match.

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -646,6 +646,8 @@ define KernelPackage/ipt-tproxy
   TITLE:=Transparent proxying support
   DEPENDS+=+kmod-ipt-conntrack +IPV6:kmod-nf-conntrack6 +IPV6:kmod-ip6tables
   KCONFIG:= \
+  	CONFIG_NF_SOCKET_IPV4 \
+  	CONFIG_NF_SOCKET_IPV6 \
   	CONFIG_NETFILTER_XT_MATCH_SOCKET \
   	CONFIG_NETFILTER_XT_TARGET_TPROXY
   FILES:= \


### PR DESCRIPTION
This applies to kernel 4.10 and newer.

See torvalds/linux@8db4c5b

The above commit, added to kernel 4.10, added new dependency
for building the NETFILTER_XT_MATCH_SOCKET (xt_socket.ko)
module. The NF_SOCKET_IPVx options (both of them) need to
be enabled in order to build the NETFILTER_XT_MATCH_SOCKET
module. Without the change the module is not built.