### PR TITLE
sh invoked oom-killer patch for sub 64MB devices

### DIFF
--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -7,15 +7,19 @@ apply_defaults() {
 	local mem="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
 	local min_free frag_low_thresh frag_high_thresh
 
-	if [ "$mem" -gt 65536 ]; then # 128M
-		min_free=16384
-	elif [ "$mem" -gt 32768 ]; then # 64M
-		min_free=8192
-	else
-		min_free=1024
-		frag_low_thresh=393216
-		frag_high_thresh=524288
-	fi
+        if [ "$mem" -gt 65536 ]; then # 128M
+                min_free=16384
+        elif [ "$mem" -gt 32768 ]; then # 64M
+                min_free=8192
+        elif [ "$mem" -gt 28672 ]; then # 32M
+                min_free=4096
+        elif [ "$mem" -gt 12288 ]; then # 16M
+                min_free=2048
+        else # 8M
+                min_free=1024
+                frag_low_thresh=393216 # Depreciated after Linux 4.17
+                frag_high_thresh=524288
+        fi
 
 	sysctl -qw vm.min_free_kbytes="$min_free"
 


### PR DESCRIPTION
This fixed 'Out of memory: Kill process' and 'xyz invoked oom-killer' crashes on a device running OpenWrt with 32MB of RAM installed.
I'm unsure if a memory leak in 18.06.02 caused so much memory to be consumed as I now have a snapshot from a week ago with this patch and the memory crashing has completely stopped.

I understand that low memory devices are hardly a priority now in OpenWrt. However, I would say with confidence that less than 2MB of memory free will almost certainly result in a crash in the event memory becomes a premium.

The numbers which proc the reclaim take into account the extra memory the kernel uses and does not provide to the system.
I'm sorry - there is no hope for sub 8MB. Those devices will crash if their memory fills up IMO.

Maintainer please note for future reference: frag_low_thresh is depreciated after Linux 4.17 according to the patch notes on kernel.org
