### PR TITLE
ccache: update to 3.7.2

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=3.7.1
+PKG_VERSION:=3.7.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=66fc121a2a33968f9ec428e02f48ff4b8896fbabb759e9c09352267014dcbe65
+PKG_HASH:=a5da0008512ff9e882097acaffb3616fae98ec25827167bb4bd1e4acf0b66793
 
 include $(INCLUDE_DIR)/host-build.mk
 

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.c
 +++ b/src/ccache.c
-@@ -2169,6 +2169,7 @@ calculate_object_hash(struct args *args,
+@@ -2189,6 +2189,7 @@ calculate_object_hash(struct args *args,
  			"CPLUS_INCLUDE_PATH",
  			"OBJC_INCLUDE_PATH",
  			"OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Update ccache to 3.7.2

Release notes:
https://ccache.dev/releasenotes.html#_ccache_3_7_2