### PR TITLE
metadata: fixup "board"

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -360,6 +360,7 @@ metadata_json = \
 			"dist": "$(call json_quote,$(VERSION_DIST))", \
 			"version": "$(call json_quote,$(VERSION_NUMBER))", \
 			"revision": "$(call json_quote,$(REVISION))", \
+			"target": "$(call json_quote,$(TARGETID))", \
 			"board": "$(call json_quote,$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)))" \
 		} \
 	}'

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -360,7 +360,7 @@ metadata_json = \
 			"dist": "$(call json_quote,$(VERSION_DIST))", \
 			"version": "$(call json_quote,$(VERSION_NUMBER))", \
 			"revision": "$(call json_quote,$(REVISION))", \
-			"board": "$(call json_quote,$(BOARD))" \
+			"board": "$(call json_quote,$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)))" \
 		} \
 	}'
 

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -355,6 +355,7 @@ json_quote=$(subst ','\'',$(subst ",\",$(1)))
 metadata_devices=$(if $(1),$(subst "$(space)","$(comma)",$(strip $(foreach v,$(1),"$(call json_quote,$(v))"))))
 metadata_json = \
 	'{ $(if $(IMAGE_METADATA),$(IMAGE_METADATA)$(comma)) \
+		"metadata_version": "1.0", \
 		"supported_devices":[$(call metadata_devices,$(1))], \
 		"version": { \
 			"dist": "$(call json_quote,$(VERSION_DIST))", \


### PR DESCRIPTION
currently the "board" parameter contains $(BOARD) which actually results
to `<target>` (like ramips, ar71xx) without subtarget. However, one
actually excepts (not?) to contain BOARD_NAME or DEVICE_NAME.

Signed-off-by: Paul Spooren <mail@aparcar.org>