### PR TITLE
ath79: add support for D-Link DIR-842 C1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -59,6 +59,7 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+dlink,dir-842-c1|\
 dlink,dir-842-c2|\
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -112,6 +112,7 @@ ath79_setup_interfaces()
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1|\
+ 	dlink,dir-842-c1|\ 
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
@@ -304,6 +305,7 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text "mac" 4)
 		wan_mac=$(mtd_get_mac_text "mac" 24)
 		;;
+	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -105,6 +105,7 @@ case "$FIRMWARE" in
 		ath9k_eeprom_extract "art" 4096 1088
 		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 4) 2
 		;;
+	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -189,6 +189,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
+	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
 	nec,wg1200cr)
 		ath10kcal_extract "art" 20480 12064

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	// Pull up on boot - otherwise the reset button won't work
+	reset-button {
+		gpio-hog;
+		output-high;
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		line-name = "reset-button";
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "devdata";
+				reg = <0x050000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "devconf";
+				reg = <0x060000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "misc";
+				reg = <0x070000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x080000 0xf50000>;
+			};
+
+			art: partition@fd0000 {
+				label = "art";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "reserved";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRIP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xcb37cb37 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x00f3cf00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c1.dts
@@ -4,8 +4,8 @@
 #include "qca9563_dlink_dir-842-c.dtsi"
 
 / {
-	compatible = "dlink,dir-842-c2", "qca,qca9563";
-	model = "D-Link DIR-842 C2";
+	compatible = "dlink,dir-842-c1", "qca,qca9563";
+	model = "D-Link DIR-842 C1";
 	
 	aliases {
 		led-boot = &power;
@@ -18,32 +18,24 @@
 		compatible = "gpio-leds";
 
 		wps {
-			label = "dir-842-c2:green:wps";
+			label = "dir-842-c1:green:wps";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		power: power {
-			label = "dir-842-c2:green:power";
+			label = "dir-842-c1:green:power";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		internet {
-			label = "dir-842-c2:green:internet";
+			label = "dir-842-c1:green:internet";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
-			label = "dir-842-c2:green:wlan";
+			label = "dir-842-c1:green:wlan";
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 	};
-};
-
-&usb_phy0 {
-	status = "okay";
-};
-
-&usb0 {
-	status = "okay";
 };

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -355,11 +355,10 @@ define Device/dlink_dir-859-a1
 endef
 TARGET_DEVICES += dlink_dir-859-a1
 
-define Device/dlink_dir-842-c2
+define Device/dlink_dir-842-c
   ATH_SOC := qca9563
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-842
-  DEVICE_VARIANT := C2
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
   KERNEL_INITRAMFS := $$(KERNEL) | seama
   IMAGES += factory.bin
@@ -374,7 +373,19 @@ define Device/dlink_dir-842-c2
   IMAGE/factory.bin := \
 	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE)
   IMAGE_SIZE := 15680k
-  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+
+define Device/dlink_dir-842-c1
+	$(Device/dlink_dir-842-c)
+	DEVICE_VARIANT := C1
+	DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += dlink_dir-842-c1
+
+define Device/dlink_dir-842-c2
+	$(Device/dlink_dir-842-c)
+	DEVICE_VARIANT := C2
+	DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += dlink_dir-842-c2
 


### PR DESCRIPTION
Hardware spec of DIR-842 C1:
SoC: QCA9563
DRAM: 128MB DDR2
Flash: 16MB SPI-NOR
Switch: QCA8337N
WiFi 5.8GHz: QCA9888
WiFi 2.4Ghz: QCA9563
USB: circuit onboard, but components are not soldered

Flash instructions:

1. Upgrade the factory.bin through the factory web interface or
   the u-boot failsafe interface.
   The firmware will boot up correctly for the first time.
   Do not power off the device after OpenWrt has booted.
   Otherwise the u-boot will enter failsafe mode as the checksum
   of the firmware has been changed.
2. Upgrade the sysupgrade.bin in OpenWrt.
   After upgrading completes the u-boot won't complain about the
   firmware checksum and it's OK to use now.
3. If you powered off the device before upgrading the sysupgrade.bin,
   just upgrade the factory.bin through the u-boot failsafe interface
   and then goto step 2.

Signed-off-by: Jackson Lim <jackcolentern@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
