### PR TITLE
ath79: add support for I-O DATA WN-AC1600DGR

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -109,6 +109,7 @@ ath79_setup_interfaces()
 		;;
 	iodata,etg3-r|\
 	iodata,wn-ac1167dgr|\
+	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr|\
 	pcs,cr5000)
@@ -261,6 +262,7 @@ ath79_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" -1)
 		;;
 	iodata,wn-ac1167dgr|\
+	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -110,6 +110,7 @@ case "$FIRMWARE" in
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 2
 		;;
 	iodata,wn-ac1167dgr|\
+	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr)
 		ath9k_eeprom_extract "art" 4096 1088

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -19,6 +19,12 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			echo $(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1) > /sys${DEVPATH}/macaddress
 		;;
+	iodata,wn-ac1600dgr)
+		# There is no eeprom data for 5 GHz wlan in "art" partition
+		# which would allow to patch the macaddress
+		[ "$PHYNBR" -eq 0 ] && \
+			echo $(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1) > /sys${DEVPATH}/macaddress
+		;;
 	phicomm,k2t)
 		# The K2T factory firmware does use LAN mac address as the 2.4G wifi mac address
 		[ "$PHYNBR" -eq 1 ] && \

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -18,18 +18,13 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 
 		power: power {
 			label = "iodata:green:power";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			default-state = "on";
-		};
-
-		copy {
-			label = "iodata:green:copy";
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
 		eco {
@@ -55,11 +50,11 @@
 		};
 	};
 
-	keys {
+	keys: keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
-		button_eco {
+		eco {
 			label = "eco";
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
@@ -71,13 +66,6 @@
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 			linux,input-type = <EV_SW>;
-			debounce-interval = <60>;
-		};
-
-		button_copy {
-			label = "copy";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_1>;
 			debounce-interval = <60>;
 		};
 
@@ -190,7 +178,6 @@
 	wifi@0,0 {
 		compatible = "pci168c,003c";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac1167dgr.dts
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac1167dgr.dts
@@ -10,3 +10,19 @@
 	compatible = "iodata,wn-ac1167dgr", "qca,qca9557";
 	model = "I-O DATA WN-AC1167DGR";
 };
+
+&leds {
+	copy {
+		label = "iodata:green:copy";
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	copy {
+		label = "copy";
+		gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_1>;
+		debounce-interval = <60>;
+	};
+};

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr.dts
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr.dts
@@ -7,20 +7,20 @@
 #include "qca9557_iodata_wn-ac-dgr.dtsi"
 
 / {
-	compatible = "iodata,wn-ac1600dgr2", "qca,qca9557";
-	model = "I-O DATA WN-AC1600DGR2";
+	compatible = "iodata,wn-ac1600dgr", "qca,qca9557";
+	model = "I-O DATA WN-AC1600DGR";
 };
 
 &leds {
-	copy {
-		label = "iodata:green:copy";
+	function {
+		label = "iodata:green:function";
 		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 	};
 };
 
 &keys {
-	copy {
-		label = "copy";
+	function {
+		label = "function";
 		gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		linux,code = <BTN_1>;
 		debounce-interval = <60>;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -349,6 +349,18 @@ define Device/iodata_wn-ac1167dgr
 endef
 TARGET_DEVICES += iodata_wn-ac1167dgr
 
+define Device/iodata_wn-ac1600dgr
+  ATH_SOC := qca9557
+  DEVICE_TITLE := I-O DATA WN-AC1600DGR
+  IMAGE_SIZE := 14656k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    senao-header -r 0x30a -p 0x60 -t 2 -v 200
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += iodata_wn-ac1600dgr
+
 define Device/iodata_wn-ac1600dgr2
   ATH_SOC := qca9557
   DEVICE_TITLE := I-O DATA WN-AC1600DGR2


### PR DESCRIPTION
I-O DATA WN-AC1600DGR is a 2.4/5 GHz band 11ac router, based on
Qualcomm Atheros QCA9557.

Specification:

- SoC:      Qualcomm Atheros QCA9557
- RAM:      128 MB
- Flash:    16 MB
- WLAN:     2.4/5 GHz
  - 2.4 GHz: 2T2R (SoC internal)
  - 5 GHz:   3T3R (QCA9880)
- Ethernet: 5x 10/100/1000 Mbps
  - Switch: QCA8337N
- LED/key:  6x/6x(4x buttons, 1x slide switch)
- UART:     through-hole on PCB
  - Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Flash instruction using factory image:

1. Connect the computer to the LAN port of WN-AC1600DGR
2. Connect power cable to WN-AC1600DGR and turn on it
3. Access to "http://192.168.0.1/" and open firmware update page
("ファームウェア")
4. Select the OpenWrt factory image and click update ("更新") button
5. Wait ~150 seconds to complete flashing

This commit also removes unnecessary "qca,no-eeprom" property from
the ath10k wifi node.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>