### PR TITLE
ar71xx, ath79: fix MAC address setup for TL-WDR4300 board

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -633,6 +633,10 @@ ar71xx_setup_macs()
 	fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
+	tl-wdr4300)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	tl-wr1043n-v5|\
 	tl-wr1043nd-v4)
 		lan_mac=$(mtd_get_mac_binary product-info 0x8)

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
@@ -183,7 +183,7 @@ static void __init wdr4300_setup(void)
 
 	ath79_register_mdio(0, 0x0);
 
-	ath79_init_mac(ath79_eth0_data.mac_addr, mac, -2);
+	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
 
 	/* GMAC0 is connected to an AR8327N switch */
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -118,7 +118,6 @@
 	pll-data = <0x06000000 0x00000101 0x00001616>;
 
 	mtd-mac-address = <&uboot 0x1fc00>;
-	mtd-mac-address-increment = <(-2)>;
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -389,6 +389,12 @@ ath79_setup_macs()
 		base_mac=$(mtd_get_mac_binary info 0x8)
 		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
+	tplink,tl-wdr3600-v1|\
+	tplink,tl-wdr4300-v1|\
+	tplink,tl-wdr4300-v1-il)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	trendnet,tew-823dru)
 		lan_mac=$(mtd_get_mac_text mac 0x4)
 		wan_mac=$(mtd_get_mac_text mac 0x18)

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -20,7 +20,10 @@ tplink,archer-c7-v4|\
 tplink,archer-c7-v5)
 	migrate_leds "^$boardonly:=tp-link:"
 	;;
-tplink,archer-c7-v2)
+tplink,archer-c7-v2|\
+tplink,tl-wdr3600-v1|\
+tplink,tl-wdr4300-v1|\
+tplink,tl-wdr4300-v1-il)
 	migrate_leds ":blue:=:green:"
 	;;
 tplink,re355-v1)


### PR DESCRIPTION
The current ethernet MAC address setup of TL-WDR4300 board is different
from the setup of stock firmware:
```
OpenWrt: lan = label_mac -2, wan = label_mac -2
  stock: lan = label_mac,    wan = label_mac +1
```
This patch applies to all devices using TL-WDR4300 board:
TL-WDR3600 v1
TL-WDR4300 v1
TL-WDR4300 v1 (IL)
TL-WDR4310 v1
Mercury MW4530R v1

Ref: #2600