### PR TITLE
firmware-utils: fix possible memory leak and resource leak

### DIFF
--- a/tools/firmware-utils/src/dns313-header.c
+++ b/tools/firmware-utils/src/dns313-header.c
@@ -168,11 +168,14 @@ int main(int argc, char **argv)
 	fdin = open(pathin, O_RDONLY);
 	if (!fdin) {
 		printf("ERROR: could not open input file\n");
+		free(buffer);
 		return 0;
 	}
 	bytes = read(fdin, buffer + HEADER_SIZE, filesize);
 	if (bytes < filesize) {
 		printf("ERROR: could not read entire file\n");
+		free(buffer);
+		close(fdin);
 		return 0;
 	}
 	close(fdin);


### PR DESCRIPTION
Add missing calls to `free` for variable `buffer`.
This could lead to a memory leak.

Add missing call to `close` for file pointer `fdin`.
This could lead to a resource leak.

