### PR TITLE
ramips: add support for ipTIME A8004T

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iptime,a8004t", "mediatek,mt7621-soc";
+	model = "ipTIME A8004T";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			label = "a8004t:orange:cpu";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "a8004t:orange:wlan2g";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "a8004t:orange:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&xhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc20>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "wdt", "jtag", "i2c";
+		ralink,function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -382,6 +382,16 @@ define Device/iptime_a6ns-m
 endef
 TARGET_DEVICES += iptime_a6ns-m
 
+define Device/iptime_a8004t
+  SOC := mt7621
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a8004t
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A8004T
+  DEVICE_PACKAGES := kmod-mt7615e kmod-usb3 wpad-basic
+endef
+TARGET_DEVICES += iptime_a8004t
+
 define Device/jcg_jhr-ac876m
   SOC := mt7621
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -74,7 +74,8 @@ ramips_setup_interfaces()
 	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
 	iodata,wn-gx300gr|\
-	iodata,wnpr2600g)
+	iodata,wnpr2600g|\
+	iptime,a8004t)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
@@ -222,7 +223,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
 		;;
-	iptime,a6ns-m)
+	iptime,a6ns-m|\
+	iptime,a8004t)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
 	jcg,jhr-ac876m)


### PR DESCRIPTION
ipTIME A8004T is a 2.4/5GHz band AC2600 router, based on Mediatek
MT7621A.

Specifications:
- SoC: MT7621A
- RAM: DDR3 256M
- Flash: SPI NOR 16MB
- WiFi:
  - 2.4GHz: MT7615E
  - 5GHz: MT7615E
- Ethernet: 5x 10/100/1000Mbps
  - Switch: SoC internal
- USB: 1 * USB3.0 port
- UART:
  - J4: 3.3V, TX, RX, GND (3.3V is the square pad) / 57600 8N1
- Other info:
  - J9: Unknown unpopulated header.

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.

Signed-off-by: Yong-hyu Ban <perillamint@quendi.moe>