### PR TITLE
ath79: Fix 11-ath10k-caldata after eth0/eth1 swap and harmonize partition labels

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -330,17 +330,11 @@ ath79_setup_macs()
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
 	tplink,archer-a7-v5|\
-	tplink,archer-c7-v5)
-		base_mac=$(mtd_get_mac_binary info 8)
-		wan_mac=$(macaddr_add "$base_mac" 1)
-		;;
-	tplink,archer-c7-v4)
-		base_mac=$(mtd_get_mac_binary config 8)
-		wan_mac=$(macaddr_add "$base_mac" 1)
-		;;
+	tplink,archer-c7-v4|\
+	tplink,archer-c7-v5|\
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
-		base_mac=$(mtd_get_mac_binary product-info 8)
+		base_mac=$(mtd_get_mac_binary info 8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,tl-wr941-v2|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -285,7 +285,7 @@ ath79_setup_macs()
 		;;
 	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary ART 4098)" -2)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 4098)" -2)
 		;;
 	engenius,ecb1750)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -144,7 +144,7 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "art" 4096 3768
 		;;
 	buffalo,wzr-hp-g450h)
-		ath9k_eeprom_extract "ART" 4096 1088
+		ath9k_eeprom_extract "art" 4096 1088
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -100,7 +100,7 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
 	elecom,wrc-1750ghbk2-i)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "art" 20480 2116
 		;;
 	engenius,ecb1750)
 		ath10kcal_extract "art" 20480 2116
@@ -134,17 +134,14 @@ case "$FIRMWARE" in
 		ath10kcal_patch_mac $(mtd_get_mac_binary art 12)
 		;;
 	openmesh,om5p-ac-v2)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	tplink,archer-a7-v5|\
+	tplink,archer-c2-v3|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
-		;;
-	tplink,archer-c2-v3)
-		ath10kcal_extract "ART" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
 		;;
 	tplink,archer-c5-v1|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -112,12 +112,17 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
-	engenius,ews511ap|\
-	glinet,gl-ar750s|\
-	glinet,gl-x750|\
-	tplink,re450-v2)
+	engenius,ews511ap)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+		;;
+	glinet,gl-ar750s)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+		;;
+	glinet,gl-x750)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0) +2)
 		;;
 	nec,wg800hp)
 		ath10kcal_extract "art" 20480 2116
@@ -132,28 +137,32 @@ case "$FIRMWARE" in
 		ath10kcal_extract "ART" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
-	tplink,archer-c2-v3)
-		ath10kcal_extract "ART" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
-		;;
-	tplink,archer-c5-v1|\
-	tplink,archer-c7-v2)
-		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
-		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
+		;;
+	tplink,archer-c2-v3)
+		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
+		;;
+	tplink,archer-c5-v1|\
+	tplink,archer-c7-v2)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
 		;;
         tplink,archer-d50-v1)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) +2)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
                 ;;
 	tplink,re350k-v1)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +2)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
+		;;
+	tplink,re450-v2)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) +1)
 		;;
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_bhr-4grv.dts
@@ -9,7 +9,7 @@
 };
 
 &eth0 {
-	mtd-mac-address = <&ART 0x0>;
+	mtd-mac-address = <&art 0x0>;
 };
 
 &sec_vpn {

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -89,9 +89,9 @@
 				label = "u-boot-env";
 			};
 
-			ART: partition@50000 {
+			art: partition@50000 {
 				reg = <0x50000 0x10000>;
-				label = "ART";
+				label = "art";
 				read-only;
 			};
 

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -57,7 +57,7 @@
 };
 
 &eth0 {
-	mtd-mac-address = <&ART 0x1002>;
+	mtd-mac-address = <&art 0x1002>;
 };
 
 &sec_vpn {
@@ -70,7 +70,7 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		mtd-mac-address = <&ART 0x1002>;
+		mtd-mac-address = <&art 0x1002>;
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -111,7 +111,7 @@
 			};
 
 			art: partition@3 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
@@ -94,7 +94,7 @@
 			};
 
 			art: partition@3 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -93,7 +93,7 @@
 			};
 
 			partition@7f0000 {
-				label = "ART";
+				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
@@ -92,7 +92,7 @@
 			};
 
 			info: partition@30000 {
-				label = "product-info";
+				label = "info";
 				reg = <0x030000 0x10000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
@@ -109,8 +109,8 @@
 				read-only;
 			};
 
-			ART: partition@7f0000 {
-				label = "ART";
+			art: partition@7f0000 {
+				label = "art";
 				reg = <0x7f0000 0x10000>;
 				read-only;
 			};
@@ -130,6 +130,6 @@
 
 &wmac {
 	status = "okay";
-	mtd-cal-data = <&ART 0x1000>;
+	mtd-cal-data = <&art 0x1000>;
 	mtd-mac-address = <&info 0x8>;
 };

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
@@ -140,7 +140,7 @@
 			};
 
 			art: partition@ff0000 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -152,8 +152,8 @@
 				reg = <0xfd0000 0x20000>;
 			};
 
-			ART: partition@ff0000 {
-				label = "ART";
+			art: partition@ff0000 {
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};
@@ -184,7 +184,7 @@
 	status = "okay";
 
 	pll-data = <0xa6000000 0x00000101 0x00001616>;
-	mtd-mac-address = <&ART 0x0>;
+	mtd-mac-address = <&art 0x0>;
 
 	phy-handle = <&phy0>;
 
@@ -195,7 +195,7 @@
 
 	phy-mode = "sgmii";
 	pll-data = <0x03000101 0x00000101 0x00001616>;
-	mtd-mac-address = <&ART 0x6>;
+	mtd-mac-address = <&art 0x6>;
 
 	fixed-link {
 		speed = <1000>;
@@ -206,6 +206,6 @@
 &wmac {
 	status = "okay";
 
-	mtd-cal-data = <&ART 0x1000>;
-	mtd-mac-address = <&ART 0xc>;
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0xc>;
 };

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -123,7 +123,7 @@
 			};
 
 			partition@3 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-1750ghbk2-i.dts
@@ -44,8 +44,8 @@
 		read-only;
 	};
 
-	ART: partition@ff0000 {
-		label = "ART";
+	art: partition@ff0000 {
+		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
 	};

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-300ghbk2-i.dts
@@ -38,8 +38,8 @@
 		read-only;
 	};
 
-	ART: partition@7f0000 {
-		label = "ART";
+	art: partition@7f0000 {
+		label = "art";
 		reg = <0x7f0000 0x010000>;
 		read-only;
 	};

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
@@ -111,7 +111,7 @@
 
 	pll-data = <0x03000101 0x00000101 0x00001919>;
 
-	mtd-mac-address = <&ART 0x1002>;
+	mtd-mac-address = <&art 0x1002>;
 	mtd-mac-address-increment = <(-1)>;
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
@@ -123,5 +123,5 @@
 
 &wmac {
 	status = "okay";
-	mtd-cal-data = <&ART 0x1000>;
+	mtd-cal-data = <&art 0x1000>;
 };

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
@@ -134,7 +134,7 @@
 			};
 
 			info: partition@7e0000 {
-				label = "product-info";
+				label = "info";
 				reg = <0x7e0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
@@ -140,7 +140,7 @@
 			};
 
 			art: partition@7f0000 {
-				label = "ART";
+				label = "art";
 				reg = <0x7f0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -223,7 +223,7 @@
 			};
 
 			info: partition@f00000 {
-				label = "config";
+				label = "info";
 				reg = <0xf00000 0x0f0000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
@@ -156,7 +156,7 @@
 			};
 
 			info: partition@610000 {
-				label = "product-info";
+				label = "info";
 				reg = <0x610000 0x020000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
@@ -41,7 +41,7 @@
 			};
 
 			info: partition@f00000 {
-				label = "product-info";
+				label = "info";
 				reg = <0xf00000 0x020000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
@@ -65,7 +65,7 @@
 			};
 
 			art: partition@ff0000 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -70,7 +70,7 @@
 			};
 
 			art: partition@ff0000 {
-				label = "ART";
+				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -46,7 +46,7 @@
 			};
 
 			info: partition@f50000 {
-				label = "product-info";
+				label = "info";
 				reg = <0xf50000 0x020000>;
 				read-only;
 			};


### PR DESCRIPTION
This patch series was initially created to fix 11-ath10k-caldata, which was not touched during the eth0/eth1 swap patch https://github.com/openwrt/openwrt/commit/c3a85189181827c8d5c2ab736428be30e4c13128

Instead of switching between eth0/eth1, I considered it more helpful to read from flash and changed accordingly.

While at it, I realized that it might be helping to harmonize info and art partition labels, so I did this in the two other patches.

RFC: I did not touch engenius,ews511ap and openmesh,om5p-ac-v2, since I do know which mtd_get_mac_* function I need to use there. Help would be welcome there.

Run-tested on Archer C7 v5.
