### PR TITLE
toolchain/binutils: use default Host/Configure rule

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -33,34 +33,33 @@ PATCH_DIR:=./patches/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/toolchain-build.mk
 
-BINUTILS_CONFIGURE:= \
-	./configure \
-		--prefix=$(TOOLCHAIN_DIR) \
-		--build=$(GNU_HOST_NAME) \
-		--host=$(GNU_HOST_NAME) \
-		--target=$(REAL_GNU_TARGET_NAME) \
-		--with-sysroot=$(TOOLCHAIN_DIR) \
-		--enable-deterministic-archives \
-		--enable-plugins \
-		--disable-multilib \
-		--disable-werror \
-		--disable-nls \
-		--disable-sim \
-		--disable-gdb \
-		$(GRAPHITE_CONFIGURE) \
-		$(SOFT_FLOAT_CONFIG_OPTION) \
-		$(call qstrip,$(CONFIG_EXTRA_BINUTILS_CONFIG_OPTIONS)) 
+HOST_CONFIGURE_ARGS = \
+	--prefix=$(TOOLCHAIN_DIR) \
+	--build=$(GNU_HOST_NAME) \
+	--host=$(GNU_HOST_NAME) \
+	--target=$(REAL_GNU_TARGET_NAME) \
+	--with-sysroot=$(TOOLCHAIN_DIR) \
+	--enable-deterministic-archives \
+	--enable-plugins \
+	--disable-multilib \
+	--disable-werror \
+	--disable-nls \
+	--disable-sim \
+	--disable-gdb \
+	$(GRAPHITE_CONFIGURE) \
+	$(SOFT_FLOAT_CONFIG_OPTION) \
+	$(call qstrip,$(CONFIG_EXTRA_BINUTILS_CONFIG_OPTIONS))
 
 ifneq ($(CONFIG_SSP_SUPPORT),)
-  BINUTILS_CONFIGURE+= \
+  HOST_CONFIGURE_ARGS+= \
 		--enable-libssp
 else
-  BINUTILS_CONFIGURE+= \
+  HOST_CONFIGURE_ARGS+= \
 		--disable-libssp
 endif
 
 ifneq ($(CONFIG_EXTRA_TARGET_ARCH),)
-  BINUTILS_CONFIGURE+= \
+  HOST_CONFIGURE_ARGS+= \
 		--enable-targets=$(call qstrip,$(CONFIG_EXTRA_TARGET_ARCH_NAME))-linux-$(TARGET_SUFFIX)
 endif
 
@@ -69,12 +68,6 @@ define Host/Prepare
 	ln -snf $(notdir $(HOST_BUILD_DIR)) $(BUILD_DIR_TOOLCHAIN)/$(PKG_NAME)
 	$(CP) $(SCRIPT_DIR)/config.{guess,sub} $(HOST_BUILD_DIR)/
 	$(SED) 's, " Linaro.*,,' $(HOST_BUILD_DIR)/bfd/version.h
-endef
-
-define Host/Configure
-	(cd $(HOST_BUILD_DIR); \
-		$(BINUTILS_CONFIGURE) \
-	);
 endef
 
 define Host/Compile


### PR DESCRIPTION
This seems to have been omitted over-time.
Using the default Host/Configure seems to work fine.

The last patches to have touched this in a major way were ~10 years ago:
33a0eb3613d ("cosmetic & coherency fixes")
7eb15898755 ("build system refactoring in preparation for allowing
              packages to do host-build steps")

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>