### PR TITLE
mvebu: Modify default EU regdomain for Linksys WRT AC devices

### DIFF
--- a/target/linux/mvebu/base-files/etc/uci-defaults/03_wireless
+++ b/target/linux/mvebu/base-files/etc/uci-defaults/03_wireless
@@ -26,7 +26,7 @@ linksys,caiman|linksys,cobra|linksys,mamba|linksys,shelby|linksys,venom)
 			REGD=CA
 		;;
 		EU)
-			REGD=DE
+			REGD=FR
 		;;
 		US)
 			REGD=US


### PR DESCRIPTION
The mwlwifi driver sets the default country code for EU (fi-
rmware region code 0x30) certified devices to FR (France),
not DE (Germany). Whilst this is a trivial fix, novice users
may not know how mwlwifi negatively reacts to a non-matching
country code and may leave the setting alone. Especially si-
nce it is under the advanced settings section in LuCI.

Signed-off-by: Jose Olivera <oliverajeo@gmail.com>

**Additional info not in original commit message:**
_Relevant mwlwifi driver code: https://github.com/kaloz/mwlwifi/commit/0a550312ddb5a9e00e8d602d5571598f25a78158_

_The mwlwifi driver readme states "Please don't change country 
code and let mwlwifi set it for you." However, OpenWrt's current 
behaviour does not adhere to this with its default, 'just flashed 
from factory' setting for EU devices._