### PR TITLE
ramips: correct DTS for Belkin F9K1109v1 to include switch definition

### DIFF
--- a/target/linux/ramips/dts/F9K110x.dtsi
+++ b/target/linux/ramips/dts/F9K110x.dtsi
@@ -2,8 +2,19 @@
 
 #include "rt3883.dtsi"
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
 / {
 	compatible = "ralink,rt3883-soc";
+
+	rtl8367b {
+		compatible = "realtek,rtl8367b";
+		gpio-sda = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+	};
+
 };
 
 &gpio1 {


### PR DESCRIPTION
This adds the switch definition for the rtl8367b switch to the DTS/DTSi for the Belkin F9K1109v1 that was mistakenly omitted from the initial commit #1791. During work with @chunkeey we split a .dts out into a .dts and .dtsi and missed pulling in the switch config. I failed to notice this during review. Apologies on that and the long delay. The code before this commit runs but no network of course. This corrects the dts and I have it running on the router. 

Signed-off-by: Kip Porterfield <kip.porterfield@gmail.com>