### PR TITLE
nghttp2: deduplicate files in libnghttp2

### DIFF
--- a/package/libs/nghttp2/Makefile
+++ b/package/libs/nghttp2/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nghttp2
 PKG_VERSION:=1.38.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 
 PKG_SOURCE_URL:=https://github.com/nghttp2/nghttp2/releases/download/v$(PKG_VERSION)
@@ -40,7 +40,7 @@ endef
 
 define Package/libnghttp2/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libnghttp2.so.* $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnghttp2.so.* $(1)/usr/lib
 endef
 
 $(eval $(call BuildPackage,libnghttp2))


### PR DESCRIPTION
libnghttp2 accidentally ships library twice:

```
$ tar -Oxzf libnghttp2-14_1.38.0-1_mips_24kc.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x root/root         0 2019-06-07 23:14 ./
drwxr-xr-x root/root         0 2019-06-07 23:14 ./usr/
drwxr-xr-x root/root         0 2019-06-07 23:14 ./usr/lib/
-rw-r--r-- root/root    144412 2019-06-07 23:14 ./usr/lib/libnghttp2.so.14
-rw-r--r-- root/root    144412 2019-06-07 23:14 ./usr/lib/libnghttp2.so.14.17.3
```

after fix, there's library and symlink (as designed):

```
$ tar -Oxzf libnghttp2-14_1.38.0-2_mips_24kc.ipk ./data.tar.gz | tar -tzvf -
drwxr-xr-x root/root         0 2019-06-07 23:14 ./
drwxr-xr-x root/root         0 2019-06-07 23:14 ./usr/
drwxr-xr-x root/root         0 2019-06-07 23:14 ./usr/lib/
lrwxrwxrwx root/root         0 2019-06-07 23:14 ./usr/lib/libnghttp2.so.14 -> libnghttp2.so.14.17.3
-rw-r--r-- root/root    144412 2019-06-07 23:14 ./usr/lib/libnghttp2.so.14.17.3
```

Binary package size reduced accordingly: 134621 -> 66593.

Compile/run-tested: ar71xx/generic.

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>