### PR TITLE
ar71xx/mikrotik: use ath10k-ct-smallbuffers for 64 MiB devices

### DIFF
--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -55,7 +55,7 @@ TARGET_DEVICES += rb-nor-flash-16M
 define Device/rb-nor-flash-16M-ac
   $(Device/rb-nor-flash-16M)
   DEVICE_TITLE := MikroTik RouterBoard (16 MB SPI NOR, 802.11ac)
-  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct ath10k-firmware-qca9887-ct kmod-usb-ehci
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct ath10k-firmware-qca9887-ct kmod-usb-ehci
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef
 TARGET_DEVICES += rb-nor-flash-16M-ac


### PR DESCRIPTION
This image is only needed on one device (wAP AC); since this target is going to be removed anyway it doesn't make sense to add an extra "low RAM" image.

My wAP AC was OOMing frequently with 19.07-rc2; this seems to have fixed it.

Thanks!