### PR TITLE
build: allow build out of tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@
 #
 
 TOPDIR:=${CURDIR}
+BUILDTOPDIR?=$(TOPDIR)
 LC_ALL:=C
 LANG:=C
 TZ:=UTC
-export TOPDIR LC_ALL LANG TZ
+export TOPDIR BUILDTOPDIR LC_ALL LANG TZ
 
 empty:=
 space:= $(empty) $(empty)
@@ -19,7 +20,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 world:
 
 DISTRO_PKG_CONFIG:=$(shell which -a pkg-config | grep -E '\/usr' | head -n 1)
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(BUILDTOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)
   _SINGLE=export MAKEFLAGS=$(space);
@@ -55,7 +56,7 @@ printdb:
 prepare: $(target/stamp-compile)
 
 clean: FORCE
-	rm -rf $(BUILD_DIR) $(STAGING_DIR) $(BIN_DIR) $(OUTPUT_DIR)/packages/$(ARCH_PACKAGES) $(BUILD_LOG_DIR) $(TOPDIR)/staging_dir/packages
+	rm -rf $(BUILD_DIR) $(STAGING_DIR) $(BIN_DIR) $(OUTPUT_DIR)/packages/$(ARCH_PACKAGES) $(BUILD_LOG_DIR) $(BUILDTOPDIR)/staging_dir/packages
 
 dirclean: clean
 	rm -rf $(STAGING_DIR_HOST) $(STAGING_DIR_HOSTPKG) $(TOOLCHAIN_DIR) $(BUILD_DIR_BASE)/host $(BUILD_DIR_BASE)/hostpkg $(BUILD_DIR_TOOLCHAIN)
@@ -66,7 +67,7 @@ $(BUILD_DIR)/.prepared: Makefile
 	@mkdir -p $$(dirname $@)
 	@touch $@
 
-tmp/.prereq_packages: .config
+$(BUILDTOPDIR)/tmp/.prereq_packages: .config
 	unset ERROR; \
 	for package in $(sort $(prereq-y) $(prereq-m)); do \
 		$(_SINGLE)$(NO_TRACE_MAKE) -s -r -C package/$$package prereq || ERROR=1; \
@@ -79,7 +80,7 @@ tmp/.prereq_packages: .config
 endif
 
 # check prerequisites before starting to build
-prereq: $(target/stamp-prereq) tmp/.prereq_packages
+prereq: $(target/stamp-prereq) $(BUILDTOPDIR)/tmp/.prereq_packages
 	@if [ ! -f "$(INCLUDE_DIR)/site/$(ARCH)" ]; then \
 		echo 'ERROR: Missing site config for architecture "$(ARCH)" !'; \
 		echo '       The missing file will cause configure scripts to fail during compilation.'; \

--- a/include/scan.mk
+++ b/include/scan.mk
@@ -1,5 +1,5 @@
 include $(TOPDIR)/include/verbose.mk
-TMP_DIR:=$(TOPDIR)/tmp
+TMP_DIR:=$(BUILDTOPDIR)/tmp
 
 all: $(TMP_DIR)/.$(SCAN_TARGET)
 
@@ -10,7 +10,7 @@ TARGET_STAMP:=$(TMP_DIR)/info/.files-$(SCAN_TARGET).stamp
 FILELIST:=$(TMP_DIR)/info/.files-$(SCAN_TARGET)-$(SCAN_COOKIE)
 OVERRIDELIST:=$(TMP_DIR)/info/.overrides-$(SCAN_TARGET)-$(SCAN_COOKIE)
 
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(BUILDTOPDIR)/staging_dir/host/bin:$(PATH)
 
 define feedname
 $(if $(patsubst feeds/%,,$(1)),,$(word 2,$(subst /, ,$(1))))
@@ -49,8 +49,8 @@ define PackageDir
 		echo Source-Makefile: $(SCAN_DIR)/$(2)/Makefile; \
 		$(if $(3),echo Override: $(3),true); \
 		$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) 2>/dev/null || { \
-			mkdir -p "$(TOPDIR)/logs/$(SCAN_DIR)/$(2)"; \
-			$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) > $(TOPDIR)/logs/$(SCAN_DIR)/$(2)/dump.txt 2>&1; \
+			mkdir -p "$(BUILDTOPDIR)/logs/$(SCAN_DIR)/$(2)"; \
+			$(NO_TRACE_MAKE) --no-print-dir -r DUMP=1 FEED="$(call feedname,$(2))" -C $(SCAN_DIR)/$(2) $(SCAN_MAKEOPTS) > $(BUILDTOPDIR)/logs/$(SCAN_DIR)/$(2)/dump.txt 2>&1; \
 			$$(call progress,ERROR: please fix $(SCAN_DIR)/$(2)/Makefile - see logs/$(SCAN_DIR)/$(2)/dump.txt for details\n) \
 			rm -f $$@; \
 		}; \

--- a/rules.mk
+++ b/rules.mk
@@ -20,7 +20,7 @@ CHECK:=1
 DUMP:=1
 endif
 
-export TMP_DIR:=$(TOPDIR)/tmp
+export TMP_DIR:=$(BUILDTOPDIR)/tmp
 export TMPDIR:=$(TMP_DIR)
 
 qstrip=$(strip $(subst ",,$(1)))
@@ -118,7 +118,7 @@ OUTPUT_DIR:=$(if $(call qstrip,$(CONFIG_BINARY_FOLDER)),$(call qstrip,$(CONFIG_B
 BIN_DIR:=$(OUTPUT_DIR)/targets/$(BOARD)/$(SUBTARGET)
 INCLUDE_DIR:=$(TOPDIR)/include
 SCRIPT_DIR:=$(TOPDIR)/scripts
-BUILD_DIR_BASE:=$(TOPDIR)/build_dir
+BUILD_DIR_BASE:=$(BUILDTOPDIR)/build_dir
 ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
   GCCV:=$(call qstrip,$(CONFIG_GCC_VERSION))
   LIBC:=$(call qstrip,$(CONFIG_LIBC))
@@ -149,23 +149,23 @@ ifeq ($(or $(CONFIG_EXTERNAL_TOOLCHAIN),$(CONFIG_TARGET_uml)),)
 endif
 
 PACKAGE_DIR:=$(BIN_DIR)/packages
-PACKAGE_DIR_ALL:=$(TOPDIR)/staging_dir/packages/$(BOARD)
+PACKAGE_DIR_ALL:=$(BUILDTOPDIR)/staging_dir/packages/$(BOARD)
 BUILD_DIR:=$(BUILD_DIR_BASE)/$(TARGET_DIR_NAME)
-STAGING_DIR:=$(TOPDIR)/staging_dir/$(TARGET_DIR_NAME)
+STAGING_DIR:=$(BUILDTOPDIR)/staging_dir/$(TARGET_DIR_NAME)
 BUILD_DIR_TOOLCHAIN:=$(BUILD_DIR_BASE)/$(TOOLCHAIN_DIR_NAME)
-TOOLCHAIN_DIR:=$(TOPDIR)/staging_dir/$(TOOLCHAIN_DIR_NAME)
+TOOLCHAIN_DIR:=$(BUILDTOPDIR)/staging_dir/$(TOOLCHAIN_DIR_NAME)
 STAMP_DIR:=$(BUILD_DIR)/stamp
 STAMP_DIR_HOST=$(BUILD_DIR_HOST)/stamp
 TARGET_ROOTFS_DIR?=$(if $(call qstrip,$(CONFIG_TARGET_ROOTFS_DIR)),$(call qstrip,$(CONFIG_TARGET_ROOTFS_DIR)),$(BUILD_DIR))
 TARGET_DIR:=$(TARGET_ROOTFS_DIR)/root-$(BOARD)
 STAGING_DIR_ROOT:=$(STAGING_DIR)/root-$(BOARD)
 STAGING_DIR_IMAGE:=$(STAGING_DIR)/image
-BUILD_LOG_DIR:=$(if $(call qstrip,$(CONFIG_BUILD_LOG_DIR)),$(call qstrip,$(CONFIG_BUILD_LOG_DIR)),$(TOPDIR)/logs)
+BUILD_LOG_DIR:=$(if $(call qstrip,$(CONFIG_BUILD_LOG_DIR)),$(call qstrip,$(CONFIG_BUILD_LOG_DIR)),$(BUILDTOPDIR)/logs)
 PKG_INFO_DIR := $(STAGING_DIR)/pkginfo
 
 BUILD_DIR_HOST:=$(if $(IS_PACKAGE_BUILD),$(BUILD_DIR_BASE)/hostpkg,$(BUILD_DIR_BASE)/host)
-STAGING_DIR_HOST:=$(TOPDIR)/staging_dir/host
-STAGING_DIR_HOSTPKG:=$(TOPDIR)/staging_dir/hostpkg
+STAGING_DIR_HOST:=$(BUILDTOPDIR)/staging_dir/host
+STAGING_DIR_HOSTPKG:=$(BUILDTOPDIR)/staging_dir/hostpkg
 
 TARGET_PATH:=$(subst $(space),:,$(filter-out .,$(filter-out ./,$(subst :,$(space),$(PATH)))))
 TARGET_INIT_PATH:=$(call qstrip,$(CONFIG_TARGET_INIT_PATH))

--- a/scripts/config/zconf.l
+++ b/scripts/config/zconf.l
@@ -354,7 +354,7 @@ void zconf_nextfile(const char *name)
 	glob_t gl;
 	int err;
 	int i;
-	char path[PATH_MAX], *p;
+	char path[PATH_MAX], *p, *env;
 
 	err = glob(name, GLOB_ERR | GLOB_MARK, NULL, &gl);
 
@@ -370,6 +370,14 @@ void zconf_nextfile(const char *name)
 			snprintf(path, sizeof(path), "%s/%s", dirname(p), name);
 			err = glob(path, GLOB_ERR | GLOB_MARK, NULL, &gl);
 			free(p);
+		}
+	}
+
+	if (err == GLOB_NOMATCH) {
+		env = getenv(SRCTREE);
+		if (env) {
+			snprintf(path, sizeof(path), "%s/%s", env, name);
+			err = glob(path, GLOB_ERR | GLOB_MARK, NULL, &gl);
 		}
 	}
 

--- a/scripts/config/zconf.lex.c_shipped
+++ b/scripts/config/zconf.lex.c_shipped
@@ -2459,7 +2459,7 @@ void zconf_nextfile(const char *name)
 	glob_t gl;
 	int err;
 	int i;
-	char path[PATH_MAX], *p;
+	char path[PATH_MAX], *p, *env;
 
 	err = glob(name, GLOB_ERR | GLOB_MARK, NULL, &gl);
 
@@ -2477,6 +2477,14 @@ void zconf_nextfile(const char *name)
 			free(p);
 		}
 	}
+
+  if (err == GLOB_NOMATCH) {
+    env = getenv(SRCTREE);
+    if (env) {
+      snprintf(path, sizeof(path), "%s/%s", env, name);
+      err = glob(path, GLOB_ERR | GLOB_MARK, NULL, &gl);
+    }
+  }
 
 	if (err) {
 		const char *reason = "unknown error";

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -10,6 +10,7 @@ use Cwd 'abs_path';
 
 chdir "$FindBin::Bin/..";
 $ENV{TOPDIR} //= getcwd();
+$ENV{BUILDTOPDIR} or $ENV{BUILDTOPDIR}=$ENV{TOPDIR};
 chdir $ENV{TOPDIR};
 $ENV{GIT_CONFIG_PARAMETERS}="'core.autocrlf=false'";
 $ENV{GREP_OPTIONS}="";
@@ -270,10 +271,10 @@ sub get_feed($) {
 sub get_installed() {
 	system("$mk -s prepare-tmpinfo OPENWRT_BUILD=");
 	clear_packages();
-	parse_package_metadata("./tmp/.packageinfo");
+	parse_package_metadata("$ENV{BUILDTOPDIR}/tmp/.packageinfo");
 	%installed_pkg = %vpackage;
 	%installed = %srcpackage;
-	%installed_targets = get_targets("./tmp/.targetinfo");
+	%installed_targets = get_targets("$ENV{BUILDTOPDIR}/tmp/.targetinfo");
 }
 
 sub search_feed {
@@ -488,8 +489,8 @@ sub lookup_target($$) {
 
 sub is_core_src($) {
 	my $src = shift;
-	foreach my $file ("tmp/info/.packageinfo-$src", glob("tmp/info/.packageinfo-*_$src")) {
-		next unless index($file, "tmp/info/.packageinfo-feeds_");
+	foreach my $file ("$ENV{BUILDTOPDIR}/tmp/info/.packageinfo-$src", glob("$ENV{BUILDTOPDIR}/tmp/info/.packageinfo-*_$src")) {
+		next unless index($file, "$ENV{BUILDTOPDIR}/tmp/info/.packageinfo-feeds_");
 		return 1 if -s $file;
 	}
 	return 0;
@@ -634,7 +635,7 @@ sub refresh_config {
 	return if not (-e '.config');
 
 	# workaround for timestamp check
-	system("rm -f tmp/.packageinfo");
+	system("rm -f $ENV{BUILDTOPDIR}/tmp/.packageinfo");
 
 	# refresh the config
 	if ($default) {

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -58,8 +58,8 @@ else
 endif
 
 	$(CP) $(TOPDIR)/target/linux $(PKG_BUILD_DIR)/target/
-	if [ -d $(TOPDIR)/staging_dir/host/lib/grub ]; then \
-		$(CP) $(TOPDIR)/staging_dir/host/lib/grub/ $(PKG_BUILD_DIR)/staging_dir/host/lib; \
+	if [ -d $(BUILDTOPDIR)/staging_dir/host/lib/grub ]; then \
+		$(CP) $(BUILDTOPDIR)/staging_dir/host/lib/grub/ $(PKG_BUILD_DIR)/staging_dir/host/lib; \
 	fi
 	rm -rf \
 		$(PKG_BUILD_DIR)/target/linux/*/files{,-*} \

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -7,13 +7,14 @@
 #
 
 TOPDIR:=${CURDIR}
+BUILDTOPDIR?=$(TOPDIR)
 LC_ALL:=C
 LANG:=C
-export TOPDIR LC_ALL LANG
+export TOPDIR BUILDTOPDIR LC_ALL LANG
 export OPENWRT_VERBOSE=s
 all: help
 
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(BUILDTOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)
   override OPENWRT_BUILD=1

--- a/target/sdk/files/Makefile
+++ b/target/sdk/files/Makefile
@@ -7,14 +7,15 @@
 #
 
 TOPDIR:=${CURDIR}
+BUILDTOPDIR?=$(TOPDIR)
 LC_ALL:=C
 LANG:=C
 SDK:=1
-export TOPDIR LC_ALL LANG SDK
+export TOPDIR BUILDTOPDIR LC_ALL LANG SDK
 
 world:
 
-export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
+export PATH:=$(BUILDTOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)
   override OPENWRT_BUILD=1

--- a/target/toolchain/Makefile
+++ b/target/toolchain/Makefile
@@ -28,7 +28,7 @@ TOOLCHAIN_PREFIX:=$(TOOLCHAIN_BUILD_DIR)/toolchain-$(ARCH)$(ARCH_SUFFIX)_gcc-$(G
 
 $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2: clean
 	mkdir -p $(TOOLCHAIN_BUILD_DIR)
-	$(TAR) -cf - -C $(TOPDIR)/staging_dir/  \
+	$(TAR) -cf - -C $(BUILDTOPDIR)/staging_dir/  \
 	       $(foreach exclude,$(EXCLUDE_DIRS),--exclude="$(exclude)") \
 	       toolchain-$(ARCH)$(ARCH_SUFFIX)_gcc-$(GCCV)$(DIR_SUFFIX) | \
 	       $(TAR) -xf - -C $(TOOLCHAIN_BUILD_DIR)

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -82,7 +82,7 @@ ifdef CONFIG_INSTALL_GCCGO
 endif
 
 ifdef CONFIG_GCC_USE_GRAPHITE
-  GRAPHITE_CONFIGURE:= --with-isl=$(TOPDIR)/staging_dir/host
+  GRAPHITE_CONFIGURE:= --with-isl=$(BUILDTOPDIR)/staging_dir/host
 else
   GRAPHITE_CONFIGURE:= --without-isl --without-cloog
 endif
@@ -114,9 +114,9 @@ GCC_CONFIGURE:= \
 		$(if $(CONFIG_mips64)$(CONFIG_mips64el),--with-arch=mips64 \
 			--with-abi=$(call qstrip,$(CONFIG_MIPS64_ABI))) \
 		$(if $(CONFIG_arc),--with-cpu=$(CONFIG_CPU_TYPE)) \
-		--with-gmp=$(TOPDIR)/staging_dir/host \
-		--with-mpfr=$(TOPDIR)/staging_dir/host \
-		--with-mpc=$(TOPDIR)/staging_dir/host \
+		--with-gmp=$(BUILDTOPDIR)/staging_dir/host \
+		--with-mpfr=$(BUILDTOPDIR)/staging_dir/host \
+		--with-mpc=$(BUILDTOPDIR)/staging_dir/host \
 		--disable-decimal-float \
 		--with-diagnostics-color=auto-if-env
 ifneq ($(CONFIG_mips)$(CONFIG_mipsel),)

--- a/toolchain/gcc/final/Makefile
+++ b/toolchain/gcc/final/Makefile
@@ -9,7 +9,7 @@ GCC_CONFIGURE += \
 	--enable-threads \
 	--with-slibdir=$(TOOLCHAIN_DIR)/lib \
 	--enable-lto \
-	--with-libelf=$(TOPDIR)/staging_dir/host
+	--with-libelf=$(BUILDTOPDIR)/staging_dir/host
 
 ifndef CONFIG_USE_GLIBC
   GCC_CONFIGURE += --disable-libsanitizer

--- a/tools/mpc/Makefile
+++ b/tools/mpc/Makefile
@@ -22,7 +22,7 @@ unexport CFLAGS
 HOST_CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-shared \
-	--with-mpfr=$(TOPDIR)/staging_dir/host \
-	--with-gmp=$(TOPDIR)/staging_dir/host
+	--with-mpfr=$(BUILDTOPDIR)/staging_dir/host \
+	--with-gmp=$(BUILDTOPDIR)/staging_dir/host
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
This MR allow move all building files out of source tree.  Implemented with new environment
variable BUILDTOPDIR with by-default value of TOPDIR. Use new variable at paths for
build artifacts. Another part of changes is replace relative paths from source
to absolute at BUILDTOPDIR.

My use case is build on case-sensitive filesystem (external SDD) with source on primary, non case sensitive filesystem. As side effects it is get fast switch configurations, you can have multiple build directories with pre-builded for different configurations.

Signed-off-by: Andrey Kunitsyn <blackicebox@gmail.com>
