### PR TITLE
base-files: add support for WiFi only devices

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -70,8 +70,6 @@ generate_network() {
 		json_select ..
 	json_select ..
 
-	[ -n "$ifname" ] || return
-
 	# force bridge for multi-interface devices (and lan)
 	case "$1:$ifname" in
 		*\ * | lan:*) type="bridge" ;;

--- a/package/base-files/files/etc/board.d/99-default_network
+++ b/package/base-files/files/etc/board.d/99-default_network
@@ -9,7 +9,8 @@ board_config_update
 
 json_is_a network object && exit 0
 
-ucidef_set_interface_lan 'eth0'
+ucidef_set_interface 'lan'
+[ -d /sys/class/net/eth0 ] && ucidef_set_interface_lan 'eth0'
 [ -d /sys/class/net/eth1 ] && ucidef_set_interface_wan 'eth1'
 
 board_config_flush

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/95_enable-wifi
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/95_enable-wifi
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[ ! -z "$(uci -q get network.lan.ifname)" ] && exit 0
+
+uci set wireless.@wifi-device[0].disabled=0
+uci commit wireless
+
+exit 0


### PR DESCRIPTION
Updated the initialization files to support devices without eth0 interface (WiFi only devices).
Instead of forcibly add eth0 interface to the "lan" network, the script will now check for its existence and add only if it exists.

Also included a uci-defaults script to automatically enable WiFi if there is no interface present on the "lan" network.

Remarks:
 * WiFi remains disabled by default as we have it today (and is only enabled if there's no interfaces on the "lan" network)
 * The script is executed at the final stage of the system initialization after all default interfaces and networks have been configured
 * Because it is a uci-defaults script it is only executed once during system initialization

This has been successfully tested on a Zsun-SD100.

Signed-off-by: Bruno Pena <brunompena@gmail.com>