### PR TITLE
fix hostapd warnings

### DIFF
--- a/package/network/services/hostapd/patches/410-limit_debug_messages.patch
+++ b/package/network/services/hostapd/patches/410-limit_debug_messages.patch
@@ -124,7 +124,7 @@
   * configuration. The contents of buf is printed out has hex dump.
   */
 -void wpa_hexdump(int level, const char *title, const void *buf, size_t len);
-+static inline void wpa_hexdump(int level, const char *title, const u8 *buf, size_t len)
++static inline void wpa_hexdump(int level, const char *title, const void *buf, size_t len)
 +{
 +	if (level < CONFIG_MSG_MIN_PRIORITY)
 +		return;

--- a/package/network/services/hostapd/patches/599-wpa_supplicant-fix-warnings.patch
+++ b/package/network/services/hostapd/patches/599-wpa_supplicant-fix-warnings.patch
@@ -1,0 +1,19 @@
+--- a/wpa_supplicant/wps_supplicant.h
++++ b/wpa_supplicant/wps_supplicant.h
+@@ -9,6 +9,7 @@
+ #ifndef WPS_SUPPLICANT_H
+ #define WPS_SUPPLICANT_H
+ 
++struct wpa_bss;
+ struct wpa_scan_results;
+ 
+ #ifdef CONFIG_WPS
+@@ -16,8 +17,6 @@ struct wpa_scan_results;
+ #include "wps/wps.h"
+ #include "wps/wps_defs.h"
+ 
+-struct wpa_bss;
+-
+ struct wps_new_ap_settings {
+ 	const char *ssid_hex;
+ 	const char *auth;


### PR DESCRIPTION
unsure if wanted.

one issue lies within an existing patch that changes the types in the signature of `wpa_hexdump`.
the other is fixing a 'bad practice?' with `wpa_supplicant/wps_supplicant.h` where it assumed that symbols used in the header are declared beforehand.
see commit descriptions.

there is another warning from duplicate definitions of `ARRAY_SIZE` when using libubox - but that goes beyond hostapd ;-)