### PR TITLE
lantiq: fix phys led

### DIFF
--- a/target/linux/lantiq/patches-4.19/0023-NET-PHY-add-led-support-for-intel-xway.patch
+++ b/target/linux/lantiq/patches-4.19/0023-NET-PHY-add-led-support-for-intel-xway.patch
@@ -42,10 +42,10 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED1L, tmp);
 +
 +	if (!of_property_read_u32(phydev->mdio.dev.of_node, "lantiq,led2h", &tmp))
-+		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED3H,  tmp);
++		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED2H,  tmp);
 +
 +	if (!of_property_read_u32(phydev->mdio.dev.of_node, "lantiq,led2l", &tmp))
-+		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED3L, tmp);
++		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED2L, tmp);
 +
 +	if (!of_property_read_u32(phydev->mdio.dev.of_node, "lantiq,led3h", &tmp))
 +		phy_write_mmd(phydev, MDIO_MMD_VEND2, XWAY_MMD_LED3H, tmp);


### PR DESCRIPTION
led2l and led2h value are incorrectly set by led3l and led3h.

It is used only by VG3503J.dts. This patch should be applied also to 19.07 and 18.06 .

Bug was introduced in commit: 863e79f8d5544a8a884375d7e867f350fddca9b9

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>