### PR TITLE
ath79: add support for KuWfi CPE830D / YunCore CPE830

### DIFF
--- a/target/linux/ath79/dts/qca9533_kuwfi_830d.dts
+++ b/target/linux/ath79/dts/qca9533_kuwfi_830d.dts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	model = "KuWfi 830D";
+	compatible = "kuwfi,830d", "qca,qca9533";
+
+	chosen {
+		bootargs = "console=ttyS0,115200 rootfstype=squashfs,jffs2 noinitrd";
+	};
+
+        aliases {
+                led-boot = &status;
+                led-failsafe = &status;
+                led-running = &status;
+                led-upgrade = &status;
+        };
+
+        keys {  
+                compatible = "gpio-keys";
+
+                reset { 
+                        label = "reset";
+                        linux,code = <KEY_RESTART>;
+                        gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+                        debounce-interval = <60>;
+                };
+        };
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "k830:green:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		status: status {
+			label = "k830:green:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		wan {
+			label = "k830:green:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac { 
+        status = "okay";
+        mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9533_kuwfi_830d.dts"
+
+/ {
+	model = "YunCore CPE830";
+	compatible = "yuncore,cpe830", "qca,qca9533";
+
+};
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -438,6 +438,15 @@ define Device/jjplus_ja76pf2
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
+define Device/kuwfi_830d
+  ATH_SOC := qca9533
+  DEVICE_TITLE := KuWfi 830D
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio uboot-envtools kmod-ath9k kmod-fs-squashfs kmod-leds-gpio kmod-ledtrig-gpio kmod-ledtrig-netdev
+  IMAGE/sysupgrade.bin := append-rootfs | pad-to 14528k | append-kernel | pad-to 16000k | check-size $$$$(IMAGE_SIZE)
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += kuwfi_830d
+
 define Device/librerouter_librerouter-v1
   ATH_SOC := qca9558
   DEVICE_TITLE := LibreRouter v1
@@ -616,3 +625,12 @@ define Device/yuncore_a770
   IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += yuncore_a770
+
+define Device/yuncore_cpe830
+  ATH_SOC := qca9533
+  DEVICE_TITLE := YunCore CPE830
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio uboot-envtools kmod-ath9k kmod-fs-squashfs kmod-leds-gpio kmod-ledtrig-gpio kmod-ledtrig-netdev
+  IMAGE/sysupgrade.bin := append-rootfs | pad-to 14528k | append-kernel | pad-to 16000k | check-size $$$$(IMAGE_SIZE)
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += yuncore_cpe830


### PR DESCRIPTION
KuWfi CPE830D / YunCore CPE830 are same (rebranded) items of an outdoor CPE/AP based on Qualcomm/Atheros QCA9533 v2 (and not QCA9531)

Board uses ath9k driver (and not ath10k as previously stated in Openwrt)

Short specification:

- 650/600/216 MHz (CPU/DDR/AHB)
- 2x 10/100 Mbps Ethernet, passive PoE support
- 64 MB of RAM (DDR2)
- 16 MB of FLASH
- 2T2R 2.4 GHz with external PA, up to 30 dBm
- 2x internal 14 dBi antennas
- 4x LED, 1x button
- No UART on PCB

Flash instruction under vendor firmware:

1. Use vendor "upgrade" web interface
2. Device shall be booting on 192.168.1.1 as default

Signed-off by: Joan Moreau <jom@grosjo.net>