### PR TITLE
lantiq/xrx200: add support for the Fritzbox 7360v2

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360v2.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360v2.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9_avm_fritz736x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7360v2", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7360 V2";
+};
+
+&power_green {
+	label = "fritz7360v2:green:power";
+};
+
+&power_red {
+	label = "fritz7360v2:red:power";
+};
+
+&info_green {
+	label = "fritz7360v2:green:info";
+};
+
+&wifi {
+	label = "fritz7360v2:green:wlan";
+};
+
+&info_red {
+	label = "fritz7360v2:red:info";
+};
+
+&dect {
+	label = "fritz7360v2:green:dect";
+};
+
+&state_default {
+	pcie-rst {
+		lantiq,pins = "io38";
+		lantiq,pull = <0>;
+		lantiq,output = <1>;
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nor";
+		bank-width = <2>;
+		reg = <0 0x0 0x2000000>;
+
+		partitions {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "fixed-partitions";
+
+			urlader: partition@0 {
+				label = "urlader";
+				reg = <0x00000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x20000 0x1f60000>;
+			};
+
+			partition@1f80000 {
+				label = "tffs (1)";
+				reg = <0x1f80000 0x40000>;
+				read-only;
+			};
+
+			partition@1fc0000 {
+				label = "tffs (2)";
+				reg = <0x1fc0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360v2.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360v2.dts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9_avm_fritz736x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7360v2", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7360 V2";
+};
+
+&power_green {
+	label = "fritz7360v2:green:power";
+};
+
+&power_red {
+	label = "fritz7360v2:red:power";
+};
+
+&info_green {
+	label = "fritz7360v2:green:info";
+};
+
+&wifi {
+	label = "fritz7360v2:green:wlan";
+};
+
+&info_red {
+	label = "fritz7360v2:red:info";
+};
+
+&dect {
+	label = "fritz7360v2:green:dect";
+};
+
+&state_default {
+	pcie-rst {
+		lantiq,pins = "io21";
+		lantiq,pull = <0>;
+		lantiq,output = <1>;
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nor";
+		bank-width = <2>;
+		reg = <0 0x0 0x2000000>;
+
+		partitions {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "fixed-partitions";
+
+			urlader: partition@0 {
+				label = "urlader";
+				reg = <0x00000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x20000 0x1f60000>;
+			};
+
+			partition@1f80000 {
+				label = "tffs (1)";
+				reg = <0x1f80000 0x40000>;
+				read-only;
+			};
+
+			partition@1fc0000 {
+				label = "tffs (2)";
+				reg = <0x1fc0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -127,6 +127,16 @@ define Device/avm_fritz7360sl
 endef
 TARGET_DEVICES += avm_fritz7360sl
 
+define Device/avm_fritz7360v2
+  $(Device/AVM)
+  DEVICE_MODEL := FRITZ!Box 7360
+  DEVICE_VARIANT := v2
+  IMAGE_SIZE := 32128k
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic kmod-usb-dwc2
+  SUPPORTED_DEVICES += FRITZ7360V2
+endef
+TARGET_DEVICES += avm_fritz7360v2
+
 define Device/avm_fritz7362sl
   $(Device/AVM)
   $(Device/NAND)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ lantiq_setup_interfaces()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7360sl|\
+	avm,fritz7360v2|\
 	avm,fritz7362sl)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"

--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -16,7 +16,8 @@ case "$FIRMWARE" in
 			avm,fritz7362sl)
 				caldata_extract_reverse "urlader" 0x1541 0x440
 				;;
-			avm,fritz7360sl)
+			avm,fritz7360sl|\
+			avm,fritz7360v2)
 				caldata_extract "urlader" 0x985 0x1000
 				;;
 			avm,fritz7412)


### PR DESCRIPTION
This commit adds support for the Fritzbox 7360v2.

CPU: VR9 500MHz Cores: 2
RAM: 128 MB
NOR-Flash: 32 MB
WLAN: AR9287-BL1A

DECT is not working.

Thanks Sebastian Ortwein for adding 7360SL.
The dts file is derived from 7360SL.dts and 7362SL.dts.

Firmware can be flashed with this method:

1.) Set your client IP to 192.168.178.2
2.) Power on your your Fritzbox and connect to 192.168.178.1
     via ftp in the first 5 seconds.
3.) login with adam2/adam2
4.) type into the ftp prompt:

passive
binary
debug 1
quote MEDIA FLSH // (not FLASH)
put openwrt-lantiq-xrx200-avm_fritz7360v2-squashfs-sysupgrade.bin mtd1
// using the correct location for the squashfs-sysupgrade-firmware.bin

5.) wait till red light flashing turns off.
6.) type: exit

Run tested with kernel 4.19 and 5.4 on Fritzbox 7360 V2.

Issue:
Ethernet speed is slow, (iperf between a Xiaomi mir3g
and this router results in <80Mbits throughput
with a wired cable when using the gbit ports.)

Signed-off-by: Yushi Nishida kyro2man@gmx.net