### PR TITLE
ar71xx: add ath10k packages back to Archer C7 v1 profile

### DIFF
--- a/target/linux/ar71xx/image/generic-tp-link.mk
+++ b/target/linux/ar71xx/image/generic-tp-link.mk
@@ -95,7 +95,7 @@ TARGET_DEVICES += archer-c5-v1
 define Device/archer-c7-v1
   $(Device/tplink-8mlzma)
   DEVICE_TITLE := TP-LINK Archer C7 v1
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca988x
   BOARDNAME := ARCHER-C7
   DEVICE_PROFILE := ARCHERC7
   TPLINK_HWID := 0x75000001


### PR DESCRIPTION
ath10k driver/firmware packages were removed due to bootloop issues
which are now mitigated, so these can be included back.
Depends on https://github.com/openwrt/openwrt/pull/2435

Signed-off-by: Tomislav Požega pozega.tomislav@gmail.com