### PR TITLE
Revert "mt76: probe load mt7615 driver asynchronously"

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -144,7 +144,6 @@ define KernelPackage/mt7615e
   DEPENDS+=@PCI_SUPPORT +kmod-mt76-core
   FILES:=\
 	$(PKG_BUILD_DIR)/mt7615/mt7615e.ko
-  MODPARAMS:=async_probe
   AUTOLOAD:=$(call AutoProbe,mt7615e)
 endef
 


### PR DESCRIPTION
@nbd168 
This reverts commit 81764319637f408623ed9f4bae3f0d149b010f07.

After said commit, users report that MT7615 no longer works on boot
and have to manually enable WiFi (via command "wifi") to make it work

Ref: https://forum.openwrt.org/t/xiaomi-r3p-no-wifi-on-boot/45509