### PR TITLE
ramips: Add new device zbt-link we2802d support.

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -463,6 +463,11 @@ zbtlink,zbt-we1226)
 	ucidef_set_led_switch "lan2" "LAN2" "$boardname:green:lan2" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x10"
 	;;
+zbtlink,zbt-we2802d)
+	set_wifi_led "$boardname:green:wlan"
+	ucidef_set_led_switch "lan1" "LAN1" "$boardname:green:lan1" "switch0" "0x01"
+	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x10"
+	;;
 zorlik,zl5900v2)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" eth0
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -375,7 +375,8 @@ ramips_setup_interfaces()
 		"1:lan:2" "2:lan:1" "4:wan" "6@eth0"
 		;;
 	lenovo,newifi-y1|\
-	zbtlink,zbt-we1226)
+	zbtlink,zbt-we1226|\
+	zbtlink,zbt-we2802d)
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we2802d.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we2802d.dts
@@ -1,0 +1,115 @@
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-we2802d", "mediatek,mt7628an-soc";
+	model = "Zbtlink ZBT-WE2802d";
+
+	aliases {
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-running = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "zbt-we2802d:green:wan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "zbt-we2802d:green:lan1";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "zbt-we2802d:green:lan2";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan: wlan {
+			label = "zbt-we2802d:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "p0led_an", "p1led_an", "p4led_an", "wdt", "wled_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x4>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x2e>;
+	mediatek,portmap = "llllw";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -573,6 +573,14 @@ define Device/zbtlink_zbt-we1226
 endef
 TARGET_DEVICES += zbtlink_zbt-we1226
 
+define Device/zbtlink_zbt-we2802d
+  MTK_SOC := mt7628an
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ZBTlink
+  DEVICE_MODEL := ZBT-WE2802d
+endef
+TARGET_DEVICES += zbtlink_zbt-we2802d
+
 define Device/zyxel_keenetic-extra-ii
   MTK_SOC := mt7628an
   IMAGE_SIZE := 14912k


### PR DESCRIPTION
MT7628DAN (580MHz), 16MB SPI NOR, 64MB DDR2 RAM.

All works great.

Signed-off-by: likai <likaisoftware@gmail.com>
