### PR TITLE
ath79: add support for Comfast WR650AC v1/v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -62,6 +62,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
+	comfast,cf-wr650ac-v1|\
+	comfast,cf-wr650ac-v2)
+		ucidef_set_interfaces_lan_wan "eth1.1" "eth0.2"
+                ucidef_add_switch "switch0" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth1" "0@eth0" "1:wan"
+                ;;
 	devolo,dvl1200e|\
 	devolo,dvl1750e)
 		ucidef_set_interface_lan "eth0 eth1"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,6 +87,10 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	comfast,cf-wr650ac-v1|\
+	comfast,cf-wr650ac-v2)
+		ath10kcal_extract "art" 20480 2116
+                ;;
 	devolo,dvl1200e|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\

--- a/target/linux/ath79/dts/qca9558_comfast_wr650ac.dtsi
+++ b/target/linux/ath79/dts/qca9558_comfast_wr650ac.dtsi
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr650ac-v1", "qca,qca9557";
+	model = "Comfast CF-WR650AC v1";
+
+	chosen {
+                bootargs = "console=ttyS0,115200n8";
+        };
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "cf-wr650ac:blue:wps";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		network {
+			label = "cf-wr650ac:blue:network";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "cf-wr650ac:blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "comfast:blue:wlan5g";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii-id";
+	};
+};
+
+&mdio1 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		phy-mode = "sgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0xB0000101 0xB0001313>;
+
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii";
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0xB0000101 0xB0001313>;
+
+	phy-handle = <&phy1>;
+	phy-mode = "sgmii";
+};

--- a/target/linux/ath79/dts/qca9558_comfast_wr650ac_v1.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_wr650ac_v1.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+#include "qca9558_comfast_wr650ac.dtsi"
+
+/ {
+        compatible = "comfast,cf-wr650ac-v1", "qca,qca9557";
+        model = "Comfast CF-WR650AC v1";
+};
+
+&spi {
+        status = "okay";
+        num-cs = <1>;
+
+        flash@0 {
+                compatible = "jedec,spi-nor";
+                reg = <0>;
+                spi-max-frequency = <25000000>;
+
+                partitions {
+                        compatible = "fixed-partitions";
+                        #address-cells = <1>;
+                        #size-cells = <1>;
+
+                        partition@0 {
+                                label = "u-boot";
+                                reg = <0x000000 0x020000>;
+                                read-only;
+                        };
+
+                        partition@20000 {
+                                label = "art";
+                                reg = <0x020000 0x010000>;
+                                read-only;
+                        };
+
+                        partition@30000 {
+                                label = "firmware";
+                                reg = <0x030000 0xfc0000>;
+                        };
+
+                        partition@ff0000 {
+                                label = "art-backup";
+                                reg = <0xff0000 0x010000>;
+                                read-only;
+                        }
+                };
+        };
+};

--- a/target/linux/ath79/dts/qca9558_comfast_wr650ac_v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_wr650ac_v2.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+#include "qca9558_comfast_wr650ac.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr650ac-v2", "qca,qca9557";
+	model = "Comfast CF-WR650AC v2";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+                                label = "firmware";
+                                reg = <0x050000 0xfa0000>;
+                        };
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			}
+		};
+	};
+};
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -171,6 +171,23 @@ define Device/comfast_cf-e120a-v3
 endef
 TARGET_DEVICES += comfast_cf-e120a-v3
 
+define Device/comfast_cf-wr650ac-v1
+  ATH_SOC := qca9558
+  DEVICE_TITLE := COMFAST CF-WR650AC v1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 1536k | append-rootfs | pad-to 16128k | check-size $$$$(IMAGE_SIZE)
+  IMAGE_SIZE := 16128k
+endef
+TARGET_DEVICES += comfast_cf-wr650ac-v1
+
+define Device/comfast_cf-wr650ac-v2
+  $(Device/cf-wr650ac-v1)
+  DEVICE_TITLE := COMFAST CF-WR650AC v2
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 1536k | append-rootfs | pad-to 16000k | check-size $$$$(IMAGE_SIZE)
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += comfast_cf-wr650ac-v2
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_TITLE := devolo WiFi pro 1200e


### PR DESCRIPTION
This is a dual band 11a/11n router with 1x wan and 4x gig lan ports.

There are two versions of this router which can be identified through the factory web interface, v1 has 128mb ram and a uboot size of 128k, v2 has 256mb ram and a uboot size of 256k, the remaining hardware and PCB markings are the same.

Factory firmware uses customized openwrt so use sysupgrade file directly.

Signed-off-by: Gareth Parker gareth41@orcon.net.nz
Signed-off-by: Joan Moreau jom@grosjo.net