### PR TITLE
ar71xx: Allow port-to-port forward on vlan disable

### DIFF
--- a/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
+++ b/target/linux/ar71xx/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_ar7240.c
@@ -943,6 +943,13 @@ ar7240_hw_apply(struct switch_dev *dev)
 			portmask[i] = 1 << AR7240_PORT_CPU;
 			portmask[AR7240_PORT_CPU] |= (1 << i);
 		}
+		/* Overwrite isolate and allow port-to-port forward */
+		for (i = 0; i < as->swdev.ports; i++) {
+			if (i == AR7240_PORT_CPU)
+				continue;
+
+			portmask[i] |= (portmask[AR7240_PORT_CPU] & (~(1 << i)));
+		}
 	}
 
 	/* update the port destination mask registers and tag settings */


### PR DESCRIPTION
This fix https://dev.archive.openwrt.org/ticket/11143

Sometimes we need to communicate with a vlan-tagged-upstream.
For example:
We disable vlan on the switch0 and use eth0.5 eth0.9 ... to
communicate with vlan5/vlan9 tagged streams
But when vlan diable, the switch port-to-port is isolate, this
should not be the case.
