### PR TITLE
Workaround for fw3 inside lxc container. 

### DIFF
--- a/package/network/config/firewall/Makefile
+++ b/package/network/config/firewall/Makefile
@@ -57,6 +57,8 @@ define Package/firewall/install
 	$(INSTALL_CONF) ./files/firewall.user $(1)/etc/firewall.user
 	$(INSTALL_DIR) $(1)/usr/share/fw3
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/helpers.conf $(1)/usr/share/fw3
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/99_firewall_lxc_workaround $(1)/lib/preinit/99_firewall_lxc_workaround
 endef
 
 $(eval $(call BuildPackage,firewall))

--- a/package/network/config/firewall/files/99_firewall_lxc_workaround
+++ b/package/network/config/firewall/files/99_firewall_lxc_workaround
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (C) 2006 OpenWrt.org
+
+firewall_lxc_workaround() {
+	local tt
+	for tt in filter nat mangle raw ; do
+	    {
+	    grep ${tt} /proc/net/ip6_tables_names || /usr/sbin/ip6tables -t ${tt} -L
+            grep ${tt} /proc/net/ip_tables_names || /usr/sbin/iptables -t ${tt} -L
+	    } >/dev/null 2>/dev/null
+	done
+
+}
+
+boot_hook_add preinit_main firewall_lxc_workaround


### PR DESCRIPTION
Inside the lxc container, fw3 cannot create iptables rules.
iptables-save returns nothing.
/proc/net/ip6_tables_names and /proc/net/ip_tables_names is empty on boot.
This workaround for this issue.