### PR TITLE
ath79: get rid of BOARD_NAME for RouterBOARD 922UAGS-5HPacD

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -742,8 +742,13 @@ platform_do_upgrade_mikrotik_rb() {
 	local fw_mtd=$(find_mtd_part kernel)
 	fw_mtd="${fw_mtd/block/}"
 	[ -n "$fw_mtd" ] || return
+
+	local board_dir=$(tar tf "$1" | grep -m 1 '^sysupgrade-.*/$')
+	board_dir=${board_dir%/}
+	[ -n "$board_dir" ] || return
+
 	mtd erase kernel
-	tar xf "$1" sysupgrade-routerboard/kernel -O | nandwrite -o "$fw_mtd" -
+	tar xf "$1" ${board_dir}/kernel -O | nandwrite -o "$fw_mtd" -
 
 	nand_do_upgrade "$1"
 }

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -115,7 +115,6 @@ define Device/mikrotik_routerboard-922uags-5hpacd
   $(Device/mikrotik)
   SOC := qca9558
   DEVICE_MODEL := RouterBOARD 922UAGS-5HPacD
-  BOARD_NAME := routerboard
   IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct \

--- a/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/nand/base-files/lib/upgrade/platform.sh
@@ -12,11 +12,17 @@ RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 platform_do_upgrade_mikrotik_nand() {
 	CI_KERNPART=none
+
 	local fw_mtd=$(find_mtd_part kernel)
 	fw_mtd="${fw_mtd/block/}"
 	[ -n "$fw_mtd" ] || return
+
+	local board_dir=$(tar tf "$1" | grep -m 1 '^sysupgrade-.*/$')
+	board_dir=${board_dir%/}
+	[ -n "$board_dir" ] || return
+
 	mtd erase kernel
-	tar xf "$1" sysupgrade-routerboard/kernel -O | nandwrite -o "$fw_mtd" -
+	tar xf "$1" ${board_dir}/kernel -O | nandwrite -o "$fw_mtd" -
 
 	nand_do_upgrade "$1"
 }


### PR DESCRIPTION
So far, specifying "BOARD_NAME := routerboard" is required by the
upgrade code of Mikrotik NAND devices, as "sysupgrade-routerboard"
is hardcoded in platform_do_upgrade_mikrotik_nand().

This patch replaces the latter with a grep for the name like it
is already done in nand_upgrade_tar() in /lib/upgrade/nand.sh.

By that, BOARD_NAME is obsolete now for this device.