### PR TITLE
sunxi: add support for Orange Pi PC Plus

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -168,6 +168,12 @@ define U-Boot/orangepi_pc
   BUILD_DEVICES:=sun8i-h3-orangepi-pc
 endef
 
+define U-Boot/orangepi_pc_plus
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Orange Pi PC Plus (H3)
+  BUILD_DEVICES:=sun8i-h3-orangepi-pc-plus
+endef
+
 define U-Boot/orangepi_plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi Plus (H3)
@@ -268,6 +274,7 @@ UBOOT_TARGETS := \
 	orangepi_r1 \
 	orangepi_one \
 	orangepi_pc \
+	orangepi_pc_plus \
 	orangepi_plus \
 	orangepi_2 \
 	orangepi_pc2 \

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -179,6 +179,16 @@ endef
 TARGET_DEVICES += sun8i-h3-orangepi-pc
 
 
+define Device/sun8i-h3-orangepi-pc-plus
+  DEVICE_TITLE:=Xunlong Orange Pi PC Plus
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
+  SUPPORTED_DEVICES:=xunlong,orangepi-pc-plus
+  SUNXI_DTS:=sun8i-h3-orangepi-pc-plus
+endef
+
+TARGET_DEVICES += sun8i-h3-orangepi-pc-plus
+
+
 define Device/sun8i-h3-orangepi-plus
   DEVICE_TITLE:=Xunlong Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi


### PR DESCRIPTION
CPU: H3 Quad-core Cortex-A7 H.265/HEVC 4K @ 1.2 Ghz
GPU: Mali400MP2 GPU @ 600MHz (supports OpenGL ES 2.0)
Memory: 1GB DDR3 (shared with GPU)
Onboard: Storage TF card (Max. 64GB) / MMC card slot
Onboard: Storage 8 GB eMMC
Onboard: Network 10/100M Ethernet RJ45
Onboard: Network WiFi 802.11 b/g/n (Realtek RTL8189FTV)
Onboard header: SPI, I2C, GPIO, UART
USB 2.0: Three USB 2.0 HOST, One USB 2.0 OTG

Known issues:
-Wifi diesn't work
