### PR TITLE
kernel: net_sched: fix a NULL pointer deref in ipt action

### DIFF
--- a/target/linux/generic/backport-4.14/380-v5.3-net-sched-Introduce-act_ctinfo-action.patch
+++ b/target/linux/generic/backport-4.14/380-v5.3-net-sched-Introduce-act_ctinfo-action.patch
@@ -532,7 +532,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
 +{
 +	struct tc_action_net *tn = net_generic(net, ctinfo_net_id);
 +
-+	return tc_action_net_init(tn, &act_ctinfo_ops);
++	return tc_action_net_init(net, tn, &act_ctinfo_ops);
 +}
 +
 +static void __net_exit ctinfo_exit_net(struct net *net)

--- a/target/linux/generic/backport-4.14/390-v5.3-net-sched-fix-action-ipt-crash.patch
+++ b/target/linux/generic/backport-4.14/390-v5.3-net-sched-fix-action-ipt-crash.patch
@@ -1,0 +1,324 @@
+From: Cong Wang <xiyou.wangcong@gmail.com>
+To: netdev@vger.kernel.org
+Cc: Cong Wang <xiyou.wangcong@gmail.com>,
+	Tony Ambardar <itugrok@yahoo.com>,
+	Jamal Hadi Salim <jhs@mojatatu.com>,
+	Jiri Pirko <jiri@resnulli.us>
+Subject: [Patch net] net_sched: fix a NULL pointer deref in ipt action
+Date: Sun, 25 Aug 2019 10:01:32 -0700
+
+The net pointer in struct xt_tgdtor_param is not explicitly
+initialized therefore is still NULL when dereferencing it.
+So we have to find a way to pass the correct net pointer to
+ipt_destroy_target().
+
+The best way I find is just saving the net pointer inside the per
+netns struct tcf_idrinfo, which could make this patch smaller.
+
+Fixes: 0c66dc1ea3f0 ("netfilter: conntrack: register hooks in netns when needed by ruleset")
+Reported-and-tested-by: Tony Ambardar <itugrok@yahoo.com>
+Cc: Jamal Hadi Salim <jhs@mojatatu.com>
+Cc: Jiri Pirko <jiri@resnulli.us>
+Signed-off-by: Cong Wang <xiyou.wangcong@gmail.com>
+
+[Backported for kernel v4.14]
+Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
+---
+ include/net/act_api.h      |  4 +++-
+ net/sched/act_bpf.c        |  2 +-
+ net/sched/act_connmark.c   |  2 +-
+ net/sched/act_csum.c       |  2 +-
+ net/sched/act_gact.c       |  2 +-
+ net/sched/act_ife.c        |  2 +-
+ net/sched/act_ipt.c        | 11 ++++++-----
+ net/sched/act_mirred.c     |  2 +-
+ net/sched/act_nat.c        |  2 +-
+ net/sched/act_pedit.c      |  2 +-
+ net/sched/act_police.c     |  2 +-
+ net/sched/act_sample.c     |  2 +-
+ net/sched/act_simple.c     |  2 +-
+ net/sched/act_skbedit.c    |  2 +-
+ net/sched/act_skbmod.c     |  2 +-
+ net/sched/act_tunnel_key.c |  2 +-
+ net/sched/act_vlan.c       |  2 +-
+ 17 files changed, 24 insertions(+), 21 deletions(-)
+
+diff --git a/include/net/act_api.h b/include/net/act_api.h
+index a10a3b1813f3..775387d6ca95 100644
+--- a/include/net/act_api.h
++++ b/include/net/act_api.h
+@@ -14,6 +14,7 @@
+ struct tcf_idrinfo {
+ 	spinlock_t	lock;
+ 	struct idr	action_idr;
++	struct net	*net;
+ };
+ 
+ struct tc_action_ops;
+@@ -104,7 +105,7 @@ struct tc_action_net {
+ };
+ 
+ static inline
+-int tc_action_net_init(struct tc_action_net *tn,
++int tc_action_net_init(struct net *net, struct tc_action_net *tn,
+ 		       const struct tc_action_ops *ops)
+ {
+ 	int err = 0;
+@@ -113,6 +114,7 @@ int tc_action_net_init(struct tc_action_net *tn,
+ 	if (!tn->idrinfo)
+ 		return -ENOMEM;
+ 	tn->ops = ops;
++	tn->idrinfo->net = net;
+ 	spin_lock_init(&tn->idrinfo->lock);
+ 	idr_init(&tn->idrinfo->action_idr);
+ 	return err;
+diff --git a/net/sched/act_bpf.c b/net/sched/act_bpf.c
+index 364a878e51cb..bdc8885c0448 100644
+--- a/net/sched/act_bpf.c
++++ b/net/sched/act_bpf.c
+@@ -402,7 +402,7 @@ static __net_init int bpf_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, bpf_net_id);
+ 
+-	return tc_action_net_init(tn, &act_bpf_ops);
++	return tc_action_net_init(net, tn, &act_bpf_ops);
+ }
+ 
+ static void __net_exit bpf_exit_net(struct net *net)
+diff --git a/net/sched/act_connmark.c b/net/sched/act_connmark.c
+index 10b7a8855a6c..de0cd73a5a5d 100644
+--- a/net/sched/act_connmark.c
++++ b/net/sched/act_connmark.c
+@@ -206,7 +206,7 @@ static __net_init int connmark_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, connmark_net_id);
+ 
+-	return tc_action_net_init(tn, &act_connmark_ops);
++	return tc_action_net_init(net, tn, &act_connmark_ops);
+ }
+ 
+ static void __net_exit connmark_exit_net(struct net *net)
+diff --git a/net/sched/act_csum.c b/net/sched/act_csum.c
+index d836f998117b..a449594553d0 100644
+--- a/net/sched/act_csum.c
++++ b/net/sched/act_csum.c
+@@ -632,7 +632,7 @@ static __net_init int csum_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, csum_net_id);
+ 
+-	return tc_action_net_init(tn, &act_csum_ops);
++	return tc_action_net_init(net, tn, &act_csum_ops);
+ }
+ 
+ static void __net_exit csum_exit_net(struct net *net)
+diff --git a/net/sched/act_gact.c b/net/sched/act_gact.c
+index a0ac42b3ed06..69512d3d0818 100644
+--- a/net/sched/act_gact.c
++++ b/net/sched/act_gact.c
+@@ -232,7 +232,7 @@ static __net_init int gact_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, gact_net_id);
+ 
+-	return tc_action_net_init(tn, &act_gact_ops);
++	return tc_action_net_init(net, tn, &act_gact_ops);
+ }
+ 
+ static void __net_exit gact_exit_net(struct net *net)
+diff --git a/net/sched/act_ife.c b/net/sched/act_ife.c
+index 16a403d17f44..aea8ee40e76b 100644
+--- a/net/sched/act_ife.c
++++ b/net/sched/act_ife.c
+@@ -837,7 +837,7 @@ static __net_init int ife_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, ife_net_id);
+ 
+-	return tc_action_net_init(tn, &act_ife_ops);
++	return tc_action_net_init(net, tn, &act_ife_ops);
+ }
+ 
+ static void __net_exit ife_exit_net(struct net *net)
+diff --git a/net/sched/act_ipt.c b/net/sched/act_ipt.c
+index 18b2fd2ba7d7..a2687dd95a3d 100644
+--- a/net/sched/act_ipt.c
++++ b/net/sched/act_ipt.c
+@@ -65,12 +65,13 @@ static int ipt_init_target(struct net *net, struct xt_entry_target *t,
+ 	return 0;
+ }
+ 
+-static void ipt_destroy_target(struct xt_entry_target *t)
++static void ipt_destroy_target(struct xt_entry_target *t, struct net *net)
+ {
+ 	struct xt_tgdtor_param par = {
+ 		.target   = t->u.kernel.target,
+ 		.targinfo = t->data,
+ 		.family   = NFPROTO_IPV4,
++		.net      = net,
+ 	};
+ 	if (par.target->destroy != NULL)
+ 		par.target->destroy(&par);
+@@ -82,7 +83,7 @@ static void tcf_ipt_release(struct tc_action *a, int bind)
+ 	struct tcf_ipt *ipt = to_ipt(a);
+ 
+ 	if (ipt->tcfi_t) {
+-		ipt_destroy_target(ipt->tcfi_t);
++		ipt_destroy_target(ipt->tcfi_t, a->idrinfo->net);
+ 		kfree(ipt->tcfi_t);
+ 	}
+ 	kfree(ipt->tcfi_tname);
+@@ -172,7 +173,7 @@ static int __tcf_ipt_init(struct net *net, unsigned int id, struct nlattr *nla,
+ 
+ 	spin_lock_bh(&ipt->tcf_lock);
+ 	if (ret != ACT_P_CREATED) {
+-		ipt_destroy_target(ipt->tcfi_t);
++		ipt_destroy_target(ipt->tcfi_t, net);
+ 		kfree(ipt->tcfi_tname);
+ 		kfree(ipt->tcfi_t);
+ 	}
+@@ -337,7 +338,7 @@ static __net_init int ipt_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, ipt_net_id);
+ 
+-	return tc_action_net_init(tn, &act_ipt_ops);
++	return tc_action_net_init(net, tn, &act_ipt_ops);
+ }
+ 
+ static void __net_exit ipt_exit_net(struct net *net)
+@@ -387,7 +388,7 @@ static __net_init int xt_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, xt_net_id);
+ 
+-	return tc_action_net_init(tn, &act_xt_ops);
++	return tc_action_net_init(net, tn, &act_xt_ops);
+ }
+ 
+ static void __net_exit xt_exit_net(struct net *net)
+diff --git a/net/sched/act_mirred.c b/net/sched/act_mirred.c
+index 6ce8de373f83..529bb064c4a4 100644
+--- a/net/sched/act_mirred.c
++++ b/net/sched/act_mirred.c
+@@ -343,7 +343,7 @@ static __net_init int mirred_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, mirred_net_id);
+ 
+-	return tc_action_net_init(tn, &act_mirred_ops);
++	return tc_action_net_init(net, tn, &act_mirred_ops);
+ }
+ 
+ static void __net_exit mirred_exit_net(struct net *net)
+diff --git a/net/sched/act_nat.c b/net/sched/act_nat.c
+index c365d01b99c8..5a136943af27 100644
+--- a/net/sched/act_nat.c
++++ b/net/sched/act_nat.c
+@@ -307,7 +307,7 @@ static __net_init int nat_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, nat_net_id);
+ 
+-	return tc_action_net_init(tn, &act_nat_ops);
++	return tc_action_net_init(net, tn, &act_nat_ops);
+ }
+ 
+ static void __net_exit nat_exit_net(struct net *net)
+diff --git a/net/sched/act_pedit.c b/net/sched/act_pedit.c
+index 656b6ada9221..b6f6bfad8b2a 100644
+--- a/net/sched/act_pedit.c
++++ b/net/sched/act_pedit.c
+@@ -458,7 +458,7 @@ static __net_init int pedit_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, pedit_net_id);
+ 
+-	return tc_action_net_init(tn, &act_pedit_ops);
++	return tc_action_net_init(net, tn, &act_pedit_ops);
+ }
+ 
+ static void __net_exit pedit_exit_net(struct net *net)
+diff --git a/net/sched/act_police.c b/net/sched/act_police.c
+index c16127109f21..a7fcc591c241 100644
+--- a/net/sched/act_police.c
++++ b/net/sched/act_police.c
+@@ -331,7 +331,7 @@ static __net_init int police_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, police_net_id);
+ 
+-	return tc_action_net_init(tn, &act_police_ops);
++	return tc_action_net_init(net, tn, &act_police_ops);
+ }
+ 
+ static void __net_exit police_exit_net(struct net *net)
+diff --git a/net/sched/act_sample.c b/net/sched/act_sample.c
+index 64fd1e9818a6..12748a01533c 100644
+--- a/net/sched/act_sample.c
++++ b/net/sched/act_sample.c
+@@ -249,7 +249,7 @@ static __net_init int sample_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, sample_net_id);
+ 
+-	return tc_action_net_init(tn, &act_sample_ops);
++	return tc_action_net_init(net, tn, &act_sample_ops);
+ }
+ 
+ static void __net_exit sample_exit_net(struct net *net)
+diff --git a/net/sched/act_simple.c b/net/sched/act_simple.c
+index f3ed63aa4111..86d8b66b9928 100644
+--- a/net/sched/act_simple.c
++++ b/net/sched/act_simple.c
+@@ -198,7 +198,7 @@ static __net_init int simp_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, simp_net_id);
+ 
+-	return tc_action_net_init(tn, &act_simp_ops);
++	return tc_action_net_init(net, tn, &act_simp_ops);
+ }
+ 
+ static void __net_exit simp_exit_net(struct net *net)
+diff --git a/net/sched/act_skbedit.c b/net/sched/act_skbedit.c
+index 6e749497009e..1a8a49e33320 100644
+--- a/net/sched/act_skbedit.c
++++ b/net/sched/act_skbedit.c
+@@ -239,7 +239,7 @@ static __net_init int skbedit_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, skbedit_net_id);
+ 
+-	return tc_action_net_init(tn, &act_skbedit_ops);
++	return tc_action_net_init(net, tn, &act_skbedit_ops);
+ }
+ 
+ static void __net_exit skbedit_exit_net(struct net *net)
+diff --git a/net/sched/act_skbmod.c b/net/sched/act_skbmod.c
+index d227599f7e73..20ea9d11821b 100644
+--- a/net/sched/act_skbmod.c
++++ b/net/sched/act_skbmod.c
+@@ -267,7 +267,7 @@ static __net_init int skbmod_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, skbmod_net_id);
+ 
+-	return tc_action_net_init(tn, &act_skbmod_ops);
++	return tc_action_net_init(net, tn, &act_skbmod_ops);
+ }
+ 
+ static void __net_exit skbmod_exit_net(struct net *net)
+diff --git a/net/sched/act_tunnel_key.c b/net/sched/act_tunnel_key.c
+index cd51f2ed55fa..62e22738022d 100644
+--- a/net/sched/act_tunnel_key.c
++++ b/net/sched/act_tunnel_key.c
+@@ -324,7 +324,7 @@ static __net_init int tunnel_key_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, tunnel_key_net_id);
+ 
+-	return tc_action_net_init(tn, &act_tunnel_key_ops);
++	return tc_action_net_init(net, tn, &act_tunnel_key_ops);
+ }
+ 
+ static void __net_exit tunnel_key_exit_net(struct net *net)
+diff --git a/net/sched/act_vlan.c b/net/sched/act_vlan.c
+index 5c10a0fce35b..c9a3eeb351fa 100644
+--- a/net/sched/act_vlan.c
++++ b/net/sched/act_vlan.c
+@@ -271,7 +271,7 @@ static __net_init int vlan_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, vlan_net_id);
+ 
+-	return tc_action_net_init(tn, &act_vlan_ops);
++	return tc_action_net_init(net, tn, &act_vlan_ops);
+ }
+ 
+ static void __net_exit vlan_exit_net(struct net *net)

--- a/target/linux/generic/backport-4.19/380-v5.3-net-sched-Introduce-act_ctinfo-action.patch
+++ b/target/linux/generic/backport-4.19/380-v5.3-net-sched-Introduce-act_ctinfo-action.patch
@@ -555,7 +555,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
 +{
 +	struct tc_action_net *tn = net_generic(net, ctinfo_net_id);
 +
-+	return tc_action_net_init(tn, &act_ctinfo_ops);
++	return tc_action_net_init(net, tn, &act_ctinfo_ops);
 +}
 +
 +static void __net_exit ctinfo_exit_net(struct list_head *net_list)

--- a/target/linux/generic/backport-4.19/390-v5.3-net-sched-fix-action-ipt-crash.patch
+++ b/target/linux/generic/backport-4.19/390-v5.3-net-sched-fix-action-ipt-crash.patch
@@ -1,0 +1,324 @@
+From: Cong Wang <xiyou.wangcong@gmail.com>
+To: netdev@vger.kernel.org
+Cc: Cong Wang <xiyou.wangcong@gmail.com>,
+	Tony Ambardar <itugrok@yahoo.com>,
+	Jamal Hadi Salim <jhs@mojatatu.com>,
+	Jiri Pirko <jiri@resnulli.us>
+Subject: [Patch net] net_sched: fix a NULL pointer deref in ipt action
+Date: Sun, 25 Aug 2019 10:01:32 -0700
+
+The net pointer in struct xt_tgdtor_param is not explicitly
+initialized therefore is still NULL when dereferencing it.
+So we have to find a way to pass the correct net pointer to
+ipt_destroy_target().
+
+The best way I find is just saving the net pointer inside the per
+netns struct tcf_idrinfo, which could make this patch smaller.
+
+Fixes: 0c66dc1ea3f0 ("netfilter: conntrack: register hooks in netns when needed by ruleset")
+Reported-and-tested-by: Tony Ambardar <itugrok@yahoo.com>
+Cc: Jamal Hadi Salim <jhs@mojatatu.com>
+Cc: Jiri Pirko <jiri@resnulli.us>
+Signed-off-by: Cong Wang <xiyou.wangcong@gmail.com>
+
+[Backported for kernel v4.19]
+Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
+---
+ include/net/act_api.h      |  4 +++-
+ net/sched/act_bpf.c        |  2 +-
+ net/sched/act_connmark.c   |  2 +-
+ net/sched/act_csum.c       |  2 +-
+ net/sched/act_gact.c       |  2 +-
+ net/sched/act_ife.c        |  2 +-
+ net/sched/act_ipt.c        | 11 ++++++-----
+ net/sched/act_mirred.c     |  2 +-
+ net/sched/act_nat.c        |  2 +-
+ net/sched/act_pedit.c      |  2 +-
+ net/sched/act_police.c     |  2 +-
+ net/sched/act_sample.c     |  2 +-
+ net/sched/act_simple.c     |  2 +-
+ net/sched/act_skbedit.c    |  2 +-
+ net/sched/act_skbmod.c     |  2 +-
+ net/sched/act_tunnel_key.c |  2 +-
+ net/sched/act_vlan.c       |  2 +-
+ 17 files changed, 24 insertions(+), 21 deletions(-)
+
+diff --git a/include/net/act_api.h b/include/net/act_api.h
+index 970303448c90..0c82d7ea6ee1 100644
+--- a/include/net/act_api.h
++++ b/include/net/act_api.h
+@@ -15,6 +15,7 @@
+ struct tcf_idrinfo {
+ 	spinlock_t	lock;
+ 	struct idr	action_idr;
++	struct net	*net;
+ };
+ 
+ struct tc_action_ops;
+@@ -107,7 +108,7 @@ struct tc_action_net {
+ };
+ 
+ static inline
+-int tc_action_net_init(struct tc_action_net *tn,
++int tc_action_net_init(struct net *net, struct tc_action_net *tn,
+ 		       const struct tc_action_ops *ops)
+ {
+ 	int err = 0;
+@@ -116,6 +117,7 @@ int tc_action_net_init(struct tc_action_net *tn,
+ 	if (!tn->idrinfo)
+ 		return -ENOMEM;
+ 	tn->ops = ops;
++	tn->idrinfo->net = net;
+ 	spin_lock_init(&tn->idrinfo->lock);
+ 	idr_init(&tn->idrinfo->action_idr);
+ 	return err;
+diff --git a/net/sched/act_bpf.c b/net/sched/act_bpf.c
+index 20fae5ca87fa..800846d77a56 100644
+--- a/net/sched/act_bpf.c
++++ b/net/sched/act_bpf.c
+@@ -413,7 +413,7 @@ static __net_init int bpf_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, bpf_net_id);
+ 
+-	return tc_action_net_init(tn, &act_bpf_ops);
++	return tc_action_net_init(net, tn, &act_bpf_ops);
+ }
+ 
+ static void __net_exit bpf_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_connmark.c b/net/sched/act_connmark.c
+index 605436747978..538dedd84e21 100644
+--- a/net/sched/act_connmark.c
++++ b/net/sched/act_connmark.c
+@@ -215,7 +215,7 @@ static __net_init int connmark_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, connmark_net_id);
+ 
+-	return tc_action_net_init(tn, &act_connmark_ops);
++	return tc_action_net_init(net, tn, &act_connmark_ops);
+ }
+ 
+ static void __net_exit connmark_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_csum.c b/net/sched/act_csum.c
+index 40437197e053..1e269441065a 100644
+--- a/net/sched/act_csum.c
++++ b/net/sched/act_csum.c
+@@ -678,7 +678,7 @@ static __net_init int csum_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, csum_net_id);
+ 
+-	return tc_action_net_init(tn, &act_csum_ops);
++	return tc_action_net_init(net, tn, &act_csum_ops);
+ }
+ 
+ static void __net_exit csum_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_gact.c b/net/sched/act_gact.c
+index 72d3347bdd41..dfef9621375e 100644
+--- a/net/sched/act_gact.c
++++ b/net/sched/act_gact.c
+@@ -263,7 +263,7 @@ static __net_init int gact_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, gact_net_id);
+ 
+-	return tc_action_net_init(tn, &act_gact_ops);
++	return tc_action_net_init(net, tn, &act_gact_ops);
+ }
+ 
+ static void __net_exit gact_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_ife.c b/net/sched/act_ife.c
+index 24047e0e5db0..bac353bea02f 100644
+--- a/net/sched/act_ife.c
++++ b/net/sched/act_ife.c
+@@ -887,7 +887,7 @@ static __net_init int ife_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, ife_net_id);
+ 
+-	return tc_action_net_init(tn, &act_ife_ops);
++	return tc_action_net_init(net, tn, &act_ife_ops);
+ }
+ 
+ static void __net_exit ife_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_ipt.c b/net/sched/act_ipt.c
+index 334f3a057671..01d3669ef498 100644
+--- a/net/sched/act_ipt.c
++++ b/net/sched/act_ipt.c
+@@ -65,12 +65,13 @@ static int ipt_init_target(struct net *net, struct xt_entry_target *t,
+ 	return 0;
+ }
+ 
+-static void ipt_destroy_target(struct xt_entry_target *t)
++static void ipt_destroy_target(struct xt_entry_target *t, struct net *net)
+ {
+ 	struct xt_tgdtor_param par = {
+ 		.target   = t->u.kernel.target,
+ 		.targinfo = t->data,
+ 		.family   = NFPROTO_IPV4,
++		.net      = net,
+ 	};
+ 	if (par.target->destroy != NULL)
+ 		par.target->destroy(&par);
+@@ -82,7 +83,7 @@ static void tcf_ipt_release(struct tc_action *a)
+ 	struct tcf_ipt *ipt = to_ipt(a);
+ 
+ 	if (ipt->tcfi_t) {
+-		ipt_destroy_target(ipt->tcfi_t);
++		ipt_destroy_target(ipt->tcfi_t, a->idrinfo->net);
+ 		kfree(ipt->tcfi_t);
+ 	}
+ 	kfree(ipt->tcfi_tname);
+@@ -182,7 +183,7 @@ static int __tcf_ipt_init(struct net *net, unsigned int id, struct nlattr *nla,
+ 
+ 	spin_lock_bh(&ipt->tcf_lock);
+ 	if (ret != ACT_P_CREATED) {
+-		ipt_destroy_target(ipt->tcfi_t);
++		ipt_destroy_target(ipt->tcfi_t, net);
+ 		kfree(ipt->tcfi_tname);
+ 		kfree(ipt->tcfi_t);
+ 	}
+@@ -353,7 +354,7 @@ static __net_init int ipt_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, ipt_net_id);
+ 
+-	return tc_action_net_init(tn, &act_ipt_ops);
++	return tc_action_net_init(net, tn, &act_ipt_ops);
+ }
+ 
+ static void __net_exit ipt_exit_net(struct list_head *net_list)
+@@ -403,7 +404,7 @@ static __net_init int xt_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, xt_net_id);
+ 
+-	return tc_action_net_init(tn, &act_xt_ops);
++	return tc_action_net_init(net, tn, &act_xt_ops);
+ }
+ 
+ static void __net_exit xt_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_mirred.c b/net/sched/act_mirred.c
+index 548614bd9366..399e3beae6cf 100644
+--- a/net/sched/act_mirred.c
++++ b/net/sched/act_mirred.c
+@@ -419,7 +419,7 @@ static __net_init int mirred_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, mirred_net_id);
+ 
+-	return tc_action_net_init(tn, &act_mirred_ops);
++	return tc_action_net_init(net, tn, &act_mirred_ops);
+ }
+ 
+ static void __net_exit mirred_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_nat.c b/net/sched/act_nat.c
+index 619828920b97..d1b47a1b145c 100644
+--- a/net/sched/act_nat.c
++++ b/net/sched/act_nat.c
+@@ -317,7 +317,7 @@ static __net_init int nat_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, nat_net_id);
+ 
+-	return tc_action_net_init(tn, &act_nat_ops);
++	return tc_action_net_init(net, tn, &act_nat_ops);
+ }
+ 
+ static void __net_exit nat_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_pedit.c b/net/sched/act_pedit.c
+index 82d258b2a75a..33c0cc5ef229 100644
+--- a/net/sched/act_pedit.c
++++ b/net/sched/act_pedit.c
+@@ -488,7 +488,7 @@ static __net_init int pedit_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, pedit_net_id);
+ 
+-	return tc_action_net_init(tn, &act_pedit_ops);
++	return tc_action_net_init(net, tn, &act_pedit_ops);
+ }
+ 
+ static void __net_exit pedit_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_police.c b/net/sched/act_police.c
+index 997c34db1491..4db25959e156 100644
+--- a/net/sched/act_police.c
++++ b/net/sched/act_police.c
+@@ -342,7 +342,7 @@ static __net_init int police_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, police_net_id);
+ 
+-	return tc_action_net_init(tn, &act_police_ops);
++	return tc_action_net_init(net, tn, &act_police_ops);
+ }
+ 
+ static void __net_exit police_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_sample.c b/net/sched/act_sample.c
+index ac37654ca292..53c33bfddb85 100644
+--- a/net/sched/act_sample.c
++++ b/net/sched/act_sample.c
+@@ -255,7 +255,7 @@ static __net_init int sample_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, sample_net_id);
+ 
+-	return tc_action_net_init(tn, &act_sample_ops);
++	return tc_action_net_init(net, tn, &act_sample_ops);
+ }
+ 
+ static void __net_exit sample_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_simple.c b/net/sched/act_simple.c
+index 658efae71a09..b418ef62e0a4 100644
+--- a/net/sched/act_simple.c
++++ b/net/sched/act_simple.c
+@@ -215,7 +215,7 @@ static __net_init int simp_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, simp_net_id);
+ 
+-	return tc_action_net_init(tn, &act_simp_ops);
++	return tc_action_net_init(net, tn, &act_simp_ops);
+ }
+ 
+ static void __net_exit simp_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_skbedit.c b/net/sched/act_skbedit.c
+index 7709710a41f7..a80179c1075f 100644
+--- a/net/sched/act_skbedit.c
++++ b/net/sched/act_skbedit.c
+@@ -316,7 +316,7 @@ static __net_init int skbedit_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, skbedit_net_id);
+ 
+-	return tc_action_net_init(tn, &act_skbedit_ops);
++	return tc_action_net_init(net, tn, &act_skbedit_ops);
+ }
+ 
+ static void __net_exit skbedit_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_skbmod.c b/net/sched/act_skbmod.c
+index 3038493d18ca..21d195296121 100644
+--- a/net/sched/act_skbmod.c
++++ b/net/sched/act_skbmod.c
+@@ -277,7 +277,7 @@ static __net_init int skbmod_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, skbmod_net_id);
+ 
+-	return tc_action_net_init(tn, &act_skbmod_ops);
++	return tc_action_net_init(net, tn, &act_skbmod_ops);
+ }
+ 
+ static void __net_exit skbmod_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_tunnel_key.c b/net/sched/act_tunnel_key.c
+index 66bfe57e74ae..43309ff2b5dc 100644
+--- a/net/sched/act_tunnel_key.c
++++ b/net/sched/act_tunnel_key.c
+@@ -579,7 +579,7 @@ static __net_init int tunnel_key_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, tunnel_key_net_id);
+ 
+-	return tc_action_net_init(tn, &act_tunnel_key_ops);
++	return tc_action_net_init(net, tn, &act_tunnel_key_ops);
+ }
+ 
+ static void __net_exit tunnel_key_exit_net(struct list_head *net_list)
+diff --git a/net/sched/act_vlan.c b/net/sched/act_vlan.c
+index da993edd2e40..41528b966440 100644
+--- a/net/sched/act_vlan.c
++++ b/net/sched/act_vlan.c
+@@ -324,7 +324,7 @@ static __net_init int vlan_init_net(struct net *net)
+ {
+ 	struct tc_action_net *tn = net_generic(net, vlan_net_id);
+ 
+-	return tc_action_net_init(tn, &act_vlan_ops);
++	return tc_action_net_init(net, tn, &act_vlan_ops);
+ }
+ 
+ static void __net_exit vlan_exit_net(struct list_head *net_list)


### PR DESCRIPTION
**Build/Run Tested**: QEMU/malta (be32), OpenWrt master, kernel v4.14.138 and v4.19.66

**Description**:
This contains kernel v4.14 and v4.19 backports of a proposed [NetDev patch](https://www.spinics.net/lists/netdev/msg595425.html) which fixes [Kernel Bugzilla 204681](https://bugzilla.kernel.org/show_bug.cgi?id=204681) and OpenWrt [FS#2461](https://bugs.openwrt.org/index.php?do=details&task_id=2461).

The bug impacts both OpenWrt branches **19.07** and **master**, and results in a kernel BUG/Oops or crash when using `tc filter ... action xt -j CONNMARK ...` commands and deleting the related filter or qdisc.

This fix separately updates `act_ctinfo` as authored and backported by Kevin Darbyshire-Bryant, to avoid patching over an existing patch.

**CC**: @ldir-EDB0 (related patch owner)