### PR TITLE
ramips: Provide label MAC address

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -511,7 +511,6 @@ ramips_setup_macs()
 	8devices,carambola|\
 	alfa-network,w502u|\
 	arcwireless,freestation5|\
-	cudy,wr1000|\
 	lenovo,newifi-y1|\
 	lenovo,newifi-y1s|\
 	netgear,wnce2001|\
@@ -547,7 +546,6 @@ ramips_setup_macs()
 	planex,vr500|\
 	samknows,whitebox-v8|\
 	youku,yk-l2|\
-	zbtlink,zbt-we1326|\
 	zbtlink,zbt-we3526)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)
 		;;
@@ -558,6 +556,7 @@ ramips_setup_macs()
 	belkin,f9k1109v1)
 		wan_mac=$(mtd_get_mac_ascii uboot-env HW_WAN_MAC)
 		lan_mac=$(mtd_get_mac_ascii uboot-env HW_LAN_MAC)
+		label_mac=$wan_mac
 		;;
 	buffalo,wcr-1166ds|\
 	buffalo,wsr-1166dhp)
@@ -574,6 +573,10 @@ ramips_setup_macs()
 	zyxel,keenetic-start)
 		# This empty case has to be kept for devices without any MAC address adjustments
 		;;
+	cudy,wr1000)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
+		;;
 	dlink,dch-m225|\
 	samsung,cy-swr1100)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
@@ -587,6 +590,17 @@ ramips_setup_macs()
 	lava,lr-25g001)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
+		;;
+	dlink,dir-615-d|\
+	dlink,dir-615-h1|\
+	glinet,gl-mt300a|\
+	glinet,gl-mt300n|\
+	glinet,gl-mt750|\
+	zbtlink,zbt-wg3526-16m|\
+	zbtlink,zbt-wg3526-32m)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	dlink,dir-645)
 		lan_mac=$(mtd_get_mac_ascii nvram lanmac)
@@ -595,6 +609,7 @@ ramips_setup_macs()
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		wan_mac=$(mtd_get_mac_ascii factory wanmac)
+		label_mac=$(cat /sys/class/ieee80211/phy1/macaddress)
 		;;
 	dovado,tiny-ac)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env LAN_MAC_ADDR)
@@ -616,7 +631,8 @@ ramips_setup_macs()
 	hiwifi,hc5861|\
 	hiwifi,hc5861b|\
 	hiwifi,hc5962)
-		lan_mac=`mtd_get_mac_ascii bdinfo "Vfac_mac "`
+		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		label_mac=$lan_mac
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
@@ -667,12 +683,23 @@ ramips_setup_macs()
 	trendnet,tew-691gr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 3)
 		;;
-	xiaomi,mir3g|\
+	vocore,vocore2|\
+	vocore,vocore2-lite)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
+		;;
+	xiaomi,mir3g)
+		lan_mac=$(mtd_get_mac_binary factory 0xe006)
+		;;
 	xiaomi,mir3p)
 		lan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$lan_mac
 		;;
 	xiaomi,miwifi-mini)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")
+		;;
+	zbtlink,zbt-we1326)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	*)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
@@ -681,6 +708,7 @@ ramips_setup_macs()
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
 	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
 board_config_update

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power_green;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_green;
+		label-mac-device = &ethernet;
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
@@ -9,6 +9,10 @@
 	compatible = "glinet,gl-mt300a", "ralink,mt7620a-soc";
 	model = "GL-MT300A";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
@@ -9,6 +9,10 @@
 	compatible = "glinet,gl-mt300n", "ralink,mt7620a-soc";
 	model = "GL-MT300N";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -9,6 +9,10 @@
 	compatible = "glinet,gl-mt750", "ralink,mt7620a-soc";
 	model = "GL-MT750";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
@@ -11,6 +11,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
@@ -11,6 +11,7 @@
 		led-failsafe = &led_power_blue;
 		led-running = &led_power_blue;
 		led-upgrade = &led_power_blue;
+		label-mac-device = &ethernet;
 	};
 
 	gpio_export {

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_blue;
 		led-running = &led_blue;
 		led-upgrade = &led_blue;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
+++ b/target/linux/ramips/dts/mt7620n_nexx_wt3020.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7621_adslr_g7.dts
+++ b/target/linux/ramips/dts/mt7621_adslr_g7.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_sys;
 		led-running = &led_sys;
 		led-upgrade = &led_sys;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power_blue;
 		led-running = &led_power_blue;
 		led-upgrade = &led_power_blue;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power_green;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_green;
+		label-mac-device = &wifi1;
 	};
 
 	chosen {
@@ -119,7 +120,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi0: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x2000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -127,7 +128,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi1: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_blue;
 		led-running = &led_blue;
 		led-upgrade = &led_blue;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
+++ b/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_netgear_r6220.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_r6220.dtsi
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_netgear_r6260_r6350_r6850.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_r6260_r6350_r6850.dtsi
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7621_ubiquiti_edgerouterx.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubiquiti_edgerouterx.dtsi
@@ -6,6 +6,10 @@
 / {
 	compatible = "ubiquiti,edgerouterx", "mediatek,mt7621-soc";
 
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -9,6 +9,10 @@
 	compatible = "zbtlink,zbt-we1326", "mediatek,mt7621-soc";
 	model = "ZBT-WE1326";
 
+	aliases {
+		label-mac-device = &wifi1;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
@@ -83,7 +87,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi0: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -91,7 +95,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi1: mt76@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_status;
 		led-running = &led_status;
 		led-upgrade = &led_status;
+		label-mac-device = &wifi0;
 	};
 
 	chosen {
@@ -92,7 +93,7 @@
 };
 
 &pcie0 {
-	wifi@0,0 {
+	wifi0: wifi@0,0 {
 		compatible = "pci14c3,7603";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
@@ -100,7 +101,7 @@
 };
 
 &pcie1 {
-	wifi@0,0 {
+	wifi1: wifi@0,0 {
 		compatible = "pci14c3,7662";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -14,6 +14,7 @@
 		led-boot = &led_wps;
 		led-failsafe = &led_wps;
 		led-upgrade = &led_wps;
+		label-mac-device = &wmac;
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/dts/mt7628an_iptime_a604m.dts
+++ b/target/linux/ramips/dts/mt7628an_iptime_a604m.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_cpu;
 		led-running = &led_cpu;
 		led-upgrade = &led_cpu;
+		label-mac-device = &ethernet;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -5,6 +5,10 @@
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -4,6 +4,10 @@
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
@@ -3,6 +3,10 @@
 / {
 	compatible = "vocore,vocore2", "mediatek,mt7628an-soc";
 
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	chosen {
 		bootargs = "console=ttyS2,115200";
 	};

--- a/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
+		label-mac-device = &wmac;
 	};
 
 	cfi@1f000000 {

--- a/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
+		label-mac-device = &wmac;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
@@ -10,6 +10,7 @@
 		led-failsafe = &led_status;
 		led-running = &led_status;
 		led-upgrade = &led_status;
+		label-mac-device = &ethernet;
 	};
 
 	gpio-export {

--- a/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
+++ b/target/linux/ramips/dts/rt5350_zyxel_keenetic-start.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_status;
 		led-running = &led_status;
 		led-upgrade = &led_status;
+		label-mac-device = &ethernet;
 	};
 
 	leds {


### PR DESCRIPTION
This patch adds the label MAC address for several devices in ramips.

It depends on https://github.com/openwrt/openwrt/pull/2159.

I create this as a separate PR so we can collect ramips devices here for some time without deferring the PR providing initial support any further.

Feel free to post information about additional devices, even if it needs discussion/finalization.

Many of the devices already added in patch need to be verified (marked with ToDo comments): Does the DTS actually refer to MAC addresses?


**Devices with open pull-request and reported address:**
Edimax RG21S   https://patchwork.ozlabs.org/patch/1134509/   `label-mac-device = &wifi0;`
Archer C5 v4   #2174   `label-mac-device = &wmac;`
~~ipTIME A604M   #2260   `label-mac-device = &ethernet;`~~