### PR TITLE
linux: mvebu: backport mx25u12835f support from linux 5.0

### DIFF
--- a/target/linux/generic/backport-4.19/460-v5.0-mtd-spi-nor-Add-support-for-mx25u12835f.patch
+++ b/target/linux/generic/backport-4.19/460-v5.0-mtd-spi-nor-Add-support-for-mx25u12835f.patch
@@ -1,0 +1,30 @@
+From 81554171373018b83f3554b9e725d2b5bf1844a5 Mon Sep 17 00:00:00 2001
+From: Alexander Sverdlin <alexander.sverdlin@nokia.com>
+Date: Fri, 13 Jul 2018 15:06:46 +0200
+Subject: [PATCH] mtd: spi-nor: Add support for mx25u12835f
+
+This chip supports dual and quad read and uniform 4K-byte erase.
+
+Signed-off-by: Alexander Sverdlin <alexander.sverdlin@nokia.com>
+Reviewed-by: Tudor Ambarus <tudor.ambarus@microchip.com>
+Signed-off-by: Boris Brezillon <boris.brezillon@bootlin.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
+index cd5e0804af50..afe12308bba6 100644
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1380,6 +1380,8 @@ static const struct flash_info spi_nor_ids[] = {
+ 	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
+ 	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
+ 	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },
++	{ "mx25u12835f", INFO(0xc22538, 0, 64 * 1024, 256,
++			 SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "mx25l25635e", INFO(0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "mx25u25635f", INFO(0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },
+ 	{ "mx25l25655e", INFO(0xc22619, 0, 64 * 1024, 512, 0) },
+-- 
+2.21.0
+


### PR DESCRIPTION
Backport mx25u12835f support from linux 5.0. ESPRESSObin and uDPU devices might have this flash memory.