### PR TITLE
scripts/dowload.pl: add archive.apache.org to apache mirror list

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -197,6 +197,7 @@ foreach my $mirror (@ARGV) {
 		push @mirrors, "https://mirror.netcologne.de/apache.org/$1";
 		push @mirrors, "https://mirror.aarnet.edu.au/pub/apache/$1";
 		push @mirrors, "https://mirror.csclub.uwaterloo.ca/apache/$1";
+		push @mirrors, "https://archive.apache.org/dist/$1";
 		push @mirrors, "http://mirror.cogentco.com/pub/apache/$1";
 		push @mirrors, "http://mirror.navercorp.com/apache/$1";
 		push @mirrors, "http://ftp.jaist.ac.jp/pub/apache/$1";


### PR DESCRIPTION
apache mirrors holds only latest releases, to download
older releases, one must use archive.apache.org to get
them.

Signed-off-by: Jiri Kastner <cz172638@github.com>
