### PR TITLE
procd: allow usage of * as procd_running() instance parameter

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -407,12 +407,12 @@ _procd_add_instance() {
 
 procd_running() {
 	local service="$1"
-	local instance="${2:-instance1}"
-	local running
+	local instance="${2:-*}"
+	[ "$instance" = "*" ] || instance="'$instance'"
 
 	json_init
 	json_add_string name "$service"
-	running=$(_procd_ubus_call list | jsonfilter -e "@['$service'].instances['$instance'].running")
+	local running=$(_procd_ubus_call list | jsonfilter -l 1 -e "@['$service'].instances[$instance].running")
 
 	[ "$running" = "true" ]
 }


### PR DESCRIPTION
service_running() implementation in /etc/rc.common use it.
It is preferable to use wildcard than assuming the instance
name is the default one.

jsonfilter returns all matches when wildcards are used, hence
the -l 1 argument used to limit output to only one value.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

@blogic @jow- 
Because current procd_running() implementation does not support wildcards,
services that rely on the default service_running() implementation will be reported
as not running:
    /etc/init.d/network running || echo service is not running