### PR TITLE
vxlan: add initial IPv4 multicast support

### DIFF
--- a/package/network/config/vxlan/files/vxlan.sh
+++ b/package/network/config/vxlan/files/vxlan.sh
@@ -26,7 +26,12 @@ vxlan_generic_setup() {
 
 	[ -n "$tunlink" ] && json_add_string link "$tunlink"
 	[ -n "$local" ] && json_add_string local "$local"
-	[ -n "$remote" ] && json_add_string remote "$remote"
+	[ -n "$remote" ] && {
+		local remgrp="remote"
+		[ "${remote%%\.*}" -ge 224 ] && \
+		[ "${remote%%\.*}" -le 239 ] && remgrp="group"
+		json_add_string "$remgrp" "$remote"
+	}
 
 	[ -n "$ttl" ] && json_add_int ttl "$ttl"
 	[ -n "$tos" ] && json_add_string tos "$tos"


### PR DESCRIPTION
while for p2p vxlan tunnel the command is:
```ip link ad vxlan22 type vxlan remote 192.168.10.10 local 192.168.10.20...```
for multicast the command needs to be
```ip link add vxlan22 type vxlan group 239.1.1.1 local 192.168.10.20...```