### PR TITLE
layerscape: fix VFIO driver build issue since linux-4.14.99

### DIFF
--- a/target/linux/layerscape/patches-4.14/825-vfio-fsl-mc-Improve-send-mc-command-and-read-respons.patch
+++ b/target/linux/layerscape/patches-4.14/825-vfio-fsl-mc-Improve-send-mc-command-and-read-respons.patch
@@ -1,0 +1,48 @@
+From 703b2ca94467a029942fa478a38f0a14c8109766 Mon Sep 17 00:00:00 2001
+From: Bharat Bhushan <bharat.bhushan@nxp.com>
+Date: Fri, 1 Mar 2019 13:33:58 +0800
+Subject: [PATCH] vfio/fsl-mc: Improve send mc-command and read response
+
+Actually there is no ordering need when reading response
+from mc-portal. Similarly when writing the mc-command,
+ordering needed before command is submitted.
+
+This patch removes un-necessary barriers, response is read
+relaxed and maintain ordering when submit command. This also
+fixes compilation issue with newer kernel.
+
+Signed-off-by: Bharat Bhushan <Bharat.Bhushan@nxp.com>
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ drivers/vfio/fsl-mc/vfio_fsl_mc.c | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+--- a/drivers/vfio/fsl-mc/vfio_fsl_mc.c
++++ b/drivers/vfio/fsl-mc/vfio_fsl_mc.c
+@@ -331,9 +331,7 @@ static int vfio_fsl_mc_dprc_wait_for_res
+ 		u64 header;
+ 		struct mc_cmd_header *resp_hdr;
+ 
+-		__iormb();
+-		header = readq(ioaddr);
+-		__iormb();
++		header = cpu_to_le64(readq_relaxed(ioaddr));
+ 
+ 		resp_hdr = (struct mc_cmd_header *)&header;
+ 		status = (enum mc_cmd_status)resp_hdr->status;
+@@ -353,9 +351,12 @@ static int vfio_fsl_mc_send_command(void
+ {
+ 	int i;
+ 
+-	/* Write at command header in the end */
+-	for (i = 7; i >= 0; i--)
+-		writeq(cmd_data[i], ioaddr + i * sizeof(uint64_t));
++	/* Write at command parameter into portal */
++	for (i = 7; i >= 1; i--)
++		writeq_relaxed(cmd_data[i], ioaddr + i * sizeof(uint64_t));
++
++	/* Write command header in the end */
++	writeq(cmd_data[0], ioaddr);
+ 
+ 	/* Wait for response before returning to user-space
+ 	 * This can be optimized in future to even prepare response


### PR DESCRIPTION
The linux-4.14.99 had introduced below upstream patch.
6636dc5e01c6 arm64: io: Ensure value passed to __iormb() is held in a 64-bit register

It was causing VFIO driver build issue. This patch is to fix it.

 CC      drivers/vfio/fsl-mc/vfio_fsl_mc.o
In file included from ./include/linux/scatterlist.h:9:0,
                 from ./include/linux/iommu.h:22,
                 from drivers/vfio/fsl-mc/vfio_fsl_mc.c:14:
drivers/vfio/fsl-mc/vfio_fsl_mc.c: In function 'vfio_fsl_mc_dprc_wait_for_response':
./arch/arm64/include/asm/io.h:122:45: error: expected expression before ')' token
        : "=r" (tmp) : "r" ((unsigned long)(v))  \
                                             ^
drivers/vfio/fsl-mc/vfio_fsl_mc.c:334:3: note: in expansion of macro '__iormb'
   __iormb();
   ^~~~~~~
./arch/arm64/include/asm/io.h:122:45: error: expected expression before ')' token
        : "=r" (tmp) : "r" ((unsigned long)(v))  \
                                             ^
drivers/vfio/fsl-mc/vfio_fsl_mc.c:336:3: note: in expansion of macro '__iormb'
   __iormb();
   ^~~~~~~

Reported-by: Mathew McBride <matt@traverse.com.au>
Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>

