### PR TITLE
ramips: add support for TP-Link RE210 v1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_re200-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_re200-v1.dts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7620a.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7620a_tplink_re2x0-v1.dtsi"
 
 / {
 	compatible = "tplink,re200-v1", "ralink,mt7620a-soc";
@@ -15,11 +12,6 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-		label-mac-device = &ethernet;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,57600n8";
 	};
 
 	leds {
@@ -56,22 +48,6 @@
 			linux,default-trigger = "phy1tpt";
 		};
 	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
 };
 
 
@@ -79,46 +55,6 @@
 	gpio {
 		ralink,group = "i2c", "uartf", "ephy", "wled", "rgmii1", "spi refclk";
 		ralink,function = "gpio";
-	};
-};
-
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <50000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			uboot: partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x20000>;
-				read-only;
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x20000 0x7c0000>;
-			};
-
-			partition@7e0000 {
-				label = "userconfig";
-				reg = <0x7e0000 0x10000>;
-				read-only;
-			};
-
-			radio: partition@7f0000 {
-				label = "radio";
-				reg = <0x7f0000 0x10000>;
-				read-only;
-			};
-		};
 	};
 };
 
@@ -132,27 +68,4 @@
 
 &gpio3 {
 	status = "okay";
-};
-
-&ethernet {
-	mtd-mac-address = <&uboot 0x1fc00>;
-};
-
-&wmac {
-	ralink,mtd-eeprom = <&radio 0x0>;
-	mtd-mac-address = <&uboot 0x1fc00>;
-};
-
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	mt76@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&radio 0x8000>;
-		mtd-mac-address = <&uboot 0x1fc00>;
-		mtd-mac-address-increment = <2>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
 };

--- a/target/linux/ramips/dts/mt7620a_tplink_re210-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_re210-v1.dts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a_tplink_re2x0-v1.dtsi"
+
+/ {
+	compatible = "tplink,re210-v1", "ralink,mt7620a-soc";
+	model = "TP-Link RE210 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re210-v1:green:power";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high {
+			label = "re210-v1:green:rssi_high";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low {
+			label = "re210-v1:red:rssi_low";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "re210-v1:green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "re210-v1:green:wlan5g";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&keys {
+	led_power {
+		label = "LED power";
+		gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "uartf", "wled", "rgmii1";
+		ralink,function = "gpio";
+	};
+};
+
+&gsw {
+	mediatek,port4 = "gmac";
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+
+	port@4 {
+		status = "okay";
+
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x7c0000>;
+			};
+
+			partition@7e0000 {
+				label = "config";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&uboot 0x1fc00>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -943,6 +943,18 @@ define Device/tplink_re200-v1
 endef
 TARGET_DEVICES += tplink_re200-v1
 
+define Device/tplink_re210-v1
+  $(Device/tplink-v1)
+  SOC := mt7620a
+  DEVICE_MODEL := RE210
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt76x0e
+  IMAGE_SIZE := 7936k
+  TPLINK_HWID := 0x02100001
+  TPLINK_FLASHLAYOUT := 8Mmtk
+endef
+TARGET_DEVICES += tplink_re210-v1
+
 define Device/vonets_var11n-300
   SOC := mt7620n
   IMAGE_SIZE := 3776k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -50,8 +50,9 @@ ramips_setup_interfaces()
 	planex,mzk-ex300np|\
 	planex,mzk-ex750np|\
 	ravpower,wd03|\
+	sercomm,na930|\
 	tplink,re200-v1|\
-	sercomm,na930)
+	tplink,re210-v1)
 		ucidef_set_interface_lan "eth0"
 		;;
 	asus,rp-n53)


### PR DESCRIPTION
Hardware
--------

SoC:   MediaTek MT7620A
RAM:   64MB
FLASH: 8MB SPI
WLAN:  2G: MediaTek MT7620A
       5G: MediaTek MT7610EN
ETH:   1x 10/100/1000M
LED:   RSSI (orange/green)
       WiFi 2G (green)
       WiFi 5G (green)
       Power (green)
       System (red / green)
BTN:   Power
       Reset
       LED
       WPS

Serial
------

P1 - Tx
P2 - Rx
P3 - GND
P4 - VCC

Pin 4 is the one closest to the LAN port.

Installation
------------

Web interface:
It is possible to upgrade to OpenWrt via the web interface. However, the
OEM firmware upgrade file is required and a tool to fix the MD5 sum of
the header. This procedure overwrites U-Boot and there is not failsafe /
recovery mode present! To prepare an image, you need to take the header
and U-Boot (i.e. 0x200 + 0x20000 bytes) from an OEM firmware file and
attach the factory image to it. Then fix the header MD5Sum1.

Serial/TFTP:
You can use initramfs for booting via RAM or flash the image directly.

Additional Notes:
If the web interface upgrade fails, you have to open your device and
attach serial console. Since the web upgrade overwrites the boot loader,
you might also brick your device.

In order to flash back to stock, the first header and U-Boot needs to be
stripped from the original firmware.

Signed-off-by: Christoph Krapp <achterin@googlemail.com>