### PR TITLE
ramips: mt7621: add support for Xiaomi Mi Router 4A Gigabit Edition

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -27,6 +27,7 @@ buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
+xiaomi,mir4a-gigabit|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -296,7 +296,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
-	cudy,wr1000)
+	cudy,wr1000|\
+	xiaomi,mir4a-gigabit)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
@@ -720,6 +721,10 @@ ramips_setup_macs()
 	xiaomi,mir3p)
 		lan_mac=$(mtd_get_mac_binary factory 0xe006)
 		label_mac=$lan_mac
+		;;
+	xiaomi,mir4a-gigabit)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$wan_mac
 		;;
 	xiaomi,miwifi-mini)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir4a-gigabit.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir4a-gigabit.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,mir4a-gigabit", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router 4A Gigabit Edition";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_orange;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: power_blue {
+			label = "mir4a-gigabit:blue:power";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_orange: power_orange {
+			label = "mir4a-gigabit:orange:power";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	button {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "Bdata";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "crash";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "cfg_bak";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "overlay";
+				reg = <0x80000 0x100000>;
+				read-only;
+			};
+
+			partition@180000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x180000 0xd00000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+	mediatek,portmap = "llllw";
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c";
+			ralink,function = "gpio";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -762,6 +762,15 @@ define Device/xiaomi_mir3p
 endef
 TARGET_DEVICES += xiaomi_mir3p
 
+define Device/xiaomi_mir4a-gigabit
+  MTK_SOC := mt7621
+  IMAGE_SIZE := 13312k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router 4A Gigabit Edition
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_mir4a-gigabit
+
 define Device/xiaoyu_xy-c5
   MTK_SOC := mt7621
   IMAGE_SIZE := 32448k


### PR DESCRIPTION
This commit adds support for the Xiaomi Mi Router 4A Gigabit Edition, an MT7621-based dual-band AC wireless router with 3 Gigabit Ethernet ports.

While the hardware is fully supported, it is not trivial to flash OpenWrt on it: no SSH/Telnet access, no TTL console, no way to stop the bootloader, firmware upgrade checks for RSA signatures, so does the U-Boot-based recovery process, etc. The only known procedure, so far, is to dump the SPI memory, modify it so that the bootloader can be stopped and then boot an initramfs "as usual".

There is a long thread with details about it at https://forum.openwrt.org/t/36685, where some people are reporting successful flashings.