### PR TITLE
kernel: fix LED netdev trigger on interface rename

### DIFF
--- a/target/linux/generic/backport-4.14/402-leds-trigger-netdev-fix-handling-on-interface-rename.patch
+++ b/target/linux/generic/backport-4.14/402-leds-trigger-netdev-fix-handling-on-interface-rename.patch
@@ -1,0 +1,54 @@
+From 0ff035231edca3713c3d0839c44e64a4ac41ef38 Mon Sep 17 00:00:00 2001
+From: Martin Schiller <ms@dev.tdt.de>
+Date: Thu, 24 Oct 2019 15:09:23 +0200
+Subject: [PATCH] leds: trigger: netdev: fix handling on interface rename
+
+The NETDEV_CHANGENAME code is not "unneeded" like it is stated in commit
+4cb6560514fa ("leds: trigger: netdev: fix refcnt leak on interface
+rename").
+
+The event was accidentally misinterpreted equivalent to
+NETDEV_UNREGISTER, but should be equivalent to NETDEV_REGISTER.
+
+This was the case in the original code from the openwrt project.
+
+Otherwise, you are unable to set netdev led triggers for (non-existent)
+netdevices, which has to be renamed. This is the case, for example, for
+ppp interfaces in openwrt.
+
+Fixes: 06f502f57d0d ("leds: trigger: Introduce a NETDEV trigger")
+Fixes: 4cb6560514fa ("leds: trigger: netdev: fix refcnt leak on interface rename")
+Signed-off-by: Martin Schiller <ms@dev.tdt.de>
+---
+ drivers/leds/trigger/ledtrig-netdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/leds/trigger/ledtrig-netdev.c b/drivers/leds/trigger/ledtrig-netdev.c
+index 136f86a1627d..d5e774d83021 100644
+--- a/drivers/leds/trigger/ledtrig-netdev.c
++++ b/drivers/leds/trigger/ledtrig-netdev.c
+@@ -302,10 +302,12 @@ static int netdev_trig_notify(struct notifier_block *nb,
+ 		container_of(nb, struct led_netdev_data, notifier);
+ 
+ 	if (evt != NETDEV_UP && evt != NETDEV_DOWN && evt != NETDEV_CHANGE
+-	    && evt != NETDEV_REGISTER && evt != NETDEV_UNREGISTER)
++	    && evt != NETDEV_REGISTER && evt != NETDEV_UNREGISTER
++	    && evt != NETDEV_CHANGENAME)
+ 		return NOTIFY_DONE;
+ 
+ 	if (!(dev == trigger_data->net_dev ||
++	      (evt == NETDEV_CHANGENAME && !strcmp(dev->name, trigger_data->device_name)) ||
+ 	      (evt == NETDEV_REGISTER && !strcmp(dev->name, trigger_data->device_name))))
+ 		return NOTIFY_DONE;
+ 
+@@ -315,6 +317,7 @@ static int netdev_trig_notify(struct notifier_block *nb,
+ 
+ 	clear_bit(NETDEV_LED_MODE_LINKUP, &trigger_data->mode);
+ 	switch (evt) {
++	case NETDEV_CHANGENAME:
+ 	case NETDEV_REGISTER:
+ 		if (trigger_data->net_dev)
+ 			dev_put(trigger_data->net_dev);
+-- 
+2.20.1
+

--- a/target/linux/generic/backport-4.19/402-leds-trigger-netdev-fix-handling-on-interface-rename.patch
+++ b/target/linux/generic/backport-4.19/402-leds-trigger-netdev-fix-handling-on-interface-rename.patch
@@ -1,0 +1,54 @@
+From 0ff035231edca3713c3d0839c44e64a4ac41ef38 Mon Sep 17 00:00:00 2001
+From: Martin Schiller <ms@dev.tdt.de>
+Date: Thu, 24 Oct 2019 15:09:23 +0200
+Subject: [PATCH] leds: trigger: netdev: fix handling on interface rename
+
+The NETDEV_CHANGENAME code is not "unneeded" like it is stated in commit
+4cb6560514fa ("leds: trigger: netdev: fix refcnt leak on interface
+rename").
+
+The event was accidentally misinterpreted equivalent to
+NETDEV_UNREGISTER, but should be equivalent to NETDEV_REGISTER.
+
+This was the case in the original code from the openwrt project.
+
+Otherwise, you are unable to set netdev led triggers for (non-existent)
+netdevices, which has to be renamed. This is the case, for example, for
+ppp interfaces in openwrt.
+
+Fixes: 06f502f57d0d ("leds: trigger: Introduce a NETDEV trigger")
+Fixes: 4cb6560514fa ("leds: trigger: netdev: fix refcnt leak on interface rename")
+Signed-off-by: Martin Schiller <ms@dev.tdt.de>
+---
+ drivers/leds/trigger/ledtrig-netdev.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/leds/trigger/ledtrig-netdev.c b/drivers/leds/trigger/ledtrig-netdev.c
+index 136f86a1627d..d5e774d83021 100644
+--- a/drivers/leds/trigger/ledtrig-netdev.c
++++ b/drivers/leds/trigger/ledtrig-netdev.c
+@@ -302,10 +302,12 @@ static int netdev_trig_notify(struct notifier_block *nb,
+ 		container_of(nb, struct led_netdev_data, notifier);
+ 
+ 	if (evt != NETDEV_UP && evt != NETDEV_DOWN && evt != NETDEV_CHANGE
+-	    && evt != NETDEV_REGISTER && evt != NETDEV_UNREGISTER)
++	    && evt != NETDEV_REGISTER && evt != NETDEV_UNREGISTER
++	    && evt != NETDEV_CHANGENAME)
+ 		return NOTIFY_DONE;
+ 
+ 	if (!(dev == trigger_data->net_dev ||
++	      (evt == NETDEV_CHANGENAME && !strcmp(dev->name, trigger_data->device_name)) ||
+ 	      (evt == NETDEV_REGISTER && !strcmp(dev->name, trigger_data->device_name))))
+ 		return NOTIFY_DONE;
+ 
+@@ -315,6 +317,7 @@ static int netdev_trig_notify(struct notifier_block *nb,
+ 
+ 	clear_bit(NETDEV_LED_MODE_LINKUP, &trigger_data->mode);
+ 	switch (evt) {
++	case NETDEV_CHANGENAME:
+ 	case NETDEV_REGISTER:
+ 		if (trigger_data->net_dev)
+ 			dev_put(trigger_data->net_dev);
+-- 
+2.20.1
+


### PR DESCRIPTION
This fixes the netdev LED trigger for interfaces, which are renamed
during initialization (e.g. ppp interfaces).

I've also sent this patch upstream to the lkml:
https://lore.kernel.org/patchwork/patch/1144281/

Fixes: FS#2193
Fixes: FS#2239


