### PR TITLE
base-files: bring up vlan interface too

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=228
+PKG_RELEASE:=229
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -19,6 +19,9 @@ preinit_ip_config() {
 	fi
 
 	ip link set dev $netdev up
+	if [ -n "$vid" ]; then
+		ip link set dev $1 up
+	fi
 	ip -4 address add $pi_ip/$pi_netmask broadcast $pi_broadcast dev $1
 }
 


### PR DESCRIPTION
While debugging a failsafe for a device, I forced it to use vlan-based preinit network.
However, the vlan subinterface was never brought up.

Tested forcing `ifname=""` before preinit_ip() on a Tp-Link Archer C5v4