### PR TITLE
[RFC]Check signatures of sysupgrades

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -13,7 +13,7 @@ __target_inc=1
 DEVICE_TYPE?=router
 
 # Default packages - the really basic set
-DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd
+DEFAULT_PACKAGES:=base-files libc libgcc busybox dropbear mtd uci opkg netifd fstools uclient-fetch logd ucert
 # For nas targets
 DEFAULT_PACKAGES.nas:=block-mount fdisk lsblk mdadm
 # For router targets

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -239,6 +239,7 @@ generate_static_system() {
 		set system.@system[-1].ttylogin='0'
 		set system.@system[-1].log_size='64'
 		set system.@system[-1].urandom_seed='0'
+		set system.@system[-1].require_image_signature='0'
 
 		delete system.ntp
 		set system.ntp='timeserver'

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -1,13 +1,9 @@
+REQUIRE_IMAGE_SIGNATURE="${REQUIRE_IMAGE_SIGNATURE:-$(uci get system.@system[-1].require_image_signature)}"
+
 fwtool_check_signature() {
 	[ $# -gt 1 ] && return 1
 
-	[ ! -x /usr/bin/ucert ] && {
-		if [ "$REQUIRE_IMAGE_SIGNATURE" = 1 ]; then
-			return 1
-		else
-			return 0
-		fi
-	}
+	[ "$REQUIRE_IMAGE_SIGNATURE" = 1 ] || return 0
 
 	if ! fwtool -q -s /tmp/sysupgrade.ucert "$1"; then
 		echo "Image signature not found"


### PR DESCRIPTION
Add option to validate the signature of sysupgrade before installing them. While this option isn't enabled per default, it can be set to check if the firmware image is signed by a trusted entity (based on /etc/opkg/keys/).