### PR TITLE
f2fs-tools: fixup SPDX license

### DIFF
--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -11,7 +11,7 @@ PKG_NAME:=f2fs-tools
 PKG_VERSION:=1.12.0
 PKG_RELEASE:=2
 
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/


### PR DESCRIPTION
The f2fs-tools have a wrong PKG_LICENSE with is not SPDX compatible.

Signed-off-by: Paul Spooren <mail@aparcar.org>