### PR TITLE
ramips: further improve support for Xiaomi MiWiFi Nano

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -66,6 +66,11 @@
 	status = "disabled";
 };
 
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,portdisable = <0x2a>;
+};
+
 &wmac {
 	status = "okay";
 	ralink,mtd-eeprom = <&factory 0x4>;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -7,13 +7,13 @@
 
 / {
 	compatible = "xiaomi,miwifi-nano", "mediatek,mt7628an-soc";
-	model = "MiWiFi Nano";
+	model = "Xiaomi MiWiFi Nano";
 
 	aliases {
-		led-boot = &led_blue;
-		led-failsafe = &led_blue;
-		led-running = &led_blue;
-		led-upgrade = &led_blue;
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
 	};
 
 	chosen {
@@ -23,17 +23,17 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_blue: status_blue {
+		led_status_blue: status_blue {
 			label = "miwifi-nano:blue:status";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
-		status_red {
+		led_status_red: status_red {
 			label = "miwifi-nano:red:status";
 			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		};
 
-		status_amber {
+		led_status_amber: status_amber {
 			label = "miwifi-nano:amber:status";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 		};
@@ -50,12 +50,10 @@
 	};
 };
 
-&pinctrl {
-	state_default: pinctrl0 {
-		gpio {
-			ralink,group = "gpio", "refclk", "wdt", "wled_an";
-			ralink,function = "gpio";
-		};
+&state_default {
+	gpio {
+		ralink,group = "gpio", "refclk", "wdt", "wled_an";
+		ralink,function = "gpio";
 	};
 };
 
@@ -79,7 +77,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-nano.dts
@@ -14,6 +14,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;
 		led-upgrade = &led_status_amber;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -171,8 +171,7 @@ ramips_setup_macs()
 	rakwireless,rak633|\
 	unielec,u7628-01-16m|\
 	wavlink,wl-wn575a3|\
-	wiznet,wizfi630s|\
-	xiaomi,miwifi-nano)
+	wiznet,wizfi630s)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
 	skylab,skw92a|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -61,8 +61,7 @@ ramips_setup_interfaces()
 	mercury,mac1200r-v2|\
 	totolink,lr1200|\
 	wavlink,wl-wn570ha1|\
-	wavlink,wl-wn575a3|\
-	xiaomi,miwifi-nano)
+	wavlink,wl-wn575a3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
@@ -108,6 +107,10 @@ ramips_setup_interfaces()
 	xiaomi,mir4a-100m)
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "0:wan" "6@eth0"
+		;;
+	xiaomi,miwifi-nano)
+		ucidef_add_switch "switch0" \
+			"0:lan:2" "2:lan:1" "4:wan" "6@eth0"
 		;;
 	zbtlink,zbt-we1226)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
This patch does the following:

- prepend vendor name to model
- set status LEDs to follow the behavior in stock FW
- add label mac address
- simplify state_default node definition
- fix switch setup
- remove redundant ralink,mtd-eeprom
- use generic name for flash node

Stock FW status indicators:
https://files.xiaomi-mi.com/files/Mi_Router_Wi-Fi_Nano/Mi_router-NANO_EN.pdf
> Yellow: power on / off
> Blue: during normal operation
> Red: in case of problems with the operation of the device

MiWiFi Nano has two LAN ports, which are in reverse order. Add port numbers
to them, and disable unused ports.

mt76 does not use ralink,mtd-eeprom, and mediatek,mtd-eeprom is already set
in SoC DTSI. mt76 will read wmac MAC address from offset +4 automatically.