### PR TITLE
[RFC][RFT] ramips: fix incorrect regs in RT5350 dtsi

### DIFF
--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -33,7 +33,7 @@
 	palmbus: palmbus@10000000 {
 		compatible = "palmbus";
 		reg = <0x10000000 0x200000>;
-		ranges = <0x0 0x10000000 0x1FFFFF>;
+		ranges = <0x0 0x10000000 0x200000>;
 
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -59,14 +59,14 @@
 			reset-names = "wdt";
 
 			interrupt-parent = <&intc>;
-			interrupts = <1>;
+			interrupts = <2>;
 		};
 
 		intc: intc@200 {
 			compatible = "ralink,rt5350-intc", "ralink,rt2880-intc";
 			reg = <0x200 0x100>;
 
-			resets = <&rstctrl 19>;
+			resets = <&rstctrl 9>;
 			reset-names = "intc";
 
 			interrupt-controller;
@@ -80,7 +80,7 @@
 			compatible = "ralink,rt5350-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
 
-			resets = <&rstctrl 20>;
+			resets = <&rstctrl 10>;
 			reset-names = "mc";
 
 			interrupt-parent = <&intc>;
@@ -364,6 +364,9 @@
 	wmac: wmac@10180000 {
 		compatible = "ralink,rt5350-wmac", "ralink,rt2880-wmac";
 		reg = <0x10180000 0x40000>;
+
+		resets = <&rstctrl 20>;
+		reset-names = "wmac";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;


### PR DESCRIPTION
Some regs, reset numbers, and interrupt numbers in RT5350 SoC dtsi
do not match with the specification in datasheet. This patch fixes them.

Ref: http://cdn.sparkfun.com/datasheets/Wireless/WiFi/RT5350.pdf

I have no clue how to test this.
My RT5350F-OLinuXino seems to work fine with this, but I'm still not sure.
Any reviews would be highly appreciated.
