### PR TITLE
ath79: add support for Comfast WR650AC v1/v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -76,6 +76,12 @@ ath79_setup_interfaces()
 	yuncore,a770)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	comfast,cf-wr650ac-v1|\
+	comfast,cf-wr650ac-v2)
+		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"
+		;;
 	devolo,dvl1200e|\
 	devolo,dvl1750e)
 		ucidef_set_interface_lan "eth0 eth1"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,6 +87,11 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	comfast,cf-wr650ac-v1|\
+	comfast,cf-wr650ac-v2|\
+	yuncore,a770)
+		ath10kcal_extract "art" 20480 2116
+		;;
 	devolo,dvl1200e|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\
@@ -155,9 +160,6 @@ case "$FIRMWARE" in
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
 		ath10kcal_extract "EEPROM" 20480 2116
-		;;
-	yuncore,a770)
-		ath10kcal_extract "art" 20480 2116
 		;;
 	esac
 	;;

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v1.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v1.dts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9558_comfast_cf-wr650ac.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr650ac-v1", "qca,qca9558";
+	model = "Comfast CF-WR650AC v1";
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "cf-wr650ac-v1:blue:wps";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		network {
+			label = "cf-wr650ac-v1:blue:network";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "cf-wr650ac-v1:blue:wlan2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "cf-wr650ac-v1:blue:wlan5";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			art: partition@20000 {
+				label = "art";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x030000 0xfc0000>;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v2.dts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9558_comfast_cf-wr650ac.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr650ac-v2", "qca,qca9558";
+	model = "Comfast CF-WR650AC v2";
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "cf-wr650ac-v2:blue:wps";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		network {
+			label = "cf-wr650ac-v2:blue:network";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "cf-wr650ac-v2:blue:wlan2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "cf-wr650ac-v2:blue:wlan5";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			art: partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac.dtsi
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac.dtsi
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <500>;
+		always-running;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	switch0@1f {
+		compatible = "qca,ar8327";
+		reg = <0x1f>;
+		qca,ar8327-initvals = <
+			0x04 0x87600000 /* PORT0 PAD MODE CTRL */
+			0x0c 0x00080080 /* PORT6 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRIP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+	mtd-mac-address = <&art 0x0>;
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+	mtd-mac-address = <&art 0x6>;
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x18>;
+};
+
+// This node is required for the Ethernet ports to work correctly.
+&gpio {
+	status = "okay";
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -180,6 +180,24 @@ define Device/comfast_cf-e5
 endef
 TARGET_DEVICES += comfast_cf-e5
 
+define Device/comfast_cf-wr650ac-v1
+  ATH_SOC := qca9558
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-WR650AC
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += comfast_cf-wr650ac-v1
+
+define Device/comfast_cf-wr650ac-v2
+  ATH_SOC := qca9558
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-WR650AC
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += comfast_cf-wr650ac-v2
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_TITLE := devolo WiFi pro 1200e


### PR DESCRIPTION
This is a dual band 11a/11n router with 1x wan and 4x gig lan ports.

There are two versions of this router which can be identified through the factory web interface, v1 has 128mb ram and a uboot size of 128k, v2 has 256mb ram and a uboot size of 256k, the remaining hardware and PCB markings are the same.

Steps to install :

Option A : Use vendor UI

Option B if A is not working
(a) Download 'backup' from vendor UI and rename it backup.tar.gz
(b) Open the archive, and update the root password in /etc/shadow by '$1$9wX3HGfB$X5Sb3kqzzBLdKRUR2kfFd0' (equivalent to 'aaa')
(c) Reboot. Scp the firwmware to the device : scp openwrt-ath79-generic-comfast_cf-wr650ac-v2-squashfs-sysupgrade.bin root@192.168.1.1:/
(d) ssh to the device and flash the firmware : cd / ; mtd -e firmware -r write openwrt-ath79-generic-comfast_cf-wr650ac-v2-squashfs-sysupgrade.bin firmware

Signed-off-by: Gareth Parker gareth41@orcon.net.nz
Signed-off-by: Ding Tengfei dtf@comfast.cn
Signed-off-by: Joan Moreau jom@grosjo.net