### PR TITLE
base-files: add user config menu at preinit stage

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -96,6 +96,10 @@ define ImageConfigOptions
 	echo 'pi_preinit_net_messages="$(CONFIG_TARGET_PREINIT_SHOW_NETMSG)"' >>$(1)/lib/preinit/00_preinit.conf
 	echo 'pi_preinit_no_failsafe_netmsg="$(CONFIG_TARGET_PREINIT_SUPPRESS_FAILSAFE_NETMSG)"' >>$(1)/lib/preinit/00_preinit.conf
 	echo 'pi_preinit_no_failsafe="$(CONFIG_TARGET_PREINIT_DISABLE_FAILSAFE)"' >>$(1)/lib/preinit/00_preinit.conf
+ifndef CONFIG_TARGET_PREINIT_USER_CONFIG_REMOVED
+	echo 'pi_user_config_wait_timeout="$(if $(CONFIG_TARGET_PREINIT_USER_CONFIG_TIMEOUT),$(CONFIG_TARGET_PREINIT_USER_CONFIG_TIMEOUT),4)"' >>$(1)/lib/preinit/00_preinit.conf
+	echo 'pi_no_user_config="$(CONFIG_TARGET_PREINIT_USER_CONFIG_DISABLED)"' >>$(1)/lib/preinit/00_preinit.conf
+endif
 endef
 
 define Build/Prepare
@@ -206,6 +210,9 @@ define Package/base-files/install
 		$(VERSION_SED_SCRIPT) $(1)/etc/opkg/distfeeds.conf)
 	$(if $(CONFIG_IPK_FILES_CHECKSUMS), \
 		rm -f $(1)/sbin/pkg_check,)
+	$(if $(CONFIG_TARGET_PREINIT_USER_CONFIG_REMOVED), \
+		rm -f $(1)/lib/preinit/90_user_config_menu $(1)/etc/hotplug-config.json $(1)/etc/rc.button/buttons \
+		rm -rf $(1)/etc/config-menu.d/,)
 endef
 
 ifneq ($(DUMP),1)

--- a/package/base-files/files/etc/config-menu.d/01_enable_wifi
+++ b/package/base-files/files/etc/config-menu.d/01_enable_wifi
@@ -1,0 +1,21 @@
+#!/bin/sh
+INVERSE=1
+
+[ -z "$1" ] && return
+if [ ! -s "/etc/config/wireless" ] ; then
+	echo -e "#!/bin/sh\n$(readlink -f $0) $1" > /etc/uci-defaults/20_set_wifi
+	return
+fi
+
+. /lib/functions.sh
+
+wifi_rfkill_set() {
+	uci set wireless.$1.disabled=$ACTION
+}
+
+ACTION=$(( ($1+$INVERSE) %2 ))
+config_load wireless
+config_foreach wifi_rfkill_set wifi-device
+
+uci commit wireless
+wifi up

--- a/package/base-files/files/etc/config-menu.d/02_disable_firewall
+++ b/package/base-files/files/etc/config-menu.d/02_disable_firewall
@@ -1,0 +1,10 @@
+#!/bin/sh
+INVERSE=0
+
+[ -z "$1" ] && return
+
+ACTION=$(( ($1+$INVERSE) %2 ))
+case "$ACTION" in
+	0)	/etc/init.d/firewall enable ;;
+	1)	/etc/init.d/firewall disable ;;
+esac

--- a/package/base-files/files/etc/diag.sh
+++ b/package/base-files/files/etc/diag.sh
@@ -35,6 +35,9 @@ set_led_state() {
 		status_led="$upgrade"
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_off
 		[ -n "$running" ] && {

--- a/package/base-files/files/etc/hotplug-config.json
+++ b/package/base-files/files/etc/hotplug-config.json
@@ -1,0 +1,9 @@
+[
+	[ "if",
+		[ "and",
+			[ "eq", "SUBSYSTEM", "button" ],
+			[ "eq", "ACTION", "released" ]
+		],
+		[ "exec", "/etc/rc.button/buttons"]
+	]
+]

--- a/package/base-files/files/etc/rc.button/buttons
+++ b/package/base-files/files/etc/rc.button/buttons
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+[ "${TYPE}" = "switch" ] || echo ${BUTTON} >> /tmp/buttons
+
+return 0
+

--- a/package/base-files/files/lib/functions/leds.sh
+++ b/package/base-files/files/lib/functions/leds.sh
@@ -73,3 +73,7 @@ status_led_blink_failsafe() {
 status_led_blink_preinit_regular() {
 	led_timer $status_led 200 200
 }
+
+status_led_blink_pulse() {
+	[ "$#" -ge 2 ] && led_timer $status_led $1 $2 || led_timer $status_led 50 950
+}

--- a/package/base-files/files/lib/preinit/90_user_config_menu
+++ b/package/base-files/files/lib/preinit/90_user_config_menu
@@ -1,0 +1,129 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+# (c) 2019, Manuel Giganto <mgigantoregistros@gmail.com>
+
+config_wait_for_key () {
+	local options_limit=$1
+	local timeout=$2
+	local buttons_file=$3
+	local keypressed
+	local buttonspressed=0
+	local wait
+
+	wait="$(mktemp)" || wait=/tmp/.wait && touch $wait
+	local undo="lock -u $wait ; rm -f $wait"
+	trap "$undo" INT
+	trap "$undo" USR1
+
+	[ -n "$timeout" ] && [ $timeout -ge 1 ] || timeout=1
+	local gettime="date +%s"
+	local now=$($gettime)
+	local deadline=$(( $now + $timeout ))
+
+	lock $wait
+	{
+		sleep $timeout
+		lock -u $wait
+	} &
+
+	{
+		while [ "$now" -lt "$deadline" ] ; do
+			wait_time=$(( $deadline - $now ))
+			user_read=""
+			read -t "$wait_time" user_read
+			if [ "$user_read" -ge 0 -a "$user_read" -le "$options_limit" ] ; then
+				keypressed=$user_read
+				break
+			fi &>/dev/null
+			now=$($gettime)
+			[ "$now" -lt "$deadline" ] && echo -n "Option not valid. Choose 0-$options_limit: "
+		done
+		lock -u $wait
+	}
+
+	lock -w $wait
+	rm -f $wait
+
+	if [ -f "$buttons_file" ] ; then
+		set -- $(wc -l $buttons_file)
+		[ "$1" -le "$options_limit" ] && buttonspressed=$1
+		rm "$buttons_file"
+	fi
+
+	[ -n "$keypressed" ] && return $keypressed || return $buttonspressed
+}
+
+notice() {
+	echo "$@"
+	preinit_net_echo "$@"
+}
+
+user_config_menu() {
+	local user_config_options
+	local no_user_config
+	local user_config_wait_timeout
+
+	user_config_options=$(ls /etc/config-menu.d)
+	set -- $user_config_options
+	local options_limit=$#
+	no_user_config=$(uci -q get user.@config[0].no_user_config) ||
+		no_user_config=$pi_no_user_config
+	[ "$no_user_config" = "y" -o "$options_limit" -eq 0 ] && return
+
+	user_config_wait_timeout=$(uci -q get user.@config[0].user_config_wait_timeout) ||
+		user_config_wait_timeout=$pi_user_config_wait_timeout
+	[ -z "$user_config_wait_timeout" ] && user_config_wait_timeout=2
+	local buttons_hook=$(mktemp -d)
+	cp -pa /etc/rc.button/buttons "$buttons_hook"
+	mount --bind "$buttons_hook" /etc/rc.button/
+	/sbin/procd -h /etc/hotplug-config.json &
+	local procd_pid=$!
+
+	local undo="kill $procd_pid ; umount /etc/rc.button/ ; rm $buttons_hook/buttons && rmdir $buttons_hook"
+	trap "$undo" INT
+	trap "$undo" USR1
+
+	while true ; do
+		set_state config
+		notice "Please press the number or any button X times within [$user_config_wait_timeout] " \
+		       "seconds to switch the config:"
+		echo "0: Exit the menu and continue booting."
+		local NUMBER=0
+		for option in $user_config_options ; do
+			optionval=$(uci -q get user.@config[0].${option})
+			msg="$((++NUMBER)): $option=$optionval -> $((($optionval+1)%2))"
+			notice "$msg"
+		done
+		echo -n "Option: "
+
+		config_wait_for_key $options_limit $user_config_wait_timeout /tmp/buttons
+		option=$?
+		if [ "$option" -ge 1 ] ; then
+			local optionvar=$(eval echo "\$$option")
+			local optionval=$(uci -q get user.@config[0].$optionvar)
+			local optionvalnew=$(( ($optionval+1)%2 ))
+			if [ ! -f "/etc/config/user" ] ; then
+				touch "/etc/config/user"
+				uci add user config &> /dev/null
+			fi
+			uci set user.@config[0].$optionvar=$optionvalnew
+			uci commit user
+			/etc/config-menu.d/$optionvar $optionvalnew
+			notice "Config changed: $optionvar=$optionvalnew"
+			echo
+			set_state failsafe
+			sleep 1
+		else
+			echo
+			notice "Continue booting..."
+			break
+		fi
+	done
+
+	kill $procd_pid
+	umount /etc/rc.button/
+	rm "$buttons_hook/buttons" && rmdir "$buttons_hook"
+	set_state preinit_regular
+}
+
+boot_hook_add preinit_main user_config_menu

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -97,6 +97,33 @@ config TARGET_PREINIT_BROADCAST
 		Broadcast address to which to send preinit network messages, as
 		as failsafe messages
 
+config TARGET_PREINIT_USER_CONFIG_TIMEOUT
+	int
+	prompt "User config wait timeout" if PREINITOPT
+	default 4
+	help
+		How long to wait for a user interaction with the user config menu
+		before continuing with a regular boot.
+		Each time the user interactues with the user config menu, this timer
+		gets reseted.
+		This value can be changed latter with:
+		uci set user.@config[0].user_config_wait_timeout option.
+
+config TARGET_PREINIT_USER_CONFIG_DISABLED
+	bool
+	prompt "Disable user config menu" if PREINITOPT
+	default n
+	help
+		Disable the user config menu at preinit stage.
+		This value can be changed latter with
+		uci set user.@config[0].no_user_config option.
+
+config TARGET_PREINIT_USER_CONFIG_REMOVED
+	bool
+	prompt "Remove user config menu files" if ( PREINITOPT && TARGET_PREINIT_USER_CONFIG_DISABLED )
+	default n
+	help
+		Remove the user config menu files from the firmware.
 
 menuconfig INITOPT
 	bool "Init configuration options" if IMAGEOPT

--- a/target/linux/ar7/base-files/etc/diag.sh
+++ b/target/linux/ar7/base-files/etc/diag.sh
@@ -21,6 +21,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 

--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -575,6 +575,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		case $(board_name) in

--- a/target/linux/bcm53xx/base-files/etc/diag.sh
+++ b/target/linux/bcm53xx/base-files/etc/diag.sh
@@ -35,6 +35,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/brcm2708/base-files/etc/diag.sh
+++ b/target/linux/brcm2708/base-files/etc/diag.sh
@@ -28,6 +28,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/brcm47xx/base-files/etc/diag.sh
+++ b/target/linux/brcm47xx/base-files/etc/diag.sh
@@ -26,6 +26,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/brcm63xx/base-files/etc/diag.sh
+++ b/target/linux/brcm63xx/base-files/etc/diag.sh
@@ -154,6 +154,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		if [ "${status_led/power}" != "$status_led" ]; then
 			status_led_on

--- a/target/linux/kirkwood/base-files/etc/diag.sh
+++ b/target/linux/kirkwood/base-files/etc/diag.sh
@@ -48,6 +48,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/mvebu/base-files/etc/diag.sh
+++ b/target/linux/mvebu/base-files/etc/diag.sh
@@ -41,6 +41,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/mxs/base-files/etc/diag.sh
+++ b/target/linux/mxs/base-files/etc/diag.sh
@@ -31,6 +31,9 @@ set_state() {
 	preinit_regular)
 		status_led_blink_preinit_regular
 		;;
+	config)
+		status_led_blink_pulse
+		;;
 	done)
 		status_led_on
 		;;

--- a/target/linux/x86/base-files/etc/diag.sh
+++ b/target/linux/x86/base-files/etc/diag.sh
@@ -73,6 +73,10 @@ set_state() {
 		status_led_blink_preinit_regular
 		;;
 
+	config)
+		status_led_blink_pulse
+		;;
+
 	done)
 		status_led_on
 		;;


### PR DESCRIPTION
Add a user menu to configure parameters at preinit stage of boot.
This menu lets the user flip any number of options between 0/1,
the value of the option is saved in /etc/config/user, the values
can be retrieved with "get user.@config[0].<option>"

The default timeout is 4 seconds
The default menu has this options:
1:01_enable_wifi	(to be used to enable the wifi if there is no rfkill)
2:02_disable_firewall	(to be used to disable the firewall)

How to recognize when the device is on user config menu:
* The device status led will blink with pulses, staying most of the
  time off.
* If the netsend option is enabled, udp packets will be sent giving
  details about the available options.
* Using the device console

Example of blinks, including the new pulse style (2s scale)
Slow:                      `--------------------____________________`
Preinit (Fast):            `--__--__--__--__--__--__--__--__--__--__`
Failsafe:                  `_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-`
Preinit_regular:           `----____----____----____----____----____`
Pulse (with default time): `-___________________-___________________`

The pulse style accept 2 parameters to configure it, `<ms on> <ms off>`,
the default value if no values are given is 50 950, used to signal the
boot menu.

How to choose an option when the device in on the menu:
 * With a console, you can just type the option number.
 * With buttons, you can press any button X times to select option X
   and then wait until the menu ends the time (timeout). At this
   stage if you choose a valid option in the menu (pressed X times...)
   you will see an acknowledge of the valid option with a fast led
   status blink (failsafe) that will last for 1 second, and then the
   user config menu will begin again resetting the time and allowing
   the user to choose more options. When the user presses any button X
   times and X is higher than the available options on the menu, it
   is considered an invalid option and the device will continue
   booting.

Note that if there is too many options, you should consider an appropriate
timeout if you intend to press a button X times... a good choice could
be to consider 1s for each 2 seconds: Timeout = Options /2

While the device is running this menu, the buttons won't work as usual,
this allows the user to press any button regardless of the device, and it
should work even with the reset button. Buttons will work as usual when
the user config menu is over, so if you use the reset button to choose an
option, make sure you don´t press the button out of time... :)

The default user menu can be configured inside the preinit options in
config menu, it can be completely removed, it can be reconfigured or
disabled using a config file once the device is booted.

The options are configured populating files in folder /etc/config-menu.d,
the options will be order by name. When the user choose a valid option,
the script associated with that option in folder /etc/config-menu.d will
be executed with argument 0 or 1 (the current value flipped).

Enable/disable the menu using config file (0 enable, 1 disable):
  uci set user.@config[0].no_user_config=<1|0>
Add new options:
  Copy an script to the folder /etc/config-menu.d
Change the menu timeout (minimum 1):
  uci set user.@config[0].user_config_wait_timeout=<seconds>

This PR is related with but don't require:
PR https://github.com/openwrt/openwrt/pull/2408 (To enable/disable the wifi radio)

Signed-off-by: Manuel Giganto <mgigantoregistros@gmail.com>
