### PR TITLE
dnsmasq: fix running of dhcp user script

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.80
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dhcp-script.sh
+++ b/package/network/services/dnsmasq/files/dhcp-script.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-[ -f "$USER_DHCPSCRIPT" ] && . "$USER_DHCPSCRIPT" "$@"
+if [ -f "$USER_DHCPSCRIPT" ]; then
+	[ -x "$USER_DHCPSCRIPT" ] && "$USER_DHCPSCRIPT" "$@" || . "$USER_DHCPSCRIPT" "$@"
+fi
 
 case "$1" in
 	add)


### PR DESCRIPTION

This PR should fixed behavior when it's possible to use only shell script as user dhcp script in dnsmasq, because of script sourcing in dhcp-script.sh
It' simillar issue to https://github.com/openwrt/openwrt/pull/1908

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
