### PR TITLE
ramips: add support for ASUS RT-AC54U

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -306,6 +306,10 @@ rp-n53)
 rt-ac51u)
 	set_wifi_led "$boardname:blue:wifi"
 	;;
+rt-ac54u)
+	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "$boardname:blue:wifi" "wlan1"
+    set_usb_led "$boardname:blue:usb"
+	;;
 rt-n12p)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" eth0.1
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:wan" eth0.2

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -196,6 +196,7 @@ ramips_setup_interfaces()
 		;;
 	ar670w|\
 	ar725w|\
+	rt-ac54u|\
 	rt-ac51u)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -436,6 +436,9 @@ ramips_board_detect() {
 	*"RT-AC51U")
 		name="rt-ac51u"
 		;;
+	*"RT-AC54U")
+		name="rt-ac54u"
+		;;
 	*"RT-G32 B1")
 		name="rt-g32-b1"
 		;;

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -1,0 +1,152 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-ac54u", "ralink,mt7620a-soc";
+	model = "Asus RT-AC54U";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "rt-ac54u:blue:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "rt-ac54u:blue:usb";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wifi {
+			label = "rt-ac54u:blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		enable-leds {
+			gpio-export,name = "enable-leds";
+			gpio-export,output = <0>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&factory 0x4>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wled", "uartf";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		led {
+			led-sources = <2>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -69,7 +69,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0{
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include "mt7620a.dtsi"

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -146,6 +146,7 @@
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
 		led {
 			led-sources = <2>;
 		};

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -144,10 +144,8 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
 		led {
 			led-sources = <2>;
 		};

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -1,4 +1,3 @@
-#GPL-2.0-or-later
 /dts-v1/;
 
 #include "mt7620a.dtsi"

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -143,6 +143,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		led {

--- a/target/linux/ramips/dts/RT-AC54U.dts
+++ b/target/linux/ramips/dts/RT-AC54U.dts
@@ -1,3 +1,4 @@
+#GPL-2.0-or-later
 /dts-v1/;
 
 #include "mt7620a.dtsi"

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -577,6 +577,14 @@ define Device/rt-ac51u
 endef
 TARGET_DEVICES += rt-ac51u
 
+define Device/rt-ac54u
+  DTS := RT-AC54U
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Asus RT-AC54U
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += rt-ac54u
+
 define Device/tiny-ac
   DTS := TINY-AC
   DEVICE_TITLE := Dovado Tiny AC


### PR DESCRIPTION
Hardware spec:

CPU: MTK MT7620A
RAM: 64MB
ROM: 16MB SPI Flash
WI1 chip1: MediaTek MT7620A
WI2 chip1: MediaTek MT7612E
Button: 2 buttons (reset, wps)
LED: 9 LEDs : 
Power (GPIO)
wifi 2G (GPIO) 
5G(MT7612E control)
USB(GPIO)
Internet LAN1 LAN2 LAN3 LAN4 (MT7620A Switch control not GPIO)

Ethernet: 5 ports, 4 LAN + 1 WAN
Other: 1x UART 1x USB2.0


GPIO 10 enable-leds Different RT-AC51U

RT-AC51U GPIO 10 setting  NOT WORK ON RT-AC54U

and 5GHZ wifi driver is Different

other settings are the same


Signed-off-by: TianYi Liao p055877632@gmail.com