### PR TITLE
[18.06] Fix Mikrotik board detection that prevent sysupgrade from working

### DIFF
--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -965,6 +965,7 @@ ar71xx_board_detect() {
 	*"MAC1200R")
 		name="mc-mac1200r"
 		;;
+	"MikroTik"*|\
 	"Mikrotik"*)
 		name=$(mikrotik_board_detect "$machine")
 		;;

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -965,7 +965,7 @@ ar71xx_board_detect() {
 	*"MAC1200R")
 		name="mc-mac1200r"
 		;;
-	"MikroTik"*)
+	"Mikrotik"*)
 		name=$(mikrotik_board_detect "$machine")
 		;;
 	*"MiniBox V1.0")

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -393,6 +393,152 @@ tplink_pharos_v2_get_model_string() {
 	dd if=$part bs=1 skip=4360 count=64 2>/dev/null | tr -d '\r\0' | head -n 1
 }
 
+mikrotik_board_detect() {
+	local machine="$1"
+
+	case "$machine" in
+	*"2011iL")
+		name="rb-2011il"
+		;;
+	*"2011iLS")
+		name="rb-2011ils"
+		;;
+	*"2011L")
+		name="rb-2011l"
+		;;
+	*"2011UAS")
+		name="rb-2011uas"
+		;;
+	*"2011UAS-2HnD")
+		name="rb-2011uas-2hnd"
+		;;
+	*"2011UiAS")
+		name="rb-2011uias"
+		;;
+	*"2011UiAS-2HnD")
+		name="rb-2011uias-2hnd"
+		;;
+	*"411/A/AH")
+		name="rb-411"
+		;;
+	*"411U")
+		name="rb-411u"
+		;;
+	*"433/AH")
+		name="rb-433"
+		;;
+	*"433UAH")
+		name="rb-433u"
+		;;
+	*"435G")
+		name="rb-435g"
+		;;
+	*"450")
+		name="rb-450"
+		;;
+	*"450G")
+		name="rb-450g"
+		;;
+	*"493/AH")
+		name="rb-493"
+		;;
+	*"493G")
+		name="rb-493g"
+		;;
+	*"750")
+		name="rb-750"
+		;;
+	*"750 r2"|\
+	*"750r2")
+		name="rb-750-r2"
+		;;
+	*"750GL")
+		name="rb-750gl"
+		;;
+	*"750P r2")
+		name="rb-750p-pbr2"
+		;;
+	*"750UP r2"|\
+	*"750UPr2")
+		name="rb-750up-r2"
+		;;
+	*"751")
+		name="rb-751"
+		;;
+	*"751G")
+		name="rb-751g"
+		;;
+	*"911-2Hn")
+		name="rb-911-2hn"
+		;;
+	*"911-5Hn")
+		name="rb-911-5hn"
+		;;
+	*"911G-2HPnD")
+		name="rb-911g-2hpnd"
+		;;
+	*"911G-5HPacD")
+		name="rb-911g-5hpacd"
+		;;
+	*"911G-5HPnD")
+		name="rb-911g-5hpnd"
+		;;
+	*"912UAG-2HPnD")
+		name="rb-912uag-2hpnd"
+		;;
+	*"912UAG-5HPnD")
+		name="rb-912uag-5hpnd"
+		;;
+	*"921GS-5HPacD r2")
+		name="rb-921gs-5hpacd-r2"
+		;;
+	*"941-2nD")
+		name="rb-941-2nd"
+		;;
+	*"951G-2HnD")
+		name="rb-951g-2hnd"
+		;;
+	*"951Ui-2HnD")
+		name="rb-951ui-2hnd"
+		;;
+	*"951Ui-2nD")
+		name="rb-951ui-2nd"
+		;;
+	*"952Ui-5ac2nD")
+		name="rb-952ui-5ac2nd"
+		;;
+	*"962UiGS-5HacT2HnT")
+		name="rb-962uigs-5hact2hnt"
+		;;
+	*"LHG 5nD")
+		name="rb-lhg-5nd"
+		;;
+	*"mAP 2nD"|\
+	*"mAP2nD")
+		name="rb-map-2nd"
+		;;
+	*"mAP L-2nD"|\
+	*"mAPL-2nD")
+		name="rb-mapl-2nd"
+		;;
+	*"SXT Lite2")
+		name="rb-sxt2n"
+		;;
+	*"SXT Lite5")
+		name="rb-sxt5n"
+		;;
+	*"wAP 2nD r2")
+		name="rb-wap-2nd"
+		;;
+	*"wAP G-5HacT2HnD"|\
+	*"wAPG-5HacT2HnD")
+		name="rb-wapg-5hact2hnd"
+		;;
+	esac
+
+	echo "$name"
+}
+
 ar71xx_board_detect() {
 	local machine
 	local name
@@ -819,6 +965,9 @@ ar71xx_board_detect() {
 	*"MAC1200R")
 		name="mc-mac1200r"
 		;;
+	"MikroTik"*)
+		name=$(mikrotik_board_detect "$machine")
+		;;
 	*"MiniBox V1.0")
 		name="minibox-v1"
 		;;
@@ -979,138 +1128,6 @@ ar71xx_board_detect() {
 		;;
 	*"Rocket M XW")
 		name="rocket-m-xw"
-		;;
-	*"RouterBOARD 2011iL")
-		name="rb-2011il"
-		;;
-	*"RouterBOARD 2011iLS")
-		name="rb-2011ils"
-		;;
-	*"RouterBOARD 2011L")
-		name="rb-2011l"
-		;;
-	*"RouterBOARD 2011UAS")
-		name="rb-2011uas"
-		;;
-	*"RouterBOARD 2011UAS-2HnD")
-		name="rb-2011uas-2hnd"
-		;;
-	*"RouterBOARD 2011UiAS")
-		name="rb-2011uias"
-		;;
-	*"RouterBOARD 2011UiAS-2HnD")
-		name="rb-2011uias-2hnd"
-		;;
-	*"RouterBOARD 411/A/AH")
-		name="rb-411"
-		;;
-	*"RouterBOARD 411U")
-		name="rb-411u"
-		;;
-	*"RouterBOARD 433/AH")
-		name="rb-433"
-		;;
-	*"RouterBOARD 433UAH")
-		name="rb-433u"
-		;;
-	*"RouterBOARD 435G")
-		name="rb-435g"
-		;;
-	*"RouterBOARD 450")
-		name="rb-450"
-		;;
-	*"RouterBOARD 450G")
-		name="rb-450g"
-		;;
-	*"RouterBOARD 493/AH")
-		name="rb-493"
-		;;
-	*"RouterBOARD 493G")
-		name="rb-493g"
-		;;
-	*"RouterBOARD 750")
-		name="rb-750"
-		;;
-	*"RouterBOARD 750 r2")
-		name="rb-750-r2"
-		;;
-	*"RouterBOARD 750GL")
-		name="rb-750gl"
-		;;
-	*"RouterBOARD 750P r2")
-		name="rb-750p-pbr2"
-		;;
-	*"RouterBOARD 750UP r2")
-		name="rb-750up-r2"
-		;;
-	*"RouterBOARD 751")
-		name="rb-751"
-		;;
-	*"RouterBOARD 751G")
-		name="rb-751g"
-		;;
-	*"RouterBOARD 911-2Hn")
-		name="rb-911-2hn"
-		;;
-	*"RouterBOARD 911-5Hn")
-		name="rb-911-5hn"
-		;;
-	*"RouterBOARD 911G-2HPnD")
-		name="rb-911g-2hpnd"
-		;;
-	*"RouterBOARD 911G-5HPacD")
-		name="rb-911g-5hpacd"
-		;;
-	*"RouterBOARD 911G-5HPnD")
-		name="rb-911g-5hpnd"
-		;;
-	*"RouterBOARD 912UAG-2HPnD")
-		name="rb-912uag-2hpnd"
-		;;
-	*"RouterBOARD 912UAG-5HPnD")
-		name="rb-912uag-5hpnd"
-		;;
-	*"RouterBOARD 921GS-5HPacD r2")
-		name="rb-921gs-5hpacd-r2"
-		;;
-	*"RouterBOARD 941-2nD")
-		name="rb-941-2nd"
-		;;
-	*"RouterBOARD 951G-2HnD")
-		name="rb-951g-2hnd"
-		;;
-	*"RouterBOARD 951Ui-2HnD")
-		name="rb-951ui-2hnd"
-		;;
-	*"RouterBOARD 951Ui-2nD")
-		name="rb-951ui-2nd"
-		;;
-	*"RouterBOARD 952Ui-5ac2nD")
-		name="rb-952ui-5ac2nd"
-		;;
-	*"RouterBOARD 962UiGS-5HacT2HnT")
-		name="rb-962uigs-5hact2hnt"
-		;;
-	*"RouterBOARD LHG 5nD")
-		name="rb-lhg-5nd"
-		;;
-	*"RouterBOARD mAP 2nD")
-		name="rb-map-2nd"
-		;;
-	*"RouterBOARD mAP L-2nD")
-		name="rb-mapl-2nd"
-		;;
-	*"RouterBOARD SXT Lite2")
-		name="rb-sxt2n"
-		;;
-	*"RouterBOARD SXT Lite5")
-		name="rb-sxt5n"
-		;;
-	*"RouterBOARD wAP 2nD r2")
-		name="rb-wap-2nd"
-		;;
-	*"RouterBOARD wAP G-5HacT2HnD")
-		name="rb-wapg-5hact2hnd"
 		;;
 	*"RouterStation")
 		name="routerstation"


### PR DESCRIPTION
Newer Mikrotik devices fail to install & sysupgrade because the boardname provided by Mikrotik changed slightly, and the OpenWrt board detection logic is too strict.

This PR backports commits that fix board detection for all Mikrotik boards. These commits have been present in master and 19.07 for several months and have been tested and improved, so it should be safe to backport.

For the first commit, I removed the cases concerning board that are supported in master but not in 18.06.