### PR TITLE
scripts: add target-wrapper.sh

### DIFF
--- a/scripts/target-wrapper.sh
+++ b/scripts/target-wrapper.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+TOPDIR=`dirname "$0"`/..
+eval env -S \
+	`make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_CONFIGURE_OPTS` \
+	PATH=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_PATH)"` \
+	CFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_CFLAGS)"` \
+	CPPFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_CPPFLAGS)"` \
+	CXXFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_CXXFLAGS)"` \
+	LDFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_LDFLAGS)"` \
+	STAGING_DIR=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.STAGING_DIR)"` \
+	`[ $# -gt 0 ] && printf '%q ' "${@}"`
+
+#

--- a/scripts/target-wrapper.sh
+++ b/scripts/target-wrapper.sh
@@ -8,6 +8,10 @@ eval env -S \
 	CXXFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_CXXFLAGS)"` \
 	LDFLAGS=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.TARGET_LDFLAGS)"` \
 	STAGING_DIR=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.STAGING_DIR)"` \
-	`[ $# -gt 0 ] && printf '%q ' "${@}"`
+	DESTDIR=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.STAGING_DIR)"` \
+	CMAKE_PREFIX_PATH=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.STAGING_DIR)/usr"` \
+	host_alias=`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.GNU_TARGET_NAME)"` \
+	PROMPT_COMMAND=\"echo -en \\\\\\e[1\\\;34m`printf '%q ' "$(make -s TOPDIR="${TOPDIR}" -f "${TOPDIR}/rules.mk" val.GNU_TARGET_NAME)"` \\\\\\e[0\\\;39m\" \
+	`printf '%q ' "${@-$SHELL}"`
 
 #


### PR DESCRIPTION
This script extracts key environment variables from rules.mk, puts them in
the environment, and then executes all arguments as a command in that
environment.  This allows one to easily use the existing OpenWRT toolchain
outside the openwrt/ checkout, e.g. to try out a new package without having
to write anything.

Signed-off-by: Derrick Lyndon Pallas <derrick@argosylabs.com>