### PR TITLE
ramips: add support for Xiaomi Mi Router 3 Pro

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -30,6 +30,7 @@ wsr-600|\
 zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
+xiaomi,mir3p|\
 mir3g)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -231,6 +231,12 @@ mikrotik,rbm11g)
 miniembplug)
 	set_wifi_led "$boardname:red:wlan"
 	;;
+xiaomi,mir3p)
+	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x10" "0x08"
+	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x02" "0x08"
+	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
+	ucidef_set_led_switch "lan3-amber" "LAN3 (amber)" "$boardname:amber:lan3" "switch0" "0x08" "0x08"
+	;;
 mir3g)
 	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x02" "0x08"
 	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x08" "0x08"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -178,6 +178,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:2" "2:lan:1" "3:lan:3" "4:lan" "0:wan" "6@eth0"
 		;;
+	xiaomi,mir3p)
+		ucidef_add_switch "switch0" \
+			"1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+		;;
 	mir3g)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "1:wan" "6t@eth0"
@@ -558,6 +562,7 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory_info 13)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
+	xiaomi,mir3p|\
 	mir3g)
 		lan_mac=$(mtd_get_mac_binary Factory 0xe006)
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -41,7 +41,8 @@ platform_do_upgrade() {
 	r6220|\
 	netgear,r6350|\
 	ubnt-erx|\
-	ubnt-erx-sfp)
+	ubnt-erx-sfp|\
+	xiaomi,mir3p)
 		nand_do_upgrade "$ARGV"
 		;;
 	tplink,c50-v4)

--- a/target/linux/ramips/dts/MIR3P.dts
+++ b/target/linux/ramips/dts/MIR3P.dts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,mir3p", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router 3 Pro";
+
+	aliases {
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_yellow;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x04000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "mir3p:red:status";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "mir3p:blue:status";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_yellow: status_yellow {
+			label = "mir3p:yellow:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "mir3p:amber:wan";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3_amber {
+			label = "mir3p:amber:lan3";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2_amber {
+			label = "mir3p:amber:lan2";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1_amber {
+			label = "mir3p:amber:lan1";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	button {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "Config";
+			reg = <0x40000 0x40000>;
+		};
+
+		partition@80000 {
+			label = "Bdata";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@c0000 {
+			label = "Factory";
+			reg = <0x0c0000 0x40000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "crash";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "crash_syslog";
+			reg = <0x140000 0x80000>;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* We keep stock xiaomi firmware (kernel0) here */
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0xf580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+	mediatek,portmap = "llllw";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "jtag", "uart2", "uart3", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -235,6 +235,22 @@ define Device/k2p
 endef
 TARGET_DEVICES += k2p
 
+define Device/xiaomi_mir3p
+  DTS := MIR3P
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE:= 4096k
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Xiaomi Mi Router 3 Pro
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := \
+	kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_mir3p
+
 define Device/mir3g
   DTS := MIR3G
   BLOCKSIZE := 128k


### PR DESCRIPTION
Hardware:

CPU:   MediaTek MT7621 (2x800MHz)
RAM:   512MB DDR3
FLASH: 256MB NAND
WiFi:  2.4GHz 4x4 MT7615 b/g/n
WiFI:  5GHz 4x4 MT7615 a/n/ac
USB:   1x 3.0
ETH:   1x WAN 10/100/1000 3x LAN 10/100/1000
LED:   Power/Status
BTN:   RESET
UART:  115200 8n1

Installation:

Stock Xiaomi firmware has the MTD split into (among others)

- kernel0
- kernel1 (4MB)
- rootfs0
- rootfs1
- overlay (ubi)

Similar to the Xiaomi MIR3G, we keep stock Xiaomi firmware in
kernel0 for ease of recovery, and install OpenWRT into kernel1 and
after.

The installation file for OpenWRT is a *squashfs-factory.bin file that
contains the kernel and a ubi partition. This is flashed as follows:

nvram set flag_try_sys1_failed=1
nvram set flag_try_sys2_failed=0
nvram commit
dd if=factory.bin bs=1M count=4 | mtd write - kernel1
dd if=factory.bin bs=1M skip=4 | mtd write - rootfs0
reboot

Reverting to stock:

The part of stock firmware we've kept in kernel0 allows us to run stock
recovery, which will re-flash stock firmware from a *.bin file on a USB.

For this we do the following:

fw_setenv flag_try_sys1_failed 0
fw_setenv flag_try_sys2_failed 1
reboot

After reboot the LED status light will blink red, at which point pressing
the 'reset' button will cause stock firmware to be installed from USB.

Signed-off-by: Ozgur Can Leonard <ozgurcan@gmail.com>
