### PR TITLE
kernel: support for Intel(R) x710 10/40GbE adapters PF/VF devices

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -642,6 +642,39 @@ endef
 $(eval $(call KernelPackage,ixgbevf))
 
 
+define KernelPackage/i40e
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) Ethernet Controller XL710 Family support
+  DEPENDS:=@PCI_SUPPORT +kmod-mdio +kmod-ptp +kmod-hwmon-core
+  KCONFIG:=CONFIG_I40E \
+    CONFIG_I40E_DCB=n
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/i40e/i40e.ko
+  AUTOLOAD:=$(call AutoProbe,i40e)
+endef
+
+define KernelPackage/i40e/description
+ Kernel modules for Intel(R) Ethernet Controller XL710 Family 40 Gigabit Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,i40e))
+
+
+define KernelPackage/i40evf
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) Ethernet Adaptive Virtual Function support
+  DEPENDS:=@PCI_SUPPORT +kmod-i40e
+  KCONFIG:=CONFIG_I40EVF
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/i40evf/i40evf.ko
+  AUTOLOAD:=$(call AutoProbe,i40evf)
+endef
+
+define KernelPackage/i40evf/description
+ Kernel modules for Intel(R) Ethernet Controller XL710 Family Virtual Function Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,i40evf))
+
+
 define KernelPackage/b44
   TITLE:=Broadcom 44xx driver
   KCONFIG:=CONFIG_B44
@@ -930,7 +963,7 @@ $(eval $(call KernelPackage,of-mdio))
 
 define KernelPackage/vmxnet3
   SUBMENU:=$(NETWORK_DEVICES_MENU)
-  TITLE:=VMware VMXNET3 ethernet driver 
+  TITLE:=VMware VMXNET3 ethernet driver
   DEPENDS:=@PCI_SUPPORT
   KCONFIG:=CONFIG_VMXNET3
   FILES:=$(LINUX_DIR)/drivers/net/vmxnet3/vmxnet3.ko

--- a/target/linux/apm821xx/Makefile
+++ b/target/linux/apm821xx/Makefile
@@ -13,7 +13,7 @@ MAINTAINER:=Chris Blake <chrisrblake93@gmail.com>, \
 	    Christian Lamparter <chunkeey@gmail.com>
 SUBTARGETS:=nand sata
 
-KERNEL_PATCHVER:=4.14
+KERNEL_PATCHVER:=4.19
 
 define Target/Description
 	Build images for AppliedMicro APM821xx based boards.

--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -14,7 +14,7 @@ FEATURES:=squashfs ramdisk
 MAINTAINER:=Imre Kaloz <kaloz@openwrt.org>
 SUBTARGETS:=generic p1020 p2020
 
-KERNEL_PATCHVER:=4.14
+KERNEL_PATCHVER:=4.19
 
 KERNELNAME:=zImage
 

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -13,7 +13,7 @@ FEATURES:=squashfs ext4 vdi vmdk pcmcia targz fpu
 SUBTARGETS:=generic legacy geode 64
 MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
-KERNEL_PATCHVER:=4.14
+KERNEL_PATCHVER:=4.19
 
 KERNELNAME:=bzImage
 


### PR DESCRIPTION
Add Support for Intel(R) 10/40GbE PCI Express x710 adapters: 
- kmod-i40e	4.14.101-1	Kernel modules for Intel(R) Ethernet Controller XL710 Family 10/40 Gigabit Ethernet adapters.	
- kmod-i40evf	4.14.101-1	Kernel modules for Intel(R) Ethernet Controller XL710 Family Virtual Function Ethernet adapters.

```
[    0.000000] Linux version 4.19.24 (openwrt@robot) (gcc version 7.4.0 (OpenWrt GCC 7.4.0 r9420-c17a68c)) #0 SMP Sat Feb 23 01:58:20 2019
[    0.000000] Command line: BOOT_IMAGE=/boot/vmlinuz root=PARTUUID=82ee4abc-02 rootfstype=ext4 rootwait console=tty0 console=ttyS0,115200n8 noinitrd
[    0.000000] x86/fpu: Supporting XSAVE feature 0x001: 'x87 floating point registers'
[    0.000000] x86/fpu: Supporting XSAVE feature 0x002: 'SSE registers'
[    0.000000] x86/fpu: Supporting XSAVE feature 0x004: 'AVX registers'
[    0.000000] x86/fpu: xstate_offset[2]:  576, xstate_sizes[2]:  256
[  3.359563] i40e: Intel(R) Ethernet Connection XL710 Network Driver - version 2.1.14-k
[  3.374535] i40e: Copyright (c) 2013 - 2014 Intel Corporation.
[  3.376581] i40evf: Intel(R) 10 Gigabit PCI Express Virtual Function Network Driver - version 2.1.14-k
[  3.377524] i40evf: Copyright (c) 2009 - 2015 Intel Corporation.
[  3.378532] i40evf 0000:00:05.0: 00:11:22:33:93:01
[  3.379527] i40evf 0000:00:05.0: MAC: 4
[  3.380096] i40evf 0000:00:05.0: Intel(R) X710 Virtual Function
[  3.384642] i40evf 0000:00:06.0: 00:11:22:33:93:02
[  3.389573] i40evf 0000:00:06.0: MAC: 4
[  3.392017] i40evf 0000:00:06.0: Intel(R) X710 Virtual Function
```

Compile-tested on: x86_64
Runtime-tested on: x86_64

Signed-off-by: Xiaobo Tian <peterwillcn@gmail.com>
