### PR TITLE
ath79: add support for TP-Link WBS210 v2

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_cpe210-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe210-v1.dts
@@ -7,3 +7,7 @@
 	compatible = "tplink,cpe210-v1", "qca,ar9344";
 	model = "TP-Link CPE210 v1";
 };
+
+&led_link4 {
+	gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/ath79/dts/ar9344_tplink_cpe220-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe220-v2.dts
@@ -7,3 +7,7 @@
 	compatible = "tplink,cpe220-v2", "qca,ar9344";
 	model = "TP-Link CPE220 v2";
 };
+
+&led_link4 {
+	gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/ath79/dts/ar9344_tplink_cpexxx-v1.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpexxx-v1.dtsi
@@ -5,10 +5,10 @@
 
 / {
 	aliases {
-		led-boot = &system;
-		led-failsafe = &system;
-		led-running = &system;
-		led-upgrade = &system;
+		led-boot = &led_link4;
+		led-failsafe = &led_link4;
+		led-running = &led_link4;
+		led-upgrade = &led_link4;
 	};
 
 	leds {
@@ -39,9 +39,8 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		system: link4 {
+		led_link4: link4 {
 			label = "tp-link:green:link4";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_wbs210-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_wbs210-v2.dts
@@ -4,10 +4,10 @@
 #include "ar9344_tplink_cpexxx-v1.dtsi"
 
 / {
-	compatible = "tplink,cpe510-v1", "qca,ar9344";
-	model = "TP-Link CPE510 v1";
+	compatible = "tplink,wbs210-v2", "qca,ar9344";
+	model = "TP-Link WBS210 v2";
 };
 
 &led_link4 {
-	gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+	gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -161,7 +161,8 @@ tplink,archer-d50-v1)
 	;;
 tplink,cpe210-v1|\
 tplink,cpe220-v2|\
-tplink,cpe510-v1)
+tplink,cpe510-v1|\
+tplink,wbs210-v2)
 	ucidef_set_led_netdev "lan0" "LAN0" "tp-link:green:lan0" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -90,6 +90,7 @@ ath79_setup_interfaces()
 	tplink,cpe210-v1|\
 	tplink,cpe220-v2|\
 	tplink,cpe510-v1|\
+	tplink,wbs210-v2|\
 	ubnt,nanostation-m|\
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -44,7 +44,8 @@ tplink,archer-c25-v1)
 	;;
 tplink,cpe210-v1|\
 tplink,cpe220-v2|\
-tplink,cpe510-v1)
+tplink,cpe510-v1|\
+tplink,wbs210-v2)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;
 ubnt,nanostation-ac)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -515,3 +515,14 @@ define Device/tplink_tl-wr842n-v3
   SUPPORTED_DEVICES += tl-wr842n-v3
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v3
+
+define Device/tplink_wbs210-v2
+  $(Device/tplink-loader-okli)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := WBS210
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := WBS210V2
+endef
+TARGET_DEVICES += tplink_wbs210-v2

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -466,6 +466,38 @@ static struct device_info boards[] = {
 	},
 
 	{
+		.id	= "WBS210V2",
+		.vendor	= "CPE510(TP-LINK|UN|N300-5):1.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"WBS210(TP-LINK|UN|N300-2|00000000):2.00\r\n"
+			"WBS210(TP-LINK|US|N300-2|55530000):2.00\r\n"
+			"WBS210(TP-LINK|EU|N300-2|45550000):2.00\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x200000},
+			{"file-system", 0x240000, 0x570000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
+	{
 		.id	= "WBS510",
 		.vendor	= "CPE510(TP-LINK|UN|N300-5):1.0\r\n",
 		.support_list =


### PR DESCRIPTION
Signed-off-by: Bernhard Geier <freifunk@geierb.de>

2.4GHz outdoor device with two detachable antennas. Technically similar to the TP-Link CPE220v2.

Successfully tested flashing from original firmware, flashing sysupgrade, LEDs, reset button, WiFi and both ethernet ports.