### PR TITLE
ath79: remove wmac mtd-mac-addres for UniFi AC family

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -115,6 +115,6 @@
 
 &wmac {
 	status = "okay";
+
 	mtd-cal-data = <&eeprom 0x1000>;
-	mtd-mac-address = <&eeprom 0x0>;
 };


### PR DESCRIPTION
~~The Ubiquiti Unifi AC Mesh devices have the following MAC addresses when running the stock firmware:~~
~~· eth0: XX:XX:XX:X0:XX:XX~~
~~· ath0: XX:XX:XX:X1:XX:XX (2.4 GHz)~~
~~· ath1: XX:XX:XX:X2:XX:XX (5 GHz)~~

~~The commit fixes the MAC address for the 2.4 GHz radio, which got the same MAC as eth0.~~

~~MAC addresses assignment for the Unifi AC Lite devices, which have a commonbase .dtsi file, is kept as it was.~~

The Ubiquiti UniFi AC family of devices had an incorrect mtd-mac-address for wmac (the WiSoC's integrated 2.4 GHz radio) which forced it to have the same MAC as eth0. This commit removes it, so that MAC assignment is coherent with the stock firmware and the ar71xx target.