### PR TITLE
ath79: fix spi-max-frequency for wAP G-5HacT2HnD

### DIFF
--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -73,7 +73,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <104000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
The introduction of ebf0d8dade (ath79: add new ar934x spi driver)
made the SPI memory unusable. Reducing the spi-max-frequency to
a smaller value makes it work again.

Tested on two MikroTik RouterBOARD wAP G-5HacT2HnD devices.