### PR TITLE
kmod-ipsec: enable CONFIG_XFRM_STATISTICS CONFIG_XFRM_MIGRATE

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -251,6 +251,8 @@ define KernelPackage/ipsec
   KCONFIG:= \
 	CONFIG_NET_KEY \
 	CONFIG_XFRM_USER \
+	CONFIG_XFRM_STATISTICS=y \
+	CONFIG_XFRM_MIGRATE=y \
 	CONFIG_INET_IPCOMP \
 	CONFIG_XFRM_IPCOMP
   FILES:=$(foreach mod,$(IPSEC-m),$(LINUX_DIR)/net/$(mod).ko)


### PR DESCRIPTION
ipsec enhancements, @lucize 

    CONFIG_XFRM_STATISTICS helps debug Strongswan or libreswan
    CONFIG_XFRM_MIGRATE used by librewan to support mobike

    Signed-off-by: Antony Antony <antony@phenome.org>
