### PR TITLE
ramips: fix lan and wan mac addresses for Cudy WR1000

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -505,6 +505,7 @@ ramips_setup_macs()
 	8devices,carambola|\
 	alfa-network,w502u|\
 	arcwireless,freestation5|\
+	cudy,wr1000|\
 	netgear,wnce2001)
 		wan_mac=$(mtd_get_mac_binary factory 46)
 		;;

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -139,6 +139,6 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x2e>;
+	mtd-mac-address = <&factory 0x28>;
 	mediatek,portmap = "llllw";
 };


### PR DESCRIPTION
LAN and WAN addresses are swapped compared to the OEM firmware.
This patch fixes the problem.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>