### PR TITLE
kernel: mtdsplit: add support for Fon(Foxconn) uimage

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -18,14 +18,15 @@
 #include <linux/mtd/partitions.h>
 #include <linux/version.h>
 #include <linux/byteorder/generic.h>
+#include <linux/crc32.h>
 
 #include "mtdsplit.h"
 
 /*
  * uimage_header itself is only 64B, but it may be prepended with another data.
- * Currently the biggest size is for Edimax devices: 20B + 64B
+ * Currently the biggest size is for Fon(Foxconn) devices: 64B + 32B
  */
-#define MAX_HEADER_LEN		84
+#define MAX_HEADER_LEN		96
 
 #define IH_MAGIC	0x27051956	/* Image Magic Number		*/
 #define IH_NMLEN		32	/* Image Name Length		*/
@@ -54,6 +55,12 @@ struct uimage_header {
 	uint8_t		ih_name[IH_NMLEN];	/* Image Name		*/
 };
 
+/* calculate same as zlib's crc32() */
+static inline uint32_t uimage_crc32(uint32_t ival, uint8_t *buf, int len)
+{
+	return crc32(ival ^ ~0UL, buf, len) ^ ~0UL;
+}
+
 static int
 read_uimage_header(struct mtd_info *mtd, size_t offset, u_char *buf,
 		   size_t header_len)
@@ -79,12 +86,12 @@ read_uimage_header(struct mtd_info *mtd, size_t offset, u_char *buf,
  * __mtdsplit_parse_uimage - scan partition and create kernel + rootfs parts
  *
  * @find_header: function to call for a block of data that will return offset
- *      of a valid uImage header if found
+ *      and tail padding length of a valid uImage header if found
  */
 static int __mtdsplit_parse_uimage(struct mtd_info *master,
-				   const struct mtd_partition **pparts,
-				   struct mtd_part_parser_data *data,
-				   ssize_t (*find_header)(u_char *buf, size_t len))
+		   const struct mtd_partition **pparts,
+		   struct mtd_part_parser_data *data,
+		   ssize_t (*find_header)(u_char *buf, size_t len, int *extralen))
 {
 	struct mtd_partition *parts;
 	u_char *buf;
@@ -96,6 +103,7 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 	size_t rootfs_size = 0;
 	int uimage_part, rf_part;
 	int ret;
+	int extralen;
 	enum mtdsplit_part_type type;
 
 	nr_parts = 2;
@@ -119,7 +127,8 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 		if (ret)
 			continue;
 
-		ret = find_header(buf, MAX_HEADER_LEN);
+		extralen = 0;
+		ret = find_header(buf, MAX_HEADER_LEN, &extralen);
 		if (ret < 0) {
 			pr_debug("no valid uImage found in \"%s\" at offset %llx\n",
 				 master->name, (unsigned long long) offset);
@@ -127,7 +136,9 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 		}
 		header = (struct uimage_header *)(buf + ret);
 
-		uimage_size = sizeof(*header) + be32_to_cpu(header->ih_size) + ret;
+		uimage_size = sizeof(*header) +
+				be32_to_cpu(header->ih_size) + ret + extralen;
+
 		if ((offset + uimage_size) > master->size) {
 			pr_debug("uImage exceeds MTD device \"%s\"\n",
 				 master->name);
@@ -205,7 +216,7 @@ err_free_parts:
 	return ret;
 }
 
-static ssize_t uimage_verify_default(u_char *buf, size_t len)
+static ssize_t uimage_verify_default(u_char *buf, size_t len, int *extralen)
 {
 	struct uimage_header *header = (struct uimage_header *)buf;
 
@@ -268,7 +279,7 @@ static struct mtd_part_parser uimage_generic_parser = {
 #define FW_MAGIC_WNDR3700V2	0x33373031
 #define FW_MAGIC_WPN824N	0x31313030
 
-static ssize_t uimage_verify_wndr3700(u_char *buf, size_t len)
+static ssize_t uimage_verify_wndr3700(u_char *buf, size_t len, int *extralen)
 {
 	struct uimage_header *header = (struct uimage_header *)buf;
 	uint8_t expected_type = IH_TYPE_FILESYSTEM;
@@ -331,7 +342,7 @@ static struct mtd_part_parser uimage_netgear_parser = {
 #define FW_EDIMAX_OFFSET	20
 #define FW_MAGIC_EDIMAX		0x43535953
 
-static ssize_t uimage_find_edimax(u_char *buf, size_t len)
+static ssize_t uimage_find_edimax(u_char *buf, size_t len, int *extralen)
 {
 	u32 *magic;
 
@@ -344,7 +355,7 @@ static ssize_t uimage_find_edimax(u_char *buf, size_t len)
 	if (be32_to_cpu(*magic) != FW_MAGIC_EDIMAX)
 		return -EINVAL;
 
-	if (!uimage_verify_default(buf + FW_EDIMAX_OFFSET, len))
+	if (!uimage_verify_default(buf + FW_EDIMAX_OFFSET, len, extralen))
 		return FW_EDIMAX_OFFSET;
 
 	return -EINVAL;
@@ -376,6 +387,65 @@ static struct mtd_part_parser uimage_edimax_parser = {
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
+
+/**************************************************
+ * Fon(Foxconn)
+ **************************************************/
+
+#define FONFXC_PAD_LEN		32
+
+static ssize_t uimage_find_fonfxc(u_char *buf, size_t len, int *extralen)
+{
+	struct uimage_header *header = (struct uimage_header *)buf;
+	uint32_t crc_orig;
+	uint32_t crc_calc;
+	ssize_t	ret = -EINVAL;
+
+	if (uimage_verify_default(buf, len, extralen) < 0)
+		return -EINVAL;
+
+	crc_orig = be32_to_cpu(header->ih_hcrc);
+
+	header->ih_hcrc = 0;
+	crc_calc = uimage_crc32(0, buf,	sizeof(*header) + FONFXC_PAD_LEN);
+
+	/* restore ih_hcrc field */
+	header->ih_hcrc = cpu_to_be32(crc_orig);
+
+	if (crc_calc == crc_orig) {
+		ret = 0;
+		*extralen = FONFXC_PAD_LEN;
+	}
+
+	return ret;
+}
+
+static int
+mtdsplit_uimage_parse_fonfxc(struct mtd_info *master,
+			      const struct mtd_partition **pparts,
+			      struct mtd_part_parser_data *data)
+{
+	return __mtdsplit_parse_uimage(master, pparts, data,
+				       uimage_find_fonfxc);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+static const struct of_device_id mtdsplit_uimage_fonfxc_of_match_table[] = {
+	{ .compatible = "fonfxc,uimage" },
+	{},
+};
+#endif
+
+static struct mtd_part_parser uimage_fonfxc_parser = {
+	.owner = THIS_MODULE,
+	.name = "fonfxc-fw",
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+	.of_match_table = mtdsplit_uimage_fonfxc_of_match_table,
+#endif
+	.parse_fn = mtdsplit_uimage_parse_fonfxc,
+	.type = MTD_PARSER_TYPE_FIRMWARE,
+};
+
 /**************************************************
  * Init
  **************************************************/
@@ -385,6 +455,7 @@ static int __init mtdsplit_uimage_init(void)
 	register_mtd_parser(&uimage_generic_parser);
 	register_mtd_parser(&uimage_netgear_parser);
 	register_mtd_parser(&uimage_edimax_parser);
+	register_mtd_parser(&uimage_fonfxc_parser);
 
 	return 0;
 }


### PR DESCRIPTION
  Fon(Foxconn) uimage has the below format:

   +--------------------------+ 0
   | uimage header            |
   |  length of ih_name = 64  |
   |  CRC is calculated for   |
   |  96 bytes region         |
   +--------------------------+ 96
   | image data binary        |
   +--------------------------+

Signed-off-by: NOGUCHI Hiroshi <drvlabo@gmail.com>
