### PR TITLE
ath79: allow forceless sysupgrade from ar71xx on fritz300e

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -158,6 +158,7 @@ define Device/avm_fritz300e
 	append-squashfs-fakeroot-be | pad-to 256 | append-rootfs | pad-rootfs | \
 	append-metadata | check-size $$$$(IMAGE_SIZE)
   DEVICE_PACKAGES := fritz-tffs rssileds -swconfig
+  SUPPORTED_DEVICES += fritz300e
 endef
 TARGET_DEVICES += avm_fritz300e
 


### PR DESCRIPTION
Add original ar71xx board name `fritz300e` for **avm_fritz300e** as alias (`SUPPORTED_DEVICES +=`) here in ath79.

Original discussion: https://github.com/openwrt/openwrt/commit/07ce940b77e6aceb095b0a16dda41e190dfc5b87#commitcomment-37240003