### PR TITLE
ramips: fix switch config for ZyXEL Keenetic Viva

### DIFF
--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -82,8 +82,8 @@
 
 	rtl8367rb {
 		compatible = "realtek,rtl8367b";
-		cpu_port = <7>;
-		realtek,extif2 = <1 0 1 1 1 1 1 1 2>;
+		cpu_port = <6>;
+		realtek,extif1 = <1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 	};
 };
@@ -138,28 +138,22 @@
 &ethernet {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+	pinctrl-0 = <&mdio_pins>;
 	mtd-mac-address = <&factory 0x00004>;
 
-	port@4 {
+	port@5 {
 		status = "okay";
 		mediatek,fixed-link = <1000 1 1 1>;
 		phy-mode = "rgmii";
-		phy-handle = <&phy4>;
 	};
 
 	mdio0: mdio-bus {
 		status = "okay";
-
-		phy4: ethernet-phy@4 {
-			reg = <4>;
-			phy-mode = "rgmii";
-		};
 	};
 };
 
 &gsw {
-	mediatek,port4 = "gmac";
+	mediatek,port5 = "gmac";
 };
 
 &wmac {

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -211,7 +211,7 @@ ramips_setup_interfaces()
 		;;
 	zyxel,keenetic-viva)
 		ucidef_add_switch "switch1" \
-			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "7t@eth0"
+			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6t@eth0"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"


### PR DESCRIPTION
Port 7 of the RTL8367B is not supported by the current driver.
However, the switch is also connected to the CPU via port 6.
Use extif1 to connect to port 5 of the CPU's Ethernet controller.