### PR TITLE
kernel: Reimplement: bridge allow receiption on disabled port

### DIFF
--- a/target/linux/generic/pending-4.14/150-bridge_allow_receiption_on_disabled_port.patch
+++ b/target/linux/generic/pending-4.14/150-bridge_allow_receiption_on_disabled_port.patch
@@ -27,7 +27,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	/* return 1 to signal the okfn() was called so it's ok to use the skb */
  	return 1;
-@@ -332,6 +335,15 @@ rx_handler_result_t br_handle_frame(stru
+@@ -332,6 +335,17 @@ rx_handler_result_t br_handle_frame(stru
  
  forward:
  	switch (p->state) {
@@ -35,9 +35,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		if (ether_addr_equal(p->br->dev->dev_addr, dest))
 +			skb->pkt_type = PACKET_HOST;
 +
-+		NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
++		if (NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
 +			dev_net(skb->dev), NULL, skb, skb->dev, NULL,
-+			br_handle_local_finish);
++			br_handle_local_finish) == 1) {
++			return RX_HANDLER_PASS;
++		}
 +		break;
 +
  	case BR_STATE_FORWARDING:

--- a/target/linux/generic/pending-4.19/150-bridge_allow_receiption_on_disabled_port.patch
+++ b/target/linux/generic/pending-4.19/150-bridge_allow_receiption_on_disabled_port.patch
@@ -25,7 +25,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	__br_handle_local_finish(skb);
  
  	/* return 1 to signal the okfn() was called so it's ok to use the skb */
-@@ -291,6 +294,15 @@ rx_handler_result_t br_handle_frame(stru
+@@ -291,6 +294,17 @@ rx_handler_result_t br_handle_frame(stru
  
  forward:
  	switch (p->state) {
@@ -33,9 +33,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		if (ether_addr_equal(p->br->dev->dev_addr, dest))
 +			skb->pkt_type = PACKET_HOST;
 +
-+		NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
++		if (NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
 +			dev_net(skb->dev), NULL, skb, skb->dev, NULL,
-+			br_handle_local_finish);
++			br_handle_local_finish) == 1) {
++			return RX_HANDLER_PASS;
++		}
 +		break;
 +
  	case BR_STATE_FORWARDING:

--- a/target/linux/generic/pending-4.9/150-bridge_allow_receiption_on_disabled_port.patch
+++ b/target/linux/generic/pending-4.9/150-bridge_allow_receiption_on_disabled_port.patch
@@ -27,7 +27,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	/* return 1 to signal the okfn() was called so it's ok to use the skb */
  	return 1;
-@@ -321,6 +324,15 @@ rx_handler_result_t br_handle_frame(stru
+@@ -321,6 +324,17 @@ rx_handler_result_t br_handle_frame(stru
  
  forward:
  	switch (p->state) {
@@ -35,9 +35,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		if (ether_addr_equal(p->br->dev->dev_addr, dest))
 +			skb->pkt_type = PACKET_HOST;
 +
-+		NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
++		if (NF_HOOK(NFPROTO_BRIDGE, NF_BR_PRE_ROUTING,
 +			dev_net(skb->dev), NULL, skb, skb->dev, NULL,
-+			br_handle_local_finish);
++			br_handle_local_finish) == 1) {
++			return RX_HANDLER_PASS;
++		}
 +		break;
 +
  	case BR_STATE_FORWARDING:


### PR DESCRIPTION
The "bridge allow receiption on disabled port" implement
was broken after these commits:
456f486b53a7cbe7035dca7323f6b5fdb58be444
b765f4be407ca407c8f446a0970aab8e7e93bffb
08802d93e2c1362f7b3b0e7ee43cea910568fe7a

It seems the kernel introduce a new patch(https://lkml.org/lkml/2019/4/24/1228)
So we have to reimplement these patches:
target/linux/generic/pending-4.9/150-bridge_allow_receiption_on_disabled_port.patch
target/linux/generic/pending-4.14/150-bridge_allow_receiption_on_disabled_port.patch
target/linux/generic/pending-4.19/150-bridge_allow_receiption_on_disabled_port.patch

This should fix the broken implementation
