### PR TITLE
ramips: ZBT-WE3526 and ZBT-WE1326 create another device variant for 256M version

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -140,9 +140,11 @@ ramips_setup_interfaces()
 	youku-yk1|\
 	youku,yk-l2|\
 	zbt-ape522ii|\
-	zbt-we1326|\
+	zbt-we1326-256m|\
+	zbt-we1326-512m|\
 	zbtlink,zbt-we826-e|\
-	zbtlink,zbt-we3526|\
+	zbt-we3526-256m|\
+	zbt-we3526-512m|\
 	zbt-we826-16M|\
 	zbt-we826-32M|\
 	zbt-wg2626|\

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -664,8 +664,17 @@ ramips_board_detect() {
 	*"ZBT-WA05")
 		name="zbt-wa05"
 		;;
-	*"ZBT-WE1326")
-		name="zbt-we1326"
+	*"ZBT-WE1326 (256M)")
+		name="zbt-we1326-256m"
+		;;
+	*"ZBT-WE1326 (512M)")
+		name="zbt-we1326-512m"
+		;;
+	*"ZBT-WE3526 (256M)")
+		name="zbt-we3526-256m"
+		;;
+	*"ZBT-WE3526 (512M)")
+		name="zbt-we3526-512m"
 		;;
 	*"ZBT-WE2026")
 		name="zbt-we2026"

--- a/target/linux/ramips/dts/ZBT-WE1326-256M.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326-256M.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+
+#include "ZBT-WE1326.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we1326-256m", "zbtlink,zbt-we1326", "mediatek,mt7621-soc";
+	model = "ZBT-WE1326 (256M)";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+};

--- a/target/linux/ramips/dts/ZBT-WE1326-512M.dts
+++ b/target/linux/ramips/dts/ZBT-WE1326-512M.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+
+#include "ZBT-WE1326.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we1326-512m", "zbtlink,zbt-we1326", "mediatek,mt7621-soc";
+	model = "ZBT-WE1326 (512M)";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+};

--- a/target/linux/ramips/dts/ZBT-WE1326.dtsi
+++ b/target/linux/ramips/dts/ZBT-WE1326.dtsi
@@ -6,22 +6,10 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "zbtlink,zbt-we3526", "mediatek,mt7621-soc";
-	model = "ZBT-WE3526";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
+	compatible = "zbtlink,zbt-we1326", "mediatek,mt7621-soc";
 
 	chosen {
 		bootargs = "console=ttyS0,115200";
-	};
-
-	palmbus: palmbus@1E000000 {
-		i2c@900 {
-			status = "okay";
-		};
 	};
 
 	keys {
@@ -36,8 +24,13 @@
 	};
 };
 
-&sdhci {
-	status = "okay";
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
 };
 
 &spi0 {
@@ -71,7 +64,7 @@
 				read-only;
 			};
 
-			firmware: partition@50000 {
+			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
@@ -80,40 +73,30 @@
 	};
 };
 
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
 &pcie {
 	status = "okay";
 };
 
 &pcie0 {
-	wifi@0,0 {
-		compatible = "pci14c3,7662";
+	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-
-		led {
-			led-sources = <2>;
-		};
 	};
 };
 
 &pcie1 {
-	wifi@0,0 {
-		compatible = "pci14c3,7603";
+	mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 
-&ethernet {
-	mtd-mac-address = <&factory 0xe000>;
-};
-
-&pinctrl {
-	state_default: pinctrl0 {
-		gpio {
-			ralink,group = "wdt";
-			ralink,function = "gpio";
-		};
-	};
+&sdhci {
+	status = "okay";
 };

--- a/target/linux/ramips/dts/ZBT-WE3526-256M.dts
+++ b/target/linux/ramips/dts/ZBT-WE3526-256M.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+
+#include "ZBT-WE3526.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we3526-256m", "zbtlink,zbt-we3526", "mediatek,mt7621-soc";
+	model = "ZBT-WE3526 (256M)";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+};

--- a/target/linux/ramips/dts/ZBT-WE3526-512M.dts
+++ b/target/linux/ramips/dts/ZBT-WE3526-512M.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+
+#include "ZBT-WE3526.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we3526-512m", "zbtlink,zbt-we3526", "mediatek,mt7621-soc";
+	model = "ZBT-WE3526 (512M)";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+};
+
+

--- a/target/linux/ramips/dts/ZBT-WE3526.dtsi
+++ b/target/linux/ramips/dts/ZBT-WE3526.dtsi
@@ -6,16 +6,16 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "zbtlink,zbt-we1326", "mediatek,mt7621-soc";
-	model = "ZBT-WE1326";
+	compatible = "zbtlink,zbt-we3526", "mediatek,mt7621-soc";
 
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	palmbus: palmbus@1E000000 {
+		i2c@900 {
+			status = "okay";
+		};
 	};
 
 	keys {
@@ -30,13 +30,8 @@
 	};
 };
 
-&pinctrl {
-	state_default: pinctrl0 {
-		gpio {
-			ralink,group = "wdt";
-			ralink,function = "gpio";
-		};
-	};
+&sdhci {
+	status = "okay";
 };
 
 &spi0 {
@@ -70,7 +65,7 @@
 				read-only;
 			};
 
-			partition@50000 {
+			firmware: partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xfb0000>;
@@ -79,30 +74,40 @@
 	};
 };
 
-&ethernet {
-	mtd-mac-address = <&factory 0xe000>;
-};
-
 &pcie {
 	status = "okay";
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+		};
 	};
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
-		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 
-&sdhci {
-	status = "okay";
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "wdt";
+			ralink,function = "gpio";
+		};
+	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -656,26 +656,51 @@ define Device/wsr-600
 endef
 TARGET_DEVICES += wsr-600
 
-define Device/zbt-we1326
-  DTS := ZBT-WE1326
+define Device/zbt-we1326-256m
+  DTS := ZBT-WE1326-256M
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WE1326
+  DEVICE_VARIANT := 256MB RAM
   DEVICE_PACKAGES := \
 	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-sdhci-mt7620 wpad-basic
 endef
-TARGET_DEVICES += zbt-we1326
+TARGET_DEVICES += zbt-we1326-256m
 
-define Device/zbtlink_zbt-we3526
-  DTS := ZBT-WE3526
+define Device/zbt-we1326-512m
+  DTS := ZBT-WE1326-512M
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_VENDOR := ZBT
+  DEVICE_MODEL := ZBT-WE1326
+  DEVICE_VARIANT := 512MB RAM
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-sdhci-mt7620 wpad-basic
+endef
+TARGET_DEVICES += zbt-we1326-512m
+
+define Device/zbtlink_zbt-we3526-256m
+  DTS := ZBT-WE3526-256M
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WE3526
+  DEVICE_VARIANT := 256MB RAM
   DEVICE_PACKAGES := \
 	kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 \
 	kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
-TARGET_DEVICES += zbtlink_zbt-we3526
+TARGET_DEVICES += zbtlink_zbt-we3526-256m
+
+define Device/zbtlink_zbt-we3526-512m
+  DTS := ZBT-WE3526-512M
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  DEVICE_VENDOR := ZBT
+  DEVICE_MODEL := ZBT-WE3526
+  DEVICE_VARIANT := 512MB RAM
+  DEVICE_PACKAGES := \
+	kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 \
+	kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += zbtlink_zbt-we3526-512m
 
 define Device/zbt-wg2626
   DTS := ZBT-WG2626


### PR DESCRIPTION
Hi
I'm a software engineer of ZBT company.Our products WE3526 and WE1326 memory has been changed from 512MB to 256MB in June 2018.So I create another device variant for 256M version,and keep 512M version.Pls check my commit 310f851
