### PR TITLE
octeon: split up remaining DEVICE_TITLE

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -23,8 +23,9 @@ define Build/strip-kernel
 endef
 
 define Device/generic
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := Octeon
   FILESYSTEMS := ext4
-  DEVICE_TITLE := Generic
 endef
 TARGET_DEVICES += generic
 


### PR DESCRIPTION
DEVICE_TITLE is split up into DEVICE_VENDOR and DEVICE_MODEL
