### PR TITLE
mac80211: distance config: allow "auto" as a value

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -24,8 +24,9 @@ drv_mac80211_init_device_config() {
 	config_add_string path phy 'macaddr:macaddr'
 	config_add_string hwmode
 	config_add_string tx_burst
+	config_add_string distance
 	config_add_int beacon_int chanbw frag rts
-	config_add_int rxantenna txantenna antenna_gain txpower distance
+	config_add_int rxantenna txantenna antenna_gain txpower
 	config_add_boolean noscan ht_coex acs_exclude_dfs
 	config_add_array ht_capab
 	config_add_array channels


### PR DESCRIPTION
The user can now enable the ACK timeout estimation algorithm (dynack)
for drivers that support it.
It is also expected that the distance config accepts the same values as:
$ iw phyX set distance XXX

Signed-off-by: Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>