### PR TITLE
base-files: add support to configure oem values

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -587,6 +587,40 @@ ucidef_set_hostname() {
 	json_select ..
 }
 
+ucidef_set_wifi_ssid() {
+	local wifi_ssid="$1"
+
+	json_select_object system
+		json_add_string wifi_ssid "$wifi_ssid"
+	json_select ..
+}
+
+ucidef_set_wifi_key() {
+	local wifi_key="$1"
+
+	json_select_object system
+		json_add_string wifi_key "$wifi_key"
+	json_select ..
+}
+
+ucidef_set_wifi_country() {
+	local wifi_country="$1"
+
+	json_select_object system
+		json_add_string wifi_country "$wifi_country"
+	json_select ..
+}
+
+ucidef_set_wifi_default() {
+	local mode_band="$1"
+	local tx_power="$2"
+
+	json_select_object system
+		json_add_string wifi_default "$mode_band"
+		[ -n "$tx_power" ] && json_add_string wifi_txpower "$tx_power"
+	json_select ..
+}
+
 ucidef_set_ntpserver() {
 	local server
 

--- a/target/linux/ath79/generic/base-files/etc/board.d/04_oem_config
+++ b/target/linux/ath79/generic/base-files/etc/board.d/04_oem_config
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 OpenWrt.org
+#
+
+. /lib/functions/uci-defaults.sh
+
+
+ath79_setup_device()
+{
+	local board="$1"
+
+	case "$board" in
+	devolo,magic-2-wifi)
+		ucidef_set_hostname devolo-$(grep SerialNumber /dev/mtd1 | grep -o ...$)
+		ucidef_set_wifi_key $(grep DlanSecurityID /dev/mtd1 | cut -d'=' -f 2 | tr -d -)
+		ucidef_set_wifi_country $(grep WiFiCountryCode /dev/mtd1 | cut -d'=' -f 2)
+		echo -e '#!/bin/sh\n[ -z ${ACTION##p*} ] && STATE=0 || STATE=1 ; ' \
+			'echo $STATE > /sys/class/gpio/gpio11/value  ; logger PLC pairing button $ACTION' \
+			 > /etc/rc.button/BTN_0 ; chmod +x /etc/rc.button/BTN_0
+		;;
+	esac
+}
+
+ath79_setup_wifi()
+{
+	local board="$1"
+
+	case "$board" in
+	devolo,magic-2-wifi)	#2.4GHz Wifi with default power
+		ucidef_set_wifi_default "g"
+		;;
+	example,5ghzdevice)	#5GHz Wifi with default power
+		ucidef_set_wifi_default "a"
+		;;
+	example,custompower)   #Custom Power
+		ucidef_set_wifi_default "" "10"
+		;;
+	example,5ghzwithpower)   #5GHz Wifi with custom power
+		ucidef_set_wifi_default "a" "12"
+		;;
+	esac
+}
+
+board_config_update
+board=$(board_name)
+ath79_setup_device $board
+ath79_setup_wifi $board
+board_config_flush
+
+exit 0


### PR DESCRIPTION
Configure hostname, ssid, key, and country based on the device oem
values, so we can use them when we generate the config. In some
devices this values can be calculated from the uboot-env partition.

base-files/etc/board.d/04_oem_config: contais the device specific
values.

added 3 new functions of 1 argument to uci-defaults.sh
 function <oem_value>
 ucidef_set_wifi_ssid:    To define the value of the oem wifi ssid
 ucidef_set_wifi_key:     To define the value of the oem wifi key
 ucidef_set_wifi_country: To define the value of the country

An example is provided for device devolo,magic-2-wifi

Signed-off-by: Manuel Giganto <mgigantoregistros@gmail.com>
