### PR TITLE
tcpdump: fix compilation of tcpdump on glibc

### DIFF
--- a/package/network/utils/tcpdump/Makefile
+++ b/package/network/utils/tcpdump/Makefile
@@ -55,7 +55,7 @@ CONFIGURE_ARGS += \
 endif
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections
-TARGET_LDFLAGS += -Wl,--gc-sections
+TARGET_LDFLAGS += -Wl,--gc-sections -lpcap
 
 CONFIGURE_VARS += \
 	BUILD_CC="$(TARGET_CC)" \


### PR DESCRIPTION
This commit fixes an issue where linkage with libpcap fails when targeting
ramips with glibc. It has been reported at https://github.com/openwrt/openwrt/pull/2488#issuecomment-546664153.

Note that this also requires the commit e8f79474c97949454b8d0ea966be006013471336, should anyone want to cherry-pick this commit into the openwrt-19.07 or other branch.