### PR TITLE
 brcm47xx: fix switch port order for Netgear WN2500RP V1

### DIFF
--- a/target/linux/brcm47xx/base-files/etc/board.d/01_network
+++ b/target/linux/brcm47xx/base-files/etc/board.d/01_network
@@ -169,6 +169,11 @@ configure_by_model() {
 			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
 		;;
 
+	"Netgear WN2500RP V1")
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5@eth0"
+		;;
+
 	"Asus RT-N16"* | \
 	"Linksys E3000 V1" | \
 	"Netgear WNR3500L")


### PR DESCRIPTION
The Netgear WN2500RP V1 switch0 already works for LAN
however the port order for the LAN ports is inverted. Correct
physical port order watched from the back of the device is:
4 / 3 / 2 / 1
WAN port is absent on this device and therefor removed
from switch config. 

Signed-off-by: Walter Sonius <walterav1984@gmail.com>