### PR TITLE
ramips: add support for ipTIME A6ns-M

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a6ns-m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a6ns-m.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iptime,a6ns-m", "mediatek,mt7621-soc";
+	model = "ipTIME A6ns-M";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "a6ns-m:blue:usb";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan5g {
+			label = "a6ns-m:blue:wlan5g";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan2g {
+			label = "a6ns-m:blue:wlan2g";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led_cpu: cpu {
+			label = "a6ns-m:blue:cpu";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "uart3", "jtag", "wdt";
+		ralink,function = "gpio";
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc20>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -361,6 +361,16 @@ define Device/iodata_wnpr2600g
 endef
 TARGET_DEVICES += iodata_wnpr2600g
 
+define Device/iptime_a6ns-m
+  MTK_SOC := mt7621
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a6nm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A6ns-M
+  DEVICE_PACKAGES := kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+endef
+TARGET_DEVICES += iptime_a6ns-m
+
 define Device/lenovo_newifi-d1
   MTK_SOC := mt7621
   IMAGE_SIZE := 32448k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -59,6 +59,7 @@ ramips_setup_interfaces()
 	asus,rt-ac65p|\
 	asus,rt-ac57u|\
 	asus,rt-ac85p|\
+	iptime,a6ns-m|\
 	mikrotik,rb750gr3|\
 	ubiquiti,edgerouterx|\
 	ubiquiti,edgerouterx-sfp|\
@@ -217,6 +218,9 @@ ramips_setup_macs()
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
+		;;
+	iptime,a6ns-m)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
 	mediatek,ap-mt7621a-v60)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x5)" 1)


### PR DESCRIPTION
ipTIME A6ns-M is a 2.4/5GHz band AC1900 router, based on MediaTek MT7621A.

Specifications:
- SoC: MT7621AT
- RAM: DDR3 128MB
- Flash: SPI NOR 16MB
- WiFi:
  - 2.4GHz: MT7615
  - 5GHz: MT7615
- Ethernet: 5x 10/100/1000Mbps
  - Switch: SoC internal
- UART:
  - J4: 3.3V, TX, RX, GND (3.3V is the square pad) / 57600 8N1

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.