### PR TITLE
layerscape: fix compilation error

### DIFF
--- a/target/linux/layerscape/patches-4.14/713-sdk_qbman-Fix-error-in-IP-revision-comparison.patch
+++ b/target/linux/layerscape/patches-4.14/713-sdk_qbman-Fix-error-in-IP-revision-comparison.patch
@@ -1,0 +1,33 @@
+From b43b4fdd5caa4f66fd712c77589c167c952ec659 Mon Sep 17 00:00:00 2001
+From: Roy Pledge <roy.pledge@nxp.com>
+Date: Mon, 6 May 2019 11:18:57 -0400
+Subject: [PATCH] sdk_qbman: Fix error in IP revision comparison
+
+The comparison for QMAN_REV31 was incorrect as it
+would always fail due to the wrong mask.
+
+This fixes the following error in newer GCC versions:
+"error: bitwise comparison always evaluates to false
+	[-Werror=tautological-compare]"
+
+Signed-off-by: Roy Pledge <roy.pledge@nxp.com>
+---
+ drivers/staging/fsl_qbman/qman_config.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/staging/fsl_qbman/qman_config.c b/drivers/staging/fsl_qbman/qman_config.c
+index 040631354df5..529f840117ea 100644
+--- a/drivers/staging/fsl_qbman/qman_config.c
++++ b/drivers/staging/fsl_qbman/qman_config.c
+@@ -812,7 +812,7 @@ int qman_set_sdest(u16 channel, unsigned int cpu_idx)
+ 
+ 	if (!qman_have_ccsr())
+ 		return -ENODEV;
+-	if ((qman_ip_rev & 0xFF00) == QMAN_REV31) {
++	if ((qman_ip_rev & 0xFFFF) == QMAN_REV31) {
+ 		/* LS1043A - only one L2 cache */
+ 		cpu_idx = 0;
+ 	}
+-- 
+2.17.1
+


### PR DESCRIPTION
This fixes a compilation error as follows:
drivers/staging/fsl_qbman/qman_config.c:815:29: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
  if ((qman_ip_rev & 0xFF00) == QMAN_REV31) {

Signed-off-by: Biwen Li <biwen.li@nxp.com>