### PR TITLE
ath79: TP-Link Archer C7 v4 swap usb led names

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -68,15 +68,15 @@
 
 		usb1 {
 			label = "tp-link:green:usb1";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port0>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		usb2 {
 			label = "tp-link:green:usb2";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port1>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
 			linux,default-trigger = "usbport";
 		};
 


### PR DESCRIPTION
In stock firmare usb1 is upper led and usb2 is lower led.
This change mantain the stock behaviour and makes usb1 port
trigger usb1 led and usb2 port trigger usb2 led.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>