### PR TITLE
ath79: add support for COMFAST CF-E560AC

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "comfast,cf-e560ac", "qca,qca9531";
+	model = "COMFAST CF-E560AC";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &eth1;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan1 {
+			label = "cf-e560ac:blue:lan1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "cf-e560ac:blue:lan2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "cf-e560ac:blue:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "cf-e560ac:blue:lan4";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system {
+			label = "cf-e560ac:blue:system";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "cf-e560ac:blue:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "cf-e560ac:blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfc0000>;
+			};
+
+			partition@fe0000 {
+				label = "configs";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&rst {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 { 
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <10>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -73,6 +73,13 @@ comfast,cf-e5)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi1" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi2" "wlan0" "66" "100"
 	;;
+comfast,cf-e560ac)
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:blue:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "$boardname:blue:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "$boardname:blue:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "$boardname:blue:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "$boardname:blue:lan4" "switch0" "0x10"
+	;;
 dlink,dir-842-c1|\
 dlink,dir-842-c2|\
 dlink,dir-842-c3|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -102,6 +102,13 @@ ath79_setup_interfaces()
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	comfast,cf-e560ac|\
+	tplink,archer-c60-v1|\
+	tplink,archer-c60-v2)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+		;;
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2)
 		ucidef_add_switch "switch0" \
@@ -226,12 +233,6 @@ ath79_setup_interfaces()
 	tplink,tl-wdr4900-v2)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
-		;;
-	tplink,archer-c60-v1|\
-	tplink,archer-c60-v2)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
 	tplink,archer-d50-v1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -123,9 +123,17 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:00:00.0.bin")
 	case $board in
-	comfast,cf-e313ac)
+	comfast,cf-e313ac|\
+	comfast,cf-e560ac)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_binary art 0x6)
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
+		;;
+	comfast,cf-e560ac)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -300,6 +300,16 @@ define Device/comfast_cf-e5
 endef
 TARGET_DEVICES += comfast_cf-e5
 
+define Device/comfast_cf-e560ac
+  SOC := qca9531
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E560AC
+  DEVICE_PACKAGES := kmod-leds-gpio kmod-usb2 kmod-ath10k-ct \
+	ath10k-firmware-qca9888-ct
+  IMAGE_SIZE := 16128k
+endef
+TARGET_DEVICES += comfast_cf-e560ac
+
 define Device/comfast_cf-wr650ac-v1
   SOC := qca9558
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
This commit adds support for the COMFAST CF-E560AC, an ap143 based
in-wall access point.

Specifications:
 - SoC: Qualcomm Atheros QCA9531
 - RAM: 128 MB
 - Storage: 16 MB flash (winbond 25Q128JV)
 - 5ghz WiFi: Qualcomm Atheros QCA9886

Recovery instructions:

This device contains built-in u-boot tftp recovery.

1. Configure PC with static IP 192.168.1.10/24 and tftp server.
2. Place desired image at /firmware_auto.bin at tftp root.
3. Connect device to PC, and power on.
4. Device will fetch flash from tftp, flash and reboot into new image.

Signed-off-by: August Huber <auh@google.com>
