### PR TITLE
base-files: fix sourcing of hotplug scripts in hotplug-call

### DIFF
--- a/package/base-files/files/sbin/hotplug-call
+++ b/package/base-files/files/sbin/hotplug-call
@@ -13,6 +13,8 @@ export DEVICENAME="${DEVPATH##*/}"
 
 [ \! -z "$1" -a -d /etc/hotplug.d/$1 ] && {
 	for script in $(ls /etc/hotplug.d/$1/* 2>&-); do (
-		[ -f $script ] && . $script
+		if [ -f "$script" ]; then
+			[ -x $script ] && $script || . $script
+		fi
 	); done
 }


### PR DESCRIPTION
The current behavior of the hotplug-call is that it  source script in /etc/hotplug.d/ regardless of it content or shebang. This causes an error if you try to use non-shell scripts (python etc.) as hotplug.
This patch fixes that by calling the script directly in case it has executable permission

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>