### PR TITLE
libs/popt: Remove rpm5.org as source URL

### DIFF
--- a/package/libs/popt/Makefile
+++ b/package/libs/popt/Makefile
@@ -14,8 +14,7 @@ PKG_RELEASE:=2
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	http://distfiles.gentoo.org/distfiles/ \
-	http://distcache.freebsd.org/ports-distfiles/ \
-	http://rpm5.org/files/popt/
+	http://distcache.freebsd.org/ports-distfiles/
 PKG_HASH:=e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
 PKG_LICENSE:=MIT
 
@@ -33,7 +32,7 @@ define Package/libpopt
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=A command line option parsing library
-  URL:=http://rpm5.org/files/popt/
+  URL:=https://web.archive.org/web/20170330133915/http://rpm5.org/files/popt/
   ABI_VERSION:=0
 endef
 


### PR DESCRIPTION
rpm5.org is once again dead/down, remove it permanently
Change URL to archive.org snapshot

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>