### PR TITLE
ramips:fix switch0 port order for tplink c20i

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -67,7 +67,6 @@ ramips_setup_interfaces()
 	glinet,gl-mt300n|\
 	glinet,gl-mt750|\
 	hiwifi,hc5661|\
-	tplink,archer-c20i|\
 	wrtnode,wrtnode|\
 	zbtlink,zbt-wa05)
 		ucidef_add_switch "switch0" \
@@ -177,6 +176,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "3:wan" "6@eth0"
 		;;
+	tplink,archer-c20i|\
 	tplink,archer-c20-v1|\
 	tplink,archer-c50-v1)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
The Openwrt wiki page of the [c20i](https://openwrt.org/toh/tp-link/archer-c20i) mentions that the switch port order doesn't resamble the physical port numbering, but gives a valid solution for the switch. Physical port order watched from the backside of the c20i from left to right is (Internet / 1 / 2 / 3 / 4).

Physical Port	Switch port
WAN	        0
LAN 3	        1
LAN 4	        2
LAN 1	        3
LAN 2	        4
(not used)	5
CPU	        6

Moving the to "tplink,archer-c20i|\" to the switch config cluster of tplink,archer models c20-v1  c50v1 fixed the switch port order numbering for me verified on 89b8dd6. 

Notice for backporting to Openwrt 19.07 (tested ok d2d1234) and maybe even Openwrt 18.06 (not tested) the device model/id has a different name "c20i" instead of "tplink,archer-c20i" and the "02_network" file resides in the parentfolder instead of "mt7620"!

This PR replaces #2581 
Signed-off-by: Walter Sonius <walterav1984@gmail.com>