### PR TITLE
ath79: add YunCore TFTP image generation helper

### DIFF
--- a/target/linux/ath79/image/common-yuncore.mk
+++ b/target/linux/ath79/image/common-yuncore.mk
@@ -1,0 +1,11 @@
+define Build/yuncore-tftp-header-ap147
+	( \
+		echo -n -e "YUNCOREsetenv bootcmd \"bootm 0x9f050000 || bootm 0x9fe80000\" &&" \
+			"saveenv && erase 0x9f050000 +0xfa0000 && cp.b 0x800600c0 0x9f050000 0xfa0000" | \
+		dd bs=192 count=1 conv=sync; \
+		dd if=$@; \
+	) > $@.new
+	mv $@.new $@
+endef
+
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1,5 +1,6 @@
 include ./common-buffalo.mk
 include ./common-netgear.mk
+include ./common-yuncore.mk
 
 DEVICE_VARS += ADDPATTERN_ID ADDPATTERN_VERSION
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK
@@ -951,6 +952,8 @@ define Device/yuncore_a770
   DEVICE_MODEL := A770
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
   IMAGE_SIZE := 16000k
+  IMAGES += tftp.bin
+  IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-ap147
 endef
 TARGET_DEVICES += yuncore_a770
 


### PR DESCRIPTION
YunCore routers based on the AP147 reference board need a prepended U-Boot command for accepting TFTP images.
This command changes the bootcmd to accept OpenWrt's flash layout and boot at the stock firmware address if this fails
and writes the firmware image to flash afterwards.

Signed-off-by: Vincent Wiemann <vincent.wiemann@ironai.com>
