### PR TITLE
[RFT] ath79: add support for GL.iNet 6408/6416 (GL.iNet V1)

### DIFF
--- a/target/linux/ath79/dts/ar9331_glinet_6408.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6408.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9331_glinet_64xx.dtsi"
+
+/ {
+	model = "GL.iNet 6408";
+	compatible = "glinet,6408", "qca,ar9331";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x7d0000>;
+				label = "firmware";
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9331_glinet_6416.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6416.dts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9331_glinet_64xx.dtsi"
+
+/ {
+	model = "GL.iNet 6416";
+	compatible = "glinet,6416", "qca,ar9331";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0xfd0000>;
+				label = "firmware";
+			};
+
+			art: partition@ff0000 {
+				reg = <0xff0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9331_glinet_64xx.dtsi
+++ b/target/linux/ath79/dts/ar9331_glinet_64xx.dtsi
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "gl-inet:red:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "gl-inet:green:lan";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -90,6 +90,10 @@ etactica,eg200)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:red:eth0" "eth0"
 	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"
 	;;
+glinet,6408|\
+glinet,6416)
+	ucidef_set_led_netdev "lan" "LAN" "gl-inet:green:lan" "eth0"
+	;;
 glinet,gl-ar150)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x02"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -557,6 +557,30 @@ define Device/etactica_eg200
 endef
 TARGET_DEVICES += etactica_eg200
 
+define Device/glinet_6408
+  $(Device/tplink-8mlzma)
+  SOC := ar9331
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := 6408
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 8000k
+  TPLINK_HWID := 0x08000001
+  SUPPORTED_DEVICES += gl-inet
+endef
+TARGET_DEVICES += glinet_6408
+
+define Device/glinet_6416
+  $(Device/tplink-16mlzma)
+  SOC := ar9331
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := 6416
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 16192k
+  TPLINK_HWID := 0x08000001
+  SUPPORTED_DEVICES += gl-inet
+endef
+TARGET_DEVICES += glinet_6416
+
 define Device/glinet_gl-ar150
   SOC := ar9330
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
_This is only build-tested and needs device testers._

This ports the GL.iNet 6408/6416 from ar71xx.

The GL-Connect GL.iNet v1 routers are basically a TP-Link TL-WR710N with
more DRAM/Flash and console/GPIO header in the same small form-factor.

The difference between 6408 and 6416 is just the flash size, but ar71xx
uses the same board name for both. So, unintended cross-flashing might
brick the device.