### PR TITLE
ath79: add support for LibreRouter v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -19,6 +19,7 @@ buffalo,wzr-hp-ag300h)
 buffalo,bhr-4grv2|\
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor|\
+librerouter,librerouter-v1|\
 ocedo,koala|\
 ocedo,raccoon|\
 openmesh,om5p-ac-v2)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -116,6 +116,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 	;;
+	librerouter,librerouter-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "5:wan" "6@eth1" "4:lan"
+	;;
 	nec,wg800hp)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "1:wan"

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -14,6 +14,9 @@ dlink,dir-825-c1|\
 dlink,dir-835-a1)
 	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"
 	;;
+librerouter,librerouter-v1)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "1" "0"
+	;;
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;

--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "librerouter,librerouter-v1", "qca,qca9558";
+	model = "LibreRouter v1";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "librerouter-v1:green:system";
+			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		wifi_green {
+			label = "librerouter-v1:green:wlan2g";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		status_blue {
+			label = "librerouter-v1:blue:status";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	button {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+		always-running;
+	};
+
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&pcie1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0x7c0000>;
+			};
+
+			partition@810000 {
+				label = "fw2";
+				reg = <0x810000 0x7d0000>;
+			};
+
+			partition@fd0000 {
+				label = "res";
+				reg = <0xfd0000 0x20000>;
+			};
+
+			ART: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x04 0x87600000 /* PORT0: RGMII, MAC0/6 exchage, tx_delay 01, rx_delay 10 */
+			0x0c 0x00000080 /* PORT6: SGMII */
+			0x10 0x81000080 /* POWER_ON_STRAP: LED open drain, SerDes auto-neg disabled */
+			0x50 0xcf37cf37 /* LED_CTRL0 */
+			0x54 0xcf37cf37 /* LED_CTRL1 */
+			0x58 0xcf37cf37 /* LED_CTRL2 */
+			0x5c 0x0        /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+	mtd-mac-address = <&ART 0x0>;
+
+	phy-handle = <&phy0>;
+
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+	mtd-mac-address = <&ART 0x6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&ART 0x1000>;
+	mtd-mac-address = <&ART 0xc>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -394,6 +394,14 @@ define Device/iodata_wn-ag300dgr
 endef
 TARGET_DEVICES += iodata_wn-ag300dgr
 
+define Device/librerouter_librerouter-v1
+  ATH_SOC := qca9558
+  DEVICE_TITLE := LibreRouter v1
+  IMAGE_SIZE := 7936k
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
+endef
+TARGET_DEVICES += librerouter_librerouter-v1
+
 define Device/nec_wg800hp
   ATH_SOC := qca9563
   DEVICE_TITLE := NEC Aterm WG800HP


### PR DESCRIPTION
Hardware
--------
SOC:   QCA9558
RAM:   128M DDR2
Flash: 16MiB SPI-NOR
ETH:   QCA8337N: 2x 10/100/1000 PoE and PoE pass-through
WiFi2: QCA9558 (bgn) 2T2R
WiFi5: 2x mPCIE with AR9582 (an) 2T2R
BTN:   1x Reset
GPIO:  multiple GPIO on header, PoE passthrough enable
UART:  3.3V 115200 8N1 header on the board
WDG:   ATTiny13 watchdog
JTAG:  header on the board
USB:   1x connector and 1x header on the board
PoE:   10-32V input in ETH port 1, passthrough in port 2
mPCIE: 2x populated with radios (but replaceable)

OpenWrt is preinstalled from factory.
Bootloader: https://github.com/librerouterorg/u-boot
Board details (specs, schematics, gerbers): https://github.com/librerouterorg/board


Signed-off-by: Santiago Piccinini <spiccinini@altermundi.net>

Based on this branch https://git.openwrt.org/?p=openwrt/staging/dangole.git;a=commit;h=6325eeec2d72a4b14883c46b8423ba8580cbd2e6 from Daniel Golle