### PR TITLE
ath79: Add support TL-WR740N-v5

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr740n-v5.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr740n-v5.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9331_tplink_tl-wr741nd-v4.dtsi"
+
+/ {
+	model = "TP-Link TL-WR740N v5";
+	compatible = "tplink,tl-wr740n-v5", "qca,ar9331";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -186,6 +186,15 @@ define Device/tplink_tl-wr740n-v4
 endef
 TARGET_DEVICES += tplink_tl-wr740n-v4
 
+define Device/tplink_tl-wr740n-v5
+  $(Device/tplink-4mlzma)
+  SOC := ar9331
+  DEVICE_MODEL := TL-WR740N
+  DEVICE_VARIANT := v5
+  TPLINK_HWID := 0x07400005
+endef
+TARGET_DEVICES += tplink_tl-wr740n-v5
+
 define Device/tplink_tl-wr741-v1
   $(Device/tplink-4m)
   SOC := ar7240

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -51,6 +51,7 @@ tplink,tl-wa901nd-v1)
 	;;
 tplink,tl-mr3420-v2|\
 tplink,tl-wr740n-v4|\
+tplink,tl-wr740n-v5|\
 tplink,tl-wr741nd-v4|\
 tplink,tl-wr841-v8)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -60,6 +60,7 @@ ath79_setup_interfaces()
 		;;
 	tplink,tl-mr3420-v2|\
 	tplink,tl-wr740n-v4|\
+	tplink,tl-wr740n-v5|\
 	tplink,tl-wr741nd-v4|\
 	tplink,tl-wr841-v8)
 		ucidef_set_interface_wan "eth1"


### PR DESCRIPTION
This port supports for the TL-WR740N v5  from ar71xx to ath79.

Specifications:
- SOC: Atheros AR9331
- CPU: 400MHz
- Flash: 4 MiB
- RAM: 32 MiB
- WLAN: Atheros AR9330 bgn
- Ethernet: 5 ports (100M)

Flash instructions:
- flash factory image from OEM WebUI : 
    openwrt-ath79-tiny-tplink_tl-wr740n-v5-squashfs-factory.bin
- sysupgrade from ar71xx image:
     openwrt-ath79-tiny-tplink_tl-wr740n-v5-squashfs-sysupgrade.bin

Note: Some device WAN label is put on the first port of eth0 instead of eth1.

Tested on: TL-WR740N-v5 hardware

Signed-off-by: Jun Su <howard0su@gmail.com>