### PR TITLE
bcm27xx: allow override files at boot image partition

### DIFF
--- a/target/linux/bcm27xx/image/Config.in
+++ b/target/linux/bcm27xx/image/Config.in
@@ -1,0 +1,6 @@
+config BCM27XX_BOOT_FILES_PARTNAME
+	string "Bootloader files location"
+	depends on TARGET_bcm27xx
+	help
+		Specify folder with files for override content of boot partition on final image.
+	

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -48,7 +48,15 @@ define Build/boot-2711
 	mcopy -i $@.boot $(KDIR)/fixup4x.dat ::
 endef
 
+BOOT_FILES:=$(call qstrip,$(CONFIG_BCM27XX_BOOT_FILES_PARTNAME))
+
 define Build/sdcard-img
+  $(if $(BOOT_FILES), \
+  	if [ -d $(BOOT_FILES) ]; then \
+		  mcopy -D o -i $@.boot $(BOOT_FILES)/* ::; \
+	  fi; \
+  ,)
+	
 	./gen_rpi_sdcard_img.sh $@ $@.boot $(IMAGE_ROOTFS) \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $(CONFIG_TARGET_ROOTFS_PARTSIZE)
 endef


### PR DESCRIPTION
Place files at overlay/boot allow override content of boot partition on final image.
This allow build ready to use,  fully preconfigured images for target device.
Maybe need use different sources location?

Signed-off-by: Andrey Kunitsyn <blackicebox@gmail.com>
