### PR TITLE
ath79: add support for the offloading CPU in AVM FRITZ!Box 3390

### DIFF
--- a/target/linux/ath79/dts/ar9342_avm_fritzbox-3390-wasp.dts
+++ b/target/linux/ath79/dts/ar9342_avm_fritzbox-3390-wasp.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "avm,fritzbox-3390-wasp", "qca,ar9342";
+	model = "AVM FRITZ!Box 3390 WASP Board";
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "rgmii";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -3,13 +3,15 @@ include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR = 0x80060000
 
-DEVICE_VARS += IMAGE_SIZE LOADER_FLASH_OFFS LOADER_TYPE
+DEVICE_VARS += IMAGE_SIZE LOADER_FLASH_OFFS LOADER_TYPE LOADER_LZMA_TEXT_START LOADER_LOADADDR
 
 define Build/loader-common
 	rm -rf $@.src
 	$(MAKE) -C lzma-loader \
 		PKG_BUILD_DIR="$@.src" \
 		TARGET_DIR="$(dir $@)" LOADER_NAME="$(notdir $@)" \
+		$(if $(LOADER_LZMA_TEXT_START),LZMA_TEXT_START=$(LOADER_LZMA_TEXT_START),) \
+		$(if $(LOADER_LOADADDR),LOADADDR=$(LOADER_LOADADDR),) \
 		$(1) compile loader.$(LOADER_TYPE)
 	mv "$@.$(LOADER_TYPE)" "$@"
 	rm -rf $@.src

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -8,6 +8,12 @@ DEVICE_VARS += ADDPATTERN_ID ADDPATTERN_VERSION
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK
 DEVICE_VARS += KERNEL_INITRAMFS_PREFIX
 
+define Build/wasp-checksum
+	$(STAGING_DIR_HOST)/bin/wasp-checksum \
+		-i "$@" -o "$@.new"
+	mv "$@.new" "$@"
+endef
+
 define Build/add-elecom-factory-initramfs
   $(eval edimax_model=$(word 1,$(1)))
   $(eval product=$(word 2,$(1)))
@@ -160,6 +166,21 @@ define Device/avm_fritz300e
   DEVICE_PACKAGES := fritz-tffs rssileds -swconfig
 endef
 TARGET_DEVICES += avm_fritz300e
+
+define Device/avm_fritzbox-3390-wasp
+  SOC := ar9342
+  DEVICE_VENDOR := AVM
+  DEVICE_MODEL := FRITZ!Box 3390 WASP
+  IMAGES :=
+  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma | \
+	loader-kernel | pad-to 4096 | pad-extra 208 | wasp-checksum
+  LOADER_LOADADDR := 0x80020000
+  LOADER_LZMA_TEXT_START := 0x81a00000
+  LOADER_TYPE := bin
+  KERNEL_INITRAMFS := $$(KERNEL)
+  DEVICE_PACKAGES := kmod-owl-loader -swconfig -uboot-env-tools
+endef
+TARGET_DEVICES += avm_fritzbox-3390-wasp
 
 define Device/avm_fritz4020
   SOC := qca9561

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -93,6 +93,7 @@ define Host/Compile
 	$(call cc,mksercommfw, -Wall)
 	$(call cc,nec-enc, -Wall --std=gnu99)
 	$(call cc,uimage_padhdr, -Wall -lz)
+	$(call cc,wasp-checksum, -Wall --std=gnu99)
 endef
 
 define Host/Install

--- a/tools/firmware-utils/src/wasp-checksum.c
+++ b/tools/firmware-utils/src/wasp-checksum.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Andreas Boehler <dev@aboehler.at>
+ *
+ * This tool was based on:
+ * 	firmware-crc.pl by Atheros Communications
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <getopt.h>     /* for getopt() */
+
+char *infile = NULL;
+char *outfile = NULL;
+char *progname;
+
+#define CHUNK_SIZE 256
+
+static void usage(int status)
+{
+	fprintf(stderr, "Usage: %s [OPTIONS...]\n", progname);
+	fprintf(stderr,
+"\n"
+"Options:\n"
+"  -i              input file name\n"
+"  -o              output file name\n"
+"  -h              show this screen\n"
+	);
+
+	exit(status);
+}
+
+int main(int argc, char *argv[]) {
+	uint32_t crc = 0;
+	FILE *in_fp;
+	FILE *out_fp;
+	uint32_t buf[CHUNK_SIZE];
+	ssize_t read;
+
+	progname = argv[0];
+
+	while ( 1 ) {
+		int c;
+
+		c = getopt(argc, argv, "i:o:h");
+		if (c == -1)
+			break;
+
+		switch (c) {
+		case 'i':
+			infile = optarg;
+			break;
+		case 'o':
+			outfile = optarg;
+			break;
+		case 'h':
+			usage(EXIT_SUCCESS);
+		default:
+			usage(EXIT_FAILURE);
+			break;
+		}
+	}
+
+	if(!infile || !outfile) {
+		usage(EXIT_FAILURE);
+	}
+
+	in_fp = fopen(infile, "r");
+	if(!in_fp) {
+		fprintf(stderr, "Error opening input file: %s\n", infile);
+		return EXIT_FAILURE;
+	}
+	out_fp = fopen(outfile, "w");
+	if(!out_fp) {
+		fprintf(stderr, "Error opening output file: %s\n", outfile);
+		fclose(in_fp);
+		return EXIT_FAILURE;
+	}
+
+	while(!feof(in_fp)) {
+		read = fread(buf, sizeof(uint32_t), CHUNK_SIZE, in_fp);
+		for(int i=0; i<read; i++) {
+			crc = crc ^ buf[i];
+		}
+		fwrite(buf, sizeof(uint32_t), read, out_fp);
+	}
+	fwrite(&crc, sizeof(uint32_t), 1, out_fp);
+	fclose(in_fp);
+	fclose(out_fp);
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The AVM FRITZ!Box 3390 is a device with two SoC: Lantiq and ath79. While the Lantiq target has access to flash and USB, the ath79 target only has Ethernet access. Thus, for the FRITZ!Box 3390 only an initramfs image is required that is uploaded to the ath79 by a firmware uploader on the ath79 target. A stage 1 firmware is uploaded via MDIO which accepts a stage 2 firmware via Ethernet. This is the stage 2 firmware.

In order to configure the ath79 instance, a separate config downloader takes care of EEPROM files and configuration data.

A PR for the Lantiq target is currently pending at #2662. 
