### PR TITLE
openvpn: fix handling of list options

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -53,13 +53,14 @@ append_list() {
 	local p; local v; local s="$1"; shift
 
 	list_cb_append() {
-		v="$1:${v}"
+		v="${v}:$1"
 	}
 
 	for p in $*; do
+		unset v
 		config_list_foreach "$s" "$p" list_cb_append
+		[ -n "$v" ] && append_param "$s" "$p" && echo " ${v:1}" >> "/var/etc/openvpn-$s.conf"
 	done
-	[ -n "$v" ] && append_param "$s" "$p" && echo " ${v%*:}" >> "/var/etc/openvpn-$s.conf"
 }
 
 section_enabled() {


### PR DESCRIPTION
This addresses an issue where the list option specified in
/etc/config/openvpn i.e. 'tls_cipher' would instead show up in the
generated openvpn-\<name\>.conf as 'ncp-ciphers'. For context,
'ncp_ciphers' appears after 'tls_cipher' in OPENVPN_LIST from
openvpn.options.

Also, the ordering of the options in the UCI config file is now
preserved when generating the OpenVPN config. The two currently
supported list options deal with cipher preferences.

Signed-off-by: Matt Merhar \<mattmerhar@protonmail.com\>