### PR TITLE
build: fix STAGING_DIR cleaning when filenames contain spaces

### DIFF
--- a/scripts/clean-package.sh
+++ b/scripts/clean-package.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+IFS="
+"
 [ -n "$1" -a -n "$2" ] || {
 	echo "Usage: $0 <file> <directory>"
 	exit 1


### PR DESCRIPTION
When looping through a package's `STAGING_FILES_LIST` (a list of file/directory paths delimited by newlines), if the path contains spaces, then the path will be split by the while loops, and the file/directory will not be deleted/removed.

This sets the internal field separator to the newline only so that the entire path is considered when deleting/removing.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>
