### PR TITLE
download.pl: add jsDelivr mirror for GitHub

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -203,9 +203,13 @@ foreach my $mirror (@ARGV) {
 		push @mirrors, "ftp://apache.cs.utah.edu/apache.org/$1";
 		push @mirrors, "ftp://apache.mirrors.ovh.net/ftp.apache.org/dist/$1";
 	} elsif ($mirror =~ /^\@GITHUB\/(.+)$/) {
+		my $dir = $1;
+		my $i = 0;
+		# replace the 2nd '/' with '@' for jsDelivr mirror
+		push @mirrors, "https://cdn.jsdelivr.net/gh/". $dir =~ s{\/}{++$i == 2 ? '@' : $&}ger;
 		# give github a few more tries (different mirrors)
 		for (1 .. 5) {
-			push @mirrors, "https://raw.githubusercontent.com/$1";
+			push @mirrors, "https://raw.githubusercontent.com/$dir";
 		}
 	} elsif ($mirror =~ /^\@GNU\/(.+)$/) {
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/gnu/$1";


### PR DESCRIPTION
jsDelivr uses the following URL for GitHub files:
`https://cdn.jsdelivr.net/gh/{username}/{repo}@{revision}/path/to/file`

For compatibility, the script will replace the 2nd '/' with '@' when
pushing the jsDelivr URL to mirrors.