### PR TITLE
rb532: split up DEVICE_TITLE

### DIFF
--- a/target/linux/rb532/image/Makefile
+++ b/target/linux/rb532/image/Makefile
@@ -36,9 +36,10 @@ define Build/lzma-loader-elf
 endef
 
 define Device/nand
+  DEVICE_VENDOR := MikroTik
+  DEVICE_MODEL := RouterBOARD 532
   CMDLINE := ubi.mtd=1 ubi.block=0,rootfs root=/dev/ubiblock0_1
   BOARD_NAME := rb532
-  DEVICE_TITLE := rb532 NAND
   SUPPORTED_DEVICES := rb532
   KERNEL_INITRAMFS := append-kernel | patch-cmdline | lzma | lzma-loader-elf
   KERNEL := $$(KERNEL_INITRAMFS) | kernel2minor -s 2048 -i 0 -c


### PR DESCRIPTION
DEVICE_TITLE is split up into DEVICE_VENDOR, DEVICE_MODEL and DEVICE_VARIANT
