### PR TITLE
[RFC] Use DTS firmware partition to obsolete IMAGE_SIZE

### DIFF
--- a/scripts/get-part-size-dtb.sh
+++ b/scripts/get-part-size-dtb.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+DTB="$1"
+FWPART="$2"
+PARTITION_NODES="$3"
+
+for part_node in $PARTITION_NODES; do
+	for partition in $(fdtget -l $DTB $part_node 2>/dev/null); do
+		name=$(fdtget $DTB $part_node/$partition label 2>/dev/null)
+		[ "$name" = "$FWPART" ] && {
+			size=$(fdtget $DTB $part_node/$partition reg | cut -d ' ' -f2)
+			if [ -n "$size" ]; then
+				echo "$size"
+				exit 0
+			fi
+		}
+	done
+done
+
+echo 0
+echo "WARNING: No $FWPART partition found" >&2
+exit 1

--- a/target/linux/ath79/dts/ar9331_etactica_eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica_eg200.dts
@@ -99,22 +99,26 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot@0 {
+			partition@0 {
+				label = "uboot";
 				reg = <0x0 0x40000>;
 				read-only;
 			};
 
-			uboot-env@40000 {
+			partition@40000 {
+				label = "uboot-env";
 				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			firmware@50000 {
-				compatible = "denx,uimage";
+			partition@50000 {
+				label = "firmware";
 				reg = <0x50000 0xfa0000>;
+				compatible = "denx,uimage";
 			};
 
-			art: art@ff0000 {
+			art: partition@ff0000 {
+				label = "art";
 				reg = <0xff0000 0x10000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -118,22 +118,26 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			uboot@0 {
+			partition@0 {
+				label = "uboot";
 				reg = <0x0 0x40000>;
 				read-only;
 			};
 
-			uboot-env@40000 {
+			partition@40000 {
+				label = "uboot-env";
 				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			firmware@50000 {
+			partition@50000 {
+				label = "firmware";
 				compatible = "denx,uimage";
 				reg = <0x50000 0xfa0000>;
 			};
 
-			art: art@ff0000 {
+			art: partition@ff0000 {
+				label = "art";
 				reg = <0xff0000 0x10000>;
 				read-only;
 			};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
@@ -29,17 +29,20 @@
 };
 
 &mtdparts {
-	uboot: u-boot@0 {
+	uboot: partition@0 {
+		label = "u-boot";
 		reg = <0x000000 0x020000>;
 		read-only;
 	};
 
-	firmware@20000 {
+	partition@20000 {
+		label = "firmware";
 		reg = <0x020000 0xfd0000>;
 		compatible = "tplink,firmware";
 	};
 
-	art: art@ff0000 {
+	art: partition@ff0000 {
+		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
 	};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c5-v1.dts
@@ -28,22 +28,37 @@
 	};
 };
 
-&mtdparts {
-	uboot: partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
-	};
+&spi {
+	status = "okay";
+	num-cs = <1>;
 
-	partition@20000 {
-		label = "firmware";
-		reg = <0x020000 0xfd0000>;
-		compatible = "tplink,firmware";
-	};
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
 
-	art: partition@ff0000 {
-		label = "art";
-		reg = <0xff0000 0x010000>;
-		read-only;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+				compatible = "tplink,firmware";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
@@ -29,17 +29,20 @@
 };
 
 &mtdparts {
-	uboot: u-boot@0 {
+	uboot: partition@0 {
+		label = "u-boot";
 		reg = <0x000000 0x020000>;
 		read-only;
 	};
 
-	firmware@20000 {
-		compatible = "tplink,firmware";
+	partition@20000 {
+		label = "firmware";
 		reg = <0x020000 0x7d0000>;
+		compatible = "tplink,firmware";
 	};
 
-	art: art@7f0000 {
+	art: partition@7f0000 {
+		label = "art";
 		reg = <0x7f0000 0x010000>;
 		read-only;
 	};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v1.dts
@@ -28,22 +28,37 @@
 	};
 };
 
-&mtdparts {
-	uboot: partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
-	};
+&spi {
+	status = "okay";
+	num-cs = <1>;
 
-	partition@20000 {
-		label = "firmware";
-		reg = <0x020000 0x7d0000>;
-		compatible = "tplink,firmware";
-	};
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
 
-	art: partition@7f0000 {
-		label = "art";
-		reg = <0x7f0000 0x010000>;
-		read-only;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+				compatible = "tplink,firmware";
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
@@ -29,17 +29,20 @@
 };
 
 &mtdparts {
-	uboot: u-boot@0 {
+	uboot: partition@0 {
+		label = "u-boot";
 		reg = <0x000000 0x020000>;
 		read-only;
 	};
 
-	firmware@20000 {
+	partition@20000 {
+		label = "firmware";
 		reg = <0x020000 0xfd0000>;
 		compatible = "tplink,firmware";
 	};
 
-	art: art@ff0000 {
+	art: partition@ff0000 {
+		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;
 	};

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7-v2.dts
@@ -28,22 +28,37 @@
 	};
 };
 
-&mtdparts {
-	uboot: partition@0 {
-		label = "u-boot";
-		reg = <0x000000 0x020000>;
-		read-only;
-	};
+&spi {
+	status = "okay";
+	num-cs = <1>;
 
-	partition@20000 {
-		label = "firmware";
-		reg = <0x020000 0xfd0000>;
-		compatible = "tplink,firmware";
-	};
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
 
-	art: partition@ff0000 {
-		label = "art";
-		reg = <0xff0000 0x010000>;
-		read-only;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+				compatible = "tplink,firmware";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
 	};
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c7.dtsi
@@ -124,23 +124,6 @@
 	};
 };
 
-&spi {
-	status = "okay";
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		mtdparts: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-		};
-	};
-};
-
 &mdio0 {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
@@ -17,46 +17,61 @@
 	};
 };
 
-&mtdparts {
-	partition@0 {
-		label = "factory-uboot";
-		reg = <0x000000 0x020000>;
-		read-only;
-	};
+&spi {
+	status = "okay";
+	num-cs = <1>;
 
-	uboot: partition@20000 {
-		label = "u-boot";
-		reg = <0x020000 0x020000>;
-		read-only;
-	};
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
 
-	partition@40000 {
-		label = "firmware";
-		reg = <0x040000 0xec0000>;
-		compatible = "denx,uimage";
-	};
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-	info: partition@f40000 {
-		label = "info";
-		reg = <0xf40000 0x020000>;
-		read-only;
-	};
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
 
-	config: partition@f60000 {
-		label = "config";
-		reg = <0xf60000 0x050000>;
-		read-only;
-	};
+			uboot: partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
 
-	partition@fc0000 {
-		label = "partition-table";
-		reg = <0xfc0000 0x010000>;
-		read-only;
-	};
+			partition@40000 {
+				label = "firmware";
+				reg = <0x040000 0xec0000>;
+				compatible = "denx,uimage";
+			};
 
-	art: partition@ff0000 {
-		label = "art";
-		reg = <0xff0000 0x010000>;
-		read-only;
+			info: partition@f40000 {
+				label = "info";
+				reg = <0xf40000 0x020000>;
+				read-only;
+			};
+
+			config: partition@f60000 {
+				label = "config";
+				reg = <0xf60000 0x050000>;
+				read-only;
+			};
+
+			partition@fc0000 {
+				label = "partition-table";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
 	};
 };

--- a/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-a7-v5.dts
@@ -18,31 +18,31 @@
 };
 
 &mtdparts {
-	factory-uboot@0 {
+	partition@0 {
 		label = "factory-uboot";
 		reg = <0x000000 0x020000>;
 		read-only;
 	};
 
-	uboot: u-boot@20000 {
+	uboot: partition@20000 {
 		label = "u-boot";
 		reg = <0x020000 0x020000>;
 		read-only;
 	};
 
-	firmware@40000 {
+	partition@40000 {
 		label = "firmware";
 		reg = <0x040000 0xec0000>;
 		compatible = "denx,uimage";
 	};
 
-	info: info@f40000 {
+	info: partition@f40000 {
 		label = "info";
 		reg = <0xf40000 0x020000>;
 		read-only;
 	};
 
-	config: config@f60000 {
+	config: partition@f60000 {
 		label = "config";
 		reg = <0xf60000 0x050000>;
 		read-only;
@@ -54,7 +54,7 @@
 		read-only;
 	};
 
-	art: art@ff0000 {
+	art: partition@ff0000 {
 		label = "art";
 		reg = <0xff0000 0x010000>;
 		read-only;

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v5.dts
@@ -17,52 +17,67 @@
 	};
 };
 
-&mtdparts {
-	partition@0 {
-		label = "factory-uboot";
-		reg = <0x000000 0x020000>;
-		read-only;
-	};
+&spi {
+	status = "okay";
+	num-cs = <1>;
 
-	partition@20000 {
-		label = "u-boot";
-		reg = <0x020000 0x020000>;
-		read-only;
-	};
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
 
-	partition@40000 {
-		label = "partition-table";
-		reg = <0x040000 0x010000>;
-		read-only;
-	};
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
-	art: partition@50000 {
-		label = "art";
-		reg = <0x050000 0x010000>;
-		read-only;
-	};
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
 
-	info: partition@60000 {
-		label = "info";
-		reg = <0x060000 0x020000>;
-		read-only;
-	};
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
 
-	partition@80000 {
-		label = "user-config";
-		reg = <0x080000 0x040000>;
-		read-only;
-	};
+			partition@40000 {
+				label = "partition-table";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
 
-	partition@c0000 {
-		label = "firmware";
-		reg = <0x0c0000 0xf00000>;
-		compatible = "denx,uimage";
-	};
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
 
-	partition@ff0000 {
-		label = "default-config";
-		reg = <0xff0000 0x010000>;
-		read-only;
+			info: partition@60000 {
+				label = "info";
+				reg = <0x060000 0x020000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "user-config";
+				reg = <0x080000 0x040000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "firmware";
+				reg = <0x0c0000 0xf00000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@ff0000 {
+				label = "default-config";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
 	};
 };

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -131,23 +131,6 @@
 	};
 };
 
-&spi {
-	status = "okay";
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		mtdparts: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-		};
-	};
-};
-
 &mdio0 {
 	status = "okay";
 

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -5,6 +5,14 @@ KERNEL_LOADADDR = 0x80060000
 
 DEVICE_VARS += IMAGE_SIZE LOADER_FLASH_OFFS LOADER_TYPE ATH_SOC
 
+define Build/check-size-firmware
+	@[ $$(sh $(TOPDIR)/scripts/get-part-size-dtb.sh $(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb \
+		"firmware" "/ahb/spi/flash/partitions /spi/flash/partitions") -ge "$$(stat -c%s $@)" ] || { \
+		echo "WARNING: Image file $@ is too big" >&2; \
+		rm -f $@; \
+	}
+endef
+
 define Build/loader-common
 	rm -rf $@.src
 	$(MAKE) -C lzma-loader \

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -3,7 +3,7 @@ include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR = 0x80060000
 
-DEVICE_VARS += IMAGE_SIZE LOADER_FLASH_OFFS LOADER_TYPE ATH_SOC
+DEVICE_VARS += LOADER_FLASH_OFFS LOADER_TYPE ATH_SOC
 
 define Build/check-size-firmware
 	@[ $$(sh $(TOPDIR)/scripts/get-part-size-dtb.sh $(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb \
@@ -75,7 +75,7 @@ define Device/Default
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size-firmware
 endef
 
 ifeq ($(SUBTARGET),generic)

--- a/target/linux/ath79/image/common-netgear.mk
+++ b/target/linux/ath79/image/common-netgear.mk
@@ -37,6 +37,6 @@ define Device/netgear_ath79
   DEVICE_VENDOR := NETGEAR
   KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
   IMAGES += factory.img
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size-firmware
+  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size-firmware
 endef

--- a/target/linux/ath79/image/common-tp-link.mk
+++ b/target/linux/ath79/image/common-tp-link.mk
@@ -71,38 +71,33 @@ endef
 define Device/tplink-4m
   $(Device/tplink-nolzma)
   TPLINK_FLASHLAYOUT := 4M
-  IMAGE_SIZE := 3904k
 endef
 
 define Device/tplink-4mlzma
   $(Device/tplink)
   TPLINK_FLASHLAYOUT := 4Mlzma
-  IMAGE_SIZE := 3904k
 endef
 
 define Device/tplink-8m
   $(Device/tplink-nolzma)
   TPLINK_FLASHLAYOUT := 8M
-  IMAGE_SIZE := 7936k
 endef
 
 define Device/tplink-8mlzma
   $(Device/tplink)
   TPLINK_FLASHLAYOUT := 8Mlzma
-  IMAGE_SIZE := 7936k
 endef
 
 define Device/tplink-16mlzma
   $(Device/tplink)
   TPLINK_FLASHLAYOUT := 16Mlzma
-  IMAGE_SIZE := 15872k
 endef
 
 define Device/tplink-safeloader
   $(Device/tplink)
   KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header -O
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
-    append-metadata | check-size $$$$(IMAGE_SIZE)
+    append-metadata | check-size-firmware
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
 

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -3,7 +3,6 @@ include ./common-tp-link.mk
 define Device/tplink_archer-a7-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 15104k
   DEVICE_MODEL := Archer A7
   DEVICE_VARIANT := v5
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -16,7 +15,6 @@ TARGET_DEVICES += tplink_archer-a7-v5
 define Device/tplink_archer-c2-v3
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C2
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
@@ -27,7 +25,6 @@ TARGET_DEVICES += tplink_archer-c2-v3
 define Device/tplink_archer-c25-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
-  IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C25
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := ARCHER-C25-V1
@@ -39,7 +36,6 @@ TARGET_DEVICES += tplink_archer-c25-v1
 define Device/tplink_archer-c58-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
-  IMAGE_SIZE := 7936k
   DEVICE_MODEL := Archer C58
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := ARCHER-C58-V1
@@ -51,7 +47,6 @@ TARGET_DEVICES += tplink_archer-c58-v1
 define Device/tplink_archer-c59-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
-  IMAGE_SIZE := 14528k
   DEVICE_MODEL := Archer C59
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := ARCHER-C59-V1
@@ -63,7 +58,6 @@ TARGET_DEVICES += tplink_archer-c59-v1
 define Device/tplink_archer-c60-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
-  IMAGE_SIZE := 7936k
   DEVICE_MODEL := Archer C60
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := ARCHER-C60-V1
@@ -75,7 +69,6 @@ TARGET_DEVICES += tplink_archer-c60-v1
 define Device/tplink_archer-c60-v2
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561
-  IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C60
   DEVICE_VARIANT := v2
   TPLINK_BOARD_ID := ARCHER-C60-V2
@@ -87,7 +80,6 @@ TARGET_DEVICES += tplink_archer-c60-v2
 define Device/tplink_archer-c6-v2
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C6
   DEVICE_VARIANT := v2
   TPLINK_BOARD_ID := ARCHER-C6-V2
@@ -134,7 +126,6 @@ TARGET_DEVICES += tplink_archer-c7-v2
 define Device/tplink_archer-c7-v4
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 15104k
   DEVICE_MODEL := Archer C7
   DEVICE_VARIANT := v4
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -147,7 +138,6 @@ TARGET_DEVICES += tplink_archer-c7-v4
 define Device/tplink_archer-c7-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 15360k
   DEVICE_MODEL := Archer C7
   DEVICE_VARIANT := v5
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -160,7 +150,6 @@ TARGET_DEVICES += tplink_archer-c7-v5
 define Device/tplink_cpe210-v1
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE210
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := rssileds
@@ -172,7 +161,6 @@ TARGET_DEVICES += tplink_cpe210-v1
 define Device/tplink_cpe210-v2
   $(Device/tplink-safeloader)
   ATH_SOC := qca9533
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE210
   DEVICE_VARIANT := v2
   TPLINK_BOARD_ID := CPE210V2
@@ -185,7 +173,6 @@ TARGET_DEVICES += tplink_cpe210-v2
 define Device/tplink_cpe210-v3
   $(Device/tplink-safeloader)
   ATH_SOC := qca9533
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE210
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := rssileds
@@ -198,7 +185,6 @@ TARGET_DEVICES += tplink_cpe210-v3
 define Device/tplink_cpe220-v2
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE220
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := rssileds
@@ -209,7 +195,6 @@ TARGET_DEVICES += tplink_cpe220-v2
 define Device/tplink_cpe510-v1
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE510
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := rssileds
@@ -221,7 +206,6 @@ TARGET_DEVICES += tplink_cpe510-v1
 define Device/tplink_cpe510-v2
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE510
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := rssileds
@@ -233,7 +217,6 @@ TARGET_DEVICES += tplink_cpe510-v2
 define Device/tplink_cpe510-v3
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE510
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := rssileds
@@ -245,7 +228,6 @@ TARGET_DEVICES += tplink_cpe510-v3
 define Device/tplink_cpe610-v1
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344
-  IMAGE_SIZE := 7680k
   DEVICE_MODEL := CPE610
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := CPE610V1
@@ -259,7 +241,6 @@ define Device/tplink_archer-d50-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca988x-ct
   BOARDNAME := ARCHER-D50-V1
-  IMAGE_SIZE := 7808k
   TPLINK_HWID := 0xC1200001
   TPLINK_HWREV := 0x00000046
   TPLINK_FLASHLAYOUT := 8Mqca
@@ -270,7 +251,7 @@ define Device/tplink_archer-d50-v1
         tplink-v2-header -s -V "ver. 1.0"
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := tplink-v2-image -s -V "ver. 2.0" | \
-        append-metadata | check-size $$$$(IMAGE_SIZE)
+        append-metadata | check-size-firmware
   SUPPORTED_DEVICES += archer-d50-v1
 endef
 TARGET_DEVICES += tplink_archer-d50-v1
@@ -278,7 +259,6 @@ TARGET_DEVICES += tplink_archer-d50-v1
 define Device/tplink_re350k-v1
   $(Device/tplink-safeloader)
   ATH_SOC := qca9558
-  IMAGE_SIZE := 13760k
   DEVICE_MODEL := RE350K
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -291,7 +271,6 @@ TARGET_DEVICES += tplink_re350k-v1
 define Device/tplink_rex5x-v1
   $(Device/tplink-safeloader)
   ATH_SOC := qca9558
-  IMAGE_SIZE := 6016k
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   TPLINK_HWID := 0x0
   TPLINK_HWREV := 0
@@ -318,7 +297,6 @@ TARGET_DEVICES += tplink_re450-v1
 define Device/tplink_re450-v2
   $(Device/tplink-safeloader)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 6016k
   DEVICE_MODEL := RE450
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
@@ -459,7 +437,6 @@ TARGET_DEVICES += tplink_tl-wr1043nd-v3
 define Device/tplink_tl-wr1043nd-v4
   $(Device/tplink-safeloader)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 15552k
   DEVICE_MODEL := TL-WR1043N/ND
   DEVICE_VARIANT := v4
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
@@ -472,7 +449,6 @@ TARGET_DEVICES += tplink_tl-wr1043nd-v4
 define Device/tplink_tl-wr1043n-v5
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9563
-  IMAGE_SIZE := 15104k
   DEVICE_MODEL := TL-WR1043N
   DEVICE_VARIANT := v5
   TPLINK_BOARD_ID := TLWR1043NV5
@@ -488,7 +464,7 @@ define Device/tplink_tl-wr2543-v1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x25430001
   IMAGE/sysupgrade.bin := append-rootfs | mktplinkfw sysupgrade -v 3.13.99 | \
-    append-metadata | check-size $$$$(IMAGE_SIZE)
+    append-metadata | check-size-firmware
   IMAGE/factory.bin := append-rootfs | mktplinkfw factory -v 3.13.99
   SUPPORTED_DEVICES += tl-wr2543-v1
 endef

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -36,12 +36,11 @@ endef
 define Device/ubnt
   DEVICE_VENDOR := Ubiquiti
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-  IMAGE_SIZE := 7552k
   UBNT_BOARD := XM
   UBNT_VERSION := 6.0.0
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | mkubntimage-split
+	append-rootfs | pad-rootfs | check-size-firmware | mkubntimage-split
 endef
 
 define Device/ubnt-xm
@@ -128,7 +127,6 @@ define Device/ubnt_lap-120
   DEVICE_MODEL := LiteAP ac
   DEVICE_VARIANT := LAP-120
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15744k
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
 endef
 TARGET_DEVICES += ubnt_lap-120
@@ -137,7 +135,6 @@ define Device/ubnt_nanobeam-ac
   $(Device/ubnt-wa)
   DEVICE_MODEL := NanoBeam AC
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15744k
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
 endef
 TARGET_DEVICES += ubnt_nanobeam-ac
@@ -146,7 +143,6 @@ define Device/ubnt_nanostation-ac
   $(Device/ubnt-wa)
   DEVICE_MODEL := Nanostation AC
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15744k
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
 endef
 TARGET_DEVICES += ubnt_nanostation-ac
@@ -155,7 +151,6 @@ define Device/ubnt_nanostation-ac-loco
   $(Device/ubnt-wa)
   DEVICE_MODEL := Nanostation AC loco
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15744k
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
 endef
 TARGET_DEVICES += ubnt_nanostation-ac-loco
@@ -170,7 +165,6 @@ TARGET_DEVICES += ubnt_unifi
 define Device/ubnt_unifiac
   DEVICE_VENDOR := Ubiquiti
   ATH_SOC := qca9563
-  IMAGE_SIZE := 7744k
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
 
@@ -207,11 +201,10 @@ define Device/ubnt_routerstation_common
   DEVICE_PACKAGES := -kmod-ath9k -wpad-mini -uboot-envtools kmod-usb-ohci kmod-usb2 fconfig
   DEVICE_VENDOR := Ubiquiti
   ATH_SOC := ar7161
-  IMAGE_SIZE := 16128k
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-rootfs | pad-rootfs | mkubntimage | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size $$$$(IMAGE_SIZE)
-#  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
+  IMAGE/factory.bin := append-rootfs | pad-rootfs | mkubntimage | check-size 16128k
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size 16128k
+#  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | check-size 16128k | sysupgrade-tar rootfs=$$$$@ | append-metadata
   KERNEL := kernel-bin | append-dtb | lzma | pad-to $$(BLOCKSIZE)
   KERNEL_INITRAMFS := kernel-bin | append-dtb
 endef
@@ -238,7 +231,6 @@ TARGET_DEVICES += ubnt_routerstation-pro
 define Device/ubnt_acb-isp
   $(Device/ubnt)
   ATH_SOC := qca9533
-  IMAGE_SIZE := 15744k
   DEVICE_MODEL := airCube ISP
   UBNT_BOARD := ACB-ISP
   UBNT_TYPE := ACB

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -23,6 +23,7 @@ endef
 define Build/add-elecom-factory-initramfs
   $(eval edimax_model=$(word 1,$(1)))
   $(eval product=$(word 2,$(1)))
+  $(eval IMAGE_SIZE=$(word 3,$(1)))
 
   $(STAGING_DIR_HOST)/bin/mkedimaximg \
 	-b -s CSYS -m $(edimax_model) \
@@ -81,9 +82,9 @@ define Device/seama
   # - 36 bytes of META data (4-bytes aligned)
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := \
-	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size-firmware
   IMAGE/factory.bin := \
-	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE)
+	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size-firmware
   SEAMA_SIGNATURE :=
 endef
 
@@ -92,7 +93,6 @@ define Device/8dev_carambola2
   DEVICE_VENDOR := 8devices
   DEVICE_MODEL := Carambola2
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += carambola2
 endef
 TARGET_DEVICES += 8dev_carambola2
@@ -103,11 +103,10 @@ define Device/adtran_bsap1880
   DEVICE_PACKAGES += -swconfig -uboot-envtools fconfig
   KERNEL := kernel-bin | append-dtb | lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb
-  IMAGE_SIZE := 11200k
   IMAGES += kernel.bin rootfs.bin
   IMAGE/kernel.bin := append-kernel | pad-to $$$$(BLOCKSIZE)
   IMAGE/rootfs.bin := append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | append-metadata | check-size 11200k
 endef
 
 define Device/adtran_bsap1800-v2
@@ -128,7 +127,6 @@ define Device/alfa-network_ap121f
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AP121F
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 kmod-usb-storage -swconfig
-  IMAGE_SIZE := 16064k
   SUPPORTED_DEVICES += ap121f
 endef
 TARGET_DEVICES += alfa-network_ap121f
@@ -137,7 +135,6 @@ define Device/aruba_ap-105
   ATH_SOC := ar7161
   DEVICE_VENDOR := Aruba
   DEVICE_MODEL := AP-105
-  IMAGE_SIZE := 16000k
   DEVICE_PACKAGES := kmod-i2c-core kmod-i2c-gpio kmod-tpm-i2c-atmel
 endef
 TARGET_DEVICES += aruba_ap-105
@@ -148,10 +145,9 @@ define Device/avm_fritz300e
   DEVICE_MODEL := FRITZ!WLAN Repeater 300E
   KERNEL := kernel-bin | append-dtb | lzma | eva-image
   KERNEL_INITRAMFS := $$(KERNEL)
-  IMAGE_SIZE := 15232k
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
 	append-squashfs-fakeroot-be | pad-to 256 | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size-firmware
   DEVICE_PACKAGES := fritz-tffs rssileds -swconfig
 endef
 TARGET_DEVICES += avm_fritz300e
@@ -160,12 +156,11 @@ define Device/avm_fritz4020
   ATH_SOC := qca9561
   DEVICE_VENDOR := AVM
   DEVICE_MODEL := FRITZ!Box 4020
-  IMAGE_SIZE := 15232k
   KERNEL := kernel-bin | append-dtb | lzma | eva-image
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
       append-squashfs-fakeroot-be | pad-to 256 | \
-      append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+      append-rootfs | pad-rootfs | append-metadata | check-size-firmware
   DEVICE_PACKAGES := fritz-tffs
   SUPPORTED_DEVICES += fritz4020
 endef
@@ -176,9 +171,8 @@ define Device/buffalo_bhr-4grv
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := BHR-4GRV
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
-  IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size 32256k
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | buffalo-tag BHR-4GRV 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
@@ -189,7 +183,6 @@ define Device/buffalo_bhr-4grv2
   ATH_SOC := qca9557
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := BHR-4GRV2
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += buffalo_bhr-4grv2
 
@@ -197,9 +190,8 @@ define Device/buffalo_wzr-hp-ag300h
   ATH_SOC := ar7161
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-HP-AG300H
-  IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size 32256k
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-AG300H 1.99 | buffalo-tag WZR-HP-AG300H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
@@ -213,9 +205,8 @@ define Device/buffalo_wzr-hp-g302h-a1a0
   DEVICE_MODEL := WZR-HP-G302H
   DEVICE_VARIANT := A1A0
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
-  IMAGE_SIZE := 32128k
   IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size 32128k
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G302H 1.99 | buffalo-tag WZR-HP-G302H 4
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g300nh2
@@ -227,9 +218,8 @@ define Device/buffalo_wzr-hp-g450h
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-HP-G450H/WZR-450HP
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
-  IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size 32256k
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | buffalo-tag WZR-HP-G450H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
@@ -242,7 +232,6 @@ define Device/comfast_cf-e110n-v2
   DEVICE_MODEL := CF-E110N
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := rssileds kmod-leds-gpio -swconfig -uboot-envtools
-  IMAGE_SIZE := 16192k
 endef
 TARGET_DEVICES += comfast_cf-e110n-v2
 
@@ -252,7 +241,6 @@ define Device/comfast_cf-e120a-v3
   DEVICE_MODEL := CF-E120A
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := rssileds kmod-leds-gpio -uboot-envtools
-  IMAGE_SIZE := 8000k
 endef
 TARGET_DEVICES += comfast_cf-e120a-v3
 
@@ -262,7 +250,6 @@ define Device/comfast_cf-e314n-v2
   DEVICE_MODEL := CF-E314N
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := rssileds
-  IMAGE_SIZE := 7936k
 endef
 TARGET_DEVICES += comfast_cf-e314n-v2
 
@@ -272,7 +259,6 @@ define Device/comfast_cf-e5
   DEVICE_MODEL := CF-E5/E7
   DEVICE_PACKAGES := rssileds kmod-leds-gpio kmod-usb-core kmod-usb2 kmod-usb-net \
 	kmod-usb-net-qmi-wwan -swconfig -uboot-envtools
-  IMAGE_SIZE := 16192k
 endef
 TARGET_DEVICES += comfast_cf-e5
 
@@ -282,7 +268,6 @@ define Device/comfast_cf-wr650ac-v1
   DEVICE_MODEL := CF-WR650AC
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 16128k
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v1
 
@@ -292,7 +277,6 @@ define Device/comfast_cf-wr650ac-v2
   DEVICE_MODEL := CF-WR650AC
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
@@ -301,7 +285,6 @@ define Device/devolo_dvl1200e
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1200e
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1200e
 
@@ -310,7 +293,6 @@ define Device/devolo_dvl1200i
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1200i
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1200i
 
@@ -319,7 +301,6 @@ define Device/devolo_dvl1750c
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1750c
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1750c
 
@@ -328,7 +309,6 @@ define Device/devolo_dvl1750e
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1750e
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1750e
 
@@ -337,7 +317,6 @@ define Device/devolo_dvl1750i
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1750i
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1750i
 
@@ -346,7 +325,6 @@ define Device/devolo_dvl1750x
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := WiFi pro 1750x
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15936k
 endef
 TARGET_DEVICES += devolo_dvl1750x
 
@@ -355,8 +333,7 @@ define Device/dlink_dir-825-b1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-825
   DEVICE_VARIANT := B1
-  IMAGE_SIZE := 6208k
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += dir-825-b1
 endef
@@ -369,12 +346,11 @@ define Device/dlink_dir-825-c1
   DEVICE_VARIANT := C1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += dir-825-c1
-  IMAGE_SIZE := 15936k
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset 15936k 26 | \
+	append-string 00DB120AR9344-RT-101214-00 | check-size-firmware
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += dlink_dir-825-c1
 
@@ -385,12 +361,11 @@ define Device/dlink_dir-835-a1
   DEVICE_VARIANT := A1
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += dir-835-a1
-  IMAGE_SIZE := 15936k
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset 15936k 26 | \
+	append-string 00DB120AR9344-RT-101214-00 | check-size-firmware
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += dlink_dir-835-a1
 
@@ -400,7 +375,6 @@ define Device/dlink_dir-859-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-859
   DEVICE_VARIANT := A1
-  IMAGE_SIZE := 15872k
   DEVICE_PACKAGES :=  kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
   SEAMA_SIGNATURE := wrgac37_dlink.2013gui_dir859
   SUPPORTED_DEVICES += dir-859-a1
@@ -421,10 +395,9 @@ define Device/dlink_dir-842-c
   # - 36 bytes of META data (4-bytes aligned)
   IMAGE/default := append-kernel | uImage lzma | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := \
-	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size-firmware
   IMAGE/factory.bin := \
-	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE)
-  IMAGE_SIZE := 15680k
+	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size-firmware
 endef
 
 define Device/dlink_dir-842-c1
@@ -452,9 +425,8 @@ define Device/elecom_wrc-1750ghbk2-i
   ATH_SOC := qca9563
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-1750GHBK2-I/C
-  IMAGE_SIZE := 15808k
   KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
-	add-elecom-factory-initramfs RN68 WRC-1750GHBK2
+	add-elecom-factory-initramfs RN68 WRC-1750GHBK2 15808k
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
 TARGET_DEVICES += elecom_wrc-1750ghbk2-i
@@ -463,9 +435,8 @@ define Device/elecom_wrc-300ghbk2-i
   ATH_SOC := qca9563
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-300GHBK2-I
-  IMAGE_SIZE := 7616k
   KERNEL_INITRAMFS := $$(KERNEL) | pad-to 2 | \
-	add-elecom-factory-initramfs RN51 WRC-300GHBK2-I
+	add-elecom-factory-initramfs RN51 WRC-300GHBK2-I 7616k
 endef
 TARGET_DEVICES += elecom_wrc-300ghbk2-i
 
@@ -474,7 +445,6 @@ define Device/embeddedwireless_dorin
   DEVICE_VENDOR := Embedded Wireless
   DEVICE_MODEL := Dorin
   DEVICE_PACKAGES := kmod-usb-chipidea2
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += embeddedwireless_dorin
 
@@ -483,11 +453,10 @@ define Device/engenius_ecb1750
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := ECB1750
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15680k
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     senao-header -r 0x101 -p 0x6d -t 2
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += engenius_ecb1750
 
@@ -496,10 +465,9 @@ define Device/engenius_epg5000
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EPG5000
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct kmod-usb2
-  IMAGE_SIZE := 14656k
   IMAGES += factory.dlf
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size-firmware | \
 	senao-header -r 0x101 -p 0x71 -t 2
   SUPPORTED_DEVICES += epg5000
 endef
@@ -510,7 +478,6 @@ define Device/engenius_ews511ap
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EWS511AP
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += engenius_ews511ap
 
@@ -520,7 +487,6 @@ define Device/etactica_eg200
   DEVICE_MODEL := EG200
   DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-ledtrig-oneshot \
 	kmod-usb-serial kmod-usb-serial-ftdi kmod-usb-storage  kmod-fs-ext4
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += rme-eg200
 endef
 TARGET_DEVICES += etactica_eg200
@@ -530,7 +496,6 @@ define Device/glinet_gl-ar150
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-AR150
   DEVICE_PACKAGES := kmod-usb-chipidea2
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar150
 endef
 TARGET_DEVICES += glinet_gl-ar150
@@ -538,7 +503,6 @@ TARGET_DEVICES += glinet_gl-ar150
 define Device/glinet_gl-ar300m-common-nor
   ATH_SOC := qca9531
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar300m
 endef
 
@@ -561,7 +525,6 @@ define Device/glinet_gl-ar750s
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-AR750S
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct block-mount
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar750s
 endef
 TARGET_DEVICES += glinet_gl-ar750s
@@ -571,7 +534,6 @@ define Device/glinet_gl-x750
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-X750
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += glinet_gl-x750
 
@@ -579,7 +541,6 @@ define Device/iodata_etg3-r
   ATH_SOC := ar9342
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := ETG3-R
-  IMAGE_SIZE := 7680k
   DEVICE_PACKAGES := -iwinfo -kmod-ath9k -wpad-basic
 endef
 TARGET_DEVICES += iodata_etg3-r
@@ -588,10 +549,9 @@ define Device/iodata_wn-ac1167dgr
   ATH_SOC := qca9557
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AC1167DGR
-  IMAGE_SIZE := 14656k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     senao-header -r 0x30a -p 0x61 -t 2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -601,10 +561,9 @@ define Device/iodata_wn-ac1600dgr
   ATH_SOC := qca9557
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AC1600DGR
-  IMAGE_SIZE := 14656k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -614,11 +573,10 @@ define Device/iodata_wn-ac1600dgr2
   ATH_SOC := qca9557
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AC1600DGR2/DGR3
-  IMAGE_SIZE := 14656k
   IMAGES += dgr2-dgr3-factory.bin
   IMAGE/dgr2-dgr3-factory.bin := \
     append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -628,10 +586,9 @@ define Device/iodata_wn-ag300dgr
   ATH_SOC := ar1022
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AG300DGR
-  IMAGE_SIZE := 15424k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     senao-header -r 0x30a -p 0x47 -t 2
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
 endef
@@ -642,11 +599,10 @@ define Device/jjplus_ja76pf2
   DEVICE_VENDOR := jjPlus
   DEVICE_MODEL := JA76PF2
   DEVICE_PACKAGES += -kmod-ath9k -swconfig -wpad-mini -uboot-envtools fconfig
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size $$$$(IMAGE_SIZE)
-#  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size 16000k
+#  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | check-size 16000k | sysupgrade-tar rootfs=$$$$@ | append-metadata
   KERNEL := kernel-bin | append-dtb | lzma | pad-to $$(BLOCKSIZE)
   KERNEL_INITRAMFS := kernel-bin | append-dtb
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
@@ -655,7 +611,6 @@ define Device/librerouter_librerouter-v1
   DEVICE_VENDOR := Librerouter
   DEVICE_MODEL := LibreRouter
   DEVICE_VARIANT := v1
-  IMAGE_SIZE := 7936k
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
@@ -664,17 +619,16 @@ define Device/nec_wg1200cr
   ATH_SOC := qca9563
   DEVICE_VENDOR := NEC
   DEVICE_MODEL := Aterm WG1200CR
-  IMAGE_SIZE := 7616k
   SEAMA_MTDBLOCK := 6
   SEAMA_SIGNATURE := wrgac72_necpf.2016gui_wg1200cr
   IMAGES += factory.bin
   IMAGE/default := \
     append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := \
-    $$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+    $$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size-firmware
   IMAGE/factory.bin := \
     $$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | nec-enc 9gsiy9nzep452pad | \
-    check-size $$$$(IMAGE_SIZE)
+    check-size-firmware
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += nec_wg1200cr
@@ -683,10 +637,9 @@ define Device/nec_wg800hp
   ATH_SOC := qca9563
   DEVICE_VENDOR := NEC
   DEVICE_MODEL := Aterm WG800HP
-  IMAGE_SIZE := 7104k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+    append-rootfs | pad-rootfs | check-size-firmware | \
     xor-image -p 6A57190601121E4C004C1E1201061957 -x | \
     nec-fw LASER_ATERM
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct-htt
@@ -699,8 +652,7 @@ define Device/ocedo_koala
   DEVICE_MODEL := Koala
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   SUPPORTED_DEVICES += koala
-  IMAGE_SIZE := 7424k
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += ocedo_koala
 
@@ -708,8 +660,7 @@ define Device/ocedo_raccoon
   ATH_SOC := ar9344
   DEVICE_VENDOR := Ocedo
   DEVICE_MODEL := Raccoon
-  IMAGE_SIZE := 7424k
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += ocedo_raccoon
 
@@ -718,8 +669,7 @@ define Device/ocedo_ursus
   DEVICE_VENDOR := Ocedo
   DEVICE_MODEL := Ursus
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 7424k
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += ocedo_ursus
 
@@ -729,7 +679,6 @@ define Device/openmesh_om5p-ac-v2
   DEVICE_MODEL := OM5P-AC
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct om-watchdog
-  IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += om5p-acv2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
@@ -738,7 +687,6 @@ define Device/pcs_cap324
   ATH_SOC := ar9344
   DEVICE_VENDOR := PowerCloud Systems
   DEVICE_MODEL := CAP324
-  IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += cap324
 endef
 TARGET_DEVICES += pcs_cap324
@@ -747,7 +695,6 @@ define Device/pcs_cr3000
   ATH_SOC := ar9341
   DEVICE_VENDOR := PowerCloud Systems
   DEVICE_MODEL := CR3000
-  IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += cr3000
 endef
 TARGET_DEVICES += pcs_cr3000
@@ -757,7 +704,6 @@ define Device/pcs_cr5000
   DEVICE_VENDOR := PowerCloud Systems
   DEVICE_MODEL := CR5000
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-core
-  IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += cr5000
 endef
 TARGET_DEVICES += pcs_cr5000
@@ -774,7 +720,6 @@ define Device/netgear_ex7300_ex6400
   NETGEAR_KERNEL_MAGIC := 0x27051956
   NETGEAR_BOARD_ID := EX7300series
   NETGEAR_HW_ID := 29765104+16+0+128
-  IMAGE_SIZE := 15552k
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | netgear-rootfs | pad-rootfs
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca99x0-ct
   $(Device/netgear_ath79)
@@ -798,9 +743,8 @@ define Device/netgear_wndr3700
   DEVICE_VARIANT := v1
   NETGEAR_KERNEL_MAGIC := 0x33373030
   NETGEAR_BOARD_ID := WNDR3700
-  IMAGE_SIZE := 7680k
   IMAGES += factory-NA.img
-  IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size-firmware
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndr3700
@@ -812,7 +756,6 @@ define Device/netgear_wndr3700v2
   NETGEAR_KERNEL_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDR3700v2
   NETGEAR_HW_ID := 29763654+16+64
-  IMAGE_SIZE := 15872k
   SUPPORTED_DEVICES += wndr3700v2
 endef
 TARGET_DEVICES += netgear_wndr3700v2
@@ -821,7 +764,6 @@ define Device/pisen_wmb001n
   ATH_SOC := ar9341
   DEVICE_VENDOR := PISEN
   DEVICE_MODEL := WMB001N
-  IMAGE_SIZE := 14080k
   DEVICE_PACKAGES := kmod-i2c-core kmod-i2c-gpio kmod-usb2
   LOADER_TYPE := bin
   LOADER_FLASH_OFFS := 0x20000
@@ -830,6 +772,8 @@ define Device/pisen_wmb001n
   COMPILE/loader-$(1).uImage := append-loader-okli $(1) | pad-to 64k | lzma | uImage lzma
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
   IMAGES += factory.bin
+  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | append-metadata | check-size 14080k
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pisen_wmb001n-factory $(1)
 endef
 TARGET_DEVICES += pisen_wmb001n
@@ -850,7 +794,6 @@ define Device/netgear_wndr3800
   NETGEAR_KERNEL_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDR3800
   NETGEAR_HW_ID := 29763654+16+128
-  IMAGE_SIZE := 15872k
   SUPPORTED_DEVICES += wndr3800
 endef
 TARGET_DEVICES += netgear_wndr3800
@@ -859,8 +802,7 @@ define Device/phicomm_k2t
   ATH_SOC := qca9563
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := K2T
-  IMAGE_SIZE := 15744k
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size-firmware
   DEVICE_PACKAGES := kmod-leds-reset kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += phicomm_k2t
@@ -871,7 +813,6 @@ define Device/qihoo_c301
   DEVICE_VENDOR := Qihoo
   DEVICE_MODEL := C301
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct uboot-envtools
-  IMAGE_SIZE := 15744k
   SEAMA_SIGNATURE := wrgac26_qihoo360_360rg
   SUPPORTED_DEVICES += qihoo-c301
 endef
@@ -881,7 +822,6 @@ define Device/rosinson_wr818
   ATH_SOC := qca9563
   DEVICE_VENDOR := Rosinson
   DEVICE_MODEL := WR818
-  IMAGE_SIZE := 15872k
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += rosinson_wr818
@@ -893,12 +833,11 @@ define Device/trendnet_tew-823dru
   DEVICE_VARIANT := v1.0R
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
   SUPPORTED_DEVICES += tew-823dru
-  IMAGE_SIZE := 15296k
   IMAGES := factory.bin sysupgrade.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00AP135AR9558-RT-131129-00 | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/default) | pad-offset 15296k 26 | \
+	append-string 00AP135AR9558-RT-131129-00 | check-size-firmware
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size-firmware
 endef
 TARGET_DEVICES += trendnet_tew-823dru
 
@@ -907,7 +846,6 @@ define Device/wd_mynet-n750
   ATH_SOC := ar9344
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := My Net N750
-  IMAGE_SIZE := 15872k
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
   SEAMA_SIGNATURE := wrgnd13_wd_av
   SUPPORTED_DEVICES += mynet-n750
@@ -919,7 +857,6 @@ define Device/wd_mynet-wifi-rangeextender
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := My Net Wi-Fi Range Extender
   DEVICE_PACKAGES := rssileds nvram -swconfig
-  IMAGE_SIZE := 7808k
   ADDPATTERN_ID := mynet-rext
   ADDPATTERN_VERSION := 1.00.01
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | cybertan-trx | \
@@ -932,7 +869,6 @@ define Device/winchannel_wb2000
   ATH_SOC := ar9344
   DEVICE_VENDOR := Winchannel
   DEVICE_MODEL := WB2000
-  IMAGE_SIZE := 15872k
   DEVICE_PACKAGES := kmod-i2c-core kmod-i2c-gpio kmod-rtc-ds1307 kmod-usb2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += winchannel_wb2000
@@ -941,7 +877,6 @@ define Device/xiaomi_mi-router-4q
   ATH_SOC := qca9561
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 4Q
-  IMAGE_SIZE := 14336k
 endef
 TARGET_DEVICES += xiaomi_mi-router-4q
 
@@ -950,7 +885,6 @@ define Device/yuncore_a770
   DEVICE_VENDOR := YunCore
   DEVICE_MODEL := A770
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
-  IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += yuncore_a770
 
@@ -958,7 +892,6 @@ define Device/zbtlink_zbt-wd323
   ATH_SOC := ar9344
   DEVICE_VENDOR := ZBT
   DEVICE_MODEL := WD323
-  IMAGE_SIZE := 16000k
   DEVICE_PACKAGES := kmod-usb2 kmod-i2c-core kmod-i2c-gpio kmod-rtc-pcf8563 \
 		     kmod-usb-serial kmod-usb-serial-cp210x uqmi
 endef

--- a/target/linux/ath79/image/tiny-netgear.mk
+++ b/target/linux/ath79/image/tiny-netgear.mk
@@ -4,7 +4,6 @@ define Device/netgear_ar7240
   ATH_SOC := ar7240
   NETGEAR_KERNEL_MAGIC := 0x32303631
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
-  IMAGE_SIZE := 3904k
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
   $(Device/netgear_ath79)
 endef

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -4,9 +4,8 @@ define Device/buffalo_whr-g301n
   ATH_SOC := ar7240
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-G301N
-  IMAGE_SIZE := 3712k
   IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size-firmware
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | buffalo-tag WHR-G301N 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += whr-g301n
@@ -18,7 +17,6 @@ define Device/pqi_air-pen
   DEVICE_VENDOR := PQI
   DEVICE_MODEL := Air-Pen
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-  IMAGE_SIZE := 7680k
   SUPPORTED_DEVICES += pqi-air-pen
 endef
 TARGET_DEVICES += pqi_air-pen


### PR DESCRIPTION
This is a first attempt to get rid of IMAGE_SIZE by reading firmware partition size from device tree and use it to check size (original proposal by @ynezz).

Currently I need to "apt install device-tree-compiler" on Debian 10 to have access to the `fdtget` function. However, this seems to be just a simple wrapper to access the kernel `fdget` function.

