### PR TITLE
ath79: create DTSI for ar9341 TP-Link devices

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -210,6 +210,17 @@ tplink,tl-mr3020-v1|\
 tplink,tl-mr3040-v2)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
+tplink,tl-mr3420-v2|\
+tplink,tl-wr740n-v4|\
+tplink,tl-wr741nd-v4|\
+tplink,tl-wr841-v8|\
+tplink,tl-wr842n-v2)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
+	;;
 tplink,tl-wr740n-v1|\
 tplink,tl-wr740n-v3|\
 tplink,tl-wr741-v1|\
@@ -221,16 +232,6 @@ tplink,tl-wr941-v4)
 	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x04"
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
-	;;
-tplink,tl-wr740n-v4|\
-tplink,tl-wr741nd-v4|\
-tplink,tl-wr841-v8|\
-tplink,tl-wr842n-v2)
-	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
-	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"
-	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x08"
-	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
-	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
 tplink,tl-wr940n-v3|\
 tplink,tl-wr940n-v4|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -247,6 +247,15 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "1:wan"
 		;;
+	tplink,tl-mr3420-v2|\
+	tplink,tl-wr740n-v4|\
+	tplink,tl-wr741nd-v4|\
+	tplink,tl-wr841-v8|\
+	tplink,tl-wr842n-v2)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
+		;;
 	tplink,tl-wr1043nd-v1)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "5@eth0"
@@ -259,14 +268,6 @@ ath79_setup_interfaces()
 	tplink,tl-wr2543-v1)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
-		;;
-	tplink,tl-wr740n-v4|\
-	tplink,tl-wr741nd-v4|\
-	tplink,tl-wr841-v8|\
-	tplink,tl-wr842n-v2)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	tplink,tl-wr941-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"

--- a/target/linux/ath79/dts/ar9341_tplink.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink.dtsi
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart;
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		system: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	model = "TP-Link TL-MR3420 v2";
+	compatible = "tplink,tl-mr3420-v2", "qca,ar9341";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+
+	usb_power {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:power:usb";
+	};
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -1,109 +1,32 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "ar9341.dtsi"
+#include "ar9341_tplink.dtsi"
 
 / {
 	model = "TP-Link TL-MR3420 v2";
 	compatible = "tplink,tl-mr3420-v2", "qca,ar9341";
+};
 
-	aliases {
-		serial0 = &uart;
-		led-boot = &system;
-		led-failsafe = &system;
-		led-running = &system;
-		led-upgrade = &system;
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
-		reset {
-			label = "Reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-
-		rfkill {
-			label = "WiFi";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		system: power {
-			label = "tp-link:green:power";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan {
-			label = "tp-link:green:wlan";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		qss {
-			label = "tp-link:green:qss";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			label = "tp-link:green:wan";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-		};
-
-		lan1 {
-			label = "tp-link:green:lan1";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-		};
-
-		lan2 {
-			label = "tp-link:green:lan2";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-		};
-
-		lan3 {
-			label = "tp-link:green:lan3";
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-		};
-
-		lan4 {
-			label = "tp-link:green:lan4";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-		};
-
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port>;
-			linux,default-trigger = "usbport";
-		};
+&keys {
+	reset {
+		label = "Reset";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		debounce-interval = <60>;
 	};
 };
 
-&ref {
-	clock-frequency = <25000000>;
-};
-
-&uart {
-	status = "okay";
+&leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&hub_port>;
+		linux,default-trigger = "usbport";
+	};
 };
 
 &gpio {
-	status = "okay";
-
 	usb_power {
 		gpio-hog;
 		gpios = <4 GPIO_ACTIVE_HIGH>;
@@ -146,32 +69,6 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-	mtd-mac-address = <&uboot 0x1fc00>;
-	mtd-mac-address-increment = <(-1)>;
-};
-
-&eth1 {
-	status = "okay";
-
-	mtd-mac-address = <&uboot 0x1fc00>;
-
-	gmac-config {
-		device = <&gmac>;
-		switch-phy-swap = <1>;
-	};
-};
-
-&wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&uboot 0x1fc00>;
 };
 
 &usb {

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -1,102 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "ar9341.dtsi"
+#include "ar9341_tplink.dtsi"
 
 / {
 	model = "TP-Link TL-WR841N/ND v8";
 	compatible = "tplink,tl-wr841-v8", "qca,ar9341";
-
-	aliases {
-		serial0 = &uart;
-		led-boot = &system;
-		led-failsafe = &system;
-		led-running = &system;
-		led-upgrade = &system;
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
-		reset {
-			label = "Reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		rfkill {
-			label = "WiFi";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		system: power {
-			label = "tp-link:green:power";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan {
-			label = "tp-link:green:wlan";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		qss {
-			label = "tp-link:green:qss";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			label = "tp-link:green:wan";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-		};
-
-		lan1 {
-			label = "tp-link:green:lan1";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-		};
-
-		lan2 {
-			label = "tp-link:green:lan2";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-		};
-
-		lan3 {
-			label = "tp-link:green:lan3";
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-		};
-
-		lan4 {
-			label = "tp-link:green:lan4";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-		};
-	};
 };
 
-&ref {
-	clock-frequency = <25000000>;
-};
-
-&uart {
-	status = "okay";
-};
-
-&gpio {
-	status = "okay";
+&keys {
+	reset {
+		label = "Reset";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
 };
 
 &spi {
@@ -133,32 +51,4 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-	mtd-mac-address = <&uboot 0x1fc00>;
-	mtd-mac-address-increment = <(-1)>;
-};
-
-&eth1 {
-	status = "okay";
-
-	mtd-mac-address = <&uboot 0x1fc00>;
-
-	pll-data = <0x06000000 0x00000101 0x00001616>;
-
-	gmac-config {
-		device = <&gmac>;
-		switch-phy-swap = <1>;
-	};
-};
-
-&wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&uboot 0x1fc00>;
 };

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -1,97 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "ar9341.dtsi"
+#include "ar9341_tplink.dtsi"
 
 / {
 	model = "TP-Link TL-WR842N/ND v2";
 	compatible = "tplink,tl-wr842n-v2", "qca,ar9341";
-
-	aliases {
-		serial0 = &uart;
-		led-boot = &system;
-		led-failsafe = &system;
-		led-running = &system;
-		led-upgrade = &system;
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <20>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
-		reset {
-			label = "Reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		rfkill {
-			label = "WiFi";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		system: power {
-			label = "tp-link:green:power";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan {
-			label = "tp-link:green:wlan";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		qss {
-			label = "tp-link:green:qss";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			label = "tp-link:green:wan";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-		};
-
-		lan1 {
-			label = "tp-link:green:lan1";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-		};
-
-		lan2 {
-			label = "tp-link:green:lan2";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-		};
-
-		lan3 {
-			label = "tp-link:green:lan3";
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-		};
-
-		lan4 {
-			label = "tp-link:green:lan4";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-		};
-
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port>;
-			linux,default-trigger = "usbport";
-		};
-	};
 
 	gpio-export {
 		compatible = "gpio-export";
@@ -104,16 +18,22 @@
 	};
 };
 
-&ref {
-	clock-frequency = <25000000>;
+&keys {
+	reset {
+		label = "Reset";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
 };
 
-&uart {
-	status = "okay";
-};
-
-&gpio {
-	status = "okay";
+&leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&hub_port>;
+		linux,default-trigger = "usbport";
+	};
 };
 
 &spi {
@@ -167,31 +87,6 @@
 	status = "okay";
 };
 
-&eth0 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-	mtd-mac-address = <&uboot 0x1fc00>;
-	mtd-mac-address-increment = <(-1)>;
-};
-
 &eth1 {
-	status = "okay";
-
 	phy-handle = <&swphy4>;
-	mtd-mac-address = <&uboot 0x1fc00>;
-	phy-mode = "gmii";
-	pll-data = <0x06000000 0x00000101 0x00001616>;
-
-	gmac-config {
-		device = <&gmac>;
-		switch-phy-swap = <1>;
-	};
-};
-
-&wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&uboot 0x1fc00>;
 };

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -55,6 +55,17 @@ define Device/tplink_tl-mr3420-v1
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v1
 
+define Device/tplink_tl-mr3420-v2
+  $(Device/tplink-4mlzma)
+  ATH_SOC := ar9341
+  DEVICE_MODEL := TL-MR3420
+  DEVICE_VARIANT := v2
+  TPLINK_HWID := 0x34200002
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += tl-mr3420-v2
+endef
+TARGET_DEVICES += tplink_tl-mr3420-v2
+
 define Device/tplink_tl-wa901nd-v2
   $(Device/tplink-4m)
   ATH_SOC := ar9132


### PR DESCRIPTION
This patch creates a shared DTSI for the TP-Link devices based
on ar9341 as those share a lot of definitions.
It looks like the DTSI can be used by upcoming device support
patches, too.

While at it, change from gpio-keys-polled to gpio-keys.