### PR TITLE
[WIP] create OpenWrt 19.07.0-rc0 tag

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git packages https://git.openwrt.org/feed/packages.git;openwrt-19.07
-src-git luci https://git.openwrt.org/project/luci.git;openwrt-19.07
-src-git routing https://git.openwrt.org/feed/routing.git;openwrt-19.07
-src-git telephony https://git.openwrt.org/feed/telephony.git;openwrt-19.07
+src-git packages https://git.openwrt.org/feed/packages.git^0b3bd0086143011db516daa63fcd9a1eab25e47f
+src-git luci https://git.openwrt.org/project/luci.git^2c0f0ea6511c553311bcbb44911e084e79cf0ff2
+src-git routing https://git.openwrt.org/feed/routing.git^931f947dd682ffb9fa9c3401d5e2019d678ab019
+src-git telephony https://git.openwrt.org/feed/telephony.git^821bcb7c58a24ea65f022ad2221ba68143533157

--- a/include/version.mk
+++ b/include/version.mk
@@ -26,13 +26,13 @@ PKG_CONFIG_DEPENDS += \
 sanitize = $(call tolower,$(subst _,-,$(subst $(space),-,$(1))))
 
 VERSION_NUMBER:=$(call qstrip,$(CONFIG_VERSION_NUMBER))
-VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),19.07-SNAPSHOT)
+VERSION_NUMBER:=$(if $(VERSION_NUMBER),$(VERSION_NUMBER),19.07.0-rc0)
 
 VERSION_CODE:=$(call qstrip,$(CONFIG_VERSION_CODE))
-VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),$(REVISION))
+VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),bf800022b2)
 
 VERSION_REPO:=$(call qstrip,$(CONFIG_VERSION_REPO))
-VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),http://downloads.openwrt.org/releases/19.07-SNAPSHOT)
+VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),http://downloads.openwrt.org/releases/19.07.0-rc0)
 
 VERSION_DIST:=$(call qstrip,$(CONFIG_VERSION_DIST))
 VERSION_DIST:=$(if $(VERSION_DIST),$(VERSION_DIST),OpenWrt)

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -183,7 +183,7 @@ if VERSIONOPT
 	config VERSION_REPO
 		string
 		prompt "Release repository"
-		default "http://downloads.openwrt.org/releases/19.07-SNAPSHOT"
+		default "http://downloads.openwrt.org/releases/19.07.0-rc0"
 		help
 			This is the repository address embedded in the image, it defaults
 			to the trunk snapshot repo; the url may contain the following placeholders:
@@ -259,7 +259,7 @@ if VERSIONOPT
 	config VERSION_CODE_FILENAMES
 		bool
 		prompt "Revision code in filenames"
-		default y
+		default n
 		help
 			Enable this to include the revision identifier or the configured
 			version code into the firmware image, SDK- and Image Builder archive


### PR DESCRIPTION
Based on the [recent discussion on the openwrt-devel mailinglist](http://lists.infradead.org/pipermail/openwrt-devel/2019-October/019290.html) I created this PR to keep track of the remaining issues blocking a ReleaseCandidate.

@jow- mentioned the following blockers: [1](http://lists.infradead.org/pipermail/openwrt-devel/2019-October/019291.html), [2](http://lists.infradead.org/pipermail/openwrt-devel/2019-October/019349.html), [3](http://lists.infradead.org/pipermail/openwrt-devel/2019-October/019363.html), 
1) ~~Blocker: LuCI master needs to be backported to 19.07
   Time estimate: 2-3 weeks~~ (see https://github.com/openwrt/openwrt/pull/2507#issuecomment-544263986)
2) ~~Blocker: All relevant sub-components for WPA-3 + GUI support, such as hostapd, iwinfo etc. need to be backported to 19.07
   Time estimate: 2 weeks~~ (see https://github.com/openwrt/openwrt/pull/2507#issuecomment-544263986)
3) Blocker: Some weaknesses in libustream-ssl client certificate handling need to  be addressed, which can only be solved by an API redesign. Band-aid fixes available but not merged, nobody worked on API redesign yet
   Time estimate: 1 week
4) ~~Blocker: Need to assert the state of the Dragonblood WPA3 vulnerabilities in 19.07's hostapd
   Time estimate: a few days I guess~~ (see https://github.com/openwrt/openwrt/pull/2507#issuecomment-544263986)
5) ~~Blocker: another blocker: opkg fails to select the correct provider package in case multiple
repositories provide the same kmod with different versions and only one of the provider satisfied version dependency constraints.~~ (see https://github.com/openwrt/openwrt/pull/2507#issuecomment-544263986)
6) Blocker: opkg, under some circumstances fails to install local packages
7) Blocker: rpcd leaks memory

I hope this helps to have a comprehensive list of Blocker that needs to be addressed.