### PR TITLE
ramips: Further improvements and fixes of MAC address setup

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -215,11 +215,44 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
-	buffalo,whr-1166d|\
-	buffalo,whr-300hp2|\
-	buffalo,whr-600d|\
-	xiaomi,miwifi-mini)
-		# This empty case has to be kept for devices without any MAC address adjustments
+	aigale,ai-br100|\
+	alfa-network,ac1200rm|\
+	asus,rt-ac51u|\
+	asus,rt-n12p|\
+	asus,rt-n14u|\
+	bdcom,wap2100-sk|\
+	dlink,dir-810l|\
+	edimax,ew-7478apc|\
+	fon,fon2601|\
+	head-weblink,hdrm200|\
+	nexx,wt3020-4m|\
+	nexx,wt3020-8m|\
+	phicomm,psg1208|\
+	phicomm,psg1218a|\
+	phicomm,psg1218b|\
+	planex,db-wrt01|\
+	planex,mzk-750dhp|\
+	ralink,mt7620a-evb|\
+	ralink,mt7620a-mt7530-evb|\
+	ralink,mt7620a-mt7610e-evb|\
+	ralink,mt7620a-v22sg-evb|\
+	sanlinking,d240|\
+	tplink,archer-c2-v1|\
+	tplink,archer-c20-v1|\
+	tplink,archer-c20i|\
+	tplink,archer-c50-v1|\
+	tplink,archer-mr200|\
+	vonets,var11n-300|\
+	wrtnode,wrtnode|\
+	youku,yk1|\
+	zbtlink,zbt-ape522ii|\
+	zbtlink,zbt-wa05|\
+	zbtlink,zbt-we2026|\
+	zbtlink,zbt-we826-16m|\
+	zbtlink,zbt-we826-32m|\
+	zbtlink,zbt-we826-e|\
+	zbtlink,zbt-wr8305rt)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	dlink,dch-m225)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
@@ -277,9 +310,6 @@ ramips_setup_macs()
 	zyxel,keenetic-omni-ii|\
 	zyxel,keenetic-viva)
 		wan_mac=$(mtd_get_mac_binary factory 0x28)
-		;;
-	*)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -143,6 +143,35 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
+	adslr,g7|\
+	afoundry,ew1200|\
+	asiarf,ap7621-001|\
+	asiarf,ap7621-nv1|\
+	firefly,firewrt|\
+	gehua,ghl-r-001|\
+	mediatek,ap-mt7621a-v60|\
+	mediatek,mt7621-eval-board|\
+	mikrotik,rb750gr3|\
+	mikrotik,rbm33g|\
+	mqmaker,witi|\
+	mtc,wr1201|\
+	netgear,r6220|\
+	netgear,wndr3700-v5|\
+	netis,wf-2881|\
+	storylink,sap-g3200u3|\
+	telco-electronics,x1|\
+	totolink,a7000r|\
+	ubiquiti,edgerouterx|\
+	ubiquiti,edgerouterx-sfp|\
+	unielec,u7621-06-16m|\
+	unielec,u7621-06-64m|\
+	wevo,11acnas|\
+	wevo,w2914ns-v2|\
+	xiaoyu,xy-c5|\
+	xzwifi,creativebox-v1|\
+	zbtlink,zbt-wg2626)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
+		;;
 	asus,rt-ac57u|\
 	d-team,newifi-d2|\
 	d-team,pbr-m1|\
@@ -167,9 +196,6 @@ ramips_setup_macs()
 		local index="$(find_mtd_index "board_data")"
 		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
 		lan_mac=$wan_mac
-		;;
-	buffalo,wsr-600dhp)
-		# This empty case has to be kept for devices without any MAC address adjustments
 		;;
 	dlink,dir-860l-b1)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
@@ -218,9 +244,6 @@ ramips_setup_macs()
 	zbtlink,zbt-wg3526-32m)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
-		;;
-	*)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	esac
 

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -136,8 +136,30 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
-	glinet,gl-mt300n-v2)
-		# This empty case has to be kept for devices without any MAC address adjustments
+	duzun,dm06|\
+	mediatek,mt7628an-eval-board|\
+	netgear,r6120|\
+	rakwireless,rak633|\
+	tplink,archer-c20-v4|\
+	tplink,archer-c50-v3|\
+	tplink,archer-c50-v4|\
+	tplink,tl-mr3420-v5|\
+	tplink,tl-wr840n-v4|\
+	tplink,tl-wr840n-v5|\
+	tplink,tl-wr841n-v13|\
+	tplink,tl-wr841n-v14|\
+	tplink,tl-wr842n-v5|\
+	unielec,u7628-01-16m|\
+	wavlink,wl-wn570ha1|\
+	wavlink,wl-wn575a3|\
+	wiznet,wizfi630s|\
+	wrtnode,wrtnode2p|\
+	wrtnode,wrtnode2r|\
+	xiaomi,mir4a-100m|\
+	xiaomi,miwifi-nano|\
+	zbtlink,zbt-we1226|\
+	zyxel,keenetic-extra-ii)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	hilink,hlk-7628n)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")
@@ -171,9 +193,6 @@ ramips_setup_macs()
 	vocore,vocore2|\
 	vocore,vocore2-lite)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
-		;;
-	*)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	esac
 

--- a/target/linux/ramips/rt288x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt288x/base-files/etc/board.d/02_network
@@ -42,7 +42,12 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
-	*)
+	airlink101,ar670w|\
+	airlink101,ar725w|\
+	asus,rt-n15|\
+	belkin,f5d8235-v1|\
+	buffalo,wzr-agl300nh|\
+	ralink,v11st-fe)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	esac

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -166,15 +166,67 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
+	7links,px-4885-4m|\
+	7links,px-4885-8m|\
+	accton,wr6202|\
+	airlive,air3gii|\
+	argus,atp-52b|\
+	asiarf,awapn2403|\
+	asiarf,awm002-evb-4m|\
+	asiarf,awm002-evb-8m|\
+	asus,rt-g32-b1|\
+	asus,rt-n10-plus|\
+	asus,rt-n13u|\
+	asus,wl-330n3g|\
+	aztech,hw550-3g|\
+	belkin,f5d8235-v2|\
+	belkin,f7c027|\
+	dlink,dap-1350|\
+	dlink,dir-300-b1|\
+	dlink,dir-600-b1|\
+	dlink,dir-610-a1|\
+	dlink,dir-620-d1|\
+	dlink,dwr-512-b|\
+	edimax,3g-6200n|\
+	edimax,3g-6200nl|\
+	fon,fonera-20n|\
+	huawei,hg255d|\
+	jcg,jhr-n805r|\
+	jcg,jhr-n825r|\
+	jcg,jhr-n926r|\
+	mofinetwork,mofi3500-3gn|\
+	netcore,nw718|\
+	nexx,wt1520-4m|\
+	nexx,wt1520-8m|\
+	nixcore,x1-16m|\
+	nixcore,x1-8m|\
+	olimex,rt5350f-olinuxino|\
+	olimex,rt5350f-olinuxino-evb|\
+	omnima,miniembplug|\
+	omnima,miniembwifi|\
+	planex,mzk-w300nh2|\
+	planex,mzk-wdpr|\
+	poray,ip2202|\
+	prolink,pwh2004|\
+	ralink,v22rw-2x2|\
+	sitecom,wl-351|\
+	teltonika,rut5xx|\
+	trendnet,tew-714tru|\
+	unbranded,wr512-3gn-4m|\
+	unbranded,wr512-3gn-8m|\
+	unbranded,xdx-rn502j|\
+	upvel,ur-326n4g|\
+	upvel,ur-336un|\
+	zyxel,keenetic|\
+	zyxel,nbg-419n|\
+	zyxel,nbg-419n-v2)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
+		;;
 	8devices,carambola|\
 	alfa-network,w502u|\
 	arcwireless,freestation5|\
 	netgear,wnce2001)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
-		;;
-	buffalo,whr-g300n|\
-	zyxel,keenetic-start)
-		# This empty case has to be kept for devices without any MAC address adjustments
 		;;
 	dlink,dir-300-b7|\
 	dlink,dir-320-b1|\
@@ -208,9 +260,6 @@ ramips_setup_macs()
 		;;
 	tenda,w306r-v2)
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 5)
-		;;
-	*)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	esac
 

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -81,9 +81,6 @@ ramips_setup_macs()
 	trendnet,tew-692gr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
-	*)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
-		;;
 	esac
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac


### PR DESCRIPTION
Based on recent device support discussion and fixes on ramips MAC address assignment, this patchset removes the misleading wan_mac default cases and fixes/tidies up several things after that.

Please refer to the individual commit description for further details.