### PR TITLE
[RFC] ath79: add read support using spi-mem

### DIFF
--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -109,6 +109,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -112,6 +112,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ath79/patches-4.19/410-spi-ath79-Implement-the-spi_mem-interface.patch
+++ b/target/linux/ath79/patches-4.19/410-spi-ath79-Implement-the-spi_mem-interface.patch
@@ -1,0 +1,70 @@
+From 8d8cdb4a6ccee5b62cc0dc64651c3946364514dc Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Mon, 10 Feb 2020 16:11:27 -0300
+Subject: [PATCH] spi: ath79: Implement the spi_mem interface
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/spi/spi-ath79.c | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+Index: linux-4.19.106/drivers/spi/spi-ath79.c
+===================================================================
+--- linux-4.19.106.orig/drivers/spi/spi-ath79.c
++++ linux-4.19.106/drivers/spi/spi-ath79.c
+@@ -19,6 +19,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/io.h>
+ #include <linux/spi/spi.h>
++#include <linux/spi/spi-mem.h>
+ #include <linux/spi/spi_bitbang.h>
+ #include <linux/bitops.h>
+ #include <linux/gpio.h>
+@@ -203,6 +204,39 @@ static u32 ath79_spi_txrx_mode0(struct s
+ 	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
+ }
+ 
++static int ath79_exec_mem_op(struct spi_mem *mem,
++                              const struct spi_mem_op *op)
++{
++	struct ath79_spi *sp = ath79_spidev_to_sp(mem->spi);
++
++	/* Ensures that reading is performed on device connected
++	   to hardware cs0 */
++	if (mem->spi->chip_select || gpio_is_valid(mem->spi->cs_gpio))
++		return -ENOTSUPP;
++
++	/* Only use for fast-read op. */
++	if (op->cmd.opcode != 0x0b || op->data.dir != SPI_MEM_DATA_IN ||
++	    op->addr.nbytes != 3 || op->dummy.nbytes != 1)
++		return -ENOTSUPP;
++
++	/* disable GPIO mode */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_FS, 0);
++
++	memcpy_fromio(op->data.buf.in, sp->base + op->addr.val, op->data.nbytes);
++
++	/* enable GPIO mode */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_FS, AR71XX_SPI_FS_GPIO);
++
++	/* restore IOC register */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_IOC, sp->ioc_base);
++
++	return 0;
++}
++
++static const struct spi_controller_mem_ops ath79_mem_ops = {
++	.exec_op = ath79_exec_mem_op,
++};
++
+ static int ath79_spi_probe(struct platform_device *pdev)
+ {
+ 	struct spi_master *master;
+@@ -237,6 +271,7 @@ static int ath79_spi_probe(struct platfo
+ 		ret = PTR_ERR(sp->base);
+ 		goto err_put_master;
+ 	}
++	master->mem_ops = &ath79_mem_ops;
+ 
+ 	sp->clk = devm_clk_get(&pdev->dev, "ahb");
+ 	if (IS_ERR(sp->clk)) {

--- a/target/linux/ath79/patches-5.4/410-spi-ath79-Implement-the-spi_mem-interface.patch
+++ b/target/linux/ath79/patches-5.4/410-spi-ath79-Implement-the-spi_mem-interface.patch
@@ -1,0 +1,70 @@
+From 8d8cdb4a6ccee5b62cc0dc64651c3946364514dc Mon Sep 17 00:00:00 2001
+From: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+Date: Mon, 10 Feb 2020 16:11:27 -0300
+Subject: [PATCH] spi: ath79: Implement the spi_mem interface
+
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/spi/spi-ath79.c | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+Index: linux-5.4.22/drivers/spi/spi-ath79.c
+===================================================================
+--- linux-5.4.22.orig/drivers/spi/spi-ath79.c
++++ linux-5.4.22/drivers/spi/spi-ath79.c
+@@ -15,6 +15,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/io.h>
+ #include <linux/spi/spi.h>
++#include <linux/spi/spi-mem.h>
+ #include <linux/spi/spi_bitbang.h>
+ #include <linux/bitops.h>
+ #include <linux/clk.h>
+@@ -133,6 +134,39 @@ static u32 ath79_spi_txrx_mode0(struct s
+ 	return ath79_spi_rr(sp, AR71XX_SPI_REG_RDS);
+ }
+ 
++static int ath79_exec_mem_op(struct spi_mem *mem,
++                              const struct spi_mem_op *op)
++{
++	struct ath79_spi *sp = ath79_spidev_to_sp(mem->spi);
++
++	/* Ensures that reading is performed on device connected
++	   to hardware cs0 */
++	if (mem->spi->chip_select || mem->spi->cs_gpiod)
++		return -ENOTSUPP;
++
++	/* Only use for fast-read op. */
++	if (op->cmd.opcode != 0x0b || op->data.dir != SPI_MEM_DATA_IN ||
++	    op->addr.nbytes != 3 || op->dummy.nbytes != 1)
++		return -ENOTSUPP;
++
++	/* disable GPIO mode */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_FS, 0);
++
++	memcpy_fromio(op->data.buf.in, sp->base + op->addr.val, op->data.nbytes);
++
++	/* enable GPIO mode */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_FS, AR71XX_SPI_FS_GPIO);
++
++	/* restore IOC register */
++	ath79_spi_wr(sp, AR71XX_SPI_REG_IOC, sp->ioc_base);
++
++	return 0;
++}
++
++static const struct spi_controller_mem_ops ath79_mem_ops = {
++	.exec_op = ath79_exec_mem_op,
++};
++
+ static int ath79_spi_probe(struct platform_device *pdev)
+ {
+ 	struct spi_master *master;
+@@ -163,6 +197,7 @@ static int ath79_spi_probe(struct platfo
+ 		ret = PTR_ERR(sp->base);
+ 		goto err_put_master;
+ 	}
++	master->mem_ops = &ath79_mem_ops;
+ 
+ 	sp->clk = devm_clk_get(&pdev->dev, "ahb");
+ 	if (IS_ERR(sp->clk)) {


### PR DESCRIPTION
kernel 4.18 dropped fast flash interface (torvalds/linux@cfd12db4f12383506ca81fddd0f20921f166afd0) in favor to a new generic [spi-mem](https://bootlin.com/blog/spi-mem-bringing-some-consistency-to-the-spi-memory-ecosystem/) interface. During upgrade from 4.14 and 4.19, the [fast_flash patch](https://github.com/openwrt/openwrt/blob/3771176c9ef9b5d231e9019bc0c872dbe3617209/target/linux/ath79/patches-4.14/461-spi-ath79-add-fast-flash-read.patch) was dropped from openwrt (3771176c9ef9b5d231e9019bc0c872dbe3617209). This resulted in slower read speed for some devices while it also uncovered a possible hardware bug with tplink,tl-wr2543-v1.

This patch was tested with tplink,tl-wr2543-v1, with 3x speed up and tplink,archer-c7-v2 with no speed up (after adding m25p,fast-read).