### PR TITLE
imagebuilder: new DISABLED_SERVICES make variable

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -78,7 +78,13 @@ define prepare_rootfs
 		done; \
 		for script in ./etc/init.d/*; do \
 			grep '#!/bin/sh /etc/rc.common' $$script >/dev/null || continue; \
-			IPKG_INSTROOT=$(1) $$(which bash) ./etc/rc.common $$script enable; \
+			if ! echo " $(3) " | grep -q " $$(basename $$script) "; then \
+				IPKG_INSTROOT=$(1) $$(which bash) ./etc/rc.common $$script enable; \
+				echo "Enabling" $$(basename $$script); \
+			else \
+				IPKG_INSTROOT=$(1) $$(which bash) ./etc/rc.common $$script disable; \
+				echo "Disabling" $$(basename $$script); \
+			fi; \
 		done || true \
 	)
 	$(if $(SOURCE_DATE_EPOCH),sed -i "s/Installed-Time: .*/Installed-Time: $(SOURCE_DATE_EPOCH)/" $(1)/usr/lib/opkg/status)

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -45,6 +45,7 @@ Building images:
 	make image FILES="<path>" # include extra files from <path>
 	make image BIN_DIR="<path>" # alternative output directory for the images
 	make image EXTRA_IMAGE_NAME="<string>" # Add this to the output image filename (sanitized)
+	make image DISABLED_SERVICES="<svc1> [<svc2> [<svc3> ..]]" # Which services in /etc/init.d/ should be disabled
 
 Print manifest:
 	List "all" packages which get installed into the image.
@@ -159,7 +160,7 @@ prepare_rootfs: FORCE
 	@echo Finalizing root filesystem...
 
 	$(CP) $(TARGET_DIR) $(TARGET_DIR_ORIG)
-	$(call prepare_rootfs,$(TARGET_DIR),$(USER_FILES))
+	$(call prepare_rootfs,$(TARGET_DIR),$(USER_FILES),$(DISABLED_SERVICES))
 
 build_image: FORCE
 	@echo
@@ -197,7 +198,8 @@ image:
 		$(if $(PROFILE),USER_PROFILE="$(PROFILE_FILTER)") \
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
-		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)"))
+		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)") \
+		$(if $(DISABLED_SERVICES),DISABLED_SERVICES="$(DISABLED_SERVICES)"))
 
 manifest: FORCE
 	$(MAKE) -s _check_profile


### PR DESCRIPTION
Adds a new variable DISABLED_SERVICES to ImageBuilder Makefile, which
defines a list of services (installed as /etc/init.d/*) to be disabled
during the build of a custom image (normally all are enabled).

It comes handy when a particular service should not be run under normal
circumstances, but should be ready in the image for situations when it
might be needed.

Signed-off-by: Richard Musil <risa2000x@gmail.com>