### PR TITLE
[RFC][RFT] ramips: remove invalid mediatek,portmap

### DIFF
--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -122,7 +122,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&rgmii1_pins &mdio_pins &phy_reset_pins>;
 
-	mediatek,portmap = "l";
 	mediatek,mdio-mode = <1>;
 
 	phy-reset-gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -169,9 +169,8 @@
 };
 
 &ethernet {
-		mtd-mac-address = <&rom 0xf100>;
-		mediatek,portmap = "llll";
-	};
+	mtd-mac-address = <&rom 0xf100>;
+};
 
 &ehci {
 	status = "okay";

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir3g-v2.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir3g-v2.dts
@@ -134,7 +134,7 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0xe000>;
-	mediatek,portmap = "lllwl";
+	mediatek,portmap = "llllw";
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -136,5 +136,8 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x28>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
 };

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -82,7 +82,10 @@
 &ethernet {
 	pinctrl-names = "default";
 	mtd-mac-address = <&factory 0xd>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
 };
 
 &wmac {

--- a/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m-split-uboot.dtsi
@@ -84,5 +84,8 @@
 
 &ethernet {
 	mtd-mac-address = <&rom 0xf100>;
-	mediatek,portmap = "wllll";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -66,5 +66,4 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0xf100>;
-	mediatek,portmap = "llllw";
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -78,8 +78,8 @@
 	mtd-mac-address-increment = <(-2)>;
 };
 
-&ethernet {
-	mediatek,portmap = "wllll";
+&esw {
+	mediatek,portmap = <0x3e>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -80,6 +80,10 @@
 	};
 };
 
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
 &pcie {
 	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
@@ -88,3 +88,7 @@
 		ralink,function = "gpio";
 	};
 };
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr802n-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr802n-v4.dts
@@ -46,5 +46,4 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0xf100>;
-	mediatek,portmap = "l";
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
@@ -62,3 +62,7 @@
 		ralink,function = "gpio";
 	};
 };
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
@@ -95,7 +95,10 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0xf100>;
-	mediatek,portmap = "wllll";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
@@ -88,3 +88,7 @@
 		ralink,function = "gpio";
 	};
 };
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v14.dts
@@ -109,7 +109,10 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0xf100>;
-	mediatek,portmap = "wllll";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
@@ -88,3 +88,7 @@
 		ralink,function = "gpio";
 	};
 };
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -123,5 +123,8 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x2e>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -118,5 +118,8 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x28>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
 };

--- a/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
@@ -71,7 +71,10 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x4>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
 };
 
 &sdhci {

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -107,5 +107,8 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x2e>;
-	mediatek,portmap = "llllw";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
 };

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -179,7 +179,10 @@
 
 &ethernet {
 	mtd-mac-address = <&factory 0x4>;
-	mediatek,portmap = "wllll";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
 };
 
 &wmac {

--- a/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
+++ b/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
@@ -115,7 +115,6 @@
 
 &esw {
 	status = "okay";
-	#mediatek,portmap = <0x3e>;
 	mediatek,portmap = <0x2f>;
 };
 

--- a/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
+++ b/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
@@ -94,7 +94,6 @@
 };
 
 &esw {
-	mediatek,portmap = <0>;
 	mediatek,portdisable = <0x2f>;
 };
 


### PR DESCRIPTION
mt7620 and mt7621 use mt7530 driver, which only accepts "llllw", "wllll",
and "lwlll" values.

mt76x8 uses esw_rt3050 driver, which does not accept mediatek,portmap with
string values.
