### PR TITLE
lantiq: add basic support for AVM FRITZ!Box 7490

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -211,6 +211,7 @@
 			compatible = "lantiq,xrx200-pinctrl";
 			#gpio-cells = <2>;
 			gpio-controller;
+			gpio-ranges = <&gpio 0 0 56>;
 			reg = <0xe100b10 0xa0>;
 
 			gphy0_led0_pins: gphy0-led0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -1,0 +1,282 @@
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_info_red;
+		led-running = &led_power;
+		led-upgrade = &led_info_red;
+
+		led-dsl = &led_internet;
+		led-internet = &led_internet;
+		led-wifi = &led_wlan;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		// key "DECT"
+		key_dect {
+			label = "dect";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+		// key "WLAN/WPS"
+		key_wlan {
+			label = "wlan";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		// led 5 "Power/DSL"
+		led_power: power {
+			label = "fritz7490:green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+		// led 4 "Internet"
+		led_internet: internet {
+			label = "fritz7490:green:internet";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+		// led 3 "FixedLine"
+		led_fixedline: fixedline {
+			label = "fritz7490:green:fixedline";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+		// led 2 "WLAN"
+		led_wlan: wlan {
+			label = "fritz7490:green:wlan";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+		// led 1 "Info"
+		led_info: info {
+			label = "fritz7490:green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+		led_info_red: info_red {
+			label = "fritz7490:red:info";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_wasp_reset {
+			gpio-export,name = "fritz7490:wasp:reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+		gpio_wasp_wakeup {
+			gpio-export,name = "fritz7490:wasp:wakeup";
+			gpio-export,output = <2>;
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy0>;
+			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "sgmii";
+			phy-handle = <&phy1>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	pcie-rst-dev {
+		gpio-hog;
+		line-name = "pcie-rst-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+
+	usb-vbus {
+		gpio-hog;
+		line-name = "usb-vbus";
+		gpios = <14 GPIO_ACTIVE_HIGH>;
+		output-low;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x40000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x40000 0x60000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0xa0000 0x60000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	flash@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <1 0x0 0x2000000>;
+
+		nand-ecc-mode = "on-die";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x1fc00000>;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -33,14 +33,13 @@
 		compatible = "gpio-keys-polled";
 		poll-interval = <100>;
 
-		// key "DECT"
-		key_dect {
+		dect {
 			label = "dect";
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_PHONE>;
 		};
-		// key "WLAN/WPS"
-		key_wlan {
+
+		wlan {
 			label = "wlan";
 			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
@@ -49,32 +48,33 @@
 
 	leds {
 		compatible = "gpio-leds";
-		// led 5 "Power/DSL"
+
 		led_power: power {
 			label = "fritz7490:green:power";
 			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
 			default-state = "keep";
 		};
-		// led 4 "Internet"
+
 		led_internet: internet {
 			label = "fritz7490:green:internet";
 			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
 		};
-		// led 3 "FixedLine"
-		led_fixedline: fixedline {
+
+		led_fixedline {
 			label = "fritz7490:green:fixedline";
 			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
 		};
-		// led 2 "WLAN"
+
 		led_wlan: wlan {
 			label = "fritz7490:green:wlan";
 			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
 		};
-		// led 1 "Info"
-		led_info: info {
+
+		led_info_green {
 			label = "fritz7490:green:info";
 			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
 		};
+
 		led_info_red: info_red {
 			label = "fritz7490:red:info";
 			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
@@ -89,6 +89,7 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
 		};
+
 		gpio_wasp_wakeup {
 			gpio-export,name = "fritz7490:wasp:wakeup";
 			gpio-export,output = <2>;
@@ -187,6 +188,7 @@
 	pinctrl-0 = <&state_default>;
 
 	state_default: pinmux {
+
 		phy-rst {
 			lantiq,pins = "io32", "io44";
 			lantiq,pull = <0>;
@@ -222,7 +224,7 @@
 	flash@4 {
 		compatible = "jedec,spi-nor";
 		reg = <4>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <80000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -235,13 +237,13 @@
 				read-only;
 			};
 
-			partition@20000 {
+			partition@40000 {
 				reg = <0x40000 0x60000>;
 				label = "tffs (1)";
 				read-only;
 			};
 
-			partition@30000 {
+			partition@a0000 {
 				reg = <0xa0000 0x60000>;
 				label = "tffs (2)";
 				read-only;
@@ -278,5 +280,6 @@
 
 &pcie0 {
 	status = "okay";
+
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -20,7 +20,6 @@
 		led-upgrade = &led_info_red;
 
 		led-dsl = &led_internet;
-		led-internet = &led_internet;
 		led-wifi = &led_wlan;
 	};
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -224,7 +224,7 @@
 	flash@4 {
 		compatible = "jedec,spi-nor";
 		reg = <4>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <33250000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -255,7 +255,7 @@
 &localbus {
 	flash@1 {
 		compatible = "lantiq,nand-xway";
-		bank-width = <2>;
+		bank-width = <1>;
 		reg = <1 0x0 0x2000000>;
 
 		nand-ecc-mode = "on-die";

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -146,6 +146,16 @@ define Device/avm_fritz7412
 endef
 TARGET_DEVICES += avm_fritz7412
 
+define Device/avm_fritz7490
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7490
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs
+endef
+TARGET_DEVICES += avm_fritz7490
+
 define Device/bt_homehub-v5a
   $(Device/NAND)
   DEVICE_VENDOR := British Telecom

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -39,7 +39,8 @@ lantiq_setup_interfaces()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7360sl|\
-	avm,fritz7362sl)
+	avm,fritz7362sl|\
+	avm,fritz7490)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
 		;;
@@ -130,7 +131,8 @@ lantiq_setup_macs()
 	avm,fritz7360sl)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
-	avm,fritz7362sl)
+	avm,fritz7362sl|\
+	avm,fritz7490)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
 		;;


### PR DESCRIPTION
Support for LAN and Switch tested and confirmed, xDSL untested.
- usb3: WIP requires firmware loader for the Renesas-µPD720202
	https://patchwork.kernel.org/patch/11329775/
- wlan: WIP see here: https://github.com/openwrt/openwrt/pull/2662
- dect: NOT supported
- ISDN/POTS: NOT supported