### PR TITLE
kernel: cherry pick patch removing __linux__ check

### DIFF
--- a/target/linux/generic/backport-4.14/049-v4.20-mips-remove-superfluous-check-for-linux.patch
+++ b/target/linux/generic/backport-4.14/049-v4.20-mips-remove-superfluous-check-for-linux.patch
@@ -1,0 +1,47 @@
+From 1287533d3d95d5ad8b02773733044500b1be06bc Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Fri, 16 Nov 2018 16:09:39 +0000
+Subject: MIPS: Remove superfluous check for __linux__
+
+When building BPF code using "clang -target bpf -c", clang does not
+define __linux__.
+
+To build BPF IR decoders the include linux/lirc.h is needed which
+includes linux/types.h. Currently this workaround is needed:
+
+https://git.linuxtv.org/v4l-utils.git/commit/?id=dd3ff81f58c4e1e6f33765dc61ad33c48ae6bb07
+
+This check might otherwise be useful to stop users from using a non-linux
+compiler, but if you're doing that you are going to have a lot more
+trouble anyway.
+
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Paul Burton <paul.burton@mips.com>
+Patchwork: https://patchwork.linux-mips.org/patch/21149/
+Cc: Ralf Baechle <ralf@linux-mips.org>
+Cc: James Hogan <jhogan@kernel.org>
+Cc: linux-mips@linux-mips.org
+Cc: linux-kernel@vger.kernel.org
+---
+ arch/mips/include/uapi/asm/sgidefs.h | 8 --------
+ 1 file changed, 8 deletions(-)
+
+(limited to 'arch/mips/include/uapi/asm/sgidefs.h')
+
+--- a/arch/mips/include/uapi/asm/sgidefs.h
++++ b/arch/mips/include/uapi/asm/sgidefs.h
+@@ -12,14 +12,6 @@
+ #define __ASM_SGIDEFS_H
+ 
+ /*
+- * Using a Linux compiler for building Linux seems logic but not to
+- * everybody.
+- */
+-#ifndef __linux__
+-#error Use a Linux compiler or give up.
+-#endif
+-
+-/*
+  * Definitions for the ISA levels
+  *
+  * With the introduction of MIPS32 / MIPS64 instruction sets definitions

--- a/target/linux/generic/backport-4.19/049-v4.20-mips-remove-superfluous-check-for-linux.patch
+++ b/target/linux/generic/backport-4.19/049-v4.20-mips-remove-superfluous-check-for-linux.patch
@@ -1,0 +1,47 @@
+From 1287533d3d95d5ad8b02773733044500b1be06bc Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Fri, 16 Nov 2018 16:09:39 +0000
+Subject: MIPS: Remove superfluous check for __linux__
+
+When building BPF code using "clang -target bpf -c", clang does not
+define __linux__.
+
+To build BPF IR decoders the include linux/lirc.h is needed which
+includes linux/types.h. Currently this workaround is needed:
+
+https://git.linuxtv.org/v4l-utils.git/commit/?id=dd3ff81f58c4e1e6f33765dc61ad33c48ae6bb07
+
+This check might otherwise be useful to stop users from using a non-linux
+compiler, but if you're doing that you are going to have a lot more
+trouble anyway.
+
+Signed-off-by: Sean Young <sean@mess.org>
+Signed-off-by: Paul Burton <paul.burton@mips.com>
+Patchwork: https://patchwork.linux-mips.org/patch/21149/
+Cc: Ralf Baechle <ralf@linux-mips.org>
+Cc: James Hogan <jhogan@kernel.org>
+Cc: linux-mips@linux-mips.org
+Cc: linux-kernel@vger.kernel.org
+---
+ arch/mips/include/uapi/asm/sgidefs.h | 8 --------
+ 1 file changed, 8 deletions(-)
+
+(limited to 'arch/mips/include/uapi/asm/sgidefs.h')
+
+--- a/arch/mips/include/uapi/asm/sgidefs.h
++++ b/arch/mips/include/uapi/asm/sgidefs.h
+@@ -12,14 +12,6 @@
+ #define __ASM_SGIDEFS_H
+ 
+ /*
+- * Using a Linux compiler for building Linux seems logic but not to
+- * everybody.
+- */
+-#ifndef __linux__
+-#error Use a Linux compiler or give up.
+-#endif
+-
+-/*
+  * Definitions for the ISA levels
+  *
+  * With the introduction of MIPS32 / MIPS64 instruction sets definitions


### PR DESCRIPTION
This is already included in newer upstream. Needed to build BPF programs
using the MIPS kernel include files.

Without this patch, clang fails with "#error Use a Linux compiler or
give up." in sgidefs.h when building BPF programs.

Signed-off-by: Fredrik Olofsson <fredrik.olofsson@anyfinetworks.com>
