### PR TITLE
 mkchkimg: use higher version code

### DIFF
--- a/tools/firmware-utils/src/mkchkimg.c
+++ b/tools/firmware-utils/src/mkchkimg.c
@@ -259,13 +259,8 @@ main (int argc, char * argv[])
 	hdr->magic = htonl (0x2a23245e);
 	hdr->header_len = htonl(header_len);
 	hdr->reserved[0] = (unsigned char)(region & 0xff);
-	hdr->reserved[1] = 1;		/* Major */
-	hdr->reserved[2] = 1;		/* Minor */
-	hdr->reserved[3] = 99;		/* Build */
-	hdr->reserved[4] = 0;
-	hdr->reserved[5] = 0;
-	hdr->reserved[6] = 0;
-	hdr->reserved[7] = 0;
+	memset(&hdr->reserved[1], 99, sizeof(hdr->reserved) - 1);
+
 	message ("       Board Id: %s", board_id);
 	message ("         Region: %s", region == 1 ? "World Wide (WW)" 
 			: (region == 2 ? "North America (NA)" : "Unknown"));


### PR DESCRIPTION
This patch changes the version code of the image header
from `1.1.99_0.0.0.0` to `99.99.99_99.99.99.99`. This
is neccessary on some devices where the stock firmware
checks the version field, possibly preventing third-party
firmware from being installed.

Signed-off-by: Joseph C. Lehner <joseph.c.lehner@gmail.com>
