### PR TITLE
ath79: add support for D-Link DIR-842 C3

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -64,6 +64,7 @@ comfast,cf-e5)
 	;;
 dlink,dir-842-c1|\
 dlink,dir-842-c2|\
+dlink,dir-842-c3|\
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -120,6 +120,7 @@ ath79_setup_interfaces()
 	dlink,dir-835-a1|\
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
+        dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
@@ -313,6 +314,7 @@ ath79_setup_macs()
 		;;
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
+        dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -107,6 +107,7 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
+        dlink,dir-842-c3|\
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -191,6 +191,7 @@ case "$FIRMWARE" in
 	case $board in
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
+        dlink,dir-842-c3|\
 	nec,wg1200cr)
 		ath10kcal_extract "art" 20480 12064
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c3.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c3.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_dlink_dir-842-c.dtsi"
+
+/ {
+	compatible = "dlink,dir-842-c3", "qca,qca9563";
+	model = "D-Link DIR-842 C3";
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "dir-842-c3:green:wps";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		power: power {
+			label = "dir-842-c3:green:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "dir-842-c3:green:internet";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "dir-842-c3:green:wlan";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -399,6 +399,13 @@ define Device/dlink_dir-842-c2
 endef
 TARGET_DEVICES += dlink_dir-842-c2
 
+define Device/dlink_dir-842-c3
+	$(Device/dlink_dir-842-c)
+	DEVICE_VARIANT := C3
+	DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += dlink_dir-842-c3
+
 define Device/elecom_wrc-1750ghbk2-i
   ATH_SOC := qca9563
   DEVICE_VENDOR := ELECOM


### PR DESCRIPTION
Hardware spec of DIR-842 C3:
SoC: QCA9563
DRAM: 128MB DDR2
Flash: 16MB SPI-NOR
Switch: QCA8337N
WiFi 5.8GHz: QCA9888
WiFi 2.4Ghz: QCA9563
USB: circuit onboard, but components are not soldered

Flash instructions:

1. Upgrade the factory.bin through the factory web interface or
   the u-boot failsafe interface.
   The firmware will boot up correctly for the first time.
   Do not power off the device after OpenWrt has booted.
   Otherwise the u-boot will enter failsafe mode as the checksum
   of the firmware has been changed.
2. Upgrade the sysupgrade.bin in OpenWrt.
   After upgrading completes the u-boot won't complain about the
   firmware checksum and it's OK to use now.
3. If you powered off the device before upgrading the sysupgrade.bin,
   just upgrade the factory.bin through the u-boot failsafe interface
   and then goto step 2.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
