### PR TITLE
ath79: add support for Airtight C-65 (Mojo Networks C-65)

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -13,6 +13,9 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+airtight,c-65)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	;;
 buffalo,wzr-hp-ag300h)
         ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
         ;;

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -8,6 +8,9 @@ board=$(board_name)
 boardname="${board##*,}"
 
 case "$board" in
+airtight,c-65)
+	ucidef_set_led_wlan "ath10k-phy0" "WiFi 5GHz" "ath10k-phy0" "phy0tpt"
+	;;
 8dev,carambola2)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:orange:eth0" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:orange:eth1" "switch0" "0x04"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -9,6 +9,9 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	airtight,c-65)
+		ucidef_set_interface_lan "eth0"
+		;;
 	aruba,ap-105|\
 	avm,fritz300e|\
 	devolo,dvl1200i|\
@@ -262,6 +265,9 @@ ath79_setup_macs()
 	local board="$1"
 
 	case "$board" in
+	airtight,c65)
+		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0)")
+		;;
 	avm,fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,6 +87,10 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	airtight,c-65)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+		;;
 	devolo,dvl1200e|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\

--- a/target/linux/ath79/dts/qca9558_airtight_c-65.dts
+++ b/target/linux/ath79/dts/qca9558_airtight_c-65.dts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	model = "AirTight C-65";
+	compatible = "airtight,c-65", "qca,qca9558";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &power_amber;
+		led-failsafe = &power_amber;
+		led-upgrade = &power_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_amber: power_amber {
+			label = "c-65:amber:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan {
+			label = "c-65:green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "c-65:green:wlan2g";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+ };
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "uboot-env";
+				reg = <0x040000 0x020000>;
+			};
+
+			partition@60000  {
+				label = "firmware";
+				reg = <0x060000 0xf90000>;
+				compatible = "denx,uimage";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		at803x-disable-smarteee;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x00>;
+	pll-data = <0x82000101 0x80000101 0x80001313>;
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	gmac-config {
+		device = <&gmac>;
+
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <0>;
+		txd-delay = <0>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -75,6 +75,15 @@ define Device/seama
   SEAMA_SIGNATURE :=
 endef
 
+define Device/airtight_c-65
+  ATH_SOC := qca9558
+  DEVICE_VENDOR := Airtight
+  DEVICE_MODEL := C-65
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += airtight_c-65
+
 define Device/8dev_carambola2
   ATH_SOC := ar9331
   DEVICE_TITLE := 8devices Carambola2


### PR DESCRIPTION
Airtight C-65 (Mojo Networks C-65) Dual radio, dual concurrent 2x2:2 MIMO 802.11ac Wave 1 access point.

Specification:

SoC	: Qualcomm Atheros QCA9558-AT4A
RAM	: DDR2 128 MiB
Flash	: SPI-NOR 2*16 MiB
WLAN	: 2.4/5 GHz 2T2R
2.4 GHz: QCA9558 (SoC)
5 GHz : QCA9882
Ethernet	: 1x 10/100/1000 Mbps
PHY : AR8035-A
LEDs/keys	: 4x/1x
UART: conn8 on PCB
conn8 =
 ----------------
| 1   2   3   4 |
 3.3v GND TX  RX
Settings: 115200 bps, no flow control

Flashing Instructions (TFTP):
1.Download "openwrt-ath79-generic-airtight_c-65-initramfs-kernel.bin" and "openwrt-ath79-generic-airtight_c-65-squashfs-sysupgrade.bin" and verify chcksums.
2. Setup TFTP sevrer with adress 192.168.1.100/24 on local machine connected to Mojo Networks C-65 device.
3. Rename "openwrt-ath79-generic-airtight_c-65-initramfs-kernel.bin" it to "c65_atnboot.bin" and put it in TFTP server root directory.
4. Powercycle the unit (very short power interruption is required, less than 1 second or it might not work) and wait about 90 seconds for the ram image to load.
5. Open a web browser and navigate to 192.168.1.1 for the router Web Interface and login with a blank password.
6. In the top menu click "System" -> "Backup/Flash Firmware",
7. Save current firmware: Select "firmware" in "Save mtdblock contents" and click "Save mtdblock" - this is your only chance to save your current firmware to be able to go back to the original state!!! No official frimware download is provided anywhere. I would do it twice to make sure the file is not corrupt due to ethernet error!
8. Flash OpenWRT frimware: In "Flash new firmware image" browse and select "openwrt-ath79-generic-airtight_c-65-squashfs-sysupgrade.bin", untick "Keep settings" and click "Flash firmware...", verify checksum with the original and click "Proceed"
9. Wait about 150 seconds for the router to flash (if you interrupt the power - you can brick it, however it is 80% recoverable if you repeat from step 4)
You just gave a new life to your Mojo Networks C-65 Wireless Access Point. Enjoy and considre donating to the project.

Return to original firmware:
Just flash the file you had backed up in step 7 of flashing instructions.

Known limitations in this release:
Wireless 5G LED behavior is inverted (steady "on" means the radio is disabled) as the LED connected to
the gpiochip on ath10k chip (QCA9882).
Only one 16Mb flash chip is available (the unit has 2).