### PR TITLE
ath79: swap eth0/eth1 on some SoCs with builtin switch

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -18,7 +18,7 @@ avm,fritz300e)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssi4" "wlan0" "80" "100"
 	;;
 avm,fritz4020)
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x1E"
 	;;
 buffalo,whr-g301n)
@@ -29,7 +29,7 @@ buffalo,whr-g301n)
 	ucidef_set_led_switch "lan4" "LAN4" "$boardname:green:lan4" "switch0" "0x10"
 	;;
 comfast,cf-e110n-v2)
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x02"
 	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:green:wlan" "phy0tpt"
 	ucidef_set_rssimon "wlan0" "200000" "1"
@@ -39,7 +39,7 @@ comfast,cf-e110n-v2)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "76" "100"
 	;;
 comfast,cf-e120a-v3)
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x04"
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:red:rssilow" "wlan0" "1" "100"
@@ -49,7 +49,7 @@ comfast,cf-e120a-v3)
 	;;
 comfast,cf-e5)
 	ucidef_set_led_switch "lan" "LAN" "$boardname:blue:lan" "switch0" "0x02"
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:wan" "eth1"
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:blue:rssi0" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
@@ -62,8 +62,8 @@ engenius,ecb1750)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0"
 	;;
 engenius,ews511ap)
-	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth0"
-	ucidef_set_led_netdev "lan2" "LAN2" "$boardname:blue:lan2" "eth1"
+	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth1"
+	ucidef_set_led_netdev "lan2" "LAN2" "$boardname:blue:lan2" "eth0"
 	;;
 etactica,eg200)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:red:eth0" "eth0"
@@ -71,18 +71,18 @@ etactica,eg200)
 	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
 	;;
 glinet,gl-ar150)
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x02"
 	;;
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor)
-	ucidef_set_led_netdev "lan" "LAN" "gl-ar300m:green:lan" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "gl-ar300m:green:lan" "eth0"
 	;;
 glinet,gl-ar300m-lite)
 	ucidef_set_led_netdev "lan" "LAN" "gl-ar300m-lite:green:lan" "eth0"
 	;;
 glinet,gl-x750)
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	;;
 netgear,wnr612-v2|\
 on,n150r)
@@ -121,7 +121,7 @@ tplink,tl-wr1043n-v5)
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
-	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	;;
 tplink,archer-c6-v2)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
@@ -165,7 +165,7 @@ tplink,tl-wr740n-v4|\
 tplink,tl-wr741nd-v4|\
 tplink,tl-wr841-v8|\
 tplink,tl-wr842n-v2)
-	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
@@ -174,7 +174,7 @@ tplink,tl-wr842n-v2)
 tplink,tl-wr841-v9|\
 tplink,tl-wr841-v11|\
 tplink,tl-wr842n-v3)
-	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
@@ -207,7 +207,7 @@ wd,mynet-wifi-rangeextender)
 	ucidef_set_led_rssi "rssihigh" "RSSIMAX" "$boardname:blue:rssi-max" "wlan0" "66" "100"
 	;;
 yuncore,a770)
-	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x10"
 	;;
 esac

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -137,9 +137,9 @@ tplink,cpe210-v3)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
 	;;
 tplink,archer-d50-v1)
-	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x1E"
-	ucidef_set_led_netdev "wan_data" "WAN Data" "tp-link:white:internet" "eth1.2" "tx rx"
-	ucidef_set_led_netdev "wan_link" "WAN Link" "tp-link:white:wan" "eth1.2" "link"
+	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x1c"
+	ucidef_set_led_switch "wan_data" "WAN Data" "tp-link:white:internet" "switch0" "0x02" "" "tx rx"
+	ucidef_set_led_switch "wan_link" "WAN Link" "tp-link:white:wan" "switch0" "0x02" "" "link"
 	;;
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -49,9 +49,9 @@ ath79_setup_interfaces()
 	pcs,cr3000|\
 	tplink,archer-c58-v1|\
 	tplink,archer-c59-v1)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
 		;;
 	buffalo,bhr-4grv|\
 	buffalo,wzr-hp-g450h)
@@ -62,7 +62,20 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
 		;;
-	buffalo,wzr-hp-ag300h)
+	buffalo,whr-g301n)
+		ucidef_set_interface_wan "eth0"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
+	buffalo,wzr-hp-ag300h|\
+	tplink,tl-mr3220-v1|\
+	tplink,tl-mr3420-v1|\
+	tplink,tl-wr841-v7|\
+	tplink,tl-wr841-v9|\
+	tplink,tl-wr841-v11|\
+	tplink,tl-wr842n-v1|\
+	tplink,tl-wr842n-v3|\
+	ubnt,airrouter)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
@@ -71,15 +84,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
-	comfast,cf-e5|\
-	glinet,gl-ar150|\
-	glinet,gl-ar300m-nand|\
-	glinet,gl-ar300m-nor|\
-	glinet,gl-x750|\
-	tplink,tl-wr810n-v1|\
-	tplink,tl-wr810n-v2|\
-	ubnt,routerstation|\
-	yuncore,a770)
+	comfast,cf-e110n-v2|\
+	comfast,cf-e120a-v3|\
+	ubnt,nanostation-m|\
+	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	devolo,dvl1200e|\
@@ -158,7 +166,12 @@ ath79_setup_interfaces()
 		;;
 	netgear,wnr612-v2|\
 	on,n150r|\
-	tplink,tl-wr841-v7)
+	tplink,tl-wr740n-v1|\
+	tplink,tl-wr740n-v3|\
+	tplink,tl-wr741-v1|\
+	tplink,tl-wr743nd-v1|\
+	tplink,tl-wr841-v5|\
+	tplink,tl-wr941-v4)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \
 		"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
@@ -171,28 +184,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:wan"
 		;;
-	tplink,archer-c5-v1|\
-	tplink,archer-c7-v1|\
-	tplink,archer-c7-v2|\
-	tplink,tl-wdr4900-v2)
-		ucidef_add_switch "switch0" \
-			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
-		;;
-	tplink,archer-d50-v1)
-		ucidef_add_switch "switch0" \
-			"0@eth1" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
-		;;
-	buffalo,whr-g301n|\
-	tplink,tl-mr3220-v1|\
-	tplink,tl-mr3420-v1|\
-	tplink,tl-wr841-v9|\
-	tplink,tl-wr841-v11|\
-	tplink,tl-wr842n-v3|\
-	ubnt,airrouter)
-		ucidef_set_interface_wan "eth0"
-		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
-		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c6-v2|\
 	tplink,archer-c7-v4|\
@@ -202,6 +193,17 @@ ath79_setup_interfaces()
 	tplink,tl-wr941n-v7-cn)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
+		;;
+	tplink,archer-c5-v1|\
+	tplink,archer-c7-v1|\
+	tplink,archer-c7-v2|\
+	tplink,tl-wdr4900-v2)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+		;;
+	tplink,archer-d50-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
 		;;
 	tplink,tl-wr1043nd-v1)
 		ucidef_add_switch "switch0" \
@@ -216,37 +218,21 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
-	tplink,tl-wr740n-v1|\
-	tplink,tl-wr740n-v3|\
-	tplink,tl-wr741-v1|\
-	tplink,tl-wr743nd-v1|\
-	tplink,tl-wr841-v5|\
-	tplink,tl-wr941-v4)
-		ucidef_set_interface_wan "eth0"
-		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan"
-		;;
-	tplink,tl-wr710n-v1)
-		ucidef_set_interface_wan "eth0"
-		ucidef_add_switch "switch0" \
-			"0@eth1" "3:lan"
-		;;
 	tplink,tl-wr740n-v4|\
 	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v8|\
-	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v2)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
+			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	tplink,tl-wr941-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
 	ubnt,acb-isp)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
-			"0@eth1" "2:lan:1" "3:lan:3" "4:lan:2"
+			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2"
 		;;
 	ubnt,routerstation-pro)
 		ucidef_set_interface_wan "eth0"
@@ -258,9 +244,9 @@ ath79_setup_interfaces()
 			"0@eth0" "5:lan" "1:wan"
 		;;
 	xiaomi,mi-router-4q)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
-			"0@eth1" "3:lan:1" "4:lan:2"
+			"0@eth0" "3:lan:1" "4:lan:2"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -78,7 +78,7 @@
 };
 
 &eth1 {
-	compatible = "qca,ar7241-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar7241-eth", "syscon";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -45,7 +45,7 @@
 };
 
 &eth0 {
-	compatible = "qca,ar7242-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar7242-eth", "syscon";
 
 	pll-data = <0x16000000 0x00000101 0x00001616>;
 	pll-reg = <0x4 0x2c 17>;
@@ -72,7 +72,7 @@
 };
 
 &eth1 {
-	compatible = "qca,ar7242-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar7242-eth", "syscon";
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -192,7 +192,7 @@
 };
 
 &eth1 {
-	compatible = "qca,ar9330-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar9330-eth", "syscon";
 
 	pll-data = <0x00110000 0x00001099 0x00991099>;
 	phy-mode = "gmii";

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -240,7 +240,7 @@
 };
 
 &eth1 {
-	compatible = "qca,ar9340-eth", "syscon", "simple-mfd";
+	compatible = "qca,ar9340-eth", "syscon";
 
 	resets = <&rst 13>;
 	reset-names = "mac";

--- a/target/linux/ath79/dts/ath79.dtsi
+++ b/target/linux/ath79/dts/ath79.dtsi
@@ -43,7 +43,7 @@
 		eth0: eth@19000000 {
 			status = "disabled";
 
-			compatible = "qca,ath79-eth", "syscon", "simple-mfd";
+			compatible = "qca,ath79-eth", "syscon";
 			reg = <0x19000000 0x200>;
 
 			interrupts = <4>;
@@ -66,7 +66,7 @@
 		eth1: eth@1a000000 {
 			status = "disabled";
 
-			compatible = "qca,ath79-eth", "syscon", "simple-mfd";
+			compatible = "qca,ath79-eth", "syscon";
 			reg = <0x1a000000 0x200>;
 
 			interrupts = <5>;

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -274,7 +274,7 @@
 &eth1 {
 	status = "okay";
 
-	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
+	compatible = "qca,qca9530-eth", "syscon";
 	resets = <&rst 13>;
 	reset-names = "mac";
 

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -257,7 +257,7 @@
 };
 
 &eth0 {
-	compatible = "qca,qca9560-eth", "syscon", "simple-mfd";
+	compatible = "qca,qca9560-eth", "syscon";
 
 	pll-data = <0x03000000 0x00000101 0x00001919>;
 	pll-reg = <0 0x48 0>;
@@ -300,7 +300,7 @@
 };
 
 &eth1 {
-	compatible = "qca,qca9560-eth", "syscon", "simple-mfd";
+	compatible = "qca,qca9560-eth", "syscon";
 
 	phy-mode = "gmii";
 

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_phy.c
@@ -75,8 +75,8 @@ int ag71xx_phy_connect(struct ag71xx *ag)
 
 	if (!ag->phy_dev) {
 		dev_err(&ag->pdev->dev,
-			"Could not connect to PHY device\n");
-		return -ENODEV;
+			"Could not connect to PHY device. Deferring probe.\n");
+		return -EPROBE_DEFER;
 	}
 
 	dev_info(&ag->pdev->dev, "connected to PHY at %s [uid=%08x, driver=%s]\n",


### PR DESCRIPTION
This makes gmac order the same as ar71xx so that we don't need a config migration script for this.
Doing so also helps merging incorrectly split mdio/gmac driver in the future.

Tested on:
TP-Link TL-WR841N v8
TP-Link TL-WR941N v4
