### PR TITLE
comgt-ncm: Add driver dependencies again

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -47,7 +47,7 @@ endef
 define Package/comgt-ncm
 $(call Package/comgt/Default)
   TITLE+=NCM 3G/4G Support
-  DEPENDS:=+comgt +wwan
+  DEPENDS:=+comgt +wwan +kmod-usb-serial-option +kmod-usb-net-huawei-cdc-ncm
 endef
 
 define Package/comgt/description


### PR DESCRIPTION
In the commit  "comgt-ncm: Fix NCM protocol" the dependencies to vendor NCM drivers were removed, because

> comgt-ncm should not depend on the USB-serial-related kernel modules, as the cdc-wdm
> control device works without them. There is also no need to depend on
> kmod-huawei-cdc-ncm, since other manufacturers (like Sony-Ericsson
> and Samsung) which use other kernel modules should also be supported.

From a user-perspective this does not make sense as installing comgt-ncm (or luci-proto-ncm) should install all needed dependencies
for using such a device. Furthermore depending on kmod-huawei-cdc-ncm does not mean that Sony-Ericsson and Samsung
devices can't be supported. By the way it seems that Sony-Ericsson and Samsung devices never used NCM, but act as serial modems.
Thus this commit adds the dependencies again.

Signed-off-by: Vincent Wiemann <vincent.wiemann@ironai.com>

If there is any use-case for NCM which has nothing to do with 3G/LTE modems, the dependencies could be added to luci-proto-ncm instead as it is tailored for this purpose.