### PR TITLE
openssl: let libopenssl depends on libopenssl-conf

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -91,7 +91,8 @@ endef
 define Package/libopenssl
 $(call Package/openssl/Default)
   SUBMENU:=SSL
-  DEPENDS:=+OPENSSL_WITH_COMPRESSION:zlib \
+  DEPENDS:=+libopenssl-conf \
+	   +OPENSSL_WITH_COMPRESSION:zlib \
 	   +OPENSSL_ENGINE_BUILTIN_AFALG:kmod-crypto-user \
 	   +OPENSSL_ENGINE_BUILTIN_DEVCRYPTO:kmod-cryptodev \
 	   +OPENSSL_ENGINE_BUILTIN_PADLOCK:kmod-crypto-hw-padlock
@@ -122,7 +123,6 @@ define Package/libopenssl-conf
   $(call Package/openssl/Default)
   SUBMENU:=SSL
   TITLE:=/etc/ssl/openssl.cnf config file
-  DEPENDS:=libopenssl
 endef
 
 define Package/libopenssl-conf/conffiles


### PR DESCRIPTION
The program, who depends libopenssl, would also depends on libopenssl-conf
This is needed to make programs like wget openssl and many others
to work correctly.

It is libopenssl need libopenssl-conf to work, but libopenssl-conf
is just some config file(s), it should not depends on libopenssl

some bug thread could be found here:
https://github.com/termux/termux-packages/issues/3426
