### PR TITLE
ipq806x: fix L2 cache scaling & core1 voltage tolerance

### DIFF
--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -50,6 +50,7 @@
 			clock-names = "cpu", "l2";
 			clock-latency = <100000>;
 			cpu-supply = <&smb208_s2b>;
+			voltage-tolerance = <5>;
 			cooling-min-state = <0>;
 			cooling-max-state = <10>;
 			#cooling-cells = <2>;

--- a/target/linux/ipq806x/patches-4.14/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
+++ b/target/linux/ipq806x/patches-4.14/0055-cpufreq-dt-Add-L2-frequency-scaling-support.patch
@@ -11,7 +11,7 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
 
 --- a/drivers/cpufreq/cpufreq-dt.c
 +++ b/drivers/cpufreq/cpufreq-dt.c
-@@ -49,11 +49,41 @@ static int set_target(struct cpufreq_pol
+@@ -49,11 +49,42 @@ static int set_target(struct cpufreq_pol
  	struct private_data *priv = policy->driver_data;
  	int ret;
  	unsigned long target_freq = policy->freq_table[index].frequency * 1000;
@@ -43,6 +43,7 @@ Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
 +			l2_freq = clk_get_rate(l2_clk);
 +
 +			if (l2_freq != new_l2_freq) {
++				ret = clk_set_rate(l2_clk, policy->l2_rate[0]);
 +				/* scale l2 with the core */
 +				ret = clk_set_rate(l2_clk, new_l2_freq);
 +			}


### PR DESCRIPTION
A cherry-pick of some of @Ansuel 's work in master to fix and cleanup frequency scaling in ipq806x in 19.07. Tested on R7800 and verified with the **mbw** tool from @facboy.

The two commits below are back ported as is without any changes.

Backport of 77e7d6c20dc6d5e50600fb4d013f4b71341e4168

 * Voltage tolerance is accounted per core, not per cpu,
 * so add missing DT entry.

Backport of 5ab9c0b388e9cf2537ef23d6e9baaf5730a14a1c

 * It has been noticed a bug in L2 cache scaling where the scaling
 * is not done proprely if the frequency is not set to the initial
 * state before the new frequency.

Signed-off-by: Marc Benoit <marcb62185@gmail.com>