### PR TITLE
ar71xx: fix failsafe interface for TL-WR940nv6

### DIFF
--- a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+++ b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
@@ -38,6 +38,7 @@ set_preinit_iface() {
 	tl-wr841n-v8|\
 	tl-wr842n-v2|\
 	tl-wr940n-v4|\
+	tl-wr940n-v6|\
 	tl-wr941nd-v6|\
 	wnr1000-v2|\
 	wnr2000-v3|\


### PR DESCRIPTION
Switches failsafe mode interface from WAN to LAN ports.

Tested on TL-WR940Nv6.0 and TL-WR940Nv6.1

Signed-off-by: Joachim Fünfer <joachim.fuenfer@stusta.net>