### PR TITLE
kernel: package driver for QCA7000 powerline chip

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1042,3 +1042,53 @@ define KernelPackage/be2net/description
 endef
 
 $(eval $(call KernelPackage,be2net))
+
+
+define KernelPackage/qca7k
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Qualcomm Atheros QCA7000 support (library for SPI/UART driver)
+  HIDDEN:=1
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/qualcomm/qca_7k_common.ko
+  KCONFIG:=CONFIG_QCA7000
+endef
+
+define KernelPackage/qca7k/description
+  Kernel module for shared code for Qualcomm Atheros QCA7000 SPI/UART drivers
+endef
+
+$(eval $(call KernelPackage,qca7k))
+
+
+define KernelPackage/qcaspi
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Qualcomm Atheros QCA7000 SPI support
+  DEPENDS:=+kmod-qca7k
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/qualcomm/qcaspi.ko
+  KCONFIG:= \
+	CONFIG_QCA7000_SPI \
+	CONFIG_SPI=y \
+	CONFIG_SPI_MASTER=y
+  AUTOLOAD:=$(call AutoProbe,qcaspi)
+endef
+
+define KernelPackage/qcaspi/description
+  Kernel module for the Qualcomm Atheros QCA7000 SPI driver
+endef
+
+$(eval $(call KernelPackage,qcaspi))
+
+
+define KernelPackage/qcauart
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Qualcomm Atheros QCA7000 UART support
+  DEPENDS:=+kmod-qca7k +kmod-serdev-ttyport @LINUX_4_19
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/qualcomm/qcauart.ko
+  KCONFIG:=CONFIG_QCA7000_UART
+  AUTOLOAD:=$(call AutoProbe,qcauart)
+endef
+
+define KernelPackage/qcauart/description
+  Kernel module for the Qualcomm Atheros QCA7000 UART driver
+endef
+
+$(eval $(call KernelPackage,qcauart))

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1230,3 +1230,36 @@ define KernelPackage/it87-wdt/description
 endef
 
 $(eval $(call KernelPackage,it87-wdt))
+
+
+define KernelPackage/serdev-core
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Serial device bus core support
+  DEPENDS:=@LINUX_4_19
+  KCONFIG:=CONFIG_SERIAL_DEV_BUS
+ifneq ($(wildcard $(LINUX_DIR)/drivers/tty/serdev/core.ko),)
+  FILES:=$(LINUX_DIR)/drivers/tty/serdev/core.ko
+endif
+endef
+
+define KernelPackage/serdev-core/description
+  Kernel module for core support for devices connected via a serial port
+endef
+
+$(eval $(call KernelPackage,serdev-core))
+
+
+define KernelPackage/serdev-ttyport
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Serial device TTY port controller support
+  DEPENDS:=+kmod-serdev-core @LINUX_4_19
+  KCONFIG:= \
+	CONFIG_SERIAL_DEV_BUS=y \
+	CONFIG_SERIAL_DEV_CTRL_TTYPORT=y
+endef
+
+define KernelPackage/serdev-ttyport/description
+  Kernel module for serial device TTY port controller support
+endef
+
+$(eval $(call KernelPackage,serdev-ttyport))


### PR DESCRIPTION
This creates kernel module packages for Linux' QCA7000 drivers.

The Qualcomm Atheros QCA7000 is a Homeplug Green PHY chipset
solution used e.g. in Electric Vehicle Supply Equipment (EVSE)
stations and/or in Electric Vehicles (EV) when doing high-level
communication according to ISO15118 or DIN70121.

Other use-cases of this chipset include embedded IoT devices
which communicate via Homeplug AV compatible powerline.

The QCA7000 firmware can be configured to be accessible via
a UART or an SPI interface.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>