### PR TITLE
While parsing dhcphosts file, in case of a duplicate entry,

### DIFF
--- a/package/network/services/dnsmasq/patches/231-fix-memory-leak-on-parsing-duplicate-entries-in-dhcphosts.patch
+++ b/package/network/services/dnsmasq/patches/231-fix-memory-leak-on-parsing-duplicate-entries-in-dhcphosts.patch
@@ -1,0 +1,10 @@
+--- dnsmasq-2.80/src/option.c	2019-05-27 18:39:53.036155520 +0530
++++ dnsmasq-2.80-new/src/option.c	2019-05-27 18:40:23.900545998 +0530
+@@ -3246,6 +3246,7 @@ static int one_opt(int option, char *arg
+ 		if ((configs->flags & CONFIG_ADDR) && configs->addr.s_addr == in.s_addr)
+ 		  {
+ 		    sprintf(errstr, _("duplicate dhcp-host IP address %s"),  inet_ntoa(in));
++                    dhcp_config_free(new);
+ 		    return 0;
+ 		  }	      
+ 	    }


### PR DESCRIPTION
free the allocated memory to dhcp_config. Otherwise,
it would create memory leak

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
