### PR TITLE
ath79: phy-ar7200-usb: do not print error on defered init

### DIFF
--- a/target/linux/ath79/patches-4.19/0004-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-4.19/0004-phy-add-ath79-usb-phys.patch
@@ -194,7 +194,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/phy/phy-ar7200-usb.c
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,136 @@
 +/*
 + * Copyright (C) 2015 Alban Bedel <albeu@free.fr>
 + *
@@ -265,7 +265,8 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +
 +	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
 +	if (IS_ERR(priv->rst_phy)) {
-+		dev_err(&pdev->dev, "phy reset is missing\n");
++		if (PTR_ERR(priv->rst_phy) != -EPROBE_DEFER)
++			dev_err(&pdev->dev, "phy reset is missing\n");
 +		return PTR_ERR(priv->rst_phy);
 +	}
 +

--- a/target/linux/ath79/patches-5.4/0004-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-5.4/0004-phy-add-ath79-usb-phys.patch
@@ -194,7 +194,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/phy/phy-ar7200-usb.c
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,136 @@
 +/*
 + * Copyright (C) 2015 Alban Bedel <albeu@free.fr>
 + *
@@ -265,7 +265,8 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +
 +	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
 +	if (IS_ERR(priv->rst_phy)) {
-+		dev_err(&pdev->dev, "phy reset is missing\n");
++		if (PTR_ERR(priv->rst_phy) != -EPROBE_DEFER)
++			dev_err(&pdev->dev, "phy reset is missing\n");
 +		return PTR_ERR(priv->rst_phy);
 +	}
 +


### PR DESCRIPTION
This is only a cosmetic correction, as the driver works as expected.
However, the error message confuses users about a missing reset definition.

On a deferd init we don´t see the following error message now:
[    0.078292] ar7200-usb-phy usb-phy: phy reset is missing

Signed-off-by: Johann Neuhauser <johann@it-neuhauser.de>