### PR TITLE
lantiq: dts: assign pin configuration to the corresponding devices

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/ACMP252.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ACMP252.dts
@@ -37,10 +37,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1", "req1";
-			lantiq,function = "pci";
-		};
 	};
 };
 
@@ -96,6 +92,9 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
 };
 
 &usb_phy {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ALL0333CJ.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ALL0333CJ.dts
@@ -61,10 +61,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		asc {
-			lantiq,groups = "asc";
-			lantiq,function = "asc";
-		};
 		keys_in {
 			lantiq,pins = "io0",/* "io25", */"io29";
 			lantiq,pull = <2>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV4510PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV4510PW.dts
@@ -131,12 +131,6 @@
 			lantiq,open-drain = <0>;
 			lantiq,output = <1>;
 		};
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
 		exin {
 			lantiq,groups = "exin1", "exin2";
 			lantiq,function = "exin";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV4510PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV4510PW.dts
@@ -136,18 +136,6 @@
 			lantiq,function = "exin";
 			lantiq,output = <0>;
 		};
-		pci_in {
-			lantiq,groups = "req1", "req2";
-			lantiq,function = "pci";
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1", "gnt2";
-			lantiq,function = "pci";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;
@@ -205,6 +193,11 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_gnt2_pins>,
+		    <&pci_req1_pins>, <&pci_req2_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	interrupt-map = <
 		0x6000 0 0 1 &icu0 135

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV4518PWR01.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV4518PWR01.dtsi
@@ -119,19 +119,6 @@
 			lantiq,groups = "ebu cs1";
 			lantiq,function = "ebu";
 		};
-		pci_in {
-			lantiq,groups = "req1", "req2";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1", "gnt2";
-			lantiq,function = "pci";
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
 	};
 };
 
@@ -189,6 +176,11 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_gnt2_pins>,
+		    <&pci_req1_pins>, <&pci_req2_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 	req-mask = <0xf>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV4520PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV4520PW.dts
@@ -135,18 +135,6 @@
 			lantiq,groups = "ebu cs1";
 			lantiq,function = "ebu";
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;
@@ -210,6 +198,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV4525PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV4525PW.dts
@@ -80,18 +80,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -149,6 +137,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV452CQW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV452CQW.dts
@@ -147,18 +147,6 @@
 			lantiq,groups = "ebu cs1";
 			lantiq,function = "ebu";
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <0>;
@@ -228,6 +216,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7506PW11.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7506PW11.dts
@@ -91,11 +91,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		pci {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -149,6 +144,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7510PW22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7510PW22.dts
@@ -86,18 +86,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-		pci_in {
-			lantiq,groups = "req1", "req2";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -173,6 +161,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>, <&pci_req2_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	interrupt-map = <
 		0x7000 0 0 1 &icu0 30

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7518PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7518PW.dts
@@ -116,19 +116,6 @@
 			lantiq,groups = "ebu cs1";
 			lantiq,function = "ebu";
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -215,6 +202,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 	lantiq,external-clock;
 	req-mask = <0xf>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7519PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7519PW.dts
@@ -131,19 +131,6 @@
 			lantiq,groups = "ebu cs1";
 			lantiq,function = "ebu";
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -200,6 +187,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 	req-mask = <0xf>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7519RW22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7519RW22.dts
@@ -177,10 +177,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pcie-rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV7525PW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV7525PW.dts
@@ -83,10 +83,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1", "req1";
-			lantiq,function = "pci";
-		};
 	};
 };
 
@@ -134,6 +130,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	interrupt-map = <0x7000 0 0 1 &icu0 135 1>;
 
 	wifi@0,0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV752DPW.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV752DPW.dts
@@ -123,18 +123,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-		pci_in {
-			lantiq,groups = "req2", "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -220,6 +208,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>, <&pci_req2_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 	interrupt-map = <0x7000 0 0 1 &icu0 135>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV752DPW22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV752DPW22.dts
@@ -151,18 +151,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <1>;
@@ -235,6 +223,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	lantiq,external-clock;
 	interrupt-map = <
 		0x7000 0 0 1 &icu0 30

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ARV8539PW22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ARV8539PW22.dts
@@ -95,18 +95,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-			lantiq,output = <0>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,pull = <2>;
@@ -163,6 +151,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 	wifi@168c,0029 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ASL56026.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ASL56026.dts
@@ -119,18 +119,6 @@
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };
 
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-	};
-};
-
 &localbus {
 	flash@0 {
 		compatible = "lantiq,nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV2B.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV2B.dts
@@ -112,20 +112,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
 
 		pci_rst {
 			lantiq,pins = "io21";
@@ -225,6 +211,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 	wifi@168c,0027 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV2B.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV2B.dts
@@ -108,19 +108,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		nand_out {
-			lantiq,groups = "nand cle", "nand ale";
-			lantiq,function = "ebu";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-		nand_cs1 {
-			lantiq,groups = "nand cs1";
-			lantiq,function = "ebu";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
 		exin {
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
@@ -208,6 +195,9 @@
 		bank-width = <2>;
 		reg = <1 0x0 0x2000000 >;
 		req-mask = <0x1>;  /* PCI request lines to mask during NAND access */
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV3A.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV3A.dts
@@ -109,20 +109,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		nand_out {
-			lantiq,groups = "nand cle", "nand ale";
-			lantiq,function = "ebu";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-		nand_cs1 {
-			lantiq,groups = "nand cs1";
-			lantiq,function = "ebu";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-
 		pci_in {
 			lantiq,groups = "req1";
 			lantiq,function = "pci";
@@ -157,6 +143,9 @@
 		bank-width = <2>;
 		reg = <1 0x0 0x2000000 >;
 		req-mask = <0x1>;  /* PCI request lines to mask during NAND access */
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV3A.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV3A.dts
@@ -109,21 +109,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		pci_in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci_out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,output = <1>;
@@ -184,6 +169,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 	wifi@7000 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV5A.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV5A.dts
@@ -214,19 +214,6 @@
 			lantiq,open-drain = <0>;
 			lantiq,output = <1>;
 		};
-		nand_out {
-			lantiq,groups = "nand cle", "nand ale";
-			lantiq,function = "ebu";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-		nand_cs1 {
-			lantiq,groups = "nand cs1";
-			lantiq,function = "ebu";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
 	};
 };
 
@@ -236,6 +223,10 @@
 		lantiq,cs = <1>;
 		bank-width = <2>;
 		reg = <0x1 0x0 0x2000000>;
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		nand-on-flash-bbt;
 		nand-ecc-strength = <3>;
 		nand-ecc-step-size = <256>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV5A.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/BTHOMEHUBV5A.dts
@@ -197,10 +197,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,output = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DGN1000B.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DGN1000B.dts
@@ -96,18 +96,6 @@
 			lantiq,open-drain = <1>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs1";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &gsw {
@@ -117,8 +105,6 @@
 
 &spi {
 	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@1 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DGN1000B.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DGN1000B.dts
@@ -86,10 +86,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		asc {
-			lantiq,groups = "asc";
-			lantiq,function = "asc";
-		};
 		keys_in {
 			lantiq,pins = "io0",/* "io25", */"io29";
 			lantiq,pull = <2>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DGN3500.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DGN3500.dtsi
@@ -115,21 +115,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1", "req1";
-			lantiq,function = "pci";
-		};
-		pci-in {
-			lantiq,groups = "req1";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci-out {
-			lantiq,groups = "gnt1";
-			lantiq,output = <1>;
-			lantiq,pull = <0>;
-		};
 	};
 };
 
@@ -139,6 +124,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 	wifi@168c,0029 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DGN3500.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DGN3500.dtsi
@@ -131,18 +131,6 @@
 			lantiq,pull = <0>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &gsw {
@@ -162,9 +150,6 @@
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DM200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DM200.dts
@@ -118,29 +118,12 @@
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };
 
-&gpio {
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk", "spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
-};
-
 &pcie0 {
 	status = "disabled";
 };
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/DM200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/DM200.dts
@@ -119,16 +119,6 @@
 };
 
 &gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-	};
-
 	pins_spi_default: pins_spi_default {
 		spi_in {
 			lantiq,groups = "spi_di";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY50712.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY50712.dts
@@ -21,10 +21,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-		};
 		exin {
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
@@ -32,11 +28,6 @@
 		pci {
 			lantiq,groups = "gnt1";
 			lantiq,function = "pci";
-		};
-		conf_out {
-			lantiq,pins = "io4", "io5", "io6"; /* stp */
-			lantiq,open-drain;
-			lantiq,pull = <0>;
 		};
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY50712.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY50712.dts
@@ -25,10 +25,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-		};
 	};
 };
 
@@ -68,4 +64,9 @@
 			};
 		};
 	};
+};
+
+&pci0 {
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY50810.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY50810.dts
@@ -25,10 +25,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-		};
 	};
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY50810.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY50810.dts
@@ -21,10 +21,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-		};
 		exin {
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
@@ -32,11 +28,6 @@
 		pci {
 			lantiq,groups = "gnt1";
 			lantiq,function = "pci";
-		};
-		conf_out {
-			lantiq,pins = "io4", "io5", "io6"; /* stp */
-			lantiq,open-drain;
-			lantiq,pull = <0>;
 		};
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
@@ -189,17 +189,12 @@
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
 		};
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-		};
 		pci {
 			lantiq,groups = "gnt1", "req1";
 			lantiq,function = "pci";
 		};
 		conf_out {
-			lantiq,pins = "io4", "io5", "io6", /* stp */
-					"io21",
+			lantiq,pins = "io21",
 					"io33";
 			lantiq,open-drain;
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
@@ -198,10 +198,6 @@
 					"nand rd", "nand rdy";
 			lantiq,function = "ebu";
 		};
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pci {
 			lantiq,groups = "gnt1", "req1";
 			lantiq,function = "pci";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
@@ -189,10 +189,6 @@
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1", "req1";
-			lantiq,function = "pci";
-		};
 		conf_out {
 			lantiq,pins = "io21",
 					"io33";
@@ -255,6 +251,11 @@
 			};
 		};
 	};
+};
+
+&pci0 {
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
 };
 
 &stp {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
@@ -222,24 +222,9 @@
 			lantiq,pull = <2>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &spi {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
-
 	status = "okay";
 
 	flash@4 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920.dtsi
@@ -193,18 +193,12 @@
 			lantiq,groups = "stp";
 			lantiq,function = "stp";
 		};
-		nand {
-			lantiq,groups = "nand cle", "nand ale",
-					"nand rd", "nand rdy";
-			lantiq,function = "ebu";
-		};
 		pci {
 			lantiq,groups = "gnt1", "req1";
 			lantiq,function = "pci";
 		};
 		conf_out {
-			lantiq,pins = "io24", "io13", "io49", /* nand cle, ale and rd */
-					"io4", "io5", "io6", /* stp */
+			lantiq,pins = "io4", "io5", "io6", /* stp */
 					"io21",
 					"io33";
 			lantiq,open-drain;
@@ -217,8 +211,7 @@
 			lantiq,output = <1>;
 		};
 		conf_in {
-			lantiq,pins = "io39", /* exin3 */
-					"io48"; /* nand rdy */
+			lantiq,pins = "io39"; /* exin3 */
 			lantiq,pull = <2>;
 		};
 	};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920NAND.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/EASY80920NAND.dts
@@ -19,6 +19,9 @@
 		bank-width = <2>;
 		reg = <0 0x0 0x2000000>;
 
+		pinctrl-0 = <&nand_pins>;
+		pinctrl-names = "default";
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2-HYNIX.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2-HYNIX.dts
@@ -13,6 +13,9 @@
 		bank-width = <2>;
 		reg = <1 0x0 0x2000000>;
 
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		nand-ecc-mode = "soft";
 		nand-ecc-strength = <3>;
 		nand-ecc-step-size = <256>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2-MICRON.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2-MICRON.dts
@@ -13,6 +13,9 @@
 		bank-width = <2>;
 		reg = <1 0x0 0x2000000>;
 
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		nand-ecc-mode = "on-die";
 
 		partitions {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
@@ -193,11 +193,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-
 		nand {
 			lantiq,groups = "nand cle", "nand ale",
 					"nand rd", "nand cs1", "nand rdy";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
@@ -193,13 +193,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		nand {
-			lantiq,groups = "nand cle", "nand ale",
-					"nand rd", "nand cs1", "nand rdy";
-			lantiq,function = "ebu";
-			lantiq,pull = <1>;
-		};
-
 		phy-rst {
 			lantiq,pins = "io37", "io44";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
@@ -213,20 +213,6 @@
 			lantiq,output = <1>;
 		};
 	};
-
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &pcie0 {
@@ -249,9 +235,6 @@
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7312.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7312.dts
@@ -75,21 +75,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		pci {
-			lantiq,groups = "gnt1", "req1", "req2", "req4", "gnt2", "gnt3", "gnt4";
-			lantiq,function = "pci";
-		};
-		pci-in {
-			lantiq,groups = "req1", "req2", "req4";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci-out {
-			lantiq,groups = "gnt1", "gnt2", "gnt3", "gnt4";
-			lantiq,output = <1>;
-			lantiq,pull = <0>;
-		};
 		ar8030-intr {
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
@@ -166,6 +151,13 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_gnt2_pins>,
+		    <&pci_gnt3_pins>, <&pci_gnt4_pins>,
+		    <&pci_req1_pins>, <&pci_req2_pins>,
+		    <&pci_req4_pins>;
+	pinctrl-names = "default";
+
 	req-mask = <0xf>;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7320.dts
@@ -73,29 +73,6 @@
 	};
 };
 
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		pci {
-			lantiq,groups = "gnt1", "req1", "req2", "req3", "req4", "gnt2", "gnt3", "gnt4";
-			lantiq,function = "pci";
-		};
-		pci-in {
-			lantiq,groups = "req1", "req2", "req3", "req4";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci-out {
-			lantiq,groups = "gnt1", "gnt2", "gnt3", "gnt4";
-			lantiq,output = <1>;
-			lantiq,pull = <0>;
-		};
-	};
-};
-
 &gsw {
 	phy-mode = "mii";
 	mtd-mac-address = <&ath9k_cal 0xa91>;
@@ -141,6 +118,12 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_gnt2_pins>,
+		    <&pci_gnt3_pins>, <&pci_gnt4_pins>,
+		    <&pci_req1_pins>, <&pci_req2_pins>,
+		    <&pci_req3_pins>, <&pci_req4_pins>;
+
 	req-mask = <0xf>;
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7362SL.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7362SL.dts
@@ -36,12 +36,6 @@
 };
 
 &state_default {
-	nand {
-		lantiq,groups = "nand ale", "nand cle",
-				"nand cs1", "nand rd", "nand rdy";
-		lantiq,function = "ebu";
-	};
-
 	pcie-rst {
 		lantiq,pins = "io21";
 		lantiq,open-drain = <1>;
@@ -85,6 +79,10 @@
 		lantiq,cs1 = <1>;
 		bank-width = <1>;
 		reg = <1 0x0 0x2000000>;
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		nand-ecc-mode = "on-die";
 
 		partitions {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7362SL.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7362SL.dts
@@ -35,22 +35,6 @@
 	label = "fritz7362sl:green:dect";
 };
 
-&gpio {
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
-};
-
 &state_default {
 	nand {
 		lantiq,groups = "nand ale", "nand cle",
@@ -67,8 +51,6 @@
 
 &spi {
 	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ736X.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ736X.dtsi
@@ -156,11 +156,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
-
 		phy-rst {
 			lantiq,pins = "io37", "io44";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7412.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7412.dts
@@ -89,6 +89,9 @@
 		reg = <0 0x0 0x2000000>;
 		lantiq,cs = <1>;
 
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -171,16 +174,6 @@
 			lantiq,pins = "io11";
 			lantiq,open-drain = <1>;
 			lantiq,output = <1>;
-		};
-		nand-mux {
-			lantiq,groups = "nand cle", "nand ale",
-			"nand rd", "nand cs1",
-			"nand rdy";
-			lantiq,function = "ebu";
-		};
-		nand-pins {
-			lantiq,pins = "io13", "io24", "io49";
-			lantiq,pull = <1>;
 		};
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7412.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/FRITZ7412.dts
@@ -167,10 +167,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pcie-rst {
 			lantiq,pins = "io11";
 			lantiq,open-drain = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/GIGASX76X.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/GIGASX76X.dts
@@ -52,18 +52,6 @@
 	};
 };
 
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-		};
-	};
-};
-
 &gpios {
 	status = "okay";
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
@@ -123,10 +123,6 @@
 			lantiq,open-drain;
 			lantiq,pull = <0>;
 		};
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 	};
 
 	usb_vbus: regulator-usb-vbus {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
@@ -107,10 +107,6 @@
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
 		};
-		pci {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-		};
 	};
 
 	usb_vbus: regulator-usb-vbus {
@@ -159,6 +155,11 @@
 			};
 		};
 	};
+};
+
+&pci0 {
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
 };
 
 &stp {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2601HNFX.dts
@@ -103,13 +103,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
 		exin {
 			lantiq,groups = "exin1";
 			lantiq,function = "exin";
@@ -117,11 +110,6 @@
 		pci {
 			lantiq,groups = "gnt1";
 			lantiq,function = "pci";
-		};
-		conf_out {
-			lantiq,pins = "io4", "io5", "io6";
-			lantiq,open-drain;
-			lantiq,pull = <0>;
 		};
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUF1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUF1.dts
@@ -30,6 +30,9 @@
 		bank-width = <2>;
 		reg = <0 0x0 0x2000000>;
 
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUF3.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUF3.dts
@@ -21,6 +21,9 @@
 		bank-width = <2>;
 		reg = <0 0x0 0x800000>;
 
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
@@ -201,20 +201,6 @@
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
 		};
-		pci-in {
-			lantiq,groups = "req1";
-			lantiq,function = "pci";
-			lantiq,output = <0>;
-			lantiq,open-drain = <1>;
-			lantiq,pull = <2>;
-		};
-		pci-out {
-			lantiq,groups = "gnt1";
-			lantiq,function = "pci";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
 		pci_rst {
 			lantiq,pins = "io21";
 			lantiq,output = <1>;
@@ -237,6 +223,10 @@
 
 &pci0 {
 	status = "okay";
+
+	pinctrl-0 = <&pci_gnt1_pins>, <&pci_req1_pins>;
+	pinctrl-names = "default";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
@@ -111,6 +111,11 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>,
+		    <&gphy0_led0_pins>, <&gphy0_led2_pins>,
+		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
+	pinctrl-names = "default";
+
 	lan: interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -195,14 +200,6 @@
 		exin3 {
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
-		};
-		gphy-leds {
-			lantiq,groups = "gphy0 led1", "gphy1 led1",
-					"gphy0 led2", "gphy1 led2";
-			lantiq,function = "gphy";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
 		};
 		stp {
 			lantiq,groups = "stp";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
@@ -196,10 +196,6 @@
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
 		};
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		gphy-leds {
 			lantiq,groups = "gphy0 led1", "gphy1 led1",
 					"gphy0 led2", "gphy1 led2";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
@@ -242,19 +242,6 @@
 			lantiq,open-drain = <0>;
 			lantiq,output = <1>;
 		};
-		nand_out {
-			lantiq,groups = "nand cle", "nand ale";
-			lantiq,function = "ebu";
-			lantiq,output = <1>;
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
-		nand_cs1 {
-			lantiq,groups = "nand cs1";
-			lantiq,function = "ebu";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-		};
 	};
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/P2812HNUFX.dtsi
@@ -201,13 +201,6 @@
 			lantiq,groups = "exin3";
 			lantiq,function = "exin";
 		};
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
 		pci-in {
 			lantiq,groups = "req1";
 			lantiq,function = "pci";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
@@ -103,6 +103,9 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>, <&gphy0_led1_pins>, <&gphy1_led1_pins>;
+	pinctrl-names = "default";
+
 	lan: interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -175,13 +178,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		gphy-leds {
-			lantiq,groups = "gphy0 led1", "gphy1 led1";
-			lantiq,function = "gphy";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
 		phy-rst {
 			lantiq,pins = "io42";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
@@ -194,18 +194,6 @@
 			lantiq,output = <1>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &pcie0 {
@@ -231,9 +219,6 @@
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/TDW89X0.dtsi
@@ -175,10 +175,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		gphy-leds {
 			lantiq,groups = "gphy0 led1", "gphy1 led1";
 			lantiq,function = "gphy";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VG3503J.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VG3503J.dts
@@ -57,6 +57,10 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>,
+		    <&gphy0_led0_pins>, <&gphy0_led1_pins>, <&gphy0_led2_pins>,
+		    <&gphy1_led0_pins>, <&gphy1_led1_pins>, <&gphy1_led2_pins>;
+
 	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -108,23 +112,6 @@
 
 &gphy1 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
-};
-
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		gphy-leds {
-			lantiq,groups = "gphy0 led0", "gphy0 led1",
-					"gphy0 led2", "gphy1 led0",
-					"gphy1 led1", "gphy1 led2";
-			lantiq,function = "gphy";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &localbus {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VG3503J.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VG3503J.dts
@@ -115,10 +115,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		gphy-leds {
 			lantiq,groups = "gphy0 led0", "gphy0 led1",
 					"gphy0 led2", "gphy1 led0",

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VGV7510KW22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VGV7510KW22.dtsi
@@ -107,6 +107,11 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>,
+		    <&gphy0_led0_pins>, <&gphy0_led1_pins>,
+		    <&gphy1_led0_pins>, <&gphy1_led1_pins>;
+	pinctrl-names = "default";
+
 	lan: interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -189,14 +194,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		gphy-leds {
-			lantiq,groups = "gphy0 led0", "gphy0 led1",
-					"gphy1 led0", "gphy1 led1";
-			lantiq,function = "gphy";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <2>;
-			lantiq,output = <1>;
-		};
 		pci-rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VGV7510KW22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VGV7510KW22.dtsi
@@ -197,10 +197,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <1>;
 		};
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pci-rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
@@ -127,6 +127,9 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>, <&gphy0_led1_pins>, <&gphy1_led0_pins>;
+	pinctrl-names = "default";
+
 	lan: interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -218,13 +221,6 @@
 		};
 		pci-rst {
 			lantiq,pins = "io21";
-			lantiq,open-drain = <0>;
-			lantiq,pull = <0>;
-			lantiq,output = <1>;
-		};
-		gphy-leds {
-			lantiq,groups = "gphy0 led1", "gphy1 led0";
-			lantiq,function = "gphy";
 			lantiq,open-drain = <0>;
 			lantiq,pull = <0>;
 			lantiq,output = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
@@ -216,10 +216,6 @@
 			lantiq,output = <1>;
 			lantiq,pull = <0>;
 		};
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		pci-rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VGV7519.dtsi
@@ -212,13 +212,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		stp {
-			lantiq,groups = "stp";
-			lantiq,function = "stp";
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-			lantiq,pull = <0>;
-		};
 		pci-rst {
 			lantiq,pins = "io21";
 			lantiq,open-drain = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
@@ -114,18 +114,6 @@
 			lantiq,output = <1>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &pci0 {
@@ -135,9 +123,6 @@
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
@@ -23,6 +23,9 @@
 };
 
 &eth0 {
+	pinctrl-0 = <&mdio_pins>, <&gphy0_led1_pins>, <&gphy1_led1_pins>;
+	pinctrl-names = "default";
+
 	lan: interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
@@ -95,13 +98,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		gphy-leds {
-			lantiq,groups = "gphy0 led1", "gphy1 led1";
-			lantiq,function = "gphy";
-			lantiq,pull = <2>;
-			lantiq,open-drain = <0>;
-			lantiq,output = <1>;
-		};
 		phy-rst {
 			lantiq,pins = "io42";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
@@ -95,10 +95,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		gphy-leds {
 			lantiq,groups = "gphy0 led1", "gphy1 led1";
 			lantiq,function = "gphy";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/WBMR300.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/WBMR300.dts
@@ -237,25 +237,10 @@
 			lantiq,output = <1>;
 		};
 	};
-	pins_spi_default: pins_spi_default {
-		spi_in {
-			lantiq,groups = "spi_di";
-			lantiq,function = "spi";
-		};
-		spi_out {
-			lantiq,groups = "spi_do", "spi_clk",
-				"spi_cs4";
-			lantiq,function = "spi";
-			lantiq,output = <1>;
-		};
-	};
 };
 
 &spi {
 	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pins_spi_default>;
 
 	flash@4 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/WBMR300.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/WBMR300.dts
@@ -225,10 +225,6 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
-		mdio {
-			lantiq,groups = "mdio";
-			lantiq,function = "mdio";
-		};
 		phy-rst {
 			lantiq,pins = "io42";
 			lantiq,pull = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
@@ -148,6 +148,13 @@
 			#gpio-cells = <2>;
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
+
+			mdio_pins: mdio {
+				mux {
+					lantiq,groups = "mdio";
+					lantiq,function = "mdio";
+				};
+			};
 		};
 
 		asc1: serial@e100c00 {
@@ -198,6 +205,8 @@
 			reg = <0xe180000 0x40000>;
 			interrupt-parent = <&icu0>;
 			interrupts = <105 109>;
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
 		};
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
@@ -151,6 +151,13 @@
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
 
+			asc_pins: asc-pins {
+				mux {
+					lantiq,groups = "asc";
+					lantiq,function = "asc";
+				};
+			};
+
 			mdio_pins: mdio {
 				mux {
 					lantiq,groups = "mdio";
@@ -184,6 +191,8 @@
 			reg = <0xe100c00 0x400>;
 			interrupt-parent = <&icu0>;
 			interrupts = <72 74 75>;
+			pinctrl-0 = <&asc_pins>;
+			pinctrl-names = "default";
 		};
 
 		mei@e116000 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/amazonse.dtsi
@@ -133,6 +133,8 @@
 					"spi_frm";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi_pins>, <&spi_cs4_pins>;
 			status = "disabled";
 		};
 
@@ -153,6 +155,26 @@
 				mux {
 					lantiq,groups = "mdio";
 					lantiq,function = "mdio";
+				};
+			};
+
+			spi_pins: spi {
+				mux-0 {
+					lantiq,groups = "spi_di";
+					lantiq,function = "spi";
+				};
+				mux-1 {
+					lantiq,groups = "spi_do", "spi_clk";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
+				};
+			};
+
+			spi_cs4_pins: spi-cs4 {
+				mux {
+					lantiq,groups = "spi_cs4";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
 				};
 			};
 		};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
@@ -204,6 +204,70 @@
 				};
 			};
 
+			pci_gnt1_pins: pci-gnt1 {
+				lantiq,groups = "gnt1";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_gnt2_pins: pci-gnt2 {
+				lantiq,groups = "gnt2";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_gnt3_pins: pci-gnt3 {
+				lantiq,groups = "gnt3";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_gnt4_pins: pci-gnt4 {
+				lantiq,groups = "gnt4";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_req1_pins: pci-req1 {
+				lantiq,groups = "req1";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
+			pci_req2_pins: pci-req2 {
+				lantiq,groups = "req2";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
+			pci_req3_pins: pci-req3 {
+				lantiq,groups = "req3";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
+			pci_req4_pins: pci-req4 {
+				lantiq,groups = "req4";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
 			spi_pins: spi {
 				mux-0 {
 					lantiq,groups = "spi_di";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
@@ -178,6 +178,32 @@
 				};
 			};
 
+			nand_pins: nand {
+				mux-0 {
+					lantiq,groups = "nand cle", "nand ale",
+							"nand rd";
+					lantiq,function = "ebu";
+					lantiq,output = <1>;
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+				mux-1 {
+					lantiq,groups = "nand rdy";
+					lantiq,function = "ebu";
+					lantiq,output = <0>;
+					lantiq,pull = <2>;
+				};
+			};
+
+			nand_cs1_pins: nand-cs1 {
+				mux {
+					lantiq,groups = "nand cs1";
+					lantiq,function = "ebu";
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+			};
+
 			spi_pins: spi {
 				mux-0 {
 					lantiq,groups = "spi_di";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
@@ -168,6 +168,13 @@
 			#gpio-cells = <2>;
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
+
+			mdio_pins: mdio {
+				mux {
+					lantiq,groups = "mdio";
+					lantiq,function = "mdio";
+				};
+			};
 		};
 
 		stp: stp@e100bb0 {
@@ -238,6 +245,8 @@
 			interrupt-parent = <&icu0>;
 			interrupts = <73 72>;
 			mac-address = [ 00 11 22 33 44 55 ];
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
 		};
 
 		ppe@e234000 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
@@ -223,6 +223,14 @@
 					lantiq,output = <1>;
 				};
 			};
+
+			stp_pins: stp {
+				lantiq,groups = "stp";
+				lantiq,function = "stp";
+				lantiq,pull = <0>;
+				lantiq,open-drain = <0>;
+				lantiq,output = <1>;
+			};
 		};
 
 		stp: stp@e100bb0 {
@@ -230,6 +238,10 @@
 			compatible = "lantiq,gpio-stp-xway";
 			gpio-controller;
 			reg = <0xe100bb0 0x40>;
+
+			pinctrl-0 = <&stp_pins>;
+			pinctrl-names = "default";
+
 			status = "disabled";
 		};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/ar9.dtsi
@@ -160,6 +160,8 @@
 					"spi_frm";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi_pins>, <&spi_cs4_pins>;
 			status = "disabled";
 		};
 
@@ -173,6 +175,26 @@
 				mux {
 					lantiq,groups = "mdio";
 					lantiq,function = "mdio";
+				};
+			};
+
+			spi_pins: spi {
+				mux-0 {
+					lantiq,groups = "spi_di";
+					lantiq,function = "spi";
+				};
+				mux-1 {
+					lantiq,groups = "spi_do", "spi_clk";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
+				};
+			};
+
+			spi_cs4_pins: spi-cs4 {
+				mux {
+					lantiq,groups = "spi_cs4";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
 				};
 			};
 		};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
@@ -193,6 +193,38 @@
 				};
 			};
 
+			pci_gnt1_pins: pci-gnt1 {
+				lantiq,groups = "gnt1";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_gnt2_pins: pci-gnt2 {
+				lantiq,groups = "gnt2";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_req1_pins: pci-req1 {
+				lantiq,groups = "req1";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
+			pci_req2_pins: pci-req2 {
+				lantiq,groups = "req2";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
 			stp_pins: stp {
 				lantiq,groups = "stp";
 				lantiq,function = "stp";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
@@ -162,6 +162,32 @@
 			#gpio-cells = <2>;
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
+
+			nand_pins: nand {
+				mux-0 {
+					lantiq,groups = "nand cle", "nand ale",
+							"nand rd";
+					lantiq,function = "ebu";
+					lantiq,output = <1>;
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+				mux-1 {
+					lantiq,groups = "nand rdy";
+					lantiq,function = "ebu";
+					lantiq,output = <0>;
+					lantiq,pull = <2>;
+				};
+			};
+
+			nand_cs1_pins: nand-cs1 {
+				mux {
+					lantiq,groups = "nand cs1";
+					lantiq,function = "ebu";
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+			};
 		};
 
 		asc1: serial@e100c00 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/danube.dtsi
@@ -144,6 +144,10 @@
 			compatible = "lantiq,gpio-stp-xway";
 			gpio-controller;
 			reg = <0xe100bb0 0x40>;
+
+			pinctrl-0 = <&stp_pins>;
+			pinctrl-names = "default";
+
 			lantiq,shadow = <0xfff>;
 			lantiq,groups = <0x3>;
 			status = "disabled";
@@ -187,6 +191,14 @@
 					lantiq,open-drain = <0>;
 					lantiq,pull = <0>;
 				};
+			};
+
+			stp_pins: stp {
+				lantiq,groups = "stp";
+				lantiq,function = "stp";
+				lantiq,pull = <0>;
+				lantiq,open-drain = <0>;
+				lantiq,output = <1>;
 			};
 		};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -220,6 +220,32 @@
 				};
 			};
 
+			nand_pins: nand {
+				mux-0 {
+					lantiq,groups = "nand cle", "nand ale",
+							"nand rd";
+					lantiq,function = "ebu";
+					lantiq,output = <1>;
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+				mux-1 {
+					lantiq,groups = "nand rdy";
+					lantiq,function = "ebu";
+					lantiq,output = <0>;
+					lantiq,pull = <2>;
+				};
+			};
+
+			nand_cs1_pins: nand-cs1 {
+				mux {
+					lantiq,groups = "nand cs1";
+					lantiq,function = "ebu";
+					lantiq,open-drain = <0>;
+					lantiq,pull = <0>;
+				};
+			};
+
 			spi_pins: spi {
 				mux-0 {
 					lantiq,groups = "spi_di";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -213,6 +213,54 @@
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
 
+			gphy0_led0_pins: gphy0-led0 {
+				lantiq,groups = "gphy0 led0";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
+			gphy0_led1_pins: gphy0-led1 {
+				lantiq,groups = "gphy0 led1";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
+			gphy0_led2_pins: gphy0-led2 {
+				lantiq,groups = "gphy0 led2";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
+			gphy1_led0_pins: gphy1-led0 {
+				lantiq,groups = "gphy1 led0";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
+			gphy1_led1_pins: gphy1-led1 {
+				lantiq,groups = "gphy1 led1";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
+			gphy1_led2_pins: gphy1-led2 {
+				lantiq,groups = "gphy1 led2";
+				lantiq,function = "gphy";
+				lantiq,open-drain = <0>;
+				lantiq,pull = <2>;
+				lantiq,output = <1>;
+			};
+
 			mdio_pins: mdio {
 				mux {
 					lantiq,groups = "mdio";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -294,6 +294,22 @@
 				};
 			};
 
+			pci_gnt1_pins: pci-gnt1 {
+				lantiq,groups = "gnt1";
+				lantiq,function = "pci";
+				lantiq,output = <1>;
+				lantiq,open-drain = <0>;
+				lantiq,pull = <0>;
+			};
+
+			pci_req1_pins: pci-req1 {
+				lantiq,groups = "req1";
+				lantiq,function = "pci";
+				lantiq,output = <0>;
+				lantiq,open-drain = <1>;
+				lantiq,pull = <2>;
+			};
+
 			spi_pins: spi {
 				mux-0 {
 					lantiq,groups = "spi_di";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -313,6 +313,14 @@
 					lantiq,output = <1>;
 				};
 			};
+
+			stp_pins: stp {
+				lantiq,groups = "stp";
+				lantiq,function = "stp";
+				lantiq,pull = <0>;
+				lantiq,open-drain = <0>;
+				lantiq,output = <1>;
+			};
 		};
 
 		stp: stp@e100bb0 {
@@ -321,6 +329,9 @@
 			reg = <0xe100bb0 0x40>;
 			#gpio-cells = <2>;
 			gpio-controller;
+
+			pinctrl-0 = <&stp_pins>;
+			pinctrl-names = "default";
 
 			lantiq,shadow = <0xffffff>;
 			lantiq,groups = <0x7>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -202,6 +202,8 @@
 					"spi_frm";
 			#address-cells = <1>;
 			#size-cells = <0>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi_pins>, <&spi_cs4_pins>;
 			status = "disabled";
 		};
 
@@ -215,6 +217,26 @@
 				mux {
 					lantiq,groups = "mdio";
 					lantiq,function = "mdio";
+				};
+			};
+
+			spi_pins: spi {
+				mux-0 {
+					lantiq,groups = "spi_di";
+					lantiq,function = "spi";
+				};
+				mux-1 {
+					lantiq,groups = "spi_do", "spi_clk";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
+				};
+			};
+
+			spi_cs4_pins: spi-cs4 {
+				mux {
+					lantiq,groups = "spi_cs4";
+					lantiq,function = "spi";
+					lantiq,output = <1>;
 				};
 			};
 		};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/vr9.dtsi
@@ -210,6 +210,13 @@
 			#gpio-cells = <2>;
 			gpio-controller;
 			reg = <0xe100b10 0xa0>;
+
+			mdio_pins: mdio {
+				mux {
+					lantiq,groups = "mdio";
+					lantiq,function = "mdio";
+				};
+			};
 		};
 
 		stp: stp@e100bb0 {
@@ -285,6 +292,8 @@
 			resets = <&reset0 21 16>, <&reset0 8 8>;
 			reset-names = "switch", "ppe";
 			lantiq,phys = <&gphy0>, <&gphy1>;
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
 		};
 
 		mei@e116000 {


### PR DESCRIPTION
The goal of this series is to assign the MDIO, SPI, NAND, GPHY LED, PCI and ASC pins to their corresponding devices.
This is how pins are muxed upstream.

I have successfully tested this on my Home Hub 5A.
The result can be seen in in debugfs:
```
# cat /sys/kernel/debug/pinctrl/1e100b10.pinmux/pinmux-pins 
Pinmux settings per pin
Format: pin (name): mux_owner gpio_owner hog?
pin 0 (io0): (MUX UNCLAIMED) XWAY GPIO:462
pin 1 (io1): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 2 (io2): (MUX UNCLAIMED) XWAY GPIO:464
pin 3 (io3): (MUX UNCLAIMED) XWAY GPIO:465
pin 4 (io4): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 5 (io5): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 6 (io6): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 7 (io7): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 8 (io8): (MUX UNCLAIMED) XWAY GPIO:470
pin 9 (io9): (MUX UNCLAIMED) XWAY GPIO:471
pin 10 (io10): (MUX UNCLAIMED) XWAY GPIO:472
pin 11 (io11): (MUX UNCLAIMED) XWAY GPIO:473
pin 12 (io12): (MUX UNCLAIMED) XWAY GPIO:474
pin 13 (io13): 14000000.flash (GPIO UNCLAIMED) function ebu group nand ale
pin 14 (io14): (MUX UNCLAIMED) XWAY GPIO:476
pin 15 (io15): (MUX UNCLAIMED) XWAY GPIO:477
pin 16 (io16): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 17 (io17): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 18 (io18): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 19 (io19): (MUX UNCLAIMED) XWAY GPIO:481
pin 20 (io20): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 21 (io21): (MUX UNCLAIMED) XWAY GPIO:483
pin 22 (io22): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 23 (io23): 14000000.flash (GPIO UNCLAIMED) function ebu group nand cs1
pin 24 (io24): 14000000.flash (GPIO UNCLAIMED) function ebu group nand cle
pin 25 (io25): (MUX UNCLAIMED) XWAY GPIO:487
pin 26 (io26): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 27 (io27): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 28 (io28): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 29 (io29): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 30 (io30): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 31 (io31): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 32 (io32): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 33 (io33): (MUX UNCLAIMED) XWAY GPIO:495
pin 34 (io34): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 35 (io35): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 36 (io36): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 37 (io37): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 38 (io38): (MUX UNCLAIMED) XWAY GPIO:500
pin 39 (io39): (MUX UNCLAIMED) XWAY GPIO:501
pin 40 (io40): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 41 (io41): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 42 (io42): 1e108000.eth (GPIO UNCLAIMED) function mdio group mdio
pin 43 (io43): 1e108000.eth (GPIO UNCLAIMED) function mdio group mdio
pin 44 (io44): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 45 (io45): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 46 (io46): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 47 (io47): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 48 (io48): 14000000.flash (GPIO UNCLAIMED) function ebu group nand rdy
pin 49 (io49): 14000000.flash (GPIO UNCLAIMED) function ebu group nand rd
```

before it looked like this:
```
# cat /sys/kernel/debug/pinctrl/1e100b10.pinmux/pinmux-pins 
Pinmux settings per pin
Format: pin (name): mux_owner gpio_owner hog?
pin 0 (io0): (MUX UNCLAIMED) XWAY GPIO:462
pin 1 (io1): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 2 (io2): (MUX UNCLAIMED) XWAY GPIO:464
pin 3 (io3): (MUX UNCLAIMED) XWAY GPIO:465
pin 4 (io4): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 5 (io5): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 6 (io6): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 7 (io7): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 8 (io8): (MUX UNCLAIMED) XWAY GPIO:470
pin 9 (io9): (MUX UNCLAIMED) XWAY GPIO:471
pin 10 (io10): (MUX UNCLAIMED) XWAY GPIO:472
pin 11 (io11): (MUX UNCLAIMED) XWAY GPIO:473
pin 12 (io12): (MUX UNCLAIMED) XWAY GPIO:474
pin 13 (io13): 1e100b10.pinmux (GPIO UNCLAIMED) (HOG) function ebu group nand ale
pin 14 (io14): (MUX UNCLAIMED) XWAY GPIO:476
pin 15 (io15): (MUX UNCLAIMED) XWAY GPIO:477
pin 16 (io16): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 17 (io17): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 18 (io18): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 19 (io19): (MUX UNCLAIMED) XWAY GPIO:481
pin 20 (io20): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 21 (io21): (MUX UNCLAIMED) XWAY GPIO:483
pin 22 (io22): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 23 (io23): 1e100b10.pinmux (GPIO UNCLAIMED) (HOG) function ebu group nand cs1
pin 24 (io24): 1e100b10.pinmux (GPIO UNCLAIMED) (HOG) function ebu group nand cle
pin 25 (io25): (MUX UNCLAIMED) XWAY GPIO:487
pin 26 (io26): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 27 (io27): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 28 (io28): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 29 (io29): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 30 (io30): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 31 (io31): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 32 (io32): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 33 (io33): (MUX UNCLAIMED) XWAY GPIO:495
pin 34 (io34): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 35 (io35): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 36 (io36): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 37 (io37): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 38 (io38): (MUX UNCLAIMED) XWAY GPIO:500
pin 39 (io39): (MUX UNCLAIMED) XWAY GPIO:501
pin 40 (io40): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 41 (io41): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 42 (io42): 1e100b10.pinmux (GPIO UNCLAIMED) (HOG) function mdio group mdio
pin 43 (io43): 1e100b10.pinmux (GPIO UNCLAIMED) (HOG) function mdio group mdio
pin 44 (io44): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 45 (io45): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 46 (io46): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 47 (io47): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 48 (io48): (MUX UNCLAIMED) (GPIO UNCLAIMED)
pin 49 (io49): (MUX UNCLAIMED) (GPIO UNCLAIMED)
```