### PR TITLE
uboot-mvebu: add support for Macronix mx25u12835f flash

### DIFF
--- a/package/boot/uboot-mvebu/patches/100-add_support_for_macronix_mx25u12835f.patch
+++ b/package/boot/uboot-mvebu/patches/100-add_support_for_macronix_mx25u12835f.patch
@@ -1,0 +1,10 @@
+--- a/drivers/mtd/spi/spi-nor-ids.c
++++ b/drivers/mtd/spi/spi-nor-ids.c
+@@ -136,6 +136,7 @@ const struct flash_info spi_nor_ids[] =
+ 	{ INFO("mx25u1635e",  0xc22535, 0, 64 * 1024,  32, SECT_4K) },
+ 	{ INFO("mx25u6435f",  0xc22537, 0, 64 * 1024, 128, SECT_4K) },
+ 	{ INFO("mx25l12805d", 0xc22018, 0, 64 * 1024, 256, 0) },
++	{ INFO("mx25u12835f", 0xc22538, 0, 64 * 1024, 256, SECT_4K) },
+ 	{ INFO("mx25l12855e", 0xc22618, 0, 64 * 1024, 256, 0) },
+ 	{ INFO("mx25l25635e", 0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ INFO("mx25u25635f", 0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },


### PR DESCRIPTION
Some A3700 boards use mx25u12835f flash, specifically uDPU andcertain versions of ESPRESSObin v7.
