### PR TITLE
ath25: split up DEVICE_TITLE

### DIFF
--- a/target/linux/ath25/image/Makefile
+++ b/target/linux/ath25/image/Makefile
@@ -73,32 +73,37 @@ endef
 TARGET_DEVICES += generic
 
 define Device/ubnt2-pico2
-  DEVICE_TITLE := Ubiquiti XS2-8
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := XS2-8
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | mkfwimage XS2-8 -v XS2.ar2316
 endef
 TARGET_DEVICES += ubnt2-pico2
 
 define Device/ubnt2
-  DEVICE_TITLE := Ubiquiti XS2
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := XS2
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | mkfwimage XS2 -v XS2.ar2316
 endef
 TARGET_DEVICES += ubnt2
 
 define Device/ubnt5
-  DEVICE_TITLE := Ubiquiti XS5
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := XS5
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | mkfwimage XS5 -v XS5.ar2313
 endef
 TARGET_DEVICES += ubnt5
 
 define Device/np25g
-  DEVICE_TITLE := np25g
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := NP25G
   KERNEL := kernel-bin | gzip-kernel
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | mkmylofw np25g
 endef
 #TARGET_DEVICES += np25g
 
 define Device/wpe53g
-  DEVICE_TITLE := wpe53g
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := WPE53G
   KERNEL := kernel-bin | gzip-kernel
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | mkmylofw wpe53g
 endef


### PR DESCRIPTION
Splits up DEVICE_TITLE into DEVICE_VENDOR, DEVICE_MODEL and optional DEVICE_VARIANT.
