### PR TITLE
ipq40xx: fix ipq40xx_setup_macs for Linksys EA6350v3

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -64,7 +64,7 @@ ipq40xx_setup_macs()
 		;;
 	linksys,ea6350v3)
 		wan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		lan_mac=$(macaddr_add $(wan_mac) +1)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	esac
 


### PR DESCRIPTION
This is a small bug fix for the EA6350v3. Thanks to Jeff for finding and reporting the issue. He/she explains the problem [here](https://forum.openwrt.org/t/add-support-for-linksys-ea6350-v3/18907/182?u=notengobattery).