### PR TITLE
Add support for BananaPi BPi-R2, second take

### DIFF
--- a/package/boot/uboot-mtk-bpi-r2/Makefile
+++ b/package/boot/uboot-mtk-bpi-r2/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2016 Gary Wang <gary.wang@bananapi.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=uboot-mtk-bpi-r2
+PKG_VERSION:=v1.0
+PKG_RELEASE:=1
+HOSTCPPFLAGS:="-I."
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/BPI-SINOVOIP/BPI-R2-LEDE-Uboot.git
+PKG_SOURCE_VERSION:=b05a4e323e1fd8727fcfe32c35d562f12b88a23b
+
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=Licenses/README
+
+PKG_MAINTAINER:=Gary Wang <gary.wang@bananapi.com>
+
+include $(INCLUDE_DIR)/u-boot.mk
+include $(INCLUDE_DIR)/package.mk
+
+define U-Boot/Default
+  BUILD_TARGET:=mediatek
+  HIDDEN:=1
+endef
+
+define U-Boot/bpi_r2
+  NAME:=Mediatek Banana Pi R2 board
+  BUILD_SUBTARGET:=mt7623
+  BUILD_DEVICES:=7623n-bananapi-bpi-r2
+endef
+
+UBOOT_TARGETS := \
+	bpi_r2
+
+
+UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	$(CP) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/mtk-bpi-r2-uboot.bin
+	$(CP) $(PKG_BUILD_DIR)/bpi_r2_preloader/EMMC_PRELOADER_1600MHz.img $(STAGING_DIR_IMAGE)/mtk-bpi-r2-preloader-emmc.bin
+	$(CP) $(PKG_BUILD_DIR)/bpi_r2_preloader/SD_PRELOADER_1600MHz.img $(STAGING_DIR_IMAGE)/mtk-bpi-r2-preloader-sd.bin
+endef
+
+define Package/u-boot/install/default
+endef
+
+$(eval $(call BuildPackage/U-Boot))

--- a/package/boot/uboot-mtk-bpi-r2/patches/002-use-static-inline.patch
+++ b/package/boot/uboot-mtk-bpi-r2/patches/002-use-static-inline.patch
@@ -1,0 +1,56 @@
+Index: uboot-mtk-bpi-r2-v1.0/arch/arm/include/asm/io.h
+===================================================================
+--- uboot-mtk-bpi-r2-v1.0.orig/arch/arm/include/asm/io.h
++++ uboot-mtk-bpi-r2-v1.0/arch/arm/include/asm/io.h
+@@ -75,7 +75,7 @@ static inline phys_addr_t virt_to_phys(v
+ #define __arch_putw(v,a)		(*(volatile unsigned short *)(a) = (v))
+ #define __arch_putl(v,a)		(*(volatile unsigned int *)(a) = (v))
+ 
+-extern inline void __raw_writesb(unsigned long addr, const void *data,
++static inline void __raw_writesb(unsigned long addr, const void *data,
+ 				 int bytelen)
+ {
+ 	uint8_t *buf = (uint8_t *)data;
+@@ -83,7 +83,7 @@ extern inline void __raw_writesb(unsigne
+ 		__arch_putb(*buf++, addr);
+ }
+ 
+-extern inline void __raw_writesw(unsigned long addr, const void *data,
++static inline void __raw_writesw(unsigned long addr, const void *data,
+ 				 int wordlen)
+ {
+ 	uint16_t *buf = (uint16_t *)data;
+@@ -91,7 +91,7 @@ extern inline void __raw_writesw(unsigne
+ 		__arch_putw(*buf++, addr);
+ }
+ 
+-extern inline void __raw_writesl(unsigned long addr, const void *data,
++static inline void __raw_writesl(unsigned long addr, const void *data,
+ 				 int longlen)
+ {
+ 	uint32_t *buf = (uint32_t *)data;
+@@ -99,21 +99,21 @@ extern inline void __raw_writesl(unsigne
+ 		__arch_putl(*buf++, addr);
+ }
+ 
+-extern inline void __raw_readsb(unsigned long addr, void *data, int bytelen)
++static inline void __raw_readsb(unsigned long addr, void *data, int bytelen)
+ {
+ 	uint8_t *buf = (uint8_t *)data;
+ 	while(bytelen--)
+ 		*buf++ = __arch_getb(addr);
+ }
+ 
+-extern inline void __raw_readsw(unsigned long addr, void *data, int wordlen)
++static inline void __raw_readsw(unsigned long addr, void *data, int wordlen)
+ {
+ 	uint16_t *buf = (uint16_t *)data;
+ 	while(wordlen--)
+ 		*buf++ = __arch_getw(addr);
+ }
+ 
+-extern inline void __raw_readsl(unsigned long addr, void *data, int longlen)
++static inline void __raw_readsl(unsigned long addr, void *data, int longlen)
+ {
+ 	uint32_t *buf = (uint32_t *)data;
+ 	while(longlen--)

--- a/package/boot/uboot-mtk-bpi-r2/patches/003-use-weak-in-board.patch
+++ b/package/boot/uboot-mtk-bpi-r2/patches/003-use-weak-in-board.patch
@@ -1,0 +1,38 @@
+Index: uboot-mtk-bpi-r2-v1.0/arch/arm/lib/board.c
+===================================================================
+--- uboot-mtk-bpi-r2-v1.0.orig/arch/arm/lib/board.c
++++ uboot-mtk-bpi-r2-v1.0/arch/arm/lib/board.c
+@@ -69,24 +69,15 @@ extern void dataflash_print_info(void);
+  ************************************************************************
+  * May be supplied by boards if desired
+  */
+-inline void __coloured_LED_init(void) {}
+-void coloured_LED_init(void) __attribute__((weak, alias("__coloured_LED_init")));
+-inline void __red_led_on(void) {}
+-void red_led_on(void) __attribute__((weak, alias("__red_led_on")));
+-inline void __red_led_off(void) {}
+-void red_led_off(void) __attribute__((weak, alias("__red_led_off")));
+-inline void __green_led_on(void) {}
+-void green_led_on(void) __attribute__((weak, alias("__green_led_on")));
+-inline void __green_led_off(void) {}
+-void green_led_off(void) __attribute__((weak, alias("__green_led_off")));
+-inline void __yellow_led_on(void) {}
+-void yellow_led_on(void) __attribute__((weak, alias("__yellow_led_on")));
+-inline void __yellow_led_off(void) {}
+-void yellow_led_off(void) __attribute__((weak, alias("__yellow_led_off")));
+-inline void __blue_led_on(void) {}
+-void blue_led_on(void) __attribute__((weak, alias("__blue_led_on")));
+-inline void __blue_led_off(void) {}
+-void blue_led_off(void) __attribute__((weak, alias("__blue_led_off")));
++__weak void coloured_LED_init(void) {}
++__weak void red_led_on(void) {}
++__weak void red_led_off(void) {}
++__weak void green_led_on(void) {}
++__weak void green_led_off(void) {}
++__weak void yellow_led_on(void) {}
++__weak void yellow_led_off(void) {}
++__weak void blue_led_on(void) {}
++__weak void blue_led_off(void) {}
+ 
+ /*
+  ************************************************************************

--- a/package/boot/uboot-mtk-bpi-r2/patches/004-use-weak-in-main.patch
+++ b/package/boot/uboot-mtk-bpi-r2/patches/004-use-weak-in-main.patch
@@ -1,0 +1,14 @@
+Index: uboot-mtk-bpi-r2-v1.0/common/main.c
+===================================================================
+--- uboot-mtk-bpi-r2-v1.0.orig/common/main.c
++++ uboot-mtk-bpi-r2-v1.0/common/main.c
+@@ -27,8 +27,7 @@ DECLARE_GLOBAL_DATA_PTR;
+ /*
+  * Board-specific Platform code can reimplement show_boot_progress () if needed
+  */
+-void inline __show_boot_progress (int val) {}
+-void show_boot_progress (int val) __attribute__((weak, alias("__show_boot_progress")));
++__weak void show_boot_progress(int val) {}
+ 
+ #define MAX_DELAY_STOP_STR 32
+ 

--- a/package/boot/uboot-mtk-bpi-r2/patches/420-gcc-7-compiler.patch
+++ b/package/boot/uboot-mtk-bpi-r2/patches/420-gcc-7-compiler.patch
@@ -1,0 +1,287 @@
+--- /dev/null
++++ b/include/linux/compiler-gcc7.h
+@@ -0,0 +1,284 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc.h> directly, include <linux/compiler.h> instead."
++#endif
++
++/*
++ * Common definitions for all gcc versions go here.
++ */
++#define GCC_VERSION (__GNUC__ * 10000		\
++		     + __GNUC_MINOR__ * 100	\
++		     + __GNUC_PATCHLEVEL__)
++
++/* Optimization barrier */
++
++/* The "volatile" is due to gcc bugs */
++#define barrier() __asm__ __volatile__("": : :"memory")
++/*
++ * This version is i.e. to prevent dead stores elimination on @ptr
++ * where gcc and llvm may behave differently when otherwise using
++ * normal barrier(): while gcc behavior gets along with a normal
++ * barrier(), llvm needs an explicit input variable to be assumed
++ * clobbered. The issue is as follows: while the inline asm might
++ * access any memory it wants, the compiler could have fit all of
++ * @ptr into memory registers instead, and since @ptr never escaped
++ * from that, it proofed that the inline asm wasn't touching any of
++ * it. This version works well with both compilers, i.e. we're telling
++ * the compiler that the inline asm absolutely may see the contents
++ * of @ptr. See also: https://llvm.org/bugs/show_bug.cgi?id=15495
++ */
++#define barrier_data(ptr) __asm__ __volatile__("": :"r"(ptr) :"memory")
++
++/*
++ * This macro obfuscates arithmetic on a variable address so that gcc
++ * shouldn't recognize the original var, and make assumptions about it.
++ *
++ * This is needed because the C standard makes it undefined to do
++ * pointer arithmetic on "objects" outside their boundaries and the
++ * gcc optimizers assume this is the case. In particular they
++ * assume such arithmetic does not wrap.
++ *
++ * A miscompilation has been observed because of this on PPC.
++ * To work around it we hide the relationship of the pointer and the object
++ * using this macro.
++ *
++ * Versions of the ppc64 compiler before 4.1 had a bug where use of
++ * RELOC_HIDE could trash r30. The bug can be worked around by changing
++ * the inline assembly constraint from =g to =r, in this particular
++ * case either is valid.
++ */
++#define RELOC_HIDE(ptr, off)						\
++({									\
++	unsigned long __ptr;						\
++	__asm__ ("" : "=r"(__ptr) : "0"(ptr));				\
++	(typeof(ptr)) (__ptr + (off));					\
++})
++
++/* Make the optimizer believe the variable can be manipulated arbitrarily. */
++#define OPTIMIZER_HIDE_VAR(var)						\
++	__asm__ ("" : "=r" (var) : "0" (var))
++
++#ifdef __CHECKER__
++#define __must_be_array(a)	0
++#else
++/* &a[0] degrades to a pointer: a different type from an array */
++#define __must_be_array(a)	BUILD_BUG_ON_ZERO(__same_type((a), &(a)[0]))
++#endif
++
++/*
++ * Force always-inline if the user requests it so via the .config,
++ * or if gcc is too old:
++ */
++#if !defined(CONFIG_ARCH_SUPPORTS_OPTIMIZED_INLINING) ||		\
++    !defined(CONFIG_OPTIMIZE_INLINING) || (__GNUC__ < 4)
++#define inline		inline		__attribute__((always_inline)) notrace
++#define __inline__	__inline__	__attribute__((always_inline)) notrace
++#define __inline	__inline	__attribute__((always_inline)) notrace
++#else
++/* A lot of inline functions can cause havoc with function tracing */
++#define inline		inline		notrace
++#define __inline__	__inline__	notrace
++#define __inline	__inline	notrace
++#endif
++
++#define __always_inline	inline __attribute__((always_inline))
++#define  noinline	__attribute__((noinline))
++
++#define __deprecated	__attribute__((deprecated))
++#define __packed	__attribute__((packed))
++#define __weak		__attribute__((weak))
++#define __alias(symbol)	__attribute__((alias(#symbol)))
++
++/*
++ * it doesn't make sense on ARM (currently the only user of __naked)
++ * to trace naked functions because then mcount is called without
++ * stack and frame pointer being set up and there is no chance to
++ * restore the lr register to the value before mcount was called.
++ *
++ * The asm() bodies of naked functions often depend on standard calling
++ * conventions, therefore they must be noinline and noclone.
++ *
++ * GCC 4.[56] currently fail to enforce this, so we must do so ourselves.
++ * See GCC PR44290.
++ */
++#define __naked		__attribute__((naked)) noinline __noclone notrace
++
++#define __noreturn	__attribute__((noreturn))
++
++/*
++ * From the GCC manual:
++ *
++ * Many functions have no effects except the return value and their
++ * return value depends only on the parameters and/or global
++ * variables.  Such a function can be subject to common subexpression
++ * elimination and loop optimization just as an arithmetic operator
++ * would be.
++ * [...]
++ */
++#define __pure			__attribute__((pure))
++#define __aligned(x)		__attribute__((aligned(x)))
++#define __printf(a, b)		__attribute__((format(printf, a, b)))
++#define __scanf(a, b)		__attribute__((format(scanf, a, b)))
++#define __attribute_const__	__attribute__((__const__))
++#define __maybe_unused		__attribute__((unused))
++#define __always_unused		__attribute__((unused))
++
++/* gcc version specific checks */
++
++#if GCC_VERSION < 30200
++# error Sorry, your compiler is too old - please upgrade it.
++#endif
++
++#if GCC_VERSION < 30300
++# define __used			__attribute__((__unused__))
++#else
++# define __used			__attribute__((__used__))
++#endif
++
++#ifdef CONFIG_GCOV_KERNEL
++# if GCC_VERSION < 30400
++#   error "GCOV profiling support for gcc versions below 3.4 not included"
++# endif /* __GNUC_MINOR__ */
++#endif /* CONFIG_GCOV_KERNEL */
++
++#if GCC_VERSION >= 30400
++#define __must_check		__attribute__((warn_unused_result))
++#define __malloc		__attribute__((__malloc__))
++#endif
++
++#if GCC_VERSION >= 40000
++
++/* GCC 4.1.[01] miscompiles __weak */
++#ifdef __KERNEL__
++# if GCC_VERSION >= 40100 &&  GCC_VERSION <= 40101
++#  error Your version of gcc miscompiles the __weak directive
++# endif
++#endif
++
++#define __used			__attribute__((__used__))
++#define __compiler_offsetof(a, b)					\
++	__builtin_offsetof(a, b)
++
++#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
++# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
++#endif
++
++#if GCC_VERSION >= 40300
++/* Mark functions as cold. gcc will assume any path leading to a call
++ * to them will be unlikely.  This means a lot of manual unlikely()s
++ * are unnecessary now for any paths leading to the usual suspects
++ * like BUG(), printk(), panic() etc. [but let's keep them for now for
++ * older compilers]
++ *
++ * Early snapshots of gcc 4.3 don't support this and we can't detect this
++ * in the preprocessor, but we can live with this because they're unreleased.
++ * Maketime probing would be overkill here.
++ *
++ * gcc also has a __attribute__((__hot__)) to move hot functions into
++ * a special section, but I don't see any sense in this right now in
++ * the kernel context
++ */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++#endif /* GCC_VERSION >= 40300 */
++
++#if GCC_VERSION >= 40500
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ *
++ * Early snapshots of gcc 4.5 don't support this and we can't detect
++ * this in the preprocessor, but we can live with this because they're
++ * unreleased.  Really, we need to have autoconf for the kernel.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__, __optimize__("no-tracer")))
++
++#endif /* GCC_VERSION >= 40500 */
++
++#if GCC_VERSION >= 40600
++/*
++ * When used with Link Time Optimization, gcc can optimize away C functions or
++ * variables which are referenced only from assembly code.  __visible tells the
++ * optimizer that something else uses this function or variable, thus preventing
++ * this.
++ */
++#define __visible	__attribute__((externally_visible))
++#endif
++
++
++#if GCC_VERSION >= 40900 && !defined(__CHECKER__)
++/*
++ * __assume_aligned(n, k): Tell the optimizer that the returned
++ * pointer can be assumed to be k modulo n. The second argument is
++ * optional (default 0), so we use a variadic macro to make the
++ * shorthand.
++ *
++ * Beware: Do not apply this to functions which may return
++ * ERR_PTRs. Also, it is probably unwise to apply it to functions
++ * returning extra information in the low bits (but in that case the
++ * compiler should see some alignment anyway, when the return value is
++ * massaged by 'flags = ptr & 3; ptr &= ~3;').
++ */
++#define __assume_aligned(a, ...) __attribute__((__assume_aligned__(a, ## __VA_ARGS__)))
++#endif
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#if GCC_VERSION >= 40400
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#endif
++#if GCC_VERSION >= 40800
++#define __HAVE_BUILTIN_BSWAP16__
++#endif
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#if GCC_VERSION >= 50000
++#define KASAN_ABI_VERSION 4
++#elif GCC_VERSION >= 40902
++#define KASAN_ABI_VERSION 3
++#endif
++
++#if GCC_VERSION >= 40902
++/*
++ * Tell the compiler that address safety instrumentation (KASAN)
++ * should not be applied to that function.
++ * Conflicts with inlining: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67368
++ */
++#define __no_sanitize_address __attribute__((no_sanitize_address))
++#endif
++
++#endif	/* gcc version >= 40000 specific checks */
++
++#if !defined(__noclone)
++#define __noclone	/* not needed */
++#endif
++
++#if !defined(__no_sanitize_address)
++#define __no_sanitize_address
++#endif
++
++/*
++ * A trick to suppress uninitialized variable warning without generating any
++ * code
++ */
++#define uninitialized_var(x) x = x

--- a/target/linux/mediatek/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/base-files/lib/upgrade/platform.sh
@@ -1,4 +1,4 @@
-platform_do_upgrade() {                 
+platform_do_upgrade() {
 	local board=$(board_name)
 	case "$board" in
 	"unielec,u7623"*)
@@ -18,6 +18,15 @@ platform_do_upgrade() {
 		sync
 		umount /tmp/recovery
 		;;
+	bananapi,bpi-r2)
+		local tar_file="$1"
+
+		echo "flashing kernel"
+		tar xf $tar_file sysupgrade-7623n-bananapi-bpi-r2/kernel -O | mtd write - kernel
+
+		echo "flashing rootfs"
+		tar xf $tar_file sysupgrade-7623n-bananapi-bpi-r2/root -O | mtd write - rootfs
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;
@@ -26,29 +35,37 @@ platform_do_upgrade() {
 
 PART_NAME=firmware
 
-platform_check_image() {                                                         
-	local board=$(board_name)                                                
-	local magic="$(get_magic_long "$1")"                                     
+platform_check_image() {
+	local board=$(board_name)
 
-	[ "$#" -gt 1 ] && return 1                                               
+	[ "$#" -gt 1 ] && return 1
 
-	case "$board" in                                                       
-	bananapi,bpi-r2|\
+	case "$board" in
+	bananapi,bpi-r2)
+		local tar_file="$1"
+		local kernel_length=`(tar xf $tar_file sysupgrade-7623n-bananapi-bpi-r2/kernel -O | wc -c) 2> /dev/null`
+		local rootfs_length=`(tar xf $tar_file sysupgrade-7623n-bananapi-bpi-r2/root -O | wc -c) 2> /dev/null`
+		[ "$kernel_length" = 0 -o "$rootfs_length" = 0 ] && {
+			echo "The upgrade image is corrupt."
+			return 1
+		}
+		;;
 	"unielec,u7623"*)
-		[ "$magic" != "27051956" ] && {   
+		local magic="$(get_magic_long "$1")"
+		[ "$magic" != "27051956" ] && {
 			echo "Invalid image type."
-			return 1                                     
-		}                                                    
-		return 0                                             
-		;;                                                   
+			return 1
+		}
+		return 0
+		;;
 
-	*)                                                           
+	*)
 		echo "Sysupgrade is not supported on your board yet."
-		return 1                                             
-		;;                                
-	esac                                      
+		return 1
+		;;
+	esac
 
-	return 0                                                                                         
+	return 0
 }
 
 platform_copy_config_emmc() {

--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -26,6 +26,22 @@ define Build/sysupgrade-emmc
 		$(IMAGE_ROOTFS)
 endef
 
+define Build/sysupgrade-bpi-r2-sd
+        ./make_bpi-r2_bundle_image.sh $@ \
+                               $(STAGING_DIR_IMAGE)/mtk-bpi-r2-preloader-sd.bin \
+                               $(STAGING_DIR_IMAGE)/mtk-bpi-r2-uboot.bin \
+                               $(IMAGE_KERNEL) \
+                               $(IMAGE_ROOTFS)
+endef
+
+define Build/sysupgrade-bpi-r2-emmc
+        ./make_bpi-r2_bundle_image.sh $@ \
+                               $(STAGING_DIR_IMAGE)/mtk-bpi-r2-preloader-emmc.bin \
+                               $(STAGING_DIR_IMAGE)/mtk-bpi-r2-uboot.bin \
+                               $(IMAGE_KERNEL) \
+                               $(IMAGE_ROOTFS)
+endef
+
 # default all platform image(fit) build 
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)

--- a/target/linux/mediatek/image/make_bpi-r2_bundle_image.sh
+++ b/target/linux/mediatek/image/make_bpi-r2_bundle_image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+set -ex
+[ $# -eq 5 ] || {
+    echo "SYNTAX: $0 <file> <preloader image> <uboot image> <kernel image> <rootfs system>"
+    exit 1
+}
+
+OUTPUT_FILE="$1"
+PRELOADER_FILE="$2"
+UBOOT_FILE="$3"
+KERNEL_FILE="$4"
+ROOTFS_FILE="$5"
+
+BS=1024
+PRELOADER_OFFSET=0    # 0KB
+UBOOT_OFFSET=320      # 320KB
+KERNEL_OFFSET=2048    # 2048KB
+ROOTFS_OFFSET=67584   # 67584KB
+
+dd bs="$BS" if="$PRELOADER_FILE"      of="$OUTPUT_FILE"    seek="$PRELOADER_OFFSET" 
+dd bs="$BS" if="$UBOOT_FILE"          of="$OUTPUT_FILE"    seek="$UBOOT_OFFSET" 
+dd bs="$BS" if="$KERNEL_FILE"         of="$OUTPUT_FILE"    seek="$KERNEL_OFFSET" 
+dd bs="$BS" if="$ROOTFS_FILE"         of="$OUTPUT_FILE"    seek="$ROOTFS_OFFSET" 

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -13,7 +13,8 @@ define Device/7623n-bananapi-bpi-r2
   DEVICE_TITLE := MTK7623n BananaPi R2
   DEVICE_DTS := mt7623n-bananapi-bpi-r2
   SUPPORTED_DEVICES := bananapi,bpi-r2
-  IMAGES := sysupgrade-sd.bin.gz
+  IMAGES := sysupgrade.tar sysupgrade-sd.bin.gz
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
   IMAGE/sysupgrade-sd.bin.gz := sysupgrade-bpi-r2-sd | gzip | append-metadata
 endef
 

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -12,6 +12,9 @@ TARGET_DEVICES += 7623a-unielec-u7623-02-emmc-512m
 define Device/7623n-bananapi-bpi-r2
   DEVICE_TITLE := MTK7623n BananaPi R2
   DEVICE_DTS := mt7623n-bananapi-bpi-r2
+  SUPPORTED_DEVICES := bananapi,bpi-r2
+  IMAGES := sysupgrade-sd.bin.gz
+  IMAGE/sysupgrade-sd.bin.gz := sysupgrade-bpi-r2-sd | gzip | append-metadata
 endef
 
 TARGET_DEVICES += 7623n-bananapi-bpi-r2

--- a/target/linux/mediatek/patches-4.14/0228-arm-dts-mtk-bpi-r2-bootargs.patch
+++ b/target/linux/mediatek/patches-4.14/0228-arm-dts-mtk-bpi-r2-bootargs.patch
@@ -1,0 +1,12 @@
+Index: linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+===================================================================
+--- linux-4.14.51.orig/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
++++ linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+@@ -19,6 +19,7 @@
+ 
+ 	chosen {
+ 		stdout-path = "serial2:115200n8";
++		bootargs = "earlyprintk console=ttyS0,115200 block2mtd.block2mtd=/dev/mmcblk1,65536,RootFs,5 mtdparts=RootFs:512k(mbr)ro,512k(uboot)ro,512k(config)ro,512k(factory)ro,32M(kernel),32M(recovery),1024M(rootfs),2048M(usrdata),-(bmtpool) rootfstype=squashfs,jffs2";
+ 	};
+ 
+ 	memory {

--- a/target/linux/mediatek/patches-4.14/0229-fix-memory-size-for-bpi-r2.patch
+++ b/target/linux/mediatek/patches-4.14/0229-fix-memory-size-for-bpi-r2.patch
@@ -1,0 +1,13 @@
+Index: linux-4.9.44/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+===================================================================
+--- linux-4.9.44.orig/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts	2017-09-02 08:21:11.998199513 +0800
++++ linux-4.9.44/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts	2017-09-02 08:33:09.452252584 +0800
+@@ -18,7 +18,7 @@
+ 	};
+ */
+ 	memory {
+-		reg = <0 0x80000000 0 0x20000000>;
++		reg = <0 0x80000000 0 0x80000000>;
+ 	};
+ 
+ 	aliases {

--- a/target/linux/mediatek/patches-4.14/0229-update-gpio-leds-for-bpi-r2.patch
+++ b/target/linux/mediatek/patches-4.14/0229-update-gpio-leds-for-bpi-r2.patch
@@ -1,0 +1,27 @@
+Index: linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+===================================================================
+--- linux-4.14.51.orig/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
++++ linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+@@ -87,19 +87,19 @@
+ 
+ 		blue {
+ 			label = "bpi-r2:pio:blue";
+-			gpios = <&pio 241 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 240 GPIO_ACTIVE_LOW>;
+ 			default-state = "off";
+ 		};
+ 
+ 		green {
+ 			label = "bpi-r2:pio:green";
+-			gpios = <&pio 240 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 241 GPIO_ACTIVE_LOW>;
+ 			default-state = "off";
+ 		};
+ 
+ 		red {
+ 			label = "bpi-r2:pio:red";
+-			gpios = <&pio 239 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 239 GPIO_ACTIVE_LOW>;
+ 			default-state = "off";
+ 		};
+ 	};

--- a/target/linux/mediatek/patches-4.14/0230-update-pcie-for-bpi-r2.patch
+++ b/target/linux/mediatek/patches-4.14/0230-update-pcie-for-bpi-r2.patch
@@ -1,0 +1,48 @@
+Index: linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+===================================================================
+--- linux-4.14.51.orig/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
++++ linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+@@ -266,6 +266,28 @@
+ 	vqmmc-supply = <&mt6323_vio18_reg>;
+ };
+ 
++&pcie {
++       pinctrl-names = "default";
++       pinctrl-0 = <&pcie_default>;
++       status = "okay";
++
++       pcie@0,0 {
++               status = "okay";
++       };
++
++       pcie@1,0 {
++               status = "okay";
++       };
++};
++
++&pcie0_phy {
++       status = "okay";
++};
++
++&pcie1_phy {
++       status = "okay";
++};
++
+ &pio {
+ 	cir_pins_a:cir@0 {
+ 		pins_cir {
+@@ -433,6 +455,14 @@
+ 		};
+ 	};
+ 
++	pcie_default: pcie_pin_default {
++		pins_cmd_dat {
++			pinmux = <MT7623_PIN_208_AUD_EXT_CK1_FUNC_PCIE0_PERST_N>,
++				 <MT7623_PIN_209_AUD_EXT_CK2_FUNC_PCIE1_PERST_N>;
++			bias-disable;
++		};
++	};
++
+ 	pwm_pins_a: pwm@0 {
+ 		pins_pwm {
+ 			pinmux = <MT7623_PIN_203_PWM0_FUNC_PWM0>,

--- a/target/linux/mediatek/patches-4.14/0231-enable-trgmii-on-bpi-r2.patch
+++ b/target/linux/mediatek/patches-4.14/0231-enable-trgmii-on-bpi-r2.patch
@@ -1,0 +1,22 @@
+Index: linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+===================================================================
+--- linux-4.14.51.orig/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
++++ linux-4.14.51/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
+@@ -141,7 +141,7 @@
+ 	gmac1: mac@1 {
+ 		compatible = "mediatek,eth-mac";
+ 		reg = <1>;
+-		phy-mode = "rgmii";
++		phy-mode = "trgmii";
+ 
+ 		fixed-link {
+ 			speed = <1000>;
+@@ -206,7 +206,7 @@
+ 					reg = <5>;
+ 					label = "cpu";
+ 					ethernet = <&gmac1>;
+-					phy-mode = "rgmii";
++					phy-mode = "trgmii";
+ 
+ 					fixed-link {
+ 						speed = <1000>;


### PR DESCRIPTION
This is a retake on https://github.com/openwrt/openwrt/pull/1135 without WiFi support, which is too messy to upstream.

Several unresolved concerns from @blogic remain which I'm not sure how to handle:
* https://github.com/openwrt/openwrt/pull/1135#discussion_r207863955
* https://github.com/openwrt/openwrt/pull/1135#pullrequestreview-143558706
* https://github.com/openwrt/openwrt/pull/1135#pullrequestreview-143558950

Another problem is that built SD image fails to create jffs2 partition when booted citing "no jffs2 nodes". One needs to run `jffs2reset` to fix that; can I do that to the image itself instead somehow?