### PR TITLE
ramips: fix LEDs not working for Asus RT-AC51U

### DIFF
--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
@@ -53,17 +53,6 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		enable-leds {
-			gpio-export,name = "enable-leds";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
 &spi0 {
@@ -112,6 +101,16 @@
 
 &ohci {
 	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+	enable-leds {
+		gpio-hog;
+		line-name = "enable-leds";
+		output-low;
+		gpios = <10 GPIO_ACTIVE_HIGH>;
+	};
 };
 
 &gpio3 {


### PR DESCRIPTION
Previously only the power LED was working.
With this patch all leds except 5GHz are working.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>