### PR TITLE
ipq806x: fix checksum offset in rootfs for Buffalo WXR-2533DHP

### DIFF
--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -5,9 +5,11 @@ include $(INCLUDE_DIR)/image.mk
 
 define Build/buffalo-rootfs-cksum
 	( \
-		echo -ne "\x$$(od -A n -t u1 $@ | tr -s ' ' '\n' | \
-			$(STAGING_DIR_HOST)/bin/awk '{s+=$$0}END{printf "%x", 255-s%256}')"; \
-	) >> $@
+		squashfs_size="$$(dd if=$@ bs=4 skip=10 count=1 2> /dev/null | od -An -tu4 | tr -d ' \n')"; \
+		od -An -tu1 $@ | tr -s ' ' '\n' | \
+			$(STAGING_DIR_HOST)/bin/awk '{s+=$$0}END{printf "%c", 255-s%256}' | \
+				dd of=$@ bs=1 seek=$${squashfs_size} count=1 conv=notrunc 2> /dev/null; \
+	)
 endef
 
 define Device/Default


### PR DESCRIPTION
The size value in squashfs property is not matched with the offset of
rootfs checksum for WXR-2533DHP after removing -nopad option from
mksquashfs.

U-Boot on WXR-2533DHP fails to get the correct checksum using that
size value and mark the rootfs as "fail". It causes a boot failure.

log:

```
Hit any key to stop autoboot:  0
Checking Bank1 Image ...
Creating 1 MTD partitions on "nand0":
0x000000000000-0x000004000000 : "mtd=0"
Rootfs Checksum Error
Bank1 Image is fail
```

log (normal):

```
Hit any key to stop autoboot:  0
Checking Bank1 Image ...
Creating 1 MTD partitions on "nand0":
0x000000000000-0x000004000000 : "mtd=0"
Bank1 Image is good
kernel_checksum is 0xa166ecf4 , rootfs_checksum is 0xa3
```

ref: build: remove harmful -nopad option from mksquashfs
     1c0290c5cc6258c48b8ba46b4f9c85a21de4f875

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>