### PR TITLE
ath10k-ct: fix incorrect multicast/broadcast rate setting

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct
-PKG_RELEASE=2
+PKG_RELEASE=3
 
 PKG_LICENSE:=GPLv2
 PKG_LICENSE_FILES:=

--- a/package/kernel/ath10k-ct/patches/163-ath10k-fix-incorrect-multicast-broadcast-rate-settin.patch
+++ b/package/kernel/ath10k-ct/patches/163-ath10k-fix-incorrect-multicast-broadcast-rate-settin.patch
@@ -1,0 +1,43 @@
+From: Pradeep kumar Chitrapu <pradeepc@codeaurora.org>
+Date: Mon, 10 Dec 2018 20:56:11 -0800
+Subject: ath10k: fix incorrect multicast/broadcast rate setting
+
+Invalid rate code is sent to firmware when multicast rate value of 0 is
+sent to driver indicating disabled case, causing broken mesh path.
+so fix that.
+
+Tested on QCA9984 with firmware 10.4-3.6.1-00827
+
+Fixes: cd93b83ad92 ("ath10k: support for multicast rate control")
+Co-developed-by: Zhi Chen <zhichen@codeaurora.org>
+Signed-off-by: Zhi Chen <zhichen@codeaurora.org>
+Signed-off-by: Pradeep Kumar Chitrapu <pradeepc@codeaurora.org>
+
+Origin: other, https://patchwork.kernel.org/patch/10723033/
+
+--- a/ath10k-4.19/mac.c
++++ b/ath10k-4.19/mac.c
+@@ -6264,8 +6264,8 @@ static void ath10k_bss_info_changed(stru
+ 	struct cfg80211_chan_def def;
+ 	u32 vdev_param, pdev_param, slottime, preamble;
+ 	u16 bitrate, hw_value;
+-	u8 rate, basic_rate_idx;
+-	int rateidx, ret = 0, hw_rate_code;
++	u8 rate, basic_rate_idx, rateidx;
++	int ret = 0, hw_rate_code, mcast_rate;
+ 	enum nl80211_band band;
+ 	const struct ieee80211_supported_band *sband;
+ 
+@@ -6438,7 +6438,11 @@ static void ath10k_bss_info_changed(stru
+ 	if (changed & BSS_CHANGED_MCAST_RATE &&
+ 	    !WARN_ON(ath10k_mac_vif_chan(arvif->vif, &def))) {
+ 		band = def.chan->band;
+-		rateidx = vif->bss_conf.mcast_rate[band] - 1;
++		mcast_rate = vif->bss_conf.mcast_rate[band];
++		if (mcast_rate > 0)
++			rateidx = mcast_rate - 1;
++		else
++			rateidx = ffs(vif->bss_conf.basic_rates) - 1;
+ 
+ 		if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY)
+ 			rateidx += ATH10K_MAC_FIRST_OFDM_RATE_IDX;

--- a/package/kernel/ath10k-ct/patches/164-ath10k-commit-rates-from-mac80211.patch
+++ b/package/kernel/ath10k-ct/patches/164-ath10k-commit-rates-from-mac80211.patch
@@ -1,0 +1,37 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 26 Feb 2019 08:06:35 +0100
+Subject: ath10k-ct: apply mac80211 rates to ath10k-ct rate state
+
+The rates from mac80211 have to be copied to the state of ath10k-ct or
+otherwise the ath10k_check_apply_special_rates function overwrites
+them again with some default values. This breaks for example the
+mcast_rate set for a wifi-iface.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+--- a/ath10k-4.19/mac.c
++++ b/ath10k-4.19/mac.c
+@@ -6460,6 +6460,7 @@ static void ath10k_bss_info_changed(stru
+ 			   "mac vdev %d mcast_rate %x\n",
+ 			   arvif->vdev_id, rate);
+ 
++		arvif->mcast_rate[band] = rate;
+ 		vdev_param = ar->wmi.vdev_param->mcast_data_rate;
+ 		ret = ath10k_wmi_vdev_set_param(ar, arvif->vdev_id,
+ 						vdev_param, rate);
+@@ -6468,6 +6469,7 @@ static void ath10k_bss_info_changed(stru
+ 				    "failed to set mcast rate on vdev %i: %d\n",
+ 				    arvif->vdev_id,  ret);
+ 
++		arvif->bcast_rate[band] = rate;
+ 		vdev_param = ar->wmi.vdev_param->bcast_data_rate;
+ 		ret = ath10k_wmi_vdev_set_param(ar, arvif->vdev_id,
+ 						vdev_param, rate);
+@@ -6494,6 +6496,7 @@ static void ath10k_bss_info_changed(stru
+ 			return;
+ 		}
+ 
++		arvif->mgt_rate[def.chan->band] = hw_rate_code;
+ 		vdev_param = ar->wmi.vdev_param->mgmt_rate;
+ 		ret = ath10k_wmi_vdev_set_param(ar, arvif->vdev_id, vdev_param,
+ 						hw_rate_code);


### PR DESCRIPTION
If no mcast_rate is set for the wifi-iface then there is no rate_idx (0) set for the bss. This can break for example 5GHz meshpoint interfaces because 0 maps to a CCK rate (11Mbit/s).

It must also be avoided that the ath10k-ct internal state for the rates is  not synced with the mac80211 rates state. Otherwise, the user specified   rate (e.g. a wifi-iface mcast_rate for a meshpoint interface) will only be  set on startup. And a short while after that, ath10k-ct specific code in ath10k_check_apply_special_rates is missing a valid rate in its own structures and is then recalculating a new default rate. This default rate is in most situations not the requested rate.

Fixes: 4df3c71cd4c5 ("ath10k-ct: Update to 2018-12-11 and use version based on 4.19")

See https://bugs.openwrt.org/index.php?do=details&task_id=2123 for a most likely related bug