### PR TITLE
lantiq: add support for AVM FRITZ!Box 3390

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -211,6 +211,7 @@
 			compatible = "lantiq,xrx200-pinctrl";
 			#gpio-cells = <2>;
 			gpio-controller;
+			gpio-ranges = <&gpio 0 0 56>;
 			reg = <0xe100b10 0xa0>;
 
 			gphy0_led0_pins: gphy0-led0 {

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -1,0 +1,315 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz3390", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3390";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+
+		led-dsl = &led_dsl;
+		led-internet = &led_info;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		power {
+			label = "power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_POWER>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "fritz3390:green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_power_red: power_red {
+			label = "fritz3390:red:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			label = "fritz3390:green:wifi";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		led_dsl: dsl {
+			label = "fritz3390:green:dsl";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan {
+			label = "fritz3390:green:lan";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info: info {
+			label = "fritz3390:green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_wasp_reset {
+			gpio-export,name = "fritz3390:wasp:reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 34 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	usb1_vbus: regulator-usb1-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB1_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy0>;
+			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy1>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	pcie-rst-dev {
+		gpio-hog;
+		line-name = "pcie-rst-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0x30000 0x10000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	flash@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <1 0x0 0x2000000>;
+
+		nand-ecc-mode = "on-die";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb1_vbus>;
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <1>;
+		#address-cells = <2>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			compatible = "pci168c,0033";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -221,6 +221,7 @@
 			compatible = "lantiq,xrx200-pinctrl";
 			#gpio-cells = <2>;
 			gpio-controller;
+			gpio-ranges = <&gpio 0 0 56>;
 			reg = <0xe100b10 0xa0>;
 
 			gphy0_led0_pins: gphy0-led0 {

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -1,0 +1,315 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz3390", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3390";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+
+		led-dsl = &led_dsl;
+		led-internet = &led_info;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		power {
+			label = "power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_POWER>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "fritz3390:green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_power_red: power_red {
+			label = "fritz3390:red:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			label = "fritz3390:green:wifi";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		led_dsl: dsl {
+			label = "fritz3390:green:dsl";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan {
+			label = "fritz3390:green:lan";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info: info {
+			label = "fritz3390:green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_wasp_reset {
+			gpio-export,name = "fritz3390:wasp:reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 34 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	usb1_vbus: regulator-usb1-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB1_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy0>;
+			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy1>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	pcie-rst-dev {
+		gpio-hog;
+		line-name = "pcie-rst-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0x30000 0x10000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	flash@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <1 0x0 0x2000000>;
+
+		nand-ecc-mode = "on-die";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb1_vbus>;
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <1>;
+		#address-cells = <2>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			compatible = "pci168c,0033";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -118,6 +118,18 @@ define Device/avm_fritz3370-rev2-micron
 endef
 TARGET_DEVICES += avm_fritz3370-rev2-micron
 
+define Device/avm_fritz3390
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3390
+  SOC := vr9
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic kmod-usb-dwc2 \
+	fritz-tffs
+endef
+TARGET_DEVICES += avm_fritz3390
+
 define Device/avm_fritz7360sl
   $(Device/AVM)
   DEVICE_MODEL := FRITZ!Box 7360 SL

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -46,6 +46,9 @@ avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron)
 	ucidef_set_led_switch "lan" "LAN" "fritz3370:green:lan" "switch0" "0x17"
 	;;
+avm,fritz3390)
+	ucidef_set_led_switch "lan" "LAN" "fritz3390:green:lan" "switch0" "0x17"
+	;;
 bt,homehub-v5a)
 	ucidef_set_led_default "dimmed" "dimmed" "dimmed" "0"
 	;;

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ lantiq_setup_interfaces()
 		;;
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl)
 		ucidef_add_switch "switch0" \
@@ -82,6 +83,7 @@ lantiq_setup_dsl()
 	arcadyan,vgv7510kw22-nor|\
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412)
@@ -127,12 +129,13 @@ lantiq_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(macaddr_add "$lan_mac" 3)
 		;;
-	avm,fritz7360sl)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
-		;;
+	avm,fritz3390|\
 	avm,fritz7362sl)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
+		;;
+	avm,fritz7360sl)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz7412)
 		tffsdev=$(find_mtd_chardev "nand-tffs")

--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -16,6 +16,9 @@ case "$FIRMWARE" in
 			avm,fritz7362sl)
 				caldata_extract_reverse "urlader" 0x1541 0x440
 				;;
+			avm,fritz3390)
+				caldata_extract_reverse "urlader" 0x2546 0x440
+				;;
 			avm,fritz7360sl)
 				caldata_extract "urlader" 0x985 0x1000
 				;;

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -11,6 +11,7 @@ platform_do_upgrade() {
 	case "$board" in
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	bt,homehub-v5a|\


### PR DESCRIPTION
The AVM FRITZ!Box 3390 is a lantiq-based device with two Atheros radios (2.4GHz and 5GHz). A few features make it special: the 5GHz WiFi is directly connected to the Lantiq CPU, but the 2.4GHz WiFi is connected to a separate ath79-based SoC. Both CPUs communicate via Ethernet.

This PR only adds support for the Lantiq side with the 5GHz WiFi. The 2.4GHz WiFi requires a separate ath79-based target along with some kernel patches and the necessary tools for uploading and configuring.