### PR TITLE
ramips: add support for I-O DATA WN-AX2033GR

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-ax2033gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-AX2033GR";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "Backup";
+		reg = <0x6b00000 0x1480000>;
+		read-only;
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2483000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 5710000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -374,6 +374,22 @@ define Device/iodata_wn-ax1167gr2
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr2
 
+define Device/iodata_wn-ax2033gr
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  UIMAGE_MAGIC := 0x434f4d42
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 51200k
+  DEVICE_VENDOR := I-O DATA
+  DEVICE_MODEL := WN-AX2033GR
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(VST.1)C10 | \
+	iodata-mstc-header
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e wpad-basic
+endef
+TARGET_DEVICES += iodata_wn-ax2033gr
+
 define Device/iodata_wn-dx1167r
   BLOCKSIZE := 128k
   PAGESIZE := 2048

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -73,6 +73,7 @@ ramips_setup_interfaces()
 	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
 	iodata,wn-ax1167gr2|\
+	iodata,wn-ax2033gr|\
 	iodata,wn-dx1167r|\
 	iodata,wn-gx300gr|\
 	iodata,wnpr2600g|\
@@ -225,6 +226,7 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
 	iodata,wn-ax1167gr2|\
+	iodata,wn-ax2033gr|\
 	iodata,wn-dx1167r|\
 	xiaomi,mir3g-v2)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -55,6 +55,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	iodata,wn-ax1167gr2|\
+	iodata,wn-ax2033gr|\
 	iodata,wn-dx1167r)
 		iodata_mstc_upgrade_prepare
 		nand_do_upgrade "$1"


### PR DESCRIPTION
I-O DATA WN-AX2033GR is roughly the same as I-O DATA
WN-AX1167GR2. The difference is Wi-Fi feature.

Specification
-------------
- SoC: MediaTek MT7621A
- RAM: DDR3 128 MiB
- Flash Memory: NAND 128 MiB (Spansion S34ML01G200TF100)
- Wi-Fi: MediaTek MT7603E
- Wi-Fi: MediaTek MT7615
- Ethernet: 5x 10 Mbps / 100 Mbps / 1000 Mbps (1x WAN, 4x LAN)
- LED: 2x green LED
- Input: 2x tactile switch, 1x slide switch
- Serial console: 57600bps, PCB through hole J5 (Vcc, TX, RX, NC, GND)
- Power: DC 12V

Flash instruction
-----------------
1. Open the router management page (192.168.0.1).
2. Update router firmware using "initramfs-kernel.bin".
3. After updating, run sysupgrade with "sysupgrade.bin".

Signed-off-by: Yanase Yuki <dev@zpc.sakura.ne.jp>

