### PR TITLE
x86: make crashdump works

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -266,10 +266,14 @@ config KERNEL_KEXEC
 config KERNEL_PROC_VMCORE
 	bool
 
+config KERNEL_PROC_KCORE
+	bool
+
 config KERNEL_CRASH_DUMP
 	depends on i386 || x86_64 || arm || armeb
 	select KERNEL_KEXEC
 	select KERNEL_PROC_VMCORE
+	select KERNEL_PROC_KCORE
 	bool "Enable support for kexec crashdump"
 	default y
 

--- a/package/boot/kexec-tools/files/kdump.defaults
+++ b/package/boot/kexec-tools/files/kdump.defaults
@@ -1,10 +1,22 @@
 #!/bin/sh
 
+# kB disable if mem low than 256MB
+memtotal=`grep MemTotal /proc/meminfo | awk '{print $2}'`
+if test $memtotal -le 262144; then
+	exit 0
+fi
+KZ=128
+if test $memtotal -ge 8388608; then
+	KZ=512
+elif test $memtotal -ge 4194304; then
+	KZ=256
+fi
+
 case $(uname -m) in
 	i?86|x86_64)
 		if ! grep -q crashkernel /boot/grub/grub.cfg; then
 			mount /boot -o remount,rw
-			sed -i 's/linux.*/& crashkernel=32M@32M/' /boot/grub/grub.cfg
+			sed -i "s/linux.*/& crashkernel=${KZ}M/" /boot/grub/grub.cfg
 			mount /boot -o remount,ro
 		fi
 		;;

--- a/package/boot/kexec-tools/files/kdump.init
+++ b/package/boot/kexec-tools/files/kdump.init
@@ -3,6 +3,8 @@
 START=41
 STOP=90
 
+BOOT_IMAGE=/boot/vmlinuz
+
 EXTRA_COMMANDS="status"
 EXTRA_HELP="        status  Print crashkernel status"
 

--- a/package/boot/kexec-tools/patches/100-kexec-tools-fix-for-Unhandled-rela-relocation-R_X86_64_PLT32-error.patch
+++ b/package/boot/kexec-tools/patches/100-kexec-tools-fix-for-Unhandled-rela-relocation-R_X86_64_PLT32-error.patch
@@ -1,0 +1,14 @@
+diff --git a/kexec/arch/x86_64/kexec-elf-rel-x86_64.c b/kexec/arch/x86_64/kexec-elf-rel-x86_64.c
+index 7fdde73..af33689 100644
+--- a/kexec/arch/x86_64/kexec-elf-rel-x86_64.c
++++ b/kexec/arch/x86_64/kexec-elf-rel-x86_64.c
+@@ -78,7 +78,8 @@ void machine_apply_elf_rel(struct mem_ehdr *UNUSED(ehdr),
+ 		if ((int64_t)value != *(int32_t *)location)
+ 			goto overflow;
+ 		break;
+-	case R_X86_64_PC32: 
++	case R_X86_64_PC32:
++	case R_X86_64_PLT32:
+ 		*(uint32_t *)location = value - address;
+ 		break;
+ 	default:


### PR DESCRIPTION
1. KERNEL_CRASH_DUMP should depends on KERNEL_PROC_KCORE (kexec use it)
2. select crashkernel mem size by totalmem
   mem <= 256M disable crashkernel by default
   mem >= 4G use 256M for crashkernel
   mem >= 8G use 512M for crashkernel
   default use 128M
3. set BOOT_IMAGE in kdump.init
4. resolve a "Unhandled rela relocation: R_X86_64_PLT32" error

Tested on x86_64
