### PR TITLE
uboot-mvebu: add uDPU board

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -29,8 +29,15 @@ define U-Boot/clearfog
   UBOOT_IMAGE:=u-boot-spl.kwb
 endef
 
+define U-Boot/uDPU
+  NAME:=Methode uDPU
+  BUILD_DEVICES:=methode_udpu
+  BUILD_SUBTARGET:=cortexa53
+endef
+
 UBOOT_TARGETS:= \
-	clearfog
+	clearfog \
+	uDPU
 
 Build/Exports:=$(Host/Exports)
 
@@ -44,7 +51,7 @@ endef
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
-	$(CP) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-u-boot-spl.kwb
+	$(CP) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-$(UBOOT_IMAGE)
 endef
 
 $(eval $(call BuildPackage/U-Boot))

--- a/package/boot/uboot-mvebu/patches/120-mvebu_armada-37xx.h_increase_max_gunzip_size.patch
+++ b/package/boot/uboot-mvebu/patches/120-mvebu_armada-37xx.h_increase_max_gunzip_size.patch
@@ -1,0 +1,13 @@
+Increase max gunzip size in mvebu_armada-37xx.h.
+This is required in order to boot itb images.
+
+--- a/include/configs/mvebu_armada-37xx.h
++++ b/include/configs/mvebu_armada-37xx.h
+@@ -12,6 +12,7 @@
+ 
+ /* additions for new ARM relocation support */
+ #define CONFIG_SYS_SDRAM_BASE	0x00000000
++#define CONFIG_SYS_BOOTM_LEN   (64 << 20)      /* Increase max gunzip size */
+ 
+ #define CONFIG_NR_DRAM_BANKS	1
+ 


### PR DESCRIPTION
* add u-boot support for uDPU
* add line to copy u-boot binary to STAGING_DIR_IMAGE, this can later be used as BL33 variable
required for ATF build
* add patch to increase max gunzip size in mvebu_armada-37xx.h which is required for
booting the itb recovery images