### PR TITLE
arm/aarch64: Set -O2 as default for Cortex-A processor cores

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -162,7 +162,11 @@ LINUX_RECONF_DIFF = $(call __linux_confcmd,$(filter-out $(LINUX_RECONFIG_TARGET)
 ifeq ($(DUMP),1)
   BuildTarget=$(BuildTargets/DumpCurrent)
 
-  CPU_CFLAGS = -Os -pipe
+  ifneq ($(findstring cortex-a,$(CPU_TYPE)),)
+    CPU_CFLAGS = -O2 -pipe
+  else
+    CPU_CFLAGS = -Os -pipe
+  endif
   ifneq ($(findstring mips,$(ARCH)),)
     ifneq ($(findstring mips64,$(ARCH)),)
       CPU_TYPE ?= mips64


### PR DESCRIPTION
Platforms using Cortex-A processor cores aren't constrained in
terms of storage as much as other supported platforms such as MIPS.
Set O2 as default since Os can severly limit performance as it's
more targeted at keeping down binary size.

Tested on mvebu, sunxi, ipq40xx
mvebu, Linksys WRT3200ACM
sunxi, Orange Pi PC
ipq40xx, Linksys EA6350v3

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>