### PR TITLE
x86: use qemu-img from STAGING_DIR_HOST

### DIFF
--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -122,7 +122,7 @@ endef
 ifneq ($(CONFIG_VDI_IMAGES),)
   define Image/Build/vdi
 	rm $(BIN_DIR)/$(IMG_COMBINED)-$(1).vdi || true
-	qemu-img convert -f raw -O vdi \
+	$(STAGING_DIR_HOST)/bin/qemu-img convert -f raw -O vdi \
 		$(BIN_DIR)/$(IMG_COMBINED)-$(1).img \
 		$(BIN_DIR)/$(IMG_COMBINED)-$(1).vdi
   endef
@@ -131,7 +131,7 @@ endif
 ifneq ($(CONFIG_VMDK_IMAGES),)
   define Image/Build/vmdk
 	rm $(BIN_DIR)/$(IMG_COMBINED)-$(1).vmdk || true
-	qemu-img convert -f raw -O vmdk \
+	$(STAGING_DIR_HOST)/bin/qemu-img convert -f raw -O vmdk \
 		$(BIN_DIR)/$(IMG_COMBINED)-$(1).img \
 		$(BIN_DIR)/$(IMG_COMBINED)-$(1).vmdk
   endef


### PR DESCRIPTION
The host tool package qemu is build for the target x86. The installed tool
qemu-img is needed to build vdi or vmdk images. In the image Makefile we
use however the host installed qemu-img command and not the tool from the
buildsystem. This commit force to use the already build qemu-img command
from the openwrt toolchain.
