### PR TITLE
Fix brcm47xx/831-old_gpio_wdt.patch for linux 4.19

### DIFF
--- a/target/linux/brcm47xx/patches-4.19/831-old_gpio_wdt.patch
+++ b/target/linux/brcm47xx/patches-4.19/831-old_gpio_wdt.patch
@@ -111,7 +111,7 @@ Signed-off-by: Mathias Adam <m.adam--openwrt@adamis.de>
 +	int first_interval;
 +} gpio_wdt_device;
 +
-+static void gpio_wdt_trigger(unsigned long unused)
++static void gpio_wdt_trigger(struct timer_list *unused)
 +{
 +	spin_lock(&gpio_wdt_device.lock);
 +	if (gpio_wdt_device.running && ticks > 0)
@@ -268,7 +268,7 @@ Signed-off-by: Mathias Adam <m.adam--openwrt@adamis.de>
 +	init_completion(&gpio_wdt_device.stop);
 +	gpio_wdt_device.queue = 0;
 +	clear_bit(0, &gpio_wdt_device.inuse);
-+	setup_timer(&gpio_wdt_device.timer, gpio_wdt_trigger, 0L);
++	timer_setup(&gpio_wdt_device.timer, gpio_wdt_trigger, 0L);
 +	gpio_wdt_device.default_ticks = ticks;
 +
 +	gpio_wdt_start();


### PR DESCRIPTION
setup_timer() was replaced by timer_setup() in linux >=4.15
