### PR TITLE
[wip][rfc] VM provisioning via 9p mounts

### DIFF
--- a/target/linux/armvirt/64/target.mk
+++ b/target/linux/armvirt/64/target.mk
@@ -2,6 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=64
 BOARDNAME:=ARMv8 multiplatform
 KERNELNAME:=Image
+DEFAULT_PACKAGES += kmod-fs-9p
 
 define Target/Description
 	Build multi-platform images for the ARMv8 instruction set architecture

--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,6 +1,6 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
-DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb kmod-bnx2
+DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb kmod-bnx2 kmod-fs-9p
 
 define Target/Description
         Build images for 64 bit systems including virtualized guests.

--- a/target/linux/x86/base-files/lib/preinit/05_provision
+++ b/target/linux/x86/base-files/lib/preinit/05_provision
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Copyright (C) 2019 Paul Spooren <mail@aparcar.org>
+
+provision() {
+    for virtio in /sys/bus/virtio/drivers/9pnet_virtio/virtio*; do
+        if [ "$(cat ${virtio}/mount_tag)" = "provision" ]; then
+            mkdir -p /provision
+            mount -t 9p -o trans=virtio,version=9p2000.L provision /provision
+            if [ -f /provision/sysupgrade.tgz ]; then
+                mv -f /provision/sysupgrade.tgz /
+            fi
+            umount /provision
+            rm -rf /provision
+        fi
+    done
+}
+
+boot_hook_add preinit_mount_root provision


### PR DESCRIPTION
When using OpenWrt VMs while developing it would be useful to provision them via config archives stored on the host machine. These commits allow to do so using 9p fs mounts.

Not fully tested, please feel free to comment.