### PR TITLE
ramips: Add support for ZBT WE826-E

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -452,6 +452,9 @@ zbt-we826-16M|\
 zbt-we826-32M)
 	set_wifi_led "zbt-we826:green:wifi"
 	;;
+zbt-we826-e)
+	set_wifi_led "zbt-we826-e:red:wifi"
+	;;
 zbtlink,zbt-we1226)
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_switch "lan1" "LAN1" "$boardname:green:lan1" "switch0" "0x01"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -135,6 +135,7 @@ ramips_setup_interfaces()
 	zbtlink,zbt-we3526|\
 	zbt-we826-16M|\
 	zbt-we826-32M|\
+	zbt-we826-e|\
 	zbt-wg2626|\
 	zbt-wg3526-16M|\
 	zbt-wg3526-32M|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -676,6 +676,9 @@ ramips_board_detect() {
 	*"ZBT-WE826 (32M)")
 		name="zbt-we826-32M"
 		;;
+	*"ZBT-WE826-E")
+		name="zbt-we826-e"
+		;;
 	*"ZBT-WG2626")
 		name="zbt-wg2626"
 		;;

--- a/target/linux/ramips/dts/ZBT-WE826-E.dts
+++ b/target/linux/ramips/dts/ZBT-WE826-E.dts
@@ -1,0 +1,104 @@
+/dts-v1/;
+
+#include "ZBT-WE826.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we826-e", "zbtlink,zbt-we826", "ralink,mt7620a-soc";
+	model = "ZBT-WE826-E";
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		sim_switch {
+			gpio-export,name = "sim_switch";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		power_mpcie {
+			gpio-export,name = "power_mpcie";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	/delete-node/ leds;
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: gsm {
+			label = "zbt-we826-e:blue:gsm";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		signal {
+			label = "zbt-we826-e:green:signal";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		sim {
+			label = "zbt-we826-e:red:sim";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		air {
+			label = "zbt-we826-e:red:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	w25q256@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "uartf", "pa", "wled";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&gpio1 {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -809,6 +809,14 @@ define Device/zbt-we826-32M
 endef
 TARGET_DEVICES += zbt-we826-32M
 
+define Device/zbt-we826-e
+  DTS := ZBT-WE826-E
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := Zbtlink ZBT-WE826-E
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
+endef
+TARGET_DEVICES += zbt-we826-e
+
 define Device/zbt-wr8305rt
   DTS := ZBT-WR8305RT
   DEVICE_TITLE := Zbtlink ZBT-WR8305RT


### PR DESCRIPTION
ZBT WE826-E is a dual-SIM version of the ZBT WE826. The router has the
following specifications:

- MT7620A (580 MHz)
- 128MB RAM
- 32MB of flash (SPI NOR)
- 5x 10/100Mbps Ethernet (MT7620A built-in switch)
- 1x microSD slot
- 1x miniPCIe slot (only USB2.0 bus)
- 2x SIM card slots (mini size)
- 1x USB2.0 port
- 1x 2.4GHz wifi (rt2800)
- 10x LEDs (4 GPIO-controlled)
- 1x reset button

The following have been tested and working:
- Ethernet switch
- wifi
- miniPCIe slot
- USB port
- microSD slot
- sysupgrade
- reset button

Installation:

The router ships with an older version of OpenWRT, but with a broken web
user interface. In order to install the image, you need to SSH into the
router and run sysupgrade. The default address of the router is
192.168.1.1, user is root and password admin. Once you are in, run the
following command:

sysupgrade -n -F openwrt-ramips-mt7620-zbt-we826-e-squashfs-sysupgrade.bin

Recovery:

The router ships with a web-based recovery system. If you need to
recover the router, keep the reset button pressed during boot and access
192.168.1.1 in your browser when your machine obtains an IP address.
Upload the firmware to start the recovery process.

How to swap SIMs:

In order to switch which SIM is used, you need to do the following:

- Turn off the modem by running the following command:
echo 0 > /sys/class/gpio/power_mpcie/value

- Write either 0 or 1 to /sys/class/gpio/sim_switch/value. After
boot/reboot, the router will always use SIM 0. You can check which SIM
slot is currently used by reading from the file mentioned in the first
sentence.

- Turn on the modem again by running the following command:
echo 1 > /sys/class/gpio/power_mpcie/value

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>