### PR TITLE
ipq8064: enable sata port

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -860,6 +860,8 @@
 			compatible = "qcom,ipq806x-ahci", "generic-ahci";
 			reg = <0x29000000 0x180>;
 
+			ports-implemented = <0x1>;
+
 			interrupts = <0 209 0x0>;
 
 			clocks = <&gcc SFAB_SATA_S_H_CLK>,


### PR DESCRIPTION
On some SOCs PORTS_IMPL register value is never programmed by the BIOS
and left at zero value. Which means that no sata ports are available for
software. AHCI driver used to cope up with this by fabricating the
port_map if the PORTS_IMPL register is read zero, but recent patch
broke this workaround as zero value was valid for nvme disks.
This patch adds ports-implemented dt bindings as workaround for this issue
in a way that DT can dictate the port_map in case where the SOCs does not
program it already.
(original text here: https://patchwork.kernel.org/patch/8686761/)
