### PR TITLE
brcm47xx: fix switch port order for Netgear WNR3500 V2

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -171,6 +171,7 @@ configure_by_model() {
 
 	"Asus RT-N16"* | \
 	"Linksys E3000 V1" | \
+	"Netgear WNR3500 V2" | \
 	"Netgear WNR3500L")
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "8@eth0"


### PR DESCRIPTION
The Netgear WNR3500 V2 switch0 already works for WAN/LAN
however the port order for the LAN ports is inverted. Correct
physical port order watched from the back of the device is:
Internet / 4 / 3 / 2 / 1 this resembles the Linksys E3000 V1.

Verified with imagebuilder edit FILES=/etc/board.d/01_network

Signed-off-by: Walter Sonius <walterav1984@gmail.com>