### PR TITLE
firmware-utils/dgfirmare: fix possible resource leak

### DIFF
--- a/tools/firmware-utils/src/dgfirmware.c
+++ b/tools/firmware-utils/src/dgfirmware.c
@@ -86,6 +86,8 @@ void write_img(unsigned char* img, const char *fname)
     fclose(fp);
     exit(-1);
   }
+
+  fclose(fp);
 }
 
 
@@ -104,6 +106,8 @@ void write_rootfs(unsigned char* img, const char *fname)
     fclose(fp);
     exit(-1);
   }
+
+  fclose(fp);
 }
 
 
@@ -122,6 +126,8 @@ void write_kernel(unsigned char* img, const char *fname)
     fclose(fp);
     exit(-1);
   }
+
+  fclose(fp);
 }
 
 


### PR DESCRIPTION
Add missing calls to `fclose` in functions `write_img`, `write_rootfs` and `write_kernel`.
The not-closed files could lead to resource leaks.