### PR TITLE
 kernel: add new cifsd module and cifsd-tools

### DIFF
--- a/package/kernel/cifsd/Makefile
+++ b/package/kernel/cifsd/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cifsd
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/cifsd-team/cifsd.git
+PKG_SOURCE_DATE:=2019-05-31
+PKG_SOURCE_VERSION:=e0804cb48a36054c0b2d392d3dabd845c9be2ad8
+PKG_MIRROR_HASH:=72797679635741ff88ded72d9c2215dc51ba15d197536bfdf1592225da11f6bd
+
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/fs-cifsd
+	SUBMENU:=Filesystems
+	TITLE:=CIFS/SMB kernel server support
+	FILES:=$(PKG_BUILD_DIR)/cifsd.ko
+	DEPENDS:= \
+		+kmod-nls-base \
+		+kmod-nls-utf8 \
+		+kmod-crypto-md4 \
+		+kmod-crypto-md5 \
+		+kmod-crypto-hmac \
+		+kmod-crypto-ecb \
+		+kmod-crypto-des \
+		+kmod-crypto-sha256 \
+		+kmod-crypto-cmac \
+		+kmod-crypto-sha512 \
+		+kmod-crypto-aead \
+		+kmod-crypto-ccm
+endef
+
+define KernelPackage/fs-cifsd/description
+	Kernel module for a CIFS/SMBv2,3 fileserver.
+endef
+
+# broken atm (needs CONFIG_KEYS=y)
+#EXTRA_CFLAGS+=-DCONFIG_CIFSD_ACL
+
+define Build/Compile
+	$(KERNEL_MAKE) SUBDIRS="$(PKG_BUILD_DIR)" \
+	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+	CONFIG_CIFS_SERVER=m \
+	modules
+endef
+
+$(eval $(call KernelPackage,fs-cifsd))

--- a/package/network/services/cifsd-tools/Makefile
+++ b/package/network/services/cifsd-tools/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cifsd-tools
+PKG_SOURCE_DATE:=2019-05-31
+PKG_SOURCE_VERSION:=d2b3a1b94e7bd09b75413a70f182c738f6528856
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/cifsd-team/cifsd-tools/tar.gz/$(PKG_SOURCE_VERSION)?
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
+PKG_HASH:=678d6a1f1f1620369c8f14d37070b38d016811177d72a227eeedccf34e80a0d3
+
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+PKG_LICENSE:=GPL-2.0
+PKG_LICENSE_FILES:=COPYING
+
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh aclocal.m4
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
+
+define Package/cifsd-tools
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Filesystem
+  TITLE:=Kernel CIFS/SMB server support and userspace tools
+  DEPENDS:=+kmod-fs-cifsd +glib2 +libnl-core +libnl-genl $(ICONV_DEPENDS)
+endef
+
+define Package/cifsd-tools/description
+  Userspace tools (cifsd, cifsadmin) for the CIFS/SMB kernel fileserver.
+  The config file location is /etc/cifs/smb.conf
+endef
+
+define Package/cifsd-tools/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcifsdtools.so* $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{cifsadmin,cifsd} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/cifs $(1)/etc/init.d
+	$(INSTALL_DATA) ./files/cifsd.config $(1)/etc/config/cifsd
+	$(INSTALL_DATA) ./files/smb.conf.template $(1)/etc/cifs/
+	$(INSTALL_BIN) ./files/cifsd.init $(1)/etc/init.d/cifsd
+	# copy examples until we have a wiki page
+	$(INSTALL_DATA) ./files/cifsd.config.example $(1)/etc/cifs/
+	$(INSTALL_DATA) ./files/smb.conf.help $(1)/etc/cifs/
+endef
+
+define Package/cifsd-tools/conffiles
+/etc/config/cifsd
+/etc/cifs/smb.conf.template 
+/etc/cifs/smb.conf
+/etc/cifs/cifsdpwd.db
+endef 
+
+$(eval $(call BuildPackage,cifsd-tools))

--- a/package/network/services/cifsd-tools/files/cifsd.config
+++ b/package/network/services/cifsd-tools/files/cifsd.config
@@ -1,0 +1,2 @@
+config globals
+	option 'description'	'Cifsd on OpenWrt'

--- a/package/network/services/cifsd-tools/files/cifsd.config.example
+++ b/package/network/services/cifsd-tools/files/cifsd.config.example
@@ -1,0 +1,11 @@
+config globals
+	option 'description'	'Cifsd on OpenWrt'
+
+config share
+	option name 'testshare'
+	option path '/tmp'
+	option guest_ok 'yes'
+	option create_mask '0666'
+	option dir_mask '0777'
+	option read_only 'no'
+	option force_root '1'

--- a/package/network/services/cifsd-tools/files/cifsd.init
+++ b/package/network/services/cifsd-tools/files/cifsd.init
@@ -1,0 +1,151 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+USE_PROCD=1
+
+CIFSD_IFACE=""
+
+smb_header()
+{
+	config_get CIFSD_IFACE $1 interface "lan loopback"
+
+	# resolve interfaces
+	local interfaces=$(
+		. /lib/functions/network.sh
+
+		local net
+		for net in $CIFSD_IFACE; do
+			local device
+			network_is_up $net || continue
+			network_get_device device "$net"
+			echo -n "${device:-$net},"
+		done
+	)
+
+	local workgroup description
+	local hostname="$(cat /proc/sys/kernel/hostname)"
+
+	config_get workgroup		$1 workgroup	"WORKGROUP"
+	config_get description		$1 description	"Cifsd on OpenWrt"
+
+	sed -e "s#|NAME|#$hostname#g" \
+	    -e "s#|WORKGROUP|#$workgroup#g" \
+	    -e "s#|DESCRIPTION|#$description#g" \
+	    -e "s#|INTERFACES|#$interfaces#g" \
+	    /etc/cifs/smb.conf.template > /var/etc/cifs/smb.conf
+
+	[ -e /etc/cifs/smb.conf ] || ln -nsf /var/etc/cifs/smb.conf /etc/cifs/smb.conf
+	
+	if [ ! -L /etc/cifs/smb.conf ]; then
+		logger -t 'cifsd' "Local custom /etc/cifs/smb.conf file detected, all UCI/Luci config settings are ignored!"
+	fi
+}
+
+smb_add_share()
+{
+	local name
+	local path
+	local comment
+	local users
+	local create_mask
+	local dir_mask
+	local browseable
+	local read_only
+	local guest_ok
+	local force_root
+	local write_list
+	local read_list
+	local hide_dot_files
+	local veto_files
+
+	config_get name $1 name
+	config_get path $1 path
+	config_get comment $1 comment
+	config_get users $1 users
+	config_get create_mask $1 create_mask
+	config_get dir_mask $1 dir_mask
+	config_get browseable $1 browseable
+	config_get read_only $1 read_only
+	config_get guest_ok $1 guest_ok
+	config_get_bool force_root	$1 force_root	0
+	config_get write_list $1 write_list
+	config_get read_list $1 read_list
+	config_get_bool hide_dot_files	$1 hide_dot_files	0
+	config_get veto_files $1 veto_files
+
+	[ -z "$name" -o -z "$path" ] && return
+
+	echo -e "\n[$name]\n\tpath = $path" >> /var/etc/cifs/smb.conf
+	[ -n "$comment" ] && echo -e "\tcomment = $comment" >> /var/etc/cifs/smb.conf
+	
+	if [ "$force_root" -eq 1 ]; then
+		echo -e "\tforce user = root" >> /var/etc/cifs/smb.conf
+		echo -e "\tforce group = root" >> /var/etc/cifs/smb.conf
+	else
+		[ -n "$users" ] && echo -e "\tvalid users = $users" >> /var/etc/cifs/smb.conf
+	fi
+
+	[ -n "$create_mask" ] && echo -e "\tcreate mask = $create_mask" >> /var/etc/cifs/smb.conf
+	[ -n "$dir_mask" ] && echo -e "\tdirectory mask = $dir_mask" >> /var/etc/cifs/smb.conf
+
+	[ -n "$browseable" ] && echo -e "\tbrowseable = $browseable" >> /var/etc/cifs/smb.conf
+	[ -n "$read_only" ] && echo -e "\tread only = $read_only" >> /var/etc/cifs/smb.conf
+	[ -n "$guest_ok" ] && echo -e "\tguest ok = $guest_ok" >> /var/etc/cifs/smb.conf
+
+	[ -n "$write_list" ] && echo -e "\twrite list = $write_list" >> /var/etc/cifs/smb.conf
+	[ -n "$read_list" ] && echo -e "\tread list = $read_list" >> /var/etc/cifs/smb.conf
+
+	[ "$hide_dot_files" -eq 1 ] && echo -e "\thide dot files = yes" >> /var/etc/cifs/smb.conf
+	[ -n "$veto_files" ] && echo -e "\tveto files = $veto_files" >> /var/etc/cifs/smb.conf
+}
+
+init_config()
+{
+	mkdir -p /var/etc/cifs
+
+	config_load cifsd
+	# allow copy&paste from samba UCI configs (we dont have a cifsd wiki yet)
+	config_foreach smb_header globals
+	config_foreach smb_header samba
+	config_foreach smb_add_share share
+	config_foreach smb_add_share sambashare
+}
+
+service_triggers()
+{
+	PROCD_RELOAD_DELAY=2000
+	
+	procd_add_reload_trigger "dhcp" "system" "cifsd"
+	
+	local i
+	for i in $CIFSD_IFACE; do
+		procd_add_reload_interface_trigger $i
+	done
+}
+
+start_service()
+{
+	init_config
+	
+	if [ ! -e /etc/cifs/smb.conf ]; then
+		logger -t 'cifsd' "missing config /etc/cifs/smb.conf, needs to-be created manually!"
+		exit 1
+	fi
+
+	[ -f /tmp/cifsd.lock ] && rm /tmp/cifsd.lock
+	
+	# try remove again before start
+	if (lsmod | grep cifsd &>/dev/null); then
+		rmmod cifsd &>/dev/null
+	fi
+	modprobe cifsd 2>/dev/null
+	if ! (lsmod | grep cifsd &>/dev/null); then
+		logger -t 'cifsd' "modprobe of cifsd module failed, cant start cifsd!"
+		exit 1
+	fi
+
+	logger -t 'cifsd' "Starting CIFS/SMB userspace service."
+	procd_open_instance
+	procd_set_param command /usr/sbin/cifsd --n
+	procd_close_instance
+}

--- a/package/network/services/cifsd-tools/files/smb.conf.help
+++ b/package/network/services/cifsd-tools/files/smb.conf.help
@@ -1,0 +1,160 @@
+;******************************************************************************
+; File to define cifsd configuration parameters which are comparable with
+; samba's ones
+;
+; Supported [global] level parameters list:
+;	- server string
+;		This controls what string will show up in browse lists next
+;		to the machine name
+;	- workgroup
+;		This controls what workgroup your server will appear to be
+;		in when queried by clients
+;	- netbios name
+;		This sets the NetBIOS name by which a SMB server is known.
+;		By default it is the same as the first component of the host's
+;		DNS name. If a machine is a browse server or logon server this
+;		name (or the first component of the hosts DNS name) will be
+;		the name that these services are advertised under.
+;	- server min protocol
+;		This setting controls the minimum protocol version that the
+;		server will allow the client to use.
+;	- server max protocol
+;		The value of the parameter (a string) is the highest protocol
+;		level that will be supported by the server.
+;	- server signing
+;		This controls whether the client is allowed or required to use
+;		SMB1 and SMB2 signing. Possible values are default, auto,
+;		mandatory and disabled.
+;	- guest account
+;		This is a username which will be used for access to services
+;		which are specified as guest ok.
+;	- max active sessions
+;		This option allows the number of simultaneous connections to
+;		a service to be limited.
+;	- ipc timeout
+;		This option specifies the number of seconds server will wait
+;		for the userspace to reply to heartbeat frames. If user space
+;		is down for more than `ipc timeout` seconds the server will
+;		reset itself - close all sessions and all TCP connections.
+;	- restrict anonymous
+;		The setting of this parameter determines whether user and
+;		group list information is returned for an anonymous connection.
+;	- map to guest
+;		This parameter can take four different values, which tell cifsd
+;		what to do with user login requests.(bad user
+;	- bind interfaces only
+;		This global parameter allows the cifsd admin to limit what
+;		interfaces on a machine will serve SMB requests.
+;	- interfaces
+;		This option allows you to override the default network
+;		interfaces list that cifsd will use for browsing. The option
+;		takes only list of interface name.
+;	- deadtime
+;		The value of the parameter (a decimal integer) represents
+;		the number of minutes of inactivity before a connection is
+;		considered dead, and it is disconnected. The deadtime only
+;		takes effect if the number of open files is zero.
+;
+; Supported [share] level parameters list:
+;	- comment
+;		comment string to associate with the new share
+;	- path
+;		This parameter specifies a directory to which the user of the
+;		service is to be given access.
+;	- guest ok
+;		If this parameter is yes for a service, then no password is
+;		required to connect to the service.
+;	- read only
+;		If this parameter is yes, then users of a service may not
+;		create or modify files in the service's directory.
+;	- browseable
+;		This controls whether this share is seen in the list of
+;		available shares in a net view and in the browse list.
+;	- write ok
+;	- writeable
+;		Inverted synonym for read only.
+;	- store dos attributes
+;		If this parameter is set cifsd attempts to first read DOS
+;		attributes (SYSTEM, HIDDEN, ARCHIVE or READ-ONLY) from a
+;		filesystem extended attribute, before mapping DOS attributes
+;		to UNIX permission bits (such as occurs with map hidden and
+;		map readonly).
+;	- oplocks
+;		This boolean option tells cifsd whether to issue oplocks
+;		(opportunistic locks) to file open requests on this share.
+;	- create mask
+;		When a file is created, the necessary permissions are calculated
+;		according to the mapping from DOS modes to UNIX permissions, and
+;		the resulting UNIX mode is then bit-wise 'AND'ed with this
+;		parameter.
+;	- directory mask
+;		This parameter is the octal modes which are used when converting
+;		DOS modes to UNIX modes when creating UNIX directories.
+;	- force group
+;		This specifies a UNIX group name that will be assigned as
+;		the default primary group for all users connecting to this
+;		service.
+;	- force user
+;		This specifies a UNIX user name that will be assigned as
+;		the default user for all users connecting to this service.
+;	- hide dot files
+;		This is a boolean parameter that controls whether files starting
+;		with a dot appear as hidden files.
+;	- hosts allow
+;		This parameter is a comma, space, or tab delimited set of hosts
+;		which are permitted to access a service
+;	- hosts deny
+;		The opposite of allow hosts - hosts listed here are NOT
+;		permitted access to services unless the specific services have
+;		their own lists to override this one. Where the lists conflict,
+;		the allow list takes precedence.
+;	- valid users
+;		This is a list of users that should be allowed to login to this
+;		service
+;	- invalid users
+;		This is a list of users that should not be allowed to login to
+;		this service.
+;	- read list
+;		This is a list of users that are given read-only access to
+;		a service.
+;	- write list
+;		This is a list of users that are given read-write access to
+;		a service.
+;	- max connections
+;		This option allows the number of simultaneous connections to
+;		a service to be limited.
+;	- veto files
+;		This is a list of files and directories that are neither visible
+;		nor accessible.
+;
+;		Veto any files containing the word Security,
+;		any ending in .tmp, and any directory containing the
+;		word root.
+;		veto files = /*Security*/*.tmp/*root*/
+;
+;		Veto the Apple specific files that a NetAtalk server
+;		creates.
+;		veto files = /.AppleDouble/.bin/.AppleDesktop/Network Trash Folder/
+;
+;
+; Rules to update this file:
+;	- Every [share] definition should start on new line
+;	- Every parameter should be indented with single tab
+;	- There should be single spaces around equal (eg: " = ")
+;	- Multiple parameters should be separated with comma
+;		eg: "invalid users = usr1,usr2,usr3"
+;
+; Make sure to configure the server after making changes to this file.
+;******************************************************************************
+
+[global]
+	server string = CIFSD on OpenWrt
+	netbios name = CIFSD
+	map to guest = Bad User
+
+[share]
+	comment = content server share
+	path = /mnt
+	guest ok = yes
+	create mask = 0777
+	directory mask = 0777

--- a/package/network/services/cifsd-tools/files/smb.conf.template
+++ b/package/network/services/cifsd-tools/files/smb.conf.template
@@ -1,0 +1,9 @@
+[global]
+	netbios name = |NAME|
+	server string = |DESCRIPTION|
+	workgroup = |WORKGROUP|
+	interfaces = |INTERFACES|
+	bind interfaces only = yes
+	ipc timeout = 8
+	deadtime = 15
+	map to guest = Bad User


### PR DESCRIPTION
Maintainer: me
Compile tested: arm/mips (master)
Run tested: arm (master)

Description:

* adds cifs/smb kernel server module cifsd
* adds userspace tools (cifsd, cifsadmin)

This is a new, simple smb2/3 compatible fileserver. The project is still relatively new, but worked fine for me as simple to setup fileshare. The devs plan to get this merged into upstream eventually, but may take a while.

The advantages over samba3/4 is size and potentially speed. I could not really test this, since my router is too powerfully, so i always get max samba network speeds. Yet i did observe lower cpu usage with this server.

I tested video, music streaming which worked fine. I also tested running [portableapps.com](https://portableapps.com/) from a mounted share, including Firefox Portable, which also works now.

In general the devs try to reuse samba config options, so that the `smb.conf` file looks very similar. Some  advanced options you may use via samba are not yet implemented, like:
```
unix charset
smb encrypt
fstype
dos filemode
inherit owner
```

PS: The firmware size (squashfs-sysupgrade.bin) for mvebu (arm) increases by 860kb with it build, where 135kb is for the cifsd+tools and the remainder is for extra dependencies, notably glib2.