### PR TITLE
brcm47xx: add switch port mapping for Netgear WNR3500L

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -170,7 +170,8 @@ configure_by_model() {
 		;;
 
 	"Asus RT-N16"* | \
-	"Linksys E3000 V1")
+	"Linksys E3000 V1" | \
+	"Netgear WNR3500L")
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "8@eth0"
 		;;


### PR DESCRIPTION
Experimentally determined:

Port 0 => WAN
Port 1..4 => LAN
Port 5..7 => unused
Port 8 => CPU

Reuses the "Linksys E3000 V1" entry, which seems to describe the same mapping.

Tested & working with a fresh OpenWRT install on this device. Thanks for your consideration.