### PR TITLE
"seq" tool check fixed

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -105,9 +105,9 @@ $(eval $(call SetupHostCommand,cp,Please install GNU fileutils, \
 	gcp --help 2>&1 | grep 'Copy SOURCE', \
 	cp --help 2>&1 | grep 'Copy SOURCE'))
 
-$(eval $(call SetupHostCommand,seq,, \
+$(eval $(call SetupHostCommand,seq,Please install seq, \
 	gseq --version, \
-	seq --version))
+	seq --version 2>&1 | grep seq))
 
 $(eval $(call SetupHostCommand,awk,Please install GNU 'awk', \
 	gawk --version 2>&1 | grep GNU, \


### PR DESCRIPTION
Problem found on alpine linux when tried to `./scripts/feeds update -a`
```sh
Build dependency: Missing seq command
```

Signed-off-by: Shara shara@protonmail.com