### PR TITLE
ath79: add support for TP-Link WDR3500 v1

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -83,6 +83,7 @@ ath79_setup_interfaces()
 	tplink,archer-c25-v1|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
+	tplink,tl-wdr3500-v1|\
 	tplink,tl-wr841-v7|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v10|\

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -159,6 +159,7 @@ case "$FIRMWARE" in
 		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 0x2
 		;;
 	ocedo,raccoon|\
+	tplink,tl-wdr3500-v1|\
 	tplink,tl-wdr3600-v1|\
 	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4900-v2|\

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr3500-v1.dts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_tl-wdrxxxx.dtsi"
+
+/ {
+	model = "TP-Link TL-WDR3500 v1";
+	compatible = "tplink,tl-wdr3500-v1", "qca,ar9344";
+};
+
+&leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "usbport";
+		trigger-sources = <&hub_port>;
+	};
+};
+
+&gpio {
+	usb_power {
+		gpio-hog;
+		gpios = <12 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:power:usb";
+	};
+};
+
+&pinmux {
+	pmx_led_wan_lan: pinmux_led_wan_lan {
+		pinctrl-single,bits = <0x10 0x2c2d0000 0xffff0000>,
+			<0x14 0x292a2b 0xffffff>;
+	};
+};
+
+&builtin_switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_led_wan_lan>;
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&ath9k {
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <2>;
+};

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -1,92 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "ar9344_tplink_tl-wdrxxxx.dtsi"
 
-#include "ar9344.dtsi"
-
-/ {
-	aliases {
-		led-boot = &system;
-		led-failsafe = &system;
-		led-running = &system;
-		led-upgrade = &system;
+&leds {
+	usb1 {
+		label = "tp-link:green:usb1";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&hub_port1>;
+		linux,default-trigger = "usbport";
 	};
 
-	leds {
-		compatible = "gpio-leds";
-
-		usb1 {
-			label = "tp-link:green:usb1";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port1>;
-			linux,default-trigger = "usbport";
-		};
-
-		usb2 {
-			label = "tp-link:green:usb2";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port2>;
-			linux,default-trigger = "usbport";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		system: system {
-			label = "tp-link:green:system";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		qss {
-			label = "tp-link:green:qss";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
+	usb2 {
+		label = "tp-link:green:usb2";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&hub_port2>;
+		linux,default-trigger = "usbport";
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wifi {
-			linux,code = <KEY_RFKILL>;
-			linux,input-type = <EV_SW>;
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-};
-
-&ref {
-	clock-frequency = <40000000>;
-};
-
-&uart {
-	status = "okay";
 };
 
 &gpio {
-	status = "okay";
-
 	lna0 {
 		gpio-hog;
 		gpios = <18 GPIO_ACTIVE_HIGH>;
@@ -113,42 +45,6 @@
 		gpios = <21 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "tp-link:power:usb2";
-	};
-};
-
-&spi {
-	num-cs = <1>;
-
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0x7d0000>;
-			};
-
-			art: partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-			};
-		};
 	};
 };
 
@@ -179,23 +75,11 @@
 	status = "okay";
 };
 
-&pcie {
-	status = "okay";
-
-	ath9k: wifi@0,0 {
-		compatible = "pci168c,0033";
-		reg = <0x0000 0 0 0 0>;
-		mtd-mac-address = <&uboot 0x1fc00>;
-		qca,no-eeprom;
-		#gpio-cells = <2>;
-		gpio-controller;
-	};
+&ath9k {
+	mtd-mac-address = <&uboot 0x1fc00>;
 };
 
 &wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -328,6 +328,17 @@ define Device/tplink_re450-v2
 endef
 TARGET_DEVICES += tplink_re450-v2
 
+define Device/tplink_tl-wdr3500-v1
+  $(Device/tplink-8mlzma)
+  ATH_SOC := ar9344
+  DEVICE_MODEL := TL-WDR3500
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x35000001
+  SUPPORTED_DEVICES += tl-wdr3500
+endef
+TARGET_DEVICES += tplink_tl-wdr3500-v1
+
 define Device/tplink_tl-wdr3600-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar9344


### PR DESCRIPTION
~~Patch 1/2 is just a copy of #2284 as it's needed as dependency here.~~

Device testing complete for WDR3500.

Working:
- Power and system LED
- Reset button
- LAN/WAN/switch configuration
- 2.4 GHz interface and LED
- LAN/WAN LEDs are set up correctly
- RF kill
- 5 GHz interface and LED
- USB including LED

(Outdated) forum discussion (in German):
https://forum.freifunk.net/t/ath79-support-for-tp-link-wdr3500/20961/8