### PR TITLE
ath79: add support for TP-Link TL-WR902AC v1

### DIFF
--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr902ac-v1", "qca,qca9531";
+	model = "TP-Link TL-WR902AC v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &wmac;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		internet {
+			label = "tp-link:green:internet";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "tp-link:green:wlan2g";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		sw1 {
+			label = "Mode switch 1";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		sw2 {
+			label = "Mode switch 2";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_usb_power {
+			gpio-export,name = "tp-link:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x730000>;
+			};
+
+			tplink: partition@750000 {
+				label = "tplink";
+				reg = <0x750000 0x0a0000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&tplink 0x8>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&tplink 0x8>;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0050";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -205,7 +205,8 @@ tplink,cpe510-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:green:link3" "wlan0" "51" "100" "-50" "13"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "76" "100" "-75" "13"
 	;;
-tplink,cpe610-v1)
+tplink,cpe610-v1|\
+tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tplink,re355-v1|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ ath79_setup_interfaces()
 	tplink,re355-v1|\
 	tplink,re450-v1|\
 	tplink,re450-v2|\
+	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-m|\
 	ubnt,bullet-m-xw|\
 	ubnt,lap-120|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,10 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
+	tplink,tl-wr902ac-v1)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary tplink 0x8) -1)
+		;;
 	esac
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -17,7 +17,8 @@ tplink,archer-c59-v2|\
 tplink,archer-c60-v1|\
 tplink,archer-c60-v2|\
 tplink,archer-c7-v4|\
-tplink,archer-c7-v5)
+tplink,archer-c7-v5|\
+tplink,tl-wr902ac-v1)
 	migrate_leds "^$boardonly:=tp-link:"
 	;;
 tplink,archer-c7-v2)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -552,6 +552,21 @@ define Device/tplink_tl-wr842n-v3
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v3
 
+define Device/tplink_tl-wr902ac-v1
+  $(Device/tplink-safeloader)
+  ATH_SOC := qca9531
+  DEVICE_MODEL := TL-WR902AC
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
+    kmod-ath10k-ct ath10k-firmware-qca9887-ct -swconfig -uboot-envtools
+  TPLINK_BOARD_ID := TL-WR902AC-V1
+  IMAGE_SIZE := 7360k
+  TPLINK_HWID := 0x0
+  TPLINK_HWREV := 0
+  SUPPORTED_DEVICES += tl-wr902ac-v1
+endef
+TARGET_DEVICES += tplink_tl-wr902ac-v1
+
 define Device/tplink_wbs210-v2
   $(Device/tplink-loader-okli)
   ATH_SOC := ar9344


### PR DESCRIPTION
TP-Link TL-WR902AC v1 is a pocket-size, dual-band (AC750), successor of
TL-MR3020 (both devices use very similar enclosure, in same size). New
device is based on Qualcomm QCA9531 v2 + QCA9887. FCC ID: TE7WR902AC.

Specification:

- 650/391/216 MHz (CPU/DDR/AHB)
- 1x 10/100 Mbps Ethernet
- 1x USB 2.0 (GPIO-controlled power)
- 64 MB of RAM (DDR2)
- 8 MB of FLASH
- 2T2R 2.4 GHz (QCA9531)
- 1T1R 5 GHz (QCA9887)
- 5x LED (GPIO-controlled), 2x button, 1x 3-pos switch
- UART pads on PCB (TP1 -> TX, TP2 -> RX, TP3 -> GND, TP4 -> 3V3, jumper
  resitors are missing on TX/RX lines)
- 1x micro USB (for power only)

Flash instructions:

Use "factory" image under vendor GUI.

Recovery instructions:

This device contains tftp recovery mode inside U-Boot. You can use it to
flash LEDE (use "factory" image) or vendor firmware.

1. Configure PC with static IP 192.168.0.66/24 and tftp server.
2. Rename "lede-ar71xx-generic-tl-wr902ac-v1-squashfs-factory.bin"
   to "wr902acv1_un_tp_recovery.bin" and place it in tftp server dir.
3. Connect PC with LAN port, press the reset button, power up the router
   and keep button pressed until WPS LED lights up.
4. Router will download file from server, write it to flash and reboot.

Root access over serial line in vendor firmware: root/sohoadmin.

Based on support in ar711x target by: Piotr Dymacz <pepe2k@gmail.com>

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>