### PR TITLE
procd: suppress ubus error message

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -72,7 +72,7 @@ _procd_ubus_call() {
 	local cmd="$1"
 
 	[ -n "$PROCD_DEBUG" ] && json_dump >&2
-	ubus call service "$cmd" "$(json_dump)"
+	ubus -S call service "$cmd" "$(json_dump)"
 	json_cleanup
 }
 


### PR DESCRIPTION
If we're stopping a service which is not running, there will be a ubus error message printed to screen
``` Command failed: Not found```
So here is the patch to suppress this internal ubus message.