### PR TITLE
ramips: Add support for Netgear EX6130

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -287,7 +287,8 @@ netgear,ex2700|\
 netgear,wn3000rp-v3)
 	set_wifi_led "$boardname:green:router"
 	;;
-netgear,ex3700)
+netgear,ex3700|\
+netgear,ex6130)
 	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "$boardname:green:router" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "$boardname:green:device" "wlan1"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -127,6 +127,7 @@ ramips_setup_interfaces()
 	loewe,wmdr-143n|\
 	netgear,ex2700|\
 	netgear,ex3700|\
+	netgear,ex6130|\
 	netgear,wn3000rp-v3|\
 	omnima,hpm|\
 	planex,cs-qr10|\

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
@@ -1,0 +1,117 @@
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7620a.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "board_data";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0 >;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		default {
+			ralink,group = "i2c", "rgmii2", "spi refclk";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
@@ -40,7 +40,7 @@
 	m25p80@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
@@ -10,8 +10,7 @@
 	};
 
 	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
+		compatible = "gpio-keys";
 
 		reset {
 			label = "reset";

--- a/target/linux/ramips/dts/mt7620a_netgear_ex6130.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex6130.dts
@@ -5,8 +5,8 @@
 #include "mt7620a_netgear_ex3700_ex6130.dtsi"
 
 / {
-	compatible = "netgear,ex3700", "ralink,mt7620a-soc";
-	model = "Netgear EX3700/EX3800";
+	compatible = "netgear,ex6130", "ralink,mt7620a-soc";
+	model = "Netgear EX6130";
 
 	aliases {
 		led-boot = &led_power_green;
@@ -19,40 +19,39 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_g {
-			label = "ex3700:green:power";
+			label = "ex6130:green:power";
 			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		power_a {
-			label = "ex3700:amber:power";
+			label = "ex6130:amber:power";
 			gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
 		};
 
 		router_g {
-			label = "ex3700:green:router";
+			label = "ex6130:green:router";
 			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
 		};
 
 		router_r {
-			label = "ex3700:red:router";
+			label = "ex6130:red:router";
 			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
 		};
 
 		device_g {
-			label = "ex3700:green:device";
+			label = "ex6130:green:device";
 			gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
 		};
 
 		device_r {
-			label = "ex3700:red:device";
+			label = "ex6130:red:device";
 			gpios = <&gpio2 21 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "ex3700:green:wps";
+			label = "ex6130:green:wps";
 			gpios = <&gpio2 27 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
-

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -612,6 +612,19 @@ define Device/netgear_ex3700
 endef
 TARGET_DEVICES += netgear_ex3700
 
+define Device/netgear_ex6130
+  MTK_SOC := mt7620a
+  NETGEAR_BOARD_ID := U12H319T50_NETGEAR
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGES += factory.chk
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | netgear-chk
+  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := EX6130
+endef
+TARGET_DEVICES += netgear_ex6130
+
 define Device/netgear_wn3000rp-v3
   MTK_SOC := mt7620a
   IMAGE_SIZE := 7872k


### PR DESCRIPTION
Specifications:
* SoC: MT7620A
* RAM: 64 MB DDR
* Flash: 8MB NOR SPI flash
* WiFi: MT7612E (5Ghz) and builtin MT7620A (2.4GHz)
* LAN: 1x100M

The -factory images can be flashed from the
device's web interface

The device seems to be an EU variant of EX3700/EX3800
and AC1200.

Signed-off-by: Frederik Noe-Sdun <Frederik.Sdun@googlemail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
