### PR TITLE
ar71xx: fix wpj531 sig1 LED gpio

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj531.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-wpj531.c
@@ -35,7 +35,7 @@
 #include "dev-wmac.h"
 #include "machtypes.h"
 
-#define WPJ531_GPIO_LED_SIG1    13
+#define WPJ531_GPIO_LED_SIG1    12
 #define WPJ531_GPIO_LED_SIG2    14
 #define WPJ531_GPIO_LED_SIG3    15
 #define WPJ531_GPIO_LED_SIG4    16


### PR DESCRIPTION
In 6c937df7, i commited a faulty GPIO num for a fix.

Signed-off-by: Leon M. George <leon@georgemail.eu>