### PR TITLE
new package: udptunnel

### DIFF
--- a/package/network/utils/udptunnel/Makefile
+++ b/package/network/utils/udptunnel/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=udptunnel
+PKG_VERSION:=1.1
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=http://www.cs.columbia.edu/~lennox/udptunnel
+PKG_HASH:=45c0e12045735bc55734076ebbdc7622c746d1fe4e6f7267fa122e2421754670
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_PARALLEL:=1
+
+PKG_LICENSE:=BSD-3-Clause
+
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/udptunnel
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Tunnel UDP packets over a TCP connection
+  URL:=http://www.cs.columbia.edu/~lennox/udptunnel/
+endef
+
+define Package/udptunnel/description 
+  UDPTunnel is a small program which can tunnel UDP packets bi-directionally
+  over a TCP connection. Its primary purpose (and original motivation) is to
+  allow multi-media conferences to traverse a firewall which allows only outgoing
+  TCP connections.
+endef
+
+define Package/udptunnel/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/udptunnel $(1)/usr/bin/
+endef
+
+$(eval $(call BuildPackage,udptunnel))

--- a/package/network/utils/udptunnel/patches/001-multicast.patch
+++ b/package/network/utils/udptunnel/patches/001-multicast.patch
@@ -1,0 +1,14 @@
+Description: Fix issue where udptunnel was failing to receive packets sent to a multicast address. (See #254834).
+Author: singh_chinmay@extenprise.net
+
+--- udptunnel-1.1.orig/udptunnel.c
++++ udptunnel-1.1/udptunnel.c
+@@ -217,7 +217,7 @@
+     (*relays)[i].udpaddr.sin_port = htons(udpport + i);
+     (*relays)[i].udpaddr.sin_family = AF_INET;
+     (*relays)[i].udp_ttl = udpttl;
+-    (*relays)[i].multicast_udp = IN_MULTICAST(htons(udpaddr.s_addr));
++    (*relays)[i].multicast_udp = IN_MULTICAST(htonl(udpaddr.s_addr));
+ 
+     (*relays)[i].tcpaddr.sin_addr = tcpaddr;
+     (*relays)[i].tcpaddr.sin_port = htons(tcpport + i);

--- a/package/network/utils/udptunnel/patches/002-main_code_fix.patch
+++ b/package/network/utils/udptunnel/patches/002-main_code_fix.patch
@@ -1,0 +1,64 @@
+Index: udptunnel-1.1/host2ip.c
+===================================================================
+--- udptunnel-1.1.orig/host2ip.c
++++ udptunnel-1.1/host2ip.c
+@@ -4,7 +4,6 @@
+ #include <netdb.h>           /* gethostbyname() */
+ #include <netinet/in.h>      /* sockaddr_in */
+ #include <arpa/inet.h>       /* inet_addr() */
+-#include <rpcsvc/ypclnt.h>   /* YP */
+ #include <ctype.h>           /* isspace() */
+ 
+ #include "host2ip.h"
+@@ -37,19 +36,9 @@ struct in_addr host2ip(char *host)
+   else if ((hep = gethostbyname(host))) {
+     in = *(struct in_addr *)(hep->h_addr_list[0]);
+   }
+-  /* As a last resort, try YP. */
+   else {
+-    static char *domain = 0;  /* YP domain */
+-    char *value;              /* key value */
+-    int value_len;            /* length of returned value */
+-
+-    if (!domain) yp_get_default_domain(&domain);
+-    if (yp_match(domain, "hosts.byname", host, strlen(host), &value, &value_len) == 0) {
+-      in.s_addr = inet_addr(value);
+-    } else {
+       /* Everything failed */
+       in.s_addr = INADDR_ANY;
+-    }
+   }
+   return in;
+ } /* host2ip */
+Index: udptunnel-1.1/udptunnel.c
+===================================================================
+--- udptunnel-1.1.orig/udptunnel.c
++++ udptunnel-1.1/udptunnel.c
+@@ -423,7 +423,7 @@ static void await_incoming_connections(s
+     for (i = 0; i < relay_count; i++) {
+       if (FD_ISSET(relays[i].tcp_listen_sock, &readfds)) {
+         struct sockaddr_in client_addr;
+-        int addrlen = sizeof(client_addr);
++        socklen_t addrlen = sizeof(client_addr);
+         
+         if ((relays[i].tcp_sock =
+              accept(relays[i].tcp_listen_sock,
+@@ -478,7 +478,7 @@ static int udp_to_tcp(struct relay *rela
+   struct out_packet p;
+   int buflen;
+   struct sockaddr_in remote_udpaddr;
+-  int addrlen = sizeof(remote_udpaddr);
++  socklen_t addrlen = sizeof(remote_udpaddr);
+ 
+   if ((buflen = recvfrom(relay->udp_recv_sock, p.buf, UDPBUFFERSIZE, 0,
+                          (struct sockaddr *) &remote_udpaddr,
+@@ -555,7 +555,8 @@ static int tcp_to_udp(struct relay *rela
+       /* There isn't a UDP listener waiting on the other end, but
+        * that's okay, it's probably just not up at the moment or something.
+        * Use getsockopt(SO_ERROR) to clear the error state. */
+-      int err, len = sizeof(err);
++      int err;
++      socklen_t len = sizeof(err);
+ 
+       if (debug > 1) {
+         fprintf(stderr, "ECONNREFUSED on udp_send_sock; clearing.\n");


### PR DESCRIPTION
This PR adds the udptunnel package from http://www.cs.columbia.edu/~lennox/udptunnel/

UDPTunnel is a small program which can tunnel UDP packets bi-directionally
over a TCP connection. Its primary purpose (and original motivation) is to
allow multi-media conferences to traverse a firewall which allows only outgoing
TCP connections.

Signed-off-by: Jan Delgado <jdelgado@gmx.net>