### PR TITLE
hostapd: add support for system cert bundle validation

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
hostapd: add support for system cert bundle validation

Currently, it is very cumbersome for a user to connect to a WPA-Enterprise
based network securely because the RADIUS server's CA certificate must first be
extracted from the EAPOL handshake using tcpdump or other methods before it can
be pinned using the ca_cert(2) fields. To make this process easier and more
secure (combined with changes in openwrt/openwrt#2654), this commit adds
support for validating against the built-in CA bundle when the ca-bundle
package is installed. Related LuCI changes in openwrt/luci#3513.

Signed-off-by: David Lam <david@thedavid.net>