### PR TITLE
mvebu: fixes commit a7e68927d0

### DIFF
--- a/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
+++ b/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
@@ -905,7 +905,7 @@ Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
 +	phylink = phylink_create(dev, dn, phy_mode, &mvneta_phylink_ops);
 +	if (IS_ERR(phylink)) {
 +		err = PTR_ERR(phylink);
-+		goto err_free_stats;
++		goto err_netdev;
 +	}
 +
 +	pp->phylink = phylink;


### PR DESCRIPTION
err_free_stats was accidentally removed from 403-net-mvneta-convert-to-phylink.patch
leading to compilation errors.

Compile-tested on: mvebu
Runtime-tested on: mvebu

Signed-off-by: George Amanakis <gamanakis@gmail.com>