### PR TITLE
Mt76 enabling data pkt transmission

### DIFF
--- a/package/kernel/mt76/patches/002--MT76-Enabling-data-pkt-transmission-during-scanning.patch
+++ b/package/kernel/mt76/patches/002--MT76-Enabling-data-pkt-transmission-during-scanning.patch
@@ -1,0 +1,14 @@
+diff --git a/tx.c b/tx.c
+index 638b839..df6d58b 100644
+--- a/tx.c
++++ b/tx.c
+@@ -435,8 +435,7 @@ mt76_txq_send_burst(struct mt76_dev *dev, struct mt76_sw_queue *sq,
+ 		if (probe)
+ 			break;
+ 
+-		if (test_bit(MT76_OFFCHANNEL, &dev->state) ||
+-		    test_bit(MT76_RESET, &dev->state))
++		if (test_bit(MT76_RESET, &dev->state))
+ 			return -EBUSY;
+ 
+ 		skb = mt76_txq_dequeue(dev, mtxq, false);


### PR DESCRIPTION
Data Packet transmission was disabled during scanning in mt76 driver.

Fix to be, enabling data packet transmission during scanning.

Note:
Mac80211 will handle channel switching. During scanning, it handles
stopping the data transmission on off channel and enabling data
transmission on operating channel also. It does not require to stop data
transmission in mt76 driver during scanning. Verified with other driver
ath9k and rt2x00 driver, data transmission was not stopped during
scanning.

Signed-off-by: vijayakumar Durai <vijayakumar.durai1@vivint.com>