### PR TITLE
openwrt-18.06: mvebu: fixes commit a7e68927d0 (related to PR #2123)

### DIFF
--- a/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
+++ b/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
@@ -905,7 +905,7 @@ Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
 +	phylink = phylink_create(dev, dn, phy_mode, &mvneta_phylink_ops);
 +	if (IS_ERR(phylink)) {
 +		err = PTR_ERR(phylink);
-+		goto err_free_stats;
++		goto err_netdev;
 +	}
 +
 +	pp->phylink = phylink;


### PR DESCRIPTION
err_free_stats has been deprecated. Replace with err_netdev.

Compile-tested on: mvebu
Runtime-tested on: mvebu

Fixes: a7e68927d047 ("kernel: bump 4.14 to 4.14.125 (FS#2305 FS#2297)")
Signed-off-by: George Amanakis <gamanakis@gmail.com>
