### PR TITLE
busybox: Fix  crond ntpd crontab

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -63,6 +63,7 @@ define Package/busybox
     $(call BUSYBOX_IF_ENABLED,XARGS,	100:/usr/bin/xargs:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,CROND,	100:/usr/sbin/crond:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,NTPD,	100:/usr/sbin/ntpd:/sbin/ntpd) \
+    $(call BUSYBOX_IF_ENABLED,CRONTAB,	100:/usr/bin/crontab:/bin/busybox) \
 
 endef
 

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -61,6 +61,8 @@ define Package/busybox
     $(call BUSYBOX_IF_ENABLED,WATCH,	100:/bin/watch:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,WGET,	100:/usr/bin/wget:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,XARGS,	100:/usr/bin/xargs:/bin/busybox) \
+    $(call BUSYBOX_IF_ENABLED,CROND,	100:/usr/sbin/crond:/bin/busybox) \
+    $(call BUSYBOX_IF_ENABLED,NTPD,	100:/usr/sbin/ntpd:/sbin/ntpd) \
 
 endef
 


### PR DESCRIPTION
This patch fixes following error during ntpd crond:

bash: ntpd: command not found
bash: crond: command not found


https://github.com/openwrt/openwrt/blob/master/package/utils/busybox/files/cron
PROG=/usr/sbin/crond No such file or directory
https://github.com/openwrt/luci/blob/master/modules/luci-mod-system/luasrc/model/cbi/admin_system/crontab.lua
luci.sys.call("/usr/bin/crontab %q" % cronfile)

https://github.com/openwrt/openwrt/blob/master/package/utils/busybox/files/sysntpd
PROG=/usr/sbin/ntpd No such file or directory
