### PR TITLE
ath79: generate firmware image for aircube-isp

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -94,8 +94,7 @@ define Device/ubnt_acb-isp
   UBNT_BOARD := ACB-ISP
   UBNT_CHIP := qca9533
   UBNT_TYPE := ACB
-  UBNT_VERSION := 6.0.0
-  IMAGES := sysupgrade.bin
+  UBNT_VERSION := 2.5.0
 endef
 TARGET_DEVICES += ubnt_acb-isp
 

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -129,6 +129,15 @@ struct fw_info fw_info[] = {
 		.sign = true,
 	},
 	{
+		.name = "ACB-ISP",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00F60000,
+		},
+		.sign = true,
+	},
+	{
 		.name = "",
 	},
 };


### PR DESCRIPTION
This adds a "factory" image for the aircube-isp devices. Flashing it
isn't too simple. You have to hack the system a bit. Thanks to Torvald
Menningen (Snap) from the OpenWRT forum for finding out how to patch the
ubntbox-binary.

- Use a version 2.5.0 of the original firmware. This is important
  because a binary file will be modified.
- Download a configuration.
- Unpack it (it's just a tar gz file without an ending).
- Add the following to uhttpd:

``````
config 'uhttpd' 'other'
	list listen_http    0.0.0.0:8080
	list listen_http    [::]:8080
	option 'home'       '/tmp/persistent/config/patch/www'
	option lua_prefix   '/lua'
	option lua_handler  '/tmp/persistent/config/patch/handler.lua'
``````

- Create a `patch` subfolder.
- Create a `patch/handler.lua` with the following content:

``````
function handle_request(env)
    uhttpd.send("Status: 200 OK\r\n")
    uhttpd.send("Content-Type: text/plain\r\n\r\n")

    local command = "/bin/sh /tmp/persistent/config/patch/patch.sh 2>&1"

    local proc = assert(io.popen(command))
    for line in proc:lines() do
        uhttpd.send(line.."\r\n")
    end
    proc:close()
end
``````

- Create a `patch/patch.sh` with the following content:

``````
#!/bin/sh -x

set -e
set -u
set -x

UBNTBOX_PATCHED="/tmp/fwupdate.real"
MD5FILE="/tmp/patchmd5"

cat <<EOF > ${MD5FILE}
c33235322da5baca5a7b237c09bc8df1  /sbin/fwupdate.real
EOF

# check md5 of files that will be patched
if ! md5sum -c ${MD5FILE}
then
        echo "******** Error when checking files. Refuse to do anything. ********"
        exit 0
fi

# prepare some overlay functionality
LOWERDIR="/tmp/lower_root"
mkdir -p ${LOWERDIR}
mount -t squashfs -oro /dev/mtdblock3 ${LOWERDIR}
overlay_some_path()
{
        PATH_TO_OVERLAY=$1
        ALIAS=$2
        UPPERDIR="/tmp/over_${ALIAS}"
        WORKDIR="/tmp/over_${ALIAS}_work"

        mkdir -p ${UPPERDIR}
        mkdir -p ${WORKDIR}

        mount -t overlay -o lowerdir=${LOWERDIR}${PATH_TO_OVERLAY},upperdir=${UPPERDIR},workdir=${WORKDIR} overlay ${PATH_TO_OVERLAY}
}

# patch the ubntbox binary.
overlay_some_path "/sbin" "sbin"
echo -en '\x10' | dd of=/sbin/fwupdate.real conv=notrunc bs=1 count=1 seek=24598

echo "******** Done ********"
``````

- Repack the configuration.
- Upload it via the normal web interface.
- Wait about a minute. The webserver should restart.
- Now there is a second web server at port 8080 which can call the lua
  script. Visit the page with a web browser. Link is for example
  http://192.168.1.1:8080/lua
- You should see the output of the script with a "*** Done ***" at the
  end. Note that the patches are not permanent. If you restart the
  router you have to re-visit the link (but not re-upload the config).
- Now you can upload an unsigned binary via the normal web interface.