### PR TITLE
ramips: improve Samsung CY-SWR1100 support

### DIFF
--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -10,8 +10,10 @@
 	model = "Samsung CY-SWR1100";
 
 	aliases {
-		led-boot = &led_wps;
-		led-failsafe = &led_wps;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 	};
 
 	nor-flash@1c000000 {
@@ -88,7 +90,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_wps: wps {
+		wps {
 			label = "cy-swr1100:blue:wps";
 			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
@@ -100,7 +102,7 @@
 			linux,default-trigger = "usbport";
 		};
 
-		power {
+		led_power: power {
 			label = "cy-swr1100:blue:power";
 			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -49,8 +49,9 @@
 			};
 
 			partition@40000 {
-				label = "devdata";
+				label = "devconf";
 				reg = <0x40000 0x10000>;
+				read-only;
 			};
 
 			partition@50000 {
@@ -69,8 +70,7 @@
 	};
 
 	keys {
-		compatible = "gpio-keys-polled";
-		poll-interval = <100>;
+		compatible = "gpio-keys";
 
 		reset {
 			label = "reset";
@@ -98,6 +98,11 @@
 			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 			trigger-sources = <&ohci_port1>, <&ehci_port1>;
 			linux,default-trigger = "usbport";
+		};
+
+		power {
+			label = "cy-swr1100:blue:power";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -130,9 +135,8 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci0,0";
+		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
-		ralink,5ghz = <0>;
 		ralink,mtd-eeprom = <&factory 0x2000>;
 	};
 };

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -89,7 +89,7 @@ define Device/samsung_cy-swr1100
   SEAMA_SIGNATURE := wrgnd10_samsung_ss815
   DEVICE_VENDOR := Samsung
   DEVICE_MODEL := CY-SWR1100
-  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 swconfig
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport swconfig
   SUPPORTED_DEVICES += cy-swr1100
 endef
 TARGET_DEVICES += samsung_cy-swr1100

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ ramips_setup_macs()
 	samsung,cy-swr1100)
 		lan_mac=$(mtd_get_mac_ascii nvram lanmac)
 		wan_mac=$(mtd_get_mac_ascii nvram wanmac)
+		label_mac=$wan_mac
 		;;
 	sitecom,wlr-6000)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x8004)" 2)

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -70,7 +70,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary devdata 0x7)
 		;;
 	samsung,cy-swr1100)
-		lan_mac=$(mtd_get_mac_ascii factory lanmac)
+		lan_mac=$(mtd_get_mac_ascii nvram lanmac)
+		wan_mac=$(mtd_get_mac_ascii nvram wanmac)
 		;;
 	sitecom,wlr-6000)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x8004)" 2)


### PR DESCRIPTION
This patch does the following:

- rename flash partitions
- switch from gpio-keys-polled to gpio-keys
- add power LED and use it as status LED
- set correct PCI ID to compatible string in wifi node
- remove ralink,5ghz property in wifi node
- fix LAN/WAN MAC addresses and provide label MAC address
- add kmod-usb-ledtrig-usbport to DEVICE_PACKAGES

Rename devdata partition to devconf as indicated in the stock firmware
partition table:
00030000-00040000: "devdata"
00040000-00050000: "devconf"

Power LED can be controlled by SoC GPIO. Use power LED for status
indication and free WPS LED for other uses.

RT3092L supports only bgn mode, so it is unnecessary to disable 5GHz band.

Ethernet MAC address setup has been broken since c3e420f28cf1. Restore
original setting.