### PR TITLE
treewide: convert MAC address/caldata offsets to hexadecimal

### DIFF
--- a/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -59,7 +59,7 @@ case "$FIRMWARE" in
 			ath9k_ubi_eeprom_extract "caldata" 20480 4096
 		else
 			ath9k_eeprom_extract "wifi_data" 20480 4096
-			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 12)
+			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0xc)
 		fi
 		;;
 	*)
@@ -77,7 +77,7 @@ case "$FIRMWARE" in
 			ath9k_ubi_eeprom_extract "caldata" 4096 4096
 		else
 			ath9k_eeprom_extract "wifi_data" 4096 4096
-			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0)
+			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0x0)
 		fi
 		;;
 	*)

--- a/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,8 +12,8 @@ ath9k_eeprom_die() {
 
 ath9k_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -26,8 +26,8 @@ ath9k_eeprom_extract() {
 
 ath9k_ubi_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local ubidev=$(nand_find_ubi $CI_UBIPART)
 	local ubi
 
@@ -40,11 +40,11 @@ ath9k_ubi_eeprom_extract() {
 }
 
 ath9k_patch_firmware_mac() {
-        local mac=$1
+	local mac=$1
 
-        [ -z "$mac" ] && return
+	[ -z "$mac" ] && return
 
-        macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=2 count=6
+	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=2 count=6
 }
 
 board=$(board_name)
@@ -56,9 +56,9 @@ case "$FIRMWARE" in
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 20480 4096
+			ath9k_ubi_eeprom_extract "caldata" 0x5000 0x1000
 		else
-			ath9k_eeprom_extract "wifi_data" 20480 4096
+			ath9k_eeprom_extract "wifi_data" 0x5000 0x1000
 			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0xc)
 		fi
 		;;
@@ -74,9 +74,9 @@ case "$FIRMWARE" in
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 4096 4096
+			ath9k_ubi_eeprom_extract "caldata" 0x1000 0x1000
 		else
-			ath9k_eeprom_extract "wifi_data" 4096 4096
+			ath9k_eeprom_extract "wifi_data" 0x1000 0x1000
 			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0x0)
 		fi
 		;;

--- a/target/linux/apm821xx/base-files/lib/preinit/05_set_iface_mac_apm821xx
+++ b/target/linux/apm821xx/base-files/lib/preinit/05_set_iface_mac_apm821xx
@@ -6,7 +6,7 @@ preinit_set_mac_address() {
 	case $(board_name) in
 		meraki,mr24|\
 		meraki,mx60)
-			mac_lan=$(mtd_get_mac_binary_ubi board-config 102)
+			mac_lan=$(mtd_get_mac_binary_ubi board-config 0x66)
 			[ -n "$mac_lan" ] && ifconfig eth0 hw ether "$mac_lan"
 			;;
 	esac

--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -604,11 +604,11 @@ ar71xx_setup_macs()
 
 	case $board in
 	archer-c7-v4)
-		base_mac=$(mtd_get_mac_binary config 8)
+		base_mac=$(mtd_get_mac_binary config 0x8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	archer-c7-v5)
-		base_mac=$(mtd_get_mac_binary info 8)
+		base_mac=$(mtd_get_mac_binary info 0x8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	dgl-5500-a1|\
@@ -619,8 +619,8 @@ ar71xx_setup_macs()
 	dir-835-a1|\
 	wndr3700v4|\
 	wndr4300)
-		lan_mac=$(mtd_get_mac_binary caldata 0)
-		wan_mac=$(mtd_get_mac_binary caldata 6)
+		lan_mac=$(mtd_get_mac_binary caldata 0x0)
+		wan_mac=$(mtd_get_mac_binary caldata 0x6)
 		;;
 	dir-869-a1|\
 	mynet-n750)
@@ -634,7 +634,7 @@ ar71xx_setup_macs()
 		;;
 	tl-wr1043n-v5|\
 	tl-wr1043nd-v4)
-		lan_mac=$(mtd_get_mac_binary product-info 8)
+		lan_mac=$(mtd_get_mac_binary product-info 0x8)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	wlr8100)

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,8 +12,8 @@ ath9k_eeprom_die() {
 
 ath9k_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -26,8 +26,8 @@ ath9k_eeprom_extract() {
 
 ath9k_ubi_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local ubidev=$(nand_find_ubi $CI_UBIPART)
 	local ubi
 
@@ -42,7 +42,7 @@ ath9k_ubi_eeprom_extract() {
 ath9k_eeprom_extract_reverse() {
 	local part=$1
 	local offset=$2
-	local count=$3
+	local count=$(($3))
 	local mtd
 	local reversed
 	local caldata
@@ -72,43 +72,43 @@ case "$FIRMWARE" in
 	case $board in
 	c-55|\
 	c-60)
-		ath9k_eeprom_extract "art" 4096 2048
+		ath9k_eeprom_extract "art" 0x1000 0x800
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	fritz4020|\
 	fritz450e)
-		ath9k_eeprom_extract_reverse "urlader" 5441 1088
+		ath9k_eeprom_extract_reverse "urlader" 0x1541 0x440
 		;;
 	mr18)
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 4096 2048
+			ath9k_ubi_eeprom_extract "caldata" 0x1000 0x800
 		else
-			ath9k_eeprom_extract "odm-caldata" 4096 2048
+			ath9k_eeprom_extract "odm-caldata" 0x1000 0x800
 		fi
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +1)
 		;;
 	r6100 | \
 	wndr3700v4 | \
 	wndr4300)
-		ath9k_eeprom_extract "caldata" 4096 2048
+		ath9k_eeprom_extract "caldata" 0x1000 0x800
 		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0x0)
 		;;
 	rambutan)
-		ath9k_eeprom_extract "art" 4096 2048
+		ath9k_eeprom_extract "art" 0x1000 0x800
 		;;
 	wlr8100)
-		ath9k_eeprom_extract "art" 4096 2048
+		ath9k_eeprom_extract "art" 0x1000 0x800
 		ath9k_patch_firmware_mac $(mtd_get_mac_ascii u-boot-env "ethaddr")
 		;;
 	z1)
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 4096 2048
+			ath9k_ubi_eeprom_extract "caldata" 0x1000 0x800
 		else
-			ath9k_eeprom_extract "origcaldata" 4096 2048
+			ath9k_eeprom_extract "origcaldata" 0x1000 0x800
 		fi
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +2)
 		;;
@@ -121,34 +121,34 @@ case "$FIRMWARE" in
 "pci_wmac0.eeprom")
 	case $board in
 	c-55)
-		ath9k_eeprom_extract "art" 20480 2048
+		ath9k_eeprom_extract "art" 0x5000 0x800
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	fritz300e)
-		ath9k_eeprom_extract_reverse "urloader" 5441 1088
+		ath9k_eeprom_extract_reverse "urloader" 0x1541 0x440
 		;;
 	mr18)
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 20480 2048
+			ath9k_ubi_eeprom_extract "caldata" 0x5000 0x800
 		else
-			ath9k_eeprom_extract "odm-caldata" 20480 2048
+			ath9k_eeprom_extract "odm-caldata" 0x5000 0x800
 		fi
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +2)
 		;;
 	wndr3700v4 | \
 	wndr4300)
-		ath9k_eeprom_extract "caldata" 20480 2048
+		ath9k_eeprom_extract "caldata" 0x5000 0x800
 		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
 	z1)
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 86016 4096
+			ath9k_ubi_eeprom_extract "caldata" 0x15000 0x1000
 		else
-			ath9k_eeprom_extract "origcaldata" 86016 4096
+			ath9k_eeprom_extract "origcaldata" 0x15000 0x1000
 		fi
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +3)
 		;;
@@ -164,9 +164,9 @@ case "$FIRMWARE" in
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 36864 2048
+			ath9k_ubi_eeprom_extract "caldata" 0x9000 0x800
 		else
-			ath9k_eeprom_extract "odm-caldata" 36864 2048
+			ath9k_eeprom_extract "odm-caldata" 0x9000 0x800
 		fi
 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +3)
 		;;

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -73,7 +73,7 @@ case "$FIRMWARE" in
 	c-55|\
 	c-60)
 		ath9k_eeprom_extract "art" 4096 2048
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	fritz4020|\
 	fritz450e)
@@ -87,13 +87,13 @@ case "$FIRMWARE" in
 		else
 			ath9k_eeprom_extract "odm-caldata" 4096 2048
 		fi
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) +1)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +1)
 		;;
 	r6100 | \
 	wndr3700v4 | \
 	wndr4300)
 		ath9k_eeprom_extract "caldata" 4096 2048
-		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0)
+		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0x0)
 		;;
 	rambutan)
 		ath9k_eeprom_extract "art" 4096 2048
@@ -110,7 +110,7 @@ case "$FIRMWARE" in
 		else
 			ath9k_eeprom_extract "origcaldata" 4096 2048
 		fi
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) +2)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +2)
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -122,7 +122,7 @@ case "$FIRMWARE" in
 	case $board in
 	c-55)
 		ath9k_eeprom_extract "art" 20480 2048
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0) +2)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	fritz300e)
 		ath9k_eeprom_extract_reverse "urloader" 5441 1088
@@ -135,12 +135,12 @@ case "$FIRMWARE" in
 		else
 			ath9k_eeprom_extract "odm-caldata" 20480 2048
 		fi
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) +2)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +2)
 		;;
 	wndr3700v4 | \
 	wndr4300)
 		ath9k_eeprom_extract "caldata" 20480 2048
-		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 12)
+		ath9k_patch_firmware_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
 	z1)
 		. /lib/upgrade/nand.sh
@@ -150,7 +150,7 @@ case "$FIRMWARE" in
 		else
 			ath9k_eeprom_extract "origcaldata" 86016 4096
 		fi
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) +3)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +3)
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -168,7 +168,7 @@ case "$FIRMWARE" in
 		else
 			ath9k_eeprom_extract "odm-caldata" 36864 2048
 		fi
-		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) +3)
+		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 0x66) +3)
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -94,7 +94,7 @@ case "$FIRMWARE" in
 		;;
 	dw33d)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(mtd_get_mac_binary art 18)
+		ath10kcal_patch_mac $(mtd_get_mac_binary art 0x12)
 		;;
 	epg5000|\
 	esr1750)
@@ -109,7 +109,7 @@ case "$FIRMWARE" in
 		;;
 	koala)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 12) +0)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0xc) +0)
 		;;
 	mc-mac1200r)
 		ath10kcal_extract "art" 20480 2116

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -7,8 +7,8 @@ ath10kcal_die() {
 
 ath10kcal_from_file() {
 	local source=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 
 	dd if=$source of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $source"
@@ -16,8 +16,8 @@ ath10kcal_from_file() {
 
 ath10kcal_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd cal_size
 
 	mtd=$(find_mtd_chardev $part)
@@ -57,17 +57,17 @@ case "$FIRMWARE" in
 	mr1750|\
 	mr1750v2|\
 	om5p-acv2)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "ART" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	archer-c25-v1|\
 	tl-wdr6500-v2)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
 	archer-c7-v4|\
 	archer-c7-v5)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;
 	cf-e355ac-v1|\
@@ -81,60 +81,60 @@ case "$FIRMWARE" in
 	oolite-v5.2-dev|\
 	sr3200|\
 	xd3200)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		;;
 	dap-2695-a1)
-		ath10kcal_extract "radiocfg" 20480 2116
+		ath10kcal_extract "radiocfg" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii bdcfg wlanmac_a)
 		;;
 	dir-869-a1|\
 	qihoo-c301)
-		ath10kcal_extract "radiocfg" 20480 2116
+		ath10kcal_extract "radiocfg" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata wlan5mac)
 		;;
 	dw33d)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_binary art 0x12)
 		;;
 	epg5000|\
 	esr1750)
-		ath10kcal_extract "caldata" 20480 2116
+		ath10kcal_extract "caldata" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	gl-ar750s|\
 	gl-ar750|\
 	tl-wpa8630)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	koala)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0xc) +0)
 		;;
 	mc-mac1200r)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -1)
 		;;
 	r6100)
-		ath10kcal_extract "caldata" 20480 2116
+		ath10kcal_extract "caldata" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) +2)
 		;;
 	rb-952ui-5ac2nd|\
 	rb-wapg-5hact2hnd)
-		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
+		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 0x5000 0x844
 		;;
 	re355|\
 	re450|\
 	tl-wr902ac-v1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	unifiac-lite|\
 	unifiac-pro)
-		ath10kcal_extract "EEPROM" 20480 2116
+		ath10kcal_extract "EEPROM" 0x5000 0x844
 		;;
 	wi2a-ac200i)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "ART" 0x5000 0x844
 		;;
 	esac
 	;;
@@ -142,26 +142,26 @@ case "$FIRMWARE" in
 	case $board in
 	archer-c5|\
 	archer-c7)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
 	nbg6616|\
 	nbg6716)
-		ath10kcal_extract "RFdata" 20480 2116
+		ath10kcal_extract "RFdata" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
 		;;
 	om5p-ac)
-		ath10kcal_extract "ART" 20480 2116
+		ath10kcal_extract "ART" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	rb-911g-5hpacd|\
 	rb-921gs-5hpacd-r2|\
 	rb-922uags-5hpacd|\
 	rb-962uigs-5hact2hnt)
-		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
+		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 0x5000 0x844
 		;;
 	wlr8100)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	esac
@@ -174,18 +174,18 @@ case "$FIRMWARE" in
 	archer-c60-v1|\
 	cf-e355ac-v2|\
 	cf-e375ac)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
 	archer-c60-v2)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;
 	cf-e385ac)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		;;
 	esac
 	;;

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,7 +17,7 @@ case "$board" in
 	archer-c59-v2|\
 	archer-c60-v1|\
 	archer-c60-v2)
-		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
+		echo $(macaddr_add $(mtd_get_mac_binary mac 0x8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;
 	*)
 		;;

--- a/target/linux/ar71xx/base-files/lib/preinit/05_set_iface_mac_ar71xx
+++ b/target/linux/ar71xx/base-files/lib/preinit/05_set_iface_mac_ar71xx
@@ -24,7 +24,7 @@ preinit_set_mac_address() {
 	case $(board_name) in
 	c-55|\
 	c-60)
-		mac_lan=$(mtd_get_mac_binary art 0)
+		mac_lan=$(mtd_get_mac_binary art 0x0)
 		[ -n "$mac_lan" ] && ifconfig eth0 hw ether "$mac_lan"
 		;;
 	dir-615-c1|\
@@ -36,19 +36,19 @@ preinit_set_mac_address() {
 		;;
 	mr18|\
 	z1)
-		mac_lan=$(mtd_get_mac_binary_ubi board-config 102)
+		mac_lan=$(mtd_get_mac_binary_ubi board-config 0x66)
 		[ -n "$mac_lan" ] && ifconfig eth0 hw ether "$mac_lan"
 		;;
 	r6100)
-		mac_lan=$(mtd_get_mac_binary caldata 0)
+		mac_lan=$(mtd_get_mac_binary caldata 0x0)
 		[ -n "$mac_lan" ] && ifconfig eth1 hw ether "$mac_lan"
-		mac_wan=$(mtd_get_mac_binary caldata 6)
+		mac_wan=$(mtd_get_mac_binary caldata 0x6)
 		[ -n "$mac_wan" ] && ifconfig eth0 hw ether "$mac_wan"
 		;;
 	rambutan)
-		mac_lan=$(mtd_get_mac_binary art 0)
+		mac_lan=$(mtd_get_mac_binary art 0x0)
 		[ -n "$mac_lan" ] && ifconfig eth0 hw ether "$mac_lan"
-		mac_wan=$(mtd_get_mac_binary art 6)
+		mac_wan=$(mtd_get_mac_binary art 0x6)
 		[ -n "$mac_wan" ] && ifconfig eth1 hw ether "$mac_wan"
 		;;
 	wrt160nl)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -297,13 +297,13 @@ ath79_setup_macs()
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
 	dlink,dir-825-b1)
-		lan_mac=$(mtd_get_mac_text "caldata" 65440)
-		wan_mac=$(mtd_get_mac_text "caldata" 65460)
+		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
+		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		lan_mac=$(mtd_get_mac_text "mac" 4)
-		wan_mac=$(mtd_get_mac_text "mac" 24)
+		lan_mac=$(mtd_get_mac_text "mac" 0x4)
+		wan_mac=$(mtd_get_mac_text "mac" 0x18)
 		;;
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
@@ -314,7 +314,7 @@ ath79_setup_macs()
 		;;
 	elecom,wrc-1750ghbk2-i|\
 	elecom,wrc-300ghbk2-i)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 4098)" -2)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" -2)
 		;;
 	engenius,ecb1750)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
@@ -328,7 +328,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;
 	engenius,ews511ap)
-		lan_mac=$(mtd_get_mac_text "u-boot-env" 233)
+		lan_mac=$(mtd_get_mac_text "u-boot-env" 0xe9)
 		eth1_mac=$(macaddr_add "$lan_mac" 1)
 		ucidef_set_interface "eth0" ifname "eth0" protocol "none" macaddr "$lan_mac"
 		ucidef_set_interface "eth1" ifname "eth1" protocol "none" macaddr "$eth1_mac"
@@ -342,13 +342,13 @@ ath79_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	nec,wg800hp)
-		lan_mac=$(mtd_get_mac_text board_data 640)
-		wan_mac=$(mtd_get_mac_text board_data 1152)
+		lan_mac=$(mtd_get_mac_text board_data 0x280)
+		wan_mac=$(mtd_get_mac_text board_data 0x480)
 		;;
 	netgear,wndr3700|\
 	netgear,wndr3700v2|\
 	netgear,wndr3800)
-		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0)")
+		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0x0)")
 		;;
 	phicomm,k2t)
 		lan_mac=$(k2t_get_mac "lan_mac")
@@ -359,7 +359,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii devdata wanmac)
 		;;
 	rosinson,wr818)
-		wan_mac=$(mtd_get_mac_binary factory 0)
+		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
 	tplink,archer-a7-v5|\
@@ -367,17 +367,17 @@ ath79_setup_macs()
 	tplink,archer-c7-v5|\
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
-		base_mac=$(mtd_get_mac_binary info 8)
+		base_mac=$(mtd_get_mac_binary info 0x8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	tplink,tl-wr941-v2|\
 	tplink,tl-wr941n-v7-cn)
-		base_mac=$(mtd_get_mac_binary u-boot 130048)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	trendnet,tew-823dru)
-		lan_mac=$(mtd_get_mac_text mac 4)
-		wan_mac=$(mtd_get_mac_text mac 24)
+		lan_mac=$(mtd_get_mac_text mac 0x4)
+		wan_mac=$(mtd_get_mac_text mac 0x18)
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,8 +12,8 @@ ath9k_eeprom_die() {
 
 ath9k_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -27,7 +27,7 @@ ath9k_eeprom_extract() {
 ath9k_eeprom_extract_reverse() {
 	local part=$1
 	local offset=$2
-	local count=$3
+	local count=$(($3))
 	local mtd
 	local reversed
 	local caldata
@@ -59,8 +59,8 @@ xor() {
 
 ath9k_patch_fw_mac() {
 	local mac=$1
-	local mac_offset=$2
-	local chksum_offset=$3
+	local mac_offset=$(($2))
+	local chksum_offset=$(($3))
 	local xor_mac
 	local xor_fw_mac
 	local xor_fw_chksum
@@ -98,39 +98,39 @@ case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
 	avm,fritz4020)
-		ath9k_eeprom_extract_reverse "urlader" 5441 1088
+		ath9k_eeprom_extract_reverse "urlader" 0x1541 0x440
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 0x4) 2
+		ath9k_eeprom_extract "art" 0x1000 0x440
+		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 0x4) 0x2
 		;;
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)
-		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 2
+		ath9k_eeprom_extract "art" 0x1000 0x440
+		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	engenius,ecb1750)
-		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 2
+		ath9k_eeprom_extract "art" 0x1000 0x440
+		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 0x2
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr)
-		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 2
+		ath9k_eeprom_extract "art" 0x1000 0x440
+		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 0x2
 		;;
 	nec,wg800hp)
-		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 2
+		ath9k_eeprom_extract "art" 0x1000 0x440
+		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 0x2
 		;;
 	qihoo,c301)
-		ath9k_eeprom_extract "radiocfg" 4096 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 2
+		ath9k_eeprom_extract "radiocfg" 0x1000 0x440
+		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -140,28 +140,28 @@ case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
 	avm,fritz300e)
-		ath9k_eeprom_extract_reverse "urloader" 5441 1088
+		ath9k_eeprom_extract_reverse "urloader" 0x1541 0x440
 		;;
 	buffalo,whr-g301n|\
 	buffalo,wzr-hp-g302h-a1a0|\
 	tplink,tl-wr841-v5|\
 	tplink,tl-wr941-v4)
-		ath9k_eeprom_extract "art" 4096 3768
+		ath9k_eeprom_extract "art" 0x1000 0xeb8
 		;;
 	buffalo,wzr-hp-g450h)
-		ath9k_eeprom_extract "art" 4096 1088
+		ath9k_eeprom_extract "art" 0x1000 0x440
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		ath9k_eeprom_extract "art" 20480 1088
-		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 2
+		ath9k_eeprom_extract "art" 0x5000 0x440
+		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 0x2
 		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3600-v1|\
 	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4900-v2|\
 	winchannel,wb2000)
-		ath9k_eeprom_extract "art" 20480 1088
+		ath9k_eeprom_extract "art" 0x5000 0x440
 		;;
 	netgear,wnr612-v2|\
 	on,n150r|\
@@ -179,21 +179,21 @@ case "$FIRMWARE" in
 	ubnt,bullet-m|\
 	ubnt,nano-m|\
 	ubnt,rocket-m)
-		ath9k_eeprom_extract "art" 4096 4096
+		ath9k_eeprom_extract "art" 0x1000 0x1000
 		;;
 	pqi,air-pen)
-		ath9k_eeprom_extract "art" 4096 2002
+		ath9k_eeprom_extract "art" 0x1000 0x7d2
 		;;
 	ubnt,unifi)
-		ath9k_eeprom_extract "art" 4096 2048
+		ath9k_eeprom_extract "art" 0x1000 0x800
 		;;
 	wd,mynet-n750)
-		ath9k_eeprom_extract "art" 20480 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan5mac") 2
+		ath9k_eeprom_extract "art" 0x5000 0x440
+		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan5mac") 0x2
 		;;
 	wd,mynet-wifi-rangeextender)
-		ath9k_eeprom_extract "art" 4096 4096
-		ath9k_patch_fw_mac_crc $(nvram get wl0_hwaddr) "$mac" 2
+		ath9k_eeprom_extract "art" 0x1000 0x1000
+		ath9k_patch_fw_mac_crc $(nvram get wl0_hwaddr) "$mac" 0x2
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -206,11 +206,11 @@ case "$FIRMWARE" in
 	netgear,wndr3700|\
 	netgear,wndr3700v2|\
 	netgear,wndr3800)
-		ath9k_eeprom_extract "art" 4096 3768
+		ath9k_eeprom_extract "art" 0x1000 0xeb8
 		;;
 	dlink,dir-825-b1)
-		ath9k_eeprom_extract "caldata" 4096 3768
-		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 524
+		ath9k_eeprom_extract "caldata" 0x1000 0xeb8
+		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -223,11 +223,11 @@ case "$FIRMWARE" in
 	netgear,wndr3700|\
 	netgear,wndr3700v2|\
 	netgear,wndr3800)
-		ath9k_eeprom_extract "art" 20480 3768
+		ath9k_eeprom_extract "art" 0x5000 0xeb8
 		;;
 	dlink,dir-825-b1)
-		ath9k_eeprom_extract "caldata" 20480 3768
-		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 524
+		ath9k_eeprom_extract "caldata" 0x5000 0xeb8
+		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -103,7 +103,7 @@ case "$FIRMWARE" in
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
 		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 4) 2
+		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "mac" 0x4) 2
 		;;
 	dlink,dir-842-c2|\
 	dlink,dir-859-a1|\
@@ -126,7 +126,7 @@ case "$FIRMWARE" in
 		;;
 	nec,wg800hp)
 		ath9k_eeprom_extract "art" 4096 1088
-		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 1664) 2
+		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 2
 		;;
 	qihoo,c301)
 		ath9k_eeprom_extract "radiocfg" 4096 1088
@@ -154,7 +154,7 @@ case "$FIRMWARE" in
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
 		ath9k_eeprom_extract "art" 20480 1088
-		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 24) 1) 2
+		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 2
 		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3600-v1|\
@@ -210,7 +210,7 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-825-b1)
 		ath9k_eeprom_extract "caldata" 4096 3768
-		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 65440) 524
+		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 524
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"
@@ -227,7 +227,7 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-825-b1)
 		ath9k_eeprom_extract "caldata" 20480 3768
-		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 65460) 1) 524
+		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 524
 		;;
 	*)
 		ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,8 +25,8 @@ ath10kcal_die() {
 
 ath10kcal_from_file() {
 	local source=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 
 	dd if=$source of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $source"
@@ -34,8 +34,8 @@ ath10kcal_from_file() {
 
 ath10kcal_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -93,53 +93,53 @@ case "$FIRMWARE" in
 	devolo,dvl1750e|\
 	devolo,dvl1750i|\
 	devolo,dvl1750x)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x0) -1)
 		;;
 	dlink,dir-859-a1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
 	elecom,wrc-1750ghbk2-i)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		;;
 	engenius,ecb1750)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	engenius,ews511ap)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	glinet,gl-ar750s)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	glinet,gl-x750)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	nec,wg800hp)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(mtd_get_mac_text board_data 0x880)
 		;;
 	ocedo,koala|\
 	ocedo,ursus)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
 	openmesh,om5p-ac-v2)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	qihoo,c301)
-		ath10kcal_extract "radiocfg" 20480 2116
+		ath10kcal_extract "radiocfg" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
 		;;
 	tplink,archer-a7-v5|\
@@ -147,29 +147,29 @@ case "$FIRMWARE" in
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		;;
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v2)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
 		;;
 	tplink,archer-d50-v1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
 		;;
 	tplink,re350k-v1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
 		;;
 	tplink,re355-v1|\
 	tplink,re450-v1)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	tplink,re450-v2)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
 	ubnt,unifiac-lite|\
@@ -180,10 +180,10 @@ case "$FIRMWARE" in
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
-		ath10kcal_extract "EEPROM" 20480 2116
+		ath10kcal_extract "EEPROM" 0x5000 0x844
 		;;
 	yuncore,a770)
-		ath10kcal_extract "art" 20480 2116
+		ath10kcal_extract "art" 0x5000 0x844
 		;;
 	esac
 	;;
@@ -191,18 +191,18 @@ case "$FIRMWARE" in
 	case $board in
 	dlink,dir-842-c2|\
 	nec,wg1200cr)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
 	netgear,ex6400|\
 	netgear,ex7300)
-		ath10kcal_extract "caldata" 20480 12064
+		ath10kcal_extract "caldata" 0x5000 0x2f20
 		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
 	phicomm,k2t)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(k2t_get_mac "5g_mac")
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
@@ -212,7 +212,7 @@ case "$FIRMWARE" in
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
 	tplink,archer-c6-v2)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mac 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -94,7 +94,7 @@ case "$FIRMWARE" in
 	devolo,dvl1750i|\
 	devolo,dvl1750x)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x0) -1)
 		;;
 	dlink,dir-859-a1)
 		ath10kcal_extract "art" 20480 2116
@@ -119,20 +119,20 @@ case "$FIRMWARE" in
 		;;
 	glinet,gl-ar750s)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	glinet,gl-x750)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0) +2)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	nec,wg800hp)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac_crc $(mtd_get_mac_text board_data 2176)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_text board_data 0x880)
 		;;
 	ocedo,koala|\
 	ocedo,ursus)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(mtd_get_mac_binary art 12)
+		ath10kcal_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
 	openmesh,om5p-ac-v2)
 		ath10kcal_extract "art" 20480 2116
@@ -148,7 +148,7 @@ case "$FIRMWARE" in
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) -1)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		;;
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v2)
@@ -170,7 +170,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,re450-v2)
 		ath10kcal_extract "art" 20480 2116
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 8) +1)
+		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
@@ -199,7 +199,7 @@ case "$FIRMWARE" in
 	netgear,ex6400|\
 	netgear,ex7300)
 		ath10kcal_extract "caldata" 20480 12064
-		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 12)
+		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
 	phicomm,k2t)
 		ath10kcal_extract "art" 20480 12064
@@ -213,7 +213,7 @@ case "$FIRMWARE" in
 	tplink,archer-c60-v2|\
 	tplink,archer-c6-v2)
 		ath10kcal_extract "art" 20480 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mac 8) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mac 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -40,7 +40,7 @@ case "$board" in
 		        mtd_get_mac_text mac 4 > /sys${DEVPATH}/macaddress
 	        # set the 5G interface mac address to WAN MAC + 1
 	        [ "$PHYNBR" -eq 0 ] && \
-		        macaddr_add "$(mtd_get_mac_text mac 24)" 1 > /sys${DEVPATH}/macaddress
+		        macaddr_add "$(mtd_get_mac_text mac 0x18)" 1 > /sys${DEVPATH}/macaddress
                 ;;
 	*)
 		;;

--- a/target/linux/brcm63xx/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/brcm63xx/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -8,8 +8,8 @@ rt2x00_eeprom_die() {
 
 rt2x00_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_part $part)
@@ -30,11 +30,11 @@ case "$FIRMWARE" in
 "rt2x00.eeprom" )
 	case $board in
 	hg556a_c)
-		rt2x00_eeprom_extract "cal_data" 130560 512
+		rt2x00_eeprom_extract "cal_data" 0x1fe00 0x200
 		;;
 	hg622 |\
 	hg655b)
-		rt2x00_eeprom_extract "cal_data" 0 512
+		rt2x00_eeprom_extract "cal_data" 0x0 0x200
 		;;
 	*)
 		rt2x00_eeprom_die "board $board is not supported yet"

--- a/target/linux/gemini/base-files/lib/preinit/05_set_ether_mac_gemini
+++ b/target/linux/gemini/base-files/lib/preinit/05_set_ether_mac_gemini
@@ -17,7 +17,7 @@ set_ether_mac() {
 		if [ -n "$part" ]; then
 			DEVID="$(dd if=$part bs=1 skip=119508 count=7 2>/dev/null)"
 			if [ "$DEVID" = "dns-313" ]; then
-				MAC1="$(mtd_get_mac_binary RedBoot 119540)"
+				MAC1="$(mtd_get_mac_binary RedBoot 0x1d2f4)"
 				ip link set eth0 address "$MAC1" 2>/dev/null
 				return 0
 			fi
@@ -30,8 +30,8 @@ set_ether_mac() {
 		if [ -n "$part" ] ; then
 			DEVID="$(dd if=$part bs=1 skip=81516 count=7 2>/dev/null)"
 			if [ "$DEVID" = "ILI9322" ] ; then
-				MAC1=$(mtd_get_mac_binary RedBoot 95040)
-				MAC2=$(mtd_get_mac_binary RedBoot 95046)
+				MAC1=$(mtd_get_mac_binary RedBoot 0x17340)
+				MAC2=$(mtd_get_mac_binary RedBoot 0x17346)
 				ip link set eth0 address "$MAC1" 2>/dev/null
 				ip link set eth1 address "$MAC2" 2>/dev/null
 				return 0

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -74,8 +74,8 @@ ipq40xx_setup_macs()
 	case "$board" in
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		wan_mac=$(mtd_get_mac_binary_ubi Factory 20486)
-		lan_mac=$(mtd_get_mac_binary_ubi Factory 4102)
+		wan_mac=$(mtd_get_mac_binary_ubi Factory 0x5006)
+		lan_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
 		;;
 	engenius,ens620ext)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -23,8 +23,8 @@ ath10kcal_die() {
 
 ath10kcal_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -37,8 +37,8 @@ ath10kcal_extract() {
 
 ath10kcal_ubi_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local ubidev
 	local ubi
 
@@ -97,8 +97,8 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:01:00.0.bin")
 	case "$board" in
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 36864 2116
-		ath10kcal_is_caldata_valid "4408" || ath10kcal_extract "ART" 36864 2116
+		ath10kcal_ubi_extract "ART" 0x9000 0x844
+		ath10kcal_is_caldata_valid "4408" || ath10kcal_extract "ART" 0x9000 0x844
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +1)
 		;;
 	esac
@@ -106,7 +106,7 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 36864 12064
+		ath10kcal_ubi_extract "Factory" 0x9000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
@@ -115,12 +115,12 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 36864 12064
+		ath10kcal_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
 		ath10kcal_patch_mac_crc $(macaddr_setbit_la $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4))
 		;;
 	openmesh,a62)
-		ath10kcal_extract "0:ART" 36864 12064
+		ath10kcal_extract "0:ART" 0x9000 0x2f20
 		;;
 	esac
 	;;
@@ -131,14 +131,14 @@ case "$FIRMWARE" in
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\
 	qcom,ap-dk01.1-c1)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		;;
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 4096 12064
+		ath10kcal_ubi_extract "Factory" 0x1000 0x2f20
 		;;
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		ath10kcal_ubi_extract "Factory" 4096 12064
+		ath10kcal_ubi_extract "Factory" 0x1000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -154,29 +154,29 @@ case "$FIRMWARE" in
 	openmesh,a62 |\
 	qxwlan,e2600ac-c1 |\
 	qxwlan,e2600ac-c2)
-		ath10kcal_extract "0:ART" 4096 12064
+		ath10kcal_extract "0:ART" 0x1000 0x2f20
 		;;
 	engenius,ens620ext)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +2)
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 4096 12064
-		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 4096 12064
+		ath10kcal_ubi_extract "ART" 0x1000 0x2f20
+		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +2)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0x0)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	esac
@@ -188,14 +188,14 @@ case "$FIRMWARE" in
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\
 	qcom,ap-dk01.1-c1)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		;;
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 20480 12064
+		ath10kcal_ubi_extract "Factory" 0x5000 0x2f20
 		;;
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		ath10kcal_ubi_extract "Factory" 20480 12064
+		ath10kcal_ubi_extract "Factory" 0x5000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -211,29 +211,29 @@ case "$FIRMWARE" in
 	openmesh,a62 |\
 	qxwlan,e2600ac-c1 |\
 	qxwlan,e2600ac-c2)
-		ath10kcal_extract "0:ART" 20480 12064
+		ath10kcal_extract "0:ART" 0x5000 0x2f20
 		;;
 	engenius,ens620ext)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +3)
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
 		;;
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 20480 12064
-		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 20480 12064
+		ath10kcal_ubi_extract "ART" 0x5000 0x2f20
+		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +3)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0xc)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;
 	esac

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -99,7 +99,7 @@ case "$FIRMWARE" in
 	meraki,mr33)
 		ath10kcal_ubi_extract "ART" 36864 2116
 		ath10kcal_is_caldata_valid "4408" || ath10kcal_extract "ART" 36864 2116
-		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 102) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +1)
 		;;
 	esac
 	;;
@@ -167,12 +167,12 @@ case "$FIRMWARE" in
 	meraki,mr33)
 		ath10kcal_ubi_extract "ART" 4096 12064
 		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 4096 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 102) +2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +2)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
 		ath10kcal_extract "ART" 4096 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0x0)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
@@ -224,12 +224,12 @@ case "$FIRMWARE" in
 	meraki,mr33)
 		ath10kcal_ubi_extract "ART" 20480 12064
 		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 20480 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 102) +3)
+		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +3)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
 		ath10kcal_extract "ART" 20480 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 12)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0xc)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -5,7 +5,7 @@
 preinit_set_mac_address() {
 	case $(board_name) in
 	asus,map-ac2200)
-		base_mac=$(mtd_get_mac_binary_ubi Factory 4102)
+		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
 		ip link set dev eth0 address $(macaddr_add "$base_mac" +1)
 		ip link set dev eth1 address $(macaddr_add "$base_mac" +3)
 		;;
@@ -15,7 +15,7 @@ preinit_set_mac_address() {
 		ip link set dev eth1 address $(macaddr_add "${base_mac}" 1)
 		;;
 	meraki,mr33)
-		mac_lan=$(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 102)
+		mac_lan=$(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66)
 		[ -n "$mac_lan" ] && ip link set dev eth0 address "$mac_lan"
 		;;
 	zyxel,nbg6617)

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -81,7 +81,7 @@ case "$FIRMWARE" in
 	case $board in
 	buffalo,wxr-2533dhp)
 		ath10kcal_extract "ART" 4096 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 30)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x1e)
 		;;
 	linksys,ea8500)
 		ath10kcal_extract "art" 4096 12064
@@ -89,21 +89,21 @@ case "$FIRMWARE" in
 		;;
 	nec,wg2600hp)
 		ath10kcal_extract "ART" 4096 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary PRODUCTDATA 12) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary PRODUCTDATA 0xc) +1)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
 		ath10kcal_extract "art" 4096 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 6) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +1)
 		;;
 	tplink,c2600)
 		ath10kcal_extract "radio" 4096 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 8) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x8) -1)
 		;;
 	tplink,vr2600v)
 		ath10kcal_extract "ART" 4096 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x0) -1)
 		;;
 	zyxel,nbg6817)
 		ath10kcal_extract "0:ART" 4096 12064
@@ -115,7 +115,7 @@ case "$FIRMWARE" in
 	case $board in
 	buffalo,wxr-2533dhp)
 		ath10kcal_extract "ART" 20480 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 24)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x18)
 		;;
 	linksys,ea8500)
 		ath10kcal_extract "art" 20480 12064
@@ -123,21 +123,21 @@ case "$FIRMWARE" in
 		;;
 	nec,wg2600hp)
 		ath10kcal_extract "ART" 20480 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary PRODUCTDATA 12)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary PRODUCTDATA 0xc)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
 		ath10kcal_extract "art" 20480 12064
-		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 6) +2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +2)
 		;;
 	tplink,c2600)
 		ath10kcal_extract "radio" 20480 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 8)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x8)
 		;;
 	tplink,vr2600v)
 		ath10kcal_extract "ART" 20480 12064
-		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x0)
 		;;
 	zyxel,nbg6817)
 		ath10kcal_extract "0:ART" 20480 12064

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -23,8 +23,8 @@ ath10kcal_die() {
 
 ath10kcal_from_file() {
 	local source=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 
 	dd if=$source of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
 		ath10kcal_die "failed to extract calibration data from $source"
@@ -32,8 +32,8 @@ ath10kcal_from_file() {
 
 ath10kcal_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -80,33 +80,33 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
 	buffalo,wxr-2533dhp)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x1e)
 		;;
 	linksys,ea8500)
-		ath10kcal_extract "art" 4096 12064
+		ath10kcal_extract "art" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +1)
 		;;
 	nec,wg2600hp)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary PRODUCTDATA 0xc) +1)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
-		ath10kcal_extract "art" 4096 12064
+		ath10kcal_extract "art" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +1)
 		;;
 	tplink,c2600)
-		ath10kcal_extract "radio" 4096 12064
+		ath10kcal_extract "radio" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x8) -1)
 		;;
 	tplink,vr2600v)
-		ath10kcal_extract "ART" 4096 12064
+		ath10kcal_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x0) -1)
 		;;
 	zyxel,nbg6817)
-		ath10kcal_extract "0:ART" 4096 12064
+		ath10kcal_extract "0:ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) +1)
 		;;
 	esac
@@ -114,33 +114,33 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
 	buffalo,wxr-2533dhp)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x18)
 		;;
 	linksys,ea8500)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +2)
 		;;
 	nec,wg2600hp)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary PRODUCTDATA 0xc)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
-		ath10kcal_extract "art" 20480 12064
+		ath10kcal_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +2)
 		;;
 	tplink,c2600)
-		ath10kcal_extract "radio" 20480 12064
+		ath10kcal_extract "radio" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x8)
 		;;
 	tplink,vr2600v)
-		ath10kcal_extract "ART" 20480 12064
+		ath10kcal_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x0)
 		;;
 	zyxel,nbg6817)
-		ath10kcal_extract "0:ART" 20480 12064
+		ath10kcal_extract "0:ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 		;;
 	esac

--- a/target/linux/lantiq/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/base-files/etc/board.d/02_network
@@ -60,19 +60,19 @@ arcadyan,arv4525pw|arcadyan,arv452cqw|arcadyan,arv7525pw|arcadyan,arv752dpw)
 
 arcadyan,arv7506pw11)
 	annex="b"
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 22)" 2)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 0x16)" 2)
 	ucidef_add_switch "switch0" \
 		"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5t@eth0"
 	;;
 
 arcadyan,arv7519pw)
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 22)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 0x16)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan" "1:lan" "2:lan" "3:lan" "4t@eth0"
 	;;
 
 arcadyan,arv7519rw22)
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary boardconfig 22)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary boardconfig 0x16)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan:5" "2:lan:3" "3:lan:4" "4:lan:1" "5:lan:2" "6t@eth0"
 	;;
@@ -104,7 +104,7 @@ bt,homehub-v3a)
 	;;
 
 bt,homehub-v5a)
-	lan_mac=$(mtd_get_mac_binary_ubi caldata 4364)
+	lan_mac=$(mtd_get_mac_binary_ubi caldata 0x110c)
 	wan_mac=$(macaddr_add "$lan_mac" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "5:wan:5" "6t@eth0"
@@ -123,7 +123,7 @@ netgear,dgn3500|netgear,dgn3500b)
 	;;
 
 netgear,dm200)
-	lan_mac=$(mtd_get_mac_binary ART 0)
+	lan_mac=$(mtd_get_mac_binary ART 0x0)
 	wan_mac=$(macaddr_add "$lan_mac" 1)
 	ucidef_set_interface_lan 'eth0'
 	;;
@@ -147,13 +147,13 @@ avm,fritz3370-rev2-micron)
 avm,fritz7312|\
 avm,fritz7320)
 	annex="b"
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2705)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 	ucidef_set_interface_lan 'eth0'
 	;;
 
 avm,fritz7360sl)
 	annex="b"
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 2705)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
 	;;
@@ -199,7 +199,7 @@ zyxel,p-2812hnu-f1|zyxel,p-2812hnu-f3)
 	;;
 
 tplink,tdw8970|tplink,tdw8980)
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary boardconfig 61696)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary boardconfig 0xf100)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan:2" "2:lan:3" "4:lan:4" "5:lan:1" "6t@eth0"
 	;;
@@ -212,20 +212,20 @@ arcadyan,vg3503j)
 	;;
 
 tplink,vr200|tplink,vr200v)
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary romfile 61696)" 1)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary romfile 0xf100)" 1)
 	ucidef_add_switch "switch0" \
 		"0:lan" "2:lan" "4:lan" "5:lan" "6t@eth0"
 	;;
 
 arcadyan,vgv7510kw22-nor|arcadyan,vgv7510kw22-brn)
 	annex="b"
-	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 22)" 2)
+	wan_mac=$(macaddr_add "$(mtd_get_mac_binary board_config 0x16)" 2)
 	ucidef_add_switch "switch0" \
 		"2:lan:2" "3:lan:1" "4:lan:4" "5:lan:3" "0:wan:5" "6t@eth0"
 	;;
 
 arcadyan,vgv7519-nor|arcadyan,vgv7519-brn)
-	wan_mac=$(mtd_get_mac_binary board_config 22)
+	wan_mac=$(mtd_get_mac_binary board_config 0x16)
 	ucidef_add_switch "switch0" \
 		"0:lan:4" "1:lan:3" "2:lan:2" "4:lan:1" "5:wan:5" "6t@eth0"
 	;;

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -40,7 +40,7 @@ case "$FIRMWARE" in
 	case $board in
 		bt,homehub-v5a)
 			ath10k_caldata_extract_ubi "caldata" 20480 2116
-			ath10k_caldata_set_macaddr $(macaddr_add $(mtd_get_mac_binary_ubi caldata 4364) +3)
+			ath10k_caldata_set_macaddr $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
 			;;
 		*)
 			ath10k_caldata_die "board $board is not supported yet"

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -30,7 +30,7 @@ ath9k_eeprom_die() {
 
 ath9k_eeprom_extract_raw() {
 	local source=$1
-	local offset=$2
+	local offset=$(($2))
 	local swap=$3
 	local size=4096
 	local bs=1
@@ -50,7 +50,7 @@ ath9k_eeprom_extract_raw() {
 ath9k_eeprom_extract_reverse() {
 	local part=$1
 	local offset=$2
-	local count=$3
+	local count=$(($3))
 	local mtd
 	local reversed
 	local caldata
@@ -102,8 +102,8 @@ ath9k_patch_fw_mac_crc() {
 
 ath9k_patch_fw_mac() {
 	local mac=$1
-	local mac_offset=$2
-	local chksum_offset=$3
+	local mac_offset=$(($2))
+	local chksum_offset=$(($3))
 	local xor_mac
 	local xor_fw_mac
 	local xor_fw_chksum
@@ -135,40 +135,40 @@ case "$FIRMWARE" in
 
 		case "$board" in
 			arcadyan,arv7518pw)
-				ath9k_eeprom_extract "boardconfig" 1024 1
+				ath9k_eeprom_extract "boardconfig" 0x400 1
 				;;
 			arcadyan,arv8539pw22)
-				ath9k_eeprom_extract "art" 1024 1
+				ath9k_eeprom_extract "art" 0x400 1
 				;;
 			bt,homehub-v2b)
-				ath9k_eeprom_extract "art" 0 1
-				ath9k_patch_fw_mac_crc "00:00:00:00:00:00" 524
+				ath9k_eeprom_extract "art" 0x0 1
+				ath9k_patch_fw_mac_crc "00:00:00:00:00:00" 0x20c
 				;;
 			bt,homehub-v3a)
-				ath9k_eeprom_extract "art-copy" 0 1
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot_env ethaddr) +2) 268
+				ath9k_eeprom_extract "art-copy" 0x0 1
+				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot_env ethaddr) +2) 0x10c
 				;;
 			bt,homehub-v5a)
-				ath9k_ubi_eeprom_extract "caldata" 4096 0
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 268
+				ath9k_ubi_eeprom_extract "caldata" 0x1000 0
+				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 0x10c
 				;;
 			netgear,dgn3500|netgear,dgn3500b)
-				ath9k_eeprom_extract "calibration" 61440 0
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 524
+				ath9k_eeprom_extract "calibration" 0xf000 0
+				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 0x20c
 				;;
 			avm,fritz3370-rev2-hynix|\
 			avm,fritz3370-rev2-micron|\
 			avm,fritz7362sl)
-				ath9k_eeprom_extract_reverse "urlader" 5441 1088
+				ath9k_eeprom_extract_reverse "urlader" 0x1541 0x440
 				;;
 			avm,fritz7312|avm,fritz7320|avm,fritz7360sl)
-				ath9k_eeprom_extract "urlader" 2437 0
+				ath9k_eeprom_extract "urlader" 0x985 0
 				;;
 			avm,fritz7412)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 4096 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
 				;;
 			tplink,tdw8970|tplink,tdw8980)
-				ath9k_eeprom_extract "boardconfig" 135168 0
+				ath9k_eeprom_extract "boardconfig" 0x21000 0
 				;;
 			*)
 				ath9k_eeprom_die "board $board is not supported yet"

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -150,7 +150,7 @@ case "$FIRMWARE" in
 				;;
 			bt,homehub-v5a)
 				ath9k_ubi_eeprom_extract "caldata" 4096 0
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 4364) +2) 268
+				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 268
 				;;
 			netgear,dgn3500|netgear,dgn3500b)
 				ath9k_eeprom_extract "calibration" 61440 0

--- a/target/linux/mpc85xx/base-files/etc/board.d/02_network
+++ b/target/linux/mpc85xx/base-files/etc/board.d/02_network
@@ -21,7 +21,7 @@ ocedo,panda)
 tplink,tl-wdr4900-v1)
 	ucidef_add_switch "switch0" \
 		"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
-	ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary config 332)"
+	ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary config 0x14c)"
 	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"

--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -26,7 +26,7 @@ tpl_set_wireless_mac()
 	local offset=$1
 	local mac
 
-	mac=$(mtd_get_mac_binary u-boot 326656)
+	mac=$(mtd_get_mac_binary u-boot 0x4fc00)
 	mac=$(macaddr_add $mac $offset)
 
 	macaddr_2bin $mac | dd bs=1 count=6 seek=2 conv=notrunc of=$FW_FILE 2>/dev/null

--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,8 +9,8 @@ ath9k_eeprom_die() {
 
 ath9k_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
@@ -43,7 +43,7 @@ case "$FIRMWARE" in
 "pci_wmac0.eeprom")
 	case $board in
 	tplink,tl-wdr4900-v1)
-		ath9k_eeprom_extract "caldata" 4096 2048
+		ath9k_eeprom_extract "caldata" 0x1000 0x800
 		tpl_set_wireless_mac 0
 		;;
 	*)
@@ -55,7 +55,7 @@ case "$FIRMWARE" in
 "pci_wmac1.eeprom")
 	case $board in
 	tplink,tl-wdr4900-v1)
-		ath9k_eeprom_extract "caldata" 20480 2048
+		ath9k_eeprom_extract "caldata" 0x5000 0x800
 		tpl_set_wireless_mac -1
 		;;
 	*)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -505,7 +505,7 @@ ramips_setup_macs()
 	alfa-network,w502u|\
 	arcwireless,freestation5|\
 	netgear,wnce2001)
-		wan_mac=$(mtd_get_mac_binary factory 46)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	arcwireless,freestation5|\
 	dlink,dir-300-b7|\
@@ -528,12 +528,12 @@ ramips_setup_macs()
 	asus,rt-ac57u|\
 	phicomm,k2p|\
 	planex,vr500)
-		lan_mac=$(mtd_get_mac_binary factory 57344)
-		wan_mac=$(mtd_get_mac_binary factory 57350)
+		lan_mac=$(mtd_get_mac_binary factory 0xe000)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
 		;;
 	asus,rt-n56u)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")
-		wan_mac=$(mtd_get_mac_binary factory 32772)
+		wan_mac=$(mtd_get_mac_binary factory 0x8004)
 		;;
 	belkin,f9k1109v1)
 		wan_mac=$(mtd_get_mac_ascii uboot-env HW_WAN_MAC)
@@ -549,12 +549,12 @@ ramips_setup_macs()
 	buffalo,whr-300hp2|\
 	buffalo,whr-600d|\
 	buffalo,wsr-600dhp)
-		wan_mac=$(mtd_get_mac_binary factory 4)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		lan_mac=$wan_mac
 		;;
 	buffalo,whr-g300n|\
 	glinet,gl-mt300n-v2)
-		wan_mac=$(mtd_get_mac_binary factory 4)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	dlink,dch-m225|\
 	samsung,cy-swr1100)
@@ -583,7 +583,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env WAN_MAC_ADDR)
 		;;
 	edimax,br-6475nd)
-		wan_mac=$(mtd_get_mac_binary devdata 7)
+		wan_mac=$(mtd_get_mac_binary devdata 0x7)
 		;;
 	edimax,br-6478ac-v2)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
@@ -592,7 +592,7 @@ ramips_setup_macs()
 	elecom,wrc-1900gst|\
 	elecom,wrc-2533gst|\
 	samknows,whitebox-v8)
-		wan_mac=$(mtd_get_mac_binary factory 57350)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
 		;;
 	hiwifi,hc5661|\
 	hiwifi,hc5661a|\
@@ -606,12 +606,12 @@ ramips_setup_macs()
 		;;
 	iodata,wn-ac1167gr|\
 	iodata,wn-ac733gr3)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 4)" -1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" -1)
 		;;
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr|\
 	trendnet,tew-692gr)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 4)" 1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
 	lenovo,newifi-d1)
 		lan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
@@ -622,24 +622,24 @@ ramips_setup_macs()
 	mediatek,linkit-smart-7688|\
 	onion,omega2|\
 	onion,omega2p)
-		wan_mac=$(mtd_get_mac_binary factory 4)
-		lan_mac=$(mtd_get_mac_binary factory 46)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
+		lan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	mercury,mac1200r-v2)
-		lan_mac=$(mtd_get_mac_binary factory_info 13)
+		lan_mac=$(mtd_get_mac_binary factory_info 0xd)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	netgear,r6220|\
 	netgear,r6350|\
 	netgear,wndr3700-v5)
-		wan_mac=$(mtd_get_mac_binary factory 4)
+		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	ohyeah,oy-0001|\
 	phicomm,k2g|\
 	skylab,skw92a)
-		lan_mac=$(mtd_get_mac_binary factory 40)
-		wan_mac=$(mtd_get_mac_binary factory 46)
+		lan_mac=$(mtd_get_mac_binary factory 0x28)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	poray,m3|\
 	poray,m4-4m|\
@@ -649,24 +649,24 @@ ramips_setup_macs()
 		lan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" -2)
 		;;
 	sitecom,wlr-6000)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 32772)" 2)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x8004)" 2)
 		;;
 	sparklan,wcr-150gn|\
 	zyxel,keenetic-omni|\
 	zyxel,keenetic-omni-ii|\
 	zyxel,keenetic-start|\
 	zyxel,keenetic-viva)
-		wan_mac=$(mtd_get_mac_binary factory 40)
+		wan_mac=$(mtd_get_mac_binary factory 0x28)
 		;;
 	tenda,w306r-v2)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 5)
 		;;
 	trendnet,tew-691gr)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 4)" 3)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 3)
 		;;
 	wiznet,wizfi630a)
-		lan_mac=$(mtd_get_mac_binary factory 4)
-		wan_mac=$(mtd_get_mac_binary factory 40)
+		lan_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(mtd_get_mac_binary factory 0x28)
 		;;
 	xiaomi,mir3g|\
 	xiaomi,mir3p)

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -7,8 +7,8 @@ rt2x00_eeprom_die() {
 
 rt2x00_eeprom_extract() {
 	local part=$1
-	local offset=$2
-	local count=$3
+	local offset=$(($2))
+	local count=$(($3))
 	local mtd
 
 	mtd=$(find_mtd_part $part)
@@ -68,7 +68,7 @@ case "$FIRMWARE" in
 		;;
 	dovado,tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
-		rt2x00_eeprom_extract "factory" 0 512
+		rt2x00_eeprom_extract "factory" 0x0 0x200
 		rt2x00_eeprom_set_macaddr $wifi_mac
 		;;
 	*)


### PR DESCRIPTION
This changes the offsets for the MAC address location in
mtd_get_mac_binary and mtd_get_mac_text to hexadecimal notation.

This will be much clearer for the reader when numbers are big, and
will also match the style used for mtd-mac-address in DTS files.

(e.g. 0x1002 is much more useful than 4098)