### PR TITLE
include: unpack.mk: remove CRLF_WORKAROUND

### DIFF
--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -58,18 +58,13 @@ ifeq ($(strip $(UNPACK_CMD)),)
       UNPACK_CMD=gzip -dc $(DL_DIR)/$(PKG_SOURCE) | $(TAR_CMD)
     endif
   endif
-  ifneq ($(strip $(CRLF_WORKAROUND)),)
-    CRLF_CMD := && find $(PKG_BUILD_DIR) -type f -print0 | xargs -0 perl -pi -e 's!\r$$$$!!g'
-  else
-    CRLF_CMD :=
-  endif
 endif
 
 ifdef PKG_BUILD_DIR
-  PKG_UNPACK ?= $(SH_FUNC) $(call UNPACK_CMD,$(PKG_BUILD_DIR)) $(call CRLF_CMD,$(PKG_BUILD_DIR))
+  PKG_UNPACK ?= $(SH_FUNC) $(call UNPACK_CMD,$(PKG_BUILD_DIR))
 endif
 ifdef HOST_BUILD_DIR
-  HOST_UNPACK ?= $(SH_FUNC) $(call UNPACK_CMD,$(HOST_BUILD_DIR)) $(call CRLF_CMD,$(HOST_BUILD_DIR))
+  HOST_UNPACK ?= $(SH_FUNC) $(call UNPACK_CMD,$(HOST_BUILD_DIR))
 endif
 
 endif # PKG_SOURCE


### PR DESCRIPTION
This patch doesn't seem to have any more users.
The only one used to be target in
`target/linux/etrax/image/e100boot/Makefile`.

That target has since been removed via commit
1080f68b2b422f1e72e402765a45d0cc3c550825 .

There doesn't seem to be any reason left for this workaround.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>