### PR TITLE
linux-5.4: fix xt_connmark.h

### DIFF
--- a/target/linux/generic/hack-5.4/645-netfilter-connmark-introduce-set-dscpmark.patch
+++ b/target/linux/generic/hack-5.4/645-netfilter-connmark-introduce-set-dscpmark.patch
@@ -87,8 +87,8 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  };
  
  enum {
-+	XT_CONNMARK_VALUE = BIT(0),
-+	XT_CONNMARK_DSCP = BIT(1)
++	XT_CONNMARK_VALUE = (1 << 0),
++	XT_CONNMARK_DSCP = (1 << 1)
 +};
 +
 +enum {


### PR DESCRIPTION
@hauke 
This fix was already applied with commit 54e39ddc2e0d ("kernel: fix
xt_connmark.h") for linux-4.19, but was probably overlooked when copying
to linux-5.4.

Fixes: c16517d26de3 ("kernel: copy kernel 4.19 code to 5.4")
Signed-off-by: Martin Schiller <ms@dev.tdt.de>
