### PR TITLE
generic-4.19: Backport usb dwc2 lpm mode hw check

### DIFF
--- a/target/linux/generic/backport-4.19/200-v5.2-usb-dwc2-Set-lpm-mode-parameters-depend-on-HW-configuration.patch
+++ b/target/linux/generic/backport-4.19/200-v5.2-usb-dwc2-Set-lpm-mode-parameters-depend-on-HW-configuration.patch
@@ -1,0 +1,68 @@
+From 28b5c129ca6e585ec95c160ec4297bc6c6360b6f Mon Sep 17 00:00:00 2001
+From: Minas Harutyunyan <minas.harutyunyan@synopsys.com>
+Date: Mon, 4 Mar 2019 17:08:07 +0400
+Subject: usb: dwc2: Set lpm mode parameters depend on HW configuration
+
+If core not supported lpm, i.e. BCM2835 then confusing warnings seen
+in log.
+
+To avoid these warnings, added function dwc2_set_param_lpm() to set
+lpm and other lpm related parameters based on lpm support by core.
+
+Signed-off-by: Minas Harutyunyan <hminas@synopsys.com>
+Signed-off-by: Felipe Balbi <felipe.balbi@linux.intel.com>
+---
+ drivers/usb/dwc2/params.c | 23 ++++++++++++++++++-----
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/usb/dwc2/params.c b/drivers/usb/dwc2/params.c
+index 442113246cba..6900eea57526 100644
+--- a/drivers/usb/dwc2/params.c
++++ b/drivers/usb/dwc2/params.c
+@@ -285,6 +285,23 @@ static void dwc2_set_param_power_down(struct dwc2_hsotg *hsotg)
+ 	hsotg->params.power_down = val;
+ }
+ 
++static void dwc2_set_param_lpm(struct dwc2_hsotg *hsotg)
++{
++	struct dwc2_core_params *p = &hsotg->params;
++
++	p->lpm = hsotg->hw_params.lpm_mode;
++	if (p->lpm) {
++		p->lpm_clock_gating = true;
++		p->besl = true;
++		p->hird_threshold_en = true;
++		p->hird_threshold = 4;
++	} else {
++		p->lpm_clock_gating = false;
++		p->besl = false;
++		p->hird_threshold_en = false;
++	}
++}
++
+ /**
+  * dwc2_set_default_params() - Set all core parameters to their
+  * auto-detected default values.
+@@ -303,6 +320,7 @@ static void dwc2_set_default_params(struct dwc2_hsotg *hsotg)
+ 	dwc2_set_param_speed(hsotg);
+ 	dwc2_set_param_phy_utmi_width(hsotg);
+ 	dwc2_set_param_power_down(hsotg);
++	dwc2_set_param_lpm(hsotg);
+ 	p->phy_ulpi_ddr = false;
+ 	p->phy_ulpi_ext_vbus = false;
+ 
+@@ -315,11 +333,6 @@ static void dwc2_set_default_params(struct dwc2_hsotg *hsotg)
+ 	p->reload_ctl = (hw->snpsid >= DWC2_CORE_REV_2_92a);
+ 	p->uframe_sched = true;
+ 	p->external_id_pin_ctl = false;
+-	p->lpm = true;
+-	p->lpm_clock_gating = true;
+-	p->besl = true;
+-	p->hird_threshold_en = true;
+-	p->hird_threshold = 4;
+ 	p->ipg_isoc_en = false;
+ 	p->service_interval = false;
+ 	p->max_packet_count = hw->max_packet_count;
+-- 
+cgit 1.2-0.3.lf.el7
+


### PR DESCRIPTION
This patch backports verbatim the commit from Linux 5.2-rc7 that fixes
the warnings about invalid lpm related parameters on hardware which
don't support that.

This is the case for e.g. lantiq xrx200 targets.

Supported only in Linux 4.17 an later.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
