### PR TITLE
ath79: add SUPPORTED_DEVICES to ubnt_nanostation-m

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -154,7 +154,7 @@ TARGET_DEVICES += ubnt_nanostation-ac-loco
 define Device/ubnt_nanostation-m
   $(Device/ubnt-xm)
   DEVICE_MODEL := Nanostation M
-  SUPPORTED_DEVICES += nano-m
+  SUPPORTED_DEVICES += nanostation-m
 endef
 TARGET_DEVICES += ubnt_nanostation-m
 


### PR DESCRIPTION
The ar71xx images for the Ubiquiti NanoStation M (XM) devices use
"nanostation-m" as board name, but the ath79 images are only
compatible with the "nano-m" board name, so sysupgrade complains.

By changing this additional supported device, sysuspgrade smoothly
upgrades from ar71xx to ath79.

Ref: openwrt#2418
