### PR TITLE
kernel: Correctly search for the FIT image in mtd partition.

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -60,8 +60,8 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	hdr_len = sizeof(struct fdt_header);
 
 	/* Parse the MTD device & search for the FIT image location */
-	for(offset = 0; offset < mtd->size; offset += mtd->erasesize) {
-		ret = mtd_read(mtd, 0, hdr_len, &retlen, (void*) &hdr);
+	for(offset = 0; offset + hdr_len < mtd->size; offset += mtd->erasesize) {
+		ret = mtd_read(mtd, offset, hdr_len, &retlen, (void*) &hdr);
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
 			       mtd->name, (unsigned long long) offset);


### PR DESCRIPTION
Correctly search for the FIT image in mtd partition. Previously all iterations of the loop checked offset=0 in the partition.

Signed-off-by: Fredrik Olofsson <fredrik.olofsson@anyfinetworks.com>
