### PR TITLE
ipq40xx: use a GPIO mux node to reset PHY

### DIFF
--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-unielec-u4019.dtsi
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-unielec-u4019.dtsi
@@ -17,7 +17,6 @@
 			status = "okay";
 			pinctrl-0 = <&mdio_pins>;
 			pinctrl-names = "default";
-			phy-reset-gpio = <&tlmm 47 0>;
 		};
 
 		ess-psgmii@98000 {
@@ -157,6 +156,13 @@
 			pins = "gpio7";
 			function = "mdc";
 			bias-pull-up;
+		};
+
+		pin_rst {
+			pins = "gpio47";
+			function = "gpio";
+			bias-disable;
+			output-high;
 		};
 	};
 

--- a/target/linux/ipq40xx/patches-4.19/700-net-add-qualcomm-mdio.patch
+++ b/target/linux/ipq40xx/patches-4.19/700-net-add-qualcomm-mdio.patch
@@ -1,15 +1,3 @@
-From 234d6f40fb4b771b396b45a9492aab463771bd0b Mon Sep 17 00:00:00 2001
-From: Kristian Evensen <kristian.evensen@gmail.com>
-Date: Tue, 6 Aug 2019 11:42:57 +0200
-Subject: [PATCH] phy: Add ipq40xx mdio driver
-
----
- drivers/net/phy/Kconfig        |   7 +
- drivers/net/phy/Makefile       |   1 +
- drivers/net/phy/mdio-ipq40xx.c | 247 +++++++++++++++++++++++++++++++++
- 3 files changed, 255 insertions(+)
- create mode 100644 drivers/net/phy/mdio-ipq40xx.c
-
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
 @@ -519,6 +519,13 @@ config XILINX_GMII2RGMII
@@ -38,7 +26,7 @@ Subject: [PATCH] phy: Add ipq40xx mdio driver
  obj-$(CONFIG_MDIO_OCTEON)	+= mdio-octeon.o
 --- /dev/null
 +++ b/drivers/net/phy/mdio-ipq40xx.c
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,196 @@
 +/*
 + * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
 + *
@@ -61,10 +49,8 @@ Subject: [PATCH] phy: Add ipq40xx mdio driver
 +#include <linux/io.h>
 +#include <linux/of_address.h>
 +#include <linux/of_mdio.h>
-+#include <linux/of_gpio.h>
 +#include <linux/phy.h>
 +#include <linux/platform_device.h>
-+#include <linux/gpio.h>
 +
 +#define MDIO_CTRL_0_REG		0x40
 +#define MDIO_CTRL_1_REG		0x44
@@ -164,60 +150,11 @@ Subject: [PATCH] phy: Add ipq40xx mdio driver
 +	return 0;
 +}
 +
-+static int ipq40xx_phy_reset(struct platform_device *pdev)
-+{
-+	struct device_node *mdio_node;
-+	int phy_reset_gpio_number;
-+	int ret;
-+
-+	mdio_node = of_find_node_by_name(NULL, "mdio");
-+	if (!mdio_node) {
-+		dev_err(&pdev->dev, "Could not find mdio node\n");
-+		return 0;
-+	}
-+
-+	ret = of_get_named_gpio(mdio_node, "phy-reset-gpio", 0);
-+	if (ret < 0) {
-+		dev_err(&pdev->dev, "Could not find phy-reset-gpio\n");
-+		return 0;
-+	}
-+
-+	phy_reset_gpio_number = ret;
-+
-+	ret = gpio_request(phy_reset_gpio_number, "phy-reset-gpio");
-+	if (ret) {
-+		dev_err(&pdev->dev, "Can't get phy-reset-gpio %d\n", ret);
-+		return ret;
-+	}
-+
-+	ret = gpio_direction_output(phy_reset_gpio_number, 0x0);
-+	if (ret) {
-+		dev_err(&pdev->dev,
-+			"Can't set direction for phy-reset-gpio %d\n", ret);
-+		goto phy_reset_out;
-+	}
-+
-+	usleep_range(1000, 10005);
-+
-+	gpio_set_value(phy_reset_gpio_number, 0x01);
-+
-+phy_reset_out:
-+	gpio_free(phy_reset_gpio_number);
-+
-+	return ret;
-+}
-+
 +static int ipq40xx_mdio_probe(struct platform_device *pdev)
 +{
 +	struct ipq40xx_mdio_data *am;
 +	struct resource *res;
-+	int i, ret;
-+
-+	ret = ipq40xx_phy_reset(pdev);
-+	if (ret) {
-+		dev_err(&pdev->dev, "Could not find qca8075 reset gpio\n");
-+		return -ENODEV;
-+	}
++	int i;
 +
 +	am = devm_kzalloc(&pdev->dev, sizeof(*am), GFP_KERNEL);
 +	if (!am)


### PR DESCRIPTION
Commit 6f6c00cfc95f made phy-reset-gpio required in mdio node, causing init failure in other ipq40xx profiles.

For Unielec U4019, use a GPIO mux node to set GPIO 47 to high.

Fixes: 6f6c00cfc95f ("ipq40xx: Add support for Unielec U4019")
@kristrev 