### PR TITLE
lua5.3: include hpp header

### DIFF
--- a/package/utils/lua5.3/Makefile
+++ b/package/utils/lua5.3/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lua
 PKG_VERSION:=5.3.5
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.lua.org/ftp/ \
@@ -123,6 +123,7 @@ endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/lua5.3 $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.3/lua{,lib,conf}.h $(1)/usr/include/lua5.3/
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.3/lua.hpp $(1)/usr/include/lua5.3/
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/lua5.3/lauxlib.h $(1)/usr/include/lua5.3/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/liblua5.3.{a,so*} $(1)/usr/lib/


### PR DESCRIPTION
The install was missing the hpp header.  Adding that in.

Signed-off-by: Colby Whitney <colby.whitney@luxul.com>
