### PR TITLE
mac80211: unify setup of iw's htmode for mesh and adhoc

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -551,7 +551,7 @@ mac80211_prepare_vif() {
 
 	case "$mode" in
 		monitor|mesh)
-			[ "$auto_channel" -gt 0 ] || iw dev "$ifname" set channel "$channel" $htmode
+			[ "$auto_channel" -gt 0 ] || iw dev "$ifname" set channel "$channel" $iw_htmode
 		;;
 	esac
 
@@ -625,40 +625,40 @@ mac80211_setup_supplicant_noctl() {
 	fi
 }
 
-mac80211_setup_adhoc_htmode() {
+mac80211_prepare_iw_htmode() {
 	case "$htmode" in
-		VHT20|HT20) ibss_htmode=HT20;;
+		VHT20|HT20) iw_htmode=HT20;;
 		HT40*|VHT40|VHT160)
 			case "$hwmode" in
 				a)
 					case "$(( ($channel / 4) % 2 ))" in
-						1) ibss_htmode="HT40+" ;;
-						0) ibss_htmode="HT40-";;
+						1) iw_htmode="HT40+" ;;
+						0) iw_htmode="HT40-";;
 					esac
 				;;
 				*)
 					case "$htmode" in
-						HT40+) ibss_htmode="HT40+";;
-						HT40-) ibss_htmode="HT40-";;
+						HT40+) iw_htmode="HT40+";;
+						HT40-) iw_htmode="HT40-";;
 						*)
 							if [ "$channel" -lt 7 ]; then
-								ibss_htmode="HT40+"
+								iw_htmode="HT40+"
 							else
-								ibss_htmode="HT40-"
+								iw_htmode="HT40-"
 							fi
 						;;
 					esac
 				;;
 			esac
-			[ "$auto_channel" -gt 0 ] && ibss_htmode="HT40+"
+			[ "$auto_channel" -gt 0 ] && iw_htmode="HT40+"
 		;;
 		VHT80)
-			ibss_htmode="80MHZ"
+			iw_htmode="80MHZ"
 		;;
 		NONE|NOHT)
-			ibss_htmode="NOHT"
+			iw_htmode="NOHT"
 		;;
-		*) ibss_htmode="" ;;
+		*) iw_htmode="" ;;
 	esac
 }
 
@@ -701,7 +701,7 @@ mac80211_setup_adhoc() {
 	mcval=
 	[ -n "$mcast_rate" ] && wpa_supplicant_add_rate mcval "$mcast_rate"
 
-	iw dev "$ifname" ibss join "$ssid" $freq $ibss_htmode fixed-freq $bssid \
+	iw dev "$ifname" ibss join "$ssid" $freq $iw_htmode fixed-freq $bssid \
 		beacon-interval $beacon_int \
 		${brstr:+basic-rates $brstr} \
 		${mcval:+mcast-rate $mcval} \
@@ -721,40 +721,7 @@ mac80211_setup_mesh() {
 	[ -n "$mcast_rate" ] && wpa_supplicant_add_rate mcval "$mcast_rate"
 	[ -n "$mesh_id" ] && ssid="$mesh_id"
 
-	case "$htmode" in
-		VHT20|HT20) mesh_htmode=HT20;;
-		HT40*|VHT40)
-			case "$hwmode" in
-				a)
-					case "$(( ($channel / 4) % 2 ))" in
-						1) mesh_htmode="HT40+" ;;
-						0) mesh_htmode="HT40-";;
-					esac
-				;;
-				*)
-					case "$htmode" in
-						HT40+) mesh_htmode="HT40+";;
-						HT40-) mesh_htmode="HT40-";;
-						*)
-							if [ "$channel" -lt 7 ]; then
-								mesh_htmode="HT40+"
-							else
-								mesh_htmode="HT40-"
-							fi
-						;;
-					esac
-				;;
-			esac
-		;;
-		VHT80)
-			mesh_htmode="80Mhz"
-		;;
-		VHT160)
-			mesh_htmode="160Mhz"
-		;;
-		*) mesh_htmode="NOHT" ;;
-	esac
-	iw dev "$ifname" mesh join "$ssid" freq $freq $mesh_htmode \
+	iw dev "$ifname" mesh join "$ssid" freq $freq $iw_htmode \
 		${mcval:+mcast-rate $mcval} \
 		beacon-interval $beacon_int
 }
@@ -799,7 +766,6 @@ mac80211_setup_vif() {
 		;;
 		adhoc)
 			wireless_vif_parse_encryption
-			mac80211_setup_adhoc_htmode
 			if [ "$wpa" -gt 0 -o "$auto_channel" -gt 0 ]; then
 				freq="$(get_freq "$phy" "$channel")"
 				mac80211_setup_supplicant_noctl $vif_enable || failed=1
@@ -926,6 +892,7 @@ drv_mac80211_setup() {
 	for_each_interface "sta adhoc mesh" mac80211_set_noscan
 	[ -n "$has_ap" ] && mac80211_hostapd_setup_base "$phy"
 
+	mac80211_prepare_iw_htmode
 	for_each_interface "sta adhoc mesh monitor" mac80211_prepare_vif
 	NEWAPLIST=
 	for_each_interface "ap" mac80211_prepare_vif


### PR DESCRIPTION
This also fixes mac80211_prepare_vif iw set channel when monitor or
mesh.

Here is more info on this issue: https://github.com/libremesh/lime-packages/issues/647