### PR TITLE
openvpn: add possibility to set param "compress" without algorithm

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.9
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -42,6 +42,7 @@ append_params() {
 		config_get v "$s" "$p"
 		IFS="$LIST_SEP"
 		for v in $v; do
+			[ "$v" = "frames_only" ] && [ "$p" = "compress" ] && unset v && append_param "$s" "$p" && echo >> "/var/etc/openvpn-$s.conf"
 			[ -n "$v" ] && [ "$p" != "push" ] && append_param "$s" "$p" && echo " $v" >> "/var/etc/openvpn-$s.conf"
 			[ -n "$v" ] && [ "$p" = "push" ] && append_param "$s" "$p" && echo " \"$v\"" >> "/var/etc/openvpn-$s.conf"
 		done


### PR DESCRIPTION
In some situations you need to set the compress param without an
algorithm. Compression will be turned off, but the packet framing for
compression will still be enabled, allowing a different setting to be
pushed later.

As it is not possible to have options with optional values at the
moment, I've introduced a pseudo value "frames_only" which will be
removed in the init script.

If anyone has a cleaner/better solution, please let me know.
