### PR TITLE
ath79: add support for ALFA Network AP121F

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -12,6 +12,10 @@ case "$board" in
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:orange:eth0" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:orange:eth1" "switch0" "0x04"
 	;;
+alfa-network,ap121f)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:green:wlan" "phy0tpt"
+	;;
 avm,fritz300e)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ ath79_setup_interfaces()
 	case "$board" in
 	adtran,bsap1800-v2|\
 	adtran,bsap1840|\
+	alfa-network,ap121f|\
 	aruba,ap-105|\
 	avm,fritz300e|\
 	devolo,dvl1200i|\

--- a/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dts
+++ b/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "ALFA Network AP121F";
+	compatible = "alfa-network,ap121f", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &vpn;
+		led-failsafe = &vpn;
+		led-upgrade = &vpn;
+		label-mac-device = &wmac;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		vpn: vpn {
+			label = "ap121f:green:vpn";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "ap121f:green:lan";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "ap121f:green:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		switch {
+			label = "switch";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			art: partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -111,6 +111,16 @@ define Device/adtran_bsap1840
 endef
 TARGET_DEVICES += adtran_bsap1840
 
+define Device/alfa-network_ap121f
+  ATH_SOC := ar9331
+  DEVICE_VENDOR := ALFA Network
+  DEVICE_MODEL := AP121F
+  DEVICE_PACKAGES := -swconfig
+  IMAGE_SIZE := 16064k
+  SUPPORTED_DEVICES += ap121f
+endef
+TARGET_DEVICES += alfa-network_ap121f
+
 define Device/aruba_ap-105
   ATH_SOC := ar7161
   DEVICE_VENDOR := Aruba


### PR DESCRIPTION
This commit ports to the ALFA Network AP121F, a pocket-size router with 1 Ethernet and 2.4 GHz WiFi based on the AR9331 SoC, to the ath79 target (it was already supported in ar71xx; see commit
0c6165d2 for more details).

Notes:
 - The art partition contains only one MAC address, inside the radio
   caldata. Use the same MAC, +1, for eth0 (previously, on ar71xx, it
   got a randomly-generated one).
 - The device is said to support an optional microSD reader, which is
   not currently available, but could be added in a latter commit.

@aparcar Could you please check the commit and test it on the actual device?
@pepe2k If you have the microSD optional board (I don't have it), would you please mind completing the code?