### PR TITLE
netifd: rework smp tune hotplug script

### DIFF
--- a/package/network/config/netifd/files/etc/hotplug.d/net/20-smp-tune
+++ b/package/network/config/netifd/files/etc/hotplug.d/net/20-smp-tune
@@ -31,10 +31,10 @@ set_hex_val() {
 	local val="$2"
 	val="$(printf %x "$val")"
 	[ -n "$DEBUG" ] && echo "$file = $val"
-	echo "$val" > "$file"
+	echo "$val" > "$file" 2>/dev/null
 }
 
-default_ps="$(uci get "network.@globals[0].default_ps")"
+default_ps="$(uci -q get "network.@globals[0].default_ps")"
 [ -n "$default_ps" -a "$default_ps" != 1 ] && exit 0
 
 exec 512>/var/lock/smp_tune.lock
@@ -47,21 +47,11 @@ for dev in /sys/class/net/*; do
 	[ -n "$(ls "${dev}/" | grep '^lower_')" ] && continue
 	[ -d "${dev}/device" ] || continue
 
-	device="$(readlink "${dev}/device")"
-	device="$(basename "$device")"
-	irq_cpu="$(find_irq_cpu "$device")"
-	irq_cpu_mask="$((1 << $irq_cpu))"
-
 	for q in ${dev}/queues/rx-*; do
-		set_hex_val "$q/rps_cpus" "$(($PROC_MASK & ~$irq_cpu_mask))"
+		set_hex_val "$q/rps_cpus" "$PROC_MASK"
 	done
 
-	ntxq="$(ls -d ${dev}/queues/tx-* | wc -l)"
-
-	idx=$(($irq_cpu + 1))
 	for q in ${dev}/queues/tx-*; do
-		set_hex_val "$q/xps_cpus" "$((1 << $idx))"
-		let "idx = idx + 1"
-		[ "$idx" -ge "$NPROCS" ] && idx=0
+		set_hex_val "$q/xps_cpus" "$PROC_MASK"
 	done
 done


### PR DESCRIPTION
It was notice that share the queues of the traffic between all core improves 
performance by a lot. The present script doesn't really tune the queue to use
more than one core but they just reassign them.
Simplify this to assign all the queue to use all the avaiable core by setting 
the value to the Number of Core present in the system + 1 to tell the kernel 
to set all of them automatically. 
Also fix some error with uci definition not present and not settable queues.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>