### PR TITLE
wireguard: Add addresses and ip6prefix to init config

### DIFF
--- a/package/network/services/wireguard/files/wireguard.sh
+++ b/package/network/services/wireguard/files/wireguard.sh
@@ -22,6 +22,8 @@ proto_wireguard_init_config() {
   proto_config_add_int    "listen_port"
   proto_config_add_int    "mtu"
   proto_config_add_string "fwmark"
+  proto_config_add_array  "addresses:list(string)"
+  proto_config_add_string "ip6prefix"
   available=1
   no_proto_task=1
 }


### PR DESCRIPTION
Currently, changes to 'addresses' or 'ip6prefix' do not cause the
interface to be reconfigured when '/etc/init.d/network reload' is
executed.

By adding 'addresses' and 'ip6prefix' to the config options specified
in proto_wireguard_init_config, netifd will restart the interface
if those options are changed and '/etc/init.d/network reload' is
executed.

Signed-off-by: Brett Mastbergen <bmastbergen@untangle.com>