### PR TITLE
base-files: add application led trigger backend

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -31,10 +31,11 @@ load_led() {
 	config_get gpio $1 gpio "0"
 	config_get inverted $1 inverted "0"
 
-	if [ "$trigger" = "rssi" ]; then
-		# handled by rssileds userspace process
-		return
-	fi
+	# execute application led trigger
+	[ -f "/usr/libexec/led-trigger/${trigger}" ] && {
+		. "/usr/libexec/led-trigger/${trigger}"
+		return 0
+	}
 
 	[ "$trigger" = "usbdev" ] && {
 		# Backward compatibility: translate to the new trigger

--- a/package/network/utils/rssileds/Makefile
+++ b/package/network/utils/rssileds/Makefile
@@ -40,6 +40,8 @@ define Package/rssileds/install
 	$(INSTALL_BIN) ./files/rssileds.init $(1)/etc/init.d/rssileds
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/rssileds $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/libexec/led-trigger
+	$(INSTALL_BIN) ./files/rssi $(1)/usr/libexec/led-trigger/
 endef
 
 $(eval $(call BuildPackage,rssileds))

--- a/package/network/utils/rssileds/files/rssi
+++ b/package/network/utils/rssileds/files/rssi
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+logger -t led-trigger "LED trigger rssi is handled by /etc/init.d/rssileds"


### PR DESCRIPTION
This is a follow up pullrequest from the discussion https://github.com/openwrt/luci/pull/2667#issuecomment-539525014 with @jow- 

This pullrequest creates the possibility to use application led trigger.
For now we only have [rssileds](https://github.com/openwrt/openwrt/tree/master/package/network/utils/rssileds) service in openwrt that could be called as an application led trigger.

- base-files: Add application led trigger backend
- rssileds: Add callback script to the new led trigger backend