### PR TITLE
base-files: add all buildinfo with INCLUDE_CONFIG

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -100,7 +100,7 @@ menu "Global build settings"
 		bool "Include build configuration in firmware" if DEVEL
 		default n
 		help
-		  If enabled, config.buildinfo will be stored in /etc/build.config of firmware.
+		  If enabled, buildinfo files will be stored in /etc/build.* of firmware.
 
 	config COLLECT_KERNEL_DEBUG
 		bool

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -198,7 +198,9 @@ define Package/base-files/install
 
 	$(if $(CONFIG_INCLUDE_CONFIG), \
 		echo -e "# Build configuration for board $(BOARD)/$(SUBTARGET)/$(PROFILE)\n" >$(1)/etc/build.config; \
-		cat $(BIN_DIR)/config.buildinfo >>$(1)/etc/build.config)
+		cat $(BIN_DIR)/config.buildinfo >>$(1)/etc/build.config; \
+		cat $(BIN_DIR)/feeds.buildinfo >>$(1)/etc/build.feeds; \
+		cat $(BIN_DIR)/version.buildinfo >>$(1)/etc/build.version)
 
 	$(if $(CONFIG_CLEAN_IPKG),, \
 		mkdir -p $(1)/etc/opkg; \


### PR DESCRIPTION
CONFIG_INCLUDE_CONFIG option is helpful for being able to rebuild the
exact same firmware as you see on a live OpenWRT instance, but it's
crucially missing feeds information, so we can't rebuild the exact same
package versions. This commit fixes this by adding the remaining feeds
(and version) buildinfo files to the image.

Signed-off-by: Xu Wang <xwang1498@gmx.com>