### PR TITLE
ath79: align naming of Ubiquiti Nanostation M

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -148,7 +148,7 @@ tplink,tl-wr841-v11)
 	;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
-ubnt,nano-m|\
+ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\
 ubnt,rocket-m)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/dts/ar7241_ubnt_nanostation-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_nanostation-m.dts
@@ -4,6 +4,6 @@
 #include "ar7241_ubnt_xm_outdoor.dtsi"
 
 / {
-	compatible = "ubnt,nano-m", "ubnt,xm", "qca,ar7241";
+	compatible = "ubnt,nanostation-m", "ubnt,xm", "qca,ar7241";
 	model = "Ubiquiti Nanostation M";
 };

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -106,16 +106,17 @@ define Device/ubnt_rocket-m
 endef
 TARGET_DEVICES += ubnt_rocket-m
 
-define Device/ubnt_nano-m
+define Device/ubnt_nanostation-m
   $(Device/ubnt-xm)
-  DEVICE_TITLE := Ubiquiti Nano-M
+  DEVICE_TITLE := Ubiquiti Nanostation M
   SUPPORTED_DEVICES += nano-m
 endef
-TARGET_DEVICES += ubnt_nano-m
+TARGET_DEVICES += ubnt_nanostation-m
 
 define Device/ubnt_nanostation-m-xw
   $(Device/ubnt-xw)
   DEVICE_TITLE := Ubiquiti Nanostation M (XW)
+  SUPPORTED_DEVICES += nano-m-xw
 endef
 TARGET_DEVICES += ubnt_nanostation-m-xw
 


### PR DESCRIPTION
Support for the Nanostation M (XW) was added in 40530c8eb with board_name "nanostation-m-xw". The current support for the "Nanostation M" uses board_name "nano-m" only.
This commit rename it to the full productname as it's used by all other boards.

Compile-test: https://buildbot.berlin.freifunk.net/builders/ath79-generic/builds/504