### PR TITLE
toolchain: Use GCC 8 by default

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,8 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_8 if arc
-	default GCC_USE_VERSION_7
+	default GCC_USE_VERSION_8
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -4,7 +4,6 @@ config GCC_VERSION_5
 
 config GCC_VERSION_8
 	default y if GCC_USE_VERSION_8
-	default y if arc
 	bool
 
 config GCC_USE_EMBEDDED_PATH_REMAP


### PR DESCRIPTION
Switch to GCC 8 for all targets

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>