### PR TITLE
ath79: TP-Link Archer C7 v4 swap usb led names

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -68,14 +68,14 @@
 
 		usb1 {
 			label = "tp-link:green:usb1";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&hub_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		usb2 {
 			label = "tp-link:green:usb2";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&hub_port0>;
 			linux,default-trigger = "usbport";
 		};


### PR DESCRIPTION
Commit 34b10b46 made usb match with the corresponding usb label.
The problem is that v4 seems to use in stock firmware the
upper led for usb 1 and the lower led for usb 2.

The led assigned varies between TP-Link models and even
same model versions. For example, Archer C7 v1 and v2 have
the leds in the reverse order.

Revert 34b10b46 and swap led labels instead, now usb port
and led label match and also respect the original behavior.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>