### PR TITLE
omcproxy: update default configuration to fix startup

### DIFF
--- a/package/network/services/omcproxy/Makefile
+++ b/package/network/services/omcproxy/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=omcproxy
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/omcproxy.git

--- a/package/network/services/omcproxy/files/omcproxy.config
+++ b/package/network/services/omcproxy/files/omcproxy.config
@@ -2,8 +2,3 @@ config proxy
 	option scope global
 	option uplink wan
 	list downlink lan
-
-config proxy
-	option scope global
-	option uplink wan6
-	list downlink lan


### PR DESCRIPTION
Omcproxy uses bridges and phisical interfaces instead of the default
configuration file's interface.

If you keep the default omcproxy config it won't start.