### PR TITLE
iwinfo: add tx_bytes and rx_bytes parameters to lua

### DIFF
--- a/package/network/utils/iwinfo/patches/199-Add-lua-tx-rx-bytes.patch
+++ b/package/network/utils/iwinfo/patches/199-Add-lua-tx-rx-bytes.patch
@@ -1,0 +1,16 @@
+--- a/iwinfo_lua.c
++++ b/iwinfo_lua.c
+@@ -325,6 +325,12 @@ static int iwinfo_L_assoclist(lua_State *L, int (*func)(const char *, char *, in
+ 			lua_pushnumber(L, e->tx_packets);
+ 			lua_setfield(L, -2, "tx_packets");
+ 
++			lua_pushnumber(L, e->rx_bytes);
++			lua_setfield(L, -2, "rx_bytes");
++
++			lua_pushnumber(L, e->tx_bytes);
++			lua_setfield(L, -2, "tx_bytes");
++
+ 			set_rateinfo(L, &e->rx_rate, true);
+ 			set_rateinfo(L, &e->tx_rate, false);
+ 
+ 


### PR DESCRIPTION
Signed-off-by: Kirill Lukonin <k.lukonin@gmail.com>

iwinfo can fetch a lot of parameters through NL80211 API, but iwinfo_lua does not support all of them.
This patch adds tx_bytes and rx_bytes to iwinfo_lua binding, because their suppors is already present in iwinfo. 

iwinfo collects tx_bytes and rx_bytes per every station, but for some reasons these parameters cannot be used from lua. A lot of people find these parameters very helpful and monitor average throughput of each station (for example).
According to this pull request
https://github.com/openwrt/packages/pull/8657
tx_bytes and rx_bytes can be used in Prometheus node exporter and help to measure average throughput per station with Prometheus (why not?).

I found this patch very helpful for me so may be it can be helpful for someone else.