### PR TITLE
openvpn: add new list option tls_ciphersuites

### DIFF
--- a/package/network/services/openvpn/files/openvpn.options
+++ b/package/network/services/openvpn/files/openvpn.options
@@ -191,6 +191,7 @@ username_as_common_name
 '
 
 OPENVPN_LIST='
-tls_cipher
 ncp_ciphers
+tls_cipher
+tls_ciphersuites
 '


### PR DESCRIPTION
To configure the list of allowable TLS 1.3 ciphersuites, the option
tls_ciphersuites is used instead of tls_ciphers.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
