### PR TITLE
ramips: fix MT7620A external PHY auto polling

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7620.c
@@ -129,9 +129,6 @@ static void mt7620_auto_poll(struct mt7620_gsw *gsw)
 		msb = phy;
 	}
 
-	if (lsb == msb)
-		lsb--;
-
 	mtk_switch_w32(gsw, PHY_AN_EN | PHY_PRE_EN | PMY_MDC_CONF(5) |
 		(msb << 8) | lsb, ESW_PHY_POLLING);
 }


### PR DESCRIPTION
When one external PHY is connected to EPHY port 4 (RGMII2),
the link state of port 4 PHY appears on port 5 in switch status.

PPSC.PHY_ST_ADDR field must not be set to 3.
When polling only port 4,
we should set both PHY_ST_ADDR and PHY_END_ADDR to 4.

Signed-off-by: NOGUCHI Hiroshi <drvlabo@gmail.com>
