### PR TITLE
[Openwrt-18.06] iptables: patch CVE-2019-11360 (security fix)

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.netfilter.org/iptables

--- a/package/network/utils/iptables/patches/900-fix-cve-2019-11360.patch
+++ b/package/network/utils/iptables/patches/900-fix-cve-2019-11360.patch
@@ -1,0 +1,13 @@
+--- a/iptables/iptables-restore.c
++++ b/iptables/iptables-restore.c
+@@ -121,6 +121,10 @@
+ 	 * longer a real hacker, but I can live with that */
+ 
+ 	for (curchar = parsestart; *curchar; curchar++) {
++		if (param_len >= sizeof(param_buffer))
++			xtables_error(PARAMETER_PROBLEM,
++			"Parameter too long!");
++
+ 		if (quote_open) {
+ 			if (escaped) {
+ 				param_buffer[param_len++] = *curchar;


### PR DESCRIPTION
This PR adds patch for CVE-2019-11360 https://nvd.nist.gov/vuln/detail/CVE-2019-11360

Patch is based on code from https://0day.work/cve-2019-11360-bufferoverflow-in-iptables-restore-v1-8-2/ 

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>
