### PR TITLE
[RFC/RFT] ar71xx: fix RSSI LED support on Ubiquiti Rocket-M Titanium

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
@@ -724,12 +724,13 @@ rme-eg200)
         ucidef_set_led_default "etactica" "etactica" "eg200:red:etactica" "ignore"
         ;;
 rocket-m-ti)
-	ucidef_set_led_rssi "rssiverylow" "RSSIVERYLOW" "ubnt:green:link1" "wlan0" "1" "100" "0" "13"
-	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:green:link2" "wlan0" "26" "100" "-25" "13"
-	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:green:link3" "wlan0" "51" "100" "-50" "13"
-	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link4" "wlan0" "76" "100" "-75" "13"
-	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link5" "wlan0" "76" "100" "-75" "13"
-	ucidef_set_led_rssi "rssiveryhigh" "RSSIVERYHIGH" "ubnt:green:link4" "wlan0" "76" "100" "-75" "13"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssiverylow" "RSSIVERYLOW" "ubnt:green:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:green:link2" "wlan0" "18" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:green:link3" "wlan0" "34" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "ubnt:green:link4" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link5" "wlan0" "67" "100"
+	ucidef_set_led_rssi "rssiveryhigh" "RSSIVERYHIGH" "ubnt:green:link6" "wlan0" "84" "100"
 	;;
 rut900)
 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth1"

--- a/target/linux/ar71xx/image/generic-ubnt.mk
+++ b/target/linux/ar71xx/image/generic-ubnt.mk
@@ -217,6 +217,7 @@ TARGET_DEVICES += ubnt-rocket-m-xw
 define Device/ubnt-rocket-m-ti
   $(Device/ubnt-xw)
   DEVICE_TITLE := Ubiquiti Rocket M TI
+  DEVICE_PACKAGES += rssileds
   BOARDNAME := UBNT-RM-TI
   UBNT_TYPE := TI
 endef


### PR DESCRIPTION
Inspired by #2551 I decided to backport RSSI LED support for Ubiquiti devices supported to ar71xx as well.
This PR enables 'rssileds' package by default on all Ubitquit XM and XW devices which have them, as per-device package (instead of adding them globally for "boards", as for example, Airrouter doesn't have those LEDS despite being an XM device).

For extra consistency, I also updated LED definitions and RSSI monitor for Rocket M Titanium, but i have no way to test it out on actual hardware, so a review or a test from @lynxis would be very welcome.

When backporting, please do not forget commit 7ebbbda29377f2d95e2bb9690f348af50ade848a in master, which fixes RSSI monitor configuration for those devices (except Rocket-M TI), but does not enable rssileds package.

Build tested on: UBNT Rocket-M, Nano-M, Bullet-M (XM and XW), Rocktet-M TI.
Run tested on: UBNT Nanobridge M5.
