### PR TITLE
ar71xx: mute script error for ar922x-led-fix

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/net/10-ar922x-led-fix
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/net/10-ar922x-led-fix
@@ -12,6 +12,9 @@
 devdir=$(dirname $DEVPATH)
 devdir=$(dirname $devdir)
 phydir=/sys$devdir/ieee80211
+
+[ -d $phydir ] || exit 0
+
 phyname=$(cat $phydir/phy*/name)
 
 [ -z $phyname -o $ACTION != "add" ] && exit 0


### PR DESCRIPTION
This commit fix the script error in syslog:

  ......

  cat: /sys/xx/phy*/name : No such file or directory
  sh: unknown operand

  ......

Signed-off-by: Rosy Song <rosysong@rosinson.com>

@jow-  @neheb 
