### PR TITLE
README: add time as a requirement

### DIFF
--- a/README
+++ b/README
@@ -11,8 +11,8 @@ To build your own firmware you need a Linux, BSD or MacOSX system (case
 sensitive filesystem required). Cygwin is unsupported because of the lack
 of a case sensitive file system.
 
-You need gcc, binutils, bzip2, flex, python, perl, make, find, grep, diff,
-unzip, gawk, getopt, subversion, libz-dev and libc headers installed.
+You need time, gcc, binutils, bzip2, flex, python, perl, make, find, grep,
+diff, unzip, gawk, getopt, subversion, libz-dev and libc headers installed.
 
 1. Run "./scripts/feeds update -a" to obtain all the latest package definitions
 defined in feeds.conf / feeds.conf.default


### PR DESCRIPTION
a long time ago, `time` was introduced as a deplendency to track time
consumption of different steps of the build process.

Signed-off-by: Paul Spooren <mail@aparcar.org>