### PR TITLE
[19.07] ramips: sync pagebuf in MT7621 NAND read_fact_bbt

### DIFF
--- a/target/linux/ramips/patches-4.14/0039-mtd-add-mt7621-nand-support.patch
+++ b/target/linux/ramips/patches-4.14/0039-mtd-add-mt7621-nand-support.patch
@@ -1298,7 +1298,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 --- /dev/null
 +++ b/drivers/mtd/nand/mtk_nand2.c
-@@ -0,0 +1,2345 @@
+@@ -0,0 +1,2346 @@
 +/******************************************************************************
 +* mtk_nand2.c - MTK NAND Flash Device Driver
 + *
@@ -3299,11 +3299,12 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		}
 +		if (mtk_nand_exec_read_page(mtd, page, mtd->writesize, chip->buffers->databuf, chip->oob_poi))
 +		{
++			chip->pagebuf = page;
 +			printk("Signature matched and data read!\n");
 +			memcpy(fact_bbt, chip->buffers->databuf, (bbt_size <= mtd->writesize)? bbt_size:mtd->writesize);
 +			return 0;
-+		}
-+
++		} else
++			chip->pagebuf = -1;
 +	}
 +	printk("failed at page %x\n", page);
 +	return -1;


### PR DESCRIPTION
In 4.14's drivers/mtd/nand/nand_base.c in nand_do_read_ops() we see
that chip->pagebuf indicates the page that is in chip->buffers->databuf
but mt7621-nand-support patch's read_fact_bbt() reads data into databuf
without updating pagebuf, causing data in databuf to be incorrect from
perspective of the number in pagebuf.

This causes problem when somebody reads page X then read_fact_bbt()
kicks in to read page Y followed by a normal read of page X. In this
scenario the nand driver will incorrectly return data at page Y for the
page X request because nand driver still thinks the databuf is page X.

This patch sets chip->pagebuf to desired page number before calling
mtk_nand_exec_read_page(), and resets it back to -1 if the read fails.

Fixes FS#2097 ("mt7621 nand mtd slave fail to read same page twice")
Signed-off-by: Leon Poon <szeleung.poon@gmail.com>
