### PR TITLE
hostapd: fix https://w1.fi/security/2019-5/

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/065-0001-EAP-pwd-server-Fix-reassembly-buffer-handling.patch
+++ b/package/network/services/hostapd/patches/065-0001-EAP-pwd-server-Fix-reassembly-buffer-handling.patch
@@ -1,0 +1,40 @@
+From fe76f487e28bdc61940f304f153a954cf36935ea Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Wed, 17 Apr 2019 01:55:32 +0300
+Subject: [PATCH 1/3] EAP-pwd server: Fix reassembly buffer handling
+
+data->inbuf allocation might fail and if that were to happen, the next
+fragment in the exchange could have resulted in NULL pointer
+dereference. Unexpected fragment with more bit might also be able to
+trigger this. Fix that by explicitly checking for data->inbuf to be
+available before using it.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/eap_server/eap_server_pwd.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+--- a/src/eap_server/eap_server_pwd.c
++++ b/src/eap_server/eap_server_pwd.c
+@@ -947,6 +947,12 @@ static void eap_pwd_process(struct eap_s
+ 	 * the first and all intermediate fragments have the M bit set
+ 	 */
+ 	if (EAP_PWD_GET_MORE_BIT(lm_exch) || data->in_frag_pos) {
++		if (!data->inbuf) {
++			wpa_printf(MSG_DEBUG,
++				   "EAP-pwd: No buffer for reassembly");
++			eap_pwd_state(data, FAILURE);
++			return;
++		}
+ 		if ((data->in_frag_pos + len) > wpabuf_size(data->inbuf)) {
+ 			wpa_printf(MSG_DEBUG, "EAP-pwd: Buffer overflow "
+ 				   "attack detected! (%d+%d > %d)",
+@@ -967,7 +973,7 @@ static void eap_pwd_process(struct eap_s
+ 	 * last fragment won't have the M bit set (but we're obviously
+ 	 * buffering fragments so that's how we know it's the last)
+ 	 */
+-	if (data->in_frag_pos) {
++	if (data->in_frag_pos && data->inbuf) {
+ 		pos = wpabuf_head_u8(data->inbuf);
+ 		len = data->in_frag_pos;
+ 		wpa_printf(MSG_DEBUG, "EAP-pwd: Last fragment, %d bytes",

--- a/package/network/services/hostapd/patches/065-0003-EAP-pwd-peer-Fix-reassembly-buffer-handling.patch
+++ b/package/network/services/hostapd/patches/065-0003-EAP-pwd-peer-Fix-reassembly-buffer-handling.patch
@@ -1,0 +1,40 @@
+From d2d1a324ce937628e4d9d9999fe113819b7d4478 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Wed, 17 Apr 2019 02:21:20 +0300
+Subject: [PATCH 3/3] EAP-pwd peer: Fix reassembly buffer handling
+
+Unexpected fragment might result in data->inbuf not being allocated
+before processing and that could have resulted in NULL pointer
+dereference. Fix that by explicitly checking for data->inbuf to be
+available before using it.
+
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/eap_peer/eap_pwd.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+--- a/src/eap_peer/eap_pwd.c
++++ b/src/eap_peer/eap_pwd.c
+@@ -969,6 +969,13 @@ eap_pwd_process(struct eap_sm *sm, void
+ 	 * buffer and ACK the fragment
+ 	 */
+ 	if (EAP_PWD_GET_MORE_BIT(lm_exch) || data->in_frag_pos) {
++		if (!data->inbuf) {
++			wpa_printf(MSG_DEBUG,
++				   "EAP-pwd: No buffer for reassembly");
++			ret->methodState = METHOD_DONE;
++			ret->decision = DECISION_FAIL;
++			return NULL;
++		}
+ 		data->in_frag_pos += len;
+ 		if (data->in_frag_pos > wpabuf_size(data->inbuf)) {
+ 			wpa_printf(MSG_INFO, "EAP-pwd: Buffer overflow attack "
+@@ -995,7 +1002,7 @@ eap_pwd_process(struct eap_sm *sm, void
+ 	/*
+ 	 * we're buffering and this is the last fragment
+ 	 */
+-	if (data->in_frag_pos) {
++	if (data->in_frag_pos && data->inbuf) {
+ 		wpa_printf(MSG_DEBUG, "EAP-pwd: Last fragment, %d bytes",
+ 			   (int) len);
+ 		pos = wpabuf_head_u8(data->inbuf);


### PR DESCRIPTION
Fix "EAP-pwd message reassembly issue with unexpected fragment"

Published: April 18, 2019
Latest version available from: https://w1.fi/security/2019-5/

Vulnerability

EAP-pwd implementation in hostapd (EAP server) and wpa_supplicant (EAP
peer) was discovered not to validate fragmentation reassembly state
properly for a case where an unexpected fragment could be received. This
could result in process termination due to NULL pointer dereference.

An attacker in radio range of a station device with wpa_supplicant
network profile enabling use of EAP-pwd could cause the wpa_supplicant
process to terminate by constructing unexpected sequence of EAP
messages. An attacker in radio range of an access point that points to
hostapd as an authentication server with EAP-pwd user enabled in runtime
configuration (or in non-WLAN uses of EAP authentication as long as the
attacker can send EAP-pwd messages to the server) could cause the
hostapd process to terminate by constructing unexpected sequence of EAP
messages.

Vulnerable versions/configurations

All hostapd and wpa_supplicant versions with EAP-pwd support
(CONFIG_EAP_PWD=y in the build configuration and EAP-pwd being enabled
in the runtime configuration) are vulnerable against the process
termination (denial of service) attack.

Possible mitigation steps

- Merge the following commits to wpa_supplicant/hostapd and rebuild:

  EAP-pwd peer: Fix reassembly buffer handling
  EAP-pwd server: Fix reassembly buffer handling

  These patches are available from https://w1.fi/security/2019-5/

- Update to wpa_supplicant/hostapd v2.8 or newer, once available

Build-tested on:
- ipq806x
- ath79
- lantiq

Runtime-tested on:

- ipq806x/ nbg6817
  - encryption=sae-mixed
  - ieee80211w=1
  - clients enforcing WPA3
  - WPA2-only clients

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>