### PR TITLE
ramips: add support for TOTOLINK LR1200

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -120,6 +120,7 @@ ramips_setup_interfaces()
 	sap-g3200u3|\
 	sk-wb8|\
 	telco-electronics,x1|\
+	totolink,lr1200|\
 	unielec,u7621-06-256m-16m|\
 	unielec,u7621-06-512m-64m|\
 	vr500|\

--- a/target/linux/ramips/dts/TOTOLINK-LR1200.dts
+++ b/target/linux/ramips/dts/TOTOLINK-LR1200.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "totolink,lr1200", "mediatek,mt7628dan";
+	model = "TOTOLINK LR1200";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "lr1200:blue:sys";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+		sms {
+			label = "lr1200:blue:sms";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+		wifi {
+			label = "lr1200:blue:wifi";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+		3g {
+			label = "lr1200:blue:3g";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+		4g {
+			label = "lr1200:blue:4g";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+		rssi1 {
+			label = "lr1200:blue:rssi1";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+		rssi2 {
+			label = "lr1200:blue:rssi2";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+		rssi3 {
+			label = "lr1200:blue:rssi3";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+		rssi4 {
+			label = "lr1200:blue:rssi4";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio1 {
+	gpio_modem_reset {
+		gpio-hog;
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "modem-reset";
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "gpio", "i2c", "i2s", "refclk", "uart1", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -170,6 +170,14 @@ define Device/skylab_skw92a
 endef
 TARGET_DEVICES += skylab_skw92a
 
+define Device/totolink_lr1200
+  DTS := TOTOLINK-LR1200
+  IMAGE_SIZE := 7872k
+  DEVICE_TITLE := TOTOLINK LR1200
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 uqmi
+endef
+TARGET_DEVICES += totolink_lr1200
+
 define Device/tplink_tl-wa801nd-v5
   $(Device/tplink)
   DTS := TL-WA801NDV5


### PR DESCRIPTION
Specifications:
- SoC: MT7628DAN (MT7628AN with 64MB built-in RAM)
- Flash: 8M SPI NOR
- Ethernet: 5x 10/100Mbps
- WiFi: 2.4G: MT7628 built-in
        5G: MT7612E
- 1x miniPCIe slot for LTE modem (only USB pins connected)
- 1x SIM slot

Flash instruction:
U-boot has a builtin web recovery page:
1. Hold the reset button while powering it up
2. Connect to the ethernet and set an IP in 192.168.1.0/24 range
3. Open your browser and upload firmware through http://192.168.1.1

Note about the LTE modem:
If your router comes with an EC25 module and it doesn't show up
as a QMI device, you should do the following to switch it to QMI
mode:
1. Install kmod-usb-serial-option and a terminal software
   (e.g. minicom or screen). All 4 serial ports of the modem
   should be available now.
2. Open /dev/ttyUSB3 with the terminal software and type this
   AT command: AT+QCFG="usbnet",0
3. Power-cycle the router. You should now get a QMI device
   recognized.

Signed-off-by: Chuanhong Guo <gch981213@gmail.com>

Note: Those RSSI LEDs are for cellular network so I don't set triggers for them.