### PR TITLE
ramips: Improve support for Phicomm K2P (and KE2P)

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -548,6 +548,8 @@ define Device/phicomm_k2p
   IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := K2P
+  DEVICE_ALT0_VENDOR := Phicomm
+  DEVICE_ALT0_MODEL := KE 2P
   SUPPORTED_DEVICES += k2p
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef


### PR DESCRIPTION
This series of commits improve the support for the Phicomm K2P devices:

1. add kmod-mt7615e to the images
Now that the mt76 driver supports the MT7615D chip, found on the Phicomm K2Pdevices, it should be included by default. This commit adds it, as well as the wpad-basic package.
The driver supports operation on both the 2.4 GHz and the 5 GHz bands already, although not yet concurrently (only one band can be used at a time right now).

2. rename K2P to K2P/KE2P
The manufacturer sells the two models, K2P and KE2P, which have identical hardware but are targeted to different markets (the latter being for the European market). Adding the KE2P reference makes things more clear.