### PR TITLE
Enable HC5962 128MB /overlay space.

### DIFF
--- a/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
+++ b/target/linux/ramips/dts/mt7621_hiwifi_hc5962.dts
@@ -79,7 +79,7 @@
 
 		partition@340000 {
 			label = "ubi";
-			reg = <0x340000 0x1E00000>;
+			reg = <0x340000 0x7c40000>;
 		};
 
 		partition@2140000 {


### PR DESCRIPTION
partition@340000 {
	label = "ubi";
	reg = <0x340000 0x7c40000>;
};

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
