### PR TITLE
brcm47xx: add switch configuration for WNR3500L

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -170,7 +170,8 @@ configure_by_model() {
 		;;
 
 	"Asus RT-N16"* | \
-	"Linksys E3000 V1")
+	"Linksys E3000 V1" | \
+	"Netgear WNR3500L")
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "8@eth0"
 		;;


### PR DESCRIPTION
Netgear WNR3500L is an already supported device, but out of the box, the device has no switch configuration and there is no wan. The correct configuration for this specific model is similar to
some other models. This simple commit adds the correct switch and the out-of-the-box experience is improved.