### PR TITLE
ipq40xx: improve ASUS RT-AC58U support

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -15,8 +15,6 @@ alfa-network,ap120c-ac)
 	ucidef_set_led_netdev "wan" "WAN" "${boardname}:amber:wan" "eth1"
 	;;
 asus,rt-ac58u)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:blue:wlan2G" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:blue:wlan5G" "phy1tpt"
 	ucidef_set_led_netdev "wan" "WAN" "${boardname}:blue:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "${boardname}:blue:lan" "switch0" "0x1e"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -79,12 +79,16 @@ ipq40xx_setup_interfaces()
 ipq40xx_setup_macs()
 {
 	local board="$1"
+	local lan_mac=""
+	local wan_mac=""
+	local label_mac=""
 
 	case "$board" in
 	asus,rt-ac58u)
 		CI_UBIPART=UBI_DEV
-		wan_mac=$(mtd_get_mac_binary_ubi Factory 0x5006)
-		lan_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
+		wan_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
+		lan_mac=$(mtd_get_mac_binary_ubi Factory 0x5006)
+		label_mac=$wan_mac
 		;;
 	cilab,meshpoint-one)
 		label_mac=$(mtd_get_mac_binary "ART" 0x1006)

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -58,20 +58,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		usb3@8af8800 {
 			status = "okay";
 
@@ -81,11 +67,6 @@
 
 				usb3_port1: port@1 {
 					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
 					#trigger-source-cells = <0>;
 				};
 			};
@@ -162,7 +143,7 @@
 		usb {
 			label = "rt-ac58u:blue:usb";
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
-			trigger-sources = <&usb3_port1>, <&usb3_port2>, <&usb2_port1>;
+			trigger-sources = <&usb3_port1>;
 			linux,default-trigger = "usbport";
 		};
 
@@ -314,9 +295,5 @@
 };
 
 &usb3_hs_phy {
-	status = "okay";
-};
-
-&usb2_hs_phy {
 	status = "okay";
 };

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -15,10 +15,10 @@
 	};
 
 	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 	};
 
 	chosen {
@@ -137,7 +137,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		power: status {
+		led_power: status {
 			label = "rt-ac58u:blue:status";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		};
@@ -150,11 +150,13 @@
 		wlan2G {
 			label = "rt-ac58u:blue:wlan2G";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
-		wan5G {
+		wlan5G {
 			label = "rt-ac58u:blue:wlan5G";
 			gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb {
@@ -224,7 +226,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		linux,modalias = "m25p80", "mx25l1606e", "n25q128a11";
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <30000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -280,7 +282,7 @@
 		#size-cells = <0>;
 		compatible = "spinand,mt29f";
 		reg = <1>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <30000000>;
 
 		/*
 		 * U-boot looks for "spinand,mt29f" node,

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -15,10 +15,10 @@
 	};
 
 	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 	};
 
 	chosen {
@@ -131,7 +131,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		power: status {
+		led_power: status {
 			label = "rt-ac58u:blue:status";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
 		};
@@ -144,11 +144,13 @@
 		wlan2G {
 			label = "rt-ac58u:blue:wlan2G";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
-		wan5G {
+		wlan5G {
 			label = "rt-ac58u:blue:wlan5G";
 			gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb {
@@ -216,7 +218,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		linux,modalias = "m25p80", "mx25l1606e", "n25q128a11";
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <30000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -270,7 +272,7 @@
 	spi-nand@1 {
 		compatible = "spi-nand";
 		reg = <1>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <30000000>;
 
 		/*
 		 * U-boot looks for "spinand,mt29f" node,

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-rt-ac58u.dts
@@ -62,20 +62,6 @@
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
 
-		usb2@60f8800 {
-			status = "okay";
-
-			dwc3@6000000 {
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				usb2_port1: port@1 {
-					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-			};
-		};
-
 		usb3@8af8800 {
 			status = "okay";
 
@@ -85,11 +71,6 @@
 
 				usb3_port1: port@1 {
 					reg = <1>;
-					#trigger-source-cells = <0>;
-				};
-
-				usb3_port2: port@2 {
-					reg = <2>;
 					#trigger-source-cells = <0>;
 				};
 			};
@@ -156,7 +137,7 @@
 		usb {
 			label = "rt-ac58u:blue:usb";
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
-			trigger-sources = <&usb3_port1>, <&usb3_port2>, <&usb2_port1>;
+			trigger-sources = <&usb3_port1>;
 			linux,default-trigger = "usbport";
 		};
 
@@ -309,10 +290,6 @@
 };
 
 &usb3_hs_phy {
-	status = "okay";
-};
-
-&usb2_hs_phy {
 	status = "okay";
 };
 


### PR DESCRIPTION
This patch does the following:

- move WiFi LED setup to DTS
- fix LAN/WAN MAC addresses and add label MAC address
- remove unnecessary usb2 and usb3_port2
- wan5G -> wlan5G, power -> led_power
- increase flash SPI frequency to 30MHz

MAC addresses are stored in Factory partition at:
0x1006: WiFi 2.4GHz, WAN (label_mac)
0x5006: WiFi 5GHz, LAN (label_mac +4)

RT-AC58U has single USB 3.0 port and only usb3_port1 is used. Remove the
rest.

By improving flash speed,
`time dd if=/dev/mtdblock8 of=/dev/null bs=2k`
is reduced from 7m 10.26s to 5m 9.52s.
Using higher frequencies did not improve speed further.