### PR TITLE
ath79: Add support for Comfast E314N-v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -50,6 +50,11 @@ comfast,cf-e120a-v3)
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;
+comfast,cf-e314n-v2)
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:white:wan" "eth0"
+	ucidef_set_led_netdev "lan" "lAN" "$boardname:white:lan" "eth1"
+	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:white:wlan" "phy0tpt"
+	;;
 engenius,ews511ap)
 	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth0"
 	ucidef_set_led_netdev "lan2" "LAN2" "$boardname:blue:lan2" "eth1"

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "comfast,cf-e314n-v2", "qca,qca9531";
+	model = "COMFAST CF-E314N v2";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &wan;
+		led-failsafe = &wan;
+		led-upgrade = &wan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &led_rssilow_pin &led_rssimediumhigh_pin &led_rssihigh_pin>;
+
+		wan: wan {
+			label = "cf-e314n-v2:white:wan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "cf-e314n-v2:white:lan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow {
+			label = "cf-e314n-v2:white:signal1";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "cf-e314n-v2:white:signal2";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "cf-e314n-v2:white:signal3";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "cf-e314n-v2:white:signal1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "cf-e314n-v2:white:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "winbond,w25q128", "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&art 0x1002>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x6>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -171,6 +171,14 @@ define Device/comfast_cf-e120a-v3
 endef
 TARGET_DEVICES += comfast_cf-e120a-v3
 
+define Device/comfast_cf-e314n-v2
+  ATH_SOC := qca9531
+  DEVICE_TITLE := COMFAST CF-E314N v2
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset -uboot-envtools
+  IMAGE_SIZE := 16192k
+endef
+TARGET_DEVICES += comfast_cf-e314n-v2
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_TITLE := devolo WiFi pro 1200e


### PR DESCRIPTION
Support for Comfast E314N-v2

Taken code from https://patchwork.ozlabs.org/patch/884850/ that was never pushed by the author, and adapted to ath79.

The Comfast E314N-V2 is a 2.4 GHz 2x2 radio with a built-in directional antenna and a second Ethernet port - very similar to the Ubiquiti NanoStation M2. The Ethernet port features a pass-through PoE capability, enabled or disabled with a slide switch. The radio is built using a Qualcomm/Atheros QCA9531 chipset.

Firmware can be flashed on these units by the following method:
1.) Apply power to the unit
2.) Immediately AFTER applying power, hold down the reset button
3.) The WAN, LAN, and wireless lights will flash - wait three seconds (three flashes) and then release the button.
4.) After a second, the lights will "flutter" quickly and the unit will be visible at 192.168.1.1. A web page will be available to enable quick and simple uploading and flashing of firmware.

During the boot process, these units also look for a tftp server at 192.168.1.10. If one is present, the firmware can be uploaded as a file called "firmware-auto.bin"