### PR TITLE
package/libs/nettle: Update to 3.5.1

### DIFF
--- a/package/libs/nettle/Makefile
+++ b/package/libs/nettle/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nettle
-PKG_VERSION:=3.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=3.5.1
+PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/nettle
-PKG_HASH:=f941cf1535cd5d1819be5ccae5babef01f6db611f9b5a777bae9c7604b8a92ad
+PKG_HASH:=75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
 
 PKG_LICENSE:=GPL-2.0+
 PKG_LICENSE_FILES:=COPYING
@@ -30,7 +30,7 @@ define Package/libnettle
   TITLE:=GNU crypto library
   URL:=http://www.lysator.liu.se/~nisse/nettle/
   DEPENDS+= +!LIBNETTLE_MINI:libgmp
-  ABI_VERSION:=6
+  ABI_VERSION:=7
 endef
 
 define Package/libnettle/config


### PR DESCRIPTION
Update (lib)nettle to 3.5.1
Bump ABI_VERSION

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>