### PR TITLE
ramips: add MT7615 wireless support for ELECOM WRC-1167GHBK2-S

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -31,6 +31,7 @@
 		wlan2g {
 			label = "wrc-1167ghbk2-s:white:wlan2g";
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
 		};
 
 		wlan5g {
@@ -144,10 +145,16 @@
 
 &pcie {
 	status = "okay";
-	/*
-	 * WRC-1167GHBK2-S has MT7615D for 2.4/5 GHz wifi,
-	 * but it's not supported in OpenWrt.
-	 */
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mtd-mac-address = <&factory 0xe000>;
+		mtd-mac-address-increment = <1>;
+	};
 };
 
 &xhci {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -172,6 +172,7 @@ define Device/elecom_wrc-1167ghbk2-s
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) |\
     elecom-wrc-factory WRC-1167GHBK2-S 0.00
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
 


### PR DESCRIPTION
ELECOM WRC-1167GHBK2-S has a MediaTek MT7615D chip for 2.4/5 GHz
wireless.

A driver package for MT7615 chip is added to OpenWrt in
a0e5ca4f3523b9eef96bff32e45f6fa8275b982f,
so add MT7615 chip support for WRC-1167GHBK2-S.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>