### PR TITLE
ipq40xx: Fix reboot on EnGenius ENS620EXT

### DIFF
--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-ens620ext.dts
@@ -63,6 +63,10 @@
 		edma@c080000 {
 			status = "okay";
 		};
+
+		restart@4ab000 {
+			status = "disabled";
+		};
 	};
 
 	buttons {

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-ens620ext.dts
@@ -67,6 +67,10 @@
 		edma@c080000 {
 			status = "okay";
 		};
+
+		restart@4ab000 {
+			status = "disabled";
+		};
 	};
 
 	buttons {


### PR DESCRIPTION
Fixed an issue where reboot would cause the AP to power down and not reboot.
The ipq4019 restart controller reboot causes the system to power down and
not recover. Fix is to disable the restart controller in the device tree
and the device reverts to using the watchdog to perform the reset.

Signed-off-by: Steve Glennon <s.glennon@cablelabs.com>