### PR TITLE
curl: update to version 7.68.0 (security fix)

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -8,15 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
-PKG_VERSION:=7.67.0
-PKG_RELEASE:=2
+PKG_VERSION:=7.68.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \
 	https://curl.mirror.anstey.ca/ \
 	https://curl.askapache.com/download/ \
 	https://curl.haxx.se/download/
-PKG_HASH:=f5d2e7320379338c3952dcc7566a140abb49edb575f9f99272455785c40e536c
+PKG_HASH:=b724240722276a27f6e770b952121a3afd097129d8c9fe18e6272dc34192035a
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Full changelog https://curl.haxx.se/changes.html#7_68_0

Update curl to version 7.68.0 also fixes CVE-2019-15601

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>


