### PR TITLE
ath79: add support for TP-Link TL-WR940N v6

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -220,6 +220,9 @@ tplink,tl-wr941nd-v6)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:blue:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:blue:lan4" "switch0" "0x02"
 	;;
+tplink,tl-wr940n-v6)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:blue:wan" "eth1"
+	;;
 trendnet,tew-823dru)
 	ucidef_set_led_netdev "wan" "WAN" "trendnet:green:planet" "eth0"
 	;;

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -90,6 +90,7 @@ ath79_setup_interfaces()
 	tplink,tl-wr842n-v3|\
 	tplink,tl-wr940n-v3|\
 	tplink,tl-wr940n-v4|\
+	tplink,tl-wr940n-v6|\
 	tplink,tl-wr941nd-v6|\
 	ubnt,airrouter)
 		ucidef_set_interface_wan "eth1"

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wr94x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr940n-v6", "qca,tp9343";
+	model = "TP-Link TL-WR940N v6";
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan_blue {
+			label = "tp-link:blue:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		diag_orange {
+			label = "tp-link:orange:diag";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -229,6 +229,20 @@ define Device/tplink_tl-wr940n-v4
 endef
 TARGET_DEVICES += tplink_tl-wr940n-v4
 
+define Device/tplink_tl-wr940n-v6
+  $(Device/tplink-4mlzma)
+  ATH_SOC := tp9343
+  DEVICE_MODEL := TL-WR940N
+  DEVICE_VARIANT := v6
+  TPLINK_HWID := 0x09400006
+  SUPPORTED_DEVICES += tl-wr940n-v6
+  IMAGES += factory-us.bin factory-eu.bin factory-br.bin
+  IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
+  IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+  IMAGE/factory-br.bin := append-rootfs | mktplinkfw factory -C BR
+endef
+TARGET_DEVICES += tplink_tl-wr940n-v6
+
 define Device/tplink_tl-wr941-v2
   $(Device/tplink-4m)
   ATH_SOC := ar9132


### PR DESCRIPTION
The TL-WR940N v6 is similar to v3/v4, it just has different
LEDs and MAC address assignment.

This Pull Request will be opened and closed again immediately.

So, someone looking for the device on OpenWrt might find it.