### PR TITLE
ar71xx: fix Arduino Yun enabling of level shifters outputs

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
@@ -141,7 +141,7 @@ static void __init ds_setup(void)
 
 	// enable OE of level shifter
 	if (gpio_request_one(DS_GPIO_OE,
-	    GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED, "OE-1") != 0)
+	    GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED, "OE-1") != 0)
 		printk("Error setting GPIO OE\n");
 
 	if (gpio_request_one(DS_GPIO_UART_ENA,
@@ -150,7 +150,7 @@ static void __init ds_setup(void)
 
 	// enable OE of level shifter
 	if (gpio_request_one(DS_GPIO_OE2,
-	    GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED, "OE-2") != 0)
+	    GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED, "OE-2") != 0)
 		printk("Error setting GPIO OE2\n");
 }
 


### PR DESCRIPTION
As show in Arduino Yun schematic [1] GPIO 21 and 22 are connected to
output enable pin (OE) of two NTB01xx level shifters.

NTB01xx datasheets [2] [3] states that OE pin are active-high
therefore we should initialize GPIO 21 (DS_GPIO_OE) and GPIO 22
(DS_GPIO_OE2) accordingly to actually enable level shifters outputs.

[1] https://www.arduino.cc/en/uploads/Main/arduino-Yun-schematic.pdf
[2] https://www.nxp.com/docs/en/data-sheet/NTB0102.pdf
[3] https://www.nxp.com/docs/en/data-sheet/NTB0104.pdf

Signed-off-by: Edoardo Scaglia <edoardo.87@gmail.com>
