### PR TITLE
urandom-seed, urngd: avoid PKG_NAME in define lines

### DIFF
--- a/package/system/urandom-seed/Makefile
+++ b/package/system/urandom-seed/Makefile
@@ -2,10 +2,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=urandom-seed
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
-PKG_LICENSE:=GPL-2.0
-
-PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+PKG_RELEASE:=2
+PKG_LICENSE:=GPL-2.0-only
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -14,7 +12,7 @@ define Package/urandom-seed
   CATEGORY:=Base system
   DEPENDS:=+getrandom
   TITLE:=/etc/urandom.seed handling for OpenWrt
-  URL:=http://openwrt.org/
+  URL:=https://openwrt.org/
 endef
 
 define Build/Prepare


### PR DESCRIPTION
> Avoid reuse of PKG_NAME in call, define and eval lines for consistency and
> readability. Write the full name instead.

Ref: https://openwrt.org/docs/guide-developer/packages

While at it, remove urandom-seed definition from base-files Makefile.