### PR TITLE
libjson-c: fix aclocal version missing error

### DIFF
--- a/package/libs/libjson-c/Makefile
+++ b/package/libs/libjson-c/Makefile
@@ -22,6 +22,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:json-c_project:json-c
 
 PKG_FIXUP:=autoreconf
+PKG_REMOVE_FILES:=autogen.sh aclocal.m4
 PKG_INSTALL:=1
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>


### PR DESCRIPTION
Maintainer: @nbd168 cc: @jow- 
_(Is "nbd168" Felix Fietkau github account?)_

* allow full autoreconf, to avoid aclocal version missmatch

Fixes this error (debian9 on master):
```
make[3]: Entering directory '/root/openwrt/package/libs/libjson-c'
CFLAGS="-O2 -I/root/openwrt/staging_dir/host/include -I/root/openwrt/staging_dir/hostpkg/include -I/root/openwrt/staging_dir/target-mips_24kc_musl/host/include -Wno-implicit-fallthrough" CPPFLAGS="-I/root/openwrt/staging_dir/host/include -I/root/openwrt/staging_dir/hostpkg/include -I/root/openwrt/staging_dir/target-mips_24kc_musl/host/include" CXXFLAGS="" LDFLAGS="-L/root/openwrt/staging_dir/host/lib -L/root/openwrt/staging_dir/hostpkg/lib -L/root/openwrt/staging_dir/target-mips_24kc_musl/host/lib" make -j1 -C /root/openwrt/build_dir/hostpkg/json-c-0.13.1
make[4]: Entering directory '/root/openwrt/build_dir/hostpkg/json-c-0.13.1'
CDPATH="${ZSH_VERSION+.}:" && cd . && /usr/bin/env bash /root/openwrt/build_dir/hostpkg/json-c-0.13.1/missing aclocal-1.14
/root/openwrt/build_dir/hostpkg/json-c-0.13.1/missing: line 81: aclocal-1.14: command not found
WARNING: 'aclocal-1.14' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
Makefile:484: recipe for target 'aclocal.m4' failed
make[4]: *** [aclocal.m4] Error 127
make[4]: Leaving directory '/root/openwrt/build_dir/hostpkg/json-c-0.13.1'
Makefile:63: recipe for target '/root/openwrt/build_dir/hostpkg/json-c-0.13.1/.built' failed
make[3]: *** [/root/openwrt/build_dir/hostpkg/json-c-0.13.1/.built] Error 2
make[3]: Leaving directory '/root/openwrt/package/libs/libjson-c'
time: package/libs/libjson-c/host-compile#0.03#0.00#0.10
package/Makefile:111: recipe for target 'package/libs/libjson-c/host/compile' failed
make[2]: *** [package/libs/libjson-c/host/compile] Error 2
make[2]: Leaving directory '/root/openwrt'
package/Makefile:107: recipe for target '/root/openwrt/staging_dir/target-mips_24kc_musl/stamp/.package_compile' failed
make[1]: *** [/root/openwrt/staging_dir/target-mips_24kc_musl/stamp/.package_compile] Error 2
make[1]: Leaving directory '/root/openwrt'
/root/openwrt/include/toplevel.mk:225: recipe for target 'world' failed
make: *** [world] Error 2
```