### PR TITLE
kernel: Fix off-by-one error in FIT mtd partition search.

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -60,7 +60,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	hdr_len = sizeof(struct fdt_header);
 
 	/* Parse the MTD device & search for the FIT image location */
-	for(offset = 0; offset + hdr_len < mtd->size; offset += mtd->erasesize) {
+	for(offset = 0; offset + hdr_len <= mtd->size; offset += mtd->erasesize) {
 		ret = mtd_read(mtd, offset, hdr_len, &retlen, (void*) &hdr);
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",


### PR DESCRIPTION
This fixes off-by-one error introduced in commit dc76900021b880820adf981bb7b1cf5ff3ffe1fd.

I spotted the error randomly, it looks like a clear off-by-one error, please verify it and apply if you think it is an error too.

Function `mtd_read` starts reading at `offset` and needs `hdr_len` number of bytes to be available. Suppose the easiest case when `offset` is `0` and `hdr_len` equals to `mtd->size` - the `for` loop will not be entered even when enough bytes are available to be read.

Same happens for any non-zero `offset`, when `hdr_len` is just enough bytes to be read until `mtd->size` is reached. Imagine that for example `mtd->size=5`, `offset=4` and `hdr_len=1`. Then `offset+hdr_len=5` and the check has to be `offset+hdr_len <= mtd->size`, i.e. `5 <= 5`. The check `offset + hdr_len` needs to be inclusive, therefore use `<=`.