### PR TITLE
busybox: install as setuid root for FEATURE_SUID=y

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -60,7 +60,7 @@ config BUSYBOX_DEFAULT_INSTALL_NO_USR
 	default n
 config BUSYBOX_DEFAULT_FEATURE_SUID
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_FEATURE_SUID_CONFIG
 	bool
 	default n

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -114,6 +114,9 @@ ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_NTPD),)
 	$(INSTALL_BIN) ./files/sysntpd $(1)/etc/init.d/sysntpd
 	$(INSTALL_BIN) ./files/ntpd-hotplug $(1)/usr/sbin/ntpd-hotplug
 endif
+ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_FEATURE_SUID),)
+	chmod u+s $(1)/bin/busybox
+endif
 	-rm -rf $(1)/lib64
 endef
 


### PR DESCRIPTION
A few busybox applets require privileged capabilities to work (such as
"traceroute" and "su").  This restriction is not relevant when
everything runs as root, but THAT is even less optimal than trusting
busybox traceroute, ping, and a few other applets to safely run setuid
to root.

Allow non-root users to use such busybox applets by installing busybox
setuid root when busybox has been compiled with support to drop setuid
root status for applets that don't need it.

Note that BUSYBOX_CONFIG_FEATURE_SUID *IS* enabled by default, so
busybox WILL BE installed setuid root by default with this change.

Full-featured capabilities support would be better (so that, e.g., the
traceroute applet could run unprivileged but with CAP_NET_RAW+ep), but
that requires support from lots of OpenWRT components (kernel,
filesystems and overlay, ROM filesystem image and build system, etc).

Note that we can't just "chmod u+s /bin/busybox" at runtime as a
"cheaper" solution: it would waste approximately 200KiB of FLASH (the
whole /bin/busybox binary gets copied into the overlay).

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>