### PR TITLE
kernel: fix xt_connmark.h

### DIFF
--- a/target/linux/generic/hack-4.19/645-netfilter-connmark-introduce-set-dscpmark.patch
+++ b/target/linux/generic/hack-4.19/645-netfilter-connmark-introduce-set-dscpmark.patch
@@ -87,8 +87,8 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  };
  
  enum {
-+	XT_CONNMARK_VALUE = BIT(0),
-+	XT_CONNMARK_DSCP = BIT(1)
++	XT_CONNMARK_VALUE = (1 << 0),
++	XT_CONNMARK_DSCP = (1 << 1)
 +};
 +
 +enum {


### PR DESCRIPTION
Commit a1cfe0dcbb24 (kernel: connmark set-dscpmark follow upstreamimg
attempt") broke the usage of xt_connmark.h in user-space (e.g.
strongswan), because the BIT() macro is unknown there.

Fixes: a1cfe0dcbb24 (kernel: connmark set-dscpmark follow upstreamimg attempt")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
