### PR TITLE
ramips: add support for TP-Link RE650 v1

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -347,7 +347,8 @@ tplink,archer-mr200)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "usb0"
 	set_wifi_led "$boardname:white:wlan"
 	;;
-tplink,re350-v1)
+tplink,re350-v1|\
+tplink,re650-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "$boardname:blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "$boardname:blue:wifi5G" "wlan1"
 	ucidef_set_led_netdev "eth_act" "LAN act" "$boardname:green:eth_act" "eth0" "tx rx"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -286,7 +286,8 @@ ramips_setup_interfaces()
 	dlink,dir-510l|\
 	glinet,vixmini|\
 	netgear,ex6150|\
-	tplink,re350-v1)
+	tplink,re350-v1|\
+	tplink,re650-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
 		;;

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,re650-v1", "mediatek,mt7621-soc";
+	model = "TP-Link RE650 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re650-v1:blue:power";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "re650-v1:blue:wifi2G";
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "re650-v1:blue:wifi5G";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_red {
+			label = "re650-v1:red:wps";
+			gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps_blue {
+			label = "re650-v1:blue:wps";
+			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		eth_act {
+			label = "re650-v1:green:eth_act";
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+		};
+
+		eth_link {
+			label = "re650-v1:green:eth_link";
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		power {
+			label = "power";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_POWER>;
+		};
+
+		led {
+			label = "led";
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	w25q64@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xde0000>;
+			};
+
+			config: partition@e00000 {
+				label = "config";
+				reg = <0xe00000 0x50000>;
+				read-only;
+			};
+
+			/* range 0xe50000 to 0xff0000 is empty in vendor
+			 * firmware, so we do not use it either
+			 */
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <1>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0x10008>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "rgmii2", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -530,24 +530,37 @@ define Device/totolink_a7000r
 endef
 TARGET_DEVICES += totolink_a7000r
 
-define Device/tplink_re350-v1
+define Device/tplink-safeloader
   MTK_SOC := mt7621
   DEVICE_VENDOR := TP-Link
+  TPLINK_BOARD_ID :=
+  KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+	append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+endef
+
+define Device/tplink_re350-v1
+  $(Device/tplink-safeloader)
   DEVICE_MODEL := RE350
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic
   TPLINK_BOARD_ID := RE350-V1
-  TPLINK_HWID := 0x0
-  TPLINK_HWREV := 0
-  TPLINK_HEADER_VERSION := 1
   IMAGE_SIZE := 6016k
-  KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
   SUPPORTED_DEVICES += re350-v1
 endef
 TARGET_DEVICES += tplink_re350-v1
+
+define Device/tplink_re650-v1
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := RE650
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+  TPLINK_BOARD_ID := RE650-V1
+  IMAGE_SIZE := 14208k
+endef
+TARGET_DEVICES += tplink_re650-v1
 
 define Device/ubiquiti_edgerouterx
   MTK_SOC := mt7621

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1366,6 +1366,43 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the RE650 */
+	{
+		.id = "RE650-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:55530000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:45550000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:4A500000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:43410000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:41550000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:41530000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0xde0000},
+			{"partition-table", 0xe00000, 0x02000},
+			{"default-mac", 0xe10000, 0x00020},
+			{"pin", 0xe10100, 0x00020},
+			{"product-info", 0xe11100, 0x01000},
+			{"soft-version", 0xe20000, 0x01000},
+			{"support-list", 0xe21000, 0x01000},
+			{"profile", 0xe22000, 0x08000},
+			{"user-config", 0xe30000, 0x10000},
+			{"default-config", 0xe40000, 0x10000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	{}
 };
 


### PR DESCRIPTION
TP-Link RE650 v1 is a dual-band AC2600 range extender,
based on MediaTek MT7621A and MT7615E. According to the
wikidevi entry for RE650 this device is identical with
TP-Link RE500 as hardware. This patch supports only RE650.

Hardware specification:

- SoC 880 MHz - MediaTek MT7621AT
- 128 MB of DDR3 RAM
- 16 MB - Winbond 25Q128FVSG
- 4T4R 2.4 GHz - MediaTek MT7615E
- 4T4R 5 GHz - MediaTek MT7615E
- 1x 1 Gbps Ethernet - MT7621AT integrated
- 7x LEDs (Power, 2G, 5G, WPS(x2), Lan(x2))
- 4x buttons (Reset, Power, WPS, LED)
- UART header on PCB

Flash instructions:

Upload
openwrt-ramips-mt7621-tplink_re650-v1-squashfs-factory.bin
from the RE650 web interface.

TFTP recovery to stock firmware:

Unfortunately, I can't find an easy way to recover the RE
without some form of hackery. The TFTP upload will only
work if selected from u-boot, which means you have to
open the device and attach to the serial console. The
TFTP update procedure does *not* accept the published
vendor firmware binaries. However, it allows to flash
a kernel + rootfs binaries and this works if you have
a backup of the original contents of the flash or create
an special image out of the vendor binaries.

Signed-off-by: Georgi Vlaev <georgi.vlaev@gmail.com>