### PR TITLE
kernel: fix incorrect dst MAC address for hw flow offload

### DIFF
--- a/target/linux/generic/pending-4.14/647-netfilter-nf_flow_table_hw-fix-incorrect-ethernet-ds.patch
+++ b/target/linux/generic/pending-4.14/647-netfilter-nf_flow_table_hw-fix-incorrect-ethernet-ds.patch
@@ -1,0 +1,87 @@
+From: Konstantin Vasin <tempest921@gmail.com>
+Date: Mon, 9 Mar 2020 18:38:54 +0300
+Subject: [PATCH] netfilter: nf_flow_table_hw: fix incorrect ethernet dst
+ address
+
+Ethernet destination for original traffic takes the source ethernet
+address in the reply direction. For reply traffic, this takes
+the source ethernet address of the original destination.
+
+This fix is based on the upstream commit 1b67e506:
+("netfilter: nf_flow_table_offload: fix incorrect ethernet dst address")
+from wenxu <wenxu@ucloud.cn>
+
+Signed-off-by: Konstantin Vasin <tempest921@gmail.com>
+---
+
+--- a/net/netfilter/nf_flow_table_hw.c
++++ b/net/netfilter/nf_flow_table_hw.c
+@@ -24,17 +24,23 @@ struct flow_offload_hw {
+ 	struct flow_offload_hw_path dest;
+ };
+ 
+-static void flow_offload_check_ethernet(struct flow_offload_tuple *tuple,
++static void flow_offload_check_ethernet(struct flow_offload *flow,
++					enum flow_offload_tuple_dir dir,
+ 					struct flow_offload_hw_path *path)
+ {
+ 	struct net_device *dev = path->dev;
+ 	struct neighbour *n;
++	const void *daddr;
++	const struct dst_entry *dst_cache;
+ 
+ 	if (dev->type != ARPHRD_ETHER)
+ 		return;
+ 
+ 	memcpy(path->eth_src, path->dev->dev_addr, ETH_ALEN);
+-	n = dst_neigh_lookup(tuple->dst_cache, &tuple->src_v4);
++
++	daddr = &flow->tuplehash[dir].tuple.src_v4;
++	dst_cache = flow->tuplehash[!dir].tuple.dst_cache;
++	n = dst_neigh_lookup(dst_cache, daddr);
+ 	if (!n)
+ 		return;
+ 
+@@ -44,17 +50,18 @@ static void flow_offload_check_ethernet(struct flow_offload_tuple *tuple,
+ }
+ 
+ static int flow_offload_check_path(struct net *net,
+-				   struct flow_offload_tuple *tuple,
++				   struct flow_offload *flow,
++				   enum flow_offload_tuple_dir dir,
+ 				   struct flow_offload_hw_path *path)
+ {
+ 	struct net_device *dev;
+ 
+-	dev = dev_get_by_index_rcu(net, tuple->iifidx);
++	dev = dev_get_by_index_rcu(net, flow->tuplehash[dir].tuple.iifidx);
+ 	if (!dev)
+ 		return -ENOENT;
+ 
+ 	path->dev = dev;
+-	flow_offload_check_ethernet(tuple, path);
++	flow_offload_check_ethernet(flow, dir, path);
+ 
+ 	if (dev->netdev_ops->ndo_flow_offload_check)
+ 		return dev->netdev_ops->ndo_flow_offload_check(path);
+@@ -133,17 +140,14 @@ flow_offload_hw_prepare(struct net *net, struct flow_offload *flow)
+ {
+ 	struct flow_offload_hw_path src = {};
+ 	struct flow_offload_hw_path dest = {};
+-	struct flow_offload_tuple *tuple;
+ 	struct flow_offload_hw *offload = NULL;
+ 
+ 	rcu_read_lock_bh();
+ 
+-	tuple = &flow->tuplehash[FLOW_OFFLOAD_DIR_ORIGINAL].tuple;
+-	if (flow_offload_check_path(net, tuple, &src))
++	if (flow_offload_check_path(net, flow, FLOW_OFFLOAD_DIR_ORIGINAL, &src))
+ 		goto out;
+ 
+-	tuple = &flow->tuplehash[FLOW_OFFLOAD_DIR_REPLY].tuple;
+-	if (flow_offload_check_path(net, tuple, &dest))
++	if (flow_offload_check_path(net, flow, FLOW_OFFLOAD_DIR_REPLY, &dest))
+ 		goto out;
+ 
+ 	if (!src.dev->netdev_ops->ndo_flow_offload)
+

--- a/target/linux/generic/pending-4.14/648-netfilter-nf_flow_table_hw-check-the-status-of-dst_n.patch
+++ b/target/linux/generic/pending-4.14/648-netfilter-nf_flow_table_hw-check-the-status-of-dst_n.patch
@@ -1,0 +1,32 @@
+From: Konstantin Vasin <tempest921@gmail.com>
+Date: Mon, 9 Mar 2020 17:41:22 +0300
+Subject: [PATCH] netfilter: nf_flow_table_hw: check the status of
+ dst_neigh
+
+It's better to check the nud_state is VALID.
+If there is not neigh previos, the lookup will
+create a non NUD_VALID with 00:00:00:00:00:00 mac.
+
+This fix is based on the upstream commit f31ad71c44
+("netfilter: nf_flow_table_offload: check the status of dst_neigh")
+from wenxu <wenxu@ucloud.cn>
+
+Signed-off-by: Konstantin Vasin <tempest921@gmail.com>
+---
+
+index e831c8830e91..1238d675a316 100644
+--- a/net/netfilter/nf_flow_table_hw.c
++++ b/net/netfilter/nf_flow_table_hw.c
+@@ -44,8 +44,10 @@ static void flow_offload_check_ethernet(struct flow_offload *flow,
+ 	if (!n)
+ 		return;
+ 
+-	memcpy(path->eth_dest, n->ha, ETH_ALEN);
+-	path->flags |= FLOW_OFFLOAD_PATH_ETHERNET;
++	if (n->nud_state & NUD_VALID) {
++		memcpy(path->eth_dest, n->ha, ETH_ALEN);
++		path->flags |= FLOW_OFFLOAD_PATH_ETHERNET;
++	}
+ 	neigh_release(n);
+ }
+ 


### PR DESCRIPTION
I tested hw flow offload engine (router DIR-882 - ramips `mt7621`, `master` branch) and found that it's broken:
1. All packets are forwarded by CPU
2. There are no entries with state BIND in debugfs (mtk_ppe/all_entry).

Network Topology:
`PC--(LAN 192.168.0.0/24)--[DUT]--(WAN 192.168.1.0/24)--SERVER (it's not default gw)`
```
PC: 192.168.0.2
DUT LAN: 192.168.0.1 (MAC address: XX:XX:XX:XX:XX:AB)
DUT WAN: 192.168.1.200 (MAC address: XX:XX:XX:XX:XX:AA)
SERVER: 192.168.1.100
DEFAULT GW: 192.168.1.1
```
sw offload and hw offload are enabled. All other settings are default.

After debugging I found the reason:
incorrect ethernet addresses calculation in `flow_offload_check_ethernet` (nf_flow_table_hw.c)

Explanation:
Start `iperf3` on SERVER (port 5201) and PC (random port 45678) to test TCP.
Now we have the next flows:
```
192.168.0.2:45678-->192.168.1.100:5201 (ORIGINAL)
192.168.1.100:5201-->192.168.1.200:45678 (REPLY)
```
For the original tuple iiface is `br-lan`, so we should use it to calculate eth addresses for the reply flow. For the reply tuple iiface is `eth0.2`, so we should use it to calculate eth addresses for the original flow.
In both cases we get a src eth address as interface address:
`memcpy(path->eth_src, path->dev->dev_addr, ETH_ALEN);`

But it's not possible to get dst mac address using `src_v4` address and `dst_cache` from the same tuple. In this case `dst_neigh_lookup` returns invalid values (all zeroes or eth address of the default gw). After that bridge stack can't find a valid entry in br-lan fdb for this invalid eth address and `flow_offload_check_path` returns an error.

There is a solution in upstream kernel from **wenxu** (since Jan 2020). So I decided to backport it.
```
1. [f31ad71c] netfilter: nf_flow_table_offload: check the status of dst_neigh
2. [1b67e506] netfilter: nf_flow_table_offload: fix incorrect ethernet dst address
```
With these patches we have an additional validation for neighbour's nud_state (use only NUD_VALID)
But more important - we use `src_v4` and `dst_cache` from different tuples. As a result, `dst_neigh_lookup` now returns a valid neighbour entry and we can use its eth address to add flows to the hardware offload.

`Result`: With this patch TCP and UDP traffic is forwarded correctly by hardware (0% CPU usage and entries in debugfs with state `BIND`).
BTW, Maybe this bug was already discussed, but I didn't find an appropriate issue.
