### PR TITLE
tools/gmp: Remove obsolete options

### DIFF
--- a/tools/gmp/Makefile
+++ b/tools/gmp/Makefile
@@ -25,8 +25,7 @@ HOST_CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-shared \
 	--disable-assembly \
-	--enable-cxx \
-	--enable-mpbsd
+	--enable-cxx
 
 ifeq ($(GNU_HOST_NAME),x86_64-linux-gnux32)
 HOST_CONFIGURE_ARGS += ABI=x32


### PR DESCRIPTION
Remove mpbsd argument

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>