### PR TITLE
mvebu: fix Linksys WRT LAN/WAN MAC addresses

### DIFF
--- a/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
+++ b/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
@@ -21,8 +21,8 @@ preinit_set_mac_address() {
 
 		mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		mac_wan=$(macaddr_setbit_la "$mac")
-		ip link set dev eth1 address $mac 2>/dev/null
-		ip link set dev eth0 address $mac_wan 2>/dev/null
+		ip link set dev eth0 address $mac 2>/dev/null
+		ip link set dev eth1 address $mac_wan 2>/dev/null
 		;;
 	linksys,mamba)
 		mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)


### PR DESCRIPTION
According to 02_network, eth0.1 is LAN and eth1.2 is WAN,
but $mac_wan was assigned incorrectly to eth0 in preinit.

Swap eth0 and eth1 to fix this.