### PR TITLE
ramips: fix WiFi MAC addresses for D-Link DIR-810L

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
@@ -143,9 +143,10 @@
 };
 
 &wmac {
-	ralink,mtd-eeprom = <&factory 0>;
+	ralink,mtd-eeprom = <&factory 0x0>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pa_pins>;
+	mtd-mac-address = <&factory 0x28>;
 };
 
 &pcie0 {
@@ -153,5 +154,7 @@
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&factory 0x28>;
+		mtd-mac-address-increment = <2>;
 	};
 };


### PR DESCRIPTION
So far, WiFi MAC addresses for this device have been set up from
caldata. However, this returns values which do not look like MAC
addresses. They also do not match stock firmware:

wlan0 (5.0): 00:11:22:00:17:D0 from 0x8004
wlan1 (2.4): 00:11:22:00:17:CD from 0x4 (and 0x2e)

It looks like the only valid MAC address on this device is at 0x28.

So, this patch changes setup to calculate addresses based on the
value at 0x28:

lan: *:0A (flash, label)
wan: *:0B (flash + 1)
wifi2: *:0A (flash)
wifi5: *:0C (flash + 2)

Thanks to Roger Pueyo Centelles <roger.pueyo@guifi.net> for
investigating this on his devices.
