### PR TITLE
ath79: fix gigabit link pll-data for EX7300

### DIFF
--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dtsi
@@ -216,7 +216,7 @@
 	mtd-mac-address = <&caldata 0x00>;
 
 	phy-handle = <&phy4>;
-	phy-mode = "rgmii";
+	phy-mode = "rgmii-rxid";
 
-	pll-data = <0x83000000 0x80000101 0x80001313>;
+	pll-data = <0x86000000 0x80000101 0x80001313>;
 };


### PR DESCRIPTION
The device did not appear to be reachable unless the connection were
forced to 100Mb or lower. Revert to previously working pll-data.

Reported-by: Moritz Schreiber <moritz@mosos.de>
Signed-off-by: Daniel Gimpelevich <daniel@gimpelevich.san-francisco.ca.us>

Please apply to master also.