### PR TITLE
dropbear: add missing zlib dependency for dropbearconvert

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -72,6 +72,7 @@ define Package/dropbearconvert
   SECTION:=utils
   CATEGORY:=Utilities
   TITLE:=Utility for converting SSH keys
+  DEPENDS:= +DROPBEAR_ZLIB:zlib
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
If CONFIG_DROPBEAR_ZLIB is set, building fails at the packaging stage
due to an undeclared dependency on libz.so.1.

As is already done for the main dropbear package, conditionally add a
dependency on zlib.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>