### PR TITLE
ramips: Fix lan/wan MAC addresses for cudy,wr1000

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -557,6 +557,9 @@ ramips_setup_macs()
 	glinet,gl-mt300n-v2)
 		wan_mac=$(mtd_get_mac_binary factory 4)
 		;;
+	cudy,wr1000)
+		lan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
+		;;
 	dlink,dch-m225|\
 	samsung,cy-swr1100)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)


### PR DESCRIPTION
The stock firmware for cudy,wr1000 sets LAN MAC address to WAN
MAC address + 1.

In OpenWrt, so far MAC addresses have been set by the default
case, i.e. WAN = eth0 + 1.
This patch fixes MAC address setup, so that it matches the stock
firmware choice.
