### PR TITLE
tfa-layerscape: fix build issue

### DIFF
--- a/package/boot/tfa-layerscape/Makefile
+++ b/package/boot/tfa-layerscape/Makefile
@@ -16,8 +16,9 @@ PKG_SOURCE_URL:=https://source.codeaurora.org/external/qoriq/qoriq-components/at
 PKG_SOURCE_VERSION:=7e34aebe658c7c3439d2d68b0ce6b9776e8e6996
 PKG_MIRROR_HASH:=9cf0bc32fa589a0ee7c48c87898679e645341f29da1253d0ba5d2e82c6ea074d
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=uboot-layerscape
+PKG_BUILD_DEPENDS:=uboot-layerscape tfa-layerscape/host
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/tfa-layerscape/Config
@@ -46,7 +47,20 @@ define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) CROSS_COMPILE=$(TARGET_CROSS) \
 		fip pbl PLAT=$(PLAT) BOOT_MODE=$(BOOT_MODE) \
 		RCW=$(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-rcw.bin \
-		BL33=$(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-uboot.bin
+		BL33=$(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-uboot.bin \
+		FIPTOOL=$(STAGING_DIR_HOST)/bin/fiptool
+endef
+
+HOST_CFLAGS += -Wall -Werror -pedantic -std=c99
+define Host/Compile
+	$(MAKE) -C \
+		$(HOST_BUILD_DIR)/tools/fiptool \
+		CFLAGS="$(HOST_CFLAGS)" \
+		LDFLAGS="$(HOST_LDFLAGS)"
+endef
+
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/fiptool/fiptool $(STAGING_DIR_HOST)/bin/
 endef
 
 define Package/tfa-layerscape/ls1012ardb
@@ -132,6 +146,7 @@ TFAS := \
   ls1088ardb-sdboot \
   ls2088ardb
 
+$(eval $(call HostBuild))
 $(foreach tfa,$(TFAS), \
 	$(eval $(Package/tfa-layerscape/$(tfa))) \
 	$(eval $(call Package/tfa-layerscape/Config,$(tfa),$(TITLE),$(BIN_BL2),$(BIN_FIP))) \

--- a/package/boot/tfa-layerscape/Makefile
+++ b/package/boot/tfa-layerscape/Makefile
@@ -48,7 +48,9 @@ define Build/Compile
 		fip pbl PLAT=$(PLAT) BOOT_MODE=$(BOOT_MODE) \
 		RCW=$(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-rcw.bin \
 		BL33=$(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-uboot.bin \
-		FIPTOOL=$(STAGING_DIR_HOST)/bin/fiptool
+		FIPTOOL=$(STAGING_DIR_HOST)/bin/fiptool \
+		CREATE_PBL=$(STAGING_DIR_HOST)/bin/create_pbl \
+		BYTE_SWAP=$(STAGING_DIR_HOST)/bin/byte_swap
 endef
 
 HOST_CFLAGS += -Wall -Werror -pedantic -std=c99
@@ -57,10 +59,14 @@ define Host/Compile
 		$(HOST_BUILD_DIR)/tools/fiptool \
 		CFLAGS="$(HOST_CFLAGS)" \
 		LDFLAGS="$(HOST_LDFLAGS)"
+	$(MAKE) -C \
+		$(HOST_BUILD_DIR)/plat/nxp/tools
 endef
 
 define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/tools/fiptool/fiptool $(STAGING_DIR_HOST)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/plat/nxp/tools/create_pbl $(STAGING_DIR_HOST)/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/plat/nxp/tools/byte_swap $(STAGING_DIR_HOST)/bin/
 endef
 
 define Package/tfa-layerscape/ls1012ardb

--- a/package/boot/tfa-layerscape/patches/001-fiptool-hostbuild-fixes.patch
+++ b/package/boot/tfa-layerscape/patches/001-fiptool-hostbuild-fixes.patch
@@ -1,0 +1,71 @@
+--- a/Makefile
++++ b/Makefile
+@@ -448,10 +448,6 @@ endif
+ CRTTOOLPATH		?=	tools/cert_create
+ CRTTOOL			?=	${CRTTOOLPATH}/cert_create${BIN_EXT}
+ 
+-# Variables for use with Firmware Image Package
+-FIPTOOLPATH		?=	tools/fiptool
+-FIPTOOL			?=	${FIPTOOLPATH}/fiptool${BIN_EXT}
+-
+ ################################################################################
+ # Include BL specific makefiles
+ ################################################################################
+@@ -661,14 +657,12 @@ endif
+ clean:
+ 	@echo "  CLEAN"
+ 	$(call SHELL_REMOVE_DIR,${BUILD_PLAT})
+-	${Q}${MAKE} --no-print-directory -C ${FIPTOOLPATH} clean
+ 	${Q}${MAKE} PLAT=${PLAT} --no-print-directory -C ${CRTTOOLPATH} clean
+ 
+ realclean distclean:
+ 	@echo "  REALCLEAN"
+ 	$(call SHELL_REMOVE_DIR,${BUILD_BASE})
+ 	$(call SHELL_DELETE_ALL, ${CURDIR}/cscope.*)
+-	${Q}${MAKE} --no-print-directory -C ${FIPTOOLPATH} clean
+ 	${Q}${MAKE} PLAT=${PLAT} --no-print-directory -C ${CRTTOOLPATH} clean
+ 
+ checkcodebase:		locate-checkpatch
+@@ -717,7 +711,7 @@ certificates: ${CRT_DEPS} ${CRTTOOL}
+ 	@${ECHO_BLANK_LINE}
+ endif
+ 
+-${BUILD_PLAT}/${FIP_NAME}: ${FIP_DEPS} ${FIPTOOL}
++${BUILD_PLAT}/${FIP_NAME}: ${FIP_DEPS}
+ 	${Q}${FIPTOOL} create ${FIP_ARGS} $@
+ 	${Q}${FIPTOOL} info $@
+ 	@${ECHO_BLANK_LINE}
+@@ -733,21 +727,16 @@ fwu_certificates: ${FWU_CRT_DEPS} ${CRTT
+ 	@${ECHO_BLANK_LINE}
+ endif
+ 
+-${BUILD_PLAT}/${FWU_FIP_NAME}: ${FWU_FIP_DEPS} ${FIPTOOL}
++${BUILD_PLAT}/${FWU_FIP_NAME}: ${FWU_FIP_DEPS}
+ 	${Q}${FIPTOOL} create ${FWU_FIP_ARGS} $@
+ 	${Q}${FIPTOOL} info $@
+ 	@${ECHO_BLANK_LINE}
+ 	@echo "Built $@ successfully"
+ 	@${ECHO_BLANK_LINE}
+ 
+-fiptool: ${FIPTOOL}
+ fip: ${BUILD_PLAT}/${FIP_NAME}
+ fwu_fip: ${BUILD_PLAT}/${FWU_FIP_NAME}
+ 
+-.PHONY: ${FIPTOOL}
+-${FIPTOOL}:
+-	${Q}${MAKE} CPPFLAGS="-DVERSION='\"${VERSION_STRING}\"'" --no-print-directory -C ${FIPTOOLPATH}
+-
+ cscope:
+ 	@echo "  CSCOPE"
+ 	${Q}find ${CURDIR} -name "*.[chsS]" > cscope.files
+--- a/tools/fiptool/Makefile
++++ b/tools/fiptool/Makefile
+@@ -37,7 +37,7 @@ all: ${PROJECT} fip_create
+ 
+ ${PROJECT}: ${OBJECTS} Makefile
+ 	@echo "  LD      $@"
+-	${Q}${HOSTCC} ${OBJECTS} -o $@ ${LDLIBS}
++	${Q}${HOSTCC} ${OBJECTS} -o $@ ${LDLIBS} $(LDFLAGS)
+ 	@${ECHO_BLANK_LINE}
+ 	@echo "Built $@ successfully"
+ 	@${ECHO_BLANK_LINE}

--- a/package/boot/tfa-layerscape/patches/002-plat-nxp-tools-fix-a-makefile-bug-that-will-use-defa.patch
+++ b/package/boot/tfa-layerscape/patches/002-plat-nxp-tools-fix-a-makefile-bug-that-will-use-defa.patch
@@ -1,0 +1,30 @@
+From 65e9a722b44bf28b98fe25b3b174761b47ec7dbd Mon Sep 17 00:00:00 2001
+From: Biwen Li <biwen.li@nxp.com>
+Date: Mon, 1 Apr 2019 13:41:55 +0800
+Subject: [PATCH 2/3] plat/nxp/tools: fix a makefile bug that will use default
+ implicit rules
+
+The patch fix a makefile bug that will use default implicit rules,
+because do not have explicit rules for the destination files.
+
+Signed-off-by: Biwen Li <biwen.li@nxp.com>
+---
+ plat/nxp/tools/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plat/nxp/tools/Makefile b/plat/nxp/tools/Makefile
+index 2095294b..0082a0be 100644
+--- a/plat/nxp/tools/Makefile
++++ b/plat/nxp/tools/Makefile
+@@ -53,7 +53,7 @@ ${PROJECT_2}: ${OBJECTS_2} Makefile
+ 	@echo "Built $@ successfully"
+ 	@${ECHO_BLANK_LINE}
+ 
+-%.o: %.c %.h Makefile
++%.o: %.c Makefile
+ 	@echo "  CC      $<"
+ 	${Q}${HOSTCC} -c ${CPPFLAGS} ${CFLAGS} ${INCLUDE_PATHS} $< -o $@
+ 
+-- 
+2.17.1
+

--- a/package/boot/tfa-layerscape/patches/003-plat-nxp-tools-fix-create_pbl-and-byte_swap-host-bui.patch
+++ b/package/boot/tfa-layerscape/patches/003-plat-nxp-tools-fix-create_pbl-and-byte_swap-host-bui.patch
@@ -1,0 +1,60 @@
+From 8a458876013991fe2f288bbe4694264b16c3b9e9 Mon Sep 17 00:00:00 2001
+From: Biwen Li <biwen.li@nxp.com>
+Date: Fri, 26 Jul 2019 15:44:10 +0800
+Subject: [PATCH 3/3] plat/nxp/tools: fix create_pbl and byte_swap host build
+
+Not compile create_pbl and byte_swap in the process of cross compilation
+
+Signed-off-by: Biwen Li <biwen.li@nxp.com>
+---
+ plat/nxp/tools/pbl_ch2.mk | 3 ---
+ plat/nxp/tools/pbl_ch3.mk | 5 -----
+ 2 files changed, 8 deletions(-)
+
+diff --git a/plat/nxp/tools/pbl_ch2.mk b/plat/nxp/tools/pbl_ch2.mk
+index afa43520..ff624dd9 100644
+--- a/plat/nxp/tools/pbl_ch2.mk
++++ b/plat/nxp/tools/pbl_ch2.mk
+@@ -20,8 +20,6 @@ ifeq ($(RCW),"")
+ else
+ 	# Generate header for bl2.bin
+ 	$(Q)$(CST_DIR)/create_hdr_isbc --in ${BUILD_PLAT}/bl2.bin --out ${BUILD_PLAT}/hdr_bl2 ${BL2_INPUT_FILE}
+-	# Compile create_pbl tool
+-	${Q}${MAKE} CPPFLAGS="-DVERSION='\"${VERSION_STRING}\"'" --no-print-directory -C ${PLAT_TOOL_PATH};\
+ 	# Add bl2.bin to RCW
+ 	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE}\
+ 			-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl ;\
+@@ -43,7 +41,6 @@ ifeq ($(RCW),"")
+ 	${Q}echo "Platform ${PLAT} requires rcw file. Please set RCW to point to the right RCW file for boot mode ${BOOT_MODE}"
+ else
+ 	# -a option appends the image for Chassis 3 devices in case of non secure boot
+-	${Q}${MAKE} CPPFLAGS="-DVERSION='\"${VERSION_STRING}\"'" --no-print-directory -C ${PLAT_TOOL_PATH};
+ 	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE} \
+ 	-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl ;
+ # Swapping of RCW is required for QSPi Chassis 2 devices
+diff --git a/plat/nxp/tools/pbl_ch3.mk b/plat/nxp/tools/pbl_ch3.mk
+index 944ae3bb..9aa8f635 100644
+--- a/plat/nxp/tools/pbl_ch3.mk
++++ b/plat/nxp/tools/pbl_ch3.mk
+@@ -27,9 +27,6 @@ else
+ 	# Generate header for bl2.bin
+ 	$(Q)$(CST_DIR)/create_hdr_isbc --in ${BUILD_PLAT}/bl2.bin --out ${BUILD_PLAT}/hdr_bl2 ${BL2_INPUT_FILE}
+ 
+-	# Compile create_pbl tool
+-	${Q}${MAKE} CPPFLAGS="-DVERSION='\"${VERSION_STRING}\"'" --no-print-directory -C ${PLAT_TOOL_PATH};\
+-
+ 	# Add Block Copy command for bl2.bin to RCW
+ 	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE}\
+ 			-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl -f ${BL2_SRC_OFFSET};\
+@@ -57,8 +54,6 @@ else  #SECURE_BOOT
+ ifeq ($(RCW),"")
+ 	${Q}echo "Platform ${PLAT} requires rcw file. Please set RCW to point to the right RCW file for boot mode ${BOOT_MODE}"
+ else
+-	${Q}${MAKE} CPPFLAGS="-DVERSION='\"${VERSION_STRING}\"'" --no-print-directory -C ${PLAT_TOOL_PATH};
+-
+ 	# Add Block Copy command and populate boot loc ptrfor bl2.bin to RCW
+ 	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE} \
+ 	-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl -f ${BL2_SRC_OFFSET};
+-- 
+2.17.1
+


### PR DESCRIPTION
build log:
        pkgbuild stdio:

        In file included from fiptool.h:16:0,
                         from fiptool.c:19:
        fiptool_platform.h:18:27: fatal error: openssl/sha.h: No such file or directory  #  include <openssl/sha.h>
                                   ^
        compilation terminated.
        Makefile:50: recipe for target fiptool.o failed
        make[4]: *** [fiptool.o] Error 1
        Makefile:749: recipe for target tools/fiptool/fiptool failed
        make[3]: *** [tools/fiptool/fiptool] Error 2
        make[3]: Leaving directory /builder/shared-workdir/build/build_dir/target-aarch64_generic_musl/tfa-layerscape-ls1012ardb/tfa-layerscape-lsdk-1903
        Makefile:135: recipe for target /builder/shared-workdir/build/build_dir/target-aarch64_generic_musl/tfa-layerscape-ls1012ardb/tfa-layerscape-lsdk-1903/.built failed

Signed-off-by: Biwen Li <biwen.li@nxp.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
