### PR TITLE
qos-script: scan interfaces only once

### DIFF
--- a/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
+++ b/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
@@ -22,10 +22,10 @@ add_insmod() {
 [ -e /etc/config/network ] && {
 	# only try to parse network config on openwrt
 
+	reset_cb
+	include /lib/network
+	scan_interfaces
 	find_ifname() {(
-		reset_cb
-		include /lib/network
-		scan_interfaces
 		config_get "$1" ifname
 	)}
 } || {


### PR DESCRIPTION
Now qos-script scan interfaces for every find_finame was called.
But only need once when the scirpts was run.
