### PR TITLE
[19.07] ramips: backport renaming of Netgear WNDR3700 v5

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -281,7 +281,7 @@ px-4885-8M)
 	;;
 r6220|\
 netgear,r6350|\
-wndr3700v5)
+netgear,wndr3700-v5)
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
 	;;
 re350-v1)

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -175,7 +175,7 @@ ramips_setup_interfaces()
 	netgear,r6120|\
 	r6220|\
 	netgear,r6350|\
-	wndr3700v5)
+	netgear,wndr3700-v5)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ramips/base-files/etc/uci-defaults/04_led_migration
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/migrations.sh
+
+board=$(board_name)
+
+case "$board" in
+fon,fonera-20n)
+	migrate_leds "^fonera20n:=fonera-20n:"
+	;;
+intenso,memory2move)
+	migrate_leds "^m2m:=memory2move:"
+	;;
+lenovo,newifi-y1)
+	migrate_leds "^y1:=newifi-y1:"
+	;;
+lenovo,newifi-y1s)
+	migrate_leds "^y1s:=newifi-y1s:"
+	;;
+netgear,wn3000rp-v3)
+	migrate_leds "^wn3000rpv3:=wn3000rp-v3:"
+	;;
+netgear,wndr3700-v5)
+	migrate_leds "^wndr3700v5:=wndr3700-v5:"
+	;;
+tplink,archer-c2-v1)
+	migrate_leds "^c2-v1:=archer-c2-v1:"
+	;;
+tplink,archer-c20-v1)
+	migrate_leds "^c20-v1:=archer-c20-v1:"
+	;;
+tplink,archer-c20-v4)
+	migrate_leds "^c20-v4:=archer-c20-v4:"
+	;;
+tplink,archer-c20i)
+	migrate_leds "^c20i:=archer-c20i:"
+	;;
+tplink,archer-c50-v1)
+	migrate_leds "^c50:=archer-c50-v1:"
+	;;
+tplink,archer-c50-v3)
+	migrate_leds "^c50-v3:=archer-c50-v3:"
+	;;
+tplink,archer-c50-v4)
+	migrate_leds "^c50-v4:=archer-c50-v4:"
+	;;
+tplink,archer-mr200)
+	migrate_leds "^mr200:=archer-mr200:"
+	;;
+youku,yk1)
+	migrate_leds "^youku-yk1:=yk1:"
+	;;
+zyxel,keenetic-omni)
+	migrate_leds "^kn_rc:=keenetic-omni:"
+	;;
+zyxel,keenetic-omni-ii)
+	migrate_leds "^kn_rc:=keenetic-omni-ii:"
+	;;
+zyxel,keenetic-viva)
+	migrate_leds "^kng_rc:=keenetic-viva:"
+	;;
+esac
+
+migrations_apply system
+
+exit 0

--- a/target/linux/ramips/base-files/lib/ramips.sh
+++ b/target/linux/ramips/base-files/lib/ramips.sh
@@ -598,9 +598,6 @@ ramips_board_detect() {
 	*"WNCE2001")
 		name="wnce2001"
 		;;
-	*"WNDR3700v5")
-		name="wndr3700v5"
-		;;
 	*"WR512-3GN (4M)")
 		name="wr512-3gn-4M"
 		;;

--- a/target/linux/ramips/dts/WNDR3700V5.dts
+++ b/target/linux/ramips/dts/WNDR3700V5.dts
@@ -12,23 +12,23 @@
 };
 
 &led_power {
-	label = "wndr3700v5:green:power";
+	label = "wndr3700-v5:green:power";
 };
 
 &led_usb {
-	label = "wndr3700v5:green:usb";
+	label = "wndr3700-v5:green:usb";
 };
 
 &led_internet {
-	label = "wndr3700v5:green:wan";
+	label = "wndr3700-v5:green:wan";
 };
 
 &led_wifi {
-	label = "wndr3700v5:green:wifi";
+	label = "wndr3700-v5:green:wifi";
 };
 
 &led_wps {
-	label = "wndr3700v5:green:wps";
+	label = "wndr3700-v5:green:wps";
 };
 
 &spi0 {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -375,6 +375,25 @@ define Device/netgear_r6350
 endef
 TARGET_DEVICES += netgear_r6350
 
+define Device/netgear_wndr3700-v5
+  DTS := WNDR3700V5
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 15232k
+  SERCOMM_HWID := AYB
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x1054
+  IMAGES += factory.img
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.img := pad-extra 320k | $$(IMAGE/default) | pad-to $$$$(BLOCKSIZE) | \
+	sercom-footer | pad-to 128 | zip WNDR3700v5.bin | sercom-seal
+  DEVICE_TITLE := Netgear WNDR3700v5
+  DEVICE_PACKAGES := \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+  SUPPORTED_DEVICES += wndr3700v5
+endef
+TARGET_DEVICES += netgear_wndr3700-v5
+
 define Device/MikroTik
   BLOCKSIZE := 64k
   IMAGE_SIZE := 16128k
@@ -560,25 +579,6 @@ define Device/mqmaker_witi-512m
 	kmod-usb-ledtrig-usbport wpad-basic
 endef
 TARGET_DEVICES += mqmaker_witi-512m
-
-define Device/netgear_wndr3700-v5
-  DTS := WNDR3700V5
-  BLOCKSIZE := 64k
-  IMAGE_SIZE := 15232k
-  SERCOMM_HWID := AYB
-  SERCOMM_HWVER := A001
-  SERCOMM_SWVER := 0x1054
-  IMAGES += factory.img
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := pad-extra 320k | $$(IMAGE/default) | pad-to $$$$(BLOCKSIZE) | \
-	sercom-footer | pad-to 128 | zip WNDR3700v5.bin | sercom-seal
-  DEVICE_TITLE := Netgear WNDR3700v5
-  DEVICE_PACKAGES := \
-	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
-  SUPPORTED_DEVICES += wndr3700v5
-endef
-TARGET_DEVICES += netgear_wndr3700-v5
 
 define Device/youhua_wr1200js
   DTS := WR1200JS

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -561,7 +561,7 @@ define Device/mqmaker_witi-512m
 endef
 TARGET_DEVICES += mqmaker_witi-512m
 
-define Device/wndr3700v5
+define Device/netgear_wndr3700-v5
   DTS := WNDR3700V5
   BLOCKSIZE := 64k
   IMAGE_SIZE := 15232k
@@ -576,8 +576,9 @@ define Device/wndr3700v5
   DEVICE_TITLE := Netgear WNDR3700v5
   DEVICE_PACKAGES := \
 	kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+  SUPPORTED_DEVICES += wndr3700v5
 endef
-TARGET_DEVICES += wndr3700v5
+TARGET_DEVICES += netgear_wndr3700-v5
 
 define Device/youhua_wr1200js
   DTS := WR1200JS


### PR DESCRIPTION
This PR updates the DEVICENAME of the Netgear WNDR3700v5 to the same as used in OpenWrt master.
It used parts of commit 2f2a319 and da0de5e. 

Probably all 3 commits can be squashed finally, but having them separate seems more easy for review.