### PR TITLE
ath79: add support for Zsun-SD100

### DIFF
--- a/target/linux/ath79/dts/ar9331_zsun_sd100.dts
+++ b/target/linux/ath79/dts/ar9331_zsun_sd100.dts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "Zsun SD100";
+	compatible = "zsun,sd100", "qca,ar9331";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "sd100:green:status";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		sdcard_event {
+			label = "sdcard_event";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		sdreader_reset {
+			gpio-export,name = "sdreader_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		sdreader_switch {
+			gpio-export,name = "sdreader_switch";
+			gpio-export,output = <0>;
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-chipselects = <0>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <104000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				label = "u-boot-env";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xbc0000>;
+			};
+
+			partition@be0000 {
+				label = "recovery";
+				reg = <0xbe0000 0x400000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "nvram";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+
+	compatible = "generic-ehci";
+	reg = <0x1b000000 0x1000>;
+
+	has-transaction-translator;
+	caps-offset = <0x100>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -274,6 +274,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan:1" "4:lan:2"
 		;;
+	zsun,sd100)
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1099,3 +1099,12 @@ define Device/zbtlink_zbt-wd323
 	kmod-usb-serial kmod-usb-serial-cp210x uqmi
 endef
 TARGET_DEVICES += zbtlink_zbt-wd323
+
+define Device/zsun_sd100
+  SOC := ar9331
+  DEVICE_VENDOR := Zsun
+  DEVICE_MODEL := SD100
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-storage
+  IMAGE_SIZE := 12032k
+endef
+TARGET_DEVICES += zsun_sd100


### PR DESCRIPTION
Zsun-SD100 is a USB WiFi SD Card Reader that uses an Atheros AR9331 WiSoC.

Specifications:
 - SoC: Atheros AR9331 (400MHz)
 - RAM: 64MB
 - Storage: 16MB SPI NOR
 - Wireless: 2.4GHz 150Mbps (802.11n 1x1)
 - Ethernet: <none, but can be added with external MagJack>

Location of MAC addresses in flash:
 - ```eth0   00:03:7f:11:56:48  <&art 0x0>```
 - ```eth1   00:03:7f:11:56:49  <&art 0x6>```
 - ```wlan0  a0:03:*            <&art 0x1002>```

Special considerations:
 - The factory u-boot uses a kernel boot offset of ```0x9FEB0000``` that is not compatible with newer releases of OpenWrt (due to kernel size)
 - To use the firmware produced by this patch you must flash a new u-boot with a kernel boot offset of ```0x9F020000```
 - Prepared images and instructions how to flash are available on the link below

Installation and additional information:
 - https://github.com/brunompena/zsun-resources