### PR TITLE
dnsmasq: conflicts with odhcpd-ipv6only

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
 PKG_VERSION:=2.80
-PKG_RELEASE:=1.4
+PKG_RELEASE:=1.5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq
@@ -54,6 +54,7 @@ $(call Package/dnsmasq/Default)
   DEPENDS+=@IPV6
   VARIANT:=dhcpv6
   PROVIDES:=dnsmasq
+  CONFLICTS:=odhcpd-ipv6only
 endef
 
 define Package/dnsmasq-full
@@ -64,6 +65,7 @@ $(call Package/dnsmasq/Default)
 	+PACKAGE_dnsmasq_full_conntrack:libnetfilter-conntrack
   VARIANT:=full
   PROVIDES:=dnsmasq
+  CONFLICTS:=odhcpd-ipv6only
 endef
 
 define Package/dnsmasq/description


### PR DESCRIPTION
dnsmasq-full and dnsmasq-dhcpv6 conflict with odhcpd-ipv6only.

Having two dhcpv6 servers installed at the same time is not a good idea.

See also https://github.com/openwrt/luci/issues/2147

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
