### PR TITLE
image.mk: remove device_ from manifest filename

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -106,7 +106,7 @@ define add_jffs2_mark
 	echo -ne '\xde\xad\xc0\xde' >> $(1)
 endef
 
-PROFILE_SANITIZED := $(call sanitize,$(PROFILE))
+PROFILE_SANITIZED := $(call sanitize,$(subst DEVICE_,,$(PROFILE)))
 
 define split_args
 $(foreach data, \


### PR DESCRIPTION
While generating per device manifest files using 'make image' I'm
currently getting this weird named manifest files containing the
unrelated string `device_` in it. This should be fixed with this patch

    openwrt-ath79-generic-8dev-carambola2.manifest

instead of

    openwrt-ath79-generic-device_8dev-carambola2.manifest

Signed-off-by: Paul Spooren <mail@aparcar.org>