### PR TITLE
ath79: set read-only soft_config for wAP G-5HacT2HnD

### DIFF
--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -107,6 +107,7 @@
 			partition@1f000 {
 				label = "soft_config";
 				reg = <0x001f000 0x001000>;
+				read-only;
 			};
 
 			partition@20000 {


### PR DESCRIPTION
Writing to the "soft_config" partition, which holds the bootloader settings, erases the contents of the previous "routerboot2" partition containing the bootloader. This happens both with mtd:

root@OpenWrt:~# md5sum /dev/mtd3 /dev/mtd4 \
 && mtd erase /dev/mtd4 && md5sum /dev/mtd3 /dev/mtd4
f386109e1ace46e75c47258aa989a8ab  /dev/mtd3
fd8f4830588d8a82ad33edca53eaed43  /dev/mtd4
Unlocking /dev/mtd4 ...
Erasing /dev/mtd4 ...
1f9cb533ace6468f61b00b75d97f5364  /dev/mtd3
6ae59e64850377ee5470c854761551ea  /dev/mtd4

and with the rbcfg tool:

root@OpenWrt:~# md5sum /dev/mtd3 /dev/mtd4 \
 && rbcfg apply && md5sum /dev/mtd3 /dev/mtd4
f386109e1ace46e75c47258aa989a8ab  /dev/mtd3
fd8f4830588d8a82ad33edca53eaed43  /dev/mtd4
1f9cb533ace6468f61b00b75d97f5364  /dev/mtd3
fd8f4830588d8a82ad33edca53eaed43  /dev/mtd4

Furthermore, since the "routerboot2" partition is read-only, it can not be easily restored. Therefore, to prevent accidental erasure of the bootloader, make the "soft_config" read-only. This is meant to be a temporary workaround, until whatever is causing the erasure of the two partitions is fixed.