### PR TITLE
ramips: add support for Youku YK-L2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -130,6 +130,7 @@ ramips_setup_interfaces()
 	mqmaker,witi-512m|\
 	wndr3700v5|\
 	youku-yk1|\
+	youku,yk-l2|\
 	zbt-ape522ii|\
 	zbt-we1326|\
 	zbtlink,zbt-we3526|\

--- a/target/linux/ramips/dts/YOUKU-YK2.dts
+++ b/target/linux/ramips/dts/YOUKU-YK2.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "youku,yk-l2", "mediatek,mt7621-soc";
+	model = "Youku YK-L2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_wps;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "yk-l2:blue:power";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_wps: wps {
+			label = "yk-l2:blue:wps";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "yk-l2:blue:usb";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "jtag", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -518,6 +518,15 @@ define Device/youhua_wr1200js
 endef
 TARGET_DEVICES += youhua_wr1200js
 
+define Device/youku_yk-l2
+  DTS := YOUKU-YK2
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Youku YK-L2
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += youku_yk-l2
+
 define Device/wsr-1166
   DTS := WSR-1166
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata


### PR DESCRIPTION
Hardware spec:

CPU: MTK MT7621A
RAM: 256MB
ROM: 16MB SPI Flash
WiFi: MT7603EN + MT7612EN
Button: 2 buttons (reset, wps)
LED: 8 LEDs (Power 2G 5G WPS Internet LAN1 LAN2 USB)
Ethernet: 3 ports, 2 LAN + 1 WAN
Other: USB3.0

Flashing instructions:

bootloader can get from:
https://downloads.pangubox.com/pb-boot/19.03.17/pb-boot-youku_l2-20190317-61b6d33.bin

telnet 192.168.11.1
put pb-boot-youku_l2-20190317-61b6d33.bin into `/tmp` directory.
mtd write /tmp/pb-boot-youku_l2-20190317-61b6d33.bin Bootloader
turn off the power
Push the reset button and turn on the power.Wait until LED start blinking (~10sec.)
Connect Ethernet port and goto http://192.168.1.1.
Upload the firmware to firmware restore page in webui.

Signed-off-by: zy <574249312@qq.com>