### PR TITLE
ar71xx: Change led trigger from usbdev to usbport

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -122,8 +122,8 @@ archer-c25-v1)
 	;;
 archer-c5|\
 archer-c7)
-	ucidef_set_led_usbdev "usb1" "USB1" "tp-link:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "tp-link:green:usb2" "2-1"
+	ucidef_set_led_usbport "usb1" "USB1" "tp-link:green:usb1" "usb1-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "tp-link:green:usb2" "usb2-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:blue:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:blue:wlan5g" "phy0tpt"
 	;;
@@ -140,7 +140,7 @@ archer-c60-v2)
 	case "$board" in
 	archer-c59-v1|\
 	archer-c59-v2)
-		ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 		;;
 	esac
 	;;
@@ -156,20 +156,20 @@ archer-c7-v5)
 
 	case "$board" in
 	archer-c7-v4)
-		ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
-		ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
+		ucidef_set_led_usbport "usb1" "USB1" "$board:green:usb1" "usb1-port1"
+		ucidef_set_led_usbport "usb2" "USB2" "$board:green:usb2" "usb2-port1"
 		;;
 	esac
 
 	case "$board" in
 	archer-c7-v5)
-		ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 		;;
 	esac
 	;;
 arduino-yun)
 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
-	ucidef_set_led_usbdev "usb" "USB" "arduino:white:usb" "1-1.1"
+	ucidef_set_led_usbport "usb" "USB" "arduino:white:usb" "1-1-port1"
 	;;
 bhr-4grv2)
 	ucidef_set_led_default "power" "POWER" "buffalo:green:power" "1"
@@ -281,10 +281,10 @@ cr3000)
 	;;
 cr5000)
 	ucidef_set_led_wlan "wlan" "WLAN" "pcs:blue:wlan" "phy0tpt"
-	ucidef_set_led_usbdev "usb" "USB" "pcs:white:wps" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "pcs:white:wps" "usb1-port1"
 	;;
 db120)
-	ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 	;;
 dr344)
 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
@@ -295,8 +295,8 @@ dragino2)
 	ucidef_set_led_netdev "wan" "WAN" "$board:red:wan" "eth1"
 	;;
 dw33d)
-	ucidef_set_led_usbdev "mmc" "MMC" "$board:blue:mmc" "1-1"
-	ucidef_set_led_usbdev "usb" "USB" "$board:blue:usb" "2-1"
+	ucidef_set_led_usbport "mmc" "MMC" "$board:blue:mmc" "usb1-port1"
+	ucidef_set_led_usbport "usb" "USB" "$board:blue:usb" "usb2-port1"
 	ucidef_set_led_netdev "internet" "INTERNET" "$board:blue:internet" "eth0"
 	ucidef_set_led_wlan "wlan2g" "WLAN-2.4G" "$board:blue:wlan-2g" "phy1tpt"
 	;;
@@ -312,7 +312,7 @@ ens202ext)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "engenius:green:wlan4" "wlan0" "75" "100" "-79" "13"
 	;;
 f9k1115v2)
-	ucidef_set_led_usbdev "usb2" "USB2" "belkin:green:usb2" "1-1"
+	ucidef_set_led_usbport "usb2" "USB2" "belkin:green:usb2" "usb1-port1"
 	;;
 fritz300e)
 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
@@ -355,7 +355,7 @@ dir-615-c1)
 	;;
 dir-825-b1|\
 dir-825-c1)
-	ucidef_set_led_usbdev "usb" "USB" "d-link:blue:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "d-link:blue:usb" "usb1-port1"
 
 	case "$board" in
 	dir-825-c1)
@@ -385,7 +385,7 @@ dlan-pro-1200-ac)
 	ucidef_set_led_gpio "plcr" "dLAN" "devolo:error:dlan" "16" "0"
 	;;
 e1700ac-v2)
-	ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$board:green:wlan2g" "phy1tpt"
 	;;
 e558-v2|\
@@ -453,7 +453,7 @@ hornet-ub-x2)
 	ucidef_set_led_netdev "lan" "LAN" "alfa:blue:lan" "eth0"
 	ucidef_set_led_netdev "wan" "WAN" "alfa:blue:wan" "eth1"
 	ucidef_set_led_wlan "wlan" "WLAN" "alfa:blue:wlan" "phy0tpt"
-	ucidef_set_led_usbdev "usb" "USB" "alfa:blue:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "alfa:blue:usb" "usb1-port1"
 	;;
 koala)
 	ucidef_set_led_default "power" "POWER" "$board:green:power" "1"
@@ -526,7 +526,7 @@ mynet-rext)
 	ucidef_set_led_wlan "wlan" "WLAN" "wd:blue:wireless" "phy0tpt"
 	;;
 mzk-w04u)
-	ucidef_set_led_usbdev "usb" "USB" "planex:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "planex:green:usb" "usb1-port1"
 	;;
 mzk-w300nh)
 	ucidef_set_led_wlan "wlan" "WLAN" "planex:green:wlan" "phy0tpt"
@@ -537,15 +537,15 @@ nbg460n_550n_550nh)
 nbg6616)
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wifi2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5" "WLAN5" "$board:green:wifi5g" "phy0tpt"
-	ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
+	ucidef_set_led_usbport "usb1" "USB1" "$board:green:usb1" "usb1-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "$board:green:usb2" "usb2-port1"
 	;;
 nbg6716)
 	ucidef_set_led_netdev "wan" "WAN" "$board:white:internet" "eth1"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:white:wifi2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5" "WLAN5" "$board:white:wifi5g" "phy0tpt"
-	ucidef_set_led_usbdev "usb1" "USB1" "$board:white:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "$board:white:usb2" "2-1"
+	ucidef_set_led_usbport "usb1" "USB1" "$board:white:usb1" "usb1-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "$board:white:usb2" "usb2-port1"
 	;;
 om2p|\
 om2p-hs|\
@@ -599,7 +599,7 @@ qihoo-c301)
 	;;
 r36a)
 	ucidef_set_led_netdev "lan" "LAN" "$board:blue:lan" "eth0"
-	ucidef_set_led_usbdev "usb" "USB" "$board:blue:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "$board:blue:usb" "usb1-port1"
 	ucidef_set_led_netdev "wan" "WAN" "$board:blue:wan" "eth1"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:blue:wlan" "phy0tpt"
 	;;
@@ -615,13 +615,13 @@ zbt-we1526)
 
 	case "$board" in
 	t830)
-		ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 		;;
 	esac
 	;;
 r6100)
 	ucidef_set_led_netdev "wan" "WAN (green)" "netgear:green:wan" "eth0"
-	ucidef_set_led_usbdev "usb" "USB" "netgear:blue:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "netgear:blue:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan" "WLAN" "netgear:blue:wlan" "phy1tpt"
 	;;
 rb-750)
@@ -743,7 +743,7 @@ som9331)
 	ucidef_set_led_switch "lan1" "LAN1" "$board:orange:lan1" "switch0" "0x08"
 	ucidef_set_led_switch "lan2" "LAN2" "$board:orange:lan2" "switch0" "0x02"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:red:wlan" "phy0tpt"
-	ucidef_set_led_usbdev "usb" "USB" "$board:green:system" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "$board:green:system" "usb1-port1"
 	;;
 sr3200)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$board:green:wlan2g" "phy1tpt"
@@ -770,13 +770,13 @@ tl-mr11u|\
 tl-mr3020|\
 tl-mr3040|\
 tl-mr3040-v2)
-	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "tp-link:green:3g" "usb1-port1"
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan" "phy0tpt"
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tl-mr3220|\
 tl-mr3420)
-	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "tp-link:green:3g" "usb1-port1"
 	;;
 tl-mr3220-v2|\
 tl-wr741nd-v4)
@@ -789,7 +789,7 @@ tl-wr741nd-v4)
 
 	case "$board" in
 	tl-mr3220-v2)
-		ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "tp-link:green:3g" "usb1-port1"
 		;;
 	esac
 	;;
@@ -807,7 +807,7 @@ tl-wr941nd-v5)
 	case "$board" in
 	tl-mr3420-v2|\
 	tl-wr842n-v2)
-		ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "tp-link:green:3g" "usb1-port1"
 		;;
 	esac
 	;;
@@ -872,17 +872,17 @@ tl-wdr3320-v2)
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:green:wlan5g" "phy0tpt"
 	;;
 tl-wdr3500)
-	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "tp-link:green:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:green:wlan2g" "phy0tpt"
 	;;
 tl-wdr4300)
-	ucidef_set_led_usbdev "usb1" "USB1" "tp-link:green:usb1" "1-1.1"
-	ucidef_set_led_usbdev "usb2" "USB2" "tp-link:green:usb2" "1-1.2"
+	ucidef_set_led_usbport "usb1" "USB1" "tp-link:green:usb1" "1-1-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "tp-link:green:usb2" "1-1-port2"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:blue:wlan2g" "phy0tpt"
 	;;
 tl-wdr4900-v2)
-	ucidef_set_led_usbdev "usb1" "USB1" "tp-link:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "tp-link:green:usb2" "2-1"
+	ucidef_set_led_usbport "usb1" "USB1" "tp-link:green:usb1" "usb1-port1"
+	ucidef_set_led_usbport "usb2" "USB2" "tp-link:green:usb2" "usb2-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:blue:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:blue:wlan5g" "phy1tpt"
 	;;
@@ -912,7 +912,7 @@ tl-wr842n-v3)
 
 	case "$board" in
 	tl-wr842n-v3)
-		ucidef_set_led_usbdev "usb" "USB" "tp-link:green:3g" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "tp-link:green:3g" "usb1-port1"
 		;;
 	esac
 	;;
@@ -924,7 +924,7 @@ tl-wr802n-v2)
 	;;
 tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
-	ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "$board:green:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$board:green:wlan2g" "phy1tpt"
 	;;
 tl-wr940n-v4|\
@@ -952,12 +952,12 @@ tl-wr942n-v1)
 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
-	ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1.2"
-	ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "1-1.1"
+	ucidef_set_led_usbport "usb1" "USB1" "$board:green:usb1" "1-1-port2"
+	ucidef_set_led_usbport "usb2" "USB2" "$board:green:usb2" "1-1-port1"
 	;;
 tl-wr1043nd|\
 tl-wr1043nd-v2)
-	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "tp-link:green:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:green:wlan" "phy0tpt"
 	;;
 tl-wr1043n-v5|\
@@ -971,13 +971,13 @@ tl-wr1043nd-v4)
 
 	case "$board" in
 	tl-wr1043nd-v4)
-		ucidef_set_led_usbdev "usb" "USB" "tp-link:green:usb" "1-1"
+		ucidef_set_led_usbport "usb" "USB" "tp-link:green:usb" "usb1-port1"
 		;;
 	esac
 	;;
 tl-wr2543n)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:green:wlan2g" "phy0tpt"
-	ucidef_set_led_usbdev "usb" "USB" "tp-link:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "tp-link:green:usb" "usb1-port1"
 	;;
 tube2h)
 	ucidef_set_led_netdev "lan" "LAN" "alfa:blue:lan" "eth0"
@@ -996,7 +996,7 @@ wndap360)
 	;;
 wndr3700)
 	ucidef_set_led_default "wan" "WAN LED (green)" "netgear:green:wan" "0"
-	ucidef_set_led_usbdev "usb" "USB" "netgear:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "netgear:green:usb" "usb1-port1"
 	;;
 wi2a-ac200i)
 	ucidef_set_led_default "power" "Power (green)" "nokia:green:power" "1"
@@ -1008,7 +1008,7 @@ wndr3700v4|\
 wndr4300)
 	ucidef_set_led_switch "wan-green" "WAN (green)" "netgear:green:wan" "switch0" "0x20" "0x08"
 	ucidef_set_led_switch "wan-amber" "WAN (amber)" "netgear:amber:wan" "switch0" "0x20" "0x06"
-	ucidef_set_led_usbdev "usb" "USB" "netgear:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "netgear:green:usb" "usb1-port1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "netgear:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "netgear:blue:wlan5g" "phy1tpt"
 	;;
@@ -1048,7 +1048,7 @@ wnr2000-v4)
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:amber:lan2" "switch0" "0x04"
 	ucidef_set_led_switch "lan3" "LAN3" "netgear:amber:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "netgear:amber:lan4" "switch0" "0x10"
-	ucidef_set_led_usbdev "usb" "USB" "netgear:amber:status" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "netgear:amber:status" "usb1-port1"
 	;;
 wnr2200)
 	ucidef_set_led_netdev "wan-amber" "WAN (amber)" "netgear:amber:wan" "eth0"
@@ -1062,7 +1062,7 @@ wnr2200)
 	ucidef_set_led_switch "lan2amber" "LAN2 (amber)" "netgear:amber:lan2" "switch0" "0x04" "0x02"
 	ucidef_set_led_switch "lan3amber" "LAN3 (amber)" "netgear:amber:lan3" "switch0" "0x08" "0x02"
 	ucidef_set_led_switch "lan4amber" "LAN4 (amber)" "netgear:amber:lan4" "switch0" "0x10" "0x02"
-	ucidef_set_led_usbdev "usb" "USB" "netgear:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "netgear:green:usb" "usb1-port1"
 	;;
 wnr612-v2)
 	ucidef_set_led_netdev "wan" "WAN" "netgear:green:wan" "eth0"
@@ -1092,12 +1092,12 @@ wzr-hp-ag300h)
 	ucidef_set_led_netdev "router" "ROUTER" "buffalo:green:router" "eth1"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "buffalo:amber:band2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "buffalo:amber:band5g" "phy1tpt"
-	ucidef_set_led_usbdev "usb" "USB" "buffalo:green:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "buffalo:green:usb" "usb1-port1"
 	;;
 wzr-hp-g300nh)
 	ucidef_set_led_wlan "wlan" "Wireless" "buffalo:green:wireless" "phy0tpt"
 	ucidef_set_led_netdev "router" "Router" "buffalo:green:router" "eth1"
-	ucidef_set_led_usbdev "usb" "USB" "buffalo:blue:usb" "1-1"
+	ucidef_set_led_usbport "usb" "USB" "buffalo:blue:usb" "usb1-port1"
 	;;
 wzr-hp-g300nh2|\
 wzr-hp-g450h)


### PR DESCRIPTION
Changed all the usb leds triggers to the actual usbport.

Signed-off-by: David Santamaría Rogado <howl.nsp at gmail.com>