### PR TITLE
procd/hotplug: add dependency to dialout and audio group

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git
@@ -45,6 +45,7 @@ define Package/procd
   CATEGORY:=Base system
   DEPENDS:=+ubusd +ubus +libjson-script +ubox +USE_GLIBC:librt +libubox +libubus
   TITLE:=OpenWrt system process manager
+  USERID:=:dialout=20 :audio=29
 endef
 
 define Package/procd-ujail


### PR DESCRIPTION
Commit 6e060bd62c85 introduced a dependency to the dialout group.
Adding this group to the "group" file in the base-files package is not
enough to handle this dependency, because after a sysupgrade this entry
will be missing in the "group" file.

To address this problem the dependencies to the required groups needs to
be set in the Makefile of the procd package.
Then, the uci-default script "13_fix_group_user" will add the groups
on first boot-up after a sysupgrade.

Fixes: 6e060bd62c85 ("base-files/hotplug: fix dedicated group for tty devices")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
