### PR TITLE
ramips: mt7620: fix build without CONFIG_DEBUG_FS

### DIFF
--- a/target/linux/ramips/patches-4.14/0048-asoc-add-mt7620-support.patch
+++ b/target/linux/ramips/patches-4.14/0048-asoc-add-mt7620-support.patch
@@ -756,7 +756,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	return 0;
 +}
 +
-+static inline void ralink_i2s_debugfs_remove(struct fsl_ssi_dbg *ssi_dbg)
++static inline void ralink_i2s_debugfs_remove(struct ralink_i2s *i2s)
 +{
 +}
 +#endif


### PR DESCRIPTION
Make the signatures of both versions of `ralink_i2s_debugfs_remove` consistent.

When the `CONFIG_KERNEL_DEBUG_FS` setting is enabled, the signature of `ralink_i2s_debugfs_remove` takes a `ralink_i2s*`, which is also what is passed in all instances when the function is called (within the scope of this patch file, at least). Disabling `CONFIG_KERNEL_DEBUG_FS` caused the compilation to fail:

	sound/soc/ralink/ralink-i2s.c: In function 'ralink_i2s_probe':
	sound/soc/ralink/ralink-i2s.c:934:28: error: passing argument 1 of 'ralink_i2s_debugfs_remove' from incompatible pointer type [-Werror=incompatible-pointer-types]
	  ralink_i2s_debugfs_remove(i2s);
	                            ^~~
	sound/soc/ralink/ralink-i2s.c:678:20: note: expected 'struct fsl_ssi_dbg *' but argument is of type 'struct ralink_i2s *'
	 static inline void ralink_i2s_debugfs_remove(struct fsl_ssi_dbg *ssi_dbg)
	                    ^~~~~~~~~~~~~~~~~~~~~~~~~
	(same error in 'ralink_i2s_remove': sound/soc/ralink/ralink-i2s.c:946:28)