### PR TITLE
ath79:  add TP-Link WR842v3

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -154,7 +154,8 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
 tplink,tl-wr841-v9|\
-tplink,tl-wr841-v11)
+tplink,tl-wr841-v11|\
+tplink,tl-wr842n-v3)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -168,6 +168,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr3420-v1|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v11|\
+	tplink,tl-wr842n-v3|\
 	ubnt,airrouter)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr842n-v3", "qca,qca9533";
+	model = "TP-Link TL-WR842N v3";
+
+	aliases {
+		led-boot = &qss_led;
+		led-failsafe = &qss_led;
+		led-running = &qss_led;
+		led-upgrade = &qss_led;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		system: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss_led: qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_green {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_red {
+			label = "tp-link:red:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "RFKILL button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+        status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -227,6 +227,16 @@ define Device/tplink_tl-wr842n-v2
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v2
 
+define Device/tplink_tl-wr842n-v3
+  $(Device/tplink-16mlzma)
+  ATH_SOC := qca9533
+  DEVICE_TITLE := TP-Link TL-WR842N v3
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x8420003
+  SUPPORTED_DEVICES += tl-wr842n-v3
+endef
+TARGET_DEVICES += tplink_tl-wr842n-v3
+
 define Device/tplink_tl-wr1043nd-v2
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9558


### PR DESCRIPTION
This adds support for the TP-Link WR842v3

* 16MB Flash; 64Mb RAM
* USB
* ath9k

Current status:
* WAN port working
* LAN ports (switch) ~~seem to not work yet~~ working
* WiFi ~~not tested~~ working (tested as Freifunk-node with AP and adhoc)
* USB ~~seems not to work, unsure if it's broken or a kernel-module is missing~~ working