### PR TITLE
ar71xx: base-files: add UBNT XM model definitions

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -82,7 +82,12 @@ ubnt_xm_board_detect() {
 	"e0a")
 		model="Ubiquiti NanoStation loco M"
 		;;
+	"e1a")
+		model="Ubiquiti PowerBridge M"
+		;;
+	"e10"|\
 	"e1b"|\
+	"e1c"|\
 	"e1d")
 		model="Ubiquiti Rocket M"
 		;;
@@ -90,8 +95,19 @@ ubnt_xm_board_detect() {
 	"e2d")
 		model="Ubiquiti Bullet M"
 		;;
+	"e21")
+		model="Ubiquiti AirGrid M"
+		;;
+	"e23"|\
+	"e2b")
+		model="Ubiquiti NanoBridge M"
+		;;
 	"e30")
 		model="Ubiquiti PicoStation M"
+		;;
+	"e4a"|\
+	"e4b")
+		model="Ubiquiti AirRouter M"
 		;;
 	esac
 


### PR DESCRIPTION
This commit adds missing model definitions for some Ubiquiti XM devices.
The list for XM devices seems to be complete now.
Source: https://git.openwrt.org/?p=project/iwinfo.git;a=blob;f=hardware.txt;

As one can see a single definition is ambiguous (of the NanoStation - e80)
as there is a Bullet with the same definition in the wild, but using
NanoStation here is safe as it will include an antenna gain compared to a Bullet.

Signed-off-by: Vincent Wiemann <vincent.wiemann@ironai.com>