### PR TITLE
mac80211: fix symbol dependency problem of rt2x00lib kernel module

### DIFF
--- a/package/kernel/mac80211/patches/rt2x00/604-rt2x00-load-eeprom-on-SoC-from-a-mtd-device-defines-.patch
+++ b/package/kernel/mac80211/patches/rt2x00/604-rt2x00-load-eeprom-on-SoC-from-a-mtd-device-defines-.patch
@@ -22,17 +22,20 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	  Supported chips: RT2880, RT3050, RT3052, RT3350, RT3352.
 --- a/drivers/net/wireless/ralink/rt2x00/rt2x00eeprom.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2x00eeprom.c
-@@ -26,11 +26,72 @@
+@@ -26,11 +26,76 @@
  
  #include <linux/kernel.h>
  #include <linux/module.h>
++#if IS_ENABLED(CONFIG_MTD)
 +#include <linux/mtd/mtd.h>
 +#include <linux/mtd/partitions.h>
++#endif
  #include <linux/of.h>
  
  #include "rt2x00.h"
  #include "rt2x00lib.h"
  
++#if IS_ENABLED(CONFIG_MTD)
 +static int rt2800lib_read_eeprom_mtd(struct rt2x00_dev *rt2x00dev)
 +{
 +	int ret = -EINVAL;
@@ -91,16 +94,19 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +	return ret;
 +}
++#endif
 +
  static const char *
  rt2x00lib_get_eeprom_file_name(struct rt2x00_dev *rt2x00dev)
  {
-@@ -58,6 +119,9 @@ static int rt2x00lib_request_eeprom_file
+@@ -58,6 +123,11 @@ static int rt2x00lib_request_eeprom_file
  	const char *ee_name;
  	int retval;
  
++#if IS_ENABLED(CONFIG_MTD)
 +	if (!rt2800lib_read_eeprom_mtd(rt2x00dev))
 +		return 0;
++#endif
 +
  	ee_name = rt2x00lib_get_eeprom_file_name(rt2x00dev);
  	if (!ee_name && test_bit(REQUIRE_EEPROM_FILE, &rt2x00dev->cap_flags)) {


### PR DESCRIPTION
This pull request fixes a problem with the rt2x00lib kernel module,
which was reported here:
https://forum.openwrt.org/t/problem-with-tp-link-tl-wn7200nd-in-openwrt-snapshot/45005

A previous commit made the rt2x00lib module depend on the mtd
module and selectively enabled the mtd module for two SoC's. On
all other systems, the rt2x00lib would still depend on a symbol
defined by the mtd module, but the mtd module would not get built.
That resulted in an error when trying to load the rt2x00lib module
("Unknown symbol get_mtd_device_nm").

This commit disables the code that said patch adds on all systems
but the two SoC's for which it adds the mtd dependency. I believe
that this is what the original patch meant to do.

Signed-off-by: Sven Over <sp@cedenti.st>