### PR TITLE
Subject: [PATCH] rt2x00: rt2x00queue: Do not increment sequence number while re-transmitting the frames.

### DIFF
--- a/package/kernel/mac80211/patches/rt2x00/987-rt2x00-do-not-increment-management-frame-sequence-number-while-retry.patch
+++ b/package/kernel/mac80211/patches/rt2x00/987-rt2x00-do-not-increment-management-frame-sequence-number-while-retry.patch
@@ -1,0 +1,39 @@
+diff --git a/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c b/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
+index 1ab507c..f62f7c0 100644
+--- a/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2x00queue.c
+@@ -207,22 +207,20 @@ static void rt2x00queue_create_tx_descriptor_seq(struct rt2x00_dev *rt2x00dev,
+ 		 */
+ 		if (test_bit(CONFIG_QOS_DISABLED, &rt2x00dev->flags))
+ 			__clear_bit(ENTRY_TXD_GENERATE_SEQ, &txdesc->flags);
+-		else
+-			/* H/W will generate sequence number */
+-			return;
++		else {
++			/*
++			 * rt2800 has a beacon problem(beacon is sent with same sequence
++			 * number more than once)with software generated sequence number.
++			 * So for beacons,hardware will generate sequence number and for
++			 * other Management frames software will generate sequence number.
++			 */
++			if (ieee80211_is_beacon(hdr->frame_control))
++				return;
++			else
++				__clear_bit(ENTRY_TXD_GENERATE_SEQ, &txdesc->flags);
++		}
+ 	}
+ 
+-	/*
+-	 * The hardware is not able to insert a sequence number. Assign a
+-	 * software generated one here.
+-	 *
+-	 * This is wrong because beacons are not getting sequence
+-	 * numbers assigned properly.
+-	 *
+-	 * A secondary problem exists for drivers that cannot toggle
+-	 * sequence counting per-frame, since those will override the
+-	 * sequence counter given by mac80211.
+-	 */
+ 	if (test_bit(ENTRY_TXD_FIRST_FRAGMENT, &txdesc->flags))
+ 		seqno = atomic_add_return(0x10, &intf->seqno);
+ 	else


### PR DESCRIPTION
Currently STA+AP re-transmitting the management frames with
incremented sequence number if hardware is assigning the sequence.

Fix is to assign the sequence number for Beacon by hardware
and for other Management frames software will assign the
sequence number

Signed-off-by: Vijayakumar Durai <vijayakumar.durai1@vivint.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
