### PR TITLE
base-files: Add /etc/shinit for non-login shell init

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -63,6 +63,7 @@ define Package/base-files/conffiles
 /etc/services
 /etc/shadow
 /etc/shells
+/etc/shinit
 /etc/sysctl.conf
 /etc/sysupgrade.conf
 $(call $(TARGET)/conffiles)

--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -1,4 +1,3 @@
-#!/bin/sh
 [ -e /tmp/.failsafe ] && export FAILSAFE=1
 
 [ -f /etc/banner ] && cat /etc/banner
@@ -13,22 +12,13 @@ export PATH="%PATH%"
 export HOME=$(grep -e "^${USER:-root}:" /etc/passwd | cut -d ":" -f 6)
 export HOME=${HOME:-/root}
 export PS1='\u@\h:\w\$ '
+export ENV=/etc/shinit
 
 case "$TERM" in
 	xterm*|rxvt*)
 		export PS1='\[\e]0;\u@\h: \w\a\]'$PS1
 		;;
 esac
-
-[ -x /bin/more ] || alias more=less
-[ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
-
-alias ll='ls -alF --color=auto'
-
-[ -z "$KSH_VERSION" -o \! -s /etc/mkshrc ] || . /etc/mkshrc
-
-[ -x /usr/bin/arp -o -x /sbin/arp ] || arp() { cat /proc/net/arp; }
-[ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
 
 [ -n "$FAILSAFE" ] || {
 	for FILE in /etc/profile.d/*.sh; do
@@ -48,12 +38,3 @@ in order to prevent unauthorized SSH logins.
 --------------------------------------------------
 EOF
 fi
-
-service() {
-	[ -f "/etc/init.d/$1" ] || {
-		echo "service "'"'"$1"'"'" not found, the following services are available:"
-		ls "/etc/init.d"
-		return 1
-	}
-	/etc/init.d/$@
-}

--- a/package/base-files/files/etc/shinit
+++ b/package/base-files/files/etc/shinit
@@ -1,0 +1,21 @@
+[ -x /bin/more ] || alias more=less
+[ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
+
+alias ll='ls -alF --color=auto'
+
+[ -z "$KSH_VERSION" -o \! -s /etc/mkshrc ] || . /etc/mkshrc
+
+[ -x /usr/bin/arp -o -x /sbin/arp ] || arp() { cat /proc/net/arp; }
+[ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
+
+service() {
+	[ -f "/etc/init.d/$1" ] || {
+		echo "service "'"'"$1"'"'" not found, the following services are available:"
+		ls "/etc/init.d"
+		return 1
+	}
+	/etc/init.d/$@
+}
+
+[ -n "$KSH_VERSION" -o \! -s "$HOME/.shinit" ] || . "$HOME/.shinit"
+[ -z "$KSH_VERSION" -o \! -s "$HOME/.mkshrc" ] || . "$HOME/.mkshrc"

--- a/package/base-files/files/lib/upgrade/keep.d/base-files-essential
+++ b/package/base-files/files/lib/upgrade/keep.d/base-files-essential
@@ -6,5 +6,6 @@
 /etc/profile
 /etc/shadow
 /etc/shells
+/etc/shinit
 /etc/sysctl.conf
 /etc/rc.local


### PR DESCRIPTION
/etc/profile (and ~/.profile) are read for login shells only, which means the aliases and functions defined there are not available to non-login shells, e.g. when using screen or tmux.

This moves the alias and function definitions from /etc/profile to /etc/shinit, and exports the `ENV` environment variable (in /etc/profile), so that all interactive shells will source /etc/shinit. (This can be
overriden in ~/.profile by unsetting `ENV` or setting it to a different file.)

(It appears that busybox ash, like dash, will only read the `ENV` file for interactive shells only.)

/etc/shinit will also source ~/.shinit if it exists.

For mksh, this also moves the sourcing of /etc/mkshrc to /etc/shinit, as that file is meant for all interactive shells.

/etc/shinit will source ~/.mkshrc instead of ~/.shinit if the user is running mksh, to compensate for the fact that mksh will not read ~/.mkshrc if ENV is set.

This also removes the shebang from /etc/profile, as the shell reads/sources the file and the shebang is unnecessary.

Signed-off-by: Jeffery To <jeffery.to@gmail.com>