### PR TITLE
[RFT] sunxi: Reduce redundant names in sunxi target

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -28,67 +28,67 @@ endef
 define U-Boot/A10-OLinuXino-Lime
   BUILD_SUBTARGET:=cortexa8
   NAME:=A10 OLinuXino LIME
-  BUILD_DEVICES:=sun4i-a10-olinuxino-lime
+  BUILD_DEVICES:=olimex_a10-olinuxino-lime
 endef
 
 define U-Boot/A13-OLinuXino
   BUILD_SUBTARGET:=cortexa8
   NAME:=A13 OlinuXino
-  BUILD_DEVICES:=sun5i-a13-olinuxino
+  BUILD_DEVICES:=olimex_a13-olinuxino
 endef
 
 define U-Boot/A20-OLinuXino-Lime
   BUILD_SUBTARGET:=cortexa7
   NAME:=A20 OLinuXino LIME
-  BUILD_DEVICES:=sun7i-a20-olinuxino-lime
+  BUILD_DEVICES:=olimex_a20-olinuxino-lime
 endef
 
 define U-Boot/A20-OLinuXino-Lime2
   BUILD_SUBTARGET:=cortexa7
   NAME:=A20 OLinuXino LIME2
-  BUILD_DEVICES:=sun7i-a20-olinuxino-lime2
+  BUILD_DEVICES:=olimex_a20-olinuxino-lime2
 endef
 
 define U-Boot/A20-OLinuXino-Lime2-eMMC
   BUILD_SUBTARGET:=cortexa7
   NAME:=A20 OLinuXino LIME2 eMMC
-  BUILD_DEVICES:=sun7i-a20-olinuxino-lime2-emmc
+  BUILD_DEVICES:=olimex_a20-olinuxino-lime2-emmc
 endef
 
 define U-Boot/A20-OLinuXino_MICRO
   BUILD_SUBTARGET:=cortexa7
   NAME:=A20 OLinuXino MICRO
-  BUILD_DEVICES:=sun7i-a20-olinuxino-micro
+  BUILD_DEVICES:=olimex_a20-olinuxino-micro
 endef
 
 define U-Boot/Bananapi
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi
-  BUILD_DEVICES:=sun7i-a20-bananapi
+  BUILD_DEVICES:=lemaker_bananapi
 endef
 
 define U-Boot/Bananapro
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapro
-  BUILD_DEVICES:=sun7i-a20-bananapro
+  BUILD_DEVICES:=lemaker_bananapro
 endef
 
 define U-Boot/Cubieboard
   BUILD_SUBTARGET:=cortexa8
   NAME:=Cubieboard
-  BUILD_DEVICES:=sun4i-a10-cubieboard
+  BUILD_DEVICES:=cubietech_a10-cubieboard
 endef
 
 define U-Boot/Cubieboard2
   BUILD_SUBTARGET:=cortexa7
   NAME:=Cubieboard2
-  BUILD_DEVICES:=sun7i-a20-cubieboard2
+  BUILD_DEVICES:=cubietech_cubieboard2
 endef
 
 define U-Boot/Cubietruck
   BUILD_SUBTARGET:=cortexa7
   NAME:=Cubietruck
-  BUILD_DEVICES:=sun7i-a20-cubietruck
+  BUILD_DEVICES:=cubietech_cubietruck
 endef
 
 define U-Boot/Hummingbird_A31
@@ -99,91 +99,91 @@ endef
 define U-Boot/Marsboard_A10
   BUILD_SUBTARGET:=cortexa8
   NAME:=Marsboard
-  BUILD_DEVICES:=sun4i-a10-marsboard
+  BUILD_DEVICES:=marsboard_a10-marsboard
 endef
 
 define U-Boot/Mele_M9
   BUILD_SUBTARGET:=cortexa7
   NAME:=Mele M9 (A31)
-  BUILD_DEVICES:=sun6i-a31-m9
+  BUILD_DEVICES:=mele_m9
 endef
 
 define U-Boot/OLIMEX_A13_SOM
   BUILD_SUBTARGET:=cortexa8
   NAME:=Olimex A13 SOM
-  BUILD_DEVICES:=sun5i-a13-olimex-som
+  BUILD_DEVICES:=olimex_a13-olimex-som
 endef
 
 define U-Boot/Linksprite_pcDuino
   BUILD_SUBTARGET:=cortexa8
   NAME:=Linksprite pcDuino
-  BUILD_DEVICES:=sun4i-a10-pcduino
+  BUILD_DEVICES:=linksprite_a10-pcduino
 endef
 
 define U-Boot/Linksprite_pcDuino3
   BUILD_SUBTARGET:=cortexa7
   NAME:=Linksprite pcDuino3
-  BUILD_DEVICES:=sun7i-a20-pcduino3
+  BUILD_DEVICES:=linksprite_pcduino3
 endef
 
 define U-Boot/Lamobo_R1
   BUILD_SUBTARGET:=cortexa7
   NAME:=Lamobo R1
-  BUILD_DEVICES:=sun7i-a20-lamobo-r1
+  BUILD_DEVICES:=lamobo_lamobo-r1
 endef
 
 define U-Boot/nanopi_m1_plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=NanoPi M1 Plus (H3)
-  BUILD_DEVICES:=sun8i-h3-nanopi-m1-plus
+  BUILD_DEVICES:=friendlyarm_nanopi-m1-plus
 endef
 
 define U-Boot/nanopi_neo
   BUILD_SUBTARGET:=cortexa7
   NAME:=U-Boot for NanoPi NEO (H3)
-  BUILD_DEVICES:=sun8i-h3-nanopi-neo
+  BUILD_DEVICES:=friendlyarm_nanopi-neo
 endef
 
 define U-Boot/orangepi_r1
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi R1 (H2+)
-  BUILD_DEVICES:=sun8i-h2-plus-orangepi-r1
+  BUILD_DEVICES:=xunlong_orangepi-r1
 endef
 
 define U-Boot/orangepi_zero
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi Zero (H2+)
-  BUILD_DEVICES:=sun8i-h2-plus-orangepi-zero
+  BUILD_DEVICES:=xunlong_orangepi-zero
 endef
 
 define U-Boot/orangepi_one
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi One (H3)
-  BUILD_DEVICES:=sun8i-h3-orangepi-one
+  BUILD_DEVICES:=xunlong_orangepi-one
 endef
 
 define U-Boot/orangepi_pc
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi PC (H3)
-  BUILD_DEVICES:=sun8i-h3-orangepi-pc
+  BUILD_DEVICES:=xunlong_orangepi-pc
 endef
 
 define U-Boot/orangepi_pc_plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi PC Plus (H3)
-  BUILD_DEVICES:=sun8i-h3-orangepi-pc-plus
+  BUILD_DEVICES:=xunlong_orangepi-pc-plus
 endef
 
 define U-Boot/orangepi_plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi Plus (H3)
-  BUILD_DEVICES:=sun8i-h3-orangepi-plus
+  BUILD_DEVICES:=xunlong_orangepi-plus
 endef
 
 define U-Boot/orangepi_2
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi 2 (H3)
-  BUILD_DEVICES:=sun8i-h3-orangepi-2
+  BUILD_DEVICES:=xunlong_orangepi-2
 endef
 
 define U-Boot/pangolin
@@ -195,7 +195,7 @@ endef
 define U-Boot/nanopi_neo_plus2
   BUILD_SUBTARGET:=cortexa53
   NAME:=NanoPi NEO Plus2 (H5)
-  BUILD_DEVICES:=sun50i-h5-nanopi-neo-plus2
+  BUILD_DEVICES:=friendlyarm_nanopi-neo-plus2
   DEPENDS:=+PACKAGE_u-boot-nanopi_neo_plus2:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -203,7 +203,7 @@ endef
 define U-Boot/nanopi_neo2
   BUILD_SUBTARGET:=cortexa53
   NAME:=NanoPi NEO2 (H5)
-  BUILD_DEVICES:=sun50i-h5-nanopi-neo2
+  BUILD_DEVICES:=friendlyarm_nanopi-neo2
   DEPENDS:=+PACKAGE_u-boot-nanopi_neo2:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -211,7 +211,7 @@ endef
 define U-Boot/pine64_plus
   BUILD_SUBTARGET:=cortexa53
   NAME:=Pine64 Plus A64
-  BUILD_DEVICES:=sun50i-a64-pine64-plus
+  BUILD_DEVICES:=pine64_pine64-plus
   DEPENDS:=+PACKAGE_u-boot-pine64_plus:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -219,13 +219,13 @@ endef
 define U-Boot/Sinovoip_BPI_M2_Plus
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M2 Plus
-  BUILD_DEVICES:=sun8i-h3-bananapi-m2-plus
+  BUILD_DEVICES:=sinovoip_bananapi-m2-plus
 endef
 
 define U-Boot/sopine_baseboard
   BUILD_SUBTARGET:=cortexa53
   NAME:=Sopine Baseboard
-  BUILD_DEVICES:=sun50i-a64-sopine-baseboard
+  BUILD_DEVICES:=pine64_sopine-baseboard
   DEPENDS:=+PACKAGE_u-boot-sopine_baseboard:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -234,7 +234,7 @@ endef
 define U-Boot/orangepi_zero_plus
   BUILD_SUBTARGET:=cortexa53
   NAME:=Xunlong Orange Pi Zero Plus
-  BUILD_DEVICES:=sun50i-h5-orangepi-zero-plus
+  BUILD_DEVICES:=xunlong_orangepi-zero-plus
   DEPENDS:=+PACKAGE_u-boot-orangepi_zero_plus:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -242,7 +242,7 @@ endef
 define U-Boot/orangepi_pc2
   BUILD_SUBTARGET:=cortexa53
   NAME:=Xunlong Orange Pi PC2
-  BUILD_DEVICES:=sun50i-h5-orangepi-pc2
+  BUILD_DEVICES:=xunlong_orangepi-pc2
   DEPENDS:=+PACKAGE_u-boot-orangepi_pc2:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
@@ -250,7 +250,7 @@ endef
 define U-Boot/Sinovoip_BPI_M2_Ultra
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M2 Ultra
-  BUILD_DEVICES:=sun8i-r40-bananapi-m2-ultra
+  BUILD_DEVICES:=lemaker_bananapi-m2-ultra
 endef
 
 UBOOT_TARGETS := \

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -37,6 +37,7 @@ define Device/Default
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
+  SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
 endef
 
 include cortex-a7.mk

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -32,12 +32,15 @@ endef
 # why \x00\x00\x00\x00 for zImage-initramfs
 define Device/Default
   PROFILES := Default
-  DEVICE_VARS := SUNXI_DTS SUNXI_UBOOT
+  DEVICE_VARS := SUNXI_SOC SUNXI_DTS SUNXI_DTS_DIR SUNXI_UBOOT
   KERNEL_NAME := zImage
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
+  SUNXI_SOC :=
+  SUNXI_DTS_DIR :=
+  SUNXI_DTS = $$(SUNXI_DTS_DIR)$$(SUNXI_SOC)-$(lastword $(subst _, ,$(1)))
 endef
 
 include cortex-a7.mk

--- a/target/linux/sunxi/image/cortex-a53.mk
+++ b/target/linux/sunxi/image/cortex-a53.mk
@@ -7,7 +7,7 @@
 #
 ifeq ($(SUBTARGET),cortexa53)
 
-define Device/sun50i-h5-nanopi-neo-plus2
+define Device/friendlyarm_nanopi-neo-plus2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Plus2
   SUPPORTED_DEVICES:=nanopi-neo-plus2
@@ -16,9 +16,9 @@ define Device/sun50i-h5-nanopi-neo-plus2
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-h5-nanopi-neo-plus2
+TARGET_DEVICES += friendlyarm_nanopi-neo-plus2
 
-define Device/sun50i-h5-nanopi-neo2
+define Device/friendlyarm_nanopi-neo2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO2
   SUPPORTED_DEVICES:=nanopi-neo2
@@ -27,51 +27,47 @@ define Device/sun50i-h5-nanopi-neo2
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-h5-nanopi-neo2
+TARGET_DEVICES += friendlyarm_nanopi-neo2
 
-define Device/sun50i-a64-pine64-plus
+define Device/pine64_pine64-plus
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := Pine64+
-  SUPPORTED_DEVICES:=pine64,pine64-plus
   SUNXI_DTS:=allwinner/sun50i-a64-pine64-plus
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-a64-pine64-plus
+TARGET_DEVICES += pine64_pine64-plus
 
-define Device/sun50i-a64-sopine-baseboard
+define Device/pine64_sopine-baseboard
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := SoPine
-  SUPPORTED_DEVICES:=pine64,sopine-baseboard
   SUNXI_DTS:=allwinner/sun50i-a64-sopine-baseboard
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-a64-sopine-baseboard
+TARGET_DEVICES += pine64_sopine-baseboard
 
 
-define Device/sun50i-h5-orangepi-zero-plus
+define Device/xunlong_orangepi-zero-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero Plus
-  SUPPORTED_DEVICES:=xunlong,orangepi-zero-plus
   SUNXI_DTS:=allwinner/sun50i-h5-orangepi-zero-plus
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-h5-orangepi-zero-plus
+TARGET_DEVICES += xunlong_orangepi-zero-plus
 
-define Device/sun50i-h5-orangepi-pc2
+define Device/xunlong_orangepi-pc2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC 2
-  SUPPORTED_DEVICES:=xunlong,orangepi-pc2
   SUNXI_DTS:=allwinner/sun50i-h5-orangepi-pc2
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
 
-TARGET_DEVICES += sun50i-h5-orangepi-pc2
+TARGET_DEVICES += xunlong_orangepi-pc2
 
 endif

--- a/target/linux/sunxi/image/cortex-a53.mk
+++ b/target/linux/sunxi/image/cortex-a53.mk
@@ -11,7 +11,8 @@ define Device/friendlyarm_nanopi-neo-plus2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Plus2
   SUPPORTED_DEVICES:=nanopi-neo-plus2
-  SUNXI_DTS:=allwinner/sun50i-h5-nanopi-neo-plus2
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-h5
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
@@ -22,7 +23,8 @@ define Device/friendlyarm_nanopi-neo2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO2
   SUPPORTED_DEVICES:=nanopi-neo2
-  SUNXI_DTS:=allwinner/sun50i-h5-nanopi-neo2
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-h5
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
@@ -32,7 +34,8 @@ TARGET_DEVICES += friendlyarm_nanopi-neo2
 define Device/pine64_pine64-plus
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := Pine64+
-  SUNXI_DTS:=allwinner/sun50i-a64-pine64-plus
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-a64
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
@@ -42,7 +45,8 @@ TARGET_DEVICES += pine64_pine64-plus
 define Device/pine64_sopine-baseboard
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := SoPine
-  SUNXI_DTS:=allwinner/sun50i-a64-sopine-baseboard
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-a64
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
@@ -53,7 +57,8 @@ TARGET_DEVICES += pine64_sopine-baseboard
 define Device/xunlong_orangepi-zero-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero Plus
-  SUNXI_DTS:=allwinner/sun50i-h5-orangepi-zero-plus
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-h5
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef
@@ -63,7 +68,8 @@ TARGET_DEVICES += xunlong_orangepi-zero-plus
 define Device/xunlong_orangepi-pc2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC 2
-  SUNXI_DTS:=allwinner/sun50i-h5-orangepi-pc2
+  SUNXI_DTS_DIR := allwinner/
+  SUNXI_SOC := sun50i-h5
   KERNEL_NAME := Image
   KERNEL := kernel-bin
 endef

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -12,7 +12,7 @@ define Device/olimex_a20-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi
-  SUNXI_DTS:=sun7i-a20-olinuxino-lime
+  SUNXI_SOC := sun7i
 endef
 
 TARGET_DEVICES += olimex_a20-olinuxino-lime
@@ -22,7 +22,7 @@ define Device/olimex_a20-olinuxino-lime2
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
-  SUNXI_DTS:=sun7i-a20-olinuxino-lime2
+  SUNXI_SOC := sun7i
 endef
 
 TARGET_DEVICES += olimex_a20-olinuxino-lime2
@@ -33,7 +33,7 @@ define Device/olimex_a20-olinuxino-lime2-emmc
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_VARIANT := eMMC
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
-  SUNXI_DTS:=sun7i-a20-olinuxino-lime2-emmc
+  SUNXI_SOC := sun7i
 endef
 
 TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
@@ -43,7 +43,7 @@ define Device/olimex_a20-olinuxino-micro
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-MICRO
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUNXI_DTS:=sun7i-a20-olinuxino-micro
+  SUNXI_SOC := sun7i
 endef
 
 TARGET_DEVICES += olimex_a20-olinuxino-micro
@@ -53,7 +53,7 @@ define Device/lemaker_bananapi
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi
-  SUNXI_DTS:=sun7i-a20-bananapi
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += lemaker_bananapi
@@ -63,7 +63,7 @@ define Device/lemaker_bananapro
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pro
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi kmod-brcmfmac
-  SUNXI_DTS:=sun7i-a20-bananapro
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += lemaker_bananapro
@@ -73,7 +73,7 @@ define Device/cubietech_cubieboard2
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard2
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUNXI_DTS:=sun7i-a20-cubieboard2
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += cubietech_cubieboard2
@@ -83,7 +83,7 @@ define Device/cubietech_cubietruck
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubietruck
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-brcmfmac
-  SUNXI_DTS:=sun7i-a20-cubietruck
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += cubietech_cubietruck
@@ -93,7 +93,7 @@ define Device/lamobo_lamobo-r1
   DEVICE_VENDOR := Lamobo
   DEVICE_MODEL := Lamobo R1
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtl8192cu swconfig wpad-basic
-  SUNXI_DTS:=sun7i-a20-lamobo-r1
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += lamobo_lamobo-r1
@@ -103,7 +103,7 @@ define Device/mele_m9
   DEVICE_VENDOR := Mele
   DEVICE_MODEL := M9
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
-  SUNXI_DTS:=sun6i-a31-m9
+  SUNXI_SOC := sun6i-a31
 endef
 
 TARGET_DEVICES += mele_m9
@@ -113,7 +113,7 @@ define Device/xunlong_orangepi-zero
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUNXI_DTS:=sun8i-h2-plus-orangepi-zero
+  SUNXI_SOC := sun8i-h2-plus
 endef
 
 TARGET_DEVICES += xunlong_orangepi-zero
@@ -123,7 +123,7 @@ define Device/xunlong_orangepi-r1
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi R1
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-usb-net kmod-usb-net-rtl8152
-  SUNXI_DTS:=sun8i-h2-plus-orangepi-r1
+  SUNXI_SOC := sun8i-h2-plus
 endef
 
 TARGET_DEVICES += xunlong_orangepi-r1
@@ -134,7 +134,7 @@ define Device/sinovoip_bananapi-m2-plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi \
 	kmod-leds-gpio kmod-ledtrig-heartbeat \
 	kmod-brcmfmac brcmfmac-firmware-43430a0-sdio wpad-basic
-  SUNXI_DTS:=sun8i-h3-bananapi-m2-plus
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += sinovoip_bananapi-m2-plus
@@ -145,7 +145,7 @@ define Device/friendlyarm_nanopi-m1-plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi \
 	kmod-leds-gpio kmod-ledtrig-heartbeat \
 	kmod-brcmfmac brcmfmac-firmware-43430-sdio wpad-basic
-  SUNXI_DTS:=sun8i-h3-nanopi-m1-plus
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += friendlyarm_nanopi-m1-plus
@@ -154,7 +154,7 @@ TARGET_DEVICES += friendlyarm_nanopi-m1-plus
 define Device/friendlyarm_nanopi-neo
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO
-  SUNXI_DTS:=sun8i-h3-nanopi-neo
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += friendlyarm_nanopi-neo
@@ -164,7 +164,7 @@ define Device/xunlong_orangepi-one
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUNXI_DTS:=sun8i-h3-orangepi-one
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += xunlong_orangepi-one
@@ -174,7 +174,7 @@ define Device/xunlong_orangepi-pc
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
-  SUNXI_DTS:=sun8i-h3-orangepi-pc
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += xunlong_orangepi-pc
@@ -184,7 +184,7 @@ define Device/xunlong_orangepi-pc-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
-  SUNXI_DTS:=sun8i-h3-orangepi-pc-plus
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += xunlong_orangepi-pc-plus
@@ -194,7 +194,7 @@ define Device/xunlong_orangepi-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUNXI_DTS:=sun8i-h3-orangepi-plus
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += xunlong_orangepi-plus
@@ -203,7 +203,7 @@ define Device/xunlong_orangepi-2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi 2
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUNXI_DTS:=sun8i-h3-orangepi-2
+  SUNXI_SOC := sun8i-h3
 endef
 
 TARGET_DEVICES += xunlong_orangepi-2
@@ -213,7 +213,7 @@ define Device/linksprite_pcduino3
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi kmod-rtl8xxxu rtl8188eu-firmware
-  SUNXI_DTS:=sun7i-a20-pcduino3
+  SUNXI_SOC := sun7i-a20
 endef
 
 TARGET_DEVICES += linksprite_pcduino3
@@ -222,7 +222,7 @@ define Device/lemaker_bananapi-m2-ultra
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi
-  SUNXI_DTS:=sun8i-r40-bananapi-m2-ultra
+  SUNXI_SOC := sun8i-r40
 endef
 
 TARGET_DEVICES += lemaker_bananapi-m2-ultra

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -8,245 +8,223 @@
 
 ifeq ($(SUBTARGET),cortexa7)
 
-define Device/sun7i-a20-olinuxino-lime
+define Device/olimex_a20-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=olimex,a20-olinuxino-lime
   SUNXI_DTS:=sun7i-a20-olinuxino-lime
 endef
 
-TARGET_DEVICES += sun7i-a20-olinuxino-lime
+TARGET_DEVICES += olimex_a20-olinuxino-lime
 
 
-define Device/sun7i-a20-olinuxino-lime2
+define Device/olimex_a20-olinuxino-lime2
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
-  SUPPORTED_DEVICES:=olimex,a20-olinuxino-lime2
   SUNXI_DTS:=sun7i-a20-olinuxino-lime2
 endef
 
-TARGET_DEVICES += sun7i-a20-olinuxino-lime2
+TARGET_DEVICES += olimex_a20-olinuxino-lime2
 
 
-define Device/sun7i-a20-olinuxino-lime2-emmc
+define Device/olimex_a20-olinuxino-lime2-emmc
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_VARIANT := eMMC
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
-  SUPPORTED_DEVICES:=olimex,a20-olinuxino-lime2-emmc
   SUNXI_DTS:=sun7i-a20-olinuxino-lime2-emmc
 endef
 
-TARGET_DEVICES += sun7i-a20-olinuxino-lime2-emmc
+TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
 
 
-define Device/sun7i-a20-olinuxino-micro
+define Device/olimex_a20-olinuxino-micro
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-MICRO
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=olimex,a20-olinuxino-micro
   SUNXI_DTS:=sun7i-a20-olinuxino-micro
 endef
 
-TARGET_DEVICES += sun7i-a20-olinuxino-micro
+TARGET_DEVICES += olimex_a20-olinuxino-micro
 
 
-define Device/sun7i-a20-bananapi
+define Device/lemaker_bananapi
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi
-  SUPPORTED_DEVICES:=lemaker,bananapi
   SUNXI_DTS:=sun7i-a20-bananapi
 endef
 
-TARGET_DEVICES += sun7i-a20-bananapi
+TARGET_DEVICES += lemaker_bananapi
 
 
-define Device/sun7i-a20-bananapro
+define Device/lemaker_bananapro
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pro
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi kmod-brcmfmac
-  SUPPORTED_DEVICES:=lemaker,bananapro
   SUNXI_DTS:=sun7i-a20-bananapro
 endef
 
-TARGET_DEVICES += sun7i-a20-bananapro
+TARGET_DEVICES += lemaker_bananapro
 
 
-define Device/sun7i-a20-cubieboard2
+define Device/cubietech_cubieboard2
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard2
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=cubietech,cubieboard2
   SUNXI_DTS:=sun7i-a20-cubieboard2
 endef
 
-TARGET_DEVICES += sun7i-a20-cubieboard2
+TARGET_DEVICES += cubietech_cubieboard2
 
 
-define Device/sun7i-a20-cubietruck
+define Device/cubietech_cubietruck
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubietruck
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-rtc-sunxi kmod-brcmfmac
-  SUPPORTED_DEVICES:=cubietech,cubietruck
   SUNXI_DTS:=sun7i-a20-cubietruck
 endef
 
-TARGET_DEVICES += sun7i-a20-cubietruck
+TARGET_DEVICES += cubietech_cubietruck
 
 
-define Device/sun7i-a20-lamobo-r1
+define Device/lamobo_lamobo-r1
   DEVICE_VENDOR := Lamobo
   DEVICE_MODEL := Lamobo R1
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtl8192cu swconfig wpad-basic
-  SUPPORTED_DEVICES:=lamobo,lamobo-r1
   SUNXI_DTS:=sun7i-a20-lamobo-r1
 endef
 
-TARGET_DEVICES += sun7i-a20-lamobo-r1
+TARGET_DEVICES += lamobo_lamobo-r1
 
 
-define Device/sun6i-a31-m9
+define Device/mele_m9
   DEVICE_VENDOR := Mele
   DEVICE_MODEL := M9
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
-  SUPPORTED_DEVICES:=mele,m9
   SUNXI_DTS:=sun6i-a31-m9
 endef
 
-TARGET_DEVICES += sun6i-a31-m9
+TARGET_DEVICES += mele_m9
 
 
-define Device/sun8i-h2-plus-orangepi-zero
+define Device/xunlong_orangepi-zero
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=xunlong,orangepi-zero
   SUNXI_DTS:=sun8i-h2-plus-orangepi-zero
 endef
 
-TARGET_DEVICES += sun8i-h2-plus-orangepi-zero
+TARGET_DEVICES += xunlong_orangepi-zero
 
 
-define Device/sun8i-h2-plus-orangepi-r1
+define Device/xunlong_orangepi-r1
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi R1
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-usb-net kmod-usb-net-rtl8152
-  SUPPORTED_DEVICES:=xunlong,orangepi-r1
   SUNXI_DTS:=sun8i-h2-plus-orangepi-r1
 endef
 
-TARGET_DEVICES += sun8i-h2-plus-orangepi-r1
+TARGET_DEVICES += xunlong_orangepi-r1
 
-define Device/sun8i-h3-bananapi-m2-plus
+define Device/sinovoip_bananapi-m2-plus
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-rtc-sunxi \
 	kmod-leds-gpio kmod-ledtrig-heartbeat \
 	kmod-brcmfmac brcmfmac-firmware-43430a0-sdio wpad-basic
-  SUPPORTED_DEVICES:=sinovoip,bananapi-m2-plus
   SUNXI_DTS:=sun8i-h3-bananapi-m2-plus
 endef
 
-TARGET_DEVICES += sun8i-h3-bananapi-m2-plus
+TARGET_DEVICES += sinovoip_bananapi-m2-plus
 
-define Device/sun8i-h3-nanopi-m1-plus
+define Device/friendlyarm_nanopi-m1-plus
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi \
 	kmod-leds-gpio kmod-ledtrig-heartbeat \
 	kmod-brcmfmac brcmfmac-firmware-43430-sdio wpad-basic
-  SUPPORTED_DEVICES:=friendlyarm,nanopi-m1-plus
   SUNXI_DTS:=sun8i-h3-nanopi-m1-plus
 endef
 
-TARGET_DEVICES += sun8i-h3-nanopi-m1-plus
+TARGET_DEVICES += friendlyarm_nanopi-m1-plus
 
 
-define Device/sun8i-h3-nanopi-neo
+define Device/friendlyarm_nanopi-neo
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO
-  SUPPORTED_DEVICES:=friendlyarm,nanopi-neo
   SUNXI_DTS:=sun8i-h3-nanopi-neo
 endef
 
-TARGET_DEVICES += sun8i-h3-nanopi-neo
+TARGET_DEVICES += friendlyarm_nanopi-neo
 
 
-define Device/sun8i-h3-orangepi-one
+define Device/xunlong_orangepi-one
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=xunlong,orangepi-one
   SUNXI_DTS:=sun8i-h3-orangepi-one
 endef
 
-TARGET_DEVICES += sun8i-h3-orangepi-one
+TARGET_DEVICES += xunlong_orangepi-one
 
 
-define Device/sun8i-h3-orangepi-pc
+define Device/xunlong_orangepi-pc
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
-  SUPPORTED_DEVICES:=xunlong,orangepi-pc
   SUNXI_DTS:=sun8i-h3-orangepi-pc
 endef
 
-TARGET_DEVICES += sun8i-h3-orangepi-pc
+TARGET_DEVICES += xunlong_orangepi-pc
 
 
-define Device/sun8i-h3-orangepi-pc-plus
+define Device/xunlong_orangepi-pc-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
-  SUPPORTED_DEVICES:=xunlong,orangepi-pc-plus
   SUNXI_DTS:=sun8i-h3-orangepi-pc-plus
 endef
 
-TARGET_DEVICES += sun8i-h3-orangepi-pc-plus
+TARGET_DEVICES += xunlong_orangepi-pc-plus
 
 
-define Device/sun8i-h3-orangepi-plus
+define Device/xunlong_orangepi-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=xunlong,orangepi-plus
   SUNXI_DTS:=sun8i-h3-orangepi-plus
 endef
 
-TARGET_DEVICES += sun8i-h3-orangepi-plus
+TARGET_DEVICES += xunlong_orangepi-plus
 
-define Device/sun8i-h3-orangepi-2
+define Device/xunlong_orangepi-2
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi 2
   DEVICE_PACKAGES:=kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=xunlong,orangepi-2
   SUNXI_DTS:=sun8i-h3-orangepi-2
 endef
 
-TARGET_DEVICES += sun8i-h3-orangepi-2
+TARGET_DEVICES += xunlong_orangepi-2
 
 
-define Device/sun7i-a20-pcduino3
+define Device/linksprite_pcduino3
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi kmod-rtl8xxxu rtl8188eu-firmware
-  SUPPORTED_DEVICES:=linksprite,pcduino3
   SUNXI_DTS:=sun7i-a20-pcduino3
 endef
 
-TARGET_DEVICES += sun7i-a20-pcduino3
+TARGET_DEVICES += linksprite_pcduino3
 
-define Device/sun8i-r40-bananapi-m2-ultra
+define Device/lemaker_bananapi-m2-ultra
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-core kmod-ata-sunxi
-  SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
   SUNXI_DTS:=sun8i-r40-bananapi-m2-ultra
 endef
 
-TARGET_DEVICES += sun8i-r40-bananapi-m2-ultra
+TARGET_DEVICES += lemaker_bananapi-m2-ultra
 
 endif

--- a/target/linux/sunxi/image/cortex-a8.mk
+++ b/target/linux/sunxi/image/cortex-a8.mk
@@ -7,18 +7,17 @@
 #
 ifeq ($(SUBTARGET),cortexa8)
 
-define Device/sun4i-a10-olinuxino-lime
+define Device/olimex_a10-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A10-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=olimex,a10-olinuxino-lime
   SUNXI_DTS:=sun4i-a10-olinuxino-lime
 endef
 
-TARGET_DEVICES += sun4i-a10-olinuxino-lime
+TARGET_DEVICES += olimex_a10-olinuxino-lime
 
 
-define Device/sun5i-a13-olimex-som
+define Device/olimex_a13-olimex-som
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-SOM
   DEVICE_PACKAGES:=kmod-rtl8192cu
@@ -26,50 +25,46 @@ define Device/sun5i-a13-olimex-som
   SUNXI_DTS:=sun5i-a13-olinuxino
 endef
 
-TARGET_DEVICES += sun5i-a13-olimex-som
+TARGET_DEVICES += olimex_a13-olimex-som
 
 
-define Device/sun5i-a13-olinuxino
+define Device/olimex_a13-olinuxino
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-OLinuXino
   DEVICE_PACKAGES:=kmod-rtl8192cu
-  SUPPORTED_DEVICES:=olimex,a13-olinuxino
   SUNXI_DTS:=sun5i-a13-olinuxino
 endef
 
-TARGET_DEVICES += sun5i-a13-olinuxino
+TARGET_DEVICES += olimex_a13-olinuxino
 
 
-define Device/sun4i-a10-cubieboard
+define Device/cubietech_a10-cubieboard
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUPPORTED_DEVICES:=cubietech,a10-cubieboard
   SUNXI_DTS:=sun4i-a10-cubieboard
 endef
 
-TARGET_DEVICES += sun4i-a10-cubieboard
+TARGET_DEVICES += cubietech_a10-cubieboard
 
 
-define Device/sun4i-a10-pcduino
+define Device/linksprite_a10-pcduino
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
-  SUPPORTED_DEVICES:=linksprite,a10-pcduino
   SUNXI_DTS:=sun4i-a10-pcduino
 endef
 
-TARGET_DEVICES += sun4i-a10-pcduino
+TARGET_DEVICES += linksprite_a10-pcduino
 
 
-define Device/sun4i-a10-marsboard
+define Device/marsboard_a10-marsboard
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
   DEVICE_PACKAGES:=mod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi sound-soc-sunxi
-  SUPPORTED_DEVICES:=marsboard,a10-marsboard
   SUNXI_DTS:=sun4i-a10-marsboard
 endef
 
-TARGET_DEVICES += sun4i-a10-marsboard
+TARGET_DEVICES += marsboard_a10-marsboard
 
 endif

--- a/target/linux/sunxi/image/cortex-a8.mk
+++ b/target/linux/sunxi/image/cortex-a8.mk
@@ -11,7 +11,7 @@ define Device/olimex_a10-olinuxino-lime
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A10-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUNXI_DTS:=sun4i-a10-olinuxino-lime
+  SUNXI_SOC := sun4i
 endef
 
 TARGET_DEVICES += olimex_a10-olinuxino-lime
@@ -22,7 +22,8 @@ define Device/olimex_a13-olimex-som
   DEVICE_MODEL := A13-SOM
   DEVICE_PACKAGES:=kmod-rtl8192cu
   SUPPORTED_DEVICES:=olimex,a13-olinuxino
-  SUNXI_DTS:=sun5i-a13-olinuxino
+  SUNXI_SOC := sun5i-a13
+  SUNXI_DTS := sun5i-a13-olinuxino
 endef
 
 TARGET_DEVICES += olimex_a13-olimex-som
@@ -32,7 +33,7 @@ define Device/olimex_a13-olinuxino
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-OLinuXino
   DEVICE_PACKAGES:=kmod-rtl8192cu
-  SUNXI_DTS:=sun5i-a13-olinuxino
+  SUNXI_SOC := sun5i
 endef
 
 TARGET_DEVICES += olimex_a13-olinuxino
@@ -42,7 +43,7 @@ define Device/cubietech_a10-cubieboard
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
-  SUNXI_DTS:=sun4i-a10-cubieboard
+  SUNXI_SOC := sun4i
 endef
 
 TARGET_DEVICES += cubietech_a10-cubieboard
@@ -52,7 +53,7 @@ define Device/linksprite_a10-pcduino
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
-  SUNXI_DTS:=sun4i-a10-pcduino
+  SUNXI_SOC := sun4i
 endef
 
 TARGET_DEVICES += linksprite_a10-pcduino
@@ -62,7 +63,7 @@ define Device/marsboard_a10-marsboard
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
   DEVICE_PACKAGES:=mod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi sound-soc-sunxi
-  SUNXI_DTS:=sun4i-a10-marsboard
+  SUNXI_SOC := sun4i
 endef
 
 TARGET_DEVICES += marsboard_a10-marsboard


### PR DESCRIPTION
_This is a copy of the patches submitted to the mailing list. It is posted here to increase the audience for testers:_
https://patchwork.ozlabs.org/project/openwrt/list/?series=147045

This consolidates the various repetitions of device names
in sunxi image Makefiles, and makes naming more consistent
in general.

This is achieved by calculating SUPPORTED_DEVICES from the
node name (as in ath79/ramips) and build the DTS name based
on that.

With this change, future device support should be easier,
as there are less cases where you just have to write the same
name again.

I've build-tested this for all subtargets, but I would be glad
about one or two device-testers.