### PR TITLE
Treewide generic

### DIFF
--- a/package/boot/uboot-imx6/Makefile
+++ b/package/boot/uboot-imx6/Makefile
@@ -17,6 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=imx6
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=u-boot.imx
 endef
 

--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -17,6 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=kirkwood
+  BUILD_SUBTARGET:=generic
 endef
 
 define U-Boot/dockstar

--- a/package/boot/uboot-omap/Makefile
+++ b/package/boot/uboot-omap/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET:=omap
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=u-boot.img MLO
   UENV:=default
 endef

--- a/package/boot/uboot-tegra/Makefile
+++ b/package/boot/uboot-tegra/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 
 define U-Boot/Default
   BUILD_TARGET := tegra
+  BUILD_SUBTARGET := generic
   HIDDEN := y
 endef
 

--- a/package/boot/uboot-zynq/Makefile
+++ b/package/boot/uboot-zynq/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/host-build.mk
 
 define U-Boot/Default
   BUILD_TARGET:=zynq
+  BUILD_SUBTARGET:=generic
   UBOOT_IMAGE:=spl/boot.bin u-boot.img
   UBOOT_CONFIG:=zynq_$(1)
   UENV:=default

--- a/target/linux/ath25/Makefile
+++ b/target/linux/ath25/Makefile
@@ -10,6 +10,7 @@ ARCH:=mips
 BOARD:=ath25
 BOARDNAME:=Atheros AR231x/AR5312
 FEATURES:=squashfs low_mem small_flash
+SUBTARGETS:=generic
 MAINTAINER:=Sergey Ryazanov <ryazanov.s.a@gmail.com>
 
 KERNEL_PATCHVER:=4.14

--- a/target/linux/ath25/generic/target.mk
+++ b/target/linux/ath25/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/cns3xxx/Makefile
+++ b/target/linux/cns3xxx/Makefile
@@ -12,6 +12,7 @@ BOARDNAME:=Cavium Networks Econa CNS3xxx
 FEATURES:=squashfs fpu gpio pcie usb usbgadget
 CPU_TYPE:=mpcore
 CPU_SUBTYPE:=vfp
+SUBTARGETS:=generic
 MAINTAINER:=Felix Fietkau <nbd@nbd.name>, \
 	    Koen Vandeputte <koen.vandeputte@ncentric.com>
 KERNEL_PATCHVER:=4.19

--- a/target/linux/cns3xxx/generic/target.mk
+++ b/target/linux/cns3xxx/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/gemini/Makefile
+++ b/target/linux/gemini/Makefile
@@ -11,6 +11,7 @@ BOARD:=gemini
 BOARDNAME:=Cortina Systems CS351x
 FEATURES:=squashfs pci rtc usb dt gpio display ext4 rootfs-part boot-part
 CPU_TYPE:=fa526
+SUBTARGETS:=generic
 MAINTAINER:=Roman Yeryomin <roman@advem.lv>
 
 KERNEL_PATCHVER:=4.19

--- a/target/linux/gemini/generic/target.mk
+++ b/target/linux/gemini/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/imx6/Makefile
+++ b/target/linux/imx6/Makefile
@@ -12,6 +12,7 @@ BOARDNAME:=Freescale i.MX 6
 FEATURES:=audio display fpu gpio pcie rtc usb usbgadget squashfs targz nand ubifs boot-part rootfs-part
 CPU_TYPE:=cortex-a9
 CPU_SUBTYPE:=neon
+SUBTARGETS:=generic
 MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 KERNEL_PATCHVER:=4.19

--- a/target/linux/imx6/generic/target.mk
+++ b/target/linux/imx6/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/kirkwood/Makefile
+++ b/target/linux/kirkwood/Makefile
@@ -11,6 +11,7 @@ BOARD:=kirkwood
 BOARDNAME:=Marvell Kirkwood
 FEATURES:=usb nand squashfs ramdisk
 CPU_TYPE:=xscale
+SUBTARGETS:=generic
 MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 KERNEL_PATCHVER:=4.14

--- a/target/linux/kirkwood/generic/target.mk
+++ b/target/linux/kirkwood/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -11,6 +11,7 @@ BOARD:=octeon
 BOARDNAME:=Cavium Networks Octeon
 FEATURES:=squashfs ramdisk pci usb
 CPU_TYPE:=octeonplus
+SUBTARGETS:=generic
 MAINTAINER:=John Crispin <john@phrozen.org>
 
 KERNEL_PATCHVER:=4.19

--- a/target/linux/octeon/generic/target.mk
+++ b/target/linux/octeon/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/octeontx/Makefile
+++ b/target/linux/octeontx/Makefile
@@ -10,6 +10,7 @@ ARCH:=aarch64
 BOARD:=octeontx
 BOARDNAME:=Octeon-TX
 FEATURES:=targz pcie gpio rtc usb fpu
+SUBTARGETS:=generic
 
 MAINTAINER:=Tim Harvey <tharvey@gateworks.com>
 

--- a/target/linux/octeontx/generic/target.mk
+++ b/target/linux/octeontx/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/omap/Makefile
+++ b/target/linux/omap/Makefile
@@ -13,6 +13,7 @@ BOARDNAME:=TI OMAP3/4/AM33xx
 FEATURES:=usb usbgadget ext4 targz fpu audio display nand squashfs
 CPU_TYPE:=cortex-a8
 CPU_SUBTYPE:=vfpv3
+SUBTARGETS:=generic
 
 KERNEL_PATCHVER:=4.14
 

--- a/target/linux/omap/generic/target.mk
+++ b/target/linux/omap/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/pistachio/Makefile
+++ b/target/linux/pistachio/Makefile
@@ -12,6 +12,7 @@ BOARDNAME:=MIPS pistachio
 FEATURES:=fpu usb usbgadget squashfs targz nand
 CPU_TYPE:=24kc
 CPU_SUBTYPE:=24kf
+SUBTARGETS:=generic
 MAINTAINER:=
 
 KERNEL_PATCHVER:=4.14

--- a/target/linux/pistachio/generic/target.mk
+++ b/target/linux/pistachio/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/rb532/Makefile
+++ b/target/linux/rb532/Makefile
@@ -10,6 +10,7 @@ ARCH:=mipsel
 BOARD:=rb532
 BOARDNAME:=Mikrotik RouterBoard 532
 FEATURES:=pci targz squashfs minor nand
+SUBTARGETS:=generic
 MAINTAINER:=Roman Yeryomin <roman@advem.lv>
 
 KERNEL_PATCHVER:=4.14

--- a/target/linux/rb532/generic/target.mk
+++ b/target/linux/rb532/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/tegra/Makefile
+++ b/target/linux/tegra/Makefile
@@ -12,6 +12,7 @@ BOARDNAME := NVIDIA Tegra
 FEATURES := audio boot-part display ext4 fpu gpio pci pcie rootfs-part rtc squashfs usb
 CPU_TYPE := cortex-a9
 CPU_SUBTYPE := vfpv3
+SUBTARGETS:=generic
 MAINTAINER := Tomasz Maciej Nowak <tomek_n@o2.pl>
 
 KERNEL_PATCHVER := 4.19

--- a/target/linux/tegra/generic/target.mk
+++ b/target/linux/tegra/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic

--- a/target/linux/zynq/Makefile
+++ b/target/linux/zynq/Makefile
@@ -12,6 +12,7 @@ BOARDNAME:=Xilinx Zynq 7000 SoCs
 FEATURES:=fpu gpio rtc usb usbgadget boot-part rootfs-part squashfs
 CPU_TYPE:=cortex-a9
 CPU_SUBTYPE:=neon
+SUBTARGETS:=generic
 MAINTAINER:=Jason Wu <jason.wu.misc@gmail.com>
 
 # future support SUBTARGETS: for both zynq and zynqmp

--- a/target/linux/zynq/generic/target.mk
+++ b/target/linux/zynq/generic/target.mk
@@ -1,0 +1,1 @@
+BOARDNAME:=Generic


### PR DESCRIPTION

treewide: add Generic subtarget if missing

As in 853e4dd OpenWrt should follow a unified structure, where every
device has a target/subtarget combination, if there is only one
subtarget, call it "Generic". This introduces predictable filenames.

 treewide: add generic subtarget to uboot

It fails to build if the uboot Makefile lacks the subtarget.