### PR TITLE
base-files: gpio switch: add named GPIO support

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=205
+PKG_RELEASE:=206
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/etc/init.d/gpio_switch
+++ b/package/base-files/files/etc/init.d/gpio_switch
@@ -16,21 +16,39 @@ load_gpio_switch()
 	config_get name "$1" name
 	config_get value "$1" value 0
 
-	local gpio_path="/sys/class/gpio/gpio${gpio_pin}"
-	# export GPIO pin for access
-	[ -d "$gpio_path" ] || {
-		echo "$gpio_pin" >/sys/class/gpio/export
-		# we need to wait a bit until the GPIO appears
-		[ -d "$gpio_path" ] || sleep 1
+	[ -z "$gpio_pin" ] && {
+		echo >&2 "Skipping gpio_switch '$name' due to missing gpio_pin"
+		return 1
 	}
 
-	# direction attribute only exists if the kernel supports changing the
-	# direction of a GPIO
-	if [ -e "${gpio_path}/direction" ]; then
-		# set the pin to output with high or low pin value
-		{ [ "$value" = "0" ] && echo "low" || echo "high"; } >"$gpio_path/direction"
+	local gpio_path
+	if [ -n "$(echo "$gpio_pin" | grep -E "^[0-9]+$")" ]; then
+		gpio_path="/sys/class/gpio/gpio${gpio_pin}"
+
+		# export GPIO pin for access
+		[ -d "$gpio_path" ] || {
+			echo "$gpio_pin" >/sys/class/gpio/export
+			# we need to wait a bit until the GPIO appears
+			[ -d "$gpio_path" ] || sleep 1
+		}
+
+		# direction attribute only exists if the kernel supports changing the
+		# direction of a GPIO
+		if [ -e "${gpio_path}/direction" ]; then
+			# set the pin to output with high or low pin value
+			{ [ "$value" = "0" ] && echo "low" || echo "high"; } \
+				>"$gpio_path/direction"
+		else
+			{ [ "$value" = "0" ] && echo "0" || echo "1"; } \
+				>"$gpio_path/value"
+		fi
 	else
-		{ [ "$value" = "0" ] && echo "0" || echo "1"; } >"$gpio_path/value"
+		gpio_path="/sys/class/gpio/${gpio_pin}"
+
+		[ -d "$gpio_path" ] && {
+			{ [ "$value" = "0" ] && echo "0" || echo "1"; } \
+				>"$gpio_path/value"
+		}
 	fi
 }
 

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -565,7 +565,7 @@ ucidef_add_gpio_switch() {
 	json_select_object gpioswitch
 		json_select_object "$cfg"
 			json_add_string name "$name"
-			json_add_int pin "$pin"
+			json_add_string pin "$pin"
 			json_add_int default "$default"
 		json_select ..
 	json_select ..


### PR DESCRIPTION
base-files: gpio switch: add named GPIO support

Previously, gpio_switch only accepts GPIO pin number as input. Once a
GPIO pin is exported and named by device tree, its pin state cannot be
configured and saved across reboots by UCI.

This patch adds support for named GPIO pins. Thus GPIO pin can be
exported by device tree with active high/low correctly configured,
having human-readable name in /sys/class/gpio/ is also now possible.

More importantly, GPIO pins which are referenced by name will be immune
from pin mapping breakage while unintentional pin number changes are
introduced by kernel or driver updates.

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>