### PR TITLE
build: remove no spaces in PATH host requirement

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -99,5 +99,5 @@ define prepare_rootfs
 	rm -rf $(1)/boot
 	$(call clean_ipkg,$(1))
 	$(call mklibs,$(1))
-	$(if $(SOURCE_DATE_EPOCH),find $(1)/ -mindepth 1 -execdir touch -hcd "@$(SOURCE_DATE_EPOCH)" "{}" +)
+	$(if $(SOURCE_DATE_EPOCH),find $(1)/ -mindepth 1 -print0 | $(XARGS) --null touch -hcd "@$(SOURCE_DATE_EPOCH)" "{}")
 endef


### PR DESCRIPTION
Replaced `-execdir` in find to with `xargs`.
The behaviour will be slightly different in that xargs won't compile a monolithic command and instead invoke a separate `touch` command for each file found.

The error that is given when spaces are in the `PATH` is something as follows:
```
find: The relative path 'path-with-spaces/' is included in the PATH environment variable, which is insecure in combination with the -execdir action of find.  Please remove that entry from $PATH
```