### PR TITLE
ramips: add support for I-O DATA MT7621 devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-ax1167gr2", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-AX1167GR2";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "Backup";
+		reg = <0x6b00000 0x1480000>;
+		read-only;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-dx1167r", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-DX1167R";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "idmkey";
+		reg = <0x6b00000 0x0100000>;
+		read-only;
+	};
+
+	partition@6c00000 {
+		label = "Backup";
+		reg = <0x6c00000 0x1380000>;
+		read-only;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "iodata:green:wps";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "iodata:green:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		repeater {
+			label = "repeater";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions: partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot-env";
+			reg = <0x0100000 0x0100000>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "factory";
+			reg = <0x0200000 0x0100000>;
+		};
+
+		partition@300000 {
+			label = "SecondBoot";
+			reg = <0x0300000 0x0100000>;
+			read-only;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x0400000 0x0400000>;
+		};
+
+		partition@800000 {
+			label = "ubi";
+			reg = <0x0800000 0x2e00000>;
+		};
+
+		partition@3600000 {
+			label = "Config";
+			reg = <0x3600000 0x0100000>;
+			read-only;
+		};
+
+		partition@3700000 {
+			label = "firmware_2";
+			reg = <0x3700000 0x3200000>;
+		};
+
+		partition@6900000 {
+			label = "Config_2";
+			reg = <0x6900000 0x0100000>;
+			read-only;
+		};
+
+		partition@6a00000 {
+			label = "persist";
+			reg = <0x6a00000 0x0100000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		ralink,group = "uart2", "uart3", "wdt";
+		ralink,function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -352,6 +352,22 @@ define Device/iodata_wn-ax1167gr
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr
 
+define Device/iodata_wn-ax1167gr2
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  UIMAGE_MAGIC := 0x434f4d42
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 51200k
+  DEVICE_VENDOR := I-O DATA
+  DEVICE_MODEL := WN-AX1167GR2
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XBC.1)b10 | \
+	iodata-mstc-header
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+endef
+TARGET_DEVICES += iodata_wn-ax1167gr2
+
 define Device/iodata_wn-dx1167r
   BLOCKSIZE := 128k
   PAGESIZE := 2048

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ ramips_setup_interfaces()
 	elecom,wrc-1900gst|\
 	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
+	iodata,wn-dx1167r|\
 	iodata,wn-gx300gr|\
 	iodata,wnpr2600g|\
 	iptime,a8004t)
@@ -222,6 +223,11 @@ ramips_setup_macs()
 	xiaoyu,xy-c5)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
+	iodata,wn-dx1167r|\
+	xiaomi,mir3g-v2)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$wan_mac
+		;;
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
@@ -265,10 +271,6 @@ ramips_setup_macs()
 	xiaomi,mir3p)
 		lan_mac=$(mtd_get_mac_binary factory 0xe006)
 		label_mac=$lan_mac
-		;;
-	xiaomi,mir3g-v2)
-		wan_mac=$(mtd_get_mac_binary factory 0xe006)
-		label_mac=$wan_mac
 		;;
 	zbtlink,zbt-we1326)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ ramips_setup_interfaces()
 	elecom,wrc-1900gst|\
 	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
+	iodata,wn-ax1167gr2|\
 	iodata,wn-dx1167r|\
 	iodata,wn-gx300gr|\
 	iodata,wnpr2600g|\
@@ -223,6 +224,7 @@ ramips_setup_macs()
 	xiaoyu,xy-c5)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
+	iodata,wn-ax1167gr2|\
 	iodata,wn-dx1167r|\
 	xiaomi,mir3g-v2)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2019 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+iodata_mstc_prepare_fail() {
+	echo "failed to check and prepare the environment, rebooting..."
+	umount -a
+	reboot -f
+}
+
+# I-O DATA devices manufactured by MSTC (MitraStar Technology Corp.)
+# have two important flags:
+# - bootnum: switch between two os images
+#     use 1st image in OpenWrt
+# - debugflag: enable/disable debug
+#     users can interrupt Z-Loader for recovering the device if enabled
+iodata_mstc_upgrade_prepare() {
+	local persist_mtd="$(find_mtd_part persist)"
+	local factory_mtd="$(find_mtd_part factory)"
+
+	if [ -z "$persist_mtd" -o -z "$factory_mtd" ]; then
+		echo 'cannot find mtd partition(s), "factory" or "persist"'
+		iodata_mstc_prepare_fail
+	fi
+
+	local bootnum=$(hexdump -s 4 -n 1 -e '"%x"' ${persist_mtd})
+	local debugflag=$(hexdump -s 65141 -n 1 -e '"%x"' ${factory_mtd})
+
+	if [ "$bootnum" != "1" -a "$bootnum" != "2" ]; then
+		echo "failed to get bootnum, please check the value at 0x4 in ${persist_mtd}"
+		iodata_mstc_prepare_fail
+	fi
+	if [ "$debugflag" != "0" -a "$debugflag" != "1" ]; then
+		echo "failed to get debugflag, please check the value at 0xFE75 in ${factory_mtd}"
+		iodata_mstc_prepare_fail
+	fi
+	echo "current: bootnum => ${bootnum}, debugflag => ${debugflag}"
+
+	if [ "$bootnum" = "2" ]; then
+		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=4 conv=notrunc of=${persist_mtd} 2>/dev/null); then
+			echo "failed to set bootnum"
+			iodata_mstc_prepare_fail
+		fi
+		echo "### switch to 1st os-image on next boot ###"
+	fi
+	if [ "$debugflag" = "0" ]; then
+		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=65141 conv=notrunc of=${factory_mtd} 2>/dev/null); then
+			echo "failed to set debugflag"
+			iodata_mstc_prepare_fail
+		fi
+		echo "### enable debug ###"
+	fi
+}

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,10 @@ platform_do_upgrade() {
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"
 		;;
+	iodata,wn-dx1167r)
+		iodata_mstc_upgrade_prepare
+		nand_do_upgrade "$1"
+		;;
 	ubiquiti,edgerouterx|\
 	ubiquiti,edgerouterx-sfp)
 		platform_upgrade_ubnt_erx "$1"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,7 @@ platform_do_upgrade() {
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"
 		;;
+	iodata,wn-ax1167gr2|\
 	iodata,wn-dx1167r)
 		iodata_mstc_upgrade_prepare
 		nand_do_upgrade "$1"


### PR DESCRIPTION
These commits add support for following I-O DATA devices with MediaTek MT7621A SoC:

- WN-AX1167GR2
- WN-DX1167R

Note: WN-AX2033GR and WN-AX2033GR2 maybe added by other people, so I put ```pcie1``` node into each device dts