### PR TITLE
[RFT] ath79: add gpio4 pinmux on TL-WR841N/ND v8/TL-WR842N v2/TL-MR3420 v2

### DIFF
--- a/target/linux/ath79/dts/ar9341_tplink.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink.dtsi
@@ -18,9 +18,6 @@
 	keys: keys {
 		compatible = "gpio-keys";
 
-		pinctrl-names = "default";
-		pinctrl-0 = <&jtag_disable_pins>;
-
 		rfkill {
 			label = "WiFi";
 			linux,code = <KEY_RFKILL>;
@@ -85,7 +82,14 @@
 };
 
 &gpio {
-	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins &pmx_usb_power>;
+};
+
+&pinmux {
+	pmx_usb_power: pinmux_usb_power {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
 };
 
 &eth0 {


### PR DESCRIPTION
This adds a pinmux to the shared DTSI for TP-Link TL-WR841N/ND v8,
TL-WR842N v2 and TL-MR3420 v2. It is supposed to be the equivalent
of:

/* config gpio4 as normal gpio function */
ath79_gpio_output_select(TL_MR3420V2_GPIO_USB_POWER,AR934X_GPIO_OUT_GPIO);

While at it, move the jtag_disable_pins to &gpio node and remove the
redundant status=okay there.

This should allow to enable USB power on these devices.

Fixes: FS#2753

---

This has been created based on a bug report:
https://bugs.openwrt.org/index.php?do=details&task_id=2753

There has been no feedback, so I need somebody to verify whether this is
working.