### PR TITLE
[WIP] cleanup some irregular image names

### DIFF
--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
@@ -4,6 +4,6 @@
 #include "ar7240_tplink_tl-wr74xn-v1.dtsi"
 
 / {
-	model = "TP-Link TL-WR841N/ND v5/v6";
+	model = "TP-Link TL-WR841N/ND v5";
 	compatible = "tplink,tl-wr841-v5", "qca,ar7240";
 };

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -169,7 +169,10 @@ define Device/tplink_tl-wr841-v5
   $(Device/tplink-4m)
   SOC := ar7240
   DEVICE_MODEL := TL-WR841N/ND
-  DEVICE_VARIANT := v5/v6
+  DEVICE_VARIANT := v5
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := TL-WR841N/ND
+  DEVICE_ALT0_VARIANT := v6
   TPLINK_HWID := 0x08410005
 endef
 TARGET_DEVICES += tplink_tl-wr841-v5

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -123,15 +123,15 @@ define Device/Default
   FILESYSTEMS := squashfs
   KERNEL_NAME := zImage
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(1).$$(2)
-  IMAGES := trx
+  IMAGES := factory.trx
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  IMAGE/trx := append-ubi | trx-nand
+  IMAGE/factory.trx := append-ubi | trx-nand
 endef
 
 define Device/asus
-  IMAGES := trx
-  IMAGE/trx := append-ubi | trx-nand | asus-trx
+  IMAGES := factory.trx
+  IMAGE/factory.trx := append-ubi | trx-nand | asus-trx
 endef
 
 define Device/asus-rt-ac56u
@@ -194,13 +194,13 @@ define Device/buffalo-wzr-900dhp
   BUFFALO_TAG_PLATFORM := bcm
   BUFFALO_TAG_VERSION := 9.99
   BUFFALO_TAG_MINOR := 9.99
-  IMAGES += factory-DHP-EU.bin factory-DHP2-JP.bin
-  IMAGE/factory-DHP-EU.bin := \
+  IMAGES += DHP-EU-factory.bin DHP2-JP-factory.bin
+  IMAGE/DHP-EU-factory.bin := \
 	append-ubi | trx-nand | buffalo-wzr-header WZR-900DHP EU | \
 	buffalo-enc WZR-900DHP $$(BUFFALO_TAG_VERSION) | \
 	buffalo-tag-dhp WZR-900DHP EU mlang20 | buffalo-enc-tag | \
 	buffalo-dhp-image
-  IMAGE/factory-DHP2-JP.bin := \
+  IMAGE/DHP2-JP-factory.bin := \
 	append-ubi | trx-nand | buffalo-wzr-header WZR-900DHP2 JP | \
 	buffalo-enc WZR-900DHP2 $$(BUFFALO_TAG_VERSION) | \
 	buffalo-tag-dhp WZR-900DHP2 JP jp | buffalo-enc-tag | \
@@ -322,8 +322,8 @@ define Device/smartrg-sr400ac
   DEVICE_VENDOR := SmartRG
   DEVICE_MODEL := SR400ac
   DEVICE_PACKAGES := $(BRCMFMAC_43602A1) $(USB3_PACKAGES)
-  IMAGES := trx
-  IMAGE/trx := append-rootfs | trx-serial
+  IMAGES := factory.trx
+  IMAGE/factory.trx := append-rootfs | trx-serial
   KERNEL_INITRAMFS_SUFFIX := .bin
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma-d16
 endef
@@ -333,7 +333,7 @@ define Device/phicomm-k3
   DEVICE_VENDOR := PHICOMM
   DEVICE_MODEL := K3
   DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
-  IMAGES := trx
+  IMAGES := factory.trx
 endef
 TARGET_DEVICES += phicomm-k3
 
@@ -341,8 +341,8 @@ define Device/tenda-ac9
   DEVICE_VENDOR := Tenda
   DEVICE_MODEL := AC9
   DEVICE_PACKAGES := $(B43) $(USB2_PACKAGES)
-  IMAGES := trx
-  IMAGE/trx := append-rootfs | trx-serial
+  IMAGES := factory.trx
+  IMAGE/factory.trx := append-rootfs | trx-serial
 endef
 TARGET_DEVICES += tenda-ac9
 
@@ -351,7 +351,7 @@ define Device/tplink-archer-c5-v2
   DEVICE_MODEL := Archer C5
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := $(B43) $(USB2_PACKAGES)
-  IMAGES := bin
+  IMAGES := factory.bin
   IMAGE/bin := append-rootfs | bcm53xx-tplink-safeloader
   TPLINK_BOARD := ARCHER-C5-V2
 endef
@@ -362,7 +362,7 @@ define Device/tplink-archer-c9-v1
   DEVICE_MODEL := Archer C9
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := $(USB3_PACKAGES)
-  IMAGES := bin
+  IMAGES := factory.bin
   IMAGE/bin := append-rootfs | bcm53xx-tplink-safeloader
   TPLINK_BOARD := ARCHERC9
 endef

--- a/target/linux/brcm47xx/image/Makefile
+++ b/target/linux/brcm47xx/image/Makefile
@@ -143,8 +143,8 @@ define Device/Default
 	KERNEL_NAME = vmlinux.lzma
 	KERNEL_INITRAMFS_NAME = vmlinux-initramfs.lzma
 	FILESYSTEMS := $(FS_64K)
-	IMAGES := trx
-	IMAGE/trx := append-rootfs | trx-with-loader
+	IMAGES := factory.trx
+	IMAGE/factory.trx := append-rootfs | trx-with-loader
 endef
 
 define Device/standard
@@ -154,7 +154,7 @@ endef
 define Device/standard-noloader-gz
   DEVICE_TITLE := Image with gzipped kernel
   KERNEL_NAME = vmlinux.gz
-  IMAGE/trx := append-rootfs | trx-without-loader
+  IMAGE/factory.trx := append-rootfs | trx-without-loader
 endef
 
 define Device/standard-noloader-nodictionarylzma
@@ -165,26 +165,26 @@ endef
 
 define Device/asus
 	DEVICE_VENDOR := ASUS
-	IMAGES := trx
-	IMAGE/trx := append-rootfs | trx-with-loader | asus-trx
+	IMAGES := factory.trx
+	IMAGE/factory.trx := append-rootfs | trx-with-loader | asus-trx
 endef
 
 define Device/linksys
 	DEVICE_VENDOR := Linksys
-	IMAGES := bin
-	IMAGE/bin := append-rootfs | trx-with-loader | linksys-bin
+	IMAGES := factory.bin
+	IMAGE/factory.bin := append-rootfs | trx-with-loader | linksys-bin
 endef
 
 define Device/motorola
 	DEVICE_VENDOR := Motorola
-	IMAGES := bin
-	IMAGE/bin := append-rootfs | trx-with-loader | motorola-bin
+	IMAGES := factory.bin
+	IMAGE/factory.bin := append-rootfs | trx-with-loader | motorola-bin
 endef
 
 define Device/netgear
 	DEVICE_VENDOR := NETGEAR
-	IMAGES := chk
-	IMAGE/chk := append-rootfs | trx-with-loader | netgear-chk
+	IMAGES := factory.chk
+	IMAGE/factory.chk := append-rootfs | trx-with-loader | netgear-chk
 endef
 
 #################################################
@@ -353,8 +353,8 @@ TARGET_DEVICES += asus-wl-hdd25
 define Device/dlink-dwl-3150
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DWL-3150
-  IMAGES := bin
-  IMAGE/bin := append-rootfs | trx-with-loader | tailed-bin
+  IMAGES := factory.bin
+  IMAGE/factory.bin := append-rootfs | trx-with-loader | tailed-bin
   BIN_TAIL := BCM-5352-2050-0000000-01
 endef
 TARGET_DEVICES += dlink-dwl-3150
@@ -363,8 +363,8 @@ define Device/edimax-ps1208-mfg
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := PS-1208MFg
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
-  IMAGES := bin
-  IMAGE/bin := append-rootfs | trx-with-loader | edimax-bin
+  IMAGES := factory.bin
+  IMAGE/factory.bin := append-rootfs | trx-with-loader | edimax-bin
 endef
 TARGET_DEVICES += edimax-ps1208-mfg
 
@@ -373,8 +373,8 @@ define Device/huawei-e970
   DEVICE_MODEL := E970
   DEVICE_PACKAGES := kmod-b43
   KERNEL_NAME = vmlinux.gz
-  IMAGES := bin
-  IMAGE/bin := append-rootfs | trx-without-loader | huawei-bin
+  IMAGES := factory.bin
+  IMAGE/factory.bin := append-rootfs | trx-without-loader | huawei-bin
 endef
 TARGET_DEVICES += huawei-e970
 
@@ -400,9 +400,9 @@ define Device/linksys-wrt54g3gv2-vf
   DEVICE_MODEL := WRT54G3GV2-VF
   DEVICE_PACKAGES := kmod-b43 $(USB2_PACKAGES)
   FILESYSTEMS := $(FS_128K)
-  IMAGES := noheader.bin bin
-  IMAGE/noheader.bin := linksys-pattern-partition | append-rootfs | trx-v2-with-loader
-  IMAGE/bin := linksys-pattern-partition | append-rootfs | trx-v2-with-loader | linksys-bin
+  IMAGES := noheader-factory.bin factory.bin
+  IMAGE/noheader-factory.bin := linksys-pattern-partition | append-rootfs | trx-v2-with-loader
+  IMAGE/factory.bin := linksys-pattern-partition | append-rootfs | trx-v2-with-loader | linksys-bin
   DEVICE_ID := 3G2V
   VERSION := 3.00.24
   SERIAL := 6
@@ -476,7 +476,7 @@ define Device/linksys-wrt300n-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-b43
   $(Device/linksys)
-  IMAGES := bin trx
+  IMAGES := factory.bin factory.trx
   DEVICE_ID := EWCB
   VERSION := 1.03.6
 endef
@@ -521,8 +521,8 @@ define Device/netgear-wgt634u
   DEVICE_MODEL := WGT634U
   DEVICE_PACKAGES := kmod-ath5k $(USB2_PACKAGES)
   FILESYSTEMS := $(FS_128K)
-  IMAGES := bin
-  IMAGE/bin := append-rootfs | trx-with-loader | prepend-with-elf
+  IMAGES := factory.bin
+  IMAGE/factory.bin := append-rootfs | trx-with-loader | prepend-with-elf
 endef
 TARGET_DEVICES += netgear-wgt634u
 
@@ -550,8 +550,8 @@ define Device/usrobotics-usr5461
   DEVICE_VENDOR := US Robotics
   DEVICE_MODEL := USR5461
   DEVICE_PACKAGES := kmod-b43 $(USB1_PACKAGES)
-  IMAGES := bin
-  IMAGE/bin := append-rootfs | trx-with-loader | usrobotics-bin
+  IMAGES := factory.bin
+  IMAGE/factory.bin := append-rootfs | trx-with-loader | usrobotics-bin
 endef
 TARGET_DEVICES += usrobotics-usr5461
 

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -201,9 +201,9 @@ define Device/cubox-i
   DEVICE_NAME := cubox
   DEVICE_PACKAGES := kmod-drm-imx kmod-drm-imx-hdmi kmod-usb-hid
   DEVICE_DTS := imx6q-cubox-i imx6dl-cubox-i imx6q-hummingboard imx6dl-hummingboard
-  IMAGES := combined.bin dtb
+  IMAGES := factory.bin dtb
   FILESYSTEMS := squashfs
-  IMAGE/combined.bin := append-rootfs | pad-extra 128k | imx6-sdcard
+  IMAGE/factory.bin := append-rootfs | pad-extra 128k | imx6-sdcard
   IMAGE/dtb := install-dtb
 endef
 TARGET_DEVICES += cubox-i
@@ -223,9 +223,9 @@ define Device/apalis
   BOOT_SCRIPT := bootscript-apalis
   UBOOT := apalis_imx6
   FILESYSTEMS := squashfs
-  IMAGES := combined.bin sysupgrade.bin
+  IMAGES := factory.bin sysupgrade.bin
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(1).$$(2)
-  IMAGE/combined.bin := append-rootfs | pad-extra 128k | apalis-emmc
+  IMAGE/factory.bin := append-rootfs | pad-extra 128k | apalis-emmc
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   ARTIFACTS := recovery.scr
   ARTIFACT/recovery.scr := recovery-scr

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -163,8 +163,8 @@ define Device/avm_fritzbox-4040
 	IMAGE_SIZE := 29056k
 	UBOOT_PATH := $(STAGING_DIR_IMAGE)/uboot-fritz4040.bin
 	UBOOT_PARTITION_SIZE := 524288
-	IMAGES = eva.bin sysupgrade.bin
-	IMAGE/eva.bin := append-uboot | pad-to $$$$(UBOOT_PARTITION_SIZE) | append-kernel | append-rootfs | pad-rootfs
+	IMAGES = factory.bin sysupgrade.bin
+	IMAGE/factory.bin := append-uboot | pad-to $$$$(UBOOT_PARTITION_SIZE) | append-kernel | append-rootfs | pad-rootfs
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 	DEVICE_PACKAGES := fritz-tffs fritz-caldata
 endef

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -96,9 +96,9 @@ define Device/avm_fritz3370
   DEVICE_VARIANT := Rev. 2
   KERNEL_SIZE := 4096k
   UBINIZE_OPTS := -E 5
-  IMAGES += eva-kernel.bin eva-filesystem.bin
+  IMAGES += eva-kernel.bin eva-rootfs.bin
   IMAGE/eva-kernel.bin := append-kernel
-  IMAGE/eva-filesystem.bin := append-ubi
+  IMAGE/eva-rootfs.bin := append-ubi
   DEVICE_PACKAGES := kmod-ath9k wpad-basic kmod-usb-dwc2 fritz-tffs
 endef
 

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -7,7 +7,7 @@
 
 define Device/Default
   PROFILES := Default
-  IMAGES := firmware.bin
+  IMAGES := factory.bin
   FILESYSTEMS := ubifs
   MKUBIFS_OPTS := -m 1 -e 262016 -c 128
   KERNEL := kernel-bin | gzip | uImage gzip
@@ -26,7 +26,7 @@ define Device/ls1012ardb
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 256KiB
   PAGESIZE := 1
-  IMAGE/firmware.bin := \
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
     ls-append $(1)-fip.bin | pad-to 5M | \
@@ -47,8 +47,8 @@ define Device/ls1012afrwy
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-frwy
   FILESYSTEMS := ext4
-  IMAGES := firmware.bin sdcard.img
-  IMAGE/firmware.bin := \
+  IMAGES := factory.bin sdcard.img
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 128K | \
     ls-append pfe.itb | pad-to 384K | \
@@ -74,7 +74,7 @@ define Device/ls1043ardb
     fmc fmc-eth-config
   DEVICE_DTS := freescale/fsl-ls1043a-rdb-sdk
   FILESYSTEMS := squashfs
-  IMAGE/firmware.bin := \
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
     ls-append $(1)-fip.bin | pad-to 5M | \
@@ -122,7 +122,7 @@ define Device/ls1046ardb
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 256KiB
   PAGESIZE := 1
-  IMAGE/firmware.bin := \
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
     ls-append $(1)-fip.bin | pad-to 5M | \
@@ -171,7 +171,7 @@ define Device/ls1088ardb
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 256KiB
   PAGESIZE := 1
-  IMAGE/firmware.bin := \
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
     ls-append $(1)-fip.bin | pad-to 5M | \
@@ -222,7 +222,7 @@ define Device/ls2088ardb
     restool
   DEVICE_DTS := freescale/fsl-ls2088a-rdb
   FILESYSTEMS := squashfs
-  IMAGE/firmware.bin := \
+  IMAGE/factory.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
     ls-append $(1)-fip.bin | pad-to 5M | \

--- a/target/linux/mpc85xx/image/Makefile
+++ b/target/linux/mpc85xx/image/Makefile
@@ -97,9 +97,9 @@ define Device/ocedo_panda
   PAGESIZE := 2048
   SUBPAGESIZE := 512
   BLOCKSIZE := 128k
-  IMAGES := fdt.bin sysupgrade.bin
+  IMAGES := tftp.fdt sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/fdt.bin := append-dtb
+  IMAGE/tftp.fdt := append-dtb
 endef
 TARGET_DEVICES += ocedo_panda
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -447,7 +447,7 @@ define Device/tplink_tl-wr841n-v14
   TPLINK_HWREV := 0x1
   TPLINK_HWREVADD := 0x14
   TPLINK_HVERSION := 3
-  IMAGE/tftp-recovery.bin := pad-extra 64k | $$(IMAGE/factory.bin)
+  IMAGE/tftp.bin := pad-extra 64k | $$(IMAGE/factory.bin)
 endef
 TARGET_DEVICES += tplink_tl-wr841n-v14
 


### PR DESCRIPTION
Cleanup image names, so that the name reflects the type of the image.

The scope of changes has yet to be determined. At least some non standard image name schemes can be rectified.

Context: The type field of the generated json files (Global build settings ---> [*] Create JSON info files per build image) is a bit messed up, because the [last part](https://github.com/openwrt/openwrt/commit/881ed09ee6e23f6c224184bb7493253c4624fb9f#diff-f270d5a89448c938eac56766f56540b6R578)  of the image name is taken. This showed a few irregularities. Usually that part is `factory` or `sysupgrade`. 
```
mkdir tmp
cd tmp
 rsync -avm  --include='*.json' --include='*/' --exclude='*' 'rsync://downloads.openwrt.org/downloads/snapshots/targets/' .
grep -r "\"type\"" . | awk '{print($3)}' | sort | uniq
```
This gives these items: `cfe, cfe-16M, cfe-4M, cfe-8M, cfe-AU, cfe-EU, cfe-bc221, chk, combined, dgr2-dgr3-factory, eva, eva-filesystem, eva-kernel, factory, factory-DHP-EU, factory-DHP2-JP, factory-NA, factory-br, factory-eu, factory-na, factory-us, factory_30, factory_35, fdt, firmware, fullimage, kernel, kernel1, nand, nand-factory, nand-sysupgrade, noheader, omnia-medkit-openwrt-mvebu-cortexa9-cznic_turris-omnia-initramfs, openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade, root, rootfs, rootfs0, sdcard, sysupgrade, sysupgrade-4M-Kernel, sysupgrade-emmc, sysupgrade-na, tftp, tftp-recovery, trx, ubinized, zImage`