### PR TITLE
Busybox: Hides menuconfig compile breaking option when using musl-libc

### DIFF
--- a/package/utils/busybox/config/editors/Config.in
+++ b/package/utils/busybox/config/editors/Config.in
@@ -128,6 +128,7 @@ config BUSYBOX_CONFIG_FEATURE_VI_REGEX_SEARCH
 	bool "Enable regex in search and replace"
 	default BUSYBOX_DEFAULT_FEATURE_VI_REGEX_SEARCH   # Uses GNU regex, which may be unavailable. FIXME
 	depends on BUSYBOX_CONFIG_FEATURE_VI_SEARCH
+	depends on CONFIG_USE_GLIBC   # musl libc does not support GNU regex
 	help
 	Use extended regex search.
 


### PR DESCRIPTION
When using musl-libc enabling BUSYBOX_DEFAULT_FEATURE_VI_REGEX_SEARCH causes compile to fail. This is due to missing gnu regex in musl-libc as mentioned here:
 https://wiki.musl-libc.org/functional-differences-from-glibc.html

This should fix the compile error mentioned in these places:

https://forum.openwrt.org/t/busybox-not-compiling/
https://github.com/openwrt/packages/issues/4453
https://dev.archive.openwrt.org/ticket/21741.html

Signed-off-by: Satadru Pramanik <satadru@umich.edu>