### PR TITLE
[18.06,19.07] build: fixup python SetupHostCommand to use python2

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -141,6 +141,8 @@ $(eval $(call SetupHostCommand,wget,Please install GNU 'wget', \
 $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
+$(eval $(call CleanupPython3))
+
 $(eval $(call SetupHostCommand,python,Please install Python 2.x, \
 	python2.7 -V 2>&1 | grep 'Python 2.7', \
 	python2 -V 2>&1 | grep 'Python 2', \

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -142,9 +142,9 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python 2.x, \
-	python2.7 -V 2>&1 | grep Python, \
-	python2 -V 2>&1 | grep Python, \
-	python -V 2>&1 | grep Python))
+	python2.7 -V 2>&1 | grep 'Python 2.7', \
+	python2 -V 2>&1 | grep 'Python 2', \
+	python -V 2>&1 | grep 'Python 2'))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
 	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -66,6 +66,18 @@ define RequireHeader
   $$(eval $$(call Require,$(1),$(2)))
 endef
 
+define CleanupPython3
+  define Require/python3-cleanup
+	if [ -f "$(STAGING_DIR_HOST)/bin/python" ] && \
+		$(STAGING_DIR_HOST)/bin/python -V 2>&1 | \
+		grep -q 'Python 3'; then \
+			rm $(STAGING_DIR_HOST)/bin/python; \
+	fi
+  endef
+
+  $$(eval $$(call Require,python3-cleanup))
+endef
+
 define QuoteHostCommand
 '$(subst ','"'"',$(strip $(1)))'
 endef


### PR DESCRIPTION
~~On some distributions (Fedora 31 at least), python now points to python3
I did a full build of ath79 in a Fedora 31 container without `python` in the PATH (only `python2` / `python3`) and the only python related failure that I see is mailman that explicitly uses `/usr/bin/python`~~

This replaces #2530

Edit: 
Here is a way to break your build env without this patch:
1) have python point to python3, and no python2
2) start the build, SetupHostCommand will create a symlink
./staging_dir/host/bin/python -> /usr/bin/python
3) build fails on scons because it can't find any python2
4) install python2 and restart the build
5) the build fails on wireless-regdb compile because python is python3 instead of python2
