### PR TITLE
Revert "ipq806x: fix EA8500 switch control"

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -39,10 +39,6 @@
 
 	soc {
 		pinmux@800000 {
-
-			pinctrl-0 = <&switch_reset>;
-			pinctrl-names = "default";
-
 			button_pins: button_pins {
 				mux {
 					pins = "gpio65", "gpio67", "gpio68";
@@ -67,16 +63,6 @@
 					function = "gpio";
 					drive-strength = <2>;
 					bias-pull-up;
-				};
-			};
-
-			switch_reset: switch_reset_pins {
-				mux {
-					pins = "gpio63";
-					function = "gpio";
-					drive-strength = <2>;
-					bias-disable;
-					output-low;
 				};
 			};
 
@@ -175,6 +161,10 @@
 		};
 
 		pcie1: pci@1b700000 {
+			status = "ok";
+		};
+
+		pcie2: pci@1b900000 {
 			status = "ok";
 		};
 
@@ -408,5 +398,3 @@
 	};
 };
 
-/delete-node/ &pcie2_pins;
-/delete-node/ &pcie2;


### PR DESCRIPTION
This reverts commit 7f694ef3d9f1121c03935c330093c594b8437098.

This patch actually broke the switch control. It will result lost control of switch after soft reboot.

Fixes: FS#2168

Signed-off-by: Adam BZH <424778940z@gmail.com>