### PR TITLE
ramips: add support for Netgear R6080

### DIFF
--- a/target/linux/ramips/dts/mt7628an_netgear_r6080.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6080.dts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6080", "mediatek,mt7628an-soc";
+	model = "Netgear R6080";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "r6080:green:lan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "r6080:green:power";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_green {
+			label = "r6080:green:wlan2g";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g_orange {
+			label = "r6080:orange:wlan2g";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_green {
+			label = "r6080:green:wan";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "r6080:orange:wan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		ralink,group = "p0led_an", "p1led_an", "p2led_an",
+					"p3led_an", "p4led_an", "wdt",
+					"wled_an";
+		ralink,function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <86000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "nvram";
+				reg = <0x60000 0x30000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0x760000>;
+			};
+
+			partition@7f0000 {
+				label = "reserved";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -40,17 +40,17 @@
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan {
+		wlan2g_green {
 			label = "r6120:green:wlan2g";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan_orange {
+		wlan2g_orange {
 			label = "r6120:orange:wlan2g";
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 
-		wan {
+		wan_green {
 			label = "r6120:green:wan";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6120.dts
@@ -43,6 +43,7 @@
 		wlan2g_green {
 			label = "r6120:green:wlan2g";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan2g_orange {

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -167,6 +167,26 @@ define Device/mercury_mac1200r-v2
 endef
 TARGET_DEVICES += mercury_mac1200r-v2
 
+define Device/netgear_r6080
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 7552k
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := R6080
+  DEVICE_PACKAGES := kmod-mt76x2
+  SERCOMM_HWID := CFR
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0040
+  IMAGES += factory.img
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
+	check-size
+  IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | \
+	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip R6080.bin | \
+	sercom-seal
+endef
+TARGET_DEVICES += netgear_r6080
+
 define Device/netgear_r6120
   BLOCKSIZE := 64k
   IMAGE_SIZE := 15744k

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -197,7 +197,7 @@ define Device/netgear_r6120
   SERCOMM_HWVER := A001
   SERCOMM_SWVER := 0x0040
   IMAGES += factory.img
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | \
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
 	pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
 	check-size $$$$(IMAGE_SIZE)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -40,14 +40,10 @@ hiwifi,hc5761a)
 mediatek,linkit-smart-7688)
 	ucidef_set_led_wlan "wifi" "wifi" "linkit-smart-7688:orange:wifi" "phy0tpt"
 	;;
-netgear,r6080)
-	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
-	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
-	;;
+netgear,r6080|\
 netgear,r6120)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
-	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"
 	;;
 rakwireless,rak633)
 	set_wifi_led "$boardname:blue:wifi"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -40,6 +40,10 @@ hiwifi,hc5761a)
 mediatek,linkit-smart-7688)
 	ucidef_set_led_wlan "wifi" "wifi" "linkit-smart-7688:orange:wifi" "phy0tpt"
 	;;
+netgear,r6080)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
+	;;
 netgear,r6120)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -90,6 +90,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch_attr "switch0" "enable" "false"
 		ucidef_set_interface_lan "eth0"
 		;;
+	netgear,r6080|\
 	netgear,r6120)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
@@ -147,6 +148,7 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	duzun,dm06|\
+	netgear,r6080|\
 	netgear,r6120|\
 	wrtnode,wrtnode2p|\
 	wrtnode,wrtnode2r|\


### PR DESCRIPTION
This adds support for the Netgear R6080, aka Netgear AC1000. 

The R6080 has almost the same hardware as the Netgear R6120,
aka Netgear AC1200. Significant adaptations:
- Removed kernel module packages providing USB support
- Remapped MTD partitions to fit within 8 MiB, instead of 16 MiB.
- Used correct SERCOMM_HWID in image header, which otherwise would
cause rejection of the image.

Specification:
- SoC: MediaTek MT7628 (580 MHz)
- Flash: 8 MiB
- RAM: 64 MiB
- Wireless: 2.4Ghz (builtin) and 5Ghz (MT7612E)
- LAN speed: 10/100
- LAN ports: 4
- WAN speed: 10/100
- WAN ports: 1
- UART (57600 8N1) on PCB

For initial flash, use nmrpflash with the resulting factory.img file, as
detailed on the R6120 wiki page. Once OpenWRT has been installed,
subsequent flashes can use the web interface and sysupgrade files.

Signed-off-by: Alex Lewontin <alex.c.lewontin@gmail.com>
