### PR TITLE
brcm63xx: add support for Telecom Italia ADSL2+ Wi-Fi N AGPWI

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -7,7 +7,10 @@
 
 board_config_update
 
-case "$(board_name)" in
+board=$(board_name)
+boardname="${board##*,}"
+
+case "$board" in
 actiontec,r1000h)
 	ucidef_set_led_usbport "usb" "USB" "R1000H:green:usb" "usb1-port1" "usb2-port1"
 	;;
@@ -17,6 +20,12 @@ adb,a4001n)
 adb,a4001n1)
 	ucidef_set_led_netdev "lan" "LAN" "A4001N1:green:eth" "eth0"
 	ucidef_set_led_usbdev "usb" "USB" "A4001N1:green:3g" "1-1"
+	;;
+adb,pdg-a4001n-a-000-1a1-ax)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:internet" "eth0.1"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:adsl" "eth0.2"
+	ucidef_set_led_netdev "wlan0" "WIFI" "$boardname:green:wifi" "wlan0"
+	ucidef_set_led_usbdev "usb" "USB" "$boardname:green:service" "1-1"
 	;;
 adb,av4202n)
 	ucidef_set_led_netdev "wlan0" "WLAN" "AV4202N:blue:wifi" "wlan0"

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ t-com,speedport-w-500v)
 	;;
 adb,a4001n1|\
 adb,a4001n|\
+adb,pdg-a4001n-a-000-1a1-ax|\
 adb,av4202n|\
 brcm,bcm963281tan|\
 brcm,bcm96328avng|\

--- a/target/linux/bcm63xx/base-files/etc/diag.sh
+++ b/target/linux/bcm63xx/base-files/etc/diag.sh
@@ -5,7 +5,10 @@
 . /lib/functions/leds.sh
 
 set_state() {
-	case "$(board_name)" in
+	board=$(board_name)
+	boardname="${board##*,}"
+
+	case "$board" in
 	actiontec,r1000h)
 		status_led="R1000H:green:power"
 		;;
@@ -14,6 +17,9 @@ set_state() {
 		;;
 	adb,a4001n1)
 		status_led="A4001N1:green:power"
+		;;
+	adb,pdg-a4001n-a-000-1a1-ax)
+		status_led="$boardname:green:power"
 		;;
 	adb,av4202n)
 		status_led="AV4202N:white:power"

--- a/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
@@ -14,6 +14,7 @@ case "$(board_name)" in
 	actiontec,r1000h|\
 	adb,a4001n|\
 	adb,a4001n1|\
+	adb,pdg-a4001n-a-000-1a1-ax|\
 	brcm,bcm96328avng|\
 	brcm,bcm963281tan|\
 	bt,voyager-2110|\

--- a/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "ADB P.DG A4001N A-000-1A1-AX";
+	compatible = "adb,pdg-a4001n-a-000-1a1-ax", "brcm,bcm6328";
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wifi-led";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_red {
+			label = "pdg-a4001n-a-000-1a1-ax:red:power";
+			gpios = <&pinctrl 8 1>;
+		};
+		power_green {
+			label = "pdg-a4001n-a-000-1a1-ax:green:power";
+			gpios = <&pinctrl 12 1>;
+			default-state = "on";
+		};
+		
+		adsl_red {
+			label = "pdg-a4001n-a-000-1a1-ax:red:adsl";
+			gpios = <&pinctrl 5 1>;
+		};
+		adsl_green {
+			label = "pdg-a4001n-a-000-1a1-ax:green:adsl";
+			gpios = <&pinctrl 3 1>;
+		};
+		
+		internet_red {
+			label = "pdg-a4001n-a-000-1a1-ax:red:internet";
+			gpios = <&pinctrl 2 1>;
+		};
+		internet_green {
+			label = "pdg-a4001n-a-000-1a1-ax:green:internet";
+			gpios = <&pinctrl 11 1>;
+		};
+		
+		wifi_red {
+			label = "pdg-a4001n-a-000-1a1-ax:red:wifi";
+			gpios = <&pinctrl 10 1>;
+		};
+		wifi_green {
+			label = "pdg-a4001n-a-000-1a1-ax:green:wifi";
+			gpios = <&pinctrl 9 1>;
+		};
+		
+		service_red {
+			label = "pdg-a4001n-a-000-1a1-ax:red:service";
+			gpios = <&pinctrl 7 1>;
+		};
+		service_green {
+			label = "pdg-a4001n-a-000-1a1-ax:green:service";
+			gpios = <&pinctrl 6 1>;
+		};
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			linux@10000 {
+				reg = <0x010000 0xfe0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			nvram@ff0000 {
+				reg = <0xff0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -215,6 +215,18 @@ define Device/adb_a4001n1
 endef
 TARGET_DEVICES += adb_a4001n1
 
+define Device/adb_pdg-a4001n-a-000-1a1-ax
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := ADB
+  DEVICE_MODEL := P.DG A4001N A-000-1A1-AX
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := 96328avng
+  CFE_CHIP_ID := 6328
+  FLASH_MB := 16
+  DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += adb_pdg-a4001n-a-000-1a1-ax
+
 define Device/adb_av4202n
   $(Device/bcm63xx)
   DEVICE_VENDOR := ADB

--- a/target/linux/bcm63xx/patches-4.14/805-board_adb_pdg-a4001n-a-000-1a1-ax.patch
+++ b/target/linux/bcm63xx/patches-4.14/805-board_adb_pdg-a4001n-a-000-1a1-ax.patch
@@ -1,0 +1,68 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -627,6 +627,49 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct board_info __initdata board_PDG_A4001N_A_000_1A1_AX = {
++	.name					= "96328avng",
++	.expected_cpu_id			= 0x6328,
++
++	.has_pci				= 1,
++	.use_fallback_sprom		= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 1,
++	.has_enetsw				= 1,
++
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "Port 1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "Port 2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "Port 3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "Port 4",
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type 				= SPROM_BCM43225,
++		.pci_bus			= 1,
++		.pci_dev			= 0,
++	},
++};
++
+ static struct board_info __initdata board_A4001N1 = {
+ 	.name					= "963281T_TEF",
+ 	.expected_cpu_id			= 0x6328,
+@@ -2720,6 +2763,7 @@ static const struct board_info __initcon
+ 	&board_AR5387un,
+ 	&board_963281TAN,
+ 	&board_A4001N,
++	&board_PDG_A4001N_A_000_1A1_AX,
+ 	&board_A4001N1,
+ 	&board_dsl_274xb_f1,
+ 	&board_FAST2704V2,
+@@ -2824,6 +2868,7 @@ static struct of_device_id const bcm963x
+ #ifdef CONFIG_BCM63XX_CPU_6328
+ 	{ .compatible = "adb,a4001n", .data = &board_A4001N, },
+ 	{ .compatible = "adb,a4001n1", .data = &board_A4001N1, },
++	{ .compatible = "adb,pdg-a4001n-a-000-1a1-ax", .data = &board_PDG_A4001N_A_000_1A1_AX, },
+ 	{ .compatible = "brcm,bcm963281tan", .data = &board_963281TAN, },
+ 	{ .compatible = "brcm,bcm96328avng", .data = &board_96328avng, },
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },

--- a/target/linux/bcm63xx/patches-4.19/805-board_adb_pdg-a4001n-a-000-1a1-ax.patch
+++ b/target/linux/bcm63xx/patches-4.19/805-board_adb_pdg-a4001n-a-000-1a1-ax.patch
@@ -1,0 +1,68 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -627,6 +627,49 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct board_info __initdata board_PDG_A4001N_A_000_1A1_AX = {
++	.name					= "96328avng",
++	.expected_cpu_id			= 0x6328,
++
++	.has_pci				= 1,
++	.use_fallback_sprom		= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 1,
++	.has_enetsw				= 1,
++
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "Port 1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "Port 2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "Port 3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "Port 4",
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type 				= SPROM_BCM43225,
++		.pci_bus			= 1,
++		.pci_dev			= 0,
++	},
++};
++
+ static struct board_info __initdata board_A4001N1 = {
+ 	.name					= "963281T_TEF",
+ 	.expected_cpu_id			= 0x6328,
+@@ -2720,6 +2763,7 @@ static const struct board_info __initcon
+ 	&board_AR5387un,
+ 	&board_963281TAN,
+ 	&board_A4001N,
++	&board_PDG_A4001N_A_000_1A1_AX,
+ 	&board_A4001N1,
+ 	&board_dsl_274xb_f1,
+ 	&board_FAST2704V2,
+@@ -2824,6 +2868,7 @@ static struct of_device_id const bcm963x
+ #ifdef CONFIG_BCM63XX_CPU_6328
+ 	{ .compatible = "adb,a4001n", .data = &board_A4001N, },
+ 	{ .compatible = "adb,a4001n1", .data = &board_A4001N1, },
++	{ .compatible = "adb,pdg-a4001n-a-000-1a1-ax", .data = &board_PDG_A4001N_A_000_1A1_AX, },
+ 	{ .compatible = "brcm,bcm963281tan", .data = &board_963281TAN, },
+ 	{ .compatible = "brcm,bcm96328avng", .data = &board_96328avng, },
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },


### PR DESCRIPTION
brcm63xx: add support for Telecom Italia ADSL2+ Wi-Fi N AGPWI

Telecom Italia ADSL2+ Wi-Fi N AGPWI a.k.a. ADB P.DG A4001N A-000-1A1-AX
is the same board as the OpenWrt's ADB P.DG A4001N with LEDs connected
to different GPIO PINs in active low configuration.

OpenWrt's ADB P.DG A4001N actually is an ADB P.DG A4001N A-000-1A1-AE

Hardware:
* SoC: Broadcom BCM6328
* RAM: 32MB
* Flash: 8MB
* Ethernet: 4x Ethernet 10/100 baseT
* Wifi 2.4GHz: Broadcom Corporation BCM43224/5 Wireless Network Adapter (rev 01)
* LEDs: 2x Power, 2x ADSL, 2x Internet, 2x Wi-Fi, 2x Service
* Buttons: 1x Reset, 1x WPS (named WiFi/LED)
* UART: 1x TTL 115200n8, TX NC RX, on J5 connector (short R192 and R193)

Installation via CFE:
* Stock CFE has to be overwriten with a Comtrend one that can upload .bin images
  with no signature check
* connect a serial port to the board
* Stop the boot process after power on by pressing enter
* set static IP 192.168.1.2
* navigate to http://192.168.1.1
* upload the OpenWrt image file