### PR TITLE
package/network: add PKGARCH:=all to non-binary packages

### DIFF
--- a/package/network/config/gre/Makefile
+++ b/package/network/config/gre/Makefile
@@ -24,6 +24,7 @@ define Package/gre
   TITLE:=Generic Routing Encapsulation config support
   DEPENDS:=+kmod-gre +IPV6:kmod-gre6 +resolveip
   PROVIDES:=grev4 grev6
+  PKGARCH:=all
 endef
 
 define Package/gre/description

--- a/package/network/config/ipip/Makefile
+++ b/package/network/config/ipip/Makefile
@@ -20,6 +20,7 @@ define Package/ipip
   MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
   TITLE:=IP in IP Tunnel config support
   DEPENDS:= +kmod-ipip +resolveip
+  PKGARCH:=all
 endef
 
 define Package/ipip/description

--- a/package/network/config/vti/Makefile
+++ b/package/network/config/vti/Makefile
@@ -18,6 +18,7 @@ define Package/vti/Default
   SECTION:=net
   CATEGORY:=Network
   MAINTAINER:=Andre Valentin <avalentin@marcant.net>
+  PKGARCH:=all
 endef
 
 define Package/vti

--- a/package/network/config/vxlan/Makefile
+++ b/package/network/config/vxlan/Makefile
@@ -12,6 +12,7 @@ define Package/vxlan
   MAINTAINER:=Matthias Schiffer <mschiffer@universe-factory.net>
   TITLE:=Virtual eXtensible LAN config support
   DEPENDS:=+kmod-vxlan
+  PKGARCH:=all
 endef
 
 define Package/vxlan/description

--- a/package/network/config/xfrm/Makefile
+++ b/package/network/config/xfrm/Makefile
@@ -12,6 +12,7 @@ define Package/xfrm/Default
   SECTION:=net
   CATEGORY:=Network
   MAINTAINER:=Andre Valentin <avalentin@marcant.net>
+  PKGARCH:=all
 endef
 
 define Package/xfrm


### PR DESCRIPTION
Packages such as xfrm contain only script files, add `PKGARCH:=all`