### PR TITLE
ath79: add support for TP-Link Archer D50 V1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -132,6 +132,11 @@ tplink,cpe210-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
 	;;
+tplink,archer-d50-v1)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x1E"
+	ucidef_set_led_netdev "wan_data" "WAN Data" "tp-link:white:internet" "eth1.2" "tx rx"
+	ucidef_set_led_netdev "wan_link" "WAN Link" "tp-link:white:wan" "eth1.2" "link"
+	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -175,6 +175,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
 		;;
+	tplink,archer-d50-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
+		;;
 	buffalo,whr-g301n|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -143,6 +143,10 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;
+        tplink,archer-d50-v1)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) +2)
+                ;;
 	tplink,re350k-v1)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +2)

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,archer-d50-v1", "qca,qca9531";
+	model = "TP-Link Archer D50 v1";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		led_wlan2g: wlan2g {
+			label = "tp-link:white:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wlan5g: wlan5g {
+			label = "tp-link:white:wlan5g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "phy1tpt";
+                };
+
+		qss_led: qss {
+			label = "tp-link:white:qss";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wan {
+			label = "tp-link:white:wan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		lan {
+			label = "tp-link:white:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		usb {
+			label = "tp-link:white:usb";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		internet {
+			label = "tp-link:white:internet";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		system: system{
+			label = "tp-link:white:system";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "RFKILL button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7a0000>;
+			};
+
+			partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x010000>;
+				read-only;
+			};
+
+			romfile: partition@7d0000 {
+				label = "romfile";
+				reg = <0x7d0000 0x010000>;
+				read-only;
+			};
+
+			partition@7e0000 {
+				label = "rom";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&romfile 0xf100>;
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&romfile 0xf100>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&romfile 0xf100>;
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -133,6 +133,27 @@ define Device/tplink_cpe210-v3
 endef
 TARGET_DEVICES += tplink_cpe210-v3
 
+define Device/tplink_archer-d50-v1
+  ATH_SOC := qca9531
+  DEVICE_TITLE := TP-Link Archer D50 v1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  BOARDNAME := ARCHER-D50-V1
+  IMAGE_SIZE := 7808k
+  TPLINK_HWID := 0xC1200001
+  TPLINK_HWREV := 0x00000046
+  TPLINK_FLASHLAYOUT := 8Mqca
+  TPLINK_HWREVADD := 0x00000000
+  TPLINK_HVERSION := 3
+  KERNEL := kernel-bin | append-dtb | lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | \
+        tplink-v2-header -s -V "ver. 1.0"
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := tplink-v2-image -s -V "ver. 2.0" | \
+        append-metadata | check-size $$$$(IMAGE_SIZE)
+  SUPPORTED_DEVICES += archer-d50-v1
+endef
+TARGET_DEVICES += tplink_archer-d50-v1
+
 define Device/tplink_re350k-v1
   $(Device/tplink-safeloader)
   ATH_SOC := qca9558

--- a/tools/firmware-utils/src/mktplinkfw2.c
+++ b/tools/firmware-utils/src/mktplinkfw2.c
@@ -159,6 +159,18 @@ static struct flash_layout layouts[] = {
 		.kernel_ep	= 0x80000000,
 		.rootfs_ofs	= 0x140000,
 	}, {
+		.id             = "8Mqca",
+		.fw_max_len     = 0x7a0000,
+		.kernel_la      = 0x80060000,
+		.kernel_ep      = 0x80060000,
+		.rootfs_ofs     = 0x140000,
+	}, {
+		.id             = "16Mqca",
+		.fw_max_len     = 0xf90000,
+		.kernel_la      = 0x80060000,
+		.kernel_ep      = 0x80060000,
+		.rootfs_ofs     = 0x140000,
+	}, {
 		/* terminating entry */
 	}
 };


### PR DESCRIPTION
This is a fixed version of this PR https://github.com/openwrt/openwrt/pull/1504.
I added the 8Mqca entry to mktplinkfw2 to make it working from flash.
I tested the flashing and restore procedure in the commit message.