### PR TITLE
ramips: change sysupgrade method and device name of netis WF-2881

### DIFF
--- a/target/linux/ramips/dts/mt7621_netis_wf-2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf-2881.dts
@@ -75,9 +75,22 @@
 		};
 
 		partition@140000 {
-			compatible = "denx,uimage";
 			label = "firmware";
 			reg = <0x140000 0x7e40000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7a40000>;
+			};
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_netis_wf2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf2881.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "netis,wf-2881", "mediatek,mt7621-soc";
-	model = "NETIS WF-2881";
+	compatible = "netis,wf2881", "mediatek,mt7621-soc";
+	model = "NETIS WF2881";
 
 	aliases {
 		led-boot = &led_wps;
@@ -25,14 +25,14 @@
 		compatible = "gpio-leds";
 
 		usb {
-			label = "wf-2881:green:usb";
+			label = "wf2881:green:usb";
 			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
 			linux,default-trigger = "usbport";
 		};
 
 		led_wps: wps {
-			label = "wf-2881:green:wps";
+			label = "wf2881:green:wps";
 			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -628,10 +628,12 @@ define Device/netis_wf-2881
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   FILESYSTEMS := squashfs
+  KERNEL_SIZE := 4096k
   IMAGE_SIZE := 129280k
-  KERNEL := $(KERNEL_DTB) | pad-offset $$(BLOCKSIZE) 64 | uImage lzma
   UBINIZE_OPTS := -E 5
-  IMAGE/sysupgrade.bin := append-kernel | append-ubi | append-metadata | \
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
 	check-size $$$$(IMAGE_SIZE)
   DEVICE_VENDOR := NETIS
   DEVICE_MODEL := WF-2881

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -624,7 +624,7 @@ define Device/netgear_wndr3700-v5
 endef
 TARGET_DEVICES += netgear_wndr3700-v5
 
-define Device/netis_wf-2881
+define Device/netis_wf2881
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   FILESYSTEMS := squashfs
@@ -636,11 +636,10 @@ define Device/netis_wf-2881
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
 	check-size $$$$(IMAGE_SIZE)
   DEVICE_VENDOR := NETIS
-  DEVICE_MODEL := WF-2881
+  DEVICE_MODEL := WF2881
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
-  SUPPORTED_DEVICES += wf-2881
 endef
-TARGET_DEVICES += netis_wf-2881
+TARGET_DEVICES += netis_wf2881
 
 define Device/phicomm_k2p
   IMAGE_SIZE := 15744k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -81,6 +81,12 @@ define Build/iodata-mstc-header
   )
 endef
 
+define Build/netis-tail
+	echo -n "$(word 1,$(1))" >> $@
+	echo -n "$(word 2,$(1))-yun" | $(STAGING_DIR_HOST)/bin/mkhash md5 | \
+		sed 's/../\\\\x&/g' | xargs echo -ne >> $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -631,12 +637,15 @@ define Device/netis_wf2881
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 129280k
   UBINIZE_OPTS := -E 5
+  DEVICE_VENDOR := NETIS
+  DEVICE_MODEL := WF2881
+  UIMAGE_NAME := WF2881_0.0.00
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | \
+	netis-tail $$(DEVICE_MODEL) $$(UIMAGE_NAME) | uImage lzma
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
 	check-size $$$$(IMAGE_SIZE)
-  DEVICE_VENDOR := NETIS
-  DEVICE_MODEL := WF2881
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
 TARGET_DEVICES += netis_wf2881

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -43,7 +43,7 @@ ramips_setup_interfaces()
 	netgear,r6350|\
 	netgear,r6850|\
 	netgear,wndr3700-v5|\
-	netis,wf-2881|\
+	netis,wf2881|\
 	wevo,11acnas|\
 	wevo,w2914ns-v2|\
 	zio,freezio)
@@ -181,7 +181,7 @@ ramips_setup_macs()
 	elecom,wrc-1900gst|\
 	elecom,wrc-2533gst|\
 	lenovo,newifi-d1|\
-	netis,wf-2881|\
+	netis,wf2881|\
 	phicomm,k2p|\
 	planex,vr500|\
 	samknows,whitebox-v8|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -49,7 +49,7 @@ platform_do_upgrade() {
 	netgear,r6260|\
 	netgear,r6350|\
 	netgear,r6850|\
-	netis,wf-2881|\
+	netis,wf2881|\
 	xiaomi,mir3g|\
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -49,6 +49,7 @@ platform_do_upgrade() {
 	netgear,r6260|\
 	netgear,r6350|\
 	netgear,r6850|\
+	netis,wf-2881|\
 	xiaomi,mir3g|\
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
~~- fix LAN/WAN MAC addresses~~
~~- fix LAN port order~~
~~- fix WiFi LEDs~~
~~- fix pinmux groups~~
~~- provide label MAC address~~
~~- switch from gpio-keys-polled to gpio-keys~~
~~- remove nonexistent u-boot-env partition~~

WF-2881 sysupgrade image uses UBI rootfs, but still relies on
default_do_upgrade. Because of this, config backup is not restored after
sysupgrade. It can be fixed by switching to nand_do_upgrade and
sysupgrade-tar image. default_do_upgrade does not handle sysupgrade-tar
properly, so one should use factory image to upgrade from older version.

It means that this commit brings a breaking change. It seems to be a
perfect opportunity to change the device name to the correct one, WF2881
without hyphen.