### PR TITLE
ramips: fix MTK_SOC for RT3662 devices

### DIFF
--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "asus,rt-n56u", "ralink,rt3883-soc";
+	compatible = "asus,rt-n56u", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "Asus RT-N56U";
 
 	aliases {

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "dlink,dir-645", "ralink,rt3883-soc";
+	compatible = "dlink,dir-645", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "D-Link DIR-645";
 
 	aliases {

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "edimax,br-6475nd", "ralink,rt3883-soc";
+	compatible = "edimax,br-6475nd", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "Edimax BR-6475nD";
 
 	aliases {

--- a/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
+++ b/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
@@ -3,7 +3,7 @@
 #include "rt3883.dtsi"
 
 / {
-	compatible = "loewe,wmdr-143n", "ralink,rt3883-soc";
+	compatible = "loewe,wmdr-143n", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "Loewe WMDR-143N";
 };
 

--- a/target/linux/ramips/dts/rt3662_omnima_hpm.dts
+++ b/target/linux/ramips/dts/rt3662_omnima_hpm.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "omnima,hpm", "ralink,rt3883-soc";
+	compatible = "omnima,hpm", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "Omnima HPM";
 
 	aliases {

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "samsung,cy-swr1100", "ralink,rt3883-soc";
+	compatible = "samsung,cy-swr1100", "ralink,rt3662-soc", "ralink,rt3883-soc";
 	model = "Samsung CY-SWR1100";
 
 	aliases {

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -6,7 +6,7 @@ define Build/mkrtn56uimg
 endef
 
 define Device/asus_rt-n56u
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7872k
   IMAGE/sysupgrade.bin += | mkrtn56uimg -s
@@ -33,7 +33,7 @@ TARGET_DEVICES += belkin_f9k1109v1
 
 define Device/dlink_dir-645
   $(Device/seama)
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7872k
   KERNEL := $(KERNEL_DTB)
@@ -46,7 +46,7 @@ endef
 TARGET_DEVICES += dlink_dir-645
 
 define Device/edimax_br-6475nd
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
@@ -60,7 +60,7 @@ endef
 TARGET_DEVICES += edimax_br-6475nd
 
 define Device/loewe_wmdr-143n
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Loewe
@@ -70,7 +70,7 @@ endef
 TARGET_DEVICES += loewe_wmdr-143n
 
 define Device/omnima_hpm
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 64k
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Omnima
@@ -82,7 +82,7 @@ TARGET_DEVICES += omnima_hpm
 
 define Device/samsung_cy-swr1100
   $(Device/seama)
-  MTK_SOC := rt3883
+  MTK_SOC := rt3662
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7872k
   KERNEL := $(KERNEL_DTB)


### PR DESCRIPTION
rt3883.mk contains both RT3662 and RT3883 device profiles, but commit
6a104ac77206 set MTK_SOC to rt3883 for all devices. This patch fixes it,
and renames dts files accordingly.

Fixes: 6a104ac77206 ("ramips/rt288x,rt3883: Name DTS files based on scheme")