### PR TITLE
 brcm63xx: add support for Netcomm NB604N 

### DIFF
--- a/target/linux/brcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/brcm63xx/base-files/etc/board.d/01_leds
@@ -74,6 +74,9 @@ livebox1)
 	ucidef_set_led_netdev "wan" "WAN" "Livebox1:red:adsl" "eth1"
 	ucidef_set_led_netdev "wlan0" "WIFI" "Livebox1:red:wifi" "wlan0"
 	;;
+nb604n)
+	ucidef_set_led_usbdev "usb" "USB" "NB604N:blue:usb" "1-1"
+	;;
 r1000h)
 	ucidef_set_led_usbport "usb" "USB" "R1000H:green:usb" "usb1-port1" "usb2-port1"
 	;;

--- a/target/linux/brcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/brcm63xx/base-files/etc/board.d/02_network
@@ -89,6 +89,7 @@ fast2504n |\
 fast2704v2 |\
 hg622 |\
 hg655b |\
+nb604n |\
 p870hw-51a_v2 |\
 r5010un_v2 |\
 vr-3025un |\

--- a/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
+++ b/target/linux/brcm63xx/base-files/lib/brcm63xx.sh
@@ -180,6 +180,9 @@ brcm63xx_dt_detect() {
 	"Inventel Livebox 1")
 		board_name="livebox1"
 		;;
+	"Netcomm NB604N")
+		board_name="nb604n"
+		;;
 	"Netgear CVG834G")
 		board_name="cvg834g"
 		;;

--- a/target/linux/brcm63xx/dts/nb604n.dts
+++ b/target/linux/brcm63xx/dts/nb604n.dts
@@ -1,0 +1,130 @@
+/dts-v1/;
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netcomm NB604N";
+	compatible = "brcm,nb604n", "brcm,bcm6328";
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&pinctrl 15 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "NB604N:blue:usb";
+			gpios = <&pinctrl 1 1>;
+		};
+
+		internet_red {
+			label = "NB604N:red:internet";
+			gpios = <&pinctrl 2 1>;
+		};
+
+		dsl {
+			label = "NB604N:blue:dsl";
+			gpios = <&pinctrl 3 1>;
+		};
+
+		power_blue {
+			label = "NB604N:blue:power";
+			gpios = <&pinctrl 4 1>;
+			default-state = "on";
+		};
+
+		power_red {
+			label = "NB604N:red:power";
+			gpios = <&pinctrl 5 1>;
+		};
+
+		wps {
+			label = "NB604N:blue:wps";
+			gpios = <&pinctrl 10 1>;
+		};
+
+		internet_blue {
+			label = "NB604N:blue:internet";
+			gpios = <&pinctrl 11 1>;
+		};
+	};
+};
+
+&hsspi {
+	status = "ok";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			linux@10000 {
+				reg = <0x010000 0x7e0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			nvram@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usb_port1_device>;
+};
+
+&uart0 {
+	status = "ok";
+};

--- a/target/linux/brcm63xx/image/bcm63xx.mk
+++ b/target/linux/brcm63xx/image/bcm63xx.mk
@@ -857,6 +857,20 @@ define Device/livebox
 endef
 TARGET_DEVICES += livebox
 
+### Netcomm ###
+define Device/NB604N
+  $(Device/bcm63xx)
+  IMAGES += sysupgrade.bin
+  DEVICE_VENDOR := Netcomm
+  DEVICE_MODEL := NB604N
+  DEVICE_DTS := nb604n
+  CFE_BOARD_ID := 96328ang
+  CFE_CHIP_ID := 6328
+  FLASH_MB := 8
+  DEVICE_PACKAGES := $(B43_PACKAGES) $(USB2_PACKAGES)
+endef
+TARGET_DEVICES += NB604N
+
 ### Netgear ###
 define Device/CVG834G
   $(Device/bcm33xx)

--- a/target/linux/brcm63xx/patches-4.14/599-board_NB604N.patch
+++ b/target/linux/brcm63xx/patches-4.14/599-board_NB604N.patch
@@ -1,0 +1,68 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -795,6 +795,49 @@
+ 	},
+ };
+ 
++static struct board_info __initdata board_NB604N = {
++	.name					= "96328ang",
++	.expected_cpu_id			= 0x6328,
++
++	.has_pci				= 1,
++	.use_fallback_sprom			= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 1,
++	.has_enetsw				= 1,
++
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "Port 1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "Port 2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "Port 3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "Port 4",
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type 				= SPROM_BCM43225,
++		.pci_bus			= 1,
++		.pci_dev			= 0,
++	},
++};
++
+ #endif /* CONFIG_BCM63XX_CPU_6328 */
+ 
+ /*
+@@ -2726,6 +2769,7 @@
+ 	&board_dsl_274xb_f1,
+ 	&board_FAST2704V2,
+ 	&board_R5010UNV2,
++	&board_NB604N,
+ #endif
+ #ifdef CONFIG_BCM63XX_CPU_6338
+ 	&board_96338gw,
+@@ -2831,6 +2875,7 @@
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },
+ 	{ .compatible = "comtrend,ar-5387un", .data = &board_AR5387un, },
+ 	{ .compatible = "d-link,dsl-274xb-f", .data = &board_dsl_274xb_f1, },
++	{ .compatible = "netcomm,nb604n", .data = &board_NB604N, },
+ 	{ .compatible = "nucom,r5010unv2", .data = &board_R5010UNV2, },
+ 	{ .compatible = "sagem,f@st2704v2", .data = &board_FAST2704V2, },
+ 	{ .compatible = "sercomm,ad1018-nor", .data = &board_AD1018, },

--- a/target/linux/brcm63xx/patches-4.19/599-board_NB604N.patch
+++ b/target/linux/brcm63xx/patches-4.19/599-board_NB604N.patch
@@ -1,0 +1,68 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -795,6 +795,49 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct board_info __initdata board_NB604N = {
++	.name					= "96328ang",
++	.expected_cpu_id			= 0x6328,
++
++	.has_pci				= 1,
++	.use_fallback_sprom			= 1,
++	.has_ohci0				= 1,
++	.has_ehci0				= 1,
++	.num_usbh_ports				= 1,
++	.has_enetsw				= 1,
++
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used		= 1,
++				.phy_id		= 1,
++				.name		= "Port 1",
++			},
++			[1] = {
++				.used		= 1,
++				.phy_id		= 2,
++				.name		= "Port 2",
++			},
++			[2] = {
++				.used		= 1,
++				.phy_id		= 3,
++				.name		= "Port 3",
++			},
++			[3] = {
++				.used		= 1,
++				.phy_id		= 4,
++				.name		= "Port 4",
++			},
++		},
++	},
++
++	.fallback_sprom = {
++		.type 				= SPROM_BCM43225,
++		.pci_bus			= 1,
++		.pci_dev			= 0,
++	},
++};
++
+ #endif /* CONFIG_BCM63XX_CPU_6328 */
+ 
+ /*
+@@ -2724,6 +2767,7 @@ static const struct board_info __initcon
+ 	&board_dsl_274xb_f1,
+ 	&board_FAST2704V2,
+ 	&board_R5010UNV2,
++	&board_NB604N,
+ #endif
+ #ifdef CONFIG_BCM63XX_CPU_6338
+ 	&board_96338gw,
+@@ -2829,6 +2873,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },
+ 	{ .compatible = "comtrend,ar-5387un", .data = &board_AR5387un, },
+ 	{ .compatible = "d-link,dsl-274xb-f", .data = &board_dsl_274xb_f1, },
++	{ .compatible = "netcomm,nb604n", .data = &board_NB604N, },
+ 	{ .compatible = "nucom,r5010unv2", .data = &board_R5010UNV2, },
+ 	{ .compatible = "sagem,f@st2704v2", .data = &board_FAST2704V2, },
+ 	{ .compatible = "sercomm,ad1018-nor", .data = &board_AD1018, },

--- a/target/linux/generic/pending-4.14/481-mtd-spi-nor-fix-s25fl064p-flags.patch
+++ b/target/linux/generic/pending-4.14/481-mtd-spi-nor-fix-s25fl064p-flags.patch
@@ -1,0 +1,25 @@
+From: Jeremy Tan <jtanx@outlook.com>
+Date: Sat, 28 Dec 2019 15:19:00 +0800
+Subject: [PATCH] mtd: spi-nor: Fix s25fl064p flags
+
+As per section 9.11 of the datasheet, there are block protect bits
+on the status register. Section 9.21 also indicates support for the
+CLSR command.
+
+Note s25sl064p should actually be s25fl064p.
+
+https://www.cypress.com/file/196856/download
+
+Signed-off-by: Jeremy Tan <jtanx@outlook.com>
+---
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1063,7 +1063,7 @@ static const struct flash_info spi_nor_i
+ 	 * for the chips listed here (without boot sectors).
+ 	 */
+ 	{ "s25sl032p",  INFO(0x010215, 0x4d00,  64 * 1024,  64, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+-	{ "s25sl064p",  INFO(0x010216, 0x4d00,  64 * 1024, 128, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "s25sl064p",  INFO(0x010216, 0x4d00,  64 * 1024, 128, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+ 	{ "s25fl256s0", INFO(0x010219, 0x4d00, 256 * 1024, 128, USE_CLSR) },
+ 	{ "s25fl256s1", INFO(0x010219, 0x4d01,  64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR) },
+ 	{ "s25fl512s",  INFO(0x010220, 0x4d00, 256 * 1024, 256, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR) },

--- a/target/linux/generic/pending-4.19/481-mtd-spi-nor-fix-s25fl064p-flags.patch
+++ b/target/linux/generic/pending-4.19/481-mtd-spi-nor-fix-s25fl064p-flags.patch
@@ -1,0 +1,25 @@
+From: Jeremy Tan <jtanx@outlook.com>
+Date: Sat, 28 Dec 2019 15:19:00 +0800
+Subject: [PATCH] mtd: spi-nor: Fix s25fl064p flags
+
+As per section 9.11 of the datasheet, there are block protect bits
+on the status register. Section 9.21 also indicates support for the
+CLSR command.
+
+Note s25sl064p should actually be s25fl064p.
+
+https://www.cypress.com/file/196856/download
+
+Signed-off-by: Jeremy Tan <jtanx@outlook.com>
+---
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1126,7 +1126,7 @@ static const struct flash_info spi_nor_i
+ 	 * for the chips listed here (without boot sectors).
+ 	 */
+ 	{ "s25sl032p",  INFO(0x010215, 0x4d00,  64 * 1024,  64, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+-	{ "s25sl064p",  INFO(0x010216, 0x4d00,  64 * 1024, 128, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "s25sl064p",  INFO(0x010216, 0x4d00,  64 * 1024, 128, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+ 	{ "s25fl256s0", INFO(0x010219, 0x4d00, 256 * 1024, 128, USE_CLSR) },
+ 	{ "s25fl256s1", INFO(0x010219, 0x4d01,  64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR) },
+ 	{ "s25fl512s",  INFO(0x010220, 0x4d00, 256 * 1024, 256, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | USE_CLSR) },


### PR DESCRIPTION
Device specifications:
* BCM6328 with BCM43225KMLG wireless NIC
* 8MB flash (S25FL064P)
* 64MB RAM
* 1 USB port, 4 ethernet ports
* 1 RJ11 port for ADSL2

OpenWRT support:
* ADSL unsupported
* Wireless support limited (works with either b43 or brcmsmac,
  but wireless speeds are slow)

Flashing instructions:
* With the device powered off, press and hold the reset button
* Power on the device, keeping the reset button held
* Release the reset button after a while, or when the power led turns blue
* Browse to 192.168.1.1 and upload the OpenWRT CFE image
* The CFE recovery modes listed here all work:
  - https://openwrt.org/docs/techref/bootloader/cfe#bcm63xx_cfe

The stock firmware can be reloaded using the same steps above.

https://openwrt.org/toh/netcomm/nb604n
