### PR TITLE
ath79: move common definitions from Archer C58/C59 to common DTSI

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
@@ -1,63 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
 #include "qca9561_tplink_archer-c5x.dtsi"
 
 / {
 	compatible = "tplink,archer-c58-v1", "qca,qca9560";
 	model = "TP-Link Archer C58 v1";
-
-	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		power: power {
-			label = "tp-link:green:power";
-			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wan_green {
-			label = "tp-link:green:wan";
-			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "tp-link:amber:wan";
-			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
-		};
-	};
 };
 
 &spi {
@@ -105,21 +53,4 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-	mtd-mac-address-increment = <1>;
-};
-
-&eth1 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-};
-
-&wmac {
-	status = "okay";
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -1,69 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
 #include "qca9561_tplink_archer-c5x.dtsi"
 
 / {
 	compatible = "tplink,archer-c59-v1", "qca,qca9560";
 	model = "TP-Link Archer C59 v1";
+};
 
-	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		power: power {
-			label = "tp-link:green:power";
-			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wan_green {
-			label = "tp-link:green:wan";
-			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "tp-link:amber:wan";
-			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
-		};
-
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "usbport";
-			trigger-sources = <&hub_port>;
-		};
+&leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "usbport";
+		trigger-sources = <&hub_port>;
 	};
 };
 
@@ -127,21 +77,4 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-	mtd-mac-address-increment = <1>;
-};
-
-&eth1 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-};
-
-&wmac {
-	status = "okay";
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
@@ -8,6 +8,13 @@
 / {
 	compatible = "tplink,archer-c5x", "qca,qca9560";
 
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};
@@ -29,6 +36,48 @@
 			#gpio-cells = <2>;
 			registers-number = <1>;
 			spi-max-frequency = <10000000>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "tp-link:green:power";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_green {
+			label = "tp-link:green:wan";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tp-link:amber:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -86,8 +135,13 @@
 };
 
 &eth0 {
+	status = "okay";
+
 	phy-mode = "mii";
 	phy-handle = <&swphy0>;
+
+	mtd-mac-address = <&mac 0x8>;
+	mtd-mac-address-increment = <1>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -95,4 +149,17 @@
 		switch-phy-addr-swap = <1>;
 		switch-phy-swap = <1>;
 	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&mac 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&mac 0x8>;
 };


### PR DESCRIPTION
The Archer C58/C59 have redundant LED and MAC address definitions
in their DTS files. This moves them to the parent DTSI file.

The patch already accounts for the upcoming Archer C59 v2.
