### PR TITLE
ath79: glinet_gl-ar750s: Add USB power & microSD

### DIFF
--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts
@@ -62,6 +62,19 @@
 			linux,default-trigger = "phy0tpt";
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+
+		gpio = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &spi {
@@ -113,17 +126,19 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
+	vbus-supply = <&usb_vbus>;
 };
 
 &usb_phy0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&usb_phy1 {
 	status = "okay";
 };
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -363,7 +363,7 @@ TARGET_DEVICES += glinet_gl-ar300m-nor
 define Device/glinet_gl-ar750s
   ATH_SOC := qca9563
   DEVICE_TITLE := GL.iNet GL-AR750S
-  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct block-mount
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar750s
 endef


### PR DESCRIPTION
The GL.iNet AR750S USB and microSD port is currently not working out
of the box.
GPIO 7 is used to control the power of the USB port. Add GPIO 7 as a
fixed-regulator for the port.
Also add &usb1 to DTS to get the microSD port to work.

Signed-off-by: Alexander Wördekemper <alexwoerde@web.de>