### PR TITLE
scripts/config: fix Make xconfig broken BUG

### DIFF
--- a/scripts/config/Makefile
+++ b/scripts/config/Makefile
@@ -42,7 +42,7 @@ mconf: $(mconf-objs) $(lxdialog-objs)
 	$(CC) -o $@ $^ $(call check_lxdialog,ldflags $(CC))
 qconf: $(qconf-cxxobjs) $(qconf-objs)
 ifneq ($(DISTRO-PKG-CONFIG),)
-	$(CXX) $(HOSTLOADLIBES_qconf) -o $@ $^
+	$(CXX) -o $@ $^ $(HOSTLOADLIBES_qconf) 
 else
 	echo "You don't have 'pkg-config' installed. Cannot continue"
 	echo "For now, you may use 'make menuconfig' instead of 'make xconfig'"


### PR DESCRIPTION
Hi,

'Make xconfig' need qconf on the scripts/config, but it compile fail with
link error, like this:
>...
>g++ -lQt5Widgets -lQt5Gui -lQt5Core -o qconf qconf.o zconf.tab.o
>/usr/bin/ld: qconf.o: in function `ConfigList::metaObject() const':
>qconf.cc:(.text+0x3eb): undefined reference to `QObjectData::dynamicMetaObject() const'
>/usr/bin/ld: qconf.o: in function `ConfigList::qt_metacast(char const*)':
>...

scripts/config/Makefile has a bug to build qconf, the library order in
static link is wrong:
`g++ -lQt5Widgets -lQt5Gui -lQt5Core -o qconf qconf.o zconf.tab.o`

it need to be this:
`g++  -o qconf qconf.o zconf.tab.o -lQt5Widgets -lQt5Gui -lQt5Core `

i just fix it.



Signed-off-by: leo chung <gewalalb@gmail.com>
