### PR TITLE
ramips: fix wps leds/btn for TP-Link TL-WA801ND v5

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
@@ -24,6 +24,12 @@
 			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
 	};
 
 	leds {
@@ -44,16 +50,21 @@
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
 		};
 
-		wps {
-			label = "tl-wa801nd-v5:orange:wps";
-			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		wps_red {
+			label = "tl-wa801nd-v5:red:wps";
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps_green {
+			label = "tl-wa801nd-v5:green:wps";
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
 
 &state_default {
 	gpio {
-		ralink,group = "p0led_an", "perst", "refclk", "wdt", "wled_an";
+		ralink,group = "p0led_an", "p1led_an", "perst", "refclk", "uart1", "wdt", "wled_an";
 		ralink,function = "gpio";
 	};
 };


### PR DESCRIPTION
- fix color and active mode for existing wps led
- add green wps led
- add wps button