### PR TITLE
ramips: add support for RAK633

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -279,6 +279,9 @@ netgear,r6350)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:wan" eth0.2
 	set_wifi_led "$boardname:green:wifi"
 	;;
+rakwireless,rak633)
+	set_wifi_led "rak633:blue:status"
+	;;
 re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "$boardname:blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "$boardname:blue:wifi5G" "wlan1"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -115,6 +115,10 @@ ramips_setup_interfaces()
 	psg1208|\
 	psg1218a|\
 	r6220|\
+	rakwireless,rak633)
+		ucidef_add_switch "switch0" \
+			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
+		;;
 	netgear,r6350|\
 	rt-n12p|\
 	sap-g3200u3|\

--- a/target/linux/ramips/dts/RAK633.dts
+++ b/target/linux/ramips/dts/RAK633.dts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "rakwireless,rak633", "mediatek,mt7628an-soc";
+	model = "RAKwireless RAK633";
+	
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+		status {
+			label = "rak633:blue:status";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wled_an", "refclk", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&i2s {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&uart2 {
+	status = "okay";
+};
+
+&gdma {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+};  

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -156,6 +156,13 @@ define Device/pbr-d1
 endef
 TARGET_DEVICES += pbr-d1
 
+define Device/rakwireless_rak633
+  DTS := RAK633
+  DEVICE_TITLE := Rakwireless RAK633
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-i2c-core kmod-i2c-mt7628
+endef
+TARGET_DEVICES += rakwireless_rak633
+
 define Device/skylab_skw92a
   DTS := SKW92A
   IMAGE_SIZE := 16064k


### PR DESCRIPTION
Specification:

CPU: MT7628 580 MHz. MIPS 24K
RAM: 64 MB
Flash: 8 MB
USB 2.0
5 Port ethernet switch

Product Specification
http://docs.rakwireless.com/en/RAK633/Hardware%20Design/RAK633_Product_Specification_V1.0.pdf

Installation:
Use the Installed uboot Bootloader. Connect a cable to serialport 0. Turn power on.
Choose the option: “Load system code then write to Flash via TFTP” and follow the instructions.

Notes:
The I2C Kernel module work not correctly. You can send and receive data. But the command i2cdetect doesn’t work. FS#845

Signed-off-by: Eike Feldmann eike.feldmann@outlook.com