### PR TITLE
ramips: add support for ZIO FREEZIO

### DIFF
--- a/target/linux/ramips/dts/mt7621_zio_freezio.dts
+++ b/target/linux/ramips/dts/mt7621_zio_freezio.dts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zio,freezio", "mediatek,mt7621-soc";
+	model = "ZIO FREEZIO";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "freezio:green:usb";
+			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&state_default {
+	gpio {
+		ralink,group = "wdt", "rgmii2";
+		ralink,function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -908,3 +908,12 @@ define Device/zbtlink_zbt-wg3526-32m
   SUPPORTED_DEVICES += ac1200pro zbt-wg3526-32M
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-32m
+
+define Device/zio_freezio
+  MTK_SOC := mt7621
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := ZIO
+  DEVICE_MODEL := FREEZIO
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += zio_freezio

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -45,7 +45,8 @@ ramips_setup_interfaces()
 	netgear,wndr3700-v5|\
 	netis,wf-2881|\
 	wevo,11acnas|\
-	wevo,w2914ns-v2)
+	wevo,w2914ns-v2|\
+	zio,freezio)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
@@ -226,7 +227,8 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
 	wevo,11acnas|\
-	wevo,w2914ns-v2)
+	wevo,w2914ns-v2|\
+	zio,freezio)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$wan_mac
 		;;


### PR DESCRIPTION
ZIO FREEZIO is a 2.4/5GHz band AC1200 router, based on MediaTek MT7621A.

Specifications:
- SoC: MT7621AT
- RAM: DDR3 128MB
- Flash: SPI NOR 16MB
- WiFi:
  - 2.4GHz: MT7603EN
  - 5GHz: MT7612EN
- Ethernet: 5x 10/100/1000Mbps
  - Switch: SoC internal
- USB: 1x 3.0
- UART:
  - J4: 3.3V, RX, TX, GND (3.3V is the square pad) / 57600 8N1

Notes:
- FREEZIO has almost the same board as WeVO W2914NS v2.
- Stock firmware is based on OpenWrt BB.

Installation via web interface:
1.  Access web admin page and turn on "OpenWrt UI mode".
2.  Flash sysupgrade image through LuCI, with the "Keep settings" option
    OFF.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.
    Make sure to NOT preserve settings.