### PR TITLE
ath79: modify device name of I-O DATA WN-AC1600DGR2

### DIFF
--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr2.dts
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr2.dts
@@ -7,8 +7,8 @@
 #include "qca9557_iodata_wn-ac-dgr.dtsi"
 
 / {
-	compatible = "iodata,wn-ac1600dgr2", "qca,qca9557";
-	model = "I-O DATA WN-AC1600DGR2";
+	compatible = "iodata,wn-ac1600dgr2", "iodata,wn-ac1600dgr3", "qca,qca9557";
+	model = "I-O DATA WN-AC1600DGR2/DGR3";
 };
 
 &leds {

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -484,10 +484,11 @@ TARGET_DEVICES += iodata_wn-ac1600dgr
 define Device/iodata_wn-ac1600dgr2
   ATH_SOC := qca9557
   DEVICE_VENDOR := I-O DATA
-  DEVICE_MODEL := WN-AC1600DGR2
+  DEVICE_MODEL := WN-AC1600DGR2/DGR3
   IMAGE_SIZE := 14656k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+  IMAGES += dgr2-dgr3-factory.bin
+  IMAGE/dgr2-dgr3-factory.bin := \
+    append-kernel | pad-to $$$$(BLOCKSIZE) | \
     append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
     senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct


### PR DESCRIPTION
The hardware of I-O DATA WN-AC1600DGR3 has completely compatibility
with WN-AC1600DGR2, so modify the device name of WN-AC1600DGR2 to show
the images for DGR2 also support DGR3.

Specification of WN-AC1600DGR3:

- SoC        : Qualcomm Atheros QCA9557
- RAM        : DDR2 128 MiB
- Flash      : SPI-NOR 16 MiB
- WLAN       : 2.4/5 GHz
  - 2.4 GHz  : QCA9557 (SoC), 2T2R
  - 5 Ghz    : QCA9880, 3T3R
- Ethernet   : 5x 10/100/1000 Mbps
  - Switch   : QCA8337N
- LEDs/Input : 6x/6x (4x buttons, 1x slide-switch)
- UART       : through-hole on PCB
  - J1: Vcc, GND, TX, RX from ethernet port side
  - 115200n8

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>