### PR TITLE
ar71xx: fix flashlayout for ap90q yuncore

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -208,7 +208,6 @@ platform_check_image() {
 	ap121f|\
 	ap132|\
 	ap531b0|\
-	ap90q|\
 	archer-c25-v1|\
 	archer-c58-v1|\
 	archer-c59-v1|\
@@ -335,6 +334,7 @@ platform_check_image() {
 
 		return 0
 		;;
+	ap90q|\
 	alfa-ap96|\
 	alfa-nx|\
 	ap121|\

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -117,8 +117,14 @@ TARGET_DEVICES += ap531b0
 define Device/ap90q
   DEVICE_TITLE := YunCore AP80Q/AP90Q
   BOARDNAME := AP90Q
+  BLOCKSIZE := 64k
   IMAGE_SIZE := 16000k
-  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),16000k(firmware),64k(art)ro
+  KERNEL_SIZE := 1472k
+  ROOTFS_SIZE := 14528k
+  CONSOLE = ttyS0,115200
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),14528k(rootfs),1408k(kernel),64k(art)ro,16000k@0x50000(firmware)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs |\
+	  pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
 endef
 TARGET_DEVICES += ap90q
 


### PR DESCRIPTION
AP90q YunCore device bricked when image loaded on a device
And update platform_check_image for AP90q

This commit corrects kernel/rootfs size with padding and sysupgrade
for AP90q

Signed-off-by: Jaymin Patel <jem.patel@gmail.com>