### PR TITLE
x86: add modern network modules to Generic target

### DIFF
--- a/target/linux/x86/generic/profiles/000-Generic.mk
+++ b/target/linux/x86/generic/profiles/000-Generic.mk
@@ -7,7 +7,8 @@
 
 define Profile/Generic
   NAME:=Generic
-  PACKAGES:=kmod-3c59x kmod-e100 kmod-e1000 kmod-natsemi kmod-ne2k-pci \
+  PACKAGES:=kmod-e1000e kmod-igb kmod-bnx2 \
+  	kmod-3c59x kmod-e100 kmod-e1000 kmod-natsemi kmod-ne2k-pci \
 	kmod-pcnet32 kmod-8139too kmod-r8169 kmod-sis900 kmod-tg3 \
 	kmod-via-rhine kmod-via-velocity
 endef


### PR DESCRIPTION
Many Atom-based embedded/industrial x86 boards can't run 64bit operating systems
due to either processor or board firmware limitations, 
but they have modern interfaces (PCIe) or have modern Intel gigabit controllers onboard.
With the current default package selection for x86 Generic target their network won't work.

Add the modern gigabit network modules needed or most likely going to be used as add-in cards, 
similar to what is the list on x86_64 target.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>