### PR TITLE
 ath79: add support for EnGenius ECB1750

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -17,6 +17,7 @@ buffalo,wzr-hp-ag300h)
         ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
         ;;
 buffalo,bhr-4grv2|\
+engenius,ecb1750|\
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor|\
 librerouter,librerouter-v1|\

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -58,6 +58,9 @@ comfast,cf-e5)
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;
+engenius,ecb1750)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0"
+	;;
 engenius,ews511ap)
 	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth0"
 	ucidef_set_led_netdev "lan2" "LAN2" "$boardname:blue:lan2" "eth1"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ath79_setup_interfaces()
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\
 	devolo,dvl1750i|\
+	engenius,ecb1750|\
 	glinet,ar300m-lite|\
 	netgear,ex6400|\
 	netgear,ex7300|\
@@ -290,6 +291,9 @@ ath79_setup_macs()
 	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary ART 4098)" -2)
+		;;
+	engenius,ecb1750)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -109,6 +109,10 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 2
 		;;
+	engenius,ecb1750)
+		ath9k_eeprom_extract "art" 4096 1088
+		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 2
+		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -102,6 +102,10 @@ case "$FIRMWARE" in
 	elecom,wrc-1750ghbk2-i)
 		ath10kcal_extract "ART" 20480 2116
 		;;
+	engenius,ecb1750)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
+		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)

--- a/target/linux/ath79/dts/qca9558_engenius_ecb1750.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_ecb1750.dts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "engenius,ecb1750", "qca,qca9557";
+	model = "EnGenius ECB1750";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power_orange;
+		led-failsafe = &power_orange;
+		led-running = &power_orange;
+		led-upgrade = &power_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange: power_orange {
+			label = "ecb1750:orange:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "ecb1750:blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "ecb1750:blue:wlan5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "ecb1750:blue:lan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x050000 0xf50000>;
+			};
+
+			partition@fa0000 {
+				label = "userconfig";
+				reg = <0xfa0000 0x050000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		at803x-disable-smarteee;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x9a000000 0x80000101 0x80001313>;
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -302,6 +302,18 @@ define Device/embeddedwireless_dorin
 endef
 TARGET_DEVICES += embeddedwireless_dorin
 
+define Device/engenius_ecb1750
+  ATH_SOC := qca9558
+  DEVICE_TITLE := EnGenius ECB1750
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15680k
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    senao-header -r 0x101 -p 0x6d -t 2
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += engenius_ecb1750
+
 define Device/engenius_epg5000
   ATH_SOC := qca9558
   DEVICE_TITLE := EnGenius EPG5000


### PR DESCRIPTION
Specification:

- Qualcomm Atheros SoC QCA9558
- 720/600/200 MHz (CPU/DDR/AHB)
- 128 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- 1x 10/100/1000 Mbps Ethernet
- 3T3R 2.4 GHz (QCA9558 WMAC)
- 3T3R 5.8 Ghz (QCA9880-BR4A, Senao PCE4553AH)

https://fccid.io/A8J-ECB1750

Tested and working:

- lan, wireless, leds, sysupgrade (tftp)

Flash instructions:

1.) tftp recovery

- use a 1GbE switch or direct attached 1GbE link
- setup client ip address 192.168.1.10 and start tftpd
- save "openwrt-ath79-generic-engenius_ecb1750-initramfs-kernel.bin" as "ap.bin" in tfpd root directory
- plugin powercord and hold reset button 10secs.. "ap.bin" will be downloaded and executed
- afterwards login via ssh and do a sysuprade

2.) oem webinterface factory install (not tested)

Use normal webinterface upgrade page und select "openwrt-ath79-generic-engenius_ecb1750-squashfs-factory.bin".

3.) oem webinterface command injection

OEM Firmware already running OpenWrt (Attitude Adjustment 12.09).
Use OEM webinterface and command injection. See wiki for details.

https://openwrt.org/toh/engenius/engenius_ecb1750_1

Signed-off-by: sven friedmann <sf.openwrt@okay.ms>