### PR TITLE
ath79: fix having random mac addresses for ethernet devices on nbg6716

### DIFF
--- a/target/linux/ath79/nand/base-files/lib/preinit/05_set_iface_mac
+++ b/target/linux/ath79/nand/base-files/lib/preinit/05_set_iface_mac
@@ -1,0 +1,12 @@
+preinit_set_mac_address() {
+	case $(board_name) in
+	zyxel,nbg6716)
+		mac_eth1=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		[ ! -z $mac_eth1 ] && ifconfig eth1 hw ether $mac_eth1
+		mac_eth0=$(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) -1)
+		[ ! -z $mac_eth0 ] && ifconfig eth0 hw ether $mac_eth0
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_set_mac_address


### PR DESCRIPTION
Mac addresses of the ethernet devices (eth0 & eth1) are randomly set at
boot time by the ag71xx driver because it it currently not possible to
retrieve with the DTS file the ascii mac address located in the
u-boot-env partition.
This commit works around this behaviour by setting the mac addresses
during the preinit phase.

Signed-off-by: Guillaume Lefebvre <guillaume@zelig.ch>