### PR TITLE
ramips: add support for Buffalo WSR-2533DHPL

### DIFF
--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "buffalo,wsr-2533dhpl", "mediatek,mt7621-soc";
+	model = "Buffalo WSR-2533DHPL";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_diag;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		internet_green {
+			label = "wsr-2533dhpl:green:internet";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		router_green {
+			label = "wsr-2533dhpl:green:router";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		router_amber {
+			label = "wsr-2533dhpl:amber:router";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_amber {
+			label = "wsr-2533dhpl:amber:internet";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wireless_amber {
+			label = "wsr-2533dhpl:amber:wireless";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "wsr-2533dhpl:green:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led_diag: diag {
+			label = "wsr-2533dhpl:amber:diag";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		wireless_green {
+			label = "wsr-2533dhpl:green:wireless";
+			gpios = <&gpio 48 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		aoss {
+			label = "aoss";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		auto {
+			label = "auto";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		bridge {
+			label = "wb";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		router {
+			label = "router";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		power {
+			label = "power";
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_POWER>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "openwrt,trx";
+				label = "firmware";
+				reg = <0x50000 0x7c0000>;
+			};
+
+			partition@810000 {
+				label = "Kernel2";
+				reg = <0x810000 0x7c0000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "glbcfg";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "board_data";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x4>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		group = "i2c", "uart2", "uart3", "wdt", "sdhci";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -196,6 +196,15 @@ define Device/buffalo_wsr-1166dhp
 endef
 TARGET_DEVICES += buffalo_wsr-1166dhp
 
+define Device/buffalo_wsr-2533dhpl
+  IMAGE_SIZE := 7936k
+  DEVICE_VENDOR := Buffalo
+  DEVICE_MODEL := WSR-2533DHPL
+  IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+endef
+TARGET_DEVICES += buffalo_wsr-2533dhpl
+
 define Device/buffalo_wsr-600dhp
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Buffalo


### PR DESCRIPTION
Buffalo WSR-2533DHPL is a 2.4/5 GHz band 11ac rouer, based on MediaTek
MT7621A.

Specification:

- SoC           : MediaTek MT7621A
- RAM           : DDR3 128 MiB
- Flash         : SPI-NOR 16 MiB
- WLAN          : 2.4/5 GHz 4T4R (2x MediaTek MT7615N)
- Ethernet      : 10/100/1000 Mbps
  - Switch      : MediaTek MT7530 (SoC)
- LED/keys      : 8x/6x (3x buttons, 2x slide-switches)
- UART          : through-hole on PCB
  - J4: 3.3V, GND, TX, RX from triangle-mark
  - 57600n8
- Power         : 12VDC 1.5A

Flash instruction using initramfs image:

1. prepare the TFTP server with the initramfs image renamed to
   "linux.trx-recovery" and IP address "192.168.11.2"
2. press the "AOSS" button while powering on the WSR-2533DHPL
3. after 10 seconds, release the "AOSS" button, WSR-2533DHPL downloads
   the initramfs image and boot with it automatically
4. on the initramfs image, download the sysupgrade image to the device
   and perform sysupgrade with it
5. wait ~120 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
