### PR TITLE
wireguard: permit storing private & preshared keys in files

### DIFF
--- a/package/network/services/wireguard/Makefile
+++ b/package/network/services/wireguard/Makefile
@@ -93,6 +93,9 @@ define Package/wireguard-tools/install
 	$(INSTALL_BIN) ./files/wireguard_watchdog $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/wireguard.sh $(1)/lib/netifd/proto/
+	$(INSTALL_DIR) -m0700 $(1)/etc/wireguard/
+	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d/
+	$(INSTALL_DATA) ./files/wireguard-tools $(1)/lib/upgrade/keep.d/
 endef
 
 define KernelPackage/wireguard

--- a/package/network/services/wireguard/files/wireguard-tools
+++ b/package/network/services/wireguard/files/wireguard-tools
@@ -1,0 +1,1 @@
+/etc/wireguard/

--- a/package/network/services/wireguard/files/wireguard.sh
+++ b/package/network/services/wireguard/files/wireguard.sh
@@ -16,6 +16,7 @@ fi
 
 proto_wireguard_init_config() {
 	proto_config_add_string "private_key"
+	proto_config_add_string "private_key_file"
 	proto_config_add_int "listen_port"
 	proto_config_add_int "mtu"
 	proto_config_add_string "fwmark"
@@ -28,6 +29,7 @@ proto_wireguard_setup_peer() {
 
 	local public_key
 	local preshared_key
+	local preshared_key_file
 	local allowed_ips
 	local route_allowed_ips
 	local endpoint_host
@@ -36,6 +38,7 @@ proto_wireguard_setup_peer() {
 
 	config_get public_key "${peer_config}" "public_key"
 	config_get preshared_key "${peer_config}" "preshared_key"
+	config_get preshared_key_file "${peer_config}" "preshared_key_file"
 	config_get allowed_ips "${peer_config}" "allowed_ips"
 	config_get_bool route_allowed_ips "${peer_config}" "route_allowed_ips" 0
 	config_get endpoint_host "${peer_config}" "endpoint_host"
@@ -44,7 +47,9 @@ proto_wireguard_setup_peer() {
 
 	echo "[Peer]" >> "${wg_cfg}"
 	echo "PublicKey=${public_key}" >> "${wg_cfg}"
-	if [ "${preshared_key}" ]; then
+	if [ "${preshared_key_file}" ]; then
+		echo "PresharedKey=`cat /etc/wireguard/${preshared_key_file}`" >> "${wg_cfg}"
+	elif [ "${preshared_key}" ]; then
 		echo "PresharedKey=${preshared_key}" >> "${wg_cfg}"
 	fi
 	for allowed_ip in $allowed_ips; do
@@ -96,11 +101,13 @@ proto_wireguard_setup() {
 	local wg_cfg="${wg_dir}/${config}"
 
 	local private_key
+	local private_key_file
 	local listen_port
 	local mtu
 
 	config_load network
 	config_get private_key "${config}" "private_key"
+	config_get private_key_file "${config}" "private_key_file"
 	config_get listen_port "${config}" "listen_port"
 	config_get addresses "${config}" "addresses"
 	config_get mtu "${config}" "mtu"
@@ -120,7 +127,11 @@ proto_wireguard_setup() {
 	umask 077
 	mkdir -p "${wg_dir}"
 	echo "[Interface]" > "${wg_cfg}"
-	echo "PrivateKey=${private_key}" >> "${wg_cfg}"
+	if [ "${private_key_file}" ]; then
+		echo "PrivateKey=`cat /etc/wireguard/${private_key_file}`" >> "${wg_cfg}"
+	else
+		echo "PrivateKey=${private_key}" >> "${wg_cfg}"
+	fi
 	if [ "${listen_port}" ]; then
 		echo "ListenPort=${listen_port}" >> "${wg_cfg}"
 	fi


### PR DESCRIPTION
Add support for storing private keys and preshared keys in files, hiding secrets from uci configuration

This is rebased pull request #1391 

Signed-off-by: Lukasz Dargiewicz <lukasz.dargiewicz@gmail.com>

