### PR TITLE
Restart network if package netifd upgraded.

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -43,4 +43,9 @@ define Package/netifd/install
 	$(CP) $(PKG_BUILD_DIR)/scripts/* $(1)/lib/netifd/
 endef
 
+define Package/netifd/postinst
+#!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/network restart
+endef
+
 $(eval $(call BuildPackage,netifd))


### PR DESCRIPTION
When user execute `opkg upgrade netifd`, then router got disconnected.
User must cut down the power and restart, or the router can't come back.....
