### PR TITLE
ath79: add support for Ubiquiti airCube ISP.

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -223,6 +223,11 @@ ath79_setup_interfaces()
 	tplink,tl-wr941-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
+	ubnt,acb-isp)
+		ucidef_set_interface_wan "eth0"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "2:lan:1" "3:lan:3" "4:lan:2"
+		;;
 	ubnt,routerstation-pro)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -26,6 +26,9 @@ librerouter,librerouter-v1)
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;
+ubnt,acb-isp)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ath79/dts/qca9533_ubnt_acb-isp.dts
+++ b/target/linux/ath79/dts/qca9533_ubnt_acb-isp.dts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "ubnt,acb-isp", "qca,qca9533";
+	model = "Ubiquiti airCube ISP";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			eeprom: partition@ff0000 {
+				label = "EEPROM";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&eeprom 0x0>;
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&eeprom 0x6>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&eeprom 0x1000>;
+	mtd-mac-address = <&eeprom 0x1002>;
+};

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -229,3 +229,15 @@ define Device/ubnt_routerstation-pro
   UBNT_CHIP := ar7100pro
 endef
 TARGET_DEVICES += ubnt_routerstation-pro
+
+define Device/ubnt_acb-isp
+  $(Device/ubnt)
+  ATH_SOC := qca9533
+  IMAGE_SIZE := 15744k
+  DEVICE_TITLE := Ubiquiti airCube ISP
+  UBNT_BOARD := ACB-ISP
+  UBNT_TYPE := ACB
+  UBNT_CHIP := qca9533
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += ubnt_acb-isp


### PR DESCRIPTION
The Ubiquiti Network airCube ISP is a cube shaped 2.4 GHz with internal
2x2 MIMO antennas. It can be supplied via a USB connector or via PoE.
There are for 10/100 Mbps ports (1 * WAN + 3 * LAN). There is an
optional PoE passthrough from the first LAN port to the WAN port.

SoC:       Qualcomm / Atheros QCA9533-BL3A
RAM:       64 MB DDR2
Flash:     16 MB SPI NOR
Ethernet:  4x 10/100 Mbps (1 WAN + 3 LAN)
LEDS:      1x via a SPI controller (not yet supported)
Buttons:   1x Reset
Serial:    1x (only RX and TX); 115200 baud, 8N1

Missing points:
- LED not yet supported
- Factory upgrade via web IF or TFTP recovery not yet supported

The serial port is on a four pin connextor labeled J1 and located
between Ethernet and USB connector. The pinout is:
1. 3V3 (out)
2. Rx (in)
3. Tx (out)
4. GND

Upgrading via serial port / U-Boot:
- Connect the serial port via a level converter
- Power the system and stop U-Boot with pressing any key when `Hit any
  key to stop autoboot` is displayed. Note: Pressing space multiple
  times untill U-Boot reaches that location works well.
- Connect a PC with the IP 192.168.1.100 (or some other in that net)
  running a TFTP-Server to one of the LAN ports. Copy the sysupgrade
  image to the server.
- Set the U-Boot server IP with
    setenv serverip 192.168.1.100
- Load the flash image to RAM with
    tftpboot 0x81000000 sysupgrade.bin
- Erase the flash with
    erase 0x9f050000 0x9ffaffff
- Write the new flash content with
    cp 0x81000000 0x9f050000 ${filesize}
- Reset the device with
    reset

Signed-off-by: Christian Mauderer <oss@c-mauderer.de>