### PR TITLE
ramips: Improve common definition for Netgear R6xxx in mt7621.mk

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -459,66 +459,70 @@ define Device/netgear_ex6150
 endef
 TARGET_DEVICES += netgear_ex6150
 
-define Device/netgear_r6220
+define Device/netgear_sercomm_nand
   MTK_SOC := mt7621
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
-  IMAGE_SIZE := 28672k
   UBINIZE_OPTS := -E 5
-  SERCOMM_HWID := AYA
-  SERCOMM_HWVER := A001
-  SERCOMM_SWVER := 0x0086
   IMAGES += factory.img kernel.bin rootfs.bin
   IMAGE/factory.img := pad-extra 2048k | append-kernel | pad-to 6144k | append-ubi | \
-	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip R6220.bin | sercom-seal
+	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip $$$$(SERCOMM_HWNAME).bin | sercom-seal
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
   DEVICE_VENDOR := NETGEAR
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+DEVICE_VARS += SERCOMM_HWNAME SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
+
+define Device/netgear_r6220
+  $(Device/netgear_sercomm_nand)
   DEVICE_MODEL := R6220
-  DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+  SERCOMM_HWNAME := R6220
+  SERCOMM_HWID := AYA
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0086
+  IMAGE_SIZE := 28672k
+  DEVICE_PACKAGES += kmod-mt76x2
   SUPPORTED_DEVICES += r6220
 endef
 TARGET_DEVICES += netgear_r6220
 
-define Device/netgear_r6260_r6350_r6850
-  MTK_SOC := mt7621
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 4096k
-  IMAGE_SIZE := 40960k
-  UBINIZE_OPTS := -E 5
+
+define Device/netgear_r6260
+  $(Device/netgear_sercomm_nand)
+  DEVICE_MODEL := R6260
+  SERCOMM_HWNAME := R6260
   SERCOMM_HWID := CHJ
   SERCOMM_HWVER := A001
   SERCOMM_SWVER := 0x0052
-  IMAGES += factory.img kernel.bin rootfs.bin
-  IMAGE/factory.img := pad-extra 2048k | append-kernel | pad-to 6144k | append-ubi | \
-	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip $$$$(DEVICE_MODEL).bin | sercom-seal
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/kernel.bin := append-kernel
-  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  DEVICE_VENDOR := NETGEAR
-  DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
-endef
-
-define Device/netgear_r6260
-  $(Device/netgear_r6260_r6350_r6850)
-  DEVICE_MODEL := R6260
+  IMAGE_SIZE := 40960k
+  DEVICE_PACKAGES += kmod-mt7615e
 endef
 TARGET_DEVICES += netgear_r6260
 
 define Device/netgear_r6350
-  $(Device/netgear_r6260_r6350_r6850)
+  $(Device/netgear_sercomm_nand)
   DEVICE_MODEL := R6350
+  SERCOMM_HWNAME := R6350
+  SERCOMM_HWID := CHJ
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0052
+  IMAGE_SIZE := 40960k
+  DEVICE_PACKAGES += kmod-mt7615e
 endef
 TARGET_DEVICES += netgear_r6350
 
 define Device/netgear_r6850
-  $(Device/netgear_r6260_r6350_r6850)
+  $(Device/netgear_sercomm_nand)
   DEVICE_MODEL := R6850
+  SERCOMM_HWNAME := R6850
+  SERCOMM_HWID := CHJ
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0052
+  IMAGE_SIZE := 40960k
+  DEVICE_PACKAGES += kmod-mt7615e
 endef
 TARGET_DEVICES += netgear_r6850
 


### PR DESCRIPTION
This patch renames and reassembles the common definition for
Netgear R6xxx devices in mt7621.mk. The following goals should be
achieved:
- Give the node a more generic name instead of adding devices to it
- Use the common definition in the (less) similar R6220 node
- Include/exclude settings into the common definition so the common
  node contains the common definitions
- Prepare for support of R6700 v2

---

This is not tested on device. Maybe it can be tested with
to-be-supported R6700 v2.