### PR TITLE
[19.07] ramips: reenable image creation for the D-Link DIR-645

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -38,7 +38,6 @@ define Device/dir-645
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_TITLE := D-Link DIR-645
   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 swconfig
-  DEFAULT := n
 endef
 TARGET_DEVICES += dir-645
 


### PR DESCRIPTION
This commit reenables the image creation for the D-Link DIR-645.

Images built for the D-Link DIR-645 work just fine, there is no reason
to disable the image creation for it.

I tested the OpenWrt 18.06.5 and 19.07.0-rc1 images, as well as an
image I built from the current 19.07 branch (git HEAD 62d5ece) with
the default 19.07 release config, and I cannot confirm the report that
commit 2607c02ed599b6118ba26e2f35e7c828c21d7275
("ramips: disable D-Link DIR-645 by default") references.
Configuration changes were applied successfully and remained set after
a reboot as well. The log also showed no anomalies.

This reverts commit 2607c02ed599b6118ba26e2f35e7c828c21d7275.