### PR TITLE
ramips: add support for Belkin F9K1109v1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -60,6 +60,10 @@ bdcom,wap2100-sk|\
 hiwifi,hc5861b)
 	set_wifi_led "$boardname:green:wlan2g"
 	;;
+belkin,f9k1109)
+	set_usb_led "$boardname:green:usb1"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:blue:wps" "eth0"
+	;;
 broadway)
 	set_wifi_led "$boardname:red:wps_active"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -198,6 +198,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	belkin,f9k1109|\
 	rt-n15|\
 	wl-351)
 		ucidef_add_switch "switch0" \
@@ -472,6 +473,10 @@ ramips_setup_macs()
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		lan_mac=$(macaddr_setbit_la "$lan_mac")
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	belkin,f9k1109)
+		wan_mac=$(mtd_get_mac_ascii uboot-env HW_WAN_MAC)
+		lan_mac=$(mtd_get_mac_ascii uboot-env HW_LAN_MAC)
 		;;
 	br-6475nd)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/dts/F9K1109.dts
+++ b/target/linux/ramips/dts/F9K1109.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "rt3883.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "belkin,f9k1109", "ralink,rt3883-soc";
+	model = "Belkin F9K1109";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: internet_amber {
+			label = "f9k1109:amber:internet";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: internet_blue {
+			label = "f9k1109:blue:internet";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		usb1 {
+			label = "f9k1109:green:usb1";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2 {
+			label = "f9k1109:green:usb2";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_amber {
+			label = "f9k1109:amber:wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "f9k1109:blue:wps";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	rtl8367b {
+		compatible = "realtek,rtl8367b";
+		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+	};
+
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "uboot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7a0000>;
+			};
+
+			partition@7f0000 {
+				label = "user-cfg";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	port@0 {
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pci {
+	status = "okay";
+};
+
+&pci1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci0,0";
+		reg = <0x10000 0 0 0 0>;
+		ralink,5ghz = <0>;
+		ralink,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -41,6 +41,18 @@ endef
 TARGET_DEVICES += dir-645
 
 
+define Device/belkin_f9k1109
+  DTS := F9K1109
+  BLOCKSIZE := 64k
+  DEVICE_TITLE := Belkin F9K1109
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 swconfig
+  IMAGE_SIZE := 7224k
+  KERNEL := kernel-bin | patch-dtb | lzma -d16 | uImage lzma
+  # Stock firmware checks for this uImage image name during upload.
+  UIMAGE_NAME := N750F9K1103VB
+endef
+TARGET_DEVICES += belkin_f9k1109
+
 define Device/hpm
   DTS := HPM
   BLOCKSIZE := 64k


### PR DESCRIPTION
Device specification:
- SoC: Ralink RT3883 (MIPS 74Kc) 500Mhz
- RAM: 64Mb
- Flash: 8MB (SPI-NOR)
- Ethernet: 10/100/1000 Mbps
- WLAN
	Wireless 1: SoC-integrated : 2.4/5 GHz
	Wireless 2: 2.4 GHz RT3092L
- LED: 2x USB, WAN, LAN
- Key: WPS, reset
- Serial: 4-pin header, (57600,8,N,1), 3.3V TTL,
	GND, RX, TX, V - J12 marking on board
- USB ports: 2 x USB 2.0

Flash instruction:

Option 1 (from bootloader web)
- Hold reset button on the back of router when plugging in power (for at-least 10 seconds after plugged in)
- Connect to a Lan port
- Set computer IP to 10.10.10.3
- Go to http://10.10.10.123 in a web browser
- Click the Browse… Button and select the *squashfs.sysupgrade.bin file then click APPLY

Option 2 (from the stock admin web)
- Go to firmware upgrade
- Upload the **factory** image *initramfs.bin first
- Boot into openwrt
- From Luci web in openwrt upload the *squashfs.sysupgrade.bin

Signed-off-by: Kip Porterfield  <kip.porterfield@gmail.com>