### PR TITLE
base-files: let config_generate split ifname containing multiple ifaces

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=207
+PKG_RELEASE:=208
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -85,12 +85,27 @@ generate_network() {
 		set network.$1.proto='none'
 	EOF
 
-	[ -n "$macaddr" ] && uci -q batch <<-EOF
-		delete network.$1_dev
-		set network.$1_dev='device'
-		set network.$1_dev.name='$ifname'
-		set network.$1_dev.macaddr='$macaddr'
-	EOF
+	[ -n "$macaddr" ] && case "$ifname" in
+	*\ *)
+		uci -q delete network.$1_dev
+		for name in $ifname; do
+			uci -q batch <<-EOF
+				delete network.${name/./_}_dev
+				set network.${name/./_}_dev='device'
+				set network.${name/./_}_dev.name='$name'
+				set network.${name/./_}_dev.macaddr='$macaddr'
+			EOF
+		done
+		;;
+	*)
+		uci -q batch <<-EOF
+			delete network.$1_dev
+			set network.$1_dev='device'
+			set network.$1_dev.name='$ifname'
+			set network.$1_dev.macaddr='$macaddr'
+		EOF
+		;;
+	esac
 
 	case "$protocol" in
 		static)


### PR DESCRIPTION
netifd does not handle network.@device[x].name properly if it contains
multiple ifaces separated by spaces. Due to this, board.d lan_mac setup
does not work if multiple ifaces are set to LAN by ucidef_set_interface_lan.
It can be fixed by creating device sections for each iface in config_generate.