### PR TITLE
ramips: mt76x8, add support for onboard sdcard reader

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -135,7 +135,7 @@ define Device/mediatek_linkit-smart-7688
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := LinkIt Smart 7688
-  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools
+  DEVICE_PACKAGES:= kmod-usb2 kmod-usb-ohci uboot-envtools kmod-sdhci-mt7620
   SUPPORTED_DEVICES += linkits7688 linkits7688d
 endef
 TARGET_DEVICES += mediatek_linkit-smart-7688


### PR DESCRIPTION
ramips: mt76x8, add support for onboard sdcard reader

The Linkit Smart 7688 has a SD-Card reader that does not work with the official build of openwrt. Adding  kmod-sdhci-mt7620 makes it working.

Signed-off-by: Ivan Hörler <i.hoerler@me.com>