### PR TITLE
ath79: add support for tp-link tl-wr1045nd v2 

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -269,7 +269,8 @@ ath79_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "5@eth0"
 		;;
 	tplink,tl-wr1043nd-v2|\
-	tplink,tl-wr1043nd-v3)
+	tplink,tl-wr1043nd-v3|\
+	tplink,tl-wr1045nd-v2)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "6@eth0"
 		;;

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1045nd-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1045nd-v2.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_tl-wr1043nd.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr1045nd-v2", "qca,qca9557";
+	model = "TP-Link TL-WR1045ND v2";
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -440,6 +440,16 @@ define Device/tplink_tl-wr1043n-v5
 endef
 TARGET_DEVICES += tplink_tl-wr1043n-v5
 
+define Device/tplink_tl-wr1045nd-v2
+  $(Device/tplink-8mlzma)
+  ATH_SOC := qca9558
+  DEVICE_MODEL := TL-WR1045ND
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x10450002
+endef
+TARGET_DEVICES += tplink_tl-wr1045nd-v2
+
 define Device/tplink_tl-wr2543-v1
   $(Device/tplink-8mlzma)
   ATH_SOC := ar7242


### PR DESCRIPTION
Initial support tp-link tl-wr1045nd v2, clone of tl-wr1043nd v3. 
Device url: https://www.tp-link.com/ru/home-networking/wifi-router/tl-wr1045nd/#specifications
Discussion: http://4pda.ru/forum/index.php?showtopic=664252&st=460


As I understand it, the device is only for the russian market.
