### PR TITLE
Lua5.3 create shared library

### DIFF
--- a/package/utils/lua5.3/Makefile
+++ b/package/utils/lua5.3/Makefile
@@ -40,8 +40,23 @@ define Package/lua5.3/Default/description
   programming, data-driven programming, and data description.
 endef
 
+define Package/liblua5.3
+$(call Package/lua53/Default)
+  SUBMENU:=
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE+= (libraries)
+  ABI_VERSION:=5.3
+endef
+
+define Package/liblua5.3/description
+$(call Package/lua53/Default/description)
+ This package contains the Lua shared libraries, needed by other programs.
+endef
+
 define Package/lua5.3
 $(call Package/lua5.3/Default)
+  DEPENDS:=+liblua5.3
   TITLE+= (interpreter)
 endef
 
@@ -52,6 +67,7 @@ endef
 
 define Package/luac5.3
 $(call Package/lua5.3/Default)
+  DEPENDS:=+liblua5.3
   TITLE+= (compiler)
 endef
 
@@ -108,7 +124,14 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/lua5.3 $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.3/lua{,lib,conf}.h $(1)/usr/include/lua5.3/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.3/lauxlib.h $(1)/usr/include/lua5.3/
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.3.a $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.3.{a,so*} $(1)/usr/lib/
+	$(LN) liblua5.3.so.0.0.0 $(1)/usr/lib/liblualib5.3.so
+endef
+
+define Package/liblua5.3/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.3.so* $(1)/usr/lib/
 endef
 
 define Package/lua5.3/install
@@ -121,6 +144,7 @@ define Package/luac5.3/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/luac5.3 $(1)/usr/bin/
 endef
 
+$(eval $(call BuildPackage,liblua5.3))
 $(eval $(call BuildPackage,lua5.3))
 $(eval $(call BuildPackage,luac5.3))
 $(eval $(call HostBuild))

--- a/package/utils/lua5.3/patches/020-shared_liblua.patch
+++ b/package/utils/lua5.3/patches/020-shared_liblua.patch
@@ -1,0 +1,322 @@
+--- a/Makefile	2019-07-02 09:24:57.554332875 -0600
++++ b/Makefile	2019-07-02 09:25:42.626694604 -0600
+@@ -41,7 +41,7 @@ PLATS= aix bsd c89 freebsd generic linux
+ # What to install.
+ TO_BIN= lua$V luac$V
+ TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
+-TO_LIB= liblua$V.a
++TO_LIB= liblua$V.a liblua$V.so.0.0.0
+ TO_MAN= lua$V.1 luac$V.1
+ 
+ # Lua version and release.
+@@ -62,6 +62,9 @@ install: dummy
+ 	cd src && $(INSTALL_EXEC) $(TO_BIN) $(INSTALL_BIN)
+ 	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
+ 	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so.0.0
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so.0
++	ln -s liblua$V.so.0.0.0 $(INSTALL_LIB)/liblua$V.so
+ 	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
+ 
+ uninstall:
+--- a/src/ldo.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/ldo.h	2019-07-02 09:25:42.626694604 -0600
+@@ -47,8 +47,8 @@ LUAI_FUNC int luaD_pcall (lua_State *L,
+ LUAI_FUNC int luaD_poscall (lua_State *L, CallInfo *ci, StkId firstResult,
+                                           int nres);
+ LUAI_FUNC void luaD_reallocstack (lua_State *L, int newsize);
+-LUAI_FUNC void luaD_growstack (lua_State *L, int n);
+-LUAI_FUNC void luaD_shrinkstack (lua_State *L);
++LUA_API void luaD_growstack (lua_State *L, int n);
++LUA_API void luaD_shrinkstack (lua_State *L);
+ LUAI_FUNC void luaD_inctop (lua_State *L);
+ 
+ LUAI_FUNC l_noret luaD_throw (lua_State *L, int errcode);
+--- a/src/lfunc.h	2017-04-19 11:39:34.000000000 -0600
++++ b/src/lfunc.h	2019-07-02 09:25:42.630694635 -0600
+@@ -47,14 +47,14 @@ struct UpVal {
+ #define upisopen(up)	((up)->v != &(up)->u.value)
+ 
+ 
+-LUAI_FUNC Proto *luaF_newproto (lua_State *L);
++LUA_API Proto *luaF_newproto (lua_State *L);
+ LUAI_FUNC CClosure *luaF_newCclosure (lua_State *L, int nelems);
+-LUAI_FUNC LClosure *luaF_newLclosure (lua_State *L, int nelems);
+-LUAI_FUNC void luaF_initupvals (lua_State *L, LClosure *cl);
+-LUAI_FUNC UpVal *luaF_findupval (lua_State *L, StkId level);
+-LUAI_FUNC void luaF_close (lua_State *L, StkId level);
++LUA_API LClosure *luaF_newLclosure (lua_State *L, int nelems);
++LUA_API void luaF_initupvals (lua_State *L, LClosure *cl);
++LUA_API UpVal *luaF_findupval (lua_State *L, StkId level);
++LUA_API void luaF_close (lua_State *L, StkId level);
+ LUAI_FUNC void luaF_freeproto (lua_State *L, Proto *f);
+-LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,
++LUA_API const char *luaF_getlocalname (const Proto *func, int local_number,
+                                          int pc);
+ 
+ 
+--- a/src/lgc.h	2017-04-19 11:39:34.000000000 -0600
++++ b/src/lgc.h	2019-07-02 09:25:42.634694666 -0600
+@@ -133,11 +133,11 @@
+ 
+ LUAI_FUNC void luaC_fix (lua_State *L, GCObject *o);
+ LUAI_FUNC void luaC_freeallobjects (lua_State *L);
+-LUAI_FUNC void luaC_step (lua_State *L);
++LUA_API void luaC_step (lua_State *L);
+ LUAI_FUNC void luaC_runtilstate (lua_State *L, int statesmask);
+ LUAI_FUNC void luaC_fullgc (lua_State *L, int isemergency);
+ LUAI_FUNC GCObject *luaC_newobj (lua_State *L, int tt, size_t sz);
+-LUAI_FUNC void luaC_barrier_ (lua_State *L, GCObject *o, GCObject *v);
++LUA_API void luaC_barrier_ (lua_State *L, GCObject *o, GCObject *v);
+ LUAI_FUNC void luaC_barrierback_ (lua_State *L, Table *o);
+ LUAI_FUNC void luaC_upvalbarrier_ (lua_State *L, UpVal *uv);
+ LUAI_FUNC void luaC_checkfinalizer (lua_State *L, GCObject *o, Table *mt);
+--- a/src/llex.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/llex.h	2019-07-02 09:25:42.630694635 -0600
+@@ -73,13 +73,13 @@ typedef struct LexState {
+ 
+ 
+ LUAI_FUNC void luaX_init (lua_State *L);
+-LUAI_FUNC void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
++LUA_API void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
+                               TString *source, int firstchar);
+ LUAI_FUNC TString *luaX_newstring (LexState *ls, const char *str, size_t l);
+-LUAI_FUNC void luaX_next (LexState *ls);
+-LUAI_FUNC int luaX_lookahead (LexState *ls);
+-LUAI_FUNC l_noret luaX_syntaxerror (LexState *ls, const char *s);
+-LUAI_FUNC const char *luaX_token2str (LexState *ls, int token);
++LUA_API void luaX_next (LexState *ls);
++LUA_API int luaX_lookahead (LexState *ls);
++LUA_API l_noret luaX_syntaxerror (LexState *ls, const char *s);
++LUA_API const char *luaX_token2str (LexState *ls, int token);
+ 
+ 
+ #endif
+--- a/src/lmem.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/lmem.h	2019-07-02 09:25:42.630694635 -0600
+@@ -56,12 +56,12 @@
+ #define luaM_reallocvector(L, v,oldn,n,t) \
+    ((v)=cast(t *, luaM_reallocv(L, v, oldn, n, sizeof(t))))
+ 
+-LUAI_FUNC l_noret luaM_toobig (lua_State *L);
++LUA_API l_noret luaM_toobig (lua_State *L);
+ 
+ /* not to be called directly */
+-LUAI_FUNC void *luaM_realloc_ (lua_State *L, void *block, size_t oldsize,
++LUA_API void *luaM_realloc_ (lua_State *L, void *block, size_t oldsize,
+                                                           size_t size);
+-LUAI_FUNC void *luaM_growaux_ (lua_State *L, void *block, int *size,
++LUA_API void *luaM_growaux_ (lua_State *L, void *block, int *size,
+                                size_t size_elem, int limit,
+                                const char *what);
+ 
+--- a/src/lobject.h	2017-04-19 11:39:34.000000000 -0600
++++ b/src/lobject.h	2019-07-02 09:25:42.630694635 -0600
+@@ -525,7 +525,7 @@ typedef struct Table {
+ #define luaO_nilobject		(&luaO_nilobject_)
+ 
+ 
+-LUAI_DDEC const TValue luaO_nilobject_;
++LUA_API const TValue luaO_nilobject_;
+ 
+ /* size of buffer for 'luaO_utf8esc' function */
+ #define UTF8BUFFSZ	8
+@@ -534,15 +534,15 @@ LUAI_FUNC int luaO_int2fb (unsigned int
+ LUAI_FUNC int luaO_fb2int (int x);
+ LUAI_FUNC int luaO_utf8esc (char *buff, unsigned long x);
+ LUAI_FUNC int luaO_ceillog2 (unsigned int x);
+-LUAI_FUNC void luaO_arith (lua_State *L, int op, const TValue *p1,
++LUA_API void luaO_arith (lua_State *L, int op, const TValue *p1,
+                            const TValue *p2, TValue *res);
+ LUAI_FUNC size_t luaO_str2num (const char *s, TValue *o);
+ LUAI_FUNC int luaO_hexavalue (int c);
+ LUAI_FUNC void luaO_tostring (lua_State *L, StkId obj);
+-LUAI_FUNC const char *luaO_pushvfstring (lua_State *L, const char *fmt,
++LUA_API const char *luaO_pushvfstring (lua_State *L, const char *fmt,
+                                                        va_list argp);
+-LUAI_FUNC const char *luaO_pushfstring (lua_State *L, const char *fmt, ...);
+-LUAI_FUNC void luaO_chunkid (char *out, const char *source, size_t len);
++LUA_API const char *luaO_pushfstring (lua_State *L, const char *fmt, ...);
++LUA_API void luaO_chunkid (char *out, const char *source, size_t len);
+ 
+ 
+ #endif
+--- a/src/lopcodes.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/lopcodes.h	2019-07-02 09:25:42.630694635 -0600
+@@ -278,7 +278,7 @@ enum OpArgMask {
+   OpArgK   /* argument is a constant or register/constant */
+ };
+ 
+-LUAI_DDEC const lu_byte luaP_opmodes[NUM_OPCODES];
++LUA_API const lu_byte luaP_opmodes[NUM_OPCODES];
+ 
+ #define getOpMode(m)	(cast(enum OpMode, luaP_opmodes[m] & 3))
+ #define getBMode(m)	(cast(enum OpArgMask, (luaP_opmodes[m] >> 4) & 3))
+@@ -287,7 +287,7 @@ LUAI_DDEC const lu_byte luaP_opmodes[NUM
+ #define testTMode(m)	(luaP_opmodes[m] & (1 << 7))
+ 
+ 
+-LUAI_DDEC const char *const luaP_opnames[NUM_OPCODES+1];  /* opcode names */
++LUA_API const char *const luaP_opnames[NUM_OPCODES+1];  /* opcode names */
+ 
+ 
+ /* number of list items to accumulate before a SETLIST instruction */
+--- a/src/lstate.h	2017-04-19 11:39:34.000000000 -0600
++++ b/src/lstate.h	2019-07-02 09:25:42.630694635 -0600
+@@ -244,9 +244,9 @@ union GCUnion {
+ 
+ LUAI_FUNC void luaE_setdebt (global_State *g, l_mem debt);
+ LUAI_FUNC void luaE_freethread (lua_State *L, lua_State *L1);
+-LUAI_FUNC CallInfo *luaE_extendCI (lua_State *L);
+-LUAI_FUNC void luaE_freeCI (lua_State *L);
+-LUAI_FUNC void luaE_shrinkCI (lua_State *L);
++LUA_API CallInfo *luaE_extendCI (lua_State *L);
++LUA_API void luaE_freeCI (lua_State *L);
++LUA_API void luaE_shrinkCI (lua_State *L);
+ 
+ 
+ #endif
+--- a/src/lstring.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/lstring.h	2019-07-02 09:25:42.630694635 -0600
+@@ -35,15 +35,15 @@
+ 
+ LUAI_FUNC unsigned int luaS_hash (const char *str, size_t l, unsigned int seed);
+ LUAI_FUNC unsigned int luaS_hashlongstr (TString *ts);
+-LUAI_FUNC int luaS_eqlngstr (TString *a, TString *b);
++LUA_API int luaS_eqlngstr (TString *a, TString *b);
+ LUAI_FUNC void luaS_resize (lua_State *L, int newsize);
+ LUAI_FUNC void luaS_clearcache (global_State *g);
+ LUAI_FUNC void luaS_init (lua_State *L);
+ LUAI_FUNC void luaS_remove (lua_State *L, TString *ts);
+ LUAI_FUNC Udata *luaS_newudata (lua_State *L, size_t s);
+-LUAI_FUNC TString *luaS_newlstr (lua_State *L, const char *str, size_t l);
+-LUAI_FUNC TString *luaS_new (lua_State *L, const char *str);
+-LUAI_FUNC TString *luaS_createlngstrobj (lua_State *L, size_t l);
++LUA_API TString *luaS_newlstr (lua_State *L, const char *str, size_t l);
++LUA_API TString *luaS_new (lua_State *L, const char *str);
++LUA_API TString *luaS_createlngstrobj (lua_State *L, size_t l);
+ 
+ 
+ #endif
+--- a/src/ltable.h	2018-05-24 13:39:05.000000000 -0600
++++ b/src/ltable.h	2019-07-02 09:25:42.630694635 -0600
+@@ -41,14 +41,14 @@
+ 
+ 
+ LUAI_FUNC const TValue *luaH_getint (Table *t, lua_Integer key);
+-LUAI_FUNC void luaH_setint (lua_State *L, Table *t, lua_Integer key,
++LUA_API void luaH_setint (lua_State *L, Table *t, lua_Integer key,
+                                                     TValue *value);
+ LUAI_FUNC const TValue *luaH_getshortstr (Table *t, TString *key);
+ LUAI_FUNC const TValue *luaH_getstr (Table *t, TString *key);
+ LUAI_FUNC const TValue *luaH_get (Table *t, const TValue *key);
+ LUAI_FUNC TValue *luaH_newkey (lua_State *L, Table *t, const TValue *key);
+-LUAI_FUNC TValue *luaH_set (lua_State *L, Table *t, const TValue *key);
+-LUAI_FUNC Table *luaH_new (lua_State *L);
++LUA_API TValue *luaH_set (lua_State *L, Table *t, const TValue *key);
++LUA_API Table *luaH_new (lua_State *L);
+ LUAI_FUNC void luaH_resize (lua_State *L, Table *t, unsigned int nasize,
+                                                     unsigned int nhsize);
+ LUAI_FUNC void luaH_resizearray (lua_State *L, Table *t, unsigned int nasize);
+--- a/src/ltm.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/ltm.h	2019-07-02 09:25:42.634694666 -0600
+@@ -55,10 +55,10 @@ typedef enum {
+ LUAI_DDEC const char *const luaT_typenames_[LUA_TOTALTAGS];
+ 
+ 
+-LUAI_FUNC const char *luaT_objtypename (lua_State *L, const TValue *o);
++LUA_API const char *luaT_objtypename (lua_State *L, const TValue *o);
+ 
+ LUAI_FUNC const TValue *luaT_gettm (Table *events, TMS event, TString *ename);
+-LUAI_FUNC const TValue *luaT_gettmbyobj (lua_State *L, const TValue *o,
++LUA_API const TValue *luaT_gettmbyobj (lua_State *L, const TValue *o,
+                                                        TMS event);
+ LUAI_FUNC void luaT_init (lua_State *L);
+ 
+@@ -66,9 +66,9 @@ LUAI_FUNC void luaT_callTM (lua_State *L
+                             const TValue *p2, TValue *p3, int hasres);
+ LUAI_FUNC int luaT_callbinTM (lua_State *L, const TValue *p1, const TValue *p2,
+                               StkId res, TMS event);
+-LUAI_FUNC void luaT_trybinTM (lua_State *L, const TValue *p1, const TValue *p2,
++LUA_API void luaT_trybinTM (lua_State *L, const TValue *p1, const TValue *p2,
+                               StkId res, TMS event);
+-LUAI_FUNC int luaT_callorderTM (lua_State *L, const TValue *p1,
++LUA_API int luaT_callorderTM (lua_State *L, const TValue *p1,
+                                 const TValue *p2, TMS event);
+ 
+ 
+--- a/src/lundump.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/lundump.h	2019-07-02 09:25:42.634694666 -0600
+@@ -23,10 +23,10 @@
+ #define LUAC_FORMAT	0	/* this is the official format */
+ 
+ /* load one chunk; from lundump.c */
+-LUAI_FUNC LClosure* luaU_undump (lua_State* L, ZIO* Z, const char* name);
++LUA_API LClosure* luaU_undump (lua_State* L, ZIO* Z, const char* name);
+ 
+ /* dump one chunk; from ldump.c */
+-LUAI_FUNC int luaU_dump (lua_State* L, const Proto* f, lua_Writer w,
++LUA_API int luaU_dump (lua_State* L, const Proto* f, lua_Writer w,
+                          void* data, int strip);
+ 
+ #endif
+--- a/src/lzio.h	2017-04-19 11:20:42.000000000 -0600
++++ b/src/lzio.h	2019-07-02 09:25:42.634694666 -0600
+@@ -61,6 +61,6 @@ struct Zio {
+ };
+ 
+ 
+-LUAI_FUNC int luaZ_fill (ZIO *z);
++LUA_API int luaZ_fill (ZIO *z);
+ 
+ #endif
+--- a/src/Makefile	2019-07-02 09:24:57.554332875 -0600
++++ b/src/Makefile	2019-07-02 09:25:42.630694635 -0600
+@@ -29,6 +29,7 @@ MYOBJS=
+ PLATS= aix bsd c89 freebsd generic linux macosx mingw posix solaris
+ 
+ LUA_A=	liblua$V.a
++LUA_SO=	liblua$V.so.0.0.0
+ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
+ 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
+ 	ltm.o lundump.o lvm.o lzio.o
+@@ -43,8 +44,9 @@ LUAC_T=	luac$V
+ LUAC_O=	luac.o
+ 
+ ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+-ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
++ALL_T= $(LUA_A) $(LUA_SO) $(LUA_T) $(LUAC_T)
+ ALL_A= $(LUA_A)
++ALL_SO= $(LUA_SO)
+ 
+ # Targets start here.
+ default: $(PLAT)
+@@ -55,14 +57,25 @@ o:	$(ALL_O)
+ 
+ a:	$(ALL_A)
+ 
++so:	$(ALL_SO)
++
+ $(LUA_A): $(BASE_O)
+ 	$(AR) $@ $(BASE_O)
+ 	$(RANLIB) $@
+ 
+-$(LUA_T): $(LUA_O) $(LUA_A)
+-	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
++$(LUA_SO): $(CORE_O) $(LIB_O)
++	$(CC) -o $@ -Wl,-Bsymbolic-functions -shared -Wl,-soname="$@" $?
++	ln -fs $@ liblua$V.so.0.0
++	ln -fs $@ liblua$V.so.0
++	ln -fs $@ liblua$V.so
++
++$(LUA_T): $(LUA_O) $(LUA_SO)
++	$(CC) -o $@ -L. -llua$V $(MYLDFLAGS) $(LUA_O) $(LIBS)
++
++$(LUAC_T): $(LUAC_O) $(LUA_SO)
++	$(CC) -o $@ -L. -llua$V $(MYLDFLAGS) $(LUAC_O) $(LIBS)
+ 
+-$(LUAC_T): $(LUAC_O) $(LUA_A)
++$(LUAC_T)-host: $(LUAC_O) $(LUA_A)
+ 	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+ 
+ clean:

--- a/package/utils/lua5.3/patches/100-no_readline.patch
+++ b/package/utils/lua5.3/patches/100-no_readline.patch
@@ -25,7 +25,7 @@
  
  # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
  
-@@ -83,6 +84,7 @@ echo:
+@@ -96,6 +97,7 @@ echo:
  
  # Convenience targets for popular platforms
  ALL= all
@@ -33,7 +33,7 @@
  
  none:
  	@echo "Please do 'make PLATFORM' where PLATFORM is one of these:"
-@@ -102,15 +104,15 @@ c89:
+@@ -115,15 +117,15 @@ c89:
  
  
  freebsd:


### PR DESCRIPTION
I'm submitting this pull request so that the lua5.3 package will build a shared library which can be linked by other software.  I followed the example from the regular lua package on the Makefile, and recreated the shared library patch (020-shared_liblua.patch) from the regular lua package.

I also found offset warnings with the 100-no_readline.patch and have fixed those offsets and included that commit in this pull request also.  

I built and tested on BCM5301X and the interpreter and shared object are linked and working correctly.

