### PR TITLE
mvebu: Fix platform_copy_config for non-generic espressobin versions

### DIFF
--- a/target/linux/mvebu/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/platform.sh
@@ -9,7 +9,8 @@ REQUIRE_IMAGE_METADATA=1
 
 platform_check_image() {
 	case "$(board_name)" in
-	cznic,turris-omnia|globalscale,espressobin|marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
+	cznic,turris-omnia|globalscale,espressobin|globalscale,espressobin-emmc|globalscale,espressobin-v7|globalscale,espressobin-v7-emmc|\
+	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
 		platform_check_image_sdcard "$ARGV"
 		;;
 	*)
@@ -37,7 +38,8 @@ platform_copy_config() {
 	linksys,caiman|linksys,cobra|linksys,mamba|linksys,rango|linksys,shelby|linksys,venom)
 		platform_copy_config_linksys
 		;;
-	cznic,turris-omnia|globalscale,espressobin|marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
+	cznic,turris-omnia|globalscale,espressobin|globalscale,espressobin-emmc|globalscale,espressobin-v7|globalscale,espressobin-v7-emmc|\
+	marvell,armada8040-mcbin|solidrun,clearfog-base-a1|solidrun,clearfog-pro-a1)
 		platform_copy_config_sdcard "$ARGV"
 		;;
 	esac


### PR DESCRIPTION
When the non-generic espressobin targets were added this board check
was not updated, meaning that config is not saved during an upgrade
of -emmc,-v7, or -v7-emmc devices.

Signed-off-by: Brett Mastbergen <bmastbergen@untangle.com>
