### PR TITLE
ipq806x: add support for Qxwlan E5200

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ netgear,d7800 |\
 netgear,r7500 |\
 netgear,r7500v2 |\
 qcom,ipq8064-ap148 |\
+qxwlan,e5200 |\
 tplink,vr2600v)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -22,6 +22,7 @@ platform_do_upgrade() {
 	netgear,r7800 |\
 	qcom,ipq8064-ap148 |\
 	qcom,ipq8064-ap161 |\
+	qxwlan,e5200 |\
 	zyxel,nbg6817)
 		nand_do_upgrade "$ARGV"
 		;;

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-e5200.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-e5200.dts
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+ *
+ * Copyright (c) 2019 Peng Zhang <sd20@qxwlan.com>
+ *
+*/
+
+#include "qcom-ipq8064-v1.0.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Qxwlan E5200";
+	compatible = "qxwlan,e5200", "qcom,ipq8064";
+
+	memory@42000000 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+
+		led-boot = &status_pass;
+		led-failsafe = &status_fail;
+		led-running = &status_pass;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			led_pins: led_pins {
+				mux {
+					pins = "gpio7", "gpio8", "gpio9",
+						"gpio26", "gpio53";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			i2c4_pins: i2c4_pinmux {
+				pins = "gpio12", "gpio13";
+				function = "gsbi4";
+				bias-disable;
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					drive-strength = <10>;
+					bias-none;
+				};
+			};
+			nand_pins: nand_pins {
+				disable {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+				pullups {
+					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30",
+						"gpio31", "gpio32","gpio51", "gpio52",
+						"gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+			serial@16340000 {
+				status = "ok";
+			};
+		};
+
+		sata-phy@1b400000 {
+			status = "ok";
+		};
+
+		sata@29000000 {
+			status = "ok";
+		};
+
+		phy@100f8800 {
+			status = "ok";
+		};
+
+		phy@100f8830 {
+			status = "ok";
+		};
+
+		phy@110f8800 {
+			status = "ok";
+		};
+
+		phy@110f8830 {
+			status = "ok";
+		};
+
+		usb30@0 {
+			status = "ok";
+		};
+
+		usb30@1 {
+			status = "ok";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "ok";
+		};
+
+		pcie1: pci@1b700000 {
+			status = "ok";
+			force_gen1 = <1>;
+		};
+
+		nand@1ac00000 {
+			status = "ok";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				partitions {
+					compatible = "qcom,smem";
+				};
+			};
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH>,
+				<&qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+			phy0: ethernet-phy@0 {
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					>;
+			};
+
+			phy4: ethernet-phy@4 {
+				reg = <4>;
+				qca,ar8327-initvals = <
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x0000c 0x80        /* PAD6_MODE */
+					>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "ok";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "ok";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		usb1 {
+			label = "e5200:green:usb1";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port0>;
+		};
+
+		usb3 {
+			label = "e5200:green:usb3";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port1>;
+		};
+
+		status_fail: status_fail {
+			label = "e5200:red:status_fail";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		esata {
+			label = "e5200:green:esata";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "disk-activity";
+		};
+
+		status_pass: status_pass {
+			label = "e5200:yellow:status_pass";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&dwc3_0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&dwc3_1 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        hub_port1: port@1 {
+                reg = <1>;
+                #trigger-source-cells = <0>;
+        };
+};
+
+&adm_dma {
+	status = "ok";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -244,6 +244,18 @@ define Device/qcom_ipq8064-db149
 endef
 TARGET_DEVICES += qcom_ipq8064-db149
 
+define Device/qxwlan_e5200
+	$(call Device/LegacyImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Qxwlan
+	DEVICE_MODEL := E5200
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := qcom-ipq8064
+	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+endef
+TARGET_DEVICES += qxwlan_e5200
+
 define Device/tplink_c2600
 	$(call Device/TpSafeImage)
 	DEVICE_DTS := qcom-ipq8064-c2600

--- a/target/linux/ipq806x/patches-4.14/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-4.14/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -699,6 +699,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -699,6 +699,19 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8084-mtp.dtb \
  	qcom-ipq4019-ap.dk01.1-c1.dtb \
  	qcom-ipq8064-ap148.dtb \
@@ -19,6 +19,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-db149.dtb \
 +	qcom-ipq8064-ap161.dtb \
 +	qcom-ipq8064-ea8500.dtb \
++	qcom-ipq8064-e5200.dtb \
 +	qcom-ipq8064-r7500.dtb \
 +	qcom-ipq8064-r7500v2.dtb \
 +	qcom-ipq8064-wg2600hp.dtb \


### PR DESCRIPTION
Qxwlan E5200 based on IPQ8064

Specifications:
SOC:	Qualcomm IPQ8064
DRAM:	256 MiB
FLASH:	256 MiB Micron MT29F2G08ABBEAH4
SWITCH:	Qualcomm QCA8337
ETH:	5x 10/100/1000 Mbps Ethernet(RJ45)
INPUT:  1x Reset button(hw), 1x Reset button(sw), 1x wps button
LED:	1x Power ,2x usb ,1x esata, 1x wan ,4x lan, 2x wifi ,1x status(red/yellow)
SERIAL: UART (J13)
USB:	2x USB3.0
POWER:	1x DC jack for main power input (9-24 V)
SLOT:	2x Pcie (J1,J7)
ESATA:	1x esata

Flash instruction (using U-Boot CLI and tftp server):

 - Configure PC with static IP 192.168.1.10 and tftp server.
 - Rename "sysupgrade" filename to "firmware.bin" and place it in tftp
   server directory.
 - Connect PC with one of RJ45 ports, power up the board and press
   "enter" key to access U-Boot CLI.
 - Use the following command to update the device to OpenWrt: "run lfw".

Flash instruction (using U-Boot web-based recovery):

 - Configure PC with static IP 192.168.1.xxx(2-254)/24.
 - Connect PC with one of RJ45 ports, press the reset button, power up
   the board and keep button pressed for around 6-7 seconds, until LEDs
   start flashing.
 - Open your browser and enter 192.168.1.1, select "sysupgrade" image
   and click the upgrade button.

Signed-off-by: 张鹏 <sd20@qxwlan.com>