### PR TITLE
glibc: backport fix for regexec buffer read overrun (BZ#24114)

### DIFF
--- a/toolchain/glibc/patches/001-regex-read-overrun.patch
+++ b/toolchain/glibc/patches/001-regex-read-overrun.patch
@@ -1,0 +1,26 @@
+commit 583dd860d5b833037175247230a328f0050dbfe9
+Author: Paul Eggert <eggert@cs.ucla.edu>
+Date:   Mon Jan 21 11:08:13 2019 -0800
+
+    regex: fix read overrun [BZ #24114]
+    
+    Problem found by AddressSanitizer, reported by Hongxu Chen in:
+    https://debbugs.gnu.org/34140
+    * posix/regexec.c (proceed_next_node):
+    Do not read past end of input buffer.
+
+--- a/posix/regexec.c
++++ b/posix/regexec.c
+@@ -1293,8 +1293,10 @@ proceed_next_node (const re_match_context_t *mctx, Idx nregs, regmatch_t *regs,
+ 	      else if (naccepted)
+ 		{
+ 		  char *buf = (char *) re_string_get_buffer (&mctx->input);
+-		  if (memcmp (buf + regs[subexp_idx].rm_so, buf + *pidx,
+-			      naccepted) != 0)
++		  if (mctx->input.valid_len - *pidx < naccepted
++		      || (memcmp (buf + regs[subexp_idx].rm_so, buf + *pidx,
++				  naccepted)
++			  != 0))
+ 		    return -1;
+ 		}
+ 	    }


### PR DESCRIPTION
Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

@dedeckeh I've reproduced the issue on an x86 openwrt build with
```
CONFIG_PACKAGE_valgrind=y
CONFIG_PACKAGE_valgrind-cachegrind=y
CONFIG_PACKAGE_valgrind-callgrind=y
CONFIG_PACKAGE_valgrind-massif=y
CONFIG_BUSYBOX_CONFIG_EXTRA_COMPAT=y
```
With current glibc:
```
root@OpenWrt:~# printf xxxxxxxxxxxxxx \|valgrind grep -i '\(\(\)*.\)*\1'
--
==5208== Memcheck, a memory error detector
==5208== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5208== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5208== Command: grep -i \\(\\(\\)*.\\)*\\1
==5208==
==5208== Invalid read of size 1
==5208==    at 0x483A873: __memcmp_sse2 (vg_replace_strmem.c:1111)
==5208==    by 0x4AFD2D2: proceed_next_node (regexec.c:1275)
==5208==    by 0x4AFD2D2: set_regs (regexec.c:1432)
==5208==    by 0x4AFE57E: re_search_internal (regexec.c:846)
==5208==    by 0x4AFEF54: re_search_stub (regexec.c:420)
==5208==    by 0x4AFF84F: re_search (regexec.c:291)
==5208==    by 0x4083F9: grep_file (in /bin/busybox)
==5208==    by 0x100001101: ???
==5208==  Address 0x4bed75e is 0 bytes after a block of size 14 alloc'd
==5208==    at 0x4837860: realloc (vg_replace_malloc.c:836)
==5208==    by 0x4AF11FB: re_string_realloc_buffers (regex_internal.c:157)
==5208==    by 0x4AF231A: extend_buffers (regexec.c:4034)
==5208==    by 0x4AFC0B9: get_subexp (regexec.c:2721)
==5208==    by 0x4AFC0B9: transit_state_bkref (regexec.c:2542)
```
With patched glibc:
```
root@OpenWrt:~# printf xxxxxxxxxxxxxx \|valgrind grep -i '\(\(\)*.\)*\1'
--
==5532== Memcheck, a memory error detector
==5532== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5532== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5532== Command: grep -i \\(\\(\\)*.\\)*\\1
==5532==
xxxxxxxxxxxxxx
==5532==
==5532== HEAP SUMMARY:
==5532==     in use at exit: 10,452 bytes in 91 blocks
==5532==   total heap usage: 589 allocs, 498 frees, 36,254 bytes allocated
==5532==
==5532== LEAK SUMMARY:
==5532==    definitely lost: 0 bytes in 0 blocks
==5532==    indirectly lost: 0 bytes in 0 blocks
==5532==      possibly lost: 0 bytes in 0 blocks
==5532==    still reachable: 10,452 bytes in 91 blocks
==5532==         suppressed: 0 bytes in 0 blocks
==5532== Rerun with --leak-check=full to see details of leaked memory
==5532==
==5532== For lists of detected and suppressed errors, rerun with: -s
==5532== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
