### PR TITLE
ath79: add support for KuWfi CPE206 based on AP143

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -102,6 +102,10 @@ glinet,gl-ar300m-lite)
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	;;
+kuwfi,cpe206)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_netdev "wlan" "WLAN" "$boardname:green:wlan" "wlan0"
+	;;
 netgear,wnr612-v2|\
 on,n150r)
 	ucidef_set_led_netdev "wan" "WAN" "netgear:green:wan" "eth0"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ath79_setup_interfaces()
 	devolo,dvl1750x|\
 	engenius,ecb1750|\
 	glinet,gl-ar300m-lite|\
+	kuwfi,cpe206|\
 	netgear,ex6400|\
 	netgear,ex7300|\
 	ocedo,koala|\

--- a/target/linux/ath79/dts/qca9531_kuwfi_cpe206.dts
+++ b/target/linux/ath79/dts/qca9531_kuwfi_cpe206.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "kuwfi,cpe206", "qca,qca9531";
+	model = "KuWfi CPE206";
+
+	aliases {
+		led-boot = &status;
+		led-failsafe = &status;
+		led-running = &status;
+		led-upgrade = &status;
+	};
+
+	keys {  
+		compatible = "gpio-keys";
+
+		reset { 
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {  
+		compatible = "gpio-leds";
+
+		lan {
+			label = "cpe206:green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		status: status {
+			label = "cpe206:green:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		wlan {
+			label = "cpe206:green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&art 0x10a0>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+	status = "okay";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x01c000>;
+				read-only;
+			};
+
+			partition@0x01c000 {
+				label = "SBI";
+				reg = <0x01c000 0x4000>;
+				read-only;
+			};
+		
+			partition@0x020000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x020000 0x780000>;
+			};
+
+			partition@0x7a0000 {
+				label = "elog";
+				reg = <0x7a0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7b0000 {
+				label = "config";
+				reg = <0x7b0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7c0000 {
+				label = "config2";
+				reg = <0x7c0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7d0000 {
+				label = "custom";
+				reg = <0x7d0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7e0000 {
+				label = "DTB";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			art: partition@0x7f0000 {
+				label = "CAL";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac { 
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -664,6 +664,15 @@ define Device/jjplus_ja76pf2
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
+define Device/kuwfi_cpe206
+  ATH_SOC := qca9531
+  DEVICE_VENDOR := KuWfi
+  DEVICE_MODEL := CPE206
+  DEVICE_PACKAGES += -uboot-envtools
+  IMAGE_SIZE := 7680k
+endef
+TARGET_DEVICES += kuwfi_cpe206
+
 define Device/librerouter_librerouter-v1
   ATH_SOC := qca9558
   DEVICE_VENDOR := Librerouter


### PR DESCRIPTION
ath79: add support for KuWfi CPE2G-9531 based on AP143

Short specification:
* CPU 650MHz / RAM 597MHz / AHB 216MHz
* Flash: 8 MB
* DRAM: 64 MB
* SoC: Qualcomm Atheros QCA9533 ver 2 rev 0
* 1 Ethernet 1000Mbps ports

Flash instruction under vendor firmware:

* push the reset button while powering up the device
* connect to 192.168.1.20
* update bootloader to default bootloader using http://superwrt.com/download/files/bootloader/20180904_v1.3.10/firmware/superwrt_fboot_qca953x_20180904.img
* reboot, and power off.
* again, push the reset button while powering up the device
* connect to 192.168.17.1
* use upgrade web interface to upload openwrt firmware
* device shall be booting on 192.168.1.1 as default

Signed-off by: Joan Moreau jom@grosjo.net