### PR TITLE
ramips: enable external amplifier for D-Link DIR-810L

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-810l.dts
@@ -143,6 +143,8 @@
 
 &wmac {
 	ralink,mtd-eeprom = <&factory 0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
 };
 
 &pcie0 {


### PR DESCRIPTION
The 2.4 GHz radio had very poor signal reception (-88 dBm for an AP sitting 5 m away). By enabling the external amplifier, received signal has improved to -50 dBm for the same AP.

Improvement can be seen in the number of networks detected, and the signal level. Before:
```
root@OpenWrt:~# iwinfo wlan1 scan | grep Signal
          Signal: -88 dBm  Quality: 22/70
          Signal: -92 dBm  Quality: 18/70
          Signal: -92 dBm  Quality: 18/70
          Signal: -92 dBm  Quality: 18/70
          Signal: -90 dBm  Quality: 20/70
          Signal: -90 dBm  Quality: 20/70
          Signal: -92 dBm  Quality: 18/70
          Signal: -70 dBm  Quality: 40/70
          Signal: -70 dBm  Quality: 40/70
          Signal: -72 dBm  Quality: 38/70
          Signal: -72 dBm  Quality: 38/70
          Signal: -72 dBm  Quality: 38/70
```

After:
```
root@OpenWrt:~# iwinfo wlan1 scan | grep Signal
          Signal: -48 dBm  Quality: 62/70
          Signal: -58 dBm  Quality: 52/70
          Signal: -62 dBm  Quality: 48/70
          Signal: -48 dBm  Quality: 62/70
          Signal: -48 dBm  Quality: 62/70
          Signal: -50 dBm  Quality: 60/70
          Signal: -58 dBm  Quality: 52/70
          Signal: -48 dBm  Quality: 62/70
          Signal: -48 dBm  Quality: 62/70
          Signal: -66 dBm  Quality: 44/70
          Signal: -20 dBm  Quality: 70/70
          Signal: -58 dBm  Quality: 52/70
          Signal: -24 dBm  Quality: 70/70
          Signal: -24 dBm  Quality: 70/70
          Signal: -66 dBm  Quality: 44/70
          Signal: -24 dBm  Quality: 70/70
          Signal: -24 dBm  Quality: 70/70
          Signal: -52 dBm  Quality: 58/70
          Signal: -66 dBm  Quality: 44/70
          Signal: -74 dBm  Quality: 36/70
          Signal: -58 dBm  Quality: 52/70
          Signal: -66 dBm  Quality: 44/70
          Signal: -62 dBm  Quality: 48/70
          Signal: -62 dBm  Quality: 48/70
          Signal: -68 dBm  Quality: 42/70
          Signal: -60 dBm  Quality: 50/70
          Signal: -84 dBm  Quality: 26/70
```
