### PR TITLE
ramips: add support for MikroTik RouterBOARD 760iGS

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik.dtsi
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		led-boot = &led_usr;
+		led-failsafe = &led_usr;
+		led-running = &led_usr;
+		led-upgrade = &led_usr;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr {
+			label = "rb750gr3:blue:pwr";
+			gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_usr: usr {
+			label = "rb750gr3:green:usr";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "mode";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
+				read-only;
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0xf000>;
+					read-only;
+				};
+
+				hard_config: partition@f000 {
+					label = "hard_config";
+					reg = <0xf000 0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0xf000>;
+					read-only;
+				};
+
+				partition@20000 {
+					label = "soft_config";
+					reg = <0x20000 0x1000>;
+				};
+
+				partition@30000 {
+					label = "bios";
+					reg = <0x30000 0x1000>;
+					read-only;
+				};
+			};
+
+			partition@40000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x040000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&hard_config 0x10>;
+	mtd-mac-address-increment = <1>;
+};
+
+&state_default {
+	gpio {
+		/* via gpio7 (uart3 group) the PoE status can be read */
+		ralink,group = "uart2", "uart3", "jtag", "wdt";
+		ralink,function = "gpio";
+	};
+};
+
+&sdhci {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-rb760igs.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-rb760igs.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_mikrotik.dtsi"
+
+/ {
+	compatible = "mikrotik,rb760igs", "mediatek,mt7621-soc";
+	model = "MikroTik RouterBOARD 760iGS";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -490,6 +490,13 @@ define Device/mikrotik_rb750gr3
 endef
 TARGET_DEVICES += mikrotik_rb750gr3
 
+define Device/mikrotik_routerboard-rb760igs
+  $(Device/MikroTik)
+  DEVICE_MODEL := RouterBOARD RB760iGS
+  DEVICE_PACKAGES += kmod-gpio-beeper
+endef
+TARGET_DEVICES += mikrotik_routerboard-rb760igs
+
 define Device/mikrotik_rbm11g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M11G

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -115,6 +115,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "6@eth0"
 		;;
+	mikrotik,rb760igs)
+		ucidef_add_switch "switch0" \
+			"1:lan:2" "2:lan:3" "3:lan:4" "4:lan:5" "0:wan:1" "6@eth0"
+		;;
 	mikrotik,rbm11g|\
 	thunder,timecloud)
 		ucidef_add_switch "switch0"
@@ -248,6 +252,10 @@ ramips_setup_macs()
 	mikrotik,rb750gr3|\
 	mikrotik,rbm33g)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary hard_config 0x10)" 2)
+		label_mac=$(mtd_get_mac_binary hard_config 0x10)
+		;;
+	mikrotik,rb760igs)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary hard_config 0x10)" 1)
 		label_mac=$(mtd_get_mac_binary hard_config 0x10)
 		;;
 	netgear,r6260|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -7,7 +7,8 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-mikrotik,rb750gr3)
+mikrotik,rb750gr3|\
+mikrotik,rb760igs)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "17"
 	;;
 telco-electronics,x1)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,7 @@ platform_do_upgrade() {
 		}
 		;;
 	mikrotik,rb750gr3|\
+	mikrotik,rb760igs|\
 	mikrotik,rbm11g|\
 	mikrotik,rbm33g)
 		[ -z "$(rootfs_type)" ] && mtd erase firmware


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD 760iGS router.

Specifications:

- SoC: MediaTek MT7621A
- CPU: 880MHz
- Flash: 16 MB
- RAM:  256 MB
- Ethernet: 5x 10/100/1000 Mbps

To boot to intramfs image in RAM:

1. Setup TFTP server to serve intramfs image.
2. Plug Ethernet cable into WAN port.
3. Unplug power, hold reset button and plug power in.  Wait for beep and then release reset button.
4. Wait for a minute. Router should be running OpenWrt, check by plugging in to port 2-5 and going to 192.168.1.1.

To install OpenWrt to flash:

1. Follow steps above to boot intramfs image in RAM.
2. Go to the web interface.
3. Navigate to System->Backup/Flash Firmware.
4. Scroll down to "Flash new firmware image."
5. Click on "Flash image...".
6. Specify the sysupgrade.bin image and click Upload.
7. Once the router reboots you will be running OpenWrt from flash.

Signed-off-by: Vince Grassia <vincenzo.grassia@zionark.com>
