### PR TITLE
firmware-utils/mkchkimg: fix possible resource leaks

### DIFF
--- a/tools/firmware-utils/src/mkchkimg.c
+++ b/tools/firmware-utils/src/mkchkimg.c
@@ -231,6 +231,7 @@ main (int argc, char * argv[])
 	if (fs_file) {
 		fs_fp = fopen (fs_file, "r");
 		if (!fs_fp) {
+			fclose(kern_fp);
 			fatal_error (errno, "Cannot open %s", fs_file);
 		}
 	}
@@ -238,6 +239,10 @@ main (int argc, char * argv[])
 	/* Open the output file */
 	out_fp = fopen (output_file, "w+");
 	if (!out_fp) {
+		fclose(kern_fp);
+		if (fs_fp) {
+			fclose(fs_fp);
+		}
 		fatal_error (errno, "Cannot open %s", output_file);
 	}
 
@@ -285,6 +290,7 @@ main (int argc, char * argv[])
 		netgear_checksum_add (&chk_part, (unsigned char *)buf, len);
 		netgear_checksum_add (&chk_whole, (unsigned char *)buf, len);
 	}
+	fclose(kern_fp);
 	hdr->kernel_chksum = netgear_checksum_fini (&chk_part);
 	message ("     Kernel Len: %u", hdr->kernel_len);
 	message ("Kernel Checksum: 0x%08x", hdr->kernel_chksum);
@@ -306,6 +312,7 @@ main (int argc, char * argv[])
 			netgear_checksum_add (&chk_part, (unsigned char *)buf, len);
 			netgear_checksum_add (&chk_whole, (unsigned char *)buf, len);
 		}
+		fclose(fs_fp);
 		hdr->rootfs_chksum = (netgear_checksum_fini (&chk_part));
 		message ("     Rootfs Len: %u", hdr->rootfs_len);
 		message ("Rootfs Checksum: 0x%08x", hdr->rootfs_chksum);
@@ -336,6 +343,7 @@ main (int argc, char * argv[])
 	}
 
 	/* Success */
+	fclose(out_fp);
 	return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Add missing `fclose` calls for file pointers `kern_fp`, `fs_fp` and `out_fp`.
Not closing files could lead to resource leaks.