### PR TITLE
ar71xx: enable ddr wb flush on qca955x

### DIFF
--- a/target/linux/ar71xx/patches-4.14/952-qca955x-enable-ddr-wb-flush.patch
+++ b/target/linux/ar71xx/patches-4.14/952-qca955x-enable-ddr-wb-flush.patch
@@ -1,0 +1,49 @@
+--- a/arch/mips/ath79/common.c
++++ b/arch/mips/ath79/common.c
+@@ -49,6 +49,8 @@ void ath79_ddr_ctrl_init(void)
+ 	if (soc_is_ar913x() || soc_is_ar724x() || soc_is_ar933x()) {
+ 		ath79_ddr_wb_flush_base = ath79_ddr_base + 0x7c;
+ 		ath79_ddr_pci_win_base = 0;
++	} else if (soc_is_qca953x() || soc_is_qca955x()) {
++		ath79_ddr_wb_flush_base = ath79_ddr_base + 0x9c;
+ 	} else {
+ 		ath79_ddr_wb_flush_base = ath79_ddr_base + 0x9c;
+ 		ath79_ddr_pci_win_base = ath79_ddr_base + 0x7c;
+--- a/arch/mips/ath79/irq.c
++++ b/arch/mips/ath79/irq.c
+@@ -99,12 +99,12 @@ static void qca955x_ip2_irq_dispatch(str
+ 	}
+ 
+ 	if (status & QCA955X_EXT_INT_PCIE_RC1_ALL) {
+-		/* TODO: flush DDR? */
++		ath79_ddr_wb_flush(3);
+ 		generic_handle_irq(ATH79_IP2_IRQ(0));
+ 	}
+ 
+ 	if (status & QCA955X_EXT_INT_WMAC_ALL) {
+-		/* TODO: flush DDR? */
++		ath79_ddr_wb_flush(4);
+ 		generic_handle_irq(ATH79_IP2_IRQ(1));
+ 	}
+ }
+@@ -124,17 +124,17 @@ static void qca955x_ip3_irq_dispatch(str
+ 	}
+ 
+ 	if (status & QCA955X_EXT_INT_USB1) {
+-		/* TODO: flush DDR? */
++		ath79_ddr_wb_flush(2);
+ 		generic_handle_irq(ATH79_IP3_IRQ(0));
+ 	}
+ 
+ 	if (status & QCA955X_EXT_INT_USB2) {
+-		/* TODO: flush DDR? */
++		ath79_ddr_wb_flush(2);
+ 		generic_handle_irq(ATH79_IP3_IRQ(1));
+ 	}
+ 
+ 	if (status & QCA955X_EXT_INT_PCIE_RC2_ALL) {
+-		/* TODO: flush DDR? */
++		ath79_ddr_wb_flush(3);
+ 		generic_handle_irq(ATH79_IP3_IRQ(2));
+ 	}
+ }


### PR DESCRIPTION
Enable flushing of write buffers on qca955x. GPL code has 0x88 reg
defined for PCI flush which is likely an error since the device
freezes on boot. So use DS default value 0xA8 for PCI flush.

Signed-off-by: Tomislav Požega <pozega.tomislav@gmail.com>