### PR TITLE
mips: fix dynamic ftrace

### DIFF
--- a/target/linux/generic/pending-3.18/305-mips_module_reloc.patch
+++ b/target/linux/generic/pending-3.18/305-mips_module_reloc.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/Makefile
 +++ b/arch/mips/Makefile
-@@ -90,8 +90,13 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
+@@ -90,8 +90,18 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
  cflags-y			+= -G 0 -mno-abicalls -fno-pic -pipe -mno-branch-likely
  cflags-y			+= -msoft-float
  LDFLAGS_vmlinux			+= -G 0 -static -n -nostdlib --gc-sections
@@ -8,8 +8,13 @@
  KBUILD_AFLAGS_MODULE		+= -mlong-calls
  KBUILD_CFLAGS_MODULE		+= -mlong-calls
 +else
-+KBUILD_AFLAGS_MODULE		+= -mno-long-calls
-+KBUILD_CFLAGS_MODULE		+= -mno-long-calls
++  ifdef CONFIG_DYNAMIC_FTRACE
++    KBUILD_AFLAGS_MODULE	+= -mlong-calls
++    KBUILD_CFLAGS_MODULE	+= -mlong-calls
++  else
++    KBUILD_AFLAGS_MODULE	+= -mno-long-calls
++    KBUILD_CFLAGS_MODULE	+= -mno-long-calls
++  endif
 +endif
  
  ifndef CONFIG_FUNCTION_TRACER

--- a/target/linux/generic/pending-4.14/305-mips_module_reloc.patch
+++ b/target/linux/generic/pending-4.14/305-mips_module_reloc.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/arch/mips/Makefile
 +++ b/arch/mips/Makefile
-@@ -93,8 +93,13 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
+@@ -93,8 +93,18 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
  cflags-y			+= -G 0 -mno-abicalls -fno-pic -pipe -mno-branch-likely
  cflags-y			+= -msoft-float
  LDFLAGS_vmlinux			+= -G 0 -static -n -nostdlib
@@ -19,8 +19,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  KBUILD_AFLAGS_MODULE		+= -mlong-calls
  KBUILD_CFLAGS_MODULE		+= -mlong-calls
 +else
-+KBUILD_AFLAGS_MODULE		+= -mno-long-calls
-+KBUILD_CFLAGS_MODULE		+= -mno-long-calls
++  ifdef CONFIG_DYNAMIC_FTRACE
++    KBUILD_AFLAGS_MODULE	+= -mlong-calls
++    KBUILD_CFLAGS_MODULE	+= -mlong-calls
++  else
++    KBUILD_AFLAGS_MODULE	+= -mno-long-calls
++    KBUILD_CFLAGS_MODULE	+= -mno-long-calls
++  endif
 +endif
  
  ifeq ($(CONFIG_RELOCATABLE),y)

--- a/target/linux/generic/pending-4.19/305-mips_module_reloc.patch
+++ b/target/linux/generic/pending-4.19/305-mips_module_reloc.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/arch/mips/Makefile
 +++ b/arch/mips/Makefile
-@@ -93,8 +93,13 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
+@@ -93,8 +93,18 @@ all-$(CONFIG_SYS_SUPPORTS_ZBOOT)+= vmlin
  cflags-y			+= -G 0 -mno-abicalls -fno-pic -pipe -mno-branch-likely
  cflags-y			+= -msoft-float
  LDFLAGS_vmlinux			+= -G 0 -static -n -nostdlib
@@ -19,8 +19,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  KBUILD_AFLAGS_MODULE		+= -mlong-calls
  KBUILD_CFLAGS_MODULE		+= -mlong-calls
 +else
-+KBUILD_AFLAGS_MODULE		+= -mno-long-calls
-+KBUILD_CFLAGS_MODULE		+= -mno-long-calls
++  ifdef CONFIG_DYNAMIC_FTRACE
++    KBUILD_AFLAGS_MODULE	+= -mlong-calls
++    KBUILD_CFLAGS_MODULE	+= -mlong-calls
++  else
++    KBUILD_AFLAGS_MODULE	+= -mno-long-calls
++    KBUILD_CFLAGS_MODULE	+= -mno-long-calls
++  endif
 +endif
  
  ifeq ($(CONFIG_RELOCATABLE),y)


### PR DESCRIPTION
This was fixed for v4.9 in 076d2ea68, now port to all kernels

Signed-off-by: Mantas Pucka <mantas@8devices.com>
