### PR TITLE
tools: tplink-safeloader: update soft_ver for TP-Link Archer C6 v2 (EU/RU/JP)

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -891,7 +891,7 @@ static struct device_info boards[] = {
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",
 		.support_trail = '\x00',
-		.soft_ver = "soft_ver:1.0.0\n",
+		.soft_ver = "soft_ver:1.1.1\n",
 
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},


### PR DESCRIPTION
This patch updates "soft_ver" for TP-Link Archer C6 v2 (EU/RU/JP).

It makes possible to upload OpenWrt on lastest vendor's firmware
as the web-based updater checks for major.minor version during upload.

Due to that on next major/minor version update TP-Link will stop
us from using the web-based firmware update tool, so it will
require a new patch on soft_ver to match major and minor version.
Up to today's latest stock firmware the patch (#.#.patch) does not
matters, that allows downgrade from 1.1.4 to 1.1.1 but do not allow
downgrade from 1.1.X to 1.0.X.

Signed-off-by: Anderson Vulczak <andi@andi.com.br>