### PR TITLE
[WIP/RFT] ramips: add support for HC5761A, improve support for HC5661A and HC5861B

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -208,6 +208,7 @@ hiwifi,hc5661)
 	set_wifi_led "$boardname:blue:wlan2g"
 	;;
 hiwifi,hc5661a|\
+hiwifi,hc5761a|\
 xzwifi,creativebox-v1)
 	ucidef_set_led_switch "internet" "internet" "$boardname:blue:internet" "switch0" "0x10"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -78,8 +78,7 @@ asus,rt-n14u)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:blue:wan" eth0.2
 	set_wifi_led "$boardname:blue:air"
 	;;
-bdcom,wap2100-sk|\
-hiwifi,hc5861b)
+bdcom,wap2100-sk)
 	set_wifi_led "$boardname:green:wlan2g"
 	;;
 belkin,f9k1109v1)
@@ -204,10 +203,13 @@ gnubee,gb-pc2)
 hauppauge,broadway)
 	set_wifi_led "$boardname:red:wps_active"
 	;;
-hiwifi,hc5661|\
-hiwifi,hc5661a)
+hiwifi,hc5661)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "eth0.2"
 	set_wifi_led "$boardname:blue:wlan2g"
+	;;
+hiwifi,hc5661a|\
+xzwifi,creativebox-v1)
+	ucidef_set_led_switch "internet" "internet" "$boardname:blue:internet" "switch0" "0x10"
 	;;
 hiwifi,hc5761|\
 hiwifi,hc5861)
@@ -425,9 +427,6 @@ xiaomi,mir3p)
 	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x02" "0x08"
 	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
 	ucidef_set_led_switch "lan3-amber" "LAN3 (amber)" "$boardname:amber:lan3" "switch0" "0x08" "0x08"
-	;;
-xzwifi,creativebox-v1)
-	ucidef_set_led_switch "internet" "internet" "$boardname:blue:internet" "switch0" "0x10"
 	;;
 youhua,wr1200js)
 	ucidef_set_led_switch "internet" "INTERNET" "$boardname:green:wan" "switch0" "0x01"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -57,6 +57,7 @@ ramips_setup_interfaces()
 	firefly,firewrt|\
 	hilink,hlk-rm04|\
 	hiwifi,hc5661a|\
+	hiwifi,hc5761a|\
 	hiwifi,hc5962|\
 	mediatek,ap-mt7621a-v60|\
 	mediatek,mt7621-eval-board|\
@@ -596,6 +597,7 @@ ramips_setup_macs()
 	hiwifi,hc5661|\
 	hiwifi,hc5661a|\
 	hiwifi,hc5761|\
+	hiwifi,hc5761a|\
 	hiwifi,hc5861|\
 	hiwifi,hc5861b|\
 	hiwifi,hc5962)

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
@@ -22,6 +22,7 @@
 		wlan2g {
 			label = "hc5661a:blue:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };
@@ -29,8 +30,16 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2c", "refclk", "wled_an";
+			ralink,group = "i2c", "refclk", "wdt", "wled_an";
 			ralink,function = "gpio";
 		};
 	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
 };

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
@@ -1,24 +1,10 @@
 /dts-v1/;
 
-#include "mt7628an.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7628an_hiwifi_hc5x61a.dtsi"
 
 / {
 	compatible = "hiwifi,hc5661a", "mediatek,mt7628an-soc";
 	model = "HiWiFi HC5661A";
-
-	aliases {
-		led-boot = &led_system;
-		led-failsafe = &led_system;
-		led-running = &led_system;
-		led-upgrade = &led_system;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
 
 	leds {
 		compatible = "gpio-leds";
@@ -27,24 +13,15 @@
 			label = "hc5661a:blue:system";
 			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 		};
+
 		internet {
 			label = "hc5661a:blue:internet";
 			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
 		};
+
 		wlan2g {
 			label = "hc5661a:blue:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
 		};
 	};
 };
@@ -56,72 +33,4 @@
 			ralink,function = "gpio";
 		};
 	};
-};
-
-&spi0 {
-	status = "okay";
-
-	m25p80@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		linux,modalias = "m25p80", "w25q128";
-		spi-max-frequency = <10000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "hw_panic";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0xf70000>;
-			};
-
-			partition@fc0000 {
-				label = "oem";
-				reg = <0xfc0000 0x20000>;
-				read-only;
-			};
-
-			bdinfo: partition@fe0000 {
-				label = "bdinfo";
-				reg = <0xfe0000 0x10000>;
-				read-only;
-			};
-
-			partition@ff0000 {
-				label = "backup";
-				reg = <0xff0000 0x10000>;
-				read-only;
-			};
-		};
-	};
-};
-
-&ethernet {
-	mtd-mac-address = <&factory 0x4>;
-	mediatek,portmap = "wllll";
-};
-
-&wmac {
-	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_hiwifi_hc5x61a.dtsi"
+
+/ {
+	compatible = "hiwifi,hc5761a", "mediatek,mt7628an-soc";
+	model = "HiWiFi HC5761A";
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "hc5761a:blue:system";
+			gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "hc5761a:blue:internet";
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "hc5761a:blue:wlan2g";
+			gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "hc5761a:blue:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "refclk", "wdt", "p3led_an", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
@@ -17,6 +17,7 @@
 		wlan2g {
 			label = "hc5861b:green:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };
@@ -28,6 +29,14 @@
 			ralink,function = "gpio";
 		};
 	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
@@ -1,24 +1,10 @@
 /dts-v1/;
 
-#include "mt7628an.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7628an_hiwifi_hc5x61a.dtsi"
 
 / {
 	compatible = "hiwifi,hc5861b", "mediatek,mt7628an-soc";
 	model = "HiWiFi HC5861B";
-
-	aliases {
-		led-boot = &led_system;
-		led-failsafe = &led_system;
-		led-running = &led_system;
-		led-upgrade = &led_system;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
 
 	leds {
 		compatible = "gpio-leds";
@@ -27,20 +13,10 @@
 			label = "hc5861b:green:system";
 			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		};
+
 		wlan2g {
 			label = "hc5861b:green:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		reset {
-			label = "reset";
-			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
 		};
 	};
 };
@@ -52,72 +28,6 @@
 			ralink,function = "gpio";
 		};
 	};
-};
-
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "hw_panic";
-				reg = <0x30000 0x10000>;
-				read-only;
-			};
-
-			factory: partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0xf70000>;
-			};
-
-			partition@fc0000 {
-				label = "oem";
-				reg = <0xfc0000 0x20000>;
-				read-only;
-			};
-
-			bdinfo: partition@fe0000 {
-				label = "bdinfo";
-				reg = <0xfe0000 0x10000>;
-				read-only;
-			};
-
-			partition@ff0000 {
-				label = "backup";
-				reg = <0xff0000 0x10000>;
-				read-only;
-			};
-		};
-	};
-};
-
-&ethernet {
-	mtd-mac-address = <&factory 0x4>;
-};
-
-&wmac {
-	status = "okay";
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5x61a.dtsi
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hiwifi,hc5x61a", "mediatek,mt7628an-soc";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "hw_panic";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf70000>;
+			};
+
+			partition@fc0000 {
+				label = "oem";
+				reg = <0xfc0000 0x20000>;
+				read-only;
+			};
+
+			bdinfo: partition@fe0000 {
+				label = "bdinfo";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "backup";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -100,6 +100,15 @@ define Device/hiwifi_hc5661a
 endef
 TARGET_DEVICES += hiwifi_hc5661a
 
+define Device/hiwifi_hc5761a
+  MTK_SOC := mt7628an
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := HiWiFi
+  DEVICE_MODEL := HC5761A
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += hiwifi_hc5761a
+
 define Device/hiwifi_hc5861b
   MTK_SOC := mt7628an
   IMAGE_SIZE := 15808k

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -93,7 +93,7 @@ TARGET_DEVICES += hilink_hlk-7628n
 
 define Device/hiwifi_hc5661a
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5661A
   SUPPORTED_DEVICES += hc5661a


### PR DESCRIPTION
For hardware specs, HiWiFi HC5761A is very similar to HC5761, the only difference is HC5761A uses MT7628AN SoC instead
For flash instructions please refer to HC5661A or HC5861B

- Create HC5X61A.dtsi for all HiWiFi MT7628AN models (HC5661A, HC5761A, HC5861B)
- Explicitly disable EHCI and OHCI nodes of HC5661A and HC5861B
- Correct image size of HC5661A (15808k)
- Fix pinctrl of HC5661A
- Use GPIO interrupt keys instead of polling
- Use tpt trigger for wireless LEDs
- Increase SPI frequency to 80MHz

Known bug:
- SD slot doesn't work (#1500)