### PR TITLE
toolchain: Use binutils 2.32 by default and remove 2.29 for ARC

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -3,7 +3,7 @@
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
 	default BINUTILS_USE_VERSION_2_31_1 if !arc
-	default BINUTILS_USE_VERSION_2_29_ARC if arc
+	default BINUTILS_USE_VERSION_2_32 if arc
 	help
 	  Select the version of binutils you wish to use.
 
@@ -23,7 +23,6 @@ choice
 		select BINUTILS_VERSION_2_31_1
 
 	config BINUTILS_USE_VERSION_2_32
-		depends on !arc
 		bool "Binutils 2.32"
 		select BINUTILS_VERSION_2_32
 

--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -7,11 +7,6 @@ choice
 	help
 	  Select the version of binutils you wish to use.
 
-	config BINUTILS_USE_VERSION_2_29_ARC
-		depends on arc
-		bool "ARC binutils 2.29"
-		select BINUTILS_VERSION_2_29_ARC
-
 	config BINUTILS_USE_VERSION_2_29_1
 		depends on !arc
 		bool "Binutils 2.29.1"

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -1,5 +1,4 @@
 config BINUTILS_VERSION_2_29_ARC
-	default y if (!TOOLCHAINOPTS && arc)
 	bool
 
 config BINUTILS_VERSION_2_29_1
@@ -10,6 +9,7 @@ config BINUTILS_VERSION_2_31_1
 	bool
 
 config BINUTILS_VERSION_2_32
+	default y if (!TOOLCHAINOPTS && arc)
 	bool
 
 config BINUTILS_VERSION

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -1,6 +1,3 @@
-config BINUTILS_VERSION_2_29_ARC
-	bool
-
 config BINUTILS_VERSION_2_29_1
 	bool
 
@@ -17,4 +14,3 @@ config BINUTILS_VERSION
 	default "2.29.1"	       if BINUTILS_VERSION_2_29_1
 	default "2.31.1"	       if BINUTILS_VERSION_2_31_1
 	default "2.32"		       if BINUTILS_VERSION_2_32
-	default "arc-2017.09"          if BINUTILS_VERSION_2_29_ARC

--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -27,15 +27,6 @@ ifeq ($(PKG_VERSION),2.32)
   PKG_HASH:=0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
 endif
 
-ifneq ($(CONFIG_BINUTILS_VERSION_2_29_ARC),)
-  PKG_REV:=arc-2017.09-release
-  PKG_SOURCE_URL:=https://github.com/foss-for-synopsys-dwc-arc-processors/binutils-gdb/archive/$(PKG_REV)/
-  PKG_SOURCE:=$(PKG_NAME)-$(PKG_REV).tar.gz
-  PKG_HASH:=2ea086fd5521e942926dd6ff6922ce31c29ee7ffc754fca3d06385e0f27600f8
-  BINUTILS_DIR:=$(PKG_NAME)-gdb-$(PKG_REV)
-  HOST_BUILD_DIR:=$(BUILD_DIR_TOOLCHAIN)/$(BINUTILS_DIR)
-endif
-
 HOST_BUILD_PARALLEL:=1
 
 PATCH_DIR:=./patches/$(PKG_VERSION)


### PR DESCRIPTION
Discussed here: https://github.com/openwrt/openwrt/pull/1803
ARC support is finally upstream so drop branched versions
@abrodkin @EvgeniiDidin