### PR TITLE
ath79: add support for TP-Link TL-WA830RE v1

### DIFF
--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7240.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &ath9k;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_switch_led_pins>;
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x3d0000>;
+				label = "firmware";
+			};
+
+			art: partition@3f0000 {
+				reg = <0x3f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&uboot 0x1fc00>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pinmux {
+	pinmux_switch_led_pins: switch_led_pins {
+		pinctrl-single,bits = <0x0 0x0 0xf8>;
+	};
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa830re-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa830re-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7240_tplink_tl-wa.dtsi"
+
+/ {
+	model = "TP-Link TL-WA830RE v1";
+	compatible = "tplink,tl-wa830re-v1", "qca,ar7240";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -66,6 +66,16 @@ define Device/tplink_tl-mr3420-v2
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v2
 
+define Device/tplink_tl-wa830re-v1
+  $(Device/tplink-4m)
+  SOC := ar7240
+  DEVICE_MODEL := TL-WA830RE
+  DEVICE_VARIANT := v1
+  TPLINK_HWID := 0x08300010
+  SUPPORTED_DEVICES += tl-wa901nd
+endef
+TARGET_DEVICES += tplink_tl-wa830re-v1
+
 define Device/tplink_tl-wa850re-v1
   $(Device/tplink-4mlzma)
   SOC := ar9341

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -41,7 +41,8 @@ on,n150r)
 	ucidef_set_led_switch "lan2" "LAN2" "netgear:green:lan2" "switch0" "0x04" "0x0f"
 	;;
 tplink,tl-mr3020-v1|\
-tplink,tl-mr3040-v2)
+tplink,tl-mr3040-v2|\
+tplink,tl-wa830re-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ath79_setup_interfaces()
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\
+	tplink,tl-wa830re-v1|\
 	tplink,tl-wa850re-v1|\
 	tplink,tl-wa850re-v2|\
 	tplink,tl-wa901nd-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -10,6 +10,7 @@ case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
 	buffalo,whr-g301n|\
+	tplink,tl-wa830re-v1|\
 	tplink,tl-wr841-v5|\
 	tplink,tl-wr941-v4)
 		caldata_extract "art" 0x1000 0xeb8


### PR DESCRIPTION
This ports support for the TL-WA830RE v1 range extender from ar71xx to
ath79.

Specifications:
- SOC: Atheros AR7240
- CPU: 400MHz
- Flash: 4 MiB (Spansion S25FL032P)
- RAM: 32 MiB (Zentel A3S56D40FTP-G5)
- WLAN: Atheros AR9280 bgn 2x2
- Ethernet: 1 port (100M)

Flash instructions:
- install from u-boot with tftp (requires serial access)
  > setenv ipaddr a.b.c.d
  > setenv serverip e.f.g.h
  > tftpboot 0x80000000 \
      openwrt-ath79-tiny-tplink_tl-wa830re-v1-squashfs-factory.bin
  > erase 0x9f020000 +0x3c0000
  > cp.b 0x80000000 0x9f020000 0x3c0000
  > bootm 0x9f020000
- flash factory image from OEM WebUI
- sysupgrade from ar71xx image

Signed-off-by: Christian Buschau <christian.buschau@mailbox.org>