### PR TITLE
ath79: convert MAC address location offsets to hexadecimal notation

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -296,13 +296,13 @@ ath79_setup_macs()
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
 	dlink,dir-825-b1)
-		lan_mac=$(mtd_get_mac_text "caldata" 65440)
-		wan_mac=$(mtd_get_mac_text "caldata" 65460)
+		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
+		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		lan_mac=$(mtd_get_mac_text "mac" 4)
-		wan_mac=$(mtd_get_mac_text "mac" 24)
+		lan_mac=$(mtd_get_mac_text "mac" 0x4)
+		wan_mac=$(mtd_get_mac_text "mac" 0x18)
 		;;
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
@@ -313,7 +313,7 @@ ath79_setup_macs()
 		;;
 	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 4098)" -2)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" -2)
 		;;
 	engenius,ecb1750)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
@@ -327,7 +327,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
 	engenius,ews511ap)
-		lan_mac=$(mtd_get_mac_text "u-boot-env" 233)
+		lan_mac=$(mtd_get_mac_text "u-boot-env" 0xe9)
 		eth1_mac=$(macaddr_add "$lan_mac" 1)
 		ucidef_set_interface "eth0" ifname "eth0" protocol "none" macaddr "$lan_mac"
 		ucidef_set_interface "eth1" ifname "eth1" protocol "none" macaddr "$eth1_mac"
@@ -341,13 +341,13 @@ ath79_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	nec,wg800hp)
-		lan_mac=$(mtd_get_mac_text board_data 640)
-		wan_mac=$(mtd_get_mac_text board_data 1152)
+		lan_mac=$(mtd_get_mac_text board_data 0x280)
+		wan_mac=$(mtd_get_mac_text board_data 0x480)
 		;;
 	netgear,wndr3700|\
 	netgear,wndr3700v2|\
 	netgear,wndr3800)
-		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0)")
+		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0x0)")
 		;;
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")
@@ -358,7 +358,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii devdata wanmac)
 		;;
 	rosinson,wr818)
-		wan_mac=$(mtd_get_mac_binary factory 0)
+		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
 	tplink,archer-a7-v5|\
@@ -366,17 +366,17 @@ ath79_setup_macs()
 	tplink,archer-c7-v5|\
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
-		base_mac=$(mtd_get_mac_binary info 8)
+		base_mac=$(mtd_get_mac_binary info 0x8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,tl-wr941-v2|\
 	tplink,tl-wr941n-v7-cn)
-		base_mac=$(mtd_get_mac_binary u-boot 130048)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	trendnet,tew-823dru)
-		lan_mac=$(mtd_get_mac_text mac 4)
-		wan_mac=$(mtd_get_mac_text mac 24)
+		lan_mac=$(mtd_get_mac_text mac 0x4)
+		wan_mac=$(mtd_get_mac_text mac 0x18)
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)


### PR DESCRIPTION
This changes the offsets for the MAC address location in 02_network
to hexadecimal notation. This will be much clearer for the reader
when number are big, and will also match the style used for
mtd-mac-address in DTS files.