### PR TITLE
ramips: add Asus RP-AC56 support

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -30,10 +30,19 @@
 #define IH_MAGIC	0x27051956	/* Image Magic Number		*/
 #define IH_NMLEN		32	/* Image Name Length		*/
 
-#define IH_OS_LINUX		5	/* Linux	*/
+#define IH_OS_LINUX		5	/* Linux			*/
 
 #define IH_TYPE_KERNEL		2	/* OS Kernel Image		*/
 #define IH_TYPE_FILESYSTEM	7	/* Filesystem Image		*/
+
+#define IH_PRODLEN		23	/* Asus product id size		*/
+/*
+ * Enum to identify uImage header type
+ */
+typedef enum {
+	HEADER_TYPE_GENERIC = 0,
+	HEADER_TYPE_ASUS    = 1
+} header_type_t;
 
 /*
  * Legacy format image header,
@@ -53,6 +62,25 @@ struct uimage_header {
 	uint8_t		ih_comp;	/* Compression Type		*/
 	uint8_t		ih_name[IH_NMLEN];	/* Image Name		*/
 };
+
+/*
+ * Asus-specific header add-on
+ * On some devices such as RP-AC56, Asus stores an additional data
+ * in ih_name field, in paricular, an offset to rootfs can be
+ * found there
+ */
+typedef struct {
+        uint8_t major;
+        uint8_t minor;
+} version_t;
+
+typedef struct {
+        version_t       kernel;
+        version_t       fs;
+        uint8_t         productid[IH_PRODLEN];
+        uint8_t         sub_fs;
+        uint32_t        ih_ksz;
+} asus_t;
 
 static int
 read_uimage_header(struct mtd_info *mtd, size_t offset, u_char *buf,
@@ -84,6 +112,7 @@ read_uimage_header(struct mtd_info *mtd, size_t offset, u_char *buf,
 static int __mtdsplit_parse_uimage(struct mtd_info *master,
 				   const struct mtd_partition **pparts,
 				   struct mtd_part_parser_data *data,
+				   const header_type_t header_type,
 				   ssize_t (*find_header)(u_char *buf, size_t len))
 {
 	struct mtd_partition *parts;
@@ -127,7 +156,29 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 		}
 		header = (struct uimage_header *)(buf + ret);
 
-		uimage_size = sizeof(*header) + be32_to_cpu(header->ih_size) + ret;
+		switch (header_type) {
+		case HEADER_TYPE_GENERIC:
+			uimage_size = sizeof(*header) + be32_to_cpu(header->ih_size) + ret;
+			break;
+		case HEADER_TYPE_ASUS:
+			/* Asus stores kernel version and fs version in first 4 bytes
+			 * of the name field, so lets check if one of first 4 bytes is
+			 * non-printable character and if yes, this is Asus header */
+			if ((header->ih_name[0] < ' ') || (header->ih_name[1] < ' ') ||
+			    (header->ih_name[2] < ' ') || (header->ih_name[3] < ' ')) {
+				asus_t *asus_tail = (asus_t *)header->ih_name;
+				uimage_size = be32_to_cpu(asus_tail->ih_ksz);
+			} else {
+				/* It does not look like an Asus modified header
+				 * so it is a generic one */
+				uimage_size = sizeof(*header) + be32_to_cpu(header->ih_size) + ret;
+			}
+			break;
+		default:
+			pr_debug("unknown uImage header %d in \"%s\"\n", header_type, master->name);
+			uimage_size = 0;
+		}
+
 		if ((offset + uimage_size) > master->size) {
 			pr_debug("uImage exceeds MTD device \"%s\"\n",
 				 master->name);
@@ -237,6 +288,7 @@ mtdsplit_uimage_parse_generic(struct mtd_info *master,
 			      struct mtd_part_parser_data *data)
 {
 	return __mtdsplit_parse_uimage(master, pparts, data,
+				      HEADER_TYPE_GENERIC,
 				      uimage_verify_default);
 }
 
@@ -254,6 +306,33 @@ static struct mtd_part_parser uimage_generic_parser = {
 	.of_match_table = mtdsplit_uimage_of_match_table,
 #endif
 	.parse_fn = mtdsplit_uimage_parse_generic,
+	.type = MTD_PARSER_TYPE_FIRMWARE,
+};
+
+static int
+mtdsplit_uimage_parse_asus(struct mtd_info *master,
+			      const struct mtd_partition **pparts,
+			      struct mtd_part_parser_data *data)
+{
+	return __mtdsplit_parse_uimage(master, pparts, data,
+				      HEADER_TYPE_ASUS,
+				      uimage_verify_default);
+}
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+static const struct of_device_id mtdsplit_asus_uimage_of_match_table[] = {
+	{ .compatible = "asus,uimage" },
+	{},
+};
+#endif
+
+static struct mtd_part_parser uimage_asus_parser = {
+	.owner = THIS_MODULE,
+	.name = "asus_uimage-fw",
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+	.of_match_table = mtdsplit_asus_uimage_of_match_table,
+#endif
+	.parse_fn = mtdsplit_uimage_parse_asus,
 	.type = MTD_PARSER_TYPE_FIRMWARE,
 };
 
@@ -304,6 +383,7 @@ mtdsplit_uimage_parse_netgear(struct mtd_info *master,
 			      struct mtd_part_parser_data *data)
 {
 	return __mtdsplit_parse_uimage(master, pparts, data,
+				      HEADER_TYPE_GENERIC,
 				      uimage_verify_wndr3700);
 }
 
@@ -356,6 +436,7 @@ mtdsplit_uimage_parse_edimax(struct mtd_info *master,
 			      struct mtd_part_parser_data *data)
 {
 	return __mtdsplit_parse_uimage(master, pparts, data,
+				       HEADER_TYPE_GENERIC,
 				       uimage_find_edimax);
 }
 
@@ -385,6 +466,7 @@ static int __init mtdsplit_uimage_init(void)
 	register_mtd_parser(&uimage_generic_parser);
 	register_mtd_parser(&uimage_netgear_parser);
 	register_mtd_parser(&uimage_edimax_parser);
+	register_mtd_parser(&uimage_asus_parser);
 
 	return 0;
 }

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -299,6 +299,10 @@ re350-v1)
 	ucidef_set_led_netdev "eth_act" "LAN act" "$boardname:green:eth_act" "eth0" "tx rx"
 	ucidef_set_led_switch "eth_link" "LAN link" "$boardname:green:eth_link" "switch0" "0x01"
 	;;
+rp-ac56)
+	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
+	;;
 rp-n53)
 	ucidef_set_led_netdev "eth" "Network" "$boardname:white:back" "eth0"
 	set_wifi_led "$boardname:blue:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -376,6 +376,9 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "6@eth0"
 		;;
+	rp-ac56)
+		ucidef_set_interface_lan "eth0"
+		;;
 	rt-n56u)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "8@eth0"

--- a/target/linux/ramips/base-files/lib/preinit/04_handle_checksumming
+++ b/target/linux/ramips/base-files/lib/preinit/04_handle_checksumming
@@ -35,8 +35,8 @@ do_checksumming_disable() {
 			echo "Checksum is already zero, nothing to do."
 		fi
 	;;
-	rt-n56u)
-		echo "Board is ASUS RT-N56U, replacing uImage header..."
+	rp-ac56|rt-n56u)
+		local board_uc=$(echo $board | tr [a-z] [A-Z])
 		local firmware_mtd=$(find_mtd_part firmware)
 		local rootfs_mtd=$(find_mtd_part rootfs)
 		local rootfs_data_mtd=$(find_mtd_part rootfs_data)
@@ -45,7 +45,14 @@ do_checksumming_disable() {
 		local offset=$(echo "$rootfs_len $rootfs_data_len 0x40" | awk -F' ' '{printf "%i",$1-$2-$3}')
 		local signature=$(dd if=$rootfs_mtd skip=$offset bs=1 count=4 2>/dev/null | hexdump -v -n 4 -e '1/1 "%02x"')
 		if [ "$signature" = "27051956" ]; then
-			dd conv=notrunc if=$rootfs_mtd skip=$offset of=$firmware_mtd bs=1 count=64 2>/dev/null
+			dd conv=notrunc if=$firmware_mtd of=/tmp/header_orig.bin bs=1 count=64 2>/dev/null
+			dd conv=notrunc if=$rootfs_mtd skip=$offset of=/tmp/header_bkp.bin bs=1 count=64 2>/dev/null
+			if ! cmp -s /tmp/header_orig.bin /tmp/header_bkp.bin; then
+				echo "Board is ASUS $board_uc, replacing header..."
+				dd conv=notrunc if=$rootfs_mtd skip=$offset of=$firmware_mtd bs=1 count=64 2>/dev/null
+			fi
+			rm /tmp/header_orig.bin
+			rm /tmp/header_bkp.bin
 		fi
 	;;
 	esac

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -424,6 +424,9 @@ ramips_board_detect() {
 	*"RN502J")
 		name="xdxrn502j"
 		;;
+	*"RP-AC56")
+		name="rp-ac56"
+		;;
 	*"RP-N53")
 		name="rp-n53"
 		;;

--- a/target/linux/ramips/dts/RP-AC56.dts
+++ b/target/linux/ramips/dts/RP-AC56.dts
@@ -1,0 +1,231 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rp-ac56", "mediatek,mt7621-soc";
+	model = "Asus RP-AC56";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_blue;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g_red {
+			label = "rp-ac56:red:wlan2g";
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g_blue {
+			label = "rp-ac56:blue:wlan2g";
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g_green {
+			label = "rp-ac56:green:wlan2g";
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_red {
+			label = "rp-ac56:red:wlan5g";
+			gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_blue {
+			label = "rp-ac56:blue:wlan5g";
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_green {
+			label = "rp-ac56:green:wlan5g";
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_white: power_white {
+			label = "rp-ac56:white:power";
+			gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_orange: power_orange {
+			label = "rp-ac56:orange:power";
+			gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_blue: power_blue {
+			label = "rp-ac56:blue:power";
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "Audio-I2S";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,bitclock-master = <&dailink0_master>;
+		simple-audio-card,frame-master = <&dailink0_master>;
+		simple-audio-card,routing =
+			"Headphone Jack", "HP_L",
+			"Headphone Jack", "HP_R";
+		simple-audio-card,mclk-fs = <256>;
+
+		simple-audio-card,cpu {
+			sound-dai = <&i2s>;
+		};
+
+		dailink0_master: simple-audio-card,codec {
+			sound-dai = <&codec>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "asus,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart2", "rgmii2";
+			ralink,function = "gpio";
+		};
+	};
+	i2s_pins: i2s {
+		i2s {
+			ralink,group = "uart3";
+			ralink,function = "i2s";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&xhci {
+	status = "disabled";
+};
+
+&i2c {
+	status = "okay";
+
+	codec: wm8960@1a {
+		#sound-dai-cells = <0>;
+		compatible = "wlf,wm8960";
+		reg = <0x1a>;
+		wlf,shared-lrclk;
+	};
+};
+
+&gdma {
+	status = "okay";
+};
+
+&i2s {
+	#sound-dai-cells = <0>;
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s_pins>;
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -84,6 +84,10 @@ define Build/ubnt-erx-factory-image
 	fi
 endef
 
+define Build/mkrtn56uimg
+        $(STAGING_DIR_HOST)/bin/mkrtn56uimg $(1) $(2) $@
+endef
+
 define Device/11acnas
   DTS := 11ACNAS
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
@@ -405,6 +409,17 @@ define Device/re6500
   DEVICE_PACKAGES := kmod-mt76x2 wpad-basic
 endef
 TARGET_DEVICES += re6500
+
+define Device/rp-ac56
+  DTS := RP-AC56
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Asus RP-AC56
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad kmod-sound-mt7620
+  IMAGES += factory.trx
+  IMAGE/factory.trx := append-kernel | append-rootfs | pad-rootfs | append-metadata | mkrtn56uimg -p RP-AC56 -f | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += rp-ac56
 
 define Device/sap-g3200u3
   DTS := SAP-G3200U3

--- a/tools/firmware-utils/src/mkrtn56uimg.c
+++ b/tools/firmware-utils/src/mkrtn56uimg.c
@@ -109,12 +109,13 @@ usage(const char *progname, int status)
 			"Options:\n"
 			"  -f <file>		generate a factory flash image <file>\n"
 			"  -s <file>		generate a sysupgrade flash image <file>\n"
+			"  -p <product id>	set product id\n"
 			"  -h			show this screen\n");
 	exit(status);
 }
 
 int
-process_image(char *progname, char *filename, op_mode_t opmode)
+process_image(const char *progname, const char *filename, const op_mode_t opmode, const char *productid)
 {
 	int 		fd, len;
 	void 		*data, *ptr;
@@ -170,7 +171,7 @@ process_image(char *progname, char *filename, op_mode_t opmode)
 		hdr->tail.asus.kernel.minor = 0;
 		hdr->tail.asus.fs.major = 0;
 		hdr->tail.asus.fs.minor = 0;
-		strncpy((char *)&hdr->tail.asus.productid, "RT-N56U", IH_PRODLEN);
+		strncpy((char *)&hdr->tail.asus.productid, productid, IH_PRODLEN);
 	}
 
 	if (hdr->tail.asus.ih_ksz == 0)
@@ -252,12 +253,12 @@ int
 main(int argc, char **argv)
 {
 	int 		opt;
-	char 		*filename, *progname;
+	char 		*filename, *progname, *productid = "RT-N56U";
 	op_mode_t	opmode = NONE;
 
 	progname = argv[0];
 
-	while ((opt = getopt(argc, argv,":s:f:h?")) != -1) {
+	while ((opt = getopt(argc, argv,":s:f:p:h?")) != -1) {
 		switch (opt) {
 		case 's':
 			opmode = SYSUPGRADE;
@@ -266,6 +267,9 @@ main(int argc, char **argv)
 		case 'f':
 			opmode = FACTORY;
 			filename = optarg;
+			break;
+		case 'p':
+			productid = optarg;
 			break;
 		case 'h':
 			opmode = NONE;
@@ -284,7 +288,7 @@ main(int argc, char **argv)
 		break;
 	case FACTORY:
 	case SYSUPGRADE:
-		return process_image(progname, filename, opmode);
+		return process_image(progname, filename, opmode, productid);
 		break;
 	}
 


### PR DESCRIPTION
    This change adds support for Asus RP-AC56 which
    is a dual band dual core 802.11ac access point

    CPU:   MT7621A dual-core 880MHz
    RAM:   64MB DDR2
    FLASH: 16MB NOR SPI
    WIFI:  2.4GHz 2x2 MT7603 b/g/n PCI
    WIFI:  5GHz 2x2 MT7662 a/b/ac PCI
    ETH:   1xLAN 1000base-T integrated
    LED:   Power, 2.4GHz WIFI, 5GHz WIFI
    BTN:   WPS, Reset
    UART:  Near ETH port, from ETH: 3V3-TxD-GND-RxD 57600 8n1
    MISC:  Audio support

    During the build, a factory update image is generated. This
    image can be used to upgrade from stock firmware.
    Another option to re-flash the device would be to hold "reset"
    button while powering it up and wait for power LED to turn
    orange. After that, an image: stock firmware or OpenWRT
    sysupdate can be pushed to 192.168.1.1 using TFTP protocol
    in binary mode
