### PR TITLE
rbextract: support devices with plain RLE caldata

### DIFF
--- a/package/utils/rbextract/Makefile
+++ b/package/utils/rbextract/Makefile
@@ -11,7 +11,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rbextract
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 CMAKE_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/utils/rbextract/src/rbextract.c
+++ b/package/utils/rbextract/src/rbextract.c
@@ -335,7 +335,7 @@ __rb_get_wlan_data(void)
 	}
 	/* Older ath79-based boards directly show the RB_MAGIC_ERD bytes followed by
 	the LZO-compressed calibration data with no RLE */
-	if (magic == RB_MAGIC_ERD) {
+	else if (magic == RB_MAGIC_ERD) {
 		if (tag_len > RB_ART_SIZE) {
 			printf("Calibration data too large\n");
 			goto err_free_lzo_in;
@@ -362,6 +362,18 @@ __rb_get_wlan_data(void)
 
 		buf_rle_out = buf_lzo_out;
 	}
+	/* Even older ath79-base boards directly have RLE-encoded calibration data,
+	without any LZO compresion nor showing RB_MAGIC_ERD bytes */
+	else {
+		printf("Decode calibration data with RLE\n");
+		err = rle_decode(tag, tag_len, buf_rle_out, RB_ART_SIZE,
+				 NULL, NULL);
+		if (err) {
+			printf("unable to decode ERD data\n");
+			goto err_free_rle_out;
+		}
+	}
+
 	return buf_rle_out;
 
 err_free_rle_out:


### PR DESCRIPTION
Very old MikroTik devices have the radio calibration data encoded in RLE and directly stored in the art (i.e., hard_config) partition, without LZO compression nor the preceding ERD magic bytes (which newer devices carry).

This commit adds a fallback for these devices: when no LZO or ERD magic bytes are read, assume raw RLE-encoded calibration data will follow.

Tested on the ath79 target with a MikroTik SXT 5nD r2 (SXT Lite5), which has the calibration data on the SPI NOR. The device is not yet supported though, as the NAND flash is not working yet.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>