### PR TITLE
armvirt: Compress rootfs if CONFIG_TARGET_IMAGES_GZIP set

### DIFF
--- a/target/linux/armvirt/image/Makefile
+++ b/target/linux/armvirt/image/Makefile
@@ -19,10 +19,23 @@ define Image/Build/Initramfs
 	)
 endef
 
+define Image/Build/gzip
+	gzip -f9n $(BIN_DIR)/$(IMG_PREFIX)-root.$(1)
+endef
+
+ifneq ($(CONFIG_TARGET_IMAGES_GZIP),)
+  define Image/Build/gzip/ext4
+	$(call Image/Build/gzip,ext4)
+  endef
+  define Image/Build/gzip/squashfs
+	$(call Image/Build/gzip,squashfs)
+  endef
+endif
+
 define Image/Build
 	$(call Image/Build/$(1))
-	dd if=$(KDIR)/root.$(1) bs=128k conv=sync | \
-		gzip -9n >$(BIN_DIR)/$(IMG_PREFIX)-root.$(1).gz
+	dd if=$(KDIR)/root.$(1) of=$(BIN_DIR)/$(IMG_PREFIX)-root.$(1) bs=128k conv=sync
+	$(call Image/Build/gzip/$(1))
 endef
 
 $(eval $(call BuildImage))


### PR DESCRIPTION
This changes the image build process to gzip the ext4/squashfs rootfs only if `CONFIG_TARGET_IMAGES_GZIP` is set.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>