### PR TITLE
ramips: add support for Netgear R6260 & R6850

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -293,10 +293,14 @@ netgear,r6120)
 	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"
 	;;
 netgear,r6220|\
-netgear,r6350|\
 netgear,wndr3700-v5)
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
 	set_wifi_led "$boardname:green:wifi"
+	;;
+netgear,r6260|\
+netgear,r6350|\
+netgear,r6850)
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
 	;;
 omnima,hpm)
 	ucidef_set_led_netdev "eth" "ETH" "$boardname:green:eth" "eth0"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -67,7 +67,9 @@ ramips_setup_interfaces()
 	mqmaker,witi|\
 	mtc,wr1201|\
 	netgear,r6220|\
+	netgear,r6260|\
 	netgear,r6350|\
+	netgear,r6850|\
 	netgear,wndr3700-v5|\
 	netis,wf-2881|\
 	nixcore,x1-16m|\
@@ -641,7 +643,9 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	netgear,r6220|\
+	netgear,r6260|\
 	netgear,r6350|\
+	netgear,r6850|\
 	netgear,wndr3700-v5)
 		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		lan_mac=$(macaddr_add "$wan_mac" 1)

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -23,7 +23,9 @@ platform_do_upgrade() {
 	case "$board" in
 	hiwifi,hc5962|\
 	netgear,r6220|\
+	netgear,r6260|\
 	netgear,r6350|\
+	netgear,r6850|\
 	xiaomi,mir3g|\
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"

--- a/target/linux/ramips/dts/mt7621_netgear_r6260.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6260.dts
@@ -7,22 +7,22 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "netgear,r6350", "mediatek,mt7621-soc";
-	model = "Netgear R6350";
+	compatible = "netgear,r6260", "mediatek,mt7621-soc";
+	model = "Netgear R6260";
 };
 
 &led_power {
-	label = "r6350:green:power";
+	label = "r6260:green:power";
 };
 
 &led_usb {
-	label = "r6350:green:usb";
+	label = "r6260:green:usb";
 };
 
 &led_internet {
-	label = "r6350:green:wan";
+	label = "r6260:green:wan";
 };
 
 &led_wifi {
-	label = "r6350:green:wifi";
+	label = "r6260:green:wifi";
 };

--- a/target/linux/ramips/dts/mt7621_netgear_r6260_r6350_r6850.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_r6260_r6350_r6850.dtsi
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "mediatek,mt7621-soc";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_usb: usb {
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		led_internet: internet {
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "SC PART_MAP";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x2800000>;
+		};
+
+		partition@2e00000 {
+			label = "reserved0";
+			reg = <0x2e00000 0x1800000>;
+			read-only;
+		};
+
+		factory: partition@4600000 {
+			label = "factory";
+			reg = <0x4600000 0x200000>;
+			read-only;
+		};
+
+		partition@4800000 {
+			label = "reserved1";
+			reg = <0x4800000 0x3800000>;
+			read-only;
+		};
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uart3", "uart2", "jtag", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_netgear_r6350.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6350.dts
@@ -130,6 +130,15 @@
 	status = "okay";
 };
 
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
 &pcie1 {
 	wifi@0,0 {
 		reg = <0x0 0 0 0 0>;

--- a/target/linux/ramips/dts/mt7621_netgear_r6850.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_r6850.dts
@@ -7,22 +7,22 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "netgear,r6350", "mediatek,mt7621-soc";
-	model = "Netgear R6350";
+	compatible = "netgear,r6850", "mediatek,mt7621-soc";
+	model = "Netgear R6850";
 };
 
 &led_power {
-	label = "r6350:green:power";
+	label = "r6850:green:power";
 };
 
 &led_usb {
-	label = "r6350:green:usb";
+	label = "r6850:green:usb";
 };
 
 &led_internet {
-	label = "r6350:green:wan";
+	label = "r6850:green:wan";
 };
 
 &led_wifi {
-	label = "r6350:green:wifi";
+	label = "r6850:green:wifi";
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -416,7 +416,12 @@ define Device/netgear_r6260_r6350_r6850
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 40960k
   UBINIZE_OPTS := -E 5
-  IMAGES += kernel.bin rootfs.bin
+  SERCOMM_HWID := CHJ
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0052
+  IMAGES += factory.img kernel.bin rootfs.bin
+  IMAGE/factory.img := pad-extra 2048k | append-kernel | pad-to 6144k | append-ubi | \
+	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip $$$$(DEVICE_MODEL).bin | sercom-seal
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -409,7 +409,7 @@ define Device/netgear_r6220
 endef
 TARGET_DEVICES += netgear_r6220
 
-define Device/netgear_r6350
+define Device/netgear_r6260_r6350_r6850
   MTK_SOC := mt7621
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -421,11 +421,27 @@ define Device/netgear_r6350
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
   DEVICE_VENDOR := NETGEAR
-  DEVICE_MODEL := R6350
   DEVICE_PACKAGES := \
 	kmod-mt7603 kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
+
+define Device/netgear_r6260
+  $(Device/netgear_r6260_r6350_r6850)
+  DEVICE_MODEL := R6260
+endef
+TARGET_DEVICES += netgear_r6260
+
+define Device/netgear_r6350
+  $(Device/netgear_r6260_r6350_r6850)
+  DEVICE_MODEL := R6350
+endef
 TARGET_DEVICES += netgear_r6350
+
+define Device/netgear_r6850
+  $(Device/netgear_r6260_r6350_r6850)
+  DEVICE_MODEL := R6850
+endef
+TARGET_DEVICES += netgear_r6850
 
 define Device/netgear_wndr3700-v5
   MTK_SOC := mt7621

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -423,7 +423,7 @@ define Device/netgear_r6350
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := R6350
   DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+	kmod-mt7603 kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
 TARGET_DEVICES += netgear_r6350
 


### PR DESCRIPTION
ramips: add support for Netgear R6260 and R6850

As Netgear uses the same image for R6260, R6350 & R6850
we can merge device tree files and generate separate
images for each device.

ramips: add factory images for Netgear R6260, R6350 and R6850

This adds factory image generation for all three
devices. These images can be flashed via WebUI
for easy installation.
    
Tested on Netgear R6260 using V1.1.0.52
Thanks to David Bauer for the inspiration