### PR TITLE
ipq806x: fix LED configuration for NEC Aterm WG2600HP

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -22,7 +22,7 @@ compex,wpq864)
 nec,wg2600hp)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5g" "phy0tpt"
-	ucidef_set_led_switch "wan" "WAN" "${boardname}:green:active" "switch0" "0x1e"
+	ucidef_set_led_switch "wan" "WAN" "${boardname}:green:active" "switch0" "0x2"
 	;;
 netgear,d7800 |\
 netgear,r7500 |\


### PR DESCRIPTION
NEC WG2600HP uses port1 on QCA8337 as a WAN port, so "0x2" should
be used as a portmask instead of "0x1e" for "WAN" LED configuration.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>