### PR TITLE
ramips: add support for I-O DATA WN-AC733GR3

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -196,7 +196,8 @@ ht-tm02)
 	ucidef_set_led_netdev "eth" "Ethernet" "$boardname:green:lan" "eth0"
 	set_wifi_led "$boardname:blue:wlan"
 	;;
-iodata,wn-ac1167gr)
+iodata,wn-ac1167gr|\
+iodata,wn-ac733gr3)
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$boardname:green:wlan5g" "phy0radio"
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$boardname:green:wlan2g" "phy1radio"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -324,7 +324,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "5:wan" "6@eth0"
 		;;
-	iodata,wn-ac1167gr)
+	iodata,wn-ac1167gr|\
+	iodata,wn-ac733gr3)
 		ucidef_add_switch "switch1" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
@@ -546,7 +547,8 @@ ramips_setup_macs()
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
-	iodata,wn-ac1167gr)
+	iodata,wn-ac1167gr|\
+	iodata,wn-ac733gr3)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary Factory 4)" -1)
 		;;
 	iodata,wn-ax1167gr|\

--- a/target/linux/ramips/dts/WN-AC733GR3.dts
+++ b/target/linux/ramips/dts/WN-AC733GR3.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-ac733gr3", "ralink,mt7620a-soc";
+	model = "I-O DATA WN-AC733GR3";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "wn-ac733gr3:green:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		notification {
+			label = "wn-ac733gr3:green:notification";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "wn-ac733gr3:green:wlan2g";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "wn-ac733gr3:green:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		gpio-sda = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			Factory: partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x8000>;
+				read-only;
+			};
+
+			iNIC_rf: partition@48000 {
+				label = "iNIC_rf";
+				reg = <0x48000 0x8000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x6d4000>;
+			};
+
+			partition@724000 {
+				label = "manufacture";
+				reg = <0x724000 0x8c000>;
+				read-only;
+			};
+
+			partition@7b0000 {
+				label = "backup";
+				reg = <0x7b0000 0x10000>;
+				read-only;
+			};
+
+			partition@7c0000 {
+				label = "storage";
+				reg = <0x7c0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins>;
+	mtd-mac-address = <&Factory 0x4>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+};
+
+&gpio0 {
+	rtl8367rb_reset {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "rtl8367rb-reset";
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uartf", "mdio";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&Factory 0x0>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -367,6 +367,18 @@ define Device/iodata_wn-ac1167gr
 endef
 TARGET_DEVICES += iodata_wn-ac1167gr
 
+define Device/iodata_wn-ac733gr3
+  DTS := WN-AC733GR3
+  DEVICE_TITLE := I-O DATA WN-AC733GR3
+  IMAGE_SIZE := 6992k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := \
+    $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+    elx-header 01040006 8844A2D168B45A2D
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += iodata_wn-ac733gr3
+
 define Device/kimax_u35wf
   DTS := U35WF
   IMAGE_SIZE := 16064k


### PR DESCRIPTION
I-O DATA WN-AC733GR3 is a 2.4/5 GHz band 11ac router, based on
MediaTek MT7620A.

Specification

- SoC		: MediaTek MT7620A
- RAM		: DDR2 64 MiB
- Flash		: SPI-NOR 8 MiB
- WLAN		: 2.4/5 GHz
  - 2.4 GHz : MT7620A (SoC), 2T2R
  - 5 GHz   : MT7610E, 1T1R
- Ethernet	: 10/100/1000 Mbps (RTL8367RB)
- LED/key	: 4x/4x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J1: Vcc, RX, GND, TX from LED side
  - 57600n8

Flash instruction using factory image:

1. Boot WN-AC733GR3 normaly
2. Access to "http://192.168.0.1/" and open firmware update page
("ファームウェア")
3. Select the OpenWrt factory image and click update ("更新") button
to perform firmware update
4. Wait ~150 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>