### PR TITLE
ltq-vdsl-mei, x86: avoid underscore in package names

### DIFF
--- a/package/kernel/lantiq/ltq-vdsl-mei/Makefile
+++ b/package/kernel/lantiq/ltq-vdsl-mei/Makefile
@@ -38,7 +38,7 @@ define KernelPackage/ltq-vdsl-vr9-mei/description
 endef
 
 
-define Package/ltq-vdsl-mei_test
+define Package/ltq-vdsl-mei-test
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Lantiq mei driver test tool
@@ -46,7 +46,7 @@ define Package/ltq-vdsl-mei_test
   DEPENDS:=@TARGET_lantiq_xrx200
 endef
 
-define Package/ltq-vdsl-mei_test/description
+define Package/ltq-vdsl-mei-test/description
 	Userland tool to directly control the mei driver, this is only needed
 	for test and development purposes.
 endef
@@ -80,9 +80,9 @@ endef
 
 $(eval $(call KernelPackage,ltq-vdsl-vr9-mei))
 
-define Package/ltq-vdsl-mei_test/install
+define Package/ltq-vdsl-mei-test/install
 	$(INSTALL_DIR) $(1)/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/mei_cpe_drv_test $(1)/bin
 endef
 
-$(eval $(call BuildPackage,ltq-vdsl-mei_test))
+$(eval $(call BuildPackage,ltq-vdsl-mei-test))

--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -20,7 +20,7 @@ endef
 
 $(eval $(call KernelPackage,sound-cs5535audio))
 
-define KernelPackage/sp5100_tco
+define KernelPackage/sp5100-tco
   SUBMENU:=$(OTHER_MENU)
   TITLE:=SP5100 Watchdog Support
   DEPENDS:=@TARGET_x86
@@ -29,8 +29,8 @@ define KernelPackage/sp5100_tco
   AUTOLOAD:=$(call AutoLoad,50,sp5100_tco,1)
 endef
 
-define KernelPackage/sp5100_tco/description
+define KernelPackage/sp5100-tco/description
  Kernel module for the SP5100_TCO hardware watchdog.
 endef
 
-$(eval $(call KernelPackage,sp5100_tco))
+$(eval $(call KernelPackage,sp5100-tco))


### PR DESCRIPTION
As 07e1d88d7beb ("kernel: avoid underscore in *6lowpan package names") shows,
underscores might cause build failures. Replace underscore with dash.
