### PR TITLE
ath79: add support for Sitecom WLR-8100

### DIFF
--- a/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
+++ b/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca9557.dtsi"
+
+/ {
+	model = "Sitecom WLR-8100 (X8 AC1750)";
+	compatible = "sitecom,wlr-8100", "qca,qca9558";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_amber;
+		led-upgrade = &led_status_amber;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wifi2g_rfkill {
+			label = "2.4GHz - RFKILL";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		wifi5g_restart {
+			label = "5GHz - RESTART";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: status_amber {
+			label = "wlr-8100:amber:status";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		ops {
+			label = "wlr-8100:white:ops";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "wlr-8100:blue:wifi2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "wlr-8100:blue:wifi5g";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xf10000>;
+			};
+
+			partition@f50000 {
+				label = "manufacture";
+				reg = <0xf50000 0x040000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "backup";
+				reg = <0xf90000  0x010000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "storage";
+				reg = <0xfa0000 0x050000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x87600000 /* PORT0 PAD MODE CTRL */
+			0x50 0xc437c437 /* LED Control Register 0 */
+			0x54 0xc337c337 /* LED Control Register 1 */
+			0x58 0x00000000 /* LED Control Register 2 */
+			0x5c 0x03ffff00 /* LED Control Register 3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&phy0>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -142,7 +142,8 @@ ath79_setup_interfaces()
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
 	elecom,wrc-1750ghbk2-i|\
-	elecom,wrc-300ghbk2-i)
+	elecom,wrc-300ghbk2-i|\
+	sitecom,wlr-8100)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
 		;;
@@ -407,7 +408,8 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
-	sitecom,wlr-7100)
+	sitecom,wlr-7100|\
+	sitecom,wlr-8100)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$lan_mac

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -37,7 +37,8 @@ case "$FIRMWARE" in
 	iodata,wn-ac1600dgr|\
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr|\
-	sitecom,wlr-7100)
+	sitecom,wlr-7100|\
+	sitecom,wlr-8100)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env ethaddr)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -121,6 +121,14 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"ath10k/cal-pci-0000:01:00.0.bin")
+	case $board in
+	sitecom,wlr-8100)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
+		;;
+	esac
+	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
 	comfast,cf-e313ac)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1086,6 +1086,22 @@ define Device/sitecom_wlr-7100
 endef
 TARGET_DEVICES += sitecom_wlr-7100
 
+define Device/sitecom_wlr-8100
+  SOC := qca9558
+  DEVICE_VENDOR := Sitecom
+  DEVICE_MODEL := WLR-8100
+  DEVICE_ALT0_VENDOR := Sitecom
+  DEVICE_ALT0_MODEL := X8 AC1750
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct kmod-usb2 kmod-usb3
+  SUPPORTED_DEVICES += wlr8100
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	senao-header -r 0x222 -p 0x56 -t 2
+  IMAGE_SIZE := 15424k
+endef
+TARGET_DEVICES += sitecom_wlr-8100
+
 define Device/teltonika_rut955
   SOC := ar9344
   DEVICE_VENDOR := Teltonika


### PR DESCRIPTION
Sitecom WLR-8100 v1 002 (marketed as X8 AC1750) is a dual band wireless
router.

Specification:

- Qualcomm Atheros SoC QCA9558
- 128 MB of RAM (DDR2)
- 16 MB of FLASH (Macronix MX25L12845EMI-10G - SPI NOR)
- 5x 10/100/1000 Mbps Ethernet
- 3T3R 2.4 GHz (QCA9558 WMAC)
- 3T3R 5.8 Ghz (QCA9880-BR4A)
- 1x USB 3.0 (Etron EJ168A)
- 1x USB 2.0
- 9x LEDs
- 2x GPIO buttons

Everything working.
Installation and restore procedure tested

Installation
1. Connect to one of LAN (yellow) ethernet ports,
2. Open router configuration interface,
3. Go to Toolbox > Firmware,
4. Browse for OpenWrt factory image with dlf extension and hit Apply,
5. Wait few minutes, after the Power LED will stop blinking, the router
	is ready for configuration.

Restore OEM FW (Linux only)
1. Download OEM FW from website (tested with WLR-8100v1002-firmware-v27.dlf)
2. Compile the FW for this router and locate the "mksenaofw" tool
	in build_dir/host/firmware-utils/bin/ inside the OpenWrt buildroot
3. Execute "mksenaofw -d WLR-8100v1002-firmware-v27.dlf -o WLR-8100v1002-firmware-v27.dlf.out" where:
	WLR-8100v1002-firmware-v27.dlf is the path to the input file
		(use the downloaded file)
	WLR-8100v1002-firmware-v27.dlf.out is the path to the output file
		(you can use the filename you want)
4. Flash the new WLR-8100v1002-firmware-v27.dlf.out file. WARNING: Do not keep settings.

Additional notes.
The original firmware has the following button configuration:
- Press for 2s the 2.4GHz button: WPS for 2.4GHz
- Press for 2s the 5GHz button: WPS for 5GHz
- Press for 15s both 2.4GHz and 5GHz buttons: Reset

I am not able to replicate this behaviour, so I used the following configuration:
- Press the 2.4GHz button: RFKILL (disable/enable every wireless interfaces)
- Press the 5GHz button: Reset

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>