### PR TITLE
ath79: fix label MAC address location for Ubiquiti XM devices

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -282,12 +282,7 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_binary "Board data" 2)
 		label_mac=$lan_mac
 		;;
-	alfa-network,ap121f|\
-	ubnt,airrouter|\
-	ubnt,bullet-m|\
-	ubnt,nanostation-m|\
-	ubnt,rocket-m|\
-	ubnt,unifi)
+	alfa-network,ap121f)
 		label_mac=$(mtd_get_mac_binary art 0x1002)
 		;;
 	avm,fritz300e)
@@ -391,6 +386,13 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text mac 0x4)
 		wan_mac=$(mtd_get_mac_text mac 0x18)
 		label_mac=$wan_mac
+		;;
+	ubnt,airrouter|\
+	ubnt,bullet-m|\
+	ubnt,nanostation-m|\
+	ubnt,rocket-m|\
+	ubnt,unifi)
+		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	ubnt,routerstation|\
 	ubnt,routerstation-pro)


### PR DESCRIPTION
The MAC address of phy0 for Ubiquiti XM devices seems to be located
in caldata with an offset of 0x20c. Adjust extraction of label MAC
address accordingly.

For alfa-network,ap121f the location 0x1002 is kept, as this has
been verified during device support preparation.

This has been tested on Picostation M2 (bullet-m) image.

Fixes: d421a8b94489 ("ath79: read label MAC address from flash
instead of using phy0/phy1")