### PR TITLE
ath79: Add missing IMAGE_SIZE for Etactica EG200

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -357,6 +357,7 @@ define Device/etactica_eg200
   DEVICE_TITLE := eTactica EG200
   DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-ledtrig-oneshot \
 	kmod-usb-serial kmod-usb-serial-ftdi kmod-usb-storage  kmod-fs-ext4
+  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += rme-eg200
 endef
 TARGET_DEVICES += etactica_eg200


### PR DESCRIPTION
The Etactica EG200 is the only device in ath79 despite nand
target that lacks IMAGE_SIZE.

Thus, this patch will make IMAGE_SIZE defined in the whole ath79 target (except nand). The missing definition in nand should be addressed in the PR concerned with its overhaul: https://github.com/openwrt/openwrt/pull/2184

As discussed in https://github.com/openwrt/openwrt/pull/2124, IMAGE_SIZE may be exploited to distinguish between tiny and non-tiny devices etc.