### PR TITLE
ramips: add support for ipTIME A104ns & A1004ns

### DIFF
--- a/target/linux/ramips/dts/mt7620a_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7620a_iptime.dtsi
@@ -21,7 +21,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_iptime_a1004ns.dts
+++ b/target/linux/ramips/dts/mt7620a_iptime_a1004ns.dts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a_iptime.dtsi"
+
+/ {
+	compatible = "iptime,a1004ns", "ralink,mt7620a-soc";
+	model = "ipTIME A1004ns";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			label = "a1004ns:blue:cpu";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "a1004ns:blue:usb";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&firmware {
+	reg = <0x30000 0xfd0000>;
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "uartf", "spi refclk";
+		ralink,function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1 {
+			reg = <1>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@2 {
+			reg = <2>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@3 {
+			reg = <3>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1f {
+			reg = <0x1f>;
+			phy-mode = "rgmii";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -489,6 +489,17 @@ define Device/iodata_wn-ac733gr3
 endef
 TARGET_DEVICES += iodata_wn-ac733gr3
 
+define Device/iptime_a1004ns
+  SOC := mt7620a
+  IMAGE_SIZE := 16192k
+  UIMAGE_NAME := a1004ns
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A1004ns
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += iptime_a1004ns
+
 define Device/iptime_a104ns
   SOC := mt7620a
   IMAGE_SIZE := 8000k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -137,7 +137,8 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "5:wan" "6@eth0"
 		;;
 	iodata,wn-ac1167gr|\
-	iodata,wn-ac733gr3)
+	iodata,wn-ac733gr3|\
+	iptime,a1004ns)
 		ucidef_add_switch "switch1" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
@@ -306,6 +307,9 @@ ramips_setup_macs()
 	iodata,wn-ac1167gr|\
 	iodata,wn-ac733gr3)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
+		;;
+	iptime,a1004ns)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
 	iptime,a104ns)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary u-boot 0x1fc20)" 2)


### PR DESCRIPTION
This adds support for ipTIME A104ns and A1004ns with MediaTek MT7620A.