### PR TITLE
ramips: add support for DLINK DIR-510L

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -368,6 +368,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5:wan" "6@eth0"
 		;;
+	dlink,dir-510l|\
 	re350-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
@@ -512,6 +513,7 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
 		;;
+	dlink,dir-510l|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-118-a1|\
 	dlink,dwr-118-a2|\

--- a/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/base-files/etc/board.d/03_gpio_switches
@@ -7,6 +7,10 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+dlink,dir-510l)
+	ucidef_add_gpio_switch "usb_enable1" "USB 1A enable" "12" "0"
+	ucidef_add_gpio_switch "usb_enable05" "USB 0.5A enable" "13" "1"
+	;;
 mikrotik,rb750gr3)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "17"
 	;;

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -54,6 +54,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "soc_wmac.eeprom")
 	case $board in
+        dlink,dir-510l|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-118-a1|\
 	dlink,dwr-118-a2|\

--- a/target/linux/ramips/dts/DIR-510L.dts
+++ b/target/linux/ramips/dts/DIR-510L.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "dlink,dir-510l", "ralink,mt7620a-soc";
+	model = "D-Link DIR-510L";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		bootargs = "console=ttyS1,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "dir-510l:green:status";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		status-red {
+			label = "dir-510l:red:status";
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+};
+
+&ethernet {
+	mediatek,portmap = "llllw";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				label = "recovery";
+				reg = <0x10000 0x200000>;
+				read-only;
+			};
+
+			partition@210000 {
+				compatible = "amit,jimage";
+				label = "firmware";
+				reg = <0x210000 0xde0000>;
+			};
+
+			config: partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76x0e@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&config 0xe490>;
+		mtd-mac-address-increment = <(2)>;
+		mediatek,mtd-eeprom = <&config 0xe05d>;
+	};
+};
+
+&gsw {
+	mediatek,port4 = "ephy";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -114,6 +114,7 @@ define Build/mkdlinkfw
 		-k $(IMAGE_KERNEL) \
 		-r $(IMAGE_ROOTFS) \
 		-o $@ \
+		$(if $(DLINK_IMAGE_OFFSET), -O $(DLINK_IMAGE_OFFSET)) \
 		-s $(DLINK_FIRMWARE_SIZE)
 endef
 
@@ -122,6 +123,7 @@ define Build/mkdlinkfw-factory
 		-m $(DLINK_ROM_ID) -f $(DLINK_FAMILY_MEMBER) \
 		-F $@ \
 		-o $@.new \
+		$(if $(DLINK_IMAGE_OFFSET), -O $(DLINK_IMAGE_OFFSET)) \
 		-s $(DLINK_FIRMWARE_SIZE)
 	mv $@.new $@
 endef

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -190,6 +190,18 @@ define Device/dir-810l
 endef
 TARGET_DEVICES += dir-810l
 
+define Device/dlink_dir-510l
+  $(Device/amit_jboot)
+  DTS := DIR-510L
+  DEVICE_TITLE := D-Link DIR-510L
+  DEVICE_PACKAGES += kmod-mt76x0e
+  DLINK_ROM_ID := DLK6E3805001
+  DLINK_FAMILY_MEMBER := 0x6E38
+  DLINK_FIRMWARE_SIZE := 0xDE0000
+  DLINK_IMAGE_OFFSET := 0x210000
+endef
+TARGET_DEVICES += dlink_dir-510l
+
 define Device/dlink_dwr-116-a1
   $(Device/amit_jboot)
   DTS := DWR-116-A1

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -3,7 +3,7 @@
 #
 
 DEVICE_VARS += TPLINK_FLASHLAYOUT TPLINK_HWID TPLINK_HWREV TPLINK_HWREVADD TPLINK_HVERSION \
-	DLINK_ROM_ID DLINK_FAMILY_MEMBER DLINK_FIRMWARE_SIZE
+	DLINK_ROM_ID DLINK_FAMILY_MEMBER DLINK_FIRMWARE_SIZE DLINK_IMAGE_OFFSET
 
 define Build/elecom-header
 	cp $@ $(KDIR)/v_0.0.0.bin
@@ -59,6 +59,15 @@ define Device/alfa-network_tube-e4g
 	-iwinfo -kmod-rt2800-pci -kmod-rt2800-soc -wpad-basic
 endef
 TARGET_DEVICES += alfa-network_tube-e4g
+
+define Device/amit_jboot
+  DLINK_IMAGE_OFFSET := 0x10000
+  KERNEL := $(KERNEL_DTB)
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
+  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-ohci
+endef
 
 define Device/Archer
   TPLINK_HWREVADD := 0
@@ -182,60 +191,46 @@ endef
 TARGET_DEVICES += dir-810l
 
 define Device/dlink_dwr-116-a1
+  $(Device/amit_jboot)
   DTS := DWR-116-A1
   DEVICE_TITLE := D-Link DWR-116 A1/A2
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci jboot-tools
   DLINK_ROM_ID := DLK6E3803001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0x7E0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
 endef
 TARGET_DEVICES += dlink_dwr-116-a1
 
 define Device/dlink_dwr-118-a1
+  $(Device/amit_jboot)
   DTS := DWR-118-A1
   DEVICE_TITLE := D-Link DWR-118 A1
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci jboot-tools kmod-mt76x0e
+  DEVICE_PACKAGES += kmod-mt76x0e
   DLINK_ROM_ID := DLK6E3811001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
 endef
 TARGET_DEVICES += dlink_dwr-118-a1
 
 define Device/dlink_dwr-118-a2
+  $(Device/amit_jboot)
   DTS := DWR-118-A2
   DEVICE_TITLE := D-Link DWR-118 A2
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci jboot-tools
+  DEVICE_PACKAGES += kmod-mt76x2
   DLINK_ROM_ID := DLK6E3814001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
 endef
 TARGET_DEVICES += dlink_dwr-118-a2
 
 define Device/dlink_dwr-921-c1
+  $(Device/amit_jboot)
   DTS := DWR-921-C1
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := D-Link DWR-921 C1
   DLINK_ROM_ID := DLK6E2414001
   DLINK_FAMILY_MEMBER := 0x6E24
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
-  DEVICE_PACKAGES := jboot-tools \
-	kmod-usb2 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += dlink_dwr-921-c1
 
@@ -248,18 +243,14 @@ endef
 TARGET_DEVICES += dlink_dwr-921-c3
 
 define Device/dlink_dwr-922-e2
+  $(Device/amit_jboot)
   DTS := DWR-922-E2
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_TITLE := D-Link DWR-922 E2
   DLINK_ROM_ID := DLK6E2414005
   DLINK_FAMILY_MEMBER := 0x6E24
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
-  DEVICE_PACKAGES := jboot-tools \
-	kmod-usb2 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += dlink_dwr-922-e2
 
@@ -418,16 +409,13 @@ endef
 TARGET_DEVICES += microwrt
 
 define Device/lava_lr-25g001
+  $(Device/amit_jboot)
   DTS := LR-25G001
   DEVICE_TITLE := LAVA LR-25G001
   DLINK_ROM_ID := LVA6E3804001
   DLINK_FAMILY_MEMBER := 0x6E38
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  KERNEL := $(KERNEL_DTB)
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
-  DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-ohci kmod-mt76x0e
+  DEVICE_PACKAGES += kmod-mt76x0e
 endef
 TARGET_DEVICES += lava_lr-25g001
 

--- a/tools/firmware-utils/src/mkdlinkfw.c
+++ b/tools/firmware-utils/src/mkdlinkfw.c
@@ -99,6 +99,7 @@ struct file_info image_info;
 char *ofname;
 char *progname;
 uint32_t firmware_size;
+uint32_t image_offset;
 uint16_t family_member;
 char *rom_id[12] = { 0 };
 char image_type;
@@ -403,7 +404,7 @@ int fill_sch2(struct sch2_header *header, char *kernel_ptr, char *rootfs_ptr)
 	header->image_crc32 = crc32(0, (uint8_t *) kernel_ptr, kernel_info.file_size);
 	header->start_addr = RAM_ENTRY_ADDR;
 	header->rootfs_addr =
-	    JBOOT_SIZE + STAG_SIZE + SCH2_SIZE + kernel_info.file_size;
+	    image_offset + STAG_SIZE + SCH2_SIZE + kernel_info.file_size;
 	header->rootfs_len = rootfs_info.file_size;
 	header->rootfs_crc32 = crc32(0, (uint8_t *) rootfs_ptr, rootfs_info.file_size);
 	header->header_crc32 = 0;
@@ -446,9 +447,9 @@ int fill_auh(struct auh_header *header, uint32_t length)
 	header->lpvs = AUH_LVPS;
 	header->mbz = 0;
 	header->time_stamp = jboot_timestamp();
-	header->erase_start = JBOOT_SIZE;
+	header->erase_start = image_offset;
 	header->erase_length = firmware_size;
-	header->data_offset = JBOOT_SIZE;
+	header->data_offset = image_offset;
 	header->data_length = length;
 	header->space4 = 0;
 	header->space5 = 0;
@@ -603,11 +604,12 @@ int main(int argc, char *argv[])
 	image_type = SYSUPGRADE;
 	family_member = 0;
 	firmware_size = 0;
+	image_offset = JBOOT_SIZE;
 
 	while (1) {
 		int c;
 
-		c = getopt(argc, argv, "f:F:i:hk:m:o:r:s:");
+		c = getopt(argc, argv, "f:F:i:hk:m:o:O:r:s:");
 		if (c == -1)
 			break;
 
@@ -631,6 +633,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'r':
 			rootfs_info.file_name = optarg;
+			break;
+		case 'O':
+			sscanf(optarg, "0x%x", &image_offset);
 			break;
 		case 'o':
 			ofname = optarg;


### PR DESCRIPTION
The DIR-510L Wireless Router are based on the MT7620A SoC.

Specification:

-MediaTek MT7620A (580 Mhz)
-128 MB of RAM
-16 MB of FLASH
-802.11bgn radio
-1x 10/100 Mbps Ethernet
-2x internal, non-detachable antennas
-UART (J3) header on PCB (57600 8n1)
-1x bi-color LED (GPIO-controlled), 2x button
-JBOOT bootloader

Known issues:
-Ethernet port is used as LAN
-No communication with charger IC. (uart bitbang needed)

Installation:
Apply factory image via d-link http web-gui.

How to revert to OEM firmware:
1.) Push the reset button and turn on the power. Wait until LED start blinking (~10sec.)
2.) Upload original factory image via JBOOT http (IP: 192.168.123.254)
3.) If http doesn't work, it can be done with curl command:
    curl -F FN=@XXXXX.bin http://192.168.123.254/upg
    where XXXXX.bin is name of firmware file.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>