### PR TITLE
ramips: add kmod-mt71615e to Netgear R6350 image for 5Ghz support

### DIFF
--- a/target/linux/ramips/dts/mt7621_netgear_r6350.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6350.dts
@@ -136,8 +136,7 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		mtd-mac-address = <&factory 0x4>;
-		mtd-mac-address-increment = <3>;
+		mtd-mac-address = <&factory 0x8004>;
 	};
 };
 
@@ -148,7 +147,6 @@
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 		mtd-mac-address = <&factory 0x4>;
-		mtd-mac-address-increment = <2>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_netgear_r6350.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6350.dts
@@ -130,11 +130,25 @@
 	status = "okay";
 };
 
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&factory 0x4>;
+		mtd-mac-address-increment = <3>;
+	};
+};
+
 &pcie1 {
 	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
+		mtd-mac-address = <&factory 0x4>;
+		mtd-mac-address-increment = <2>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_netgear_r6350.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6350.dts
@@ -136,7 +136,6 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
-		mtd-mac-address = <&factory 0x8004>;
 	};
 };
 
@@ -146,7 +145,6 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
-		mtd-mac-address = <&factory 0x4>;
 	};
 };
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -423,7 +423,7 @@ define Device/netgear_r6350
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := R6350
   DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+	kmod-mt7603 kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
 TARGET_DEVICES += netgear_r6350
 


### PR DESCRIPTION
This cover all  FCC ID PY317300390  Netgear devices:
R6350
R6260
R6850
WAC124 
Tested ok on my R6260 with Intel AC8260 