### PR TITLE
ramips: add support for TP-Link RE200 v2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re200-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200-v2.dts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_tplink_re200.dtsi"
+
+/ {
+	compatible = "tplink,re200-v2", "mediatek,mt7628an-soc";
+	model = "TP-Link RE200 v2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "re200-v2:green:wps";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "re200-v2:green:wifi";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "re200-v2:green:lan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "re200-v2:green:power";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g_green {
+			label = "re200-v2:green:wifi2g";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g_green {
+			label = "re200-v2:green:wifi5g";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g_red {
+			label = "re200-v2:red:wifi2g";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g_red {
+			label = "re200-v2:red:wifi5g";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "p4led_an", "p3led_an", "p2led_an", "p1led_an",
+				"p0led_an", "wled_an", "i2c", "wdt", "refclk";
+		ralink,function = "gpio";
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x7a0000>;
+			};
+
+			config: partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x30000>;
+				read-only;
+			};
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0x2008>;
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&config 0x2008>;
+	mtd-mac-address-increment = <1>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&config 0x2008>;
+		mtd-mac-address-increment = <2>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -265,6 +265,7 @@ define Device/tplink-safeloader
 	append-metadata | check-size $$$$(IMAGE_SIZE)
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
+DEVICE_VARS += TPLINK_BOARD_ID
 
 define Device/tplink_archer-c20-v4
   $(Device/tplink)
@@ -326,6 +327,16 @@ define Device/tplink_archer-c50-v4
   SUPPORTED_DEVICES += tplink,c50-v4
 endef
 TARGET_DEVICES += tplink_archer-c50-v4
+
+define Device/tplink_re200-v2
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE200
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt76x0e
+  TPLINK_BOARD_ID := RE200-V2
+endef
+TARGET_DEVICES += tplink_re200-v2
 
 define Device/tplink_re305-v1
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -64,6 +64,7 @@ tplink,archer-c50-v4)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
+tplink,re200-v2|\
 tplink,tl-mr3020-v3|\
 tplink,tl-wa801nd-v5)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ ramips_setup_interfaces()
 	alfa-network,awusfree1|\
 	d-team,pbr-d1|\
 	tama,w06|\
+	tplink,re200-v2|\
 	tplink,re305-v1|\
 	tplink,tl-mr3020-v3|\
 	tplink,tl-wr802n-v4)

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1436,6 +1436,49 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+  /** Firmware layout for the RE200 v2 */
+	{
+		.id     = "RE200-V2",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:00000000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:41520000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:41550000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:42520000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:43410000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:45530000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:45550000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:49440000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:4a500000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:4b520000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:52550000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:54570000}\n"
+			"{product_name:RE200,product_ver:2.0.0,special_id:55530000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x7a0000},
+			{"partition-table", 0x7c0000, 0x02000},
+			{"default-mac", 0x7c2000, 0x00020},
+			{"pin", 0x7c2100, 0x00020},
+			{"product-info", 0x7c3100, 0x01000},
+			{"soft-version", 0x7c4200, 0x01000},
+			{"support-list", 0x7c5200, 0x01000},
+			{"profile", 0x7c6200, 0x08000},
+			{"config-info", 0x7ce200, 0x00400},
+			{"user-config", 0x7d0000, 0x10000},
+			{"default-config", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
   /** Firmware layout for the RE305 v1 */
 	{
 		.id     = "RE305-V1",


### PR DESCRIPTION
TP-Link RE200 v2 is a wireless range extender with Ethernet and 2.4G and 5G
WiFi with internal antennas. It's based on MediaTek MT7628AN+MT7610EN.

Specifications
--------------

- MediaTek MT7628AN (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 1x 10/100 Mbps Ethernet
- UART header on PCB (57600 8n1)
- 8x LED (GPIO-controlled), 2x button

There are 2.4G and 5G LEDs in red and green which are controlled
separately.

MAC addresses
-------------

The MAC address assignment matches stock firmware, i.e.:
LAN : *:0D
2.4G: *:0E
5G  : *:0F

Installation
------------

Web Interface
-------------

It is possible to upgrade to OpenWrt via the web interface. Simply flash
the -factory.bin from OEM. In contrast to a stock firmware, this will not
overwrite U-Boot.

Serial console
--------------

Opening the case is quite hard, since it is welded together. Rename the
OpenWrt factory image to "test.bin", then plug in the device and quickly
press "2" to enter flash mode (no line feed). Follow the prompts until
OpenWrt is installed.

Unfortunately, this devices does not offer a recovery mode or a tftp
installation method. If the web interface upgrade fails, you have to open
your device and attach serial console.

Additonal notes
---------------

It is possible to flash back to stock by using tplink-safeloader to create
a sysupgrade image based on a stock update. After the first boot, it is
necessary upgrade to another stock image, otherwise subsequent boots
fail with LZMA ERROR 1 and you have to attach serial to recover the device.

Most GPIOs are based on work from Forum User Flole, who is working on the v3 device.