### PR TITLE
ath79: Add support for TP9343-based TP-Link TL-WR94x devices

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -211,6 +211,15 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+tplink,tl-wr940n-v3|\
+tplink,tl-wr940n-v4|\
+tplink,tl-wr941nd-v6)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:blue:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:blue:lan1" "switch0" "0x10"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:blue:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:blue:lan3" "switch0" "0x04"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:blue:lan4" "switch0" "0x02"
+	;;
 trendnet,tew-823dru)
 	ucidef_set_led_netdev "wan" "WAN" "trendnet:green:planet" "eth0"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -88,6 +88,9 @@ ath79_setup_interfaces()
 	tplink,tl-wr841-v12|\
 	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v3|\
+	tplink,tl-wr940n-v3|\
+	tplink,tl-wr940n-v4|\
+	tplink,tl-wr941nd-v6|\
 	ubnt,airrouter)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wr940n-v3.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr940n-v3", "qca,tp9343";
+	model = "TP-Link TL-WR940N v3";
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wr94x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:blue:system";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		qss {
+			label = "tp-link:blue:qss";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:blue:wlan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_blue {
+			label = "tp-link:blue:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_red {
+			label = "tp-link:red:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1 {
+			label = "tp-link:blue:lan1";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:blue:lan2";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:blue:lan3";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:blue:lan4";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wr94x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr940n-v4", "qca,tp9343";
+	model = "TP-Link TL-WR940N v4";
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: system {
+			label = "tp-link:blue:system";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		qss {
+			label = "tp-link:blue:qss";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:blue:wlan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_blue {
+			label = "tp-link:blue:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_red {
+			label = "tp-link:red:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1 {
+			label = "tp-link:blue:lan1";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:blue:lan2";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:blue:lan3";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:blue:lan4";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr941nd-v6.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr941nd-v6.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wr940n-v3.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr941nd-v6", "qca,tp9343";
+	model = "TP-Link TL-WR941ND v6";
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr94x.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr94x.dtsi
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi_button {
+			label = "WiFi button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot:	partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "mii";
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -205,6 +205,30 @@ define Device/tplink_tl-wr841-v12
 endef
 TARGET_DEVICES += tplink_tl-wr841-v12
 
+define Device/tplink_tl-wr940n-v3
+  $(Device/tplink-4mlzma)
+  ATH_SOC := tp9343
+  DEVICE_MODEL := TL-WR940N
+  DEVICE_VARIANT := v3
+  TPLINK_HWID := 0x09410006
+  SUPPORTED_DEVICES += tl-wr941nd-v6
+endef
+TARGET_DEVICES += tplink_tl-wr940n-v3
+
+define Device/tplink_tl-wr940n-v4
+  $(Device/tplink-4mlzma)
+  ATH_SOC := tp9343
+  DEVICE_MODEL := TL-WR940N
+  DEVICE_VARIANT := v4
+  TPLINK_HWID := 0x09400004
+  SUPPORTED_DEVICES += tl-wr940n-v4
+  IMAGES += factory-us.bin factory-eu.bin factory-br.bin
+  IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
+  IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+  IMAGE/factory-br.bin := append-rootfs | mktplinkfw factory -C BR
+endef
+TARGET_DEVICES += tplink_tl-wr940n-v4
+
 define Device/tplink_tl-wr941-v2
   $(Device/tplink-4m)
   ATH_SOC := ar9132
@@ -223,6 +247,16 @@ define Device/tplink_tl-wr941-v4
   TPLINK_HWID := 0x09410004
 endef
 TARGET_DEVICES += tplink_tl-wr941-v4
+
+define Device/tplink_tl-wr941nd-v6
+  $(Device/tplink-4mlzma)
+  ATH_SOC := tp9343
+  DEVICE_MODEL := TL-WR941ND
+  DEVICE_VARIANT := v6
+  TPLINK_HWID := 0x09410006
+  SUPPORTED_DEVICES += tl-wr941nd-v6
+endef
+TARGET_DEVICES += tplink_tl-wr941nd-v6
 
 define Device/tplink_tl-wr941n-v7-cn
   $(Device/tplink-4mlzma)


### PR DESCRIPTION
This adds support to the named devices.

Tested:
TL-WR940v3 @CodeFetch
TL-WR940v4 @CodeFetch 

TL-WR941v6 is a 100 % clone of TL-WR940v3