### PR TITLE
ramips: add support for TP-Link RE305 v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,re305-v1", "mediatek,mt7628an-soc";
+	model = "TP-Link RE305 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re305-v1:blue:power";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "re305-v1:blue:wlan2g";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "re305-v1:blue:wlan5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		rssi1 {
+			label = "re305-v1:red:rssi";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "re305-v1:blue:rssi";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x5e0000>;
+			};
+
+			config: partition@600000 {
+				label = "config";
+				reg = <0x600000 0x50000>;
+				read-only;
+			};
+
+			/*
+				The flash space between 0x650000 and 0x7f0000 is blank in the
+				stock firmware so it is left out as well.
+			*/
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "refclk", "wdt", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an";
+		ralink,function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <2>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&config 0x10008>;
+	mtd-mac-address-increment = <1>;
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0x10008>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -267,6 +267,20 @@ endef
 DEVICE_VARS += TPLINK_FLASHLAYOUT TPLINK_HWID TPLINK_HWREV TPLINK_HWREVADD
 DEVICE_VARS += TPLINK_HVERSION
 
+define Device/tplink-safeloader
+  SOC := mt7628an
+  DEVICE_VENDOR := TP-Link
+  TPLINK_BOARD_ID :=
+  TPLINK_HWID := 0x0
+  TPLINK_HWREV := 0
+  TPLINK_HEADER_VERSION := 1
+  KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
+	append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+endef
+
 define Device/tplink_archer-c20-v4
   $(Device/tplink)
   IMAGE_SIZE := 7808k
@@ -312,6 +326,16 @@ define Device/tplink_archer-c50-v4
   SUPPORTED_DEVICES += tplink,c50-v4
 endef
 TARGET_DEVICES += tplink_archer-c50-v4
+
+define Device/tplink_re305-v1
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 6016k
+  DEVICE_MODEL := RE305
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt76x2
+  TPLINK_BOARD_ID := RE305-V1
+endef
+TARGET_DEVICES += tplink_re305-v1
 
 define Device/tplink_tl-mr3020-v3
   $(Device/tplink)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ ramips_setup_interfaces()
 	alfa-network,awusfree1|\
 	d-team,pbr-d1|\
 	tama,w06|\
+	tplink,re305-v1|\
 	tplink,tl-mr3020-v3|\
 	tplink,tl-wr802n-v4)
 		ucidef_set_interface_lan "eth0"

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1437,6 +1437,42 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+  /** Firmware layout for the RE305 v1 */
+	{
+		.id     = "RE305-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:45550000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:55530000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:4a500000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:42520000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:4b520000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:41550000}\n"
+			"{product_name:RE305,product_ver:1.0.0,special_id:43410000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x5e0000},
+			{"partition-table", 0x600000, 0x02000},
+			{"default-mac", 0x610000, 0x00020},
+			{"pin", 0x610100, 0x00020},
+			{"product-info", 0x611100, 0x01000},
+			{"soft-version", 0x620000, 0x01000},
+			{"support-list", 0x621000, 0x01000},
+			{"profile", 0x622000, 0x08000},
+			{"user-config", 0x630000, 0x10000},
+			{"default-config", 0x640000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the RE350 v1 */
 	{
 		.id     = "RE350-V1",


### PR DESCRIPTION
Specification:

SoC: MediaTek MT7628AN
RAM: 64MiB
Flash: 8MiB
Wifi:
  - 2.4GHz: MT7628AN
  - 5GHz: MT7612EN
LAN: 1x 10/100 Mbps

Flash instructions:
Flash factory image through stock firmware WEB UI.
Back to stock is possible by using TFTP and stripping down the Firmware provided by TP-Link to a initramfs.

Signed-off-by: Steffen Förster <nemesis@chemnitz.freifunk.net>
