### PR TITLE
linux-firmware: DRM: add amdgpu firmware

### DIFF
--- a/package/firmware/linux-firmware/amdgpu.mk
+++ b/package/firmware/linux-firmware/amdgpu.mk
@@ -1,0 +1,9 @@
+Package/amdgpu-firmware = $(call Package/firmware-default,AMDGPU Video Driver firmware)
+define Package/amdgpu-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/amdgpu
+	$(CP) \
+		$(PKG_BUILD_DIR)/amdgpu/*.bin \
+		$(1)/lib/firmware/amdgpu
+endef
+
+$(eval $(call BuildPackage,amdgpu-firmware))


### PR DESCRIPTION
add firmware needed for amdgpu DRM display

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
