### PR TITLE
wireguard: add procd init service

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20200513
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/

--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -49,6 +49,8 @@ define Package/wireguard-tools/install
 	$(INSTALL_BIN) ./files/wireguard_watchdog $(1)/usr/bin/
 	$(INSTALL_DIR) $(1)/lib/netifd/proto/
 	$(INSTALL_BIN) ./files/wireguard.sh $(1)/lib/netifd/proto/
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/wireguard.init $(1)/etc/init.d/wireguard
 endef
 
 $(eval $(call BuildPackage,wireguard-tools))

--- a/package/network/utils/wireguard-tools/files/wireguard.init
+++ b/package/network/utils/wireguard-tools/files/wireguard.init
@@ -34,6 +34,51 @@ wireguard_check_interface() {
 	echo "$n_sum" > "${WG_DIR}/${cfg}.check"
 }
 
+wireguard_fw_rules() {
+	local zone="$1"
+	local port="$2"
+
+	json_add_object ""
+	json_add_string type rule
+	json_add_string src "$zone"
+	json_add_string proto udp
+	json_add_string dest_port "$port"
+	json_add_string target ACCEPT
+	json_close_object
+}
+
+wireguard_start_interface() {
+	local cfg="${1}"
+
+	local proto listen_port zone
+
+	config_get proto "${cfg}" proto
+	[ "${proto}" = "wireguard" ] || return 0
+
+	config_get listen_port "${cfg}" listen_port
+
+	procd_open_instance "${cfg}"
+	procd_set_param command /bin/true
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	[ -n "$listen_port" ] && {
+		procd_open_data
+		json_add_array firewall
+		config_list_foreach "$cfg" allowed_zones wireguard_fw_rules "$listen_port"
+		json_close_array
+		procd_close_data
+	}
+	procd_close_instance
+}
+
+service_started() {
+	procd_set_config_changed firewall
+}
+
+service_stopped() {
+	procd_set_config_changed firewall
+}
+
 service_triggers() {
 	procd_add_reload_trigger "network"
 }
@@ -42,4 +87,5 @@ start_service() {
 	mkdir -p "${WG_DIR}"
 	config_load network
 	config_foreach wireguard_check_interface interface
+	config_foreach wireguard_start_interface interface
 }

--- a/package/network/utils/wireguard-tools/files/wireguard.init
+++ b/package/network/utils/wireguard-tools/files/wireguard.init
@@ -1,0 +1,45 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+USE_PROCD=1
+
+WG_DIR="/tmp/wireguard"
+
+wireguard_check_peer(){
+	local cfg="${1}"
+	local cfile="${2}"
+
+	uci show "network.${cfg}" >> "${cfile}"
+}
+
+wireguard_check_interface() {
+	local cfg="${1}"
+	local proto cfile n_sum o_sum
+
+	config_get proto "${cfg}" proto
+	[ "${proto}" = "wireguard" ] || return 0
+	cfile="$(mktemp -p "${WG_DIR}")"
+	config_foreach wireguard_check_peer "wireguard_${1}" "${cfile}"
+
+	. /lib/functions/network.sh
+
+	n_sum="$(md5sum "${cfile}" | cut -d" " -f1)"
+	rm -rf "${cfile}"
+	[ -f "${WG_DIR}/${cfg}.check" ] && {
+		o_sum="$(cat "${WG_DIR}/${cfg}.check")"
+		[ "${o_sum}" != "${n_sum}" ] && {
+			network_is_up "${cfg}" && ifup "${cfg}"
+		}
+	}
+	echo "$n_sum" > "${WG_DIR}/${cfg}.check"
+}
+
+service_triggers() {
+	procd_add_reload_trigger "network"
+}
+
+start_service() {
+	mkdir -p "${WG_DIR}"
+	config_load network
+	config_foreach wireguard_check_interface interface
+}


### PR DESCRIPTION
This pullrequest adds some improvements and a fix for the wireguard proto handling.
I have already send some patches to the mailinglist but no one felt addressed more or less. @jow-.
So I try it with a pullrequest.

Changes already fixed:
* wireguard: skip peer config if public key of the peer is not defined
[Already send via Mailinglist](https://patchwork.ozlabs.org/patch/1204567/)
**[Is already fixed in openwrt master](https://github.com/openwrt/openwrt/commit/7151054abd5d43bf4c623e311a4c1046af4fff94#diff-781e06caaf632d4cf7d4b6eff8c854d2)**
- wireguard: fix interface remove on lonely peers
[Already send via Mailinglist](https://patchwork.ozlabs.org/patch/1204578/)
difference from Mailinglist is that I changed **procd** `boot()` to `start_service()`
**[Is already fixed in LuCI master](https://github.com/openwrt/luci/commit/890dcac2de7b1d6bc6768c69ea7129d27a809ef9#diff-10b0bc939a6ce69b067b6c9c7990c677)**

Changes still pending:
* wireguard: add procd firewall3 inbound rule support
Add an additional uci option **allowed_zones** so we can open the Configured UDP on this firewall zone.
* wireguard: fix reload config on peer change
[Already send via Mailinglist](https://patchwork.ozlabs.org/patch/1202476/)
difference from Mailinglist is that I changed **procd** `boot()` to `start_service()`


