### PR TITLE
ramips: convert Xiaomi MIR3G to the new DTS based board name detection

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -32,7 +32,7 @@ zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 xiaomi,mir3p|\
-mir3g)
+xiaomi,mir3g)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 esac

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -235,17 +235,6 @@ mikrotik,rbm11g)
 miniembplug)
 	set_wifi_led "$boardname:red:wlan"
 	;;
-xiaomi,mir3p)
-	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x10" "0x08"
-	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x02" "0x08"
-	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
-	ucidef_set_led_switch "lan3-amber" "LAN3 (amber)" "$boardname:amber:lan3" "switch0" "0x08" "0x08"
-	;;
-mir3g)
-	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x02" "0x08"
-	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x08" "0x08"
-	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
-	;;
 mlw221|\
 mlwg2)
 	set_wifi_led "$boardname:blue:wifi"
@@ -419,6 +408,17 @@ we1026-5g-16m)
 wrh-300cr)
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:ethernet" "eth0"
+	;;
+xiaomi,mir3g)
+	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x02" "0x08"
+	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x08" "0x08"
+	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
+	;;
+xiaomi,mir3p)
+	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x10" "0x08"
+	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x02" "0x08"
+	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
+	ucidef_set_led_switch "lan3-amber" "LAN3 (amber)" "$boardname:amber:lan3" "switch0" "0x08" "0x08"
 	;;
 xzwifi,creativebox-v1)
 	ucidef_set_led_switch "internet" "internet" "$boardname:blue:internet" "switch0" "0x10"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -179,10 +179,6 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:2" "2:lan:1" "3:lan:3" "4:lan" "0:wan" "6@eth0"
 		;;
-	mir3g)
-		ucidef_add_switch "switch0" \
-			"2:lan:2" "3:lan:1" "1:wan" "6t@eth0"
-		;;
 	psg1218b)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "3:wan" "6@eth0"
@@ -436,6 +432,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "0:wan" "6@eth0"
 		;;
+	xiaomi,mir3g)
+		ucidef_add_switch "switch0" \
+			"2:lan:2" "3:lan:1" "1:wan" "6t@eth0"
+		;;
 	xiaomi,mir3p)
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
@@ -566,10 +566,6 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory_info 13)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
-	mir3g|\
-	xiaomi,mir3p)
-		lan_mac=$(mtd_get_mac_binary Factory 0xe006)
-		;;
 	miwifi-mini)
 		wan_mac=$(cat /sys/class/net/eth0/address)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
@@ -650,6 +646,10 @@ ramips_setup_macs()
 		;;
 	wlr-6000)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 32772)" 2)
+		;;
+	xiaomi,mir3g|\
+	xiaomi,mir3p)
+		lan_mac=$(mtd_get_mac_binary Factory 0xe006)
 		;;
 	*)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -277,9 +277,6 @@ ramips_board_detect() {
 	*"Mercury MAC1200R v2")
 		name="mac1200rv2"
 		;;
-	*"Mi Router 3G")
-		name="mir3g"
-		;;
 	*"MicroWRT")
 		name="microwrt"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -37,11 +37,11 @@ platform_do_upgrade() {
 
 	case "$board" in
 	hc5962|\
-	mir3g|\
 	r6220|\
 	netgear,r6350|\
 	ubnt-erx|\
 	ubnt-erx-sfp|\
+	xiaomi,mir3g|\
 	xiaomi,mir3p)
 		nand_do_upgrade "$ARGV"
 		;;

--- a/target/linux/ramips/dts/MIR3G.dts
+++ b/target/linux/ramips/dts/MIR3G.dts
@@ -10,10 +10,10 @@
 	model = "Xiaomi Mi Router 3G";
 
 	aliases {
-		led-boot = &led_status_blue;
-		led-failsafe = &led_status_blue;
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;
-		led-upgrade = &led_status_blue;
+		led-upgrade = &led_status_yellow;
 	};
 
 	memory@0 {
@@ -28,7 +28,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		status_red {
+		led_status_red: status_red {
 			label = "mir3g:red:status";
 			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		};
@@ -38,7 +38,7 @@
 			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
-		status_yellow {
+		led_status_yellow: status_yellow {
 			label = "mir3g:yellow:status";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
@@ -59,7 +59,7 @@
 		};
 	};
 
-	keys {
+	button {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
@@ -70,7 +70,7 @@
 		};
 	};
 
-	reg_usb_vbus: reg_usb_vbus {
+	reg_usb_vbus: regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -251,7 +251,7 @@ define Device/xiaomi_mir3p
 endef
 TARGET_DEVICES += xiaomi_mir3p
 
-define Device/mir3g
+define Device/xiaomi_mir3g
   DTS := MIR3G
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -264,11 +264,12 @@ define Device/mir3g
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_TITLE := Xiaomi Mi Router 3G
   SUPPORTED_DEVICES += R3G
+  SUPPORTED_DEVICES += mir3g
   DEVICE_PACKAGES := \
 	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic \
 	uboot-envtools
 endef
-TARGET_DEVICES += mir3g
+TARGET_DEVICES += xiaomi_mir3g
 
 define Device/mt7621
   DTS := MT7621


### PR DESCRIPTION
Fix Xiaomi Mi Router 3G based on feedback received when adding support for the Xiaomi Mi Router 3 Pro.

Signed-off-by: Ozgur Can Leonard <ozgurcan@gmail.com>