### PR TITLE
Enable wifi with oem or mac password

### DIFF
--- a/package/base-files/files/etc/uci-defaults/30_reconfigure_wifi
+++ b/package/base-files/files/etc/uci-defaults/30_reconfigure_wifi
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+FLAG="/tmp/wifi.update"
+[ -f "$FLAG" ] && rm -f "$FLAG" || exit 0
+
+wifi_set() {
+	uci set wireless.$1.$2
+}
+
+logger "Reconfiguring the wifi to ensure it uses the /etc/board.json"
+
+config_load wireless
+config_foreach wifi_rfkill_set wifi-device
+
+config_load wireless
+CFG=/etc/board.json
+json_load "$(cat ${CFG})"
+if json_is_a system object; then
+	json_select system
+		local wifi_ssid wifi_key wifi_country wifi_txpower wifi_default
+		json_get_vars wifi_ssid wifi_key wifi_country wifi_txpower wifi_default
+	json_select ..
+fi
+
+[ -n "$wifi_country" ] && config_foreach wifi_set wifi-device country="$wifi_country"
+[ -n "$wifi_txpower" ] && config_foreach wifi_set wifi-device txpower="$wifi_txpower"
+grep -q $'^\xf7$' $(find /sys/firmware/devicetree -name linux,code) || \
+	if [ -n "$wifi_default" ] then ;
+		wifi_radio=$(uci show wireless|grep 11$wifi_default | cut -d. -f2)
+		[ -n "$wifi_radio" ] && uci set wireless.$wifi_radio.disabled=0
+	fi
+[ -n "$wifi_ssid" ] && config_foreach wifi_set wifi-iface ssid="$wifi_ssid"
+[ -n "$wifi_key" ] && config_foreach wifi_set wifi-iface key="$wifi_key"
+[ -n "$wifi_key" ] && uci -q set system.@system[0].default_key=$wifi_key && uci -q commit system
+[ -n "$(uci changes wireless)" ] && uci commit wireless && wifi reload
+
+exit 0

--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -3,6 +3,8 @@
 
 append DRIVERS "mac80211"
 
+. /lib/functions/system.sh
+
 lookup_phy() {
 	[ -n "$phy" ] && {
 		[ -d /sys/class/ieee80211/$phy ] && return
@@ -60,6 +62,20 @@ check_mac80211_device() {
 detect_mac80211() {
 	devidx=0
 	config_load wireless
+	CFG=/etc/board.json
+
+	[ -s "$CFG" ] || touch "/tmp/wifi.update"
+	json_load "$(cat ${CFG})"
+	if json_is_a system object; then
+		json_select system
+			local wifi_ssid wifi_key wifi_country wifi_txpower wifi_default
+			json_get_vars wifi_ssid wifi_key wifi_country wifi_txpower wifi_default
+		json_select ..
+	fi
+
+	encryption="psk2"
+	key=$(< /dev/urandom tr -dc ".,+:;%_A-Z-0-9" | head -c${1:-40};echo;)
+
 	while :; do
 		config_get type "radio$devidx" type
 		[ -n "$type" ] || break
@@ -76,9 +92,13 @@ detect_mac80211() {
 		[ "$found" -gt 0 ] && continue
 
 		mode_band="g"
-		channel="11"
+		channel="1"
 		htmode=""
 		ht_capab=""
+		[ -n "$wifi_txpower" ] && tx_power="set wireless.radio${devidx}.txpower=$wifi_txpower" \
+			|| [ -n "$wifi_country" ] || tx_power="set wireless.radio${devidx}.txpower=5"
+		[ -n "$wifi_country" ] && country="$wifi_country" || country="00"
+		[ -n "$wifi_ssid" ] && ssid=$wifi_ssid || ssid=OpenWrt-$(hexdump -ve '"%02X"' -n4 /dev/urandom)
 
 		iw phy "$dev" info | grep -q 'Capabilities:' && htmode=HT20
 
@@ -89,6 +109,15 @@ detect_mac80211() {
 		}
 
 		[ -n "$htmode" ] && ht_capab="set wireless.radio${devidx}.htmode=$htmode"
+		disable_legacy=$( [ "$mode_band" = "g" ] && echo "set wireless.radio${devidx}.legacy_rates='0'" )
+
+		disabled=1
+		grep -q $'^\xf7$' $(find /sys/firmware/devicetree -name linux,code) || \
+			if [ -n "$wifi_default" ] ; then
+				[ "$wifi_default" = "$mode_band" ] && disabled="0"
+			else
+				[[ -n "$wifi_key" && -n "$wifi_country" || "$mode_band" = "g" ]] && disabled=0
+			fi
 
 		path="$(mac80211_phy_to_path "$dev")"
 		if [ -n "$path" ]; then
@@ -102,19 +131,25 @@ detect_mac80211() {
 			set wireless.radio${devidx}.type=mac80211
 			set wireless.radio${devidx}.channel=${channel}
 			set wireless.radio${devidx}.hwmode=11${mode_band}
+			${disable_legacy}
+			${tx_power}
 			${dev_id}
 			${ht_capab}
-			set wireless.radio${devidx}.disabled=1
+			set wireless.radio${devidx}.country=${country}
+			set wireless.radio${devidx}.disabled=${disabled}
 
 			set wireless.default_radio${devidx}=wifi-iface
 			set wireless.default_radio${devidx}.device=radio${devidx}
 			set wireless.default_radio${devidx}.network=lan
 			set wireless.default_radio${devidx}.mode=ap
-			set wireless.default_radio${devidx}.ssid=OpenWrt
-			set wireless.default_radio${devidx}.encryption=none
+			set wireless.default_radio${devidx}.ssid=${ssid}
+			set wireless.default_radio${devidx}.encryption=${encryption}
+			set wireless.default_radio${devidx}.key=${key}
 EOF
 		uci -q commit wireless
 
 		devidx=$(($devidx + 1))
 	done
+
+	uci -q set system.@system[0].default_key=$key && uci -q commit system
 }


### PR DESCRIPTION
kernel: cfg80211: enable secure wifi with mac as key

Allow the system to create a default wifi configuration
with wifi enabled using PSK2 and the interface mac as
password. This will allow access to some devices after
firmware installation, when no ethernet interface is
available such as some wifi extenders/plc devices, and
accessing through WAN is firewall blocked...

The wifi configuration will use oem ssid, key, and country
if those values are defined, if they are not configured will
use by other label_mac or eth0 mac.

When label-mac or eth0-mac are used, the value will be
transformed from AA:BB:CC:DD to aa_bb_cc_dd_ee_ff

If oem country is not defined, it will be set to the safe
worldwide domain, XX by default.

If oem key is not defined transmission level for security
reasons will be low but enough to allow connections within
the same room so the user can connect and configure properly.

If oem ssid, key and country are defined, both radios will
go up, otherwise only 2.4Ghz will go up in channel 6 avoiding
the channel edges in case of calibration issues with the device.

Signed-off-by: Manuel Giganto <mgigantoregistros@gmail.com>