### PR TITLE
at91: split up DEVICE_TITLE

### DIFF
--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -54,7 +54,8 @@ endef
 
 define Device/at91-sama5d2_xplained
   $(Device/evaluation-dtb)
-  DEVICE_TITLE := Microchip(Atmel AT91) SAMA5D2 Xplained
+  DEVICE_VENDOR := Microchip
+  DEVICE_MODEL := SAMA5D2 Xplained
   KERNEL_SIZE := 6144k
   $(Device/evaluation-sdimage)
 endef
@@ -62,7 +63,8 @@ TARGET_DEVICES += at91-sama5d2_xplained
 
 define Device/at91-sama5d27_som1_ek
   $(Device/evaluation-dtb)
-  DEVICE_TITLE := Microchip(Atmel AT91) SAMA5D27 SOM1 Ek
+  DEVICE_VENDOR := Microchip
+  DEVICE_MODEL := SAMA5D27 SOM1 Ek
   KERNEL_SIZE := 6144k
   $(Device/evaluation-sdimage)
 endef
@@ -70,7 +72,8 @@ TARGET_DEVICES += at91-sama5d27_som1_ek
 
 define Device/at91-sama5d2_ptc_ek
   $(Device/evaluation-dtb)
-  DEVICE_TITLE := Microchip(Atmel AT91) SAMA5D2 PTC Ek
+  DEVICE_VENDOR := Microchip
+  DEVICE_MODEL := SAMA5D2 PTC Ek
   KERNEL_SIZE := 6144k
   $(Device/evaluation-sdimage)
 endef
@@ -79,7 +82,8 @@ TARGET_DEVICES += at91-sama5d2_ptc_ek
 
 define Device/at91-sama5d3_xplained
   $(Device/evaluation-dtb)
-  DEVICE_TITLE := Microchip(Atmel AT91) SAMA5D3 Xplained
+  DEVICE_VENDOR := Microchip
+  DEVICE_MODEL := SAMA5D3 Xplained
   KERNEL_SIZE := 6144k
   $(Device/evaluation-sdimage)
 endef
@@ -89,7 +93,8 @@ ifeq ($(strip $(CONFIG_EXTERNAL_KERNEL_TREE)),"")
  ifeq ($(strip $(CONFIG_KERNEL_GIT_CLONE_URI)),"")
   define Device/wb50n
     $(Device/evaluation-fit)
-    DEVICE_TITLE := Laird WB50N
+    DEVICE_VENDOR := Laird
+    DEVICE_MODEL := WB50N
     DEVICE_PACKAGES := \
 	  kmod-mmc-at91 kmod-ath6kl-sdio ath6k-firmware \
 	  kmod-usb-storage kmod-fs-vfat kmod-fs-msdos \
@@ -106,7 +111,8 @@ endif
 
 define Device/at91-sama5d4_xplained
   $(Device/evaluation-dtb)
-  DEVICE_TITLE := Microchip(Atmel AT91) SAMA5D4 Xplained
+  DEVICE_VENDOR := Microchip
+  DEVICE_MODEL := SAMA5D4 Xplained
   KERNEL_SIZE := 6144k
   BLOCKSIZE := 256k
   PAGESIZE := 4096


### PR DESCRIPTION
DEVICE_TITLE is split up into DEVICE_VENDOR, DEVICE_MODEL and DEVICE_VARIANT
Uses DEVICE_ALT* variables for alternative vendor/retailer names.