### PR TITLE
ath79: add leds migrations for archer-c7-v2 and v4

### DIFF
--- a/target/linux/ath79/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/base-files/etc/uci-defaults/04_led_migration
@@ -9,6 +9,12 @@ case "$board" in
 engenius,epg5000)
 	migrate_leds ":wlan-2g=:wlan2g" ":wlan-5g=:wlan5g"
 	;;
+tplink,archer-c7-v2)
+	migrate_leds ":blue:=:green:"
+	;;
+tplink,archer-c7-v4)
+	migrate_leds "archer-c7-v4:=tp-link:"
+	;;
 tplink,archer-c7-v5)
 	migrate_leds "archer-c7-v5:=tp-link:"
 	;;


### PR DESCRIPTION
In ar71xx v2 has blue color defined because the same mach-*.c is also used
for TL-WDR4900 model with blue leds. ath79 v2 dts defines them as green.

For v4 the situation is the same as v5 so the conversion is identical only
v4 instead v5.

So now upgrading from ar71xx to ath79 should be also smoother for v2 and v4.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>