### PR TITLE
ath79: add support for 8devices Carambola2 development board

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -8,6 +8,10 @@ board=$(board_name)
 boardname="${board##*,}"
 
 case "$board" in
+8dev,carambola2)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:orange:eth0" "eth0"
+	ucidef_set_led_switch "wan" "WAN" "$boardname:orange:eth1" "switch0" "0x04"
+	;;
 avm,fritz300e)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -9,6 +9,18 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	8dev,carambola2|\
+	comfast,cf-e5|\
+	glinet,gl-ar150|\
+	glinet,gl-ar300m-nand|\
+	glinet,gl-ar300m-nor|\
+	glinet,gl-x750|\
+	tplink,tl-wr810n-v1|\
+	tplink,tl-wr810n-v2|\
+	ubnt,routerstation|\
+	yuncore,a770)
+		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+		;;
 	avm,fritz300e|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\
@@ -68,17 +80,6 @@ ath79_setup_interfaces()
 	buffalo,wzr-hp-g302h-a1a0)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
-		;;
-	comfast,cf-e5|\
-	glinet,gl-ar150|\
-	glinet,gl-ar300m-nand|\
-	glinet,gl-ar300m-nor|\
-	glinet,gl-x750|\
-	tplink,tl-wr810n-v1|\
-	tplink,tl-wr810n-v2|\
-	ubnt,routerstation|\
-	yuncore,a770)
-		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	devolo,dvl1200e|\
 	devolo,dvl1750e|\

--- a/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
+++ b/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "8devices Carambola2";
+	compatible = "8dev,carambola2", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "carambola2:green:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		eth0 {
+			label = "carambola2:orange:eth0";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		eth1 {
+			label = "carambola2:orange:eth1";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	num-chipselects = <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <104000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			art: partition@fe0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+        status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+                device = <&gmac>;
+
+                switch-phy-addr-swap = <1>;
+                switch-phy-swap = <1>;
+        };
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&art 0x6>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -75,6 +75,15 @@ define Device/seama
   SEAMA_SIGNATURE :=
 endef
 
+define Device/8dev_carambola2
+  ATH_SOC := ar9331
+  DEVICE_TITLE := 8devices Carambola2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2
+  IMAGE_SIZE := 16000k
+  SUPPORTED_DEVICES += carambola2
+endef
+TARGET_DEVICES += 8dev_carambola2
+
 define Device/avm_fritz300e
   ATH_SOC := ar7242
   DEVICE_TITLE := AVM FRITZ!WLAN Repeater 300E


### PR DESCRIPTION
Specifications:

- Atheros AR9331 (400 MHz)
- 64 MB of RAM (DDR2)
- 16 MB of Flash (SPI)
- 1T1R 2.4 Wlan (AR9331)
- 2x 10/100 Mbps Ethernet
- 3x LEDs, 1x gpio button
- 1x USB 2.0, 5V
- UART over usb, 115200n8

Signed-off-by: Rytis Zigmantavičius <rytis.z@8devices.com>
