### PR TITLE
 base-files: add reboot only button handler

### DIFF
--- a/package/base-files/files/etc/rc.button/reboot
+++ b/package/base-files/files/etc/rc.button/reboot
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+[ "${ACTION}" = "released" ] || exit 0
+
+if [ "$SEEN" -ge 5 ]
+then
+	echo "REBOOT" > /dev/console
+	sync
+	reboot
+fi
+
+return 0

--- a/package/kernel/button-hotplug/src/button-hotplug.c
+++ b/package/kernel/button-hotplug/src/button-hotplug.c
@@ -85,6 +85,7 @@ static struct bh_map button_map[] = {
 	BH_MAP(BTN_9,		"BTN_9"),
 	BH_MAP(KEY_RESTART,	"reset"),
 	BH_MAP(KEY_POWER,	"power"),
+	BH_MAP(KEY_POWER2,	"reboot"),
 	BH_MAP(KEY_RFKILL,	"rfkill"),
 	BH_MAP(KEY_WPS_BUTTON,	"wps"),
 	BH_MAP(KEY_WIMAX,	"wwan"),

--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -100,6 +100,7 @@ static struct bh_map button_map[] = {
 	BH_MAP(KEY_LIGHTS_TOGGLE,	"lights_toggle"),
 	BH_MAP(KEY_PHONE,		"phone"),
 	BH_MAP(KEY_POWER,		"power"),
+	BH_MAP(KEY_POWER2,		"reboot"),
 	BH_MAP(KEY_RESTART,		"reset"),
 	BH_MAP(KEY_RFKILL,		"rfkill"),
 	BH_MAP(KEY_VIDEO,		"video"),

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/BTHOMEHUBV5A.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/BTHOMEHUBV5A.dts
@@ -48,7 +48,7 @@
 		restart {
 			label = "restart";
 			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_POWER>;
+			linux,code = <KEY_POWER2>;
 		};
 	};
 


### PR DESCRIPTION
For devices such as BTHOMEHUBV5A with both reset and restart buttons, its easily accessible restart button has been assigned to KEY_POWER power script to poweroff preventing accidental (or malicious) factory resets by KEY_RESTART reset script. However an easily accessible button immediately powering off the device is also undesirable.

As KEY_RESTART is already used for reset script (and there's no KEY_REBOOT in Linux input events), use KEY_POWER2 for rebooting via new reboot script with 5 second seen delay.

Fixes FS#1965

