### PR TITLE
uci: add host build target

### DIFF
--- a/package/system/uci/Makefile
+++ b/package/system/uci/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uci
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uci.git
 PKG_SOURCE_PROTO:=git
@@ -21,10 +21,14 @@ PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+PKG_BUILD_DEPENDS := uci/host
 
 PKG_BUILD_PARALLEL:=0
 
+HOST_BUILD_DEPENDS:=libubox/host
+
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 # set to 1 to enable debugging
@@ -76,6 +80,11 @@ define Package/uci/install
 	$(CP) ./files/* $(1)/
 endef
 
+CMAKE_HOST_OPTIONS += \
+	-DBUILD_LUA=OFF \
+	-DCMAKE_SKIP_RPATH=FALSE \
+	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOST}/lib"
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_BUILD_DIR)/uci{,_config,_blob,map}.h $(1)/usr/include
@@ -84,6 +93,11 @@ define Build/InstallDev
 	$(CP) $(PKG_BUILD_DIR)/libucimap.a $(1)/usr/lib
 endef
 
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/uci $(STAGING_DIR_HOST)/bin/uci
+endef
+
 $(eval $(call BuildPackage,uci))
 $(eval $(call BuildPackage,libuci))
 $(eval $(call BuildPackage,libuci-lua))
+$(eval $(call HostBuild))

--- a/package/system/uci/Makefile
+++ b/package/system/uci/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uci
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uci.git
 PKG_SOURCE_PROTO:=git
@@ -26,6 +26,7 @@ PKG_BUILD_DEPENDS := uci/host
 PKG_BUILD_PARALLEL:=0
 
 HOST_BUILD_DEPENDS:=libubox/host
+HOST_PATCH_DIR := ./patches-host
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk

--- a/package/system/uci/patches-host/001-fix-langjump-compile-error-host-build.patch
+++ b/package/system/uci/patches-host/001-fix-langjump-compile-error-host-build.patch
@@ -1,0 +1,11 @@
+--- a/uci_internal.h
++++ b/uci_internal.h
+@@ -185,7 +185,7 @@ struct uci_backend _var = {		\
+  */
+ #define UCI_HANDLE_ERR(ctx) do {	\
+ 	DPRINTF("ENTER: %s\n", __func__); \
+-	int __val = 0;			\
++	unsigned long __val = 0;	\
+ 	if (!ctx)			\
+ 		return UCI_ERR_INVAL;	\
+ 	ctx->err = 0;			\


### PR DESCRIPTION
This change enables the uci build for the compilation host and could then be used during image building on the host. Until now a script had to be stored in `/etc/uci-defaults` to set the parameters at the target with the help of uci because we do not support uci handling on the build host. With this change we can use uci on host and on the target. The scripts under `/etc/uci-defaults` that were added because of the missing uci host support are not needed anymore.

With this change, uci could also be used in the following scripts.
* `define Package/<package_name>/preinst`
* `define Package/<package_name>/postinst`
* `define Package/<package_name>/prerm`
* `define Package/<package_name>/postrm`

A lot of `/etc/uci-defaults` script in the LuCI feed are then superfluous and can be moved into the opkg package scripts.

> define Package/luci-app-mwan3/postinst
> #!/bin/sh
> echo "Add luci-app-mwan3 to ucitrack"
> uci -q -p "$${IPKG_INSTROOT}/tmp" -c "$${IPKG_INSTROOT}/etc/config" batch <<-EOF >/dev/null
> 	del ucitrack.@mwan3[-1]
> 	add ucitrack mwan3
> 	set ucitrack.@mwan3[-1].exec="/etc/init.d/mwan3 reload"
> 	commit ucitrack
> EOF
> 
> if [ -z "$${IPKG_INSTROOT}" ]; then
> 	rm -f /tmp/luci-indexcache
> fi
> endef

For compiling to work for older gcc versions `debian jessie`, the uci source for the host build must be patched. 
