### PR TITLE
generic: 4.19 and 5.4: Add 4B_OPCODES flag to w25q256

### DIFF
--- a/target/linux/generic/backport-4.19/464-v5.6-mtd-spi-nor-Add-4B_OPCODES-flag-to-w25q256.patch
+++ b/target/linux/generic/backport-4.19/464-v5.6-mtd-spi-nor-Add-4B_OPCODES-flag-to-w25q256.patch
@@ -14,7 +14,7 @@ Signed-off-by: Tudor Ambarus <tudor.ambarus@microchip.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1257,7 +1257,9 @@ static const struct flash_info spi_nor_i
+@@ -1244,7 +1244,9 @@ static const struct flash_info spi_nor_i
  	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },

--- a/target/linux/generic/backport-5.4/464-v5.6-mtd-spi-nor-Add-4B_OPCODES-flag-to-w25q256.patch
+++ b/target/linux/generic/backport-5.4/464-v5.6-mtd-spi-nor-Add-4B_OPCODES-flag-to-w25q256.patch
@@ -1,0 +1,27 @@
+From 10050a02f7d508fa88f70fcfceefbacd13488ca7 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Mon, 23 Dec 2019 17:05:49 +0200
+Subject: [PATCH] mtd: spi-nor: Add 4B_OPCODES flag to w25q256
+
+The w25q256 supports 4-byte opcodes so lets add the flag.
+Tested on OpenWrt under 4.19.82 kernel on 8devices Habanero.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+Signed-off-by: Tudor Ambarus <tudor.ambarus@microchip.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -2480,7 +2480,9 @@ static const struct flash_info spi_nor_i
+ 	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },
+-	{ "w25q256", INFO(0xef4019, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "w25q256", INFO(0xef4019, 0, 64 * 1024, 512,
++			  SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			  SPI_NOR_4B_OPCODES) },
+ 	{ "w25q256jvm", INFO(0xef7019, 0, 64 * 1024, 512,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024,

--- a/target/linux/generic/pending-4.19/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
+++ b/target/linux/generic/pending-4.19/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1457,7 +1457,7 @@ static int spi_nor_write(struct mtd_info
+@@ -1459,7 +1459,7 @@ static int spi_nor_write(struct mtd_info
  
  		write_enable(nor);
  		ret = nor->write(nor, addr, page_remain, buf + i);
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  			goto write_err;
  		written = ret;
  
-@@ -1466,13 +1466,6 @@ static int spi_nor_write(struct mtd_info
+@@ -1468,13 +1468,6 @@ static int spi_nor_write(struct mtd_info
  			goto write_err;
  		*retlen += written;
  		i += written;

--- a/target/linux/generic/pending-4.19/465-m25p80-mx-disable-software-protection.patch
+++ b/target/linux/generic/pending-4.19/465-m25p80-mx-disable-software-protection.patch
@@ -8,7 +8,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2735,6 +2735,7 @@ static int spi_nor_init(struct spi_nor *
+@@ -2737,6 +2737,7 @@ static int spi_nor_init(struct spi_nor *
  	 */
  	if (JEDEC_MFR(nor->info) == SNOR_MFR_ATMEL ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_INTEL ||

--- a/target/linux/generic/pending-4.19/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
+++ b/target/linux/generic/pending-4.19/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
@@ -17,7 +17,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2737,6 +2737,7 @@ static int spi_nor_init(struct spi_nor *
+@@ -2739,6 +2739,7 @@ static int spi_nor_init(struct spi_nor *
  	    JEDEC_MFR(nor->info) == SNOR_MFR_INTEL ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_MACRONIX ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_SST ||
@@ -25,7 +25,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  	    nor->info->flags & SPI_NOR_HAS_LOCK) {
  		write_enable(nor);
  		write_sr(nor, 0);
-@@ -2873,7 +2874,8 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2875,7 +2876,8 @@ int spi_nor_scan(struct spi_nor *nor, co
  
  	/* NOR protection support for STmicro/Micron chips and similar */
  	if (JEDEC_MFR(info) == SNOR_MFR_MICRON ||

--- a/target/linux/generic/pending-4.19/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
+++ b/target/linux/generic/pending-4.19/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	depends on ARCH_AT91 || (ARM && COMPILE_TEST && !ARCH_EBSA110)
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2649,10 +2649,12 @@ static int spi_nor_select_erase(struct s
+@@ -2651,10 +2651,12 @@ static int spi_nor_select_erase(struct s
  
  #ifdef CONFIG_MTD_SPI_NOR_USE_4K_SECTORS
  	/* prefer "small sector" erase if possible */

--- a/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-xtx-xt25f128b.patch
+++ b/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-xtx-xt25f128b.patch
@@ -30,7 +30,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1273,6 +1273,9 @@ static const struct flash_info spi_nor_i
+@@ -1275,6 +1275,9 @@ static const struct flash_info spi_nor_i
  	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
  	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
  	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },

--- a/target/linux/generic/pending-5.4/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
+++ b/target/linux/generic/pending-5.4/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2704,7 +2704,7 @@ static int spi_nor_write(struct mtd_info
+@@ -2706,7 +2706,7 @@ static int spi_nor_write(struct mtd_info
  
  		write_enable(nor);
  		ret = spi_nor_write_data(nor, addr, page_remain, buf + i);

--- a/target/linux/generic/pending-5.4/465-m25p80-mx-disable-software-protection.patch
+++ b/target/linux/generic/pending-5.4/465-m25p80-mx-disable-software-protection.patch
@@ -8,7 +8,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -4884,6 +4884,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -4886,6 +4886,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	 */
  	if (JEDEC_MFR(nor->info) == SNOR_MFR_ATMEL ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_INTEL ||

--- a/target/linux/generic/pending-5.4/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
+++ b/target/linux/generic/pending-5.4/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
@@ -17,7 +17,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -4397,6 +4397,7 @@ static void st_micron_set_default_init(s
+@@ -4399,6 +4399,7 @@ static void st_micron_set_default_init(s
  
  static void winbond_set_default_init(struct spi_nor *nor)
  {
@@ -25,7 +25,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  	nor->params.set_4byte = winbond_set_4byte;
  }
  
-@@ -4886,6 +4887,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -4888,6 +4889,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	    JEDEC_MFR(nor->info) == SNOR_MFR_INTEL ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_MACRONIX ||
  	    JEDEC_MFR(nor->info) == SNOR_MFR_SST ||

--- a/target/linux/generic/pending-5.4/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
+++ b/target/linux/generic/pending-5.4/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	depends on OF && (ARM || ARM64 || COMPILE_TEST)
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -4464,6 +4464,7 @@ static void spi_nor_info_init_params(str
+@@ -4466,6 +4466,7 @@ static void spi_nor_info_init_params(str
  	struct spi_nor_erase_map *map = &params->erase_map;
  	const struct flash_info *info = nor->info;
  	struct device_node *np = spi_nor_get_flash_node(nor);
@@ -47,7 +47,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	u8 i, erase_mask;
  
  	/* Initialize legacy flash parameters and settings. */
-@@ -4527,6 +4528,21 @@ static void spi_nor_info_init_params(str
+@@ -4529,6 +4530,21 @@ static void spi_nor_info_init_params(str
  	 */
  	erase_mask = 0;
  	i = 0;
@@ -69,7 +69,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (info->flags & SECT_4K_PMC) {
  		erase_mask |= BIT(i);
  		spi_nor_set_erase_type(&map->erase_type[i], 4096u,
-@@ -4538,6 +4554,7 @@ static void spi_nor_info_init_params(str
+@@ -4540,6 +4556,7 @@ static void spi_nor_info_init_params(str
  				       SPINOR_OP_BE_4K);
  		i++;
  	}

--- a/target/linux/generic/pending-5.4/479-mtd-spi-nor-add-xtx-xt25f128b.patch
+++ b/target/linux/generic/pending-5.4/479-mtd-spi-nor-add-xtx-xt25f128b.patch
@@ -30,7 +30,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2504,6 +2504,9 @@ static const struct flash_info spi_nor_i
+@@ -2506,6 +2506,9 @@ static const struct flash_info spi_nor_i
  	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
  	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
  	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },


### PR DESCRIPTION
This patch backports the upstream patch that adds the 4B_OPCODES flag to w25q256 under 4.19 and 5.4 kernels.
This is needed for ipq40xx and ramips.

Signed-off-by: Robert Marko <robimarko@gmail.com>