### PR TITLE
comgt: add delay option for 3g proto

### DIFF
--- a/package/network/utils/comgt/files/3g.sh
+++ b/package/network/utils/comgt/files/3g.sh
@@ -17,6 +17,7 @@ proto_3g_init_config() {
 	proto_config_add_string "apn"
 	proto_config_add_string "service"
 	proto_config_add_string "pincode"
+	proto_config_add_string "delay"
 	proto_config_add_string "dialnumber"
 }
 
@@ -29,6 +30,7 @@ proto_3g_setup() {
 	json_get_var service service
 	json_get_var pincode pincode
 	json_get_var dialnumber dialnumber
+	json_get_var delay delay
 
 	[ -n "$dat_device" ] && device=$dat_device
 
@@ -37,6 +39,8 @@ proto_3g_setup() {
 		proto_set_available "$interface" 0
 		return 1
 	}
+
+	[ -n "$delay" ] && sleep "$delay"
 
 	case "$service" in
 		cdma|evdo)


### PR DESCRIPTION
All protos for wwan (ncm,qmi,mbim) do have a delay option.
To standardize that add also the missing delay option to the 3g proto.
