### PR TITLE
ath79: add support for Devolo Magic 2 WIFI

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -71,7 +71,7 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
-devolo,dlan2-2400-ac)
+devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:status:dlan" "eth0.1" "rx"
 	;;
 dlink,dir-842-c1|\

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -71,6 +71,9 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+devolo,dlan2-2400-ac)
+	ucidef_set_led_netdev "plcw" "dLAN" "devolo:status:dlan" "eth0.1" "rx"
+	;;
 dlink,dir-842-c1|\
 dlink,dir-842-c2|\
 dlink,dir-842-c3|\

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -71,6 +71,9 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+devolo,magic-2-wifi)
+	ucidef_set_led_netdev "plcw" "dLAN" "devolo:status:dlan" "eth0.1" "rx"
+	;;
 dlink,dir-842-c1|\
 dlink,dir-842-c2|\
 dlink,dir-842-c3|\

--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -71,6 +71,11 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+devolo,dlan2-2400-ac|\
+devolo,magic2wifi)
+	ucidef_set_led_netdev "plcw" "dLAN" "devolo:status:dlan" "eth0.1" "rx"
+	ucidef_set_led_wlan "wlan" "WLAN" "devolo:status:wlan" "phy1tpt"
+	;;
 dlink,dir-842-c1|\
 dlink,dir-842-c2|\
 dlink,dir-842-c3|\

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -124,7 +124,7 @@ ath79_setup_interfaces()
 	ocedo,ursus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
-	devolo,dlan2-2400-ac)
+	devolo,magic-2-wifi)
 		ucidef_add_switch "switch0" "0@eth0" "2:wan" "3:lan" "4:lan"
 		;;
 	dlink,dir-825-b1)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -124,6 +124,11 @@ ath79_setup_interfaces()
 	ocedo,ursus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	devolo,dlan2-2400-ac|\
+	devolo,magic2wifi)
+		ucidef_set_interface_lan "eth0"
+		ucidef_add_switch "switch0" "0@eth0" "2:wan" "3:lan" "4:lan"
+		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -124,6 +124,9 @@ ath79_setup_interfaces()
 	ocedo,ursus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	devolo,dlan2-2400-ac)
+		ucidef_add_switch "switch0" "0@eth0" "2:wan" "3:lan" "4:lan"
+		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -124,6 +124,9 @@ ath79_setup_interfaces()
 	ocedo,ursus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	devolo,magic-2-wifi)
+		ucidef_add_switch "switch0" "0@eth0" "2:wan" "3:lan" "4:lan"
+		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -320,6 +323,9 @@ ath79_setup_macs()
 	avm,fritz4020)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
+		;;
+	devolo,magic-2-wifi)
+		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
 		;;
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -324,6 +324,9 @@ ath79_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
+	devolo,magic-2-wifi)
+		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
+		;;
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)
 		wan_mac=$(mtd_get_mac_text "caldata" 0xffb4)

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -31,6 +31,10 @@ comfast,cf-e5)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
+devolo,magic-2-wifi)
+	ucidef_add_gpio_switch "plc_pairing" "PLC pairing" "11" "1"
+	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "1"
+	;;
 dlink,dir-825-c1|\
 dlink,dir-835-a1)
 	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -31,6 +31,11 @@ comfast,cf-e5)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
+devolo,dlan2-2400-ac)
+	ucidef_add_gpio_switch "plc_pairing" "PLC pairing" "11" "1"
+	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "1"
+	ucidef_add_gpio_switch "wlan_power" "WLAN power" "21" "1"
+	;;
 dlink,dir-825-c1|\
 dlink,dir-835-a1)
 	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -31,6 +31,12 @@ comfast,cf-e5)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
+devolo,dlan2-2400-ac|\
+devolo,magic2wifi)
+	ucidef_add_gpio_switch "plc_pairing" "PLC pairing" "11" "1"
+	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "1"
+	ucidef_add_gpio_switch "wlan_power" "WLAN power" "21" "1"
+	;;
 dlink,dir-825-c1|\
 dlink,dir-835-a1)
 	ucidef_add_gpio_switch "wan_led_auto" "WAN LED Auto" "20" "0"

--- a/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/base-files/etc/board.d/03_gpio_switches
@@ -31,10 +31,9 @@ comfast,cf-e5)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
-devolo,dlan2-2400-ac)
+devolo,magic-2-wifi)
 	ucidef_add_gpio_switch "plc_pairing" "PLC pairing" "11" "1"
 	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "1"
-	ucidef_add_gpio_switch "wlan_power" "WLAN power" "21" "1"
 	;;
 dlink,dir-825-c1|\
 dlink,dir-835-a1)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -89,6 +89,7 @@ case "$FIRMWARE" in
 	case $board in
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
+	devolo,magic-2-wifi|\
 	yuncore,a770)
 		ath10kcal_extract "art" 0x5000 0x844
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -87,6 +87,8 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	devolo,dlan2-2400-ac|\
+	devolo,magic2wifi|\
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	yuncore,a770)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -89,7 +89,7 @@ case "$FIRMWARE" in
 	case $board in
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
-	devolo,dlan2-2400-ac|\
+	devolo,magic-2-wifi|\
 	yuncore,a770)
 		ath10kcal_extract "art" 0x5000 0x844
 		;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -89,6 +89,7 @@ case "$FIRMWARE" in
 	case $board in
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
+	devolo,dlan2-2400-ac|\
 	yuncore,a770)
 		ath10kcal_extract "art" 0x5000 0x844
 		;;

--- a/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "Devolo Magic 2 Wifi";
+	compatible = "devolo,dlan2-2400-ac", "devolo,magic2wifi", "qca,ar9344";
+
+	aliases {
+		led-boot = &system;
+		led-failsafe = &system;
+		led-running = &system;
+		led-upgrade = &system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "devolo:status:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		system: lan_status {
+			label = "devolo:status:dlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+//			default-state = "on";
+		};
+
+		dlan_error {
+			label = "devolo:error:dlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+		wifi_button {
+			label = "WIFI button";
+			//                        linux,code = <KEY_RFKILL>;
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+		dlan_button {
+			label = "DLAN button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&gpio {
+	status = "okay";
+
+	wlan_power {
+		line-name = "WLAN power";
+		gpios = <21 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_enable {
+		line-name = "PLC enable";
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_pairing {
+		line-name = "PLC pairing";
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};
+
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Config1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "Config2";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0xf80000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+
+};
+
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x02000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x1002>;
+	mtd-mac-address-increment = <2>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+/*	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+*/
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+//	mtd-mac-address-increment = <(-2)>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&art 0x5006>;
+		qca,no-eeprom;
+	};
+};
+
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x06400000 /* PORT0: RGMII, MAC0/6 exchage, tx_delay 01, No rx_delay. To reset use 0x86400000 */
+			0x08 0x00000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			//0xe4 0x0002a545  /* UNKNOWN */
+		>;
+	};
+};
+
+
+

--- a/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
@@ -85,7 +85,6 @@
 	};
 };
 
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan2-2400-ac.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "Devolo Magic 2 Wifi";
+	compatible = "devolo,dlan2-2400-ac", "qca,ar9344";
+
+	aliases {
+		led-boot = &plcr;
+		led-failsafe = &plcr;
+		led-running = &plcw;
+		led-upgrade = &plcr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan: wlan {
+			label = "devolo:status:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		plcw: lan_status {
+			label = "devolo:status:dlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		plcr: dlan_error {
+			label = "devolo:error:dlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+		wifi_button {
+			label = "WIFI button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+		dlan_button {
+			label = "DLAN button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&gpio {
+	status = "okay";
+
+	wlan_power {
+		line-name = "WLAN power";
+		gpios = <21 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_enable {
+		line-name = "PLC enable";
+		gpios = <13 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_pairing {
+		line-name = "PLC pairing";
+		gpios = <11 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};
+
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Config1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "Config2";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0xf80000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x02000000 0x00000101 0x00001616>; /* default for ar934x, except for 1000M */
+
+	mtd-mac-address = <&art 0x1002>;
+	mtd-mac-address-increment = <2>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+		mtd-mac-address = <&art 0x5006>;
+		qca,no-eeprom;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x06400000 /* PORT0: RGMII, MAC0/6 exchage, tx_delay 01, No rx_delay. To reset use 0x86400000 */
+			0x08 0x00000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_devolo_magic-2-wifi.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_magic-2-wifi.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	model = "Devolo Magic 2 Wifi";
+	compatible = "devolo,magic-2-wifi", "qca,ar9344";
+
+	aliases {
+		led-boot = &plcr;
+		led-failsafe = &plcr;
+		led-running = &plcw;
+		led-upgrade = &plcr;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan: wlan {
+			label = "devolo:status:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		plcw: lan_status {
+			label = "devolo:status:dlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		plcr: dlan_error {
+			label = "devolo:error:dlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset_button {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+		wifi_button {
+			label = "WIFI button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+		dlan_button {
+			label = "DLAN button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&gpio {
+	status = "okay";
+
+	wlan_power {
+		gpio-hog;
+		line-name = "WLAN power";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_enable {
+		line-name = "PLC enable";
+		gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	plc_pairing {
+		line-name = "PLC pairing";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		output-high;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Config1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "Config2";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0xf80000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x02000000 0x00000101 0x00001616>; /* default for ar934x, except for 1000M */
+
+	mtd-mac-address = <&art 0x1002>;
+	mtd-mac-address-increment = <2>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {	/* Wifi ath9K 2.4GHz 802.11bgn */
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 { /* ath10k 5GHz 802.11anac 2x2MIMO */
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x06400000 /* PORT0: RGMII, MAC0/6 exchage, tx_delay 01, No rx_delay. To reset use 0x86400000 */
+			0x08 0x00000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_devolo_magic-2-wifi.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_magic-2-wifi.dts
@@ -8,13 +8,14 @@
 
 / {
 	model = "Devolo Magic 2 Wifi";
-	compatible = "devolo,dlan2-2400-ac", "qca,ar9344";
+	compatible = "devolo,magic-2-wifi", "qca,ar9344";
 
 	aliases {
 		led-boot = &plcr;
 		led-failsafe = &plcr;
 		led-running = &plcw;
 		led-upgrade = &plcr;
+		label-mac-device = &eth0;
 	};
 
 	leds {
@@ -67,20 +68,21 @@
 	status = "okay";
 
 	wlan_power {
+		gpio-hog;
 		line-name = "WLAN power";
-		gpios = <21 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		output-high;
 	};
 
 	plc_enable {
 		line-name = "PLC enable";
-		gpios = <13 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		output-high;
 	};
 
 	plc_pairing {
 		line-name = "PLC pairing";
-		gpios = <11 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		output-high;
 	};
 };
@@ -159,7 +161,7 @@
 	phy-handle = <&phy0>;
 };
 
-&wmac {
+&wmac {	/* Wifi ath9K 2.4GHz 802.11bgn */
 	status = "okay";
 	mtd-cal-data = <&art 0x1000>;
 };
@@ -167,10 +169,9 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 { /* ath10k 5GHz 802.11anac 2x2MIMO */
 		compatible = "pci168c,003c";
 		reg = <0x0000 0 0 0 0>;
-		mtd-mac-address = <&art 0x5006>;
 		qca,no-eeprom;
 	};
 };

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -297,14 +297,14 @@ define Device/comfast_cf-wr650ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
-define Device/devolo_dlan2-2400-ac
+define Device/devolo_magic-2-wifi
   ATH_SOC := ar9344
   DEVICE_VENDOR := Devolo
-  DEVICE_MODEL := Magic 2 WIFI
+  DEVICE_MODEL := Magic 2 WiFi
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-gpio-button-hotplug
   IMAGE_SIZE := 15872k
 endef
-TARGET_DEVICES += devolo_dlan2-2400-ac
+TARGET_DEVICES += devolo_magic-2-wifi
 
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -297,6 +297,17 @@ define Device/comfast_cf-wr650ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
+define Device/devolo_dlan2-2400-ac
+  ATH_SOC := ar9344
+  DEVICE_VENDOR := Devolo
+  DEVICE_MODEL := Magic 2 WIFI
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-ledtrig-gpio kmod-gpio-button-hotplug kmod-leds-gpio gpiod-tools \
+                     ebtables kmod-ebtables kmod-ebtables-ipv4 kmod-ebtables-ipv6 hostapd-utils wifitoggle wpad ip-full
+  SUPPORTED_DEVICES += dlan2-2400-ac
+  IMAGE_SIZE := 15872k
+endef
+TARGET_DEVICES += devolo_dlan2-2400-ac
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_VENDOR := devolo

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -297,6 +297,15 @@ define Device/comfast_cf-wr650ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
+define Device/devolo_magic-2-wifi
+  ATH_SOC := ar9344
+  DEVICE_VENDOR := Devolo
+  DEVICE_MODEL := Magic 2 WiFi
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-gpio-button-hotplug
+  IMAGE_SIZE := 15872k
+endef
+TARGET_DEVICES += devolo_magic-2-wifi
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_VENDOR := devolo

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -297,6 +297,15 @@ define Device/comfast_cf-wr650ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
+define Device/devolo_dlan2-2400-ac
+  ATH_SOC := ar9344
+  DEVICE_VENDOR := Devolo
+  DEVICE_MODEL := Magic 2 WIFI
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-gpio-button-hotplug
+  IMAGE_SIZE := 15872k
+endef
+TARGET_DEVICES += devolo_dlan2-2400-ac
+
 define Device/devolo_dvl1200e
   ATH_SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
This path support Devolo Magic 2 WIFI, board devolo_dlan2-2400-ac.
This device is a plc wifi router/extender with 2 Ethernet ports,
has a G.hn PLC and uses LCMP protocol from Home Grid Forum.

Hardware:
   SoC:         AR9344
   CPU:         560 MHz
   Flash:       16 MiB (W25Q128JVSIQ)
   RAM:         128 MiB DDR2
   Ethernet:    2xLAN 10/100/1000
   PLC:         88LX5152 (MaxLinear G.hn)
   PLC Flash:   W25Q32JVSSIQ
   PLC Uplink:  1Gbps MIMO
   PLC Link:    RGMII 1Gbps (WAN)
   WiFi:        Atheros AR9340 2.4GHz 802.11bgn
                Atheros AR9882-BR4A 5GHz 802.11ac
   Switch:      QCA8337, Port0:CPU, Port2:PLC, Port3:LAN1, Port4:LAN2
   Button:      3x Buttons (Reset, wifi and plc)
   LED:         3x Leds (wifi, plc white, plc red)
   GPIO Switch: 11-PLC Pairing (Active Low)
                13-PLC Enable
                21-WLAN power

Recommendations: Configure and link your PLC with OEM firmware
BEFORE you flash the device. PLC configuration/link should
remain in a different memory and should work straight forward
after flashing.

Restrictions: PLC link detection to trigger plc red led is not
available. PLC G.hn chip is not compatible with open-plc-tools,
it uses LCMP protocol with AES-128 and requires a different
software.

Notes: Pairing should be possible with gpio switch. Default
configuration will trigger wifi led with 2.4Ghz wifi traffic
and plc white led with wan traffic.

Flash instruction (TFTP):
1. Set PC to fixed ip address 192.168.0.100
2. Download the sysupgrade image and rename it to uploadfile
3. Start a tftp server with the image file in its root directory
4. Turn off the router
5. Press and hold Reset button
6. Turn on router with the reset button pressed and wait ~15 seconds
7. Release the reset button and after a short time
   the firmware should be transferred from the tftp server
8. Allow 1-2 minutes for the first boot.

Signed-off-by: Manuel Giganto <mgigantoregistros@gmail.com>