### PR TITLE
ramips: add support for Netgear EX6100 v1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -11,7 +11,7 @@
 		led-upgrade = &led_power_green;
 	};
 
-	keys {
+	keys: keys {
 		compatible = "gpio-keys";
 
 		reset {
@@ -27,7 +27,7 @@
 		};
 	};
 
-	leds {
+	leds: leds {
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {

--- a/target/linux/ramips/dts/mt7620a_netgear_ex6100-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex6100-v1.dts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_netgear_ex3x00_ex61xx.dtsi"
+
+/ {
+	compatible = "netgear,ex6100-v1", "ralink,mt7620a-soc";
+	model = "Netgear EX6100 v1";
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		linux,code = <BTN_0>;
+		linux,input-type = <EV_SW>;
+		gpios = <&gpio2 30 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&leds {
+	router_arrow {
+		label = "blue:router-arrow";
+		gpios = <&gpio2 29 GPIO_ACTIVE_LOW>;
+	};
+
+	client_arrow {
+		label = "blue:client-arrow";
+		gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,port5 = "gmac";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -693,6 +693,20 @@ define Device/netgear_ex3700
 endef
 TARGET_DEVICES += netgear_ex3700
 
+define Device/netgear_ex6100-v1
+  SOC := mt7620a
+  NETGEAR_BOARD_ID := U12H248T00_NETGEAR
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGES += factory.chk
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size | netgear-chk
+  DEVICE_PACKAGES := kmod-mt76x0e rssileds
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := EX6100
+  DEVICE_VARIANT := v1
+endef
+TARGET_DEVICES += netgear_ex6100-v1
+
 define Device/netgear_ex6120
   SOC := mt7620a
   NETGEAR_BOARD_ID := U12H319T30_NETGEAR

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -158,6 +158,14 @@ netgear,ex6130)
 	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "green:router" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "green:device" "wlan1"
 	;;
+netgear,ex6100-v1)
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "routerlinkred" "Router Poor Link" "red:router" "wlan1" "1" "66"
+	ucidef_set_led_rssi "routerlinkgreen" "Router Best Link" "green:router" "wlan1" "34" "100"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "clientlinkred" "Client Poor Link" "red:device" "wlan0" "1" "66"
+	ucidef_set_led_rssi "clientlinkgreen" "Client Best Link" "green:device" "wlan0" "34" "100"
+	;;
 netgear,jwnr2010-v5)
 	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x08"
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -54,6 +54,7 @@ ramips_setup_interfaces()
 	microduino,microwrt|\
 	netgear,ex2700|\
 	netgear,ex3700|\
+	netgear,ex6100-v1|\
 	netgear,ex6120|\
 	netgear,ex6130|\
 	netgear,wn3000rp-v3|\


### PR DESCRIPTION
Specifications:
* SoC: MT7620A
* RAM: 64 MB DDR
* Flash: 8MB NOR SPI flash
* WiFi: MT7610E (5GHz) and builtin MT7620A (2.4GHz)
* LAN: 1x1000M (RTL8211E)

Installation:
The *-factory.chk images can be flashed from the
device's web interface or via nmrpflash.

Back to stock:
Use nmrpflash. Don't flash .chk firmware in OpenWrt.

This device is similar to EX6130, but uses RTL8211E for GbE LAN.

Thank @playya for his pull request #2286, this is based on it.
Thank @Icenowy for help making RTL8211E ethernet work.

5GHz WiFi is broken, maybe it's mt76 driver issue.
I don't have a device with GbE at this time so I don't know if GbE works. If you have this device please help test it, thanks!