### PR TITLE
fstools: Disable lazy init for ext4 overlay

### DIFF
--- a/package/system/fstools/patches/100-disable-lazy-init.patch
+++ b/package/system/fstools/patches/100-disable-lazy-init.patch
@@ -1,0 +1,13 @@
+diff --git a/libfstools/rootdisk.c b/libfstools/rootdisk.c
+index dd00c1b..f3b87fc 100644
+--- a/libfstools/rootdisk.c
++++ b/libfstools/rootdisk.c
+@@ -270,7 +270,7 @@ static int rootdisk_volume_init(struct volume *v)
+ 		if (rootdisk_use_f2fs(p))
+ 			snprintf(str, sizeof(str), "mkfs.f2fs -q -l rootfs_data %s", v->blk);
+ 		else
+-			snprintf(str, sizeof(str), "mkfs.ext4 -q -L rootfs_data %s", v->blk);
++			snprintf(str, sizeof(str), "mkfs.ext4 -q -E lazy_itable_init=0,lazy_journal_init=0 -L rootfs_data %s", v->blk);
+ 		ret = system(str);
+ 		break;
+ 	default:


### PR DESCRIPTION
ext4 lazy init can make writes very bursty and if your storage
interface and/or device isn't very fast it may cause I/O errors and
apparently doesn't play nice with loop device.

Sources:
http://fibrevillage.com/storage/474-ext4-lazy-init
https://www.spinics.net/lists/kernel/msg2903344.html

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>