### PR TITLE
firmware-utils/mkfwimage: fix possible memory and resource leak

### DIFF
--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -437,6 +437,7 @@ static int build_image(image_info_t* im)
 	if ((f = fopen(im->outputfile, "w")) == NULL)
 	{
 		ERROR("Can not create output file: '%s'\n", im->outputfile);
+		free(mem);
 		return -10;
 	}
 
@@ -444,6 +445,8 @@ static int build_image(image_info_t* im)
 	{
 		ERROR("Could not write %d bytes into file: '%s'\n",
 				mem_size, im->outputfile);
+		free(mem);
+		fclose(f);
 		return -11;
 	}
 

--- a/tools/firmware-utils/src/mkfwimage2.c
+++ b/tools/firmware-utils/src/mkfwimage2.c
@@ -363,12 +363,15 @@ static int build_image(void)
 	/* write in-memory buffer into file */
 	if ((f = fopen(im.outputfile, "w")) == NULL) {
 		ERROR("Can not create output file: '%s'\n", im.outputfile);
+		free(mem);
 		return -10;
 	}
 
 	if (fwrite(mem, mem_size, 1, f) != 1) {
 		ERROR("Could not write %d bytes into file: '%s'\n",
 				mem_size, im.outputfile);
+		free(mem);
+		fclose(f);
 		return -11;
 	}
 


### PR DESCRIPTION
Add missing calls to `free` for variable `mem`.
Add missing call to `fclose` for variable `f`.

The same changes were made in both `mkfwimage.c` and `mkfwimage2.c`.
