### PR TITLE
ramips: remove duplicate dts nodes of MediaTek LinkIt Smart 7688

### DIFF
--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -82,10 +82,6 @@
 	};
 };
 
-&wmac {
-	status = "okay";
-};
-
 &spi0 {
 	status = "okay";
 


### PR DESCRIPTION
There are two identical wmac nodes in the dts file of MediaTek LinkIt Smart 7688, so delete one of them.

Signed-off-by: Jack Chen <redchenjs@live.com>
