### PR TITLE
ramips: change status LED for Buffalo WHR-G300N

### DIFF
--- a/target/linux/ramips/dts/WHR-G300N.dts
+++ b/target/linux/ramips/dts/WHR-G300N.dts
@@ -10,10 +10,9 @@
 	model = "Buffalo WHR-G300N";
 
 	aliases {
-		led-boot = &led_router;
-		led-failsafe = &led_router;
-		led-running = &led_router;
-		led-upgrade = &led_router;
+		led-boot = &led_diag;
+		led-failsafe = &led_diag;
+		led-upgrade = &led_diag;
 	};
 
 	cfi@1f000000 {
@@ -62,12 +61,12 @@
 	leds {
 		compatible = "gpio-leds";
 
-		diag {
+		led_diag: diag {
 			label = "whr-g300n:red:diag";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
-		led_router: router {
+		router {
 			label = "whr-g300n:green:router";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
Buffalo WHR-G300N has a LED for power status indication, but it is not
connected to the GPIO and cannot be controlled by the kernel. So,
WHR-G300N uses "ROUTER" LED as the system status LED instead.

This commit changes it to use "DIAG" LED insted of "ROUTER" like
WHR-G301N in ath79 target.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>