### PR TITLE
mvebu: add support for Turris Omnia 2019

### DIFF
--- a/target/linux/mvebu/base-files/lib/upgrade/sdcard.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/sdcard.sh
@@ -88,15 +88,6 @@ platform_do_upgrade_sdcard() {
 		get_image "$@" | dd of="/dev/$diskdev" bs=1 skip=440 count=4 seek=440 conv=fsync
 	fi
 
-	case "$board" in
-	cznic,turris-omnia)
-		fw_setenv openwrt_bootargs 'earlyprintk console=ttyS0,115200 root=/dev/mmcblk0p2 rootfstype=auto rootwait'
-		fw_setenv openwrt_mmcload 'setenv bootargs "$openwrt_bootargs cfg80211.freg=$regdomain"; fatload mmc 0 0x01000000 zImage; fatload mmc 0 0x02000000 armada-385-turris-omnia.dtb'
-		fw_setenv factory_mmcload 'setenv bootargs "$bootargs cfg80211.freg=$regdomain"; btrload mmc 0 0x01000000 boot/zImage @; btrload mmc 0 0x02000000 boot/dtb @'
-		fw_setenv mmcboot 'run openwrt_mmcload || run factory_mmcload; bootz 0x01000000 - 0x02000000'
-		;;
-	esac
-
 	sleep 1
 }
 

--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/35_turris-omnia_uboot-env
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/35_turris-omnia_uboot-env
@@ -1,0 +1,44 @@
+# This must be sourced after 30_uboot-envtools
+
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+cznic,turris-omnia)
+	# Do nothing if this is not the old U-Boot
+	grep -q 'U-Boot 2015.10-rc2' /dev/mtd0 || exit 0
+	# Do nothing if we already have distro_bootcmd
+	fw_printenv distro_bootcmd >/dev/null 2>/dev/null && exit 0
+	# Set the complete environment, since U-Boot does not merge the default environment from its own image!
+	fw_setenv -s - <<-"EOF"
+		baudrate 115200
+		bootdelay 3
+		ethact neta2
+		fdt_high 0x10000000
+		initrd_high 0x10000000
+		bootargs earlyprintk console=ttyS0,115200 rootfstype=btrfs rootdelay=2 root=b301 rootflags=subvol=@,commit=5 rw
+		bootcmd i2c dev 1; i2c read 0x2a 0x9 1 0x00FFFFF0; setexpr.b rescue *0x00FFFFF0; if test $rescue -ge 1; then echo BOOT RESCUE; run rescueboot; else echo BOOT eMMC FS; run mmcboot; setenv bootargs; run distro_bootcmd; fi
+		rescueboot i2c mw 0x2a.1 0x3 0x1c 1; i2c mw 0x2a.1 0x4 0x1c 1; mw.l 0x01000000 0x00ff000c; i2c write 0x01000000 0x2a.1 0x5 4 -s; setenv bootargs "$bootargs omniarescue=$rescue"; sf probe; sf read 0x1000000 0x100000 0x700000; bootz 0x1000000
+		mmcboot btrload mmc 0 ${kernel_addr_r} boot/zImage @ && btrload mmc 0 ${fdt_addr_r} boot/dtb @ && setenv bootargs ${bootargs} cfg80211.freg=${regdomain} && bootz ${kernel_addr_r} - ${fdt_addr_r}
+		kernel_addr_r 0x1000000
+		scriptaddr 0x1800000
+		fdt_addr_r 0x2000000
+		boot_targets mmc0 scsi0
+		boot_prefixes / /boot/
+		boot_scripts boot.scr
+		distro_bootcmd scsi_need_init=true; for target in ${boot_targets}; do run bootcmd_${target}; done
+		bootcmd_mmc0 devnum=0; run mmc_boot
+		mmc_boot if mmc dev ${devnum}; then devtype=mmc; run scan_dev_for_boot_part; fi
+		bootcmd_scsi0 devnum=0; run scsi_boot
+		scsi_boot run scsi_init; if scsi dev ${devnum}; then devtype=scsi; run scan_dev_for_boot_part; fi
+		scsi_init if ${scsi_need_init}; then scsi_need_init=false; scsi scan; fi
+		scan_dev_for_boot_part for distro_bootpart in 1; do if fstype ${devtype} ${devnum}:${distro_bootpart} bootfstype; then run scan_dev_for_boot; fi; done
+		scan_dev_for_boot echo Scanning ${devtype} ${devnum}:${distro_bootpart}...; for prefix in ${boot_prefixes}; do run scan_dev_for_scripts; done
+		scan_dev_for_scripts for script in ${boot_scripts}; do if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}${script}; then echo Found U-Boot script ${prefix}${script}; run boot_a_script; echo SCRIPT FAILED: continuing...; fi; done
+		boot_a_script load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr} ${prefix}${script}; source ${scriptaddr}
+	EOF
+	;;
+esac
+
+exit 0

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -39,11 +39,12 @@ define Device/cznic_turris-omnia
     wpad-basic-wolfssl kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     partx-utils kmod-i2c-mux-pca954x
   IMAGES := $$(IMAGE_PREFIX)-sysupgrade.img.gz omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz
-  IMAGE/$$(IMAGE_PREFIX)-sysupgrade.img.gz := boot-img | sdcard-img | gzip | append-metadata
+  IMAGE/$$(IMAGE_PREFIX)-sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   IMAGE/omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz := omnia-medkit-initramfs | gzip
   IMAGE_NAME = $$(2)
   SOC := armada-385
   SUPPORTED_DEVICES += armada-385-turris-omnia
+  BOOT_SCRIPT := turris-omnia
 endef
 TARGET_DEVICES += cznic_turris-omnia
 

--- a/target/linux/mvebu/image/turris-omnia.bootscript
+++ b/target/linux/mvebu/image/turris-omnia.bootscript
@@ -1,0 +1,17 @@
+# Determine root device
+setexpr rootpart ${distro_bootpart} + 1
+if test ${devtype} = mmc -a ${devnum} = 0; then
+	setenv rootdev /dev/mmcblk0p${rootpart}
+elif test ${devtype} = scsi -a ${devnum} = 0; then
+	setenv rootdev /dev/sda${rootpart}
+else
+	# New U-Boot only
+	part uuid ${devtype} ${devnum}:${rootpart} uuid
+	setenv rootdev PARTUUID=${uuid}
+fi
+setenv bootargs earlyprintk console=ttyS0,115200 root=${rootdev} rootfstype=auto rootwait
+
+# Load and boot
+load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} @DTB@.dtb
+load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} zImage
+bootz ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
The latest revision of the Turris Omnia (CZ11NIC23) is being shipped with a newer U-Boot version (2019.07). This version (a) relies on the existence of `/boot.scr` and (b) stores the firmware environment at 0xF0000, instead of 0xC0000.

Let's support the new U-Boot version, by adding the necessary boot script (similar to clearfog.bootscript) to the sysupgrade image, and adding some version logic to `/etc/uci-defaults/30_uboot-envtools`.

Installation with the new U-Boot works _without_ the "medkit", since the associated rescue system already includes shells accessible via serial _and_ ssh.

At the same time, improve the installation / sysupgrade procedure for the Turris Omnia with legacy U-Boot: (a) update the environment at first boot, and not during sysupgrade; (b) write the complete required set of environment variables, not just a part of it; (c) make use of the same boot script, to have unified behaviour.

Verification status:

- Turris Omnia 2019: Two successful installations reported below.
- Turris Omnia (CZ11NIC13) with legacy U-Boot: I have successfully executed a complete OpenWrt re-installation cycle with 4-LED reflash. Users should now be able to revert to factory OS, without manually resetting the environment. Also, 7-LED rescue shell works fine.