### PR TITLE
uqmi: give the modem time to release the client ids

### DIFF
--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uqmi
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uqmi.git

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -180,6 +180,8 @@ proto_qmi_setup() {
 	fi
 
 	uqmi -s -d "$device" --sync > /dev/null 2>&1
+	# Wait for connection context release
+	sleep 5
 
 	echo "Waiting for network registration"
 	local registration_timeout=0


### PR DESCRIPTION
If you have a multi provider SIM card that is allowed to log in to any
network, then there is a problem if you immediately register a network
again after a `uqmi --sync` call. The `uqmi --sync` call does not happen
immediately but is delayed and the modem can log into another network
with multiprovider SIM card during connection setup. The result is that
if you don't wait, the message **unable to connect to IPv4** appears in the log.
If you wait after a `uqmi --sync` before the next network registration check the problem is solved.

I do not know if this is the best way to wait there or maybe there is another way, but it works for me. Maybe @bmork could give as a feedback if this a good decision. As he has good knowledge about the qmi interface 
