### PR TITLE
ramips:fix switch0 port order for tplink c20i 

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -227,7 +227,7 @@ ramips_setup_interfaces()
 	awm002-evb-4M|\
 	awm002-evb-8M|\
 	bdcom,wap2100-sk|\
-	c20i|)
+	c20i)
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -227,7 +227,10 @@ ramips_setup_interfaces()
 	awm002-evb-4M|\
 	awm002-evb-8M|\
 	bdcom,wap2100-sk|\
-	c20i|\
+	c20i|)
+		ucidef_add_switch "switch0" \
+			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
+		;;
 	dir-645|\
 	gl-mt300a|\
 	gl-mt300n|\

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -227,10 +227,6 @@ ramips_setup_interfaces()
 	awm002-evb-4M|\
 	awm002-evb-8M|\
 	bdcom,wap2100-sk|\
-	c20i)
-		ucidef_add_switch "switch0" \
-			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
-		;;
 	dir-645|\
 	gl-mt300a|\
 	gl-mt300n|\
@@ -266,6 +262,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
+	c20i|\
 	c50|\
 	tplink,c20-v1)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
EDIT:
Need a little help with the inconsistent naming of this device in the openwrt project!
However I'm not sure about the model name because of inconsistend naming in the Openwrt project! Since the device model is called C20i from TP-LINK brand followed by "AC750 Wireless Dual Band Router" without the word "archer" written anywhere on the device or its labels! The openwrt luci webinterface status page shows: TP-Link Archer C20i when I login into the router, but the firmware files used for flashing are called "ArcherC20i-squashfs-sysupgrade.bin". The /etc/board.json has model id "c20i" so my guess is that the 02_network "c20i" model refers to this model which this PR request was made for?
Or should it be "tplink,c20i" or "archer,c20i"?

The Openwrt wiki page of the [c20i](https://openwrt.org/toh/tp-link/archer-c20i) mentions that the switch port order doesn't resamble the physical port numbering, but gives a valid solution for the switch. 

Physical Port	Switch port
WAN	        0
LAN 3	        1
LAN 4	        2
LAN 1	        3
LAN 2	        4
(not used)	5
CPU	        6

By quick and dirty adding the switch0 ports index variable and number in "/etc/board.json" gives a valid port order, without flashing the firmware.

```
"switch0": {
			"enable": true,
			"reset": true,
			"ports": [
				{
					"num": 1,
					"role": "lan",
					"index": 3
				},
				{
					"num": 2,
					"role": "lan",
					"index": 4
				},
				{
					"num": 3,
					"role": "lan",
					"index": 1
				},
				{
					"num": 4,
					"role": "lan",
					"index": 2
				},
				{
					"num": 0,
					"role": "wan"
				},
				{
					"num": 6,
					"device": "eth0",
					"need_tag": false,
					"want_untag": false
				}
			],
			"roles": [
				{
					"role": "lan",
					"ports": "1 2 3 4 6t",
					"device": "eth0.1"
				},
				{
					"role": "wan",
					"ports": "0 6t",
					"device": "eth0.2"
				}
			]
		}
```
The real fix should offcourse be editing /etc/board.d/02_network with suggested ucidef switch layout and reflash the device (still needs testing).

```
swconfig list
Found: switch0 - mt7620

swconfig dev switch0 show
Global attributes:
	enable_vlan: 1
	mib: Switch MIB counters
PPE_AC_BCNT0: 0
PPE_AC_PCNT0: 0
PPE_AC_BCNT63: 0
PPE_AC_PCNT63: 0
PPE_MTR_CNT0: 0
PPE_MTR_CNT63: 0
GDM1_TX_GBCNT: 0
GDM1_TX_GPCNT: 0
GDM1_TX_SKIPCNT: 0
GDM1_TX_COLCNT: 0
GDM1_RX_GBCNT1: 0
GDM1_RX_GPCNT1: 0
GDM1_RX_OERCNT: 0
GDM1_RX_FERCNT: 0
GDM1_RX_SERCNT: 0
GDM1_RX_LERCNT: 0
GDM1_RX_CERCNT: 0
GDM1_RX_FCCNT: 0
GDM2_TX_GBCNT: 0
GDM2_TX_GPCNT: 0
GDM2_TX_SKIPCNT: 0
GDM2_TX_COLCNT: 0
GDM2_RX_GBCNT: 0
GDM2_RX_GPCNT: 0
GDM2_RX_OERCNT: 0
GDM2_RX_FERCNT: 0
GDM2_RX_SERCNT: 0
GDM2_RX_LERCNT: 3
GDM2_RX_CERCNT: 0
GDM2_RX_FCCNT: 0

Port 0:
	mib: Port 0 MIB counters
TxGPC      : 3581
TxBOC      : 0
TxGOC      : 574531
TxEPC      : 0
RxGPC      : 4724
RxBOC      : 0
RxGOC      : 2062331
RxEPC1     : 0
RxEPC2     : 15

	pvid: 2
	link: port:0 link:up speed:100baseT full-duplex 
Port 1:
	mib: Port 1 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 803
	link: port:1 link:down
Port 2:
	mib: Port 2 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 1
	link: port:2 link:down
Port 3:
	mib: Port 3 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 1
	link: port:3 link:down
Port 4:
	mib: Port 4 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 1
	link: port:4 link:down
Port 5:
	mib: Port 5 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 0
	link: port:5 link:down
Port 6:
	mib: Port 6 MIB counters
TxGPC      : 4709
TxBOC      : 0
TxGOC      : 2079701
TxEPC      : 0
RxGPC      : 3670
RxBOC      : 0
RxGOC      : 601851
RxEPC1     : 0
RxEPC2     : 89

	pvid: 0
	link: port:6 link:up speed:1000baseT full-duplex 
Port 7:
	mib: Port 7 MIB counters
TxGPC      : 0
TxBOC      : 0
TxGOC      : 0
TxEPC      : 0
RxGPC      : 0
RxBOC      : 0
RxGOC      : 0
RxEPC1     : 0
RxEPC2     : 0

	pvid: 0
	link: port:7 link:down
VLAN 1:
	vid: 1
	ports: 2 3 4 6t 
VLAN 2:
	vid: 2
	ports: 0 6t 
VLAN 3:
	vid: 803
	ports: 0t 1 6t
```

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.

Still figuring out howto squash this into a single commit to follow the rules... 
