### PR TITLE
build: add buildinfo as single Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,11 @@ diffconfig: FORCE
 	mkdir -p $(BIN_DIR)
 	$(SCRIPT_DIR)/diffconfig.sh > $(BIN_DIR)/config.buildinfo
 
-prepare: .config $(tools/stamp-compile) $(toolchain/stamp-compile)
+buildinfo: FORCE
 	$(_SINGLE)$(SUBMAKE) -r diffconfig buildversion feedsversion
+
+prepare: .config $(tools/stamp-compile) $(toolchain/stamp-compile)
+	$(_SINGLE)$(SUBMAKE) -r buildinfo
 
 world: prepare $(target/stamp-compile) $(package/stamp-compile) $(package/stamp-install) $(target/stamp-install) FORCE
 	$(_SINGLE)$(SUBMAKE) -r package/index


### PR DESCRIPTION
The prepare target was added some 11 years ago to build tools and
toolchain and was recently extended to  create buildinfo files for
reproducibility, meaning {feeds,version,config}.buildinfo.

As the buildbot workflow is more complex than the single prepare (kmod
feed insertion), prepare is only used to create those buildinfo files.
Running prepare however runs `target/compile` as well, taking time even
everything is already compiled.

Splitting this allows the buildbot to run only the `buildinfo` target
while others can still use the convenience feature `prepare`.

Signed-off-by: Paul Spooren <mail@aparcar.org>