### PR TITLE
ramips: add CUDY WR1000 support

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -91,6 +91,11 @@ cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:white:ethernet" eth0.1
 	set_wifi_led "$boardname:white:wifi"
 	;;
+cudy,wr1000)
+	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x10"
+	ucidef_set_led_switch "lan1" "lan1" "$boardname:blue:lan1" "switch0" "0x08"
+	ucidef_set_led_switch "lan2" "lan2" "$boardname:blue:lan2" "switch0" "0x04"
+	;;
 d240)
 	set_wifi_led "$boardname:blue:wifi"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -298,6 +298,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6t@eth0"
 		;;
+	cudy,wr1000)
+		ucidef_add_switch "switch0" \
+			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+		;;
 	cy-swr1100)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "9@eth0"

--- a/target/linux/ramips/dts/WR1000.dts
+++ b/target/linux/ramips/dts/WR1000.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "cudy,wr1000", "mediatek,mt7628an-soc";
+	model = "Cudy WR1000";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "rfkill";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan1 {
+			label = "wr1000:blue:lan1";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "wr1000:blue:lan2";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "wr1000:blue:wan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "wr1000:blue:wlan2g";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wps: wps {
+			label = "wr1000:blue:wps";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2s", "refclk", "wdt", "p4led_an",
+					"p3led_an", "p2led_an", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x2e>;
+	mediatek,portmap = "llllw";
+};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -11,6 +11,7 @@ DEVICE_VARS += DTS IMAGE_SIZE NETGEAR_BOARD_ID NETGEAR_HW_ID
 DEVICE_VARS += BUFFALO_TAG_PLATFORM BUFFALO_TAG_VERSION BUFFALO_TAG_MINOR
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK
 DEVICE_VARS += SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
+DEVICE_VARS += JCG_MAXSIZE
 
 loadaddr-y := 0x80000000
 loadaddr-$(CONFIG_TARGET_ramips_rt288x) := 0x88000000
@@ -44,6 +45,11 @@ define Device/seama
   IMAGE/factory.bin := \
 	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE)
   SEAMA_SIGNATURE :=
+endef
+
+define Build/jcg-header
+	$(STAGING_DIR_HOST)/bin/jcgimage -v $(1) $(if $(JCG_MAXSIZE), -m $(JCG_MAXSIZE),) -u $@ -o $@.new
+	mv $@.new $@
 endef
 
 define Build/patch-dtb

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -27,6 +27,19 @@ define Device/alfa-network_awusfree1
 endef
 TARGET_DEVICES += alfa-network_awusfree1
 
+define Device/cudy_wr1000
+  DTS := WR1000
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGES += factory.bin
+  IMAGE/factory.bin := \
+        $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | jcg-header 92.122
+  JCG_MAXSIZE := 8060928
+  DEVICE_TITLE := Cudy WR1000
+  DEVICE_PACKAGES := kmod-mt76x2
+  SUPPORTED_DEVICES += wr1000
+endef
+TARGET_DEVICES += cudy_wr1000
+
 define Device/tama_w06
   DTS := W06
   IMAGE_SIZE := 15040k

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -21,11 +21,6 @@ define Build/hilink-header
 	mv $@.new $@
 endef
 
-define Build/jcg-header
-	$(STAGING_DIR_HOST)/bin/jcgimage -v $(1) -u $@ -o $@.new
-	mv $@.new $@
-endef
-
 
 define Device/3g150b
   DTS := 3G150B

--- a/tools/firmware-utils/src/jcgimage.c
+++ b/tools/firmware-utils/src/jcgimage.c
@@ -2,6 +2,7 @@
  * jcgimage - Create a JCG firmware image
  *
  * Copyright (C) 2015 Reinhard Max <reinhard@m4x.de>
+ * Copyright (C) 2019 Davide Fioravanti <pantanastyle@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -44,6 +45,11 @@
  * image. If it is too large, it wraps around and overwrites U-Boot,
  * requiring JTAG to revive the board. To prevent such bricking from
  * happening, this tool refuses to build such overlong images.
+ *
+ * Using -m is possible to set the maximum size of the payload.
+ * Otherwise the default MAXSIZE will be used.
+ * For an 8Mb flash, the corresponding maxsize is:
+ * 8 * 1024 * 1024 - 5 * 64 * 1024 = 8388608 - 327680 = 8060928
  *
  * Two more conditions have to be met for a JCG image to be accepted
  * as a valid update by the web interface of the stock firware:
@@ -92,6 +98,7 @@
 #include <sys/mman.h>
 #include <arpa/inet.h>
 #include <assert.h>
+#include <inttypes.h>
 
 /*
  * JCG Firmware image header
@@ -292,8 +299,8 @@ craftcrc(uint32_t dcrc, uint8_t *buf, size_t len)
 void
 usage() {
 	fprintf(stderr, "Usage:\n"
-		"jcgimage -o outfile -u uImage [-v version]\n"
-		"jcgimage -o outfile -k kernel -f rootfs [-v version]\n");
+		"jcgimage -o outfile -u uImage [-m maxsize] [-v version]\n"
+		"jcgimage -o outfile -k kernel -f rootfs [-m maxsize] [-v version]\n");
 	exit(1);
 }
 
@@ -314,6 +321,8 @@ main(int argc, char **argv)
 	char *file1 = NULL;
 	char *file2 = NULL;
 	char *version = NULL;
+	size_t maxsize = MAXSIZE;
+	char *endptr;
 	int mode = MODE_UNKNOWN;
 	int fdo, fd1, fd2;
 	size_t size1, size2, sizeu, sizeo, off1, off2;
@@ -324,7 +333,7 @@ main(int argc, char **argv)
 	assert(sizeof(struct uimage_header) == 64);
 	set_source_date_epoch();
 
-	while ((c = getopt(argc, argv, "o:k:f:u:v:h")) != -1) {
+	while ((c = getopt(argc, argv, "o:k:f:u:v:m:h")) != -1) {
 		switch (c) {
 		case 'o':
 			imagefile = optarg;
@@ -349,6 +358,11 @@ main(int argc, char **argv)
 
 			mode = MODE_UIMAGE;
 			file1 = optarg;
+			break;
+		case 'm':
+			if (optarg != NULL)
+				maxsize = strtoimax(optarg, &endptr, 10);
+
 			break;
 		case 'v':
 			version = optarg;
@@ -385,8 +399,8 @@ main(int argc, char **argv)
 		sizeo = sizeof(*jh) + sizeu;
 	}
 
-	if (sizeo > MAXSIZE)
-		errx(1, "payload too large: %zd > %zd\n", sizeo, MAXSIZE);
+	if (sizeo > maxsize)
+		errx(1, "payload too large: %zd > %zd\n", sizeo, maxsize);
 
 
 	fdo = open(imagefile, O_RDWR | O_CREAT | O_TRUNC, 00644);


### PR DESCRIPTION
Cudy WR1200 is an AC1200 AP with 3-port FE and 2 non-detachable antennas

The "...-factory.bin" image is flashable directly through the stock web interface
Once OpenWrt is installed, the "...-sysupgrade.bin" image must be used.

I edited the old JCG factory image tool to make it compatible with >4MB flash sizes.
I added the -m argument to specify a custom MAXSIZE
If the -m argument is not present the tool should works as a normal 4MB flash size (for backward compatibility)
