### PR TITLE
Revert "iw: compile with LTO enabled"

### DIFF
--- a/package/network/utils/iw/Makefile
+++ b/package/network/utils/iw/Makefile
@@ -47,8 +47,7 @@ TARGET_CPPFLAGS:= \
 	-I$(STAGING_DIR)/usr/include/libnl-tiny \
 	$(TARGET_CPPFLAGS) \
 	-DCONFIG_LIBNL20 \
-	-D_GNU_SOURCE \
-	-flto
+	-D_GNU_SOURCE
 
 ifeq ($(BUILD_VARIANT),full)
   TARGET_CPPFLAGS += -DIW_FULL
@@ -57,7 +56,7 @@ endif
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS) -ffunction-sections -fdata-sections" \
-	LDFLAGS="$(TARGET_LDFLAGS) -Wl,--gc-sections -flto" \
+	LDFLAGS="$(TARGET_LDFLAGS) -Wl,--gc-sections" \
 	NL1FOUND="" NL2FOUND=Y \
 	NLLIBNAME="libnl-tiny" \
 	LIBS="-lm -lnl-tiny" \


### PR DESCRIPTION
After update to 5.0.1 iw-full package failed to display command list on
ipq40xx device. Root cause was found to be LTO reordering causing
incorrect detection of command struct size in:

iw.c:552
	cmd_size = labs((long)&__section_set - (long)&__section_get);

This has been also reported previously in http://lists.infradead.org/pipermail/openwrt-devel/2018-October/014220.html


Signed-off-by: Mantas Pucka <mantas@8devices.com>


