### PR TITLE
base-files: use jshn lib for ubus sysupgrade argument generation

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -360,18 +360,15 @@ if [ -n "$FAILSAFE" ]; then
 	printf '%s\x00%s\x00%s' "$RAM_ROOT" "$IMAGE" "$COMMAND" >/tmp/sysupgrade
 	lock -u /tmp/.failsafe
 else
-	force_attr=""
-	[ $FORCE -eq 1 ] && force_attr="\"force\": true,"
-	backup_attr=""
-	[ $SAVE_CONFIG -eq 1 ] && backup_attr="\"backup\": $(json_string $CONF_TAR),"
-	ubus call system sysupgrade "{
-		\"prefix\": $(json_string "$RAM_ROOT"),
-		\"path\": $(json_string "$IMAGE"),
-		$force_attr
-		$backup_attr
-		\"command\": $(json_string "$COMMAND"),
-		\"options\": {
-			\"save_partitions\": $SAVE_PARTITIONS
-		}
-	}"
+	json_init
+	json_add_string prefix "$RAM_ROOT"
+	json_add_string path "$IMAGE"
+	[ $FORCE -eq 1 ] && json_add_boolean force 1
+	[ $SAVE_CONFIG -eq 1 ] && json_add_string backup "$CONF_TAR"
+	json_add_string command "$COMMAND"
+	json_add_object options
+	json_add_int save_partitions "$SAVE_PARTITIONS"
+	json_close_object
+
+	ubus call system sysupgrade "$(json_dump)"
 fi


### PR DESCRIPTION
With this change the jshn library will be used, to build the json arguments
for the ubus sysupgrade method. This improves readability and is
familiar practice in OpenWrt.

In this turn also the debug possibility was added for the json arguments
on ubus sysupgrade if the option -v was added on the sysupgrade
command line.
