### PR TITLE
openwrt-18.06: build: Accept BIN_DIR parameter for legacy-images

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -581,7 +581,7 @@ define BuildImage
 		$(call Image/Prepare)
 
     legacy-images-prepare-make: image_prepare
-		$(MAKE) legacy-images-prepare
+		$(MAKE) legacy-images-prepare BIN_DIR="$(BIN_DIR)"
 
   else
     image_prepare:
@@ -605,7 +605,7 @@ define BuildImage
 
   legacy-images-make: install-images
 	$(call Image/mkfs/ubifs/legacy)
-	$(MAKE) legacy-images
+	$(MAKE) legacy-images BIN_DIR="$(BIN_DIR)"
 
   install: install-images
 	$(call Image/Manifest)


### PR DESCRIPTION
BIN_DIR can be set to overwrite the output path for new images. This is an
advertised feature for the imagebuilder and is used by systems like
LibreMesh's chef.

The legacy images are build using a new sub-make which doesn't receive the
variable overwrites of the parent make process. As result, the BIN_DIR is
automatically defined to the default value from rules.mk. The images will
therefore not be placed in the output path which was selected by the user.

Providing BIN_DIR as an explicit variable override to the sub-make works
around this problem.

Fixes: 26c771452cd8 ("image.mk: add LegacyDevice wrapper to allow legacy image building code to be used for device profiles")
Reported-by: Paul Spooren <mail@aparcar.org>
Signed-off-by: Sven Eckelmann <sven@narfation.org>
(cherry picked from commit 9a5a10eb6924efa519e1d9e27b61dc254876f9ec)