### PR TITLE
dnsmasq: dnssec+ntp initscript fixes

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -962,10 +962,9 @@ dnsmasq_start()
 		xappend "--conf-file=$TRUSTANCHORSFILE"
 		xappend "--dnssec"
 		[ -x /etc/init.d/sysntpd ] && {
-			/etc/init.d/sysntpd enabled
-			[ "$?" -ne 0 -o "$(uci_get system.ntp.enabled)" = "1" ] && {
+			if /etc/init.d/sysntpd enabled || [ "$(uci_get system.ntp.enabled)" = "1" ] ; then
 				[ -f "$TIMEVALIDFILE" ] || xappend "--dnssec-no-timecheck"
-			}
+			fi
 		}
 		config_get_bool dnsseccheckunsigned "$cfg" dnsseccheckunsigned 1
 		[ "$dnsseccheckunsigned" -eq 0 ] && xappend "--dnssec-check-unsigned=no"

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -207,7 +207,7 @@ filter_dnsmasq() {
 
 	# use entry when no instance entry set, or if it matches
 	config_get found_cfg "$cfg" "instance"
-	if [ -z "$found_cfg" -o "$found_cfg" = "$match_cfg" ]; then
+	if [ -z "$found_cfg" ] || [ "$found_cfg" = "$match_cfg" ]; then
 		$func $cfg
 	fi
 }
@@ -326,10 +326,10 @@ dhcp_host_add() {
 	config_get ip "$cfg" ip
 	config_get hostid "$cfg" hostid
 
-	[ -n "$ip" -o -n "$name" -o -n "$hostid" ] || return 0
+	[ -z "$ip" ] && [ -z "$name" ] && [ -z "$hostid" ] && return 0
 
 	config_get_bool dns "$cfg" dns 0
-	[ "$dns" = "1" -a -n "$ip" -a -n "$name" ] && {
+	[ "$dns" = "1" ] && [ -n "$ip" ] && [ -n "$name" ] && {
 		echo "$ip $name${DOMAIN:+.$DOMAIN}" >> $HOSTFILE_TMP
 	}
 
@@ -343,13 +343,13 @@ dhcp_host_add() {
 		for m in $mac; do append macs "$m" ","; done
 	fi
 
-	if [ $DNSMASQ_DHCP_VER -eq 6 -a -n "$duid" ]; then
+	if [ $DNSMASQ_DHCP_VER -eq 6 ] && [ -n "$duid" ]; then
 		# --dhcp-host=id:00:03:00:01:12:00:00:01:02:03,[::beef],lap
 		# one (virtual) machine gets one DUID per RFC3315
 		duids="id:${duid// */}"
 	fi
 
-	if [ -z "$macs" -a -z "$duids" ]; then
+	if [ -z "$macs" ] && [ -z "$duids" ]; then
 		# --dhcp-host=lap,192.168.0.199,[::beef]
 		[ -n "$name" ] || return 0
 		macs="$name"
@@ -416,7 +416,7 @@ dhcp_this_host_add() {
 				dhcp_domain_add "" "$routername" "$lanaddr"
 			fi
 
-			if [ -n "$ulaprefix" -a -n "$lanaddrs6" ] ; then
+			if [ -n "$ulaprefix" ] && [ -n "$lanaddrs6" ] ; then
 				for lanaddr6 in $lanaddrs6 ; do
 					case "$lanaddr6" in
 					"${ulaprefix%%:/*}"*)
@@ -472,7 +472,7 @@ dhcp_boot_add() {
 	config_get servername "$cfg" servername
 	config_get serveraddress "$cfg" serveraddress
 
-	[ -n "$serveraddress" -a ! -n "$servername" ] && return 0
+	[ -n "$serveraddress" ] && [ ! -n "$servername" ] && return 0
 
 	xappend "--dhcp-boot=${networkid:+net:$networkid,}${filename}${servername:+,$servername}${serveraddress:+,$serveraddress}"
 
@@ -566,7 +566,7 @@ dhcp_add() {
 	fi
 
 
-	if [ $DNSMASQ_DHCP_VER -eq 6 -a "$ra" = "server" ] ; then
+	if [ $DNSMASQ_DHCP_VER -eq 6 ] && [ "$ra" = "server" ] ; then
 		# Note: dnsmasq cannot just be a DHCPv6 server (all-in-1)
 		# and let some other machine(s) send RA pointing to it.
 
@@ -805,13 +805,13 @@ dnsmasq_start()
 	$PROG --version | grep -osqE "^Compile time options:.* DHCPv6( |$)" && DHCPv6CAPABLE=1 || DHCPv6CAPABLE=0
 
 
-	if [ -x /usr/sbin/odhcpd -a -x /etc/init.d/odhcpd ] ; then
+	if [ -x /usr/sbin/odhcpd ] && [ -x /etc/init.d/odhcpd ] ; then
 		local odhcpd_is_main odhcpd_is_enabled
 		config_get odhcpd_is_main odhcpd maindhcp 0
 		/etc/init.d/odhcpd enabled && odhcpd_is_enabled=1 || odhcpd_is_enabled=0
 
 
-		if [ "$odhcpd_is_enabled" -eq 0 -a "$DHCPv6CAPABLE" -eq 1 ] ; then
+		if [ "$odhcpd_is_enabled" -eq 0 ] && [ "$DHCPv6CAPABLE" -eq 1 ] ; then
 			# DHCP V4 and V6 in DNSMASQ
 			DNSMASQ_DHCP_VER=6
 		elif [ "$odhcpd_is_main" -gt 0 ] ; then
@@ -834,7 +834,7 @@ dnsmasq_start()
 		if [ -x /etc/init.d/dhcpd ] ; then
 			/etc/init.d/dhcpd enabled && DNSMASQ_DHCP_VER=0
 		fi
-		if [ -x /etc/init.d/dhcpd6 -a "$DNSMASQ_DHCP_VER" -gt 0 ] ; then
+		if [ -x /etc/init.d/dhcpd6 ] && [ "$DNSMASQ_DHCP_VER" -gt 0 ] ; then
 			/etc/init.d/dhcpd6 enabled && DNSMASQ_DHCP_VER=4
 		fi
 	fi
@@ -918,13 +918,13 @@ dnsmasq_start()
 	fi
 
 	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"
-	[ -n "$leasefile" -a \! -e "$leasefile" ] && touch "$leasefile"
+	[ -n "$leasefile" ] && [ ! -e "$leasefile" ] && touch "$leasefile"
 	config_get_bool cachelocal "$cfg" cachelocal 1
 
 	config_get_bool noresolv "$cfg" noresolv 0
 	if [ "$noresolv" != "1" ]; then
 		config_get resolvfile "$cfg" resolvfile /tmp/resolv.conf.d/resolv.conf.auto
-		[ -n "$resolvfile" -a ! -e "$resolvfile" ] && touch "$resolvfile"
+		[ -n "$resolvfile" ] && [ ! -e "$resolvfile" ] && touch "$resolvfile"
 		xappend "--resolv-file=$resolvfile"
 		[ "$resolvfile" = "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=1
 		resolvdir="$(dirname "$resolvfile")"
@@ -1085,7 +1085,7 @@ dnsmasq_stop()
 	config_get_bool noresolv "$cfg" noresolv 0
 	config_get resolvfile "$cfg" "resolvfile"
 
-	[ "$noresolv" = 0 -a "$resolvfile" = "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=1
+	[ "$noresolv" = 0 ] && [ "$resolvfile" = "/tmp/resolv.conf.d/resolv.conf.auto" ] && localuse=1
 	config_get_bool localuse "$cfg" localuse "$localuse"
 	[ "$localuse" -gt 0 ] && ln -sf "/tmp/resolv.conf.d/resolv.conf.auto" /tmp/resolv.conf
 
@@ -1099,7 +1099,7 @@ add_interface_trigger()
 	config_get interface "$1" interface
 	config_get_bool ignore "$1" ignore 0
 
-	[ -n "$interface" -a $ignore -eq 0 ] && procd_add_interface_trigger "interface.*" "$interface" /etc/init.d/dnsmasq reload
+	[ -n "$interface" ] && [ $ignore -eq 0 ] && procd_add_interface_trigger "interface.*" "$interface" /etc/init.d/dnsmasq reload
 }
 
 service_triggers()
@@ -1127,7 +1127,7 @@ start_service() {
 		local type="$1"
 		local name="$2"
 		if [ "$type" = "dnsmasq" ]; then
-			if [ -n "$instance" -a "$instance" = "$name" ]; then
+			if [ -n "$instance" ] && [ "$instance" = "$name" ]; then
 				instance_found=1
 			fi
 		fi
@@ -1156,7 +1156,7 @@ stop_service() {
 		local type="$1"
 		local name="$2"
 		if [ "$type" = "dnsmasq" ]; then
-			if [ -n "$instance" -a "$instance" = "$name" ]; then
+			if [ -n "$instance" ] && [ "$instance" = "$name" ]; then
 				instance_found=1
 			fi
 		fi


### PR DESCRIPTION
Fix FS#2574 (dnssec + ntp chicken-and-egg workaround not working), and also remove the use of "test -a" and "test -o" (as in "[ ... -a ... ]" and "[ ... -o ... ]").

The individual commits have more details in their commit logs.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>