### PR TITLE
tools/sed: Update to 4.8

### DIFF
--- a/tools/sed/Makefile
+++ b/tools/sed/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=sed
-PKG_VERSION:=4.7
+PKG_VERSION:=4.8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
-PKG_HASH:=2885768cd0a29ff8d58a6280a270ff161f6a3deb5690b2be6c49f46d4c67bd6a
+PKG_HASH:=f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633
 export SED:=
 
 HOST_BUILD_PARALLEL:=1
@@ -24,7 +24,9 @@ include $(INCLUDE_DIR)/host-build.mk
 HOST_CONFIGURE_ARGS += \
 	--disable-acl \
 	--disable-nls \
-	--enable-threads=pth
+	--enable-threads=posix \
+	--disable-i18n \
+	--without-selinux
 
 HOST_CONFIGURE_VARS += \
 	ac_cv_search_setfilecon=no \


### PR DESCRIPTION
Update sed to 4.8
Use POSIX threads
Disable i18n and selinux support

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>