### PR TITLE
lantiq: fix dsl_control status handling.

### DIFF
--- a/package/network/config/ltq-adsl-app/Makefile
+++ b/package/network/config/ltq-adsl-app/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dsl_cpe_control_danube
 PKG_VERSION:=3.24.4.4
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/dsl_cpe_control-$(PKG_VERSION)
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources/

--- a/package/network/config/ltq-adsl-app/files/dsl_control
+++ b/package/network/config/ltq-adsl-app/files/dsl_control
@@ -4,9 +4,9 @@
 START=97
 USE_PROCD=1
 
-EXTRA_COMMANDS="status lucistat"
-EXTRA_HELP="	status  Get DSL status information
-	lucistat  Get status information if lua friendly format"
+EXTRA_COMMANDS="dslstat lucistat"
+EXTRA_HELP="	dslstat Get DSL status information
+	lucistat Get status information in lua friendly format"
 
 [ -f /lib/functions/lantiq_dsl.sh ] && . /lib/functions/lantiq_dsl.sh
 

--- a/package/network/config/ltq-vdsl-app/Makefile
+++ b/package/network/config/ltq-vdsl-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-app
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BASE_NAME:=dsl_cpe_control
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources

--- a/package/network/config/ltq-vdsl-app/files/dsl_control
+++ b/package/network/config/ltq-vdsl-app/files/dsl_control
@@ -4,9 +4,9 @@
 START=97
 USE_PROCD=1
 
-EXTRA_COMMANDS="status lucistat"
-EXTRA_HELP="	status  Get DSL status information
-	lucistat  Get status information if lua friendly format"
+EXTRA_COMMANDS="dslstat lucistat"
+EXTRA_HELP="	dslstat Get DSL status information
+	lucistat Get status information in lua friendly format"
 
 [ -f /lib/functions/lantiq_dsl.sh ] && . /lib/functions/lantiq_dsl.sh
 

--- a/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
+++ b/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
@@ -728,7 +728,7 @@ profile() {
 	fi
 }
 
-status() {
+dslstat() {
 	vendor
 	chipset
 	xtse
@@ -744,6 +744,6 @@ status() {
 
 lucistat() {
 	echo "local dsl={}"
-	status
+	dslstat
 	echo "return dsl"
 }


### PR DESCRIPTION
Commit 7519a36774ca ("base-files,procd: add generic service status")
introduced the generic 'status' command which broke the previous
dsl_control status output. To fix this, let's rename the "old" command
to "dslstat".

Fixes: 7519a36774ca ("base-files,procd: add generic service status")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
