### PR TITLE
sunxi: add support for Sinovoip Banana Pi M2 Plus

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -204,6 +204,12 @@ define U-Boot/pine64_plus
   UENV:=a64
 endef
 
+define U-Boot/Sinovoip_BPI_M2_Plus
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Bananapi M2 Plus
+  BUILD_DEVICES:=sun8i-h3-bananapi-m2-plus
+endef
+
 define U-Boot/sopine_baseboard
   BUILD_SUBTARGET:=cortexa53
   NAME:=Sopine Baseboard
@@ -260,6 +266,7 @@ UBOOT_TARGETS := \
 	orangepi_pc2 \
 	pangolin \
 	pine64_plus \
+	Sinovoip_BPI_M2_Plus \
 	sopine_baseboard \
 	orangepi_zero_plus
 

--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -52,6 +52,15 @@ define Package/brcmfmac-firmware-43430-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-43430-sdio))
 
+Package/brcmfmac-firmware-43430a0-sdio = $(call Package/firmware-default,Broadcom BCM43430a0 FullMac SDIO firmware)
+define Package/brcmfmac-firmware-43430a0-sdio/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcm/brcmfmac43430a0-sdio.bin \
+		$(1)/lib/firmware/brcm/brcmfmac43430a0-sdio.bin
+endef
+$(eval $(call BuildPackage,brcmfmac-firmware-43430a0-sdio))
+
 Package/brcmfmac-firmware-43455-sdio = $(call Package/firmware-default,Broadcom BCM43455 FullMac SDIO firmware)
 define Package/brcmfmac-firmware-43455-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm

--- a/target/linux/sunxi/base-files/lib/firmware/brcm/brcmfmac43430a0-sdio.txt
+++ b/target/linux/sunxi/base-files/lib/firmware/brcm/brcmfmac43430a0-sdio.txt
@@ -1,0 +1,1 @@
+brcmfmac43430-sdio.txt

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2016 OpenWrt.org
+# Copyright (C) 2013-2019 OpenWrt.org
 # Copyright (C) 2016 Yousong Zhou
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -127,6 +127,16 @@ endef
 
 TARGET_DEVICES += sun8i-h2-plus-orangepi-r1
 
+define Device/sun8i-h3-bananapi-m2-plus
+  DEVICE_TITLE:=Sinovoip Banana Pi M2 Plus
+  DEVICE_PACKAGES:=kmod-rtc-sunxi \
+	kmod-leds-gpio kmod-ledtrig-heartbeat \
+	kmod-brcmfmac brcmfmac-firmware-43430a0-sdio wpad-basic
+  SUPPORTED_DEVICES:=sinovoip,bananapi-m2-plus
+  SUNXI_DTS:=sun8i-h3-bananapi-m2-plus
+endef
+
+TARGET_DEVICES += sun8i-h3-bananapi-m2-plus
 
 define Device/sun8i-h3-nanopi-m1-plus
   DEVICE_TITLE:=FriendlyArm NanoPi M1 Plus


### PR DESCRIPTION
CPU: H3 Quad-core Cortex-A7 H.265/HEVC 4K @ 1.2 Ghz
GPU: Mali400MP2 GPU @ 600MHz (supports OpenGL ES 2.0)
Memory: 1GB DDR3 (shared with GPU)
Onboard: Storage TF card (Max. 64GB) / MMC card slot
Onboard: Network 10/100M Ethernet RJ45 (Realtek RTL8211E)
Onboard: Network BT4.0/WiFi 802.11 b/g/n (Ampak AP6212)
Onboard header: SPI, I2C, GPIO, UART
USB 2.0: Two USB 2.0 HOST, One USB 2.0 OTG

Untested:
Audio, Video

Not working:
Bluetooth

