### PR TITLE
mac80211: ath10k: fix incorrect multicast/broadcast rate setting

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=mac80211
 
 PKG_VERSION:=4.19.23-1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v4.19.23/
 PKG_HASH:=703e940b542eb56067fcd847a7c69398dcc9829f34472647eea4211cb2ab3b83
 

--- a/package/kernel/mac80211/patches/ath/979-ath10k-fix-incorrect-multicast-broadcast-rate-settin.patch
+++ b/package/kernel/mac80211/patches/ath/979-ath10k-fix-incorrect-multicast-broadcast-rate-settin.patch
@@ -1,0 +1,43 @@
+From: Pradeep kumar Chitrapu <pradeepc@codeaurora.org>
+Date: Mon, 10 Dec 2018 20:56:11 -0800
+Subject: ath10k: fix incorrect multicast/broadcast rate setting
+
+Invalid rate code is sent to firmware when multicast rate value of 0 is
+sent to driver indicating disabled case, causing broken mesh path.
+so fix that.
+
+Tested on QCA9984 with firmware 10.4-3.6.1-00827
+
+Fixes: cd93b83ad92 ("ath10k: support for multicast rate control")
+Co-developed-by: Zhi Chen <zhichen@codeaurora.org>
+Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
+Signed-off-by: Pradeep Kumar Chitrapu <pradeepc@codeaurora.org>
+
+Origin: other, https://patchwork.kernel.org/patch/10723033/
+
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -5484,8 +5484,8 @@ static void ath10k_bss_info_changed(stru
+ 	struct cfg80211_chan_def def;
+ 	u32 vdev_param, pdev_param, slottime, preamble;
+ 	u16 bitrate, hw_value;
+-	u8 rate, basic_rate_idx;
+-	int rateidx, ret = 0, hw_rate_code;
++	u8 rate, basic_rate_idx, rateidx;
++	int ret = 0, hw_rate_code, mcast_rate;
+ 	enum nl80211_band band;
+ 	const struct ieee80211_supported_band *sband;
+ 
+@@ -5658,7 +5658,11 @@ static void ath10k_bss_info_changed(stru
+ 	if (changed & BSS_CHANGED_MCAST_RATE &&
+ 	    !WARN_ON(ath10k_mac_vif_chan(arvif->vif, &def))) {
+ 		band = def.chan->band;
+-		rateidx = vif->bss_conf.mcast_rate[band] - 1;
++		mcast_rate = vif->bss_conf.mcast_rate[band];
++		if (mcast_rate > 0)
++			rateidx = mcast_rate - 1;
++		else
++			rateidx = ffs(vif->bss_conf.basic_rates) - 1;
+ 
+ 		if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY)
+ 			rateidx += ATH10K_MAC_FIRST_OFDM_RATE_IDX;


### PR DESCRIPTION
If no mcast_rate is set for the wifi-iface then there is no rate_idx (0) set for the bss. This breaks for example 5GHz meshpoint interfaces because 0 maps to a CCK rate (11Mbit/s).

Fixes: db90c243a0b9 ("mac80211: update to version based on 4.19-rc4")


See https://bugs.openwrt.org/index.php?do=details&task_id=2123 for a most likely related bug