### PR TITLE
lantiq_dsl: fix service status

### DIFF
--- a/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
+++ b/target/linux/lantiq/base-files/lib/functions/lantiq_dsl.sh
@@ -728,7 +728,7 @@ profile() {
 	fi
 }
 
-status() {
+status_service() {
 	vendor
 	chipset
 	xtse


### PR DESCRIPTION
Fix breaking change introduced in commit 7519a36774ca
("base-files,procd: add generic service status") where the old service
'status' function doesn't work anymore and needs to be renamed to
'status_service'.

This also fixes luci's status overview on lantiq devices, which parse
the output of "/etc/init.d/dsl_control status" in regular intervals.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>