### PR TITLE
ramips: add support for ipTIME A604M

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -304,7 +304,8 @@ ramips_setup_interfaces()
 	elecom,wrc-2533gst|\
 	huawei,hg255d|\
 	iodata,wn-ax1167gr|\
-	iodata,wn-gx300gr)
+	iodata,wn-gx300gr|\
+	iptime,a604m)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
@@ -615,6 +616,9 @@ ramips_setup_macs()
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary Factory 4)" 1)
+		;;
+	iptime,a604m)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
 	lenovo,newifi-d1)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/dts/mt7628an_iptime_a604m.dts
+++ b/target/linux/ramips/dts/mt7628an_iptime_a604m.dts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iptime,a604m", "mediatek,mt7628an-soc";
+	model = "ipTIME A604M";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "a604m:blue:wlan5g";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_cpu: cpu {
+			label = "a604m:blue:cpu";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "a604m:blue:wlan2g";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0x7c0000>;
+			};
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uart1", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc20>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -109,6 +109,16 @@ define Device/hiwifi_hc5861b
 endef
 TARGET_DEVICES += hiwifi_hc5861b
 
+define Device/iptime_a604m
+  MTK_SOC := mt7628an
+  IMAGE_SIZE := 7936k
+  UIMAGE_NAME := a604m
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A604M
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += iptime_a604m
+
 define Device/mediatek_linkit-smart-7688
   MTK_SOC := mt7628an
   IMAGE_SIZE := $(ralink_default_fw_size_32M)

--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=mt76x8
 BOARDNAME:=MT76x8 based boards
-FEATURES+=usb
+FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-mt7603 wpad-basic


### PR DESCRIPTION
ipTIME A604M is a 2.4/5GHz band AC1200 router, based on MediaTek
MT7628AN.

Specifications:
- SoC: MT7628AN
- RAM: DDR2 64MB
- Flash: SPI NOR 8MB
- WiFi:
  - 2.4GHz: SoC internal
  - 5GHz: MT7612EN
- Ethernet: 5x 10/100Mbps
  - Switch: SoC internal
- UART:
  - J1: 3.3V, TX, RX, GND (3.3V is the square pad) / 57600 8N1

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.