### PR TITLE
sunxi: build image for the NanoPi NEO Air

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -138,6 +138,12 @@ define U-Boot/nanopi_m1_plus
   BUILD_DEVICES:=sun8i-h3-nanopi-m1-plus
 endef
 
+define U-Boot/nanopi_neo_air
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=U-Boot for NanoPi NEO Air (H3)
+  BUILD_DEVICES:=sun8i-h3-nanopi-neo-air
+endef
+
 define U-Boot/nanopi_neo
   BUILD_SUBTARGET:=cortexa7
   NAME:=U-Boot for NanoPi NEO (H3)
@@ -274,6 +280,7 @@ UBOOT_TARGETS := \
 	Lamobo_R1 \
 	nanopi_m1_plus \
 	nanopi_neo \
+	nanopi_neo_air \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
 	orangepi_zero \

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -165,6 +165,19 @@ endef
 TARGET_DEVICES += sun8i-h3-nanopi-m1-plus
 
 
+define Device/sun8i-h3-nanopi-neo-air
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi NEO Air
+  DEVICE_PACKAGES:=kmod-rtc-sunxi \
+	kmod-leds-gpio kmod-ledtrig-heartbeat \
+	kmod-brcmfmac brcmfmac-firmware-43430-sdio wpad-basic
+  SUPPORTED_DEVICES:=friendlyarm,nanopi-neo-air
+  SUNXI_DTS:=sun8i-h3-nanopi-neo-air
+endef
+
+TARGET_DEVICES += sun8i-h3-nanopi-neo-air
+
+
 define Device/sun8i-h3-nanopi-neo
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO


### PR DESCRIPTION
Add support for NanoPI NEO Air dev board - H3, 512M RAM, 8G eMMC, AP6212A Wireless module, no  Ethernet. Standard sunxi SD-card install procedure.
