### PR TITLE
ath79: TP-Link CPE210 v3

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -123,6 +123,14 @@ tplink,archer-c6-v2)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
 	;;
+tplink,cpe210-v3)
+	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:green:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:green:link2" "wlan0" "30" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
+	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ ath79_setup_interfaces()
 	pcs,cap324|\
 	pisen,wmm003n|\
 	pqi,air-pen|\
+	tplink,cpe210-v3|\
 	tplink,re350k-v1|\
 	tplink,re450-v2|\
 	tplink,tl-mr10u|\

--- a/target/linux/ath79/dts/qca9533_tplink_cpe210-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210-v3.dts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,cpe210-v3", "qca,qca9533";
+	model = "TP-LINK CPE210 v3";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		link1 {
+			label = "tp-link:green:link1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		link2 {
+			label = "tp-link:green:link2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		link3 {
+			label = "tp-link:green:link3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		system: link4 {
+			label = "tp-link:green:link4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "partition-table";
+				reg = <0x020000 0x10000>;
+				read-only;
+			};
+
+			info: partition@30000 {
+				label = "product-info";
+				reg = <0x030000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0x780000>;
+				compatible = "tplink,firmware";
+			};
+
+			config: partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x30000>;
+			};
+
+			ART: partition@7f0000 {
+				label = "ART";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&info 0x8>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&ART 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -109,6 +109,19 @@ define Device/tplink_archer-c7-v5
 endef
 TARGET_DEVICES += tplink_archer-c7-v5
 
+define Device/tplink_cpe210-v3
+  $(Device/tplink-safeloader)
+  ATH_SOC := qca9533
+  IMAGE_SIZE := 7680k
+  DEVICE_TITLE := TP-Link CPE210 v3
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := CPE210V3
+  LOADER_TYPE := elf
+  KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header -O
+  SUPPORTED_DEVICES += cpe210-v3
+endef
+TARGET_DEVICES += tplink_cpe210-v3
+
 define Device/tplink_re350k-v1
   $(Device/tplink)
   ATH_SOC := qca9558

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -197,6 +197,41 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "support-list",
 	},
 
+	/** Firmware layout for the CPE210 V3 */
+	{
+		.id     = "CPE210V3",
+		.vendor = "CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"CPE210(TP-LINK|EU|N300-2|45550000):3.0\r\n"
+			"CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n"
+			"CPE210(TP-LINK|UN|N300-2):3.0\r\n"
+			"CPE210(TP-LINK|EU|N300-2):3.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x01000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"device-info", 0x31400, 0x00400},
+			{"signature", 0x32000, 0x00400},
+			{"device-id", 0x33000, 0x00100},
+			{"firmware", 0x40000, 0x770000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x01000},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
 	/** Firmware layout for the CPE510/520 */
 	{
 		.id	= "CPE510",


### PR DESCRIPTION
Adding Support for TP-Link CPE210 v3
Specifications:

    * SoC: Qualcomm Atheros QCA9533 (650MHz)
    * RAM: 64MB
    * Storage: 8 MB SPI NOR
    * Wireless: 2.4GHz N based built into SoC 2x2
    * Ethernet: 1x 100/10 Mbps, integrated into SoC, 24V POE IN

Installation:
    Flash factory image through stock firmware WEB UI or through TFTP
    To get to TFTP recovery just hold reset button while powering on for around 4-5 seconds and release.
    Rename factory image to recovery.bin
    Stock TFTP server IP:192.168.0.100
    Stock device TFTP adress:192.168.0.254

Thanks to robimarko for the work inside the ar71xx tree.

Signed-off-by: Mario Schroen <m.schroen@web.de>