### PR TITLE
layerscape: update traverse board name and sysupgrade

### DIFF
--- a/target/linux/layerscape/base-files/lib/upgrade/platform.sh
+++ b/target/linux/layerscape/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,7 @@
+
 #!/bin/sh
 #
-# Copyright 2015-2018 Traverse Technologies
+# Copyright 2015-2019 Traverse Technologies
 #
 platform_do_upgrade_traverse_nandubi() {
 	bootsys=$(fw_printenv bootsys | awk -F= '{{print $2}}')
@@ -8,60 +9,25 @@ platform_do_upgrade_traverse_nandubi() {
 	if [ "$bootsys" -eq "2" ]; then
 		newbootsys=1
 	fi
-	mkdir -p /tmp/image
-	cd /tmp/image
-	get_image "$1" > image.tar
-	ls -la image.tar
-	files=$(tar -tf image.tar)
-	echo "Files in image:"
-	echo $files
-	for f in $files
-	do
-		part_name=$(echo $f | awk -F '/' '{{print $2}}')
-		if [ -z "$part_name" ] || [ "$part_name" = "CONTROL" ]; then
-			continue
-		fi
 
-		[ "$part_name" = "root" ] && part_name="rootfs"
-
-		volume=$part_name
-		if [ "$part_name" = "kernel" ] || [ "$part_name" = "rootfs" ]; then
-			volume="${part_name}${newbootsys}"
-		fi
-		volume_id=$(ubinfo -d 0 --name $volume | awk '/Volume ID/ {print $3}')
-		file_size=$(tar -tvf image.tar $f | awk '{{print $3}}')
-		echo "$f size $file_size"
-		tar -xOf image.tar $f | ubiupdatevol -s $file_size /dev/ubi0_$volume_id -
-		
-		echo "$volume upgraded"
-	done
+	# If nand_do_upgrade succeeds, we don't have an opportunity to add any actions of
+	# our own, so do it here and set back on failure
+	echo "Setting bootsys to #${newbootsys}"
 	fw_setenv bootsys $newbootsys
-	echo "Upgrade complete"
-}
-platform_copy_config() {
-	bootsys=$(fw_printenv bootsys | awk -F= '{{print $2}}')
-	rootvol=rootfs$bootsys
-	volume_id=$(ubinfo -d 0 --name $rootvol | awk '/Volume ID/ {print $3}')
-	mkdir -p /mnt/oldsys
-	mount -t ubifs -o rw,noatime /dev/ubi0_$volume_id /mnt/oldsys
-	cp -af "$CONF_TAR" /mnt/oldsys
-	umount /mnt/oldsys
+	CI_UBIPART="nandubi"
+	CI_KERNPART="kernel${newbootsys}"
+	CI_ROOTPART="rootfs${newbootsys}"
+	nand_do_upgrade "$ARGV" || (echo "Upgrade failed, setting bootsys ${bootsys}" && fw_setenv bootsys $bootsys)
+
 }
 platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
 	traverse,ls1043v | \
-	traverse,ls1043s | \
-	traverse,five64)
-		local tar_file="$1"
-		local kernel_length=$( (tar xf $tar_file sysupgrade-traverse-five64/kernel -O | wc -c) 2> /dev/null)
-		local rootfs_length=$( (tar xf $tar_file sysupgrade-traverse-five64/root -O | wc -c) 2> /dev/null)
-		[ "$kernel_length" -eq 0 -o "$rootfs_length" -eq 0 ] && {
-			echo "The upgrade image is corrupt."
-			return 1
-		}
-		return 0
+	traverse,ls1043s)
+		nand_do_platform_check "traverse-ls1043" $1
+		return $?
 		;;
 	*)
 		echo "Sysupgrade is not currently supported on $board"
@@ -75,8 +41,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	traverse,ls1043v | \
-	traverse,ls1043s | \
-	traverse,five64)
+	traverse,ls1043s)
 		platform_do_upgrade_traverse_nandubi "$ARGV"
 		;;
 	*)
@@ -88,7 +53,7 @@ platform_pre_upgrade() {
 	# Force the creation of fw_printenv.lock
 	mkdir -p /var/lock
 	touch /var/lock/fw_printenv.lock
-	
+
 	export RAMFS_COPY_BIN="/usr/sbin/fw_printenv /usr/sbin/fw_setenv /usr/sbin/ubinfo /bin/echo ${RAMFS_COPY_BIN}"
 	export RAMFS_COPY_DATA="/etc/fw_env.config /var/lock/fw_printenv.lock ${RAMFS_COPY_DATA}"
 }

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -7,8 +7,6 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
-ITB_BOARDS = traverse-five64
-
 LS_SD_ROOTFSPART_OFFSET = 64
 LS_SD_IMAGE_SIZE = $(shell echo $$((($(LS_SD_ROOTFSPART_OFFSET) + \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)) * 1024 * 1024)))

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -231,18 +231,18 @@ define Device/ls2088ardb
 endef
 TARGET_DEVICES += ls2088ardb
 
-define Device/traverse-five64
+define Device/traverse-ls1043
   KERNEL_NAME := Image
   KERNEL_SUFFIX := -kernel.itb
   KERNEL_INSTALL := 1
   FDT_LOADADDR = 0x90000000
   FILESYSTEMS := ubifs
-  DEVICE_TITLE := Traverse LS1043 Boards (Five64, LS1043S)
+  DEVICE_TITLE := Traverse LS1043 Boards
   DEVICE_PACKAGES += \
     layerscape-fman-ls1043ardb \
-    uboot-envtools uboot-traverse-ls1043v uboot-traverse-ls1043v-sdcard \
+    uboot-envtools \
     kmod-i2c-core kmod-i2c-mux-pca954x \
-    kmod-hwmon-core kmod-hwmon-ltc2990 kmod-hwmon-pac1934 kmod-hwmon-emc17xx\
+    kmod-hwmon-core \
     kmod-gpio-pca953x kmod-input-gpio-keys-polled \
     kmod-rtc-isl1208
   DEVICE_DESCRIPTION = \
@@ -253,9 +253,9 @@ define Device/traverse-five64
   DEVICE_DTS_CONFIG = ls1043s
   KERNEL := kernel-bin | gzip | traverse-fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb $$(FDT_LOADADDR)
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb $$(FDT_LOADADDR)
-  IMAGES = root sysupgrade.tar
+  IMAGES = root sysupgrade.bin
   IMAGE/root = append-rootfs
-  IMAGE/sysupgrade.tar = sysupgrade-tar
+  IMAGE/sysupgrade.bin = sysupgrade-tar | append-metadata
   MKUBIFS_OPTS := -m 2048 -e 124KiB -c 4096
 endef
-TARGET_DEVICES += traverse-five64
+TARGET_DEVICES += traverse-ls1043


### PR DESCRIPTION
This pull updates the board data for the Traverse boards in target/layerscape and simplifies the sysupgrade script

Previously traverse-five64 was used as the board name as it was presumed that the "retail" version would be more widely known, however there will be some naming changes as new products are released soon.

To make things consistent I propose using traverse-<socname>, e.g traverse-ls1043
References to packages that are not currently in OpenWrt (such as hwmon drivers and u-boot) have been removed as well - we will push to get them upstreamed.

For sysupgrade, most of the steps we were doing were the same as the existing nand_do_upgrade - so the platform.sh can be simplified down a fair bit. The sysupgrade file has also been renamed to sysupgrade.bin to be consistent with other targets.

Signed-off-by: Mathew McBride <matt@traverse.com.au>