### PR TITLE
kernel: fix *-gpio-custom module unloading

### DIFF
--- a/package/kernel/i2c-gpio-custom/Makefile
+++ b/package/kernel/i2c-gpio-custom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=i2c-gpio-custom
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/kernel/i2c-gpio-custom/src/i2c-gpio-custom.c
+++ b/package/kernel/i2c-gpio-custom/src/i2c-gpio-custom.c
@@ -56,7 +56,7 @@
 
 #define DRV_NAME	"i2c-gpio-custom"
 #define DRV_DESC	"Custom GPIO-based I2C driver"
-#define DRV_VERSION	"0.1.1"
+#define DRV_VERSION	"0.1.2"
 
 #define PFX		DRV_NAME ": "
 
@@ -101,7 +101,7 @@ static void i2c_gpio_custom_cleanup(void)
 
 	for (i = 0; i < nr_devices; i++)
 		if (devices[i])
-			platform_device_put(devices[i]);
+			platform_device_unregister(devices[i]);
 }
 
 static int __init i2c_gpio_custom_add_one(unsigned int id, unsigned int *params)

--- a/package/kernel/w1-gpio-custom/Makefile
+++ b/package/kernel/w1-gpio-custom/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=w1-gpio-custom
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/kernel/w1-gpio-custom/src/w1-gpio-custom.c
+++ b/package/kernel/w1-gpio-custom/src/w1-gpio-custom.c
@@ -47,7 +47,7 @@
 
 #define DRV_NAME	"w1-gpio-custom"
 #define DRV_DESC	"Custom GPIO-based W1 driver"
-#define DRV_VERSION	"0.1.1"
+#define DRV_VERSION	"0.1.2"
 
 #define PFX		DRV_NAME ": "
 
@@ -86,7 +86,7 @@ static void w1_gpio_custom_cleanup(void)
 
 	for (i = 0; i < nr_devices; i++)
 		if (devices[i])
-			platform_device_put(devices[i]);
+			platform_device_unregister(devices[i]);
 }
 
 static int __init w1_gpio_custom_add_one(unsigned int id, unsigned int *params)


### PR DESCRIPTION
Unloading and reloading the modules fails, as platform_device_put() does not
release resources fully.

root@OpenWrt:/# insmod i2c-gpio-custom bus0=0,18,0,5
[  196.860620] Custom GPIO-based I2C driver version 0.1.1
[  196.871162] ------------[ cut here ]------------
[  196.880517] WARNING: CPU: 0 PID: 1365 at fs/sysfs/dir.c:31 0x80112158
[  196.893431] sysfs: cannot create duplicate filename '/devices/platform/i2c-gpio.0'
...
[  197.513200] kobject_add_internal failed for i2c-gpio.0 with -EEXIST, don't try to register things with the same name in the same directory.

This patch fixes it by replacing platform_device_put() to
platform_device_unregister().
