### PR TITLE
WIP ath79: support compex WPJ531

### DIFF
--- a/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
+++ b/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "compex,wpj531-16m", "qca,qca9531";
+	model = "Compex WPJ531 (16MB flash)";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_led_eth_pins>;
+
+		sig1 {
+			label = "wpj531:red:sig1";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "wpj531:yellow:sig2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		sig3 {
+			label = "wpj531:green:sig3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		sig4 {
+			label = "wpj531:green:sig4";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pinmux {
+	pinmux_led_eth_pins: pinmux_led_eth_pins {
+		pinctrl-single,bits = <0x8 0x2b000000 0xff000000>, <0xc 0x00002d00 0x0000ff00>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "firmware";
+				reg = <0x030000 0xfc0000>;
+				compatible = "denx,uimage";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x2e018>;
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&uboot 0x2e010>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -118,6 +118,13 @@ enterasys,ws-ap3705i)
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:white:dlan" "eth0.1" "rx"
 	;;
+compex,wpj531-16m)
+	ucidef_set_rssimon "wlan0" "1000000" "1"
+	ucidef_set_led_rssi "sig1" "SIG1" "$boardname:red:sig1" "wlan0" "85" "100"
+	ucidef_set_led_rssi "sig2" "SIG2" "$boardname:yellow:sig2" "wlan0" "75" "100"
+	ucidef_set_led_rssi "sig3" "SIG3" "$boardname:green:sig3" "wlan0" "65" "100"
+	ucidef_set_led_rssi "sig4" "SIG4" "$boardname:green:sig4" "wlan0" "50" "100"
+	;;
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -108,6 +108,7 @@ ath79_setup_interfaces()
 	comfast,cf-e110n-v2|\
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\
+	compex,wpj531-16m|\
 	tplink,cpe210-v1|\
 	tplink,cpe220-v2|\
 	tplink,cpe220-v3|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -418,6 +418,17 @@ define Device/comfast_cf-wr752ac-v1
 endef
 TARGET_DEVICES += comfast_cf-wr752ac-v1
 
+define Device/compex_wpj531-16m
+  SOC := qca9531
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 16128k
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := WPJ531
+  DEVICE_VARIANT := 16M
+  SUPPORTED_DEVICES += wpj531
+endef
+TARGET_DEVICES += compex_wpj531-16m
+
 define Device/devolo_dvl1200e
   SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
Hello :-)

Here's the current state of my effort porting a compex board from ar71xx to ath79.

As an additional enhancement, I'm including instructions for building images that can be used to flash boards with the "hold the reset button during uboot"-method (cpximg).

After this is merged, my goal is to port the WPJ344 and WPJ563 as well.
This is where i keep their respective ports:
https://github.com/yogo1212/openwrt/tree/wpj344_wpj563