### PR TITLE
ramips: add support for the TP-Link TL-WA850RE v4

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wa850re-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wa850re-v4.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wa850re-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WA850RE v4";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	aliases {
+		label-mac-device = &ethernet;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tl-wa850re-v4:blue:power";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tl-wa850re-v4:blue:lan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-wa850re-v4:blue:wlan";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		range_extender {
+			label = "tl-wa850re-v4:blue:re";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "tl-wa850re-v4:blue:rssi1";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "tl-wa850re-v4:blue:rssi2";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi3 {
+			label = "tl-wa850re-v4:blue:rssi3";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi4 {
+			label = "tl-wa850re-v4:blue:rssi4";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi5 {
+			label = "tl-wa850re-v4:blue:rssi5";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x3a0000>;
+			};
+
+			config: partition@3c0000 {
+				label = "config";
+				reg = <0x3c0000 0x30000>;
+				read-only;
+			};
+
+			radio: partition@3f0000 {
+				label = "radio";
+				reg = <0x3f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&radio 0x0>;
+	mtd-mac-address = <&config 0x4008>;
+	mtd-mac-address-increment = <1>;
+};
+
+&ethernet {
+	mtd-mac-address = <&config 0x4008>;
+};
+
+&state_default {
+	gpio {
+		ralink,group = "i2c", "refclk", "wdt", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "wled_an";
+		ralink,function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -359,6 +359,16 @@ define Device/tplink_tl-wa801nd-v5
 endef
 TARGET_DEVICES += tplink_tl-wa801nd-v5
 
+define Device/tplink_tl-wa850re-v4
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := TL-WA850RE
+  DEVICE_VARIANT := v4
+  IMAGE_SIZE := 3712k
+  TPLINK_BOARD_ID := TLWA850REV4
+  DEVICE_PACKAGES := -wpad-basic wpad-mini rssileds
+endef
+TARGET_DEVICES += tplink_tl-wa850re-v4
+
 define Device/tplink_tl-wr802n-v4
   $(Device/tplink-v2)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -75,6 +75,14 @@ tplink,tl-wr842n-v5)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
+tplink,tl-wa850re-v4)
+	ucidef_set_led_netdev "lan" "lan" "$boardname:blue:lan" "eth0"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:blue:rssi1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "$boardname:blue:rssi2" "wlan0" "20" "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:blue:rssi3" "wlan0" "40" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:blue:rssi4" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:blue:rssi5" "wlan0" "80" "100"
+	;;
 tplink,tl-wr840n-v4)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ramips_setup_interfaces()
 	tplink,re200-v2|\
 	tplink,re305-v1|\
 	tplink,tl-mr3020-v3|\
+	tplink,tl-wa850re-v4|\
 	tplink,tl-wr802n-v4)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1258,6 +1258,44 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the TL-WA850RE v4 */
+	{
+		.id     = "TLWA850REV4",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:55530000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:45550000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:4B520000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:42520000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:4A500000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:41550000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:41520000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:54570000}\n"
+			"{product_name:TL-WA850RE,product_ver:4.0.0,special_id:45530000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x3a2000},
+			{"partition-table", 0x3c2000, 0x02000},
+			{"default-mac", 0x3c4000, 0x00020},
+			{"pin",	0x3c4100, 0x00020},
+			{"product-info", 0x3c5000, 0x01000},
+			{"soft-version", 0x3c6000, 0x01000},
+			{"support-list", 0x3c7000, 0x01000},
+			{"profile", 0x3c8000, 0x08000},
+			{"user-config",	0x3d0000, 0x10000},
+			{"default-config", 0x3e0000, 0x10000},
+			{"radio", 0x3f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the TL-WA855RE v1 */
 	{
 		.id     = "TLWA855REV1",


### PR DESCRIPTION
PR-only intro - I have this booting from flash now (if i make the image small enough), and am very tired so decided to give it out for review in the meantime...

--
TP-Link TL-WA850RE is a wireless range extender with Ethernet and 2.4G
WiFi with internal antennas. It's based on a MediaTek MT7628NN.

Specifications
--------------

- MediaTek MT7628NN (575 Mhz)
- 32 MB of RAM
- 4 MB of FLASH (SPI)
- 2T2R 2.4 Ghz WiFi
- 1x 10/100 Mbps Ethernet
- UART header on PCB (57600 8n1)
- 9x LED (GPIO), 2x button

Installation
------------

Web Interface
-------------

WIP: Installing via the web interface not tested but i assume possible.

Serial console
--------------

Opening the case is quite hard, since it is welded together. Rename the
OpenWrt factory image to "test.bin", then plug in the device and quickly
press "2" to enter flash mode (no line feed). Follow the prompts until
OpenWrt is installed.

Unfortunately, this devices does not offer a recovery mode or a tftp
installation method. If the web interface upgrade fails, you have to open
your device and attach serial console. Since the web upgrade overwrites
the boot loader, you might also brick your device.

Additional notes
----------------

MAC address assignment is based on stock-firmware. For me, the device
assigns the MAC on the label to Ethernet and +1 of that to the 2.4G WiFi.

Signed-off-by: Urja Rannikko <urjaman@gmail.com>

---
N.B. This WIP commit message is quite muchly based on the RE200 v1 commit
message :)