### PR TITLE
toolchain/gcc: correct the check expr for newer clang

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -89,7 +89,7 @@ endif
 
 GCC_CONFIGURE:= \
 	SHELL="$(BASH)" \
-	$(if $(shell gcc --version 2>&1 | grep LLVM), \
+	$(if $(shell gcc --version 2>&1 | grep -E "Apple.(LLVM|clang)"), \
 		CFLAGS="-O2 -fbracket-depth=512 -pipe" \
 		CXXFLAGS="-O2 -fbracket-depth=512 -pipe" \
 	) \


### PR DESCRIPTION
This fixes gcc build error within clang 11.0, it tweaks the version string from LLVM to clang as the following:

```
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Apple clang version 11.0.0 (clang-1100.0.33.12)
```

And the build error looks like `fatal error: bracket nesting level exceeded maximum of 256` that gets fixed at 479c256 for clang <10.