### PR TITLE
lantiq: enable 5ghz wifi on VR200/VR200v

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/VR200.dtsi
@@ -132,6 +132,25 @@
 	};
 };
 
+&pcie0 {
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <2>;
+		#address-cells = <3>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			reg = <0 0 0 0 0>;
+			mediatek,mtd-eeprom = <&radio 0x0000>;
+			big-endian;
+			ieee80211-freq-limit = <5000000 6000000>;
+			mtd-mac-address = <&romfile 0xf100>;
+			mtd-mac-address-increment = <2>;
+		};
+	};
+};
+
 &pci0 {
 	status = "okay";
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_HIGH>;
@@ -189,7 +208,7 @@
 				read-only;
 			};
 
-			partition@ff0000 {
+			radio: partition@ff0000 {
 				reg = <0xff0000 0x10000>;
 				label = "radio";
 				read-only;

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -49,7 +49,7 @@ define Device/tplink_vr200
   TPLINK_HWID := 0x63e64801
   TPLINK_HWREV := 0x53
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic kmod-usb-dwc2 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += VR200
 endef
 TARGET_DEVICES += tplink_vr200
@@ -63,7 +63,7 @@ define Device/tplink_vr200v
   TPLINK_HWID := 0x73b70801
   TPLINK_HWREV := 0x2f
   IMAGE_SIZE := 15808k
-  DEVICE_PACKAGES:= kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
+  DEVICE_PACKAGES:= kmod-mt76x0e wpad-basic kmod-usb-dwc2 kmod-usb-ledtrig-usbport kmod-ltq-tapi kmod-ltq-vmmc
   SUPPORTED_DEVICES += VR200v
 endef
 TARGET_DEVICES += tplink_vr200v


### PR DESCRIPTION
Enable mt76 driver on VR200/VR200v.

Signed-off-by: Kevin Schmidt <kevin.patrick.schmidt@googlemail.com>
