### PR TITLE
[RFQ]mac80211: check if MAC is already in use

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -389,7 +389,12 @@ mac80211_generate_mac() {
 	}
 
 	[ "$((0x$mask6))" -lt 255 ] && {
-		printf "%s:%s:%s:%s:%s:%02x" $1 $2 $3 $4 $5 $(( 0x$6 ^ $id ))
+		local tmpmac=$(printf "%s:%s:%s:%s:%s:%02x" $1 $2 $3 $4 $5 $(( 0x$6 ^ $id )))
+		until ! grep -qF "$tmpmac" /sys/class/net/*/address ; do
+			id=$(($id + 1))
+			tmpmac=$(printf "%s:%s:%s:%s:%s:%02x" $1 $2 $3 $4 $5 $(( 0x$6 ^ $id )))
+		done
+		echo $tmpmac
 		return
 	}
 


### PR DESCRIPTION
Targets using multiple interface likely have MAC addresses
assigned in a row. If we have now manipulate the lower bits
the MACs may be reused by other devices.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
