### PR TITLE
linux-firmware: update to 20190416

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,13 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
+PKG_VERSION:=20190416
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2018-12-16
-PKG_SOURCE_VERSION:=211de1679a68b8ab0f841a8058df35e13e3963f0
-PKG_MIRROR_HASH:=894a13a44c9de58528488682feb3ade582725cd766a16ccaca07089628229d90
-PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
+PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=4851120ea69436fd5088fc72674798ad343c5ddb89ac6b4161225357d1eda08c
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
Update linux-firmware to 20190416, which includes updated firmwares e.g. for ath10k
Also switch to official tarball source