### PR TITLE
wrt350nv2-builder: Fix memory leak

### DIFF
--- a/tools/wrt350nv2-builder/src/wrt350nv2-builder.c
+++ b/tools/wrt350nv2-builder/src/wrt350nv2-builder.c
@@ -556,6 +556,7 @@ int create_bin_file(char *bin_filename) {
 		}
 	}
 
+	free(buffer);
 	return exitcode;
 }
 


### PR DESCRIPTION
Add missing call to `free` for variable `buffer` in function `create_bin_file`.
