### PR TITLE
ipq40xx minor clock and CPU fixes

### DIFF
--- a/target/linux/ipq40xx/patches-4.14/072-qcom-ipq4019-add-cpu-operating-points-for-cpufreq-su.patch
+++ b/target/linux/ipq40xx/patches-4.14/072-qcom-ipq4019-add-cpu-operating-points-for-cpufreq-su.patch
@@ -10,7 +10,7 @@ Signed-off-by: Matthew McClintock <mmcclint@codeaurora.org>
 Signed-off-by: John Crispin <john@phrozen.org>
 ---
  arch/arm/boot/dts/qcom-ipq4019.dtsi | 34 ++++++++++++++++++++++++++--------
- 1 file changed, 26 insertions(+), 8 deletions(-)
+ 1 file changed, 30 insertions(+), 8 deletions(-)
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
@@ -54,7 +54,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  		};
  
  		L2: l2-cache {
-@@ -94,6 +90,28 @@
+@@ -94,6 +90,32 @@
  		};
  	};
  
@@ -65,18 +65,22 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +		opp-48000000 {
 +			opp-hz = /bits/ 64 <48000000>;
 +			clock-latency-ns = <256000>;
++			opp-microvolt = <1100000>;
 +		};
 +		opp-200000000 {
 +			opp-hz = /bits/ 64 <200000000>;
 +			clock-latency-ns = <256000>;
++			opp-microvolt = <1100000>;
 +		};
 +		opp-500000000 {
 +			opp-hz = /bits/ 64 <500000000>;
 +			clock-latency-ns = <256000>;
++			opp-microvolt = <1100000>;
 +		};
 +		opp-716000000 {
 +			opp-hz = /bits/ 64 <716000000>;
 +			clock-latency-ns = <256000>;
++			opp-microvolt = <1100000>;
 +		};
 +	};
 +

--- a/target/linux/ipq40xx/patches-4.14/073-qcom-ipq4019-fix-cpu0-s-qcom-saw2-reg-value.patch
+++ b/target/linux/ipq40xx/patches-4.14/073-qcom-ipq4019-fix-cpu0-s-qcom-saw2-reg-value.patch
@@ -22,7 +22,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -262,7 +262,7 @@
+@@ -266,7 +266,7 @@
  
                  saw0: regulator@b089000 {
                          compatible = "qcom,saw2";

--- a/target/linux/ipq40xx/patches-4.14/077-qcom-ipq4019-add-USB-devicetree-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/077-qcom-ipq4019-add-USB-devicetree-nodes.patch
@@ -41,7 +41,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  };
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -410,5 +410,79 @@
+@@ -414,5 +414,79 @@
  					  "legacy";
  			status = "disabled";
  		};

--- a/target/linux/ipq40xx/patches-4.14/078-ARM-dts-ipq4019-Add-a-few-peripheral-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/078-ARM-dts-ipq4019-Add-a-few-peripheral-nodes.patch
@@ -41,7 +41,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  	};
  
  	cpus {
-@@ -132,6 +134,12 @@
+@@ -136,6 +138,12 @@
  		};
  	};
  
@@ -54,7 +54,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  	timer {
  		compatible = "arm,armv7-timer";
  		interrupts = <1 2 0xf08>,
-@@ -177,13 +185,13 @@
+@@ -181,13 +189,13 @@
  			#gpio-cells = <2>;
  			interrupt-controller;
  			#interrupt-cells = <2>;
@@ -70,7 +70,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			clocks = <&gcc GCC_BLSP1_AHB_CLK>;
  			clock-names = "bam_clk";
  			#dma-cells = <1>;
-@@ -191,7 +199,7 @@
+@@ -195,7 +203,7 @@
  			status = "disabled";
  		};
  
@@ -79,7 +79,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			compatible = "qcom,spi-qup-v2.2.1";
  			reg = <0x78b5000 0x600>;
  			interrupts = <GIC_SPI 95 IRQ_TYPE_LEVEL_HIGH>;
-@@ -200,10 +208,26 @@
+@@ -204,10 +212,26 @@
  			clock-names = "core", "iface";
  			#address-cells = <1>;
  			#size-cells = <0>;
@@ -107,7 +107,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			compatible = "qcom,i2c-qup-v2.2.1";
  			reg = <0x78b7000 0x600>;
  			interrupts = <GIC_SPI 97 IRQ_TYPE_LEVEL_HIGH>;
-@@ -212,14 +236,29 @@
+@@ -216,14 +240,29 @@
  			clock-names = "iface", "core";
  			#address-cells = <1>;
  			#size-cells = <0>;
@@ -138,7 +138,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			clocks = <&gcc GCC_CRYPTO_AHB_CLK>;
  			clock-names = "bam_clk";
  			#dma-cells = <1>;
-@@ -293,7 +332,7 @@
+@@ -297,7 +336,7 @@
  		serial@78af000 {
  			compatible = "qcom,msm-uartdm-v1.4", "qcom,msm-uartdm";
  			reg = <0x78af000 0x200>;
@@ -147,7 +147,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			status = "disabled";
  			clocks = <&gcc GCC_BLSP1_UART1_APPS_CLK>,
  				<&gcc GCC_BLSP1_AHB_CLK>;
-@@ -305,7 +344,7 @@
+@@ -309,7 +348,7 @@
  		serial@78b0000 {
  			compatible = "qcom,msm-uartdm-v1.4", "qcom,msm-uartdm";
  			reg = <0x78b0000 0x200>;
@@ -156,7 +156,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			status = "disabled";
  			clocks = <&gcc GCC_BLSP1_UART2_APPS_CLK>,
  				<&gcc GCC_BLSP1_AHB_CLK>;
-@@ -327,6 +366,101 @@
+@@ -331,6 +370,101 @@
  			reg = <0x4ab000 0x4>;
  		};
  
@@ -258,7 +258,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  		wifi0: wifi@a000000 {
  			compatible = "qcom,ipq4019-wifi";
  			reg = <0xa000000 0x200000>;
-@@ -360,7 +494,7 @@
+@@ -364,7 +498,7 @@
  				     <GIC_SPI 45 IRQ_TYPE_EDGE_RISING>,
  				     <GIC_SPI 46 IRQ_TYPE_EDGE_RISING>,
  				     <GIC_SPI 47 IRQ_TYPE_EDGE_RISING>,
@@ -267,7 +267,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			interrupt-names =  "msi0",  "msi1",  "msi2",  "msi3",
  					   "msi4",  "msi5",  "msi6",  "msi7",
  					   "msi8",  "msi9", "msi10", "msi11",
-@@ -402,7 +536,7 @@
+@@ -406,7 +540,7 @@
  				     <GIC_SPI 61 IRQ_TYPE_EDGE_RISING>,
  				     <GIC_SPI 62 IRQ_TYPE_EDGE_RISING>,
  				     <GIC_SPI 63 IRQ_TYPE_EDGE_RISING>,

--- a/target/linux/ipq40xx/patches-4.14/079-ARM-dts-ipq4019-fix-PCI-range.patch
+++ b/target/linux/ipq40xx/patches-4.14/079-ARM-dts-ipq4019-fix-PCI-range.patch
@@ -12,7 +12,7 @@ Signed-off-by: Mathias Kresin <dev@kresin.me>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -381,7 +381,7 @@
+@@ -385,7 +385,7 @@
  			#size-cells = <2>;
  
  			ranges = <0x81000000 0 0x40200000 0x40200000 0 0x00100000

--- a/target/linux/ipq40xx/patches-4.14/080-pinctrl-msm-fix-gpio-hog-related-boot-issues.patch
+++ b/target/linux/ipq40xx/patches-4.14/080-pinctrl-msm-fix-gpio-hog-related-boot-issues.patch
@@ -61,7 +61,7 @@ Origin: other, https://patchwork.kernel.org/patch/10339127/
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -182,6 +182,7 @@
+@@ -186,6 +186,7 @@
  			compatible = "qcom,ipq4019-pinctrl";
  			reg = <0x01000000 0x300000>;
  			gpio-controller;

--- a/target/linux/ipq40xx/patches-4.14/084-ARM-dts-ipq4019-Add-a-default-chosen-node.patch
+++ b/target/linux/ipq40xx/patches-4.14/084-ARM-dts-ipq4019-Add-a-default-chosen-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  			status = "ok";
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -346,7 +346,7 @@
+@@ -350,7 +350,7 @@
  			regulator;
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/086-ARM-dts-qcom-ipq4019-enlarge-PCIe-BAR-range.patch
+++ b/target/linux/ipq40xx/patches-4.14/086-ARM-dts-qcom-ipq4019-enlarge-PCIe-BAR-range.patch
@@ -29,7 +29,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -397,8 +397,8 @@
+@@ -401,8 +401,8 @@
  			#address-cells = <3>;
  			#size-cells = <2>;
  

--- a/target/linux/ipq40xx/patches-4.14/087-ARM-dts-qcom-ipq4019-Fix-MSI-IRQ-type.patch
+++ b/target/linux/ipq40xx/patches-4.14/087-ARM-dts-qcom-ipq4019-Fix-MSI-IRQ-type.patch
@@ -21,7 +21,7 @@ Reviewed-by: Bjorn Andersson <bjorn.andersson@linaro.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -400,7 +400,7 @@
+@@ -404,7 +404,7 @@
  			ranges = <0x81000000 0 0x40200000 0x40200000 0 0x00100000>,
  				 <0x82000000 0 0x40300000 0x40300000 0 0x00d00000>;
  

--- a/target/linux/ipq40xx/patches-4.14/089-ipq40xx-fix-sleep-clock.patch
+++ b/target/linux/ipq40xx/patches-4.14/089-ipq40xx-fix-sleep-clock.patch
@@ -1,0 +1,29 @@
+From 4d44bb1031a68d7d5b604d3b340c059f41ca62af Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Mon, 6 May 2019 20:55:16 +0300
+Subject: [PATCH] ipq40xx: fix sleep clock
+
+It seems like sleep_clk was copied from ipq806x.
+Fix ipq40xx sleep_clk to the value QSDK defines.
+
+Also rename the sleep clock node like the GCC driver names it.
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -141,9 +141,9 @@
+ 	};
+ 
+ 	clocks {
+-		sleep_clk: sleep_clk {
++		sleep_clk: gcc_sleep_clk_src {
+ 			compatible = "fixed-clock";
+-			clock-frequency = <32768>;
++			clock-frequency = <32000>;
+ 			#clock-cells = <0>;
+ 		};
+ 

--- a/target/linux/ipq40xx/patches-4.14/090-ipq40xx-fix-high-resolution-timer.patch
+++ b/target/linux/ipq40xx/patches-4.14/090-ipq40xx-fix-high-resolution-timer.patch
@@ -1,0 +1,30 @@
+From 09f145f417a5d64d6b8d4476699dfb0eccc6c784 Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Tue, 7 May 2019 10:14:05 +0300
+Subject: [PATCH] ipq40xx: fix high resolution timer
+
+Cherry-picked from CAF QSDK repo.
+Original commit message:
+The kernel is failing in switching the timer for high resolution
+mode and clock source operates in 10ms resolution. The always-on
+property needs to be given for timer device tree node to make
+clock source working in 1ns resolution.
+
+Change-Id: I7c00b3c74d97c2a30ac9f05e18b511a0550fd459
+Signed-off-by: Abhishek Sahu <absahu@codeaurora.org>
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -167,6 +167,7 @@
+ 			     <1 4 0xf08>,
+ 			     <1 1 0xf08>;
+ 		clock-frequency = <48000000>;
++		always-on;
+ 	};
+ 
+ 	soc {

--- a/target/linux/ipq40xx/patches-4.14/091-ipq40xx-add-support-for-secondary-cores-bringup.patch
+++ b/target/linux/ipq40xx/patches-4.14/091-ipq40xx-add-support-for-secondary-cores-bringup.patch
@@ -1,0 +1,174 @@
+From 6126701397fa6c884fd78453d995e49df91a566a Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Mon, 13 May 2019 11:25:05 +0300
+Subject: [PATCH] ipq40xx: Add support for secondary cores bringup
+
+Cherry-pick QSDK patches to enable proper ipq40xx
+secondary cores bringup.
+
+https://source.codeaurora.org/quic/qsdk/oss/kernel/linux-msm/commit/?h=eggplant&id=f810b63c356bd72d9b89fb9c0b7e27c250c3540f
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ Documentation/devicetree/bindings/arm/cpus.txt |  1 +
+ arch/arm/boot/dts/qcom-ipq4019.dtsi            | 16 +++----
+ arch/arm/mach-qcom/platsmp.c                   | 62 ++++++++++++++++++++++++++
+ 3 files changed, 71 insertions(+), 8 deletions(-)
+
+--- a/Documentation/devicetree/bindings/arm/cpus.txt
++++ b/Documentation/devicetree/bindings/arm/cpus.txt
+@@ -210,6 +210,7 @@ described below.
+ 			    "marvell,98dx3236-smp"
+ 			    "mediatek,mt6589-smp"
+ 			    "mediatek,mt81xx-tz-smp"
++			    "qcom,arm-cortex-a7acc"
+ 			    "qcom,gcc-msm8660"
+ 			    "qcom,kpss-acc-v1"
+ 			    "qcom,kpss-acc-v2"
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -52,7 +52,7 @@
+ 		cpu@0 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc0>;
+ 			qcom,saw = <&saw0>;
+@@ -65,7 +65,7 @@
+ 		cpu@1 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc1>;
+ 			qcom,saw = <&saw1>;
+@@ -78,7 +78,7 @@
+ 		cpu@2 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc2>;
+ 			qcom,saw = <&saw2>;
+@@ -91,7 +91,7 @@
+ 		cpu@3 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc3>;
+ 			qcom,saw = <&saw3>;
+@@ -302,22 +302,22 @@
+ 		};
+ 
+                 acc0: clock-controller@b088000 {
+-			compatible = "qcom,kpss-acc-v2";
++			compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b088000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc1: clock-controller@b098000 {
+-			compatible = "qcom,kpss-acc-v2";
++			compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b098000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc2: clock-controller@b0a8000 {
+-			compatible = "qcom,kpss-acc-v2";
++			compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b0a8000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc3: clock-controller@b0b8000 {
+-			compatible = "qcom,kpss-acc-v2";
++			compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b0b8000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+--- a/arch/arm/mach-qcom/platsmp.c
++++ b/arch/arm/mach-qcom/platsmp.c
+@@ -89,6 +89,53 @@ static int scss_release_secondary(unsign
+ 	return 0;
+ }
+ 
++static int a7ss_release_secondary(unsigned int cpu)
++{
++	struct device_node *node;
++	void __iomem *base;
++	struct resource res;
++
++	node = of_find_compatible_node(NULL, NULL, "qcom,arm-cortex-a7acc");
++	if (!node) {
++		pr_err("%s: can't find node\n", __func__);
++		return -ENXIO;
++	}
++
++	if (of_address_to_resource(node, 0, &res)) {
++		of_node_put(node);
++		return -ENXIO;
++	}
++
++	res.start += cpu * 0x10000;
++
++	base = ioremap(res.start, 0x1000);
++	of_node_put(node);
++
++	if (!base)
++		return -ENOMEM;
++
++	/* Enable Clamp signal and assert core reset */
++	writel_relaxed(0x00000033, base + 0x04);
++	mb(); /* barrier */
++
++	/* Set GDHS and delay counter */
++	writel_relaxed(0x20000001, base + 0x14);
++	mb(); /* barrier */
++
++	udelay(2);
++
++	/* Enable Core memory HS */
++	writel_relaxed(0x00020008, base + 0x04);
++	mb(); /* barrier */
++
++	/* Report that the CPU is powered up */
++	writel_relaxed(0x00020088, base + 0x04);
++	mb(); /* barrier */
++
++	iounmap(base);
++	return 0;
++}
++
+ static int kpssv1_release_secondary(unsigned int cpu)
+ {
+ 	int ret = 0;
+@@ -307,6 +354,11 @@ static int msm8660_boot_secondary(unsign
+ 	return qcom_boot_secondary(cpu, scss_release_secondary);
+ }
+ 
++static int a7ss_boot_secondary(unsigned int cpu, struct task_struct *idle)
++{
++	return qcom_boot_secondary(cpu, a7ss_release_secondary);
++}
++
+ static int kpssv1_boot_secondary(unsigned int cpu, struct task_struct *idle)
+ {
+ 	return qcom_boot_secondary(cpu, kpssv1_release_secondary);
+@@ -361,3 +413,13 @@ static const struct smp_operations qcom_
+ #endif
+ };
+ CPU_METHOD_OF_DECLARE(qcom_smp_kpssv2, "qcom,kpss-acc-v2", &qcom_smp_kpssv2_ops);
++
++static struct smp_operations qcom_smp_a7ss_ops __initdata = {
++	.smp_prepare_cpus       = qcom_smp_prepare_cpus,
++	.smp_secondary_init     = qcom_secondary_init,
++	.smp_boot_secondary     = a7ss_boot_secondary,
++#ifdef CONFIG_HOTPLUG_CPU
++	.cpu_die                = qcom_cpu_die,
++#endif
++};
++CPU_METHOD_OF_DECLARE(qcom_smp_a7ss, "qcom,arm-cortex-a7acc", &qcom_smp_a7ss_ops);

--- a/target/linux/ipq40xx/patches-4.14/701-dts-ipq4019-add-mdio-node.patch
+++ b/target/linux/ipq40xx/patches-4.14/701-dts-ipq4019-add-mdio-node.patch
@@ -15,7 +15,7 @@ so the info might change.
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -562,6 +562,34 @@
+@@ -566,6 +566,34 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/701-dts-ipq4019-add-mdio-node.patch
+++ b/target/linux/ipq40xx/patches-4.14/701-dts-ipq4019-add-mdio-node.patch
@@ -15,7 +15,7 @@ so the info might change.
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -566,6 +566,34 @@
+@@ -567,6 +567,34 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/702-dts-ipq4019-add-PHY-switch-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/702-dts-ipq4019-add-PHY-switch-nodes.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -590,6 +590,29 @@
+@@ -594,6 +594,29 @@
  			};
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/702-dts-ipq4019-add-PHY-switch-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.14/702-dts-ipq4019-add-PHY-switch-nodes.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -594,6 +594,29 @@
+@@ -595,6 +595,29 @@
  			};
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/711-dts-ipq4019-add-ethernet-essedma-node.patch
+++ b/target/linux/ipq40xx/patches-4.14/711-dts-ipq4019-add-ethernet-essedma-node.patch
@@ -25,7 +25,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  	};
  
  	cpus {
-@@ -617,6 +619,64 @@
+@@ -618,6 +620,64 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.14/711-dts-ipq4019-add-ethernet-essedma-node.patch
+++ b/target/linux/ipq40xx/patches-4.14/711-dts-ipq4019-add-ethernet-essedma-node.patch
@@ -25,7 +25,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  	};
  
  	cpus {
-@@ -613,6 +615,64 @@
+@@ -617,6 +619,64 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/072-v4.20-ARM-dts-qcom-ipq4019-add-cpu-operating-points-for-cp.patch
+++ b/target/linux/ipq40xx/patches-4.19/072-v4.20-ARM-dts-qcom-ipq4019-add-cpu-operating-points-for-cp.patch
@@ -10,8 +10,8 @@ Signed-off-by: Matthew McClintock <mmcclint@codeaurora.org>
 Signed-off-by: John Crispin <john@phrozen.org>
 Signed-off-by: Andy Gross <andy.gross@linaro.org>
 ---
- arch/arm/boot/dts/qcom-ipq4019.dtsi | 54 ++++++++++++++---------------
- 1 file changed, 26 insertions(+), 28 deletions(-)
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 58 ++++++++++++++---------------
+ 1 file changed, 30 insertions(+), 28 deletions(-)
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
@@ -79,7 +79,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
  		};
  
  		L2: l2-cache {
-@@ -136,6 +112,28 @@
+@@ -136,6 +112,32 @@
  		};
  	};
  
@@ -89,18 +89,22 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
 +
 +		opp-48000000 {
 +			opp-hz = /bits/ 64 <48000000>;
++			opp-microvolt = <1100000>;
 +			clock-latency-ns = <256000>;
 +		};
 +		opp-200000000 {
 +			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <1100000>;
 +			clock-latency-ns = <256000>;
 +		};
 +		opp-500000000 {
 +			opp-hz = /bits/ 64 <500000000>;
++			opp-microvolt = <1100000>;
 +			clock-latency-ns = <256000>;
 +		};
 +		opp-716000000 {
 +			opp-hz = /bits/ 64 <716000000>;
++			opp-microvolt = <1100000>;
 +			clock-latency-ns = <256000>;
 + 		};
 +	};

--- a/target/linux/ipq40xx/patches-4.19/073-v4.20-ARM-dts-qcom-ipq4019-fix-cpu0-s-qcom-saw2-reg-value.patch
+++ b/target/linux/ipq40xx/patches-4.19/073-v4.20-ARM-dts-qcom-ipq4019-fix-cpu0-s-qcom-saw2-reg-value.patch
@@ -23,7 +23,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -321,7 +321,7 @@
+@@ -325,7 +325,7 @@
  
                  saw0: regulator@b089000 {
                          compatible = "qcom,saw2";

--- a/target/linux/ipq40xx/patches-4.19/077-qcom-ipq4019-add-USB-devicetree-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.19/077-qcom-ipq4019-add-USB-devicetree-nodes.patch
@@ -41,7 +41,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  };
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -564,5 +564,79 @@
+@@ -568,5 +568,79 @@
  					  "legacy";
  			status = "disabled";
  		};

--- a/target/linux/ipq40xx/patches-4.19/079-v4.20-ARM-dts-qcom-ipq4019-fix-PCI-range.patch
+++ b/target/linux/ipq40xx/patches-4.19/079-v4.20-ARM-dts-qcom-ipq4019-fix-PCI-range.patch
@@ -14,7 +14,7 @@ Signed-off-by: Andy Gross <andy.gross@linaro.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -401,7 +401,7 @@
+@@ -405,7 +405,7 @@
  			#size-cells = <2>;
  
  			ranges = <0x81000000 0 0x40200000 0x40200000 0 0x00100000

--- a/target/linux/ipq40xx/patches-4.19/080-ARM-dts-qcom-add-gpio-ranges-property.patch
+++ b/target/linux/ipq40xx/patches-4.19/080-ARM-dts-qcom-add-gpio-ranges-property.patch
@@ -60,7 +60,7 @@ will be executed twice with the same parameters for the same pinctrl.
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -202,6 +202,7 @@
+@@ -206,6 +206,7 @@
  			compatible = "qcom,ipq4019-pinctrl";
  			reg = <0x01000000 0x300000>;
  			gpio-controller;

--- a/target/linux/ipq40xx/patches-4.19/083-ARM-dts-qcom-ipq4019-enlarge-PCIe-BAR-range.patch
+++ b/target/linux/ipq40xx/patches-4.19/083-ARM-dts-qcom-ipq4019-enlarge-PCIe-BAR-range.patch
@@ -29,7 +29,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -401,8 +401,8 @@
+@@ -405,8 +405,8 @@
  			#address-cells = <3>;
  			#size-cells = <2>;
  

--- a/target/linux/ipq40xx/patches-4.19/084-ARM-dts-qcom-ipq4019-Fix-MSI-IRQ-type.patch
+++ b/target/linux/ipq40xx/patches-4.19/084-ARM-dts-qcom-ipq4019-Fix-MSI-IRQ-type.patch
@@ -21,7 +21,7 @@ Reviewed-by: Bjorn Andersson <bjorn.andersson@linaro.org>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -404,7 +404,7 @@
+@@ -408,7 +408,7 @@
  			ranges = <0x81000000 0 0x40200000 0x40200000 0 0x00100000>,
  				 <0x82000000 0 0x40300000 0x40300000 0 0x00d00000>;
  

--- a/target/linux/ipq40xx/patches-4.19/085-ipq40xx-fix-sleep-clock.patch
+++ b/target/linux/ipq40xx/patches-4.19/085-ipq40xx-fix-sleep-clock.patch
@@ -1,0 +1,29 @@
+From 4d44bb1031a68d7d5b604d3b340c059f41ca62af Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Mon, 6 May 2019 20:55:16 +0300
+Subject: [PATCH] ipq40xx: fix sleep clock
+
+It seems like sleep_clk was copied from ipq806x.
+Fix ipq40xx sleep_clk to the value QSDK defines.
+
+Also rename the sleep clock node like the GCC driver names it.
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -145,9 +145,9 @@
+ 	};
+ 
+ 	clocks {
+-		sleep_clk: sleep_clk {
++		sleep_clk: gcc_sleep_clk_src {
+ 			compatible = "fixed-clock";
+-			clock-frequency = <32768>;
++			clock-frequency = <32000>;
+ 			#clock-cells = <0>;
+ 		};
+ 

--- a/target/linux/ipq40xx/patches-4.19/086-ipq40xx-fix-high-resolution-timer.patch
+++ b/target/linux/ipq40xx/patches-4.19/086-ipq40xx-fix-high-resolution-timer.patch
@@ -1,0 +1,30 @@
+From 09f145f417a5d64d6b8d4476699dfb0eccc6c784 Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Tue, 7 May 2019 10:14:05 +0300
+Subject: [PATCH] ipq40xx: fix high resolution timer
+
+Cherry-picked from CAF QSDK repo.
+Original commit message:
+The kernel is failing in switching the timer for high resolution
+mode and clock source operates in 10ms resolution. The always-on
+property needs to be given for timer device tree node to make
+clock source working in 1ns resolution.
+
+Change-Id: I7c00b3c74d97c2a30ac9f05e18b511a0550fd459
+Signed-off-by: Abhishek Sahu <absahu@codeaurora.org>
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -171,6 +171,7 @@
+ 			     <1 4 0xf08>,
+ 			     <1 1 0xf08>;
+ 		clock-frequency = <48000000>;
++		always-on;
+ 	};
+ 
+ 	soc {

--- a/target/linux/ipq40xx/patches-4.19/087-ipq40xx-Add-support-for-secondary-cores-bringup.patch
+++ b/target/linux/ipq40xx/patches-4.19/087-ipq40xx-Add-support-for-secondary-cores-bringup.patch
@@ -1,0 +1,174 @@
+From 6126701397fa6c884fd78453d995e49df91a566a Mon Sep 17 00:00:00 2001
+From: Pavel Kubelun <be.dissent@gmail.com>
+Date: Mon, 13 May 2019 11:25:05 +0300
+Subject: [PATCH] ipq40xx: Add support for secondary cores bringup
+
+Cherry-pick QSDK patches to enable proper ipq40xx
+secondary cores bringup.
+
+https://source.codeaurora.org/quic/qsdk/oss/kernel/linux-msm/commit/?h=eggplant&id=f810b63c356bd72d9b89fb9c0b7e27c250c3540f
+
+Signed-off-by: Pavel Kubelun <be.dissent@gmail.com>
+---
+ Documentation/devicetree/bindings/arm/cpus.txt |  1 +
+ arch/arm/boot/dts/qcom-ipq4019.dtsi            | 16 +++----
+ arch/arm/mach-qcom/platsmp.c                   | 62 ++++++++++++++++++++++++++
+ 3 files changed, 71 insertions(+), 8 deletions(-)
+
+--- a/Documentation/devicetree/bindings/arm/cpus.txt
++++ b/Documentation/devicetree/bindings/arm/cpus.txt
+@@ -216,6 +216,7 @@ described below.
+ 			    "marvell,98dx3236-smp"
+ 			    "mediatek,mt6589-smp"
+ 			    "mediatek,mt81xx-tz-smp"
++			    "qcom,arm-cortex-a7acc"
+ 			    "qcom,gcc-msm8660"
+ 			    "qcom,kpss-acc-v1"
+ 			    "qcom,kpss-acc-v2"
+--- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
+@@ -52,7 +52,7 @@
+ 		cpu@0 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc0>;
+ 			qcom,saw = <&saw0>;
+@@ -66,7 +66,7 @@
+ 		cpu@1 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc1>;
+ 			qcom,saw = <&saw1>;
+@@ -80,7 +80,7 @@
+ 		cpu@2 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc2>;
+ 			qcom,saw = <&saw2>;
+@@ -94,7 +94,7 @@
+ 		cpu@3 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a7";
+-			enable-method = "qcom,kpss-acc-v2";
++			enable-method = "qcom,arm-cortex-a7acc";
+ 			next-level-cache = <&L2>;
+ 			qcom,acc = <&acc3>;
+ 			qcom,saw = <&saw3>;
+@@ -306,22 +306,22 @@
+ 		};
+ 
+                 acc0: clock-controller@b088000 {
+-                        compatible = "qcom,kpss-acc-v2";
++                        compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b088000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc1: clock-controller@b098000 {
+-                        compatible = "qcom,kpss-acc-v2";
++                        compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b098000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc2: clock-controller@b0a8000 {
+-                        compatible = "qcom,kpss-acc-v2";
++                        compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b0a8000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+                 acc3: clock-controller@b0b8000 {
+-                        compatible = "qcom,kpss-acc-v2";
++                        compatible = "qcom,arm-cortex-a7acc";
+                         reg = <0x0b0b8000 0x1000>, <0xb008000 0x1000>;
+                 };
+ 
+--- a/arch/arm/mach-qcom/platsmp.c
++++ b/arch/arm/mach-qcom/platsmp.c
+@@ -89,6 +89,53 @@ static int scss_release_secondary(unsign
+ 	return 0;
+ }
+ 
++static int a7ss_release_secondary(unsigned int cpu)
++{
++	struct device_node *node;
++	void __iomem *base;
++	struct resource res;
++
++	node = of_find_compatible_node(NULL, NULL, "qcom,arm-cortex-a7acc");
++	if (!node) {
++		pr_err("%s: can't find node\n", __func__);
++		return -ENXIO;
++	}
++
++	if (of_address_to_resource(node, 0, &res)) {
++		of_node_put(node);
++		return -ENXIO;
++	}
++
++	res.start += cpu * 0x10000;
++
++	base = ioremap(res.start, 0x1000);
++	of_node_put(node);
++
++	if (!base)
++		return -ENOMEM;
++
++	/* Enable Clamp signal and assert core reset */
++	writel_relaxed(0x00000033, base + 0x04);
++	mb(); /* barrier */
++
++	/* Set GDHS and delay counter */
++	writel_relaxed(0x20000001, base + 0x14);
++	mb(); /* barrier */
++
++	udelay(2);
++
++	/* Enable Core memory HS */
++	writel_relaxed(0x00020008, base + 0x04);
++	mb(); /* barrier */
++
++	/* Report that the CPU is powered up */
++	writel_relaxed(0x00020088, base + 0x04);
++	mb(); /* barrier */
++
++	iounmap(base);
++	return 0;
++}
++
+ static int kpssv1_release_secondary(unsigned int cpu)
+ {
+ 	int ret = 0;
+@@ -307,6 +354,11 @@ static int msm8660_boot_secondary(unsign
+ 	return qcom_boot_secondary(cpu, scss_release_secondary);
+ }
+ 
++static int a7ss_boot_secondary(unsigned int cpu, struct task_struct *idle)
++{
++	return qcom_boot_secondary(cpu, a7ss_release_secondary);
++}
++
+ static int kpssv1_boot_secondary(unsigned int cpu, struct task_struct *idle)
+ {
+ 	return qcom_boot_secondary(cpu, kpssv1_release_secondary);
+@@ -361,3 +413,13 @@ static const struct smp_operations qcom_
+ #endif
+ };
+ CPU_METHOD_OF_DECLARE(qcom_smp_kpssv2, "qcom,kpss-acc-v2", &qcom_smp_kpssv2_ops);
++
++static struct smp_operations qcom_smp_a7ss_ops __initdata = {
++	.smp_prepare_cpus       = qcom_smp_prepare_cpus,
++	.smp_secondary_init     = qcom_secondary_init,
++	.smp_boot_secondary     = a7ss_boot_secondary,
++#ifdef CONFIG_HOTPLUG_CPU
++	.cpu_die                = qcom_cpu_die,
++#endif
++};
++CPU_METHOD_OF_DECLARE(qcom_smp_a7ss, "qcom,arm-cortex-a7acc", &qcom_smp_a7ss_ops);

--- a/target/linux/ipq40xx/patches-4.19/701-dts-ipq4019-add-mdio-node.patch
+++ b/target/linux/ipq40xx/patches-4.19/701-dts-ipq4019-add-mdio-node.patch
@@ -15,7 +15,7 @@ so the info might change.
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -566,6 +566,34 @@
+@@ -570,6 +570,34 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/701-dts-ipq4019-add-mdio-node.patch
+++ b/target/linux/ipq40xx/patches-4.19/701-dts-ipq4019-add-mdio-node.patch
@@ -15,7 +15,7 @@ so the info might change.
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -570,6 +570,34 @@
+@@ -571,6 +571,34 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -598,6 +598,29 @@
+@@ -599,6 +599,29 @@
  			};
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
+++ b/target/linux/ipq40xx/patches-4.19/702-dts-ipq4019-add-PHY-switch-nodes.patch
@@ -14,7 +14,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/arm/boot/dts/qcom-ipq4019.dtsi
 +++ b/arch/arm/boot/dts/qcom-ipq4019.dtsi
-@@ -594,6 +594,29 @@
+@@ -598,6 +598,29 @@
  			};
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/711-dts-ipq4019-add-ethernet-essedma-node.patch
+++ b/target/linux/ipq40xx/patches-4.19/711-dts-ipq4019-add-ethernet-essedma-node.patch
@@ -25,7 +25,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  	};
  
  	cpus {
-@@ -621,6 +623,64 @@
+@@ -622,6 +624,64 @@
  			status = "disabled";
  		};
  

--- a/target/linux/ipq40xx/patches-4.19/711-dts-ipq4019-add-ethernet-essedma-node.patch
+++ b/target/linux/ipq40xx/patches-4.19/711-dts-ipq4019-add-ethernet-essedma-node.patch
@@ -25,7 +25,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
  	};
  
  	cpus {
-@@ -617,6 +619,64 @@
+@@ -621,6 +623,64 @@
  			status = "disabled";
  		};
  


### PR DESCRIPTION
Main fixes are:
1. Sleep clock change. Currently it's set to 32768 in upstream kernel, but QSDK defines it as 32000. I believe sleep clock was just copied from ipq806x or similar target. If someone with datasheet could clarify the correct clock - good, if not then I guess QSDK knows it better.
2. Secondary cpu cores bringup procedure. Potentially fixes secondary cores reset issue. https://patchwork.kernel.org/patch/10467835/
Other fixes are minor.