### PR TITLE
kernel: mtd: enforce sub-partitions access mode

### DIFF
--- a/target/linux/generic/hack-4.14/401-mtd-enforce-access-mode.patch
+++ b/target/linux/generic/hack-4.14/401-mtd-enforce-access-mode.patch
@@ -1,0 +1,68 @@
+--- a/drivers/mtd/mtdchar.c
++++ b/drivers/mtd/mtdchar.c
+@@ -578,6 +578,7 @@
+ 			       struct blkpg_ioctl_arg *arg)
+ {
+ 	struct blkpg_partition p;
++	uint32_t mask_flags;
+ 
+ 	if (!capable(CAP_SYS_ADMIN))
+ 		return -EPERM;
+@@ -595,7 +596,10 @@
+ 		/* Sanitize user input */
+ 		p.devname[BLKPG_DEVNAMELTH - 1] = '\0';
+ 
+-		return mtd_add_partition(mtd, p.devname, p.start, p.length);
++		/* No mtd flags masking required */
++		mask_flags = 0;
++
++		return mtd_add_partition(mtd, p.devname, p.start, p.length, mask_flags);
+ 
+ 	case BLKPG_DEL_PARTITION:
+ 
+--- a/drivers/mtd/mtdpart.c
++++ b/drivers/mtd/mtdpart.c
+@@ -726,7 +726,7 @@
+ }
+ 
+ int mtd_add_partition(struct mtd_info *parent, const char *name,
+-		      long long offset, long long length)
++		      long long offset, long long length, uint32_t mask_flags)
+ {
+ 	struct mtd_partition part;
+ 	struct mtd_part *new;
+@@ -747,6 +747,7 @@
+ 	part.name = name;
+ 	part.size = length;
+ 	part.offset = offset;
++	part.mask_flags = mask_flags;
+ 
+ 	new = allocate_partition(parent, &part, -1, offset);
+ 	if (IS_ERR(new))
+@@ -866,10 +867,14 @@
+ 		/* adjust partition offsets */
+ 		parts[i].offset += slave->offset;
+ 
++		/* adjust partition mask */
++		parts[i].mask_flags = !(slave->mtd.orig_flags & MTD_WRITEABLE) ? MTD_WRITEABLE : 0;
++
+ 		mtd_add_partition(slave->parent,
+ 				  parts[i].name,
+ 				  parts[i].offset,
+-				  parts[i].size);
++				  parts[i].size,
++				  parts[i].mask_flags);
+ 	}
+ 
+ 	kfree(parts);
+--- a/include/linux/mtd/partitions.h
++++ b/include/linux/mtd/partitions.h
+@@ -114,7 +114,7 @@
+ 
+ int mtd_is_partition(const struct mtd_info *mtd);
+ int mtd_add_partition(struct mtd_info *master, const char *name,
+-		      long long offset, long long length);
++		      long long offset, long long length, uint32_t mask_flags);
+ int mtd_del_partition(struct mtd_info *master, int partno);
+ struct mtd_info *mtdpart_get_master(const struct mtd_info *mtd);
+ uint64_t mtdpart_get_offset(const struct mtd_info *mtd);

--- a/target/linux/generic/hack-4.19/401-mtd-enforce-access-mode.patch
+++ b/target/linux/generic/hack-4.19/401-mtd-enforce-access-mode.patch
@@ -1,0 +1,68 @@
+--- a/drivers/mtd/mtdchar.c
++++ b/drivers/mtd/mtdchar.c
+@@ -566,6 +566,7 @@
+ 			       struct blkpg_ioctl_arg *arg)
+ {
+ 	struct blkpg_partition p;
++	uint32_t mask_flags;
+ 
+ 	if (!capable(CAP_SYS_ADMIN))
+ 		return -EPERM;
+@@ -583,7 +584,10 @@
+ 		/* Sanitize user input */
+ 		p.devname[BLKPG_DEVNAMELTH - 1] = '\0';
+ 
+-		return mtd_add_partition(mtd, p.devname, p.start, p.length);
++		/* No mtd flags masking required */
++		mask_flags = 0;
++
++		return mtd_add_partition(mtd, p.devname, p.start, p.length, mask_flags);
+ 
+ 	case BLKPG_DEL_PARTITION:
+ 
+--- a/drivers/mtd/mtdpart.c
++++ b/drivers/mtd/mtdpart.c
+@@ -679,7 +679,7 @@
+ }
+ 
+ int mtd_add_partition(struct mtd_info *parent, const char *name,
+-		      long long offset, long long length)
++		      long long offset, long long length, uint32_t mask_flags)
+ {
+ 	struct mtd_partition part;
+ 	struct mtd_part *new;
+@@ -700,6 +700,7 @@
+ 	part.name = name;
+ 	part.size = length;
+ 	part.offset = offset;
++	part.mask_flags = mask_flags;
+ 
+ 	new = allocate_partition(parent, &part, -1, offset);
+ 	if (IS_ERR(new))
+@@ -819,10 +820,14 @@
+ 		/* adjust partition offsets */
+ 		parts[i].offset += slave->offset;
+ 
++		/* adjust partition mask */
++		parts[i].mask_flags = !(slave->mtd.orig_flags & MTD_WRITEABLE) ? MTD_WRITEABLE : 0;
++
+ 		mtd_add_partition(slave->parent,
+ 				  parts[i].name,
+ 				  parts[i].offset,
+-				  parts[i].size);
++				  parts[i].size,
++				  parts[i].mask_flags);
+ 	}
+ 
+ 	kfree(parts);
+--- a/include/linux/mtd/partitions.h
++++ b/include/linux/mtd/partitions.h
+@@ -114,7 +114,7 @@
+ 
+ int mtd_is_partition(const struct mtd_info *mtd);
+ int mtd_add_partition(struct mtd_info *master, const char *name,
+-		      long long offset, long long length);
++		      long long offset, long long length, uint32_t mask_flags);
+ int mtd_del_partition(struct mtd_info *master, int partno);
+ struct mtd_info *mtdpart_get_master(const struct mtd_info *mtd);
+ uint64_t mtdpart_get_offset(const struct mtd_info *mtd);


### PR DESCRIPTION
### kernel: mtd: enforce sub-partitions access mode

Currently it's not possible to effectively mark a "firmware" partition
as read-only. The sub-partitions "kernel", "rootfs" and "rootfs_data"
are always created as read-write (ignoring the parent access mode).

This patch enforces the access mode of sub-partitions to match the
parent partition, which is useful for recovery images that are meant
to be fully read-only to avoid accidental damage from end-user.

An example of such implementation (read-only firmware image) is the
recovery image used on the [Zsun-SD100](https://github.com/brunompena/zsun-resources).

_Please note the related patch for [fstools](http://patchwork.ozlabs.org/patch/1217561/) to enable this read-only
concept._

> This patch is modificiation of #2535 which was too strict and was
> causing issues with devices whose partition layout was not padded
> to the mtd blocksize (see [this link](http://patchwork.ozlabs.org/comment/2347196/) for additional details).

Signed-off-by: Bruno Pena <brunompena@gmail.com>