### PR TITLE
scripts: fix empty subtarget

### DIFF
--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -6,7 +6,11 @@ import hashlib
 
 
 def e(variable, default=None):
-    return os.environ.get(variable, default)
+    value = os.environ.get(variable)
+    if value == None or value == '':
+        return default
+    else:
+        return value
 
 
 json_path = "{}{}{}.json".format(e("BIN_DIR"), os.sep, e("IMAGE_PREFIX"))


### PR DESCRIPTION
Environment variable SUBTARGET is always set, but may be empty, in which case we want to use the default.

Signed-off-by: Moritz Warning <moritzwarning@web.de>