### PR TITLE
[RFC] mac80211/hostapd: add support for 256-QAM on 802.11n

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -107,7 +107,7 @@ mac80211_hostapd_setup_base() {
 	[ -n "$acs_exclude_dfs" ] && [ "$acs_exclude_dfs" -gt 0 ] &&
 		append base_cfg "acs_exclude_dfs=1" "$N"
 
-	json_get_vars noscan ht_coex
+	json_get_vars noscan ht_coex vendor_vht
 	json_get_values ht_capab_list ht_capab tx_burst
 	json_get_values channel_list channels
 
@@ -230,7 +230,7 @@ mac80211_hostapd_setup_base() {
 	esac
 	[ "$hwmode" = "a" ] || enable_ac=0
 
-	if [ "$enable_ac" != "0" ]; then
+	if [ "$enable_ac" != "0" -o "$vendor_vht" = "1" ]; then
 		json_get_vars \
 			rxldpc:1 \
 			short_gi_80:1 \

--- a/package/kernel/mac80211/patches/ath/983-ath10k-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/ath/983-ath10k-allow-vht-on-2g.patch
@@ -1,0 +1,10 @@
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -4718,6 +4718,7 @@ static void ath10k_mac_setup_ht_vht_cap(
+ 	if (ar->phy_capability & WHAL_WLAN_11G_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_2GHZ];
+ 		band->ht_cap = ht_cap;
++		band->vht_cap = vht_cap;
+ 	}
+ 	if (ar->phy_capability & WHAL_WLAN_11A_CAPABILITY) {
+ 		band = &ar->mac.sbands[NL80211_BAND_5GHZ];

--- a/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
+++ b/package/kernel/mac80211/patches/subsys/600-mac80211-allow-vht-on-2g.patch
@@ -1,0 +1,36 @@
+--- a/net/mac80211/vht.c
++++ b/net/mac80211/vht.c
+@@ -135,7 +135,8 @@ ieee80211_vht_cap_ie_to_sta_vht_cap(stru
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/util.c
++++ b/net/mac80211/util.c
+@@ -1769,7 +1769,8 @@ static int ieee80211_build_preq_ies_band
+ 	/* Check if any channel in this sband supports at least 80 MHz */
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;
+--- a/net/mac80211/mlme.c
++++ b/net/mac80211/mlme.c
+@@ -4824,7 +4824,8 @@ static int ieee80211_prep_channel(struct
+ 	have_80mhz = false;
+ 	for (i = 0; i < sband->n_channels; i++) {
+ 		if (sband->channels[i].flags & (IEEE80211_CHAN_DISABLED |
+-						IEEE80211_CHAN_NO_80MHZ))
++						IEEE80211_CHAN_NO_80MHZ) &&
++						(sband->band != NL80211_BAND_2GHZ))
+ 			continue;
+ 
+ 		have_80mhz = true;

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -98,6 +98,7 @@ hostapd_common_add_device_config() {
 	config_add_int local_pwr_constraint
 	config_add_string require_mode
 	config_add_boolean legacy_rates
+	config_add_boolean vendor_vht
 
 	config_add_string acs_chan_bias
 	config_add_array hostapd_options
@@ -113,7 +114,7 @@ hostapd_prepare_device_config() {
 	local base_cfg=
 
 	json_get_vars country country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
-		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode
+		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode vendor_vht
 
 	hostapd_set_log_options base_cfg
 
@@ -149,6 +150,7 @@ hostapd_prepare_device_config() {
 	[ "$hwmode" = "g" ] && {
 		[ "$legacy_rates" -eq 0 ] && set_default rate_list "6000 9000 12000 18000 24000 36000 48000 54000"
 		[ -n "$require_mode" ] && set_default basic_rate_list "6000 12000 24000"
+		[ -n "$vendor_vht" ] && append base_cfg "vendor_vht=$vendor_vht" "$N"
 	}
 
 	case "$require_mode" in


### PR DESCRIPTION
Some vendors allow VHT (256-QAM) rate on 802.11n, but mac80211 does not allow it (yet).
Add a hack to let mac80211 allow VHT

Tested on IPQ4019 and mvebu/mwlwifi

mac80211 patch was from @Ansuel 