### PR TITLE
generic: kernel: Add missing config option

### DIFF
--- a/target/linux/generic/config-4.14
+++ b/target/linux/generic/config-4.14
@@ -1205,6 +1205,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_SIL_SII8620 is not set
 # CONFIG_DRM_STI is not set
 # CONFIG_DRM_STM is not set
+# CONFIG_DRM_SUN4I is not set
 # CONFIG_DRM_TILCDC is not set
 # CONFIG_DRM_TINYDRM is not set
 # CONFIG_DRM_TI_TFP410 is not set

--- a/target/linux/generic/config-4.19
+++ b/target/linux/generic/config-4.19
@@ -1272,6 +1272,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_SIL_SII8620 is not set
 # CONFIG_DRM_STI is not set
 # CONFIG_DRM_STM is not set
+# CONFIG_DRM_SUN4I is not set
 # CONFIG_DRM_THINE_THC63LVD1024 is not set
 # CONFIG_DRM_TILCDC is not set
 # CONFIG_DRM_TINYDRM is not set

--- a/target/linux/generic/config-4.9
+++ b/target/linux/generic/config-4.9
@@ -1113,6 +1113,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_RADEON is not set
 # CONFIG_DRM_SII902X is not set
 # CONFIG_DRM_STI is not set
+# CONFIG_DRM_SUN4I is not set
 # CONFIG_DRM_TILCDC is not set
 # CONFIG_DRM_TOSHIBA_TC358767 is not set
 # CONFIG_DRM_UDL is not set


### PR DESCRIPTION
DRM packages break modules compilation for sunxi target,
cortexa7 and cortexa8 subtargets.

This patch add missing symbol to generic config.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
