### PR TITLE
ath79: add support for KuWfi CPE206

### DIFF
--- a/target/linux/ath79/dts/qca9531_kuwfi_cpe206.dts
+++ b/target/linux/ath79/dts/qca9531_kuwfi_cpe206.dts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "kuwfi,cpe206", "qca,qca9531";
+	model = "KuWfi CPE206";
+
+	aliases {
+		led-boot = &status;
+		led-failsafe = &status;
+		led-running = &status;
+		led-upgrade = &status;
+	};
+
+	keys {  
+		compatible = "gpio-keys";
+
+		reset { 
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {  
+		compatible = "gpio-leds";
+
+		lan {
+			label = "cpe206:green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		status: status {
+			label = "cpe206:green:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		wlan {
+			label = "cpe206:green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&art 0x10a0>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+	status = "okay";
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x01c000>;
+				read-only;
+			};
+
+			partition@0x01c000 {
+				label = "SBI";
+				reg = <0x01c000 0x4000>;
+				read-only;
+			};
+		
+			partition@0x020000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x020000 0x780000>;
+			};
+
+			partition@0x7a0000 {
+				label = "elog";
+				reg = <0x7a0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7b0000 {
+				label = "config";
+				reg = <0x7b0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7c0000 {
+				label = "config2";
+				reg = <0x7c0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7d0000 {
+				label = "custom";
+				reg = <0x7d0000 0x10000>;
+				read-only;
+			};
+
+			partition@0x7e0000 {
+				label = "DTB";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			art: partition@0x7f0000 {
+				label = "CAL";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac { 
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -12,7 +12,8 @@ case "$board" in
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:orange:eth0" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:orange:eth1" "switch0" "0x04"
 	;;
-alfa-network,ap121f)
+alfa-network,ap121f|\
+kuwfi,cpe206)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
 	;;
 avm,fritz300e)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ath79_setup_interfaces()
 	devolo,dvl1750x|\
 	engenius,ecb1750|\
 	glinet,gl-ar300m-lite|\
+	kuwfi,cpe206|\
 	netgear,ex6400|\
 	netgear,ex7300|\
 	ocedo,koala|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -674,6 +674,17 @@ define Device/jjplus_ja76pf2
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
+define Device/kuwfi_cpe206
+  ATH_SOC := qca9531
+  DEVICE_VENDOR := KuWfi
+  DEVICE_MODEL := CPE206
+  DEVICE_ALT0_VENDOR = KuWfi
+  DEVICE_ALT0_MODEL = CPE2G-9531
+  DEVICE_PACKAGES := -uboot-envtools
+  IMAGE_SIZE := 7680k
+endef
+TARGET_DEVICES += kuwfi_cpe206
+
 define Device/librerouter_librerouter-v1
   ATH_SOC := qca9558
   DEVICE_VENDOR := Librerouter


### PR DESCRIPTION
Previously closed before for no (constructive) reason, and despite the (inappropriate) accusation of "trying to harm openwrt" (whereas this is just another device), I still hope for the best, so this to be included in the tree.

The only missing piece is to find the actual location of the MAC address of the LAN port.

Would anyone have an original device , together with the initial MAC address, that would be a lot of help.
