### PR TITLE
ar71xx: fix RB941-2nD detection

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1095,6 +1095,9 @@ ar71xx_board_detect() {
 	*"RouterBOARD 941-2nD")
 		name="rb-941-2nd"
 		;;
+        *"RouterBOARD RB941-2nD")
+		name="rb-941-2nd"
+		;;
 	*"RouterBOARD 951G-2HnD")
 		name="rb-951g-2hnd"
 		;;


### PR DESCRIPTION
Some hAP lite routers aren't detected by OpenWRT because /proc/cpuinfo shows "RouterBOARD RB941-2nD" instead of "RouterBOARD 941-2nD". 
This PR aims to fix this and has been successfully tested.