### PR TITLE
base-files: add console to inittab

### DIFF
--- a/target/linux/x86/base-files/etc/inittab
+++ b/target/linux/x86/base-files/etc/inittab
@@ -3,3 +3,4 @@
 ttyS0::askfirst:/usr/libexec/login.sh
 hvc0::askfirst:/usr/libexec/login.sh
 tty1::askfirst:/usr/libexec/login.sh
+console::askfirst:/usr/libexec/login.sh


### PR DESCRIPTION
When running OpenWrt inside an LXC container no shell is opend as LXC
defaults to a virtual /dev/console.

This patch allows to enter a shell after starting the container via
`lxc-start`, without it is only posible to access a shell on tty1 via
`lxc-console`.

Signed-off-by: Paul Spooren <mail@aparcar.org>