### PR TITLE
ath79: uap-ac-* adjust spi speed + use fast-read opcode for mx25l12805d

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -62,7 +62,9 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <50000000>;
+		/* The unifiac series uses mx25l12805d with fast-read support */
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Signed-off-by: MartB <mart.b@outlook.de>

The mx25l12805d is used in all the ac unifi devices i found on the internet, according to its datasheet the spi clock of 50000000 and the chip specific fast read opcode is supported.

run tested on uap-ac-pro.