### PR TITLE
mpc85xx: Use uncompressed kernel on the HiveAP-330

### DIFF
--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -85,7 +85,7 @@ define Device/hiveap-330
   DEVICE_TITLE := Aerohive HiveAP-330
   DEVICE_PACKAGES := kmod-tpm-i2c-atmel
   BLOCKSIZE := 128k
-  KERNEL_NAME := zImage
+  KERNEL := kernel-bin | uImage none
   KERNEL_SIZE := 8m
   KERNEL_INITRAMFS := copy-file $(KDIR)/vmlinux-initramfs | uImage none
   SUPPORTED_DEVICES := aerohive,hiveap-330


### PR DESCRIPTION
It seems that newer builds of OpenWRT have a gzip kernel larger than 2MB~, which for some reason fails to boot on this board. However, we have 8MB of kernel space and currently the uncompressed kernel is 6.5MB~, so we have some space to grow until a better solution is worked out.

Before:

	## Booting kernel from Legacy Image at ee840000 ...
	  Image Name:   Linux-4.19.53
	  Created:      2019-06-22  11:17:48 UTC
	  Image Type:   PowerPC Linux Kernel Image (gzip compressed)
	  Data Size:    2315724 Bytes =  2.2 MB
	  Load Address: 00000000
	  Entry Point:  00000000
	  Verifying Checksum ... OK
	## Loading init Ramdisk from Legacy Image at 02000000 ...
	  Image Name:   OpenWrt fake ramdisk
	  Created:      2019-06-22  11:17:48 UTC
	  Image Type:   PowerPC Linux RAMDisk Image (uncompressed)
	  Data Size:    0 Bytes =  0 kB
	  Load Address: 00000000
	  Entry Point:  00000000
	  Verifying Checksum ... OK
	## Flattened Device Tree blob at ec000000
	  Booting using the fdt blob at 0xec000000
	  Uncompressing Kernel Image ... Error: Bad gzipped data
	GUNZIP: uncompress, out-of-mem or overwrite error - must RESET board to recover
	  Loading Ramdisk to 10000000, end 10000000 ... OK
	  Loading Device Tree to 00ffa000, end 00fffc78 ... OK
	ft_fixup_l2cache: FDT_ERR_NOTFOUND

After:

	## Booting kernel from Legacy Image at ee840000 ...
	   Image Name:   POWERPC OpenWrt Linux-4.19.53
	   Created:      2019-06-22  11:17:48 UTC
	   Image Type:   PowerPC Linux Kernel Image (uncompressed)
	   Data Size:    6724584 Bytes =  6.4 MB
	   Load Address: 00000000
	   Entry Point:  00000000
	   Verifying Checksum ... OK  
	## Loading init Ramdisk from Legacy Image at 02000000 ...
	   Image Name:   OpenWrt fake ramdisk
	   Created:      2019-06-22  11:17:48 UTC
	   Image Type:   PowerPC Linux RAMDisk Image (uncompressed)
	   Data Size:    0 Bytes =  0 kB
	   Load Address: 00000000
	   Entry Point:  00000000
	   Verifying Checksum ... OK
	## Flattened Device Tree blob at ec000000
	   Booting using the fdt blob at 0xec000000
	   Loading Kernel Image ... OK
	OK
	   Loading Ramdisk to 10000000, end 10000000 ... OK
	   Loading Device Tree to 00ffa000, end 00fffc78 ... OK

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>