### PR TITLE
lantiq: ltq-ptm: vr9: fix skb handling in ptm_hard_start_xmit()

### DIFF
--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -336,6 +336,9 @@ static int ptm_hard_start_xmit(struct sk_buff *skb, struct net_device *dev)
         dma_cache_wback((unsigned long)skb->data, skb->len);
     }
 
+    /* make the skb unowned */
+    skb_orphan(skb);
+
     *(struct sk_buff **)((unsigned int)skb->data - byteoff - sizeof(struct sk_buff *)) = skb;
     /*  write back to physical memory   */
     dma_cache_wback((unsigned long)skb->data - byteoff - sizeof(struct sk_buff *), skb->len + byteoff + sizeof(struct sk_buff *));


### PR DESCRIPTION
Call skb_orphan(skb) to call the owner's destructor function and make
the skb unowned.

This is necessary to prevent sk_wmem_alloc of a socket from overflowing,
which leads to ENOBUFS errors on application level.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>

This PR is related to my message on the mailing list:
http://lists.infradead.org/pipermail/openwrt-devel/2020-January/021305.html
