### PR TITLE
[RFC]treewide: sanitize all profiles

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -106,7 +106,7 @@ define add_jffs2_mark
 	echo -ne '\xde\xad\xc0\xde' >> $(1)
 endef
 
-PROFILE_SANITIZED := $(call sanitize,$(subst DEVICE_,,$(PROFILE)))
+PROFILE_SANITIZED := $(subst DEVICE_,,$(PROFILE))
 
 define split_args
 $(foreach data, \

--- a/target/linux/ar7/ac49x/profiles/210-None.mk
+++ b/target/linux/ar7/ac49x/profiles/210-None.mk
@@ -5,13 +5,13 @@
 # See /LICENSE for more information.
 #
 
-define Profile/None
+define Profile/none
   NAME:=No WiFi
   PACKAGES:=
 endef
 
-define Profile/None/Description
+define Profile/none/Description
 	Package set without WiFi support
 endef
-$(eval $(call Profile,None))
+$(eval $(call Profile,none))
 

--- a/target/linux/ar7/generic/profiles/100-Annex-A.mk
+++ b/target/linux/ar7/generic/profiles/100-Annex-A.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Annex-A
+define Profile/annex-a
   NAME:=Annex-A DSL firmware (default)
   PACKAGES:=kmod-pppoa ppp-mod-pppoa linux-atm atm-tools br2684ctl \
 	    kmod-sangam-atm-annex-a
 endef
 
-define Profile/Annex-A/Description
+define Profile/annex-a/Description
 	Package set compatible with Annex-A DSL lines (most countries).
 endef
-$(eval $(call Profile,Annex-A))
+$(eval $(call Profile,annex-a))
 

--- a/target/linux/ar7/generic/profiles/110-Annex-B.mk
+++ b/target/linux/ar7/generic/profiles/110-Annex-B.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Annex-B
+define Profile/annex-b
   NAME:=Annex-B DSL firmware
   PACKAGES:=kmod-pppoa ppp-mod-pppoa linux-atm atm-tools br2684ctl \
 	    kmod-sangam-atm-annex-b
 endef
 
-define Profile/Annex-B/Description
+define Profile/annex-b/Description
 	Package set compatible with Annex-B DSL lines (Germany).
 endef
-$(eval $(call Profile,Annex-B))
+$(eval $(call Profile,annex-b))
 

--- a/target/linux/ar7/generic/profiles/200-Texas.mk
+++ b/target/linux/ar7/generic/profiles/200-Texas.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Texas
+define Profile/texas
   NAME:=Texas Instruments WiFi (mac80211)
   PACKAGES:=kmod-acx-mac80211
 endef
 
-define Profile/Texas/Description
+define Profile/texas/Description
 	Package set compatible with hardware using Texas Instruments WiFi cards
 	using the mac80211 driver.
 endef
-$(eval $(call Profile,Texas))
+$(eval $(call Profile,texas))
 

--- a/target/linux/ar7/generic/profiles/210-None.mk
+++ b/target/linux/ar7/generic/profiles/210-None.mk
@@ -5,13 +5,13 @@
 # See /LICENSE for more information.
 #
 
-define Profile/None
+define Profile/none
   NAME:=No WiFi
   PACKAGES:=
 endef
 
-define Profile/None/Description
+define Profile/none/Description
 	Package set without WiFi support
 endef
-$(eval $(call Profile,None))
+$(eval $(call Profile,none))
 

--- a/target/linux/brcm47xx/generic/profiles/100-Broadcom-b43.mk
+++ b/target/linux/brcm47xx/generic/profiles/100-Broadcom-b43.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b43
+define Profile/broadcom-b43
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (b43, default)
   PACKAGES:=kmod-b44 kmod-tg3 kmod-bgmac kmod-b43 kmod-b43legacy
 endef
 
-define Profile/Broadcom-b43/Description
+define Profile/broadcom-b43/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the mac80211, b43 and
 	b43legacy drivers and b44, tg3 or bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-b43))
+$(eval $(call Profile,broadcom-b43))
 

--- a/target/linux/brcm47xx/generic/profiles/101-Broadcom-wl.mk
+++ b/target/linux/brcm47xx/generic/profiles/101-Broadcom-wl.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-wl
+define Profile/broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
   PACKAGES:=-wpad-basic kmod-b44 kmod-tg3 kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
-define Profile/Broadcom-wl/Description
+define Profile/broadcom-wl/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the proprietary Broadcom
 	wireless "wl" driver and b44, tg3 or bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-wl))
+$(eval $(call Profile,broadcom-wl))
 

--- a/target/linux/brcm47xx/generic/profiles/104-Broadcom-ath5k.mk
+++ b/target/linux/brcm47xx/generic/profiles/104-Broadcom-ath5k.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-ath5k
+define Profile/broadcom-ath5k
   NAME:=Broadcom SoC, all Ethernet, Atheros WiFi (ath5k)
   PACKAGES:=kmod-b44 kmod-tg3 kmod-bgmac kmod-ath5k
 endef
 
-define Profile/Broadcom-ath5k/Description
+define Profile/broadcom-ath5k/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC with Atheros Wifi cards using the mac80211 and ath5k drivers and
 	b44, tg3 or bgmac Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-ath5k))
+$(eval $(call Profile,broadcom-ath5k))
 

--- a/target/linux/brcm47xx/generic/profiles/105-Broadcom-none.mk
+++ b/target/linux/brcm47xx/generic/profiles/105-Broadcom-none.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-none
+define Profile/broadcom-none
   NAME:=Broadcom SoC, all Ethernet, No WiFi
   PACKAGES:=-wpad-basic kmod-b44 kmod-tg3 kmod-bgmac
 endef
 
-define Profile/Broadcom-none/Description
+define Profile/broadcom-none/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC without any Wifi cards and b44, tg3 or bgmac Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-none))
+$(eval $(call Profile,broadcom-none))
 

--- a/target/linux/brcm47xx/generic/profiles/200-Broadcom-b44-b43.mk
+++ b/target/linux/brcm47xx/generic/profiles/200-Broadcom-b44-b43.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b44-b43
+define Profile/broadcom-b44-b43
   NAME:=Broadcom SoC, b44 Ethernet, BCM43xx WiFi (b43, default)
   PACKAGES:=kmod-b44 kmod-b43 kmod-b43legacy
 endef
 
-define Profile/Broadcom-b44-b43/Description
+define Profile/broadcom-b44-b43/Description
 	Package set compatible with hardware older Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the mac80211, b43 and
 	b43legacy drivers and b44 Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-b44-b43))
+$(eval $(call Profile,broadcom-b44-b43))
 

--- a/target/linux/brcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
+++ b/target/linux/brcm47xx/generic/profiles/201-Broadcom-b44-wl.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b44-wl
+define Profile/broadcom-b44-wl
   NAME:=Broadcom SoC, b44 Ethernet, BCM43xx WiFi (wl, proprietary)
   PACKAGES:=-wpad-basic kmod-b44 kmod-brcm-wl wlc nas
 endef
 
-define Profile/Broadcom-b44-wl/Description
+define Profile/broadcom-b44-wl/Description
 	Package set compatible with hardware older Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the proprietary Broadcom
 	wireless "wl" driver and b44 Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-b44-wl))
+$(eval $(call Profile,broadcom-b44-wl))
 

--- a/target/linux/brcm47xx/generic/profiles/204-Broadcom-b44-ath5k.mk
+++ b/target/linux/brcm47xx/generic/profiles/204-Broadcom-b44-ath5k.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b44-ath5k
+define Profile/broadcom-b44-ath5k
   NAME:=Broadcom SoC, b44 Ethernet, Atheros WiFi (ath5k)
   PACKAGES:=kmod-b44 kmod-ath5k
 endef
 
-define Profile/Broadcom-b44-ath5k/Description
+define Profile/broadcom-b44-ath5k/Description
 	Package set compatible with hardware older Broadcom BCM47xx or BCM535x
 	SoC with Atheros Wifi cards using the mac80211 and ath5k drivers and
 	b44 Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-b44-ath5k))
+$(eval $(call Profile,broadcom-b44-ath5k))
 

--- a/target/linux/brcm47xx/generic/profiles/205-Broadcom-b44-none.mk
+++ b/target/linux/brcm47xx/generic/profiles/205-Broadcom-b44-none.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b44-none
+define Profile/broadcom-b44-none
   NAME:=Broadcom SoC, b44 Ethernet, No WiFi
   PACKAGES:=-wpad-basic kmod-b44
 endef
 
-define Profile/Broadcom-b44-none/Description
+define Profile/broadcom-b44-none/Description
 	Package set compatible with hardware older Broadcom BCM47xx or BCM535x
 	SoC without any Wifi cards and b44 Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-b44-none))
+$(eval $(call Profile,broadcom-b44-none))
 

--- a/target/linux/brcm47xx/generic/profiles/210-Broadcom-tg3-b43.mk
+++ b/target/linux/brcm47xx/generic/profiles/210-Broadcom-tg3-b43.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-tg3-b43
+define Profile/broadcom-tg3-b43
   NAME:=Broadcom SoC, tg3 Ethernet, BCM43xx WiFi (b43)
   PACKAGES:=kmod-b43 kmod-tg3
 endef
 
-define Profile/Broadcom-tg3-b43/Description
+define Profile/broadcom-tg3-b43/Description
 	Package set compatible with hardware Broadcom BCM4705/BCM4785
 	SoCs with Broadcom BCM43xx Wifi cards using the mac80211 and b43
 	driver and tg3 Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-tg3-b43))
+$(eval $(call Profile,broadcom-tg3-b43))
 

--- a/target/linux/brcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
+++ b/target/linux/brcm47xx/generic/profiles/211-Broadcom-tg3-wl.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-tg3-wl
+define Profile/broadcom-tg3-wl
   NAME:=Broadcom SoC, tg3 Ethernet, BCM43xx WiFi (wl, proprietary)
   PACKAGES:=-wpad-basic kmod-brcm-wl wlc nas kmod-tg3
 endef
 
-define Profile/Broadcom-tg3-wl/Description
+define Profile/broadcom-tg3-wl/Description
 	Package set compatible with hardware Broadcom BCM4705/BCM4785
 	SoC with Broadcom BCM43xx Wifi cards using the proprietary Broadcom
 	wireless "wl" driver and tg3 Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-tg3-wl))
+$(eval $(call Profile,broadcom-tg3-wl))
 

--- a/target/linux/brcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
+++ b/target/linux/brcm47xx/generic/profiles/215-Broadcom-tg3-none.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-tg3-none
+define Profile/broadcom-tg3-none
   NAME:=Broadcom SoC, tg3 Ethernet, no WiFi
   PACKAGES:=-wpad-basic kmod-tg3
 endef
 
-define Profile/Broadcom-tg3-none/Description
+define Profile/broadcom-tg3-none/Description
 	Package set compatible with hardware Broadcom BCM4705/BCM4785
 	SoC without any Wifi cards and tg3 Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-tg3-none))
+$(eval $(call Profile,broadcom-tg3-none))
 

--- a/target/linux/brcm47xx/generic/profiles/220-Broadcom-bgmac-b43.mk
+++ b/target/linux/brcm47xx/generic/profiles/220-Broadcom-bgmac-b43.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-bgmac-b43
+define Profile/broadcom-bgmac-b43
   NAME:=Broadcom SoC, bgmac Ethernet, BCM43xx WiFi (b43)
   PACKAGES:=kmod-bgmac kmod-b43
 endef
 
-define Profile/Broadcom-bgmac-b43/Description
+define Profile/broadcom-bgmac-b43/Description
 	Package set compatible with hardware newer Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the mac80211 and b43
 	drivers and bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-bgmac-b43))
+$(eval $(call Profile,broadcom-bgmac-b43))
 

--- a/target/linux/brcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
+++ b/target/linux/brcm47xx/generic/profiles/221-Broadcom-bgmac-wl.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-bgmac-wl
+define Profile/broadcom-bgmac-wl
   NAME:=Broadcom SoC, bgmac Ethernet, BCM43xx WiFi (wl, proprietary)
   PACKAGES:=-wpad-basic kmod-bgmac kmod-brcm-wl wlc nas
 endef
 
-define Profile/Broadcom-bgmac-wl/Description
+define Profile/broadcom-bgmac-wl/Description
 	Package set compatible with hardware newer Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the proprietary Broadcom
 	wireless "wl" driver and bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-bgmac-wl))
+$(eval $(call Profile,broadcom-bgmac-wl))
 

--- a/target/linux/brcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
+++ b/target/linux/brcm47xx/generic/profiles/225-Broadcom-bgmac-none.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-bgmac-none
+define Profile/broadcom-bgmac-none
   NAME:=Broadcom SoC, bgmac Ethernet, No WiFi
   PACKAGES:=-wpad-basic kmod-bgmac
 endef
 
-define Profile/Broadcom-bgmac-none/Description
+define Profile/broadcom-bgmac-none/Description
 	Package set compatible with hardware newer Broadcom BCM47xx or BCM535x
 	SoC without any Wifi cards and bgmac Ethernet driver.
 endef
-$(eval $(call Profile,Broadcom-bgmac-none))
+$(eval $(call Profile,broadcom-bgmac-none))
 

--- a/target/linux/brcm47xx/generic/profiles/226-Broadcom-bgmac-brcsmac.mk
+++ b/target/linux/brcm47xx/generic/profiles/226-Broadcom-bgmac-brcsmac.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-bgmac-brcmsmac
+define Profile/broadcom-bgmac-brcmsmac
   NAME:=Broadcom SoC, bgmac Ethernet, BCM43xx WiFi (brcmsmac)
   PACKAGES:=kmod-bgmac kmod-brcmsmac
 endef
 
-define Profile/Broadcom-bgmac-brcmsmac/Description
+define Profile/broadcom-bgmac-brcmsmac/Description
 	Package set compatable with newer gigabit + N based bcm47xx SoCs with
 	Broadcom BCM43xx Wifi cards using the mac80211 brcmsmac driver and
 	bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-bgmac-brcmsmac))
+$(eval $(call Profile,broadcom-bgmac-brcmsmac))
 

--- a/target/linux/brcm47xx/generic/profiles/PS-1208MFG.mk
+++ b/target/linux/brcm47xx/generic/profiles/PS-1208MFG.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Ps1208mfg
+define Profile/ps1208mfg
   NAME:=Edimax PS-1208MFG
   PACKAGES:=-firewall -dropbear -dnsmasq -mtd -ppp -wpad-basic kmod-b44 block-mount kmod-usb-storage kmod-usb2 kmod-usb-ohci -iptables -swconfig kmod-fs-ext4
 endef
 
-define Profile/Ps1208mfg/Description
+define Profile/ps1208mfg/Description
 	Package set optimize for edimax PS-1208MFG printserver
 endef
 
-$(eval $(call Profile,Ps1208mfg))
+$(eval $(call Profile,ps1208mfg))
 

--- a/target/linux/brcm47xx/legacy/profiles/100-Broadcom-b43.mk
+++ b/target/linux/brcm47xx/legacy/profiles/100-Broadcom-b43.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-b43
+define Profile/broadcom-b43
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (b43, default)
   PACKAGES:=kmod-b43 kmod-b43legacy
 endef
 
-define Profile/Broadcom-b43/Description
+define Profile/broadcom-b43/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the mac80211, b43 and
 	b43legacy drivers and b44, tg3 or bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-b43))
+$(eval $(call Profile,broadcom-b43))
 

--- a/target/linux/brcm47xx/legacy/profiles/101-Broadcom-wl.mk
+++ b/target/linux/brcm47xx/legacy/profiles/101-Broadcom-wl.mk
@@ -5,16 +5,16 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-wl
+define Profile/broadcom-wl
   NAME:=Broadcom SoC, all Ethernet, BCM43xx WiFi (wl, proprietary)
   PACKAGES:=-wpad-mini kmod-brcm-wl-mini wlc nas
 endef
 
-define Profile/Broadcom-wl/Description
+define Profile/broadcom-wl/Description
 	Package set compatible with hardware any Broadcom BCM47xx or BCM535x
 	SoC with Broadcom BCM43xx Wifi cards using the proprietary Broadcom
 	wireless "wl" driver and b44, tg3 or bgmac Ethernet driver.
 endef
 
-$(eval $(call Profile,Broadcom-wl))
+$(eval $(call Profile,broadcom-wl))
 

--- a/target/linux/brcm47xx/mips74k/profiles/100-Broadcom-b43.mk
+++ b/target/linux/brcm47xx/mips74k/profiles/100-Broadcom-b43.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-mips74k-b43
+define Profile/broadcom-mips74k-b43
   NAME:=Broadcom SoC, BCM43xx WiFi (b43)
   PACKAGES:=kmod-b43
 endef
 
-define Profile/Broadcom-mips74k-b43/Description
+define Profile/broadcom-mips74k-b43/Description
 	Package set for devices with BCM43xx WiFi including mac80211 and b43
 	driver.
 endef
 
-$(eval $(call Profile,Broadcom-mips74k-b43))
+$(eval $(call Profile,broadcom-mips74k-b43))
 

--- a/target/linux/brcm47xx/mips74k/profiles/101-Broadcom-brcsmac.mk
+++ b/target/linux/brcm47xx/mips74k/profiles/101-Broadcom-brcsmac.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-mips74k-brcmsmac
+define Profile/broadcom-mips74k-brcmsmac
   NAME:=Broadcom SoC, BCM43xx WiFi (brcmsmac)
   PACKAGES:=kmod-brcmsmac
 endef
 
-define Profile/Broadcom-mips74k-brcmsmac/Description
+define Profile/broadcom-mips74k-brcmsmac/Description
 	Package set for devices with BCM43xx WiFi including mac80211 and
 	brcmsmac driver.
 endef
 
-$(eval $(call Profile,Broadcom-mips74k-brcmsmac))
+$(eval $(call Profile,broadcom-mips74k-brcmsmac))
 

--- a/target/linux/brcm47xx/mips74k/profiles/102-Broadcom-wl.mk
+++ b/target/linux/brcm47xx/mips74k/profiles/102-Broadcom-wl.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-mips74k-wl
+define Profile/broadcom-mips74k-wl
   NAME:=Broadcom SoC, BCM43xx WiFi (proprietary wl)
   PACKAGES:=-wpad-basic kmod-brcm-wl wlc nas
 endef
 
-define Profile/Broadcom-mips74k-wl/Description
+define Profile/broadcom-mips74k-wl/Description
 	Package set for devices with BCM43xx WiFi including proprietary (and
 	closed source) driver "wl".
 endef
 
-$(eval $(call Profile,Broadcom-mips74k-wl))
+$(eval $(call Profile,broadcom-mips74k-wl))
 

--- a/target/linux/brcm47xx/mips74k/profiles/103-Broadcom-none.mk
+++ b/target/linux/brcm47xx/mips74k/profiles/103-Broadcom-none.mk
@@ -5,14 +5,14 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Broadcom-mips74k-none
+define Profile/broadcom-mips74k-none
   NAME:=Broadcom SoC, No WiFi
   PACKAGES:=-wpad-basic
 endef
 
-define Profile/Broadcom-mips74k-none/Description
+define Profile/broadcom-mips74k-none/Description
 	Package set for devices without a WiFi.
 endef
 
-$(eval $(call Profile,Broadcom-mips74k-none))
+$(eval $(call Profile,broadcom-mips74k-none))
 

--- a/target/linux/brcm63xx/profiles/default.mk
+++ b/target/linux/brcm63xx/profiles/default.mk
@@ -11,7 +11,7 @@ define Profile/Default
   PRIORITY:=1
 endef
 
-define Profile/Default/description
+define Profile/Default/Description
   Package set compatible with most boards.
 endef
 

--- a/target/linux/ixp4xx/generic/profiles/105-Atheros-ath5k.mk
+++ b/target/linux/ixp4xx/generic/profiles/105-Atheros-ath5k.mk
@@ -5,13 +5,13 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Atheros-ath5k
+define Profile/atheros-ath5k
   NAME:=Atheros WiFi (atk5k)
   PACKAGES:=kmod-ath5k
 endef
 
-define Profile/Atheros-ath5k/Description
+define Profile/atheros-ath5k/Description
 	Package set compatible with hardware using Atheros WiFi cards
 endef
-$(eval $(call Profile,Atheros-ath5k))
+$(eval $(call Profile,atheros-ath5k))
 

--- a/target/linux/ixp4xx/generic/profiles/200-NSLU2.mk
+++ b/target/linux/ixp4xx/generic/profiles/200-NSLU2.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/NSLU2
+define Profile/nslu2
   NAME:=Linksys NSLU2
   PACKAGES:=-wpad-basic -kmod-ath5k kmod-scsi-core \
 	kmod-usb-core kmod-usb-ohci-pci kmod-usb2-pci kmod-usb-storage \
 	kmod-fs-ext4
 endef
 
-define Profile/NSLU2/Description
+define Profile/nslu2/Description
 	Package set optimized for the Linksys NSLU2
 endef
-$(eval $(call Profile,NSLU2))
+$(eval $(call Profile,nslu2))
 

--- a/target/linux/ixp4xx/generic/profiles/300-NAS100d.mk
+++ b/target/linux/ixp4xx/generic/profiles/300-NAS100d.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-define Profile/NAS100d
+define Profile/nas100d
   NAME:=Iomega NAS 100d
   PACKAGES:=kmod-ath5k \
 	kmod-scsi-core \
@@ -14,8 +14,8 @@ define Profile/NAS100d
 	kmod-fs-ext4
 endef
 
-define Profile/NAS100d/Description
+define Profile/nas100d/Description
 	Package set optimized for the Iomega NAS 100d
 endef
-$(eval $(call Profile,NAS100d))
+$(eval $(call Profile,nas100d))
 

--- a/target/linux/ixp4xx/generic/profiles/400-DSMG600RevA.mk
+++ b/target/linux/ixp4xx/generic/profiles/400-DSMG600RevA.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-define Profile/DSMG600RevA
+define Profile/dsmg600reva
   NAME:=DSM-G600 Rev A
   PACKAGES:=kmod-via-velocity \
 	kmod-ath5k \
@@ -15,8 +15,8 @@ define Profile/DSMG600RevA
 	kmod-fs-ext4
 endef
 
-define Profile/DSMG600RevA/Description
+define Profile/dsmg600reva/Description
 	Package set optimized for the DSM-G600 Rev A
 endef
-$(eval $(call Profile,DSMG600RevA))
+$(eval $(call Profile,dsmg600reva))
 

--- a/target/linux/ixp4xx/generic/profiles/500-USR8200.mk
+++ b/target/linux/ixp4xx/generic/profiles/500-USR8200.mk
@@ -5,15 +5,15 @@
 # See /LICENSE for more information.
 #
 
-define Profile/USR8200
+define Profile/usr8200
   NAME:=USRobotics USR8200
   PACKAGES:=-wpad-basic kmod-scsi-core \
 	kmod-usb-core kmod-usb-uhci kmod-usb2-pci kmod-usb-storage \
 	kmod-fs-ext4 kmod-firewire kmod-firewire-ohci kmod-firewire-sbp2
 endef
 
-define Profile/USR8200/Description
+define Profile/usr8200/Description
 	Package set optimized for the USRobotics USR8200
 endef
-$(eval $(call Profile,USR8200))
+$(eval $(call Profile,usr8200))
 

--- a/target/linux/ixp4xx/harddisk/profiles/100-FSG3.mk
+++ b/target/linux/ixp4xx/harddisk/profiles/100-FSG3.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-define Profile/FSG3
+define Profile/fsg3
   NAME:=Freecom FSG-3
   PACKAGES:= \
 	kmod-ath5k \
@@ -13,8 +13,8 @@ define Profile/FSG3
 	kmod-fs-ext4 kmod-fs-reiserfs
 endef
 
-define Profile/FSG3/Description
+define Profile/fsg3/Description
 	Package set optimized for the Freecom FSG-3
 endef
-$(eval $(call Profile,FSG3))
+$(eval $(call Profile,fsg3))
 

--- a/target/linux/x86/geode/profiles/100-Geos.mk
+++ b/target/linux/x86/geode/profiles/100-Geos.mk
@@ -5,7 +5,7 @@
 # See /LICENSE for more information.
 #
 
-define Profile/Geos
+define Profile/geos
   NAME:=Geos
   PACKAGES:= \
 		soloscli linux-atm br2684ctl ppp-mod-pppoa pppdump pppstats \
@@ -13,7 +13,7 @@ define Profile/Geos
 		kmod-usb-ohci-pci kmod-hwmon-lm90
 endef
 
-define Profile/Geos/Description
+define Profile/geos/Description
 	Traverse Technologies Geos ADSL router
 endef
-$(eval $(call Profile,Geos))
+$(eval $(call Profile,geos))


### PR DESCRIPTION
All profiles should be lowercase and free of white spaces, instead of
doing so within image.mk, have them already well formatted.

Signed-off-by: Paul Spooren <mail@aparcar.org>