### PR TITLE
x86: verbose profile titles

### DIFF
--- a/target/linux/x86/64/profiles/000-Generic.mk
+++ b/target/linux/x86/64/profiles/000-Generic.mk
@@ -1,15 +1,15 @@
 #
-# Copyright (C) 2006-2015 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 define Profile/Generic
-  NAME:=Generic
+  NAME:=Generic x86/64
 endef
 
 define Profile/Generic/Description
-	Generic Profile
+	Generic Profile for x86/64 architecture
 endef
 $(eval $(call Profile,Generic))

--- a/target/linux/x86/generic/profiles/000-Generic.mk
+++ b/target/linux/x86/generic/profiles/000-Generic.mk
@@ -1,12 +1,12 @@
 #
-# Copyright (C) 2006-2009 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 define Profile/Generic
-  NAME:=Generic
+  NAME:=Generic x86
   PACKAGES:=kmod-e1000e kmod-igb kmod-bnx2 \
 	kmod-3c59x kmod-e100 kmod-e1000 kmod-natsemi kmod-ne2k-pci \
 	kmod-pcnet32 kmod-8139too kmod-r8169 kmod-sis900 kmod-tg3 \
@@ -14,6 +14,6 @@ define Profile/Generic
 endef
 
 define Profile/Generic/Description
-	Generic Profile
+	Generic Profile for x86 architecture
 endef
 $(eval $(call Profile,Generic))

--- a/target/linux/x86/geode/profiles/000-Generic.mk
+++ b/target/linux/x86/geode/profiles/000-Generic.mk
@@ -1,12 +1,12 @@
 #
-# Copyright (C) 2006-2009 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 define Profile/Generic
-  NAME:=Generic
+  NAME:=Generic x86/Geode
   PACKAGES:= \
 		soloscli linux-atm br2684ctl ppp-mod-pppoa pppdump pppstats \
 		hwclock flashrom tc kmod-pppoa kmod-8139cp kmod-mppe \

--- a/target/linux/x86/geode/profiles/100-Geos.mk
+++ b/target/linux/x86/geode/profiles/100-Geos.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2006-2009 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.

--- a/target/linux/x86/legacy/profiles/000-Generic.mk
+++ b/target/linux/x86/legacy/profiles/000-Generic.mk
@@ -1,18 +1,18 @@
 #
-# Copyright (C) 2006-2009 OpenWrt.org
+# Copyright (C) 2006-2019 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 define Profile/Generic
-  NAME:=Generic
+  NAME:=Generic x86/legacy
   PACKAGES:=kmod-3c59x kmod-e100 kmod-e1000 kmod-natsemi kmod-ne2k-pci \
 	kmod-pcnet32 kmod-8139too kmod-r8169 kmod-sis900 kmod-tg3 \
 	kmod-via-rhine kmod-via-velocity
 endef
 
 define Profile/Generic/Description
-	Generic Profile
+	Generic Profile for x86 legacy architecutre
 endef
 $(eval $(call Profile,Generic))


### PR DESCRIPTION
So far (nearly) all x86 profiles are called "Generic" which makes it
hard to distinguish them in special cases, like searching for a specific
profile (without pre-selecting target/subtarget).

To make this change locally working, remove the tmp/ folder to force
reload of menuconfig.

As these files are infrequently touched, the Copyright was updated as
well.

Signed-off-by: Paul Spooren <mail@aparcar.org>