### PR TITLE
ramips: mt7620: fix 5GHz WiFi LED on DWR-118-A1

### DIFF
--- a/target/linux/ramips/dts/DWR-118-A1.dts
+++ b/target/linux/ramips/dts/DWR-118-A1.dts
@@ -149,6 +149,11 @@
 		mtd-mac-address = <&config 0xe496>;
 		mtd-mac-address-increment = <(2)>;
 		mediatek,mtd-eeprom = <&config 0xe083>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 


### PR DESCRIPTION
Support for D-Link DWR-118 A1 was added before LEDs feature
in mt76x0e driver.

This fixes the 5GHz WiFi LED which was previously inverted.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
