### PR TITLE
modules: add alx kernel module for Atheros AR816x/AR817x ethernet support

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -33,6 +33,18 @@ endef
 $(eval $(call KernelPackage,skge))
 
 
+define KernelPackage/alx
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Qualcomm Atheros AR816x/AR817x PCI-E Ethernet Network Driver
+  DEPENDS:=@PCI_SUPPORT +kmod-mdio
+  KCONFIG:=CONFIG_ALX
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/atheros/alx/alx.ko
+  AUTOLOAD:=$(call AutoProbe,alx)
+endef
+
+$(eval $(call KernelPackage,alx))
+
+
 define KernelPackage/atl2
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Atheros L2 Fast Ethernet support


### PR DESCRIPTION
Add a module package for the (mainline) alx kernel module.

These ethernet cards can be found onboard various x86/ x64_64 Gigabyte
mainboards since the sandy-bridge/ ivy-bridge era.

This driver supports the following QCA/ "Killer" ethernet cards:

	1969:1091 - AR8161 Gigabit Ethernet
	1969:1090 - AR8162 Fast Ethernet
	1969:10A1 - AR8171 Gigabit Ethernet
	1969:10A0 - AR8172 Fast Ethernet

	1969:E091 - Killer E2200 Gigabit Ethernet
	1969:E0A1 - Killer E2400 Gigabit Ethernet
	1969:E0B1 - Killer E2500 Gigabit Ethernet

Successfully runtime tested with the onboard ethernet card of a
Gigabyte GA-H77M-D3H ivy-bridge mainboard (x86_64/ EFI image):

02:00.0 Ethernet controller [0200]: Qualcomm Atheros AR8161 Gigabit Ethernet [1969:1091] (rev 10)
	Subsystem: Gigabyte Technology Co., Ltd AR8161 Gigabit Ethernet [1458:e000]
	Kernel driver in use: alx
	Kernel modules: alx

alx 0000:02:00.0 eth0: Qualcomm Atheros AR816x/AR817x Ethernet [94:de:80:XX:XX:XX]
alx 0000:02:00.0 eth0: NIC Up: 1 Gbps Full

While mainboards with this chipset aren't rare, they are far from being as common as e1000 or r8169, so I've chosen to package it up as a dedicated package, rather than enabling it in the x86/ x86_64 kernel config.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>