### PR TITLE
ath79: add support for D-Link DIR-842 C2

### DIFF
--- a/package/system/mtd/src/fis.c
+++ b/package/system/mtd/src/fis.c
@@ -139,8 +139,6 @@ done:
 int
 fis_remap(struct fis_part *old, int n_old, struct fis_part *new, int n_new)
 {
-	struct fis_image_desc *fisdir = NULL;
-	struct fis_image_desc *redboot = NULL;
 	struct fis_image_desc *first = NULL;
 	struct fis_image_desc *last = NULL;
 	struct fis_image_desc *first_fb = NULL;
@@ -163,12 +161,6 @@ fis_remap(struct fis_part *old, int n_old, struct fis_part *new, int n_new)
 	while ((char *) desc < end) {
 		if (!desc->hdr.name[0] || (desc->hdr.name[0] == 0xff))
 			break;
-
-		if (!strcmp((char *) desc->hdr.name, "FIS directory"))
-			fisdir = desc;
-
-		if (!strcmp((char *) desc->hdr.name, "RedBoot"))
-			redboot = desc;
 
 		/* update max offset */
 		if (offset < desc->hdr.flash_base)
@@ -209,18 +201,6 @@ fis_remap(struct fis_part *old, int n_old, struct fis_part *new, int n_new)
 	desc--;
 
 	size = offset - first_fb->hdr.flash_base;
-
-#ifdef notyet
-	desc = first - 1;
-	if (redboot && (desc >= redboot)) {
-		if (first->hdr.flash_base - desc->hdr.size > desc->hdr.flash_base) {
-			int delta = first->hdr.flash_base - desc->hdr.size - desc->hdr.flash_base;
-
-			offset -= delta;
-			size += delta;
-		}
-	}
-#endif
 
 	last++;
 	desc = first + n_new;

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -59,6 +59,7 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+dlink,dir-842-c2|\
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;
@@ -140,7 +141,9 @@ tplink,tl-wr842n-v3)
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
 tplink,archer-c58-v1|\
-tplink,archer-c59-v1)
+tplink,archer-c59-v1|\
+tplink,archer-c60-v1|\
+tplink,archer-c60-v2)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	;;
@@ -158,9 +161,20 @@ tplink,cpe210-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "80" "100"
 	;;
+tplink,cpe510-v2|\
+tplink,cpe510-v3)
+	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:green:link1" "wlan0" "1" "100" "0" "13"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:green:link2" "wlan0" "26" "100" "-25" "13"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "51" "100" "-50" "13"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "76" "100" "-75" "13"
+	;;
 tplink,cpe610-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
+tplink,re355-v1|\
+tplink,re450-v1|\
 tplink,re450-v2)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"
@@ -191,6 +205,9 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+trendnet,tew-823dru)
+       ucidef_set_led_netdev "wan" "WAN" "trendnet:green:planet" "eth0"
+       ;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
 ubnt,nanostation-m|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -28,8 +28,12 @@ ath79_setup_interfaces()
 	pqi,air-pen|\
 	tplink,cpe210-v2|\
 	tplink,cpe210-v3|\
+	tplink,cpe510-v2|\
+	tplink,cpe510-v3|\
 	tplink,cpe610-v1|\
 	tplink,re350k-v1|\
+	tplink,re355-v1|\
+	tplink,re450-v1|\
 	tplink,re450-v2|\
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\
@@ -62,7 +66,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
 		;;
-	buffalo,bhr-4grv2)
+	buffalo,bhr-4grv2|\
+	trendnet,tew-823dru)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
 		;;
@@ -107,6 +112,7 @@ ath79_setup_interfaces()
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1|\
+	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
@@ -212,6 +218,12 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
 		;;
+	tplink,archer-c60-v1|\
+	tplink,archer-c60-v2)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+		;;
 	tplink,archer-d50-v1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
@@ -292,6 +304,7 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text "mac" 4)
 		wan_mac=$(mtd_get_mac_text "mac" 24)
 		;;
+	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)
@@ -360,6 +373,10 @@ ath79_setup_macs()
 	tplink,tl-wr941n-v7-cn)
 		base_mac=$(mtd_get_mac_binary u-boot 130048)
 		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
+	trendnet,tew-823dru)
+		lan_mac=$(mtd_get_mac_text mac 4)
+		wan_mac=$(mtd_get_mac_text mac 24)
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -105,6 +105,7 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 4) 2
 		;;
+	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -163,6 +163,11 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
 		;;
+	tplink,re355-v1|\
+	tplink,re450-v1)
+		ath10kcal_extract "art" 20480 2116
+		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+		;;
 	tplink,re450-v2)
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) +1)
@@ -184,6 +189,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
+	dlink,dir-842-c2|\
 	nec,wg1200cr)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
@@ -203,6 +209,8 @@ case "$FIRMWARE" in
 		;;
 	tplink,archer-c58-v1|\
 	tplink,archer-c59-v1|\
+	tplink,archer-c60-v1|\
+	tplink,archer-c60-v2|\
 	tplink,archer-c6-v2)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mac 8) -1)

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -34,6 +34,14 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			k2t_get_mac "lan_mac" > /sys${DEVPATH}/macaddress
 		;;
+	trendnet,tew-823dru)
+	        # set the 2.4G interface mac address to LAN MAC
+	        [ "$PHYNBR" -eq 1 ] && \
+		        mtd_get_mac_text mac 4 > /sys${DEVPATH}/macaddress
+	        # set the 5G interface mac address to WAN MAC + 1
+	        [ "$PHYNBR" -eq 0 ] && \
+		        macaddr_add "$(mtd_get_mac_text mac 24)" 1 > /sys${DEVPATH}/macaddress
+                ;;
 	*)
 		;;
 esac

--- a/target/linux/ath79/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/base-files/etc/uci-defaults/04_led_migration
@@ -18,6 +18,12 @@ tplink,archer-c7-v4)
 tplink,archer-c7-v5)
 	migrate_leds "archer-c7-v5:=tp-link:"
 	;;
+tplink,re355-v1)
+	migrate_leds "re355:=tp-link:"
+	;;
+tplink,re450-v1)
+	migrate_leds "re450:=tp-link:"
+	;;
 wd,mynet-n750)
 	migrate_leds "wd:=mynet-n750:"
 	;;

--- a/target/linux/ath79/dts/ar9344_tplink_cpe510-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe510-v2.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpe510.dtsi"
+
+/ {
+	compatible = "tplink,cpe510-v2", "qca,ar9344";
+	model = "TP-Link CPE510 v2";
+};

--- a/target/linux/ath79/dts/ar9344_tplink_cpe510-v3.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe510-v3.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpe510.dtsi"
+
+/ {
+	compatible = "tplink,cpe510-v3", "qca,ar9344";
+	model = "TP-Link CPE510 v3";
+};

--- a/target/linux/ath79/dts/ar9344_tplink_cpe510.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe510.dtsi
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		link1 {
+			label = "tp-link:green:link1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		link2 {
+			label = "tp-link:green:link2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		link3 {
+			label = "tp-link:green:link3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		system: link4 {
+			label = "tp-link:green:link4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "partition-table";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			info: partition@30000 {
+				label = "info";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0x780000>;
+
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "kernel";
+					reg = <0x000000 0x200000>;
+				};
+
+				partition@200000 {
+					label = "rootfs";
+					reg = <0x200000 0x580000>;
+				};
+			};
+
+			partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x030000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x08>;
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x08>;
+
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	status = "okay";
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr2.dts
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac1600dgr2.dts
@@ -7,8 +7,8 @@
 #include "qca9557_iodata_wn-ac-dgr.dtsi"
 
 / {
-	compatible = "iodata,wn-ac1600dgr2", "qca,qca9557";
-	model = "I-O DATA WN-AC1600DGR2";
+	compatible = "iodata,wn-ac1600dgr2", "iodata,wn-ac1600dgr3", "qca,qca9557";
+	model = "I-O DATA WN-AC1600DGR2/DGR3";
 };
 
 &leds {

--- a/target/linux/ath79/dts/qca9558_tplink_re355-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_re355-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_rex5x.dtsi"
+
+/ {
+	compatible = "tplink,re355-v1", "qca,qca9558";
+	model = "TP-Link RE355 v1";
+};

--- a/target/linux/ath79/dts/qca9558_tplink_re450-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_re450-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_rex5x.dtsi"
+
+/ {
+	compatible = "tplink,re450-v1", "qca,qca9558";
+	model = "TP-Link RE450 v1";
+};

--- a/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		mdio-gpio0 = &mdio2;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tp-link:blue:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "tp-link:blue:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:blue:wlan5g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan_link {
+			label = "tp-link:green:lan_link";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_data {
+			label = "tp-link:green:lan_data";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "tp-link:blue:wps";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps_red {
+			label = "tp-link:red:wps";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		leds {
+			label = "LED control button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	mdio2: mdio {
+		compatible = "virtual,mdio-gpio";
+
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>, /* MDC */
+			<&gpio 1 GPIO_ACTIVE_HIGH>; /* MDIO */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@4 {
+			reg = <4>;
+			reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x5e0000>;
+			};
+
+			partition@600000 {
+				label = "partition-table";
+				reg = <0x600000 0x010000>;
+				read-only;
+			};
+
+			info: partition@610000 {
+				label = "info";
+				reg = <0x610000 0x020000>;
+				read-only;
+			};
+
+			partition@630000 {
+				label = "config";
+				reg = <0x630000 0x1c0000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&info 0x8>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+	mtd-mac-address-increment = <(-1)>;
+};

--- a/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
+++ b/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	compatible = "trendnet,tew-823dru", "qca,qca9558";
+	model = "TRENDNET TEW-823DRU";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange {
+			label = "trendnet:orange:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		system: power_green {
+			label = "trendnet:green:power";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		planet_green {
+			label = "trendnet:green:planet";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		planet_orange {
+			label = "trendnet:orange:planet";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xef0000>;
+			};
+
+			partition@f30000 {
+				label = "lang";
+				reg = <0xf30000 0x030000>;
+				read-only;
+			};
+
+			partition@f60000 {
+				label = "my-dlink";
+				reg = <0xf60000 0x080000>;
+				read-only;
+			};
+
+			mac: partition@fe0000 {
+				label = "mac";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRIP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v1.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9561_tplink_archer-c6x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c60-v1", "qca,qca9561";
+	model = "TP-Link Archer C60 v1";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			mac: partition@10000 {
+				label = "mac";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0x7c0000>;
+			};
+
+			partition@7e0000 {
+				label = "tplink";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9561_tplink_archer-c6x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c60-v2", "qca,qca9561";
+	model = "TP-Link Archer C60 v2";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-boot";
+				reg = <0x000000 0x01fb00>;
+				read-only;
+			};
+
+			mac: partition@1fb00 {
+				label = "mac";
+				reg = <0x01fb00 0x000500>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0x7a0000>;
+			};
+
+			partition@7d0000 {
+				label = "tplink";
+				reg = <0x7d0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c6x.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c6x.dtsi
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi_button {
+			label = "WiFi button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_green {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tp-link:amber:wan";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&mac 0x8>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&mac 0x8>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&mac 0x8>;
+};

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c2.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c2.dts
@@ -7,8 +7,8 @@
 #include "qca956x.dtsi"
 
 / {
-	model = "D-Link DIR-859 A1";
-	compatible = "dlink,dir-859-a1", "qca,qca9563";
+	model = "D-Link DIR-842 C2";
+	compatible = "dlink,dir-842-c2", "qca,qca9563";
 
 	aliases {
 		led-boot = &power;
@@ -25,32 +25,33 @@
 		compatible = "gpio-leds";
 
 		wps {
-			label = "dir-859-a1:green:wps";
+			label = "dir-842-c2:green:wps";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		power: power {
-			label = "dir-859-a1:green:power";
+			label = "dir-842-c2:green:power";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		internet {
-			label = "dir-859-a1:green:internet";
+			label = "dir-842-c2:green:internet";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
-			label = "dir-859-a1:green:wlan";
+			label = "dir-842-c2:green:wlan";
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 	};
 
 	keys {
-		compatible = "gpio-keys";
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
 
 		wps {
-			linux,code = <KEY_RESTART>;
+			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
@@ -61,24 +62,17 @@
 			debounce-interval = <60>;
 		};
 	};
+	
+	reset-button {
+		gpio-hog;
+		output-high;
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		line-name = "reset-button";
+    };
 
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		gpio_switch_reset {
-			gpio-export,name = "dir-859-a1:reset:switch";
-			gpio-export,output = <1>;
-			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
 &uart {
-	status = "okay";
-};
-
-&gpio {
 	status = "okay";
 };
 
@@ -102,13 +96,13 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "bootloader";
+				label = "u-boot";
 				reg = <0x000000 0x40000>;
 				read-only;
 			};
 
 			partition@40000 {
-				label = "bdcfg";
+				label = "u-boot-env";
 				reg = <0x040000 0x10000>;
 				read-only;
 			};
@@ -124,16 +118,28 @@
 				reg = <0x060000 0x10000>;
 				read-only;
 			};
-
+			
 			partition@70000 {
-				compatible = "seama";
-				label = "firmware";
-				reg = <0x070000 0xf80000>;
+				label = "misc";
+				reg = <0x070000 0x10000>;
+				read-only;
 			};
 
-			art: partition@ff0000 {
+			partition@80000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x080000 0xf50000>;
+			};
+
+			art: partition@fd0000 {
 				label = "art";
-				reg = <0xff0000 0x010000>;
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+			
+			partition@fe0000 {
+				label = "reserved";
+				reg = <0xfe0000 0x020000>;
 				read-only;
 			};
 		};
@@ -174,4 +180,19 @@
 &wmac {
 	status = "okay";
 	qca,no-eeprom;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
 };

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -60,6 +60,30 @@ define Device/tplink_archer-c59-v1
 endef
 TARGET_DEVICES += tplink_archer-c59-v1
 
+define Device/tplink_archer-c60-v1
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9561
+  IMAGE_SIZE := 7936k
+  DEVICE_MODEL := Archer C60
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := ARCHER-C60-V1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SUPPORTED_DEVICES += archer-c60-v1
+endef
+TARGET_DEVICES += tplink_archer-c60-v1
+
+define Device/tplink_archer-c60-v2
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9561
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := Archer C60
+  DEVICE_VARIANT := v2
+  TPLINK_BOARD_ID := ARCHER-C60-V2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SUPPORTED_DEVICES += archer-c60-v2
+endef
+TARGET_DEVICES += tplink_archer-c60-v2
+
 define Device/tplink_archer-c6-v2
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
@@ -159,6 +183,40 @@ define Device/tplink_cpe210-v3
 endef
 TARGET_DEVICES += tplink_cpe210-v3
 
+define Device/tplink_cpe510-v2
+  $(Device/tplink-safeloader)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := CPE510
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := CPE510V2
+  LOADER_TYPE := elf
+  LOADER_FLASH_OFFS := 0x43000 
+  COMPILE := loader-$(1).elf 
+  COMPILE/loader-$(1).elf := loader-okli-compile 
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49 | loader-okli $(1) 12288
+  SUPPORTED_DEVICES += cpe510-v2
+endef
+TARGET_DEVICES += tplink_cpe510-v2
+
+define Device/tplink_cpe510-v3
+  $(Device/tplink-safeloader)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := CPE510
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := CPE510V3
+  LOADER_TYPE := elf
+  LOADER_FLASH_OFFS := 0x43000 
+  COMPILE := loader-$(1).elf 
+  COMPILE/loader-$(1).elf := loader-okli-compile 
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49 | loader-okli $(1) 12288
+  SUPPORTED_DEVICES += cpe510-v3
+endef
+TARGET_DEVICES += tplink_cpe510-v3
+
 define Device/tplink_cpe610-v1
   $(Device/tplink-safeloader)
   ATH_SOC := ar9344
@@ -209,6 +267,33 @@ define Device/tplink_re350k-v1
   TPLINK_HWREV := 0
 endef
 TARGET_DEVICES += tplink_re350k-v1
+
+define Device/tplink_rex5x-v1
+  $(Device/tplink-safeloader)
+  ATH_SOC := qca9558
+  IMAGE_SIZE := 6016k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  TPLINK_HWID := 0x0
+  TPLINK_HWREV := 0
+endef
+
+define Device/tplink_re355-v1
+  $(Device/tplink_rex5x-v1)
+  DEVICE_MODEL := RE355
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := RE355
+  SUPPORTED_DEVICES += re355
+endef
+TARGET_DEVICES += tplink_re355-v1
+
+define Device/tplink_re450-v1
+  $(Device/tplink_rex5x-v1)
+  DEVICE_MODEL := RE450
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := RE450
+  SUPPORTED_DEVICES += re450
+endef
+TARGET_DEVICES += tplink_re450-v1
 
 define Device/tplink_re450-v2
   $(Device/tplink-safeloader)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -355,6 +355,30 @@ define Device/dlink_dir-859-a1
 endef
 TARGET_DEVICES += dlink_dir-859-a1
 
+define Device/dlink_dir-842-c2
+  ATH_SOC := qca9563
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-842
+  DEVICE_VARIANT := C2
+  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
+  KERNEL_INITRAMFS := $$(KERNEL) | seama
+  IMAGES += factory.bin
+  SEAMA_MTDBLOCK := 5
+  # 64 bytes offset:
+  # - 28 bytes seama_header
+  # - 36 bytes of META data (4-bytes aligned)
+  IMAGE/default := append-kernel | uImage lzma | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
+  IMAGE/sysupgrade.bin := \
+	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := \
+	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE) 
+  IMAGE_SIZE := 15680k
+  DEVICE_PACKAGES :=  kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SEAMA_SIGNATURE := wrgac65_dlink.2015_dir842
+endef
+TARGET_DEVICES += dlink_dir-842-c2
+
+
 define Device/elecom_wrc-1750ghbk2-i
   ATH_SOC := qca9563
   DEVICE_VENDOR := ELECOM
@@ -520,10 +544,11 @@ TARGET_DEVICES += iodata_wn-ac1600dgr
 define Device/iodata_wn-ac1600dgr2
   ATH_SOC := qca9557
   DEVICE_VENDOR := I-O DATA
-  DEVICE_MODEL := WN-AC1600DGR2
+  DEVICE_MODEL := WN-AC1600DGR2/DGR3
   IMAGE_SIZE := 14656k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+  IMAGES += dgr2-dgr3-factory.bin
+  IMAGE/dgr2-dgr3-factory.bin := \
+    append-kernel | pad-to $$$$(BLOCKSIZE) | \
     append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
     senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -774,6 +799,22 @@ define Device/rosinson_wr818
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += rosinson_wr818
+
+define Device/trendnet_tew-823dru
+  ATH_SOC := qca9558
+  DEVICE_VENDOR := Trendnet
+  DEVICE_MODEL := TEW-823DRU
+  DEVICE_VARIANT := v1.0R
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  SUPPORTED_DEVICES += tew-823dru
+  IMAGE_SIZE := 15296k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
+	append-string 00AP135AR9558-RT-131129-00 | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += trendnet_tew-823dru
 
 define Device/wd_mynet-n750
   $(Device/seama)

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -347,7 +347,8 @@ tplink,archer-mr200)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "usb0"
 	set_wifi_led "$boardname:white:wlan"
 	;;
-tplink,re350-v1)
+tplink,re350-v1|\
+tplink,re650-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "$boardname:blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "$boardname:blue:wifi5G" "wlan1"
 	ucidef_set_led_netdev "eth_act" "LAN act" "$boardname:green:eth_act" "eth0" "tx rx"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -285,7 +285,8 @@ ramips_setup_interfaces()
 	dlink,dir-510l|\
 	glinet,vixmini|\
 	netgear,ex6150|\
-	tplink,re350-v1)
+	tplink,re350-v1|\
+	tplink,re650-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
 		;;

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,re650-v1", "mediatek,mt7621-soc";
+	model = "TP-Link RE650 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re650-v1:blue:power";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "re650-v1:blue:wifi2G";
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "re650-v1:blue:wifi5G";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_red {
+			label = "re650-v1:red:wps";
+			gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps_blue {
+			label = "re650-v1:blue:wps";
+			gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		eth_act {
+			label = "re650-v1:green:eth_act";
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+		};
+
+		eth_link {
+			label = "re650-v1:green:eth_link";
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		power {
+			label = "power";
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_POWER>;
+		};
+
+		led {
+			label = "led";
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	w25q64@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xde0000>;
+			};
+
+			config: partition@e00000 {
+				label = "config";
+				reg = <0xe00000 0x50000>;
+				read-only;
+			};
+
+			/* range 0xe50000 to 0xff0000 is empty in vendor
+			 * firmware, so we do not use it either
+			 */
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <1>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0x10008>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "rgmii2", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -531,24 +531,40 @@ define Device/totolink_a7000r
 endef
 TARGET_DEVICES += totolink_a7000r
 
-define Device/tplink_re350-v1
+define Device/tplink-safeloader
   MTK_SOC := mt7621
   DEVICE_VENDOR := TP-Link
+  TPLINK_BOARD_ID :=
+  TPLINK_HWID := 0x0
+  TPLINK_HWREV := 0
+  TPLINK_HEADER_VERSION := 1
+  KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+	append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+endef
+
+define Device/tplink_re350-v1
+  $(Device/tplink-safeloader)
   DEVICE_MODEL := RE350
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic
   TPLINK_BOARD_ID := RE350-V1
-  TPLINK_HWID := 0x0
-  TPLINK_HWREV := 0
-  TPLINK_HEADER_VERSION := 1
   IMAGE_SIZE := 6016k
-  KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
   SUPPORTED_DEVICES += re350-v1
 endef
 TARGET_DEVICES += tplink_re350-v1
+
+define Device/tplink_re650-v1
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := RE650
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+  TPLINK_BOARD_ID := RE650-V1
+  IMAGE_SIZE := 14208k
+endef
+TARGET_DEVICES += tplink_re650-v1
 
 define Device/ubiquiti_edgerouterx
   MTK_SOC := mt7621

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -278,6 +278,91 @@ static struct device_info boards[] = {
 		.first_sysupgrade_partition = "os-image",
 		.last_sysupgrade_partition = "support-list",
 	},
+
+	/** Firmware layout for the CPE510 V2 */
+	{
+		.id     = "CPE510V2",
+		.vendor = "CPE510(TP-LINK|UN|N300-5):2.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"CPE510(TP-LINK|EU|N300-5|00000000):2.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5|45550000):2.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5|55530000):2.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|00000000):2.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|45550000):2.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|55530000):2.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|00000000):2.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|45550000):2.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|55530000):2.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5):2.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5):2.0\r\n"
+			"CPE510(TP-LINK|US|N300-5):2.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x200000},
+			{"file-system", 0x240000, 0x570000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
+	/** Firmware layout for the CPE510 V3 */
+	{
+		.id     = "CPE510V3",
+		.vendor = "CPE510(TP-LINK|UN|N300-5):3.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"CPE510(TP-LINK|EU|N300-5|00000000):3.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5|45550000):3.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5|55530000):3.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|00000000):3.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|45550000):3.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|55530000):3.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|00000000):3.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|45550000):3.0\r\n"
+			"CPE510(TP-LINK|US|N300-5|55530000):3.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5):3.0\r\n"
+			"CPE510(TP-LINK|EU|N300-5):3.0\r\n"
+			"CPE510(TP-LINK|US|N300-5):3.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x200000},
+			{"file-system", 0x240000, 0x570000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
 	/** Firmware layout for the CPE610V1 */
 	{
 		.id     = "CPE610V1",
@@ -1359,6 +1444,43 @@ static struct device_info boards[] = {
 			{"default-config", 0x640000, 0x10000},
 			{"radio", 0x7f0000, 0x10000},
 
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
+	/** Firmware layout for the RE650 */
+	{
+		.id = "RE650-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:55530000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:45550000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:4A500000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:43410000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:41550000}\r\n"
+			"{product_name:RE650,product_ver:1.0.0,special_id:41530000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0xde0000},
+			{"partition-table", 0xe00000, 0x02000},
+			{"default-mac", 0xe10000, 0x00020},
+			{"pin", 0xe10100, 0x00020},
+			{"product-info", 0xe11100, 0x01000},
+			{"soft-version", 0xe20000, 0x01000},
+			{"support-list", 0xe21000, 0x01000},
+			{"profile", 0xe22000, 0x08000},
+			{"user-config", 0xe30000, 0x10000},
+			{"default-config", 0xe40000, 0x10000},
+			{"radio", 0xff0000, 0x10000},
 			{NULL, 0, 0}
 		},
 


### PR DESCRIPTION
Hardware spec of DIR-842 C2:
SoC: QCA9563
DRAM: 128MB DDR2
Flash: 16MB SPI-NOR
Switch: QCA8337N
WiFi 5.8GHz: QCA9888
WiFi 2.4Ghz: QCA9563
USB: 2.0

Flash instructions:

1. Upgrade the factory.bin through the factory web interface or the u-boot
   failsafe interface.
   The firmware will boot up correctly for the first time.
   Do not power off the device after OpenWrt has booted. Otherwise the u-boot
   will enter failsafe mode as the checksum of the firmware has been changed.
2. Upgrade the sysupgrade.bin in OpenWrt.
   After upgrading completes the u-boot won't complain about the firmware
   checksum and it's OK to use now.
3. If you powered off the device before upgrading the sysupgrade.bin, just
   upgrade the factory.bin through the u-boot failsafe interface and then goto
   step 2.

Signed-off-by: Jackson Lim <jackcolentern@gmail.com>