### PR TITLE
ath79: add support for TP-Link Archer A6 v2 (US/TW) / C6 v2 (US)

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
@@ -4,48 +4,48 @@
 #include "qca9563_tplink_archer-x6-v2.dtsi"
 
 / {
-	compatible = "tplink,archer-c6-v2", "qca,qca9563";
-	model = "TP-Link Archer C6 v2 (EU/RU/JP)";
+	compatible = "tplink,archer-c6-v2-us", "qca,qca9563";
+	model = "TP-Link Archer C6 v2 (US) / A6 v2 (US/TW)";
 
 	leds {
 		compatible = "gpio-leds";
 
 		led_power: power {
 			label = "tp-link:green:power";
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		wlan2g {
 			label = "tp-link:green:wlan2g";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan5g {
 			label = "tp-link:green:wlan5g";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		lan {
 			label = "tp-link:green:lan";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
 			label = "tp-link:green:wan";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_fail {
 			label = "tp-link:amber:wan";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {
 			label = "tp-link:green:wps";
-			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -62,7 +62,7 @@
 		wps {
 			label = "WPS button";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
 	};
@@ -84,7 +84,7 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "u-boot";
+				label = "factory-boot";
 				reg = <0x000000 0x020000>;
 				read-only;
 			};
@@ -96,20 +96,26 @@
 			};
 
 			partition@30000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x030000 0x7a0000>;
-			};
-
-			partition@7d0000 {
-				label = "tplink";
-				reg = <0x7d0000 0x020000>;
+				label = "u-boot";
+				reg = <0x030000 0x020000>;
 				read-only;
 			};
 
-			art: partition@7f0000 {
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "tplink";
+				reg = <0xfd0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
 				label = "art";
-				reg = <0x7f0000 0x010000>;
+				reg = <0xff0000 0x010000>;
 				read-only;
 			};
 		};

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x6-v2.dtsi
@@ -18,66 +18,6 @@
 		led-upgrade = &led_power;
 		label-mac-device = &eth0;
 	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_power: power {
-			label = "tp-link:green:power";
-			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-			default-state = "on";
-		};
-
-		wlan2g {
-			label = "tp-link:green:wlan2g";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:green:wlan5g";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			label = "tp-link:green:wan";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_fail {
-			label = "tp-link:amber:wan";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "WPS button";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
 };
 
 &pcie {
@@ -90,54 +30,6 @@
 
 &gpio {
 	status = "okay";
-};
-
-&spi {
-	status = "okay";
-
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			mac: partition@20000 {
-				label = "mac";
-				reg = <0x020000 0x010000>;
-				read-only;
-			};
-
-			partition@30000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x030000 0x7a0000>;
-			};
-
-			partition@7d0000 {
-				label = "tplink";
-				reg = <0x7d0000 0x020000>;
-				read-only;
-			};
-
-			art: partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-			};
-		};
-	};
 };
 
 &mdio0 {

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -146,7 +146,8 @@ tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x04"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
-tplink,archer-c6-v2)
+tplink,archer-c6-v2|\
+tplink,archer-c6-v2-us)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3C"
 	ucidef_set_led_switch "wan" "WAN" "tp-link:green:wan" "switch0" "0x02"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -207,6 +207,7 @@ ath79_setup_interfaces()
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c6-v2|\
+	tplink,archer-c6-v2-us|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,tl-wdr3600-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -148,7 +148,8 @@ case "$FIRMWARE" in
 	tplink,archer-c59-v2|\
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
-	tplink,archer-c6-v2)
+	tplink,archer-c6-v2|\
+	tplink,archer-c6-v2-us)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary mac 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -88,11 +88,25 @@ define Device/tplink_archer-c6-v2
   ATH_SOC := qca9563
   IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C6
-  DEVICE_VARIANT := v2
+  DEVICE_VARIANT := v2 (EU/RU/JP)
   TPLINK_BOARD_ID := ARCHER-C6-V2
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += tplink_archer-c6-v2
+
+define Device/tplink_archer-c6-v2-us
+  $(Device/tplink-safeloader-uimage)
+  ATH_SOC := qca9563
+  IMAGE_SIZE := 15872k
+  DEVICE_MODEL := Archer C6
+  DEVICE_VARIANT := v2 (US)
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := Archer A6
+  DEVICE_ALT0_VARIANT := v2 (US/TW)
+  TPLINK_BOARD_ID := ARCHER-C6-V2-US
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_archer-c6-v2-us
 
 define Device/tplink_archer-c60-v1
   $(Device/tplink-safeloader-uimage)

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -881,7 +881,7 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
-	/** Firmware layout for the C6v2 */
+	/** Firmware layout for the Archer C6 v2 (EU/RU/JP) */
 	{
 		.id	= "ARCHER-C6-V2",
 		.vendor	= "",
@@ -891,7 +891,7 @@ static struct device_info boards[] = {
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",
 		.support_trail = '\x00',
-		.soft_ver = "soft_ver:1.0.0\n",
+		.soft_ver = "soft_ver:1.1.1\n",
 
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},
@@ -916,6 +916,40 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the Archer C6 v2 (US) and Archer A6 v2 (US/TW) */
+	{
+		.id     = "ARCHER-C6-V2-US",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:Archer A6,product_ver:2.0.0,special_id:55530000}\n"
+			"{product_name:Archer A6,product_ver:2.0.0,special_id:54570000}\n"
+			"{product_name:Archer C6,product_ver:2.0.0,special_id:55530000}\n",
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.1.1\n",
+
+		.partitions = {
+			{"factory-boot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00200},
+			{"pin", 0x20200, 0x00100},
+			{"product-info", 0x20300, 0x00200},
+			{"device-id", 0x20500, 0x0fb00},
+			{"fs-uboot", 0x30000, 0x20000},
+			{"firmware", 0x50000, 0xf89400},
+			{"soft-version", 0xfd9400, 0x00100},
+			{"extra-para", 0xfd9500, 0x00100},
+			{"support-list", 0xfd9600, 0x00200},
+			{"profile", 0xfd9800, 0x03000},
+			{"default-config", 0xfdc800, 0x03000},
+			{"partition-table", 0xfdf800, 0x00800},
+			{"user-config", 0xfe0000, 0x0c000},
+			{"certificate", 0xfec000, 0x04000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
 
 	/** Firmware layout for the C60v1 */
 	{
@@ -2068,6 +2102,9 @@ static void build_image(const char *output,
 		parts[5] = put_data("extra-para", mdat, 11);
 	} else if (strcasecmp(info->id, "ARCHER-C6-V2") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00};
+		parts[5] = put_data("extra-para", mdat, 11);
+	} else if (strcasecmp(info->id, "ARCHER-C6-V2-US") == 0) {
+		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
 	}
 


### PR DESCRIPTION
This patch is based on #1689 and adds support for
TP-Link Archer C6 v2 (US) and A6 (US / TW)

The hardware is the same as EU and RU variant, except for GPIOs (LEDS/Buttons),
flash(chip/partitions) and UART being available on the board.

- SOC: Qualcomm QCA9563 @ 775MHz
- Flash: GigaDevice GD25Q127CS1G (16MiB)
- RAM: Zentel A3R1GE40JBF (128 MiB DDR2)
- Ethernet: Qualcomm QCA8337N: 4x 1Gbps LAN + 1x 1Gbps WAN
- Wireless:
  - 2.4GHz (bgn) QCA9563 integrated (3x3)
  - 5GHz (ac) Qualcomm QCA9886 (2x2)
- Button: 1x power, 1x reset, 1x wps
- LED: 6x LEDs: power, wlan2g, wlan5g, lan, wan, wps
- UART: 115200, 8n1 (header available on board)

Known issues:
 - Wireless: 5GHz is known to have lower RSSI signal, it affects speed and range.

Flash instructions:

Upload openwrt-ath79-generic-tplink_archer-c6-v2-us-squashfs-factory.bin
via the router Web interface.

Flash instruction using tftp recovery:

1. Connect the computer to one of the LAN ports of the router
2. Set the computer IP to 192.168.0.66
3. Start a tftp server with the OpenWrt factory image in the
   tftp root directory renamed to ArcherA6v2_tp_recovery.bin.
4. Connect power cable to router, press and hold the
   reset button and turn the router on
5. Keep the reset button pressed until the WPS LED lights up
6. Wait ~150 seconds to complete flashing

Flash partitioning: I've followed #1689 for defining the partition layout
for this patch. The partition named as "tplink" @ 0xfd0000 is marked
as read only as it is where some config for stock firmware are stored.
On stock firmware those stock partitions starts at 0xfd9400 however
I had not been able to make it functional starting on the same address as
on stock fw, so it has been partitioned following #1689 and not the stock
partition layout for this specific partition. Due to that firmware/rootfs
partition lenght is 0xf80000 and not 0xf89400 as stock.

According to the GPL code, the EU/RU/JP variant does have different GPIO pins
assignment to LEDs and buttons, also the flash memory layout is different.

GPL Source Code: https://static.tp-link.com/resources/gpl/gpl-A6v2_us.tar.gz

Signed-off-by: Anderson Vulczak <andi@andi.com.br>