### PR TITLE
bcm53xx: Add support for Arris SBR-AC1900P

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -38,6 +38,10 @@ asus,rt-ac87u)
 	ifname=eth1
 	etXmacaddr=$(nvram get et1macaddr)
 	;;
+arris,sbr-ac1900p)
+	ifname=eth2
+	etXmacaddr=$(nvram get et2macaddr)
+	;;
 dlink,dir-885l | \
 netgear,r7900 | \
 netgear,r8000 | \
@@ -66,6 +70,17 @@ netgear,r8500)
 
 	# These devices should use eth2 so their eth0 interface often has no MAC
 	# assigned. Manually assign eth2's MAC to the LAN.
+	et2macaddr="$(nvram get et2macaddr)"
+	[ -n "$et2macaddr" ] && ucidef_set_interface_macaddr "lan" "$et2macaddr"
+	[ -n "$wan_macaddr" ] && ucidef_set_interface_macaddr "wan" "$wan_macaddr"
+
+	board_config_flush
+	exit 0
+	;;
+arris,sbr-ac1900p)
+	ucidef_add_switch "switch0" \
+		"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "7t@eth1"
+	#it seems a bug in b53, set cpu port from 8 to 7 and eth2 to eth1
 	et2macaddr="$(nvram get et2macaddr)"
 	[ -n "$et2macaddr" ] && ucidef_set_interface_macaddr "lan" "$et2macaddr"
 	[ -n "$wan_macaddr" ] && ucidef_set_interface_macaddr "wan" "$wan_macaddr"

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -320,6 +320,12 @@ define Device/phicomm-k3
 endef
 TARGET_DEVICES += phicomm-k3
 
+define Device/arris-sbr-ac1900p
+  DEVICE_TITLE := ARRIS SBR-AC1900P
+  DEVICE_PACKAGES := $(USB3_PACKAGES)
+endef
+TARGET_DEVICES += arris-sbr-ac1900p
+
 define Device/tenda-ac9
   DEVICE_TITLE := Tenda AC9
   DEVICE_PACKAGES := $(B43) $(USB2_PACKAGES)

--- a/target/linux/bcm53xx/patches-4.14/322-ARM-dts-BCM5301X-Add-DT-for-ARRIS-SBR-AC1900P.patch
+++ b/target/linux/bcm53xx/patches-4.14/322-ARM-dts-BCM5301X-Add-DT-for-ARRIS-SBR-AC1900P.patch
@@ -1,0 +1,118 @@
+This router has BCM4709A0 SoC, 128 MiB NAND flash (MX30LF1G18AC-TI),
+256 MiB memory and 4 x LAN and 1 x WAN ports.
+WiFi chips are BCM4360 x 2.
+USB2.0 x 1. USB3.0 x 1.
+this router cpu port only used port 8,but b53 must set port 7, is it a bug?
+see 700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
+
+
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -105,6 +105,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4709-netgear-r7000.dtb \
+ 	bcm4709-netgear-r8000.dtb \
+ 	bcm4709-tplink-archer-c9-v1.dtb \
++	bcm4709-arris-sbr-ac1900p.dtb \
+ 	bcm47094-dlink-dir-885l.dtb \
+ 	bcm47094-linksys-panamera.dtb \
+ 	bcm47094-luxul-abr-4500.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm4709-arris-sbr-ac1900p.dts
+@@ -0,0 +1,97 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * DTS for ARRIS SBR-AC1900P
++ *
++ * Copyright (C) 2019 Shi Zhangqiang <lostlonger.g@gmail.com>
++ * Copyright (C) 2019 Xu Zhaowei <paldier@hotmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm4709.dtsi"
++#include "bcm5301x-nand-cs0-bch4.dtsi"
++
++/ {
++	compatible = "arris,sbr-ac1900p", "brcm,bcm4709", "brcm,bcm4708";
++	model = "ARRIS SBR-AC1900P";
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	memory {
++		reg = <0x00000000 0x08000000
++		       0x88000000 0x08000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		restart {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 19 GPIO_ACTIVE_LOW>;
++		};
++		
++		wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 20 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&uart1 {
++	status = "okay";
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 18 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 21 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3_phy {
++	status = "okay";
++};
++
++&nandcs {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		partition@0 {
++			label = "boot";
++			reg = <0x0000000 0x0080000>;
++			read-only;
++		};
++
++		partition@80000 {
++			label = "nvram";
++			reg = <0x0080000 0x0180000>;
++		};
++
++		partition@200000 {
++			label = "firmware";
++			reg = <0x0200000 0x6600000>;
++			compatible = "brcm,trx";
++		};
++
++		partition@6800000 {
++			label = "env";
++			reg = <0x6800000 0x0200000>;
++			read-only;
++		};
++
++		partition@6a00000 {
++			label = "data";
++			reg = <0x6a00000 0x1600000>;
++		};
++	};
++};
++

--- a/target/linux/bcm53xx/patches-4.14/700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
+++ b/target/linux/bcm53xx/patches-4.14/700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
@@ -21,7 +21,7 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
  
  #include "b53_regs.h"
  #include "b53_priv.h"
-@@ -1579,6 +1580,28 @@ static int b53_switch_init(struct b53_de
+@@ -1579,6 +1580,30 @@ static int b53_switch_init(struct b53_de
  			return ret;
  	}
  
@@ -34,6 +34,8 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 +		sw_dev->cpu_port = 8;
 +	else if (of_machine_is_compatible("netgear,r8500"))
 +		sw_dev->cpu_port = 8;
++	else if (of_machine_is_compatible("arris,sbr-ac1900p"))
++		sw_dev->cpu_port = 7;
 +
 +	/* Enable extra ports */
 +	if (of_machine_is_compatible("tenda,ac9"))


### PR DESCRIPTION
This router has BCM4709A0 SoC, 128 MiB NAND flash (MX30LF1G18AC-TI),
256 MiB memory and 4 x LAN and 1 x WAN ports.
WiFi chips are BCM4360 x 2.
USB2.0 x 1. USB3.0 x 1.
this router cpu port only used port 8,but b53 must set port 7, is it a bug?
see 700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
