### PR TITLE
ath79: add support for NEC Aterm WG1200CR

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -128,6 +128,13 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:wan" "6@eth1" "4:lan"
 	;;
+	nec,wg1200cr|\
+	ubnt,nanostation-ac|\
+	ubnt,unifiac-mesh-pro|\
+	ubnt,unifiac-pro)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "3:wan"
+		;;
 	nec,wg800hp)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "1:wan"
@@ -234,12 +241,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:lan" "1:wan"
 		;;
-	ubnt,nanostation-ac|\
-	ubnt,unifiac-mesh-pro|\
-	ubnt,unifiac-pro)
-		ucidef_add_switch "switch0" \
-			"0@eth0" "2:lan" "3:wan"
-		;;
 	xiaomi,mi-router-4q)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \
@@ -272,7 +273,8 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text "mac" 4)
 		wan_mac=$(mtd_get_mac_text "mac" 24)
 		;;
-	dlink,dir-859-a1)
+	dlink,dir-859-a1|\
+	nec,wg1200cr)
 		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -117,6 +117,10 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 2
 		;;
+	nec,wg1200cr)
+		ath9k_eeprom_extract "art" 4096 1088
+		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata wlan24mac) 2
+		;;
 	nec,wg800hp)
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 1664) 2

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -163,6 +163,12 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
+	nec,wg1200cr)
+		ath10kcal_extract "art" 20480 12064
+		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	phicomm,k2t)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(k2t_get_mac "5g_mac")

--- a/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
+++ b/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	model = "NEC Aterm WG1200CR";
+	compatible = "nec,wg1200cr", "qca,qca9563";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		/* other LEDs are connected to ath10k (QCA9888) gpiochip */
+
+		power_green: power_green {
+			label = "wg1200cr:green:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_red: power_red {
+			label = "wg1200cr:red:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		bridge {
+			label = "br";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+
+		converter {
+			label = "cnv";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "devdata";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "devconf";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "misc";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "wifimngdata";
+				reg = <0x070000 0x010000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x080000 0x770000>;
+			};
+
+			partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0056";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -42,6 +42,12 @@ define Build/add-elecom-factory-initramfs
   fi
 endef
 
+define Build/nec-enc
+  $(STAGING_DIR_HOST)/bin/nec-enc \
+    -i $@ -o $@.new -k $(1)
+  mv $@.new $@
+endef
+
 define Build/nec-fw
   ( stat -c%s $@ | tr -d "\n" | dd bs=16 count=1 conv=sync; ) >> $@
   ( \
@@ -445,6 +451,24 @@ define Device/librerouter_librerouter-v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
+
+define Device/nec_wg1200cr
+  ATH_SOC := qca9563
+  DEVICE_TITLE := NEC Aterm WG1200CR
+  IMAGE_SIZE := 7616k
+  SEAMA_MTDBLOCK := 6
+  SEAMA_SIGNATURE := wrgac72_necpf.2016gui_wg1200cr
+  IMAGES += factory.bin
+  IMAGE/default := \
+    append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
+  IMAGE/sysupgrade.bin := \
+    $$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := \
+    $$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | nec-enc 9gsiy9nzep452pad | \
+    check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += nec_wg1200cr
 
 define Device/nec_wg800hp
   ATH_SOC := qca9563

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -85,6 +85,7 @@ define Host/Compile
 	$(call cc,mkdlinkfw mkdlinkfw-lib, -lz -Wall --std=c99)
 	$(call cc,dns313-header, -Wall)
 	$(call cc,mksercommfw, -Wall)
+	$(call cc,nec-enc, -Wall)
 endef
 
 define Host/Install

--- a/tools/firmware-utils/src/nec-enc.c
+++ b/tools/firmware-utils/src/nec-enc.c
@@ -1,0 +1,138 @@
+/*
+ * nec-enc.c - encode/decode nec firmware with key
+ *
+ * based on xorimage.c in OpenWrt
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#define KEY_LEN     16
+#define PATTERN_LEN 251
+
+int xor_pattern(uint8_t *data, size_t len, const char *key, int k_len, int k_off)
+{
+	int offset = k_off;
+	while (len--) {
+		*data ^= key[offset];
+		data++;
+		offset = (offset + 1) % k_len;
+	}
+	return offset;
+}
+
+void xor_data(uint8_t *data, size_t len, const uint8_t *pattern)
+{
+	for (int i = 0; i < len; i++) {
+		*data ^= pattern[i];
+		data++;
+	}
+}
+
+void usage(void)
+{
+	fprintf(stderr, "Usage: nec-enc [-i infile] [-o outfile] [-k <key>]\n");
+	exit(EXIT_FAILURE);
+}
+
+int main(int argc, char **argv)
+{
+	unsigned char buf[1024];
+	FILE *in = stdin;
+	FILE *out = stdout;
+	char *ifn = NULL;
+	char *ofn = NULL;
+	unsigned char buf_pattern[1024];
+	const char *key = NULL;
+	int c;
+	size_t n;
+	int k_len, k_off = 0;
+	int ptn = 0;
+
+	while ((c = getopt(argc, argv, "i:o:k:h")) != -1) {
+		switch (c) {
+			case 'i':
+				ifn = optarg;
+				break;
+			case 'o':
+				ofn = optarg;
+				break;
+			case 'k':
+				key = optarg;
+				break;
+			case 'h':
+			default:
+				usage();
+		}
+	}
+
+	if (optind != argc || optind == 1) {
+		fprintf(stderr, "illegal arg \"%s\"\n", argv[optind]);
+		usage();
+	}
+
+	if (ifn && !(in = fopen(ifn, "r"))) {
+		fprintf(stderr, "can not open \"%s\" for reading\n", ifn);
+		usage();
+	}
+
+	if (ofn && !(out = fopen(ofn, "w"))) {
+		fprintf(stderr, "can not open \"%s\" for writing\n", ofn);
+		usage();
+	}
+
+	if (!key) {
+		fprintf(stderr, "key is not specified\n");
+		usage();
+	}
+
+	k_len = strlen(key);
+	if (k_len == 0 || k_len > KEY_LEN) {
+		fprintf (stderr, "key length is incorrect\n");
+		usage();
+	}
+
+	while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
+		if (n < sizeof(buf)) {
+			if (ferror(in)) {
+			FREAD_ERROR:
+				fprintf(stderr, "fread error\n");
+				return EXIT_FAILURE;
+			}
+		}
+
+		for (int i = 0; i < n; i++) {
+			buf_pattern[i] = ptn + 1;
+			ptn++;
+			if (ptn > 250) ptn = 0;
+		}
+
+		k_off = xor_pattern(buf_pattern, n, key, k_len, k_off);
+
+		xor_data(buf, n, buf_pattern);
+
+		if (!fwrite(buf, n, 1, out)) {
+		FWRITE_ERROR:
+			fprintf(stderr, "fwrite error\n");
+			return EXIT_FAILURE;
+		}
+	}
+
+	if (ferror(in)) {
+		goto FREAD_ERROR;
+	}
+
+	if (fflush(out)) {
+		goto FWRITE_ERROR;
+	}
+
+	fclose(in);
+	fclose(out);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
NEC Aterm WG1200CR is a 2.4/5 GHz band 11ac router, based on Qualcomm
Atheros QCA9563.

Specification:

- SoC		: Qualcomm Atheros QCA9563
- RAM		: DDR2 128 MiB
- Flash		: SPI-NOR 8 MiB
- WLAN		: 2.4/5 GHz 2T2R
  - 2.4 GHz: QCA9563 (SoC)
  - 5 GHz  : QCA9888
- Ethernet	: 2x 10/100/1000 Mbps
  - Switch : QCA8334
- LEDs/keys	: 12x/4x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - JP1: Vcc, GND, NC, TX, RX from power connector side
  - 115200 bps

Flash instruction using factory image:

1. Boot WG1200CR normaly
2. Access to "http://192.168.10.1/" and open firmware update page
("ファームウェア更新")
3. Select the OpenWrt factory image and click update ("更新") button
to perform firmware update
4. Wait ~150 seconds to complete flashing

Known issues:

- cannot be controlled LEDs other than Power (Green/Red)
  - only Power LEDs are connected to SoC GPIO; other LEDs connected to
    the gpiochip on ath10k chip (QCA9888)

Note:

- The U-Boot on WG1200CR loads Linux Kernel as a uImage
  - log:
```
## Booting image at 9f080040 ...
   Image Name:   MIPS Seattle Linux-3.3.8
   Created:      2018-11-05   9:39:44 UTC
   Image Type:   MIPS Linux Multi-File Image (lzma compressed)
   Data Size:    1064192 Bytes =  1 MB
   Load Address: 80060000
   Entry Point:  80060000
   Contents:
   Image 0:  1064184 Bytes =  1 MB
   Verifying Checksum at 0x9f080080 ...OK
   Uncompressing Multi-File Image ... OK
No initrd
## Transferring control to Linux (at address 80060000) ...
## Giving linux memsize in bytes, 134217728
 
Starting kernel ...
```

  - dumped OEM firmware:
```
$ hexdump -n 128 -C mtd5_firmware.bin
00000000  5e a3 a4 17 00 00 00 24  00 71 70 20 38 08 72 93  |^......$.qp 8.r.|
00000010  ed 3f fa 42 bf 9a e5 83  08 6e 93 d5 64 65 76 3d  |.?.B.....n..dev=|
00000020  2f 64 65 76 2f 6d 74 64  62 6c 6f 63 6b 2f 36 00  |/dev/mtdblock/6.|
00000030  74 79 70 65 3d 66 69 72  6d 77 61 72 65 00 00 00  |type=firmware...|
00000040  27 05 19 56 eb ac 39 da  5b e0 0f e0 00 10 3d 00  |'..V..9.[.....=.|
00000050  80 06 00 00 80 06 00 00  1e f7 e4 68 05 05 04 03  |...........h....|
00000060  4d 49 50 53 20 53 65 61  74 74 6c 65 20 4c 69 6e  |MIPS Seattle Lin|
00000070  75 78 2d 33 2e 33 2e 38  00 00 00 00 00 00 00 00  |ux-3.3.8........|
00000080
```