### PR TITLE
image.mk: keep underscores when sanitize PROFILE

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -106,7 +106,7 @@ define add_jffs2_mark
 	echo -ne '\xde\xad\xc0\xde' >> $(1)
 endef
 
-PROFILE_SANITIZED := $(call sanitize,$(subst DEVICE_,,$(PROFILE)))
+PROFILE_SANITIZED := $(call tolower,$(subst DEVICE_,,$(subst $(space),-,$(PROFILE))))
 
 define split_args
 $(foreach data, \


### PR DESCRIPTION
Underscores don't harm in filenames, however the sanitize function from
version.mk replaces them, causing inconsistent filenames.

A fix tried to solve this previously via
dfe99645dbdd4460f394beaa3a05091cd40b5942 however I did not look close
enough:

    openwrt-ath79-generic-8dev-carambola2.manifest # current
    openwrt-ath79-generic_8dev-carambola2.manifest # patched
    ---------------------^

Eventually the sanitization of PROFILES *could* be removed as more and
more profiles follow the device tree approach of vendor_model, neither
containing upper case letters nor spaces.

Signed-off-by: Paul Spooren <mail@aparcar.org>