### PR TITLE
lantiq: add set_port_link feature to xrx200-net driver

### DIFF
--- a/target/linux/lantiq/patches-4.19/0025-NET-MIPS-lantiq-adds-xrx200-net.patch
+++ b/target/linux/lantiq/patches-4.19/0025-NET-MIPS-lantiq-adds-xrx200-net.patch
@@ -209,7 +209,7 @@ Subject: [PATCH 25/36] NET: MIPS: lantiq: adds xrx200-net
 +};
 --- /dev/null
 +++ b/drivers/net/ethernet/lantiq_xrx200.c
-@@ -0,0 +1,1889 @@
+@@ -0,0 +1,1924 @@
 +/*
 + *   This program is free software; you can redistribute it and/or modify it
 + *   under the terms of the GNU General Public License version 2 as published
@@ -433,6 +433,7 @@ Subject: [PATCH 25/36] NET: MIPS: lantiq: adds xrx200-net
 +struct xrx200_hw {
 +	struct clk *clk;
 +	struct mii_bus *mii_bus;
++	u8 phy_addr[XRX200_MAX_PORT];
 +
 +	struct xrx200_chan chan[XRX200_MAX_DMA];
 +	u16 vlan_vid[XRX200_MAX_VLAN];
@@ -947,6 +948,34 @@ Subject: [PATCH 25/36] NET: MIPS: lantiq: adds xrx200-net
 +	return 0;
 +}
 +
++static int xrx200sw_set_port_link(struct switch_dev *dev, int port,
++				struct switch_port_link *link)
++{
++	if (port >= XRX200_MAX_PORT)
++		return -EINVAL;
++
++	return switch_generic_set_link(dev, port, link);
++}
++
++static int xrx200_mdio_wr(struct mii_bus *bus, int addr, int reg, u16 val);
++static int xrx200_mdio_rd(struct mii_bus *bus, int addr, int reg);
++
++static int xrx200sw_phy_read16(struct switch_dev *dev, int addr, u8 reg, u16 *value)
++{
++	struct xrx200_hw *hw = container_of(dev, struct xrx200_hw, swdev);
++
++	*value =  xrx200_mdio_rd(hw->mii_bus, hw->phy_addr[addr], reg);
++
++	return 0;
++}
++
++static int xrx200sw_phy_write16(struct switch_dev *dev, int addr, u8 reg, u16 value)
++{
++	struct xrx200_hw *hw = container_of(dev, struct xrx200_hw, swdev);
++
++	return xrx200_mdio_wr(hw->mii_bus, hw->phy_addr[addr], reg, value);
++}
++
 +static int xrx200_set_port_attr(struct switch_dev *dev, const struct switch_attr *attr, struct switch_val *val)
 +{
 +	if (val->port_vlan >= XRX200_MAX_PORT)
@@ -1043,7 +1072,10 @@ Subject: [PATCH 25/36] NET: MIPS: lantiq: adds xrx200-net
 +	.get_port_pvid = xrx200sw_get_port_pvid,
 +	.reset_switch = xrx200sw_reset_switch,
 +	.get_port_link = xrx200sw_get_port_link,
++	.set_port_link = xrx200sw_set_port_link,
 +//	.get_port_stats = xrx200sw_get_port_stats, //TODO
++	.phy_read16 = xrx200sw_phy_read16,
++	.phy_write16 = xrx200sw_phy_write16,
 +};
 +
 +static int xrx200sw_init(struct xrx200_hw *hw)
@@ -1897,6 +1929,9 @@ Subject: [PATCH 25/36] NET: MIPS: lantiq: adds xrx200-net
 +
 +	/* store the port id in the hw struct so we can map ports -> devices */
 +	priv->hw->port_map[p->num] = priv->hw->num_devs;
++
++	/* store the phy addr in the hw struct so we can map ports -> phys */
++	priv->hw->phy_addr[p->num] = p->phy_addr;
 +}
 +
 +static const struct net_device_ops xrx200_netdev_ops = {


### PR DESCRIPTION
This makes it possible to configure the link attributes (aneg, duplex,
speed) of each switch ports.
