### PR TITLE
lantiq: fritz7320: fix wireless led trigger

### DIFF
--- a/target/linux/lantiq/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/base-files/etc/board.d/01_leds
@@ -57,9 +57,6 @@ avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron)
 	ucidef_set_led_switch "lan" "LAN" "fritz3370:green:lan" "switch0" "0x17"
 	;;
-avm,fritz7320)
-	ucidef_set_led_netdev "wifi" "wifi" "fritz7320:green:wlan" "wlan0"
-	;;
 zyxel,p-2812hnu-f1|\
 zyxel,p-2812hnu-f3)
 	ucidef_set_led_wlan "wifi" "wifi" "p2812hnufx:green:wlan" "phy0radio"


### PR DESCRIPTION
The led wireless trigger is set wrong.
It is set correctly to phy0tpt without specifying it here.