### PR TITLE
ath79: add ath9k mtd-cal-data in dts for nbg6716

### DIFF
--- a/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
@@ -260,6 +260,8 @@
 
 &wmac {
 	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
 };
 
 &pcie1 {

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -13,10 +13,6 @@ case "$FIRMWARE" in
 	netgear,wndr4300)
 		caldata_extract "caldata" 0x1000 0x440
 		;;
-	zyxel,nbg6716)
-		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env ethaddr)
-		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+[ "$ACTION" = add ] || exit
+
+PHYNBR=${DEVPATH##*/phy}
+
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case $board in
+zyxel,nbg6716)
+	# Set mac address for ath9k device
+	[ "$PHYNBR" -eq 1 ] && \
+		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 2 > /sys${DEVPATH}/macaddress
+	;;
+esac


### PR DESCRIPTION
There was no detection of the ath9k caldata from art partition in dts file
for Zyxel NBG6716. This prevented the ath9k radio from being properly
initialised and induced the following error messages:
  ath: phy1: Unable to initialize hardware; initialization status: -5
  ath9k 18100000.wmac: failed to initialize device
  ath9k: probe of 18100000.wmac failed with error -5

Signed-off-by: Guillaume Lefebvre <guillaume@zelig.ch>
