### PR TITLE
[19.07]imagebuilder: fix `make info` for empty SUPPORTED_DEVICES

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -76,7 +76,8 @@ USER_PROFILE ?= $(firstword $(PROFILE_NAMES))
 PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 	echo '$(patsubst DEVICE_%,%,$(p)):'; $(if $($(p)_NAME),echo '    $(subst ','"'"',$($(p)_NAME))'; ) \
 	echo '    Packages: $($(p)_PACKAGES)'; echo '    hasImageMetadata: $($(p)_HAS_IMAGE_METADATA)'; \
-	[ "$($(p)_SUPPORTED_DEVICES)" ] && echo '    SupportedDevices: $($(p)_SUPPORTED_DEVICES)'; )
+	$(if $($(p)_SUPPORTED_DEVICES),echo '    SupportedDevices: $($(p)_SUPPORTED_DEVICES)';) )
+
 
 .profiles.mk: .targetinfo
 	@$(SCRIPT_DIR)/target-metadata.pl profile_mk $< '$(BOARD)$(if $(SUBTARGET),/$(SUBTARGET))' > $@


### PR DESCRIPTION
For x86/64 (maybe more) target the SUPPORTED_DEVICES variable is empty
which causes the `&&` junction to fail, producing a non zero exit code.

Tested-by: Paul Spooren <mail@aparcar.org>
Fixed-by: Jo-Philipp Wich <jo@mein.io>
Signed-off-by: Paul Spooren <mail@aparcar.org>