### PR TITLE
elfutils: bump to 0.178

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
-PKG_VERSION:=0.177
-PKG_RELEASE:=2
+PKG_VERSION:=0.178
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
-PKG_HASH:=fa489deccbcae7d8c920f60d85906124c1989c591196d90e0fd668e3dc05042e
+PKG_HASH:=31e7a00e96d4e9c4bda452e1f2cdac4daf8abd24f5e154dee232131899f3a0f2
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -62,6 +62,7 @@ CONFIGURE_ARGS += --disable-nls
 endif
 
 CONFIGURE_ARGS += \
+	--disable-debuginfod \
 	--program-prefix=eu- \
 	--without-lzma
 

--- a/package/libs/elfutils/patches/003-libintl-compatibility.patch
+++ b/package/libs/elfutils/patches/003-libintl-compatibility.patch
@@ -12,9 +12,9 @@
  
 --- a/libdw/libdwP.h
 +++ b/libdw/libdwP.h
-@@ -35,7 +35,9 @@
- #include <libdw.h>
+@@ -37,7 +37,9 @@
  #include <dwarf.h>
+ #include "atomics.h"
  
 -
 +#ifdef _ /* fix libintl-stub */
@@ -25,7 +25,7 @@
  
 --- a/libdwfl/libdwflP.h
 +++ b/libdwfl/libdwflP.h
-@@ -43,6 +43,9 @@
+@@ -44,6 +44,9 @@
  
  typedef struct Dwfl_Process Dwfl_Process;
  
@@ -60,7 +60,7 @@
  Requires.private: zlib
 --- a/configure.ac
 +++ b/configure.ac
-@@ -543,6 +543,9 @@ AC_CONFIG_FILES([config/libelf.pc config
+@@ -577,6 +577,9 @@ AC_CONFIG_FILES([config/libelf.pc config
  AC_SUBST(USE_NLS, yes)
  AM_PO_SUBDIRS
  

--- a/package/libs/elfutils/patches/005-build_only_libs.patch
+++ b/package/libs/elfutils/patches/005-build_only_libs.patch
@@ -1,12 +1,11 @@
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -27,8 +27,7 @@ AM_MAKEFLAGS = --no-print-directory
+@@ -27,7 +27,7 @@ AM_MAKEFLAGS = --no-print-directory
  pkginclude_HEADERS = version.h
  
- # Add doc back when we have some real content.
--SUBDIRS = config m4 lib libelf libebl libdwelf libdwfl libdw libcpu libasm \
--	  backends src po tests
-+SUBDIRS = config m4 lib libelf libebl libdwelf libdwfl libdw libasm
+ SUBDIRS = config m4 lib libelf libcpu backends libebl libdwelf libdwfl libdw \
+-	  libasm src po doc tests
++	  libasm
  
- EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
- 	     COPYING COPYING-GPLV2 COPYING-LGPLV3
+ if DEBUGINFOD
+ SUBDIRS += debuginfod

--- a/package/libs/elfutils/patches/100-musl-compat.patch
+++ b/package/libs/elfutils/patches/100-musl-compat.patch
@@ -35,7 +35,7 @@ https://sourceware.org/bugzilla/show_bug.cgi?id=21002
  # define LE64(n)	(n)
 --- a/libdw/libdw_alloc.c
 +++ b/libdw/libdw_alloc.c
-@@ -73,5 +73,5 @@ __attribute ((noreturn)) attribute_hidde
+@@ -147,5 +147,5 @@ __attribute ((noreturn)) attribute_hidde
  __libdw_oom (void)
  {
    while (1)
@@ -44,12 +44,20 @@ https://sourceware.org/bugzilla/show_bug.cgi?id=21002
  }
 --- a/libdwfl/dwfl_error.c
 +++ b/libdwfl/dwfl_error.c
-@@ -154,7 +154,7 @@ dwfl_errmsg (int error)
+@@ -154,7 +154,16 @@ dwfl_errmsg (int error)
    switch (error &~ 0xffff)
      {
      case OTHER_ERROR (ERRNO):
--      return strerror_r (error & 0xffff, "bad", 0);
-+      return strerror_l (error & 0xffff, LC_GLOBAL_LOCALE);
++#if defined(__GLIBC__)
+       return strerror_r (error & 0xffff, "bad", 0);
++#else
++      {
++        static __thread char buf[128] = "";
++        if (0 == strerror_r(error & 0xffff, buf, sizeof(buf)))
++          return buf;
++      }
++      return "strerror_r() failed";
++#endif
      case OTHER_ERROR (LIBELF):
        return elf_errmsg (error & 0xffff);
      case OTHER_ERROR (LIBDW):

--- a/package/libs/elfutils/patches/101-no-fts.patch
+++ b/package/libs/elfutils/patches/101-no-fts.patch
@@ -72,7 +72,7 @@
  	struct parse_opt *opt = state->hook;
 --- a/libdwfl/Makefile.am
 +++ b/libdwfl/Makefile.am
-@@ -49,7 +49,7 @@ libdwfl_a_SOURCES = dwfl_begin.c dwfl_en
+@@ -50,7 +50,7 @@ libdwfl_a_SOURCES = dwfl_begin.c dwfl_en
  		    argp-std.c find-debuginfo.c \
  		    dwfl_build_id_find_elf.c \
  		    dwfl_build_id_find_debuginfo.c \


### PR DESCRIPTION
Fix compile error with uclibc introduced by f4da28c301890115e5c6b632aa6550fbc59f8e24

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

Compiled tested for mips, mipsel, x86, x86_64, arm, arc, including musl and uclibc.
No runtime test performed.