### PR TITLE
[19.07] mvebu: Clearfog Pro fix emmc boot without microSD card

### DIFF
--- a/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
+++ b/target/linux/mvebu/base-files/lib/preinit/06_set_iface_mac
@@ -29,17 +29,6 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $mac 2>/dev/null
 		ip link set dev eth1 address $mac 2>/dev/null
 		;;
-	marvell,a385-db-ap|solidrun,clearfog*a1)
-		# rename interfaces back to the way they were with 4.4
-		case "$(readlink /sys/class/net/eth0)" in
-			*f1070000*)
-				ip link set eth0 name tmp0
-				ip link set eth1 name eth0
-				ip link set eth2 name eth1
-				ip link set tmp0 name eth2
-			;;
-		esac
-		;;
 	esac
 }
 

--- a/target/linux/mvebu/patches-4.14/416-ARM-dts-armada388-clearfog-emmc-on-clearfog-pro.patch
+++ b/target/linux/mvebu/patches-4.14/416-ARM-dts-armada388-clearfog-emmc-on-clearfog-pro.patch
@@ -1,0 +1,12 @@
+Index: linux-4.14.167/arch/arm/boot/dts/armada-388-clearfog-pro.dts
+===================================================================
+--- linux-4.14.167.orig/arch/arm/boot/dts/armada-388-clearfog-pro.dts
++++ linux-4.14.167/arch/arm/boot/dts/armada-388-clearfog-pro.dts
+@@ -46,6 +46,7 @@
+  *     OTHER DEALINGS IN THE SOFTWARE.
+  */
+ #include "armada-388-clearfog.dts"
++#include "armada-38x-solidrun-microsom-emmc.dtsi"
+ 
+ / {
+ 	model = "SolidRun Clearfog Pro A1";


### PR DESCRIPTION
emmc boot fails on "Waiting for root device /dev/mmcblk0p1".
Clearfog Base has been fixed for while, but Clearfog Pro has been forgotten.

Signed-off-by: sven friedmann <sf.openwrt@okay.ms>