### PR TITLE
ath79: add support for Ubiquiti NanoStation Loco M (XM)

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_nanostation-loco-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_nanostation-loco-m.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7241_ubnt_xm_outdoor.dtsi"
+
+/ {
+	compatible = "ubnt,nanostation-loco-m", "ubnt,xm", "qca,ar7241";
+	model = "Ubiquiti Nanostation Loco M";
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -244,6 +244,7 @@ trendnet,tew-823dru)
 	;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
+ubnt,nanostation-loco-m|\
 ubnt,nanostation-loco-m-xw|\
 ubnt,nanostation-m|\
 ubnt,nanostation-m-xw|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ath79_setup_interfaces()
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac-loco|\
+	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-loco-m-xw|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
@@ -425,6 +426,7 @@ ath79_setup_macs()
 		;;
 	ubnt,airrouter|\
 	ubnt,bullet-m|\
+	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
 	ubnt,rocket-m|\
 	ubnt,unifi)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -90,6 +90,7 @@ case "$FIRMWARE" in
 	tplink,tl-wr842n-v1|\
 	ubnt,airrouter|\
 	ubnt,bullet-m|\
+	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
 	ubnt,rocket-m)
 		caldata_extract "art" 0x1000 0x1000

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -179,6 +179,14 @@ define Device/ubnt_nanostation-ac-loco
 endef
 TARGET_DEVICES += ubnt_nanostation-ac-loco
 
+define Device/ubnt_nanostation-loco-m
+  $(Device/ubnt-xm)
+  DEVICE_MODEL := Nanostation Loco M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_nanostation-loco-m
+
 define Device/ubnt_nanostation-loco-m-xw
   $(Device/ubnt-xw)
   DEVICE_MODEL := Nanostation Loco M


### PR DESCRIPTION
This commit adds support for the NanoStation Loco M2/M5 XM devices on the ath79 target (support was long ago available on ar71xx).

Specifications:
* AR7241 SoC @400 MHz
* 32 MB RAM
* 8 MB SPI flash
* 1x 10/100 Mbps Ethernet, 24 Vdc PoE-in
* NS Loco M2: built-in antenna: 8 dBi; AR9287
* NS Loco M5: built-in antenna: 13 dBi; 2T2R 5 GHz radio
* POWER/LAN green LEDs
* 4x RSSI LEDs (red, orange, green, green)
* UART (115200 8N1) on PCB

Flashing via TFTP:
* Use a pointy tool (e.g., pen cap, paper clip) and keep the reset
  button on the device or on the PoE supply pressed
* Power on the device via PoE (keep reset button pressed)
* Keep pressing until LEDs flash alternatively LED1+LED3 => LED2+LED4 => LED1+LED3, etc.
* Release reset button
* The device starts a TFTP server at 192.168.1.20
* Set a static IP on the computer (e.g., 192.168.1.21/24)
* Upload via tftp the factory image:
  $ tftp 192.168.1.20
  tftp> bin
  tftp> trace
  tftp> put openwrt-ath79-generic-xxxxx-ubnt_nanostation-loco-m-squashfs-factory.bin
