### PR TITLE
ath79: add support for TP-Link Archer C60 v3

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
@@ -8,6 +8,18 @@
 	model = "TP-Link Archer C60 v2";
 };
 
+&leds {
+	wan_amber {
+		label = "tp-link:amber:wan";
+		gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+	};
+
+	wps {
+		label = "tp-link:green:wps";
+		gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+	};
+};
+
 &spi {
 	status = "okay";
 	num-cs = <1>;

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
@@ -4,24 +4,19 @@
 #include "qca9561_tplink_archer-c6x.dtsi"
 
 / {
-	compatible = "tplink,archer-c60-v1", "qca,qca9561";
-	model = "TP-Link Archer C60 v1";
+	compatible = "tplink,archer-c60-v3", "qca,qca9561";
+	model = "TP-Link Archer C60 v3";
 };
 
 &leds {
 	wan_amber {
 		label = "tp-link:amber:wan";
-		gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-	};
-
-	wps {
-		label = "tp-link:green:wps";
 		gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 	};
 };
-
 &spi {
 	status = "okay";
+
 	num-cs = <1>;
 
 	flash@0 {
@@ -35,26 +30,32 @@
 			#size-cells = <1>;
 
 			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x010000>;
+				label = "factory-boot";
+				reg = <0x000000 0x01fb00>;
 				read-only;
 			};
 
-			mac: partition@10000 {
+			mac: partition@1fb00 {
 				label = "mac";
-				reg = <0x010000 0x010000>;
+				reg = <0x01fb00 0x000500>;
 				read-only;
 			};
 
 			partition@20000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x020000 0x7c0000>;
+				label = "u-boot";
+				reg = <0x020000 0x010000>;
+				read-only;
 			};
 
-			partition@7e0000 {
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0x7a0000>;
+			};
+
+			partition@7d0000 {
 				label = "tplink";
-				reg = <0x7e0000 0x010000>;
+				reg = <0x7d0000 0x020000>;
 				read-only;
 			};
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c6x.dtsi
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c6x.dtsi
@@ -34,7 +34,7 @@
 		};
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 
 		led_power: power {
@@ -60,19 +60,9 @@
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 
-		wan_amber {
-			label = "tp-link:amber:wan";
-			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-		};
-
 		lan {
 			label = "tp-link:green:lan";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-		};
-
-		wps {
-			label = "tp-link:green:wps";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -177,7 +177,8 @@ tplink,archer-c58-v1|\
 tplink,archer-c59-v1|\
 tplink,archer-c59-v2|\
 tplink,archer-c60-v1|\
-tplink,archer-c60-v2)
+tplink,archer-c60-v2|\
+tplink,archer-c60-v3)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -82,6 +82,7 @@ ath79_setup_interfaces()
 	tplink,archer-c25-v1|\
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
+	tplink,archer-c60-v3|\
 	tplink,tl-wdr3500-v1|\
 	tplink,tl-wr842n-v1|\
 	tplink,tl-wr842n-v3|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -171,6 +171,7 @@ case "$FIRMWARE" in
 	tplink,archer-c59-v2|\
 	tplink,archer-c60-v1|\
 	tplink,archer-c60-v2|\
+	tplink,archer-c60-v3|\
 	tplink,archer-c6-v2|\
 	tplink,archer-c6-v2-us)
 		caldata_extract "art" 0x5000 0x2f20

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -135,6 +135,17 @@ define Device/tplink_archer-c60-v2
 endef
 TARGET_DEVICES += tplink_archer-c60-v2
 
+define Device/tplink_archer-c60-v3
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9561
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := Archer C60
+  DEVICE_VARIANT := v3
+  TPLINK_BOARD_ID := ARCHER-C60-V3
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_archer-c60-v3
+
 define Device/tplink_archer-c7-v1
   $(Device/tplink-8mlzma)
   SOC := qca9558

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1021,6 +1021,42 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the C60v3 */
+	{
+		.id     = "ARCHER-C60-V3",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:42520000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:45550000}\r\n"
+			"{product_name:Archer C60,product_ver:3.0.0,special_id:55530000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:3.0.0\n",
+
+		.partitions = {
+			{"factory-boot", 0x00000, 0x1fb00},
+			{"default-mac", 0x1fb00, 0x00200},
+			{"pin", 0x1fd00, 0x00100},
+			{"product-info", 0x1fe00, 0x00100},
+			{"device-id", 0x1ff00, 0x00100},
+			{"fs-uboot", 0x20000, 0x10000},
+			{"firmware", 0x30000, 0x7a0000},
+			{"soft-version", 0x7d9500, 0x00100},
+			{"support-list", 0x7d9600, 0x00100},
+			{"extra-para", 0x7d9700, 0x00100},
+			{"profile", 0x7d9800, 0x03000},
+			{"default-config", 0x7dc800, 0x03000},
+			{"partition-table", 0x7df800, 0x00800},
+			{"user-config", 0x7e0000, 0x0c000},
+			{"certificate", 0x7ec000, 0x04000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the C5 */
 	{
 		.id     = "ARCHER-C5-V2",
@@ -2172,6 +2208,7 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "ARCHER-C25-V1") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C59-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V2") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C60-V3") == 0 ||
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);


### PR DESCRIPTION
TP-Link Archer C60 v3 is a dual-band AC1350 router,
based on Qualcomm/Atheros QCA9561 + QCA9886.

Specification:

- 775/650/258 MHz (CPU/DDR/AHB)
- 64 MB of RAM (DDR2)
- 8 MB of FLASH (SPI NOR)
- 3T3R 2.4 GHz
- 2T2R 5 GHz
- 5x 10/100 Mbps Ethernet
- 7x LED, 2x button
- UART header on PCB

Flash instruction (WebUI):
Download *-factory.bin image and upload it via the firmwary upgrade
function of the stock firmware WebUI.

Flash instruction (TFTP):
1. Set PC to fixed IP address 192.168.0.66
2. Download *-factory.bin image and rename it to tp_recovery.bin
3. Start a tftp server with the file tp_recovery.bin in its root
   directory
4. Turn off the router
5. Press and hold reset button
6. Turn on router with the reset button pressed and wait ~15 seconds
7. Release the reset button and after a short time the firmware should
   be transferred from the tftp server
8. Wait ~30 second to complete recovery

---

This is based on a forum post of a ar71xx patch based on try/error on 18.06:
https://forum.openwrt.org/t/archer-c60-v3-is-possible-to-install-openwrt-firmware/41727/14
