### PR TITLE
ipq40xx: add support for EnGenius ENH1350EXT

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -33,6 +33,7 @@ ALLWIFIBOARDS:= \
 	engenius_eap2200 \
 	engenius_emd1 \
 	engenius_emr3500 \
+	engenius_enh1350ext \
 	ezviz_cs-w3-wd1200g-eup \
 	linksys_ea8300 \
 	mobipromo_cm520-79f \
@@ -105,6 +106,7 @@ $(eval $(call generate-ipq-wifi-package,dlink_dap2610,D-Link DAP-2610))
 $(eval $(call generate-ipq-wifi-package,engenius_eap2200,EnGenius EAP2200))
 $(eval $(call generate-ipq-wifi-package,engenius_emd1,EnGenius EMD1))
 $(eval $(call generate-ipq-wifi-package,engenius_emr3500,EnGenius EMR3500))
+$(eval $(call generate-ipq-wifi-package,engenius_enh1350ext,EnGenius ENH1350EXT))
 $(eval $(call generate-ipq-wifi-package,ezviz_cs-w3-wd1200g-eup,EZVIZ CS-W3-WD1200G EUP))
 $(eval $(call generate-ipq-wifi-package,linksys_ea8300,Linksys EA8300))
 $(eval $(call generate-ipq-wifi-package,mobipromo_cm520-79f,MobiPromo CM520-79F))

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -36,6 +36,9 @@ engenius,eap1300)
 engenius,eap2200)
 	ucidef_set_led_netdev "lan1" "LAN1" "${boardname}:blue:lan1" "eth0"
 	ucidef_set_led_netdev "lan2" "LAN2" "${boardname}:blue:lan2" "eth1"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2G" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5G" "phy1tpt"
+	ucidef_set_led_netdev "lan" "LAN" "${boardname}:green:lan" "eth0"
 	;;
 engenius,ens620ext)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2G" "phy0tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ipq40xx_setup_interfaces()
 	dlink,dap-2610 |\
 	engenius,eap1300|\
 	engenius,emd1|\
+	engenius,enh1350ext|\
 	meraki,mr33|\
 	netgear,ex6100v2|\
 	netgear,ex6150v2|\

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -105,6 +105,7 @@ case "$FIRMWARE" in
 		caldata_extract "0:ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 		;;
+	engenius,enh1350ext |\
 	engenius,ens620ext)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +2)
@@ -193,6 +194,7 @@ case "$FIRMWARE" in
 		caldata_extract "0:ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) +1)
 		;;
+	engenius,enh1350ext |\
 	engenius,ens620ext)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +3)

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-enh1350ext.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-enh1350ext.dts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "EnGenius ENH1350EXT";
+	compatible = "engenius,enh1350ext";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "enh1350ext:amber:power";
+			gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "enh1350ext:green:lan";
+			gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2G {
+			label = "enh1350ext:green:wlan2G";
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5G {
+			label = "enh1350ext:green:wlan5G";
+			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		mux {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		mux_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&blsp1_spi1 { /* BLSP1 QUP1 */
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+			partition@60000 {
+				label = "QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+			partition@c0000 {
+				label = "CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+			partition@d0000 {
+				label = "DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "APPSBLENV"; /* uboot env*/
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+			partition@f0000 {
+				label = "APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+			partition@170000 {
+				label = "ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "userconfig";
+				reg = <0x00180000 0x00080000>;
+				read-only;
+			};
+			partition@200000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x00200000 0x1e00000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "EnGenius-ENH1350EXT";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "EnGenius-ENH1350EXT";
+};

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-enh1350ext.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-enh1350ext.dts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "EnGenius ENH1350EXT";
+	compatible = "engenius,enh1350ext";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+	aliases {
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			label = "enh1350ext:amber:power";
+			gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "enh1350ext:green:lan";
+			gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2G {
+			label = "enh1350ext:green:wlan2G";
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5G {
+			label = "enh1350ext:green:wlan5G";
+			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		mux {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		mux_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&blsp1_spi1 { /* BLSP1 QUP1 */
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+			partition@60000 {
+				label = "QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+			partition@c0000 {
+				label = "CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+			partition@d0000 {
+				label = "DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "APPSBLENV"; /* uboot env*/
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+			partition@f0000 {
+				label = "APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+			partition@170000 {
+				label = "ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "userconfig";
+				reg = <0x00180000 0x00080000>;
+				read-only;
+			};
+			partition@200000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x00200000 0x1e00000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "EnGenius-ENH1350EXT";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "EnGenius-ENH1350EXT";
+};

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -391,6 +391,20 @@ define Device/engenius_emr3500
 endef
 TARGET_DEVICES += engenius_emr3500
 
+define Device/engenius_enh1350ext
+	$(call Device/FitImage)
+	DEVICE_VENDOR := EnGenius
+	DEVICE_MODEL := ENH1350EXT
+	DEVICE_DTS_CONFIG := config@4
+	DEVICE_DTS := qcom-ipq4018-enh1350ext
+	KERNEL_SIZE := 4096k
+	IMAGE_SIZE := 30720k
+	IMAGES := sysupgrade.bin factory.bin
+	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+	IMAGE/factory.bin := qsdk-ipq-factory-nor | check-size $$$$(IMAGE_SIZE)
+endef
+TARGET_DEVICES += engenius_enh1350ext
+
 define Device/engenius_ens620ext
 	$(call Device/FitImage)
 	DEVICE_VENDOR := EnGenius

--- a/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -785,11 +785,47 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -785,11 +785,48 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -21,6 +21,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-ea6350v3.dtb \
 +	qcom-ipq4018-eap1300.dtb \
 +	qcom-ipq4018-emd1.dtb \
++	qcom-ipq4018-enh1350ext.dtb \
 +	qcom-ipq4018-ens620ext.dtb \
 +	qcom-ipq4018-ex6100v2.dtb \
 +	qcom-ipq4018-ex6150v2.dtb \

--- a/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -837,11 +837,48 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -837,11 +837,49 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -22,6 +22,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-eap1300.dtb \
 +	qcom-ipq4018-emd1.dtb \
 +	qcom-ipq4018-emr3500.dtb \
++	qcom-ipq4018-enh1350ext.dtb \
 +	qcom-ipq4018-ens620ext.dtb \
 +	qcom-ipq4018-ex6100v2.dtb \
 +	qcom-ipq4018-ex6150v2.dtb \


### PR DESCRIPTION
EnGenius ENH1350EXT is an Outdoor AP with PoE support,
based on Qualcomm IPQ4018.

Short specification:

SoC:    Qualcomm IPQ4018
RAM:    256MiB
FLASH:  32MiB
ETH:    Qualcomm QCA8072, with 54V PoE support.
WLAN0:  Qualcomm Atheros QCA4018 2.4GHz 802.11b/g/n 2x2
WLAN1:  Qualcomm Atheros QCA4018 5GHz 802.11n/ac W2 2x2
LED:    - Power:          amber
        - LAN(PoE):       green
        - Wi-Fi 2.4GHz:   green
        - Wi-Fi 5GHz:     green
BTN:    RESET(on PoE)
        - 2 ~ 5 sec:    1 sec.
        - 5 ~ 10 sec:   2 sec.
        - 10 ~ 20 sec:  3 sec.

Flash instruction:

From EnGenius firmware to OpenWrt firmware:

In Firmware Upgrade page, upgrade your
openwrt-ipq40xx-generic-engenius_enh1350ext-squashfs-factory.bin
directly.

From OpenWrt firmware to EnGenius firmware:

1. Setup a TFTP server on your computer and configure static IP to 192.168.99.8
   Put the EnGenius firmware in the TFTP server directory on your computer.
2. Power up ENH1350EXT. Press 4 and then press any key to enter u-boot.
3. Download EnGenius firmware
   (IPQ40xx) # tftpboot 0x84000000 openwrt-ipq40xx-enh1350ext-nor-loader-s.img
4. Flash the firmware
   (IPQ40xx) # imgaddr=0x84000000 && source 0x84000000:script
5. Reboot
   (IPQ40xx) # reset

Signed-off-by: Guan-Hong Lin <GH.Lin@senao.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
