### PR TITLE
lua: fix number overflow

### DIFF
--- a/package/utils/lua/patches/013-lnum-fix-64bit-long.patch
+++ b/package/utils/lua/patches/013-lnum-fix-64bit-long.patch
@@ -1,0 +1,36 @@
+diff --git a/src/lnum_config.h b/src/lnum_config.h
+index 19d7a42..1092eea 100644
+--- a/src/lnum_config.h
++++ b/src/lnum_config.h
+@@ -141,7 +141,12 @@
+ #endif
+ 
+ #ifndef lua_str2ul
+-# define lua_str2ul (unsigned LUA_INTEGER)strtoul
++# if LONG_MAX > LUA_INTEGER_MAX
++#   define LONG_OVERFLOW_LUA_INTEGER
++    unsigned LUA_INTEGER lua_str2ul( const char *str, char **endptr, int base );
++# else
++#  define lua_str2ul (unsigned LUA_INTEGER)strtoul
++# endif
+ #endif
+ #ifndef LUA_INTEGER_MIN
+ # define LUA_INTEGER_MIN (-LUA_INTEGER_MAX -1)  /* -2^16|32 */
+diff --git a/src/lnum.c b/src/lnum.c
+index 1456b6a..37e423b 100644
+--- a/src/lnum.c
++++ b/src/lnum.c
+@@ -310,3 +310,13 @@ int try_unmint( lua_Integer *r, lua_Integer ib ) {
+   return 0;
+ }
+ 
++#ifdef LONG_OVERFLOW_LUA_INTEGER
++unsigned LUA_INTEGER lua_str2ul( const char *str, char **endptr, int base ) {
++  unsigned long v= strtoul(str, endptr, base);
++  if ( v > LUA_INTEGER_MAX ) {
++    errno= ERANGE;
++    v= ULONG_MAX;
++  }
++  return (unsigned LUA_INTEGER)v;
++}
++#endif


### PR DESCRIPTION
### What's wrong
On some 64bit system, 
libc's strtoul defined as `unsigned long strtoul(const char *__restrict, char **__restrict, int);`(stdlib.h), 
but lua_str2ul defined as `#define lua_str2ul (unsigned int)strtoul`, lose high 32bits, results that:
1. print(4294967296) output 0;
2. tonumber("4294967296") return 0;
3. print(6442450944) output 6442450944 as excepted;
4. tonumber("6442450944") return 6442450944 as excepted.

### The commit
Implement lua_str2ul to handle overflow.

### Tested device:
Model: Zidoo Z9S
CPU: RTD1296 (aarch64_cortex-a53)
OS: OpenWrt SNAPSHOT (https://downloads.openwrt.org/snapshots/targets/sunxi/cortexa53/)

