### PR TITLE
uboot-oxnas: fix memory leak in tool mkox820crc

### DIFF
--- a/package/boot/uboot-oxnas/src/tools/mkox820crc.c
+++ b/package/boot/uboot-oxnas/src/tools/mkox820crc.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv)
 
 	if (status != file_length) {
 		printf("Failed to load image\n");
+		free(executable);
 		return -ENOENT;
 	}
 
@@ -111,6 +112,7 @@ int main(int argc, char **argv)
 	status = lseek(in_file, 0, SEEK_SET);
 	if (status != 0) {
 		printf("failed to rewind\n");
+		free(executable);
 		return 1;
 	}
 	len = write(in_file, &img_header, sizeof(img_header));
@@ -118,6 +120,7 @@ int main(int argc, char **argv)
 	len = write(in_file, executable, file_length);
 	assert(len == file_length);
 	close(in_file);
+	free(executable);
 
 	return 0;
 }


### PR DESCRIPTION
In function `main` add calls to `free` for the variable `executable`.
This is needed because the variable `executable` is allocated but
never freed. This cause a memory leak.
