### PR TITLE
ath79: Add support for TP-Link Archer C59v2

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -158,6 +158,7 @@ tplink,tl-wr842n-v3)
 	;;
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1|\
+tplink,archer-c59-v2|\
 tplink,archer-c60-v1|\
 tplink,archer-c60-v2)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -59,7 +59,8 @@ ath79_setup_interfaces()
 	avm,fritz4020|\
 	pcs,cr3000|\
 	tplink,archer-c58-v1|\
-	tplink,archer-c59-v1)
+	tplink,archer-c59-v1|\
+	tplink,archer-c59-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -214,6 +214,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,archer-c58-v1|\
 	tplink,archer-c59-v1|\
+	tplink,archer-c59-v2|\
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
 	tplink,archer-c6-v2)

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
@@ -1,63 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
 #include "qca9561_tplink_archer-c5x.dtsi"
 
 / {
 	compatible = "tplink,archer-c58-v1", "qca,qca9560";
 	model = "TP-Link Archer C58 v1";
-
-	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		power: power {
-			label = "tp-link:green:power";
-			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wan_green {
-			label = "tp-link:green:wan";
-			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "tp-link:amber:wan";
-			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
-		};
-	};
 };
 
 &spi {
@@ -105,21 +53,4 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-	mtd-mac-address-increment = <1>;
-};
-
-&eth1 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-};
-
-&wmac {
-	status = "okay";
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -1,69 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
 #include "qca9561_tplink_archer-c5x.dtsi"
 
 / {
 	compatible = "tplink,archer-c59-v1", "qca,qca9560";
 	model = "TP-Link Archer C59 v1";
+};
 
-	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		power: power {
-			label = "tp-link:green:power";
-			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wan_green {
-			label = "tp-link:green:wan";
-			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "tp-link:amber:wan";
-			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
-		};
-
-		usb {
-			label = "tp-link:green:usb";
-			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "usbport";
-			trigger-sources = <&hub_port>;
-		};
+&leds {
+	usb {
+		label = "tp-link:green:usb";
+		gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "usbport";
+		trigger-sources = <&hub_port>;
 	};
 };
 
@@ -127,21 +77,4 @@
 			};
 		};
 	};
-};
-
-&eth0 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-	mtd-mac-address-increment = <1>;
-};
-
-&eth1 {
-	status = "okay";
-	mtd-mac-address = <&mac 0x8>;
-};
-
-&wmac {
-	status = "okay";
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9561_tplink_archer-c5x.dtsi"
+
+/ {
+	compatible = "tplink,archer-c59-v2", "qca,qca9560";
+	model = "TP-Link Archer C59 v2";
+};
+
+&leds {
+	usb	{
+		label =	"tp-link:green:usb";
+		gpios =	<&led_gpio 7 GPIO_ACTIVE_LOW>;
+		linux,default-trigger =	"usbport";
+		trigger-sources	= <&hub_port>;
+	};
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			mac: partition@30000 {
+				label = "mac";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xe10000>;
+			};
+
+			partition@e50000 {
+				label = "tplink";
+				reg = <0xe50000 0x1a0000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c5x.dtsi
@@ -8,6 +8,13 @@
 / {
 	compatible = "tplink,archer-c5x", "qca,qca9560";
 
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
 	};
@@ -29,6 +36,48 @@
 			#gpio-cells = <2>;
 			registers-number = <1>;
 			spi-max-frequency = <10000000>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "tp-link:green:power";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_green {
+			label = "tp-link:green:wan";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "tp-link:amber:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -86,8 +135,13 @@
 };
 
 &eth0 {
+	status = "okay";
+
 	phy-mode = "mii";
 	phy-handle = <&swphy0>;
+
+	mtd-mac-address = <&mac 0x8>;
+	mtd-mac-address-increment = <1>;
 
 	gmac-config {
 		device = <&gmac>;
@@ -95,4 +149,17 @@
 		switch-phy-addr-swap = <1>;
 		switch-phy-swap = <1>;
 	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&mac 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -60,6 +60,18 @@ define Device/tplink_archer-c59-v1
 endef
 TARGET_DEVICES += tplink_archer-c59-v1
 
+define Device/tplink_archer-c59-v2
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9561
+  IMAGE_SIZE := 14400k
+  DEVICE_MODEL := Archer C59
+  DEVICE_VARIANT := v2
+  TPLINK_BOARD_ID := ARCHER-C59-V2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  SUPPORTED_DEVICES += archer-c59-v2
+endef
+TARGET_DEVICES += tplink_archer-c59-v2
+
 define Device/tplink_archer-c60-v1
   $(Device/tplink-safeloader-uimage)
   ATH_SOC := qca9561


### PR DESCRIPTION
Adds support for TP-Link Archer C59v2 to the ath79 platform.

Based on changes made in PR #2364
