### PR TITLE
ath79: add support for Arduino Yun

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -152,10 +152,26 @@ macaddr_geteui() {
 	echo ${mac:9:2}$sep${mac:12:2}$sep${mac:15:2}
 }
 
-macaddr_setbit_la() {
+macaddr_setbit() {
 	local mac=$1
+	local bit=${2:-0}
 
-	printf "%02x:%s" $((0x${mac%%:*} | 0x02)) ${mac#*:}
+	[ $bit -gt 0 -a $bit -le 48 ] || return
+
+	printf "%012x" $(( 0x${mac//:/} | 2**(48-bit) )) | sed -e 's/\(.\{2\}\)/\1:/g' -e 's/:$//'
+}
+
+macaddr_unsetbit() {
+	local mac=$1
+	local bit=${2:-0}
+
+	[ $bit -gt 0 -a $bit -le 48 ] || return
+
+	printf "%012x" $(( 0x${mac//:/} & ~(2**(48-bit)) )) | sed -e 's/\(.\{2\}\)/\1:/g' -e 's/:$//'
+}
+
+macaddr_setbit_la() {
+	macaddr_setbit $1 7
 }
 
 macaddr_2bin() {

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -14,6 +14,7 @@ board=$(board_name)
 
 case "$board" in
 alfa-network,ap121f|\
+arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 domywifi,dw33d|\

--- a/target/linux/ath79/dts/ar9331_arduino_yun.dts
+++ b/target/linux/ath79/dts/ar9331_arduino_yun.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "Arduino Yun";
+	compatible = "arduino,yun", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+	};
+
+	chosen {
+		bootargs = "console=ttyATH0,250000";
+	};
+
+	ahb {
+		apb {
+			pinmux_extended: pinmux@18040030 {
+				compatible = "pinctrl-single";
+				reg = <0x18040030 0x4>;
+
+				pinctrl-single,bit-per-mux;
+				pinctrl-single,register-width = <32>;
+				pinctrl-single,function-mask = <0x1>;
+				#pinctrl-cells = <2>;
+
+				enable_gpio11: pinmux_enable_gpio11 {
+					pinctrl-single,bits = <0x0 0x200 0x200>;
+				};
+			};
+
+			pinmux_bootstrap: pinmux@180600ac {
+				compatible = "pinctrl-single";
+				reg = <0x180600ac 0x4>;
+
+				pinctrl-single,bit-per-mux;
+				pinctrl-single,register-width = <32>;
+				pinctrl-single,function-mask = <0x1>;
+				#pinctrl-cells = <2>;
+
+				enable_gpio26_gpio27: pinmux_enable_gpio26_gpio27 {
+					pinctrl-single,bits = <0x0 0x40000 0x40000>;
+				};
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "yun:blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "yun:white:usb";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		config {
+			label = "config";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_spi_enable {
+			gpio-export,name = "yun:oe:spi";
+			gpio-export,output = <0>;
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_handshake_enable {
+			gpio-export,name = "yun:oe:hs";
+			gpio-export,output = <0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_uart_enable {
+			gpio-export,name = "yun:oe:uart";
+			gpio-export,output = <0>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&pinmux {
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins &switch_led_disable_pins>;
+};
+
+&switch_led_disable_pins {
+	pinctrl-single,bits = <0x0 0x80 0xf8>;
+};
+
+&pinmux_extended {
+	pinctrl-names = "default";
+	pinctrl-0 = <&enable_gpio11>;
+};
+
+&pinmux_bootstrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&enable_gpio26_gpio27>;
+};
+
+&usb {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+
+	port@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <1>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf90000>;
+			};
+
+			partition@fe0000 {
+				label = "nvram";
+				reg = <0xfe0000 0x10000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&eth1 {
+	status = "okay";
+
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ ath79_setup_interfaces()
 	adtran,bsap1800-v2|\
 	adtran,bsap1840|\
 	alfa-network,ap121f|\
+	arduino,yun|\
 	aruba,ap-105|\
 	avm,fritz1750e|\
 	avm,fritz300e|\
@@ -337,6 +338,11 @@ ath79_setup_macs()
 		;;
 	alfa-network,ap121f)
 		label_mac=$(mtd_get_mac_binary art 0x1002)
+		;;
+	arduino,yun)
+		base_mac=$(mtd_get_mac_binary art 0x1002)
+		lan_mac=$(macaddr_setbit $base_mac 29)
+		[ $lan_mac = $base_mac ] && lan_mac=$(macaddr_unsetbit $base_mac 29)
 		;;
 	avm,fritz1750e|\
 	avm,fritz450e)

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -7,6 +7,9 @@ board=$(board_name)
 boardonly="${board##*,}"
 
 case "$board" in
+arduino,yun)
+	migrate_leds "arduino:=yun:"
+	;;
 engenius,epg5000)
 	migrate_leds ":wlan-2g=:wlan2g" ":wlan-5g=:wlan5g"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -153,6 +153,17 @@ define Device/alfa-network_ap121f
 endef
 TARGET_DEVICES += alfa-network_ap121f
 
+define Device/arduino_yun
+  SOC := ar9331
+  DEVICE_VENDOR := Arduino
+  DEVICE_MODEL := Yun
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 kmod-usb-ledtrig-usbport \
+	kmod-usb-storage block-mount -swconfig
+  IMAGE_SIZE := 15936k
+  SUPPORTED_DEVICES += arduino-yun
+endef
+TARGET_DEVICES += arduino_yun
+
 define Device/aruba_ap-105
   SOC := ar7161
   DEVICE_VENDOR := Aruba

--- a/target/linux/ath79/patches-4.19/921-serial-core-add-support-for-boot-console-with-arbitr.patch
+++ b/target/linux/ath79/patches-4.19/921-serial-core-add-support-for-boot-console-with-arbitr.patch
@@ -1,0 +1,54 @@
+From 4d3c17975c7814884a721fe693b3adf5c426d759 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Tue, 10 Nov 2015 22:18:39 +0100
+Subject: [RFC] serial: core: add support for boot console with arbitrary
+ baud rates
+
+The Arduino Yun uses a baud rate of 250000 by default. The serial is
+going over the Atmel ATmega and is used to connect to this chip.
+Without this patch Linux wants to switch the console to 9600 Baud.
+
+With this patch Linux will use the configured baud rate and not a
+default one specified in uart_register_driver().
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+[rebased to 4.14, slightly reworded commit message]
+Signed-off-by: Sungbo Eo <mans0n@gorani.run>
+---
+ drivers/tty/serial/serial_core.c | 6 +++++-
+ include/linux/console.h          | 1 +
+ 2 files changed, 6 insertions(+), 1 deletions(-)
+
+--- a/drivers/tty/serial/serial_core.c
++++ b/drivers/tty/serial/serial_core.c
+@@ -219,6 +219,8 @@ static int uart_port_startup(struct tty_
+ 	if (retval == 0) {
+ 		if (uart_console(uport) && uport->cons->cflag) {
+ 			tty->termios.c_cflag = uport->cons->cflag;
++			tty->termios.c_ospeed = uport->cons->baud;
++			tty->termios.c_ispeed = uport->cons->baud;
+ 			uport->cons->cflag = 0;
+ 		}
+ 		/*
+@@ -2058,8 +2060,10 @@ uart_set_options(struct uart_port *port,
+ 	 * Allow the setting of the UART parameters with a NULL console
+ 	 * too:
+ 	 */
+-	if (co)
++	if (co) {
+ 		co->cflag = termios.c_cflag;
++		co->baud = baud;
++	}
+ 
+ 	return 0;
+ }
+--- a/include/linux/console.h
++++ b/include/linux/console.h
+@@ -153,6 +153,7 @@ struct console {
+ 	short	flags;
+ 	short	index;
+ 	int	cflag;
++	int	baud;
+ 	void	*data;
+ 	struct	 console *next;
+ };

--- a/target/linux/ath79/patches-5.4/921-serial-core-add-support-for-boot-console-with-arbitr.patch
+++ b/target/linux/ath79/patches-5.4/921-serial-core-add-support-for-boot-console-with-arbitr.patch
@@ -1,0 +1,54 @@
+From 4d3c17975c7814884a721fe693b3adf5c426d759 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Tue, 10 Nov 2015 22:18:39 +0100
+Subject: [RFC] serial: core: add support for boot console with arbitrary
+ baud rates
+
+The Arduino Yun uses a baud rate of 250000 by default. The serial is
+going over the Atmel ATmega and is used to connect to this chip.
+Without this patch Linux wants to switch the console to 9600 Baud.
+
+With this patch Linux will use the configured baud rate and not a
+default one specified in uart_register_driver().
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+[rebased to 4.14, slightly reworded commit message]
+Signed-off-by: Sungbo Eo <mans0n@gorani.run>
+---
+ drivers/tty/serial/serial_core.c | 6 +++++-
+ include/linux/console.h          | 1 +
+ 2 files changed, 6 insertions(+), 1 deletions(-)
+
+--- a/drivers/tty/serial/serial_core.c
++++ b/drivers/tty/serial/serial_core.c
+@@ -220,6 +220,8 @@ static int uart_port_startup(struct tty_
+ 	if (retval == 0) {
+ 		if (uart_console(uport) && uport->cons->cflag) {
+ 			tty->termios.c_cflag = uport->cons->cflag;
++			tty->termios.c_ospeed = uport->cons->baud;
++			tty->termios.c_ispeed = uport->cons->baud;
+ 			uport->cons->cflag = 0;
+ 		}
+ 		/*
+@@ -2104,8 +2106,10 @@ uart_set_options(struct uart_port *port,
+ 	 * Allow the setting of the UART parameters with a NULL console
+ 	 * too:
+ 	 */
+-	if (co)
++	if (co) {
+ 		co->cflag = termios.c_cflag;
++		co->baud = baud;
++	}
+ 
+ 	return 0;
+ }
+--- a/include/linux/console.h
++++ b/include/linux/console.h
+@@ -153,6 +153,7 @@ struct console {
+ 	short	flags;
+ 	short	index;
+ 	int	cflag;
++	int	baud;
+ 	void	*data;
+ 	struct	 console *next;
+ };


### PR DESCRIPTION
Arduino Yun is a microcontroller development board, based on Atmel
ATmega32u4 and Atheros AR9331.

Specifications:
- MCU: ATmega32U4
- SoC: AR9331
- RAM: DDR2 64MB
- Flash: SPI NOR 16MB
- WiFi:
  - 2.4GHz: SoC internal
- Ethernet: 1x 10/100Mbps
- USB: 1x 2.0
- MicroSD: 1x SDHC

Notes:
- Stock firmware is based on OpenWrt AA.
- The MCU can be programmed with avrdude linuxgpio.

Installation:
1.  Update U-Boot environment variables to adapt to new partition scheme.
    You'll need to access serial console via YunSerialTerminal.
```
> setenv bootcmd "run addboard; run addtty; run addparts; run addrootfs; bootm 0x9f050000 || bootm 0x9fea0000"
> setenv mtdparts "spi0.0:256k(u-boot)ro,64k(u-boot-env),15936k(firmware),64k(nvram),64k(art)ro"
> saveenv
```
2.  Boot into stock firmware normally and perform sysupgrade with
    sysupgrade image.
```
# sysupgrade -n -F /tmp/sysupgrade.bin
```