### PR TITLE
base-files: rc.common: show supplied EXTRA_HELP

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -109,7 +109,7 @@ ${INIT_TRACE:+set -x}
 	EXTRA_HELP="\
 	running	Check if service is running
 	status	Service status
-	"
+${EXTRA_HELP}"
 
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")


### PR DESCRIPTION
If packages USE_PROCD, then append the EXTRA_HELP of the packages. Until
now the packages EXTRA_HELP was replaced by the help for extra commands of
procd and if a package supplied help for other commands, it was discarded.

Signed-off-by: Peter Stadler <peter.stadler@student.uibk.ac.at>