### PR TITLE
brcm47xx: fix switch port order for Netgear WN2500RP V1

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -142,9 +142,9 @@ configure_by_model() {
 	"Microsoft MN-700")
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;
-		
-	"Netgear WN2500RP V1" | \
-	"Asus WL500GP V2")
+
+	"Asus WL500GP V2" | \
+	"Netgear WN2500RP V1")
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "5@eth0"
 		;;

--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -142,7 +142,8 @@ configure_by_model() {
 	"Microsoft MN-700")
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;
-
+		
+	"Netgear WN2500RP V1" | \
 	"Asus WL500GP V2")
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "5@eth0"


### PR DESCRIPTION
Physical port order watched from the backside of the WN2500RP
(from left to right) is: 4 / 3 / 2 / 1 / missing wan port!

Currently a wan port is configured in the switch as num 4, its physical absent 
on the device. Although its incorrect its rather usefull to easy setup the device
as a LAN/WAN router by just swapping one of the untagged LAN ports to it.

Signed-off-by: Walter Sonius <walterav1984@gmail.com>