### PR TITLE
ramips: mt7620: select kmod-rt2800-pci driver for RT5592

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -56,7 +56,7 @@ define Device/alfa-network_tube-e4g
   IMAGE_SIZE := 16064k
   DEVICE_TITLE := ALFA Network Tube-E4G
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools uqmi \
-	-iwinfo -kmod-rt2800-pci -kmod-rt2800-soc -wpad-basic
+	-iwinfo -kmod-rt2800-soc -wpad-basic
 endef
 TARGET_DEVICES += alfa-network_tube-e4g
 
@@ -574,6 +574,7 @@ TARGET_DEVICES += phicomm_k2g
 define Device/rp-n53
   DTS := RP-N53
   DEVICE_TITLE := Asus RP-N53
+  DEVICE_PACKAGES := kmod-rt2800-pci
 endef
 TARGET_DEVICES += rp-n53
 
@@ -677,6 +678,7 @@ define Device/whr-600d
   DTS := WHR-600D
   IMAGE_SIZE := 6848k
   DEVICE_TITLE := Buffalo WHR-600D
+  DEVICE_PACKAGES := kmod-rt2800-pci
 endef
 TARGET_DEVICES += whr-600d
 


### PR DESCRIPTION
ASUS RP-N53 and Buffalo WHR-600D use RT5592 for 5GHz wireless
After commit 367813b9b17 the driver for RT5592 (rt2800pci)
is not selected by default anymore, which broke their 5GHz wireless
Add it back to device packages

Fixes: 367813b9b17 ("ramips: mt7620: fix dependencies")