### PR TITLE
ath79: remove unnecessary packages from I-O DATA ETG3-R

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -375,6 +375,7 @@ define Device/iodata_etg3-r
   ATH_SOC := ar9342
   DEVICE_TITLE := I-O DATA ETG3-R
   IMAGE_SIZE := 7680k
+  DEVICE_PACKAGES := -iwinfo -kmod-ath9k -wpad-basic
 endef
 TARGET_DEVICES += iodata_etg3-r
 


### PR DESCRIPTION
I-O DATA ETG3-R is a wired router. So wireless-related packages are
unnecessary and remove those packages from default configuration to
reduce flash usage.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>