### PR TITLE
hostapd: fix space variable and configuration that way

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -87,8 +87,8 @@ DRIVER_MAKEOPTS= \
 	CONFIG_IEEE80211AC=$(HOSTAPD_IEEE80211AC) \
 	CONFIG_DRIVER_WEXT=$(CONFIG_DRIVER_WEXT_SUPPORT) \
 
-space :=
-space +=
+nullstring :=
+space := $(nullstring) # end of the line
 
 ifneq ($(LOCAL_VARIANT),mini)
   DRIVER_MAKEOPTS += CONFIG_IEEE80211W=$(CONFIG_DRIVER_11W_SUPPORT)


### PR DESCRIPTION
The hack used to get space variable probably no longer works with newest
make. This replaces it with version suggested in GNU make documentation.
http://www.gnu.org/software/make/manual/make.html#Flavors

Signed-off-by: Karel Kočí <cynerd@email.cz>