### PR TITLE
ramips: Limit usable channels for MTC Wireless Router WR1201

### DIFF
--- a/target/linux/ramips/dts/WR1201.dts
+++ b/target/linux/ramips/dts/WR1201.dts
@@ -125,7 +125,7 @@
 	wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
+		ieee80211-freq-limit = <5170000 5250000>;
 
 		led {
 			led-sources = <2>;


### PR DESCRIPTION
ramips: Limit usable channels for MTC Wireless Router WR1201

This hardware is limited to channels 36,40,44 and 48 at 5GHz band