### PR TITLE
ath79: use ath10k-ct-smallbuffers for TP-Link RE355/RE450 v1

### DIFF
--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -337,7 +337,7 @@ define Device/tplink_rex5x-v1
   $(Device/tplink-safeloader)
   SOC := qca9558
   IMAGE_SIZE := 6016k
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
   TPLINK_HWID := 0x0
   TPLINK_HWREV := 0
 endef


### PR DESCRIPTION
Both devices are available in 64M and 128M RAM configurations but there
is no visial indication which configuration one might get.
So just to be sure we properly support both configurations switch to
kmod-atk10k-ct-smallbuffers.
