### PR TITLE
ramips: add support for ELECOM WRC-733GHBK

### DIFF
--- a/target/linux/ramips/dts/mt7620a_elecom_wrc-733ghbk.dts
+++ b/target/linux/ramips/dts/mt7620a_elecom_wrc-733ghbk.dts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "elecom,wrc-733ghbk", "ralink,mt7620a-soc";
+	model = "ELECOM WRC-733GHBK";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "wrc-733ghbk:red:wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "wrc-733ghbk:blue:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "wrc-733ghbk:blue:wlan2g";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		wlan5g {
+			label = "wrc-733ghbk:blue:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		router {
+			label = "rt";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	rtl8367rb {
+		compatible = "realtek,rtl8367b";
+		gpio-sda = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "nvram";
+				reg = <0x50000 0x20000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "edimax,uimage";
+				label = "firmware";
+				reg = <0x70000 0x780000>;
+			};
+
+			partition@7f0000 {
+				label = "hwconfig";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+};
+
+&gpio0 {
+	rtl8367rb_reset {
+		gpio-hog;
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "rtl8367rb-reset";
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "uartf", "mdio";
+		ralink,function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	/* A MAC address for 5 GHz wireless is stored as a text in
+	 * "hwconfig" partition and a raw hex MAC address is not stored
+	 * anywhere in the flash. mt76 driver does not support text MAC
+	 * address, so correct MAC address cannot be used for 5 GHz
+	 * wireless.
+	 */
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -354,6 +354,18 @@ define Device/edimax_ew-7478apc
 endef
 TARGET_DEVICES += edimax_ew-7478apc
 
+define Device/elecom_wrc-733ghbk
+  SOC := mt7620a
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-733GHBK
+  IMAGE_SIZE := 7680k
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+    edimax-header -s CSYS -m RN62 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+    append-metadata | check-size $$$$(IMAGE_SIZE)
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += elecom_wrc-733ghbk
+
 define Device/elecom_wrh-300cr
   SOC := mt7620n
   IMAGE_SIZE := 14272k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -114,6 +114,12 @@ ramips_setup_interfaces()
 		ucidef_add_switch_attr "switch0" "enable" "false"
 		ucidef_set_interface_lan "eth0"
 		;;
+	elecom,wrc-733ghbk|\
+	iodata,wn-ac1167gr|\
+	iodata,wn-ac733gr3)
+		ucidef_add_switch "switch1" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
+		;;
 	engenius,esr600)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "0@eth0"
@@ -133,11 +139,6 @@ ramips_setup_interfaces()
 	hiwifi,hc5861)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "5:wan" "6@eth0"
-		;;
-	iodata,wn-ac1167gr|\
-	iodata,wn-ac733gr3)
-		ucidef_add_switch "switch1" \
-			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
 	iptime,a104ns)
 		ucidef_add_switch "switch0" \
@@ -282,6 +283,11 @@ ramips_setup_macs()
 		;;
 	edimax,br-6478ac-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 2)
+		;;
+	elecom,wrc-733ghbk)
+		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
+		wan_mac=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
+		label_mac=$wan_mac
 		;;
 	engenius,esr600)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -39,6 +39,11 @@ case "$FIRMWARE" in
 		caldata_extract "factory" 0x0 0x200
 		caldata_patch_mac $wifi_mac 0x4
 		;;
+	elecom,wrc-733ghbk)
+		wifi_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.2G.0.MAC.Address)
+		caldata_extract "factory" 0x0 0x200
+		caldata_patch_mac $wifi_mac 0x4
+		;;
 	*)
 		caldata_die "Please define mtd-eeprom in $board DTS file!"
 		;;


### PR DESCRIPTION
ELECOM WRC-733GHBK is a 2.4/5 GHz band 11ac router, based on MediaTek
MT7620A.

Specification:

- SoC		: MediaTek MT7620A
- RAM		: DDR2 64 MiB
- Flash		: SPI-NOR 8 MiB
- WLAN		: 2.4/5 GHz
  - 2.4 GHz : MT7620A (SoC), 2T2R
  - 5 GHz   : MT7610E, 1T1R
- Ethernet	: 10/100/1000 Mbps (RTL8367RB)
- LED/key	: 4x/3x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J1: Vcc, RX, GND, TX from LED side
  - 57600n8

Flash instruction using sysupgrade image:

1. Prepare a computer with an IP address in range 192.168.1.0/24 and
connect cable to LAN port on WRC-733GHBK
2. Hold reset button on WRC-733GHBK and connect power cable
3. After ~5 seconds, release reset button and put the sysupgrade
image to 192.168.1.6 from the computer via TFTP
example (Windows):
  tftp -i 192.168.1.6 PUT firmware.bin
4. Wait ~150 seconds to complete flashing

(Alternative):

1. Boot WRC-733GHBK normaly
2. Access to "http://192.168.2.1/" and open firmware update page
("ファームウェア更新　手動更新(アップデート)")
3. Select OpenWrt sysupgrade image and click apply ("適用") button to
perform firmware update
4. Wait ~150 seconds to complete flashing

Known issues:

- correct MAC address is not used for 5 GHz wireless

  In this device, MAC addresses are only stored as texts in "hwconfig"
  partition. The MAC address configurations for ethernet and rt2x00
  wireless support text address, but for mt76 is not. So currently,
  a generated random MAC address is used for 5 GHz wireless (MT7610E)
  and correct one is not used.

  Note: Linux Kernel 5.2 starts supporting NVMEM MAC address in DT,
        but it's not backported to kernel versions used	by OpenWrt.

- LAN/WAN port side LEDs are not controlled

  Those LEDs are connected to RTL8367RB switch, but LED is not
  implemented in rt8367b driver and those won't light/flash.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>