### PR TITLE
ramips: add support for ADSLR G7

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -31,6 +31,10 @@ ramips_setup_interfaces()
 	local board="$1"
 
 	case $board in
+	adslr,g7)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
+		;;
 	accton,wr6202|\
 	alfa-network,w502u|\
 	netcore,nw718|\

--- a/target/linux/ramips/dts/mt7621_adslr_g7.dts
+++ b/target/linux/ramips/dts/mt7621_adslr_g7.dts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "adslr,g7", "mediatek,mt7621-soc";
+	model = "ADSLR G7";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "g7:blue:sys";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -535,6 +535,15 @@ define Device/totolink_a7000r
 endef
 TARGET_DEVICES += totolink_a7000r
 
+define Device/adslr_g7
+  MTK_SOC := mt7621
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ADSLR
+  DEVICE_MODEL := G7
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+endef
+TARGET_DEVICES += adslr_g7
+
 define Device/tplink-safeloader
   MTK_SOC := mt7621
   DEVICE_VENDOR := TP-Link


### PR DESCRIPTION
SoC: MT7621AT
RAM: 256MB
Flash: 16M SPI
Ethernet: 5x GE ports
WiFi: 2.4G: MT7615N
5G: MT7615N

Flash instruction:
1.Modify the file to linux.bin
2.Set up FTP service
3.Computer settings fixed IP: 192.168.179.50 255.255.255.0
4.Turn on the power and press and hold the reset button until the indicator light is on for about 5 seconds.

More detailed information: https://www.right.com.cn/forum/thread-481788-1-1.html

The machine lights up the LED light normally, the switch is normal, the WIFI is normal, and the upgrade is normal.
