### PR TITLE
treewide: Move caldata extraction and MAC patching to common file

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -17,6 +17,22 @@ NO_EXPORT=1
 LOAD_STATE=1
 LIST_SEP=" "
 
+# xor multiple hex values of the same length
+xor() {
+	local val
+	local ret="0x$1"
+	local retlen=${#1}
+
+	shift
+	while [ -n "$1" ]; do
+		val="0x$1"
+		ret=$((ret ^ val))
+		shift
+	done
+
+	printf "%0${retlen}x" "$ret"
+}
+
 append() {
 	local var="$1"
 	local value="$2"

--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -1,0 +1,75 @@
+# Copyright (C) 2019 OpenWrt.org
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+caldata_die() {
+	echo "caldata: " "$*"
+	exit 1
+}
+
+caldata_extract() {
+	local part=$1
+	local offset=$(($2))
+	local count=$(($3))
+	local mtd
+
+	mtd=$(find_mtd_chardev $part)
+	[ -n "$mtd" ] || caldata_die "no mtd device found for partition $part"
+
+	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+		caldata_die "failed to extract calibration data from $mtd"
+}
+
+caldata_extract_ubi() {
+	local part=$1
+	local offset=$(($2))
+	local count=$(($3))
+	local ubidev
+	local ubi
+
+	. /lib/upgrade/nand.sh
+
+	ubidev=$(nand_find_ubi $CI_UBIPART)
+	ubi=$(nand_find_volume $ubidev $part)
+	[ -n "$ubi" ] || caldata_die "no UBI volume found for $part"
+
+	dd if=/dev/$ubi of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+		caldata_die "failed to extract calibration data from $ubi"
+}
+
+caldata_extract_reverse() {
+	local part=$1
+	local offset=$2
+	local count=$(($3))
+	local mtd
+	local reversed
+	local caldata
+
+	mtd=$(find_mtd_chardev "$part")
+	reversed=$(hexdump -v -s $offset -n $count -e '/1 "%02x "' $mtd)
+
+	for byte in $reversed; do
+		caldata="\x${byte}${caldata}"
+	done
+
+	printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
+}
+
+caldata_from_file() {
+	local source=$1
+	local offset=$(($2))
+	local count=$(($3))
+
+	dd if=$source of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+		caldata_die "failed to extract calibration data from $source"
+}
+
+caldata_valid() {
+	local expected="$1"
+
+	magic=$(hexdump -v -n 2 -e '1/1 "%02x"' /lib/firmware/$FIRMWARE)
+	[[ "$magic" == "$expected" ]]
+	return $?
+}
+

--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -73,3 +73,56 @@ caldata_valid() {
 	return $?
 }
 
+caldata_patch_chksum() {
+	local mac=$1
+	local mac_offset=$(($2))
+	local chksum_offset=$(($3))
+	local xor_mac
+	local xor_fw_mac
+	local xor_fw_chksum
+
+	xor_mac=${mac//:/}
+	xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
+
+	xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
+	xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
+
+	xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
+	xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
+
+	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
+		dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
+}
+
+caldata_patch_fw_mac() {
+	local mac=$1
+	local mac_offset=$(($2))
+	local chksum_offset=$3
+
+	[ -z "$mac" -o -z "$mac_offset" ] && return
+
+	[ -n "$chksum_offset" ] && caldata_patch_chksum "$mac" "$mac_offset" "$chksum_offset"
+
+	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc oflag=seek_bytes bs=6 seek=$mac_offset count=1 || \
+		caldata_die "failed to write MAC address to eeprom file"
+}
+
+caldata_patch_fw_mac_crc() {
+	local mac=$1
+	local mac_offset=$2
+	local chksum_offset=$((mac_offset - 10))
+
+	caldata_patch_fw_mac "$mac" "$mac_offset" "$chksum_offset"
+}
+
+ath10kcal_patch_mac() {
+	local mac=$1
+
+	caldata_patch_fw_mac "$mac" 0x6
+}
+
+ath10kcal_patch_mac_crc() {
+	local mac=$1
+
+	caldata_patch_fw_mac "$mac" 0x6 0x2
+}

--- a/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -4,14 +4,6 @@
 
 . /lib/functions/caldata.sh
 
-ath9k_patch_firmware_mac() {
-	local mac=$1
-
-	[ -z "$mac" ] && return
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=2 count=6
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in
@@ -24,7 +16,7 @@ case "$FIRMWARE" in
 			caldata_extract_ubi "caldata" 0x5000 0x1000
 		else
 			caldata_extract "wifi_data" 0x5000 0x1000
-			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0xc)
+			caldata_patch_fw_mac $(mtd_get_mac_binary wifi_data 0xc) 0x2
 		fi
 		;;
 	*)
@@ -42,7 +34,7 @@ case "$FIRMWARE" in
 			caldata_extract_ubi "caldata" 0x1000 0x1000
 		else
 			caldata_extract "wifi_data" 0x1000 0x1000
-			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0x0)
+			caldata_patch_fw_mac $(mtd_get_mac_binary wifi_data 0x0) 0x2
 		fi
 		;;
 	*)

--- a/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/apm821xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -2,42 +2,7 @@
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
-. /lib/functions/system.sh
-
-ath9k_eeprom_die() {
-	echo "ath9k eeprom: " "$*"
-	exit 1
-}
-
-ath9k_eeprom_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		ath9k_eeprom_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath9k_eeprom_die "failed to extract from $mtd"
-}
-
-ath9k_ubi_eeprom_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local ubidev=$(nand_find_ubi $CI_UBIPART)
-	local ubi
-
-	ubi=$(nand_find_volume $ubidev $part)
-	[ -n "$ubi" ] || \
-		ath9k_eeprom_die "no UBI volume found for $part"
-
-	dd if=/dev/$ubi of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath9k_eeprom_die "failed to extract from $ubi"
-}
+. /lib/functions/caldata.sh
 
 ath9k_patch_firmware_mac() {
 	local mac=$1
@@ -56,14 +21,14 @@ case "$FIRMWARE" in
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 0x5000 0x1000
+			caldata_extract_ubi "caldata" 0x5000 0x1000
 		else
-			ath9k_eeprom_extract "wifi_data" 0x5000 0x1000
+			caldata_extract "wifi_data" 0x5000 0x1000
 			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0xc)
 		fi
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;
@@ -74,14 +39,14 @@ case "$FIRMWARE" in
 		. /lib/upgrade/nand.sh
 
 		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
-			ath9k_ubi_eeprom_extract "caldata" 0x1000 0x1000
+			caldata_extract_ubi "caldata" 0x1000 0x1000
 		else
-			ath9k_eeprom_extract "wifi_data" 0x1000 0x1000
+			caldata_extract "wifi_data" 0x1000 0x1000
 			ath9k_patch_firmware_mac $(mtd_get_mac_binary wifi_data 0x0)
 		fi
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -2,45 +2,7 @@
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
-. /lib/functions/system.sh
-
-ath9k_eeprom_die() {
-	echo "ath9k eeprom: " "$*"
-	exit 1
-}
-
-ath9k_eeprom_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		ath9k_eeprom_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath9k_eeprom_die "failed to extract from $mtd"
-}
-
-ath9k_eeprom_extract_reverse() {
-	local part=$1
-	local offset=$2
-	local count=$(($3))
-	local mtd
-	local reversed
-	local caldata
-
-	mtd=$(find_mtd_chardev "$part")
-	reversed=$(hexdump -v -s $offset -n $count -e '/1 "%02x "' $mtd)
-
-	for byte in $reversed; do
-		caldata="\x${byte}${caldata}"
-	done
-
-	printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
-}
+. /lib/functions/caldata.sh
 
 ath9k_patch_fw_mac() {
 	local mac=$1
@@ -83,11 +45,11 @@ case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
 	avm,fritz4020)
-		ath9k_eeprom_extract_reverse "urlader" 0x1541 0x440
+		caldata_extract_reverse "urlader" 0x1541 0x440
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_text "mac" 0x4) 0x2
 		;;
 	dlink,dir-842-c1|\
@@ -96,11 +58,11 @@ case "$FIRMWARE" in
 	dlink,dir-859-a1|\
 	nec,wg1200cr|\
 	wd,mynet-n750)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	engenius,ecb1750)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 0x2
 		;;
 	engenius,epg5000|\
@@ -108,39 +70,39 @@ case "$FIRMWARE" in
 	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 0x2
 		;;
 	nec,wg800hp)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 0x2
 		;;
 	qihoo,c301)
-		ath9k_eeprom_extract "radiocfg" 0x1000 0x440
+		caldata_extract "radiocfg" 0x1000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
 	avm,fritz300e)
-		ath9k_eeprom_extract_reverse "urloader" 0x1541 0x440
+		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
 	buffalo,whr-g301n|\
 	buffalo,wzr-hp-g302h-a1a0|\
 	tplink,tl-wr841-v5|\
 	tplink,tl-wr941-v4)
-		ath9k_eeprom_extract "art" 0x1000 0xeb8
+		caldata_extract "art" 0x1000 0xeb8
 		;;
 	buffalo,wzr-hp-g450h)
-		ath9k_eeprom_extract "art" 0x1000 0x440
+		caldata_extract "art" 0x1000 0x440
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
-		ath9k_eeprom_extract "art" 0x5000 0x440
+		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 0x2
 		;;
 	ocedo,raccoon|\
@@ -149,7 +111,7 @@ case "$FIRMWARE" in
 	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4900-v2|\
 	winchannel,wb2000)
-		ath9k_eeprom_extract "art" 0x5000 0x440
+		caldata_extract "art" 0x5000 0x440
 		;;
 	netgear,wnr612-v2|\
 	on,n150r|\
@@ -167,24 +129,24 @@ case "$FIRMWARE" in
 	ubnt,bullet-m|\
 	ubnt,nano-m|\
 	ubnt,rocket-m)
-		ath9k_eeprom_extract "art" 0x1000 0x1000
+		caldata_extract "art" 0x1000 0x1000
 		;;
 	pqi,air-pen)
-		ath9k_eeprom_extract "art" 0x1000 0x7d2
+		caldata_extract "art" 0x1000 0x7d2
 		;;
 	ubnt,unifi)
-		ath9k_eeprom_extract "art" 0x1000 0x800
+		caldata_extract "art" 0x1000 0x800
 		;;
 	wd,mynet-n750)
-		ath9k_eeprom_extract "art" 0x5000 0x440
+		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan5mac") 0x2
 		;;
 	wd,mynet-wifi-rangeextender)
-		ath9k_eeprom_extract "art" 0x1000 0x1000
+		caldata_extract "art" 0x1000 0x1000
 		ath9k_patch_fw_mac $(nvram get wl0_hwaddr) "$mac" 0x2
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;
@@ -195,14 +157,14 @@ case "$FIRMWARE" in
 	netgear,wndr3700v2|\
 	netgear,wndr3800|\
 	netgear,wndr3800ch)
-		ath9k_eeprom_extract "art" 0x1000 0xeb8
+		caldata_extract "art" 0x1000 0xeb8
 		;;
 	dlink,dir-825-b1)
-		ath9k_eeprom_extract "caldata" 0x1000 0xeb8
+		caldata_extract "caldata" 0x1000 0xeb8
 		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;
@@ -213,14 +175,14 @@ case "$FIRMWARE" in
 	netgear,wndr3700v2|\
 	netgear,wndr3800|\
 	netgear,wndr3800ch)
-		ath9k_eeprom_extract "art" 0x5000 0xeb8
+		caldata_extract "art" 0x5000 0xeb8
 		;;
 	dlink,dir-825-b1)
-		ath9k_eeprom_extract "caldata" 0x5000 0xeb8
+		caldata_extract "caldata" 0x5000 0xeb8
 		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -4,41 +4,6 @@
 
 . /lib/functions/caldata.sh
 
-ath9k_patch_fw_mac() {
-	local mac=$1
-	local mac_offset=$(($2))
-	local chksum_offset=$3
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
-
-	[ -z "$mac" -o -z "$mac_offset" ] && return
-
-	[ -n "$chksum_offset" ] && {
-		xor_mac=${mac//:/}
-		xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-		xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-		xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-		xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-		xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-		printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-			dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$(($chksum_offset)) count=2
-	}
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc oflag=seek_bytes bs=6 seek=$mac_offset count=1
-}
-
-ath9k_patch_fw_mac_crc() {
-	local mac=$1
-	local mac_offset=$2
-	local chksum_offset=$((mac_offset - 10))
-
-	ath9k_patch_fw_mac "${mac}" "${mac_offset}" "${chksum_offset}"
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in
@@ -50,7 +15,7 @@ case "$FIRMWARE" in
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
 		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_text "mac" 0x4) 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_text "mac" 0x4) 0x2
 		;;
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
@@ -59,11 +24,11 @@ case "$FIRMWARE" in
 	nec,wg1200cr|\
 	wd,mynet-n750)
 		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	engenius,ecb1750)
 		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 0x2
+		caldata_patch_fw_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env "athaddr") +1) 0x2
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
@@ -71,15 +36,15 @@ case "$FIRMWARE" in
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr)
 		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_ascii u-boot-env ethaddr) 0x2
 		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_text board_data 0x680) 0x2
 		;;
 	qihoo,c301)
 		caldata_extract "radiocfg" 0x1000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan24mac") 0x2
 		;;
 	*)
 		caldata_die "board $board is not supported yet"
@@ -103,7 +68,7 @@ case "$FIRMWARE" in
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)
 		caldata_extract "art" 0x5000 0x440
-		ath9k_patch_fw_mac $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 0x2
+		caldata_patch_fw_mac $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1) 0x2
 		;;
 	ocedo,raccoon|\
 	tplink,tl-wdr3500-v1|\
@@ -139,11 +104,11 @@ case "$FIRMWARE" in
 		;;
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440
-		ath9k_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan5mac") 0x2
+		caldata_patch_fw_mac $(mtd_get_mac_ascii devdata "wlan5mac") 0x2
 		;;
 	wd,mynet-wifi-rangeextender)
 		caldata_extract "art" 0x1000 0x1000
-		ath9k_patch_fw_mac $(nvram get wl0_hwaddr) "$mac" 0x2
+		caldata_patch_fw_mac $(nvram get wl0_hwaddr) "$mac" 0x2
 		;;
 	*)
 		caldata_die "board $board is not supported yet"
@@ -161,7 +126,7 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-825-b1)
 		caldata_extract "caldata" 0x1000 0xeb8
-		ath9k_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
+		caldata_patch_fw_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
 		;;
 	*)
 		caldata_die "board $board is not supported yet"
@@ -179,7 +144,7 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-825-b1)
 		caldata_extract "caldata" 0x5000 0xeb8
-		ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c
+		caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c
 		;;
 	*)
 		caldata_die "board $board is not supported yet"

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -42,21 +42,6 @@ ath9k_eeprom_extract_reverse() {
 	printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
 }
 
-xor() {
-	local val
-	local ret="0x$1"
-	local retlen=${#1}
-
-	shift
-	while [ -n "$1" ]; do
-		val="0x$1"
-		ret=$((ret ^ val))
-		shift
-	done
-
-	printf "%0${retlen}x" "$ret"
-}
-
 ath9k_patch_fw_mac() {
 	local mac=$1
 	local mac_offset=$(($2))

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -5,37 +5,6 @@
 . /lib/functions/caldata.sh
 . /lib/functions/k2t.sh
 
-ath10kcal_patch_mac() {
-	local mac=$1
-
-	[ -z "$mac" ] && return
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc oflag=seek_bytes bs=6 seek=6 count=1
-}
-
-ath10kcal_patch_mac_crc() {
-	local mac=$1
-	local mac_offset=6
-	local chksum_offset=2
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
-
-	xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-	ath10kcal_patch_mac "$mac" && {
-		xor_mac=${mac//:/}
-		xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-		xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-		xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-		printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-			dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
-	}
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,22 +1,7 @@
 #!/bin/sh
 
+. /lib/functions.sh
 . /lib/functions/k2t.sh
-
-# xor multiple hex values of the same length
-xor() {
-	local val
-	local ret="0x$1"
-	local retlen=${#1}
-
-	shift
-	while [ -n "$1" ]; do
-		val="0x$1"
-		ret=$((ret ^ val))
-		shift
-	done
-
-	printf "%0${retlen}x" "$ret"
-}
 
 ath10kcal_die() {
 	echo "ath10cal: " "$*"
@@ -79,7 +64,6 @@ ath10kcal_patch_mac_crc() {
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
 . /lib/functions/system.sh
 
 board=$(board_name)

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,35 +1,9 @@
 #!/bin/sh
 
-. /lib/functions.sh
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions/caldata.sh
 . /lib/functions/k2t.sh
-
-ath10kcal_die() {
-	echo "ath10cal: " "$*"
-	exit 1
-}
-
-ath10kcal_from_file() {
-	local source=$1
-	local offset=$(($2))
-	local count=$(($3))
-
-	dd if=$source of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath10kcal_die "failed to extract calibration data from $source"
-}
-
-ath10kcal_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		ath10kcal_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath10kcal_die "failed to extract calibration data from $mtd"
-}
 
 ath10kcal_patch_mac() {
 	local mac=$1
@@ -62,10 +36,6 @@ ath10kcal_patch_mac_crc() {
 	}
 }
 
-[ -e /lib/firmware/$FIRMWARE ] && exit 0
-
-. /lib/functions/system.sh
-
 board=$(board_name)
 
 case "$FIRMWARE" in
@@ -74,7 +44,7 @@ case "$FIRMWARE" in
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	yuncore,a770)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		;;
 	devolo,dvl1200e|\
 	devolo,dvl1200i|\
@@ -82,54 +52,54 @@ case "$FIRMWARE" in
 	devolo,dvl1750e|\
 	devolo,dvl1750i|\
 	devolo,dvl1750x)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x0) -1)
 		;;
 	dlink,dir-859-a1)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
 	elecom,wrc-1750ghbk2-i)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		;;
 	engenius,ecb1750)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	engenius,ews511ap)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	glinet,gl-ar750|\
 	glinet,gl-ar750s)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	glinet,gl-x750)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	nec,wg800hp)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(mtd_get_mac_text board_data 0x880)
 		;;
 	ocedo,koala|\
 	ocedo,ursus)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
 	openmesh,om5p-ac-v2)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	qihoo,c301)
-		ath10kcal_extract "radiocfg" 0x5000 0x844
+		caldata_extract "radiocfg" 0x5000 0x844
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
 		;;
 	tplink,archer-a7-v5|\
@@ -137,29 +107,29 @@ case "$FIRMWARE" in
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		;;
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v2)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
 		;;
 	tplink,archer-d50-v1)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
 		;;
 	tplink,re350k-v1)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
 		;;
 	tplink,re355-v1|\
 	tplink,re450-v1)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	tplink,re450-v2)
-		ath10kcal_extract "art" 0x5000 0x844
+		caldata_extract "art" 0x5000 0x844
 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
 	ubnt,unifiac-lite|\
@@ -170,7 +140,7 @@ case "$FIRMWARE" in
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,unifiac-pro)
-		ath10kcal_extract "EEPROM" 0x5000 0x844
+		caldata_extract "EEPROM" 0x5000 0x844
 		;;
 	esac
 	;;
@@ -180,18 +150,18 @@ case "$FIRMWARE" in
 	dlink,dir-842-c2|\
 	dlink,dir-842-c3|\
 	nec,wg1200cr)
-		ath10kcal_extract "art" 0x5000 0x2f20
+		caldata_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata wlan5mac)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
 	netgear,ex6400|\
 	netgear,ex7300)
-		ath10kcal_extract "caldata" 0x5000 0x2f20
+		caldata_extract "caldata" 0x5000 0x2f20
 		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
 	phicomm,k2t)
-		ath10kcal_extract "art" 0x5000 0x2f20
+		caldata_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(k2t_get_mac "5g_mac")
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
@@ -202,7 +172,7 @@ case "$FIRMWARE" in
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
 	tplink,archer-c6-v2)
-		ath10kcal_extract "art" 0x5000 0x2f20
+		caldata_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mac 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin

--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -26,33 +26,33 @@ case "$FIRMWARE" in
 		;;
 	dlink,dir-859-a1)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
+		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii devdata "wlan5mac")
 		;;
 	elecom,wrc-1750ghbk2-i)
 		caldata_extract "art" 0x5000 0x844
 		;;
 	engenius,ecb1750)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
 		;;
 	engenius,ews511ap)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
 	glinet,gl-ar750|\
 	glinet,gl-ar750s)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)
 		;;
 	glinet,gl-x750)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x5000 0x844
@@ -61,11 +61,11 @@ case "$FIRMWARE" in
 	ocedo,koala|\
 	ocedo,ursus)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(mtd_get_mac_binary art 0xc)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary art 0xc)
 		;;
 	openmesh,om5p-ac-v2)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
+		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	qihoo,c301)
 		caldata_extract "radiocfg" 0x5000 0x844
@@ -77,29 +77,29 @@ case "$FIRMWARE" in
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		;;
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v2)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
 		;;
 	tplink,archer-d50-v1)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary romfile 0xf100) +2)
 		;;
 	tplink,re350k-v1)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary config 0x10008) +2)
 		;;
 	tplink,re355-v1|\
 	tplink,re450-v1)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	tplink,re450-v2)
 		caldata_extract "art" 0x5000 0x844
-		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
+		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-mesh|\
@@ -127,7 +127,7 @@ case "$FIRMWARE" in
 	netgear,ex6400|\
 	netgear,ex7300)
 		caldata_extract "caldata" 0x5000 0x2f20
-		ath10kcal_patch_mac $(mtd_get_mac_binary caldata 0xc)
+		ath10kcal_patch_mac_crc $(mtd_get_mac_binary caldata 0xc)
 		;;
 	phicomm,k2t)
 		caldata_extract "art" 0x5000 0x2f20

--- a/target/linux/brcm63xx/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/brcm63xx/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -1,28 +1,9 @@
 #!/bin/sh
 # Based on gabors ralink wisoc implementation.
 
-rt2x00_eeprom_die() {
-	echo "rt2x00 eeprom: " "$*"
-	exit 1
-}
-
-rt2x00_eeprom_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_part $part)
-	[ -n "$mtd" ] || \
-		rt2x00_eeprom_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count || \
-		rt2x00_eeprom_die "failed to extract from $mtd"
-}
-
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
+. /lib/functions/caldata.sh
 
 board=$(board_name)
 
@@ -30,14 +11,14 @@ case "$FIRMWARE" in
 "rt2x00.eeprom" )
 	case $board in
 	hg556a_c)
-		rt2x00_eeprom_extract "cal_data" 0x1fe00 0x200
+		caldata_extract "cal_data" 0x1fe00 0x200
 		;;
 	hg622 |\
 	hg655b)
-		rt2x00_eeprom_extract "cal_data" 0x0 0x200
+		caldata_extract "cal_data" 0x0 0x200
 		;;
 	*)
-		rt2x00_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -4,31 +4,6 @@
 
 . /lib/functions/caldata.sh
 
-ath10kcal_patch_mac_crc() {
-	local mac=$1
-	local mac_offset=6
-	local chksum_offset=2
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
-
-	[ -z "$mac" ] && return
-
-	xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=6 count=6
-
-	xor_mac=${mac//:/}
-	xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-	xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-		dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,20 +1,6 @@
 #!/bin/sh
 
-# xor multiple hex values of the same length
-xor() {
-	local val
-	local ret="0x$1"
-	local retlen=${#1}
-
-	shift
-	while [ -n "$1" ]; do
-		val="0x$1"
-		ret=$((ret ^ val))
-		shift
-	done
-
-	printf "%0${retlen}x" "$ret"
-}
+. /lib/functions.sh
 
 ath10kcal_die() {
 	echo "ath10cal: " "$*"
@@ -88,7 +74,6 @@ ath10kcal_is_caldata_valid() {
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
 . /lib/functions/system.sh
 
 board=$(board_name)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,43 +1,8 @@
 #!/bin/sh
 
-. /lib/functions.sh
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-ath10kcal_die() {
-	echo "ath10cal: " "$*"
-	exit 1
-}
-
-ath10kcal_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		ath10kcal_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath10kcal_die "failed to extract calibration data from $mtd"
-}
-
-ath10kcal_ubi_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local ubidev
-	local ubi
-
-	. /lib/upgrade/nand.sh
-
-	ubidev=$(nand_find_ubi $CI_UBIPART)
-	ubi=$(nand_find_volume $ubidev $part)
-	[ -n "$ubi" ] || \
-		ath10kcal_die "no UBI volume found for $part"
-
-	dd if=/dev/$ubi of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		ath10kcal_die "failed to extract from $ubi"
-}
+. /lib/functions/caldata.sh
 
 ath10kcal_patch_mac_crc() {
 	local mac=$1
@@ -64,26 +29,14 @@ ath10kcal_patch_mac_crc() {
 		dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
 }
 
-ath10kcal_is_caldata_valid() {
-	local expected="$1"
-
-	magic=$(hexdump -v -n 2 -e '1/1 "%02x"' /lib/firmware/$FIRMWARE)
-	[[ "$magic" == "$expected" ]]
-	return $?
-}
-
-[ -e /lib/firmware/$FIRMWARE ] && exit 0
-
-. /lib/functions/system.sh
-
 board=$(board_name)
 
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:01:00.0.bin")
 	case "$board" in
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 0x9000 0x844
-		ath10kcal_is_caldata_valid "4408" || ath10kcal_extract "ART" 0x9000 0x844
+		caldata_extract_ubi "ART" 0x9000 0x844
+		caldata_valid "4408" || caldata_extract "ART" 0x9000 0x844
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +1)
 		;;
 	esac
@@ -91,7 +44,7 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 0x9000 0x2f20
+		caldata_extract_ubi "Factory" 0x9000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
@@ -104,12 +57,12 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 0x9000 0x2f20
+		caldata_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
 		ath10kcal_patch_mac_crc $(macaddr_setbit_la $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4))
 		;;
 	openmesh,a62)
-		ath10kcal_extract "0:ART" 0x9000 0x2f20
+		caldata_extract "0:ART" 0x9000 0x2f20
 		;;
 	esac
 	;;
@@ -120,14 +73,14 @@ case "$FIRMWARE" in
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\
 	qcom,ap-dk01.1-c1)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		;;
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 0x1000 0x2f20
+		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		ath10kcal_ubi_extract "Factory" 0x1000 0x2f20
+		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -147,29 +100,29 @@ case "$FIRMWARE" in
 	openmesh,a62 |\
 	qxwlan,e2600ac-c1 |\
 	qxwlan,e2600ac-c2)
-		ath10kcal_extract "0:ART" 0x1000 0x2f20
+		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
 	engenius,ens620ext)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +2)
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 0x1000 0x2f20
-		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract_ubi "ART" 0x1000 0x2f20
+		caldata_valid "202f" || caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +2)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0x0)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
 	esac
@@ -181,14 +134,14 @@ case "$FIRMWARE" in
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\
 	qcom,ap-dk01.1-c1)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		;;
 	asus,map-ac2200)
-		ath10kcal_ubi_extract "Factory" 0x5000 0x2f20
+		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		ath10kcal_ubi_extract "Factory" 0x5000 0x2f20
+		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -208,29 +161,29 @@ case "$FIRMWARE" in
 	openmesh,a62 |\
 	qxwlan,e2600ac-c1 |\
 	qxwlan,e2600ac-c2)
-		ath10kcal_extract "0:ART" 0x5000 0x2f20
+		caldata_extract "0:ART" 0x5000 0x2f20
 		;;
 	engenius,ens620ext)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +3)
 		;;
 	linksys,ea8300)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
 		;;
 	meraki,mr33)
-		ath10kcal_ubi_extract "ART" 0x5000 0x2f20
-		ath10kcal_is_caldata_valid "202f" || ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract_ubi "ART" 0x5000 0x2f20
+		caldata_valid "202f" || caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66) +3)
 		;;
 	netgear,ex6100v2 |\
 	netgear,ex6150v2)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary dnidata 0xc)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
 		;;
 	esac

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,34 +1,8 @@
 #!/bin/sh
 
-. /lib/functions.sh
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-ath10kcal_die() {
-	echo "ath10cal: " "$*"
-	exit 1
-}
-
-ath10kcal_from_file() {
-	local source=$1
-	local offset=$(($2))
-	local count=$(($3))
-
-	dd if=$source of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
-		ath10kcal_die "failed to extract calibration data from $source"
-}
-
-ath10kcal_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		ath10kcal_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
-		ath10kcal_die "failed to extract calibration data from $mtd"
-}
+. /lib/functions/caldata.sh
 
 ath10kcal_patch_mac_crc() {
 	local mac=$1
@@ -55,43 +29,39 @@ ath10kcal_patch_mac_crc() {
 		dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
 }
 
-[ -e /lib/firmware/$FIRMWARE ] && exit 0
-
-. /lib/functions/system.sh
-
 board=$(board_name)
 
 case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
 	buffalo,wxr-2533dhp)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x1e)
 		;;
 	linksys,ea8500)
-		ath10kcal_extract "art" 0x1000 0x2f20
+		caldata_extract "art" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +1)
 		;;
 	nec,wg2600hp)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary PRODUCTDATA 0xc) +1)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
-		ath10kcal_extract "art" 0x1000 0x2f20
+		caldata_extract "art" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +1)
 		;;
 	tplink,c2600)
-		ath10kcal_extract "radio" 0x1000 0x2f20
+		caldata_extract "radio" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x8) -1)
 		;;
 	tplink,vr2600v)
-		ath10kcal_extract "ART" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary default-mac 0x0) -1)
 		;;
 	zyxel,nbg6817)
-		ath10kcal_extract "0:ART" 0x1000 0x2f20
+		caldata_extract "0:ART" 0x1000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) +1)
 		;;
 	esac
@@ -99,33 +69,33 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
 	buffalo,wxr-2533dhp)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary ART 0x18)
 		;;
 	linksys,ea8500)
-		ath10kcal_extract "art" 0x5000 0x2f20
+		caldata_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +2)
 		;;
 	nec,wg2600hp)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary PRODUCTDATA 0xc)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
-		ath10kcal_extract "art" 0x5000 0x2f20
+		caldata_extract "art" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary art 0x6) +2)
 		;;
 	tplink,c2600)
-		ath10kcal_extract "radio" 0x5000 0x2f20
+		caldata_extract "radio" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x8)
 		;;
 	tplink,vr2600v)
-		ath10kcal_extract "ART" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_binary default-mac 0x0)
 		;;
 	zyxel,nbg6817)
-		ath10kcal_extract "0:ART" 0x5000 0x2f20
+		caldata_extract "0:ART" 0x5000 0x2f20
 		ath10kcal_patch_mac_crc $(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 		;;
 	esac

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -1,20 +1,6 @@
 #!/bin/sh
 
-# xor multiple hex values of the same length
-xor() {
-	local val
-	local ret="0x$1"
-	local retlen=${#1}
-
-	shift
-	while [ -n "$1" ]; do
-		val="0x$1"
-		ret=$((ret ^ val))
-		shift
-	done
-
-	printf "%0${retlen}x" "$ret"
-}
+. /lib/functions.sh
 
 ath10kcal_die() {
 	echo "ath10cal: " "$*"
@@ -71,7 +57,6 @@ ath10kcal_patch_mac_crc() {
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
 . /lib/functions/system.sh
 
 board=$(board_name)

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -4,31 +4,6 @@
 
 . /lib/functions/caldata.sh
 
-ath10kcal_patch_mac_crc() {
-	local mac=$1
-	local mac_offset=6
-	local chksum_offset=2
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
-
-	[ -z "$mac" ] && return
-
-	xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=6 count=6
-
-	xor_mac=${mac//:/}
-	xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-	xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-	xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-		dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$chksum_offset count=2
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -3,29 +3,7 @@
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
-. /lib/functions/system.sh
-. /lib/upgrade/nand.sh
-
-ath10k_caldata_die() {
-	echo "ath10k caldata: " "$*"
-	exit 1
-}
-
-ath10k_caldata_extract_ubi() {
-	local part=$1
-	local offset=$2
-	local count=$3
-	local ubidev=$(nand_find_ubi $CI_UBIPART)
-	local ubi
-
-	ubi=$(nand_find_volume $ubidev $part)
-	[ -n "$ubi" ] || \
-		ath10k_caldata_die "no UBI volume found for $part"
-
-	dd if=/dev/$ubi of=/lib/firmware/$FIRMWARE bs=1 skip=$offset count=$count 2>/dev/null || \
-		ath10k_caldata_die "failed to extract from $ubi"
-}
+. /lib/functions/caldata.sh
 
 ath10k_caldata_set_macaddr() {
 	local macaddr=$1
@@ -39,11 +17,11 @@ case "$FIRMWARE" in
 	board=$(board_name)
 	case $board in
 		bt,homehub-v5a)
-			ath10k_caldata_extract_ubi "caldata" 20480 2116
+			caldata_extract_ubi "caldata" 0x5000 0x844
 			ath10k_caldata_set_macaddr $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
 			;;
 		*)
-			ath10k_caldata_die "board $board is not supported yet"
+			caldata_die "board $board is not supported yet"
 			;;
 	esac
 	;;

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -5,20 +5,13 @@
 
 . /lib/functions/caldata.sh
 
-ath10k_caldata_set_macaddr() {
-	local macaddr=$1
-
-	macaddr_2bin $macaddr | dd of=/lib/firmware/$FIRMWARE \
-				conv=notrunc bs=1 seek=6 count=6
-}
-
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:02:00.0.bin")
 	board=$(board_name)
 	case $board in
 		bt,homehub-v5a)
 			caldata_extract_ubi "caldata" 0x5000 0x844
-			ath10k_caldata_set_macaddr $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
+			ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
 			;;
 		*)
 			caldata_die "board $board is not supported yet"

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,7 +11,7 @@ case "$FIRMWARE" in
 	case $board in
 		bt,homehub-v5a)
 			caldata_extract_ubi "caldata" 0x5000 0x844
-			ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
+			ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +3)
 			;;
 		*)
 			caldata_die "board $board is not supported yet"

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -3,14 +3,8 @@
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-. /lib/functions.sh
-. /lib/functions/system.sh
+. /lib/functions/caldata.sh
 . /lib/upgrade/nand.sh
-
-ath9k_eeprom_die() {
-	echo "ath9k eeprom: $*"
-	exit 1
-}
 
 ath9k_eeprom_extract_raw() {
 	local source=$1
@@ -28,25 +22,7 @@ ath9k_eeprom_extract_raw() {
 	fi
 
 	dd if=$source of=/lib/firmware/$FIRMWARE bs=$bs skip=$offset count=$size $conv 2>/dev/null || \
-			ath9k_eeprom_die "failed to extract from $mtd"
-}
-
-ath9k_eeprom_extract_reverse() {
-	local part=$1
-	local offset=$2
-	local count=$(($3))
-	local mtd
-	local reversed
-	local caldata
-
-	mtd=$(find_mtd_chardev "$part")
-	reversed=$(hexdump -v -s $offset -n $count -e '/1 "%02x "' $mtd)
-
-	for byte in $reversed; do
-		caldata="\x${byte}${caldata}"
-	done
-
-	printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
+			caldata_die "failed to extract from $mtd"
 }
 
 ath9k_eeprom_extract() {
@@ -57,7 +33,7 @@ ath9k_eeprom_extract() {
 
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || \
-		ath9k_eeprom_die "no mtd device found for partition $part"
+		caldata_die "no mtd device found for partition $part"
 
 	ath9k_eeprom_extract_raw $mtd $offset $swap
 }
@@ -71,7 +47,7 @@ ath9k_ubi_eeprom_extract() {
 
 	ubi=$(nand_find_volume $ubidev $part)
 	[ -n "$ubi" ] || \
-		ath9k_eeprom_die "no UBI volume found for $part"
+		caldata_die "no UBI volume found for $part"
 
 	ath9k_eeprom_extract_raw /dev/$ubi $offset $swap
 }
@@ -143,7 +119,7 @@ case "$FIRMWARE" in
 			avm,fritz3370-rev2-hynix|\
 			avm,fritz3370-rev2-micron|\
 			avm,fritz7362sl)
-				ath9k_eeprom_extract_reverse "urlader" 0x1541 0x440
+				caldata_extract_reverse "urlader" 0x1541 0x440
 				;;
 			avm,fritz7312|avm,fritz7320|avm,fritz7360sl)
 				ath9k_eeprom_extract "urlader" 0x985 0
@@ -155,7 +131,7 @@ case "$FIRMWARE" in
 				ath9k_eeprom_extract "boardconfig" 0x21000 0
 				;;
 			*)
-				ath9k_eeprom_die "board $board is not supported yet"
+				caldata_die "board $board is not supported yet"
 				;;
 		esac
 		;;

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -1,55 +1,23 @@
 #!/bin/sh
-# Based on ar71xx 10-ath9k-eeprom
 
 [ -e /lib/firmware/$FIRMWARE ] && exit 0
 
 . /lib/functions/caldata.sh
-. /lib/upgrade/nand.sh
 
-ath9k_eeprom_extract_raw() {
-	local source=$1
-	local offset=$(($2))
-	local swap=$3
-	local size=4096
-	local bs=1
-	local conv=
-
-	if [ $swap -gt 0 ]; then
-		bs=2
-		conv="conv=swab"
-		size=$((size / bs))
-		offset=$((offset / bs))
-	fi
-
-	dd if=$source of=/lib/firmware/$FIRMWARE bs=$bs skip=$offset count=$size $conv 2>/dev/null || \
-			caldata_die "failed to extract from $mtd"
-}
-
-ath9k_eeprom_extract() {
+caldata_extract_swap() {
 	local part=$1
 	local offset=$2
-	local swap=$3
+	local count=$3
 	local mtd
 
 	mtd=$(find_mtd_chardev $part)
-	[ -n "$mtd" ] || \
-		caldata_die "no mtd device found for partition $part"
+	[ -n "$mtd" ] || caldata_die "no mtd device found for partition $part"
 
-	ath9k_eeprom_extract_raw $mtd $offset $swap
-}
+	offset=$(($offset / 2))
+	count=$(($count / 2))
 
-ath9k_ubi_eeprom_extract() {
-	local part=$1
-	local offset=$2
-	local swap=$3
-	local ubidev=$(nand_find_ubi $CI_UBIPART)
-	local ubi
-
-	ubi=$(nand_find_volume $ubidev $part)
-	[ -n "$ubi" ] || \
-		caldata_die "no UBI volume found for $part"
-
-	ath9k_eeprom_extract_raw /dev/$ubi $offset $swap
+	dd if=$mtd of=/lib/firmware/$FIRMWARE bs=2 skip=$offset count=$count conv=swab 2>/dev/null || \
+		caldata_die "failed to extract calibration data from $mtd"
 }
 
 case "$FIRMWARE" in
@@ -60,25 +28,25 @@ case "$FIRMWARE" in
 
 		case "$board" in
 			arcadyan,arv7518pw)
-				ath9k_eeprom_extract "boardconfig" 0x400 1
+				caldata_extract_swap "boardconfig" 0x400 0x1000
 				;;
 			arcadyan,arv8539pw22)
-				ath9k_eeprom_extract "art" 0x400 1
+				caldata_extract_swap "art" 0x400 0x1000
 				;;
 			bt,homehub-v2b)
-				ath9k_eeprom_extract "art" 0x0 1
+				caldata_extract_swap "art" 0x0 0x1000
 				caldata_patch_fw_mac_crc "00:00:00:00:00:00" 0x20c
 				;;
 			bt,homehub-v3a)
-				ath9k_eeprom_extract "art-copy" 0x0 1
+				caldata_extract_swap "art-copy" 0x0 0x1000
 				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot_env ethaddr) +2) 0x10c
 				;;
 			bt,homehub-v5a)
-				ath9k_ubi_eeprom_extract "caldata" 0x1000 0
+				caldata_extract_ubi "caldata" 0x1000 0x1000
 				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 0x10c
 				;;
 			netgear,dgn3500|netgear,dgn3500b)
-				ath9k_eeprom_extract "calibration" 0xf000 0
+				caldata_extract "calibration" 0xf000 0x1000
 				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 0x20c
 				;;
 			avm,fritz3370-rev2-hynix|\
@@ -87,13 +55,13 @@ case "$FIRMWARE" in
 				caldata_extract_reverse "urlader" 0x1541 0x440
 				;;
 			avm,fritz7312|avm,fritz7320|avm,fritz7360sl)
-				ath9k_eeprom_extract "urlader" 0x985 0
+				caldata_extract "urlader" 0x985 0x1000
 				;;
 			avm,fritz7412)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 4096 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
 				;;
 			tplink,tdw8970|tplink,tdw8980)
-				ath9k_eeprom_extract "boardconfig" 0x21000 0
+				caldata_extract "boardconfig" 0x21000 0x1000
 				;;
 			*)
 				caldata_die "board $board is not supported yet"

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -52,41 +52,6 @@ ath9k_ubi_eeprom_extract() {
 	ath9k_eeprom_extract_raw /dev/$ubi $offset $swap
 }
 
-ath9k_patch_fw_mac_crc() {
-	local mac=$1
-	local mac_offset=$2
-	local chksum_offset=$((mac_offset - 10))
-
-	ath9k_patch_fw_mac "${mac}" "${mac_offset}" "${chksum_offset}"
-}
-
-ath9k_patch_fw_mac() {
-	local mac=$1
-	local mac_offset=$(($2))
-	local chksum_offset=$3
-	local xor_mac
-	local xor_fw_mac
-	local xor_fw_chksum
-
-	[ -z "$mac" -o -z "$mac_offset" ] && return
-
-	[ -n "$chksum_offset" ] && {
-		xor_mac=${mac//:/}
-		xor_mac="${xor_mac:0:4} ${xor_mac:4:4} ${xor_mac:8:4}"
-
-		xor_fw_mac=$(hexdump -v -n 6 -s $mac_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-		xor_fw_mac="${xor_fw_mac:0:4} ${xor_fw_mac:4:4} ${xor_fw_mac:8:4}"
-
-		xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
-		xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
-
-		printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
-			dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$(($chksum_offset)) count=2
-	}
-
-	macaddr_2bin $mac | dd of=/lib/firmware/$FIRMWARE conv=notrunc bs=1 seek=$mac_offset count=6
-}
-
 case "$FIRMWARE" in
 	"ath9k-eeprom-pci-0000:00:0e.0.bin" | \
 	"ath9k-eeprom-pci-0000:01:00.0.bin" | \
@@ -102,19 +67,19 @@ case "$FIRMWARE" in
 				;;
 			bt,homehub-v2b)
 				ath9k_eeprom_extract "art" 0x0 1
-				ath9k_patch_fw_mac_crc "00:00:00:00:00:00" 0x20c
+				caldata_patch_fw_mac_crc "00:00:00:00:00:00" 0x20c
 				;;
 			bt,homehub-v3a)
 				ath9k_eeprom_extract "art-copy" 0x0 1
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot_env ethaddr) +2) 0x10c
+				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot_env ethaddr) +2) 0x10c
 				;;
 			bt,homehub-v5a)
 				ath9k_ubi_eeprom_extract "caldata" 0x1000 0
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 0x10c
+				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_binary_ubi caldata 0x110c) +2) 0x10c
 				;;
 			netgear,dgn3500|netgear,dgn3500b)
 				ath9k_eeprom_extract "calibration" 0xf000 0
-				ath9k_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 0x20c
+				caldata_patch_fw_mac_crc $(macaddr_add $(mtd_get_mac_ascii uboot-env ethaddr) +2) 0x20c
 				;;
 			avm,fritz3370-rev2-hynix|\
 			avm,fritz3370-rev2-micron|\

--- a/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -7,22 +7,6 @@
 . /lib/functions/system.sh
 . /lib/upgrade/nand.sh
 
-# xor multiple hex values of the same length
-xor() {
-	local val
-	local ret="0x$1"
-	local retlen=${#1}
-
-	shift
-	while [ -n "$1" ]; do
-		val="0x$1"
-		ret=$((ret ^ val))
-		shift
-	done
-
-	printf "%0${retlen}x" "$ret"
-}
-
 ath9k_eeprom_die() {
 	echo "ath9k eeprom: $*"
 	exit 1

--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -1,11 +1,8 @@
 #!/bin/sh
 
-FW_FILE="/lib/firmware/$FIRMWARE"
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-ath9k_eeprom_die() {
-	echo "ath9k eeprom: " "$*" >&2
-	exit 1
-}
+. /lib/functions/caldata.sh
 
 ath9k_eeprom_extract() {
 	local part=$1
@@ -15,10 +12,10 @@ ath9k_eeprom_extract() {
 
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || \
-		ath9k_eeprom_die "no mtd device found for partition $part"
+		caldata_die "no mtd device found for partition $part"
 
-	dd if=$mtd bs=$offset skip=1 count=1 2>/dev/null | dd of=$FW_FILE bs=$count count=1 2>/dev/null || \
-		ath9k_eeprom_die "failed to extract from $mtd"
+	dd if=$mtd bs=$offset skip=1 count=1 2>/dev/null | dd of=/lib/firmware/$FIRMWARE bs=$count count=1 2>/dev/null || \
+		caldata_die "failed to extract from $mtd"
 }
 
 tpl_set_wireless_mac()
@@ -29,13 +26,8 @@ tpl_set_wireless_mac()
 	mac=$(mtd_get_mac_binary u-boot 0x4fc00)
 	mac=$(macaddr_add $mac $offset)
 
-	macaddr_2bin $mac | dd bs=1 count=6 seek=2 conv=notrunc of=$FW_FILE 2>/dev/null
+	macaddr_2bin $mac | dd bs=1 count=6 seek=2 conv=notrunc of=/lib/firmware/$FIRMWARE 2>/dev/null
 }
-
-[ -e $FW_FILE ] && exit 0
-
-. /lib/functions.sh
-. /lib/functions/system.sh
 
 board=$(board_name)
 
@@ -47,7 +39,7 @@ case "$FIRMWARE" in
 		tpl_set_wireless_mac 0
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;
@@ -59,7 +51,7 @@ case "$FIRMWARE" in
 		tpl_set_wireless_mac -1
 		;;
 	*)
-		ath9k_eeprom_die "board $board is not supported yet"
+		caldata_die "board $board is not supported yet"
 		;;
 	esac
 	;;

--- a/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/mpc85xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -24,9 +24,8 @@ tpl_set_wireless_mac()
 	local mac
 
 	mac=$(mtd_get_mac_binary u-boot 0x4fc00)
-	mac=$(macaddr_add $mac $offset)
 
-	macaddr_2bin $mac | dd bs=1 count=6 seek=2 conv=notrunc of=/lib/firmware/$FIRMWARE 2>/dev/null
+	caldata_patch_fw_mac $(macaddr_add $mac $offset) 0x2
 }
 
 board=$(board_name)

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -1,23 +1,8 @@
 #!/bin/sh
 
-rt2x00_eeprom_die() {
-	echo "rt2x00 eeprom: " "$*"
-	exit 1
-}
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
 
-rt2x00_eeprom_extract() {
-	local part=$1
-	local offset=$(($2))
-	local count=$(($3))
-	local mtd
-
-	mtd=$(find_mtd_part $part)
-	[ -n "$mtd" ] || \
-		rt2x00_eeprom_die "no mtd device found for partition $part"
-
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
-		rt2x00_eeprom_die "failed to extract from $mtd"
-}
+. /lib/functions/caldata.sh
 
 jboot_eeprom_extract() {
 	local part=$1
@@ -26,28 +11,22 @@ jboot_eeprom_extract() {
 
 	mtd=$(find_mtd_part $part)
 	[ -n "$mtd" ] || \
-		rt2x00_eeprom_die "no mtd device found for partition $part"
+		caldata_die "no mtd device found for partition $part"
 
 	jboot_config_read -i $mtd -o $offset -e /lib/firmware/$FIRMWARE  2>/dev/null || \
-		rt2x00_eeprom_die "failed to extract from $mtd"
+		caldata_die "failed to extract from $mtd"
 }
 
 rt2x00_eeprom_set_macaddr() {
 	local macaddr=$1
 
 	[ -n "$macaddr" ] || \
-		rt2x00_eeprom_die "invalid wlan mac address"
+		caldata_die "invalid wlan mac address"
 
 	macaddr_2bin $macaddr | dd of=/lib/firmware/$FIRMWARE \
 				conv=notrunc oflag=seek_bytes bs=6 seek=4 count=1 2>/dev/null || \
-		rt2x00_eeprom_die "failed to write mac address to eeprom file"
+		caldata_die "failed to write mac address to eeprom file"
 }
-
-FW="/lib/firmware/$FIRMWARE"
-[ -e "$FW" ] && exit 0
-
-. /lib/functions.sh
-. /lib/functions/system.sh
 
 board=$(board_name)
 
@@ -68,11 +47,11 @@ case "$FIRMWARE" in
 		;;
 	dovado,tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
-		rt2x00_eeprom_extract "factory" 0x0 0x200
+		caldata_extract "factory" 0x0 0x200
 		rt2x00_eeprom_set_macaddr $wifi_mac
 		;;
 	*)
-		rt2x00_eeprom_die "Please define mtd-eeprom in $board DTS file!"
+		caldata_die "Please define mtd-eeprom in $board DTS file!"
 		;;
 	esac
 	;;

--- a/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -17,17 +17,6 @@ jboot_eeprom_extract() {
 		caldata_die "failed to extract from $mtd"
 }
 
-rt2x00_eeprom_set_macaddr() {
-	local macaddr=$1
-
-	[ -n "$macaddr" ] || \
-		caldata_die "invalid wlan mac address"
-
-	macaddr_2bin $macaddr | dd of=/lib/firmware/$FIRMWARE \
-				conv=notrunc oflag=seek_bytes bs=6 seek=4 count=1 2>/dev/null || \
-		caldata_die "failed to write mac address to eeprom file"
-}
-
 board=$(board_name)
 
 case "$FIRMWARE" in
@@ -43,12 +32,12 @@ case "$FIRMWARE" in
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000
-		rt2x00_eeprom_set_macaddr $wifi_mac
+		caldata_patch_fw_mac $wifi_mac 0x4
 		;;
 	dovado,tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
 		caldata_extract "factory" 0x0 0x200
-		rt2x00_eeprom_set_macaddr $wifi_mac
+		caldata_patch_fw_mac $wifi_mac 0x4
 		;;
 	*)
 		caldata_die "Please define mtd-eeprom in $board DTS file!"


### PR DESCRIPTION
_This is a clone of the same set of patches (v2) sent to the mailing list, added here just to allow discussion on GitHub:_

This is an update of my patchset unifying caldata extraction and MAC patching. I've improved some tiny things and despite that mostly done rebasing.
I've also included the patch for the special situation in lantiq I sent separately for v1.

The patchset removes 417 lines of redundant code, which despite that also included several variations of the same approach.

This has been tested on:
- ath79/ath9k: WDR4300 v1
- ath79/ath10k: Archer C60 v2, Archer C7 v5
- ipq40xx: Netgear EX6150v2
- ipq806x: TP-Link C2600
- mpc85xx: WDR4900 v1

I would be happy about other tests, especially for ramips and lantiq.

Untested targets:
- apm821xx
- brcm63xx
- lantiq
- ramips

Feel free to pick one :-)