### PR TITLE
6in4: add rfc1918 check function and add myip he.net api parameter logic

### DIFF
--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -9,6 +9,20 @@
 	init_proto "$@"
 }
 
+# Function taken from 6to4 package (6to4.sh), flipped returns
+test_6in4_rfc1918()
+{
+	local oIFS="$IFS"; IFS="."; set -- $1; IFS="$oIFS"
+	[ $1 -eq  10 ] && return 1
+	[ $1 -eq 192 ] && [ $2 -eq 168 ] && return 1
+	[ $1 -eq 172 ] && [ $2 -ge  16 ] && [ $2 -le  31 ] && return 1
+
+	# RFC 6598
+	[ $1 -eq 100 ] && [ $2 -ge  64 ] && [ $2 -le 127 ] && return 1
+
+	return 0
+}
+
 proto_6in4_update() {
 	sh -c '
 		timeout=5
@@ -97,6 +111,11 @@ proto_6in4_setup() {
 		}
 
 		local url="$http://ipv4.tunnelbroker.net/nic/update?hostname=$tunnelid"
+		
+		test_6in4_rfc1918 "$ipaddr" && {
+			local url="${url}&myip=${ipaddr}"
+		}
+
 		local try=0
 		local max=3
 


### PR DESCRIPTION
6in4: add rfc1918 check function

This is a precursor to adding proper support for multiple
6in4 tunnels with the already programmed tunlink parameter.
This is an essential sanity check so as to not break existing
and working behind NAT setups.

Signed-off-by: Sean Kenny <skenny@wfap.ca>

6in4: add myip he.net api parameter logic

This is to add proper support for multiple 6in4 tunnels
with the already programmed tunlink parameter.
As it stands before this commit, if there is a multi wan setup that
consists of dynamic ips, there is no way to use the
dynamic update feature as the he.net api is implicitly using
the ip address of the caller. This will explicitly use the
ipaddr specified in the interface config OR the ip of the
tunlink interface specified in the dynamic update api call instead
ONLY if the final resolved ipaddr variable is not an rfc1918 address.

Signed-off-by: Sean Kenny <skenny@wfap.ca>