### PR TITLE
ath79: Add support for TP-Link Archer C25 v1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -126,6 +126,16 @@ tplink,archer-c6-v2)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
 	;;
+tplink,archer-c25-v1|\
+tplink,tl-wr841-v9|\
+tplink,tl-wr841-v11|\
+tplink,tl-wr842n-v3)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
+	;;
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
@@ -173,15 +183,6 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
-	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
-	;;
-tplink,tl-wr841-v9|\
-tplink,tl-wr841-v11|\
-tplink,tl-wr842n-v3)
-	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
-	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
-	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
-	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
 ubnt,bullet-m|\

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -122,14 +122,19 @@ tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+tplink,archer-c6-v2)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
+	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
+	;;
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	;;
-tplink,archer-c6-v2)
-	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
-	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
+tplink,archer-d50-v1)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x1c"
+	ucidef_set_led_switch "wan_data" "WAN Data" "tp-link:white:internet" "switch0" "0x02" "" "tx rx"
+	ucidef_set_led_switch "wan_link" "WAN Link" "tp-link:white:wan" "switch0" "0x02" "" "link"
 	;;
 tplink,cpe210-v2|\
 tplink,cpe210-v3)
@@ -139,11 +144,6 @@ tplink,cpe210-v3)
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:green:link2" "wlan0" "30" "100"
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
-	;;
-tplink,archer-d50-v1)
-	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x1c"
-	ucidef_set_led_switch "wan_data" "WAN Data" "tp-link:white:internet" "switch0" "0x02" "" "tx rx"
-	ucidef_set_led_switch "wan_link" "WAN Link" "tp-link:white:wan" "switch0" "0x02" "" "link"
 	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -68,6 +68,7 @@ ath79_setup_interfaces()
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
 	buffalo,wzr-hp-ag300h|\
+	tplink,archer-c25-v1|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
 	tplink,tl-wr841-v7|\

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -23,6 +23,10 @@ dlink,dir-835-a1)
 librerouter,librerouter-v1)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "1" "0"
 	;;
+tplink,archer-c25-v1)
+	ucidef_add_gpio_switch "led_control" "LED control" "21" "0"
+	ucidef_add_gpio_switch "led_reset" "LED reset" "19" "1"
+	;;
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -141,6 +141,10 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
+	tplink,archer-c25-v1)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
+		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5)

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c25-v1", "qca,qca9561";
+	model = "TP-Link Archer C25 v1";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		/* can be removed on 4.19 */
+		gpio-sck = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		gpio-mosi = <&gpio 14 GPIO_ACTIVE_HIGH>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi_button {
+			label = "WiFi button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_green {
+			label = "tp-link:green:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tp-link:amber:wan";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0x7a0000>;
+			};
+
+			config: partition@7d0000 {
+				label = "config";
+				reg = <0x7d0000 0x010000>;
+				read-only;
+			};
+
+			info: partition@7e0000 {
+				label = "info";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
+
+	status = "okay";
+	mtd-mac-address = <&info 0x8>;
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&info 0x8>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -22,6 +22,17 @@ define Device/tplink_archer-c2-v3
 endef
 TARGET_DEVICES += tplink_archer-c2-v3
 
+define Device/tplink_archer-c25-v1
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9561
+  IMAGE_SIZE := 7808k
+  DEVICE_TITLE := TP-Link Archer C25 v1
+  TPLINK_BOARD_ID := ARCHER-C25-V1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  SUPPORTED_DEVICES += archer-c25-v1
+endef
+TARGET_DEVICES += tplink_archer-c25-v1
+
 define Device/tplink_archer-c58-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561


### PR DESCRIPTION
The TP-Link Archer C25 is a low-cost dual-band router.

Specification:

- CPU: Atheros QCA9561 775 MHz
- RAM: 64 MB
- Flash: 8 MB
- Wifi: 3x3 2.4 GHz (integrated), 1x1 5 GHz QCA9887
- NET: 5x 10/100 Mbps Ethernet

Some LEDs are controlled by an additional 74HC595 chip, but not
all of them.