### PR TITLE
octeon: Use Linux 4.19 kernel by default

### DIFF
--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -13,8 +13,7 @@ FEATURES:=squashfs ramdisk pci usb
 CPU_TYPE:=octeonplus
 MAINTAINER:=John Crispin <john@phrozen.org>
 
-KERNEL_PATCHVER:=4.14
-KERNEL_TESTING_PATCHVER := 4.19
+KERNEL_PATCHVER:=4.19
 
 define Target/Description
 	Build firmware images for Cavium Networks Octeon-based boards.


### PR DESCRIPTION
Use Linux kernel 4.19 by default

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>