### PR TITLE
ar71xx: fix ath79/rb4xx IRQ initialization on kernel 4.14

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-rb4xx.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-rb4xx.c
@@ -88,7 +88,7 @@ static struct platform_device rb4xx_nand_device = {
 	.id	= -1,
 };
 
-static struct ath79_pci_irq rb4xx_pci_irqs[] __initdata = {
+static struct ath79_pci_irq rb4xx_pci_irqs[] = {
 	{
 		.slot	= 17,
 		.pin	= 1,


### PR DESCRIPTION
Apply the same approach as commit 3b53d6fd to fix IRQ initialization for ath79-based chipsets on rb4xx.

Signed-off-by: W. Michael Petullo <mike@flyn.org>