### PR TITLE
mvebu: fix ESPRESSObin network detection

### DIFF
--- a/package/boot/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-envtools/files/mvebu
@@ -18,6 +18,9 @@ cznic,turris-omnia)
 	ubootenv_add_uci_config "/dev/mtd0" "0xC0000" "0x10000" "0x40000"
 	;;
 globalscale,espressobin|\
+globalscale,espressobin-emmc|\
+globalscale,espressobin-v7|\
+globalscale,espressobin-v7-emmc|\
 marvell,armada8040-mcbin)
 	ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
 	;;

--- a/target/linux/mvebu/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/base-files/etc/board.d/02_network
@@ -15,7 +15,10 @@ cznic,turris-omnia)
 	ucidef_set_interface_lan "lan0 lan1 lan2 lan3 lan4"
 	ucidef_set_interface_wan "eth2"
 	;;
-globalscale,espressobin)
+globalscale,espressobin|\
+globalscale,espressobin-emmc|\
+globalscale,espressobin-v7|\
+globalscale,espressobin-v7-emmc)
 	ucidef_set_interfaces_lan_wan "lan0 lan1" "wan"
 	;;
 linksys,caiman|\

--- a/target/linux/mvebu/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/platform.sh
@@ -23,7 +23,8 @@ platform_do_upgrade() {
 	linksys,caiman|linksys,cobra|linksys,mamba|linksys,rango|linksys,shelby|linksys,venom)
 		platform_do_upgrade_linksys "$ARGV"
 		;;
-	cznic,turris-omnia|globalscale,espressobin|marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
+	cznic,turris-omnia|globalscale,espressobin|globalscale,espressobin-emmc|globalscale,espressobin-v7|globalscale,espressobin-v7-emmc|\
+	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
 		platform_do_upgrade_sdcard "$ARGV"
 		;;
 	*)


### PR DESCRIPTION
Since every version of ESPRESSObin has different device tree,
v7 and eMMC variants currently don't have network interfaces.
Per my knowledge, interfaces are same on every device so adding
wildcard after the device name will fix the issue.

Signed-off-by: Vladimir Vid <vladimir.vid@sartura.hr>