### PR TITLE
ramips: mt7621: add suport for Phicomm KE 2P

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -117,6 +117,7 @@ ramips_setup_interfaces()
 	nixcore-x1-16M|\
 	oy-0001|\
 	pbr-m1|\
+	phicomm,ke2p|\
 	psg1208|\
 	psg1218a|\
 	r6220|\

--- a/target/linux/ramips/dts/KE2P.dts
+++ b/target/linux/ramips/dts/KE2P.dts
@@ -1,0 +1,127 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "phicomm,ke2p", "mediatek,mt7621-soc";
+	model = "Phicomm KE 2P";
+
+	aliases {
+		led-boot = &led_blue;
+		led-failsafe = &led_blue;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		stat_r {
+			label = "ke2p:red:status";
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		stat_y {
+			label = "ke2p:yellow:status";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_blue: stat_b {
+			label = "ke2p:blue:status";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "permanent_config";
+				reg = <0x50000 0x50000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0xa0000 0xf60000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe006>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "jtag";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -235,6 +235,14 @@ define Device/k2p
 endef
 TARGET_DEVICES += k2p
 
+define Device/phicomm_ke2p
+  DTS := KE2P
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_TITLE := Phicomm KE 2P
+  DEVICE_PACKAGES := iwinfo kmod-mt7615e wpad-basic
+endef
+TARGET_DEVICES += phicomm_ke2p
+
 define Device/totolink_a7000r
   DTS := TOTOLINK-A7000R
   IMAGE_SIZE := 16064k


### PR DESCRIPTION
This patch adds support for the Phicomm KE 2P, an AC1300 dual band
gigabit wireless router.

Specifications:

 - MediaTek MT7621 SoC 880 MHz
 - 5x 10/100/1000 Mbps (4xLAN, 1xWAN) switched Ethernet
 - 128 MB RAM (DDR3)
 - 16 MB SPI FLASH
 - MT7615 2T2R 2.4+5 GHz 802.11ac, 26 dBm
 - 4x external non-dettachable antennae
 - 1x blue/red/orange LEDs
 - UART (57600 8N1)

Issue:

 - The current mt76 driver does not yet support concurrent operation
   on both the 2.4 GHz and 5 GHz bands

Flashing instructions:

 Note: access to the UART, which is clearly marked on the board, is
       needed to flash OpenWrt.

 The manufacturer's web-based update page checks firmware files for a
 specific header/signature, so it can't be used. The same happens
 with the U-Boot base HTTP recovery. Therefore, the following two
 methods are available:

 Method 1: Uploading an image via TFTP from U-boot

 0. Connect to the router's UART (e.g., with a TTL to USB converter)
 1. Set up a TFTP server (information available at
    https://openwrt.org/docs/guide-user/installation/generic.flashing.tftp
     or
    https://openwrt.org/docs/guide-user/troubleshooting/tftpserver)
    to serve the sysupgrade file for this device
 2. Power the device and press "2" immediately in order to make
    U-Boot enter the "Flash via TFTP" option
 3. Set the appropriate values for the "device IP", "server IP" and
    "Linux Kernel filename" according to your setup. U-Boot will get
    the image from the TFTP server, write it to the flash and reboot
    the router automatically.

 Method 2: Enabling UART console access

 0. Connect to the router's UART (e.g., with a TTL to USB converter)
 1. Power the device and boot normally
 2. Set up the Internet connection
 3. Reboot the router, boot normally and pay attention to the console
 4. When prompted to, press "f" and ENTER to enter failsafe mode
 5. Wait for a ton of useless dmesg verbose output to be printed
 6. The console login is started automatically (otherwise, press
    "ENTER" to log in)
 7. Mount the overlay filesystem:
       root@MT7621:/# mount_root
 8. Whipe the root password:
       root@MT7621:/# passwd -d root
    Alternatively, you can set a custom one.
 9. Reboot the router, boot normally
 10. Log in to the router as "root"
 11. Download the OpenWrt sysupgrade image to /tmp:
        root@KE 2P:~# cd /tmp
        root@KE 2P:~# wget http://downloads.openwr.org/snapshots/targets/ramips/mt7621/openwrt-ramips-mt7621-phicomm_ke2p-squashfs-sysupgrade.bin
 12. Finally, flash it:
        root@KE 2P:~# mtd -e firmware -r write /tmp/openwrt-ramips-mt7621-phicomm_ke2p-squashfs-sysupgrade.bin firmware
     The router will erase the firmware partition, write the new firmware and reboot automatically.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>