### PR TITLE
comgt-3g: fix seting interface as "unavailable" when "bind" fired on tty*

### DIFF
--- a/package/network/utils/comgt/files/3g.usb
+++ b/package/network/utils/comgt/files/3g.usb
@@ -14,10 +14,10 @@ find_3g_iface() {
 	local dev=$(uci_get network "$cfg" device)
 
 	if [ "${dev##*/}" = "${tty##*/}" ]; then
-		if [ "$ACTION" = add ]; then
-			available=1
-		else
+		if [ "$ACTION" = remove ]; then
 			available=0
+		else
+			available=1
 		fi
 		proto_set_available "$cfg" $available
 	fi


### PR DESCRIPTION
My modem not works after reboot, in LuCI i get "Error: Network device is not present"
In logs: 

```
Sat Jan 25 23:00:37 2020 daemon.notice netifd: Interface 'ppp0' is setting up now
Sat Jan 25 23:00:40 2020 daemon.notice netifd: Interface 'ppp0' is now down
```

When i click "restart" on ppp0 - nothing happens and no any logs in logread. 

After few hours debug i found cause - interface has marked as "not available" by proto_set_available(). 

But all needed ttyUSB's exists:
```
root@OpenWrt:~# ls /dev/ttyUSB*
/dev/ttyUSB0  /dev/ttyUSB1  /dev/ttyUSB2  /dev/ttyUSB3
```

I added debug to /etc/hotplug.d/tty/30-3g:

```
root@OpenWrt:~# cat /tmp/ololo2.log
ACTION=add proto=3g cfg=ppp0 tty=/dev/ttyUSB3
proto_set_available ppp0 1

ACTION=add proto=3g cfg=ppp0 tty=/dev/ttyUSB3
proto_set_available ppp0 1

ACTION=bind proto=3g cfg=ppp0 tty=/dev/ttyUSB3
proto_set_available ppp0 0
```

And what do we see?

When hotplug script triggered with action "bind" - then interface marked as disabled. 

And this confirms the code:
```
	if [ "${dev##*/}" = "${tty##*/}" ]; then
		if [ "$ACTION" = add ]; then # interface set "available" only if ACTION=add !!!
			available=1
		else
			available=0
		fi
		
		proto_set_available "$cfg" $available
	fi
```

May be, this code written before "bind" action was added or in some cases "bind" fires before "add" (in my case, i get randomly "bind" and "add" order)...

I dont know, why this script handles other actions, rather than "add" and "remove"...
Two ways for fix:

**Change condition**
```
	if [ "${dev##*/}" = "${tty##*/}" ]; then
		if [ "$ACTION" = add ]; then
			available=1
		else
			available=0
		fi
		proto_set_available "$cfg" $available
	fi
```

replace with:
```
	if [ "${dev##*/}" = "${tty##*/}" ]; then
		if [ "$ACTION" = remove ]; then
			available=0
		else
			available=1
		fi
		proto_set_available "$cfg" $available
	fi
```

**OR handle only "add" / "remove"**
```
[ -e "/dev/$DEVICENAME" ] || [ "$ACTION" = remove ] || exit 0
```

replace with

```
[ "$ACTION" = add ] || [ "$ACTION" = remove ] || exit 0
```

All variants works fine. 