### PR TITLE
busybox: update to 1.30.1

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
-PKG_VERSION:=1.30.0
-PKG_RELEASE:=4
+PKG_VERSION:=1.30.1
+PKG_RELEASE:=1
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://www.busybox.net/downloads \
 		http://sources.buildroot.net
-PKG_HASH:=9553da068c0a30b1b8b72479908c1ba58672e2be7b535363a88de5e0f7bc04ce
+PKG_HASH:=3d1d04a4dbd34048f4794815a5c48ebb9eb53c5277e09ffffc060323b95dfbdc
 
 PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
Minor bugfix release. 

Release notes at: https://busybox.net/

Fixes for
 * bc/dc
 * sed (backslash parsing for 'w' command)
 * ip (vlan fixes)
 * grep (fixes for -x -v)
 * ls (-i compat)


No need to refresh patches or config defaults

Run-tested with ipq806x / R7800
