### PR TITLE
kernel: add missing drm symbol

### DIFF
--- a/target/linux/generic/config-4.14
+++ b/target/linux/generic/config-4.14
@@ -1222,6 +1222,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_UDL is not set
 # CONFIG_DRM_VBOXVIDEO is not set
 # CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VIRTIO_GPU is not set
 # CONFIG_DRM_VMWGFX is not set
 # CONFIG_DS1682 is not set
 # CONFIG_DS1803 is not set

--- a/target/linux/generic/config-4.19
+++ b/target/linux/generic/config-4.19
@@ -1293,6 +1293,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_UDL is not set
 # CONFIG_DRM_VBOXVIDEO is not set
 # CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VIRTIO_GPU is not set
 # CONFIG_DRM_VKMS is not set
 # CONFIG_DRM_VMWGFX is not set
 # CONFIG_DRM_XEN is not set

--- a/target/linux/generic/config-4.9
+++ b/target/linux/generic/config-4.9
@@ -1118,6 +1118,7 @@ CONFIG_DQL=y
 # CONFIG_DRM_TOSHIBA_TC358767 is not set
 # CONFIG_DRM_UDL is not set
 # CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VIRTIO_GPU is not set
 # CONFIG_DS1682 is not set
 # CONFIG_DS1803 is not set
 # CONFIG_DST_CACHE is not set


### PR DESCRIPTION
dependency introduced with module drm-kms-helper

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

