### PR TITLE
base-files: fix output of EXTRA_HELP for procd based services

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -109,7 +109,7 @@ ${INIT_TRACE:+set -x}
 	EXTRA_HELP="\
 	running	Check if service is running
 	status	Service status
-	"
+${EXTRA_HELP}"
 
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")


### PR DESCRIPTION
This fixes the output of the EXTRA_HELP value for services
like dropbear or the lantiq dsl_control, which do add extra commands
by their own.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
