### PR TITLE
bzip2: add linker option LDFLAGS

### DIFF
--- a/package/utils/bzip2/patches/021-fix-LDFLAGS.patch
+++ b/package/utils/bzip2/patches/021-fix-LDFLAGS.patch
@@ -1,0 +1,11 @@
+--- a/Makefile-libbz2_so
++++ b/Makefile-libbz2_so
+@@ -35,7 +35,7 @@ OBJS= blocksort.o  \
+       bzlib.o
+ 
+ all: $(OBJS)
+-	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
++	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 $(LDFLAGS) -o libbz2.so.1.0.8 $(OBJS)
+ 	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
+ 	rm -f libbz2.so.1.0
+ 	ln -s libbz2.so.1.0.8 libbz2.so.1.0


### PR DESCRIPTION
Hi,

I'm use ramips MT76x8, and i find  if gcc not link whith this LDFLAGS on libbzip2.so,
when execute "file libbz2.so.1.0.8"  file will recognize as pie executable ELF file ( which should be shared object):

> libbz2.so.1.0.8: ELF 32-bit LSB **pie executable**, MIPS, MIPS32 rel2 version 1 (SYSV), dynamically linked, with debug_info, not stripped

This because the file command version before 5.36(my ubuntu laptop has 5.35 version)  has a bug and not recognize correctly ,  and LDFLAGS has  -znow -zrelro make the result correctly.

This is important because the include/rootfs.mk  file depend on the result to check file type:
```
ifdef CONFIG_USE_MKLIBS
  define mklibs
	rm -rf $(TMP_DIR)/mklibs-progs $(TMP_DIR)/mklibs-out
	# first find all programs and add them to the mklibs list
	find $(STAGING_DIR_ROOT) -type f -perm /100 -exec \
		file -r -N -F '' {} + | \
		awk ' /executable.*dynamically/ { print $$1 }' > $(TMP_DIR)/mklibs-progs
	# find all loadable objects that are not regular libraries and add them to the list as well
	find $(STAGING_DIR_ROOT) -type f -name \*.so\* -exec \
		file -r -N -F '' {} + | \
		awk ' /shared object/ { print $$1 }' > $(TMP_DIR)/mklibs-libs
	mkdir -p $(TMP_DIR)/mklibs-out
        ....
  endef
endif
```

Signed-off-by: leo chung <gewalalb@gmail.com>
