### PR TITLE
ipq806x: scaling improvement and dts rework

### DIFF
--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ap148.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ap148.dts
@@ -66,24 +66,27 @@
 	};
 
 	nand_pins: nand_pins {
-		mux {
+		disable {
 			pins = "gpio34", "gpio35", "gpio36",
-			       "gpio37", "gpio38", "gpio39",
-			       "gpio40", "gpio41", "gpio42",
-			       "gpio43", "gpio44", "gpio45",
-			       "gpio46", "gpio47";
+			       "gpio37", "gpio38";
 			function = "nand";
 			drive-strength = <10>;
 			bias-disable;
 		};
+
 		pullups {
 			pins = "gpio39";
+			function = "nand";
+			drive-strength = <10>;
 			bias-pull-up;
 		};
+
 		hold {
 			pins = "gpio40", "gpio41", "gpio42",
 			       "gpio43", "gpio44", "gpio45",
 			       "gpio46", "gpio47";
+			function = "nand";
+			drive-strength = <10>;
 			bias-bus-hold;
 		};
 	};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ap161.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ap161.dts
@@ -45,24 +45,27 @@
 				};
 			};
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -76,24 +76,27 @@
 			};
 
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -76,24 +76,27 @@
 			};
 
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -77,24 +77,27 @@
 			};
 
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -81,24 +81,27 @@
 			};
 
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -504,11 +504,9 @@
 	};
 
 	nand_pins: nand_pins {
-		mux {
+		disable {
 			pins = "gpio34", "gpio35", "gpio36", "gpio37",
-			       "gpio38", "gpio39", "gpio40", "gpio41",
-			       "gpio42", "gpio43", "gpio44", "gpio45",
-			       "gpio46", "gpio47";
+			       "gpio38";
 			function = "nand";
 			drive-strength = <10>;
 			bias-disable;
@@ -516,12 +514,16 @@
 
 		pullups {
 			pins = "gpio39";
+			function = "nand";
+			drive-strength = <10>;
 			bias-pull-up;
 		};
 
 		hold {
 			pins = "gpio40", "gpio41", "gpio42", "gpio43",
 			       "gpio44", "gpio45", "gpio46", "gpio47";
+			function = "nand";
+			drive-strength = <10>;
 			bias-bus-hold;
 		};
 	};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
@@ -473,12 +473,9 @@
 	};
 
 	nand_pins: nand_pins {
-		mux {
+		disable {
 			pins = "gpio34", "gpio35", "gpio36",
-			       "gpio37", "gpio38", "gpio39",
-			       "gpio40", "gpio41", "gpio42",
-			       "gpio43", "gpio44", "gpio45",
-			       "gpio46", "gpio47";
+			       "gpio37", "gpio38";
 			function = "nand";
 			drive-strength = <10>;
 			bias-disable;
@@ -486,6 +483,8 @@
 
 		pullups {
 			pins = "gpio39";
+			function = "nand";
+			drive-strength = <10>;
 			bias-pull-up;
 		};
 
@@ -493,6 +492,8 @@
 			pins = "gpio40", "gpio41", "gpio42",
 			       "gpio43", "gpio44", "gpio45",
 			       "gpio46", "gpio47";
+			function = "nand";
+			drive-strength = <10>;
 			bias-bus-hold;
 		};
 	};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -546,6 +546,15 @@
 		};
 	};
 
+	fab-scaling {
+		compatible = "qcom,fab-scaling";
+		clocks = <&rpmcc RPM_APPS_FABRIC_A_CLK>, <&rpmcc RPM_EBI1_A_CLK>;
+		clock-names = "apps-fab-clk", "ddr-fab-clk";
+		fab_freq_high = <533000000>;
+		fab_freq_nominal = <400000000>;
+		cpu_freq_threshold = <1000000000>;
+	};
+
 	firmware {
 		scm {
 			compatible = "qcom,scm-ipq806x";

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -67,6 +67,9 @@
 
 		qcom,l2 {
 			qcom,l2-rates = <384000000 1000000000 1200000000>;
+			qcom,l2-cpufreq = <384000000 600000000 1200000000>;
+			qcom,l2-volt = <1100000 1100000 1150000>;
+			qcom,l2-supply = <&smb208_s1a>;
 		};
 
 		idle-states {

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -70,24 +70,27 @@
 			};
 
 			nand_pins: nand_pins {
-				mux {
+				disable {
 					pins = "gpio34", "gpio35", "gpio36",
-					       "gpio37", "gpio38", "gpio39",
-					       "gpio40", "gpio41", "gpio42",
-					       "gpio43", "gpio44", "gpio45",
-					       "gpio46", "gpio47";
+					       "gpio37", "gpio38";
 					function = "nand";
 					drive-strength = <10>;
 					bias-disable;
 				};
+
 				pullups {
 					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
 					bias-pull-up;
 				};
+
 				hold {
 					pins = "gpio40", "gpio41", "gpio42",
 					       "gpio43", "gpio44", "gpio45",
 					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
 					bias-bus-hold;
 				};
 			};

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -24,6 +24,10 @@
 	};
 	
 	cpus {
+		qcom,l2 {
+			qcom,l2-cpufreq = <384000000 600000000 1400000000>;
+		};
+
 		idle-states {
 			CPU_SPC: spc {
 				status = "disabled";

--- a/target/linux/ipq806x/patches-4.19/0054-cpufreq-dt-Handle-OPP-voltage-adjust-events.patch
+++ b/target/linux/ipq806x/patches-4.19/0054-cpufreq-dt-Handle-OPP-voltage-adjust-events.patch
@@ -91,19 +91,12 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
  static int resources_available(void)
  {
  	struct device *cpu_dev;
-@@ -161,6 +200,7 @@ static int cpufreq_init(struct cpufreq_p
- 	bool fallback = false;
- 	const char *name;
- 	int ret;
-+	struct srcu_notifier_head *opp_srcu_head;
- 
- 	cpu_dev = get_cpu_device(policy->cpu);
- 	if (!cpu_dev) {
-@@ -251,10 +291,13 @@ static int cpufreq_init(struct cpufreq_p
+@@ -251,10 +291,14 @@ static int cpufreq_init(struct cpufreq_p
  				__func__, ret);
  	}
  
 +	mutex_init(&priv->lock);
++	priv->opp_nb.notifier_call = opp_notifier;
 +	dev_pm_opp_register_notifier(cpu_dev, &priv->opp_nb);
 +
  	ret = dev_pm_opp_init_cpufreq_table(cpu_dev, &freq_table);

--- a/target/linux/ipq806x/patches-4.19/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
+++ b/target/linux/ipq806x/patches-4.19/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
@@ -53,9 +53,9 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
  		arch_set_freq_scale(policy->related_cpus, freq,
  				    policy->cpuinfo.max_freq);
 @@ -201,6 +230,8 @@ static int cpufreq_init(struct cpufreq_p
+	bool fallback = false;
  	const char *name;
  	int ret;
- 	struct srcu_notifier_head *opp_srcu_head;
 +	struct device_node *l2_np;
 +	struct clk *l2_clk = NULL;
  
@@ -82,7 +82,7 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
  
  	struct clk		*clk;
 +	struct clk		*l2_clk; /* L2 clock */
-+	unsigned int		l2_rate[3]; /* L2 bus clock rate thresholds */
++	unsigned int	l2_rate[3]; /* L2 bus clock rate thresholds */
  	struct cpufreq_cpuinfo	cpuinfo;/* see above */
  
  	unsigned int		min;    /* in kHz */

--- a/target/linux/ipq806x/patches-4.19/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
+++ b/target/linux/ipq806x/patches-4.19/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
@@ -1,88 +1,161 @@
-From 0759cdff49f1cf361bf503c13f7bcb33da43ab95 Mon Sep 17 00:00:00 2001
-From: Georgi Djakov <georgi.djakov@linaro.org>
-Date: Tue, 8 Sep 2015 11:24:41 +0300
-Subject: [PATCH 55/69] cpufreq-dt: Add L2 frequency scaling support
-
-Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
----
- drivers/cpufreq/cpufreq-dt.c | 41 ++++++++++++++++++++++++++++++++++++++++-
- include/linux/cpufreq.h      |  2 ++
- 2 files changed, 42 insertions(+), 1 deletion(-)
-
 --- a/drivers/cpufreq/cpufreq-dt.c
 +++ b/drivers/cpufreq/cpufreq-dt.c
-@@ -49,11 +49,40 @@ static int set_target(struct cpufreq_pol
+@@ -48,16 +48,71 @@ static int set_target(struct cpufreq_pol
+ {
  	struct private_data *priv = policy->driver_data;
  	unsigned long freq = policy->freq_table[index].frequency;
- 	int ret;
 +	struct clk *l2_clk = policy->l2_clk;
-+	unsigned int l2_freq;
-+	unsigned long new_l2_freq = 0;
++	struct regulator *l2_regulator = policy->l2_regulator;
++	unsigned long l2_freq, target_l2_freq;
++	unsigned long l2_vol, target_l2_vol;
++	unsigned long target_freq;
+ 	int ret;
  
  	mutex_lock(&priv->lock);
  	ret = dev_pm_opp_set_rate(priv->cpu_dev, freq * 1000);
  
  	if (!ret) {
-+		if (!IS_ERR(l2_clk) && policy->l2_rate[0] && policy->l2_rate[1] &&
-+				policy->l2_rate[2]) {
++		if (policy->l2_rate_set) {
 +			static unsigned long krait_l2[CONFIG_NR_CPUS] = { };
-+			int cpu, ret = 0;
-+			unsigned long target_freq = freq * 1000;
++			int cpu, l2_index, tol = 0;
 +
-+			if (target_freq >= policy->l2_rate[2])
-+				new_l2_freq = policy->l2_rate[2];
-+			else if (target_freq >= policy->l2_rate[1])
-+				new_l2_freq = policy->l2_rate[1];
-+			else
-+				new_l2_freq = policy->l2_rate[0];
++			target_freq = freq * 1000;
 +
-+			krait_l2[policy->cpu] = new_l2_freq;
++			krait_l2[policy->cpu] = target_freq;
 +			for_each_present_cpu(cpu)
-+				new_l2_freq = max(new_l2_freq, krait_l2[cpu]);
++				target_freq = max(target_freq, krait_l2[cpu]);
++
++			for (l2_index = 2; l2_index >= 0; l2_index--)
++				if (target_freq >= policy->l2_cpufreq[l2_index])
++					break;
 +
 +			l2_freq = clk_get_rate(l2_clk);
++			target_l2_freq = policy->l2_rate[l2_index];
 +
-+			if (l2_freq != new_l2_freq) {
-+				ret = clk_set_rate(l2_clk, policy->l2_rate[0]);
++			if (l2_freq != target_l2_freq) {
++
++				/*
++				 * Set to idle bin if switching from normal to high bin 
++				 * or vice versa
++				 */
++				if ( (l2_index == 2 && l2_freq == policy->l2_rate[1]) ||
++					 (l2_index == 1 && l2_freq == policy->l2_rate[2]) ) {
++					ret = clk_set_rate(l2_clk, policy->l2_rate[0]);
++					if (ret)
++						goto exit;
++				}
 +				/* scale l2 with the core */
-+				ret = clk_set_rate(l2_clk, new_l2_freq);
++				ret = clk_set_rate(l2_clk, target_l2_freq);
++				if (ret)
++					goto exit;
++
++				if (policy->l2_volt_set) {
++
++					l2_vol = regulator_get_voltage(l2_regulator);
++					target_l2_vol = policy->l2_volt[l2_index];
++
++					if (l2_vol != target_l2_vol) {
++						tol = target_l2_vol * policy->l2_volt_tol / 100;
++						ret = regulator_set_voltage_tol(l2_regulator,target_l2_vol,tol);
++						if (ret)
++							goto exit;
++					}
++				}
 +			}
 +		}
-+
  		priv->opp_freq = freq * 1000;
  		arch_set_freq_scale(policy->related_cpus, freq,
  				    policy->cpuinfo.max_freq);
-@@ -201,6 +230,8 @@ static int cpufreq_init(struct cpufreq_p
-	bool fallback = false;
+ 	}
++
++exit:
+ 	mutex_unlock(&priv->lock);
+ 
+ 	return ret;
+@@ -202,6 +257,9 @@ static int cpufreq_init(struct cpufreq_p
+ 	bool fallback = false;
  	const char *name;
  	int ret;
-+	struct device_node *l2_np;
++	struct device_node *np, *l2_np;
 +	struct clk *l2_clk = NULL;
++	struct regulator *l2_regulator = NULL;
  
  	cpu_dev = get_cpu_device(policy->cpu);
  	if (!cpu_dev) {
-@@ -307,6 +338,13 @@ static int cpufreq_init(struct cpufreq_p
+@@ -309,6 +367,57 @@ static int cpufreq_init(struct cpufreq_p
  
  	policy->suspend_freq = dev_pm_opp_get_suspend_opp_freq(cpu_dev) / 1000;
  
++	policy->l2_rate_set = false;
++	policy->l2_volt_set = false;
++
 +	l2_clk = clk_get(cpu_dev, "l2");
 +	if (!IS_ERR(l2_clk))
 +		policy->l2_clk = l2_clk;
++
 +	l2_np = of_find_node_by_name(NULL, "qcom,l2");
-+	if (l2_np)
++	if (l2_np) {
++		struct device_node *vdd;
++		np = of_node_get(priv->cpu_dev->of_node);
++
++		if (np)
++			of_property_read_u32(np, "voltage-tolerance", &policy->l2_volt_tol);
++
 +		of_property_read_u32_array(l2_np, "qcom,l2-rates", policy->l2_rate, 3);
++		if (policy->l2_rate[0] && policy->l2_rate[1] && policy->l2_rate[2]) {
++			policy->l2_rate_set = true;
++			of_property_read_u32_array(l2_np, "qcom,l2-cpufreq", policy->l2_cpufreq, 3);
++			of_property_read_u32_array(l2_np, "qcom,l2-volt", policy->l2_volt, 3);
++		} else
++			pr_warn("L2: failed to parse L2 rates\n");
++
++		if (!policy->l2_cpufreq[0] && !policy->l2_cpufreq[1] && 
++			!policy->l2_cpufreq[2] && policy->l2_rate_set) {
++			int i;
++
++			pr_warn("L2: failed to parse target cpu freq, using defaults\n");
++			for (i = 0; i < 3; i++)
++				policy->l2_cpufreq[i] = policy->l2_rate[i];
++		}
++
++		if (policy->l2_volt[0] && policy->l2_volt[1] && policy->l2_volt[2] &&
++			policy->l2_volt_tol && policy->l2_rate_set) {
++			vdd = of_parse_phandle(l2_np, "qcom,l2-supply", 0);
++
++			if (vdd) {
++				l2_regulator = devm_regulator_get(cpu_dev, vdd->name);
++				if (!IS_ERR(l2_regulator)) {
++					policy->l2_regulator = l2_regulator;
++					policy->l2_volt_set = true;
++				} else {
++					pr_warn("failed to get l2 supply\n");
++					l2_regulator = NULL;
++				}
++
++				of_node_put(vdd);
++			}
++		}
++	}
 +
  	/* Support turbo/boost mode */
  	if (policy_has_boost_freq(policy)) {
  		/* This gets disabled by core on driver unregister */
 --- a/include/linux/cpufreq.h
 +++ b/include/linux/cpufreq.h
-@@ -73,6 +73,8 @@ struct cpufreq_policy {
+@@ -72,7 +72,15 @@ struct cpufreq_policy {
+ 						should set cpufreq */
  	unsigned int		cpu;    /* cpu managing this policy, must be online */
  
- 	struct clk		*clk;
-+	struct clk		*l2_clk; /* L2 clock */
-+	unsigned int	l2_rate[3]; /* L2 bus clock rate thresholds */
+-	struct clk		*clk;
++	struct clk			*clk;
++	struct clk			*l2_clk; /* L2 clock */
++	struct regulator	*l2_regulator; /* L2 supply */
++	unsigned int		l2_rate[3]; /* L2 bus clock rate */
++	bool				l2_rate_set;
++	unsigned int		l2_cpufreq[3]; /* L2 target CPU frequency */
++	unsigned int		l2_volt[3]; /* L2 voltage array */
++	bool				l2_volt_set;
++	unsigned int		l2_volt_tol; /* L2 voltage tolerance */
  	struct cpufreq_cpuinfo	cpuinfo;/* see above */
  
  	unsigned int		min;    /* in kHz */

--- a/target/linux/ipq806x/patches-4.19/0057-add-fab-scaling-support-with-cpufreq.patch
+++ b/target/linux/ipq806x/patches-4.19/0057-add-fab-scaling-support-with-cpufreq.patch
@@ -1,0 +1,243 @@
+--- a/drivers/clk/qcom/Makefile
++++ b/drivers/clk/qcom/Makefile
+@@ -15,6 +15,7 @@ clk-qcom-$(CONFIG_KRAIT_CLOCKS) += clk-k
+ clk-qcom-y += clk-hfpll.o
+ clk-qcom-y += reset.o
+ clk-qcom-$(CONFIG_QCOM_GDSC) += gdsc.o
++clk-qcom-y += fab_scaling.o
+ 
+ # Keep alphabetically sorted by config
+ obj-$(CONFIG_APQ_GCC_8084) += gcc-apq8084.o
+--- /dev/null
++++ b/drivers/clk/qcom/fab_scaling.c
+@@ -0,0 +1,172 @@
++/*
++ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++#include <linux/kernel.h>
++#include <linux/init.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/err.h>
++#include <linux/io.h>
++#include <linux/of.h>
++#include <linux/of_device.h>
++#include <linux/clk.h>
++#include <linux/clk-provider.h>
++#include <linux/slab.h>
++#include <linux/fab_scaling.h>
++
++struct qcom_fab_scaling_data {
++	u32 fab_freq_high;
++	u32 fab_freq_nominal;
++	u32 cpu_freq_threshold;
++	struct clk *apps_fab_clk;
++	struct clk *ddr_fab_clk;
++};
++
++static struct qcom_fab_scaling_data *drv_data;
++
++int scale_fabrics(unsigned long max_cpu_freq)
++{	
++	struct clk *apps_fab_clk = drv_data->apps_fab_clk,
++	           *ddr_fab_clk = drv_data->ddr_fab_clk;
++	unsigned long target_freq, cur_freq;
++	int ret;
++
++	/* Skip fab scaling if the driver is not ready */
++	if (!apps_fab_clk || !ddr_fab_clk)
++		return 0;
++
++	if (max_cpu_freq > drv_data->cpu_freq_threshold)
++		target_freq = drv_data->fab_freq_high;
++	else
++		target_freq = drv_data->fab_freq_nominal;
++
++	cur_freq = clk_get_rate(ddr_fab_clk);
++
++	if (target_freq != cur_freq) {
++		ret = clk_set_rate(apps_fab_clk, target_freq);
++		if (ret)
++			return ret;
++		ret = clk_set_rate(ddr_fab_clk, target_freq);
++		if (ret)
++			return ret;
++	}
++
++	return 0;
++}
++EXPORT_SYMBOL(scale_fabrics);
++
++static int ipq806x_fab_scaling_probe(struct platform_device *pdev)
++{
++	struct device_node *np = pdev->dev.of_node;
++	struct clk *apps_fab_clk, *ddr_fab_clk;
++	int ret;
++
++	if (!np)
++		return -ENODEV;
++	
++	drv_data = kzalloc(sizeof(*drv_data), GFP_KERNEL);
++	if (!drv_data)
++		return -ENOMEM;
++
++	if (of_property_read_u32(np, "fab_freq_high", &drv_data->fab_freq_high)) {
++		pr_err("FABRICS turbo freq not found. Using defaults...\n");
++		drv_data->fab_freq_high = 533000000;
++	}
++
++	if (of_property_read_u32(np, "fab_freq_nominal", &drv_data->fab_freq_nominal)) {
++		pr_err("FABRICS nominal freq not found. Using defaults...\n");
++		drv_data->fab_freq_nominal = 400000000;
++	}
++
++	if (of_property_read_u32(np, "cpu_freq_threshold", &drv_data->cpu_freq_threshold)) {
++		pr_err("FABRICS cpu freq threshold not found. Using defaults...\n");
++		drv_data->cpu_freq_threshold = 1000000000;
++	}
++
++	drv_data->apps_fab_clk = devm_clk_get(&pdev->dev, "apps-fab-clk");
++	apps_fab_clk = drv_data->apps_fab_clk;
++	ret = PTR_ERR_OR_ZERO(apps_fab_clk);
++	if (ret) {
++		/*
++		 * If apps fab clk node is present, but clock is not yet
++		 * registered, we should try defering probe.
++		 */
++		if (ret != -EPROBE_DEFER) {
++			pr_err("Failed to get APPS FABRIC clock: %d\n", ret);
++			ret = -ENODEV;
++		}
++		goto err;
++	}
++
++	clk_set_rate(apps_fab_clk, drv_data->fab_freq_high);
++	clk_prepare_enable(apps_fab_clk);
++
++	drv_data->ddr_fab_clk = devm_clk_get(&pdev->dev, "ddr-fab-clk");
++	ddr_fab_clk = drv_data->ddr_fab_clk;
++	ret = PTR_ERR_OR_ZERO(ddr_fab_clk);
++	if (ret) {
++		/*
++		 * If ddr fab clk node is present, but clock is not yet
++		 * registered, we should try defering probe.
++		 */
++		if (ret != -EPROBE_DEFER) {
++			pr_err("Failed to get DDR FABRIC clock: %d\n", ret);
++			ddr_fab_clk = NULL;
++			ret = -ENODEV;
++		}
++		goto err;
++	}
++
++	clk_set_rate(ddr_fab_clk, drv_data->fab_freq_high);
++	clk_prepare_enable(ddr_fab_clk);
++
++	return 0;
++err:
++	kfree(drv_data);
++	return ret;
++}
++
++static int ipq806x_fab_scaling_remove(struct platform_device *pdev)
++{
++	kfree(drv_data);
++	return 0;
++}
++
++static const struct of_device_id fab_scaling_ipq806x_match_table[] = {
++	{ .compatible = "qcom,fab-scaling" },
++	{ }
++};
++
++static struct platform_driver fab_scaling_ipq806x_driver = {
++	.probe		= ipq806x_fab_scaling_probe,
++	.remove		= ipq806x_fab_scaling_remove,
++	.driver		= {
++		.name   = "fab-scaling",
++		.of_match_table = fab_scaling_ipq806x_match_table,
++	},
++};
++
++static int __init fab_scaling_ipq806x_init(void)
++{
++	return platform_driver_register(&fab_scaling_ipq806x_driver);
++}
++late_initcall(fab_scaling_ipq806x_init);
++
++static void __exit fab_scaling_ipq806x_exit(void)
++{
++	platform_driver_unregister(&fab_scaling_ipq806x_driver);
++}
++module_exit(fab_scaling_ipq806x_exit);
+--- /dev/null
++++ b/include/linux/fab_scaling.h
+@@ -0,0 +1,31 @@
++/*
++ * Copyright (c) 2015, The Linux Foundation. All rights reserved.
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++
++#ifndef __FAB_SCALING_H
++#define __FAB_SCALING_H
++
++/**
++ * scale_fabrics - Scale DDR and APPS FABRICS
++ *
++ * This function monitors all the registered clocks and does APPS
++ * and DDR FABRIC scaling based on the idle frequencies with which
++ * it was registered.
++ *
++ */
++int scale_fabrics(unsigned long max_cpu_freq);
++
++#endif
+--- a/drivers/cpufreq/cpufreq-dt.c
++++ b/drivers/cpufreq/cpufreq-dt.c
+@@ -24,6 +24,7 @@
+ #include <linux/regulator/consumer.h>
+ #include <linux/slab.h>
+ #include <linux/thermal.h>
++#include <linux/fab_scaling.h>
+ 
+ #include "cpufreq-dt.h"
+ 
+@@ -101,6 +102,13 @@ static int set_target(struct cpufreq_pol
+ 					}
+ 				}
+ 			}
++
++			/*
++			 * Scale fabrics with max freq across all cores
++			 */
++			ret = scale_fabrics(target_freq);
++			if (ret)
++				goto exit;
+ 		}
+ 		priv->opp_freq = freq * 1000;
+ 		arch_set_freq_scale(policy->related_cpus, freq,


### PR DESCRIPTION
This patchset rework the dts to a better pinmux definition.
Modify the L2 scaling patch to reflect the original QSDK scaling, add
support for l2 regulator voltage scaling and l2 frequency scaling based
on cpu frequency.
Add fab-scaling support to switch to idle frequency when the router is
idle.
Fix a broken patch that introduce voltage scaling but never actually use it.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>