### PR TITLE
ath79: add support for Trendnet TEW-823DRU

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -185,6 +185,9 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+trendnet,tew-823dru)
+       ucidef_set_led_netdev "wan" "WAN" "trendnet:green:planet" "eth0"
+       ;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
 ubnt,nanostation-m|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -58,7 +58,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
 		;;
-	buffalo,bhr-4grv2)
+	buffalo,bhr-4grv2|\
+	trendnet,tew-823dru)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
 		;;
@@ -342,6 +343,10 @@ ath79_setup_macs()
 	tplink,tl-wr941n-v7-cn)
 		base_mac=$(mtd_get_mac_binary u-boot 130048)
 		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
+	trendnet,tew-823dru)
+		lan_mac=$(mtd_get_mac_text mac 4)
+		wan_mac=$(mtd_get_mac_text mac 24)
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -30,6 +30,14 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			echo $(k2t_get_mac "lan_mac") > /sys${DEVPATH}/macaddress
 		;;
+	trendnet,tew-823dru)
+	        # set the 2.4G interface mac address to LAN MAC
+	        [ "$PHYNBR" -eq 1 ] && \
+		        mtd_get_mac_text mac 4 > /sys${DEVPATH}/macaddress
+	        # set the 5G interface mac address to WAN MAC + 1
+	        [ "$PHYNBR" -eq 0 ] && \
+		        macaddr_add "$(mtd_get_mac_text mac 24)" 1 > /sys${DEVPATH}/macaddress
+                ;;
 	*)
 		;;
 esac

--- a/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
+++ b/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+
+	compatible = "trendnet,tew-823dru", "qca,qca9558";
+        model = "TRENDNET TEW-823DRU";
+
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange {
+			label = "trendnet:orange:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		system: power_green {
+			label = "trendnet:green:power";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		planet_green {
+			label = "trendnet:green:planet";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		planet_orange {
+			label = "trendnet:orange:planet";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+		
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xef0000>;
+			};
+
+			
+			partition@f30000 {
+				label = "lang";
+				reg = <0xf30000 0x030000>;
+				read-only;
+			};
+
+			partition@f60000 {
+				label = "my-dlink";
+				reg = <0xf60000 0x080000>;
+				read-only;
+			};
+
+			
+			mac: partition@fe0000 {
+				label = "mac";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRIP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+	
+};
+
+&eth1 {
+	status = "okay";
+	
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+	
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -664,6 +664,22 @@ define Device/rosinson_wr818
 endef
 TARGET_DEVICES += rosinson_wr818
 
+define Device/trendnet_tew-823dru
+  ATH_SOC := qca9558
+  DEVICE_VENDOR := Trendnet
+  DEVICE_MODEL := TEW-823DRU
+  DEVICE_VARIANT := v1.0R
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  SUPPORTED_DEVICES += tew-823dru
+  IMAGE_SIZE := 15296k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
+	append-string 00AP135AR9558-RT-131129-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += trendnet_tew-823dru
+
 define Device/wd_mynet-n750
   $(Device/seama)
   ATH_SOC := ar9344


### PR DESCRIPTION
Trendnet TEW-823DRU is a dual-band AC1750 router.
The router section is based on Qualcomm/Atheros QCA9558 + QCA9880.

Specification:

720 MHz CPU
256 MB of RAM
16 MB of FLASH
3T3R 2.4 GHz
3T3R 5 GHz
5x 10/100/1000 Mbps Ethernet

Firmware can be flashed from the web interface with no issues.

Signed-off-by: Pramod Pancha <pancha@vill.com>
