### PR TITLE
ath79: specify N and ND subversions of TL-WR941 with ALT0_MODEL

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -278,7 +278,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
-	tplink,tl-wr941-v2)
+	tplink,tl-wr941-v2|\
+	tplink,tl-wr941-v3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
 	ubnt,acb-isp)
@@ -418,6 +419,7 @@ ath79_setup_macs()
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,tl-wr941-v2|\
+	tplink,tl-wr941-v3|\
 	tplink,tl-wr941n-v7-cn)
 		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		wan_mac=$(macaddr_add "$base_mac" 1)

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v3.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v3.dts
@@ -4,6 +4,6 @@
 #include "ar9132_tplink_tl-wr941.dtsi"
 
 / {
-	compatible = "tplink,tl-wr941-v2", "qca,ar9132";
-	model = "TP-Link TL-WR941N/ND v2";
+	compatible = "tplink,tl-wr941-v3", "qca,ar9132";
+	model = "TP-Link TL-WR941N/ND v3";
 };

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941.dtsi
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941.dtsi
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9132.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button1 {
+			label = "qss";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		qss_r {
+			label = "tp-link:red:qss";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		qss_g {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	dsa {
+		compatible = "marvell,dsa";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		dsa,mii-bus = <&mdio0>;
+		dsa,ethernet = <&eth0>;
+
+		switch@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "wan";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "cpu";
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "rmii";
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -242,8 +242,10 @@ TARGET_DEVICES += tplink_tl-wr940n-v4
 define Device/tplink_tl-wr941-v2
   $(Device/tplink-4m)
   ATH_SOC := ar9132
-  DEVICE_MODEL := TL-WR941N/ND
+  DEVICE_MODEL := TL-WR941ND
   DEVICE_VARIANT := v2/v3
+  DEVICE_ALT0_MODEL := TL-WR941N
+  DEVICE_ALT0_VARIANT := v2/v3
   TPLINK_HWID := 0x09410002
   TPLINK_HWREV := 2
 endef
@@ -252,8 +254,10 @@ TARGET_DEVICES += tplink_tl-wr941-v2
 define Device/tplink_tl-wr941-v4
   $(Device/tplink-4m)
   ATH_SOC := ar7240
-  DEVICE_MODEL := TL-WR941N/ND
+  DEVICE_MODEL := TL-WR941ND
   DEVICE_VARIANT := v4
+  DEVICE_ALT0_MODEL := TL-WR941N
+  DEVICE_ALT0_VARIANT := v4
   TPLINK_HWID := 0x09410004
 endef
 TARGET_DEVICES += tplink_tl-wr941-v4

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -243,13 +243,25 @@ define Device/tplink_tl-wr941-v2
   $(Device/tplink-4m)
   ATH_SOC := ar9132
   DEVICE_MODEL := TL-WR941ND
-  DEVICE_VARIANT := v2/v3
+  DEVICE_VARIANT := v2
   DEVICE_ALT0_MODEL := TL-WR941N
-  DEVICE_ALT0_VARIANT := v2/v3
+  DEVICE_ALT0_VARIANT := v2
   TPLINK_HWID := 0x09410002
   TPLINK_HWREV := 2
 endef
 TARGET_DEVICES += tplink_tl-wr941-v2
+
+define Device/tplink_tl-wr941-v3
+  $(Device/tplink-4m)
+  ATH_SOC := ar9132
+  DEVICE_MODEL := TL-WR941ND
+  DEVICE_VARIANT := v3
+  DEVICE_ALT0_MODEL := TL-WR941N
+  DEVICE_ALT0_VARIANT := v3
+  TPLINK_HWID := 0x09410002
+  TPLINK_HWREV := 2
+endef
+TARGET_DEVICES += tplink_tl-wr941-v3
 
 define Device/tplink_tl-wr941-v4
   $(Device/tplink-4m)


### PR DESCRIPTION
TP-Link's TL-WR941 is sold with detachable antennas
internationally (ND version), but with fixed antennas in China
(N version). While hardware and images are similar for both
variants of v2 and v4, they are different for v6.

Having both explicitly will make it easier for user to identify
the correct image, and mostly importantly will raise awareness
that N and ND are not necessarily always the same as for
TL-WR841 series.

With an image selection webpage, using ALT0_MODEL as in this
patch will provide the option to list versions for N and ND
separately.

~~This depends on PR #2250~~ 2250 is merged.