### PR TITLE
base-files and busybox: increase kernel entropy pool when seeding

### DIFF
--- a/package/base-files/files/lib/preinit/81_urandom_seed
+++ b/package/base-files/files/lib/preinit/81_urandom_seed
@@ -8,8 +8,16 @@ _do_urandom_seed() {
     [ -f "$1" ] || { log_urandom_seed "Seed file not found ($1)"; return; }
     [ -O "$1" -a -G "$1" -a ! -x "$1" ] || { log_urandom_seed "Wrong owner / permissions for $1"; return; }
 
-    log_urandom_seed "Seeding with $1"
-    cat "$1" > /dev/urandom
+    ENTROPY=$(cat /proc/sys/kernel/random/entropy_avail)
+    log_urandom_seed "entropy_avail = $ENTROPY"
+
+    SIZE=$(wc -c < "$1")
+    log_urandom_seed "Seeding with $SIZE bytes from $1"
+
+    rngseed "$1"
+
+    ENTROPY=$(cat /proc/sys/kernel/random/entropy_avail)
+    log_urandom_seed "entropy_avail = $ENTROPY"
 }
 
 do_urandom_seed() {

--- a/package/utils/busybox/config/coreutils/Config.in
+++ b/package/utils/busybox/config/coreutils/Config.in
@@ -548,6 +548,12 @@ config BUSYBOX_CONFIG_RMDIR
 	default BUSYBOX_DEFAULT_RMDIR
 	help
 	rmdir is used to remove empty directories.
+config BUSYBOX_CONFIG_RNGSEED
+	bool "rngseed"
+	default BUSYBOX_DEFAULT_RNGSEED
+	help
+	rngseed is used to seed the kernel random number generator with
+	the contents of the specified file.
 config BUSYBOX_CONFIG_SEQ
 	bool "seq (3.8 kb)"
 	default BUSYBOX_DEFAULT_SEQ

--- a/package/utils/busybox/patches/410-rngseed.patch
+++ b/package/utils/busybox/patches/410-rngseed.patch
@@ -1,0 +1,66 @@
+--- /dev/null	2019-05-14 12:36:31.663493429 -0700
++++ busybox-1.28.4/coreutils/rngseed.c	2019-05-16 16:58:03.170495363 -0700
+@@ -0,0 +1,63 @@
++/* vi: set sw=4 ts=4: */
++/*
++ * rngseed implementation for busybox
++ *
++ * Copyright (C) 2019  Dustin Lundquist  <d.lundquist@temperednetworks.com>
++ *
++ * Licensed under GPLv2 or later, see file LICENSE in this source tree.
++ */
++//config:config RNGSEED
++//config:	bool "rngseed (1.0 kb)"
++//config:	default y
++//config:	help
++//config:	rngseed is used to seed the kernel random number generator with
++//config:	the contents of the specified file.
++//config:
++
++//applet:IF_RNGSEED(APPLET(rngseed, BB_DIR_SBIN, BB_SUID_DROP))
++
++//kbuild:lib-$(CONFIG_RNGSEED) += rngseed.o
++
++#include "libbb.h"
++#include <linux/random.h>
++
++//usage:#define rngseed_trivial_usage
++//usage:       "[FILE]"
++//usage:#define rngseed_full_usage "\n\n"
++//usage:       "Seed kernel RNG with file contents"
++//usage:
++//usage:#define rngseed_example_usage
++//usage:       "$ rngseed /etc/urandom.seed"
++
++int rngseed_main(int argc, char **argv) MAIN_EXTERNALLY_VISIBLE;
++int rngseed_main(int argc UNUSED_PARAM, char **argv)
++{
++    int retval = EXIT_FAILURE;
++    int rnd_fd = -1, input_fd = -1;
++
++    rnd_fd = open_or_warn("/dev/urandom", O_WRONLY);
++    if (argv[1])
++        input_fd = open_or_warn(argv[1], O_RDONLY);
++    else
++        bb_show_usage();
++
++    if (rnd_fd >= 0 && input_fd >= 0) {
++        struct rand_pool_info {
++            int    entropy_count;
++            int    buf_size;
++            __u32  buf[256];
++        } entropy;
++
++        while ((entropy.buf_size = read(input_fd, entropy.buf, sizeof(entropy.buf))) > 0) {
++            entropy.entropy_count = entropy.buf_size * 8;
++
++            if (ioctl(rnd_fd, RNDADDENTROPY, &entropy) >= 0)
++                retval = EXIT_SUCCESS;
++        }
++
++        close(input_fd);
++        close(rnd_fd);
++    }
++
++	fflush_stdout_and_exit(retval);
++}


### PR DESCRIPTION
Simply writing to /dev/urandom does not increase the kernel's entropy
count, this casuses processes obtaining randomness to block.
Particularly processes using OpenSSL's RAND_bytes() will block until the
kernel emits 'random: crng init done'. This can take upwards of twenty
minutes.

Instrumenting preinit/81_urandom_seed I found the kernel entropy pool
does not increase when writing to /dev/urandom:

    # dmesg| grep random
    [    0.000000] random: get_random_bytes called from
    start_kernel+0x80/0x454 with crng_init=0
    [    1.889637] random: fast init done
    [    5.322128] urandom-seed: entropy_avail = 12
    [    5.327646] urandom-seed: Seeding with 4096 bytes from
    /etc/urandom.seed
    [    5.336108] urandom-seed: entropy_avail = 12
    [    6.355560] urandom-seed: entropy_avail = 12
    [    7.382840] urandom-seed: entropy_avail = 12
    [    7.775650] random: jshn: uninitialized urandom read (4 bytes read)
    [    7.924178] random: jshn: uninitialized urandom read (4 bytes read)
    [    8.070080] random: jshn: uninitialized urandom read (4 bytes read)
    [  200.196863] random: crng init done
    [  200.196902] random: 7 urandom warning(s) missed due to ratelimiting

According to random(4) the entropy count is only increased when using
the RNDADDENTROPY ioctl.

On platforms with a hardware random number generator rngd is a good
option, while this daemon can be used to seed from a file it continue to
run in the background. In this patch I've added a rngseed applet to
busybox and use that to seed from /etc/urandom.seed. I've also logged
the available entropy before and after seeding and the size of the seed
file.

    # dmesg | grep random
    [    0.000000] random: get_random_bytes called from
    start_kernel+0x80/0x454 with crng_init=0
    [    1.543748] random: fast init done
    [    4.814904] urandom-seed: entropy_avail = 12
    [    4.819980] urandom-seed: Seeding with 512 bytes from
    /etc/urandom.seed
    [    4.822915] random: crng init done
    [    4.827132] urandom-seed: entropy_avail = 2244

Signed-off-by: Dustin Lundquist <d.lundquist@temperednetworks.com>