### PR TITLE
ramips/mt76x8: add DEVICE_VENDOR for tl-wr840n-v5

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -362,6 +362,7 @@ TARGET_DEVICES += tplink_tl-wr840n-v4
 define Device/tplink_tl-wr840n-v5
   MTK_SOC := mt7628an
   IMAGE_SIZE := 3904k
+  DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := TL-WR840N
   DEVICE_VARIANT := v5
   TPLINK_FLASHLAYOUT := 4Mmtk


### PR DESCRIPTION
All other TP-Link versions got this it included, however it is missing
for v4.

Signed-off-by: Paul Spooren <mail@aparcar.org>