### PR TITLE
lua: fix number overflow

### DIFF
--- a/package/utils/lua/Makefile
+++ b/package/utils/lua/Makefile
@@ -92,6 +92,8 @@ endef
 
 TARGET_CFLAGS += -DLUA_USE_LINUX $(FPIC) -std=gnu99
 
+TARGET_CFLAGS += $(if $(CONFIG_ARCH_64BIT),-DLNUM_INT64)
+
 define Build/Compile
 	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		CC="$(TARGET_CROSS)gcc" \


### PR DESCRIPTION
### What's wrong
On some 64bit system, 
libc's strtoul defined as `unsigned long strtoul(const char *__restrict, char **__restrict, int);`(stdlib.h), 
but lua_str2ul defined as `#define lua_str2ul (unsigned int)strtoul`, lose high 32bits, results that:
1. print(4294967296) output 0;
2. tonumber("4294967296") return 0;
3. print(6442450944) output 6442450944 as excepted;
4. tonumber("6442450944") return 6442450944 as excepted.

### The commit
Compile lua in 64bit will fix that.

### Tested device:
Model: Zidoo Z9S
CPU: RTD1296 (aarch64_cortex-a53)
OS: OpenWrt SNAPSHOT (https://downloads.openwrt.org/snapshots/targets/sunxi/cortexa53/)
