### PR TITLE
treewide: Remove some bashism

### DIFF
--- a/package/network/services/igmpproxy/files/igmpproxy.init
+++ b/package/network/services/igmpproxy/files/igmpproxy.init
@@ -66,7 +66,9 @@ igmp_add_firewall_routing() {
 	config_get direction $1 direction
 	config_get zone $1 zone
 
-	[ "$direction" = "downstream" -a -n "$zone" ] || return 0
+	if [ "$direction" != "downstream" ] || [ -z "$zone" ]; then
+		return 0
+	fi
 
 # First drop SSDP packets then accept all other multicast
 

--- a/package/network/services/igmpproxy/files/igmpproxy.init
+++ b/package/network/services/igmpproxy/files/igmpproxy.init
@@ -43,7 +43,7 @@ igmp_add_phyint() {
 
 	append netdevs "$device"
 
-	[[ "$direction" = "upstream" ]] && has_upstream=1
+	[ "$direction" = "upstream" ] && has_upstream=1
 
 	echo -e "\nphyint $device $direction ratelimit 0 threshold 1" >> /var/etc/igmpproxy.conf
 
@@ -66,7 +66,7 @@ igmp_add_firewall_routing() {
 	config_get direction $1 direction
 	config_get zone $1 zone
 
-	[[ "$direction" = "downstream" && ! -z "$zone" ]] || return 0
+	[ "$direction" = "downstream" -a -n "$zone" ] || return 0
 
 # First drop SSDP packets then accept all other multicast
 
@@ -105,7 +105,7 @@ igmp_add_firewall_network() {
 	json_add_string target ACCEPT
 	json_close_object
 
-	[[ "$direction" = "upstream" ]] && {
+	[ "$direction" = "upstream" ] && {
 		upstream="$zone"
 		config_foreach igmp_add_firewall_routing phyint
 	}


### PR DESCRIPTION
This removes some non POSIX extensions from the shell-scripts, as already done in d6ac8ca76c04ed39d7dd5de73d3b921819934186. It targets "[[" and "==".
