### PR TITLE
sunxi: add support for Orange Pi One

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -156,6 +156,12 @@ define U-Boot/orangepi_zero
   BUILD_DEVICES:=sun8i-h2-plus-orangepi-zero
 endef
 
+define U-Boot/orangepi_one
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Orange Pi One (H3)
+  BUILD_DEVICES:=sun8i-h3-orangepi-one
+endef
+
 define U-Boot/orangepi_pc
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi PC (H3)
@@ -260,6 +266,7 @@ UBOOT_TARGETS := \
 	nanopi_neo2 \
 	orangepi_zero \
 	orangepi_r1 \
+	orangepi_one \
 	orangepi_pc \
 	orangepi_plus \
 	orangepi_2 \

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -159,6 +159,16 @@ endef
 TARGET_DEVICES += sun8i-h3-nanopi-neo
 
 
+define Device/sun8i-h3-orangepi-one
+  DEVICE_TITLE:=Xunlong Orange Pi One
+  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  SUPPORTED_DEVICES:=xunlong,orangepi-one
+  SUNXI_DTS:=sun8i-h3-orangepi-one
+endef
+
+TARGET_DEVICES += sun8i-h3-orangepi-one
+
+
 define Device/sun8i-h3-orangepi-pc
   DEVICE_TITLE:=Xunlong Orange Pi PC
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug


### PR DESCRIPTION
CPU: H3 Quad-core Cortex-A7 H.265/HEVC 4K @ 1.2 Ghz
GPU: Mali400MP2 GPU @ 600MHz (supports OpenGL ES 2.0)
Memory: 512MB DDR3 (shared with GPU)
Onboard: Storage TF card (Max. 64GB) / MMC card slot
Onboard header: SPI, I2C, GPIO, UART
USB 2.0: One USB 2.0 HOST, One USB 2.0 OTG
