### PR TITLE
ramips: convert TP-Link TL-MR3020v3 to tpt trigger and merge config

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -61,6 +61,7 @@
 		wlan {
 			label = "tl-mr3020-v3:green:wlan";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wa801nd-v5.dts
@@ -48,6 +48,7 @@
 		wlan {
 			label = "tl-wa801nd-v5:green:wlan";
 			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps_red {

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -64,19 +64,15 @@ tplink,archer-c50-v4)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
-tplink,tl-mr3020-v3)
-	set_wifi_led "$boardname:green:wlan"
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth0"
+tplink,tl-mr3020-v3|\
+tplink,tl-wa801nd-v5)
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v5|\
 tplink,tl-wr842n-v5)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
-	;;
-tplink,tl-wa801nd-v5)
-	ucidef_set_led_wlan "wlan" "wlan" "$boardname:green:wlan" "phy0tpt"
-	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
 	;;
 tplink,tl-wr840n-v4)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan" "phy0tpt"


### PR DESCRIPTION
This converts the TP-Link TL-MR3020v3 board to use the WLAN throughput
LED trigger in order to react to all VAPs.

It also moves the WLAN trigger config of the TP-Link TL-WA801NDv5 to the
DTS and merges the now identical LAN LED configs.

Verified these changes on a TL-MR3020v3.