### PR TITLE
treewide: Drop usage of unzip and bzcat

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -128,10 +128,6 @@ $(eval $(call SetupHostCommand,stat,Cannot find a file stat utility, \
 	gstat -c%s $(TOPDIR)/Makefile, \
 	stat -c%s $(TOPDIR)/Makefile))
 
-$(eval $(call SetupHostCommand,unzip,Please install 'unzip', \
-	unzip 2>&1 | grep zipfile, \
-	unzip))
-
 $(eval $(call SetupHostCommand,bzip2,Please install 'bzip2', \
 	bzip2 --version </dev/null))
 

--- a/include/unpack.mk
+++ b/include/unpack.mk
@@ -7,7 +7,7 @@
 
 HOST_TAR:=$(TAR)
 TAR_CMD=$(HOST_TAR) -C $(1)/.. $(TAR_OPTIONS)
-UNZIP_CMD=unzip -q -d $(1)/.. $(DL_DIR)/$(PKG_SOURCE)
+UNZIP_CMD=bsdtar -C $(1)/.. -xf $(DL_DIR)/$(PKG_SOURCE)
 
 ifeq ($(PKG_SOURCE),)
   PKG_UNPACK ?= true
@@ -25,7 +25,7 @@ ifeq ($(strip $(UNPACK_CMD)),)
     endif
     ifeq ($(filter bzip2 bz2 bz tbz2 tbz,$(EXT)),$(EXT))
       EXT:=$(call ext,$(PKG_SOURCE:.$(EXT)=))
-      DECOMPRESS_CMD:=bzcat $(DL_DIR)/$(PKG_SOURCE) |
+      DECOMPRESS_CMD:=bsdcat $(DL_DIR)/$(PKG_SOURCE) |
     endif
     ifeq ($(filter xz txz,$(EXT)),$(EXT))
       EXT:=$(call ext,$(PKG_SOURCE:.$(EXT)=))

--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -7,7 +7,7 @@
 
 include $(TOPDIR)/rules.mk
 
-UNPACK_CMD=unzip -q -p $(DL_DIR)/$(PKG_SOURCE) $(PKG_SOURCE_UNZIP) | gzip -dc | $(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+UNPACK_CMD=bsdtar --to-stdout -xf $(DL_DIR)/$(PKG_SOURCE) $(PKG_SOURCE_UNZIP) | gzip -dc | $(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 PKG_NAME:=cypress-firmware
 PKG_VERSION:=v4.14.77-2020_0115

--- a/scripts/patch-kernel.sh
+++ b/scripts/patch-kernel.sh
@@ -28,7 +28,7 @@ for i in ${patchdir}/${patchpattern} ; do
 	*.bz2)
 	type="bzip2"; uncomp="bunzip2 -dc"; ;; 
 	*.zip)
-	type="zip"; uncomp="unzip -d"; ;; 
+	type="zip"; uncomp="bsdtar --to-stdout -xf"; ;;
 	*.Z)
 	type="compress"; uncomp="uncompress -c"; ;; 
 	*)


### PR DESCRIPTION
Remove unzip dependency and usage of both unzip and bzcat treewide
and use libarchive package instead.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>