### PR TITLE
kernel: remove further obsolete kernel version switches

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -157,18 +157,13 @@ endif
 
 
 # Disable noisy checks by default as in upstream
-ifeq ($(strip $(call kernel_patchver_ge,4.7.0)),1)
-  DTC_FLAGS += -Wno-unit_address_vs_reg
-endif
-ifeq ($(strip $(call kernel_patchver_ge,4.12.0)),1)
-  DTC_FLAGS += \
-	-Wno-unit_address_vs_reg \
-	-Wno-simple_bus_reg \
-	-Wno-unit_address_format \
-	-Wno-pci_bridge \
-	-Wno-pci_device_bus_num \
-	-Wno-pci_device_reg
-endif
+DTC_FLAGS += \
+  -Wno-unit_address_vs_reg \
+  -Wno-simple_bus_reg \
+  -Wno-unit_address_format \
+  -Wno-pci_bridge \
+  -Wno-pci_device_bus_num \
+  -Wno-pci_device_reg
 ifeq ($(strip $(call kernel_patchver_ge,4.17.0)),1)
   DTC_FLAGS += \
 	-Wno-avoid_unnecessary_addr_size \

--- a/include/target.mk
+++ b/include/target.mk
@@ -51,10 +51,6 @@ else
   endif
 endif
 
-ifneq ($(filter 4.9,$(KERNEL_PATCHVER)),)
-  DEFAULT_PACKAGES.router:=$(filter-out kmod-ipt-offload,$(DEFAULT_PACKAGES.router))
-endif
-
 # Add device specific packages (here below to allow device type set from subtarget)
 DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
 

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -53,11 +53,8 @@ define KernelPackage/bluetooth
 	$(LINUX_DIR)/net/bluetooth/bnep/bnep.ko \
 	$(LINUX_DIR)/net/bluetooth/hidp/hidp.ko \
 	$(LINUX_DIR)/drivers/bluetooth/hci_uart.ko \
-	$(LINUX_DIR)/drivers/bluetooth/btusb.ko
-ifeq ($(strip $(call CompareKernelPatchVer,$(KERNEL_PATCHVER),ge,4.1.0)),1)
-  FILES+= \
+	$(LINUX_DIR)/drivers/bluetooth/btusb.ko \
 	$(LINUX_DIR)/drivers/bluetooth/btintel.ko
-endif
   AUTOLOAD:=$(call AutoProbe,bluetooth rfcomm bnep hidp hci_uart btusb)
 endef
 

--- a/target/linux/bcm53xx/modules.mk
+++ b/target/linux/bcm53xx/modules.mk
@@ -9,9 +9,7 @@ define KernelPackage/phy-bcm-ns-usb2
   KCONFIG:=CONFIG_PHY_BCM_NS_USB2
   DEPENDS:=@TARGET_bcm53xx
   SUBMENU:=$(USB_MENU)
-  FILES:=\
-	$(LINUX_DIR)/drivers/phy/phy-bcm-ns-usb2.ko@lt4.13 \
-	$(LINUX_DIR)/drivers/phy/broadcom/phy-bcm-ns-usb2.ko@gt4.13
+  FILES:=$(LINUX_DIR)/drivers/phy/broadcom/phy-bcm-ns-usb2.ko
   AUTOLOAD:=$(call AutoLoad,45,phy-bcm-ns-usb2,1)
 endef
 
@@ -27,9 +25,7 @@ define KernelPackage/phy-bcm-ns-usb3
   KCONFIG:=CONFIG_PHY_BCM_NS_USB3
   DEPENDS:=@TARGET_bcm53xx
   SUBMENU:=$(USB_MENU)
-  FILES:=\
-	$(LINUX_DIR)/drivers/phy/phy-bcm-ns-usb3.ko@lt4.13 \
-	$(LINUX_DIR)/drivers/phy/broadcom/phy-bcm-ns-usb3.ko@ge4.13
+  FILES:=$(LINUX_DIR)/drivers/phy/broadcom/phy-bcm-ns-usb3.ko
   AUTOLOAD:=$(call AutoLoad,45,phy-bcm-ns-usb3,1)
 endef
 


### PR DESCRIPTION
Most of the kernel version switches below 4.14 were removed in commit
97940f876616 ("kernel: remove obsolete kernel version switches"),
but some of them still remained. Remove them now.