### PR TITLE
ar71xx: Add Mikrotik RB912R-2nD (ltAP mini)

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -106,6 +106,7 @@ ar71xx_setup_interfaces()
 	rb-911g-2hpnd|\
 	rb-911g-5hpacd|\
 	rb-911g-5hpnd|\
+	rb-912r-2nd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
 	rb-921gs-5hpacd-r2|\

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -486,6 +486,9 @@ mikrotik_board_detect() {
 	*"911G-5HPnD")
 		name="rb-911g-5hpnd"
 		;;
+	*"RB912R-2nD")
+		name="rb-912r-2nd"
+		;;
 	*"912UAG-2HPnD")
 		name="rb-912uag-2hpnd"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -555,6 +555,7 @@ platform_check_image() {
 	rb-911g-2hpnd|\
 	rb-911g-5hpnd|\
 	rb-911g-5hpacd|\
+	rb-912r-2nd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
 	rb-921gs-5hpacd-r2|\
@@ -755,6 +756,7 @@ platform_pre_upgrade() {
 	rb-750up-r2|\
 	rb-911-2hn|\
 	rb-911-5hn|\
+	rb-912r-2nd|\
 	rb-931-2nd|\
 	rb-941-2nd|\
 	rb-951ui-2nd|\
@@ -879,6 +881,7 @@ platform_do_upgrade() {
 	rb-911g-2hpnd|\
 	rb-911g-5hpacd|\
 	rb-911g-5hpnd|\
+	rb-912r-2nd|\
 	rb-912uag-2hpnd|\
 	rb-912uag-5hpnd|\
 	rb-921gs-5hpacd-r2|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
@@ -1191,6 +1191,7 @@ config ATH79_MACH_RBSPI
 	  MikroTik RouterBOARD SXT Lite 2 r3
 	  MikroTik RouterBOARD wAP
 	  MikroTik RouterBOARD wAP R-2nD
+	  MikroTik RouterBOARD LtAP mini R-2nD
 
 config ATH79_MACH_RBSXTLITE
 	bool "MikroTik RouterBOARD SXT Lite"

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -217,6 +217,7 @@ enum ath79_mach_type {
 	ATH79_MACH_RB_751G,			/* Mikrotik RouterBOARD 751G */
 	ATH79_MACH_RB_911L,			/* Mikrotik RouterBOARD 911-2Hn/911-5Hn boards */
 	ATH79_MACH_RB_922GS,			/* Mikrotik RouterBOARD 911/922GS boards */
+	ATH79_MACH_RB_LTAP,			/* Mikrotik RouterBOARD LtAP mini R-2nD   */
 	ATH79_MACH_RB_931,			/* MikroTik RouterBOARD 931-2nD */
 	ATH79_MACH_RB_941,			/* MikroTik RouterBOARD 941-2nD */
 	ATH79_MACH_RB_951G,			/* Mikrotik RouterBOARD 951G */

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -46,7 +46,7 @@ define Device/rb-nor-flash-16M
   DEVICE_PACKAGES := rbcfg rssileds -nand-utils kmod-ledtrig-gpio
   IMAGE_SIZE := 16000k
   KERNEL_INSTALL := 1
-  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd rb-sxt-2nd-r3
+  SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-912r-2nd rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd rb-sxt-2nd-r3
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef

--- a/target/linux/ar71xx/patches-4.14/701-MIPS-ath79-add-routerboard-detection.patch
+++ b/target/linux/ar71xx/patches-4.14/701-MIPS-ath79-add-routerboard-detection.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/ath79/prom.c
 +++ b/arch/mips/ath79/prom.c
-@@ -136,6 +136,32 @@ void __init prom_init(void)
+@@ -136,6 +136,33 @@ void __init prom_init(void)
  		initrd_end = initrd_start + fw_getenvl("initrd_size");
  	}
  #endif
@@ -28,6 +28,7 @@
 +	    strstr(arcs_cmdline, "board=2011r") ||
 +	    strstr(arcs_cmdline, "board=711Gr100") ||
 +	    strstr(arcs_cmdline, "board=911L") ||
++	    strstr(arcs_cmdline, "board=ltap-hb") ||
 +	    strstr(arcs_cmdline, "board=922gs"))
 +		ath79_prom_append_cmdline("console", "ttyS0,115200");
  }


### PR DESCRIPTION
This commit adds support for the Mikrotik RB912R-2nD (ltAP mini)

See https://mikrotik.com/product/ltap_mini for more info.

Specifications:
- SoC: Qualcomm Atheros QCA9531 (650 MHz)
- RAM: 64 MB
- Storage: 16 MB NOR
- Ethernet: 1x 100/10 Mbps, integrated, passive PoE-in 24V
- PCIe: 1x Mini slot (also contains USB 2.0 for 3G/LTE modems)
- SIM slot: 2x full-SIM

Working:
- USB & mini PCIe
- Wireless
- Ethernet
- LED's
- Reset button
- Sysupgrade

Not working:
- Board/system detection

Installation:

- Boot vmlinux-initramfs image via BOOTP/TFTP and then flash sysupgrade
image using "sysupgrade -n"
