### PR TITLE
ath79: glinet_gl-ar750s: Use QCA9887 firmware

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -363,7 +363,7 @@ TARGET_DEVICES += glinet_gl-ar300m-nor
 define Device/glinet_gl-ar750s
   ATH_SOC := qca9563
   DEVICE_TITLE := GL.iNet GL-AR750S
-  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar750s
 endef


### PR DESCRIPTION
_Note: This may already be present by way of https://git.openwrt.org/?p=openwrt/staging/ynezz.git;a=commit;h=2929e2ce4b9c27b003e788c2350af8d1bb734f97_

The GL.iNet AR750S is based around the QCA9563
and requires the QCA9887 firmware for operation.

Signed-off-by: Jeff Kletsky <git-commits@allycomm.com>

