### PR TITLE
octeon: Generate writable images for ERL

### DIFF
--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=mips64
 BOARD:=octeon
 BOARDNAME:=Cavium Networks Octeon
-FEATURES:=squashfs ramdisk pci usb
+FEATURES:=squashfs ramdisk pci usb rootfs-part boot-part
 CPU_TYPE:=octeonplus
 MAINTAINER:=John Crispin <john@phrozen.org>
 

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -7,38 +7,57 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+FAT32_BLOCK_SIZE=1024
+FAT32_BLOCKS=$(shell echo $$(($(CONFIG_TARGET_KERNEL_PARTSIZE)*1024*1024/$(FAT32_BLOCK_SIZE))))
+
+define Build/boot-img
+  $(RM) -rf $@.boot
+  mkfs.fat $@.boot -C $(FAT32_BLOCKS)
+  mcopy -i $@.boot $(IMAGE_KERNEL) ::vmlinux.64
+endef
+
+define Build/usb-img
+  ./edgerouter_gen_usb_img.sh $@ $@.boot $(IMAGE_ROOTFS) $(CONFIG_TARGET_KERNEL_PARTSIZE) $(CONFIG_TARGET_ROOTFS_PARTSIZE)
+endef
+
 define Device/Default
-  PROFILES = Default $$(DEVICE_NAME)
+  PROFILES = Default
   KERNEL_NAME := vmlinux.elf
   KERNEL_INITRAMFS_NAME := vmlinux-initramfs.elf
   KERNEL := kernel-bin | strip-kernel | patch-cmdline
-  IMAGES := sysupgrade.tar
-  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-extra 128k | sysupgrade-tar rootfs=$$$$@
-  IMAGE/sysupgrade.tar := sysupgrade-tar
 endef
 
 define Build/strip-kernel
-	# Workaround pre-SDK-1.9.0 u-boot versions not handling the .notes section
-	$(TARGET_CROSS)strip -R .notes $@ -o $@.stripped && mv $@.stripped $@
+  # Workaround pre-SDK-1.9.0 u-boot versions not handling the .notes section
+  $(TARGET_CROSS)strip -R .notes $@ -o $@.stripped && mv $@.stripped $@
 endef
 
 define Device/generic
-  FILESYSTEMS := ext4
   DEVICE_TITLE := Generic
+  FILESYSTEMS := ext4
+  IMAGES := sysupgrade.tar
+  IMAGE/sysupgrade.tar := sysupgrade-tar
 endef
 TARGET_DEVICES += generic
 
 ER_CMDLINE:=-mtdparts=phys_mapped_flash:640k(boot0)ro,640k(boot1)ro,64k(eeprom)ro root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
 define Device/er
-  CMDLINE := $(ER_CMDLINE) 
+  CMDLINE := $(ER_CMDLINE)
   DEVICE_TITLE := Ubiquiti EdgeRouter
+  FILESYSTEMS := squashfs
+  IMAGES := sysupgrade.tar
+  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-extra 128k | sysupgrade-tar rootfs=$$$$@
 endef
 TARGET_DEVICES += er
 
 ERLITE_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0)ro,512k(boot1)ro,64k(eeprom)ro root=/dev/sda2 rootfstype=squashfs,ext4 rootwait
 define Device/erlite
-  CMDLINE := $(ERLITE_CMDLINE) 
+  CMDLINE := $(ERLITE_CMDLINE)
   DEVICE_TITLE := Ubiquiti EdgeRouter Lite
+  FILESYSTEMS := squashfs
+  IMAGES := factory.img.gz sysupgrade.tar
+  IMAGE/factory.img.gz/squashfs := boot-img | usb-img | gzip
+  IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-extra 128k | sysupgrade-tar rootfs=$$$$@
 endef
 TARGET_DEVICES += erlite
 

--- a/target/linux/octeon/image/edgerouter_gen_usb_img.sh
+++ b/target/linux/octeon/image/edgerouter_gen_usb_img.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -x
+[ $# -eq 5 ] || {
+    echo "SYNTAX: $0 <file> <bootfs image> <rootfs image> <bootfs size> <rootfs size>"
+    exit 1
+}
+
+OUTPUT="$1"
+BOOTFS="$2"
+ROOTFS="$3"
+BOOTFSSIZE="$4"
+ROOTFSSIZE="$5"
+
+head=4
+sect=63
+
+set `ptgen -o $OUTPUT -h $head -s $sect -l 1024 -t b -p ${BOOTFSSIZE}M -t 83 -p ${ROOTFSSIZE}M`
+
+BOOTOFFSET="$(($1 / 512))"
+BOOTSIZE="$(($2 / 512))"
+ROOTFSOFFSET="$(($3 / 512))"
+ROOTFSSIZE="$(($4 / 512))"
+
+dd bs=512 if="$BOOTFS" of="$OUTPUT" seek="$BOOTOFFSET" conv=notrunc
+dd bs=512 if="$ROOTFS" of="$OUTPUT" seek="$ROOTFSOFFSET" conv=notrunc


### PR DESCRIPTION
Generate writable images for EdgeRouter Lite

Based on:
https://github.com/openwrt/openwrt/tree/master/target/linux/apm821xx/image
https://github.com/openwrt/openwrt/tree/master/target/linux/sunxi/image

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>