### PR TITLE
fstools: block-mount: fix restart of fstab service

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fstools
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/fstools.git

--- a/package/system/fstools/files/fstab.init
+++ b/package/system/fstools/files/fstab.init
@@ -11,6 +11,10 @@ start() {
 	echo "this file has been obsoleted. please call \"/sbin/block mount\" directly"
 }
 
+restart() {
+	start
+}
+
 stop() {
 	/sbin/block umount
 }


### PR DESCRIPTION
Restarting service causes file-systems to be unmounted without being
mounted back. When this service was obsoleted it should have been
implemented in a way that all actions are ignored. Up to this commit
default handler was called when restart was requested. This default
handler just simply calls stop and start. That means that stop called
unmount but start just printed that this service is obsoleted.

This instead implements restart that just prints same message like start
does. It just calls start in reality. This makes restart unavailable for
call.

Signed-off-by: Karel Kočí <karel.koci@nic.cz>