### PR TITLE
ath79: fix USB speed issues on ar934x devices like TP-Link WDR3600/WDR4300

### DIFF
--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -199,8 +199,8 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar9340-usb-phy", "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
-		resets = <&rst 4>, <&rst 3>;
+		reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+		resets = <&rst 11>, <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;
 

--- a/target/linux/ath79/patches-4.19/0004-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-4.19/0004-phy-add-ath79-usb-phys.patch
@@ -194,7 +194,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/phy/phy-ar7200-usb.c
-@@ -0,0 +1,123 @@
+@@ -0,0 +1,135 @@
 +/*
 + * Copyright (C) 2015 Alban Bedel <albeu@free.fr>
 + *
@@ -212,6 +212,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +
 +struct ar7200_usb_phy {
 +	struct reset_control	*rst_phy;
++	struct reset_control	*rst_phy_analog;
 +	struct reset_control	*suspend_override;
 +	struct phy		*phy;
 +	int			gpio;
@@ -222,12 +223,12 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	struct ar7200_usb_phy *priv = phy_get_drvdata(phy);
 +	int err = 0;
 +
-+	if (priv->rst_phy)
-+		err = reset_control_deassert(priv->rst_phy);
-+	if (!err && priv->suspend_override)
++	if (priv->suspend_override)
 +		err = reset_control_assert(priv->suspend_override);
-+	if (err && priv->rst_phy)
-+		err = reset_control_assert(priv->rst_phy);
++	if (priv->rst_phy)
++		err |= reset_control_deassert(priv->rst_phy);
++	if (priv->rst_phy_analog)
++		err |= reset_control_deassert(priv->rst_phy_analog);
 +
 +	return err;
 +}
@@ -241,6 +242,8 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +		err = reset_control_deassert(priv->suspend_override);
 +	if (priv->rst_phy)
 +		err |= reset_control_assert(priv->rst_phy);
++	if (priv->rst_phy_analog)
++		err |= reset_control_assert(priv->rst_phy_analog);
 +
 +	return err;
 +}
@@ -264,6 +267,15 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	if (IS_ERR(priv->rst_phy)) {
 +		dev_err(&pdev->dev, "phy reset is missing\n");
 +		return PTR_ERR(priv->rst_phy);
++	}
++
++	priv->rst_phy_analog = devm_reset_control_get_optional(
++		&pdev->dev, "usb-phy-analog");
++	if (IS_ERR(priv->rst_phy_analog)) {
++		if (PTR_ERR(priv->rst_phy_analog) == -ENOENT)
++			priv->rst_phy_analog = NULL;
++		else
++			return PTR_ERR(priv->rst_phy_analog);
 +	}
 +
 +	priv->suspend_override = devm_reset_control_get_optional(


### PR DESCRIPTION
The new of driver for the ath79 target is missing a reset definition that has a dramastic performance decrease on at least the TP-Link WDR3600/WDR4300 and similar devices.

This performance decrease on ath79 over ar71xx was reported on:
- OpenWRT Forum [#46794](https://forum.openwrt.org/t/usb-wdr4300-low-speed-on-external-storage/46794)
- GitHub PR https://github.com/openwrt/openwrt/pull/964
- Flyspray [#2567](https://bugs.openwrt.org/index.php?do=details&task_id=2567)

The kernel log prints `not running at top speed; connect to a high speed hub` for all connected usb device without this pr.

After comparing the old mach-driver **arch/mips/ath79/dev-usb.c** with the new of-driver **drivers/phy/phy-ar7200-usb.c** it turns out that there is some different behavior and a missing reset for the analog part of the usb unit on ar934x.

This commits add the missing reset signal, reorders the assertion of the reset bits and removed the logic that puts the phy into reset if deasserting the phy reset or asserting the suspend_override bits failed.

## Test on my TP-Link WDR3600

### Without this PR
**internal 4-port usb hub and usb-stick is detected like:**
```
[    5.918324] usb 1-1: new full-speed USB device number 2 using ehci-platform
[    6.182793] usb 1-1: not running at top speed; connect to a high speed hub
[    6.206210] hub 1-1:1.0: USB hub found
[    6.212253] hub 1-1:1.0: 4 ports detected
[    6.539842] usb 1-1.1: new full-speed USB device number 3 using ehci-platform
[    6.942394] usb 1-1.1: not running at top speed; connect to a high speed hub
[    7.032767] usb-storage 1-1.1:1.0: USB Mass Storage device detected
```
```
root@OpenWrt:~# lsusb -t
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=ehci-platform/1p, 480M
    |__ Port 1: Dev 2, If 0, Class=Hub, Driver=hub/4p, 12M
        |__ Port 1: Dev 3, If 0, Class=Mass Storage, Driver=usb-storage, 12M
```
**raw write test:**
```
root@OpenWrt:~# time dd if=/dev/zero of=/dev/sda1 bs=10M count=100 conv=fsync
100+0 records in
100+0 records out
real	16m 11.47s
user	0m 0.00s
sys	0m 17.72s
1000M / 971s = 1.0299 M/s
```

### With this PR
**internal 4-port usb hub and usb-stick is detected like:**
```
[    5.918948] usb 1-1: new high-speed USB device number 2 using ehci-platform
[    6.192680] hub 1-1:1.0: USB hub found
[    6.198768] hub 1-1:1.0: 4 ports detected
[    6.530023] usb 1-1.1: new high-speed USB device number 3 using ehci-platform
[    7.002807] usb-storage 1-1.1:1.0: USB Mass Storage device detected
```
```
root@OpenWrt_Second:~# lsusb -t
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=ehci-platform/1p, 480M
    |__ Port 1: Dev 2, If 0, Class=Hub, Driver=hub/4p, 480M
        |__ Port 1: Dev 3, If 0, Class=Mass Storage, Driver=usb-storage, 480M
```
**raw write test:**
```
root@OpenWrt:~# time dd if=/dev/zero of=/dev/sda1 bs=10M count=100 conv=fsync
100+0 records in
100+0 records out
real	1m 33.13s
user	0m 0.00s
sys	0m 16.75s
1000M / 93s = 10,75 M/s
```

## Test on other devices that uses the **ar7200-usb-phy** driver

**For now, this PR should only change the behavior on devices with ar934x based devices.**

If you think you are affected by this, then check your kernel log with `dmesg` if you are seeing `not running at top speed; connect to a high speed hub` after you connected a usb device.

The following device trees include files uses this driver:
```
ar7240.dtsi
ar7241.dtsi
ar7242.dtsi
ar9132.dtsi
ar9330.dtsi
ar934x.dtsi
qca953x.dtsi
qca9557.dtsi
qca956x.dtsi
```

## Backporting to 19.07 (kernel 4.14)
If this should be also applied to 19.07, then i will create a second PR for the 19.07 branch.
