### PR TITLE
ramips: wevo: set uImage name and status led

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -728,6 +728,7 @@ TARGET_DEVICES += unielec_u7621-06-64m
 define Device/wevo_11acnas
   MTK_SOC := mt7621
   IMAGE_SIZE := 16064k
+  UIMAGE_NAME := 11AC-NAS-Router(0.0.0)
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := 11AC NAS Router
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
@@ -738,6 +739,7 @@ TARGET_DEVICES += wevo_11acnas
 define Device/wevo_w2914ns-v2
   MTK_SOC := mt7621
   IMAGE_SIZE := 16064k
+  UIMAGE_NAME := W2914NS-V2(0.0.0)
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := W2914NS
   DEVICE_VARIANT := v2


### PR DESCRIPTION
~~- set uImage name similar to that of stock FW, so that the stock bootloader will not complain.~~
~~- remove WAN port index.~~
~~- load WAN MAC address directly from the flash.~~
~~- provide label MAC address.~~
~~- use USB LED for boot/failsafe/upgrade status indication.~~
~~- replace gpio-keys-polled with gpio-keys.~~
~~- increase flash's SPI frequency to 80MHz.~~
~~- add mt76 led nodes to make WiFi LEDs work.~~
~~- drop unnecessary pinmux groups.~~

The stock firmware and bootloader only accept uImage with names that match
certain patterns. This patch enables OpenWrt installation from stock
firmware without having to reflash the bootloader or access the UART
console.

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

And also make use of the USB LED for boot/failsafe/upgrade status
indication. After boot it returns to its original role.
