### PR TITLE
scripts: add size_compare script

### DIFF
--- a/scripts/size_compare.py
+++ b/scripts/size_compare.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# This script compares local file sizes with remote files and prints an overview
+#
+# env variables
+#   TARGET_DIR where to look for the local files
+#   REMOTE_URL where to look for the remote files
+#
+
+import os
+import subprocess
+import multiprocessing
+from urllib import request
+
+target_dir = "./bin" + os.environ.get("TARGET_DIR", "")
+
+remote_url = os.environ.get("REMOTE_URL", "https://downloads.openwrt.org/snapshots")
+
+local_files = []
+results_queue = multiprocessing.Queue()
+
+
+def compare_sizes(filename):
+    """
+    compare local and remote filesize
+    """
+    try:
+        size_local = os.path.getsize("./bin" + filename)
+        response = request.urlopen(remote_url + filename)
+        size_remote = int(response.info()["Content-Length"])
+        results_queue.put((filename, size_local - size_remote))
+    except:
+        print("error on {}".format(filename))
+
+
+for root, dirs, files in os.walk(target_dir):
+    for filename in files:
+        if not filename in [
+            "Packages",
+            "Packages.gz",
+            "Packages.manifest",
+            "Packages.sig",
+            "sha256sums",
+            "config.buildinfo",
+            "feeds.buildinfo",
+            "version.buildinfo",
+        ]:
+            local_files.append(os.path.join(root[5:], filename))
+
+if not os.path.exists(target_dir):
+    print(f"{target_dir} not found")
+    quit(1)
+
+if not remote_url.startswith("http"):
+    print(f"{remote_url} must be a valid url")
+    quit(1)
+
+
+# check 50 files in parallel
+pool = multiprocessing.Pool(50)
+pool.map(compare_sizes, local_files)
+
+results = []
+
+# convert queue to array
+for i in range(0, results_queue.qsize()):
+    results.append(results_queue.get())
+
+
+# sort array
+for filename, size_diff in sorted(results):
+    if size_diff == 0:
+        continue
+    prefix = "+"
+    if size_diff < 0:
+        prefix = "-"
+    print("{} {:>10}B {}".format(prefix, size_diff, filename))


### PR DESCRIPTION
The script allows to check the file size diff between local and remote
files. The `TARGET_DIR` env variable allows to select subfolders of the
local binary folder.

Example output:

    a@reboot:~/src/openwrt/openwrt$ TARGET_DIR=/targets/ath79/generic/packages/ python3 scripts/size_compare.py
    +          3B /targets/ath79/generic/packages/base-files_205-r11131-e78c1baa9f_mips_24kc.ipk
    +         16B /targets/ath79/generic/packages/fstools_2019-09-21-4327ed40-1_mips_24kc.ipk
    -         -6B /targets/ath79/generic/packages/fwtool_1_mips_24kc.ipk
    +         36B /targets/ath79/generic/packages/iptables_1.8.3-2_mips_24kc.ipk
    +         67B /targets/ath79/generic/packages/iwinfo_2019-09-22-313e8270-1_mips_24kc.ipk
    +        424B /targets/ath79/generic/packages/kmod-ath9k-common_4.19.75+5.3-rc4-1-1_mips_24kc.ipk
    -        -84B /targets/ath79/generic/packages/kmod-ath9k_4.19.75+5.3-rc4-1-1_mips_24kc.ipk
    -        -26B /targets/ath79/generic/packages/kmod-ath_4.19.75+5.3-rc4-1-1_mips_24kc.ipk
    +        155B /targets/ath79/generic/packages/kmod-cfg80211_4.19.75+5.3-rc4-1-1_mips_24kc.ipk
    -         -5B /targets/ath79/generic/packages/kmod-gpio-button-hotplug_4.19.75-3_mips_24kc.ipk
    -        -35B /targets/ath79/generic/packages/kmod-ip6tables_4.19.75-1_mips_24kc.ipk
    -      -2124B /targets/ath79/generic/packages/kmod-ipt-conntrack_4.19.75-1_mips_24kc.ipk
    -       -219B /targets/ath79/generic/packages/kmod-ipt-core_4.19.75-1_mips_24kc.ipk
    -        -46B /targets/ath79/generic/packages/kmod-ipt-nat_4.19.75-1_mips_24kc.ipk
    -        -42B /targets/ath79/generic/packages/kmod-ipt-offload_4.19.75-1_mips_24kc.ipk
    -         -5B /targets/ath79/generic/packages/kmod-lib-crc-ccitt_4.19.75-1_mips_24kc.ipk
    +        739B /targets/ath79/generic/packages/kmod-mac80211_4.19.75+5.3-rc4-1-1_mips_24kc.ipk
    -         -4B /targets/ath79/generic/packages/kmod-nf-conntrack6_4.19.75-1_mips_24kc.ipk
    -      -4144B /targets/ath79/generic/packages/kmod-nf-conntrack_4.19.75-1_mips_24kc.ipk
    -       -297B /targets/ath79/generic/packages/kmod-nf-flow_4.19.75-1_mips_24kc.ipk
    -       -637B /targets/ath79/generic/packages/kmod-nf-ipt6_4.19.75-1_mips_24kc.ipk
    -       -856B /targets/ath79/generic/packages/kmod-nf-ipt_4.19.75-1_mips_24kc.ipk
    -      -1184B /targets/ath79/generic/packages/kmod-nf-nat_4.19.75-1_mips_24kc.ipk
    -       -165B /targets/ath79/generic/packages/kmod-nf-reject6_4.19.75-1_mips_24kc.ipk
    -       -108B /targets/ath79/generic/packages/kmod-nf-reject_4.19.75-1_mips_24kc.ipk
    -        -19B /targets/ath79/generic/packages/kmod-ppp_4.19.75-1_mips_24kc.ipk
    -       -275B /targets/ath79/generic/packages/kmod-pppoe_4.19.75-1_mips_24kc.ipk
    -         -4B /targets/ath79/generic/packages/kmod-pppox_4.19.75-1_mips_24kc.ipk
    +         18B /targets/ath79/generic/packages/kmod-slhc_4.19.75-1_mips_24kc.ipk
    +        464B /targets/ath79/generic/packages/libc_1.1.23-2_mips_24kc.ipk
    +          2B /targets/ath79/generic/packages/libip4tc2_1.8.3-2_mips_24kc.ipk
    +          9B /targets/ath79/generic/packages/libip6tc2_1.8.3-2_mips_24kc.ipk
    +         72B /targets/ath79/generic/packages/libiwinfo20181126_2019-09-22-313e8270-1_mips_24kc.ipk
    -      -1372B /targets/ath79/generic/packages/libxtables12_1.8.3-2_mips_24kc.ipk
    -         -5B /targets/ath79/generic/packages/mtd_25_mips_24kc.ipk
    +          9B /targets/ath79/generic/packages/uboot-envtools_2019.07-1_mips_24kc.ipk

Signed-off-by: Paul Spooren <mail@aparcar.org>
