### PR TITLE
ramips: add support for TP-Link Archer C20 v5

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -42,11 +42,13 @@
 		wlan5g {
 			label = "archer-c20-v4:green:wlan5g";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g {
 			label = "archer-c20-v4:green:wlan2g";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {
@@ -82,7 +84,7 @@
 
 &state_default {
 	gpio {
-		ralink,group = "i2s", "refclk", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "wdt";
+		ralink,group = "i2s", "gpio", "refclk", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "wdt";
 		ralink,function = "gpio";
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_tplink_8m-split-uboot.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,archer-c20-v5", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer C20 v5";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "archer-c20-v5:green:power";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2 {
+			label = "archer-c20-v5:green:wlan2g";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5 {
+			label = "archer-c20-v5:green:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		lan {
+			label = "archer-c20-v5:green:lan";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "archer-c20-v5:green:wan";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "archer-c20-v5:orange:wan";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "archer-c20-v5:green:wps";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2s", "gpio", "refclk", "p0led_an", "p1led_an",
+					"p2led_an", "p3led_an", "p4led_an", "wdt";
+		ralink,function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&rom 0xf100>;
+		mtd-mac-address-increment = <(-1)>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -282,6 +282,21 @@ define Device/tplink_archer-c20-v4
 endef
 TARGET_DEVICES += tplink_archer-c20-v4
 
+define Device/tplink_archer-c20-v5
+  $(Device/tplink)
+  IMAGE_SIZE := 7616k
+  DEVICE_MODEL := Archer C20
+  DEVICE_VARIANT := v5
+  TPLINK_FLASHLAYOUT := 8MSUmtk
+  TPLINK_HWID := 0xc200005
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x5
+  TPLINK_HVERSION := 3
+  DEVICE_PACKAGES := kmod-mt76x0e
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += tplink_archer-c20-v5
+
 define Device/tplink_archer-c50-v3
   $(Device/tplink)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -55,7 +55,6 @@ tama,w06)
 tplink,archer-c20-v4)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
-	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:green:wlan2g" "wlan0"
 	;;
 tplink,archer-c50-v3|\
 tplink,archer-c50-v4)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -52,7 +52,8 @@ tama,w06)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:green:wlan" "phy0tpt"
 	;;
-tplink,archer-c20-v4)
+tplink,archer-c20-v4|\
+tplink,archer-c20-v5)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -40,6 +40,7 @@ ramips_setup_interfaces()
 	hiwifi,hc5861b|\
 	skylab,skw92a|\
 	tplink,archer-c20-v4|\
+	tplink,archer-c20-v5|\
 	tplink,archer-c50-v3|\
 	tplink,archer-c50-v4|\
 	tplink,tl-mr3420-v5|\
@@ -191,6 +192,7 @@ ramips_setup_macs()
 	tplink,tl-wr842n-v5)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xf100)" 1)
 		;;
+	tplink,archer-c20-v5|\
 	tplink,archer-c50-v4)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
 		;;

--- a/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,7 @@ platform_do_upgrade() {
 		}
 		default_do_upgrade "$1"
 		;;
+	tplink,archer-c20-v5|\
 	tplink,archer-c50-v4)
 		MTD_ARGS="-t romfile"
 		default_do_upgrade "$1"


### PR DESCRIPTION
TP-Link Archer C20 v5 is a router with 5-port FE switch and
non-detachable antennas. It's based on MediaTek MT7628N+MT7610EN.

Specification:
- MediaTek MT7628N/N (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 5x 10/100 Mbps Ethernet
- 3x external, non-detachable antennas
- UART (J1) header on PCB (115200 8n1)
- 7x LED (GPIO-controlled*), 2x button, power input switch

* WAN LED in this devices is a dual-color, dual-leads type which isn't
  (fully) supported by gpio-leds driver. This type of LED requires both
  GPIOs state change at the same time to select color or turn it off.
  For now, we support/use only the green part of the LED.

Create Factory image
--------------------
As all installation methods require a U-Boot to be integrated into the
Image (and we do not ship one with the image) we are not able to create
an image in the OpenWRT build-process.

Download a TP-Link image from their Website and a OpenWRT sysupgrade
image for the device and build yourself a factory image like following:

TP-Link image:             tpl.bin
OpenWRT sysupgrade image:  owrt.bin

 > dd if=tpl.bin of=boot.bin bs=131584 count=1
 > cat owrt.bin >> boot.bin

Installing via Web-UI
---------------------
Upload the boot.bin via TP-Links firmware upgrade tool in the
web-interface.

Installing via Recovery
-----------------------
Activate Web-Recovery by beginning the upgrade Process with a
Firmware-Image from TP-Link. After starting the Firmware Upgrade,
wait ~3 seconds (When update status is switching to 0%), then
disconnect the power supply from the device. Upgrade flag (which
activates Web-Recovery) is written before the OS-image is touched and
removed after write is succesfull, so this procedure should be safe.

Plug the power back in. It will come up in Recovery-Mode on 192.168.0.1.
When active, all LEDs but the WPS LED are off.
Remeber to assign yourself a static IP-address as DHCP is not active in
this mode.

The boot.bin can now be uploaded and flashed using the web-recovery.

Installing via TFTP
-------------------
Prepare an image like following (Filenames from factory image steps
apply here)

 > dd if=/dev/zero of=tp_recovery.bin bs=196608 count=1
 > dd if=tpl.bin of=tmp.bin bs=131584 count=1
 > dd if=tmp.bin of=boot.bin bs=512 skip=1
 > cat boot.bin >> tp_recovery.bin
 > cat owrt.bin >> tp_recovery.bin

Place tp_recovery.bin in root directory of TFTP server and listen on
192.168.0.66/24.

Connect router LAN ports with your computer and power up the router
while pressing the reset button. The router will download the image via
tftp and after ~1 Minute reboot into OpenWRT.

U-Boot CLI
----------
U-Boot CLI can be activated by holding down '4' on bootup.

Dual U-Boot
-----------
This is TP-Link MediaTek device with a split-uboot feature design like
a TP-Link Archer C50 v4. The first (factory-uboot) provides recovery via
TFTP and HTTP, jumping straight into the second (firmware-uboot) if no
recovery needs to be performed. The firmware-uboot unpacks and executed
the kernel.

Web-Recovery
------------
TP-Link integrated a new Web-Recovery like the one on the Archer C7v4 /
TL-WR1043v5 / Archer C50v4. Stock-firmware sets a flag in the "romfile"
partition before beginning to write and removes it afterwards. If the
router boots with this flag set, bootloader will automatically start
Web-recovery and listens on 192.168.0.1. This way, the vendor-firmware
or an OpenWRT factory image can be written.

By doing the same while performing sysupgrade, we can take advantage of
the Web-recovery in OpenWRT.

It is important to note that Web-Recovery is only based on this flag. It
can't detect e.g. a crashing kernel or other means. Once activated it
won't boot the OS before a recovery action (either via TFTP or HTTP) is
performed. This recovery-mode is indicated by an illuminated WPS-LED on
boot.