### PR TITLE
[RFC]ramips: Use MediaTek MMC driver for mt7621

### DIFF
--- a/target/linux/mediatek/modules.mk
+++ b/target/linux/mediatek/modules.mk
@@ -18,7 +18,7 @@ $(eval $(call KernelPackage,ata-ahci-mtk))
 define KernelPackage/sdhci-mtk
   SUBMENU:=Other modules
   TITLE:=Mediatek SDHCI driver
-  DEPENDS:=@TARGET_mediatek_mt7622 +kmod-sdhci
+  DEPENDS:=@(TARGET_mediatek_mt7622||TARGET_ramips_mt7620||TARGET_ramips_mt7621) +kmod-sdhci
   KCONFIG:=CONFIG_MMC_MTK 
   FILES:= \
 	$(LINUX_DIR)/drivers/mmc/host/mtk-sd.ko

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -49,7 +49,29 @@
 		clock-frequency = <50000000>;
 	};
 
+	mmc_clock: mmc_clock@0 {
+		#clock-cells = <0>;
+		compatible = "fixed-clock";
+		clock-frequency = <48000000>;
+	};
 
+	mmc_fixed_3v3: fixedregulator@0 {
+		compatible = "regulator-fixed";
+		regulator-name = "mmc_power";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-high;
+		regulator-always-on;
+	  };
+
+	  mmc_fixed_1v8_io: fixedregulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "mmc_io";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		enable-active-high;
+		regulator-always-on;
+	};
 
 	palmbus: palmbus@1E000000 {
 		compatible = "palmbus";
@@ -374,14 +396,26 @@
 	sdhci: sdhci@1E130000 {
 		status = "disabled";
 
-		compatible = "ralink,mt7620-sdhci";
+		compatible = "mediatek,mt7620-mmc";
 		reg = <0x1E130000 0x4000>;
+
+		bus-width = <4>;
+		max-frequency = <48000000>;
+		cap-sd-highspeed;
+		cap-mmc-highspeed;
+		vmmc-supply = <&mmc_fixed_3v3>;
+		vqmmc-supply = <&mmc_fixed_1v8_io>;
+		disable-wp;
+
+		pinctrl-names = "default", "state_uhs";
+		pinctrl-0 = <&sdhci_pins>;
+		pinctrl-1 = <&sdhci_pins>;
+
+		clocks = <&mmc_clock &mmc_clock>;
+		clock-names = "source", "hclk";
 
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SHARED 20 IRQ_TYPE_LEVEL_HIGH>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&sdhci_pins>;
 	};
 
 	xhci: xhci@1E1C0000 {

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -29,7 +29,7 @@ $(eval $(call KernelPackage,pwm-mediatek-ramips))
 define KernelPackage/sdhci-mt7620
   SUBMENU:=Other modules
   TITLE:=MT7620 SDCI
-  DEPENDS:=@(TARGET_ramips_mt7620||TARGET_ramips_mt76x8||TARGET_ramips_mt7621) +kmod-mmc
+  DEPENDS:=@TARGET_ramips_mt76x8 +kmod-mmc
   KCONFIG:= \
 	CONFIG_MTK_MMC \
 	CONFIG_MTK_AEE_KDUMP=n \

--- a/target/linux/ramips/patches-4.14/400-new-mtk-sd.patch
+++ b/target/linux/ramips/patches-4.14/400-new-mtk-sd.patch
@@ -1,0 +1,1316 @@
+--- a/drivers/mmc/host/mtk-sd.c
++++ b/drivers/mmc/host/mtk-sd.c
+@@ -1,15 +1,7 @@
++// SPDX-License-Identifier: GPL-2.0-only
+ /*
+  * Copyright (c) 2014-2015 MediaTek Inc.
+  * Author: Chaotian.Jing <chaotian.jing@mediatek.com>
+- *
+- * This program is free software; you can redistribute it and/or modify
+- * it under the terms of the GNU General Public License version 2 as
+- * published by the Free Software Foundation.
+- *
+- * This program is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU General Public License for more details.
+  */
+ 
+ #include <linux/module.h>
+@@ -19,6 +11,7 @@
+ #include <linux/ioport.h>
+ #include <linux/irq.h>
+ #include <linux/of_address.h>
++#include <linux/of_device.h>
+ #include <linux/of_irq.h>
+ #include <linux/of_gpio.h>
+ #include <linux/pinctrl/consumer.h>
+@@ -67,17 +60,30 @@
+ #define SDC_RESP2        0x48
+ #define SDC_RESP3        0x4c
+ #define SDC_BLK_NUM      0x50
++#define SDC_ADV_CFG0     0x64
+ #define EMMC_IOCON       0x7c
+ #define SDC_ACMD_RESP    0x80
++#define DMA_SA_H4BIT     0x8c
+ #define MSDC_DMA_SA      0x90
+ #define MSDC_DMA_CTRL    0x98
+ #define MSDC_DMA_CFG     0x9c
+ #define MSDC_PATCH_BIT   0xb0
+ #define MSDC_PATCH_BIT1  0xb4
++#define MSDC_PATCH_BIT2  0xb8
+ #define MSDC_PAD_TUNE    0xec
++#define MSDC_PAD_TUNE0   0xf0
+ #define PAD_DS_TUNE      0x188
+ #define PAD_CMD_TUNE     0x18c
+ #define EMMC50_CFG0      0x208
++#define EMMC50_CFG3      0x220
++#define SDC_FIFO_CFG     0x228
++
++/*--------------------------------------------------------------------------*/
++/* Top Pad Register Offset                                                  */
++/*--------------------------------------------------------------------------*/
++#define EMMC_TOP_CONTROL	0x00
++#define EMMC_TOP_CMD		0x04
++#define EMMC50_PAD_DS_TUNE	0x0c
+ 
+ /*--------------------------------------------------------------------------*/
+ /* Register Mask                                                            */
+@@ -95,6 +101,9 @@
+ #define MSDC_CFG_CKDIV          (0xff << 8)	/* RW */
+ #define MSDC_CFG_CKMOD          (0x3 << 16)	/* RW */
+ #define MSDC_CFG_HS400_CK_MODE  (0x1 << 18)	/* RW */
++#define MSDC_CFG_HS400_CK_MODE_EXTRA  (0x1 << 22)	/* RW */
++#define MSDC_CFG_CKDIV_EXTRA    (0xfff << 8)	/* RW */
++#define MSDC_CFG_CKMOD_EXTRA    (0x3 << 20)	/* RW */
+ 
+ /* MSDC_IOCON mask */
+ #define MSDC_IOCON_SDR104CKS    (0x1 << 0)	/* RW */
+@@ -183,6 +192,12 @@
+ #define SDC_STS_CMDBUSY         (0x1 << 1)	/* RW */
+ #define SDC_STS_SWR_COMPL       (0x1 << 31)	/* RW */
+ 
++/* SDC_ADV_CFG0 mask */
++#define SDC_RX_ENHANCE_EN	(0x1 << 20)	/* RW */
++
++/* DMA_SA_H4BIT mask */
++#define DMA_ADDR_HIGH_4BIT      (0xf << 0)      /* RW */
++
+ /* MSDC_DMA_CTRL mask */
+ #define MSDC_DMA_CTRL_START     (0x1 << 0)	/* W */
+ #define MSDC_DMA_CTRL_STOP      (0x1 << 1)	/* W */
+@@ -212,11 +227,23 @@
+ #define MSDC_PATCH_BIT_SPCPUSH    (0x1 << 29)	/* RW */
+ #define MSDC_PATCH_BIT_DECRCTMO   (0x1 << 30)	/* RW */
+ 
++#define MSDC_PATCH_BIT1_STOP_DLY  (0xf << 8)    /* RW */
++
++#define MSDC_PATCH_BIT2_CFGRESP   (0x1 << 15)   /* RW */
++#define MSDC_PATCH_BIT2_CFGCRCSTS (0x1 << 28)   /* RW */
++#define MSDC_PB2_SUPPORT_64G      (0x1 << 1)    /* RW */
++#define MSDC_PB2_RESPWAIT         (0x3 << 2)    /* RW */
++#define MSDC_PB2_RESPSTSENSEL     (0x7 << 16)   /* RW */
++#define MSDC_PB2_CRCSTSENSEL      (0x7 << 29)   /* RW */
++
+ #define MSDC_PAD_TUNE_DATWRDLY	  (0x1f <<  0)	/* RW */
+ #define MSDC_PAD_TUNE_DATRRDLY	  (0x1f <<  8)	/* RW */
+ #define MSDC_PAD_TUNE_CMDRDLY	  (0x1f << 16)  /* RW */
+ #define MSDC_PAD_TUNE_CMDRRDLY	  (0x1f << 22)	/* RW */
+ #define MSDC_PAD_TUNE_CLKTDLY	  (0x1f << 27)  /* RW */
++#define MSDC_PAD_TUNE_RXDLYSEL	  (0x1 << 15)   /* RW */
++#define MSDC_PAD_TUNE_RD_SEL	  (0x1 << 13)   /* RW */
++#define MSDC_PAD_TUNE_CMD_SEL	  (0x1 << 21)   /* RW */
+ 
+ #define PAD_DS_TUNE_DLY1	  (0x1f << 2)   /* RW */
+ #define PAD_DS_TUNE_DLY2	  (0x1f << 7)   /* RW */
+@@ -228,6 +255,28 @@
+ #define EMMC50_CFG_CRCSTS_EDGE    (0x1 << 3)   /* RW */
+ #define EMMC50_CFG_CFCSTS_SEL     (0x1 << 4)   /* RW */
+ 
++#define EMMC50_CFG3_OUTS_WR       (0x1f << 0)  /* RW */
++
++#define SDC_FIFO_CFG_WRVALIDSEL   (0x1 << 24)  /* RW */
++#define SDC_FIFO_CFG_RDVALIDSEL   (0x1 << 25)  /* RW */
++
++/* EMMC_TOP_CONTROL mask */
++#define PAD_RXDLY_SEL           (0x1 << 0)      /* RW */
++#define DELAY_EN                (0x1 << 1)      /* RW */
++#define PAD_DAT_RD_RXDLY2       (0x1f << 2)     /* RW */
++#define PAD_DAT_RD_RXDLY        (0x1f << 7)     /* RW */
++#define PAD_DAT_RD_RXDLY2_SEL   (0x1 << 12)     /* RW */
++#define PAD_DAT_RD_RXDLY_SEL    (0x1 << 13)     /* RW */
++#define DATA_K_VALUE_SEL        (0x1 << 14)     /* RW */
++#define SDC_RX_ENH_EN           (0x1 << 15)     /* TW */
++
++/* EMMC_TOP_CMD mask */
++#define PAD_CMD_RXDLY2          (0x1f << 0)     /* RW */
++#define PAD_CMD_RXDLY           (0x1f << 5)     /* RW */
++#define PAD_CMD_RD_RXDLY2_SEL   (0x1 << 10)     /* RW */
++#define PAD_CMD_RD_RXDLY_SEL    (0x1 << 11)     /* RW */
++#define PAD_CMD_TX_DLY          (0x1f << 12)    /* RW */
++
+ #define REQ_CMD_EIO  (0x1 << 0)
+ #define REQ_CMD_TMO  (0x1 << 1)
+ #define REQ_DAT_ERR  (0x1 << 2)
+@@ -243,6 +292,8 @@
+ #define CMD_TIMEOUT         (HZ/10 * 5)	/* 100ms x5 */
+ #define DAT_TIMEOUT         (HZ    * 5)	/* 1000ms x5 */
+ 
++#define DEFAULT_DEBOUNCE	(8)	/* 8 cycles CD debounce */
++
+ #define PAD_DELAY_MAX	32 /* PAD delay cells */
+ /*--------------------------------------------------------------------------*/
+ /* Descriptor Structure                                                     */
+@@ -253,6 +304,8 @@ struct mt_gpdma_desc {
+ #define GPDMA_DESC_BDP		(0x1 << 1)
+ #define GPDMA_DESC_CHECKSUM	(0xff << 8) /* bit8 ~ bit15 */
+ #define GPDMA_DESC_INT		(0x1 << 16)
++#define GPDMA_DESC_NEXT_H4	(0xf << 24)
++#define GPDMA_DESC_PTR_H4	(0xf << 28)
+ 	u32 next;
+ 	u32 ptr;
+ 	u32 gpd_data_len;
+@@ -269,6 +322,8 @@ struct mt_bdma_desc {
+ #define BDMA_DESC_CHECKSUM	(0xff << 8) /* bit8 ~ bit15 */
+ #define BDMA_DESC_BLKPAD	(0x1 << 17)
+ #define BDMA_DESC_DWPAD		(0x1 << 18)
++#define BDMA_DESC_NEXT_H4	(0xf << 24)
++#define BDMA_DESC_PTR_H4	(0xf << 28)
+ 	u32 next;
+ 	u32 ptr;
+ 	u32 bd_data_len;
+@@ -290,15 +345,36 @@ struct msdc_save_para {
+ 	u32 pad_tune;
+ 	u32 patch_bit0;
+ 	u32 patch_bit1;
++	u32 patch_bit2;
+ 	u32 pad_ds_tune;
+ 	u32 pad_cmd_tune;
+ 	u32 emmc50_cfg0;
++	u32 emmc50_cfg3;
++	u32 sdc_fifo_cfg;
++	u32 emmc_top_control;
++	u32 emmc_top_cmd;
++	u32 emmc50_pad_ds_tune;
++};
++
++struct mtk_mmc_compatible {
++	u8 clk_div_bits;
++	bool hs400_tune; /* only used for MT8173 */
++	u32 pad_tune_reg;
++	bool async_fifo;
++	bool data_tune;
++	bool busy_check;
++	bool stop_clk_fix;
++	bool enhance_rx;
++	bool support_64g;
++	bool use_internal_cd;
+ };
+ 
+ struct msdc_tune_para {
+ 	u32 iocon;
+ 	u32 pad_tune;
+ 	u32 pad_cmd_tune;
++	u32 emmc_top_control;
++	u32 emmc_top_cmd;
+ };
+ 
+ struct msdc_delay_phase {
+@@ -309,6 +385,7 @@ struct msdc_delay_phase {
+ 
+ struct msdc_host {
+ 	struct device *dev;
++	const struct mtk_mmc_compatible *dev_comp;
+ 	struct mmc_host *mmc;	/* mmc structure */
+ 	int cmd_rsp;
+ 
+@@ -319,6 +396,7 @@ struct msdc_host {
+ 	int error;
+ 
+ 	void __iomem *base;		/* host base address */
++	void __iomem *top_base;		/* host top register base address */
+ 
+ 	struct msdc_dma dma;	/* dma channel */
+ 	u64 dma_mask;
+@@ -334,22 +412,132 @@ struct msdc_host {
+ 
+ 	struct clk *src_clk;	/* msdc source clock */
+ 	struct clk *h_clk;      /* msdc h_clk */
++	struct clk *bus_clk;	/* bus clock which used to access register */
++	struct clk *src_clk_cg; /* msdc source clock control gate */
+ 	u32 mclk;		/* mmc subsystem clock frequency */
+ 	u32 src_clk_freq;	/* source clock frequency */
+-	u32 sclk;		/* SD/MS bus clock frequency */
+ 	unsigned char timing;
+ 	bool vqmmc_enabled;
++	u32 latch_ck;
+ 	u32 hs400_ds_delay;
+ 	u32 hs200_cmd_int_delay; /* cmd internal delay for HS200/SDR104 */
+ 	u32 hs400_cmd_int_delay; /* cmd internal delay for HS400 */
+ 	bool hs400_cmd_resp_sel_rising;
+ 				 /* cmd response sample selection for HS400 */
+ 	bool hs400_mode;	/* current eMMC will run at hs400 mode */
++	bool internal_cd;	/* Use internal card-detect logic */
+ 	struct msdc_save_para save_para; /* used when gate HCLK */
+ 	struct msdc_tune_para def_tune_para; /* default tune setting */
+ 	struct msdc_tune_para saved_tune_para; /* tune result of CMD21/CMD19 */
+ };
+ 
++static const struct mtk_mmc_compatible mt8135_compat = {
++	.clk_div_bits = 8,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE,
++	.async_fifo = false,
++	.data_tune = false,
++	.busy_check = false,
++	.stop_clk_fix = false,
++	.enhance_rx = false,
++	.support_64g = false,
++};
++
++static const struct mtk_mmc_compatible mt8173_compat = {
++	.clk_div_bits = 8,
++	.hs400_tune = true,
++	.pad_tune_reg = MSDC_PAD_TUNE,
++	.async_fifo = false,
++	.data_tune = false,
++	.busy_check = false,
++	.stop_clk_fix = false,
++	.enhance_rx = false,
++	.support_64g = false,
++};
++
++static const struct mtk_mmc_compatible mt8183_compat = {
++	.clk_div_bits = 12,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE0,
++	.async_fifo = true,
++	.data_tune = true,
++	.busy_check = true,
++	.stop_clk_fix = true,
++	.enhance_rx = true,
++	.support_64g = true,
++};
++
++static const struct mtk_mmc_compatible mt2701_compat = {
++	.clk_div_bits = 12,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE0,
++	.async_fifo = true,
++	.data_tune = true,
++	.busy_check = false,
++	.stop_clk_fix = false,
++	.enhance_rx = false,
++	.support_64g = false,
++};
++
++static const struct mtk_mmc_compatible mt2712_compat = {
++	.clk_div_bits = 12,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE0,
++	.async_fifo = true,
++	.data_tune = true,
++	.busy_check = true,
++	.stop_clk_fix = true,
++	.enhance_rx = true,
++	.support_64g = true,
++};
++
++static const struct mtk_mmc_compatible mt7622_compat = {
++	.clk_div_bits = 12,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE0,
++	.async_fifo = true,
++	.data_tune = true,
++	.busy_check = true,
++	.stop_clk_fix = true,
++	.enhance_rx = true,
++	.support_64g = false,
++};
++
++static const struct mtk_mmc_compatible mt8516_compat = {
++	.clk_div_bits = 12,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE0,
++	.async_fifo = true,
++	.data_tune = true,
++	.busy_check = true,
++	.stop_clk_fix = true,
++};
++
++static const struct mtk_mmc_compatible mt7620_compat = {
++	.clk_div_bits = 8,
++	.hs400_tune = false,
++	.pad_tune_reg = MSDC_PAD_TUNE,
++	.async_fifo = false,
++	.data_tune = false,
++	.busy_check = false,
++	.stop_clk_fix = false,
++	.enhance_rx = false,
++	.use_internal_cd = true,
++};
++
++static const struct of_device_id msdc_of_ids[] = {
++	{ .compatible = "mediatek,mt8135-mmc", .data = &mt8135_compat},
++	{ .compatible = "mediatek,mt8173-mmc", .data = &mt8173_compat},
++	{ .compatible = "mediatek,mt8183-mmc", .data = &mt8183_compat},
++	{ .compatible = "mediatek,mt2701-mmc", .data = &mt2701_compat},
++	{ .compatible = "mediatek,mt2712-mmc", .data = &mt2712_compat},
++	{ .compatible = "mediatek,mt7622-mmc", .data = &mt7622_compat},
++	{ .compatible = "mediatek,mt8516-mmc", .data = &mt8516_compat},
++	{ .compatible = "mediatek,mt7620-mmc", .data = &mt7620_compat},
++	{}
++};
++MODULE_DEVICE_TABLE(of, msdc_of_ids);
++
+ static void sdr_set_bits(void __iomem *reg, u32 bs)
+ {
+ 	u32 val = readl(reg);
+@@ -447,7 +635,12 @@ static inline void msdc_dma_setup(struct msdc_host *host, struct msdc_dma *dma,
+ 		/* init bd */
+ 		bd[j].bd_info &= ~BDMA_DESC_BLKPAD;
+ 		bd[j].bd_info &= ~BDMA_DESC_DWPAD;
+-		bd[j].ptr = (u32)dma_address;
++		bd[j].ptr = lower_32_bits(dma_address);
++		if (host->dev_comp->support_64g) {
++			bd[j].bd_info &= ~BDMA_DESC_PTR_H4;
++			bd[j].bd_info |= (upper_32_bits(dma_address) & 0xf)
++					 << 28;
++		}
+ 		bd[j].bd_data_len &= ~BDMA_DESC_BUFLEN;
+ 		bd[j].bd_data_len |= (dma_len & BDMA_DESC_BUFLEN);
+ 
+@@ -466,7 +659,10 @@ static inline void msdc_dma_setup(struct msdc_host *host, struct msdc_dma *dma,
+ 	dma_ctrl &= ~(MSDC_DMA_CTRL_BRUSTSZ | MSDC_DMA_CTRL_MODE);
+ 	dma_ctrl |= (MSDC_BURST_64B << 12 | 1 << 8);
+ 	writel_relaxed(dma_ctrl, host->base + MSDC_DMA_CTRL);
+-	writel((u32)dma->gpd_addr, host->base + MSDC_DMA_SA);
++	if (host->dev_comp->support_64g)
++		sdr_set_field(host->base + DMA_SA_H4BIT, DMA_ADDR_HIGH_4BIT,
++			      upper_32_bits(dma->gpd_addr) & 0xf);
++	writel(lower_32_bits(dma->gpd_addr), host->base + MSDC_DMA_SA);
+ }
+ 
+ static void msdc_prepare_data(struct msdc_host *host, struct mmc_request *mrq)
+@@ -502,14 +698,19 @@ static void msdc_set_timeout(struct msdc_host *host, u32 ns, u32 clks)
+ 
+ 	host->timeout_ns = ns;
+ 	host->timeout_clks = clks;
+-	if (host->sclk == 0) {
++	if (host->mmc->actual_clock == 0) {
+ 		timeout = 0;
+ 	} else {
+-		clk_ns  = 1000000000UL / host->sclk;
++		clk_ns  = 1000000000UL / host->mmc->actual_clock;
+ 		timeout = (ns + clk_ns - 1) / clk_ns + clks;
+ 		/* in 1048576 sclk cycle unit */
+ 		timeout = (timeout + (0x1 << 20) - 1) >> 20;
+-		sdr_get_field(host->base + MSDC_CFG, MSDC_CFG_CKMOD, &mode);
++		if (host->dev_comp->clk_div_bits == 8)
++			sdr_get_field(host->base + MSDC_CFG,
++				      MSDC_CFG_CKMOD, &mode);
++		else
++			sdr_get_field(host->base + MSDC_CFG,
++				      MSDC_CFG_CKMOD_EXTRA, &mode);
+ 		/*DDR mode will double the clk cycles for data timeout */
+ 		timeout = mode >= 2 ? timeout * 2 : timeout;
+ 		timeout = timeout > 1 ? timeout - 1 : 0;
+@@ -520,14 +721,18 @@ static void msdc_set_timeout(struct msdc_host *host, u32 ns, u32 clks)
+ 
+ static void msdc_gate_clock(struct msdc_host *host)
+ {
++	clk_disable_unprepare(host->src_clk_cg);
+ 	clk_disable_unprepare(host->src_clk);
++	clk_disable_unprepare(host->bus_clk);
+ 	clk_disable_unprepare(host->h_clk);
+ }
+ 
+ static void msdc_ungate_clock(struct msdc_host *host)
+ {
+ 	clk_prepare_enable(host->h_clk);
++	clk_prepare_enable(host->bus_clk);
+ 	clk_prepare_enable(host->src_clk);
++	clk_prepare_enable(host->src_clk_cg);
+ 	while (!(readl(host->base + MSDC_CFG) & MSDC_CFG_CKSTB))
+ 		cpu_relax();
+ }
+@@ -538,17 +743,23 @@ static void msdc_set_mclk(struct msdc_host *host, unsigned char timing, u32 hz)
+ 	u32 flags;
+ 	u32 div;
+ 	u32 sclk;
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
+ 
+ 	if (!hz) {
+ 		dev_dbg(host->dev, "set mclk to 0\n");
+ 		host->mclk = 0;
++		host->mmc->actual_clock = 0;
+ 		sdr_clr_bits(host->base + MSDC_CFG, MSDC_CFG_CKPDN);
+ 		return;
+ 	}
+ 
+ 	flags = readl(host->base + MSDC_INTEN);
+ 	sdr_clr_bits(host->base + MSDC_INTEN, flags);
+-	sdr_clr_bits(host->base + MSDC_CFG, MSDC_CFG_HS400_CK_MODE);
++	if (host->dev_comp->clk_div_bits == 8)
++		sdr_clr_bits(host->base + MSDC_CFG, MSDC_CFG_HS400_CK_MODE);
++	else
++		sdr_clr_bits(host->base + MSDC_CFG,
++			     MSDC_CFG_HS400_CK_MODE_EXTRA);
+ 	if (timing == MMC_TIMING_UHS_DDR50 ||
+ 	    timing == MMC_TIMING_MMC_DDR52 ||
+ 	    timing == MMC_TIMING_MMC_HS400) {
+@@ -568,8 +779,12 @@ static void msdc_set_mclk(struct msdc_host *host, unsigned char timing, u32 hz)
+ 
+ 		if (timing == MMC_TIMING_MMC_HS400 &&
+ 		    hz >= (host->src_clk_freq >> 1)) {
+-			sdr_set_bits(host->base + MSDC_CFG,
+-				     MSDC_CFG_HS400_CK_MODE);
++			if (host->dev_comp->clk_div_bits == 8)
++				sdr_set_bits(host->base + MSDC_CFG,
++					     MSDC_CFG_HS400_CK_MODE);
++			else
++				sdr_set_bits(host->base + MSDC_CFG,
++					     MSDC_CFG_HS400_CK_MODE_EXTRA);
+ 			sclk = host->src_clk_freq >> 1;
+ 			div = 0; /* div is ignore when bit18 is set */
+ 		}
+@@ -587,12 +802,32 @@ static void msdc_set_mclk(struct msdc_host *host, unsigned char timing, u32 hz)
+ 			sclk = (host->src_clk_freq >> 2) / div;
+ 		}
+ 	}
+-	sdr_set_field(host->base + MSDC_CFG, MSDC_CFG_CKMOD | MSDC_CFG_CKDIV,
+-		      (mode << 8) | div);
+-	sdr_set_bits(host->base + MSDC_CFG, MSDC_CFG_CKPDN);
++	sdr_clr_bits(host->base + MSDC_CFG, MSDC_CFG_CKPDN);
++	/*
++	 * As src_clk/HCLK use the same bit to gate/ungate,
++	 * So if want to only gate src_clk, need gate its parent(mux).
++	 */
++	if (host->src_clk_cg)
++		clk_disable_unprepare(host->src_clk_cg);
++	else
++		clk_disable_unprepare(clk_get_parent(host->src_clk));
++	if (host->dev_comp->clk_div_bits == 8)
++		sdr_set_field(host->base + MSDC_CFG,
++			      MSDC_CFG_CKMOD | MSDC_CFG_CKDIV,
++			      (mode << 8) | div);
++	else
++		sdr_set_field(host->base + MSDC_CFG,
++			      MSDC_CFG_CKMOD_EXTRA | MSDC_CFG_CKDIV_EXTRA,
++			      (mode << 12) | div);
++	if (host->src_clk_cg)
++		clk_prepare_enable(host->src_clk_cg);
++	else
++		clk_prepare_enable(clk_get_parent(host->src_clk));
++
+ 	while (!(readl(host->base + MSDC_CFG) & MSDC_CFG_CKSTB))
+ 		cpu_relax();
+-	host->sclk = sclk;
++	sdr_set_bits(host->base + MSDC_CFG, MSDC_CFG_CKPDN);
++	host->mmc->actual_clock = sclk;
+ 	host->mclk = hz;
+ 	host->timing = timing;
+ 	/* need because clk changed. */
+@@ -603,21 +838,39 @@ static void msdc_set_mclk(struct msdc_host *host, unsigned char timing, u32 hz)
+ 	 * mmc_select_hs400() will drop to 50Mhz and High speed mode,
+ 	 * tune result of hs200/200Mhz is not suitable for 50Mhz
+ 	 */
+-	if (host->sclk <= 52000000) {
++	if (host->mmc->actual_clock <= 52000000) {
+ 		writel(host->def_tune_para.iocon, host->base + MSDC_IOCON);
+-		writel(host->def_tune_para.pad_tune, host->base + MSDC_PAD_TUNE);
++		if (host->top_base) {
++			writel(host->def_tune_para.emmc_top_control,
++			       host->top_base + EMMC_TOP_CONTROL);
++			writel(host->def_tune_para.emmc_top_cmd,
++			       host->top_base + EMMC_TOP_CMD);
++		} else {
++			writel(host->def_tune_para.pad_tune,
++			       host->base + tune_reg);
++		}
+ 	} else {
+ 		writel(host->saved_tune_para.iocon, host->base + MSDC_IOCON);
+-		writel(host->saved_tune_para.pad_tune, host->base + MSDC_PAD_TUNE);
+ 		writel(host->saved_tune_para.pad_cmd_tune,
+ 		       host->base + PAD_CMD_TUNE);
++		if (host->top_base) {
++			writel(host->saved_tune_para.emmc_top_control,
++			       host->top_base + EMMC_TOP_CONTROL);
++			writel(host->saved_tune_para.emmc_top_cmd,
++			       host->top_base + EMMC_TOP_CMD);
++		} else {
++			writel(host->saved_tune_para.pad_tune,
++			       host->base + tune_reg);
++		}
+ 	}
+ 
+-	if (timing == MMC_TIMING_MMC_HS400)
+-		sdr_set_field(host->base + PAD_CMD_TUNE,
++	if (timing == MMC_TIMING_MMC_HS400 &&
++	    host->dev_comp->hs400_tune)
++		sdr_set_field(host->base + tune_reg,
+ 			      MSDC_PAD_TUNE_CMDRRDLY,
+ 			      host->hs400_cmd_int_delay);
+-	dev_dbg(host->dev, "sclk: %d, timing: %d\n", host->sclk, timing);
++	dev_dbg(host->dev, "sclk: %d, timing: %d\n", host->mmc->actual_clock,
++		timing);
+ }
+ 
+ static inline u32 msdc_cmd_find_resp(struct msdc_host *host,
+@@ -770,6 +1023,8 @@ static void msdc_request_done(struct msdc_host *host, struct mmc_request *mrq)
+ 	msdc_track_cmd_data(host, mrq->cmd, mrq->data);
+ 	if (mrq->data)
+ 		msdc_unprepare_data(host, mrq);
++	if (host->error)
++		msdc_reset_hw(host);
+ 	mmc_request_done(host->mmc, mrq);
+ }
+ 
+@@ -881,10 +1136,12 @@ static void msdc_start_command(struct msdc_host *host,
+ 		struct mmc_request *mrq, struct mmc_command *cmd)
+ {
+ 	u32 rawcmd;
++	unsigned long flags;
+ 
+ 	WARN_ON(host->cmd);
+ 	host->cmd = cmd;
+ 
++	mod_delayed_work(system_wq, &host->req_timeout, DAT_TIMEOUT);
+ 	if (!msdc_cmd_is_ready(host, mrq, cmd))
+ 		return;
+ 
+@@ -896,9 +1153,11 @@ static void msdc_start_command(struct msdc_host *host,
+ 
+ 	cmd->error = 0;
+ 	rawcmd = msdc_cmd_prepare_raw_cmd(host, mrq, cmd);
+-	mod_delayed_work(system_wq, &host->req_timeout, DAT_TIMEOUT);
+ 
++	spin_lock_irqsave(&host->lock, flags);
+ 	sdr_set_bits(host->base + MSDC_INTEN, cmd_ints_mask);
++	spin_unlock_irqrestore(&host->lock, flags);
++
+ 	writel(cmd->arg, host->base + SDC_ARG);
+ 	writel(rawcmd, host->base + SDC_CMD);
+ }
+@@ -1118,6 +1377,32 @@ static void msdc_request_timeout(struct work_struct *work)
+ 	}
+ }
+ 
++static void __msdc_enable_sdio_irq(struct msdc_host *host, int enb)
++{
++	if (enb) {
++		sdr_set_bits(host->base + MSDC_INTEN, MSDC_INTEN_SDIOIRQ);
++		sdr_set_bits(host->base + SDC_CFG, SDC_CFG_SDIOIDE);
++	} else {
++		sdr_clr_bits(host->base + MSDC_INTEN, MSDC_INTEN_SDIOIRQ);
++		sdr_clr_bits(host->base + SDC_CFG, SDC_CFG_SDIOIDE);
++	}
++}
++
++static void msdc_enable_sdio_irq(struct mmc_host *mmc, int enb)
++{
++	unsigned long flags;
++	struct msdc_host *host = mmc_priv(mmc);
++
++	spin_lock_irqsave(&host->lock, flags);
++	__msdc_enable_sdio_irq(host, enb);
++	spin_unlock_irqrestore(&host->lock, flags);
++
++	if (enb)
++		pm_runtime_get_noresume(host->dev);
++	else
++		pm_runtime_put_noidle(host->dev);
++}
++
+ static irqreturn_t msdc_irq(int irq, void *dev_id)
+ {
+ 	struct msdc_host *host = (struct msdc_host *) dev_id;
+@@ -1132,6 +1417,8 @@ static irqreturn_t msdc_irq(int irq, void *dev_id)
+ 		spin_lock_irqsave(&host->lock, flags);
+ 		events = readl(host->base + MSDC_INT);
+ 		event_mask = readl(host->base + MSDC_INTEN);
++		if ((events & event_mask) & MSDC_INT_SDIOIRQ)
++			__msdc_enable_sdio_irq(host, 0);
+ 		/* clear interrupts */
+ 		writel(events & event_mask, host->base + MSDC_INT);
+ 
+@@ -1140,7 +1427,16 @@ static irqreturn_t msdc_irq(int irq, void *dev_id)
+ 		data = host->data;
+ 		spin_unlock_irqrestore(&host->lock, flags);
+ 
+-		if (!(events & event_mask))
++		if ((events & event_mask) & MSDC_INT_SDIOIRQ)
++			sdio_signal_irq(host->mmc);
++
++		if ((events & event_mask) & MSDC_INT_CDSC) {
++			if (host->internal_cd)
++				mmc_detect_change(host->mmc, msecs_to_jiffies(20));
++			events &= ~MSDC_INT_CDSC;
++		}
++
++		if (!(events & (event_mask & ~MSDC_INT_SDIOIRQ)))
+ 			break;
+ 
+ 		if (!mrq) {
+@@ -1165,6 +1461,7 @@ static irqreturn_t msdc_irq(int irq, void *dev_id)
+ static void msdc_init_hw(struct msdc_host *host)
+ {
+ 	u32 val;
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
+ 
+ 	/* Configure to MMC/SD mode, clock free running */
+ 	sdr_set_bits(host->base + MSDC_CFG, MSDC_CFG_MODE | MSDC_CFG_CKPDN);
+@@ -1172,41 +1469,137 @@ static void msdc_init_hw(struct msdc_host *host)
+ 	/* Reset */
+ 	msdc_reset_hw(host);
+ 
+-	/* Disable card detection */
+-	sdr_clr_bits(host->base + MSDC_PS, MSDC_PS_CDEN);
+-
+ 	/* Disable and clear all interrupts */
+ 	writel(0, host->base + MSDC_INTEN);
+ 	val = readl(host->base + MSDC_INT);
+ 	writel(val, host->base + MSDC_INT);
+ 
+-	writel(0, host->base + MSDC_PAD_TUNE);
++	/* Configure card detection */
++	if (host->internal_cd) {
++		sdr_set_field(host->base + MSDC_PS, MSDC_PS_CDDEBOUNCE,
++			      DEFAULT_DEBOUNCE);
++		sdr_set_bits(host->base + MSDC_PS, MSDC_PS_CDEN);
++		sdr_set_bits(host->base + MSDC_INTEN, MSDC_INTEN_CDSC);
++		sdr_set_bits(host->base + SDC_CFG, SDC_CFG_INSWKUP);
++	} else {
++		sdr_clr_bits(host->base + SDC_CFG, SDC_CFG_INSWKUP);
++		sdr_clr_bits(host->base + MSDC_PS, MSDC_PS_CDEN);
++		sdr_clr_bits(host->base + MSDC_INTEN, MSDC_INTEN_CDSC);
++	}
++
++	if (host->top_base) {
++		writel(0, host->top_base + EMMC_TOP_CONTROL);
++		writel(0, host->top_base + EMMC_TOP_CMD);
++	} else {
++		writel(0, host->base + tune_reg);
++	}
+ 	writel(0, host->base + MSDC_IOCON);
+ 	sdr_set_field(host->base + MSDC_IOCON, MSDC_IOCON_DDLSEL, 0);
+ 	writel(0x403c0046, host->base + MSDC_PATCH_BIT);
+ 	sdr_set_field(host->base + MSDC_PATCH_BIT, MSDC_CKGEN_MSDC_DLY_SEL, 1);
+-	writel(0xffff0089, host->base + MSDC_PATCH_BIT1);
++	writel(0xffff4089, host->base + MSDC_PATCH_BIT1);
+ 	sdr_set_bits(host->base + EMMC50_CFG0, EMMC50_CFG_CFCSTS_SEL);
+ 
++	if (host->dev_comp->stop_clk_fix) {
++		sdr_set_field(host->base + MSDC_PATCH_BIT1,
++			      MSDC_PATCH_BIT1_STOP_DLY, 3);
++		sdr_clr_bits(host->base + SDC_FIFO_CFG,
++			     SDC_FIFO_CFG_WRVALIDSEL);
++		sdr_clr_bits(host->base + SDC_FIFO_CFG,
++			     SDC_FIFO_CFG_RDVALIDSEL);
++	}
++
++	if (host->dev_comp->busy_check)
++		sdr_clr_bits(host->base + MSDC_PATCH_BIT1, (1 << 7));
++
++	if (host->dev_comp->async_fifo) {
++		sdr_set_field(host->base + MSDC_PATCH_BIT2,
++			      MSDC_PB2_RESPWAIT, 3);
++		if (host->dev_comp->enhance_rx) {
++			if (host->top_base)
++				sdr_set_bits(host->top_base + EMMC_TOP_CONTROL,
++					     SDC_RX_ENH_EN);
++			else
++				sdr_set_bits(host->base + SDC_ADV_CFG0,
++					     SDC_RX_ENHANCE_EN);
++		} else {
++			sdr_set_field(host->base + MSDC_PATCH_BIT2,
++				      MSDC_PB2_RESPSTSENSEL, 2);
++			sdr_set_field(host->base + MSDC_PATCH_BIT2,
++				      MSDC_PB2_CRCSTSENSEL, 2);
++		}
++		/* use async fifo, then no need tune internal delay */
++		sdr_clr_bits(host->base + MSDC_PATCH_BIT2,
++			     MSDC_PATCH_BIT2_CFGRESP);
++		sdr_set_bits(host->base + MSDC_PATCH_BIT2,
++			     MSDC_PATCH_BIT2_CFGCRCSTS);
++	}
++
++	if (host->dev_comp->support_64g)
++		sdr_set_bits(host->base + MSDC_PATCH_BIT2,
++			     MSDC_PB2_SUPPORT_64G);
++	if (host->dev_comp->data_tune) {
++		if (host->top_base) {
++			sdr_set_bits(host->top_base + EMMC_TOP_CONTROL,
++				     PAD_DAT_RD_RXDLY_SEL);
++			sdr_clr_bits(host->top_base + EMMC_TOP_CONTROL,
++				     DATA_K_VALUE_SEL);
++			sdr_set_bits(host->top_base + EMMC_TOP_CMD,
++				     PAD_CMD_RD_RXDLY_SEL);
++		} else {
++			sdr_set_bits(host->base + tune_reg,
++				     MSDC_PAD_TUNE_RD_SEL |
++				     MSDC_PAD_TUNE_CMD_SEL);
++		}
++	} else {
++		/* choose clock tune */
++		if (host->top_base)
++			sdr_set_bits(host->top_base + EMMC_TOP_CONTROL,
++				     PAD_RXDLY_SEL);
++		else
++			sdr_set_bits(host->base + tune_reg,
++				     MSDC_PAD_TUNE_RXDLYSEL);
++	}
++
+ 	/* Configure to enable SDIO mode.
+ 	 * it's must otherwise sdio cmd5 failed
+ 	 */
+ 	sdr_set_bits(host->base + SDC_CFG, SDC_CFG_SDIO);
+ 
+-	/* disable detect SDIO device interrupt function */
++	/* Config SDIO device detect interrupt function */
+ 	sdr_clr_bits(host->base + SDC_CFG, SDC_CFG_SDIOIDE);
+ 
+ 	/* Configure to default data timeout */
+ 	sdr_set_field(host->base + SDC_CFG, SDC_CFG_DTOC, 3);
+ 
+ 	host->def_tune_para.iocon = readl(host->base + MSDC_IOCON);
+-	host->def_tune_para.pad_tune = readl(host->base + MSDC_PAD_TUNE);
++	host->saved_tune_para.iocon = readl(host->base + MSDC_IOCON);
++	if (host->top_base) {
++		host->def_tune_para.emmc_top_control =
++			readl(host->top_base + EMMC_TOP_CONTROL);
++		host->def_tune_para.emmc_top_cmd =
++			readl(host->top_base + EMMC_TOP_CMD);
++		host->saved_tune_para.emmc_top_control =
++			readl(host->top_base + EMMC_TOP_CONTROL);
++		host->saved_tune_para.emmc_top_cmd =
++			readl(host->top_base + EMMC_TOP_CMD);
++	} else {
++		host->def_tune_para.pad_tune = readl(host->base + tune_reg);
++		host->saved_tune_para.pad_tune = readl(host->base + tune_reg);
++	}
+ 	dev_dbg(host->dev, "init hardware done!");
+ }
+ 
+ static void msdc_deinit_hw(struct msdc_host *host)
+ {
+ 	u32 val;
++
++	if (host->internal_cd) {
++		/* Disabled card-detect */
++		sdr_clr_bits(host->base + MSDC_PS, MSDC_PS_CDEN);
++		sdr_clr_bits(host->base + SDC_CFG, SDC_CFG_INSWKUP);
++	}
++
+ 	/* Disable and clear all interrupts */
+ 	writel(0, host->base + MSDC_INTEN);
+ 
+@@ -1219,19 +1612,32 @@ static void msdc_init_gpd_bd(struct msdc_host *host, struct msdc_dma *dma)
+ {
+ 	struct mt_gpdma_desc *gpd = dma->gpd;
+ 	struct mt_bdma_desc *bd = dma->bd;
++	dma_addr_t dma_addr;
+ 	int i;
+ 
+ 	memset(gpd, 0, sizeof(struct mt_gpdma_desc) * 2);
+ 
++	dma_addr = dma->gpd_addr + sizeof(struct mt_gpdma_desc);
+ 	gpd->gpd_info = GPDMA_DESC_BDP; /* hwo, cs, bd pointer */
+-	gpd->ptr = (u32)dma->bd_addr; /* physical address */
+ 	/* gpd->next is must set for desc DMA
+ 	 * That's why must alloc 2 gpd structure.
+ 	 */
+-	gpd->next = (u32)dma->gpd_addr + sizeof(struct mt_gpdma_desc);
++	gpd->next = lower_32_bits(dma_addr);
++	if (host->dev_comp->support_64g)
++		gpd->gpd_info |= (upper_32_bits(dma_addr) & 0xf) << 24;
++
++	dma_addr = dma->bd_addr;
++	gpd->ptr = lower_32_bits(dma->bd_addr); /* physical address */
++	if (host->dev_comp->support_64g)
++		gpd->gpd_info |= (upper_32_bits(dma_addr) & 0xf) << 28;
++
+ 	memset(bd, 0, sizeof(struct mt_bdma_desc) * MAX_BD_NUM);
+-	for (i = 0; i < (MAX_BD_NUM - 1); i++)
+-		bd[i].next = (u32)dma->bd_addr + sizeof(*bd) * (i + 1);
++	for (i = 0; i < (MAX_BD_NUM - 1); i++) {
++		dma_addr = dma->bd_addr + sizeof(*bd) * (i + 1);
++		bd[i].next = lower_32_bits(dma_addr);
++		if (host->dev_comp->support_64g)
++			bd[i].bd_info |= (upper_32_bits(dma_addr) & 0xf) << 24;
++	}
+ }
+ 
+ static void msdc_ops_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
+@@ -1335,6 +1741,30 @@ static struct msdc_delay_phase get_best_delay(struct msdc_host *host, u32 delay)
+ 	return delay_phase;
+ }
+ 
++static inline void msdc_set_cmd_delay(struct msdc_host *host, u32 value)
++{
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
++
++	if (host->top_base)
++		sdr_set_field(host->top_base + EMMC_TOP_CMD, PAD_CMD_RXDLY,
++			      value);
++	else
++		sdr_set_field(host->base + tune_reg, MSDC_PAD_TUNE_CMDRDLY,
++			      value);
++}
++
++static inline void msdc_set_data_delay(struct msdc_host *host, u32 value)
++{
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
++
++	if (host->top_base)
++		sdr_set_field(host->top_base + EMMC_TOP_CONTROL,
++			      PAD_DAT_RD_RXDLY, value);
++	else
++		sdr_set_field(host->base + tune_reg, MSDC_PAD_TUNE_DATRRDLY,
++			      value);
++}
++
+ static int msdc_tune_response(struct mmc_host *mmc, u32 opcode)
+ {
+ 	struct msdc_host *host = mmc_priv(mmc);
+@@ -1343,19 +1773,19 @@ static int msdc_tune_response(struct mmc_host *mmc, u32 opcode)
+ 	struct msdc_delay_phase internal_delay_phase;
+ 	u8 final_delay, final_maxlen;
+ 	u32 internal_delay = 0;
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
+ 	int cmd_err;
+ 	int i, j;
+ 
+ 	if (mmc->ios.timing == MMC_TIMING_MMC_HS200 ||
+ 	    mmc->ios.timing == MMC_TIMING_UHS_SDR104)
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
++		sdr_set_field(host->base + tune_reg,
+ 			      MSDC_PAD_TUNE_CMDRRDLY,
+ 			      host->hs200_cmd_int_delay);
+ 
+ 	sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
+ 	for (i = 0 ; i < PAD_DELAY_MAX; i++) {
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_CMDRDLY, i);
++		msdc_set_cmd_delay(host, i);
+ 		/*
+ 		 * Using the same parameters, it may sometimes pass the test,
+ 		 * but sometimes it may fail. To make sure the parameters are
+@@ -1373,13 +1803,13 @@ static int msdc_tune_response(struct mmc_host *mmc, u32 opcode)
+ 	}
+ 	final_rise_delay = get_best_delay(host, rise_delay);
+ 	/* if rising edge has enough margin, then do not scan falling edge */
+-	if (final_rise_delay.maxlen >= 12 && final_rise_delay.start < 4)
++	if (final_rise_delay.maxlen >= 12 ||
++	    (final_rise_delay.start == 0 && final_rise_delay.maxlen >= 4))
+ 		goto skip_fall;
+ 
+ 	sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
+ 	for (i = 0; i < PAD_DELAY_MAX; i++) {
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_CMDRDLY, i);
++		msdc_set_cmd_delay(host, i);
+ 		/*
+ 		 * Using the same parameters, it may sometimes pass the test,
+ 		 * but sometimes it may fail. To make sure the parameters are
+@@ -1403,20 +1833,18 @@ static int msdc_tune_response(struct mmc_host *mmc, u32 opcode)
+ 		final_maxlen = final_fall_delay.maxlen;
+ 	if (final_maxlen == final_rise_delay.maxlen) {
+ 		sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
+-		sdr_set_field(host->base + MSDC_PAD_TUNE, MSDC_PAD_TUNE_CMDRDLY,
+-			      final_rise_delay.final_phase);
+ 		final_delay = final_rise_delay.final_phase;
+ 	} else {
+ 		sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
+-		sdr_set_field(host->base + MSDC_PAD_TUNE, MSDC_PAD_TUNE_CMDRDLY,
+-			      final_fall_delay.final_phase);
+ 		final_delay = final_fall_delay.final_phase;
+ 	}
+-	if (host->hs200_cmd_int_delay)
++	msdc_set_cmd_delay(host, final_delay);
++
++	if (host->dev_comp->async_fifo || host->hs200_cmd_int_delay)
+ 		goto skip_internal;
+ 
+ 	for (i = 0; i < PAD_DELAY_MAX; i++) {
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
++		sdr_set_field(host->base + tune_reg,
+ 			      MSDC_PAD_TUNE_CMDRRDLY, i);
+ 		mmc_send_tuning(mmc, opcode, &cmd_err);
+ 		if (!cmd_err)
+@@ -1424,7 +1852,7 @@ static int msdc_tune_response(struct mmc_host *mmc, u32 opcode)
+ 	}
+ 	dev_dbg(host->dev, "Final internal delay: 0x%x\n", internal_delay);
+ 	internal_delay_phase = get_best_delay(host, internal_delay);
+-	sdr_set_field(host->base + MSDC_PAD_TUNE, MSDC_PAD_TUNE_CMDRRDLY,
++	sdr_set_field(host->base + tune_reg, MSDC_PAD_TUNE_CMDRRDLY,
+ 		      internal_delay_phase.final_phase);
+ skip_internal:
+ 	dev_dbg(host->dev, "Final cmd pad delay: %x\n", final_delay);
+@@ -1488,11 +1916,12 @@ static int msdc_tune_data(struct mmc_host *mmc, u32 opcode)
+ 	u8 final_delay, final_maxlen;
+ 	int i, ret;
+ 
++	sdr_set_field(host->base + MSDC_PATCH_BIT, MSDC_INT_DAT_LATCH_CK_SEL,
++		      host->latch_ck);
+ 	sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_DSPL);
+ 	sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_W_DSPL);
+ 	for (i = 0 ; i < PAD_DELAY_MAX; i++) {
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_DATRRDLY, i);
++		msdc_set_data_delay(host, i);
+ 		ret = mmc_send_tuning(mmc, opcode, NULL);
+ 		if (!ret)
+ 			rise_delay |= (1 << i);
+@@ -1506,8 +1935,7 @@ static int msdc_tune_data(struct mmc_host *mmc, u32 opcode)
+ 	sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_DSPL);
+ 	sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_W_DSPL);
+ 	for (i = 0; i < PAD_DELAY_MAX; i++) {
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_DATRRDLY, i);
++		msdc_set_data_delay(host, i);
+ 		ret = mmc_send_tuning(mmc, opcode, NULL);
+ 		if (!ret)
+ 			fall_delay |= (1 << i);
+@@ -1519,29 +1947,99 @@ static int msdc_tune_data(struct mmc_host *mmc, u32 opcode)
+ 	if (final_maxlen == final_rise_delay.maxlen) {
+ 		sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_DSPL);
+ 		sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_W_DSPL);
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_DATRRDLY,
+-			      final_rise_delay.final_phase);
+ 		final_delay = final_rise_delay.final_phase;
+ 	} else {
+ 		sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_DSPL);
+ 		sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_W_DSPL);
+-		sdr_set_field(host->base + MSDC_PAD_TUNE,
+-			      MSDC_PAD_TUNE_DATRRDLY,
+-			      final_fall_delay.final_phase);
+ 		final_delay = final_fall_delay.final_phase;
+ 	}
++	msdc_set_data_delay(host, final_delay);
+ 
+ 	dev_dbg(host->dev, "Final data pad delay: %x\n", final_delay);
+ 	return final_delay == 0xff ? -EIO : 0;
+ }
+ 
++/*
++ * MSDC IP which supports data tune + async fifo can do CMD/DAT tune
++ * together, which can save the tuning time.
++ */
++static int msdc_tune_together(struct mmc_host *mmc, u32 opcode)
++{
++	struct msdc_host *host = mmc_priv(mmc);
++	u32 rise_delay = 0, fall_delay = 0;
++	struct msdc_delay_phase final_rise_delay, final_fall_delay = { 0,};
++	u8 final_delay, final_maxlen;
++	int i, ret;
++
++	sdr_set_field(host->base + MSDC_PATCH_BIT, MSDC_INT_DAT_LATCH_CK_SEL,
++		      host->latch_ck);
++
++	sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
++	sdr_clr_bits(host->base + MSDC_IOCON,
++		     MSDC_IOCON_DSPL | MSDC_IOCON_W_DSPL);
++	for (i = 0 ; i < PAD_DELAY_MAX; i++) {
++		msdc_set_cmd_delay(host, i);
++		msdc_set_data_delay(host, i);
++		ret = mmc_send_tuning(mmc, opcode, NULL);
++		if (!ret)
++			rise_delay |= (1 << i);
++	}
++	final_rise_delay = get_best_delay(host, rise_delay);
++	/* if rising edge has enough margin, then do not scan falling edge */
++	if (final_rise_delay.maxlen >= 12 ||
++	    (final_rise_delay.start == 0 && final_rise_delay.maxlen >= 4))
++		goto skip_fall;
++
++	sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
++	sdr_set_bits(host->base + MSDC_IOCON,
++		     MSDC_IOCON_DSPL | MSDC_IOCON_W_DSPL);
++	for (i = 0; i < PAD_DELAY_MAX; i++) {
++		msdc_set_cmd_delay(host, i);
++		msdc_set_data_delay(host, i);
++		ret = mmc_send_tuning(mmc, opcode, NULL);
++		if (!ret)
++			fall_delay |= (1 << i);
++	}
++	final_fall_delay = get_best_delay(host, fall_delay);
++
++skip_fall:
++	final_maxlen = max(final_rise_delay.maxlen, final_fall_delay.maxlen);
++	if (final_maxlen == final_rise_delay.maxlen) {
++		sdr_clr_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
++		sdr_clr_bits(host->base + MSDC_IOCON,
++			     MSDC_IOCON_DSPL | MSDC_IOCON_W_DSPL);
++		final_delay = final_rise_delay.final_phase;
++	} else {
++		sdr_set_bits(host->base + MSDC_IOCON, MSDC_IOCON_RSPL);
++		sdr_set_bits(host->base + MSDC_IOCON,
++			     MSDC_IOCON_DSPL | MSDC_IOCON_W_DSPL);
++		final_delay = final_fall_delay.final_phase;
++	}
++
++	msdc_set_cmd_delay(host, final_delay);
++	msdc_set_data_delay(host, final_delay);
++
++	dev_dbg(host->dev, "Final pad delay: %x\n", final_delay);
++	return final_delay == 0xff ? -EIO : 0;
++}
++
+ static int msdc_execute_tuning(struct mmc_host *mmc, u32 opcode)
+ {
+ 	struct msdc_host *host = mmc_priv(mmc);
+ 	int ret;
+-
+-	if (host->hs400_mode)
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
++
++	if (host->dev_comp->data_tune && host->dev_comp->async_fifo) {
++		ret = msdc_tune_together(mmc, opcode);
++		if (host->hs400_mode) {
++			sdr_clr_bits(host->base + MSDC_IOCON,
++				     MSDC_IOCON_DSPL | MSDC_IOCON_W_DSPL);
++			msdc_set_data_delay(host, 0);
++		}
++		goto tune_done;
++	}
++	if (host->hs400_mode &&
++	    host->dev_comp->hs400_tune)
+ 		ret = hs400_tune_response(mmc, opcode);
+ 	else
+ 		ret = msdc_tune_response(mmc, opcode);
+@@ -1555,9 +2053,16 @@ static int msdc_execute_tuning(struct mmc_host *mmc, u32 opcode)
+ 			dev_err(host->dev, "Tune data fail!\n");
+ 	}
+ 
++tune_done:
+ 	host->saved_tune_para.iocon = readl(host->base + MSDC_IOCON);
+-	host->saved_tune_para.pad_tune = readl(host->base + MSDC_PAD_TUNE);
++	host->saved_tune_para.pad_tune = readl(host->base + tune_reg);
+ 	host->saved_tune_para.pad_cmd_tune = readl(host->base + PAD_CMD_TUNE);
++	if (host->top_base) {
++		host->saved_tune_para.emmc_top_control = readl(host->top_base +
++				EMMC_TOP_CONTROL);
++		host->saved_tune_para.emmc_top_cmd = readl(host->top_base +
++				EMMC_TOP_CMD);
++	}
+ 	return ret;
+ }
+ 
+@@ -1566,7 +2071,16 @@ static int msdc_prepare_hs400_tuning(struct mmc_host *mmc, struct mmc_ios *ios)
+ 	struct msdc_host *host = mmc_priv(mmc);
+ 	host->hs400_mode = true;
+ 
+-	writel(host->hs400_ds_delay, host->base + PAD_DS_TUNE);
++	if (host->top_base)
++		writel(host->hs400_ds_delay,
++		       host->top_base + EMMC50_PAD_DS_TUNE);
++	else
++		writel(host->hs400_ds_delay, host->base + PAD_DS_TUNE);
++	/* hs400 mode must set it to 0 */
++	sdr_clr_bits(host->base + MSDC_PATCH_BIT2, MSDC_PATCH_BIT2_CFGCRCSTS);
++	/* to improve read performance, set outstanding to 2 */
++	sdr_set_field(host->base + EMMC50_CFG3, EMMC50_CFG3_OUTS_WR, 2);
++
+ 	return 0;
+ }
+ 
+@@ -1579,13 +2093,43 @@ static void msdc_hw_reset(struct mmc_host *mmc)
+ 	sdr_clr_bits(host->base + EMMC_IOCON, 1);
+ }
+ 
++static void msdc_ack_sdio_irq(struct mmc_host *mmc)
++{
++	unsigned long flags;
++	struct msdc_host *host = mmc_priv(mmc);
++
++	spin_lock_irqsave(&host->lock, flags);
++	__msdc_enable_sdio_irq(host, 1);
++	spin_unlock_irqrestore(&host->lock, flags);
++}
++
++static int msdc_get_cd(struct mmc_host *mmc)
++{
++	struct msdc_host *host = mmc_priv(mmc);
++	int val;
++
++	if (mmc->caps & MMC_CAP_NONREMOVABLE)
++		return 1;
++
++	if (!host->internal_cd)
++		return mmc_gpio_get_cd(mmc);
++
++	val = readl(host->base + MSDC_PS) & MSDC_PS_CDSTS;
++	if (mmc->caps2 & MMC_CAP2_CD_ACTIVE_HIGH)
++		return !!val;
++	else
++		return !val;
++}
++
+ static const struct mmc_host_ops mt_msdc_ops = {
+ 	.post_req = msdc_post_req,
+ 	.pre_req = msdc_pre_req,
+ 	.request = msdc_ops_request,
+ 	.set_ios = msdc_ops_set_ios,
+ 	.get_ro = mmc_gpio_get_ro,
+-	.get_cd = mmc_gpio_get_cd,
++	.get_cd = msdc_get_cd,
++	.enable_sdio_irq = msdc_enable_sdio_irq,
++	.ack_sdio_irq = msdc_ack_sdio_irq,
+ 	.start_signal_voltage_switch = msdc_ops_switch_volt,
+ 	.card_busy = msdc_card_busy,
+ 	.execute_tuning = msdc_execute_tuning,
+@@ -1596,6 +2140,9 @@ static const struct mmc_host_ops mt_msdc_ops = {
+ static void msdc_of_property_parse(struct platform_device *pdev,
+ 				   struct msdc_host *host)
+ {
++	of_property_read_u32(pdev->dev.of_node, "mediatek,latch-ck",
++			     &host->latch_ck);
++
+ 	of_property_read_u32(pdev->dev.of_node, "hs400-ds-delay",
+ 			     &host->hs400_ds_delay);
+ 
+@@ -1623,6 +2170,7 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 		dev_err(&pdev->dev, "No DT found\n");
+ 		return -EINVAL;
+ 	}
++
+ 	/* Allocate MMC host for this device */
+ 	mmc = mmc_alloc_host(sizeof(struct msdc_host), &pdev->dev);
+ 	if (!mmc)
+@@ -1640,8 +2188,15 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 		goto host_free;
+ 	}
+ 
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 1);
++	if (res) {
++		host->top_base = devm_ioremap_resource(&pdev->dev, res);
++		if (IS_ERR(host->top_base))
++			host->top_base = NULL;
++	}
++
+ 	ret = mmc_regulator_get_supply(mmc);
+-	if (ret == -EPROBE_DEFER)
++	if (ret)
+ 		goto host_free;
+ 
+ 	host->src_clk = devm_clk_get(&pdev->dev, "source");
+@@ -1656,6 +2211,14 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 		goto host_free;
+ 	}
+ 
++	host->bus_clk = devm_clk_get(&pdev->dev, "bus_clk");
++	if (IS_ERR(host->bus_clk))
++		host->bus_clk = NULL;
++	/*source clock control gate is optional clock*/
++	host->src_clk_cg = devm_clk_get(&pdev->dev, "source_cg");
++	if (IS_ERR(host->src_clk_cg))
++		host->src_clk_cg = NULL;
++
+ 	host->irq = platform_get_irq(pdev, 0);
+ 	if (host->irq < 0) {
+ 		ret = -EINVAL;
+@@ -1686,11 +2249,28 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 	msdc_of_property_parse(pdev, host);
+ 
+ 	host->dev = &pdev->dev;
++	host->dev_comp = of_device_get_match_data(&pdev->dev);
+ 	host->mmc = mmc;
+ 	host->src_clk_freq = clk_get_rate(host->src_clk);
+ 	/* Set host parameters to mmc */
+ 	mmc->ops = &mt_msdc_ops;
+-	mmc->f_min = DIV_ROUND_UP(host->src_clk_freq, 4 * 255);
++	if (host->dev_comp->clk_div_bits == 8)
++		mmc->f_min = DIV_ROUND_UP(host->src_clk_freq, 4 * 255);
++	else
++		mmc->f_min = DIV_ROUND_UP(host->src_clk_freq, 4 * 4095);
++
++	if (!(mmc->caps & MMC_CAP_NONREMOVABLE) &&
++	    !mmc_can_gpio_cd(mmc) &&
++	    host->dev_comp->use_internal_cd) {
++		/*
++		 * Is removable but no GPIO declared, so
++		 * use internal functionality.
++		 */
++		host->internal_cd = true;
++	}
++
++	if (mmc->caps & MMC_CAP_SDIO_IRQ)
++		mmc->caps2 |= MMC_CAP2_SDIO_IRQ_NOTHREAD;
+ 
+ 	mmc->caps |= MMC_CAP_ERASE | MMC_CAP_CMD23;
+ 	/* MMC core transfer sizes tunable parameters */
+@@ -1699,7 +2279,10 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 	mmc->max_blk_size = 2048;
+ 	mmc->max_req_size = 512 * 1024;
+ 	mmc->max_blk_count = mmc->max_req_size / 512;
+-	host->dma_mask = DMA_BIT_MASK(32);
++	if (host->dev_comp->support_64g)
++		host->dma_mask = DMA_BIT_MASK(36);
++	else
++		host->dma_mask = DMA_BIT_MASK(32);
+ 	mmc_dev(mmc)->dma_mask = &host->dma_mask;
+ 
+ 	host->timeout_clks = 3 * 1048576;
+@@ -1722,7 +2305,7 @@ static int msdc_drv_probe(struct platform_device *pdev)
+ 	msdc_init_hw(host);
+ 
+ 	ret = devm_request_irq(&pdev->dev, host->irq, msdc_irq,
+-		IRQF_TRIGGER_LOW | IRQF_ONESHOT, pdev->name, host);
++			       IRQF_TRIGGER_NONE, pdev->name, host);
+ 	if (ret)
+ 		goto release;
+ 
+@@ -1788,28 +2371,56 @@ static int msdc_drv_remove(struct platform_device *pdev)
+ #ifdef CONFIG_PM
+ static void msdc_save_reg(struct msdc_host *host)
+ {
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
++
+ 	host->save_para.msdc_cfg = readl(host->base + MSDC_CFG);
+ 	host->save_para.iocon = readl(host->base + MSDC_IOCON);
+ 	host->save_para.sdc_cfg = readl(host->base + SDC_CFG);
+-	host->save_para.pad_tune = readl(host->base + MSDC_PAD_TUNE);
+ 	host->save_para.patch_bit0 = readl(host->base + MSDC_PATCH_BIT);
+ 	host->save_para.patch_bit1 = readl(host->base + MSDC_PATCH_BIT1);
++	host->save_para.patch_bit2 = readl(host->base + MSDC_PATCH_BIT2);
+ 	host->save_para.pad_ds_tune = readl(host->base + PAD_DS_TUNE);
+ 	host->save_para.pad_cmd_tune = readl(host->base + PAD_CMD_TUNE);
+ 	host->save_para.emmc50_cfg0 = readl(host->base + EMMC50_CFG0);
++	host->save_para.emmc50_cfg3 = readl(host->base + EMMC50_CFG3);
++	host->save_para.sdc_fifo_cfg = readl(host->base + SDC_FIFO_CFG);
++	if (host->top_base) {
++		host->save_para.emmc_top_control =
++			readl(host->top_base + EMMC_TOP_CONTROL);
++		host->save_para.emmc_top_cmd =
++			readl(host->top_base + EMMC_TOP_CMD);
++		host->save_para.emmc50_pad_ds_tune =
++			readl(host->top_base + EMMC50_PAD_DS_TUNE);
++	} else {
++		host->save_para.pad_tune = readl(host->base + tune_reg);
++	}
+ }
+ 
+ static void msdc_restore_reg(struct msdc_host *host)
+ {
++	u32 tune_reg = host->dev_comp->pad_tune_reg;
++
+ 	writel(host->save_para.msdc_cfg, host->base + MSDC_CFG);
+ 	writel(host->save_para.iocon, host->base + MSDC_IOCON);
+ 	writel(host->save_para.sdc_cfg, host->base + SDC_CFG);
+-	writel(host->save_para.pad_tune, host->base + MSDC_PAD_TUNE);
+ 	writel(host->save_para.patch_bit0, host->base + MSDC_PATCH_BIT);
+ 	writel(host->save_para.patch_bit1, host->base + MSDC_PATCH_BIT1);
++	writel(host->save_para.patch_bit2, host->base + MSDC_PATCH_BIT2);
+ 	writel(host->save_para.pad_ds_tune, host->base + PAD_DS_TUNE);
+ 	writel(host->save_para.pad_cmd_tune, host->base + PAD_CMD_TUNE);
+ 	writel(host->save_para.emmc50_cfg0, host->base + EMMC50_CFG0);
++	writel(host->save_para.emmc50_cfg3, host->base + EMMC50_CFG3);
++	writel(host->save_para.sdc_fifo_cfg, host->base + SDC_FIFO_CFG);
++	if (host->top_base) {
++		writel(host->save_para.emmc_top_control,
++		       host->top_base + EMMC_TOP_CONTROL);
++		writel(host->save_para.emmc_top_cmd,
++		       host->top_base + EMMC_TOP_CMD);
++		writel(host->save_para.emmc50_pad_ds_tune,
++		       host->top_base + EMMC50_PAD_DS_TUNE);
++	} else {
++		writel(host->save_para.pad_tune, host->base + tune_reg);
++	}
+ }
+ 
+ static int msdc_runtime_suspend(struct device *dev)
+@@ -1839,12 +2450,6 @@ static const struct dev_pm_ops msdc_dev_pm_ops = {
+ 	SET_RUNTIME_PM_OPS(msdc_runtime_suspend, msdc_runtime_resume, NULL)
+ };
+ 
+-static const struct of_device_id msdc_of_ids[] = {
+-	{   .compatible = "mediatek,mt8135-mmc", },
+-	{}
+-};
+-MODULE_DEVICE_TABLE(of, msdc_of_ids);
+-
+ static struct platform_driver mt_msdc_driver = {
+ 	.probe = msdc_drv_probe,
+ 	.remove = msdc_drv_remove,


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

NAND support will probably break. Probably needs this change: https://github.com/openwrt/openwrt/commit/6069bdd0871a20b5adce8d2f677946e05a2da609#diff-5ccccffae0e8e462248de390cd729e35

Posting here in case anyone else wants to test. Initial results seem good.

Patch was done by diffing linux-next with kernel 4.14.