### PR TITLE
ead: fix resource leak in tinysrp

### DIFF
--- a/package/network/services/ead/src/tinysrp/t_pw.c
+++ b/package/network/services/ead/src/tinysrp/t_pw.c
@@ -94,8 +94,10 @@ t_openpw(fp)
   else
     close_flag = 0;
 
-  if((tpw = malloc(sizeof(struct t_pw))) == NULL)
+  if((tpw = malloc(sizeof(struct t_pw))) == NULL) {
+    fclose(fp);
     return NULL;
+  }
   tpw->instream = fp;
   tpw->close_on_exit = close_flag;
   tpw->state = FILE_ONLY;


### PR DESCRIPTION
Add call to `fclose` for file pointer `fp` in function `t_openpw`.
The resource leak could happen during an error handling.
