### PR TITLE
Fix error: after USB modem repluged it does not connect until reboot device or restart network.

### DIFF
--- a/package/network/utils/comgt/files/3g.usb
+++ b/package/network/utils/comgt/files/3g.usb
@@ -15,11 +15,11 @@ find_3g_iface() {
 
 	if [ "${dev##*/}" = "${tty##*/}" ]; then
 		if [ "$ACTION" = add ]; then
-			available=1
-		else
-			available=0
+			proto_set_available "$cfg" 1
 		fi
-		proto_set_available "$cfg" $available
+		if [ "$ACTION" = remove ]; then
+			proto_set_available "$cfg" 0
+		fi
 	fi
 }
 

--- a/package/network/utils/wwan/files/wwan.usbmisc
+++ b/package/network/utils/wwan/files/wwan.usbmisc
@@ -17,7 +17,8 @@ find_wwan_iface() {
 	[ -z "$device" -a "$proto" = wwan ] || [ "$device" = "/dev/$DEVNAME" ] || return 0
 	if [ "$ACTION" = add ]; then
 		proto_set_available "$cfg" 1
-	else
+	fi
+	if [ "$ACTION" = remove ]; then
 		proto_set_available "$cfg" 0
 	fi
 	exit 0


### PR DESCRIPTION
Fix error: after USB modem repluged it does not connect until reboot device or restart network.

Hotplug manager send: "remove" -> "add" -> "bind" events,
script interpret bind as "not add" = "remove" and mark device
as unavailable.