### PR TITLE
ramips: add support for EnGenius ESR600

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -186,6 +186,10 @@ elecom,wrh-300cr)
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:ethernet" "eth0"
 	;;
+engenius,esr600)
+	ucidef_set_led_netdev "wlan5g" "5.0GHz" "$boardname:blue:wlan5g" "wlan0"
+	ucidef_set_led_netdev "wlan2g" "2.4GHz" "$boardname:blue:wlan2g" "wlan1"
+	;;
 glinet,gl-mt300a|\
 glinet,gl-mt300n|\
 glinet,gl-mt750)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -329,6 +329,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
+	engenius,esr600)
+		ucidef_add_switch "switch0" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "0@eth0"
+		;;
 	fon,fon2601)
 		ucidef_add_switch "switch0" \
 			"0:lan" "4:wan" "6@eth0"
@@ -608,6 +612,10 @@ ramips_setup_macs()
 	netgear,r6350|\
 	netgear,r6850)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
+		;;
+	engenius,esr600)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
 	hiwifi,hc5661|\
 	hiwifi,hc5661a|\

--- a/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,esr600", "ralink,mt7620a-soc";
+	model = "EnGenius ESR600";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "esr600:amber:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wps2g {
+			label = "esr600:amber:wps2g";
+			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "esr600:blue:wlan5g";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "esr600:blue:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+	};
+
+ };
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			iNIC_rf: partition@50000 {
+				label = "iNIC_rf";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "firmware";
+				reg = <0x60000 0xf40000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fa0000 {
+				label = "backup";
+				reg = <0xfa0000 0x10000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "storage";
+				reg = <0xfb0000 0x50000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+	mtd-mac-address = <&iNIC_rf 0x4>;
+
+	port@5 {
+		status = "okay";
+		phy-mode = "rgmii";
+		mediatek,fixed-link = <1000 1 1 1>;
+	};
+
+	mdio-bus {
+		status = "okay";
+		mediatek,mdio-mode;
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+			qca,ar8327-initvals = <
+				0x10 0x40000000 /* POWER-ON STRAPPING */
+				0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+				0x7c 0x0000007e /* PORT0 STATUS */
+				0x0c 0x05600000 /* PORT6 PAD MODE CTRL */
+				0x94 0x0000007e /* PORT6 STATUS */
+				>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group =	"i2c",	/* gpio0: 1-2 */
+				"uartf",	/* gpio0: 7-14 */
+				"nd_sd",	/* gpio2: 45-59 */
+				"wled";		/* gpio3: 72 */
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci1814,5592";
+		reg = <0x0 0 0 0 0>;
+		ralink,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&iNIC_rf 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -372,6 +372,19 @@ define Device/elecom_wrh-300cr
 endef
 TARGET_DEVICES += elecom_wrh-300cr
 
+define Device/engenius_esr600
+  MTK_SOC := mt7620a
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 15616k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+       senao-header -r 0x101 -p 0x57 -t 2
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ESR600
+  DEVICE_PACKAGES += kmod-rt2800-pci kmod-usb-core kmod-usb-storage kmod-usb-ohci kmod-usb-ehci
+endef
+TARGET_DEVICES += engenius_esr600
+
 define Device/fon_fon2601
   MTK_SOC := mt7620a
   IMAGE_SIZE := 15936k


### PR DESCRIPTION
The EnGenius ESR600 is a dual band wireless router with a 4-port gigabit
Ethernet switch, a gigabit Ethernet WAN port and a USB port.

Specification:

- Bootloader:	U-Boot
- SoC:		MediaTek MT7620A (600 MHz)
- Flash:	16MB, Macronix MX25L12845E
- RAM:		64MB, Nanya NT5TU32M16DG-AC
- Serial:	115200 baud, no header, 3.3V
  		J2: Vcc (arrow), Gnd, Tx, Rx
- USB:		USB 2, 5V
- Ethernet:	5 x 1 Gb/s 4 LAN 1 WAN, Atheros AR8327
- WiFi0:	5 GHz 802.11 b/g/n Ralink RT5592N
  		300 Mb/s, 2T2R
- WiFi1:	2.4 GHz 802.11 b/g/n integrated
  		300 Mb/s, 2T2R
- Antennas:	2 per radio, internal
- LEDs:		1 programmable power (amber)
  		2 programable radio (blue)
		1 programable WPS-5G (blue)
		1 non-programable WAN activity (blue)
		1 unconfigured WPS-2.4G (amber)
- Buttons:	GPIO: Reset, WPS

Installation:

Use the OEM web interface to install the ...-factory.dlf image.
Use the OpenWRT ...-sysupgrade.bin image for future upgrades.

The J2 serial port can be accessed either by soldering in a header,
standard 0.1" spacing, or by using pogo-pins against the back side.

As configured by the OEM, the U-Boot boot delay is short, however quickly
typing "1" leads to the U-Boot "System load Linux to SDRAM via TFTP"
prompt.  The TFTP client is configured by default with its own address as
192.168.99.9,  server as 192.168.99.8, and file name as "uImageESR600"
It will load an OpenWRT initramfs kernel with this method.

Known issues:

1) Only the ports externally labeled WAN, LAN3 and LAN4 are operational.
LAN1 and LAN2 do not appear to power up. This issue is also present
in the Lava LR25G001 which uses the same/similar Atheros switch.

2) The amber WPS-2.4G LED (in the same light guide as the
blue WPS-5G LED) is not configured in the DTS.

3) The blue WAN activity LED is not present in the DTS.
Configuring it as GPIO driven causes the AR8327 switch to
fail to initialize.

Signed-off-by: Nick Briggs <nicholas.h.briggs@gmail.com>