### PR TITLE
ramips: Fix and tidy up IMAGE_SIZE

### DIFF
--- a/target/linux/ramips/dts/rt3050_allnet_all0256n-4m.dts
+++ b/target/linux/ramips/dts/rt3050_allnet_all0256n-4m.dts
@@ -41,7 +41,7 @@
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0x3c8000>;
+				reg = <0x50000 0x3b0000>;
 			};
 		};
 	};

--- a/target/linux/ramips/dts/rt3050_tenda_w150m.dts
+++ b/target/linux/ramips/dts/rt3050_tenda_w150m.dts
@@ -48,7 +48,7 @@
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0x3c8000>;
+				reg = <0x50000 0x3b0000>;
 			};
 		};
 	};

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
@@ -38,7 +38,7 @@
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0x3c8000>;
+				reg = <0x50000 0x3b0000>;
 			};
 		};
 	};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -27,7 +27,6 @@ define Device/Default
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS = $$(MTK_SOC)_$(1)
   IMAGES := sysupgrade.bin
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   sysupgrade_bin := append-kernel | append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -147,11 +147,6 @@ define Build/sercom-footer
 	$(call Build/sercom-seal,-f)
 endef
 
-ralink_default_fw_size_4M=3866624
-ralink_default_fw_size_8M=8060928
-ralink_default_fw_size_16M=16449536
-ralink_default_fw_size_32M=33226752
-
 ifeq ($(SUBTARGET),rt288x)
 include rt288x.mk
 endif

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -56,7 +56,7 @@ endef
 define Build/trx
 	$(STAGING_DIR_HOST)/bin/trx $(1) \
 		-o $@ \
-		-m $(IMAGE_SIZE) \
+		-m $$(($(subst k, * 1024,$(IMAGE_SIZE)))) \
 		-f $(IMAGE_KERNEL) \
 		-a 4 -f $(IMAGE_ROOTFS)
 endef

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -150,7 +150,7 @@ endef
 
 ralink_default_fw_size_4M=3866624
 ralink_default_fw_size_8M=8060928
-ralink_default_fw_size_16M=16121856
+ralink_default_fw_size_16M=16449536
 ralink_default_fw_size_32M=33226752
 
 ifeq ($(SUBTARGET),rt288x)

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -86,7 +86,7 @@ endef
 
 define Device/asus_rp-n53
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RP-N53
   DEVICE_PACKAGES := kmod-rt2800-pci
@@ -96,7 +96,7 @@ TARGET_DEVICES += asus_rp-n53
 
 define Device/asus_rt-ac51u
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-AC51U
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -106,7 +106,7 @@ TARGET_DEVICES += asus_rt-ac51u
 
 define Device/asus_rt-n12p
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N11P/RT-N12+/RT-N12Eb1
   SUPPORTED_DEVICES += rt-n12p
@@ -115,7 +115,7 @@ TARGET_DEVICES += asus_rt-n12p
 
 define Device/asus_rt-n14u
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N14u
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -134,7 +134,7 @@ TARGET_DEVICES += bdcom_wap2100-sk
 
 define Device/buffalo_whr-1166d
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-1166D
   DEVICE_PACKAGES := kmod-mt76x2
@@ -144,7 +144,7 @@ TARGET_DEVICES += buffalo_whr-1166d
 
 define Device/buffalo_whr-300hp2
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-300HP2
   SUPPORTED_DEVICES += whr-300hp2
@@ -153,7 +153,7 @@ TARGET_DEVICES += buffalo_whr-300hp2
 
 define Device/buffalo_whr-600d
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-600D
   DEVICE_PACKAGES := kmod-rt2800-pci
@@ -163,7 +163,7 @@ TARGET_DEVICES += buffalo_whr-600d
 
 define Device/buffalo_wmr-300
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WMR-300
   SUPPORTED_DEVICES += wmr-300
@@ -172,7 +172,7 @@ TARGET_DEVICES += buffalo_wmr-300
 
 define Device/comfast_cf-wr800n
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Comfast
   DEVICE_MODEL := CF-WR800N
   SUPPORTED_DEVICES += cf-wr800n
@@ -298,7 +298,7 @@ TARGET_DEVICES += dlink_dwr-922-e2
 
 define Device/dovado_tiny-ac
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Dovado
   DEVICE_MODEL := Tiny AC
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
@@ -444,7 +444,7 @@ TARGET_DEVICES += hiwifi_hc5861
 
 define Device/hnet_c108
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := HNET
   DEVICE_MODEL := C108
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
@@ -533,7 +533,7 @@ TARGET_DEVICES += lava_lr-25g001
 
 define Device/lenovo_newifi-y1
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Lenovo
   DEVICE_MODEL := Y1
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
@@ -543,7 +543,7 @@ TARGET_DEVICES += lenovo_newifi-y1
 
 define Device/lenovo_newifi-y1s
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Lenovo
   DEVICE_MODEL := Y1S
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
@@ -553,7 +553,7 @@ TARGET_DEVICES += lenovo_newifi-y1s
 
 define Device/linksys_e1700
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x013326
@@ -578,7 +578,7 @@ define Device/netgear_ex2700
   NETGEAR_HW_ID := 29764623+4+0+32+2x2+0
   NETGEAR_BOARD_ID := EX2700
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | append-uImage-fakehdr filesystem
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
@@ -605,7 +605,7 @@ TARGET_DEVICES += netgear_ex3700
 
 define Device/netgear_wn3000rp-v3
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   NETGEAR_HW_ID := 29764836+8+0+32+2x2+0
   NETGEAR_BOARD_ID := WN3000RPv3
   BLOCKSIZE := 4k
@@ -623,7 +623,7 @@ TARGET_DEVICES += netgear_wn3000rp-v3
 define Device/nexx_wt3020-4m
   MTK_SOC := mt7620n
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	poray-header -B WT3020 -F 4M
@@ -636,7 +636,7 @@ TARGET_DEVICES += nexx_wt3020-4m
 
 define Device/nexx_wt3020-8m
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	poray-header -B WT3020 -F 8M
@@ -650,7 +650,7 @@ TARGET_DEVICES += nexx_wt3020-8m
 
 define Device/ohyeah_oy-0001
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Oh Yeah
   DEVICE_MODEL := OY-0001
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -669,7 +669,7 @@ TARGET_DEVICES += phicomm_k2g
 
 define Device/phicomm_psg1208
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1208
   DEVICE_PACKAGES := kmod-mt76x2
@@ -679,7 +679,7 @@ TARGET_DEVICES += phicomm_psg1208
 
 define Device/phicomm_psg1218a
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1218
   DEVICE_VARIANT:= Ax
@@ -690,7 +690,7 @@ TARGET_DEVICES += phicomm_psg1218a
 
 define Device/phicomm_psg1218b
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1218
   DEVICE_VARIANT := Bx
@@ -701,7 +701,7 @@ TARGET_DEVICES += phicomm_psg1218b
 
 define Device/planex_cs-qr10
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := CS-QR10
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci \
@@ -713,7 +713,7 @@ TARGET_DEVICES += planex_cs-qr10
 
 define Device/planex_db-wrt01
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := DB-WRT01
   SUPPORTED_DEVICES += db-wrt01
@@ -722,7 +722,7 @@ TARGET_DEVICES += planex_db-wrt01
 
 define Device/planex_mzk-750dhp
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-750DHP
   DEVICE_PACKAGES := kmod-mt76x0e
@@ -751,7 +751,7 @@ TARGET_DEVICES += planex_mzk-ex750np
 
 define Device/ralink_mt7620a-evb
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a EVB
 endef
@@ -759,7 +759,7 @@ TARGET_DEVICES += ralink_mt7620a-evb
 
 define Device/ralink_mt7620a-mt7530-evb
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a + MT7530 EVB
   SUPPORTED_DEVICES += mt7620a_mt7530
@@ -768,7 +768,7 @@ TARGET_DEVICES += ralink_mt7620a-mt7530-evb
 
 define Device/ralink_mt7620a-mt7610e-evb
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a + MT7610e EVB
   DEVICE_PACKAGES := kmod-mt76x0e
@@ -787,7 +787,7 @@ TARGET_DEVICES += ralink_mt7620a-v22sg-evb
 
 define Device/ravpower_wd03
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Ravpower
   DEVICE_MODEL := WD03
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -796,7 +796,7 @@ TARGET_DEVICES += ravpower_wd03
 
 define Device/sanlinking_d240
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Sanlinking Technologies
   DEVICE_MODEL := D240
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
@@ -875,7 +875,7 @@ TARGET_DEVICES += tplink_archer-c50-v1
 
 define Device/tplink_archer-mr200
   $(Device/Archer)
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   TPLINK_FLASHLAYOUT := 8MLmtk
   TPLINK_HWID := 0xd7500001
   TPLINK_HWREV := 0x4a
@@ -887,7 +887,7 @@ TARGET_DEVICES += tplink_archer-mr200
 
 define Device/vonets_var11n-300
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   BLOCKSIZE := 4k
   DEVICE_VENDOR := Vonets
   DEVICE_MODEL := VAR11N-300
@@ -896,7 +896,7 @@ TARGET_DEVICES += vonets_var11n-300
 
 define Device/wrtnode_wrtnode
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := WRTNode
   DEVICE_MODEL := WRTNode
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -916,7 +916,7 @@ TARGET_DEVICES += xiaomi_miwifi-mini
 
 define Device/youku_yk1
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := YOUKU
   DEVICE_MODEL := YK1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 kmod-usb-ledtrig-usbport
@@ -926,7 +926,7 @@ TARGET_DEVICES += youku_yk1
 
 define Device/yukai_bocco
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := YUKAI Engineering
   DEVICE_MODEL := BOCCO
   DEVICE_PACKAGES := kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
@@ -936,7 +936,7 @@ TARGET_DEVICES += yukai_bocco
 
 define Device/zbtlink_we1026-5g-16m
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE1026-5G
   DEVICE_VARIANT := 16M
@@ -986,7 +986,7 @@ TARGET_DEVICES += zbtlink_zbt-we2026
 
 define Device/zbtlink_zbt-we826-16m
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE826
   DEVICE_VARIANT := 16M
@@ -997,7 +997,7 @@ TARGET_DEVICES += zbtlink_zbt-we826-16m
 
 define Device/zbtlink_zbt-we826-32m
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE826
   DEVICE_VARIANT := 32M
@@ -1018,7 +1018,7 @@ TARGET_DEVICES += zbtlink_zbt-we826-e
 
 define Device/zbtlink_zbt-wr8305rt
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WR8305RT
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -1028,7 +1028,7 @@ TARGET_DEVICES += zbtlink_zbt-wr8305rt
 
 define Device/zte_q7
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZTE
   DEVICE_MODEL := Q7
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -1038,7 +1038,7 @@ TARGET_DEVICES += zte_q7
 
 define Device/zyxel_keenetic-omni
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Omni
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -1051,7 +1051,7 @@ TARGET_DEVICES += zyxel_keenetic-omni
 
 define Device/zyxel_keenetic-omni-ii
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Omni II
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -1064,7 +1064,7 @@ TARGET_DEVICES += zyxel_keenetic-omni-ii
 
 define Device/zyxel_keenetic-viva
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Viva
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport kmod-switch-rtl8366-smi kmod-switch-rtl8367b

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -490,7 +490,7 @@ TARGET_DEVICES += kimax_u35wf
 
 define Device/kingston_mlw221
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Kingston
   DEVICE_MODEL := MLW221
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
@@ -500,7 +500,7 @@ TARGET_DEVICES += kingston_mlw221
 
 define Device/kingston_mlwg2
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Kingston
   DEVICE_MODEL := MLWG2
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -105,6 +105,7 @@ TARGET_DEVICES += asus_rt-ac51u
 
 define Device/asus_rt-n12p
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N11P/RT-N12+/RT-N12Eb1
   SUPPORTED_DEVICES += rt-n12p
@@ -113,6 +114,7 @@ TARGET_DEVICES += asus_rt-n12p
 
 define Device/asus_rt-n14u
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N14u
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -131,7 +133,7 @@ TARGET_DEVICES += bdcom_wap2100-sk
 
 define Device/buffalo_whr-1166d
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 15040k
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-1166D
   DEVICE_PACKAGES := kmod-mt76x2
@@ -141,7 +143,7 @@ TARGET_DEVICES += buffalo_whr-1166d
 
 define Device/buffalo_whr-300hp2
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 6848k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-300HP2
   SUPPORTED_DEVICES += whr-300hp2
@@ -150,7 +152,7 @@ TARGET_DEVICES += buffalo_whr-300hp2
 
 define Device/buffalo_whr-600d
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 6848k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-600D
   DEVICE_PACKAGES := kmod-rt2800-pci
@@ -190,6 +192,7 @@ TARGET_DEVICES += dlink_dch-m225
 define Device/dlink_dir-510l
   $(Device/amit_jboot)
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 14208k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-510L
   DEVICE_PACKAGES += kmod-mt76x0e
@@ -213,6 +216,7 @@ TARGET_DEVICES += dlink_dir-810l
 define Device/dlink_dwr-116-a1
   $(Device/amit_jboot)
   MTK_SOC := mt7620n
+  IMAGE_SIZE := 8064k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-116
   DEVICE_VARIANT := A1/A2
@@ -225,6 +229,7 @@ TARGET_DEVICES += dlink_dwr-116-a1
 define Device/dlink_dwr-118-a1
   $(Device/amit_jboot)
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 16256k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-118
   DEVICE_VARIANT := A1
@@ -238,6 +243,7 @@ TARGET_DEVICES += dlink_dwr-118-a1
 define Device/dlink_dwr-118-a2
   $(Device/amit_jboot)
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 16256k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-118
   DEVICE_VARIANT := A2
@@ -251,7 +257,7 @@ TARGET_DEVICES += dlink_dwr-118-a2
 define Device/dlink_dwr-921-c1
   $(Device/amit_jboot)
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16256k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-921
   DEVICE_VARIANT := C1
@@ -276,7 +282,7 @@ TARGET_DEVICES += dlink_dwr-921-c3
 define Device/dlink_dwr-922-e2
   $(Device/amit_jboot)
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16256k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-922
   DEVICE_VARIANT := E2
@@ -302,7 +308,7 @@ define Device/edimax_br-6478ac-v2
   DEVICE_MODEL := BR-6478AC
   DEVICE_VARIANT := V2
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 7616k
+  IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN68 -f 0x70000 -S 0x01100000 | pad-rootfs | \
 	append-metadata | check-size $$$$(IMAGE_SIZE)
@@ -351,7 +357,7 @@ TARGET_DEVICES += edimax_ew-7478apc
 
 define Device/elecom_wrh-300cr
   MTK_SOC := mt7620n
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 14272k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	elecom-header
@@ -364,7 +370,7 @@ TARGET_DEVICES += elecom_wrh-300cr
 
 define Device/glinet_gl-mt300a
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT300A
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -374,7 +380,7 @@ TARGET_DEVICES += glinet_gl-mt300a
 
 define Device/glinet_gl-mt300n
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT300N
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -384,7 +390,7 @@ TARGET_DEVICES += glinet_gl-mt300n
 
 define Device/glinet_gl-mt750
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT750
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
@@ -434,7 +440,7 @@ TARGET_DEVICES += hiwifi_hc5861
 
 define Device/hnet_c108
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 16777216
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := HNET
   DEVICE_MODEL := C108
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620
@@ -511,6 +517,7 @@ TARGET_DEVICES += kingston_mlwg2
 define Device/lava_lr-25g001
   $(Device/amit_jboot)
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 16256k
   DEVICE_VENDOR := LAVA
   DEVICE_MODEL := LR-25G001
   DLINK_ROM_ID := LVA6E3804001
@@ -712,6 +719,7 @@ TARGET_DEVICES += planex_mzk-750dhp
 
 define Device/planex_mzk-ex300np
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 7360k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-EX300NP
   SUPPORTED_DEVICES += mzk-ex300np
@@ -720,6 +728,7 @@ TARGET_DEVICES += planex_mzk-ex300np
 
 define Device/planex_mzk-ex750np
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 7360k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-EX750NP
   DEVICE_PACKAGES := kmod-mt76x2
@@ -753,6 +762,7 @@ TARGET_DEVICES += ralink_mt7620a-mt7610e-evb
 
 define Device/ralink_mt7620a-v22sg-evb
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 130560k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a V22SG
   SUPPORTED_DEVICES += mt7620a_v22sg
@@ -790,6 +800,7 @@ TARGET_DEVICES += sercomm_na930
 
 define Device/tplink_archer-c20i
   $(Device/Archer)
+  IMAGE_SIZE := 7808k
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc2000001
   TPLINK_HWREV := 58
@@ -803,6 +814,7 @@ TARGET_DEVICES += tplink_archer-c20i
 
 define Device/tplink_archer-c20-v1
   $(Device/Archer)
+  IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += tplink,c20-v1
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc2000001
@@ -817,6 +829,7 @@ TARGET_DEVICES += tplink_archer-c20-v1
 
 define Device/tplink_archer-c2-v1
   $(Device/Archer)
+  IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += tplink,c2-v1
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc7500001
@@ -830,6 +843,7 @@ TARGET_DEVICES += tplink_archer-c2-v1
 
 define Device/tplink_archer-c50-v1
   $(Device/Archer)
+  IMAGE_SIZE := 7808k
   TPLINK_FLASHLAYOUT := 8Mmtk
   TPLINK_HWID := 0xc7500001
   TPLINK_HWREV := 69
@@ -875,7 +889,7 @@ TARGET_DEVICES += wrtnode_wrtnode
 
 define Device/xiaomi_miwifi-mini
   MTK_SOC := mt7620a
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := MiWiFi Mini
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
@@ -904,7 +918,7 @@ TARGET_DEVICES += yukai_bocco
 
 define Device/zbtlink_we1026-5g-16m
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 16777216
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE1026-5G
   DEVICE_VARIANT := 16M
@@ -915,6 +929,7 @@ TARGET_DEVICES += zbtlink_we1026-5g-16m
 
 define Device/zbtlink_zbt-ape522ii
   MTK_SOC := mt7620a
+  IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-APE522II
   DEVICE_PACKAGES := kmod-mt76x2
@@ -924,6 +939,7 @@ TARGET_DEVICES += zbtlink_zbt-ape522ii
 
 define Device/zbtlink_zbt-cpe102
   MTK_SOC := mt7620n
+  IMAGE_SIZE := 7552k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-CPE102
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -933,6 +949,7 @@ TARGET_DEVICES += zbtlink_zbt-cpe102
 
 define Device/zbtlink_zbt-wa05
   MTK_SOC := mt7620n
+  IMAGE_SIZE := 7552k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WA05
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -942,6 +959,7 @@ TARGET_DEVICES += zbtlink_zbt-wa05
 
 define Device/zbtlink_zbt-we2026
   MTK_SOC := mt7620n
+  IMAGE_SIZE := 7552k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE2026
   SUPPORTED_DEVICES += zbt-we2026

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -86,6 +86,7 @@ endef
 
 define Device/asus_rp-n53
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RP-N53
   DEVICE_PACKAGES := kmod-rt2800-pci
@@ -162,6 +163,7 @@ TARGET_DEVICES += buffalo_whr-600d
 
 define Device/buffalo_wmr-300
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WMR-300
   SUPPORTED_DEVICES += wmr-300
@@ -170,6 +172,7 @@ TARGET_DEVICES += buffalo_wmr-300
 
 define Device/comfast_cf-wr800n
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Comfast
   DEVICE_MODEL := CF-WR800N
   SUPPORTED_DEVICES += cf-wr800n
@@ -295,6 +298,7 @@ TARGET_DEVICES += dlink_dwr-922-e2
 
 define Device/dovado_tiny-ac
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Dovado
   DEVICE_MODEL := Tiny AC
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci
@@ -549,6 +553,7 @@ TARGET_DEVICES += lenovo_newifi-y1s
 
 define Device/linksys_e1700
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x013326
@@ -600,6 +605,7 @@ TARGET_DEVICES += netgear_ex3700
 
 define Device/netgear_wn3000rp-v3
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   NETGEAR_HW_ID := 29764836+8+0+32+2x2+0
   NETGEAR_BOARD_ID := WN3000RPv3
   BLOCKSIZE := 4k
@@ -630,6 +636,7 @@ TARGET_DEVICES += nexx_wt3020-4m
 
 define Device/nexx_wt3020-8m
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	poray-header -B WT3020 -F 8M
@@ -662,6 +669,7 @@ TARGET_DEVICES += phicomm_k2g
 
 define Device/phicomm_psg1208
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1208
   DEVICE_PACKAGES := kmod-mt76x2
@@ -671,6 +679,7 @@ TARGET_DEVICES += phicomm_psg1208
 
 define Device/phicomm_psg1218a
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1218
   DEVICE_VARIANT:= Ax
@@ -681,6 +690,7 @@ TARGET_DEVICES += phicomm_psg1218a
 
 define Device/phicomm_psg1218b
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := PSG1218
   DEVICE_VARIANT := Bx
@@ -691,6 +701,7 @@ TARGET_DEVICES += phicomm_psg1218b
 
 define Device/planex_cs-qr10
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := CS-QR10
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci \
@@ -702,6 +713,7 @@ TARGET_DEVICES += planex_cs-qr10
 
 define Device/planex_db-wrt01
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := DB-WRT01
   SUPPORTED_DEVICES += db-wrt01
@@ -710,6 +722,7 @@ TARGET_DEVICES += planex_db-wrt01
 
 define Device/planex_mzk-750dhp
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-750DHP
   DEVICE_PACKAGES := kmod-mt76x0e
@@ -738,6 +751,7 @@ TARGET_DEVICES += planex_mzk-ex750np
 
 define Device/ralink_mt7620a-evb
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a EVB
 endef
@@ -745,6 +759,7 @@ TARGET_DEVICES += ralink_mt7620a-evb
 
 define Device/ralink_mt7620a-mt7530-evb
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a + MT7530 EVB
   SUPPORTED_DEVICES += mt7620a_mt7530
@@ -753,6 +768,7 @@ TARGET_DEVICES += ralink_mt7620a-mt7530-evb
 
 define Device/ralink_mt7620a-mt7610e-evb
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7620a + MT7610e EVB
   DEVICE_PACKAGES := kmod-mt76x0e
@@ -859,6 +875,7 @@ TARGET_DEVICES += tplink_archer-c50-v1
 
 define Device/tplink_archer-mr200
   $(Device/Archer)
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   TPLINK_FLASHLAYOUT := 8MLmtk
   TPLINK_HWID := 0xd7500001
   TPLINK_HWREV := 0x4a
@@ -909,6 +926,7 @@ TARGET_DEVICES += youku_yk1
 
 define Device/yukai_bocco
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := YUKAI Engineering
   DEVICE_MODEL := BOCCO
   DEVICE_PACKAGES := kmod-sound-core kmod-sound-mt7620 kmod-i2c-ralink
@@ -1000,6 +1018,7 @@ TARGET_DEVICES += zbtlink_zbt-we826-e
 
 define Device/zbtlink_zbt-wr8305rt
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WR8305RT
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -1009,6 +1028,7 @@ TARGET_DEVICES += zbtlink_zbt-wr8305rt
 
 define Device/zte_q7
   MTK_SOC := mt7620a
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := ZTE
   DEVICE_MODEL := Q7
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -1018,6 +1038,7 @@ TARGET_DEVICES += zte_q7
 
 define Device/zyxel_keenetic-omni
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Omni
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -1030,6 +1051,7 @@ TARGET_DEVICES += zyxel_keenetic-omni
 
 define Device/zyxel_keenetic-omni-ii
   MTK_SOC := mt7620n
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Omni II
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -806,7 +806,7 @@ TARGET_DEVICES += sanlinking_d240
 
 define Device/sercomm_na930
   MTK_SOC := mt7620a
-  IMAGE_SIZE := 20m
+  IMAGE_SIZE := 20480k
   DEVICE_VENDOR := Sercomm
   DEVICE_MODEL := NA930
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -86,7 +86,7 @@ endef
 
 define Device/afoundry_ew1200
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := AFOUNDRY
   DEVICE_MODEL := EW1200
   DEVICE_PACKAGES := \
@@ -128,7 +128,7 @@ TARGET_DEVICES += buffalo_wsr-1166dhp
 
 define Device/buffalo_wsr-600dhp
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-600DHP
   DEVICE_PACKAGES := kmod-mt7603 kmod-rt2800-pci wpad-basic
@@ -142,7 +142,7 @@ define Device/dlink_dir-860l-b1
   BLOCKSIZE := 64k
   SEAMA_SIGNATURE := wrgac13_dlink.2013gui_dir860lb
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | uImage lzma
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-860L
   DEVICE_VARIANT := B1
@@ -153,7 +153,7 @@ TARGET_DEVICES += dlink_dir-860l-b1
 
 define Device/d-team_newifi-d2
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Newifi
   DEVICE_MODEL := D2
   DEVICE_PACKAGES := \
@@ -163,7 +163,7 @@ TARGET_DEVICES += d-team_newifi-d2
 
 define Device/d-team_pbr-m1
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := PandoraBox
   DEVICE_MODEL := PBR-M1
   DEVICE_PACKAGES := \
@@ -209,7 +209,7 @@ TARGET_DEVICES += elecom_wrc-2533gst
 
 define Device/firefly_firewrt
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Firefly
   DEVICE_MODEL := FireWRT
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
@@ -219,7 +219,7 @@ TARGET_DEVICES += firefly_firewrt
 
 define Device/gehua_ghl-r-001
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := GeHua
   DEVICE_MODEL := GHL-R-001
   DEVICE_PACKAGES := \
@@ -232,7 +232,7 @@ define Device/gnubee_gb-pc1
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud One
   DEVICE_PACKAGES := kmod-ata-core kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
 
@@ -241,7 +241,7 @@ define Device/gnubee_gb-pc2
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud Two
   DEVICE_PACKAGES := kmod-ata-core kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
 
@@ -284,7 +284,7 @@ TARGET_DEVICES += iodata_wn-gx300gr
 
 define Device/lenovo_newifi-d1
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Newifi
   DEVICE_MODEL := D1
   DEVICE_PACKAGES := \
@@ -295,7 +295,7 @@ TARGET_DEVICES += lenovo_newifi-d1
 
 define Device/linksys_re6500
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := RE6500
   DEVICE_PACKAGES := kmod-mt76x2 wpad-basic
@@ -305,7 +305,7 @@ TARGET_DEVICES += linksys_re6500
 
 define Device/mediatek_ap-mt7621a-v60
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
   DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620
@@ -357,7 +357,7 @@ TARGET_DEVICES += mikrotik_rbm33g
 
 define Device/mqmaker_witi
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := MQmaker
   DEVICE_MODEL := WiTi
   DEVICE_PACKAGES := \
@@ -486,7 +486,7 @@ TARGET_DEVICES += planex_vr500
 
 define Device/samknows_whitebox-v8
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := SamKnows
   DEVICE_MODEL := Whitebox 8
   DEVICE_PACKAGES := \
@@ -498,7 +498,7 @@ TARGET_DEVICES += samknows_whitebox-v8
 
 define Device/storylink_sap-g3200u3
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := STORYLiNK
   DEVICE_MODEL := SAP-G3200U3
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
@@ -517,7 +517,7 @@ TARGET_DEVICES += telco-electronics_x1
 
 define Device/thunder_timecloud
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
   DEVICE_PACKAGES := kmod-usb3
@@ -615,7 +615,7 @@ TARGET_DEVICES += unielec_u7621-06-512m-64m
 
 define Device/wevo_11acnas
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := 11AC NAS Router
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
@@ -625,7 +625,7 @@ TARGET_DEVICES += wevo_11acnas
 
 define Device/wevo_w2914ns-v2
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := W2914NS
   DEVICE_VARIANT := v2
@@ -675,7 +675,7 @@ TARGET_DEVICES += xiaomi_mir3p
 
 define Device/xzwifi_creativebox-v1
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
   DEVICE_PACKAGES := \
@@ -696,7 +696,7 @@ TARGET_DEVICES += youhua_wr1200js
 
 define Device/youku_yk-l2
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Youku
   DEVICE_MODEL := YK-L2
   DEVICE_PACKAGES := \
@@ -706,7 +706,7 @@ TARGET_DEVICES += youku_yk-l2
 
 define Device/zbtlink_zbt-we1326
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WE1326
   DEVICE_PACKAGES := \
@@ -717,7 +717,7 @@ TARGET_DEVICES += zbtlink_zbt-we1326
 
 define Device/zbtlink_zbt-we3526
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WE3526
   DEVICE_PACKAGES := \
@@ -728,7 +728,7 @@ TARGET_DEVICES += zbtlink_zbt-we3526
 
 define Device/zbtlink_zbt-wg2626
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WG2626
   DEVICE_PACKAGES := \
@@ -740,7 +740,7 @@ TARGET_DEVICES += zbtlink_zbt-wg2626
 
 define Device/zbtlink_zbt-wg3526-16m
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 16M
@@ -753,7 +753,7 @@ TARGET_DEVICES += zbtlink_zbt-wg3526-16m
 
 define Device/zbtlink_zbt-wg3526-32m
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 32M

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -98,7 +98,7 @@ TARGET_DEVICES += afoundry_ew1200
 
 define Device/asiarf_ap7621-001
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
   DEVICE_PACKAGES := \
@@ -118,7 +118,7 @@ TARGET_DEVICES += asus_rt-ac57u
 define Device/buffalo_wsr-1166dhp
   MTK_SOC := mt7621
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15936k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-1166DHP
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic
@@ -251,7 +251,7 @@ define Device/hiwifi_hc5962
   PAGESIZE := 2048
   KERNEL_SIZE := 2097152
   UBINIZE_OPTS := -E 5
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32768k
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
@@ -314,7 +314,7 @@ TARGET_DEVICES += mediatek_ap-mt7621a-v60
 define Device/mediatek_mt7621-eval-board
   MTK_SOC := mt7621
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 15104k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7621 EVB
   SUPPORTED_DEVICES += mt7621
@@ -475,7 +475,7 @@ TARGET_DEVICES += phicomm_k2p
 
 define Device/planex_vr500
   MTK_SOC := mt7621
-  IMAGE_SIZE := 66453504
+  IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
   DEVICE_PACKAGES := kmod-usb3
@@ -515,6 +515,7 @@ TARGET_DEVICES += telco-electronics_x1
 
 define Device/thunder_timecloud
   MTK_SOC := mt7621
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
   DEVICE_PACKAGES := kmod-usb3
@@ -569,6 +570,7 @@ TARGET_DEVICES += tplink_re650-v1
 
 define Device/ubiquiti_edgerouterx
   MTK_SOC := mt7621
+  IMAGE_SIZE := 256768k
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 3145728
   KERNEL_INITRAMFS := $$(KERNEL) | ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
@@ -636,7 +638,7 @@ define Device/xiaomi_mir3g
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
-  IMAGE_SIZE := 32768k
+  IMAGE_SIZE := 124416k
   UBINIZE_OPTS := -E 5
   IMAGES += kernel1.bin rootfs0.bin
   IMAGE/kernel1.bin := append-kernel
@@ -658,7 +660,7 @@ define Device/xiaomi_mir3p
   PAGESIZE := 2048
   KERNEL_SIZE:= 4096k
   UBINIZE_OPTS := -E 5
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 255488k
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 3 Pro
   IMAGES += factory.bin

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -465,7 +465,7 @@ TARGET_DEVICES += netis_wf-2881
 
 define Device/phicomm_k2p
   MTK_SOC := mt7621
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := K2P
   SUPPORTED_DEVICES += k2p

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -295,6 +295,7 @@ TARGET_DEVICES += lenovo_newifi-d1
 
 define Device/linksys_re6500
   MTK_SOC := mt7621
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := RE6500
   DEVICE_PACKAGES := kmod-mt76x2 wpad-basic
@@ -497,6 +498,7 @@ TARGET_DEVICES += samknows_whitebox-v8
 
 define Device/storylink_sap-g3200u3
   MTK_SOC := mt7621
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := STORYLiNK
   DEVICE_MODEL := SAP-G3200U3
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -275,7 +275,7 @@ TARGET_DEVICES += iodata_wn-ax1167gr
 
 define Device/iodata_wn-gx300gr
   MTK_SOC := mt7621
-  IMAGE_SIZE := 7798784
+  IMAGE_SIZE := 7616k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-GX300GR
   DEVICE_PACKAGES := kmod-mt7603 wpad-basic

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -57,6 +57,7 @@ TARGET_DEVICES += d-team_pbr-d1
 
 define Device/duzun_dm06
   MTK_SOC := mt7628an
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := DuZun
   DEVICE_MODEL := DM06
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -183,6 +184,7 @@ TARGET_DEVICES += onion_omega2p
 
 define Device/rakwireless_rak633
   MTK_SOC := mt7628an
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Rakwireless
   DEVICE_MODEL := RAK633
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -4,7 +4,7 @@
 
 define Device/alfa-network_awusfree1
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AWUSFREE1
   DEVICE_PACKAGES := uboot-envtools
@@ -33,7 +33,7 @@ TARGET_DEVICES += buffalo_wcr-1166ds
 
 define Device/cudy_wr1000
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
         $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | jcg-header 92.122
@@ -47,7 +47,7 @@ TARGET_DEVICES += cudy_wr1000
 
 define Device/d-team_pbr-d1
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := PandoraBox
   DEVICE_MODEL := PBR-D1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -57,7 +57,7 @@ TARGET_DEVICES += d-team_pbr-d1
 
 define Device/duzun_dm06
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := DuZun
   DEVICE_MODEL := DM06
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -87,7 +87,7 @@ TARGET_DEVICES += glinet_vixmini
 
 define Device/hilink_hlk-7628n
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := HILINK
   DEVICE_MODEL := HLK-7628N
 endef
@@ -113,7 +113,7 @@ TARGET_DEVICES += hiwifi_hc5861b
 
 define Device/mediatek_linkit-smart-7688
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := LinkIt Smart 7688
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
@@ -164,7 +164,7 @@ TARGET_DEVICES += netgear_r6120
 
 define Device/onion_omega2
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Onion
   DEVICE_MODEL := Omega2
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
@@ -174,7 +174,7 @@ TARGET_DEVICES += onion_omega2
 
 define Device/onion_omega2p
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Onion
   DEVICE_MODEL := Omega2+
   DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
@@ -184,7 +184,7 @@ TARGET_DEVICES += onion_omega2p
 
 define Device/rakwireless_rak633
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Rakwireless
   DEVICE_MODEL := RAK633
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -437,7 +437,7 @@ TARGET_DEVICES += unielec_u7628-01-128m-16m
 
 define Device/vocore_vocore2
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := VoCore
   DEVICE_MODEL := VoCore2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
@@ -448,7 +448,7 @@ TARGET_DEVICES += vocore_vocore2
 
 define Device/vocore_vocore2-lite
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := VoCore
   DEVICE_MODEL := VoCore2-Lite
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
@@ -459,7 +459,7 @@ TARGET_DEVICES += vocore_vocore2-lite
 
 define Device/wavlink_wl-wn570ha1
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wavlink
   DEVICE_MODEL := WL-WN570HA1
   DEVICE_PACKAGES := kmod-mt76x0e
@@ -468,7 +468,7 @@ TARGET_DEVICES += wavlink_wl-wn570ha1
 
 define Device/wavlink_wl-wn575a3
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wavlink
   DEVICE_MODEL := WL-WN575A3
   DEVICE_PACKAGES := kmod-mt76x2
@@ -478,7 +478,7 @@ TARGET_DEVICES += wavlink_wl-wn575a3
 
 define Device/widora_neo-16m
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Widora
   DEVICE_MODEL := Widora-NEO
   DEVICE_VARIANT := 16M
@@ -489,7 +489,7 @@ TARGET_DEVICES += widora_neo-16m
 
 define Device/widora_neo-32m
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Widora
   DEVICE_MODEL := Widora-NEO
   DEVICE_VARIANT := 32M
@@ -499,7 +499,7 @@ TARGET_DEVICES += widora_neo-32m
 
 define Device/wiznet_wizfi630s
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := WIZnet
   DEVICE_MODEL := WizFi630S
 endef
@@ -507,7 +507,7 @@ TARGET_DEVICES += wiznet_wizfi630s
 
 define Device/wrtnode_wrtnode2p
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := WRTnode
   DEVICE_MODEL := WRTnode 2P
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -517,7 +517,7 @@ TARGET_DEVICES += wrtnode_wrtnode2p
 
 define Device/wrtnode_wrtnode2r
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := WRTnode
   DEVICE_MODEL := WRTnode 2R
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
@@ -537,7 +537,7 @@ TARGET_DEVICES += xiaomi_mir4a-100m
 
 define Device/xiaomi_miwifi-nano
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := MiWiFi Nano
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -547,7 +547,7 @@ TARGET_DEVICES += xiaomi_miwifi-nano
 
 define Device/zbtlink_zbt-we1226
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZBTlink
   DEVICE_MODEL := ZBT-WE1226
 endef

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -13,6 +13,7 @@ TARGET_DEVICES += alfa-network_awusfree1
 
 define Device/buffalo_wcr-1166ds
   MTK_SOC := mt7628an
+  IMAGE_SIZE := 7936k
   BUFFALO_TAG_PLATFORM := MTK
   BUFFALO_TAG_VERSION := 9.99
   BUFFALO_TAG_MINOR := 9.99
@@ -93,7 +94,7 @@ TARGET_DEVICES += hilink_hlk-7628n
 
 define Device/hiwifi_hc5661a
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5661A
   SUPPORTED_DEVICES += hc5661a
@@ -122,7 +123,7 @@ TARGET_DEVICES += mediatek_linkit-smart-7688
 define Device/mediatek_mt7628an-eval-board
   MTK_SOC := mt7628an
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7628 EVB
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -132,6 +133,7 @@ TARGET_DEVICES += mediatek_mt7628an-eval-board
 
 define Device/mercury_mac1200r-v2
   MTK_SOC := mt7628an
+  IMAGE_SIZE := 7936k
   DEVICE_VENDOR := Mercury
   DEVICE_MODEL := MAC1200R
   DEVICE_VARIANT := v2.0
@@ -444,7 +446,7 @@ TARGET_DEVICES += vocore_vocore2
 
 define Device/vocore_vocore2-lite
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := VoCore
   DEVICE_MODEL := VoCore2-Lite
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
@@ -503,7 +505,7 @@ TARGET_DEVICES += wiznet_wizfi630s
 
 define Device/wrtnode_wrtnode2p
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
   DEVICE_VENDOR := WRTnode
   DEVICE_MODEL := WRTnode 2P
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
@@ -513,7 +515,7 @@ TARGET_DEVICES += wrtnode_wrtnode2p
 
 define Device/wrtnode_wrtnode2r
   MTK_SOC := mt7628an
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
   DEVICE_VENDOR := WRTnode
   DEVICE_MODEL := WRTnode 2R
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -144,7 +144,7 @@ TARGET_DEVICES += mercury_mac1200r-v2
 define Device/netgear_r6120
   MTK_SOC := mt7628an
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15744k
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := R6120
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -83,7 +83,7 @@ TARGET_DEVICES += buffalo_wzr-agl300nh
 define Device/dlink_dap-1522-a1
   MTK_SOC := rt2880
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 3801088
+  IMAGE_SIZE := 3712k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DAP-1522
   DEVICE_VARIANT := A1

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -14,7 +14,7 @@ define Device/airlink101_ar670w
   BLOCKSIZE := 64k
   DEVICE_VENDOR := Airlink
   DEVICE_MODEL := AR670W
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3840k
   KERNEL := $(KERNEL_DTB) | pad-to $$(BLOCKSIZE)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
@@ -25,6 +25,7 @@ TARGET_DEVICES += airlink101_ar670w
 
 define Device/airlink101_ar725w
   MTK_SOC := rt2880
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
   DEVICE_VENDOR := Airlink
   DEVICE_MODEL := AR725W
   IMAGES += factory.bin
@@ -47,7 +48,7 @@ TARGET_DEVICES += asus_rt-n15
 
 define Device/belkin_f5d8235-v1
   MTK_SOC := rt2880
-  IMAGE_SIZE := 7744k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Belkin
   DEVICE_MODEL := F5D8235
   DEVICE_VARIANT := V1

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -25,7 +25,7 @@ TARGET_DEVICES += airlink101_ar670w
 
 define Device/airlink101_ar725w
   MTK_SOC := rt2880
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Airlink
   DEVICE_MODEL := AR725W
   IMAGES += factory.bin
@@ -38,7 +38,7 @@ TARGET_DEVICES += airlink101_ar725w
 define Device/asus_rt-n15
   MTK_SOC := rt2880
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N15
   DEVICE_PACKAGES := kmod-switch-rtl8366s
@@ -48,7 +48,7 @@ TARGET_DEVICES += asus_rt-n15
 
 define Device/belkin_f5d8235-v1
   MTK_SOC := rt2880
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Belkin
   DEVICE_MODEL := F5D8235
   DEVICE_VARIANT := V1
@@ -61,7 +61,7 @@ TARGET_DEVICES += belkin_f5d8235-v1
 define Device/buffalo_wli-tx4-ag300n
   MTK_SOC := rt2880
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WLI-TX4-AG300N
   DEVICE_PACKAGES := kmod-switch-ip17xx
@@ -72,7 +72,7 @@ TARGET_DEVICES += buffalo_wli-tx4-ag300n
 define Device/buffalo_wzr-agl300nh
   MTK_SOC := rt2880
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-AGL300NH
   DEVICE_PACKAGES := kmod-switch-rtl8366s
@@ -101,7 +101,7 @@ TARGET_DEVICES += dlink_dap-1522-a1
 define Device/ralink_v11st-fe
   MTK_SOC := rt2880
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := V11ST-FE
   SUPPORTED_DEVICES += v11st-fe

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -296,7 +296,7 @@ TARGET_DEVICES += belkin_f7c027
 define Device/buffalo_whr-g300n
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 3801088
+  IMAGE_SIZE := 3712k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-G300N
   IMAGES += tftp.bin

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -23,7 +23,7 @@ endef
 
 define Device/7links_px-4885-4m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := 7Links
   DEVICE_MODEL := PX-4885
   DEVICE_VARIANT := 4M
@@ -35,7 +35,7 @@ TARGET_DEVICES += 7links_px-4885-4m
 
 define Device/7links_px-4885-8m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := 7Links
   DEVICE_MODEL := PX-4885
   DEVICE_VARIANT := 8M
@@ -47,7 +47,7 @@ TARGET_DEVICES += 7links_px-4885-8m
 
 define Device/8devices_carambola
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := 8devices
   DEVICE_MODEL := Carambola
   DEVICE_PACKAGES :=
@@ -57,7 +57,7 @@ TARGET_DEVICES += 8devices_carambola
 
 define Device/accton_wr6202
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Accton
   DEVICE_MODEL := WR6202
   SUPPORTED_DEVICES += wr6202
@@ -67,7 +67,7 @@ TARGET_DEVICES += accton_wr6202
 define Device/airlive_air3gii
   MTK_SOC := rt5350
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := AirLive
   DEVICE_MODEL := Air3GII
   SUPPORTED_DEVICES += air3gii
@@ -76,7 +76,7 @@ TARGET_DEVICES += airlive_air3gii
 
 define Device/alfa-network_w502u
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ALFA
   DEVICE_MODEL := Networks W502U
   SUPPORTED_DEVICES += w502u
@@ -85,7 +85,7 @@ TARGET_DEVICES += alfa-network_w502u
 
 define Device/allnet_all0256n-4m
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Allnet
   DEVICE_MODEL := ALL0256N
   DEVICE_VARIANT := 4M
@@ -96,7 +96,7 @@ TARGET_DEVICES += allnet_all0256n-4m
 
 define Device/allnet_all0256n-8m
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Allnet
   DEVICE_MODEL := ALL0256N
   DEVICE_VARIANT := 8M
@@ -150,7 +150,7 @@ TARGET_DEVICES += alphanetworks_asl26555-8m
 
 define Device/arcwireless_freestation5
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ARC Wireless
   DEVICE_MODEL := FreeStation
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-rt2500-usb kmod-rt2800-usb kmod-rt2x00-usb
@@ -170,7 +170,7 @@ TARGET_DEVICES += argus_atp-52b
 define Device/asiarf_awapn2403
   MTK_SOC := rt3052
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AWAPN2403
   SUPPORTED_DEVICES += awapn2403
@@ -179,7 +179,7 @@ TARGET_DEVICES += asiarf_awapn2403
 
 define Device/asiarf_awm002-evb-4m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AWM002-EVB
   DEVICE_VARIANT := 4M
@@ -191,7 +191,7 @@ TARGET_DEVICES += asiarf_awm002-evb-4m
 
 define Device/asiarf_awm002-evb-8m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AWM002-EVB/AWM003-EVB
   DEVICE_VARIANT := 8M
@@ -204,7 +204,7 @@ TARGET_DEVICES += asiarf_awm002-evb-8m
 define Device/asus_rt-g32-b1
   MTK_SOC := rt3050
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-G32
   DEVICE_VARIANT := B1
@@ -215,7 +215,7 @@ TARGET_DEVICES += asus_rt-g32-b1
 define Device/asus_rt-n10-plus
   MTK_SOC := rt3050
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N10+
   SUPPORTED_DEVICES += rt-n10-plus
@@ -224,7 +224,7 @@ TARGET_DEVICES += asus_rt-n10-plus
 
 define Device/asus_rt-n13u
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N13U
   DEVICE_PACKAGES := kmod-leds-gpio kmod-rt2800-pci kmod-usb-dwc2
@@ -235,7 +235,7 @@ TARGET_DEVICES += asus_rt-n13u
 define Device/asus_wl-330n
   MTK_SOC := rt3050
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := WL-330N
   SUPPORTED_DEVICES += wl-330n
@@ -245,7 +245,7 @@ TARGET_DEVICES += asus_wl-330n
 define Device/asus_wl-330n3g
   MTK_SOC := rt3050
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := WL-330N3G
   DEVICE_PACKAGES :=
@@ -264,7 +264,7 @@ TARGET_DEVICES += aximcom_mr-102n
 
 define Device/aztech_hw550-3g
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Aztech
   DEVICE_MODEL := HW550-3G
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-dwc2 kmod-usb-ledtrig-usbport
@@ -322,7 +322,7 @@ TARGET_DEVICES += dlink_dap-1350
 
 define Device/dlink_dcs-930
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DCS-930
   DEVICE_PACKAGES := kmod-video-core kmod-video-uvc kmod-sound-core kmod-usb-audio kmod-usb-core kmod-usb-dwc2
@@ -332,7 +332,7 @@ TARGET_DEVICES += dlink_dcs-930
 
 define Device/dlink_dcs-930l-b1
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DCS-930L
   DEVICE_VARIANT := B1
@@ -343,7 +343,7 @@ TARGET_DEVICES += dlink_dcs-930l-b1
 
 define Device/dlink_dir-300-b1
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | wrg-header wrgn23_dlwbr_dir300b
@@ -357,7 +357,7 @@ TARGET_DEVICES += dlink_dir-300-b1
 define Device/dlink_dir-300-b7
   MTK_SOC := rt5350
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-300
   DEVICE_VARIANT := B7
@@ -367,7 +367,7 @@ TARGET_DEVICES += dlink_dir-300-b7
 
 define Device/dlink_dir-320-b1
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-320
   DEVICE_VARIANT := B1
@@ -377,7 +377,7 @@ TARGET_DEVICES += dlink_dir-320-b1
 
 define Device/dlink_dir-600-b1
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | wrg-header wrgn23_dlwbr_dir600b
@@ -394,7 +394,7 @@ define Device/dlink_dir-610-a1
   BLOCKSIZE := 4k
   SEAMA_SIGNATURE := wrgn59_dlob.hans_dir610
   KERNEL := $(KERNEL_DTB)
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-610
   DEVICE_VARIANT := A1
@@ -405,7 +405,7 @@ TARGET_DEVICES += dlink_dir-610-a1
 
 define Device/dlink_dir-615-d
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | wrg-header wrgn23_dlwbr_dir615d
@@ -420,7 +420,7 @@ define Device/dlink_dir-615-h1
   MTK_SOC := rt3352
   BLOCKSIZE := 4k
   IMAGES += factory.bin
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | senao-header -r 0x218 -p 0x30 -t 3
   DEVICE_VENDOR := D-Link
@@ -432,7 +432,7 @@ TARGET_DEVICES += dlink_dir-615-h1
 
 define Device/dlink_dir-620-a1
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := A1
@@ -442,7 +442,7 @@ TARGET_DEVICES += dlink_dir-620-a1
 
 define Device/dlink_dir-620-d1
   MTK_SOC := rt3352
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := D1
@@ -472,7 +472,7 @@ TARGET_DEVICES += dlink_dwr-512-b
 
 define Device/easyacc_wizard-8800
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := EasyAcc
   DEVICE_MODEL := WIZARD 8800
@@ -507,7 +507,7 @@ TARGET_DEVICES += edimax_3g-6200nl
 define Device/engenius_esr-9753
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := ESR-9753
   SUPPORTED_DEVICES += esr-9753
@@ -516,7 +516,7 @@ TARGET_DEVICES += engenius_esr-9753
 
 define Device/fon_fonera-20n
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | \
 	edimax-header -s RSDK -m NL1T -f 0x50000 -S 0xc0000
@@ -530,7 +530,7 @@ TARGET_DEVICES += fon_fonera-20n
 define Device/hame_mpr-a1
   MTK_SOC := rt5350
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := HAME
   DEVICE_MODEL := MPR
@@ -542,7 +542,7 @@ TARGET_DEVICES += hame_mpr-a1
 
 define Device/hame_mpr-a2
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := HAME
   DEVICE_MODEL := MPR
@@ -565,7 +565,7 @@ TARGET_DEVICES += hauppauge_broadway
 
 define Device/hilink_hlk-rm04
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | hilink-header
@@ -577,7 +577,7 @@ TARGET_DEVICES += hilink_hlk-rm04
 
 define Device/hootoo_ht-tm02
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := HooToo
   DEVICE_MODEL := HT-TM02
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
@@ -588,7 +588,7 @@ TARGET_DEVICES += hootoo_ht-tm02
 define Device/huawei_d105
   MTK_SOC := rt3050
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Huawei
   DEVICE_MODEL := D105
   SUPPORTED_DEVICES += d105
@@ -606,7 +606,7 @@ TARGET_DEVICES += huawei_hg255d
 
 define Device/intenso_memory2move
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := Intenso
   DEVICE_MODEL := Memory 2 Move
@@ -619,7 +619,7 @@ TARGET_DEVICES += intenso_memory2move
 
 define Device/jcg_jhr-n805r
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | jcg-header 29.24
@@ -631,7 +631,7 @@ TARGET_DEVICES += jcg_jhr-n805r
 
 define Device/jcg_jhr-n825r
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | jcg-header 23.24
@@ -643,7 +643,7 @@ TARGET_DEVICES += jcg_jhr-n825r
 
 define Device/jcg_jhr-n926r
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | jcg-header 25.24
@@ -655,7 +655,7 @@ TARGET_DEVICES += jcg_jhr-n926r
 
 define Device/mofinetwork_mofi3500-3gn
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := MoFi Network
   DEVICE_MODEL := MOFI3500-3GN
   SUPPORTED_DEVICES += mofi3500-3gn
@@ -688,7 +688,7 @@ TARGET_DEVICES += netgear_wnce2001
 
 define Device/nexaira_bc2
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := NexAira
   DEVICE_MODEL := BC2
   SUPPORTED_DEVICES += bc2
@@ -697,7 +697,7 @@ TARGET_DEVICES += nexaira_bc2
 
 define Device/nexx_wt1520-4m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B WT1520 -F 4M
@@ -710,7 +710,7 @@ TARGET_DEVICES += nexx_wt1520-4m
 
 define Device/nexx_wt1520-8m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B WT1520 -F 8M
@@ -745,7 +745,7 @@ TARGET_DEVICES += nixcore_x1-8m
 
 define Device/olimex_rt5350f-olinuxino
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := OLIMEX
   DEVICE_MODEL := RT5350F-OLinuXino
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 \
@@ -757,7 +757,7 @@ TARGET_DEVICES += olimex_rt5350f-olinuxino
 
 define Device/olimex_rt5350f-olinuxino-evb
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := OLIMEX
   DEVICE_MODEL := RT5350F-OLinuXino-EVB
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 \
@@ -769,7 +769,7 @@ TARGET_DEVICES += olimex_rt5350f-olinuxino-evb
 
 define Device/omnima_miniembplug
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Omnima
   DEVICE_MODEL := MiniEMBPlug
   SUPPORTED_DEVICES += miniembplug
@@ -778,7 +778,7 @@ TARGET_DEVICES += omnima_miniembplug
 
 define Device/omnima_miniembwifi
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Omnima
   DEVICE_MODEL := MiniEMBWiFi
   SUPPORTED_DEVICES += miniembwifi
@@ -788,7 +788,7 @@ TARGET_DEVICES += omnima_miniembwifi
 define Device/petatel_psr-680w
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Petatel
   DEVICE_MODEL := PSR-680W Wireless 3G Router
   SUPPORTED_DEVICES += psr-680w
@@ -798,7 +798,7 @@ TARGET_DEVICES += petatel_psr-680w
 define Device/planex_mzk-dp150n
   MTK_SOC := rt5350
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-DP150N
   DEVICE_PACKAGES := kmod-spi-dev
@@ -829,7 +829,7 @@ TARGET_DEVICES += planex_mzk-wdpr
 
 define Device/poray_ip2202
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := IP2202
   SUPPORTED_DEVICES += ip2202
@@ -838,7 +838,7 @@ TARGET_DEVICES += poray_ip2202
 
 define Device/poray_m3
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B M3 -F 4M
@@ -852,7 +852,7 @@ TARGET_DEVICES += poray_m3
 
 define Device/poray_m4-4m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B M4 -F 4M
@@ -867,7 +867,7 @@ TARGET_DEVICES += poray_m4-4m
 
 define Device/poray_m4-8m
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B M4 -F 8M
@@ -881,7 +881,7 @@ TARGET_DEVICES += poray_m4-8m
 
 define Device/poray_x5
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B X5 -F 8M
@@ -894,7 +894,7 @@ TARGET_DEVICES += poray_x5
 
 define Device/poray_x8
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B X8 -F 8M
@@ -907,7 +907,7 @@ TARGET_DEVICES += poray_x8
 
 define Device/prolink_pwh2004
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Prolink
   DEVICE_MODEL := PWH2004
   DEVICE_PACKAGES :=
@@ -918,7 +918,7 @@ TARGET_DEVICES += prolink_pwh2004
 define Device/ralink_v22rw-2x2
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := AP-RT3052-V22RW-2X2
   SUPPORTED_DEVICES += v22rw-2x2
@@ -928,7 +928,7 @@ TARGET_DEVICES += ralink_v22rw-2x2
 define Device/sitecom_wl-351
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Sitecom
   DEVICE_MODEL := WL-351 v1
   DEVICE_PACKAGES := kmod-switch-rtl8366rb kmod-swconfig swconfig
@@ -939,7 +939,7 @@ TARGET_DEVICES += sitecom_wl-351
 define Device/skyline_sl-r7205
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Skyline
   DEVICE_MODEL := SL-R7205 Wireless 3G Router
   SUPPORTED_DEVICES += sl-r7205
@@ -949,7 +949,7 @@ TARGET_DEVICES += skyline_sl-r7205
 define Device/sparklan_wcr-150gn
   MTK_SOC := rt3050
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Sparklan
   DEVICE_MODEL := WCR-150GN
   SUPPORTED_DEVICES += wcr-150gn
@@ -958,7 +958,7 @@ TARGET_DEVICES += sparklan_wcr-150gn
 
 define Device/teltonika_rut5xx
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT5XX
   DEVICE_PACKAGES := om-watchdog
@@ -969,7 +969,7 @@ TARGET_DEVICES += teltonika_rut5xx
 define Device/tenda_3g150b
   MTK_SOC := rt5350
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := Tenda
   DEVICE_MODEL := 3G150B
@@ -980,7 +980,7 @@ TARGET_DEVICES += tenda_3g150b
 
 define Device/tenda_3g300m
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   UIMAGE_NAME := 3G150M_SPI Kernel Image
   DEVICE_VENDOR := Tenda
   DEVICE_MODEL := 3G300M
@@ -991,7 +991,7 @@ TARGET_DEVICES += tenda_3g300m
 
 define Device/tenda_w150m
   MTK_SOC := rt3050
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   UIMAGE_NAME:= W150M Kernel Image
   DEVICE_VENDOR := Tenda
   DEVICE_MODEL := W150M
@@ -1001,7 +1001,7 @@ TARGET_DEVICES += tenda_w150m
 
 define Device/tenda_w306r-v2
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   UIMAGE_NAME:= linkn Kernel Image
   DEVICE_VENDOR := Tenda
   DEVICE_MODEL := W306R
@@ -1013,7 +1013,7 @@ TARGET_DEVICES += tenda_w306r-v2
 define Device/trendnet_tew-638apb-v2
   MTK_SOC := rt3050
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGE/sysupgrade.bin := $$(sysupgrade_bin) | umedia-header 0x026382 | \
         append-metadata | check-size $$$$(IMAGE_SIZE)
   DEVICE_VENDOR := TRENDnet
@@ -1025,7 +1025,7 @@ TARGET_DEVICES += trendnet_tew-638apb-v2
 
 define Device/trendnet_tew-714tru
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-714TRU
   SUPPORTED_DEVICES += tew-714tru
@@ -1034,7 +1034,7 @@ TARGET_DEVICES += trendnet_tew-714tru
 
 define Device/unbranded_a5-v11
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B A5-V11 -F 4M
@@ -1047,7 +1047,7 @@ TARGET_DEVICES += unbranded_a5-v11
 
 define Device/unbranded_wr512-3gn-4m
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 4M
@@ -1057,7 +1057,7 @@ TARGET_DEVICES += unbranded_wr512-3gn-4m
 
 define Device/unbranded_wr512-3gn-8m
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 8M
@@ -1068,7 +1068,7 @@ TARGET_DEVICES += unbranded_wr512-3gn-8m
 define Device/unbranded_xdx-rn502j
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := XDX
   DEVICE_MODEL := RN502J
   SUPPORTED_DEVICES += xdxrn502j
@@ -1078,7 +1078,7 @@ TARGET_DEVICES += unbranded_xdx-rn502j
 define Device/upvel_ur-326n4g
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := UPVEL
   DEVICE_MODEL := UR-326N4G
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-dwc2 kmod-usb-ledtrig-usbport
@@ -1088,7 +1088,7 @@ TARGET_DEVICES += upvel_ur-326n4g
 
 define Device/upvel_ur-336un
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := UPVEL
   DEVICE_MODEL := UR-336UN
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-dwc2 kmod-usb-ledtrig-usbport
@@ -1124,7 +1124,7 @@ TARGET_DEVICES += vocore_vocore-8m
 
 define Device/wansview_ncs601w
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wansview
   DEVICE_MODEL := NCS601W
   DEVICE_PACKAGES := kmod-video-core kmod-video-uvc \
@@ -1135,7 +1135,7 @@ TARGET_DEVICES += wansview_ncs601w
 
 define Device/wiznet_wizfi630a
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 16064k
   DEVICE_VENDOR := WIZnet
   DEVICE_MODEL := WizFi630A
   SUPPORTED_DEVICES += wizfi630a
@@ -1144,7 +1144,7 @@ TARGET_DEVICES += wiznet_wizfi630a
 
 define Device/zorlik_zl5900v2
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Zorlik
   DEVICE_MODEL := ZL5900V2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-ledtrig-netdev
@@ -1154,7 +1154,7 @@ TARGET_DEVICES += zorlik_zl5900v2
 define Device/zyxel_keenetic
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ehci kmod-usb-ledtrig-usbport
@@ -1164,7 +1164,7 @@ TARGET_DEVICES += zyxel_keenetic
 
 define Device/zyxel_keenetic-start
   MTK_SOC := rt5350
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := Keenetic Start
 endef
@@ -1173,7 +1173,7 @@ TARGET_DEVICES += zyxel_keenetic-start
 define Device/zyxel_nbg-419n
   MTK_SOC := rt3052
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3776k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NBG-419N
   SUPPORTED_DEVICES += nbg-419n
@@ -1182,7 +1182,7 @@ TARGET_DEVICES += zyxel_nbg-419n
 
 define Device/zyxel_nbg-419n-v2
   MTK_SOC := rt3352
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NBG-419N
   DEVICE_VARIANT := v2

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -247,6 +247,7 @@ TARGET_DEVICES += asus_wl-330n3g
 
 define Device/aximcom_mr-102n
   MTK_SOC := rt3052
+  IMAGE_SIZE := 7744k
   DEVICE_VENDOR := AXIMCom
   DEVICE_MODEL := MR-102N
   SUPPORTED_DEVICES += mr-102n
@@ -347,7 +348,7 @@ TARGET_DEVICES += dlink_dir-300-b1
 define Device/dlink_dir-300-b7
   MTK_SOC := rt5350
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-300
   DEVICE_VARIANT := B7
@@ -439,7 +440,7 @@ TARGET_DEVICES += dlink_dir-620-d1
 
 define Device/dlink_dwr-512-b
   MTK_SOC := rt5350
-  IMAGE_SIZE := 7800k
+  IMAGE_SIZE := 8064k
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWR-512
   DEVICE_VARIANT := B
@@ -549,6 +550,7 @@ TARGET_DEVICES += hauppauge_broadway
 
 define Device/hilink_hlk-rm04
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_4M)
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | hilink-header
@@ -654,7 +656,7 @@ TARGET_DEVICES += netcore_nw718
 
 define Device/netgear_wnce2001
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_4M)
+  IMAGE_SIZE := 3392k
   IMAGES += factory.bin factory-NA.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	dap-header -s RT3052-AP-WNCE2001-3 -r WW -v 1.0.0.99
@@ -794,6 +796,7 @@ TARGET_DEVICES += planex_mzk-w300nh2
 
 define Device/planex_mzk-wdpr
   MTK_SOC := rt3052
+  IMAGE_SIZE := 6656k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := MZK-WDPR
   SUPPORTED_DEVICES += mzk-wdpr
@@ -926,6 +929,7 @@ TARGET_DEVICES += sparklan_wcr-150gn
 
 define Device/teltonika_rut5xx
   MTK_SOC := rt3050
+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT5XX
   DEVICE_PACKAGES := om-watchdog

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -35,6 +35,7 @@ TARGET_DEVICES += 7links_px-4885-4m
 
 define Device/7links_px-4885-8m
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := 7Links
   DEVICE_MODEL := PX-4885
   DEVICE_VARIANT := 8M
@@ -46,6 +47,7 @@ TARGET_DEVICES += 7links_px-4885-8m
 
 define Device/8devices_carambola
   MTK_SOC := rt3050
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := 8devices
   DEVICE_MODEL := Carambola
   DEVICE_PACKAGES :=
@@ -55,6 +57,7 @@ TARGET_DEVICES += 8devices_carambola
 
 define Device/accton_wr6202
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Accton
   DEVICE_MODEL := WR6202
   SUPPORTED_DEVICES += wr6202
@@ -73,6 +76,7 @@ TARGET_DEVICES += airlive_air3gii
 
 define Device/alfa-network_w502u
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := ALFA
   DEVICE_MODEL := Networks W502U
   SUPPORTED_DEVICES += w502u
@@ -92,6 +96,7 @@ TARGET_DEVICES += allnet_all0256n-4m
 
 define Device/allnet_all0256n-8m
   MTK_SOC := rt3050
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Allnet
   DEVICE_MODEL := ALL0256N
   DEVICE_VARIANT := 8M
@@ -145,6 +150,7 @@ TARGET_DEVICES += alphanetworks_asl26555-8m
 
 define Device/arcwireless_freestation5
   MTK_SOC := rt3050
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := ARC Wireless
   DEVICE_MODEL := FreeStation
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-rt2500-usb kmod-rt2800-usb kmod-rt2x00-usb
@@ -185,6 +191,7 @@ TARGET_DEVICES += asiarf_awm002-evb-4m
 
 define Device/asiarf_awm002-evb-8m
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AWM002-EVB/AWM003-EVB
   DEVICE_VARIANT := 8M
@@ -217,6 +224,7 @@ TARGET_DEVICES += asus_rt-n10-plus
 
 define Device/asus_rt-n13u
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N13U
   DEVICE_PACKAGES := kmod-leds-gpio kmod-rt2800-pci kmod-usb-dwc2
@@ -256,6 +264,7 @@ TARGET_DEVICES += aximcom_mr-102n
 
 define Device/aztech_hw550-3g
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Aztech
   DEVICE_MODEL := HW550-3G
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-dwc2 kmod-usb-ledtrig-usbport
@@ -358,6 +367,7 @@ TARGET_DEVICES += dlink_dir-300-b7
 
 define Device/dlink_dir-320-b1
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-320
   DEVICE_VARIANT := B1
@@ -422,6 +432,7 @@ TARGET_DEVICES += dlink_dir-615-h1
 
 define Device/dlink_dir-620-a1
   MTK_SOC := rt3050
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := A1
@@ -431,6 +442,7 @@ TARGET_DEVICES += dlink_dir-620-a1
 
 define Device/dlink_dir-620-d1
   MTK_SOC := rt3352
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-620
   DEVICE_VARIANT := D1
@@ -460,6 +472,7 @@ TARGET_DEVICES += dlink_dwr-512-b
 
 define Device/easyacc_wizard-8800
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := EasyAcc
   DEVICE_MODEL := WIZARD 8800
@@ -503,6 +516,7 @@ TARGET_DEVICES += engenius_esr-9753
 
 define Device/fon_fonera-20n
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | \
 	edimax-header -s RSDK -m NL1T -f 0x50000 -S 0xc0000
@@ -528,6 +542,7 @@ TARGET_DEVICES += hame_mpr-a1
 
 define Device/hame_mpr-a2
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := HAME
   DEVICE_MODEL := MPR
@@ -562,6 +577,7 @@ TARGET_DEVICES += hilink_hlk-rm04
 
 define Device/hootoo_ht-tm02
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := HooToo
   DEVICE_MODEL := HT-TM02
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
@@ -590,6 +606,7 @@ TARGET_DEVICES += huawei_hg255d
 
 define Device/intenso_memory2move
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   UIMAGE_NAME:= Linux Kernel Image
   DEVICE_VENDOR := Intenso
   DEVICE_MODEL := Memory 2 Move
@@ -638,6 +655,7 @@ TARGET_DEVICES += jcg_jhr-n926r
 
 define Device/mofinetwork_mofi3500-3gn
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := MoFi Network
   DEVICE_MODEL := MOFI3500-3GN
   SUPPORTED_DEVICES += mofi3500-3gn
@@ -670,6 +688,7 @@ TARGET_DEVICES += netgear_wnce2001
 
 define Device/nexaira_bc2
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := NexAira
   DEVICE_MODEL := BC2
   SUPPORTED_DEVICES += bc2
@@ -691,6 +710,7 @@ TARGET_DEVICES += nexx_wt1520-4m
 
 define Device/nexx_wt1520-8m
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B WT1520 -F 8M
@@ -725,6 +745,7 @@ TARGET_DEVICES += nixcore_x1-8m
 
 define Device/olimex_rt5350f-olinuxino
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := OLIMEX
   DEVICE_MODEL := RT5350F-OLinuXino
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 \
@@ -736,6 +757,7 @@ TARGET_DEVICES += olimex_rt5350f-olinuxino
 
 define Device/olimex_rt5350f-olinuxino-evb
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := OLIMEX
   DEVICE_MODEL := RT5350F-OLinuXino-EVB
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 \
@@ -747,6 +769,7 @@ TARGET_DEVICES += olimex_rt5350f-olinuxino-evb
 
 define Device/omnima_miniembplug
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Omnima
   DEVICE_MODEL := MiniEMBPlug
   SUPPORTED_DEVICES += miniembplug
@@ -755,6 +778,7 @@ TARGET_DEVICES += omnima_miniembplug
 
 define Device/omnima_miniembwifi
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Omnima
   DEVICE_MODEL := MiniEMBWiFi
   SUPPORTED_DEVICES += miniembwifi
@@ -805,6 +829,7 @@ TARGET_DEVICES += planex_mzk-wdpr
 
 define Device/poray_ip2202
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := IP2202
   SUPPORTED_DEVICES += ip2202
@@ -842,6 +867,7 @@ TARGET_DEVICES += poray_m4-4m
 
 define Device/poray_m4-8m
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B M4 -F 8M
@@ -855,6 +881,7 @@ TARGET_DEVICES += poray_m4-8m
 
 define Device/poray_x5
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B X5 -F 8M
@@ -867,6 +894,7 @@ TARGET_DEVICES += poray_x5
 
 define Device/poray_x8
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := \
 	$$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | poray-header -B X8 -F 8M
@@ -879,6 +907,7 @@ TARGET_DEVICES += poray_x8
 
 define Device/prolink_pwh2004
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Prolink
   DEVICE_MODEL := PWH2004
   DEVICE_PACKAGES :=
@@ -996,6 +1025,7 @@ TARGET_DEVICES += trendnet_tew-638apb-v2
 
 define Device/trendnet_tew-714tru
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-714TRU
   SUPPORTED_DEVICES += tew-714tru
@@ -1027,6 +1057,7 @@ TARGET_DEVICES += unbranded_wr512-3gn-4m
 
 define Device/unbranded_wr512-3gn-8m
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := WR512-3GN
   DEVICE_VARIANT := 8M
@@ -1057,6 +1088,7 @@ TARGET_DEVICES += upvel_ur-326n4g
 
 define Device/upvel_ur-336un
   MTK_SOC := rt3052
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := UPVEL
   DEVICE_MODEL := UR-336UN
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-dwc2 kmod-usb-ledtrig-usbport
@@ -1092,6 +1124,7 @@ TARGET_DEVICES += vocore_vocore-8m
 
 define Device/wansview_ncs601w
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Wansview
   DEVICE_MODEL := NCS601W
   DEVICE_PACKAGES := kmod-video-core kmod-video-uvc \
@@ -1111,6 +1144,7 @@ TARGET_DEVICES += wiznet_wizfi630a
 
 define Device/zorlik_zl5900v2
   MTK_SOC := rt5350
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Zorlik
   DEVICE_MODEL := ZL5900V2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-ledtrig-netdev

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -579,7 +579,7 @@ TARGET_DEVICES += huawei_d105
 
 define Device/huawei_hg255d
   MTK_SOC := rt3052
-  IMAGE_SIZE := $(ralink_default_fw_size_16M)
+  IMAGE_SIZE := 15744k
   DEVICE_VENDOR := HuaWei
   DEVICE_MODEL := HG255D
   SUPPORTED_DEVICES += hg255d

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -23,7 +23,7 @@ define Device/belkin_f9k1109v1
   DEVICE_MODEL := F9K1109
   DEVICE_VARIANT := Version 1.0
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 swconfig
-  IMAGE_SIZE := 7224k
+  IMAGE_SIZE := 7808k
   KERNEL := kernel-bin | append-dtb | lzma -d16 | uImage lzma
   # Stock firmware checks for this uImage image name during upload.
   UIMAGE_NAME := N750F9K1103VB

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -8,7 +8,7 @@ endef
 define Device/asus_rt-n56u
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGE/sysupgrade.bin += | mkrtn56uimg -s
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N56U
@@ -35,7 +35,7 @@ define Device/dlink_dir-645
   $(Device/seama)
   MTK_SOC := rt3883
   BLOCKSIZE := 4k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   KERNEL := $(KERNEL_DTB)
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_VENDOR := D-Link
@@ -62,7 +62,7 @@ TARGET_DEVICES += edimax_br-6475nd
 define Device/loewe_wmdr-143n
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Loewe
   DEVICE_MODEL := WMDR-143N
   SUPPORTED_DEVICES += wmdr-143n
@@ -84,7 +84,7 @@ define Device/samsung_cy-swr1100
   $(Device/seama)
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   KERNEL := $(KERNEL_DTB)
   SEAMA_SIGNATURE := wrgnd10_samsung_ss815
   DEVICE_VENDOR := Samsung
@@ -111,7 +111,7 @@ TARGET_DEVICES += sitecom_wlr-6000
 define Device/trendnet_tew-691gr
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x026910
@@ -125,7 +125,7 @@ TARGET_DEVICES += trendnet_tew-691gr
 define Device/trendnet_tew-692gr
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
-  IMAGE_SIZE := $(ralink_default_fw_size_8M)
+  IMAGE_SIZE := 7872k
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x026920

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -8,6 +8,7 @@ endef
 define Device/asus_rt-n56u
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGE/sysupgrade.bin += | mkrtn56uimg -s
   DEVICE_VENDOR := Asus
   DEVICE_MODEL := RT-N56U
@@ -34,6 +35,7 @@ define Device/dlink_dir-645
   $(Device/seama)
   MTK_SOC := rt3883
   BLOCKSIZE := 4k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   KERNEL := $(KERNEL_DTB)
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_VENDOR := D-Link
@@ -60,6 +62,7 @@ TARGET_DEVICES += edimax_br-6475nd
 define Device/loewe_wmdr-143n
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   DEVICE_VENDOR := Loewe
   DEVICE_MODEL := WMDR-143N
   SUPPORTED_DEVICES += wmdr-143n
@@ -81,6 +84,7 @@ define Device/samsung_cy-swr1100
   $(Device/seama)
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   KERNEL := $(KERNEL_DTB)
   SEAMA_SIGNATURE := wrgnd10_samsung_ss815
   DEVICE_VENDOR := Samsung
@@ -107,6 +111,7 @@ TARGET_DEVICES += sitecom_wlr-6000
 define Device/trendnet_tew-691gr
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x026910
@@ -120,6 +125,7 @@ TARGET_DEVICES += trendnet_tew-691gr
 define Device/trendnet_tew-692gr
   MTK_SOC := rt3883
   BLOCKSIZE := 64k
+  IMAGE_SIZE := $(ralink_default_fw_size_8M)
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
 	umedia-header 0x026920


### PR DESCRIPTION
This series of patches aims at tidying up IMAGE_SIZE in ramips target. While I initially just wanted to check for missing values, I found that many devices seem to have wrong IMAGE_SIZE set.
Despite, ramips has a default IMAGE_SIZE which is used for all devices without a specific one.

So, in this patchset:
- Patch 1 addresses ralink_default_fw_size_16M being set strangely by setting it to a more consistent value
- Patches 2-6 fix all incorrectly set IMAGE_SIZE values for the different subtargets
- Patches 7 and 8 deal with some optional cosmetic tidy-up.

**This should be ready for merge.**