### PR TITLE
openwrt-18.06: ar71xx: Backport TP-Link Archer C7v5 WAN fix and IMAGE_SIZE fix

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -580,6 +580,10 @@ ar71xx_setup_macs()
 		base_mac=$(mtd_get_mac_binary config 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
+	archer-c7-v5)
+		base_mac=$(mtd_get_mac_binary info 8)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	dgl-5500-a1|\
 	dir-825-c1)
 		wan_mac=$(mtd_get_mac_ascii nvram "wan_mac")

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -146,7 +146,7 @@ define Device/archer-c7-v5
   DEVICE_TITLE := TP-LINK Archer C7 v5
   BOARDNAME := ARCHER-C7-V5
   TPLINK_BOARD_ID := ARCHER-C7-V5
-  IMAGE_SIZE := 15104k
+  IMAGE_SIZE := 15360k
   MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,128k@0x60000(info)ro,1536k@0xc0000(kernel),13824k(rootfs),15360k@0xc0000(firmware)
   SUPPORTED_DEVICES := archer-c7-v5
 endef

--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -147,7 +147,7 @@ define Device/archer-c7-v5
   BOARDNAME := ARCHER-C7-V5
   TPLINK_BOARD_ID := ARCHER-C7-V5
   IMAGE_SIZE := 15104k
-  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,1536k@0xc0000(kernel),13824k(rootfs),15360k@0xc0000(firmware)
+  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,64k@0x50000(art)ro,128k@0x60000(info)ro,1536k@0xc0000(kernel),13824k(rootfs),15360k@0xc0000(firmware)
   SUPPORTED_DEVICES := archer-c7-v5
 endef
 TARGET_DEVICES += archer-c7-v5


### PR DESCRIPTION
This backports the ar71xx changes from PR https://github.com/openwrt/openwrt/pull/1965 back to openwrt-18.06 and thus fixes the WAN MAC address there.

While at it, also adjust the IMAGE_SIZE, which seems to have been forgotten to update.

All run-tested onn an Archer C7v5.