### PR TITLE
ath79: Add missing reset button for TP-Link CPE210 v2 and v3

### DIFF
--- a/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
@@ -47,6 +47,16 @@
 		};
 	};
 
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &uart {


### PR DESCRIPTION
Reset button support seems to be missing in ath79.

Run-tested on CPE210 v2.
