### PR TITLE
malta: Build/gzip rootfs by default

### DIFF
--- a/target/linux/malta/Makefile
+++ b/target/linux/malta/Makefile
@@ -12,7 +12,7 @@ CPU_TYPE:=24kc
 SUBTARGETS:=le be le64 be64
 INITRAMFS_EXTRA_FILES:=
 MAINTAINER:=Florian Fainelli <florian@openwrt.org>
-FEATURES:=ramdisk
+FEATURES:=cpiogz ext4 ramdisk squashfs targz
 
 KERNEL_PATCHVER:=4.14
 

--- a/target/linux/malta/image/Makefile
+++ b/target/linux/malta/image/Makefile
@@ -43,9 +43,23 @@ define Image/Build/Initramfs
 	cp $(KDIR)/vmlinux-initramfs $(BIN_DIR)/$(IMG_PREFIX)-vmlinux-initramfs.bin
 endef
 
+define Image/Build/gzip
+	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-root.$(1)
+endef
+
+ifneq ($(CONFIG_TARGET_IMAGES_GZIP),)
+  define Image/Build/gzip/ext4
+	$(call Image/Build/gzip,ext4)
+  endef
+  define Image/Build/gzip/squashfs
+	$(call Image/Build/gzip,squashfs)
+  endef
+endif
+
 define Image/Build
 	$(call Image/Build/$(1))
 	dd if=$(KDIR)/root.$(1) of=$(BIN_DIR)/$(IMG_PREFIX)-root.$(1) bs=128k conv=sync
+	$(call Image/Build/gzip/$(1))
 endef
 
 $(eval $(call BuildImage))


### PR DESCRIPTION
Being able to download the ext4 rootfs makes testing (with qemu) much easier.

This also adds gzipping for the rootfs.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>