### PR TITLE
[RFC] sunxi: single ext4 partition for SUNXI, Micro SD card and eMMC

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -82,6 +82,14 @@ menu "Target Images"
 		help
 		  Build an ext4 root filesystem.
 
+		config TARGET_SUNXI_BOOTFS_EXT4_ONLY
+			bool "EXT4 only image for Allwinner SUNXI"
+			depends on TARGET_ROOTFS_EXT4FS
+			depends on TARGET_sunxi
+			default y
+			help
+			  Create ext4 only image, for SUNXI One EXT4 bootable partition.
+
 		config TARGET_EXT4_RESERVED_PCT
 			int "Percentage of reserved blocks in root filesystem"
 			depends on TARGET_ROOTFS_EXT4FS

--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -296,11 +296,19 @@ UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 UBOOT_MAKE_FLAGS += \
 	BL31=$(STAGING_DIR_IMAGE)/bl31.bin
 
+SUNXI_ROOT_PRE:= mmcblk0
+SUNXI_ROOT_PART:= $(if $(CONFIG_TARGET_SUNXI_BOOTFS_EXT4_ONLY),1,2)
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	sed -e s/$(SUNXI_ROOT_PRE)/$(SUNXI_ROOT_PRE)p$(SUNXI_ROOT_PART)/ uEnv-$(UENV).txt > $(STAGING_DIR_IMAGE)/uEnv-$(UENV)-usd-p$(SUNXI_ROOT_PART).txt
 	$(CP) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-u-boot-with-spl.bin
-	mkimage -C none -A arm -T script -d uEnv-$(UENV).txt \
-		$(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot.scr
+	mkimage -C none -A arm -T script -d $(STAGING_DIR_IMAGE)/uEnv-$(UENV)-usd-p$(SUNXI_ROOT_PART).txt \
+		$(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot-usd-p$(SUNXI_ROOT_PART).scr
+	$(CP) $(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot-usd-p$(SUNXI_ROOT_PART).scr $(STAGING_DIR_IMAGE)/boot.scr
+	$(CP) $(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot-usd-p$(SUNXI_ROOT_PART).scr $(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot.scr
+	sed -e s/$(SUNXI_ROOT_PRE)/mmcblk2p1/ uEnv-$(UENV).txt > $(STAGING_DIR_IMAGE)/uEnv-$(UENV)-emmc-p1.txt
+	mkimage -C none -A arm -T script -d $(STAGING_DIR_IMAGE)/uEnv-$(UENV)-emmc-p1.txt \
+		$(STAGING_DIR_IMAGE)/$(BUILD_DEVICES)-boot-emmc-p1.scr
 endef
 
 define Package/u-boot/install/default

--- a/package/boot/uboot-sunxi/uEnv-a64.txt
+++ b/package/boot/uboot-sunxi/uEnv-a64.txt
@@ -1,5 +1,12 @@
-setenv loadkernel fatload mmc 0 \$kernel_addr_r uImage
-setenv loaddtb fatload mmc 0 \$fdt_addr_r dtb
-setenv bootargs console=ttyS0,115200 earlyprintk root=/dev/mmcblk0p2 rootwait earlycon=uart,mmio32,0x01c28000
+# Print boot source
+itest.b *0x10028 == 0x00 && echo "U-boot loaded from SD"
+itest.b *0x10028 == 0x02 && echo "U-boot loaded from eMMC or secondary SD"
+itest.b *0x10028 == 0x03 && echo "U-boot loaded from SPI"
+echo "Boot script loaded from ${devtype}"
+#
+#
+setenv loadkernel load ${devtype} ${devnum} \$kernel_addr_r /boot/uImage
+setenv loaddtb load ${devtype} ${devnum} \$fdt_addr_r /boot/dtb
+setenv bootargs console=ttyS0,115200 earlyprintk root=/dev/mmcblk0 rootwait earlycon=uart,mmio32,0x01c28000
 setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
 run uenvcmd

--- a/target/linux/sunxi/base-files/lib/upgrade/platform.sh
+++ b/target/linux/sunxi/base-files/lib/upgrade/platform.sh
@@ -29,7 +29,7 @@ platform_copy_config() {
 	local partdev
 
 	if export_partdevice partdev 1; then
-		mount -t vfat -o rw,noatime "/dev/$partdev" /mnt
+		mount -o rw,noatime "/dev/$partdev" /mnt
 		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
 		umount /mnt
 	fi

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -13,20 +13,36 @@ FAT32_BLOCKS=$(shell echo $$(($(CONFIG_SUNXI_SD_BOOT_PARTSIZE)*1024*1024/$(FAT32
 
 KERNEL_LOADADDR:=0x40008000
 
-define Build/sunxi-sdcard
+define Build/sunxi-sdcard-boot-fat
 	rm -f $@.boot
 	mkfs.fat $@.boot -C $(FAT32_BLOCKS)
+	mkdir -p $(STAGING_DIR_IMAGE)/tmp/boot
+	$(CP) $(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-boot.scr $(STAGING_DIR_IMAGE)/tmp/boot/boot.scr
+	$(CP) $(DTS_DIR)/$(SUNXI_DTS).dtb $(STAGING_DIR_IMAGE)/tmp/boot/dtb
+	$(CP)  $(IMAGE_KERNEL) $(STAGING_DIR_IMAGE)/tmp/boot/uImage
+	 mcopy -i $@.boot -s $(STAGING_DIR_IMAGE)/tmp/boot ::/
+	$(call Build/sunxi-sdcard-rootfs,SUNXI_BOOT_FAT)
+	rm -f $@.boot
+	rm -fr  $(STAGING_DIR_IMAGE)/tmp/boot
+endef
 
-	mcopy -i $@.boot $(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-boot.scr ::boot.scr
-	mcopy -i $@.boot $(DTS_DIR)/$(SUNXI_DTS).dtb ::dtb
-	mcopy -i $@.boot $(IMAGE_KERNEL) ::uImage
+define Build/sunxi-sdcard-boot-ext4
+	$(call Build/sunxi-sdcard-rootfs,SUNXI_BOOT_EXT4)
+endef
+
+define Build/sunxi-sdcard-rootfs
 	./gen_sunxi_sdcard_img.sh $@ \
 		$@.boot \
 		$(IMAGE_ROOTFS) \
 		$(CONFIG_SUNXI_SD_BOOT_PARTSIZE) \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) \
-		$(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-u-boot-with-spl.bin
-	rm -f $@.boot
+		$(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-u-boot-with-spl.bin \
+		$(1)
+endef
+
+define Build/sunxi-sdcard
+ $(if $(findstring -ext4-,$@),$(if $(CONFIG_TARGET_SUNXI_BOOTFS_EXT4_ONLY),\
+  $(call Build/sunxi-sdcard-boot-ext4),$(call Build/sunxi-sdcard-boot-fat)),$(call Build/sunxi-sdcard-boot-fat))
 endef
 
 # why \x00\x00\x00\x00 for zImage-initramfs
@@ -37,6 +53,7 @@ define Device/Default
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  SUNXI_BOOTFS := SUNXI_BOOT_FAT
 endef
 
 include cortex-a7.mk

--- a/target/linux/sunxi/image/gen_sunxi_sdcard_img.sh
+++ b/target/linux/sunxi/image/gen_sunxi_sdcard_img.sh
@@ -7,8 +7,8 @@
 #
 
 set -ex
-[ $# -eq 6 ] || {
-    echo "SYNTAX: $0 <file> <bootfs image> <rootfs image> <bootfs size> <rootfs size> <u-boot image>"
+[ $# -eq 7 ] || {
+	echo "SYNTAX: $0 <file> <bootfs image> <rootfs image> <bootfs size> <rootfs size> <u-boot image> <boot fs type>"
     exit 1
 }
 
@@ -18,17 +18,26 @@ ROOTFS="$3"
 BOOTFSSIZE="$4"
 ROOTFSSIZE="$5"
 UBOOT="$6"
+SUNXIBOOTFS="$7"
 
 head=4
 sect=63
 
-set $(ptgen -o $OUTPUT -h $head -s $sect -l 1024 -t c -p ${BOOTFSSIZE}M -t 83 -p ${ROOTFSSIZE}M)
+if [[ "${SUNXIBOOTFS}" = "SUNXI_BOOT_EXT4" ]]; then
+	set `ptgen -o $OUTPUT -h $head -s $sect -l 1024 -t 83 -p ${ROOTFSSIZE}M`
+	ROOTFSOFFSET="$(($1 / 512))"
+	ROOTFSSIZE="$(($2 / 512))"
+	NPART=1
+	dd bs=1024 if="$UBOOT" of="$OUTPUT" seek=8 conv=notrunc
+else
+	set `ptgen -o $OUTPUT -h $head -s $sect -l 1024 -t c -p ${BOOTFSSIZE}M -t 83 -p ${ROOTFSSIZE}M`
+	BOOTOFFSET="$(($1 / 512))"
+	BOOTSIZE="$(($2 / 512))"
+	ROOTFSOFFSET="$(($3 / 512))"
+	ROOTFSSIZE="$(($4 / 512))"
+	NPART=2
+	dd bs=1024 if="$UBOOT" of="$OUTPUT" seek=8 conv=notrunc
+	dd bs=512 if="$BOOTFS" of="$OUTPUT" seek="$BOOTOFFSET" conv=notrunc
+fi
 
-BOOTOFFSET="$(($1 / 512))"
-BOOTSIZE="$(($2 / 512))"
-ROOTFSOFFSET="$(($3 / 512))"
-ROOTFSSIZE="$(($4 / 512))"
-
-dd bs=1024 if="$UBOOT" of="$OUTPUT" seek=8 conv=notrunc
-dd bs=512 if="$BOOTFS" of="$OUTPUT" seek="$BOOTOFFSET" conv=notrunc
 dd bs=512 if="$ROOTFS" of="$OUTPUT" seek="$ROOTFSOFFSET" conv=notrunc


### PR DESCRIPTION
I have been using this patch, initial version, for a year. If you like this idea let me know.

sunxi: single ext4 partition for Micro SD card and eMMC

    add single ext4 partition image for SUNXI Allwinner, devices;
    without a DOS partition.

    * single ext4 partition instead of current dual partition image(DOS + ext4)
    * This would make it easier to install to eMMC, see sunxi-emmc-ext4-install.sh
      https://github.com/antonyantony/openwrt/tree/emmc-install
    * sysupgrade support on Micro SD card, single ext4
    * tar.gz image contains uboot files, and dtb file to install to eMMC

    Next on my wish list:
    * support sysupgrade for eMMC on Sunxi, it works for SD card.
    * would love to see dual partition support, primary and backup partions (with root and kernel)
    * get fw_printenv and fw_settenv and /etc/fw_env.config working for sunxi.
     https://blog.night-shade.org.uk/2014/01/fw_printenv-config-for-allwinner-devices/
     once fw_setenv works properly it could be easier to support dual partition.
    * support different partition sizes?


hauke  comments?