### PR TITLE
treewide: Provide label MAC address

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -260,6 +260,11 @@ generate_static_system() {
 				uci -q set "system.@system[-1].hostname=$hostname"
 			fi
 
+			local label_macaddr
+			if json_get_var label_macaddr label_macaddr; then
+				uci -q set "system.@system[-1].label_macaddr=$label_macaddr"
+			fi
+
 			if json_is_a ntpserver array; then
 				local keys key
 				json_get_keys keys ntpserver

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -19,6 +19,7 @@ get_mac_label() {
 
 	[ -n "$macdevice" ] && macaddr=$(get_mac_binary "$basepath/$macdevice/mac-address" 0 2>/dev/null)
 	[ -n "$macaddr" ] || macaddr=$(get_mac_binary "$basepath/$macdevice/local-mac-address" 0 2>/dev/null)
+	[ -n "$macaddr" ] || macaddr=$(uci -q get system.@system[0].label_macaddr)
 	echo $macaddr
 }
 

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -12,6 +12,16 @@ get_mac_binary() {
 	hexdump -v -n 6 -s $offset -e '5/1 "%02x:" 1/1 "%02x"' $path 2>/dev/null
 }
 
+get_mac_label() {
+	local basepath="/proc/device-tree"
+	local macdevice="$(cat "$basepath/aliases/label-mac-device" 2>/dev/null)"
+	local macaddr
+
+	[ -n "$macdevice" ] && macaddr=$(get_mac_binary "$basepath/$macdevice/mac-address" 0 2>/dev/null)
+	[ -n "$macaddr" ] || macaddr=$(get_mac_binary "$basepath/$macdevice/local-mac-address" 0 2>/dev/null)
+	echo $macaddr
+}
+
 find_mtd_chardev() {
 	local INDEX=$(find_mtd_index "$1")
 	local PREFIX=/dev/mtd

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -307,6 +307,14 @@ ucidef_set_interface_macaddr() {
 	ucidef_set_interface "$network" macaddr "$macaddr"
 }
 
+ucidef_set_label_macaddr() {
+	local macaddr="$1"
+
+	json_select_object system
+		json_add_string label_macaddr "$macaddr"
+	json_select ..
+}
+
 ucidef_add_atm_bridge() {
 	local vpi="$1"
 	local vci="$2"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -314,9 +314,19 @@ ath79_setup_macs()
 	adtran,bsap1800-v2|\
 	adtran,bsap1840)
 		lan_mac=$(mtd_get_mac_binary "Board data" 2)
+		label_mac=$lan_mac
+		;;
+	alfa-network,ap121f|\
+	ubnt,airrouter|\
+	ubnt,bullet-m|\
+	ubnt,nanostation-m|\
+	ubnt,rocket-m|\
+	ubnt,unifi)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	avm,fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	avm,fritz4020)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
@@ -334,8 +344,13 @@ ath79_setup_macs()
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
 	dlink,dir-842-c3|\
+	nec,wg1200cr)
+		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
+		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
+		label_mac=$lan_mac
+		;;
 	dlink,dir-859-a1|\
-	nec,wg1200cr|\
+	qihoo,c301|\
 	wd,mynet-n750)
 		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
@@ -346,12 +361,9 @@ ath79_setup_macs()
 		;;
 	engenius,ecb1750)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		label_mac=$(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
-	engenius,epg5000|\
-	iodata,wn-ac1167dgr|\
-	iodata,wn-ac1600dgr|\
-	iodata,wn-ac1600dgr2|\
-	iodata,wn-ag300dgr)
+	engenius,epg5000)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
@@ -364,6 +376,15 @@ ath79_setup_macs()
 	iodata,etg3-r)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(macaddr_add "$lan_mac" -1)
+		label_mac=$wan_mac
+		;;
+	iodata,wn-ac1167dgr|\
+	iodata,wn-ac1600dgr|\
+	iodata,wn-ac1600dgr2|\
+	iodata,wn-ag300dgr)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
+		label_mac=$wan_mac
 		;;
 	jjplus,ja76pf2)
 		wan_mac=$(fconfig -s -r -d $(find_mtd_part "RedBoot config") -n alias/ethaddr)
@@ -372,6 +393,7 @@ ath79_setup_macs()
 	nec,wg800hp)
 		lan_mac=$(mtd_get_mac_text board_data 0x280)
 		wan_mac=$(mtd_get_mac_text board_data 0x480)
+		label_mac=$wan_mac
 		;;
 	netgear,wndr3700|\
 	netgear,wndr3700v2|\
@@ -381,10 +403,6 @@ ath79_setup_macs()
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")
 		wan_mac=$(k2t_get_mac "wan_mac")
-		;;
-	qihoo,c301)
-		lan_mac=$(mtd_get_mac_ascii devdata lanmac)
-		wan_mac=$(mtd_get_mac_ascii devdata wanmac)
 		;;
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
@@ -406,6 +424,7 @@ ath79_setup_macs()
 	trendnet,tew-823dru)
 		lan_mac=$(mtd_get_mac_text mac 0x4)
 		wan_mac=$(mtd_get_mac_text mac 0x18)
+		label_mac=$wan_mac
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)
@@ -419,6 +438,7 @@ ath79_setup_macs()
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
 	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
 board_config_update

--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &power_red;
 		led-running = &power_green;
 		led-upgrade = &power_green;
+		label-mac-device = &eth0;
 	};
 
 	extosc: ref {

--- a/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr3700.dtsi
@@ -12,6 +12,7 @@
 		led-failsafe = &power_orange;
 		led-running = &power_green;
 		led-upgrade = &power_orange;
+		label-mac-device = &eth0;
 	};
 
 	chosen {

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr74xn-v1.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &ath9k;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &ath9k;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &ath9k;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar7241_ubnt_airrouter.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_airrouter.dts
@@ -12,6 +12,7 @@
 		led-failsafe = &globe;
 		led-running = &globe;
 		led-upgrade = &globe;
+		label-mac-device = &wifi;
 	};
 
 	airrouter-leds {

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &dome_green;
 		led-running = &dome_green;
 		led-upgrade = &dome_green;
+		label-mac-device = &wifi;
 	};
 
 	extosc: ref {
@@ -110,7 +111,7 @@
 &pcie {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
 	};

--- a/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm.dtsi
@@ -89,7 +89,7 @@
 &pcie {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
 	};

--- a/target/linux/ath79/dts/ar7241_ubnt_xm_outdoor.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_xm_outdoor.dtsi
@@ -9,6 +9,7 @@
 	aliases {
 		led-boot = &link4;
 		led-failsafe = &link4;
+		label-mac-device = &wifi;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
+		label-mac-device = &ath9k;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -10,6 +10,10 @@
 	compatible = "buffalo,wzr-hp-g450h", "qca,ar7242";
 	model = "Buffalo WZR-HP-G450H/WZR-450HP";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	ath9k-leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	chosen {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	extosc: ref {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	extosc: ref {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &eth0;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -15,6 +15,7 @@
 		led-boot = &wlan;
 		led-failsafe = &wlan;
 		led-upgrade = &wlan;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
+++ b/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
@@ -12,6 +12,7 @@
 
 	aliases {
 		serial0 = &uart;
+		label-mac-device = &wmac;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
@@ -16,6 +16,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &wmac;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -13,6 +13,7 @@
 	aliases {
 		led-boot = &led_lan;
 		led-failsafe = &led_lan;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
@@ -13,6 +13,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v1.dts
@@ -16,6 +16,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &eth0;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &wmac;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9341_tplink.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink.dtsi
@@ -13,6 +13,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &wmac;
 	};
 
 	keys: keys {

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -14,6 +14,7 @@
 		led-running = &system;
 		led-upgrade = &system;
 		led-failsafe = &system;
+		label-mac-device = &wmac;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
@@ -15,6 +15,7 @@
 		led-boot = &wan;
 		led-failsafe = &wan;
 		led-upgrade = &wan;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9344_tplink_cpexxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpexxx.dtsi
@@ -7,6 +7,10 @@
 #include "ar9344.dtsi"
 
 / {
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
@@ -6,6 +6,10 @@
 / {
 	model = "TP-Link TL-WDR3500 v1";
 	compatible = "tplink,tl-wdr3500-v1", "qca,ar9344";
+
+	aliases {
+		label-mac-device = &wmac;
+	};
 };
 
 &leds {

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -2,6 +2,12 @@
 
 #include "ar9344_tplink_tl-wdrxxxx.dtsi"
 
+/ {
+	aliases {
+		label-mac-device = &ath9k;
+	};
+};
+
 &leds {
 	usb1 {
 		label = "tp-link:green:usb1";

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
@@ -10,6 +10,10 @@
 	compatible = "comfast,cf-e5", "qca,qca9531";
 	model = "COMFAST CF-E5/E7";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_status;
 		led-running = &led_status;
 		led-upgrade = &led_status;
+		label-mac-device = &eth0;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
@@ -10,6 +10,10 @@
 	compatible = "glinet,gl-ar750", "qca,qca9531";
 	model = "GL.iNet GL-AR750";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -10,6 +10,10 @@
 	compatible = "tplink,archer-d50-v1", "qca,qca9531";
 	model = "TP-Link Archer D50 v1";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -11,6 +11,10 @@
 		bootargs = "console=ttyS0,115200n8";
 	};
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	gpio_leds: leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &power_led;
 		led-running = &power_led;
 		led-upgrade = &power_led;
+		label-mac-device = &eth1;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9533_ubnt_acb-isp.dts
+++ b/target/linux/ath79/dts/qca9533_ubnt_acb-isp.dts
@@ -10,6 +10,10 @@
 	compatible = "ubnt,acb-isp", "qca,qca9533";
 	model = "Ubiquiti airCube ISP";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
+++ b/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &eth1;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &power_amber;
 		led-running = &power_green;
 		led-upgrade = &power_amber;
+		label-mac-device = &eth0;
 	};
 
 	led_spi {

--- a/target/linux/ath79/dts/qca9558_ocedo_koala.dts
+++ b/target/linux/ath79/dts/qca9558_ocedo_koala.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth1;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
@@ -17,6 +17,7 @@
 		led-running = &led_power;
 		led-upgrade = &led_power;
 		mdio-gpio0 = &mdio2;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &eth1;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &wmac;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
@@ -55,6 +55,7 @@
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
@@ -13,6 +13,7 @@
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
+		label-mac-device = &eth1;
 	};
 
 	chosen {

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	led_spi {

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &eth0;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
@@ -16,6 +16,7 @@
 		led-failsafe = &system;
 		led-running = &system;
 		led-upgrade = &system;
+		label-mac-device = &wmac;
 	};
 
 	gpio_leds: leds {

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac-lite.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac-lite.dtsi
@@ -2,6 +2,12 @@
 
 #include "qca9563_ubnt_unifiac.dtsi"
 
+/ {
+	aliases {
+		label-mac-device = &eth0;
+	};
+};
+
 &mdio0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac-pro.dtsi
@@ -2,6 +2,12 @@
 
 #include "qca9563_ubnt_unifiac.dtsi"
 
+/ {
+	aliases {
+		label-mac-device = &eth0;
+	};
+};
+
 &mdio0 {
 	status = "okay";
 	phy-mask = <0>;

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -29,6 +29,7 @@
 		led-failsafe = &general;
 		led-running = &power;
 		led-upgrade = &general;
+		label-mac-device = &gmac2;
 	};
 
 	chosen {

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -34,6 +34,7 @@
 		led-failsafe = &power_amber;
 		led-running = &power_white;
 		led-upgrade = &power_amber;
+		label-mac-device = &gmac2;
 	};
 
 	chosen {

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/hiveap-330.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &tricolor_red;
 		led-running = &tricolor_green;
 		led-upgrade = &tricolor_red;
+		label-mac-device = &enet0;
 	};
 
 	chosen {

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -28,6 +28,7 @@
 		led-failsafe = &system_green;
 		led-running = &system_green;
 		led-upgrade = &system_green;
+		label-mac-device = &enet0;
 	};
 
 	memory {


### PR DESCRIPTION
**Problem description:**
Despite that most of the netifs have different MAC addresses, each device typically has one specific MAC address which is printed on a sticker somewhere.
This specific address may act as an identifier for the device which is apparent to the user, and thus is used e.g. for MAC adresses or IP addresses of routers in Freifunk firmware.
Other possible uses might be a router-specific SSID instead of "OpenWrt" as suggested in this PR: https://github.com/openwrt/openwrt/pull/1370

**Solution concept:**
One can introduce an alias to the device DTS files which references the node bearing the MAC address of interest:
```
aliases {
    label-mac-device = &eth0;
};
```
By adding a small function ~~"get_mac_primary"~~ "get_mac_label" to /lib/functions/system.sh, this can then be used to retrieve the "label" MAC address where required.
This is not limited to ethernet devices, but can also be WiFi etc.

**Notes:**
- Each device needs the label-mac-device to be specified in its DTS. However, a missing primary-mac-address is not detrimental to a device's functionality.
- Users of the get_mac_label function will have to take care for a missing label-mac-device themselves (= if it returns nothing)
- In the second patch I updated the ath79 devices where I know the sticker MAC address myself. Feel free to share information about other devices.

**CURRENT STATE:**
- **Waiting for merge**
- Latest version run-tested on Archer C60 V2 (DTS-based variant) and on Ubiquiti Picostation M2 (bullet-m, board.d-based variant)
- ~~ToDo: Need help for ipq40xx (=> identification of ethernet nodes)~~
- ~~Question: Is there a preference ethernet over WiFi or vice-versa if ambiguous~~
- Optional: Add data about additional targets/devices when provided
- ~~ToDo: Squash ath79 into one commit~~

**Devices with open pull-request and reported address:**
~~D-Link DIR-842 C1   #2276   label_mac=$lan_mac~~
~~D-Link DIR-842 C2   #2259   label_mac=$lan_mac~~
COMFAST CF-E313AC   #1942   `label-mac-device = &eth1;`
~~CPExxx @ ar9344   #2252   `label-mac-device = &wmac;`~~
~~GL-AR750   https://patchwork.ozlabs.org/patch/1135461/    `label-mac-device = &eth0;`~~
~~ALFA Network AP121F    #2199   `label_mac=$(cat /sys/class/ieee80211/phy0/mac-address)`~~
TP-Link Archer D7(b) v1   #2079   `label-mac-device = &wmac;`

**Devices where label-mac-device is already set:**
Archer C60 v1/v2
TP-Link TL-WR940N v3/v4
TP-Link TL-WR941N v6