### PR TITLE
ath79: restore gpio-export for USB power control on TL-WDR3600/4300

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -6,6 +6,34 @@
 	aliases {
 		label-mac-device = &ath9k;
 	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_usb1_power {
+			gpio-export,name = "tp-link:power:usb1";
+			gpio-export,output = <1>;
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_usb2_power {
+			gpio-export,name = "tp-link:power:usb2";
+			gpio-export,output = <1>;
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_ext_lna0 {
+			gpio-export,name = "tp-link:ext:lna0";
+			gpio-export,output = <1>;
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_ext_lna1 {
+			gpio-export,name = "tp-link:ext:lna1";
+			gpio-export,output = <1>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &leds {
@@ -21,36 +49,6 @@
 		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&hub_port2>;
 		linux,default-trigger = "usbport";
-	};
-};
-
-&gpio {
-	lna0 {
-		gpio-hog;
-		gpios = <18 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "tp-link:ext:lna0";
-	};
-
-	lna1 {
-		gpio-hog;
-		gpios = <19 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "tp-link:ext:lna1";
-	};
-
-	usb1_power {
-		gpio-hog;
-		gpios = <22 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "tp-link:power:usb1";
-	};
-
-	usb2_power {
-		gpio-hog;
-		gpios = <21 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "tp-link:power:usb2";
 	};
 };
 


### PR DESCRIPTION
This partially reverts commit 32144ba275d163ce6e7d93546ab4414f03f508fb.

This commit replaced gpio-exports in favor of gpio-hogs for enabling USB
power at boot, but this rids the user of control of the USB port power
present on this device for a long time. It was agreed on a mailing list
[1] that this is not the way to go, and this patch breaks a very common
use-case of WWAN modem reset by power cycle, used on a lot USB equipped
routers, hence revert this change until a better solution can be found.

[1] http://lists.infradead.org/pipermail/openwrt-devel/2019-November/020151.html

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

Compile- and run-tested on TL-WDR4300 v1.3