### PR TITLE
bcm47xx: add support for Netgear R6200 V1

### DIFF
--- a/target/linux/bcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/bcm47xx/base-files/etc/board.d/01_network
@@ -177,6 +177,11 @@ configure_by_model() {
 			"0:wan" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "8@eth0"
 		;;
 
+	"Netgear R6200 V1")
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "8@eth0"
+		;;
+
 	"Netgear WN2500RP V1")
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5@eth0"

--- a/target/linux/bcm47xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm47xx/base-files/lib/upgrade/platform.sh
@@ -18,6 +18,7 @@ platform_expected_image() {
 	local model="$(cat /tmp/sysinfo/model)"
 
 	case "$model" in
+		"Netgear R6200 V1")	echo "chk U12H192T00_NETGEAR"; return;;
 		"Netgear WGR614 V8")	echo "chk U12H072T00_NETGEAR"; return;;
 		"Netgear WGR614 V9")	echo "chk U12H094T00_NETGEAR"; return;;
 		"Netgear WGR614 V10")	echo "chk U12H139T01_NETGEAR"; return;;

--- a/target/linux/bcm47xx/image/mips74k.mk
+++ b/target/linux/bcm47xx/image/mips74k.mk
@@ -305,6 +305,16 @@ define Device/linksys-e4200-v1
 endef
 TARGET_DEVICES += linksys-e4200-v1
 
+define Device/netgear-r6200-v1
+  DEVICE_MODEL := R6200
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
+  $(Device/netgear)
+  NETGEAR_BOARD_ID := U12H192T00_NETGEAR
+  NETGEAR_REGION := 1
+endef
+TARGET_DEVICES += netgear-r6200-v1
+
 define Device/netgear-wgr614-v10-na
   DEVICE_MODEL := WGR614
   DEVICE_VARIANT := v10 (NA)

--- a/target/linux/bcm47xx/patches-4.19/032-v5.4-MIPS-BCM47XX-Add-support-for-Netgear-R6200v1.patch
+++ b/target/linux/bcm47xx/patches-4.19/032-v5.4-MIPS-BCM47XX-Add-support-for-Netgear-R6200v1.patch
@@ -1,0 +1,46 @@
+--- a/arch/mips/bcm47xx/board.c
++++ b/arch/mips/bcm47xx/board.c
+@@ -160,6 +160,7 @@ struct bcm47xx_board_type_list1 bcm47xx_board_list_board_id[] __initconst = {
+ 	{{BCM47XX_BOARD_LUXUL_XVW_P30_V1, "Luxul XVW-P30 V1"}, "luxul_xvwp30_v1"},
+ 	{{BCM47XX_BOARD_LUXUL_XWR_600_V1, "Luxul XWR-600 V1"}, "luxul_xwr600_v1"},
+ 	{{BCM47XX_BOARD_LUXUL_XWR_1750_V1, "Luxul XWR-1750 V1"}, "luxul_xwr1750_v1"},
++	{{BCM47XX_BOARD_NETGEAR_R6200_V1, "Netgear R6200 V1"}, "U12H192T00_NETGEAR"},
+ 	{{BCM47XX_BOARD_NETGEAR_WGR614V8, "Netgear WGR614 V8"}, "U12H072T00_NETGEAR"},
+ 	{{BCM47XX_BOARD_NETGEAR_WGR614V9, "Netgear WGR614 V9"}, "U12H094T00_NETGEAR"},
+ 	{{BCM47XX_BOARD_NETGEAR_WGR614_V10, "Netgear WGR614 V10"}, "U12H139T01_NETGEAR"},
+--- a/arch/mips/bcm47xx/buttons.c
++++ b/arch/mips/bcm47xx/buttons.c
+@@ -384,6 +384,13 @@ bcm47xx_buttons_motorola_wr850gv2v3[] __initconst = {
+
+ /* Netgear */
+
++static const struct gpio_keys_button
++bcm47xx_buttons_netgear_r6200_v1[] __initconst = {
++	BCM47XX_GPIO_KEY(2, KEY_RFKILL),
++	BCM47XX_GPIO_KEY(3, KEY_RESTART),
++	BCM47XX_GPIO_KEY(4, KEY_WPS_BUTTON),
++};
++
+ static const struct gpio_keys_button
+ bcm47xx_buttons_netgear_wndr3400v1[] __initconst = {
+ 	BCM47XX_GPIO_KEY(4, KEY_RESTART),
+@@ -664,6 +671,9 @@ int __init bcm47xx_buttons_register(void)
+ 		err = bcm47xx_copy_bdata(bcm47xx_buttons_motorola_wr850gv2v3);
+ 		break;
+
++	case BCM47XX_BOARD_NETGEAR_R6200_V1:
++		err = bcm47xx_copy_bdata(bcm47xx_buttons_netgear_r6200_v1);
++		break;
+ 	case BCM47XX_BOARD_NETGEAR_WNDR3400V1:
+ 		err = bcm47xx_copy_bdata(bcm47xx_buttons_netgear_wndr3400v1);
+ 		break;
+--- a/arch/mips/include/asm/mach-bcm47xx/bcm47xx_board.h
++++ b/arch/mips/include/asm/mach-bcm47xx/bcm47xx_board.h
+@@ -98,6 +98,7 @@ enum bcm47xx_board {
+ 	BCM47XX_BOARD_MOTOROLA_WR850GP,
+ 	BCM47XX_BOARD_MOTOROLA_WR850GV2V3,
+
++	BCM47XX_BOARD_NETGEAR_R6200_V1,
+ 	BCM47XX_BOARD_NETGEAR_WGR614V8,
+ 	BCM47XX_BOARD_NETGEAR_WGR614V9,
+ 	BCM47XX_BOARD_NETGEAR_WGR614_V10,

--- a/target/linux/bcm47xx/patches-4.19/320-MIPS-BCM47XX-Devices-database-update-for-4.x.patch
+++ b/target/linux/bcm47xx/patches-4.19/320-MIPS-BCM47XX-Devices-database-update-for-4.x.patch
@@ -8,10 +8,10 @@
  	{{BCM47XX_BOARD_LINKSYS_WRT54G3GV2, "Linksys WRT54G3GV2-VF"}, "WRT54G3GV2-VF", "1.0"},
  	{{BCM47XX_BOARD_LINKSYS_WRT610NV1, "Linksys WRT610N V1"}, "WRT610N", "1.0"},
  	{{BCM47XX_BOARD_LINKSYS_WRT610NV2, "Linksys WRT610N V2"}, "WRT610N", "2.0"},
-@@ -160,9 +161,12 @@ struct bcm47xx_board_type_list1 bcm47xx_
- 	{{BCM47XX_BOARD_LUXUL_XVW_P30_V1, "Luxul XVW-P30 V1"}, "luxul_xvwp30_v1"},
+@@ -161,9 +162,12 @@ struct bcm47xx_board_type_list1 bcm47xx_
  	{{BCM47XX_BOARD_LUXUL_XWR_600_V1, "Luxul XWR-600 V1"}, "luxul_xwr600_v1"},
  	{{BCM47XX_BOARD_LUXUL_XWR_1750_V1, "Luxul XWR-1750 V1"}, "luxul_xwr1750_v1"},
+ 	{{BCM47XX_BOARD_NETGEAR_R6200_V1, "Netgear R6200 V1"}, "U12H192T00_NETGEAR"},
 +	{{BCM47XX_BOARD_NETGEAR_R6300_V1, "Netgear R6300 V1"}, "U12H218T00_NETGEAR"},
  	{{BCM47XX_BOARD_NETGEAR_WGR614V8, "Netgear WGR614 V8"}, "U12H072T00_NETGEAR"},
  	{{BCM47XX_BOARD_NETGEAR_WGR614V9, "Netgear WGR614 V9"}, "U12H094T00_NETGEAR"},
@@ -55,8 +55,8 @@
  bcm47xx_buttons_linksys_wrt54g3gv2[] __initconst = {
  	BCM47XX_GPIO_KEY(5, KEY_WIMAX),
  	BCM47XX_GPIO_KEY(6, KEY_RESTART),
-@@ -385,6 +403,17 @@ bcm47xx_buttons_motorola_wr850gv2v3[] __
- /* Netgear */
+@@ -392,6 +410,17 @@ bcm47xx_buttons_netgear_r6200_v1[] __ini
+ };
  
  static const struct gpio_keys_button
 +bcm47xx_buttons_netgear_r6300_v1[] __initconst = {
@@ -73,7 +73,7 @@
  bcm47xx_buttons_netgear_wndr3400v1[] __initconst = {
  	BCM47XX_GPIO_KEY(4, KEY_RESTART),
  	BCM47XX_GPIO_KEY(6, KEY_WPS_BUTTON),
-@@ -471,6 +500,9 @@ int __init bcm47xx_buttons_register(void
+@@ -478,6 +507,9 @@ int __init bcm47xx_buttons_register(void
  	int err;
  
  	switch (board) {
@@ -83,7 +83,7 @@
  	case BCM47XX_BOARD_ASUS_RTN12:
  		err = bcm47xx_copy_bdata(bcm47xx_buttons_asus_rtn12);
  		break;
-@@ -601,6 +633,12 @@ int __init bcm47xx_buttons_register(void
+@@ -608,6 +640,12 @@ int __init bcm47xx_buttons_register(void
  	case BCM47XX_BOARD_LINKSYS_WRT310NV1:
  		err = bcm47xx_copy_bdata(bcm47xx_buttons_linksys_wrt310nv1);
  		break;
@@ -96,10 +96,10 @@
  	case BCM47XX_BOARD_LINKSYS_WRT54G3GV2:
  		err = bcm47xx_copy_bdata(bcm47xx_buttons_linksys_wrt54g3gv2);
  		break;
-@@ -664,6 +702,12 @@ int __init bcm47xx_buttons_register(void
- 		err = bcm47xx_copy_bdata(bcm47xx_buttons_motorola_wr850gv2v3);
+@@ -674,6 +712,12 @@ int __init bcm47xx_buttons_register(void
+ 	case BCM47XX_BOARD_NETGEAR_R6200_V1:
+ 		err = bcm47xx_copy_bdata(bcm47xx_buttons_netgear_r6200_v1);
  		break;
- 
 +	case BCM47XX_BOARD_NETGEAR_R6300_V1:
 +		err = bcm47xx_copy_bdata(bcm47xx_buttons_netgear_r6300_v1);
 +		break;
@@ -119,10 +119,10 @@
  	BCM47XX_BOARD_LINKSYS_WRT54G3GV2,
  	BCM47XX_BOARD_LINKSYS_WRT54G_TYPE_0101,
  	BCM47XX_BOARD_LINKSYS_WRT54G_TYPE_0467,
-@@ -98,9 +99,12 @@ enum bcm47xx_board {
- 	BCM47XX_BOARD_MOTOROLA_WR850GP,
+@@ -99,9 +100,12 @@ enum bcm47xx_board {
  	BCM47XX_BOARD_MOTOROLA_WR850GV2V3,
  
+ 	BCM47XX_BOARD_NETGEAR_R6200_V1,
 +	BCM47XX_BOARD_NETGEAR_R6300_V1,
  	BCM47XX_BOARD_NETGEAR_WGR614V8,
  	BCM47XX_BOARD_NETGEAR_WGR614V9,


### PR DESCRIPTION
The Netgear R6200 V1 is a 2.4/5 GHz band 11ac router, based on the Broadcom BCM4718A1.

Specification:

CPU: BCM4718A1 480 MHz. MIPS 74K
RAM: 128 MB
Flash: 16 MB
Ethernet: 5 Ports all 10/100/1000 Mbps, 1 WAN + 4 LAN
WiFi: BCM4718A1(2.4GHz) + BCM4352(5GHz)
USB: 1 USB 2.0
LEDs: Power, Internet, Wireless, USB and a Logo LED
Switches: Reset, Wireless, WPS
Other: 1 UART, 1 I2C

Product Specification:
https://wikidevi.com/wiki/Netgear_R6200v1
The Offical Netgear page only covers the V2 Specifications

Installation:
1. Boot R6200V1 Normally
2. Access the Router's Admin page should be "http://192.168.1.1/"
3. Go to the "Advanced" tab on the top and inside "Administration" on the side bar is "Router Update"
4. Select the OpenWrt build with the name netgear-r6200-v1-squashfs.chk and upload to device
5. Wait for firmware to finish flashing  

Issues:
5Ghz Band is unsupported due to it needing a Propietary driver (BCM4360)
LEDs for the Logo LED, Power Status, Wireless Status, and USB status are Controlled by a 74x164 shift register that the original firmware controlled via bit banging.
As of now the power LED stays amber and the WAN indicator is controlled by the ethernet switch driver.

Notes:
My device has the model number U12H19T01 on the board but the factory firmware updater recognizes only U12H19T00, which matches the model in the original firmware, with the region set to 1 as the proper firmware for a Netgear R6200 V1 from North America.

Signed-off-by: Edward Matijevic motolav@gmail.com