### PR TITLE
lldpd: add management IP setting

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://media.luffy.cx/files/lldpd

--- a/package/network/services/lldpd/files/lldpd.config
+++ b/package/network/services/lldpd/files/lldpd.config
@@ -5,13 +5,15 @@ config lldpd config
 	option enable_edp 1
 
 	option agentxsocket /var/run/agentx.sock
-	
+
 	option lldp_class 4
 	option lldp_location "2:FR:6:Commercial Rd:3:Roseville:19:4"
 
 	# if empty, the distribution description is sent
 	#option lldp_description "OpenWrt System"
 	#option lldp_hostname "Modified Hostname"
+
+	#option lldp_mgmt_ip "!192.168.1.1"
 
 	# interfaces to listen on
 	list interface "loopback"

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -42,11 +42,15 @@ write_lldpd_conf()
 		fi
 	done
 
+	local lldp_mgmt_ip
+	config_get lldp_mgmt_ip 'config' 'lldp_mgmt_ip'
+
 	# Clear out the config file first
 	echo -n > "$LLDPD_CONF"
 	[ -n "$ifnames" ] && echo "configure system interface pattern" "$ifnames" >> "$LLDPD_CONF"
 	[ -n "$lldp_description" ] && echo "configure system description" "\"$lldp_description\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
+	[ -n "$lldp_mgmt_ip" ] && echo "configure system ip management pattern" "\"$lldp_mgmt_ip\"" >> "$LLDPD_CONF"
 
 	# Since lldpd's sysconfdir is /tmp, we'll symlink /etc/lldpd.d to /tmp/$LLDPD_CONFS_DIR
 	[ -e $LLDPD_CONFS_DIR ] || ln -s /etc/lldpd.d $LLDPD_CONFS_DIR
@@ -103,6 +107,8 @@ reload_service() {
 		unconfigure lldp custom-tlv
 		unconfigure system interface pattern
 		unconfigure system description
+		unconfigure system hostname
+		unconfigure system ip management pattern
 	EOF
 	# Rewrite lldpd.conf
 	# If something changed it should be included by the lldpcli call


### PR DESCRIPTION
add option to set management IP pattern

also add missing 'unconfigure system hostname'

for exampe pattern '!192.168.1.1' makes it possible that
WAN IP is selected instead LAN IP

Signed-off-by: Daniel A. Maierhofer <git@damadmai.at>