### PR TITLE
ar71xx: Archer C7 v1 LED names and RFKILL fixes

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -124,8 +124,8 @@ archer-c5|\
 archer-c7)
 	ucidef_set_led_usbport "usb1" "USB1" "tp-link:green:usb1" "usb1-port1"
 	ucidef_set_led_usbport "usb2" "USB2" "tp-link:green:usb2" "usb2-port1"
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:blue:wlan2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:blue:wlan5g" "phy0tpt"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:green:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:green:wlan5g" "phy0tpt"
 	;;
 archer-c58-v1|\
 archer-c59-v1|\

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -85,8 +85,6 @@ get_status_led() {
 	tl-wr902ac-v1)
 		status_led="$board:green:power"
 		;;
-	archer-c5|\
-	archer-c7|\
 	tl-mr10u|\
 	tl-mr12u|\
 	tl-mr13u|\
@@ -450,6 +448,8 @@ get_status_led() {
 	tl-mr6400)
 		status_led="tp-link:white:power"
 		;;
+	archer-c5|\
+	archer-c7|\
 	tl-mr3220|\
 	tl-mr3220-v2|\
 	tl-mr3420|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7.c
@@ -50,7 +50,7 @@
 #define ARCHER_C7_GPIO_LED_USB1		18
 #define ARCHER_C7_GPIO_LED_USB2		19
 
-#define ARCHER_C7_GPIO_BTN_RFKILL	13
+#define ARCHER_C7_GPIO_BTN_RFKILL	23
 #define ARCHER_C7_V2_GPIO_BTN_RFKILL	23
 #define ARCHER_C7_GPIO_BTN_RESET	16
 
@@ -74,22 +74,22 @@ static struct flash_platform_data archer_c7_flash_data = {
 
 static struct gpio_led archer_c7_leds_gpio[] __initdata = {
 	{
-		.name		= "tp-link:blue:qss",
+		.name		= "tp-link:green:qss",
 		.gpio		= ARCHER_C7_GPIO_LED_QSS,
 		.active_low	= 1,
 	},
 	{
-		.name		= "tp-link:blue:system",
+		.name		= "tp-link:green:system",
 		.gpio		= ARCHER_C7_GPIO_LED_SYSTEM,
 		.active_low	= 1,
 	},
 	{
-		.name		= "tp-link:blue:wlan2g",
+		.name		= "tp-link:green:wlan2g",
 		.gpio		= ARCHER_C7_GPIO_LED_WLAN2G,
 		.active_low	= 1,
 	},
 	{
-		.name		= "tp-link:blue:wlan5g",
+		.name		= "tp-link:green:wlan5g",
 		.gpio		= ARCHER_C7_GPIO_LED_WLAN5G,
 		.active_low	= 1,
 	},
@@ -142,11 +142,11 @@ static struct gpio_keys_button archer_c7_v2_gpio_keys[] __initdata = {
 };
 
 static const struct ar8327_led_info archer_c7_leds_ar8327[] = {
-	AR8327_LED_INFO(PHY0_0, HW, "tp-link:blue:wan"),
-	AR8327_LED_INFO(PHY1_0, HW, "tp-link:blue:lan1"),
-	AR8327_LED_INFO(PHY2_0, HW, "tp-link:blue:lan2"),
-	AR8327_LED_INFO(PHY3_0, HW, "tp-link:blue:lan3"),
-	AR8327_LED_INFO(PHY4_0, HW, "tp-link:blue:lan4"),
+	AR8327_LED_INFO(PHY0_0, HW, "tp-link:green:wan"),
+	AR8327_LED_INFO(PHY1_0, HW, "tp-link:green:lan1"),
+	AR8327_LED_INFO(PHY2_0, HW, "tp-link:green:lan2"),
+	AR8327_LED_INFO(PHY3_0, HW, "tp-link:green:lan3"),
+	AR8327_LED_INFO(PHY4_0, HW, "tp-link:green:lan4"),
 };
 
 /* GMAC0 of the AR8327 switch is connected to the QCA9558 SoC via SGMII */


### PR DESCRIPTION
All leds on these boards are green. v1 has RFKILL GPIO 23 for production
units (it had GPIO 13 only for test phase units, and these are rather
very rare to find). As for the previous attempt to fix this and revert
due to WDR boards have blue leds, it was wrong: WDR board does not use
common setup (false).

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>