### PR TITLE
ipq40xx: wpj428 cpximg and reboot

### DIFF
--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -32,6 +32,10 @@
 
 		mdio@90000 {
 			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+			reset-delay-us = <2000>;
 		};
 
 		ess-psgmii@98000 {
@@ -129,6 +133,20 @@
 };
 
 &tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
 	serial_pins: serial_pinmux {
 		mux {
 			pins = "gpio60", "gpio61";

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -222,6 +222,21 @@ define Device/compex_wpj419
 endef
 TARGET_DEVICES += compex_wpj419
 
+define Build/mkmylofw_32m
+  $(eval device_id=$(word 1,$(1)))
+  $(eval revision=$(word 2,$(1)))
+
+  size="$$(python -c \
+    "import os, math; \
+    size=math.ceil(os.stat('$@').st_size / 65536) * 65536; \
+    print(hex(size))")"; \
+  $(STAGING_DIR_HOST)/bin/mkmylofw \
+    -B WPE72 -i 0x11f6:$(device_id):0x11f6:$(device_id) -r $(revision) -s 0x2000000 \
+    -p0x180000:$$size:al:0x84000000:"OpenWRT":$@ \
+    $@.new
+  @mv $@.new $@
+endef
+
 define Device/compex_wpj428
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Compex
@@ -231,8 +246,9 @@ define Device/compex_wpj428
 	BLOCKSIZE := 64k
 	IMAGE_SIZE := 31232k
 	KERNEL_SIZE := 4096k
-	IMAGES = sysupgrade.bin
+	IMAGES = sysupgrade.bin cpximg-6A04.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+	IMAGE/cpximg-6A04.bin := append-kernel | append-rootfs | pad-rootfs | mkmylofw_32m 0x8A2 3
 	DEVICE_PACKAGES := kmod-gpio-beeper
 endef
 TARGET_DEVICES += compex_wpj428


### PR DESCRIPTION
hi :-)

see commit description for what the cpximg is used for.
there's also another variant `6A03` around but i haven't got one and can't check which parameters it uses.

the reboot-issue discussed in https://github.com/openwrt/openwrt/pull/787 is fixed like with the unielec-u4019 or like compex https://github.com/compex-systems/lede/blob/openwrt-18.06/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts#L32.
the workaround with installing another version of u-boot doesn't work anymore since the file is no longer available.

'nudging' the detection isn't enough.
i've also got a patch (based on the compex repo) for sending SPI commands on shutdown but it appears to be working without that ugly thing.
EDIT: 4 byte opcodes have been added in the meantime.

gpio52/53 are EMDC/EMDIO.