### PR TITLE
busybox: Fix sysntpd

### DIFF
--- a/package/utils/busybox/files/sysntpd
+++ b/package/utils/busybox/files/sysntpd
@@ -4,7 +4,7 @@
 START=98
 
 USE_PROCD=1
-PROG=/usr/sbin/ntpd
+PROG=/sbin/ntpd
 HOTPLUG_SCRIPT=/usr/sbin/ntpd-hotplug
 
 get_dhcp_ntp_servers() {


### PR DESCRIPTION
This patch fixes following error during ntpd:

  bash: ntpd: command not found