### PR TITLE
firmware-utils: mkchkimg: fix flash from stock Netgear firmware

### DIFF
--- a/tools/firmware-utils/src/mkchkimg.c
+++ b/tools/firmware-utils/src/mkchkimg.c
@@ -260,12 +260,12 @@ main (int argc, char * argv[])
 	hdr->header_len = htonl(header_len);
 	hdr->reserved[0] = (unsigned char)(region & 0xff);
 	hdr->reserved[1] = 1;		/* Major */
-	hdr->reserved[2] = 1;		/* Minor */
+	hdr->reserved[2] = 9;		/* Minor */
 	hdr->reserved[3] = 99;		/* Build */
-	hdr->reserved[4] = 0;
-	hdr->reserved[5] = 0;
-	hdr->reserved[6] = 0;
-	hdr->reserved[7] = 0;
+	hdr->reserved[4] = 99;
+	hdr->reserved[5] = 99;
+	hdr->reserved[6] = 99;
+	hdr->reserved[7] = 99;
 	message ("       Board Id: %s", board_id);
 	message ("         Region: %s", region == 1 ? "World Wide (WW)" 
 			: (region == 2 ? "North America (NA)" : "Unknown"));


### PR DESCRIPTION
This is based on the work done by Michael Evans in https://bugs.openwrt.org/index.php?do=details&task_id=2009. 

I built this and successfully flashed the CHK onto an R8000 running the latest available Netgear firmware. Trying to flash the latest released image resulted in the same error reported in FS#2009.