### PR TITLE
curl: bump to 7.64.0

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.63.0
-PKG_RELEASE:=2
+PKG_VERSION:=7.64.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	https://curl.mirror.anstey.ca/ \
 	https://curl.askapache.com/download/ \
 	https://curl.haxx.se/download/
-PKG_HASH:=9600234c794bfb8a0d3f138e9294d60a20e7a5f10e35ece8cf518e2112d968c4
+PKG_HASH:=2f2f13fa34d44aa29cb444077ad7dc4dc6d189584ad552e0aaeb06e608af6001
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING

--- a/package/network/utils/curl/patches/310-mbedtls-disable-runtime-version-check.patch
+++ b/package/network/utils/curl/patches/310-mbedtls-disable-runtime-version-check.patch
@@ -1,6 +1,6 @@
 --- a/lib/vtls/mbedtls.c
 +++ b/lib/vtls/mbedtls.c
-@@ -811,7 +811,7 @@ static void Curl_mbedtls_session_free(vo
+@@ -813,7 +813,7 @@ static void Curl_mbedtls_session_free(vo
  
  static size_t Curl_mbedtls_version(char *buffer, size_t size)
  {


### PR DESCRIPTION
@dedeckeh 
Fixed CVEs:

CVE-2018-16890
CVE-2019-3822
CVE-2019-3823

For other changes in version 7.64.0 see https://curl.haxx.se/changes.html#7_64_0