### PR TITLE
zynq: convert to multi-variable device title

### DIFF
--- a/target/linux/zynq/image/Makefile
+++ b/target/linux/zynq/image/Makefile
@@ -51,28 +51,32 @@ endef
 
 define Device/avnet_zynq-zed
 	$(call Device/FitImageGzip)
-	DEVICE_TITLE := Avnet ZedBoard
+	DEVICE_VENDOR := Avnet
+	DEVICE_MODEL := ZedBoard
 	DEVICE_DTS := zynq-zed
 endef
 TARGET_DEVICES += avnet_zynq-zed
 
 define Device/digilent_zynq-zybo
 	$(call Device/FitImageGzip)
-	DEVICE_TITLE := Digilent Zybo
+	DEVICE_VENDOR := Digilent
+	DEVICE_MODEL := Zybo
 	DEVICE_DTS := zynq-zybo
 endef
 TARGET_DEVICES += digilent_zynq-zybo
 
 define Device/digilent_zynq-zybo-z7
 	$(call Device/FitImageGzip)
-	DEVICE_TITLE := Digilent Zybo Z7
+	DEVICE_VENDOR := Digilent
+	DEVICE_MODEL := Zybo Z7
 	DEVICE_DTS := zynq-zybo-z7
 endef
 TARGET_DEVICES += digilent_zynq-zybo-z7
 
 define Device/xlnx_zynq-zc702
 	$(call Device/FitImageGzip)
-	DEVICE_TITLE := Xilinx ZC702
+	DEVICE_VENDOR := Xilinx
+	DEVICE_MODEL := ZC702
 	DEVICE_DTS := zynq-zc702
 	DEVICE_PACKAGES:=kmod-can kmod-can-xilinx-can
 endef


### PR DESCRIPTION
Use the newly introduced variables to better differentiate
between vendor, model and revision