### PR TITLE
uqmi: make the link layer protocol configurable

### DIFF
--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uqmi
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uqmi.git


### PR DESCRIPTION
This enables you to select your prefered link layer protocol.

Using raw-ip instead of 802.3 could lead to slightly better performance
on some systems.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
