### PR TITLE
ramips: add #pwm-cells property to MT76x8 dts

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -232,6 +232,7 @@
 		pwm: pwm@5000 {
 			compatible = "mediatek,mt7628-pwm";
 			reg = <0x5000 0x1000>;
+			#pwm-cells = <2>;
 
 			resets = <&rstctrl 31>;
 			reset-names = "pwm";


### PR DESCRIPTION
To be able to configure pwms the pwm driver needs to know the number off
cells in the "pwms" property. For this platform this is 2.

Signed-off-by: Micke Prag <micke.prag@telldus.se>
