### PR TITLE
tplink-safeloader: fix compilation warnings

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1684,11 +1684,12 @@ static struct image_partition_entry read_file(const char *part_name, const char 
 
 	size_t len = statbuf.st_size;
 
-	if (add_jffs2_eof)
+	if (add_jffs2_eof) {
 		if (file_system_partition)
 			len = ALIGN(len + file_system_partition->base, 0x10000) + sizeof(jffs2_eof_mark) - file_system_partition->base;
 		else
 			len = ALIGN(len, 0x10000) + sizeof(jffs2_eof_mark);
+	}
 
 	struct image_partition_entry entry = alloc_image_partition(part_name, len);
 
@@ -2038,7 +2039,7 @@ static int add_flash_partition(
 		unsigned long base,
 		unsigned long size)
 {
-	int ptr;
+	size_t ptr;
 	/* check if the list has a free entry */
 	for (ptr = 0; ptr < max_entries; ptr++, part_list++) {
 		if (part_list->name == NULL &&
@@ -2091,7 +2092,7 @@ static int read_partition_table(
 	if (fseek(file, offset, SEEK_SET) < 0)
 		error(1, errno, "Can not seek in the firmware");
 
-	if (fread(buf, 1, 2048, file) < 0)
+	if (fread(buf, 2048, 1, file) != 1)
 		error(1, errno, "Can not read fwup-ptn from the firmware");
 
 	buf[2047] = '\0';
@@ -2182,18 +2183,18 @@ static void write_partition(
 	fseek(input_file, entry->base + firmware_offset, SEEK_SET);
 
 	for (offset = 0; sizeof(buf) + offset <= entry->size; offset += sizeof(buf)) {
-		if (fread(buf, sizeof(buf), 1, input_file) < 0)
+		if (fread(buf, sizeof(buf), 1, input_file) != 1)
 			error(1, errno, "Can not read partition from input_file");
 
-		if (fwrite(buf, sizeof(buf), 1, output_file) < 0)
+		if (fwrite(buf, sizeof(buf), 1, output_file) != 1)
 			error(1, errno, "Can not write partition to output_file");
 	}
 	/* write last chunk smaller than buffer */
 	if (offset < entry->size) {
 		offset = entry->size - offset;
-		if (fread(buf, offset, 1, input_file) < 0)
+		if (fread(buf, offset, 1, input_file) != 1)
 			error(1, errno, "Can not read partition from input_file");
-		if (fwrite(buf, offset, 1, output_file) < 0)
+		if (fwrite(buf, offset, 1, output_file) != 1)
 			error(1, errno, "Can not write partition to output_file");
 	}
 }
@@ -2246,7 +2247,7 @@ static int extract_firmware(const char *input, const char *output_directory)
 		error(1, 0, "Error can not read the partition table (fwup-ptn)");
 	}
 
-	for (int i = 0; i < max_entries; i++) {
+	for (size_t i = 0; i < max_entries; i++) {
 		if (entries[i].name == NULL &&
 				entries[i].base == 0 &&
 				entries[i].size == 0)
@@ -2262,7 +2263,7 @@ static struct flash_partition_entry *find_partition(
 		struct flash_partition_entry *entries, size_t max_entries,
 		const char *name, const char *error_msg)
 {
-	for (int i = 0; i < max_entries; i++, entries++) {
+	for (size_t i = 0; i < max_entries; i++, entries++) {
 		if (strcmp(entries->name, name) == 0)
 			return entries;
 	}
@@ -2274,19 +2275,19 @@ static struct flash_partition_entry *find_partition(
 static void write_ff(FILE *output_file, size_t size)
 {
 	char buf[4096];
-	int offset;
+	size_t offset;
 
 	memset(buf, 0xff, sizeof(buf));
 
 	for (offset = 0; offset + sizeof(buf) < size ; offset += sizeof(buf)) {
-		if (fwrite(buf, sizeof(buf), 1, output_file) < 0)
+		if (fwrite(buf, sizeof(buf), 1, output_file) != 1)
 			error(1, errno, "Can not write 0xff to output_file");
 	}
 
 	/* write last chunk smaller than buffer */
 	if (offset < size) {
 		offset = size - offset;
-		if (fwrite(buf, offset, 1, output_file) < 0)
+		if (fwrite(buf, offset, 1, output_file) != 1)
 			error(1, errno, "Can not write partition to output_file");
 	}
 }


### PR DESCRIPTION
Fixed tools/firmware-utils/src/tplink-safeloader.c compilation warnings (by host system gcc-5.4.0):
```
tplink-safeloader.c: In function ‘read_file’:
tplink-safeloader.c:1687:5: warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wparentheses]
  if (add_jffs2_eof)
     ^
tplink-safeloader.c: In function ‘add_flash_partition’:
tplink-safeloader.c:2043:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for (ptr = 0; ptr < max_entries; ptr++, part_list++) {
                    ^
tplink-safeloader.c:2050:10: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  if (ptr == max_entries) {
          ^
tplink-safeloader.c: In function ‘read_partition_table’:
tplink-safeloader.c:2094:32: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  if (fread(buf, 1, 2048, file) < 0)
                                ^
tplink-safeloader.c: In function ‘write_partition’:
tplink-safeloader.c:2185:46: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fread(buf, sizeof(buf), 1, input_file) < 0)
                                              ^
tplink-safeloader.c:2188:48: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fwrite(buf, sizeof(buf), 1, output_file) < 0)
                                                ^
tplink-safeloader.c:2194:41: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fread(buf, offset, 1, input_file) < 0)
                                         ^
tplink-safeloader.c:2196:43: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fwrite(buf, offset, 1, output_file) < 0)
                                           ^
tplink-safeloader.c: In function ‘extract_firmware’:
tplink-safeloader.c:2249:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for (int i = 0; i < max_entries; i++) {
                    ^
tplink-safeloader.c: In function ‘find_partition’:
tplink-safeloader.c:2265:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  for (int i = 0; i < max_entries; i++, entries++) {
                    ^
tplink-safeloader.c: In function ‘write_ff’:
tplink-safeloader.c:2282:48: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fwrite(buf, sizeof(buf), 1, output_file) < 0)
                                                ^
tplink-safeloader.c:2287:13: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  if (offset < size) {
             ^
tplink-safeloader.c:2289:43: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
   if (fwrite(buf, offset, 1, output_file) < 0)
                                           ^
```