### PR TITLE
toolchain: glibc ldd env path fixup

### DIFF
--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -510,6 +510,7 @@ ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
   define Package/ldd/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(CP) $(TOOLCHAIN_DIR)/bin/ldd $(1)/usr/bin/
+	sed -i 's,^#!.*,#!/bin/sh,' $(1)/usr/bin/ldd
   endef
 
   define Package/ldconfig/install


### PR DESCRIPTION
for PACKAGE_ldd
it just copy the staging_dir/toolchain-x86_64_gcc-5.5.0_glibc/bin/ldd to ipk installation path
where the first line in shell script `ldd` is not correct:
```
#! /mnt/Data/Sources/openwrt/x-wrt/staging_dir/host/bin/bash
```
which should be
```
#!/bin/sh
```
