### PR TITLE
base-files: fix build for /sbin/pkg_check

### DIFF
--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -207,7 +207,7 @@ $(_endef)
 	(cd $$(IDIR_$(1)); \
 		( \
 			find . -type f \! -path ./CONTROL/\* -exec sha256sum \{\} \; 2> /dev/null | \
-			sed 's|\([[:blank:]]\)\./|\1/|' > $$(IDIR_$(1))/CONTROL/files-sha256 \
+			sed 's|\([[:blank:]]\)\./|\1/|' > $$(IDIR_$(1))/CONTROL/files-sha256sum \
 		) || true \
 	)
     endif

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -204,8 +204,8 @@ define Package/base-files/install
 		mkdir -p $(1)/etc/opkg; \
 		$(call FeedSourcesAppend,$(1)/etc/opkg/distfeeds.conf); \
 		$(VERSION_SED_SCRIPT) $(1)/etc/opkg/distfeeds.conf)
-	$(if $(CONFIG_IPK_FILES_CHECKSUMS), \
-		rm -f $(1)/sbin/pkg_check,)
+	$(if $(CONFIG_IPK_FILES_CHECKSUMS),, \
+		rm -f $(1)/sbin/pkg_check)
 endef
 
 ifneq ($(DUMP),1)


### PR DESCRIPTION
Setting CONFIG_IPK_FILES_CHECKSUMS=y causes sha256 checksum files to be
included with the packages to check for corruption. This commit fixes two
issues:
- /sbin/pkg_check was being removed incorrectly if IPK_FILES_CHECKSUMS=y
- checksums were being saved in the wrong file

Signed-off-by: Xu Wang <xwang1498@gmx.com>