### PR TITLE
Fix error: after USB modem repluged it does not connect until reboot device or restart network.

### DIFF
--- a/package/network/utils/comgt/files/3g.usb
+++ b/package/network/utils/comgt/files/3g.usb
@@ -14,12 +14,12 @@ find_3g_iface() {
 	local dev=$(uci_get network "$cfg" device)
 
 	if [ "${dev##*/}" = "${tty##*/}" ]; then
-		if [ "$ACTION" = add ]; then
-			available=1
+		if [ "$ACTION" = remove ]; then
+			proto_set_available "$cfg" 0
 		else
-			available=0
+			# add, bind...
+			proto_set_available "$cfg" 1
 		fi
-		proto_set_available "$cfg" $available
 	fi
 }
 

--- a/package/network/utils/wwan/files/wwan.usbmisc
+++ b/package/network/utils/wwan/files/wwan.usbmisc
@@ -15,10 +15,11 @@ find_wwan_iface() {
 
 	[ "$proto" = wwan ] || [ "$proto" = mbim ] || [ "$proto" = qmi ] || [ "$proto" = ncm ] || return 0
 	[ -z "$device" -a "$proto" = wwan ] || [ "$device" = "/dev/$DEVNAME" ] || return 0
-	if [ "$ACTION" = add ]; then
-		proto_set_available "$cfg" 1
-	else
+	if [ "$ACTION" = remove ]; then
 		proto_set_available "$cfg" 0
+	else
+		# add, bind...
+		proto_set_available "$cfg" 1
 	fi
 	exit 0
 }


### PR DESCRIPTION
Fix error: after USB modem repluged it does not connect until reboot device or restart network.

Hotplug manager send: "remove" -> "add" -> "bind" events,
script interpret bind as "not add" = "remove" and mark device
as unavailable.