### PR TITLE
dnsmasq: add hotplug if ignore is set for ADD_WAN_FQDN in line 468

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1053,12 +1053,11 @@ dnsmasq_stop()
 
 add_interface_trigger()
 {
-	local interface ignore
+	local interface
 
 	config_get interface "$1" interface
-	config_get_bool ignore "$1" ignore 0
 
-	[ -n "$interface" -a $ignore -eq 0 ] && procd_add_interface_trigger "interface.*" "$interface" /etc/init.d/dnsmasq reload
+	[ -n "$interface" ] && procd_add_interface_trigger "interface.*" "$interface" /etc/init.d/dnsmasq reload
 }
 
 service_triggers()


### PR DESCRIPTION
This fix the local dns name and ip resolving of no dhcp interfaces.

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>
