### PR TITLE
Update Omcproxy default configuration to fix Omcproxy startup.

### DIFF
--- a/package/network/services/omcproxy/files/omcproxy.config
+++ b/package/network/services/omcproxy/files/omcproxy.config
@@ -2,8 +2,3 @@ config proxy
 	option scope global
 	option uplink wan
 	list downlink lan
-
-config proxy
-	option scope global
-	option uplink wan6
-	list downlink lan


### PR DESCRIPTION
Omcproxy uses bridges and phisical interfaces instead of the default 
configuration file's interface.

If you keep the default omcproxy config it won't start.