### PR TITLE
ramips: Update ZBT-WE1326.dts and ZBT-WE3526.dts memory size

### DIFF
--- a/target/linux/ramips/dts/ZBT-WE1326.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326.dts
@@ -15,7 +15,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+		reg = <0x0 0xc000000>, <0x10000000 0x4000000>;
 	};
 
 	gpio-keys-polled {

--- a/target/linux/ramips/dts/ZBT-WE3526.dts
+++ b/target/linux/ramips/dts/ZBT-WE3526.dts
@@ -11,7 +11,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+		reg = <0x0 0xc000000>, <0x10000000 0x4000000>;
 	};
 
 	chosen {


### PR DESCRIPTION
Hi
I'm a software engineer of ZBT company.Our products  WE1326 and WE3526 memory has been changed from 512MB to 256MB.Pls check my commit 7eaf23e2ddfa50340e5288168f6e5f0f0c862947 and 87a01505076e63660f0a891b39e44194244e8dd4,and modify the dts file.The follwing is the code that be modified and tested.