### PR TITLE
kirkwood: fix naming of HDD LED files for NSA325

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/01_leds
+++ b/target/linux/kirkwood/base-files/etc/board.d/01_leds
@@ -46,8 +46,8 @@ case "$board" in
 "zyxel,nsa325")
 	ucidef_set_led_default "health" "health" "nsa325:green:sys" "1"
 	ucidef_set_led_usbhost "usb" "USB" "nsa325:green:usb"
-	ucidef_set_led_ataport "hdd1" "HDD1" "nsa325:green:sata1" "1"
-	ucidef_set_led_ataport "hdd2" "HDD2" "nsa325:green:sata2" "2"
+	ucidef_set_led_ataport "hdd1" "HDD1" "nsa325:green:hdd1" "1"
+	ucidef_set_led_ataport "hdd2" "HDD2" "nsa325:green:hdd2" "2"
 	;;
 esac
 


### PR DESCRIPTION
on 19.07 release there is no sata1/sata2 file in /sys/class/leds on my NSA325. LEDs did not show any disk activity. Changing the LED names to the existing hdd1/hdd2 files makes them work.
