### PR TITLE
target/octeon: Re-enable ext4 images

### DIFF
--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips64
 BOARD:=octeon
 BOARDNAME:=Cavium Networks Octeon
-FEATURES:=squashfs ramdisk pci usb
+FEATURES:=squashfs ext4 ramdisk pci usb
 CPU_TYPE:=octeonplus
 MAINTAINER:=John Crispin <john@phrozen.org>
 


### PR DESCRIPTION
F2FS/loop seems unreliable on the EdgeRouer Lite at least and throws 
random I/O errors while ext4 doesn't.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>