### PR TITLE
tools: firmware-utils: tplink-safeloader: add support for TP-Link Archer A9-V6

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -692,6 +692,54 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the A9 v6*/
+	{
+		.id     = "ARCHER-A9-V6",
+		.support_list =
+            "SupportList:\n"
+			"{product_name:Archer A9,product_ver:6.0,special_id:55530000}\n"
+			"{product_name:Archer A9,product_ver:6.0,special_id:45550000}\n"
+			"{product_name:Archer A9,product_ver:6.0,special_id:52550000}\n"
+			"{product_name:Archer A1900,product_ver:6.0,special_id:4A500000}\n"
+			"{product_name:Archer C90,product_ver:6.0,special_id:55530000}\n",
+
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.0.99\n",
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"factory-boot",     0x00000,  0x20000},
+			{"fs-uboot",         0x20000,  0x20000},
+			{"partition-table",  0x40000,  0x10000},
+			{"radio",            0x50000,  0x10000},
+			{"default-mac",      0x60000,  0x00200},
+			{"pin",              0x60200,  0x00200},
+			{"device-id",        0x60400,  0x00100},
+			{"product-info",     0x60500,  0x0fb00},
+			{"soft-version",     0x70000,  0x01000},
+			{"extra-para",       0x71000,  0x01000},
+			{"support-list",     0x72000,  0x0a000},
+			{"profile",          0x7c000,  0x04000},
+			{"user-config",      0x80000,  0x10000},
+			{"ap-config",        0x90000,  0x10000},
+			{"apdef-config",     0xa0000,  0x10000},
+			{"router-config",    0xb0000,  0x10000},
+
+
+			{"firmware",        0xc0000,  0xf00000},	/* Stock: name os-image base 0xc0000  size 0x120000 */
+									/* Stock: name file-system base 0x1e0000 size 0xde0000 */
+
+			{"log",              0xfc0000,  0x20000},
+			{"certificate",      0xfe0000,  0x10000},
+			{"default-config",   0xff0000,  0x10000},
+            {NULL, 0, 0}
+
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the C2v3 */
 	{
 		.id     = "ARCHER-C2-V3",
@@ -2175,7 +2223,11 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
-	} else if (strcasecmp(info->id, "ARCHER-A7-V5") == 0 || strcasecmp(info->id, "ARCHER-C7-V4") == 0 || strcasecmp(info->id, "ARCHER-C7-V5") == 0) {
+	} else
+    if (strcasecmp(info->id, "ARCHER-A7-V5") == 0 ||
+	    strcasecmp(info->id, "ARCHER-A9-V6") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C7-V4") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C7-V5") == 0) {
 		const char mdat[11] = {0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0xca, 0x00, 0x01, 0x00, 0x00};
 		parts[5] = put_data("extra-para", mdat, 11);
 	} else if (strcasecmp(info->id, "ARCHER-C6-V2") == 0) {


### PR DESCRIPTION
tools: firmware-utils: tplink-safeloader: add support for TP-Link Archer A9-V6
TianYi Liao admin@gs320.com

p.s.
tplink-safeloader is work
firmware can flash in
but i not idea add devices support
ar71xx and ath79 i try
no uart and kernel crash god damm

and god damm A9-V6 SOC QCN5502 is MIPS 74K (ATH79)
who say QCN5502 is ARM?