### PR TITLE
ath79: add support for Comfast CF-WR752AC v1

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-wr752ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-wr752ac-v1.dts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr752ac-v1", "qca,qca9531";
+	model = "COMFAST CF-WR752AC v1";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &pinmux_wlan2g_led &pinmux_wlan5g_led>;
+
+		led_lan: lan {
+			label = "cf-wr752ac-v1:blue:lan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "cf-wr752ac-v1:green:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "cf-wr752ac-v1:red:wlan5g";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+
+&pinmux {
+	pinmux_wlan2g_led: pinmux_wlan2g {
+		pinctrl-single,bits = <0xc 0x0 0xff000000>;
+	};
+
+	pinmux_wlan5g_led: pinmux_wlan5g {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor" ;
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			partition@ff0000 {
+				label = "nvram";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -80,6 +80,10 @@ comfast,cf-e560ac)
 	ucidef_set_led_switch "lan3" "LAN3" "$boardname:blue:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "$boardname:blue:lan4" "switch0" "0x10"
 	;;
+comfast,cf-wr752ac-v1|\
+engenius,ecb1750)
+	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0"
+	;;
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:white:dlan" "eth0.1" "rx"
 	;;
@@ -88,9 +92,6 @@ dlink,dir-842-c2|\
 dlink,dir-842-c3|\
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
-	;;
-engenius,ecb1750)
-	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0"
 	;;
 engenius,ews511ap)
 	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 	alfa-network,ap121f|\
 	aruba,ap-105|\
 	avm,fritz300e|\
+	comfast,cf-wr752ac-v1|\
 	devolo,dvl1200i|\
 	devolo,dvl1750c|\
 	devolo,dvl1750i|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -140,7 +140,8 @@ case "$FIRMWARE" in
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 		;;
-	comfast,cf-e560ac)
+	comfast,cf-e560ac|\
+	comfast,cf-wr752ac-v1)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -346,6 +346,17 @@ define Device/comfast_cf-wr650ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr650ac-v2
 
+define Device/comfast_cf-wr752ac-v1
+  SOC := qca9531
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-WR752AC
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9888-ct \
+	-uboot-envtools
+  IMAGE_SIZE := 16192k
+endef
+TARGET_DEVICES += comfast_cf-wr752ac-v1
+
 define Device/devolo_dvl1200e
   SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
- Qualcomm QCA9531 + QCA9886
- dual band, antenna 2*3dBi
- Output power 50mW (17dBm)
- 1x 10/100 Mbps LAN RJ45
- 128MB RAM / 16 MB FLASH
- 3 LEDs (red/green/blue)
  incorporated in
  "color wheel reset switch"
- UART 115200 8N1

Flashing instructions:

 The U-boot bootloader contains a recovery HTTP server
 to upload the  firmware. Push the reset button while powering the
 device on and keep it pressed for ~10 seconds. The device's LEDs will
 blink several times and the recovery page will be at
 http://192.168.1.1; use it to upload the sysupgrade image.

 Alternatively, the original firmware is based on OpenWrt so a
 sysupgrade image can be installed via the stock web GUI. Settings from
 the original firmware will be saved and restored on the new one, so a
 factory reset will be needed. To do so, once the new firmware is flashed,
 enter into failsafe mode by pressing the reset button several times during
 the boot process, until it starts flashing. Once in failsafe mode, perform
 a factory reset as usual.

Signed-off-by: Roman Hampel <rhamp@arcor.de>