### PR TITLE
ath79: add support for Ubiquiti EdgeSwitch/ToughSwitch 5XP

### DIFF
--- a/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-5xp.dts
+++ b/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-5xp.dts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7242_ubnt_sw.dtsi"
+
+/ {
+	compatible = "ubnt,edgeswitch-5xp", "ubnt,sw", "qca,ar7242";
+	model = "Ubiquiti EdgeSwitch 5XP";
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		poe_24v_port1 {
+			gpio-export,name = "ubnt:24v-poe:port1";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		poe_24v_port2 {
+			gpio-export,name = "ubnt:24v-poe:port2";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		poe_24v_port3 {
+			gpio-export,name = "ubnt:24v-poe:port3";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		poe_24v_port4 {
+			gpio-export,name = "ubnt:24v-poe:port4";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		poe_24v_port5 {
+			gpio-export,name = "ubnt:24v-poe:port5";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-switch@0 {
+		compatible = "qca,ar8327";
+		reg = <0x0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x05100000 /* PORT0 PAD MODE CTRL */
+			0x0c 0x05100000 /* PORT6 PAD MODE CTRL */
+			0x50 0x40004000 /* LED_CTRL0 */
+			0x54 0x40004000 /* LED_CTRL1 */
+			0x58 0x40004000 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy0>;
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};

--- a/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-8xp.dts
+++ b/target/linux/ath79/dts/ar7242_ubnt_edgeswitch-8xp.dts
@@ -1,66 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "ar7242.dtsi"
+#include "ar7242_ubnt_sw.dtsi"
 
 / {
-	compatible = "ubnt,edgeswitch-8xp", "qca,ar7242";
+	compatible = "ubnt,edgeswitch-8xp", "ubnt,sw", "qca,ar7242";
 	model = "Ubiquiti EdgeSwitch 8XP";
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
-	};
-
-	aliases {
-		led-boot = &led_usr;
-		led-failsafe = &led_usr;
-		led-running = &led_usr;
-		led-upgrade = &led_usr;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_usr: usr {
-			label = "ubnt:yellow:usr";
-			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-
-	gpio_spi {
-		compatible = "spi-gpio";
-		#address-cells = <0x1>;
-		ranges;
-
-		sck-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
-		cs-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
-		num-chipselects = <1>;
-
-		gpio_hc595: gpio_spi@0 {
-			compatible = "fairchild,74hc595";
-			reg = <0>;
-			registers-number = <2>;
-			spi-max-frequency = <100000>;
-			enable-gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
-
-			gpio-controller;
-			#gpio-cells = <2>;
-		};
-	};
 
 	gpio-export {
 		compatible = "gpio-export";
@@ -163,54 +108,6 @@
 	};
 };
 
-&spi {
-	status = "okay";
-
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				reg = <0x000000 0x040000>;
-				label = "u-boot";
-				read-only;
-			};
-
-			partition@40000 {
-				reg = <0x040000 0x010000>;
-				label = "u-boot-env";
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				reg = <0x050000 0x760000>;
-				label = "firmware";
-			};
-
-			partition@7b0000 {
-				reg = <0x7b0000 0x040000>;
-				label = "cfg";
-				read-only;
-			};
-
-			art: partition@7f0000 {
-				reg = <0x7f0000 0x010000>;
-				label = "art";
-				read-only;
-			};
-		};
-	};
-};
-
 &mdio0 {
 	status = "okay";
 
@@ -278,29 +175,6 @@
 	};
 };
 
-&usb_phy {
-	status = "okay";
-};
-
-&usb {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	status = "okay";
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
-};
-
-&pcie {
-	status = "okay";
-};
-
-&uart {
-	status = "okay";
-};
-
 &eth0 {
 	status = "okay";
 
@@ -313,10 +187,4 @@
 		speed = <1000>;
 		full-duplex;
 	};
-};
-
-&eth1 {
-	status = "okay";
-
-	mtd-mac-address = <&art 0x6>;
 };

--- a/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
+++ b/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7242.dtsi"
+
+/ {
+	compatible = "ubnt,sw", "qca,ar7242";
+	model = "Ubiquiti Networks SW board";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-running = &led_usr;
+		led-upgrade = &led_usr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_usr: usr {
+			label = "ubnt:yellow:usr";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <0x1>;
+		ranges;
+
+		sck-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_spi@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <2>;
+			spi-max-frequency = <100000>;
+			enable-gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x040000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x040000 0x010000>;
+				label = "u-boot-env";
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				reg = <0x050000 0x760000>;
+				label = "firmware";
+			};
+
+			partition@7b0000 {
+				reg = <0x7b0000 0x040000>;
+				label = "cfg";
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -259,6 +259,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2"
 		;;
+	ubnt,edgeswitch-5xp)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:lan"
+		;;
 	ubnt,edgeswitch-8xp)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -129,6 +129,12 @@ define Device/ubnt_bullet-m-xw
 endef
 TARGET_DEVICES += ubnt_bullet-m-xw
 
+define Device/ubnt_edgeswitch-5xp
+  $(Device/ubnt-sw)
+  DEVICE_MODEL := EdgeSwitch 5XP
+endef
+TARGET_DEVICES += ubnt_edgeswitch-5xp
+
 define Device/ubnt_edgeswitch-8xp
   $(Device/ubnt-sw)
   DEVICE_MODEL := EdgeSwitch 8XP


### PR DESCRIPTION
The Ubiquiti ToughSwitch 5XP is a 5-port PoE Gigabit switch with a single
Fast-Ethernet management port. It supports both 24V passive PoE out on all
five ports.

Flash:8 MB
RAM:  64 MB
SoC:  AR7242
Switch:   ar8327
USB:  1x USB 2.0
Ethernet: 5x GbE, 1x FE

Installation of the firware is possible either via serial + tftpboot or
the factory firmware update function via webinterface.

By default the single Fast-Ethernet port labeled "MGMT" is configured as the WAN port.
Thus access to the device is only possible via the five switch ports.

Serial: 3v3 115200 8n1

The serial header is located in the lower left corner of the switches PCB:

```
|
|
|
| o
| o RX
| o TX
| o GND
|
|
++  +-++-+  ++  ++  +
+--+ ++ +--++--++--+
```
Depends on #2587 