### PR TITLE
toolchain: Fixed ARM toolchain compilation for gcc 8.x

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -180,9 +180,9 @@ GCC_MAKE:= \
 	export SHELL="$(BASH)"; \
 	$(MAKE) \
 		CFLAGS="$(HOST_CFLAGS)" \
-		CFLAGS_FOR_TARGET="$(TARGET_CFLAGS)" \
-		CXXFLAGS_FOR_TARGET="$(TARGET_CFLAGS)" \
-		GOCFLAGS_FOR_TARGET="$(TARGET_CFLAGS)"
+		CFLAGS_FOR_TARGET="$(filter-out -m%,$(call qstrip,$(TARGET_CFLAGS)))" \
+		CXXFLAGS_FOR_TARGET="$(filter-out -m%,$(call qstrip,$(TARGET_CFLAGS)))" \
+		GOCFLAGS_FOR_TARGET="$(filter-out -m%,$(call qstrip,$(TARGET_CFLAGS)))"
 
 define Host/SetToolchainInfo
 	$(SED) 's,TARGET_CROSS=.*,TARGET_CROSS=$(REAL_GNU_TARGET_NAME)-,' $(TOOLCHAIN_DIR)/info.mk

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -161,9 +161,13 @@ ifneq ($(GCC_ARCH),)
   GCC_CONFIGURE+= --with-arch=$(GCC_ARCH)
 endif
 
-ifneq ($(CONFIG_SOFT_FLOAT),y)
-  ifeq ($(CONFIG_arm),y)
+ifeq ($(CONFIG_arm),y)
+  GCC_CONFIGURE+= \
+	--with-cpu=$(word 1, $(subst +," ,$(CONFIG_CPU_TYPE)))
+
+  ifneq ($(CONFIG_SOFT_FLOAT),y)
     GCC_CONFIGURE+= \
+		--with-fpu=$(word 2, $(subst +, ",$(CONFIG_CPU_TYPE))) \
 		--with-float=hard
   endif
 endif


### PR DESCRIPTION
Set default GCC ARM CPU and FPU architectures, to resolve kernel compilation failures under gcc 8.x