### PR TITLE
tools/bison: Update to 3.5.1

### DIFF
--- a/tools/bison/Makefile
+++ b/tools/bison/Makefile
@@ -7,17 +7,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bison
-PKG_VERSION:=3.5
+PKG_VERSION:=3.5.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
-PKG_HASH:=55e4a023b1b4ad19095a5f8279f0dc048fa29f970759cea83224a6d5e7a3a641
+PKG_HASH:=3e7e097bd9709a2d5e40e69446b74b149733b3de864fadb7a9b54eca7b2a4dd0
 
 HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
-HOST_CONFIGURE_ARGS += --enable-threads=pth
+HOST_CONFIGURE_ARGS += --enable-threads=posix --disable-nls
 
 define Host/Clean
 	-$(MAKE) -C $(HOST_BUILD_DIR) uninstall


### PR DESCRIPTION
Update bison to 3.5.1
Use POSIX threads
Disable NLS support

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>