### PR TITLE
[RFC] ath79: Fix/update DTS for TP-Link Archer A7/C7 v5

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -604,6 +604,10 @@ ar71xx_setup_macs()
 		base_mac=$(mtd_get_mac_binary config 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
+	archer-c7-v5)
+		base_mac=$(mtd_get_mac_binary info 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	dgl-5500-a1|\
 	dir-825-c1)
 		wan_mac=$(mtd_get_mac_ascii nvram "wan_mac")

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -154,7 +154,7 @@ define Device/archer-c7-v5
   BOARDNAME := ARCHER-C7-V5
   TPLINK_BOARD_ID := ARCHER-C7-V5
   IMAGE_SIZE := 15360k
-  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,15360k@0xc0000(firmware)
+  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,128k@0x60000(info)ro,15360k@0xc0000(firmware)
   SUPPORTED_DEVICES := archer-c7-v5
 endef
 TARGET_DEVICES += archer-c7-v5

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -319,6 +319,11 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
+	tplink,archer-a7-v5|\
+	tplink,archer-c7-v5)
+		base_mac=$(mtd_get_mac_binary info 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	tplink,archer-c7-v4)
 		base_mac=$(mtd_get_mac_binary config 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)

--- a/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
@@ -8,6 +8,15 @@
 	model = "TP-Link Archer A7 v5";
 };
 
+&gpio_keys {
+	reset {
+		label = "Reset button";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
 &mtdparts {
 	factory-uboot@0 {
 		label = "factory-uboot";

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
@@ -8,6 +8,15 @@
 	model = "TP-Link Archer C7 v5";
 };
 
+&gpio_keys {
+	reset {
+		label = "Reset button";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
 &mtdparts {
 	partition@0 {
 		label = "factory-uboot";

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -24,17 +24,58 @@
 			default-state = "on";
 		};
 
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
 		led_wlan2g: wlan2g {
 			label = "tp-link:green:wlan2g";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port0>;
-			linux,default-trigger = "usbport";
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "tp-link:orange:wan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -91,49 +132,6 @@
 	hub_port0: port@1 {
 		reg = <1>;
 		#trigger-source-cells = <0>;
-	};
-};
-
-&gpio_leds {
-	wlan5g {
-		label = "tp-link:green:wlan5g";
-		gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
-		linux,default-trigger = "phy0tpt";
-	};
-
-	wan {
-		label = "tp-link:green:wan";
-		gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-	};
-
-	wan_fail {
-		label = "tp-link:orange:wan";
-		gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-	};
-
-	lan1 {
-		label = "tp-link:green:lan1";
-		gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-	};
-
-	lan2 {
-		label = "tp-link:green:lan2";
-		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-	};
-
-	lan3 {
-		label = "tp-link:green:lan3";
-		gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-	};
-
-	lan4 {
-		label = "tp-link:green:lan4";
-		gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-	};
-
-	wps {
-		label = "tp-link:green:wps";
-		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -85,13 +85,6 @@
 	gpio_keys: keys {
 		compatible = "gpio-keys";
 
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
 		wps {
 			label = "WPS button";
 			linux,code = <KEY_WPS_BUTTON>;

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -12,7 +12,10 @@
 	};
 
 	aliases {
-		led-status = &system;
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
 	};
 
 	gpio_leds: leds {


### PR DESCRIPTION
During the support for the Archer C7 v4 some possible improvements for the C7 v5 have been indicated [1].

This PR is supposed to collect some (hopefully all) of them.

> It is worth mentioning that Archer C7 v5 DTS most probably should be fixed according to this pull request, because its DTS contains the following issues:
> 
> * There is only one LED alias `led-status`, so I doubt that anything blinks during boot indicating correct boot stage
> * qca,ar8327-initvals:
>   
>   * it initializes LEDS, but if v5 is same as v4, there are no ethernet LEDS on the backpanel, so it is meaningless to initialize them
>   * it does not initialize PORT6, so it will look like connected - ar71xx code initializes also PORT6 and it appears as disconnected (I have tested this on v4)
>   * if v5 also uses QCA8337N, the PORT0 PAD CTRL init value on ath79 is different to one used during init on ar71xx, where the highest bit is set (bit MAC06_EXCHANGE_EN). I cannot say what this change means, though, but my intention was to have v4 init values aligned (ath79 uses the same values as ar71xx).

I would be glad about some help with the qca,ar8327-initvals stuff.

Will be able to test on a C7 v5 soon. Feedback from A7 v5 would be glad.

Done:
* Merge LEDS
* led-status
* Update reset button GPIO
* Fix WAN-MAC for ath79
* Fix WAN-MAC for ar71xx (requires to add info partition first)

ToDo:
* check/fix qca,ar8327-initvals

[1] https://github.com/openwrt/openwrt/pull/1726#issuecomment-455096720