### PR TITLE
scripts/feeds: fix preference of package install

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -517,19 +517,19 @@ sub install_src {
 	my $force = shift;
 	my $ret = 0;
 
-	$feed = lookup_src($feed, $name);
-	unless ($feed) {
+	my $select_feed = lookup_src($feed, $name);
+	unless ($select_feed) {
 		$installed{$name} and return 0;
 		$feed_src->{$name} or warn "WARNING: No feed for source package '$name' found\n";
 		return 0;
 	}
 
 	# switch to the metadata for the selected feed
-	get_feed($feed->[1]);
+	get_feed($select_feed->[1]);
 	my $src = $feed_src->{$name} or return 1;
 
 	# enable force flag if feed src line was declared with --force
-	if (exists($feed->[3]{force})) {
+	if (exists($select_feed->[3]{force})) {
 		$force = 1;
 	}
 
@@ -554,12 +554,12 @@ sub install_src {
 	}
 
 	if ($override) {
-		warn "Overriding core package '$name' with version from $feed->[1]\n";
+		warn "Overriding core package '$name' with version from $select_feed->[1]\n";
 	} else {
-		warn "Installing package '$name' from $feed->[1]\n";
+		warn "Installing package '$name' from $select_feed->[1]\n";
 	}
 
-	do_install_src($feed, $src) == 0 or do {
+	do_install_src($select_feed, $src) == 0 or do {
 		warn "failed.\n";
 		return 1;
 	};
@@ -594,15 +594,15 @@ sub install_package {
 	my $name = shift;
 	my $force = shift;
 
-	$feed = lookup_package($feed, $name);
-	unless ($feed) {
+	my $select_feed = lookup_package($feed, $name);
+	unless ($select_feed) {
 		$installed_pkg{$name} and return 0;
 		$feed_vpackage->{$name} or warn "WARNING: No feed for package '$name' found\n";
 		return 0;
 	}
 
 	# switch to the metadata for the selected feed
-	get_feed($feed->[1]);
+	get_feed($select_feed->[1]);
 	my $pkg = $feed_vpackage->{$name} or return 1;
 	return install_src($feed, $pkg->[0]{src}{name}, $force);
 }
@@ -612,14 +612,12 @@ sub install_target_or_package {
 	my $name = shift;
 	my $force = shift;
 
-	my $this_feed_target = lookup_target($feed, $name);
-	$this_feed_target and do {
-		return install_target($this_feed_target, $name);
+	lookup_target($feed, $name) and do {
+		return install_target($feed, $name);
 	};
 
-	my $this_feed_src = lookup_src($feed, $name);
-	$this_feed_src and do {
-		return install_src($this_feed_src, $name, $force);
+	lookup_src($feed, $name) and do {
+		return install_src($feed, $name, $force);
 	};
 
 	return install_package($feed, $name, $force);


### PR DESCRIPTION
The previous behavior prefered same feed for dependent packages as
initial package. This caused inconsitency in installation of packages.
The difference was if two feeds provide same package (different version)
there was different result if you executed install for that specific
version compared to install for package depending on it from different
feed.

This ensures that preferred feed is propagated without change and
selected feed is used only really for package it was selected for.