### PR TITLE
crypto-linux: 5.4 fix devcrypto module load

### DIFF
--- a/package/kernel/cryptodev-linux/patches/100-v50rc5-module-load.patch
+++ b/package/kernel/cryptodev-linux/patches/100-v50rc5-module-load.patch
@@ -1,0 +1,50 @@
+From f971e0cd4a0ebe59fb2e8e17240399bf6901b09b Mon Sep 17 00:00:00 2001
+From: "Derald D. Woods" <woods.technical@gmail.com>
+Date: Sun, 10 Feb 2019 13:22:19 -0600
+Subject: [PATCH] Fix module loading with Linux v5.0-rc5
+
+This commit fixes this module load error:
+[...]
+[   29.112091] cryptodev: loading out-of-tree module taints kernel.
+[   29.128906] cryptodev: Unknown symbol crypto_givcipher_type (err -2)
+[   29.188842] cryptodev: Unknown symbol crypto_givcipher_type (err -2)
+modprobe: can't load module cryptodev (extra/cryptodev.ko): unknown symbol in module, or unknown parameter
+[...]
+
+Upstream Linux support for unused GIVCIPHER, and others, was dropped here:
+
+c79b411eaa72 (crypto: skcipher - remove remnants of internal IV generators)
+
+Signed-off-by: Derald D. Woods <woods.technical@gmail.com>
+---
+ cryptlib.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/cryptlib.c b/cryptlib.c
+index 6e66698..4a87037 100644
+--- a/cryptlib.c
++++ b/cryptlib.c
+@@ -38,7 +38,9 @@
+ #include "cryptodev_int.h"
+ #include "cipherapi.h"
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0))
+ extern const struct crypto_type crypto_givcipher_type;
++#endif
+ 
+ static void cryptodev_complete(struct crypto_async_request *req, int err)
+ {
+@@ -157,8 +159,11 @@ int cryptodev_cipher_init(struct cipher_data *out, const char *alg_name,
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0))
+ 		tfm = crypto_skcipher_tfm(out->async.s);
+-		if ((tfm->__crt_alg->cra_type == &crypto_ablkcipher_type) ||
+-		    (tfm->__crt_alg->cra_type == &crypto_givcipher_type)) {
++		if ((tfm->__crt_alg->cra_type == &crypto_ablkcipher_type)
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0))
++		    || (tfm->__crt_alg->cra_type == &crypto_givcipher_type)
++#endif
++							) {
+ 			struct ablkcipher_alg *alg;
+ 
+ 			alg = &tfm->__crt_alg->cra_ablkcipher;


### PR DESCRIPTION
Tested on mvebu targets mamba, rango with mvebu 5.4 WIP, mamba with current 4.19.x

Signed-off-by: Kabuli Chana <newtownBuild@gmail.com>
