### PR TITLE
ath79: add SUPPORTED_DEVICES to ubnt_nanostation-m-xw

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -119,7 +119,7 @@ define Device/ubnt_nanostation-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Nanostation M
   DEVICE_VARIANT := XW
-  SUPPORTED_DEVICES += nano-m-xw
+  SUPPORTED_DEVICES += nano-m-xw nanostation-m-xw
 endef
 TARGET_DEVICES += ubnt_nanostation-m-xw
 


### PR DESCRIPTION
The ar71xx images for the Ubiquiti NanoStation M (XW) devices use "nanostation-m-xw" as the board name, but the ath79 images are only compatible with the "nano-m-xw" board name, so sysupgrade complains.

By adding this additional supported device, sysuspgrade smoothly upgrades from ar71xx to ath79.

Tested on a NanoStation M (XW) running OpenWrt ar71xx r10250-016d1eb.