### PR TITLE
mvebu: image: fix generic-arm64.bootscript mmc selection

### DIFF
--- a/target/linux/mvebu/image/generic-arm64.bootscript
+++ b/target/linux/mvebu/image/generic-arm64.bootscript
@@ -4,7 +4,13 @@ if test -n "${console}"; then
 	setenv bootargs "${bootargs} ${console}"
 fi
 
-load mmc 0:1 ${fdt_addr} @DTB@.dtb
-load mmc 0:1 ${kernel_addr} Image
+if mmc dev 0; then
+	setenv mmcdev 0
+elif mmc dev 1; then
+	setenv mmcdev 1
+fi
+
+load mmc ${mmcdev}:1 ${fdt_addr} @DTB@.dtb
+load mmc ${mmcdev}:1 ${kernel_addr} Image
 
 booti ${kernel_addr} - ${fdt_addr}


### PR DESCRIPTION
Since every version of ESPRESSObin has different device tree,
v7 and eMMC variants currently don't have network interfaces.
Per my knowledge, interfaces are same on every device so adding
wildcard after the device name will fix the issue.

Signed-off-by: Vladimir Vid <vladimir.vid@sartura.hr>