### PR TITLE
lantiq: Fix fw_cutter LzmaWrapper

### DIFF
--- a/package/kernel/lantiq/ltq-vdsl-fw/src/LzmaWrapper.c
+++ b/package/kernel/lantiq/ltq-vdsl-fw/src/LzmaWrapper.c
@@ -153,7 +153,7 @@ int lzma_inflate(unsigned char *source, int s_len, unsigned char *dest, int *d_l
     outStream = 0;
   else
   {
-    if (outSizeFull > d_len)
+    if (outSizeFull > *d_len)
       outStream = 0;
     else
       outStream = dest;


### PR DESCRIPTION
The destination buffer size `d_len` is passed to `lzma_inflate` as a
pointer. Therefore, it needs to be dereferenced to compare its content.

Signed-off-by: Christian Franke <nobody@nowhere.ws>