### PR TITLE
kernel: 4.19: fix crash when setting up spi-gpio

### DIFF
--- a/target/linux/generic/hack-4.19/801-spi-gpio-fix-num-cs-0.patch
+++ b/target/linux/generic/hack-4.19/801-spi-gpio-fix-num-cs-0.patch
@@ -1,0 +1,19 @@
+--- a/drivers/spi/spi-gpio.c
++++ b/drivers/spi/spi-gpio.c
+@@ -242,10 +241,12 @@ static int spi_gpio_setup(struct spi_dev
+ 	 * The CS GPIOs have already been
+ 	 * initialized from the descriptor lookup.
+ 	 */
+-	cs = spi_gpio->cs_gpios[spi->chip_select];
+-	if (!spi->controller_state && cs)
+-		status = gpiod_direction_output(cs,
+-						!(spi->mode & SPI_CS_HIGH));
++	if (spi_gpio->has_cs) {
++		cs = spi_gpio->cs_gpios[spi->chip_select];
++		if (!spi->controller_state && cs)
++			status = gpiod_direction_output(cs,
++						  !(spi->mode & SPI_CS_HIGH));
++	}
+ 
+ 	if (!status)
+ 		status = spi_bitbang_setup(spi);


### PR DESCRIPTION
If an spi-gpio was specified with `num-chipselects = <0>`, kernel will crash:
```
[    1.017144] Unable to handle kernel paging request at virtual address 32697073
[    1.017176] pgd = (ptrval)
[    1.023253] [32697073] *pgd=00000000
[    1.026004] Internal error: Oops: 5 [#1] SMP ARM
[    1.029679] Modules linked in:
[    1.034283] CPU: 2 PID: 1 Comm: swapper/0 Not tainted 4.19.72 #0
[    1.037148] Hardware name: Generic DT based system
[    1.043320] PC is at validate_desc+0x28/0x80
[    1.047912] LR is at gpiod_direction_output+0x14/0x128
...
[    1.265296] [<c0544db4>] (validate_desc) from [<c0545228>] (gpiod_direction_output+0x14/0x128)
[    1.273451] [<c0545228>] (gpiod_direction_output) from [<c05fa714>] (spi_gpio_setup+0x58/0x64)
[    1.281953] [<c05fa714>] (spi_gpio_setup) from [<c05f7258>] (spi_setup+0x12c/0x148)
[    1.290540] [<c05f7258>] (spi_setup) from [<c05f7330>] (spi_add_device+0xbc/0x12c)
[    1.298094] [<c05f7330>] (spi_add_device) from [<c05f7f74>] (spi_register_controller+0x838/0x924)
[    1.305735] [<c05f7f74>] (spi_register_controller) from [<c05fa494>] (spi_bitbang_start+0x108/0x120)
[    1.314677] [<c05fa494>] (spi_bitbang_start) from [<c05faa34>] (spi_gpio_probe+0x314/0x338)
[    1.323881] [<c05faa34>] (spi_gpio_probe) from [<c05a844c>] (platform_drv_probe+0x34/0x70)
```
The cause is `spi_gpio_setup()` did not check if the spi-gpio ever has chipselect pins
before setting their direction and results in out-of-boundary error.

There is a similar fix upstream torvalds/linux@249e2632dcd0509b8f8f296f5aabf4d48dfd6da8.