### PR TITLE
linux-firmware: DRM: add radeon firmware

### DIFF
--- a/package/firmware/linux-firmware/radeon.mk
+++ b/package/firmware/linux-firmware/radeon.mk
@@ -1,0 +1,9 @@
+Package/radeon-firmware = $(call Package/firmware-default,Radeon Video Driver firmware)
+define Package/radeon-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/radeon
+	$(CP) \
+		$(PKG_BUILD_DIR)/radeon/*.bin \
+		$(1)/lib/firmware/radeon
+endef
+
+$(eval $(call BuildPackage,radeon-firmware))


### PR DESCRIPTION
add firmware needed for radeon DRM display, prepare for Xorg support

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
