### PR TITLE
tools/cmake: update to 3.16.2

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.15.1
+PKG_VERSION:=3.16.2
 PKG_CPE_ID:=cpe:/a:kitware:cmake
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
-		https://cmake.org/files/v3.15/
-PKG_HASH:=18dec548d8f8b04d53c60f9cedcebaa6762f8425339d1e2c889c383d3ccdd7f7
+		https://cmake.org/files/v3.16/
+PKG_HASH:=8c09786ec60ca2be354c29829072c38113de9184f29928eb9da8446a5f2ce6a9
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/100-disable_qt_tests.patch
+++ b/tools/cmake/patches/100-disable_qt_tests.patch
@@ -1,8 +1,8 @@
 --- a/Tests/RunCMake/CMakeLists.txt
 +++ b/Tests/RunCMake/CMakeLists.txt
-@@ -325,15 +325,6 @@ add_RunCMake_test(no_install_prefix)
- add_RunCMake_test(configure_file)
- add_RunCMake_test(CTestTimeoutAfterMatch)
+@@ -375,15 +375,6 @@ else()
+   message(WARNING "Could not find or build ctresalloc")
+ endif()
  
 -find_package(Qt4 QUIET)
 -find_package(Qt5Core QUIET)
@@ -18,7 +18,7 @@
    add_RunCMake_test(FindPkgConfig)
 --- a/Tests/CMakeLists.txt
 +++ b/Tests/CMakeLists.txt
-@@ -483,13 +483,6 @@ if(BUILD_TESTING)
+@@ -489,13 +489,6 @@ if(BUILD_TESTING)
  
    list(APPEND TEST_BUILD_DIRS ${CMake_TEST_INSTALL_PREFIX})
  

--- a/tools/cmake/patches/120-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/120-curl-fix-libressl-linking.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 ---
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -453,6 +453,14 @@ if(CMAKE_USE_OPENSSL)
+@@ -459,6 +459,14 @@ if(CMAKE_USE_OPENSSL)
    set(USE_OPENSSL ON)
    set(HAVE_LIBCRYPTO ON)
    set(HAVE_LIBSSL ON)

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1168,7 +1168,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1248,7 +1248,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if [ "x${cmake_parallel_make}" != "x" ]; then


### PR DESCRIPTION
Update cmake to 3.16.2 and refresh patches.

Release notes:
https://cmake.org/cmake/help/v3.16/release/3.16.html

Tested by compiling ipq806x/R7800 firmware including some cmake packages.