### PR TITLE
ath79: add support for PISEN TS-D084

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ath79_setup_interfaces()
 	ocedo,koala|\
 	ocedo,raccoon|\
 	pcs,cap324|\
+	pisen,ts-d084|\
 	pisen,wmb001n|\
 	pisen,wmm003n|\
 	pqi,air-pen|\

--- a/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "Pisen TS-D084";
+	compatible = "pisen,ts-d084", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "ts-d084:blue:system";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			firmware: partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1,5 +1,6 @@
 include ./common-buffalo.mk
 include ./common-netgear.mk
+include ./common-tp-link.mk
 
 DEVICE_VARS += ADDPATTERN_ID ADDPATTERN_VERSION
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK
@@ -786,6 +787,16 @@ define Device/netgear_wndr3700v2
   SUPPORTED_DEVICES += wndr3700v2
 endef
 TARGET_DEVICES += netgear_wndr3700v2
+
+define Device/pisen_ts-d084
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9331
+  DEVICE_VENDOR := PISEN
+  DEVICE_MODEL := TS-D084
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-chipidea2
+  TPLINK_HWID := 0x07030101
+endef
+TARGET_DEVICES += pisen_ts-d084
 
 define Device/pisen_wmb001n
   ATH_SOC := ar9341


### PR DESCRIPTION
PISEN TS-D084 is an wireless router with a battery and integrated power supply based on Atheros AR9331.

Specification:

- 400/400/200 MHz (CPU/DDR/AHB)
- 64 MB of RAM (DDR2)
- 8 MB of FLASH (SPI NOR)
- 1x 10/100 Mbps Ethernet
- 1T1R 2.4 GHz (AR9331)
- 1x USB 2.0

Flash instruction:
The manufacturer are using exactly the same firmware header as TP-LINK
TL-WR703N (including device ID!).

Signed-off-by: xixiao zheng <xixiaozheng64@gmail.com>

