### PR TITLE
[RFT] ath79: add PoE passthrough switch for Nanostation (XM/XW)

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -52,6 +52,12 @@ tplink,wbs210-v2)
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;
+ubnt,nanostation-m)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "8"
+	;;
+ubnt,nanostation-m-xw)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "2"
+	;;
 ubnt,acb-isp)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
 	;;


### PR DESCRIPTION
This adds the gpio switch to enable PoE passthrough on Ubiquiti
Nanostation (XM/XW).

Values are copied from the implementation in ar71xx.