### PR TITLE
mac80211: ath(9|10)k: Allow 6dBi as maximum antenna gain for FCC

### DIFF
--- a/package/kernel/ath10k-ct/patches/204-ath10k-fix-max-antenna-gain-unit.patch
+++ b/package/kernel/ath10k-ct/patches/204-ath10k-fix-max-antenna-gain-unit.patch
@@ -1,0 +1,49 @@
+From: Sven Eckelmann <seckelmann@datto.com>
+Date: Tue, 11 Jun 2019 13:58:35 +0200
+Subject: ath10k: fix max antenna gain unit
+
+Most of the txpower for the ath10k firmware is stored as twicepower (0.5 dB
+steps). This isn't the case for max_antenna_gain - which is still expected
+by the firmware as dB.
+
+The firmware is converting it from dB to the internal (twicepower)
+representation when it calculates the limits of a channel. This can be seen
+in tpc_stats when configuring "12" as max_antenna_gain. Instead of the
+expected 12 (6 dB), the tpc_stats shows 24 (12 dB).
+
+Tested on QCA9888 and IPQ4019 with firmware 10.4-3.5.3-00057.
+
+Fixes: 02256930d9b8 ("ath10k: use proper tx power unit")
+Signed-off-by: Sven Eckelmann <seckelmann@datto.com>
+
+Forwarded: https://patchwork.kernel.org/patch/10986723/
+
+--- a/ath10k-4.19/mac.c
++++ b/ath10k-4.19/mac.c
+@@ -1185,7 +1185,7 @@ static int ath10k_monitor_vdev_start(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = channel->max_power * 2;
+ 	arg.channel.max_reg_power = channel->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = channel->max_antenna_gain * 2;
++	arg.channel.max_antenna_gain = channel->max_antenna_gain;
+ 
+ 	reinit_completion(&ar->vdev_setup_done);
+ 
+@@ -1627,7 +1627,7 @@ static int ath10k_vdev_start_restart(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = chandef->chan->max_power * 2;
+ 	arg.channel.max_reg_power = chandef->chan->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain * 2;
++	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain;
+ 
+ 	/* CT Firmware can support 32+ VDEVS, but can only support
+ 	 * beacon-ing devs with dev ids 0 - 31 due to firmware limitations.
+@@ -3799,7 +3799,7 @@ static int ath10k_update_channel_list(st
+ 			ch->min_power = 0;
+ 			ch->max_power = channel->max_power * 2;
+ 			ch->max_reg_power = channel->max_reg_power * 2;
+-			ch->max_antenna_gain = channel->max_antenna_gain * 2;
++			ch->max_antenna_gain = channel->max_antenna_gain;
+ 			ch->reg_class_id = 0; /* FIXME */
+ 
+ 			/* FIXME: why use only legacy modes, why not any

--- a/package/kernel/ath10k-ct/patches/205-ath10k-adjust-tx-power-reduction-for-US-regulatory-d.patch
+++ b/package/kernel/ath10k-ct/patches/205-ath10k-adjust-tx-power-reduction-for-US-regulatory-d.patch
@@ -1,0 +1,101 @@
+From: Sven Eckelmann <seckelmann@datto.com>
+Date: Wed, 28 Nov 2018 16:16:27 +0100
+Subject: ath10k: adjust tx power reduction for US regulatory domain
+
+FCC allows maximum antenna gain of 6 dBi. 15.247(b)(4):
+
+> (4) The conducted output power limit
+> specified in paragraph (b) of this section
+> is based on the use of antennas
+> with directional gains that do not exceed
+> 6 dBi. Except as shown in paragraph
+> (c) of this section, if transmitting
+> antennas of directional gain greater
+> than 6 dBi are used, the conducted
+> output power from the intentional radiator
+> shall be reduced below the stated
+> values in paragraphs (b)(1), (b)(2),
+> and (b)(3) of this section, as appropriate,
+> by the amount in dB that the
+> directional gain of the antenna exceeds
+> 6 dBi.
+
+https://www.gpo.gov/fdsys/pkg/CFR-2013-title47-vol1/pdf/CFR-2013-title47-vol1-sec15-247.pdf
+
+Signed-off-by: Sven Eckelmann <seckelmann@datto.com>
+
+Forwarded: no
+
+--- a/ath10k-4.19/mac.c
++++ b/ath10k-4.19/mac.c
+@@ -1153,6 +1153,40 @@ static inline int ath10k_vdev_setup_sync
+ 	return ar->last_wmi_vdev_start_status;
+ }
+ 
++static u32 ath10k_get_max_antenna_gain(struct ath10k *ar,
++				       u32 ch_max_antenna_gain)
++{
++	u32 max_antenna_gain;
++
++	if (ar->dfs_detector && ar->dfs_detector->region == NL80211_DFS_FCC) {
++		/* FCC allows maximum antenna gain of 6 dBi. 15.247(b)(4):
++		 *
++		 * > (4) The conducted output power limit
++		 * > specified in paragraph (b) of this section
++		 * > is based on the use of antennas
++		 * > with directional gains that do not exceed
++		 * > 6 dBi. Except as shown in paragraph
++		 * > (c) of this section, if transmitting
++		 * > antennas of directional gain greater
++		 * > than 6 dBi are used, the conducted
++		 * > output power from the intentional radiator
++		 * > shall be reduced below the stated
++		 * > values in paragraphs (b)(1), (b)(2),
++		 * > and (b)(3) of this section, as appropriate,
++		 * > by the amount in dB that the
++		 * > directional gain of the antenna exceeds
++		 * > 6 dBi.
++		 *
++		 * https://www.gpo.gov/fdsys/pkg/CFR-2013-title47-vol1/pdf/CFR-2013-title47-vol1-sec15-247.pdf
++		 */
++		max_antenna_gain = 6;
++	} else {
++		max_antenna_gain = 0;
++	}
++
++	return max(ch_max_antenna_gain, max_antenna_gain);
++}
++
+ static int ath10k_monitor_vdev_start(struct ath10k *ar, int vdev_id)
+ {
+ 	struct cfg80211_chan_def *chandef = NULL;
+@@ -1185,7 +1219,8 @@ static int ath10k_monitor_vdev_start(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = channel->max_power * 2;
+ 	arg.channel.max_reg_power = channel->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = channel->max_antenna_gain;
++	arg.channel.max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++						channel->max_antenna_gain);
+ 
+ 	reinit_completion(&ar->vdev_setup_done);
+ 
+@@ -1627,7 +1662,8 @@ static int ath10k_vdev_start_restart(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = chandef->chan->max_power * 2;
+ 	arg.channel.max_reg_power = chandef->chan->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain;
++	arg.channel.max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++					chandef->chan->max_antenna_gain);
+ 
+ 	/* CT Firmware can support 32+ VDEVS, but can only support
+ 	 * beacon-ing devs with dev ids 0 - 31 due to firmware limitations.
+@@ -3799,7 +3835,8 @@ static int ath10k_update_channel_list(st
+ 			ch->min_power = 0;
+ 			ch->max_power = channel->max_power * 2;
+ 			ch->max_reg_power = channel->max_reg_power * 2;
+-			ch->max_antenna_gain = channel->max_antenna_gain;
++			ch->max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++						channel->max_antenna_gain);
+ 			ch->reg_class_id = 0; /* FIXME */
+ 
+ 			/* FIXME: why use only legacy modes, why not any

--- a/package/kernel/mac80211/patches/ath/365-ath9k-adjust-tx-power-reduction-for-US-regulatory-do.patch
+++ b/package/kernel/mac80211/patches/ath/365-ath9k-adjust-tx-power-reduction-for-US-regulatory-do.patch
@@ -3,7 +3,7 @@ Date: Wed, 19 Jul 2017 08:49:31 +0200
 Subject: [PATCH] ath9k: adjust tx power reduction for US regulatory
  domain
 
-FCC regulatory rules allow for up to 3 dBi antenna gain. Account for
+FCC regulatory rules allow for up to 6 dBi antenna gain. Account for
 this in the EEPROM based tx power reduction code.
 
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
@@ -15,9 +15,9 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (ant_gain > max_gain)
  		ant_reduction = ant_gain - max_gain;
  
-+	/* FCC allows maximum antenna gain of 3 dBi */
++	/* FCC allows maximum antenna gain of 6 dBi */
 +	if (reg->region == NL80211_DFS_FCC)
-+		ant_reduction = max_t(int, ant_reduction - 6, 0);
++		ant_reduction = max_t(int, ant_reduction - 12, 0);
 +
  	ah->eep_ops->set_txpower(ah, chan, ctl,
  				 ant_reduction, new_pwr, test);

--- a/package/kernel/mac80211/patches/ath/980-ath10k-fix-max-antenna-gain-unit.patch
+++ b/package/kernel/mac80211/patches/ath/980-ath10k-fix-max-antenna-gain-unit.patch
@@ -1,0 +1,49 @@
+From: Sven Eckelmann <seckelmann@datto.com>
+Date: Tue, 11 Jun 2019 13:58:35 +0200
+Subject: ath10k: fix max antenna gain unit
+
+Most of the txpower for the ath10k firmware is stored as twicepower (0.5 dB
+steps). This isn't the case for max_antenna_gain - which is still expected
+by the firmware as dB.
+
+The firmware is converting it from dB to the internal (twicepower)
+representation when it calculates the limits of a channel. This can be seen
+in tpc_stats when configuring "12" as max_antenna_gain. Instead of the
+expected 12 (6 dB), the tpc_stats shows 24 (12 dB).
+
+Tested on QCA9888 and IPQ4019 with firmware 10.4-3.5.3-00057.
+
+Fixes: 02256930d9b8 ("ath10k: use proper tx power unit")
+Signed-off-by: Sven Eckelmann <seckelmann@datto.com>
+
+Forwarded: https://patchwork.kernel.org/patch/10986723/
+
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -1020,7 +1020,7 @@ static int ath10k_monitor_vdev_start(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = channel->max_power * 2;
+ 	arg.channel.max_reg_power = channel->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = channel->max_antenna_gain * 2;
++	arg.channel.max_antenna_gain = channel->max_antenna_gain;
+ 
+ 	reinit_completion(&ar->vdev_setup_done);
+ 
+@@ -1462,7 +1462,7 @@ static int ath10k_vdev_start_restart(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = chandef->chan->max_power * 2;
+ 	arg.channel.max_reg_power = chandef->chan->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain * 2;
++	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain;
+ 
+ 	if (arvif->vdev_type == WMI_VDEV_TYPE_AP) {
+ 		arg.ssid = arvif->u.ap.ssid;
+@@ -3139,7 +3139,7 @@ static int ath10k_update_channel_list(st
+ 			ch->min_power = 0;
+ 			ch->max_power = channel->max_power * 2;
+ 			ch->max_reg_power = channel->max_reg_power * 2;
+-			ch->max_antenna_gain = channel->max_antenna_gain * 2;
++			ch->max_antenna_gain = channel->max_antenna_gain;
+ 			ch->reg_class_id = 0; /* FIXME */
+ 
+ 			/* FIXME: why use only legacy modes, why not any

--- a/package/kernel/mac80211/patches/ath/981-ath10k-adjust-tx-power-reduction-for-US-regulatory-d.patch
+++ b/package/kernel/mac80211/patches/ath/981-ath10k-adjust-tx-power-reduction-for-US-regulatory-d.patch
@@ -1,0 +1,101 @@
+From: Sven Eckelmann <seckelmann@datto.com>
+Date: Wed, 28 Nov 2018 16:16:27 +0100
+Subject: ath10k: adjust tx power reduction for US regulatory domain
+
+FCC allows maximum antenna gain of 6 dBi. 15.247(b)(4):
+
+> (4) The conducted output power limit
+> specified in paragraph (b) of this section
+> is based on the use of antennas
+> with directional gains that do not exceed
+> 6 dBi. Except as shown in paragraph
+> (c) of this section, if transmitting
+> antennas of directional gain greater
+> than 6 dBi are used, the conducted
+> output power from the intentional radiator
+> shall be reduced below the stated
+> values in paragraphs (b)(1), (b)(2),
+> and (b)(3) of this section, as appropriate,
+> by the amount in dB that the
+> directional gain of the antenna exceeds
+> 6 dBi.
+
+https://www.gpo.gov/fdsys/pkg/CFR-2013-title47-vol1/pdf/CFR-2013-title47-vol1-sec15-247.pdf
+
+Signed-off-by: Sven Eckelmann <seckelmann@datto.com>
+
+Forwarded: no
+
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -988,6 +988,40 @@ static inline int ath10k_vdev_setup_sync
+ 	return 0;
+ }
+ 
++static u32 ath10k_get_max_antenna_gain(struct ath10k *ar,
++				       u32 ch_max_antenna_gain)
++{
++	u32 max_antenna_gain;
++
++	if (ar->dfs_detector && ar->dfs_detector->region == NL80211_DFS_FCC) {
++		/* FCC allows maximum antenna gain of 6 dBi. 15.247(b)(4):
++		 *
++		 * > (4) The conducted output power limit
++		 * > specified in paragraph (b) of this section
++		 * > is based on the use of antennas
++		 * > with directional gains that do not exceed
++		 * > 6 dBi. Except as shown in paragraph
++		 * > (c) of this section, if transmitting
++		 * > antennas of directional gain greater
++		 * > than 6 dBi are used, the conducted
++		 * > output power from the intentional radiator
++		 * > shall be reduced below the stated
++		 * > values in paragraphs (b)(1), (b)(2),
++		 * > and (b)(3) of this section, as appropriate,
++		 * > by the amount in dB that the
++		 * > directional gain of the antenna exceeds
++		 * > 6 dBi.
++		 *
++		 * https://www.gpo.gov/fdsys/pkg/CFR-2013-title47-vol1/pdf/CFR-2013-title47-vol1-sec15-247.pdf
++		 */
++		max_antenna_gain = 6;
++	} else {
++		max_antenna_gain = 0;
++	}
++
++	return max(ch_max_antenna_gain, max_antenna_gain);
++}
++
+ static int ath10k_monitor_vdev_start(struct ath10k *ar, int vdev_id)
+ {
+ 	struct cfg80211_chan_def *chandef = NULL;
+@@ -1020,7 +1054,8 @@ static int ath10k_monitor_vdev_start(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = channel->max_power * 2;
+ 	arg.channel.max_reg_power = channel->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = channel->max_antenna_gain;
++	arg.channel.max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++						channel->max_antenna_gain);
+ 
+ 	reinit_completion(&ar->vdev_setup_done);
+ 
+@@ -1462,7 +1497,8 @@ static int ath10k_vdev_start_restart(str
+ 	arg.channel.min_power = 0;
+ 	arg.channel.max_power = chandef->chan->max_power * 2;
+ 	arg.channel.max_reg_power = chandef->chan->max_reg_power * 2;
+-	arg.channel.max_antenna_gain = chandef->chan->max_antenna_gain;
++	arg.channel.max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++					chandef->chan->max_antenna_gain);
+ 
+ 	if (arvif->vdev_type == WMI_VDEV_TYPE_AP) {
+ 		arg.ssid = arvif->u.ap.ssid;
+@@ -3139,7 +3175,8 @@ static int ath10k_update_channel_list(st
+ 			ch->min_power = 0;
+ 			ch->max_power = channel->max_power * 2;
+ 			ch->max_reg_power = channel->max_reg_power * 2;
+-			ch->max_antenna_gain = channel->max_antenna_gain;
++			ch->max_antenna_gain = ath10k_get_max_antenna_gain(ar,
++						channel->max_antenna_gain);
+ 			ch->reg_class_id = 0; /* FIXME */
+ 
+ 			/* FIXME: why use only legacy modes, why not any


### PR DESCRIPTION
@nbd168 added a patch in 9b6585b11a48c62566418b920afe14204f40f87b to increase the allowed maximum antenna gain from 0 to 3 dBi. I asked him by mail why 3 dBi and not 5 dBi but got no answer (or the answer was lost).

The https://www.gpo.gov/fdsys/pkg/CFR-2013-title47-vol1/pdf/CFR-2013-title47-vol1-sec15-247.pdf seems to specify 6 dBi as maximum and not 3 dBi. Thus increase this for ath9k and introduced it for ath10k. The ath10k change also requires a fix to send the data correctly to the firmware. This fix was already forwarded to upstream.