### PR TITLE
ramips: add support for TP-Link RE200v1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_re200-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_re200-v1.dts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,re200-v1", "ralink,mt7620a-soc";
+	model = "TP-Link RE200 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re200-v1:green:power";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "re200-v1:green:lan";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "re200-v1:green:wlan";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		qss {
+			label = "re200-v1:green:qss";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_red {
+			label = "re200-v1:red:wlan2g";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_green {
+			label = "re200-v1:green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "uartf", "ephy", "wled", "rgmii1", "spi refclk";
+		ralink,function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x7c0000>;
+			};
+
+			partition@7e0000 {
+				label = "userconfig";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&uboot 0x1fc00>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -198,6 +198,9 @@ tplink,archer-mr200)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "usb0"
 	set_wifi_led "$boardname:white:wlan"
 	;;
+tplink,re200-v1)
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
+	;;
 youku,yk1)
 	set_wifi_led "$boardname:blue:air"
 	ucidef_set_led_switch "wan" "wan" "$boardname:blue:wan" "switch0" "0x10"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -50,6 +50,7 @@ ramips_setup_interfaces()
 	planex,mzk-ex300np|\
 	planex,mzk-ex750np|\
 	ravpower,wd03|\
+	tplink,re200-v1|\
 	sercomm,na930)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/tools/firmware-utils/src/mktplinkfw.c
+++ b/tools/firmware-utils/src/mktplinkfw.c
@@ -145,6 +145,12 @@ static struct flash_layout layouts[] = {
 		.kernel_ep	= 0x80060000,
 		.rootfs_ofs	= 0x100000,
 	}, {
+		.id		= "8Mmtk",
+		.fw_max_len	= 0x7c0000,
+		.kernel_la	= 0x80000000,
+		.kernel_ep	= 0x8000c310,
+		.rootfs_ofs	= 0x100000,
+	}, {
 		.id		= "16M",
 		.fw_max_len	= 0xf80000,
 		.kernel_la	= 0x80060000,


### PR DESCRIPTION
TP-Link RE200v1 is a wireless range extender with Ethernet and 2.4G and 5G
WiFi with internal antennas. It's based on MediaTek MT7620A+MT7610EN.

### Specification:

- MediaTek MT7620A (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 1x 10/100 Mbps Ethernet
- UART header on PCB (57600 8n1)
- 8x LED (GPIO-controlled; only 6 supported), 2x button

There are 2.4G and 5G LEDs in red and green which are controlled
separately. The 5G LED is currently not supported, since the GPIOs couldn't
be determined.

### Installation:

#### Web Interface
It is possible to upgrade to OpenWrt via the web interface. However, the
OEM firmware upgrade file is required and a tool to fix the MD5 sum of
the header. This procedure overwrites U-Boot and there is no failsafe / 
recovery mode present! To prepare an image, you need to take the header
and U-Boot (i.e. 0x200 + 0x20000 bytes) from an OEM firmware file and
attach the factory image to it. Then fix the header MD5Sum1.

#### Serial console
Opening the case is quite hard, since it is welded together. Rename the
OpenWrt factory image to "test.bin", then plug in the device and quickly
press "2" to enter flash mode (no line feed). Follow the prompts until
OpenWrt is installed.

Unfortunately, this devices does not offer a recovery mode or a tftp
installation method. If the web interface upgrade fails, you have to open
your device and attach serial console. Since the web upgrade overwrites
the boot loader, you might also brick your device.

### Additional notes:

This seems to be the first ramips device with a TP-Link v1 header. The
original firmware has the string "EU" embedded, there might be some region-
checking going on during the firmware upgrade process. The original
firmware also contains U-Boot and thus overwrites the boot loader during
upgrade.
In order to flash back to stock, the first header and U-Boot needs to be
stripped from the original firmware.