### PR TITLE
ath79: add LED trigger for TL-WR902AC v1 WAN LED

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -219,6 +219,7 @@ tplink,cpe510-v3)
 tplink,cpe610-v1|\
 tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
+	ucidef_set_led_netdev "internet" "Internet" "tp-link:green:internet" "eth0"
 	;;
 tplink,re355-v1|\
 tplink,re450-v1|\


### PR DESCRIPTION
Inspired by commit c48b571ad708, add an LED trigger for the WAN LED on top of
the TP-Link TL-WR902AC v1. Currently, only the LED on the port itself shows the
link state, while the LED on top of the device stays dark.

The WAN port of the device is a hybrid LAN/WAN one, hence why the LED at the
port was labled LAN.

Compile/run-tested-on: TL-WR902AC V1 (ath79)

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>