### PR TITLE
ramips: fix vlan retag on mt7621

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -934,7 +934,7 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 		skb->protocol = eth_type_trans(skb, netdev);
 
 		if (netdev->features & NETIF_F_HW_VLAN_CTAG_RX &&
-		    RX_DMA_VID(trxd.rxd3))
+		    RX_DMA_TAG & trxd.rxd2 && RX_DMA_VID(trxd.rxd3))
 			__vlan_hwaccel_put_tag(skb, htons(ETH_P_8021Q),
 					       RX_DMA_VID(trxd.rxd3));
 


### PR DESCRIPTION
When ethernet packets in some vlan leave a switch port,
they're untagged if this port is set as untagged in this vlan.
These untagged ethernet packet can be received and properly processed
by mt7621 cpu ethernet port at eth0.
But in commit c9262a9, the untagged ethernet packets will be retagged
by hardware, letting eth0 unusable.
Fix it by avoiding to retag untagged packets.

Signed-off-by: Frank Di Matteo <dimatto@foxmail.com>

