### PR TITLE
ath79: Use -v1 suffix for TP-Link WDR3600/4300

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -190,8 +190,8 @@ ath79_setup_interfaces()
 	tplink,archer-c6-v2|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
-	tplink,tl-wdr3600|\
-	tplink,tl-wdr4300|\
+	tplink,tl-wdr3600-v1|\
+	tplink,tl-wdr4300-v1|\
 	tplink,tl-wr941n-v7-cn)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -152,8 +152,8 @@ case "$FIRMWARE" in
 		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 24) 1) 2
 		;;
 	ocedo,raccoon|\
-	tplink,tl-wdr3600|\
-	tplink,tl-wdr4300|\
+	tplink,tl-wdr3600-v1|\
+	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4900-v2|\
 	winchannel,wb2000)
 		ath9k_eeprom_extract "art" 20480 1088

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3600-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3600-v1.dts
@@ -4,6 +4,6 @@
 #include "ar9344_tplink_tl-wdr4300.dtsi"
 
 / {
-	model = "TP-Link WDR3600";
-	compatible = "tplink,tl-wdr3600", "qca,ar9344";
+	model = "TP-Link TL-WDR3600 v1";
+	compatible = "tplink,tl-wdr3600-v1", "qca,ar9344";
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300-v1.dts
@@ -4,6 +4,6 @@
 #include "ar9344_tplink_tl-wdr4300.dtsi"
 
 / {
-	model = "TP-Link WDR4300";
-	compatible = "tplink,tl-wdr4300", "qca,ar9344";
+	model = "TP-Link TL-WDR4300 v1";
+	compatible = "tplink,tl-wdr4300-v1", "qca,ar9344";
 };

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -192,25 +192,25 @@ define Device/tplink_re450-v2
 endef
 TARGET_DEVICES += tplink_re450-v2
 
-define Device/tplink_tl-wdr3600
+define Device/tplink_tl-wdr3600-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9344
-  DEVICE_TITLE := TP-Link TL-WDR3600
+  DEVICE_TITLE := TP-Link TL-WDR3600 v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x36000001
   SUPPORTED_DEVICES += tl-wdr4300
 endef
-TARGET_DEVICES += tplink_tl-wdr3600
+TARGET_DEVICES += tplink_tl-wdr3600-v1
 
-define Device/tplink_tl-wdr4300
+define Device/tplink_tl-wdr4300-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9344
-  DEVICE_TITLE := TP-Link TL-WDR4300
+  DEVICE_TITLE := TP-Link TL-WDR4300 v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x43000001
   SUPPORTED_DEVICES += tl-wdr4300
 endef
-TARGET_DEVICES += tplink_tl-wdr4300
+TARGET_DEVICES += tplink_tl-wdr4300-v1
 
 define Device/tplink_tl-wdr4900-v2
   $(Device/tplink-8mlzma)


### PR DESCRIPTION
In ath79, identifiers tplink_tl-wdr3600 and tplink_tl-wdr4300 have
been used while most other TP-Link devices include the revision.

Although their actually is only one major revision of these
devices, they bear the revision on their bottom (v1.x). TP-Link
also refers to it as V1 on its web page.

This patch thus adds -v1 to both devices so it is more consistent
with other devices and with what you would expect from reading
the on-device sticker and the support pages.

---

Since this is about consistency, I would be much obliged if this would be added to openwrt-19.07, too, before it is released.