### PR TITLE
[RFC] busybox: disable SUSv2-compatibility by default

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -12,7 +12,7 @@ config BUSYBOX_DEFAULT_FEDORA_COMPAT
 	default n
 config BUSYBOX_DEFAULT_INCLUDE_SUSv2
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_LONG_OPTS
 	bool
 	default y


### PR DESCRIPTION
This disables compatibility to the obsolete features removed before SUSv3, they are probably not needed anymore.

I just saw this option by reviewing the busybox-configuration, but did not do a runtime-test. 