### PR TITLE
kernel: netfilter: swap iifidx and oifidx

### DIFF
--- a/target/linux/generic/hack-4.19/670-netfilter-swap-iifidx-and-oifidx.patch
+++ b/target/linux/generic/hack-4.19/670-netfilter-swap-iifidx-and-oifidx.patch
@@ -1,0 +1,13 @@
+--- a/net/netfilter/nf_flow_table_core.c
++++ b/net/netfilter/nf_flow_table_core.c
+@@ -51,8 +51,8 @@ flow_offload_fill_dir(struct flow_offloa
+ 	ft->src_port = ctt->src.u.tcp.port;
+ 	ft->dst_port = ctt->dst.u.tcp.port;
+ 
+-	ft->iifidx = other_dst->dev->ifindex;
+-	ft->oifidx = dst->dev->ifindex;
++	ft->oifidx = other_dst->dev->ifindex;
++	ft->iifidx = dst->dev->ifindex;
+ 	ft->dst_cache = dst;
+ }
+ 


### PR DESCRIPTION
Since upstream commit netfilter: nft_flow_offload: fix interaction
with vrf slave device flow offload has been broken on 4.19
Simple swap of iifidx and oifidx restores it to a working state.
Fixes FS#2389
Tested on Archer C7 v1

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>