### PR TITLE
kirkwood: Make factory image flashable via stock firmware's Web UI

### DIFF
--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -82,6 +82,9 @@ define Device/linksys_audi
   DEVICE_TITLE := Linksys EA3500 (Audi)
   DEVICE_PACKAGES := kmod-mwl8k swconfig wpad-basic kmod-gpio-button-hotplug
   DEVICE_DTS := kirkwood-linksys-audi
+  PAGESIZE := 512
+  SUBPAGESIZE := 256
+  BLOCKSIZE := 16KiB
   KERNEL_SIZE := 2624k
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
Fix [FS#505](https://bugs.openwrt.org/index.php?do=details&task_id=505) - Can't install LEDE on Linksys EA3500

The default sizes render Device/linksys_audi images un-flashable.
Restore the pagesize, subpagesize, and blocksize for linksys_audi
from [pre-merged OpenWRT](https://github.com/openwrt/archive/raw/master/target/linux/kirkwood/image/Makefile).

Tested and successfully installed on a brand new Linksys EA3500
an openwrt-19.07-snapshot-r10547-9cae5a8289-kirkwood-linksys_audi-
squashfs-factory.bin image built with the device-specific sizes.