### PR TITLE
ramips: rework network settings for HC5861

### DIFF
--- a/target/linux/ramips/dts/HC5861.dts
+++ b/target/linux/ramips/dts/HC5861.dts
@@ -103,10 +103,3 @@
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
-
-&state_default {
-	gpio {
-		ralink,group = "uartf", "wled", "rgmii2", "ephy";
-		ralink,function = "gpio";
-	};
-};


### PR DESCRIPTION
dts: disable port4 and leave it ephy mode because it connect to nothing
switch port5 connected to GE port we use it as wan port