### PR TITLE
[RFT] ramips: mt7621: add support for memory detection

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -63,8 +63,7 @@ ramips_setup_interfaces()
 	mediatek,mt7621-eval-board|\
 	mediatek,mt7628an-eval-board|\
 	mercury,mac1200r-v2|\
-	mqmaker,witi-256m|\
-	mqmaker,witi-512m|\
+	mqmaker,witi|\
 	mtc,wr1201|\
 	netgear,r6220|\
 	netgear,r6350|\

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
+++ b/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_run;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_asiarf_ap7621-001.dts
+++ b/target/linux/ramips/dts/mt7621_asiarf_ap7621-001.dts
@@ -10,11 +10,6 @@
 	compatible = "asiarf,ap7621-001", "mediatek,mt7621-soc";
 	model = "AsiaRF AP7621-001";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power_blue;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_sys;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power_green;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power_green;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
@@ -14,11 +14,6 @@
 		led-upgrade = &led_power_green;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
+++ b/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
+++ b/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
@@ -10,11 +10,6 @@
 	compatible = "gehua,ghl-r-001", "mediatek,mt7621-soc";
 	model = "GeHua GHL-R-001";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_status;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_status;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
+++ b/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_status;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_blue;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_linksys_re6500.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re6500.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
@@ -6,11 +6,6 @@
 	compatible = "mediatek,ap-mt7621a-v60", "mediatek,mt7621-soc";
 	model = "Mediatek AP-MT7621A-V60 EVB";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_mediatek_mt7621-eval-board.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_mt7621-eval-board.dts
@@ -6,11 +6,6 @@
 	compatible = "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
 	model = "Mediatek MT7621 evaluation board";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_mikrotik_rb750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_rb750gr3.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_usr;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_mikrotik_rbm11g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_rbm11g.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_usr;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_mikrotik_rbm33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_rbm33g.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_usr;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi-256m.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi-256m.dts
@@ -5,9 +5,4 @@
 / {
 	compatible = "mqmaker,witi-256m", "mqmaker,witi", "mediatek,mt7621-soc";
 	model = "MQmaker WiTi (256MB RAM)";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi-256m.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi-256m.dts
@@ -1,8 +1,0 @@
-/dts-v1/;
-
-#include "mt7621_mqmaker_witi.dtsi"
-
-/ {
-	compatible = "mqmaker,witi-256m", "mqmaker,witi", "mediatek,mt7621-soc";
-	model = "MQmaker WiTi (256MB RAM)";
-};

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi-512m.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi-512m.dts
@@ -5,9 +5,4 @@
 / {
 	compatible = "mqmaker,witi-512m", "mqmaker,witi", "mediatek,mt7621-soc";
 	model = "MQmaker WiTi (512MB RAM)";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
 };

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi-512m.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi-512m.dts
@@ -1,8 +1,0 @@
-/dts-v1/;
-
-#include "mt7621_mqmaker_witi.dtsi"
-
-/ {
-	compatible = "mqmaker,witi-512m", "mqmaker,witi", "mediatek,mt7621-soc";
-	model = "MQmaker WiTi (512MB RAM)";
-};

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
@@ -7,6 +7,7 @@
 
 / {
 	compatible = "mqmaker,witi", "mediatek,mt7621-soc";
+	model = "MQmaker WiTi";
 
 	chosen {
 		bootargs = "console=ttyS0,57600";

--- a/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
+++ b/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &power_amber;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_r6220.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_r6220.dtsi
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_r6350.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6350.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_netis_wf-2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf-2881.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_wps;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_blue;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_planex_vr500.dts
+++ b/target/linux/ramips/dts/mt7621_planex_vr500.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -15,11 +15,6 @@
 		led-upgrade = &led_wps;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
+++ b/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
@@ -9,11 +9,6 @@
 	compatible = "storylink,sap-g3200u3", "mediatek,mt7621-soc";
 	model = "STORYLiNK SAP-G3200U3";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -81,11 +81,6 @@
 			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
+++ b/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_statuso;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_sys;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_ubiquiti_edgerouterx.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubiquiti_edgerouterx.dtsi
@@ -6,11 +6,6 @@
 / {
 	compatible = "ubiquiti,edgerouterx", "mediatek,mt7621-soc";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-256m-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-256m-16m.dts
@@ -42,11 +42,6 @@
 / {
 	compatible = "unielec,u7621-06-256m-16m", "unielec,u7621-06", "mediatek,mt7621-soc";
 	model = "UniElec U7621-06 (256M RAM/16M flash)";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-512m-64m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-512m-64m.dts
@@ -43,11 +43,6 @@
 / {
 	compatible = "unielec,u7621-06-512m-64m", "unielec,u7621-06", "mediatek,mt7621-soc";
 	model = "UniElec U7621-06 (512M RAM/64M flash)";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_wevo_11acnas.dts
+++ b/target/linux/ramips/dts/mt7621_wevo_11acnas.dts
@@ -6,11 +6,6 @@
 	compatible = "wevo,11acnas", "wevo,w2914ns-v2", "mediatek,mt7621-soc";
 	model = "WeVO 11AC NAS Router";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dts
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dts
@@ -5,11 +5,6 @@
 / {
 	model = "WeVO W2914NS v2";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir3g.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_status_yellow;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir3p.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir3p.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_status_yellow;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x04000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -17,12 +17,6 @@
 		led-upgrade = &led_sys;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1C000000>,
-		      <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -14,11 +14,6 @@
 		led-failsafe = &led_wps;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_wps;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x10000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -13,11 +13,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
@@ -9,11 +9,6 @@
 	compatible = "zbtlink,zbt-we3526", "mediatek,mt7621-soc";
 	model = "ZBT-WE3526";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_status;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -13,11 +13,6 @@
 		led-upgrade = &led_status;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
+++ b/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
@@ -76,11 +76,6 @@
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
 };
 
 &ehci {

--- a/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
+++ b/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
@@ -24,11 +24,6 @@
 		serial0 = &uart2;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
+++ b/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
@@ -9,11 +9,6 @@
 	compatible = "duzun,dm06", "mediatek,mt7628an-soc";
 	model = "DuZun DM06";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <100>;

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_glinet_vixmini.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_vixmini.dts
@@ -21,11 +21,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -10,11 +10,6 @@
 	compatible = "hilink,hlk-7628n", "mediatek,mt7628an-soc";
 	model = "HILINK HLK-7628N";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5661a.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5861b.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -24,11 +24,6 @@
 		serial0 = &uart2;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	bootstrap {
 		compatible = "mediatek,linkit";
 

--- a/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
@@ -5,11 +5,6 @@
 / {
 	compatible = "mediatek,mt7628an-eval-board", "mediatek,mt7628an-soc";
 	model = "Mediatek MT7628AN evaluation board";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
 };
 
 &pinctrl {

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,57600";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 		led_status: status {

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_onion_omega2.dts
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2.dts
@@ -5,11 +5,6 @@
 / {
 	compatible = "onion,omega2", "mediatek,mt7628an-soc";
 	model = "Onion Omega2";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
 };
 
 &firmware {

--- a/target/linux/ramips/dts/mt7628an_onion_omega2p.dts
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2p.dts
@@ -5,11 +5,6 @@
 / {
 	compatible = "onion,omega2p", "onion,omega2", "mediatek,mt7628an-soc";
 	model = "Onion Omega2+";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
 };
 
 &firmware {

--- a/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
+++ b/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
@@ -10,11 +10,6 @@
 	compatible = "rakwireless,rak633", "mediatek,mt7628an-soc";
 	model = "Rakwireless RAK633";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
+++ b/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
@@ -19,11 +19,6 @@
 		bootargs = "console=ttyS0,57600";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -9,11 +9,6 @@
 	compatible = "tama,w06", "mediatek,mt7628an-soc";
 	model = "Tama W06";
 
-	memory@0{
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_sys;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -5,11 +5,6 @@
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -4,11 +4,6 @@
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
@@ -22,11 +22,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01-128m-16m.dts
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01-128m-16m.dts
@@ -39,11 +39,6 @@
 / {
 	compatible = "unielec,u7628-01-128m-16m", "unielec,u7628-01", "mediatek,mt7628an-soc";
 	model = "UniElec U7628-01 (128M RAM/16M flash)";
-
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -12,11 +12,6 @@
 		bootargs = "console=ttyS0,57600";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -12,11 +12,6 @@
 		bootargs = "console=ttyS0,57600";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
+++ b/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
@@ -17,11 +17,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -14,11 +14,6 @@
 		bootargs = "console=ttyS1,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	aliases {
 		led-boot = &led_run;
 		led-failsafe = &led_run;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mir4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mir4a-100m.dts
@@ -14,11 +14,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	aliases {
 		led-boot = &power_yellow;
 		led-failsafe = &power_yellow;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -20,11 +20,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -19,11 +19,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x4000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -16,11 +16,6 @@
 		led-upgrade = &led_power;
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x8000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS0,57600n8";
 	};

--- a/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
+++ b/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
@@ -9,11 +9,6 @@
 	compatible = "hilink,hlk-rm04", "ralink,rt5350-soc";
 	model = "HILINK HLK-RM04";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x1000000>;
-	};
-
 	chosen {
 		bootargs = "console=ttyS1,57600";
 	};

--- a/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
+++ b/target/linux/ramips/dts/rt5350_nexx_wt1520.dtsi
@@ -6,11 +6,6 @@
 / {
 	compatible = "nexx,wt1520", "ralink,rt5350-soc";
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x0 0x2000000>;
-	};
-
 	keys {
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -344,30 +344,17 @@ define Device/mikrotik_rbm33g
 endef
 TARGET_DEVICES += mikrotik_rbm33g
 
-define Device/mqmaker_witi-256m
+define Device/mqmaker_witi
   MTK_SOC := mt7621
   IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := MQmaker
   DEVICE_MODEL := WiTi
-  DEVICE_VARIANT := 256MB RAM
   DEVICE_PACKAGES := \
 	kmod-ata-core kmod-ata-ahci kmod-mt76x2 kmod-sdhci-mt7620 kmod-usb3 \
 	kmod-usb-ledtrig-usbport wpad-basic
-  SUPPORTED_DEVICES += witi
+  SUPPORTED_DEVICES += witi mqmaker,witi-256m mqmaker,witi-512m
 endef
-TARGET_DEVICES += mqmaker_witi-256m
-
-define Device/mqmaker_witi-512m
-  MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
-  DEVICE_VENDOR := MQmaker
-  DEVICE_MODEL := WiTi
-  DEVICE_VARIANT := 512MB RAM
-  DEVICE_PACKAGES := \
-	kmod-ata-core kmod-ata-ahci kmod-mt76x2 kmod-sdhci-mt7620 kmod-usb3 \
-	kmod-usb-ledtrig-usbport wpad-basic
-endef
-TARGET_DEVICES += mqmaker_witi-512m
+TARGET_DEVICES += mqmaker_witi
 
 define Device/mtc_wr1201
   MTK_SOC := mt7621

--- a/target/linux/ramips/patches-4.14/105-mt7621-memory-detect.patch
+++ b/target/linux/ramips/patches-4.14/105-mt7621-memory-detect.patch
@@ -1,0 +1,125 @@
+From b5a52351a66f3c2a7a207548aa87d78ff2d336c0 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Wed, 10 Jul 2019 00:24:48 +0800
+Subject: [PATCH] MIPS: ralink: mt7621: add memory detection support
+
+mt7621 has the following memory map:
+0x0-0x1c000000: lower 448m memory
+0x1c000000-0x2000000: peripheral registers
+0x20000000-0x2400000: higher 64m memory
+
+detect_memory_region in arch/mips/kernel/setup.c only add the first
+memory region and isn't suitable for 512m memory detection because
+it may accidentally read the memory area for peripheral registers.
+
+This commit adds memory detection capability for mt7621:
+1. add the highmem area when 512m is detected.
+2. guard memcmp from accessing peripheral registers:
+     This only happens when some weird user decided to change
+     kernel load address to 256m or higher address. Since this
+     is a quite unusual case, we just skip 512m testing and return
+     256m as memory size.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ arch/mips/include/asm/mach-ralink/mt7621.h |  7 ++---
+ arch/mips/ralink/mt7621.c                  | 30 +++++++++++++++++++---
+ 2 files changed, 30 insertions(+), 7 deletions(-)
+
+--- a/arch/mips/include/asm/mach-ralink/mt7621.h
++++ b/arch/mips/include/asm/mach-ralink/mt7621.h
+@@ -46,9 +46,10 @@
+ #define CPU_PLL_FBDIV_MASK		0x7f
+ #define CPU_PLL_FBDIV_SHIFT		4
+ 
+-#define MT7621_DRAM_BASE                0x0
+-#define MT7621_DDR2_SIZE_MIN		32
+-#define MT7621_DDR2_SIZE_MAX		256
++#define MT7621_LOWMEM_BASE		0x0
++#define MT7621_LOWMEM_MAX_SIZE		0x1C000000
++#define MT7621_HIGHMEM_BASE		0x20000000
++#define MT7621_HIGHMEM_SIZE		0x4000000
+ 
+ #define MT7621_CHIP_NAME0		0x3637544D
+ #define MT7621_CHIP_NAME1		0x20203132
+--- a/arch/mips/ralink/mt7621.c
++++ b/arch/mips/ralink/mt7621.c
+@@ -15,6 +15,7 @@
+ #include <linux/clk-provider.h>
+ #include <dt-bindings/clock/mt7621-clk.h>
+ 
++#include <asm/bootinfo.h>
+ #include <asm/mipsregs.h>
+ #include <asm/smp-ops.h>
+ #include <asm/mips-cps.h>
+@@ -57,6 +58,8 @@
+ #define MT7621_GPIO_MODE_SDHCI_SHIFT	18
+ #define MT7621_GPIO_MODE_SDHCI_GPIO	1
+ 
++static void *detect_magic __initdata = detect_memory_region;
++
+ static struct rt2880_pmx_func uart1_grp[] =  { FUNC("uart1", 0, 1, 2) };
+ static struct rt2880_pmx_func i2c_grp[] =  { FUNC("i2c", 0, 3, 2) };
+ static struct rt2880_pmx_func uart3_grp[] = {
+@@ -141,6 +144,28 @@ static struct clk *__init mt7621_add_sys
+ 	return clk;
+ }
+ 
++void __init mt7621_memory_detect(void)
++{
++	void *dm = &detect_magic;
++	phys_addr_t size;
++
++	for (size = 32 * SZ_1M; size < 256 * SZ_1M; size <<= 1) {
++		if (!memcmp(dm, dm + size, sizeof(detect_magic)))
++			break;
++	}
++
++	if ((size == 256 * SZ_1M) &&
++	    (CPHYSADDR(dm + size) < MT7621_LOWMEM_MAX_SIZE) &&
++	    memcmp(dm, dm + size, sizeof(detect_magic))) {
++		add_memory_region(MT7621_LOWMEM_BASE, MT7621_LOWMEM_MAX_SIZE,
++				  BOOT_MEM_RAM);
++		add_memory_region(MT7621_HIGHMEM_BASE, MT7621_HIGHMEM_SIZE,
++				  BOOT_MEM_RAM);
++	} else {
++		add_memory_region(MT7621_LOWMEM_BASE, size, BOOT_MEM_RAM);
++	}
++}
++
+ void __init ralink_clk_init(void)
+ {
+ 	u32 syscfg, xtal_sel, clkcfg, clk_sel, curclk, ffiv, ffrac;
+@@ -319,10 +344,7 @@ void prom_soc_init(struct ralink_soc_inf
+ 		(rev >> CHIP_REV_VER_SHIFT) & CHIP_REV_VER_MASK,
+ 		(rev & CHIP_REV_ECO_MASK));
+ 
+-	soc_info->mem_size_min = MT7621_DDR2_SIZE_MIN;
+-	soc_info->mem_size_max = MT7621_DDR2_SIZE_MAX;
+-	soc_info->mem_base = MT7621_DRAM_BASE;
+-
++	soc_info->mem_detect = mt7621_memory_detect;
+ 	rt2880_pinmux_data = mt7621_pinmux_data;
+ 
+ 
+--- a/arch/mips/ralink/common.h
++++ b/arch/mips/ralink/common.h
+@@ -19,6 +19,7 @@ struct ralink_soc_info {
+ 	unsigned long mem_size;
+ 	unsigned long mem_size_min;
+ 	unsigned long mem_size_max;
++	void (*mem_detect)(void);
+ };
+ extern struct ralink_soc_info soc_info;
+ 
+--- a/arch/mips/ralink/of.c
++++ b/arch/mips/ralink/of.c
+@@ -89,6 +89,8 @@ void __init plat_mem_setup(void)
+ 	of_scan_flat_dt(early_init_dt_find_memory, NULL);
+ 	if (memory_dtb)
+ 		of_scan_flat_dt(early_init_dt_scan_memory, NULL);
++	else if (soc_info.mem_detect)
++		soc_info.mem_detect();
+ 	else if (soc_info.mem_size)
+ 		add_memory_region(soc_info.mem_base, soc_info.mem_size * SZ_1M,
+ 				  BOOT_MEM_RAM);


### PR DESCRIPTION
This PR adds proper memory detection for mt7621 and drops memory nodes in dts, letting kernel do a memory detection.
mt76x8 has the ability to detect its memory from the very beginning so this PR also drops memory nodes for mt76x8 routers.

RFT:
I've tested this PR on 512M and 128M mt7621 routers.
I hope someone could test this on a 256M mt7621 router.