### PR TITLE
 kernel: revert patch for Gigadevice-GD25D05 for kernel 5.4

### DIFF
--- a/target/linux/generic/backport-5.4/507-v5.6-iio-chemical-sps30-fix-missing-triggered-buffer-depe.patch
+++ b/target/linux/generic/backport-5.4/507-v5.6-iio-chemical-sps30-fix-missing-triggered-buffer-depe.patch
@@ -17,8 +17,6 @@ Signed-off-by: Petr Štetiar <ynezz@true.cz>
  drivers/iio/chemical/Kconfig | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/drivers/iio/chemical/Kconfig b/drivers/iio/chemical/Kconfig
-index 0b91de4df8f4..a7e65a59bf42 100644
 --- a/drivers/iio/chemical/Kconfig
 +++ b/drivers/iio/chemical/Kconfig
 @@ -91,6 +91,8 @@ config SPS30

--- a/target/linux/generic/backport-5.4/800-v5.5-iio-imu-Add-support-for-the-FXOS8700-IMU.patch
+++ b/target/linux/generic/backport-5.4/800-v5.5-iio-imu-Add-support-for-the-FXOS8700-IMU.patch
@@ -40,8 +40,6 @@ Signed-off-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>
  create mode 100644 drivers/iio/imu/fxos8700_i2c.c
  create mode 100644 drivers/iio/imu/fxos8700_spi.c
 
-diff --git a/drivers/iio/imu/Kconfig b/drivers/iio/imu/Kconfig
-index f3c7282..60bb102 100644
 --- a/drivers/iio/imu/Kconfig
 +++ b/drivers/iio/imu/Kconfig
 @@ -40,6 +40,33 @@ config ADIS16480
@@ -78,11 +76,9 @@ index f3c7282..60bb102 100644
  config KMX61
  	tristate "Kionix KMX61 6-axis accelerometer and magnetometer"
  	depends on I2C
-diff --git a/drivers/iio/imu/Makefile b/drivers/iio/imu/Makefile
-index 4a69588..5237fd4 100644
 --- a/drivers/iio/imu/Makefile
 +++ b/drivers/iio/imu/Makefile
-@@ -14,6 +14,11 @@ adis_lib-$(CONFIG_IIO_ADIS_LIB_BUFFER) += adis_buffer.o
+@@ -14,6 +14,11 @@ adis_lib-$(CONFIG_IIO_ADIS_LIB_BUFFER) +
  obj-$(CONFIG_IIO_ADIS_LIB) += adis_lib.o
  
  obj-y += bmi160/
@@ -94,9 +90,6 @@ index 4a69588..5237fd4 100644
  obj-y += inv_mpu6050/
  
  obj-$(CONFIG_KMX61) += kmx61.o
-diff --git a/drivers/iio/imu/fxos8700.h b/drivers/iio/imu/fxos8700.h
-new file mode 100644
-index 00000000..6dfb8d7
 --- /dev/null
 +++ b/drivers/iio/imu/fxos8700.h
 @@ -0,0 +1,10 @@
@@ -110,9 +103,6 @@ index 00000000..6dfb8d7
 +			const char *name, bool use_spi);
 +
 +#endif  /* FXOS8700_H_ */
-diff --git a/drivers/iio/imu/fxos8700_core.c b/drivers/iio/imu/fxos8700_core.c
-new file mode 100644
-index 00000000..7b47be4
 --- /dev/null
 +++ b/drivers/iio/imu/fxos8700_core.c
 @@ -0,0 +1,649 @@
@@ -765,9 +755,6 @@ index 00000000..7b47be4
 +MODULE_AUTHOR("Robert Jones <rjones@gateworks.com>");
 +MODULE_DESCRIPTION("FXOS8700 6-Axis Acc and Mag Combo Sensor driver");
 +MODULE_LICENSE("GPL v2");
-diff --git a/drivers/iio/imu/fxos8700_i2c.c b/drivers/iio/imu/fxos8700_i2c.c
-new file mode 100644
-index 00000000..3ceb763
 --- /dev/null
 +++ b/drivers/iio/imu/fxos8700_i2c.c
 @@ -0,0 +1,71 @@
@@ -842,9 +829,6 @@ index 00000000..3ceb763
 +MODULE_AUTHOR("Robert Jones <rjones@gateworks.com>");
 +MODULE_DESCRIPTION("FXOS8700 I2C driver");
 +MODULE_LICENSE("GPL v2");
-diff --git a/drivers/iio/imu/fxos8700_spi.c b/drivers/iio/imu/fxos8700_spi.c
-new file mode 100644
-index 00000000..57e7bb6
 --- /dev/null
 +++ b/drivers/iio/imu/fxos8700_spi.c
 @@ -0,0 +1,59 @@
@@ -907,6 +891,3 @@ index 00000000..57e7bb6
 +MODULE_AUTHOR("Robert Jones <rjones@gateworks.com>");
 +MODULE_DESCRIPTION("FXOS8700 SPI driver");
 +MODULE_LICENSE("GPL v2");
--- 
-2.7.4
-

--- a/target/linux/generic/pending-5.4/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
+++ b/target/linux/generic/pending-5.4/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
@@ -1,0 +1,29 @@
+From d68b4aa22e8c625685bfad642dd7337948dc0ad1 Mon Sep 17 00:00:00 2001
+From: Koen Vandeputte <koen.vandeputte@ncentric.com>
+Date: Mon, 6 Jan 2020 13:07:56 +0100
+Subject: [PATCH] mtd: spi-nor: add support for Gigadevice GD25D05
+
+Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
+index f4afe123e9dc..a34fa42d47a2 100644
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -2346,6 +2346,11 @@ static const struct flash_info spi_nor_ids[] = {
+ 	{ "mb85rs1mt", INFO(0x047f27, 0, 128 * 1024, 1, SPI_NOR_NO_ERASE) },
+ 
+ 	/* GigaDevice */
++	{
++		"gd25d05", INFO(0xc84010, 0, 64 * 1024,  1,
++			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++	},
+ 	{
+ 		"gd25q16", INFO(0xc84015, 0, 64 * 1024,  32,
+ 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
+-- 
+2.17.1
+

--- a/target/linux/generic/pending-5.4/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
+++ b/target/linux/generic/pending-5.4/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
@@ -8,22 +8,17 @@ Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
  drivers/mtd/spi-nor/spi-nor.c | 5 +++++
  1 file changed, 5 insertions(+)
 
-diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
-index f4afe123e9dc..a34fa42d47a2 100644
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2346,6 +2346,11 @@ static const struct flash_info spi_nor_ids[] = {
- 	{ "mb85rs1mt", INFO(0x047f27, 0, 128 * 1024, 1, SPI_NOR_NO_ERASE) },
+@@ -2203,6 +2203,11 @@ static const struct flash_info spi_nor_i
  
  	/* GigaDevice */
-+	{
+ 	{
 +		"gd25d05", INFO(0xc84010, 0, 64 * 1024,  1,
 +			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
 +			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
 +	},
- 	{
++	{
  		"gd25q16", INFO(0xc84015, 0, 64 * 1024,  32,
  			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
--- 
-2.17.1
-
+ 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)


### PR DESCRIPTION
Now we have support for 5.4 kernel, so revert patch:
481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch

partially revert: c6e33b7cb4e07af312068a8b549aa1daa0e6d872