### PR TITLE
Include new extensions in uhttpd self-signed certs

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -56,7 +56,8 @@ generate_keys() {
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${commonname:-OpenWrt}$UNIQUEID"/CN="${commonname:-OpenWrt}"
+			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${commonname:-OpenWrt}$UNIQUEID"/CN="${commonname:-OpenWrt}" \
+			-addext extendedKeyUsage=serverAuth -addext subjectAltName=DNS:"${commonname:-OpenWrt}"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"


### PR DESCRIPTION
The introduction of MacOS Catalina introduces new requirements for self-signed certificates.
See: https://support.apple.com/en-us/HT210176
These new requirements include the addition of two TLS server certificate extensions.
- extendedKeyUsage
- subjectAltName
The extendedKeyUsage must be set to serverAuth.
The subjectAltName must be set to the DNS name of the server.
In the absense of these new extensions, when the LUCI web interface is configured to use HTTPS and
self-signed certs, MacOS user running Google Chrome browsers will not be able to access the LUCI web enterface.
If you are generating self-signed certs which do not include that extension, Chrome will
report "NET::ERR_CERT_INVALID" instead of "NET::ERR_CERT_AUTHORITY_INVALID".  You can click through to ignore the latter, but not the former.

This change updates the uhttpd init script to generate a self-signed cert that meets the new requirements.
Signed-off-by: Pat Fruth <pat@patfruth.com>