### PR TITLE
build: deactivate prepare run target/compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ check: $(tools/stamp-check) $(toolchain/stamp-check) $(package/stamp-check)
 printdb:
 	@true
 
-prepare: $(target/stamp-compile)
-
 clean: FORCE
 	rm -rf $(BUILD_DIR) $(STAGING_DIR) $(BIN_DIR) $(OUTPUT_DIR)/packages/$(ARCH_PACKAGES) $(BUILD_LOG_DIR) $(TOPDIR)/staging_dir/packages
 


### PR DESCRIPTION
the prepare target is added twice

* 53a1d55b34 add 'make prepare' target for building the tools and
toolchain

and

* 61f503c77a add a "make prepare" target which builds everything up to
target/compile, useful for scripts/deptest.sh

This changes the behaviour back to the more intuitive one where it only
compiles tools and toolchain.

Signed-off-by: Paul Spooren <mail@aparcar.org>