### PR TITLE
uhttpd: disable persistent http connections

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -76,7 +76,7 @@ config uhttpd main
 	# HTTP Keep-Alive, specifies the timeout for persistent
 	# HTTP/1.1 connections. Setting this to 0 will disable
 	# persistent HTTP connections.
-	option http_keepalive	20
+	option http_keepalive	0
 
 	# TCP Keep-Alive, send periodic keep-alive probes
 	# over established connections to detect dead peers.


### PR DESCRIPTION
The default value for persistent http connections causes trouble using luci in some browsers (XHR timeouts). 
Verified in openwrt 19.07.0-rc2 on a TP-Link RE450v2 with Chrome 78.
Disabling persistent http connections immediately sovles the problem so I suggest to set this as the default value.

Further discussion: [https://forum.openwrt.org/t/xhr-timeout-error-message/46696](https://forum.openwrt.org/t/xhr-timeout-error-message/46696)

Compile tested: ath79, TP-LINK RE450 v2, 19.07.0-rc2

Signed-off-by: Philipp Schuster <philippschuster@gmx.com>