### PR TITLE
ar71xx: use platform code for qca955x usb0 init

### DIFF
--- a/target/linux/ar71xx/patches-4.14/951-qca955x-usb0-platform.patch
+++ b/target/linux/ar71xx/patches-4.14/951-qca955x-usb0-platform.patch
@@ -1,0 +1,14 @@
+--- a/arch/mips/ath79/dev-usb.c
++++ b/arch/mips/ath79/dev-usb.c
+@@ -317,7 +317,10 @@ static void __init qca955x_usb_setup(voi
+ {
+ 	ath79_ehci_pdata_v2.reset_notifier = qca955x_usb_reset_notifier;
+ 
+-	ar9xxx_ci_usb_setup(0, ATH79_IP3_IRQ(0));
++	ath79_usb_register("ehci-platform", 0,
++			   QCA955X_EHCI0_BASE, QCA955X_EHCI_SIZE,
++			   ATH79_IP3_IRQ(0),
++			   &ath79_ehci_pdata_v2, sizeof(ath79_ehci_pdata_v2));
+ 
+ 	ath79_usb_register("ehci-platform", 1,
+ 			   QCA955X_EHCI1_BASE, QCA955X_EHCI_SIZE,


### PR DESCRIPTION
Switch from ci_usb_setup to generic platform initialization of
usb0 port.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>