### PR TITLE
ramips: reduce lzma dictionary size for D-Link DIR-645

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -36,7 +36,7 @@ define Device/dlink_dir-645
   SOC := rt3662
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7872k
-  KERNEL := $(KERNEL_DTB)
+  KERNEL := kernel-bin | append-dtb | lzma -d10
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-645


### PR DESCRIPTION
Currently this device fails to boot with the OpenWrt snapshot images
(release images are unaffected). The error message is:
"LZMA ERROR 1 - must RESET board to recover".

This happens because the kernel image is too big for the bootloader
to boot. This commit works around this by decreasing the lzma dictionary
size option from the default 23 to 10.

Before this change the current OpenWrt snapshot image (uncompressed
kernel size 4875139 bytes) failed to boot, while now an even bigger
image (kernel 4.19 with snapshot default config; uncompressed kernel
size 5162833 bytes) boots just fine.

The highest lzma dictionary size option this image booted with was 11.
10 was chosen to have a bit more room for growth.

An unavoidable side-effect of this change is that the compressed kernel
image will take up more space.

Total image size with different dictionary size options:
D23 - 3973903 bytes (base)
D16 - 4113167 bytes (+3.5%  - +139264 bytes)
D12 - 4317967 bytes (+8.7%  - +344064‬ bytes)
D11 - 4383503 bytes (+10.3% - +409600 bytes)
D10 - 4461327 bytes (+12.3% - +487424 bytes)

Fixes: FS#1484