### PR TITLE
lantiq-dsl: fix value of FECS counter

### DIFF
--- a/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
+++ b/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
@@ -451,7 +451,8 @@ latency_delay() {
 errors() {
 	local lsctg
 	local dpctg
-	local ccsg
+	local fecsf
+	local fecsn
 	local esf
 	local esn
 	local sesf
@@ -468,16 +469,15 @@ errors() {
 	local hecf
 	local hecn
 
-	local fecn
-	local fecf
-
 	lsctg=$(dsl_cmd pmlsctg 1)
+	fecsf=$(dsl_val "$lsctg" nFECS)
 	esf=$(dsl_val "$lsctg" nES)
 	sesf=$(dsl_val "$lsctg" nSES)
 	lossf=$(dsl_val "$lsctg" nLOSS)
 	uasf=$(dsl_val "$lsctg" nUAS)
 
 	lsctg=$(dsl_cmd pmlsctg 0)
+	fecsn=$(dsl_val "$lsctg" nFECS)
 	esn=$(dsl_val "$lsctg" nES)
 	sesn=$(dsl_val "$lsctg" nSES)
 	lossn=$(dsl_val "$lsctg" nLOSS)
@@ -493,15 +493,9 @@ errors() {
 	crc_pn=$(dsl_val "$dpctg" nCRC_P)
 	crcp_pn=$(dsl_val "$dpctg" nCRCP_P)
 
-	ccsg=$(dsl_cmd pmccsg 0 1 0)
-	fecf=$(dsl_val "$ccsg" nFEC)
-
-	ccsg=$(dsl_cmd pmccsg 0 0 0)
-	fecn=$(dsl_val "$ccsg" nFEC)
-
 	if [ "$action" = "lucistat" ]; then
-		echo "dsl.errors_fec_near=${fecn:-nil}"
-		echo "dsl.errors_fec_far=${fecf:-nil}"
+		echo "dsl.errors_fecs_near=${fecsn:-nil}"
+		echo "dsl.errors_fecs_far=${fecsf:-nil}"
 		echo "dsl.errors_es_near=${esn:-nil}"
 		echo "dsl.errors_es_far=${esf:-nil}"
 		echo "dsl.errors_ses_near=${sesn:-nil}"
@@ -517,7 +511,7 @@ errors() {
 		echo "dsl.errors_crcp_p_near=${crcp_pn:-nil}"
 		echo "dsl.errors_crcp_p_far=${crcp_pf:-nil}"
 	else
-		echo "Forward Error Correction Seconds (FECS):  Near: ${fecn} / Far: ${fecf}"
+		echo "Forward Error Correction Seconds (FECS):  Near: ${fecsn} / Far: ${fecsf}"
 		echo "Errored seconds (ES):                     Near: ${esn} / Far: ${esf}"
 		echo "Severely Errored Seconds (SES):           Near: ${sesn} / Far: ${sesf}"
 		echo "Loss of Signal Seconds (LOSS):            Near: ${lossn} / Far: ${lossf}"


### PR DESCRIPTION
Instead of the nFECS value, the nFEC value (the number of corrected code words)
was mistakenly used.

This should also be fixed in openwrt-19.07.
