### PR TITLE
 ath79: Add support for TP-Link TL-WR1043N v5

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -107,7 +107,8 @@ tplink,archer-c7-v5)
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x20"
 	;;
 tplink,archer-c2-v3|\
-tplink,tl-wr1043nd-v4)
+tplink,tl-wr1043nd-v4|\
+tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x20"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -95,7 +95,8 @@ ath79_setup_interfaces()
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
-	tplink,tl-wr1043nd-v4)
+	tplink,tl-wr1043nd-v4|\
+	tplink,tl-wr1043n-v5)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
@@ -339,7 +340,8 @@ ath79_setup_macs()
 		base_mac=$(mtd_get_mac_binary config 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
-	tplink,tl-wr1043nd-v4)
+	tplink,tl-wr1043nd-v4|\
+	tplink,tl-wr1043n-v5)
 		base_mac=$(mtd_get_mac_binary product-info 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_tl-wr1043n.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr1043n-v5", "qca,qca9563";
+	model = "TP-Link TL-WR1043N v5";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xec0000>;
+			};
+
+			info: partition@f00000 {
+				label = "product-info";
+				reg = <0xf00000 0x020000>;
+				read-only;
+			};
+
+			partition@f20000 {
+				label = "config";
+				reg = <0xf20000 0x0a0000>;
+				read-only;
+			};
+
+			partition@fc0000 {
+				label = "partition-table";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "logs";
+				reg = <0xfd0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
@@ -86,17 +86,6 @@
 			debounce-interval = <60>;
 		};
 	};
-
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		gpio_usb_power {
-			gpio-export,name = "tp-link:power:usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
 &uart {
@@ -105,65 +94,6 @@
 
 &gpio {
 	status = "okay";
-};
-
-&spi {
-	status = "okay";
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0xf30000>;
-			};
-
-			info: partition@f50000 {
-				label = "product-info";
-				reg = <0xf50000 0x020000>;
-				read-only;
-			};
-
-			partition@f70000 {
-				label = "config";
-				reg = <0xf70000 0x050000>;
-				read-only;
-			};
-
-			partition@fc0000 {
-				label = "partition-table";
-				reg = <0xfc0000 0x010000>;
-				read-only;
-			};
-
-			partition@fd0000 {
-				label = "logs";
-				reg = <0xfd0000 0x020000>;
-				read-only;
-			};
-
-			art: partition@ff0000 {
-				label = "ART";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
-	};
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -1,14 +1,81 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
 #include "qca9563_tplink_tl-wr1043n.dtsi"
 
 / {
 	compatible = "tplink,tl-wr1043nd-v4", "qca,qca9563";
 	model = "TP-Link TL-WR1043ND v4";
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "tp-link:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xf30000>;
+			};
+
+			info: partition@f50000 {
+				label = "product-info";
+				reg = <0xf50000 0x020000>;
+				read-only;
+			};
+
+			partition@f70000 {
+				label = "config";
+				reg = <0xf70000 0x050000>;
+				read-only;
+			};
+
+			partition@fc0000 {
+				label = "partition-table";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "logs";
+				reg = <0xfd0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
 };
 
 &gpio_leds {

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -187,16 +187,6 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
-define Device/tplink_tl-wr1043nd-v1
-  $(Device/tplink-8m)
-  ATH_SOC := ar9132
-  DEVICE_TITLE := TP-Link TL-WR1043N/ND v1
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
-  TPLINK_HWID := 0x10430001
-  SUPPORTED_DEVICES += tl-wr1043nd
-endef
-TARGET_DEVICES += tplink_tl-wr1043nd-v1
-
 define Device/tplink_tl-wr810n-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := qca9531
@@ -252,6 +242,16 @@ define Device/tplink_tl-wr842n-v3
   SUPPORTED_DEVICES += tl-wr842n-v3
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v3
+
+define Device/tplink_tl-wr1043nd-v1
+  $(Device/tplink-8m)
+  ATH_SOC := ar9132
+  DEVICE_TITLE := TP-Link TL-WR1043N/ND v1
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x10430001
+  SUPPORTED_DEVICES += tl-wr1043nd
+endef
+TARGET_DEVICES += tplink_tl-wr1043nd-v1
 
 define Device/tplink_tl-wr1043nd-v2
   $(Device/tplink-8mlzma)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -285,6 +285,16 @@ define Device/tplink_tl-wr1043nd-v4
 endef
 TARGET_DEVICES += tplink_tl-wr1043nd-v4
 
+define Device/tplink_tl-wr1043n-v5
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 15104k
+  DEVICE_TITLE := TP-Link TL-WR1043N v5
+  TPLINK_BOARD_ID := TLWR1043NV5
+  SUPPORTED_DEVICES += tl-wr1043n-v5
+endef
+TARGET_DEVICES += tplink_tl-wr1043n-v5
+
 define Device/tplink_tl-wr2543-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar7242


### PR DESCRIPTION
This adds ath79 support for the TP-Link TL-WR1043N v5

Tested factory-flashing, all ports, LEDs, WiFi and buttons on v5.