### PR TITLE
dnsmasq: pass DNSSEC flags only when compiled in

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.80
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -22,45 +22,10 @@ DHCPSCRIPT="/usr/lib/dnsmasq/dhcp-script.sh"
 
 DNSMASQ_DHCP_VER=4
 
-dnsmasq_ignore_opt() {
-	local opt="$1"
-
-	if [ -z "$dnsmasq_features" ]; then
-		dnsmasq_features="$(dnsmasq --version | grep -m1 'Compile time options:' | cut -d: -f2) "
-		[ "${dnsmasq_features#* DHCP }" = "$dnsmasq_features" ] || dnsmasq_has_dhcp=1
-		[ "${dnsmasq_features#* DHCPv6 }" = "$dnsmasq_features" ] || dnsmasq_has_dhcp6=1
-		[ "${dnsmasq_features#* DNSSEC }" = "$dnsmasq_features" ] || dnsmasq_has_dnssec=1
-		[ "${dnsmasq_features#* TFTP }" = "$dnsmasq_features" ] || dnsmasq_has_tftp=1
-		[ "${dnsmasq_features#* ipset }" = "$dnsmasq_features" ] || dnsmasq_has_ipset=1
-	fi
-
-	case "$opt" in
-		dhcp-duid|\
-		ra-param)
-			[ -z "$dnsmasq_has_dhcp6" ] ;;
-		dhcp-*|\
-		bootp-*|\
-		pxe-*)
-			[ -z "$dnsmasq_has_dhcp" ] ;;
-		dnssec-*|\
-		trust-anchor)
-			[ -z "$dnsmasq_has_dnssec" ] ;;
-		tftp-*)
-			[ -z "$dnsmasq_has_tftp" ] ;;
-		ipset)
-			[ -z "$dnsmasq_has_ipset" ] ;;
-		*)
-			return 1
-	esac
-}
-
 xappend() {
-	local value="${1#--}"
-	local opt="${value%%=*}"
+	local value="$1"
 
-	if ! dnsmasq_ignore_opt "$opt"; then
-		echo "$value" >>$CONFIGFILE_TMP
-	fi
+	echo "${value#--}" >> $CONFIGFILE_TMP
 }
 
 hex_to_hostid() {

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -99,6 +99,12 @@ has_handler() {
 	return 1
 }
 
+has_feature() {
+	local feature="$1"
+
+	$PROG --version | grep -osqE "^Compile time options:.* ${feature}( |\$)"
+}
+
 append_bool() {
 	local section="$1"
 	local option="$2"
@@ -767,8 +773,8 @@ dnsmasq_start()
 		xappend "--conf-file=${dnsmasqconffile}"
 	}
 
-	$PROG --version | grep -osqE "^Compile time options:.* DHCPv6( |$)" && DHCPv6CAPABLE=1 || DHCPv6CAPABLE=0
-
+	has_feature DHCPv6 && DHCPv6CAPABLE=1 || DHCPv6CAPABLE=0
+	has_feature DNSSEC && DNSSECCAPABLE=1 || DNSSECCAPABLE=0
 
 	if [ -x /usr/sbin/odhcpd -a -x /etc/init.d/odhcpd ] ; then
 		local odhcpd_is_main odhcpd_is_enabled
@@ -921,17 +927,32 @@ dnsmasq_start()
 		config_list_foreach "$cfg" rebind_domain append_rebind_domain
 	}
 
+	# The "dnssec" option used to be a pure boolean and when enabled
+	# without having the "dnsmasq-full" package installed dnsmasq wouldn't
+	# start. Setting the option to the value "2" emits a warning, but
+	# enables DNSSEC validation if and only if it's available in the
+	# daemon.
+	#
+	# Discussion: https://github.com/openwrt/openwrt/pull/1812
 	config_get_bool dnssec "$cfg" dnssec 0
-	[ "$dnssec" -gt 0 ] && {
-		xappend "--conf-file=$TRUSTANCHORSFILE"
-		xappend "--dnssec"
-		[ -x /etc/init.d/sysntpd ] && {
-			/etc/init.d/sysntpd enabled
-			[ "$?" -ne 0 -o "$(uci_get system.ntp.enabled)" = "1" ] && {
-				[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
+	config_get dnssec_raw "$cfg" dnssec 0
+	[ "$dnssec" -gt 0 -o "$dnssec_raw" -eq 2 ] && {
+		if [ "$DNSSECCAPABLE" -eq 0 -a "$dnssec_raw" -eq 2 ]; then
+			logger -t dnsmasq -p warn \
+				'DNSSEC validation is not available in the'\
+				'dnsmasq binary and thus DISABLED. Install'\
+				'the "dnsmasq-full" package!'
+		else
+			xappend "--conf-file=$TRUSTANCHORSFILE"
+			xappend "--dnssec"
+			[ -x /etc/init.d/sysntpd ] && {
+				/etc/init.d/sysntpd enabled
+				[ "$?" -ne 0 -o "$(uci_get system.ntp.enabled)" = "1" ] && {
+					[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
+				}
 			}
-		}
-		append_bool "$cfg" dnsseccheckunsigned "--dnssec-check-unsigned"
+			append_bool "$cfg" dnsseccheckunsigned "--dnssec-check-unsigned"
+		fi
 	}
 
 	config_get addmac "$cfg" addmac 0


### PR DESCRIPTION
Official OpenWrt builds usually have the "dnsmasq" package installed. In
order to enable DNSSEC validation it's necessary to replace it with the
"dnsmasq-full" package and to set the "dnssec" option.

During an upgrade to a newer version the baseline "dnsmasq" build is
installed again and consequently fails to start because it rejects the
"--dnssec" flag:
```
$ dnsmasq --dnssec
dnsmasq: DNSSEC not available: set HAVE_DNSSEC in src/config.h
```
With this change the same logic as for DHCPv6 detection is used by
checking the output of "dnsmasq --version" to determine whether DNSSEC
support is compiled in. Only when available are the DNSSEC-related flags
passed.