### PR TITLE
ar71xx: update qca-usb-quirks patch

### DIFF
--- a/target/linux/ar71xx/patches-4.14/525-MIPS-ath79-enable-qca-usb-quirks.patch
+++ b/target/linux/ar71xx/patches-4.14/525-MIPS-ath79-enable-qca-usb-quirks.patch
@@ -77,7 +77,7 @@
 +
 +	switch (pdev->id) {
 +	case 0:
-+		base = 0x18116c94;
++		base = 0x18116d94;
 +		break;
 +
 +	case 1:


### PR DESCRIPTION
Base address for USB0 has changed from 0x18116c94 on AR934X
to 0x18116d94 on QCA9558. CP Typo remained for years here...

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>