### PR TITLE
package: Add support for mac address based vlan in hostapd.sh

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -595,16 +595,16 @@ hostapd_set_bss_options() {
                         for mac in $maclist; do
                                 echo "$mac" | grep -v deny | sed -e 's/,/ /g'
                         done
-                        [ -n "$macfile" -a -f "$macfile" ] && cat "$macfile" | grep -v deny
+                        [ -n "$macfile" -a -f "$macfile" ] && cat "$macfile" | grep -v deny | sed -e 's/,/ /g'
                 ) > "$_macfile"
 
                 [ "$macfilter" = "vlan" ] && {
                         rm -f "$_macfile.deny"
                         (
                                 for mac in $maclist; do
-                                        echo "$mac" | grep deny
+                                        echo "$mac" | grep deny | cut -d "," -f1
                                 done
-                                [ -n "$macfile" -a -f "$macfile" ] && cat "$macfile" | grep deny
+                                [ -n "$macfile" -a -f "$macfile" ] && cat "$macfile" | grep deny | cut -d "," -f1
                         ) > "$_macfile.deny"
                 }
 	}


### PR DESCRIPTION
Add support for vlans, based on mac addresses in /lib/netifd/hostapd.sh.
Now, you can assign a vlan id to a mac address, without using radius and also deny others at the same time. 
This can be done by using the list maclist option in /etc/config/wireless, while setting option macfilter to 'vlan'. 

Here is a full example:

config wifi-iface 'default_radio1'
        option device 'radio1'
        option mode 'ap'
        option ssid 'VLANbasedMAC'
        option encryption 'psk2+ccmp'
        option key 'mySup3RS3CreTP@ssw0rD'
        option macfilter 'vlan'
        option dynamic_vlan '1'
        option vlan_naming '1'
        option vlan_bridge 'br-vlan'
        option vlan_tagged_interface 'eth0'
        option vlan_file '/etc/hostapd/hostapd-wlan1.vlan'
        list maclist 'aa:bb:cc:dd:ee:ff,1234'
        list maclist 'aa:bb:cc:dd:ee:00,1235'
        list maclist 'aa:bb:cc:dd:ee:11,deny'

This will direct aa:bb:cc:dd:ee:ff to vlan 1234, while aa:bb:cc:dd:ee:f0 goes to vlan 1235. Host aa:bb:cc:dd:ee:11 is denied. Also, you have to create a VLAN file (see option vlan_file below), which looks like the following one:

1234 wlan1.1234
1235 wlan1.1235

If you wanna know, how this exactly works, see hostapd man page and search for macaddr_acl=2.
