### PR TITLE
ath79: add support for Aruba AP-105

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -9,6 +9,7 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	aruba,ap-105|\
 	avm,fritz300e|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\

--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7100.dtsi"
+
+/ {
+	compatible = "aruba,ap-105", "qca,ar7161";
+	model = "Aruba AP-105";
+
+	chosen {
+		bootargs = "console=ttyS0,9600";
+	};
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_green;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_green: power_green {
+			label = "ap-105:green:power";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power_red {
+			label = "ap-105:red:power";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		wifi_2g_red: wifi_2g_red {
+			label = "ap-105:red:wlan2g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_5g_red: wifi_5g_red {
+			label = "ap-105:red:wlan5g";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wifi_2g_green {
+			label = "ap-105:green:wlan2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_5g_green {
+			label = "ap-105:green:wlan5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		scl-gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+
+		/* can be removed on 4.19 */
+		gpios = <&gpio 5 GPIO_ACTIVE_LOW>,
+			<&gpio 4 GPIO_ACTIVE_LOW>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		tpm@29 {
+			compatible = "atmel,at97sc3203s";
+			reg = <0x29>;
+
+			/* triggering it, will also kill system */
+			reset-gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 { /* 2.4 GHz */
+		compatible = "pci168c,0029";
+		mtd-mac-address = <&hwinfo 0x1c>;
+		mtd-mac-address-increment = <1>;
+		reg = <0x8800 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 { /* 5 GHz */
+		compatible = "pci168c,0029";
+		mtd-mac-address = <&hwinfo 0x1c>;
+		mtd-mac-address-increment = <2>;
+		reg = <0x9000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&hwinfo 0x1c>;
+
+	pll-data = <0x00110000 0x00001099 0x00991099>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x40000 0xfa0000>;
+				compatible = "denx,uimage";
+			};
+
+			hwinfo: partition@fe0000 {
+				label = "hwinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "u-boot-env";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -75,6 +75,14 @@ define Device/seama
   SEAMA_SIGNATURE :=
 endef
 
+define Device/aruba_ap-105
+  ATH_SOC := ar7161
+  DEVICE_TITLE := Aruba AP-105
+  IMAGE_SIZE := 16000k
+  DEVICE_PACKAGES := kmod-i2c-core kmod-i2c-gpio kmod-tpm-i2c-atmel
+endef
+TARGET_DEVICES += aruba_ap-105
+
 define Device/avm_fritz300e
   ATH_SOC := ar7242
   DEVICE_TITLE := AVM FRITZ!WLAN Repeater 300E


### PR DESCRIPTION
SoC: Atheros AR7161-8C1A @ 680 MHz
RAM: 128MB - 2x Etron Technology EM6AB160TSA-5G
NOR: 16MB - 1x MXIC MX25L12845EMI-10G (SPI-NOR)
WI1: Atheros AR9223-AC1A 802.11bgn
WI2: Atheros AR9220-AC1A 802.11an
ETH: Atheros AR8021-BL1E + PoE
LED: Dual-Color Power/Status, Ethernet, WLAN2G and WLAN5G
BTN: 1 x Reset
I2C: AT97SC4303s TPM (needs driver!)
CON: RS232-level 8P8C/RJ45 Console Port - 9600 Baud

Factory installation:

 - Needs a u-boot replacement. See Wiki for
   information on how to do a in-circut flash with
   a SPI-Flasher like a CH314A or flashrom. Wiki page
   can be found at https://openwrt.org/toh/aruba/aruba_ap-105

 - Be careful when dis- and reassembling the device to
   not squish any of the antenna cables in the process!

 - Be sure to make a full 16 MiB backup of your device
   before flashing the new u-boot! This is needed if you
   ever have interest in reverting back to stock firmware.

Not working:

 - TPM (needs a driver)

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>