### PR TITLE
[RFC] Ninja and meson support

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -1,0 +1,63 @@
+ifneq ($(__meson_mk_inc),1)
+__meson_mk_inc=1
+
+include $(TOPDIR)/include/ninja.mk
+
+CROSS_CONF_FILE=$(PKG_BUILD_DIR)/cross_conf.txt
+HOST_PYTHON3_BIN ?= python3
+HOST_MESON_BIN=$(STAGING_DIR_HOST)/meson/meson.py
+MESON_BUILD_DIR ?= builddir
+
+BINPATH=$(TOPDIR)/staging_dir/host/usr/bin:$(PATH)
+MESON_ENDIAN := $(if $(CONFIG_BIG_ENDIAN),big,little)
+
+define CreateCrossconf
+	echo [binaries] >$(CROSS_CONF_FILE)
+	echo c = \'$(TARGET_CC_NOCACHE)\' >>$(CROSS_CONF_FILE)
+	echo cpp = \'$(TARGET_CXX_NOCACHE)\'>>$(CROSS_CONF_FILE)
+	echo ar = \'$(TARGET_AR)\'>>$(CROSS_CONF_FILE)
+	echo strip = \'$(TARGET_CROSS)strip\' >> $(CROSS_CONF_FILE)
+	echo nm = \'$(TARGET_NM)\' >> $(CROSS_CONF_FILE)
+	echo ld = \'$(TARGET_CROSS)ld\' >> $(CROSS_CONF_FILE)
+	echo pkgconfig = \'$(PKG_CONFIG).real\'>>$(CROSS_CONF_FILE)
+
+	echo [host_machine]>>$(CROSS_CONF_FILE)
+	echo system = \'linux\'>>$(CROSS_CONF_FILE)
+	echo cpu_family = \'$(ARCH)\'>>$(CROSS_CONF_FILE)
+	echo cpu = \'$(CONFIG_TARGET_SUBTARGET)\'>>$(CROSS_CONF_FILE)
+	echo endian = \'$(MESON_ENDIAN)\' >> $(CROSS_CONF_FILE)
+	echo [build_machine]>>$(CROSS_CONF_FILE)
+	echo system = \'linux\'>>$(CROSS_CONF_FILE)
+	echo cpu_family = \'x86_64\'>>$(CROSS_CONF_FILE)
+	echo cpu = \'i686\'>>$(CROSS_CONF_FILE)
+	echo endian = \'little\'>>$(CROSS_CONF_FILE)
+endef
+
+define Build/Meson/Configure
+	$(call CreateCrossconf)
+	[ -d "$(PKG_BUILD_DIR)/$(MESON_BUILD_DIR)" ] || mkdir -p "$(PKG_BUILD_DIR)/$(MESON_BUILD_DIR)"
+	cd $(PKG_BUILD_DIR) && \
+	PATH=$(BINPATH) PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(HOST_PYTHON3_BIN) $(HOST_MESON_BIN) $(MESON_BUILD_DIR) --cross-file $(CROSS_CONF_FILE) $(MESON_ARGS)
+endef
+
+define Build/Meson/Compile
+	$(call Build/Ninja/Compile,$(MESON_BUILD_DIR))
+endef
+
+define Build/Meson/Install
+	$(call Build/Ninja/Install,$(MESON_BUILD_DIR))
+endef
+
+define Build/Configure
+	$(call Build/Meson/Configure)
+endef
+
+define Build/Compile
+	$(call Build/Meson/Compile)
+endef
+
+define Build/Install
+	$(call Build/Meson/Install)
+endef
+
+endif

--- a/include/ninja.mk
+++ b/include/ninja.mk
@@ -1,0 +1,31 @@
+ifneq ($(__ninja_mk_inc),1)
+__ninja_mk_inc=1
+
+HOST_NINJA_DIR:=$(STAGING_DIR_HOST)
+HOST_NINJA_BIN:=$(HOST_NINJA_DIR)/usr/bin/ninja
+
+CMAKE_INSTALL_PREFIX=$(PKG_BUILD_DIR)/ipkg-install/usr
+CMAKE_GENERATOR="Ninja"
+
+define Build/Ninja/Compile
+	cd $(PKG_BUILD_DIR)/$(1) && $(HOST_NINJA_BIN)
+endef
+
+define Build/Ninja/Install
+	DESTDIR=$(PKG_BUILD_DIR)/ipkg-install  $(HOST_NINJA_BIN) install -C $(PKG_BUILD_DIR)/$(strip $(1))
+endef
+
+# Don't overwrite Compile or Install section in
+# case of meson and use one defined in meson.mk
+ifneq ($(__meson_mk_inc),1)
+
+define Build/Compile
+	$(call Build/Ninja/Compile)
+endef
+
+define Build/Install
+	$(call Build/Ninja/Install)
+endef
+endif
+
+endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,6 +27,7 @@ tools-y += sstrip make-ext4fs e2fsprogs mtd-utils mkimage
 tools-y += firmware-utils patch-image quilt padjffs2
 tools-y += mm-macros missing-macros cmake scons bc findutils gengetopt patchelf
 tools-y += mtools dosfstools libressl
+tools-y += ninja meson
 tools-$(CONFIG_TARGET_orion_generic) += wrt350nv2-builder upslug2
 tools-$(CONFIG_TARGET_x86) += qemu
 tools-$(CONFIG_TARGET_mxs) += elftosb sdimage

--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2019 CZ.NIC, z. s. p. o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=meson
+PKG_VERSION:=0.51.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)/
+PKG_HASH:=2f75fdf6d586d3595c03a07afcd0eaae11f68dd33fea5906a434d22a409ed63f
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
+
+include $(INCLUDE_DIR)/host-build.mk
+
+define Host/Compile
+	true
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOST)/meson
+	$(CP) -R $(HOST_BUILD_DIR)/* $(STAGING_DIR_HOST)/meson/
+endef
+
+define Host/Clean
+	$(call Host/Clean/Default)
+	rm -rf $(STAGING_DIR_HOST)/meson
+endef
+
+$(eval $(call HostBuild))

--- a/tools/ninja/Makefile
+++ b/tools/ninja/Makefile
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2019 CZ.NIC z.s.p.o. (https://www.nic.cz/)
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ninja
+PKG_VERSION:=1.9.0
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/ninja-build/ninja/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=5d7ec75828f8d3fd1a0c2f31b5b0cea780cdfe1031359228c428c1a48bfcd5b9
+
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=COPYING
+
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+
+HOST_CONFIGURE_ARGS := --bootstrap
+
+define Host/Compile
+	cd  $(HOST_BUILD_DIR) && python3 configure.py $(HOST_CONFIGURE_ARGS)
+endef
+
+define Host/Install
+	$(INSTALL_DIR) $(STAGING_DIR_HOST)/usr/bin/
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/ninja $(STAGING_DIR_HOST)/usr/bin/
+endef
+
+define Host/Clean
+	$(call Host/Clean/Default)
+	rm -f $(STAGING_DIR_HOST)/usr/bin/ninja
+endef
+
+$(eval $(call HostBuild))


### PR DESCRIPTION
This PR adds support for Ninja and Meson. 

I tried to follow conclusions which raised from different attempts in another PRs.


Right now this approach is used in TurrisOS (OpenWrt fork) for building knot-resolver https://gitlab.labs.nic.cz/turris/turris-os-packages/blob/test/net/knot-resolver/Makefile#L27
After meson and ninja will be in OpenWrt, I would like to push knot-resolver package openwrt/package repository.


Related PR:
Meson support in include/ (closed) - https://github.com/openwrt/openwrt/pull/2147
Enable switch CMAKE_GENERATOR - https://github.com/openwrt/openwrt/pull/1912
Switch to python3 - https://github.com/openwrt/openwrt/pull/1937

I will be glad for any comments. 