### PR TITLE
ramips: add support for HILINK HLK-7628N

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -17,6 +17,7 @@ case $board in
 	set_wifi_led "$boardname:amber:wlan"
 	;;
 3g-6200nl|\
+hilink,hlk-7628n|\
 skylab,skw92a|\
 wnce2001)
 	set_wifi_led "$boardname:green:wlan"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -219,6 +219,7 @@ ramips_setup_interfaces()
 	gl-mt300a|\
 	gl-mt300n|\
 	gl-mt750|\
+	hilink,hlk-7628n|\
 	hiwifi,hc5861b|\
 	jhr-n805r|\
 	jhr-n825r|\
@@ -496,6 +497,7 @@ ramips_setup_macs()
 	dir-620-a1|\
 	esr-9753|\
 	freestation5|\
+	hilink,hlk-7628n|\
 	hlk-rm04|\
 	mpr-a1|\
 	psr-680w|\

--- a/target/linux/ramips/dts/HLK-7628N.dts
+++ b/target/linux/ramips/dts/HLK-7628N.dts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hilink,hlk-7628n", "mediatek,mt7628an-soc";
+	model = "HILINK HLK-7628N";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "hlk-7628n:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -81,6 +81,13 @@ define Device/hc5661a
 endef
 TARGET_DEVICES += hc5661a
 
+define Device/hilink_hlk-7628n
+  DTS := HLK-7628N
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DEVICE_TITLE := HILINK HLK7628N
+endef
+TARGET_DEVICES += hilink_hlk-7628n
+
 define Device/hiwifi_hc5861b
   DTS := HC5861B
   IMAGE_SIZE := 15808k


### PR DESCRIPTION
* ramips: add support for HILINK HLK-7628N

Specification:

CPU:       MT7628 580 MHz. MIPS 24K
RAM:       128 MB
Flash:     32 MB
WIFI:      802.11n/g/b 20/40 MHz
Ethernet:  5 Port ethernet switch
UART:      2x
LED:        1x wifi led
BUTTON: 1x reset button

Tested the following items：
Ethernet Switch
WIFI 
UART
WIFI LED
RESET BUTTON
SYSUPGRADE

Flash instruction:
The U-boot is based on Ralink SDK so we can flash the firmware using UART:
1. Configure PC with a static IP address and setup an TFTP server.
2. Put the firmware into the tftp directory.
3. Connect the UART0 line as described on the PCB.
4. Power up the device and press 2, follow the instruction to
   set device and tftp server IP address and input the firmware
   file name. U-boot will then load the firmware and write it into
   the flash.
5. After firmware is started connect via ethernet at 192.168.1.1

Signed-off-by: Liu Yu <f78fk@live.com>
