### PR TITLE
ath79: add Support for the TP-LINK WBS510 v1.0/v2.0 Device 

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_wbs510-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_wbs510-v1.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpexxx-v1.dtsi"
+
+/ {
+	compatible = "tplink,wbs510-v1", "qca,ar9344";
+	model = "TP-Link WBS510 v1";
+};
+
+&led_link4 {
+	gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/ath79/dts/ar9344_tplink_wbs510-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_wbs510-v2.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpexxx-v1.dtsi"
+
+/ {
+	compatible = "tplink,wbs510-v2", "qca,ar9344";
+	model = "TP-Link WBS510 v2";
+};
+
+&led_link4 {
+	gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -176,6 +176,7 @@ tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
 tplink,wbs210-v2|\
+tplink,wbs510-v1|\
 tplink,wbs510-v2)
 	ucidef_set_led_netdev "lan0" "LAN0" "tp-link:green:lan0" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -175,7 +175,8 @@ tplink,cpe210-v1|\
 tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
-tplink,wbs210-v2)
+tplink,wbs210-v2|\
+tplink,wbs510-v2)
 	ucidef_set_led_netdev "lan0" "LAN0" "tp-link:green:lan0" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x10"
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -92,6 +92,7 @@ ath79_setup_interfaces()
 	tplink,cpe220-v3|\
 	tplink,cpe510-v1|\
 	tplink,wbs210-v2|\
+	tplink,wbs510-v1|\
 	tplink,wbs510-v2|\
 	ubnt,nanostation-m|\
 	ubnt,routerstation)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -92,6 +92,7 @@ ath79_setup_interfaces()
 	tplink,cpe220-v3|\
 	tplink,cpe510-v1|\
 	tplink,wbs210-v2|\
+	tplink,wbs510-v2|\
 	ubnt,nanostation-m|\
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -46,7 +46,8 @@ tplink,cpe210-v1|\
 tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
-tplink,wbs210-v2)
+tplink,wbs210-v2|\
+tplink,wbs510-v2)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;
 ubnt,nanostation-ac)

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -47,6 +47,7 @@ tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
 tplink,wbs210-v2|\
+tplink,wbs510-v1|\
 tplink,wbs510-v2)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -548,3 +548,14 @@ define Device/tplink_wbs210-v2
   TPLINK_BOARD_ID := WBS210V2
 endef
 TARGET_DEVICES += tplink_wbs210-v2
+
+define Device/tplink_wbs510-v2
+  $(Device/tplink-loader-okli)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := WBS510
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := WBS510V2
+endef
+TARGET_DEVICES += tplink_wbs510-v2

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -549,6 +549,18 @@ define Device/tplink_wbs210-v2
 endef
 TARGET_DEVICES += tplink_wbs210-v2
 
+define Device/tplink_wbs510-v1
+  $(Device/tplink-loader-okli)
+  ATH_SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := WBS510
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := WBS510
+  SUPPORTED_DEVICES += wbs510
+endef
+TARGET_DEVICES += tplink_wbs510-v1
+
 define Device/tplink_wbs510-v2
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -570,6 +570,39 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "support-list",
 	},
 
+	{
+		.id	= "WBS510V2",
+		.vendor	= "CPE510(TP-LINK|UN|N300-5):1.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"WBS510(TP-LINK|UN|N300-5|00000000):2.0\r\n"
+			"WBS510(TP-LINK|US|N300-5|55530000):2.0\r\n"
+			"WBS510(TP-LINK|EU|N300-5|45550000):2.0\r\n"
+			"WBS510(TP-LINK|CA|N300-5|43410000):2.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x200000},
+			{"file-system", 0x240000, 0x570000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
 	/** Firmware layout for the C2600 */
 	{
 		.id = "C2600",

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -545,7 +545,8 @@ static struct device_info boards[] = {
 			"SupportList:\r\n"
 			"WBS510(TP-LINK|UN|N300-5):1.20\r\n"
 			"WBS510(TP-LINK|US|N300-5):1.20\r\n"
-			"WBS510(TP-LINK|EU|N300-5):1.20\r\n",
+			"WBS510(TP-LINK|EU|N300-5):1.20\r\n"
+			"WBS510(TP-LINK|CA|N300-5):1.20\r\n",
 		.support_trail = '\xff',
 		.soft_ver = NULL,
 


### PR DESCRIPTION
This adds support for a popular low-cost 5GHz N based AP

Specifications:
- SoC: Atheros AR9344
- RAM: 64MB
- Storage: 8 MB SPI NOR
- Wireless: 5GHz 300 Mbps, 2x RP-SMA connector, 27 dBm TX power
- Ethernet: 1x 10/100 Mbps with 24V POE IN, 1x 10/100 Mbps

Installation:
Flash factory image through stock firmware WEB UI
or through TFTP
To get to TFTP recovery just hold reset button while powering on for
around 4-5 seconds and release.
Rename factory image to recovery.bin
Stock TFTP server IP:192.168.0.100
Stock device TFTP adress:192.168.0.254

Signed-off-by: Andrew Cameron apcameron@softhome.net

[wbs510v2_dmesg.txt](https://github.com/openwrt/openwrt/files/3861372/wbs510v2_dmesg.txt)
[wbs510v1_dmesg.txt](https://github.com/openwrt/openwrt/files/3861373/wbs510v1_dmesg.txt)
