### PR TITLE
x86: kernel upgrade to 4.19

### DIFF
--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -13,7 +13,7 @@ FEATURES:=squashfs ext4 vdi vmdk pcmcia targz fpu
 SUBTARGETS:=generic legacy geode 64
 MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
-KERNEL_PATCHVER:=4.14
+KERNEL_PATCHVER:=4.19
 
 KERNELNAME:=bzImage
 


### PR DESCRIPTION
```
[    0.000000] Linux version 4.19.24 (openwrt@robot) (gcc version 7.4.0 (OpenWrt GCC 7.4.0 r9420-c17a68c)) #0 SMP Sat Feb 23 01:58:20 2019
[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz root=PARTUUID=82ee4abc-02 rootfstype=ext4 rootwait console=tty0 console=ttyS0,115200n8 noinitrd
[    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
[    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
[    0.000000] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
[    0.000000] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
```
Compile-tested on: x86_64
Runtime-tested on: x86_64

Signed-off-by: Xiaobo Tian <peterwillcn@gmail.com>
