### PR TITLE
wolfssl: fix build in busybox environments

### DIFF
--- a/package/libs/wolfssl/patches/101-AR-flags-configure-update.patch
+++ b/package/libs/wolfssl/patches/101-AR-flags-configure-update.patch
@@ -1,0 +1,28 @@
+From 42eacece82b6375a9f4bab3903a1a39f7d1dd579 Mon Sep 17 00:00:00 2001
+From: John Safranek <john@wolfssl.com>
+Date: Tue, 5 Mar 2019 09:26:30 -0800
+Subject: [PATCH] AR flags configure update In at least one environment the
+ check for particular AR options was failing due to a bash script bug. Deleted
+ an extra pair of parenthesis triggering an arithmetic statement when
+ redundant grouping was desired.
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index f09f20d9b..f9a7cca60 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -15,7 +15,7 @@ AC_CONFIG_AUX_DIR([build-aux])
+ : ${CFLAGS=""}
+ 
+ # Test ar for the "U" option. Should be checked before the libtool macros.
+-xxx_ar_flags=$((ar --help) 2>&1)
++xxx_ar_flags=$(ar --help 2>&1)
+ AS_CASE([$xxx_ar_flags],[*'use actual timestamps and uids/gids'*],[: ${AR_FLAGS="Ucru"}])
+ 
+ AC_PROG_CC
+-- 
+2.20.1
+


### PR DESCRIPTION
The configure script was broken in alpine-3.9 based docker containers. Fixed in wolfSSL >3.15.7.

Signed-off-by: Moritz Warning <moritzwarning@web.de>

Tested with openwrt 18.06 and openwrt master.

Reference:  https://github.com/wolfSSL/wolfssl/pull/2139 / https://forum.openwrt.org/t/cmake-build-error-and-wolfssl-error-in-alpine/25140/16?u=mwarning