### PR TITLE
ipq806x: adapt pr openwrt#1003 (...enlarge r7800 flash...) to r7500v2

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -257,13 +257,7 @@
 
 					ubi@1880000 {
 						label = "ubi";
-						reg = <0x1880000 0x1C00000>;
-					};
-
-					netgear@3480000 {
-						label = "netgear";
-						reg = <0x3480000 0x4480000>;
-						read-only;
+						reg = <0x1880000 0x6080000>;
 					};
 
 					reserve@7900000 {


### PR DESCRIPTION
Netgrear OEM firmware contains a 'netgear' partition followed 'ubi',
which can be used in openwrt for larger ubi space. (similar to NetgearR7800)
original author (notmyrealhandle) tested this on R7500v2 and point that
OEM firmware can auto rebuild this partition (if used by openwrt).

Author:    notmyrealhandle<22336358+notmyrealhandle@users.noreply.github.com>
Signed-off-by: wangxinyu <comicfans44@gmail.com>