### PR TITLE
base-files: more verbose check_image_signature

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=197
+PKG_RELEASE:=198
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -2,7 +2,8 @@ fwtool_check_signature() {
 	[ $# -gt 1 ] && return 1
 
 	[ ! -x /usr/bin/ucert ] && {
-		if [ "$REQUIRE_IMAGE_SIGNATURE" = 1 ]; then
+		if [ "$REQUIRE_IMAGE_SIGNATURE" = 1 -a "$FORCE" != 1 ]; then
+			echo "Can't validate signature due to missing ucert package. Use sysupgrade -F to override this check"
 			return 1
 		else
 			return 0


### PR DESCRIPTION
Give a proper error message if the ucert package is missing and ignore
it completly if sysupgrade ran with -F.

Signed-off-by: Paul Spooren <mail@aparcar.org>