### PR TITLE
busybox: add ALTERNATIVES for brctl

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -46,6 +46,7 @@ define Package/busybox
   DEPENDS:=+BUSYBOX_CONFIG_PAM:libpam +BUSYBOX_CONFIG_NTPD:jsonfilter
   MENU:=1
   ALTERNATIVES:=\
+    $(call BUSYBOX_IF_ENABLED,BRCTL,	100:/usr/sbin/brctl:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,FIND,	100:/usr/bin/find:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,FLOCK,	100:/usr/bin/flock:/bin/busybox) \
     $(call BUSYBOX_IF_ENABLED,FREE,	100:/usr/bin/free:/bin/busybox) \


### PR DESCRIPTION
Busybox brctl applet conflicts with the version from bridge-utils.
Fix this by using ALTERNATIVE support for brctl in busybox.

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>