### PR TITLE
kernel: add exFAT driver for Linux 5.4

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -163,6 +163,30 @@ endef
 $(eval $(call KernelPackage,fs-efivarfs))
 
 
+define KernelPackage/fs-exfat-staging
+  SUBMENU:=$(FS_MENU)
+  TITLE:=exFAT filesystem support
+  KCONFIG:= \
+	CONFIG_EXFAT_FS \
+	CONFIG_EXFAT_DONT_MOUNT_VFAT=y \
+	CONFIG_EXFAT_DISCARD=y \
+	CONFIG_EXFAT_DELAYED_SYNC=n \
+	CONFIG_EXFAT_KERNEL_DEBUG=n \
+	CONFIG_EXFAT_DEBUG_MSG=n \
+	CONFIG_EXFAT_DEFAULT_CODEPAGE=437 \
+	CONFIG_EXFAT_DEFAULT_IOCHARSET="utf8"
+  FILES:=$(LINUX_DIR)/drivers/staging/exfat/exfat.ko
+  AUTOLOAD:=$(call AutoLoad,30,exfat,1)
+  DEPENDS:=@LINUX_5_4 +kmod-nls-base
+endef
+
+define KernelPackage/fs-exfat-staging/description
+ Kernel module for exFAT filesystem support
+endef
+
+$(eval $(call KernelPackage,fs-exfat-staging))
+
+
 define KernelPackage/fs-exportfs
   SUBMENU:=$(FS_MENU)
   TITLE:=exportfs kernel server support


### PR DESCRIPTION
Add exFAT driver for Linux 5.4
To avoid conflict with exfat-nofuse in feeds/packages, name it exfat-staging