### PR TITLE
ramips: add kmod-mt7615e to Xiaomi Mi Router 3 Pro images

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mir3p.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir3p.dts
@@ -156,15 +156,16 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -669,7 +669,8 @@ define Device/xiaomi_mir3p
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
   DEVICE_PACKAGES := \
-	kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic uboot-envtools
+	kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic \
+	uboot-envtools
 endef
 TARGET_DEVICES += xiaomi_mir3p
 


### PR DESCRIPTION
Now that the mt76/mt7615e driver is in Openwrt, might as well use it.
