### PR TITLE
lantiq: kernel 4.14: fix usb_phy1 reset status bit in vr9.dts

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/vr9.dtsi
@@ -143,7 +143,7 @@
 				reg = <0x34 4>, <0x3c 4>;
 				status = "disabled";
 
-				resets = <&reset1 5 4>, <&reset0 4 4>;
+				resets = <&reset1 5 5>, <&reset0 4 4>;
 				reset-names = "phy", "ctrl";
 				#phy-cells = <0>;
 			};


### PR DESCRIPTION
The status of USB PHY 1 Reset Domain is also in bit 5 of RST_STAT2.