### PR TITLE
base-files: add service_stopped as a post stop hook

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -131,6 +131,9 @@ ${INIT_TRACE:+set -x}
 		procd_lock
 		stop_service "$@"
 		procd_kill "$(basename ${basescript:-$initscript})" "$1"
+		if type service_stopped >/dev/null 2>&1; then
+			service_stopped
+		fi
 	}
 
 	reload() {


### PR DESCRIPTION
Purpose of these changes is to introduce a hook for post service shutdown in a similar fashion to the existing hook `service_started`. I found it to be useful to specify a hook that is called once the service has been stopped and not before the service is stopped like the `stop_service` hook does.

It's implemented mostly in the same form as the hook invocation for the already existing hook `service_started` with the only exception that I did not reuse the `eval` indirection since I don't see why it's needed here.
