### PR TITLE
ath79: add support for TP-Link Archer D7/D7b v1

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7-v1.dts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_archer-d7.dtsi"
+
+/ {
+	compatible = "tplink,archer-d7-v1", "qca,qca9558";
+	model = "TP-Link Archer D7 v1";
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		mtdparts: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xf90000>;
+			};
+
+			partition@fb0000 {
+				label = "radioDECT";
+				reg = <0xfb0000 0x010000>;
+				read-only;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			romfs: partition@fd0000 {
+				label = "romfs";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "rom";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&romfs 0xf100>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	mtd-mac-address = <&romfs 0xf100>;
+};
+
+&wmac {
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&romfs 0xf100>;
+};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:white:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "tp-link:white:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt", "phy1tpt";
+		};
+
+		lan {
+			label = "tp-link:white:lan";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "tp-link:white:usb";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port1>, <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		qss {
+			label = "tp-link:white:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	reg_usb0_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_usb1_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x50 0xc737c737 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x0030c300 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&phy0>;
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dr_mode = "host";
+	vbus-supply = <&reg_usb0_vbus>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dr_mode = "host";
+	vbus-supply = <&reg_usb1_vbus>;
+	status = "okay";
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7b-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7b-v1.dts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_archer-d7.dtsi"
+
+/ {
+	compatible = "tplink,archer-d7b-v1", "qca,qca9558";
+	model = "TP-Link Archer D7b v1";
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		mtdparts: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xfa0000>;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			romfs: partition@fd0000 {
+				label = "romfs";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "reserve";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&romfs 0xf100>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	mtd-mac-address = <&romfs 0xf100>;
+};
+
+&wmac {
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&romfs 0xf100>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -183,6 +183,10 @@ tplink,archer-d50-v1)
 	ucidef_set_led_switch "wan_data" "WAN Data" "tp-link:white:internet" "switch0" "0x02" "" "tx rx"
 	ucidef_set_led_switch "wan_link" "WAN Link" "tp-link:white:wan" "switch0" "0x02" "" "link"
 	;;
+tplink,archer-d7-v1|\
+tplink,archer-d7b-v1)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x3c"
+	;;
 tplink,cpe210-v1|\
 tplink,cpe220-v2|\
 tplink,cpe220-v3|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -239,6 +239,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
 		;;
+	tplink,archer-d7-v1|\
+	tplink,archer-d7b-v1)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "3:lan:3" "4:lan:2" "5:lan:1" "6@eth0" "2:wan:4" "1:wan:5"
+		;;
 	tplink,tl-mr6400-v1)
 		ucidef_set_interfaces_lan_wan "eth0.1 eth1" "usb0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -102,6 +102,11 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
 		;;
+	tplink,archer-d7-v1|\
+	tplink,archer-d7b-v1)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary romfs 0xf100) +2)
+		;;
 	tplink,re350k-v1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -206,6 +206,36 @@ define Device/tplink_archer-d50-v1
 endef
 TARGET_DEVICES += tplink_archer-d50-v1
 
+define Device/tplink_archer-d7-v1
+  $(Device/tplink-v2)
+  SOC := qca9558
+  DEVICE_MODEL := Archer D7
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
+  kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15936k
+  TPLINK_HWID := 0x89300001
+  TPLINK_HWREV := 0x0000002D
+  TPLINK_FLASHLAYOUT := 16Mqca
+  TPLINK_HWREVADD := 0x00000002
+endef
+TARGET_DEVICES += tplink_archer-d7-v1
+
+define Device/tplink_archer-d7b-v1
+  $(Device/tplink-v2)
+  SOC := qca9558
+  DEVICE_MODEL := Archer D7b
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
+  kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 16000k
+  TPLINK_HWID := 0x89300001
+  TPLINK_HWREV := 0x0000003D
+  TPLINK_FLASHLAYOUT := 16Mqca
+  TPLINK_HWREVADD := 0x00000000
+endef
+TARGET_DEVICES += tplink_archer-d7b-v1
+
 define Device/tplink_cpe210-v1
   $(Device/tplink-safeloader-okli)
   SOC := ar9344


### PR DESCRIPTION
TP-Link Archer D7 v1 is a dual-band AC1750 router + modem.
The router section is based on Qualcomm/Atheros QCA9558 + QCA9880.
The "DSL" section is based on BCM6318 but it's currently not supported.

The Archer D7b seems to differ from the Archer D7 only in the
partition table

Router section - Specification:

775/650/258 MHz (CPU/DDR/AHB)
128 MB of RAM (DDR2)
16 MB of FLASH (SPI NOR)
3T3R 2.4 GHz
3T3R 5 GHz
4x 10/100/1000 Mbps Ethernet
7x LED, 2x button
UART header on PCB

Known issues:

Broadband LED (missing GPIO - probably driven by the BCM6318)
Internet LED (missing GPIO - probably driven by the BCM6318)
WIFI LED (working only for one interface at time, while in the
OEM firmware works for both wifi interfaces)
DSL not working (eth0) (WIP)

UART connection
---------------
J1 HEADER (Qualcomm CPU)
. VCC
. GND
. RX
O TX

J41 HEADER (Broadcom CPU)
. VCC
. GND
. RX
O TX

The following instructions require a connection to the J1 UART header
and are tested for the Archer D7 v1.
If you have an Arhcer D7b v1, you should change the names accordingly.

Flash instructions under U-Boot, using UART
------------------------------------------
 1. Press "tpl" to stop autobooting and obtain U-Boot CLI access.
 2. Setup ip addresses for U-Boot and your tftp server.
 3. Issue below commands:
        tftpboot 0x81000000 openwrt-ath79-generic-tplink_archer-d7-v1-squashfs-sysupgrade.bin
        erase 0x9f020000 +f90000
        cp.b 0x81000000 0x9f020000 0xf90000
        reset

Initramfs instructions under U-Boot for testing, using UART
----------------------------------------------------------
 1. Press "tpl" to stop autobooting and obtain U-Boot CLI access.
 2. Setup ip addresses for U-Boot and your tftp server.
 3. Issue below commands:
        tftpboot 0x81000000 openwrt-ath79-generic-tplink_archer-d7-v1-initramfs-kernel.bin
        bootm 0x81000000
 4. Here you can backup the original firmware and/or flash the sysupgrade openwrt if you want

Restore the original firmware
-----------------------------
 0. Backup every partition using the OpenWrt web interface
 1. Download the OEM firmware from the TP-Link website
 2. Extract the bin file in a folder (eg. Archer_D7v1_1.6.0_0.9.1_up_boot(160216)_2016-02-16_15.55.48.bin)
 3. Remove the U-Boot and the Broadcom image part from the file.
    Issue the following command:
        dd if="Archer_D7v1_1.6.0_0.9.1_up_boot(160216)_2016-02-16_15.55.48.bin" of="Archer_D7v1_1.6.0_0.9.1_up_boot(160216)_2016-02-16_15.55.48.bin.mod" skip=257 bs=512 count=31872
 4. Double check the .mod file size. It must be 16318464 bytes.
 5. Flash it using the OpenWrt web interface. Force the update if needed.
    WARNING: Remember to NOT keep settings.

 5b. (Alternative to 5.) Flash it using the U-Boot and UART connection.
     Issue below commands in the U-Boot:
        tftpboot 0x81000000 Archer_D7v1_1.6.0_0.9.1_up_boot(160216)_2016-02-16_15.55.48.bin.mod
        erase 0x9f020000 +f90000
        cp.b 0x81000000 0x9f020000 0xf90000
        reset

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>