### PR TITLE
[RFT] ath79: add support for TP-Link TL-WA850RE v1 and TL-WA860RE v1

### DIFF
--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &wmac;
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa850re-v1.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa850re-v1.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9341_tplink_tl-wa.dtsi"
+
+/ {
+	model = "TP-Link TL-WA850RE v1";
+	compatible = "tplink,tl-wa850re-v1", "qca,ar9341";
+
+	aliases {
+		led-boot = &led_re;
+		led-failsafe = &led_re;
+		led-running = &led_re;
+		led-upgrade = &led_re;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:blue:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:blue:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_re: re {
+			label = "tp-link:blue:re";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "tp-link:blue:signal1";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "tp-link:blue:signal2";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "tp-link:blue:signal3";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		signal4 {
+			label = "tp-link:blue:signal4";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		signal5 {
+			label = "tp-link:blue:signal5";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa860re-v1.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa860re-v1.dts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9341_tplink_tl-wa.dtsi"
+
+/ {
+	model = "TP-Link TL-WA860RE v1";
+	compatible = "tplink,tl-wa860re-v1", "qca,ar9341";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		onoff {
+			label = "ONOFF";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "tp-link:green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_power_orange: power_orange {
+			label = "tp-link:orange:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_green {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan_orange {
+			label = "tp-link:orange:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -77,6 +77,16 @@ define Device/tplink_tl-wa850re-v1
 endef
 TARGET_DEVICES += tplink_tl-wa850re-v1
 
+define Device/tplink_tl-wa860re-v1
+  $(Device/tplink-4mlzma)
+  SOC := ar9341
+  DEVICE_MODEL := TL-WA860RE
+  DEVICE_VARIANT := v1
+  TPLINK_HWID := 0x08600001
+  SUPPORTED_DEVICES += tl-wa860re
+endef
+TARGET_DEVICES += tplink_tl-wa860re-v1
+
 define Device/tplink_tl-wa901nd-v2
   $(Device/tplink-4m)
   SOC := ar9132

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -66,6 +66,17 @@ define Device/tplink_tl-mr3420-v2
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v2
 
+define Device/tplink_tl-wa850re-v1
+  $(Device/tplink-4mlzma)
+  SOC := ar9341
+  DEVICE_MODEL := TL-WA850RE
+  DEVICE_VARIANT := v1
+  TPLINK_HWID := 0x08500001
+  DEVICE_PACKAGES := rssileds
+  SUPPORTED_DEVICES += tl-wa850re
+endef
+TARGET_DEVICES += tplink_tl-wa850re-v1
+
 define Device/tplink_tl-wa901nd-v2
   $(Device/tplink-4m)
   SOC := ar9132

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -41,7 +41,8 @@ on,n150r)
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
 tplink,tl-mr3020-v1|\
-tplink,tl-mr3040-v2)
+tplink,tl-mr3040-v2|\
+tplink,tl-wa860re-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -54,6 +54,15 @@ tplink,tl-wr841-v8)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x02"
 	;;
+tplink,tl-wa850re-v1)
+	ucidef_set_led_netdev "lan" "LAN" "tp-link:blue:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "tp-link:blue:signal1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "tp-link:blue:signal2" "wlan0" "20" "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "tp-link:blue:signal3" "wlan0" "40" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "tp-link:blue:signal4" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:blue:signal5" "wlan0" "80" "100"
+	;;
 tplink,tl-wr740n-v1|\
 tplink,tl-wr740n-v3|\
 tplink,tl-wr741-v1|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -33,6 +33,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\
 	tplink,tl-wa850re-v1|\
+	tplink,tl-wa860re-v1|\
 	tplink,tl-wa901nd-v2|\
 	tplink,tl-wr703n)
 		ucidef_set_interface_lan "eth0"

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\
+	tplink,tl-wa850re-v1|\
 	tplink,tl-wa901nd-v2|\
 	tplink,tl-wr703n)
 		ucidef_set_interface_lan "eth0"


### PR DESCRIPTION
This ports device support for the old v1 versions of TL-WA850RE and TL-WA860RE from ar71xx.

_This is done based on code only, I do not own the devices. Please test, but be aware of the risks explained below._

~~Based on the reports by @Gingernut1978 and on the dmesg, it seems that eth0 is not coming up properly.~~

WA850RE has been merged, and network setup for WA860RE is the same. So, risk for bricking should be lower now.

**Nevertheless, make sure you have WiFi enabled by default for testing, or you risk locking you out of the device. Any hints welcome on what's wrong with the network setup.**

Current development state is available at: https://git.openwrt.org/?p=openwrt/staging/adrian.git;a=shortlog;h=refs/heads/rft-devices-ath79

Those devices are ugly for several reasons:
- 4/32
- integrated power supply
- hard to open
- no "easy" TFTP

So, bricking the device will cause more pain than usual on these devices.

I will keep this open for about a month in case someone is interested.