### PR TITLE
ramips: LED_POLARITY rt3050-esw on MT7628AN/MT7688

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/esw_rt3050.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/esw_rt3050.c
@@ -617,6 +617,10 @@ static void esw_hw_init(struct rt305x_esw *esw)
 		/* reset EPHY */
 		fe_reset(RT5350_RESET_EPHY);
 
+		/* set the led polarity */
+		esw_w32(esw, esw->reg_led_polarity & 0x1F,
+			RT5350_EWS_REG_LED_POLARITY);
+
 		rt305x_mii_write(esw, 0, 31, 0x2000); /* change G2 page */
 		rt305x_mii_write(esw, 0, 26, 0x0020);
 


### PR DESCRIPTION
The device tree property "mediatek,led_polarity" is ignored for
MT7628AN and MT7688. According to the datasheet both SoCs have
the matching register. Therefore the property should be applied
on these two devices as well.
