### PR TITLE
ramips: switch from set_usb_led to ucidef_set_led_usbport

### DIFF
--- a/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
@@ -18,7 +18,7 @@ led_wlan="$(get_dt_led wlan)"
 
 case $board in
 belkin,f9k1109v1)
-	set_usb_led "$boardname:green:usb1"
+	ucidef_set_led_usbport "usb" "USB" "$boardname:green:usb1" "usb1-port1"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:blue:wps" "eth0"
 	;;
 edimax,br-6475nd)


### PR DESCRIPTION
set_usb_led() was removed in 772b27c20736. Use ucidef_set_led_usbport() instead.

Fixes: f2c83532f92c ("ramips: add support for Belkin F9K1109v1")