### PR TITLE
ath79: add support for COMFAST CF-E120A v3

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -38,6 +38,15 @@ comfast,cf-e110n-v2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "76" "100"
 	;;
+	comfast,cf-e120a-v3)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x04"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:red:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "$boardname:red:rssimediumlow" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssimediumhigh" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "76" "100"
+	;;
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "comfast,cf-e120a-v3", "qca,ar9344";
+	model = "COMFAST CF-E120A v3";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &wan;
+		led-failsafe = &wan;
+		led-upgrade = &wan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_rssimediumhigh_pin>;
+
+		wan: wan {
+			label = "cf-e120a-v3:green:wan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "cf-e120a-v3:green:lan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "cf-e120a-v3:green:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssilow {
+			label = "cf-e120a-v3:red:rssilow";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "cf-e120a-v3:red:rssimediumlow";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "cf-e120a-v3:green:rssimediumhigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "cf-e120a-v3:green:rssihigh";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pinmux {
+		led_rssimediumhigh_pin: pinmux_rssimediumhigh_pin {
+			pinctrl-single,bits = <0x10 0x0 0xff>;
+		};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			firmware: partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			nvram: partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&art 0x6>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -162,6 +162,14 @@ define Device/comfast_cf-e110n-v2
 endef
 TARGET_DEVICES += comfast_cf-e110n-v2
 
+define Device/comfast_cf-e120a-v3
+  ATH_SOC := ar9344
+  DEVICE_TITLE := COMFAST CF-E120A v3
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio -uboot-envtools
+  IMAGE_SIZE := 8000k
+endef
+TARGET_DEVICES += comfast_cf-e120a-v3
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_TITLE := devolo WiFi pro 1200e


### PR DESCRIPTION
This patch adds support for the COMFAST CF-E120A v3, an outdoor wireless
CPE with two Ethernet ports and a 802.11an radio.

Specifications:

 - AR9344 SoC
 - 535/400/267 MHz (CPU/DDR/AHB)
 - 2x 10/100 Mbps Ethernet, both with PoE-in support
 - 64 MB of RAM (DDR2)
 - 8 MB of FLASH
 - 2T2R 5 GHz, up to 25 dBm
 - 11 dBi built-in antenna
 - POWER/LAN/WAN/WLAN green LEDs
 - 4x RSSI LEDs (2x red, 2x green)
 - UART (115200 8N1) and GPIO (J9) headers on PCB

Flashing instructions:

 The original firmware is based on OpenWrt so a sysupgrade image can be
 installed via the stock web GUI. Settings from the original firmware
 will be saved and restored on the new want, so a factory reset will be
 needed: once the new firmware is flashed, perform the factory reset by
 pushing the reset button several times during the boot process, while
 the WAN LED flashes, until it starts flashing quicker.

 The U-boot bootloader contains a recovery HTTP server to upload the
 firmware. Push the reset button while powering the device on and
 keep it pressed for >10 seconds. The recovery page will be at
 http://192.168.1.1

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>