### PR TITLE
build: introduce buildinfo files for reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,18 @@ prereq: $(target/stamp-prereq) tmp/.prereq_packages
 checksum: FORCE
 	$(call sha256sums,$(BIN_DIR),$(CONFIG_BUILDBOT))
 
+buildconfig: FORCE
+	$(SCRIPT_DIR)/getver.sh > $(BIN_DIR)/version.buildinfo
+
+feedsconfig: FORCE
+	$(SCRIPT_DIR)/feeds list -fs > $(BIN_DIR)/feeds.buildinfo
+
 diffconfig: FORCE
 	mkdir -p $(BIN_DIR)
-	$(SCRIPT_DIR)/diffconfig.sh > $(BIN_DIR)/config.seed
+	$(SCRIPT_DIR)/diffconfig.sh > $(BIN_DIR)/config.buildinfo
 
 prepare: .config $(tools/stamp-compile) $(toolchain/stamp-compile)
-	$(_SINGLE)$(SUBMAKE) -r diffconfig
+	$(_SINGLE)$(SUBMAKE) -r diffconfig feedsconfig buildconfig
 
 world: prepare $(target/stamp-compile) $(package/stamp-compile) $(package/stamp-install) $(target/stamp-install) FORCE
 	$(_SINGLE)$(SUBMAKE) -r package/index

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -89,7 +89,7 @@ menu "Global build settings"
 		bool "Include build configuration in firmware" if DEVEL
 		default n
 		help
-		  If enabled, config.seed will be stored in /etc/build.config of firmware.
+		  If enabled, config.buildinfo will be stored in /etc/build.config of firmware.
 
 	config COLLECT_KERNEL_DEBUG
 		bool

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -198,7 +198,7 @@ define Package/base-files/install
 
 	$(if $(CONFIG_INCLUDE_CONFIG), \
 		echo -e "# Build configuration for board $(BOARD)/$(SUBTARGET)/$(PROFILE)\n" >$(1)/etc/build.config; \
-		cat $(BIN_DIR)/config.seed >>$(1)/etc/build.config)
+		cat $(BIN_DIR)/config.buildinfo >>$(1)/etc/build.config)
 
 	$(if $(CONFIG_CLEAN_IPKG),, \
 		mkdir -p $(1)/etc/opkg; \


### PR DESCRIPTION
generate feeds.buildinfo and commit.buildinfo in build dir after
containing the feed revisions (via ./scripts/feeds list -sf) as well as
the current revision of buildroot (via ./scripts/getver.sh).

With this information it should be possible to reproduce any build,
especially the release builds.

Usage would be to move feeds.buildinfo to feeds.conf and git checkout the
revision hash of commit.buildinfo.

Content of feeds.buildinfo would look similar to this:

    src-git routing https://git.openwrt.org/feed/routing.git^bf475d6
    src-git telephony https://git.openwrt.org/feed/telephony.git^470eb8e
    ...

Content of commit.buildinfo would look similar to this:

    commit=r10203+1-c12bd3a21b

Without the exact feed revision it is not possible to determine
installed package versions.

Also rename config.seed to config.buildinfo to follow the recommended
style of https://reproducible-builds.org/docs/recording/

Signed-off-by: Paul Spooren <mail@aparcar.org>