### PR TITLE
[19.07] Revert "dnsmasq: skip options that are not compiled in"

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -22,45 +22,10 @@ DHCPSCRIPT="/usr/lib/dnsmasq/dhcp-script.sh"
 
 DNSMASQ_DHCP_VER=4
 
-dnsmasq_ignore_opt() {
-	local opt="$1"
-
-	if [ -z "$dnsmasq_features" ]; then
-		dnsmasq_features="$(dnsmasq --version | grep -m1 'Compile time options:' | cut -d: -f2) "
-		[ "${dnsmasq_features#* DHCP }" = "$dnsmasq_features" ] || dnsmasq_has_dhcp=1
-		[ "${dnsmasq_features#* DHCPv6 }" = "$dnsmasq_features" ] || dnsmasq_has_dhcp6=1
-		[ "${dnsmasq_features#* DNSSEC }" = "$dnsmasq_features" ] || dnsmasq_has_dnssec=1
-		[ "${dnsmasq_features#* TFTP }" = "$dnsmasq_features" ] || dnsmasq_has_tftp=1
-		[ "${dnsmasq_features#* ipset }" = "$dnsmasq_features" ] || dnsmasq_has_ipset=1
-	fi
-
-	case "$opt" in
-		dhcp-duid|\
-		ra-param)
-			[ -z "$dnsmasq_has_dhcp6" ] ;;
-		dhcp-*|\
-		bootp-*|\
-		pxe-*)
-			[ -z "$dnsmasq_has_dhcp" ] ;;
-		dnssec-*|\
-		trust-anchor)
-			[ -z "$dnsmasq_has_dnssec" ] ;;
-		tftp-*)
-			[ -z "$dnsmasq_has_tftp" ] ;;
-		ipset)
-			[ -z "$dnsmasq_has_ipset" ] ;;
-		*)
-			return 1
-	esac
-}
-
 xappend() {
-	local value="${1#--}"
-	local opt="${value%%=*}"
+	local value="$1"
 
-	if ! dnsmasq_ignore_opt "$opt"; then
-		echo "$value" >>$CONFIGFILE_TMP
-	fi
+	echo "${value#--}" >> $CONFIGFILE_TMP
 }
 
 hex_to_hostid() {


### PR DESCRIPTION
The revert contained in this pull request is also part of #1812 which hasn't been reviewed as of this writing. DNSSEC validation in OpenWRT 19.07 is _not working_ without this revert. The other change in #1812 would be nice to have, but isn't required.
<hr>

This reverts commit 04b45d3a31fac45c472ad3c31d98268d1c309763 and
0299a4b73e729504dfdc5c4563535db082bdf941. The changes caused dnsmasq to
silently ignore configured options instead of failing or at least
logging warnings.

In addition DNSSEC support was rendered unusable: The trust anchors are
loaded from a configuration file ("--conf-file=$TRUSTANCHORSFILE"), an
option which wasn't considered by the filter and thus caused dnsmasq
without DNSSEC support to not start (the trust anchor file is only
included with the "dnsmasq-full" package). In addition the plain
"--dnssec" option was not recognized by the filter.

The reverted change is better implemented as feature-specific code which
also issues warnings to the user if a feature is enabled by
configuration, but not available in the installed build.