### PR TITLE
kmod-ebtables*: move NAT targets to kmod-ebtables

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -322,9 +322,9 @@ $(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_VLAN, $(P_EBT)ebt_vlan))
 # targets
 $(eval $(call nf_add,EBTABLES_IP4,CONFIG_BRIDGE_EBT_ARPREPLY, $(P_EBT)ebt_arpreply))
 $(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_MARK_T, $(P_EBT)ebt_mark))
-$(eval $(call nf_add,EBTABLES_IP4,CONFIG_BRIDGE_EBT_DNAT, $(P_EBT)ebt_dnat))
+$(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_DNAT, $(P_EBT)ebt_dnat))
 $(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_REDIRECT, $(P_EBT)ebt_redirect))
-$(eval $(call nf_add,EBTABLES_IP4,CONFIG_BRIDGE_EBT_SNAT, $(P_EBT)ebt_snat))
+$(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_SNAT, $(P_EBT)ebt_snat))
 
 # watchers
 $(eval $(call nf_add,EBTABLES_WATCHERS,CONFIG_BRIDGE_EBT_LOG, $(P_EBT)ebt_log))


### PR DESCRIPTION
Move SNAT and DNAT support from kmod-ebtables-ip4 to kmod-ebtables
because these targets operate on MAC addresses not IPv4 and
kmod-ebtables already supports NAT table and the related REDIRECT
target.

Signed-off-by: Ali MJ Al-Nasrawy <alimjalnasrawy@gmail.com>