### PR TITLE
Add mt7615 80211 driver support to dts for R3P

### DIFF
--- a/target/linux/ramips/dts/MIR3P.dts
+++ b/target/linux/ramips/dts/MIR3P.dts
@@ -164,6 +164,8 @@
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mediatek,5ghz = <0>;
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 
@@ -172,6 +174,7 @@
 		compatible = "pci14c3,7615";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
+		mediatek,2ghz = <0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };


### PR DESCRIPTION
Little fix for support 80211 MT7615 driver for Xiaomi R3P
