### PR TITLE
ramips: fix LED labels not updated during device name updates

### DIFF
--- a/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/migrations.sh
+
+board=$(board_name)
+
+case "$board" in
+fon,fonera-20n)
+	migrate_leds "^fonera20n:=fonera-20n:"
+	;;
+intenso,memory2move)
+	migrate_leds "^m2m:=memory2move:"
+	;;
+lenovo,newifi-y1)
+	migrate_leds "^y1:=newifi-y1:"
+	;;
+lenovo,newifi-y1s)
+	migrate_leds "^y1s:=newifi-y1s:"
+	;;
+netgear,wn3000rp-v3)
+	migrate_leds "^wn3000rpv3:=wn3000rp-v3:"
+	;;
+netgear,wndr3700-v5)
+	migrate_leds "^wndr3700v5:=wndr3700-v5:"
+	;;
+tplink,archer-c2-v1)
+	migrate_leds "^c2-v1:=archer-c2-v1:"
+	;;
+tplink,archer-c20-v1)
+	migrate_leds "^c20-v1:=archer-c20-v1:"
+	;;
+tplink,archer-c20-v4)
+	migrate_leds "^c20-v4:=archer-c20-v4:"
+	;;
+tplink,archer-c20i)
+	migrate_leds "^c20i:=archer-c20i:"
+	;;
+tplink,archer-c50-v1)
+	migrate_leds "^c50:=archer-c50-v1:"
+	;;
+tplink,archer-c50-v3)
+	migrate_leds "^c50-v3:=archer-c50-v3:"
+	;;
+tplink,archer-c50-v4)
+	migrate_leds "^c50-v4:=archer-c50-v4:"
+	;;
+tplink,archer-mr200)
+	migrate_leds "^mr200:=archer-mr200:"
+	;;
+youku,yk1)
+	migrate_leds "^youku-yk1:=yk1:"
+	;;
+zyxel,keenetic-omni)
+	migrate_leds "^kn_rc:=keenetic-omni:"
+	;;
+zyxel,keenetic-omni-ii)
+	migrate_leds "^kn_rc:=keenetic-omni-ii:"
+	;;
+zyxel,keenetic-viva)
+	migrate_leds "^kng_rc:=keenetic-viva:"
+	;;
+esac
+
+migrations_apply system
+
+exit 0

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
@@ -17,34 +17,34 @@
 		compatible = "gpio-leds";
 
 		led_power: power {
-			label = "y1:blue:power";
+			label = "newifi-y1:blue:power";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan1 {
-			label = "y1:blue:wifi";
+			label = "newifi-y1:blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2 {
-			label = "y1:blue:wifi5g";
+			label = "newifi-y1:blue:wifi5g";
 			gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "y1:blue:usb";
+			label = "newifi-y1:blue:usb";
 			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		lan {
-			label = "y1:blue:lan";
+			label = "newifi-y1:blue:lan";
 			gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
 		};
 
 		internet {
-			label = "y1:blue:internet";
+			label = "newifi-y1:blue:internet";
 			gpios = <&gpio2 11 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
@@ -38,39 +38,39 @@
 		compatible = "gpio-leds";
 
 		power1 {
-			label = "y1s:yellow:power";
+			label = "newifi-y1s:yellow:power";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power_blue: power2 {
-			label = "y1s:blue:power";
+			label = "newifi-y1s:blue:power";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan1 {
-			label = "y1s:yellow:wifi";
+			label = "newifi-y1s:yellow:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2 {
-			label = "y1s:blue:wifi";
+			label = "newifi-y1s:blue:wifi";
 			gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
 		};
 
 		usb1 {
-			label = "y1s:yellow:usb";
+			label = "newifi-y1s:yellow:usb";
 			gpios = <&gpio2 13 GPIO_ACTIVE_LOW>;
 		};
 
 		usb2 {
-			label = "y1s:blue:usb";
+			label = "newifi-y1s:blue:usb";
 			gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		internet {
-			label = "y1s:blue:internet";
+			label = "newifi-y1s:blue:internet";
 			gpios = <&gpio2 11 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_netgear_wn3000rp-v3.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3000rp-v3.dts
@@ -26,48 +26,48 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_g {
-			label = "wn3000rpv3:green:power";
+			label = "wn3000rp-v3:green:power";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		power_r {
-			label = "wn3000rpv3:red:power";
+			label = "wn3000rp-v3:red:power";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		client_g {
-			label = "wn3000rpv3:green:client";
+			label = "wn3000rp-v3:green:client";
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 
 		client_r {
-			label = "wn3000rpv3:red:client";
+			label = "wn3000rp-v3:red:client";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
 
 		router_g {
-			label = "wn3000rpv3:green:router";
+			label = "wn3000rp-v3:green:router";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		router_r {
-			label = "wn3000rpv3:red:router";
+			label = "wn3000rp-v3:red:router";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "wn3000rpv3:green:wps";
+			label = "wn3000rp-v3:green:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 
 		l_arrow {
-			label = "wn3000rpv3:blue:leftarrow";
+			label = "wn3000rp-v3:blue:leftarrow";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		r_arrow {
-			label = "wn3000rpv3:blue:rightarrow";
+			label = "wn3000rp-v3:blue:rightarrow";
 			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -33,29 +33,29 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c2-v1:green:lan";
+			label = "archer-c2-v1:green:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "c2-v1:green:usb";
+			label = "archer-c2-v1:green:usb";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		led_wps: wps {
-			label = "c2-v1:green:wps";
+			label = "archer-c2-v1:green:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "c2-v1:green:wan";
+			label = "archer-c2-v1:green:wan";
 			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
-			label = "c2-v1:green:wlan";
+			label = "archer-c2-v1:green:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c20-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c20-v1.dts
@@ -24,45 +24,45 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c20-v1:blue:lan";
+			label = "archer-c20-v1:blue:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "c20-v1:blue:power";
+			label = "archer-c20-v1:blue:power";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			default-state = "keep";
 		};
 
 		usb {
-			label = "c20-v1:blue:usb";
+			label = "archer-c20-v1:blue:usb";
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		wan {
-			label = "c20-v1:blue:wan";
+			label = "archer-c20-v1:blue:wan";
 			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 		};
 
 		wan_orange {
-			label = "c20-v1:orange:wan";
+			label = "archer-c20-v1:orange:wan";
 			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 
 		wlan5g {
-			label = "c20-v1:blue:wlan5g";
+			label = "archer-c20-v1:blue:wlan5g";
 			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2g {
-			label = "c20-v1:blue:wlan2g";
+			label = "archer-c20-v1:blue:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c20-v1:blue:wps";
+			label = "archer-c20-v1:blue:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c20i.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c20i.dts
@@ -16,25 +16,25 @@
 	leds {
 		compatible = "gpio-leds";
 		lan {
-			label = "c20i:blue:lan";
+			label = "archer-c20i:blue:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 		usb {
-			label = "c20i:blue:usb";
+			label = "archer-c20i:blue:usb";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 		wps {
-			label = "c20i:blue:wps";
+			label = "archer-c20i:blue:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 		wan {
-			label = "c20i:blue:wan";
+			label = "archer-c20i:blue:wan";
 			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 		};
 		wlan {
-			label = "c20i:blue:wlan";
+			label = "archer-c20i:blue:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c50-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c50-v1.dts
@@ -24,45 +24,45 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c50:green:lan";
+			label = "archer-c50-v1:green:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "c50:green:power";
+			label = "archer-c50-v1:green:power";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		usb {
-			label = "c50:green:usb";
+			label = "archer-c50-v1:green:usb";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		wan {
-			label = "c50:green:wan";
+			label = "archer-c50-v1:green:wan";
 			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_orange {
-			label = "c50:orange:wan";
+			label = "archer-c50-v1:orange:wan";
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan5g {
-			label = "c50:green:wlan5g";
+			label = "archer-c50-v1:green:wlan5g";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2g {
-			label = "c50:green:wlan2g";
+			label = "archer-c50-v1:green:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c50:green:wps";
+			label = "archer-c50-v1:green:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -24,52 +24,52 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "mr200:white:lan";
+			label = "archer-mr200:white:lan";
 			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "mr200:white:wan";
+			label = "archer-mr200:white:wan";
 			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "mr200:white:power";
+			label = "archer-mr200:white:power";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 
 		4g {
-			label = "mr200:white:4g";
+			label = "archer-mr200:white:4g";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "mr200:white:wps";
+			label = "archer-mr200:white:wps";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 
 		signal1 {
-			label = "mr200:white:signal1";
+			label = "archer-mr200:white:signal1";
 			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
 		};
 
 		signal2 {
-			label = "mr200:white:signal2";
+			label = "archer-mr200:white:signal2";
 			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
 		};
 
 		signal3 {
-			label = "mr200:white:signal3";
+			label = "archer-mr200:white:signal3";
 			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
 		};
 
 		signal4 {
-			label = "mr200:white:signal4";
+			label = "archer-mr200:white:signal4";
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
-			label = "mr200:white:wlan";
+			label = "archer-mr200:white:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -19,21 +19,21 @@
 	leds {
 		compatible = "gpio-leds";
 		wan {
-			label = "youku-yk1:blue:wan";
+			label = "yk1:blue:wan";
 			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 		air {
-			label = "youku-yk1:blue:air";
+			label = "yk1:blue:air";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 		usb {
-			label = "youku-yk1:blue:usb";
+			label = "yk1:blue:usb";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 		led_power: power {
-			label = "youku-yk1:blue:power";
+			label = "yk1:blue:power";
 			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -20,29 +20,29 @@
 		compatible = "gpio-leds";
 
 		wan {
-			label = "kng_rc:green:wan";
+			label = "keenetic-viva:green:wan";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "kng_rc:green:usb";
+			label = "keenetic-viva:green:usb";
 			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		power_alert {
-			label = "kng_rc:red:power";
+			label = "keenetic-viva:red:power";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi {
-			label = "kng_rc:green:wifi";
+			label = "keenetic-viva:green:wifi";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power_green: power {
-			label = "kng_rc:green:power";
+			label = "keenetic-viva:green:power";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -20,24 +20,24 @@
 		compatible = "gpio-leds";
 
 		wan {
-			label = "kn_rc:green:wan";
+			label = "keenetic-omni-ii:green:wan";
 			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "kn_rc:green:usb";
+			label = "keenetic-omni-ii:green:usb";
 			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		wifi {
-			label = "kn_rc:green:wifi";
+			label = "keenetic-omni-ii:green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "kn_rc:green:power";
+			label = "keenetic-omni-ii:green:power";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -20,24 +20,24 @@
 		compatible = "gpio-leds";
 
 		wan {
-			label = "kn_rc:green:wan";
+			label = "keenetic-omni:green:wan";
 			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "kn_rc:green:usb";
+			label = "keenetic-omni:green:usb";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		wifi {
-			label = "kn_rc:green:wifi";
+			label = "keenetic-omni:green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "kn_rc:green:power";
+			label = "keenetic-omni:green:power";
 			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_wndr3700-v5.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wndr3700-v5.dts
@@ -12,23 +12,23 @@
 };
 
 &led_power {
-	label = "wndr3700v5:green:power";
+	label = "wndr3700-v5:green:power";
 };
 
 &led_usb {
-	label = "wndr3700v5:green:usb";
+	label = "wndr3700-v5:green:usb";
 };
 
 &led_internet {
-	label = "wndr3700v5:green:wan";
+	label = "wndr3700-v5:green:wan";
 };
 
 &led_wifi {
-	label = "wndr3700v5:green:wifi";
+	label = "wndr3700-v5:green:wifi";
 };
 
 &led_wps {
-	label = "wndr3700v5:green:wps";
+	label = "wndr3700-v5:green:wps";
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -20,37 +20,37 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c20-v4:green:lan";
+			label = "archer-c20-v4:green:lan";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "c20-v4:green:power";
+			label = "archer-c20-v4:green:power";
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "c20-v4:green:wan";
+			label = "archer-c20-v4:green:wan";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_orange {
-			label = "c20-v4:orange:wan";
+			label = "archer-c20-v4:orange:wan";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan5g {
-			label = "c20-v4:green:wlan5g";
+			label = "archer-c20-v4:green:wlan5g";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2g {
-			label = "c20-v4:green:wlan2g";
+			label = "archer-c20-v4:green:wlan2g";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c20-v4:green:wps";
+			label = "archer-c20-v4:green:wps";
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -37,37 +37,37 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "c50-v3:green:lan";
+			label = "archer-c50-v3:green:lan";
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "c50-v3:green:power";
+			label = "archer-c50-v3:green:power";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "c50-v3:green:wan";
+			label = "archer-c50-v3:green:wan";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_orange {
-			label = "c50-v3:orange:wan";
+			label = "archer-c50-v3:orange:wan";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
-			label = "c50-v3:green:wlan2g";
+			label = "archer-c50-v3:green:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan5 {
-			label = "c50-v3:green:wlan5g";
+			label = "archer-c50-v3:green:wlan5g";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c50-v3:green:wps";
+			label = "archer-c50-v3:green:wps";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
@@ -38,37 +38,37 @@
 		compatible = "gpio-leds";
 
 		led_power: power {
-			label = "c50-v4:green:power";
+			label = "archer-c50-v4:green:power";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan2 {
-			label = "c50-v4:green:wlan2g";
+			label = "archer-c50-v4:green:wlan2g";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan5 {
-			label = "c50-v4:green:wlan5g";
+			label = "archer-c50-v4:green:wlan5g";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
 		lan {
-			label = "c50-v4:green:lan";
+			label = "archer-c50-v4:green:lan";
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "c50-v4:green:wan";
+			label = "archer-c50-v4:green:wan";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_orange {
-			label = "c50-v4:orange:wan";
+			label = "archer-c50-v4:orange:wan";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
-			label = "c50-v4:green:wps";
+			label = "archer-c50-v4:green:wps";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
+++ b/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
@@ -57,17 +57,17 @@
 		compatible = "gpio-leds";
 
 		wifi {
-			label = "fonera20n:orange:wifi";
+			label = "fonera-20n:orange:wifi";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "fonera20n:green:power";
+			label = "fonera-20n:green:power";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 		};
 
 		usb {
-			label = "fonera20n:orange:usb";
+			label = "fonera-20n:orange:usb";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&otg_port1>;
 			linux,default-trigger = "usbport";

--- a/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
+++ b/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
@@ -24,12 +24,12 @@
 		compatible = "gpio-leds";
 
 		led_wifi: wifi {
-			label = "m2m:blue:wifi";
+			label = "memory2move:blue:wifi";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "m2m:green:wan";
+			label = "memory2move:green:wan";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};
 	};


### PR DESCRIPTION
In commit d93969a13a5b ("ramips: Improve compatible for TP-Link
Archer devices") and subsequent ones, names of several devices
in ramips have been changed.
Since LED names are frequently invoked by $boardname, this has
broken LED setup in 01_leds, as $boardname and prefix in DTS
do not match anymore.

This patch updates device name prefixes for LEDs in DTS files,
and provides a migration script.

**Question:**
This patch includes many TP-Link devices. Is there something speaking against using "tplink" for those instead of the boardname as in ath79?