### PR TITLE
ramips: add support for ZBT-WE1326-v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -132,6 +132,7 @@ ramips_setup_interfaces()
 	youku-yk1|\
 	zbt-ape522ii|\
 	zbt-we1326|\
+	zbtlink,zbt-we1326-v5|\
 	zbtlink,zbt-we3526|\
 	zbt-we826-16M|\
 	zbt-we826-32M|\

--- a/target/linux/ramips/dts/ZBT-WE1326-v5.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326-v5.dts
@@ -1,0 +1,108 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zbtlink,zbt-we1326-v5", "mediatek,mt7621-soc";
+	model = "ZBT-WE1326-v5";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&sdhci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -560,6 +560,15 @@ define Device/zbt-we1326
 endef
 TARGET_DEVICES += zbt-we1326
 
+define Device/zbtlink_zbt-we1326-v5
+  DTS := ZBT-WE1326-v5
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := ZBT WE1326 v5
+  DEVICE_PACKAGES := \
+        kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-sdhci-mt7620 wpad-basic
+endef
+TARGET_DEVICES += zbtlink_zbt-we1326-v5
+
 define Device/zbtlink_zbt-we3526
   DTS := ZBT-WE3526
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
ramips: add support for ZBT-WE1326-v5
ZBT-WE1326 hardware revision 5 has 256MiB RAM (Nanya NT5CC128M16IP-DI) instead of 512MiB.
Specification:
- SoC: MT7621AT, MT7603EN and MT7612EN
- Flash: 16 MiB (W25Q128FVSG)
- RAM: 256 MiB (NT5CC128M16IP-DI)
- Ethernet: 1 x WAN (10/100/1000Mbps) and 4 x LAN (10/100/1000 Mbps)
- Others: USB 3.0, micro SD slot, reset button and 8 x LEDs

How to install:
- The original firmware in v5 does not allow to upload OpenWrt image file, so the procedure is to upload from recovery.
- Follow this steps to access recovery and write firmware.
1 - Configure LAN interface on 192.168.1.0/24 subnet or enable DCHP (recovery mode has DHCP server)
2 - Press and hold reset button for 5-10 seconds while powering the device.
3 - Access 192.168.1.1 click on "恢复" and upload "squashfs-sysupgrade.bin" image file. DO NOT upload "squashfs-factory" image file, as it will not work correctly (because Openwrt will boot but filesystems are not correctly mounted).

Signed-off-by: David Bosque <contact@wifiseguro.es>