### PR TITLE
ipset: size optimizations

### DIFF
--- a/package/network/utils/ipset/Makefile
+++ b/package/network/utils/ipset/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ipset
 PKG_VERSION:=7.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://ipset.netfilter.org
@@ -43,7 +43,10 @@ $(call Package/ipset/Default)
 endef
 
 CONFIGURE_ARGS += \
+	--disable-static \
 	--with-kbuild="$(LINUX_DIR)"
+
+TARGET_LDFLAGS += -Wl,--gc-sections,--as-needed
 
 MAKE_FLAGS += \
 	ARCH="$(LINUX_KARCH)" \
@@ -52,7 +55,7 @@ MAKE_FLAGS += \
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include $(1)/usr/lib $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/libipset $(1)/usr/include/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libipset.{a,so*} $(1)/usr/lib/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libipset.so* $(1)/usr/lib/
 	$(CP) $(PKG_BUILD_DIR)/lib/libipset.pc $(1)/usr/lib/pkgconfig/
 endef
 


### PR DESCRIPTION
`ipset` utility was linked statically to libipset. Disable static library for dynamic linking to save space.
Add `-Wl,--gc-sections,--as-needed` for further reduction

MIPS ipk size:
ipset: 29KiB -> 2KiB
libipset: 39KiB -> 38KiB