### PR TITLE
ar71xx: add VLAN switch to target ENS202EXT (Corrected)

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -191,7 +191,6 @@ ar71xx_setup_interfaces()
 	all0315n|\
 	dlan-hotspot|\
 	dlan-pro-500-wp|\
-	ens202ext|\
 	ja76pf2|\
 	rocket-m-ti|\
 	ubnt-unifi-outdoor)
@@ -580,6 +579,11 @@ ar71xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "5:wan"
 		;;
+	ens202ext)
+                ucidef_set_interfaces_lan_wan "eth1.1" "eth1.2"
+                ucidef_add_switch "switch0" \
+                        "0@eth1" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
+                ;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;


### PR DESCRIPTION
The target ENS202EXT was just recently added right before the stable release of Openwrt 18.

It flashes fine, but the physical switch is almost impossible to use until you have a VLAN set up. Tested on two devices.

The actual problem is that eth0 represents nothing for whatever reason. In other words, both WAN and LAN are running from eth1. There may be an underlying problem in the build, but for now, I assume that this is correct and that a VLAN switch is an appropriate fix.

Also, it's virtually impossible to get the switch running right through LuCI. It is one thing to get a switch to appear, but attempting to configure it breaks the whole thing. The VLAN has to be set up perfectly, otherwise, interfaces will not start up, and one is forced to reset settings, OR, the new LuCI feature kicks in and reverses any steps. It is extremely difficult to determine which virtual ports correspond to which physical ethernet ports without being able to set up the switch in LuCI.

Temporary Workaround:
followed directions here
[openwrt/luci#867](https://github.com/openwrt/luci/issues/867)

Signed-off-by: Michael Pratt [mpratt51@gmail.com](mailto:mpratt51@gmail.com)