### PR TITLE
lantiq: use wpad-basic for devices with enough storage

### DIFF
--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -490,7 +490,7 @@ define Device/avm_fritz7312
   DEVICE_DTS := FRITZ7312
   IMAGE_SIZE := 15744k
   DEVICE_TITLE := AVM FRITZ!Box 7312
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-mini \
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
@@ -673,7 +673,7 @@ define Device/avm_fritz7412
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
   DEVICE_TITLE := AVM FRITZ!Box 7412
-  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-mini kmod-ltq-tapi kmod-ltq-vmmc fritz-tffs-nand fritz-caldata
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic kmod-ltq-tapi kmod-ltq-vmmc fritz-tffs-nand fritz-caldata
 endef
 TARGET_DEVICES += avm_fritz7412
 


### PR DESCRIPTION
As i use this device as dump ap with 802.11r and this device has plenty of available flash switch to wpad-basic as default.

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>

Please **cherry-pick** also to branch **openwrt-19.07**.

Thanks