### PR TITLE
include: unpack.mk: parametrize CRLF_CMD rule

### DIFF
--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -59,7 +59,7 @@ ifeq ($(strip $(UNPACK_CMD)),)
     endif
   endif
   ifneq ($(strip $(CRLF_WORKAROUND)),)
-    CRLF_CMD := && find $(PKG_BUILD_DIR) -type f -print0 | xargs -0 perl -pi -e 's!\r$$$$!!g'
+    CRLF_CMD := && find $(1) -type f -print0 | xargs -0 perl -pi -e 's!\r$$$$!!g'
   else
     CRLF_CMD :=
   endif


### PR DESCRIPTION
CRLF_CMD is called with both $(PKG_BUILD_DIR) & $(HOST_BUILD_DIR) as
arguments, but the actual command doesn't use the passed argument. It keeps
using $(PKG_BUILD_DIR).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>