### PR TITLE
uboot-envtools: add support for gl-[ar150|domino|mifi]

### DIFF
--- a/package/boot/uboot-envtools/files/ar71xx
+++ b/package/boot/uboot-envtools/files/ar71xx
@@ -85,6 +85,11 @@ dr342|\
 dr531)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0xf800" "0x10000"
 	;;
+gl-ar150|\
+gl-domino|\
+gl-mifi)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
+	;;
 rambutan)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	ubootenv_add_uci_config "/dev/mtd1" "0x100000" "0x20000" "0x20000"

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -44,6 +44,9 @@ yuncore,xd4200)
 buffalo,wzr-hp-ag300h)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
 	;;
+glinet,gl-ar150)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
+	;;
 netgear,wndr3700)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x10000"
 	;;

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -462,7 +462,7 @@ define Device/gl-ar150
   BOARDNAME := GL-AR150
   IMAGE_SIZE := 16000k
   CONSOLE := ttyATH0,115200
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),16000k(firmware),64k(art)ro
 endef
 TARGET_DEVICES += gl-ar150
 
@@ -516,7 +516,7 @@ define Device/gl-domino
   BOARDNAME := DOMINO
   IMAGE_SIZE := 16000k
   CONSOLE := ttyATH0,115200
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),16000k(firmware),64k(art)ro
 endef
 TARGET_DEVICES += gl-domino
 
@@ -526,7 +526,7 @@ define Device/gl-mifi
   BOARDNAME := GL-MIFI
   IMAGE_SIZE := 16000k
   CONSOLE := ttyATH0,115200
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),16000k(firmware),64k(art)ro
 endef
 TARGET_DEVICES += gl-mifi
 


### PR DESCRIPTION
ar71xx: Change u-boot-env partition writable

Changed u-boot-env partition mount rw for:
gl-ar150
gl-domino
gl-mifi

uboot-envtools: Add ubootenv uci_config

Added ubootenv uci_config for:
gl-ar150
gl-domino
gl-mifi

Signed-off-by: Kimmo Vuorinen <kimmo.vuorinen@gmail.com>