### PR TITLE
base-files: supress service restart of umount

### DIFF
--- a/package/base-files/files/etc/init.d/umount
+++ b/package/base-files/files/etc/init.d/umount
@@ -2,6 +2,11 @@
 # Copyright (C) 2006 OpenWrt.org
 
 STOP=90
+
+restart() {
+	:
+}
+
 stop() {
 	sync
 	/bin/umount -a -d -r


### PR DESCRIPTION
Restart is in default implemented so it calls stop and start. This is
pretty unsafe to call on umount service. This service should not do
anything on restart the same way as on start. Only use of this service
is on stop.

Signed-off-by: Karel Kočí <cynerd@email.cz>

This is also present in both OpenWRT 18.06 and OpenWRT 19.07 branches so it should be pushed to them as well I think.