### PR TITLE
scripts: time.pl: Don't print the time on stderr

### DIFF
--- a/scripts/time.pl
+++ b/scripts/time.pl
@@ -54,7 +54,7 @@ else {
 	my ($sec2, $usec2) = gettime();
 	my (undef, undef, $cuser, $csystem) = times();
 
-	printf STDERR "%s#%.2f#%.2f#%.2f\n",
+	printf STDOUT "%s#%.2f#%.2f#%.2f\n",
 		$prefix, $cuser, $csystem,
 		($sec2 - $sec) + ($usec2 - $usec) / 1000000;
 


### PR DESCRIPTION
Having the build time written on stderr make it appear with V=w
although it is not an error or warning. Just write the time on stdout
to have it part of the build log like all the rest, but not clutter
the output when only warnings and errors should be shown.

Signed-off-by: Alban Bedel <albeu@free.fr>