### PR TITLE
ath79: add support for Ubiquiti NanoStation Loco M (XW)

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-loco-m-xw.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-loco-m-xw.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_xw.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-loco-m-xw", "ubnt,xw", "qca,ar9342";
+	model = "Ubiquiti Nanostation Loco M (XW)";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		phy-mode = "mii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy1>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -236,6 +236,7 @@ trendnet,tew-823dru)
 	;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
+ubnt,nanostation-loco-m-xw|\
 ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\
 ubnt,rocket-m)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ath79_setup_interfaces()
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac-loco|\
+	ubnt,nanostation-loco-m-xw|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -179,6 +179,14 @@ define Device/ubnt_nanostation-ac-loco
 endef
 TARGET_DEVICES += ubnt_nanostation-ac-loco
 
+define Device/ubnt_nanostation-loco-m-xw
+  $(Device/ubnt-xw)
+  DEVICE_MODEL := Nanostation Loco M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += loco-m-xw
+endef
+TARGET_DEVICES += ubnt_nanostation-loco-m-xw
+
 define Device/ubnt_nanostation-m
   $(Device/ubnt-xm)
   DEVICE_MODEL := Nanostation M


### PR DESCRIPTION
This commit adds support for the NanoStation Loco M2/M5 XW devices on the ath79 target (support was long ago available on ar71xx).

Specifications:

 - AR9342 SoC @535 MHz
 - 64 MB RAM
 - 8 MB SPI flash
 - 1x 10/100 Mbps Ethernet, 24 Vdc PoE-in
 - AR8032 switch
 - 2T2R 5 GHz radio, 22 dBm
 - 13 dBi built-in antenna
 - POWER/LAN green LEDs
 - 4x RSSI LEDs (red, orange, green, green)
 - UART (115200 8N1) on PCB

Flashing via TFTP:

 - Use a pointy tool (e.g., pen cap, paper clip) and keep the reset
   button on the device or on the PoE supply pressed
 - Power on the device via PoE (keep reset button pressed)
 - Keep pressing until LEDs flash alternatively LED1+LED3 =>
   LED2+LED4 => LED1+LED3, etc.
 - Release reset button
 - The device starts a TFTP server at 192.168.1.20
 - Set a static IP on the computer (e.g., 192.168.1.21/24)
 - Upload via tftp the factory image:
   $ tftp 192.168.1.20
   tftp> bin
   tftp> trace
   tftp> put openwrt-ath79-generic-xxxxx-ubnt_nanostation-loco-m-xw-squashfs-factory.bin

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>