### PR TITLE
gre: add ipv6 parameter to gre interfaces

### DIFF
--- a/package/network/config/gre/files/gre.sh
+++ b/package/network/config/gre/files/gre.sh
@@ -13,8 +13,8 @@ gre_generic_setup() {
 	local local="$3"
 	local remote="$4"
 	local link="$5"
-	local mtu ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
-	json_get_vars mtu ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
+	local mtu ipv6 ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
+	json_get_vars mtu ipv6 ttl tos zone ikey okey icsum ocsum iseqno oseqno multicast
 
 	[ -z "$multicast" ] && multicast=1
 
@@ -23,6 +23,7 @@ gre_generic_setup() {
 	proto_add_tunnel
 	json_add_string mode "$mode"
 	json_add_int mtu "${mtu:-1280}"
+	json_add_boolean ipv6 "${ipv6:-1}"
 	[ -n "$df" ] && json_add_boolean df "$df"
 	[ -n "$ttl" ] && json_add_int ttl "$ttl"
 	[ -n "$tos" ] && json_add_string tos "$tos"
@@ -248,6 +249,7 @@ gre_generic_init_config() {
 	available=1
 
 	proto_config_add_int "mtu"
+	proto_config_add_boolean "ipv6"
 	proto_config_add_int "ttl"
 	proto_config_add_string "tos"
 	proto_config_add_string "tunlink"


### PR DESCRIPTION
IPv6 protocol is enabled on all gre interfaces, but gre(v6)tap
interfaces are usually added to a bridge interface, in which case
IPv6 should be enabled only on the bridge interface.

@dedeckeh I've test it with these commands:
root@mymodem:~# uci show network.gt1
network.gt1=interface
network.gt1.proto='gretap'
network.gt1.tunlink='titan'
network.gt1.peer='1.2.3.4'
network.gt1.peeraddr='1.2.3.4'
network.gt1.mtu='1500'
root@mymodem:~# ip a show dev gre4t-gt1
59: gre4t-gt1@vlan_wan_1ip: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether e6:75:ac:3c:35:46 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::e475:acff:fe3c:3546/64 scope link 
       valid_lft forever preferred_lft forever
root@mymodem:~# uci set network.gt1.ipv6=0
root@mymodem:~# ifup gt1
root@mymodem:~# ip a show dev gre4t-gt1
67: gre4t-gt1@vlan_wan_1ip: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 8e:ec:14:95:02:40 brd ff:ff:ff:ff:ff:ff


