### PR TITLE
netfilter: fix checking method of conntrack helper

### DIFF
--- a/target/linux/generic/hack-4.14/941-fix-checking-method-of-conntrack-helper.patch
+++ b/target/linux/generic/hack-4.14/941-fix-checking-method-of-conntrack-helper.patch
@@ -1,0 +1,51 @@
+From addf8974ce9987e2946e04624fe806a98390786e Mon Sep 17 00:00:00 2001
+From: HsiuWen Yen <y.hsiuwen@gmail.com>
+Date: Wed, 30 Jan 2019 11:45:25 +0800
+Subject: [PATCH] fix checking method of conntrack helper
+
+This patch uses nfct_help() to detect whether an established connection
+needs conntrack helper instead of using test_bit(IPS_HELPER_BIT,
+&ct->status).
+
+The reason for this modification is that IPS_HELPER_BIT is only set when
+the conntrack helper is attached by explicit CT target.
+
+However, in the case that a device enables conntrack helper via the other
+ways (e.g., command "echo 1 > /proc/sys/net/netfilter/nf_conntrack_helper")
+, the status of IPS_HELPER_BIT will not present any change. That means the
+IPS_HELPER_BIT might lose the checking ability in the context.
+
+Signed-off-by: HsiuWen Yen <y.hsiuwen@gmail.com>
+---
+ net/netfilter/xt_FLOWOFFLOAD.c             | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/net/netfilter/xt_FLOWOFFLOAD.c
++++ b/net/netfilter/xt_FLOWOFFLOAD.c
+@@ -12,6 +12,7 @@
+ #include <net/ip.h>
+ #include <net/netfilter/nf_conntrack.h>
+ #include <net/netfilter/nf_flow_table.h>
++#include <net/netfilter/nf_conntrack_helper.h>
+ 
+ static struct nf_flowtable nf_flowtable;
+ static HLIST_HEAD(hooks);
+@@ -245,6 +246,7 @@ flowoffload_tg(struct sk_buff *skb, const struct xt_action_param *par)
+ 	struct nf_flow_route route;
+ 	struct flow_offload *flow;
+ 	struct nf_conn *ct;
++	const struct nf_conn_help *help;
+ 
+ 	if (xt_flowoffload_skip(skb))
+ 		return XT_CONTINUE;
+@@ -264,7 +266,8 @@ flowoffload_tg(struct sk_buff *skb, const struct xt_action_param *par)
+ 		return XT_CONTINUE;
+ 	}
+ 
+-	if (test_bit(IPS_HELPER_BIT, &ct->status))
++	help = nfct_help(ct);
++	if (help)
+ 		return XT_CONTINUE;
+ 
+ 	if (ctinfo == IP_CT_NEW ||
+


### PR DESCRIPTION
This patch uses nfct_help() to detect whether an established connection
needs conntrack helper instead of using test_bit(IPS_HELPER_BIT,
&ct->status).

The reason for this modification is that IPS_HELPER_BIT is only set when
the conntrack helper is attached by explicit CT target.

However, in the case that a device enables conntrack helper via the other
ways (e.g., command "echo 1 > /proc/sys/net/netfilter/nf_conntrack_helper")
, the status of IPS_HELPER_BIT will not present any change. That means the
IPS_HELPER_BIT might lose the checking ability in the context.

Signed-off-by: HsiuWen Yen <y.hsiuwen@gmail.com>
