### PR TITLE
toolchain: Use binutils 2.32 by default

### DIFF
--- a/toolchain/binutils/Config.in
+++ b/toolchain/binutils/Config.in
@@ -2,8 +2,7 @@
 
 choice
 	prompt "Binutils Version" if TOOLCHAINOPTS
-	default BINUTILS_USE_VERSION_2_31_1 if !arc
-	default BINUTILS_USE_VERSION_2_32 if arc
+	default BINUTILS_USE_VERSION_2_32
 	help
 	  Select the version of binutils you wish to use.
 

--- a/toolchain/binutils/Config.version
+++ b/toolchain/binutils/Config.version
@@ -2,11 +2,10 @@ config BINUTILS_VERSION_2_29_1
 	bool
 
 config BINUTILS_VERSION_2_31_1
-	default y if (!TOOLCHAINOPTS && !arc)
 	bool
 
 config BINUTILS_VERSION_2_32
-	default y if (!TOOLCHAINOPTS && arc)
+	default y if !TOOLCHAINOPTS
 	bool
 
 config BINUTILS_VERSION


### PR DESCRIPTION
Switch to binutils 2.32 for all targets

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>