### PR TITLE
ipq40xx: ipq4018: add support for Corewav M018U0 SOM S1

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -48,6 +48,7 @@ case "$FIRMWARE" in
 	8dev,jalapeno |\
 	alfa-network,ap120c-ac |\
 	cilab,meshpoint-one |\
+	corewav,m018u0-s1 |\
 	ezviz,cs-w3-wd1200g-eup |\
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\
@@ -131,6 +132,7 @@ case "$FIRMWARE" in
 	8dev,jalapeno |\
 	alfa-network,ap120c-ac |\
 	cilab,meshpoint-one |\
+	corewav,m018u0-s1 |\
 	ezviz,cs-w3-wd1200g-eup |\
 	glinet,gl-b1300 |\
 	linksys,ea6350v3 |\

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -9,6 +9,11 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(macaddr_add "$base_mac" +1)
 		ip link set dev eth1 address $(macaddr_add "$base_mac" +3)
 		;;
+	corewav,m018u0-s1)
+		base_mac=$(mtd_get_mac_binary ART 0x1006)
+		ip link set dev eth0 address $(macaddr_add "$base_mac" +2)
+		ip link set dev eth1 address $(macaddr_add "$base_mac" +3)
+		;;
 	ezviz,cs-w3-wd1200g-eup)
 		ip link set dev eth0 address $(mtd_get_mac_binary "ART" 0x6)
 		ip link set dev eth1 address $(mtd_get_mac_binary "ART" 0x0)

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-m018u0-s1.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-m018u0-s1.dts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq4018-m018u0.dtsi"
+
+/ {
+	model = "Corewav M018U0 SOM S1";
+	compatible = "corewav,m018u0-s1";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+};
+
+&blsp1_spi1 {
+	mx25l25635f@0 {
+		compatible = "mx25l25635f", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		SBL1@0 {
+			label = "SBL1";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		MIBIB@40000 {
+			label = "MIBIB";
+			reg = <0x40000 0x20000>;
+			read-only;
+		};
+
+		QSEE@60000 {
+			label = "QSEE";
+			reg = <0x60000 0x60000>;
+			read-only;
+		};
+
+		CDT@c0000 {
+			label = "CDT";
+			reg = <0xc0000 0x10000>;
+			read-only;
+		};
+
+		DDRPARAMS@d0000 {
+			label = "DDRPARAMS";
+			reg = <0xd0000 0x10000>;
+			read-only;
+		};
+
+		APPSBLENV@e0000 {
+			label = "APPSBLENV";
+			reg = <0xe0000 0x10000>;
+			read-only;
+		};
+
+		APPSBL@f0000 {
+			label = "APPSBL";
+			reg = <0xf0000 0x80000>;
+			read-only;
+		};
+
+		ART@170000 {
+			label = "ART";
+			reg = <0x170000 0x10000>;
+			read-only;
+		};
+
+		kernel@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		rootfs@580000 {
+			label = "rootfs";
+			reg = <0x580000 0xa80000>;
+		};
+
+		firmware@180000 {
+			label = "firmware";
+			reg = <0x180000 0xe80000>;
+		};
+	};
+};

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-m018u0.dtsi
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4018-m018u0.dtsi
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	compatible = "qcom,ipq4019";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		rng@22000 {
+			status = "okay";
+		};
+
+		pinctrl@1000000 {
+			serial_pins: serial_pinmux {
+				mux {
+					pins = "gpio60", "gpio61";
+					function = "blsp_uart0";
+					bias-disable;
+				};
+			};
+
+			spi_0_pins: spi_0_pinmux {
+				pinmux {
+					function = "blsp_spi0";
+					pins = "gpio55", "gpio56", "gpio57";
+				};
+
+				pinmux_cs {
+					function = "gpio";
+					pins = "gpio54";
+				};
+
+				pinconf {
+					pins = "gpio55", "gpio56", "gpio57";
+					drive-strength = <12>;
+					bias-disable;
+				};
+
+				pinconf_cs {
+					pins = "gpio54";
+					drive-strength = <2>;
+					bias-disable;
+					output-high;
+				};
+			};
+		};
+
+		blsp_dma: dma@7884000 {
+			status = "okay";
+		};
+
+		spi@78b5000 {
+			pinctrl-0 = <&spi_0_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+			cs-gpios = <&tlmm 54 0>;
+		};
+
+		serial@78af000 {
+			pinctrl-0 = <&serial_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+		};
+
+		cryptobam: dma@8e04000 {
+			status = "okay";
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		wifi@a000000 {
+			status = "okay";
+		};
+
+		wifi@a800000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+
+		usb3_ss_phy: ssphy@9a000 {
+			status = "okay";
+		};
+
+		usb3_hs_phy: hsphy@a6000 {
+			status = "okay";
+		};
+
+		usb3: usb3@8af8800 {
+			status = "okay";
+		};
+
+		usb2_hs_phy: hsphy@a8000 {
+			status = "okay";
+		};
+
+		usb2: usb2@60f8800 {
+			status = "okay";
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Corewav-M018U0";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Corewav-M018U0";
+};

--- a/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4018-m018u0-s1.dts
+++ b/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4018-m018u0-s1.dts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq4018-m018u0.dtsi"
+
+/ {
+	model = "Corewav M018U0 SOM S1";
+	compatible = "corewav,m018u0-s1";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+};
+
+&blsp1_spi1 {
+	mx25l25635f@0 {
+		compatible = "mx25l25635f", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		SBL1@0 {
+			label = "SBL1";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		MIBIB@40000 {
+			label = "MIBIB";
+			reg = <0x40000 0x20000>;
+			read-only;
+		};
+
+		QSEE@60000 {
+			label = "QSEE";
+			reg = <0x60000 0x60000>;
+			read-only;
+		};
+
+		CDT@c0000 {
+			label = "CDT";
+			reg = <0xc0000 0x10000>;
+			read-only;
+		};
+
+		DDRPARAMS@d0000 {
+			label = "DDRPARAMS";
+			reg = <0xd0000 0x10000>;
+			read-only;
+		};
+
+		APPSBLENV@e0000 {
+			label = "APPSBLENV";
+			reg = <0xe0000 0x10000>;
+			read-only;
+		};
+
+		APPSBL@f0000 {
+			label = "APPSBL";
+			reg = <0xf0000 0x80000>;
+			read-only;
+		};
+
+		ART@170000 {
+			label = "ART";
+			reg = <0x170000 0x10000>;
+			read-only;
+		};
+
+		kernel@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		rootfs@580000 {
+			label = "rootfs";
+			reg = <0x580000 0xa80000>;
+		};
+
+		firmware@180000 {
+			label = "firmware";
+			reg = <0x180000 0xe80000>;
+		};
+	};
+};

--- a/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4018-m018u0.dtsi
+++ b/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4018-m018u0.dtsi
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	compatible = "qcom,ipq4019";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		rng@22000 {
+			status = "okay";
+		};
+
+		pinctrl@1000000 {
+			serial_pins: serial_pinmux {
+				mux {
+					pins = "gpio60", "gpio61";
+					function = "blsp_uart0";
+					bias-disable;
+				};
+			};
+
+			spi_0_pins: spi_0_pinmux {
+				pinmux {
+					function = "blsp_spi0";
+					pins = "gpio55", "gpio56", "gpio57";
+				};
+
+				pinmux_cs {
+					function = "gpio";
+					pins = "gpio54";
+				};
+
+				pinconf {
+					pins = "gpio55", "gpio56", "gpio57";
+					drive-strength = <12>;
+					bias-disable;
+				};
+
+				pinconf_cs {
+					pins = "gpio54";
+					drive-strength = <2>;
+					bias-disable;
+					output-high;
+				};
+			};
+		};
+
+		blsp_dma: dma@7884000 {
+			status = "okay";
+		};
+
+		spi@78b5000 {
+			pinctrl-0 = <&spi_0_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+			cs-gpios = <&tlmm 54 0>;
+		};
+
+		serial@78af000 {
+			pinctrl-0 = <&serial_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+		};
+
+		cryptobam: dma@8e04000 {
+			status = "okay";
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		wifi@a000000 {
+			status = "okay";
+		};
+
+		wifi@a800000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+
+		usb3_ss_phy: ssphy@9a000 {
+			status = "okay";
+		};
+
+		usb3_hs_phy: hsphy@a6000 {
+			status = "okay";
+		};
+
+		usb3: usb3@8af8800 {
+			status = "okay";
+		};
+
+		usb2_hs_phy: hsphy@a8000 {
+			status = "okay";
+		};
+
+		usb2: usb2@60f8800 {
+			status = "okay";
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Corewav-M018U0";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Corewav-M018U0";
+};

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -305,6 +305,21 @@ define Device/compex_wpj428
 endef
 TARGET_DEVICES += compex_wpj428
 
+define Device/corewav_m018u0-s1
+	DEVICE_VENDOR := Corewav
+	DEVICE_MODEL := M018U0
+	DEVICE_VARIANT := S1
+	SOC := qcom-ipq4018
+	DEVICE_DTS_CONFIG := config@4
+	KERNEL_INSTALL := 1
+	KERNEL_SIZE := 4096k
+	IMAGE_SIZE := 15552k
+	$(call Device/FitImage)
+	IMAGES := sysupgrade.bin
+	IMAGE/sysupgrade.bin := append-kernel | pad-to $$$${KERNEL_SIZE} | append-rootfs | pad-rootfs | append-metadata
+endef
+TARGET_DEVICES += corewav_m018u0-s1
+
 define Device/dlink_dap-2610
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := D-Link

--- a/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -785,11 +785,46 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -785,11 +785,47 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -26,6 +26,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-ex6150v2.dtb \
 +	qcom-ipq4018-fritzbox-4040.dtb \
 +	qcom-ipq4018-jalapeno.dtb \
++	qcom-ipq4018-m018u0-s1.dtb \
 +	qcom-ipq4018-meshpoint-one.dtb \
 +	qcom-ipq4018-nbg6617.dtb \
 +	qcom-ipq4018-rt-ac58u.dtb \

--- a/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -837,11 +837,46 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -837,11 +837,47 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -26,6 +26,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-ex6150v2.dtb \
 +	qcom-ipq4018-fritzbox-4040.dtb \
 +	qcom-ipq4018-jalapeno.dtb \
++	qcom-ipq4018-m018u0-s1.dtb \
 +	qcom-ipq4018-meshpoint-one.dtb \
 +	qcom-ipq4018-nbg6617.dtb \
 +	qcom-ipq4018-rt-ac58u.dtb \


### PR DESCRIPTION
ipq40xx: ipq4018: add support for Corewav M018U0 SOM S1

    SoC:    Qualcomm ipq4018
    CPU:    Quad core ARM v7 Cortex A7 717MHz
    RAM:    256MB
    FLASH:  NOR:16MB
    ETH:    5 x GMAC Gigabit
    POE:    802.3 af POE
    WIFI:   1 x 2.4Ghz Atheros qca4019 2x2
            1 x 5 Ghz Atheros qca4019 2x2 MU-MIMO
    USB:    USB 3.0 X 1
    PCI:    1 x mini pcie slot(Only for Lte module with USB2.0)
    SIM:    1 x slot
    SD:     1 x microSD slot
    BTN:    reset
    UART:   1 x 3 pin debug connector (UART)
    GPIOs:  7 pin connector
    POWER:  12V 2A  dc jack

Installation  via bootloader
------------

tftpboot openwrt-ipq40xx-generic-corewav_m018u0-s1-squashfs-sysupgrade.bin
sf probe && sf erase 0x180000 +$filesize && sf write $fileaddr 0x180000 $filesize && reset;

Signed-off-by: Will Zhang <will_zhang@rockeetech.com>
