### PR TITLE
ccache: update to 3.7.4

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=3.7.2
+PKG_VERSION:=3.7.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=a5da0008512ff9e882097acaffb3616fae98ec25827167bb4bd1e4acf0b66793
+PKG_HASH:=04c0af414b8cf89e541daed59735547fbfd323b1aaa983da0216f6b6731e6836
 
 include $(INCLUDE_DIR)/host-build.mk
 

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.c
 +++ b/src/ccache.c
-@@ -2189,6 +2189,7 @@ calculate_object_hash(struct args *args,
+@@ -2197,6 +2197,7 @@ calculate_object_hash(struct args *args,
  			"CPLUS_INCLUDE_PATH",
  			"OBJC_INCLUDE_PATH",
  			"OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Update ccache to 3.7.4

Release notes:
https://ccache.dev/releasenotes.html#_ccache_3_7_4