### PR TITLE
busybox: Fix ntpd-hotplug installation

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -120,6 +120,7 @@ endef
 
 define Package/busybox/install
 	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
 ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_CROND),)
 	$(INSTALL_BIN) ./files/cron $(1)/etc/init.d/cron


### PR DESCRIPTION
This patch fixes following error during ntpd-hotplug binary installation:

   install: cannot create regular file 'build_dir/target-x86_64_musl/busybox-1.30.1/.pkgdir/busybox/usr/sbin/ntpd-hotplug': No such file or directory