### PR TITLE
mpc85xx: Fix Aerohive HiveAP-330 initramfs image

### DIFF
--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -11,6 +11,10 @@ define rootfs_align
 $(patsubst %-256k,0x40000,$(patsubst %-128k,0x20000,$(patsubst %-64k,0x10000,$(patsubst squashfs%,0x4,$(patsubst root.%,%,$(1))))))
 endef
 
+define Build/copy-file
+	cat "$(1)" > "$@"
+endef
+
 # combine kernel and rootfs into one image
 # mktplinkfw <type> <optional extra arguments to mktplinkfw binary>
 # <type> is "sysupgrade" or "factory"
@@ -80,6 +84,7 @@ define Device/hiveap-330
   BLOCKSIZE := 128k
   KERNEL_NAME := zImage
   KERNEL_SIZE := 8m
+  KERNEL_INITRAMFS := copy-file $(KDIR)/vmlinux-initramfs | uImage none
   SUPPORTED_DEVICES := aerohive,hiveap-330
   IMAGES := fdt.bin sysupgrade.bin
   IMAGE/fdt.bin := append-dtb


### PR DESCRIPTION
At some point our initramfs image grew over 6MB, which is causing an issue when uncompressing in the stock bootloader:

```
=> bootm 0x5000000 - 0x1000000;
## Booting kernel from Legacy Image at 05000000 ...
   Image Name:   Linux-4.19.24
   Created:      2019-02-23   1:58:20 UTC
   Image Type:   PowerPC Linux Kernel Image (gzip compressed)
   Data Size:    6752470 Bytes =  6.4 MB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 01000000
   Booting using the fdt blob at 0x1000000
   Uncompressing Kernel Image ... Error: inflate() returned -5
GUNZIP: uncompress, out-of-mem or overwrite error - must RESET board to recover
   Loading Device Tree to 00ffa000, end 00fffc78 ... OK
```

To get around this, we need to move to an uncompressed image for the initramfs image. While this makes a larger image, it is thankfully bootable so people can then convert their devices to run OpenWRT. It's worth noting the non-initramfs image is under 3M, so it will be ages before we have any issues with the flashed kernel.

Also tagging @chunkeey 