### PR TITLE
[RFC] treewide: tidy up image recipes

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -269,7 +269,7 @@ define Build/xor-image
 endef
 
 define Build/check-size
-	@[ $$(($(subst k,* 1024,$(subst m, * 1024k,$(1))))) -ge "$$(stat -c%s $@)" ] || { \
+	@[ $$(($(subst k,* 1024,$(subst m, * 1024k,$(if $(1),$(1),$(IMAGE_SIZE)))))) -ge "$$(stat -c%s $@)" ] || { \
 		echo "WARNING: Image file $@ is too big" >&2; \
 		rm -f $@; \
 	}

--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -212,7 +212,7 @@ define Device/netgear_wndr4700
 	    append-uImage-fakehdr filesystem | dtb | create-uImage-dtb | prepend-dtb
   KERNEL_INITRAMFS := kernel-bin | gzip | dtb | MuImage-initramfs gzip
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-		       netgear-dni | check-size $$$$(IMAGE_SIZE)
+		       netgear-dni | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   ARTIFACT/device-tree.dtb := export-dtb | uImage none
   NETGEAR_BOARD_ID := WNDR4700

--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -170,7 +170,7 @@ define Device/netgear_wndap6x0
   KERNEL_SIZE := 4032k
   KERNEL := dtb | kernel-bin | gzip | MuImage-initramfs gzip
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi
   UBINIZE_OPTS := -E 5
 endef
 
@@ -211,7 +211,7 @@ define Device/netgear_wndr4700
   KERNEL := kernel-bin | lzma | uImage lzma | pad-offset $$(BLOCKSIZE) 64 | \
 	    append-uImage-fakehdr filesystem | dtb | create-uImage-dtb | prepend-dtb
   KERNEL_INITRAMFS := kernel-bin | gzip | dtb | MuImage-initramfs gzip
-  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 		       netgear-dni | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   ARTIFACT/device-tree.dtb := export-dtb | uImage none

--- a/target/linux/ar71xx/image/Makefile
+++ b/target/linux/ar71xx/image/Makefile
@@ -63,7 +63,7 @@ define Device/Default
   KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma
   COMPILE :=
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size
 endef
 
 $(eval $(call BuildImage))

--- a/target/linux/ar71xx/image/common-tp-link.mk
+++ b/target/linux/ar71xx/image/common-tp-link.mk
@@ -73,7 +73,7 @@ define Device/tplink-safeloader
   $(Device/tplink)
   KERNEL := kernel-bin | patch-cmdline | lzma | tplink-v1-header
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
 

--- a/target/linux/ar71xx/image/generic-ubnt.mk
+++ b/target/linux/ar71xx/image/generic-ubnt.mk
@@ -50,7 +50,7 @@ define Device/ubnt
   UBNT_BOARD := XM
   UBNT_VERSION := 6.0.0
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split
 endef
 
@@ -128,7 +128,7 @@ define Device/ubnt-unifiac
   IMAGE_SIZE := 7744k
   MTDPARTS := spi0.0:384k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),7744k(ubnt-airos)ro,128k(bs),256k(cfg)ro,64k(EEPROM)ro
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size
 endef
 
 define Device/ubnt-unifiac-lite
@@ -257,7 +257,7 @@ define Device/ubnt-routerstation
   IMAGE_SIZE := 16128k
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/factory.bin := append-rootfs | pad-rootfs | mkubntimage
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | combined-image | check-size
   KERNEL := kernel-bin | patch-cmdline | lzma | pad-to $$(BLOCKSIZE)
 endef
 
@@ -304,7 +304,7 @@ define Device/ubnt-uap-pro
   DEVICE_PROFILE := UBNT UAPPRO
   KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma | jffs2 kernel0
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage2
 endef
 TARGET_DEVICES += ubnt-uap-pro

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -101,7 +101,7 @@ define Device/ap121f
   MTDPARTS := spi0.0:192k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
   SUPPORTED_DEVICES := ap121f
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += ap121f
 
@@ -132,9 +132,9 @@ define Device/ap91-5g
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),6144k(rootfs),1600k(kernel),64k(config)ro,64k(art)ro,7744k@0x50000(firmware)
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/factory.bin := append-rootfs | pad-rootfs |\
-	alfa-network-rootfs-header | append-kernel | check-size $$$$(IMAGE_SIZE)
+	alfa-network-rootfs-header | append-kernel | check-size
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs |\
-	pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
+	pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size
 endef
 
 define Device/arduino-yun
@@ -302,7 +302,7 @@ define Device/e1700ac-v2-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e1700ac-v2-16M
 
@@ -321,7 +321,7 @@ define Device/e558-v2-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art),-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e558-v2-16M
 
@@ -340,7 +340,7 @@ define Device/e600g-v2-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e600g-v2-16M
 
@@ -360,7 +360,7 @@ define Device/e600gac-v2-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e600gac-v2-16M
 
@@ -379,7 +379,7 @@ define Device/e750a-v4-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art),-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e750a-v4-16M
 
@@ -398,7 +398,7 @@ define Device/e750g-v8-16M
   IMAGE_SIZE := 15936k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(pri-data)ro,64k(art),-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += e750g-v8-16M
 
@@ -493,7 +493,7 @@ define Device/gl-ar750
   IMAGE_SIZE := 16000k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += gl-ar750
 
@@ -506,7 +506,7 @@ define Device/gl-ar750s
   IMAGE_SIZE := 16000k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += gl-ar750s
 
@@ -539,7 +539,7 @@ define Device/gl-usb150
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
   SUPPORTED_DEVICES := gl-usb150
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += gl-usb150
 
@@ -574,7 +574,7 @@ define Device/mr12
   MTDPARTS := spi0.0:256k(u-boot)ro,256k(u-boot-env)ro,13440k(rootfs),2240k(kernel),64k(mac),128k(art)ro,15680k@0x80000(firmware)
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size
   IMAGES := kernel.bin rootfs.bin sysupgrade.bin
 endef
 TARGET_DEVICES += mr12
@@ -602,7 +602,7 @@ define Device/dr344
   ROOTFS_SIZE := 6336k
   IMAGE_SIZE := 7744k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,6336k(rootfs),1408k(kernel),64k(nvram),64k(art)ro,7744k@0x50000(firmware)
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size
 endef
 
 define Device/dr531
@@ -625,9 +625,9 @@ define Device/wndr3700
   IMAGES := sysupgrade.bin factory.img factory-NA.img
   KERNEL := kernel-bin | patch-cmdline | lzma -d20 | netgear-uImage lzma
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | netgear-squashfs | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size $$$$(IMAGE_SIZE)
-  IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | check-size
+  IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | check-size
+  IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | check-size
 endef
 TARGET_DEVICES += wndr3700
 
@@ -826,7 +826,7 @@ define Device/r36a
   IMAGE_SIZE := 15872k
   MTDPARTS := spi0.0:384k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += r36a
 
@@ -854,10 +854,10 @@ define Device/rut900
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs |\
 	pad-rootfs | teltonika-fw-fake-checksum | append-string master |\
-	append-md5sum-bin | check-size $$$$(IMAGE_SIZE)
+	append-md5sum-bin | check-size
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
 	append-rootfs | pad-rootfs | append-metadata |\
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += rut900
 
@@ -1023,7 +1023,7 @@ define Device/t830
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),16000k(firmware),64k(art)ro
   SUPPORTED_DEVICES := t830
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += t830
 
@@ -1057,7 +1057,7 @@ define Device/n5q
   IMAGE_SIZE := 15872k
   MTDPARTS := spi0.0:384k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += n5q
 
@@ -1074,8 +1074,8 @@ define Device/NBG6616
   RAS_VERSION := "$(VERSION_DIST) $(REVISION)"
   IMAGES := factory.bin sysupgrade.bin
   KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma | jffs2 boot/vmlinux.lzma.uImage
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | pad-to 64k | check-size $$$$(IMAGE_SIZE) | zyxel-ras-image
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | pad-to 64k | check-size | zyxel-ras-image
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size
   # We cannot currently build a factory image. It is the sysupgrade image
   # prefixed with a header (which is actually written into the MTD device).
   # The header is 2kiB and is filled with 0xff. The format seems to be:
@@ -1107,7 +1107,7 @@ define Device/c-55
   KERNEL_SIZE := 2048k
   IMAGE_SIZE := 15872k
   MTDPARTS := spi0.0:256k(u-boot)ro,128k(u-boot-env)ro,2048k(kernel),13824k(rootfs),13824k(opt)ro,2624k(failsafe)ro,64k(art)ro,15872k@0x60000(firmware)
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size
 endef
 TARGET_DEVICES += c-55
 
@@ -1139,10 +1139,10 @@ define Device/seama
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := \
 	$$(IMAGE/default) | seama | pad-rootfs | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/factory.bin := \
 	$$(IMAGE/default) | seama | pad-rootfs | \
-	seama-seal | check-size $$$$(IMAGE_SIZE)
+	seama-seal | check-size
   SEAMA_SIGNATURE :=
 endef
 
@@ -1157,7 +1157,7 @@ define Device/dir-869-a1
   IMAGE/factory.bin := \
 	$$(IMAGE/default) | pad-rootfs -x 64 | \
 	seama | seama-seal -m "signature=$$$$(SEAMA_SIGNATURE)" | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += dir-869-a1
 
@@ -1200,7 +1200,7 @@ define Device/dap-1330-a1
   BOARDNAME := DAP-1330-A1
   IMAGES := factory.img sysupgrade.bin
   IMAGE_SIZE := 7936k
-  IMAGE/factory.img := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | mkdapimg2 917504
+  IMAGE/factory.img := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | mkdapimg2 917504
   MTDPARTS := spi0.0:64k(u-boot)ro,64k(art)ro,64k(mp)ro,64k(config)ro,7936k(firmware)
   DAP_SIGNATURE := HONEYBEE-FIRMWARE-DAP-1330
 endef
@@ -1212,8 +1212,8 @@ define Device/dap-2695-a1
   BOARDNAME := DAP-2695-A1
   IMAGES := factory.img sysupgrade.bin
   IMAGE_SIZE := 15360k
-  IMAGE/factory.img := append-kernel | pad-offset 65536 160 | append-rootfs | wrgg-pad-rootfs | mkwrggimg | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := append-kernel | pad-offset 65536 160 | mkwrggimg | append-rootfs | wrgg-pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.img := append-kernel | pad-offset 65536 160 | append-rootfs | wrgg-pad-rootfs | mkwrggimg | check-size
+  IMAGE/sysupgrade.bin := append-kernel | pad-offset 65536 160 | mkwrggimg | append-rootfs | wrgg-pad-rootfs | check-size
   KERNEL := kernel-bin | patch-cmdline | relocate-kernel | lzma
   KERNEL_INITRAMFS := $$(KERNEL) | mkwrggimg
   MTDPARTS := spi0.0:256k(bootloader)ro,64k(bdcfg)ro,64k(rgdb)ro,64k(langpack)ro,15360k(firmware),448k(captival)ro,64k(certificate)ro,64k(radiocfg)ro
@@ -1229,7 +1229,7 @@ define Device/wam250
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),128k(nvram)ro,15872k(firmware),64k(art)ro
   SUPPORTED_DEVICES := wam250
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += wam250
 
@@ -1275,7 +1275,7 @@ define Device/wpj344
   BOARDNAME := WPJ344
   SUPPORTED_DEVICES := wpj344
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += wpj344
 
@@ -1292,7 +1292,7 @@ define Device/wpj558
   BOARDNAME := WPJ558
   SUPPORTED_DEVICES := wpj558
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += wpj558
 
@@ -1318,7 +1318,7 @@ define Device/AVM
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
 	append-squashfs-fakeroot-be | pad-to 256 | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 
 define Device/fritz300e

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -48,7 +48,7 @@ define Device/rb-nor-flash-16M
   KERNEL_INSTALL := 1
   SUPPORTED_DEVICES := rb-750-r2 rb-750up-r2 rb-750p-pbr2 rb-911-2hn rb-911-5hn rb-931-2nd rb-941-2nd rb-951ui-2nd rb-952ui-5ac2nd rb-962uigs-5hact2hnt rb-lhg-5nd rb-map-2nd rb-mapl-2nd rb-wap-2nd rb-wapr-2nd rb-sxt-2nd-r3
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += rb-nor-flash-16M
 

--- a/target/linux/ar71xx/image/mikrotik.mk
+++ b/target/linux/ar71xx/image/mikrotik.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += MIKROTIK_CHUNKSIZE
+
 define Device/mikrotik
   PROFILES := Default
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
@@ -9,7 +11,6 @@ define Device/mikrotik
   MIKROTIK_CHUNKSIZE :=
   IMAGE/sysupgrade.bin/squashfs :=
 endef
-DEVICE_VARS += MIKROTIK_CHUNKSIZE
 
 define Device/mikrotik-nand
   $(Device/mikrotik)

--- a/target/linux/ar71xx/image/nand.mk
+++ b/target/linux/ar71xx/image/nand.mk
@@ -35,7 +35,7 @@ define Device/domywifi-dw33d
   BOARDNAME := DW33D
   IMAGE_SIZE := 16000k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware);ar934x-nfc:96m(rootfs_data),32m(backup)ro
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 14528k | append-kernel | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 14528k | append-kernel | check-size
 endef
 TARGET_DEVICES += domywifi-dw33d
 
@@ -52,7 +52,7 @@ define Device/hiveap-121
   MTDPARTS := spi0.0:512k(u-boot)ro,64k(u-boot-env),64k(hw-info)ro,64k(boot-info)ro,64k(boot-sinfo)ro;ar934x-nfc:4096k(u-boot-1),4096k(u-boot-env-1),5m(kernel),111m(ubi),4096k(wifi-info)ro
   IMAGES := sysupgrade.tar factory.bin
   KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | check-size
   IMAGE/sysupgrade.tar := sysupgrade-tar
 endef
 TARGET_DEVICES += hiveap-121

--- a/target/linux/ar71xx/image/tiny-senao.mk
+++ b/target/linux/ar71xx/image/tiny-senao.mk
@@ -23,6 +23,6 @@ define Device/ens202ext
   IMAGES += factory.bin
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),320k(custom)ro,1536k(kernel),12096k(rootfs),2048k(failsafe)ro,64k(art)ro,13632k@0xa0000(firmware)
   IMAGE/factory.bin := append-rootfs | pad-rootfs | senao-factory-image ens202ext
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size
 endef
 TARGET_DEVICES += ens202ext

--- a/target/linux/ar71xx/image/tiny.mk
+++ b/target/linux/ar71xx/image/tiny.mk
@@ -15,7 +15,7 @@ define Device/bhr-4grv2
   IMAGE_SIZE := 16000k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware)
   IMAGES := sysupgrade.bin factory.bin
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | mkbuffaloimg
 endef
 
@@ -27,5 +27,5 @@ define Device/zbt-we1526
   KERNEL_SIZE := 1472k
   ROOTFS_SIZE := 14528k
   MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,14528k(rootfs),1472k(kernel),64k(art)ro,16000k@0x50000(firmware)
-  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to $$$$(ROOTFS_SIZE) | append-kernel | check-size
 endef

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -65,7 +65,7 @@ define Device/Default
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 
 ifeq ($(SUBTARGET),generic)

--- a/target/linux/ath79/image/common-netgear.mk
+++ b/target/linux/ath79/image/common-netgear.mk
@@ -38,7 +38,7 @@ define Device/netgear_ath79
   KERNEL := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
   IMAGES += factory.img
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/factory.img := $$(IMAGE/default) | netgear-dni | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef

--- a/target/linux/ath79/image/common-tp-link.mk
+++ b/target/linux/ath79/image/common-tp-link.mk
@@ -31,7 +31,7 @@ define Device/tplink-v2
   KERNEL := kernel-bin | append-dtb | lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | tplink-v2-header
   IMAGE/sysupgrade.bin := tplink-v2-image -s | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 
 define Device/tplink-nolzma
@@ -79,7 +79,7 @@ define Device/tplink-safeloader
   TPLINK_HWREV := 0x0
   KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header -O
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef
 

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -541,7 +541,7 @@ define Device/tplink_tl-wr2543-v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   TPLINK_HWID := 0x25430001
   IMAGE/sysupgrade.bin := tplink-v1-image sysupgrade -v 3.13.99 | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := tplink-v1-image factory -v 3.13.99
   SUPPORTED_DEVICES += tl-wr2543n
 endef

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -34,7 +34,7 @@ define Device/ubnt
   DEVICE_PACKAGES := kmod-usb2
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | mkubntimage-split
+	append-rootfs | pad-rootfs | check-size | mkubntimage-split
 endef
 
 define Device/ubnt-bz
@@ -241,7 +241,7 @@ define Device/ubnt_routerstation_common
   IMAGE_SIZE := 16128k
   IMAGES := factory.bin
   IMAGE/factory.bin := append-rootfs | pad-rootfs | mkubntimage | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   KERNEL := kernel-bin | append-dtb | lzma | pad-to $$(BLOCKSIZE)
   KERNEL_INITRAMFS := kernel-bin | append-dtb
 endef

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -99,9 +99,9 @@ define Device/seama
   # - 36 bytes of META data (4-bytes aligned)
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | seama | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
-	seama-seal | check-size $$$$(IMAGE_SIZE)
+	seama-seal | check-size
   SEAMA_SIGNATURE :=
 endef
 
@@ -127,7 +127,7 @@ define Device/adtran_bsap1880
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | \
-	check-size $$$$(IMAGE_SIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
+	check-size | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
 define Device/adtran_bsap1800-v2
@@ -171,7 +171,7 @@ define Device/avm_fritz300e
   IMAGE_SIZE := 15232k
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
 	append-squashfs-fakeroot-be | pad-to 256 | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := fritz-tffs rssileds -swconfig
   SUPPORTED_DEVICES += fritz300e
 endef
@@ -186,7 +186,7 @@ define Device/avm_fritz4020
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
 	append-squashfs-fakeroot-be | pad-to 256 | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := fritz-tffs
   SUPPORTED_DEVICES += fritz4020
 endef
@@ -200,7 +200,7 @@ define Device/buffalo_bhr-4grv
   IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | \
 	buffalo-tag BHR-4GRV 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
@@ -223,7 +223,7 @@ define Device/buffalo_wzr-hp-ag300h
   IMAGE_SIZE := 32320k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-AG300H 1.99 | \
 	buffalo-tag WZR-HP-AG300H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
@@ -242,7 +242,7 @@ define Device/buffalo_wzr-hp-g302h-a1a0
   IMAGE_SIZE := 32128k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G302H 1.99 | \
 	buffalo-tag WZR-HP-G302H 4
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
@@ -258,7 +258,7 @@ define Device/buffalo_wzr-hp-g450h
   IMAGE_SIZE := 32256k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | \
 	buffalo-tag WZR-HP-G450H 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
@@ -426,7 +426,7 @@ define Device/dlink_dir-825-b1
   DEVICE_VARIANT := B1
   IMAGE_SIZE := 6208k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-leds-reset kmod-owl-loader
   SUPPORTED_DEVICES += dir-825-b1
@@ -446,9 +446,9 @@ define Device/dlink_dir-825-c1
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
 	pad-rootfs
   IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+	append-string 00DB120AR9344-RT-101214-00 | check-size
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += dlink_dir-825-c1
 
@@ -464,9 +464,9 @@ define Device/dlink_dir-835-a1
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
 	pad-rootfs
   IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00DB120AR9344-RT-101214-00 | check-size $$$$(IMAGE_SIZE)
+	append-string 00DB120AR9344-RT-101214-00 | check-size
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += dlink_dir-835-a1
 
@@ -485,9 +485,9 @@ define Device/dlink_dir-842-c
   IMAGE/default := append-kernel | uImage lzma | \
 	pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | seama | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
-	seama-seal | check-size $$$$(IMAGE_SIZE)
+	seama-seal | check-size
   IMAGE_SIZE := 15680k
 endef
 
@@ -561,10 +561,10 @@ define Device/engenius_ecb1750
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   IMAGE_SIZE := 15680k
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x101 -p 0x6d -t 2
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
 endef
 TARGET_DEVICES += engenius_ecb1750
 
@@ -576,7 +576,7 @@ define Device/engenius_epg5000
   IMAGE_SIZE := 14656k
   IMAGES += factory.dlf
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x101 -p 0x71 -t 2
   SUPPORTED_DEVICES += epg5000
 endef
@@ -694,7 +694,7 @@ define Device/iodata_wn-ac1167dgr
   IMAGE_SIZE := 14656k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x30a -p 0x61 -t 2
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -707,7 +707,7 @@ define Device/iodata_wn-ac1600dgr
   IMAGE_SIZE := 14656k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -720,7 +720,7 @@ define Device/iodata_wn-ac1600dgr2
   IMAGE_SIZE := 14656k
   IMAGES += dgr2-dgr3-factory.bin
   IMAGE/dgr2-dgr3-factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x30a -p 0x60 -t 2 -v 200
   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
 endef
@@ -733,7 +733,7 @@ define Device/iodata_wn-ag300dgr
   IMAGE_SIZE := 15424k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x30a -p 0x47 -t 2
   DEVICE_PACKAGES := kmod-usb2
 endef
@@ -774,9 +774,9 @@ define Device/nec_wg1200cr
   IMAGES += factory.bin
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | seama | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | pad-rootfs -x 64 | seama | \
-	seama-seal | nec-enc 9gsiy9nzep452pad | check-size $$$$(IMAGE_SIZE)
+	seama-seal | nec-enc 9gsiy9nzep452pad | check-size
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += nec_wg1200cr
@@ -788,7 +788,7 @@ define Device/nec_wg800hp
   IMAGE_SIZE := 7104k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	xor-image -p 6A57190601121E4C004C1E1201061957 -x | nec-fw LASER_ATERM
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct-htt
 endef
@@ -836,7 +836,7 @@ define Device/netgear_wndr3700
   IMAGE_SIZE := 7680k
   IMAGES += factory-NA.img
   IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndr3700
@@ -893,7 +893,7 @@ define Device/netgear_wnr2200-8m
   IMAGE_SIZE := 7808k
   IMAGES += factory-NA.img
   IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   SUPPORTED_DEVICES += wnr2200
 endef
 TARGET_DEVICES += netgear_wnr2200-8m
@@ -917,7 +917,7 @@ define Device/ocedo_koala
   SUPPORTED_DEVICES += koala
   IMAGE_SIZE := 7424k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
 endef
 TARGET_DEVICES += ocedo_koala
 
@@ -927,7 +927,7 @@ define Device/ocedo_raccoon
   DEVICE_MODEL := Raccoon
   IMAGE_SIZE := 7424k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
 endef
 TARGET_DEVICES += ocedo_raccoon
 
@@ -938,7 +938,7 @@ define Device/ocedo_ursus
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   IMAGE_SIZE := 7424k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
 endef
 TARGET_DEVICES += ocedo_ursus
 
@@ -987,7 +987,7 @@ define Device/phicomm_k2t
   DEVICE_MODEL := K2T
   IMAGE_SIZE := 15744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-leds-reset kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9888-ct
 endef
 TARGET_DEVICES += phicomm_k2t
@@ -1075,7 +1075,7 @@ define Device/sitecom_wlr-7100
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct-smallbuffers kmod-usb2
   IMAGES += factory.dlf
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x222 -p 0x53 -t 2
   IMAGE_SIZE := 7488k
 endef
@@ -1091,7 +1091,7 @@ define Device/sitecom_wlr-8100
   SUPPORTED_DEVICES += wlr8100
   IMAGES += factory.dlf
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x222 -p 0x56 -t 2
   IMAGE_SIZE := 15424k
 endef
@@ -1112,10 +1112,10 @@ define Device/teltonika_rut955
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs |\
 	pad-rootfs | teltonika-fw-fake-checksum | append-string master |\
-	append-md5sum-bin | check-size $$$$(IMAGE_SIZE)
+	append-md5sum-bin | check-size
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
 	append-rootfs | pad-rootfs | append-metadata |\
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += teltonika_rut955
 
@@ -1131,9 +1131,9 @@ define Device/trendnet_tew-823dru
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
 	pad-rootfs
   IMAGE/factory.bin := $$(IMAGE/default) | pad-offset $$$$(IMAGE_SIZE) 26 | \
-	append-string 00AP135AR9558-RT-131129-00 | check-size $$$$(IMAGE_SIZE)
+	append-string 00AP135AR9558-RT-131129-00 | check-size
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += trendnet_tew-823dru
 

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -19,7 +19,7 @@ define Device/mikrotik_routerboard-wap-g-5hact2hnd
   IMAGE_SIZE := 16256k
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -1,5 +1,7 @@
 include ./common-netgear.mk	# for netgear-uImage
 
+DEVICE_VARS += RAS_ROOTFS_SIZE RAS_BOARD RAS_VERSION
+
 # attention: only zlib compression is allowed for the boot fs
 define Build/zyxel-buildkerneljffs
 	rm -rf  $(KDIR_TMP)/zyxelnbg6716
@@ -216,4 +218,3 @@ define Device/zyxel_nbg6716
   UBINIZE_OPTS := -E 5
 endef
 TARGET_DEVICES += zyxel_nbg6716
-DEVICE_VARS += RAS_ROOTFS_SIZE RAS_BOARD RAS_VERSION

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -41,7 +41,7 @@ define Device/aerohive_hiveap-121
   SUPPORTED_DEVICES += hiveap-121
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += aerohive_hiveap-121
@@ -60,7 +60,7 @@ define Device/domywifi_dw33d
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += domywifi_dw33d
 
@@ -143,9 +143,9 @@ define Device/netgear_ath79_nand
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d20 | netgear-uImage lzma
   IMAGES := sysupgrade.bin factory.img
   IMAGE/factory.img := append-kernel | append-ubi | netgear-dni | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   UBINIZE_OPTS := -E 5
 endef
 

--- a/target/linux/ath79/image/tiny-netgear.mk
+++ b/target/linux/ath79/image/tiny-netgear.mk
@@ -56,7 +56,7 @@ define Device/netgear_wnr2000-v3
 	append-rootfs | pad-rootfs
   IMAGES += factory-NA.img
   IMAGE/factory-NA.img := $$(IMAGE/default) | netgear-dni NA | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   SUPPORTED_DEVICES += wnr2000-v3
   $(Device/netgear_ath79)
 endef

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -7,7 +7,7 @@ define Device/buffalo_whr-g301n
   IMAGE_SIZE := 3712k
   IMAGES += factory.bin tftp.bin
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | check-size
   IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | \
 	buffalo-tag WHR-G301N 3
   IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
@@ -25,7 +25,7 @@ define Device/dlink_dir-615-e4
   IMAGES += factory.bin
   IMAGE/default := append-kernel | append-rootfs | pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/factory.bin := $$(IMAGE/default) | \
 	check-size $$$$(FACTORY_IMAGE_SIZE) | pad-to $$$$(FACTORY_IMAGE_SIZE) | \
 	append-string "AP99-AR7240-RT-091105-05"

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -3,6 +3,12 @@
 # BCM33XX/BCM63XX Profiles
 #
 
+DEVICE_VARS += HCS_MAGIC_BYTES HCS_REV_MIN HCS_REV_MAJ
+DEVICE_VARS += BLOCK_SIZE FLASH_MB IMAGE_OFFSET
+DEVICE_VARS += CFE_BOARD_ID CFE_CHIP_ID CFE_EXTRAS
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION
+DEVICE_VARS += REDBOOT_PREFIX
+
 define Device/bcm33xx
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-lzma bin | hcs-initramfs
   IMAGES :=
@@ -10,7 +16,6 @@ define Device/bcm33xx
   HCS_REV_MIN :=
   HCS_REV_MAJ :=
 endef
-DEVICE_VARS += HCS_MAGIC_BYTES HCS_REV_MIN HCS_REV_MAJ
 
 define Device/bcm63xx
   FILESYSTEMS := squashfs jffs2-64k jffs2-128k
@@ -31,8 +36,6 @@ define Device/bcm63xx
   CFE_CHIP_ID :=
   CFE_EXTRAS = --block-size $$(BLOCK_SIZE) --image-offset $$(if $$(IMAGE_OFFSET),$$(IMAGE_OFFSET),$$(BLOCK_SIZE))
 endef
-DEVICE_VARS += BLOCK_SIZE FLASH_MB IMAGE_OFFSET
-DEVICE_VARS += CFE_BOARD_ID CFE_CHIP_ID CFE_EXTRAS
 
 define Device/bcm63xx_netgear
   $(Device/bcm63xx)
@@ -42,7 +45,6 @@ define Device/bcm63xx_netgear
   NETGEAR_BOARD_ID :=
   NETGEAR_REGION :=
 endef
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_REGION
 
 define Device/bcm63xx_redboot
   FILESYSTEMS := squashfs
@@ -52,7 +54,6 @@ define Device/bcm63xx_redboot
   IMAGE/redboot.bin := redboot-bin
   REDBOOT_PREFIX := $$(IMAGE_PREFIX)
 endef
-DEVICE_VARS += REDBOOT_PREFIX
 
 ### Generic ###
 define Device/brcm_bcm963281tan

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -1,8 +1,9 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
-DEVICE_VARS += RAS_BOARD RAS_ROOTFS_SIZE RAS_VERSION \
-	       WRGG_DEVNAME WRGG_SIGNATURE
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+DEVICE_VARS += RAS_BOARD RAS_ROOTFS_SIZE RAS_VERSION
+DEVICE_VARS += WRGG_DEVNAME WRGG_SIGNATURE
 
 define Device/Default
 	PROFILES := Default
@@ -51,7 +52,6 @@ define Device/DniImage
 	IMAGE/factory.img := append-kernel | pad-offset 64k 64 | append-uImage-fakehdr filesystem | append-rootfs | pad-rootfs | netgear-dni
 	IMAGE/sysupgrade.bin := append-kernel | pad-offset 64k 64 | append-uImage-fakehdr filesystem | append-rootfs | pad-rootfs | append-metadata
 endef
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 
 define Build/mkmylofw_32m
 	$(eval device_id=$(word 1,$(1)))

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -95,7 +95,7 @@ define Device/8dev_habanero-dvk
 	SOC := qcom-ipq4019
 	DEVICE_PACKAGES := ipq-wifi-8dev_habanero-dvk
 	IMAGES := sysupgrade.bin
-	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += 8dev_habanero-dvk
 
@@ -287,8 +287,8 @@ define Device/dlink_dap-2610
 	# the sysupgrade image only the kernel is included in the wrgg checksum,
 	# but this is not flashable from the D-link http server.
 	# append-rootfs must start on an erase block boundary.
-	IMAGE/factory.bin    := append-kernel | pad-offset 6144k 160 | append-rootfs | wrgg-image | check-size $$$$(IMAGE_SIZE)
-	IMAGE/sysupgrade.bin := append-kernel | wrgg-image | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | append-metadata
+	IMAGE/factory.bin    := append-kernel | pad-offset 6144k 160 | append-rootfs | wrgg-image | check-size
+	IMAGE/sysupgrade.bin := append-kernel | wrgg-image | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 	DEVICE_PACKAGES := ipq-wifi-dlink_dap2610
 endef
 TARGET_DEVICES += dlink_dap-2610
@@ -328,7 +328,7 @@ define Device/engenius_emd1
 	IMAGE_SIZE := 30720k
 	IMAGES := sysupgrade.bin factory.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	IMAGE/factory.bin := qsdk-ipq-factory-nor | check-size $$$$(IMAGE_SIZE)
+	IMAGE/factory.bin := qsdk-ipq-factory-nor | check-size
 endef
 TARGET_DEVICES += engenius_emd1
 
@@ -352,9 +352,9 @@ define Device/engenius_ens620ext
 	KERNEL_SIZE := 5120k
 	FILESYSTEMS := squashfs
 	IMAGES := sysupgrade.bin factory_30.bin factory_35.bin
-	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | append-metadata
-	IMAGE/factory_30.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE) | SenaoFW $$$$(PRODUCT_ID) $$$$(FW_VER)
-	IMAGE/factory_35.bin := qsdk-ipq-factory-nor | check-size $$$$(IMAGE_SIZE) | SenaoFW $$$$(PRODUCT_ID_NEW) $$$$(FW_VER_NEW)
+	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
+	IMAGE/factory_30.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | check-size | SenaoFW $$$$(PRODUCT_ID) $$$$(FW_VER)
+	IMAGE/factory_35.bin := qsdk-ipq-factory-nor | check-size | SenaoFW $$$$(PRODUCT_ID_NEW) $$$$(FW_VER_NEW)
 endef
 TARGET_DEVICES += engenius_ens620ext
 

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -3,6 +3,9 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+DEVICE_VARS += TPLINK_BOARD_ID
+
 define Build/buffalo-rootfs-cksum
 	( \
 		echo -ne "\x$$(od -A n -t u1 $@ | tr -s ' ' '\n' | \
@@ -58,7 +61,6 @@ define Device/DniImage
 	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | append-ubi | netgear-dni
 	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | append-metadata
 endef
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 
 define Device/TpSafeImage
 	KERNEL_SUFFIX := -uImage
@@ -69,7 +71,6 @@ define Device/TpSafeImage
 	IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 	IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | append-metadata
 endef
-DEVICE_VARS += TPLINK_BOARD_ID
 
 define Device/ZyXELImage
 	KERNEL_SUFFIX := -uImage

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -75,7 +75,7 @@ define Device/iom_ix2-200
   UBINIZE_OPTS := -E 5
   IMAGE_SIZE := 31744k
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += iom_ix2-200
 

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -66,7 +66,7 @@ define Device/Default
   DEVICE_DTS = $$(SOC)_$(1)
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 
 define Device/NAND/xway
@@ -91,14 +91,14 @@ endef
 define Device/lantiqBrnImage
   KERNEL := kernel-bin | append-dtb | mkbrncmdline | lzma-no-dict
   IMAGES := factory.bin
-  IMAGE/factory.bin := mkbrnimg | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := mkbrnimg | check-size
 endef
 DEVICE_VARS += SIGNATURE MAGIC CRC32_POLY
 
 define Device/lantiqFullImage
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-offset 4 0
   IMAGES := sysupgrade.bin fullimage.bin
-  IMAGE/fullimage.bin := fullimage | check-size $$$$(IMAGE_SIZE)
+  IMAGE/fullimage.bin := fullimage | check-size
 endef
 
 define Device/AVM
@@ -106,7 +106,7 @@ define Device/AVM
   KERNEL := kernel-bin | append-dtb | lzma | eva-image
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-avm-fakeroot | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 
 ifeq ($(SUBTARGET),ase)

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -52,6 +52,7 @@ define Build/fullimage
 	rm $@.tmp
 endef
 
+DEVICE_VARS += SIGNATURE MAGIC CRC32_POLY
 DTS_DIR := $(DTS_DIR)/lantiq
 
 # Shared device definition: applies to every defined device
@@ -93,7 +94,6 @@ define Device/lantiqBrnImage
   IMAGES := factory.bin
   IMAGE/factory.bin := mkbrnimg | check-size
 endef
-DEVICE_VARS += SIGNATURE MAGIC CRC32_POLY
 
 define Device/lantiqFullImage
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-offset 4 0

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -89,10 +89,10 @@ define Device/netgear_dgn3500
 	factory-na.img factory.img
   IMAGE/sysupgrade-na.bin := \
 	append-kernel | append-rootfs | dgn3500-sercom-footer 0x0 "NA" | \
-	pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | append-metadata | check-size
   IMAGE/sysupgrade.bin := \
 	append-kernel | append-rootfs | dgn3500-sercom-footer 0x0 "WW" | \
-	pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | append-metadata | check-size
   IMAGE/factory-na.img := \
 	pad-extra $(DGN3500_KERNEL_OFFSET_DEC) | append-kernel | append-rootfs | \
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "NA" | pad-rootfs | \
@@ -119,7 +119,7 @@ define Device/netgear_dgn3500b
   IMAGES += factory.img
   IMAGE/sysupgrade.bin := \
 	append-kernel | append-rootfs | dgn3500-sercom-footer 0x0 "DE" | \
-	pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | append-metadata | check-size
   IMAGE/factory.img := \
 	pad-extra $(DGN3500_KERNEL_OFFSET_DEC) | append-kernel | append-rootfs | \
 	dgn3500-sercom-footer $(DGN3500_KERNEL_OFFSET_HEX) "DE" | pad-rootfs | \

--- a/target/linux/lantiq/image/tp-link.mk
+++ b/target/linux/lantiq/image/tp-link.mk
@@ -9,7 +9,7 @@ define Device/lantiqTpLink
 	tplink-v2-header -s -V "ver. 1.0"
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := tplink-v2-image -s -V "ver. 1.0" | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
 endef
 
 define Device/tplink_tdw8970

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+
 define Device/alphanetworks_asl56026
   DEVICE_VENDOR := Alpha
   DEVICE_MODEL := ASL56026
@@ -199,7 +201,6 @@ define Device/netgear_dm200
   NETGEAR_BOARD_ID := DM200
   NETGEAR_HW_ID := 29765233+8+0+64+0+0
 endef
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 TARGET_DEVICES += netgear_dm200
 
 define Device/zyxel_p-2812hnu-f1

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -193,7 +193,7 @@ define Device/netgear_dm200
   IMAGE/sysupgrade.bin := append-kernel | \
 	pad-offset 64k 64 | append-uImage-fakehdr filesystem | \
 	pad-offset 64k 64 | append-uImage-fakehdr filesystem | \
-	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-rootfs | pad-rootfs | append-metadata | check-size
   IMAGE/factory.img := $$(IMAGE/sysupgrade.bin) | netgear-dni
   IMAGE_SIZE := 7872k
   NETGEAR_BOARD_ID := DM200

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -11,6 +11,7 @@ JFFS2_BLOCKSIZE = 128k
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+DEVICE_VARS += BOOT_SCRIPT UBOOT
 KERNEL_LOADADDR := 0x00008000
 
 define Build/boot-scr
@@ -96,7 +97,6 @@ define Device/Default
   UBOOT :=
   BOOT_SCRIPT :=
 endef
-DEVICE_VARS += BOOT_SCRIPT UBOOT
 
 define Device/Default-arm64
   BOOT_SCRIPT := generic-arm64

--- a/target/linux/omap/image/Makefile
+++ b/target/linux/omap/image/Makefile
@@ -33,7 +33,6 @@ endef
 
 define Device/Default
   PROFILES := Default
-  DEVICE_VARS :=
   KERNEL_NAME := zImage
   KERNEL := kernel-bin
   IMAGES := sdcard.img.gz

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -29,7 +29,7 @@ define Device/Default
   IMAGES := sysupgrade.bin
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   sysupgrade_bin := append-kernel | append-rootfs | pad-rootfs
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size
 endef
 
 define Device/seama
@@ -41,9 +41,9 @@ define Device/seama
   # - 36 bytes of META data (4-bytes aligned)
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | append-rootfs
   IMAGE/sysupgrade.bin := \
-	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	$$(IMAGE/default) | seama | pad-rootfs | append-metadata | check-size
   IMAGE/factory.bin := \
-	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size $$$$(IMAGE_SIZE)
+	$$(IMAGE/default) | pad-rootfs -x 64 | seama | seama-seal | check-size
   SEAMA_SIGNATURE :=
 endef
 

--- a/target/linux/ramips/image/common-tp-link.mk
+++ b/target/linux/ramips/image/common-tp-link.mk
@@ -12,7 +12,7 @@ define Device/tplink-v1
   IMAGES += factory.bin
   IMAGE/factory.bin := tplink-v1-image factory -e -O
   IMAGE/sysupgrade.bin := tplink-v1-image sysupgrade -e -O | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 
 define Device/tplink-v2
@@ -27,7 +27,7 @@ define Device/tplink-v2
   IMAGES += factory.bin
   IMAGE/factory.bin := tplink-v2-image -e
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 
 define Device/tplink-safeloader
@@ -39,6 +39,6 @@ define Device/tplink-safeloader
   KERNEL := $(KERNEL_DTB) | tplink-v1-header -e -O
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
 endef

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -298,7 +298,7 @@ define Device/edimax_br-6478ac-v2
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN68 -f 0x70000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
 	kmod-usb-ledtrig-usbport
 endef
@@ -312,7 +312,7 @@ define Device/edimax_ew-7476rpc
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN79 -f 0x70000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
 endef
 TARGET_DEVICES += edimax_ew-7476rpc
@@ -325,7 +325,7 @@ define Device/edimax_ew-7478ac
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN70 -f 0x70000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
 endef
 TARGET_DEVICES += edimax_ew-7478ac
@@ -338,7 +338,7 @@ define Device/edimax_ew-7478apc
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN75 -f 0x70000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
 	kmod-usb-ledtrig-usbport
 endef
@@ -348,7 +348,7 @@ define Device/elecom_wrh-300cr
   SOC := mt7620n
   IMAGE_SIZE := 14272k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-header
   DEVICE_VENDOR := Elecom
   DEVICE_MODEL := WRH-300CR
@@ -362,7 +362,7 @@ define Device/engenius_esr600
   BLOCKSIZE := 64k
   IMAGE_SIZE := 15616k
   IMAGES += factory.dlf
-  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size | \
 	senao-header -r 0x101 -p 0x57 -t 2
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := ESR600
@@ -379,7 +379,7 @@ define Device/fon_fon2601
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
   KERNEL_INITRAMFS := $$(KERNEL) | fonfxcimage
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | fonfxcimage | \
-	pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+	pad-rootfs | append-metadata | check-size
 endef
 TARGET_DEVICES += fon_fon2601
 
@@ -471,7 +471,7 @@ define Device/iodata_wn-ac1167gr
   DEVICE_MODEL := WN-AC1167GR
   IMAGE_SIZE := 6864k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 01040016 8844A2D168B45A2D
   DEVICE_PACKAGES := kmod-mt76x2
 endef
@@ -483,7 +483,7 @@ define Device/iodata_wn-ac733gr3
   DEVICE_MODEL := WN-AC733GR3
   IMAGE_SIZE := 6992k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 01040006 8844A2D168B45A2D
   DEVICE_PACKAGES := kmod-mt76x0e kmod-switch-rtl8367b
 endef
@@ -579,7 +579,7 @@ define Device/linksys_e1700
   SOC := mt7620a
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	umedia-header 0x013326
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := E1700
@@ -606,7 +606,7 @@ define Device/netgear_ex2700
   IMAGES += factory.bin
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | \
 	append-uImage-fakehdr filesystem
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	netgear-dni
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := EX2700
@@ -621,7 +621,7 @@ define Device/netgear_ex3700
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7744k
   IMAGES += factory.chk
-  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size | \
 	netgear-chk
   DEVICE_PACKAGES := kmod-mt76x2
   DEVICE_VENDOR := NETGEAR
@@ -636,7 +636,7 @@ define Device/netgear_ex6130
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7744k
   IMAGES += factory.chk
-  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size | \
 	netgear-chk
   DEVICE_PACKAGES := kmod-mt76x2
   DEVICE_VENDOR := NETGEAR
@@ -653,7 +653,7 @@ define Device/netgear_wn3000rp-v3
   IMAGES += factory.bin
   KERNEL := $(KERNEL_DTB) | uImage lzma | pad-offset 64k 64 | \
 	append-uImage-fakehdr filesystem
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	netgear-dni
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WN3000RP
@@ -667,7 +667,7 @@ define Device/nexx_wt3020-4m
   BLOCKSIZE := 4k
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B WT3020 -F 4M
   DEVICE_VENDOR := Nexx
   DEVICE_MODEL := WT3020
@@ -680,7 +680,7 @@ define Device/nexx_wt3020-8m
   SOC := mt7620n
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B WT3020 -F 8M
   DEVICE_VENDOR := Nexx
   DEVICE_MODEL := WT3020
@@ -1126,7 +1126,7 @@ define Device/zyxel_keenetic-omni
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to 64k | \
-	check-size $$$$(IMAGE_SIZE) | zyimage -d 4882 -v "ZyXEL Keenetic Omni"
+	check-size | zyimage -d 4882 -v "ZyXEL Keenetic Omni"
   SUPPORTED_DEVICES += kn_rc
 endef
 TARGET_DEVICES += zyxel_keenetic-omni
@@ -1139,7 +1139,7 @@ define Device/zyxel_keenetic-omni-ii
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to 64k | \
-	check-size $$$$(IMAGE_SIZE) | \
+	check-size | \
 	zyimage -d 2102034 -v "ZyXEL Keenetic Omni II"
   SUPPORTED_DEVICES += kn_rf
 endef
@@ -1154,7 +1154,7 @@ define Device/zyxel_keenetic-viva
 	kmod-switch-rtl8366-smi kmod-switch-rtl8367b
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to 64k | \
-	check-size $$$$(IMAGE_SIZE) | zyimage -d 8997 -v "ZyXEL Keenetic Viva"
+	check-size | zyimage -d 8997 -v "ZyXEL Keenetic Viva"
   SUPPORTED_DEVICES += kng_rc
 endef
 TARGET_DEVICES += zyxel_keenetic-viva

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -7,7 +7,7 @@ include ./common-tp-link.mk
 DEFAULT_SOC := mt7621
 
 KERNEL_DTB += -d21
-DEVICE_VARS += UIMAGE_MAGIC
+DEVICE_VARS += UIMAGE_MAGIC SERCOMM_HWNAME
 
 # The OEM webinterface expects an kernel with initramfs which has the uImage
 # header field ih_name.
@@ -554,7 +554,6 @@ define Device/netgear_sercomm_nand
   DEVICE_VENDOR := NETGEAR
   DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
-DEVICE_VARS += SERCOMM_HWNAME SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
 
 define Device/netgear_r6220
   $(Device/netgear_sercomm_nand)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -165,7 +165,7 @@ define Device/asus_rt-ac65p
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e wpad-basic uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ac65p
@@ -181,7 +181,7 @@ define Device/asus_rt-ac85p
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e wpad-basic uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ac85p
@@ -245,7 +245,7 @@ define Device/edimax_ra21s
   DEVICE_ALT0_VENDOR := Edimax
   DEVICE_ALT0_MODEL := Gemini RA21S
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 02020040 8844A2D168B45A2D
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
@@ -256,7 +256,7 @@ define Device/edimax_rg21s
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := Gemini AC2600 RG21S
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 02020038 8844A2D168B45A2D
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
@@ -267,7 +267,7 @@ define Device/elecom_wrc-1167ghbk2-s
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-1167GHBK2-S
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-wrc-factory WRC-1167GHBK2-S 0.00
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
@@ -278,7 +278,7 @@ define Device/elecom_wrc-1900gst
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-1900GST
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-gst-factory WRC-1900GST 0.00
 endef
 TARGET_DEVICES += elecom_wrc-1900gst
@@ -288,7 +288,7 @@ define Device/elecom_wrc-2533gst
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-2533GST
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-gst-factory WRC-2533GST 0.00
 endef
 TARGET_DEVICES += elecom_wrc-2533gst
@@ -337,7 +337,7 @@ define Device/hiwifi_hc5962
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5962
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 wpad-basic
@@ -402,7 +402,7 @@ define Device/iodata_wnpr2600g
   DEVICE_MODEL := WNPR2600G
   IMAGE_SIZE := 13952k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 0104003a 8844A2D168B45A2D
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
@@ -429,7 +429,7 @@ TARGET_DEVICES += iptime_a8004t
 define Device/jcg_jhr-ac876m
   IMAGE_SIZE := 16064k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	jcg-header 89.1
   JCG_MAXSIZE := 16064k
   DEVICE_VENDOR := JCG
@@ -484,7 +484,7 @@ define Device/MikroTik
   KERNEL := $(KERNEL_DTB) | loader-kernel
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 
 define Device/mikrotik_rb750gr3
@@ -534,7 +534,7 @@ define Device/netgear_ex6150
   NETGEAR_BOARD_ID := U12H318T00_NETGEAR
   IMAGE_SIZE := 14848k
   IMAGES += factory.chk
-  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size | \
 	netgear-chk
 endef
 TARGET_DEVICES += netgear_ex6150
@@ -550,7 +550,7 @@ define Device/netgear_sercomm_nand
 	zip $$$$(SERCOMM_HWNAME).bin | sercom-seal
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/kernel.bin := append-kernel
-  IMAGE/rootfs.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/rootfs.bin := append-ubi | check-size
   DEVICE_VENDOR := NETGEAR
   DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
 endef
@@ -643,7 +643,7 @@ define Device/netgear_wndr3700-v5
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
 	pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/factory.img := pad-extra 320k | $$(IMAGE/default) | \
 	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | \
 	zip WNDR3700v5.bin | sercom-seal
@@ -668,7 +668,7 @@ define Device/netis_wf2881
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   DEVICE_VENDOR := NETIS
   DEVICE_MODEL := WF2881
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
@@ -850,7 +850,7 @@ define Device/xiaomi_mir3g
   UBINIZE_OPTS := -E 5
   IMAGES += kernel1.bin rootfs0.bin
   IMAGE/kernel1.bin := append-kernel
-  IMAGE/rootfs0.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/rootfs0.bin := append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 3G
@@ -884,7 +884,7 @@ define Device/xiaomi_mir3p
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   DEVICE_PACKAGES := kmod-mt7615e kmod-usb3 kmod-usb-ledtrig-usbport \
 	wpad-basic uboot-envtools
 endef

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -34,7 +34,7 @@ TARGET_DEVICES += buffalo_wcr-1166ds
 define Device/cudy_wr1000
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	jcg-header 92.122
   JCG_MAXSIZE := 7872k
   DEVICE_VENDOR := Cudy
@@ -180,7 +180,7 @@ define Device/netgear_r6120
   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | \
 	pad-rootfs
   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
   IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | \
 	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip R6120.bin | \
 	sercom-seal
@@ -592,6 +592,6 @@ define Device/zyxel_keenetic-extra-ii
 	kmod-usb-ledtrig-usbport
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
-	check-size $$$$(IMAGE_SIZE) | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
+	check-size | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -18,7 +18,7 @@ define Device/airlink101_ar670w
   IMAGE_SIZE := 3840k
   KERNEL := $(KERNEL_DTB) | pad-to $$(BLOCKSIZE)
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	wrg-header wrgn16a_airlink_ar670w
   SUPPORTED_DEVICES += ar670w
 endef
@@ -87,7 +87,7 @@ define Device/dlink_dap-1522-a1
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 96 | \
 	append-rootfs | pad-rootfs -x 96 | wrg-header wapnd01_dlink_dap1522 | \
-	check-size $$$$(IMAGE_SIZE)
+	check-size
 endef
 TARGET_DEVICES += dlink_dap-1522-a1
 

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -301,7 +301,7 @@ define Device/buffalo_whr-g300n
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-G300N
   IMAGES += tftp.bin
-  IMAGE/tftp.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/tftp.bin := $$(sysupgrade_bin) | check-size | \
 	buffalo-tftp-header
   SUPPORTED_DEVICES += whr-g300n
 endef
@@ -311,9 +311,9 @@ define Device/dlink_dap-1350
   SOC := rt3052
   IMAGES += factory.bin factory-NA.bin
   IMAGE_SIZE := 7488k
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	dap-header -s RT3052-AP-DAP1350WW-3
-  IMAGE/factory-NA.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory-NA.bin := $$(sysupgrade_bin) | check-size | \
 	dap-header -s RT3052-AP-DAP1350-3
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DAP-1350
@@ -348,7 +348,7 @@ define Device/dlink_dir-300-b1
   SOC := rt3050
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	wrg-header wrgn23_dlwbr_dir300b
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-300
@@ -382,7 +382,7 @@ define Device/dlink_dir-600-b1
   SOC := rt3050
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	wrg-header wrgn23_dlwbr_dir600b
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-600
@@ -410,7 +410,7 @@ define Device/dlink_dir-615-d
   SOC := rt3050
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	wrg-header wrgn23_dlwbr_dir615d
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-615
@@ -486,7 +486,7 @@ define Device/edimax_3g-6200n
   IMAGE_SIZE := 3648k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m 3G62 -f 0x50000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := 3g-6200n
   SUPPORTED_DEVICES += 3g-6200n
@@ -498,7 +498,7 @@ define Device/edimax_3g-6200nl
   IMAGE_SIZE := 3648k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m 3G62 -f 0x50000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := 3g-6200nl
   SUPPORTED_DEVICES += 3g-6200nl
@@ -568,7 +568,7 @@ define Device/hilink_hlk-rm04
   SOC := rt5350
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	hilink-header
   DEVICE_VENDOR := Hi-Link
   DEVICE_MODEL := HLK-RM04
@@ -621,7 +621,7 @@ define Device/jcg_jhr-n805r
   SOC := rt3050
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	jcg-header 29.24
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := JHR-N805R
@@ -633,7 +633,7 @@ define Device/jcg_jhr-n825r
   SOC := rt3052
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	jcg-header 23.24
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := JHR-N825R
@@ -645,7 +645,7 @@ define Device/jcg_jhr-n926r
   SOC := rt3052
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	jcg-header 25.24
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := JHR-N926R
@@ -676,9 +676,9 @@ define Device/netgear_wnce2001
   SOC := rt3052
   IMAGE_SIZE := 3392k
   IMAGES += factory.bin factory-NA.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	dap-header -s RT3052-AP-WNCE2001-3 -r WW -v 1.0.0.99
-  IMAGE/factory-NA.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory-NA.bin := $$(sysupgrade_bin) | check-size | \
 	dap-header -s RT3052-AP-WNCE2001-3 -r NA -v 1.0.0.99
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WNCE2001
@@ -699,7 +699,7 @@ define Device/nexx_wt1520-4m
   SOC := rt5350
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B WT1520 -F 4M
   DEVICE_VENDOR := Nexx
   DEVICE_MODEL := WT1520
@@ -712,7 +712,7 @@ define Device/nexx_wt1520-8m
   SOC := rt5350
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B WT1520 -F 8M
   DEVICE_VENDOR := Nexx
   DEVICE_MODEL := WT1520
@@ -840,7 +840,7 @@ define Device/poray_m3
   SOC := rt5350
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B M3 -F 4M
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := M3
@@ -853,7 +853,7 @@ define Device/poray_m4-4m
   SOC := rt5350
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B M4 -F 4M
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := M4
@@ -867,7 +867,7 @@ define Device/poray_m4-8m
   SOC := rt5350
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B M4 -F 8M
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := M4
@@ -881,7 +881,7 @@ define Device/poray_x5
   SOC := rt5350
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B X5 -F 8M
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := X5/X6
@@ -894,7 +894,7 @@ define Device/poray_x8
   SOC := rt5350
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B X8 -F 8M
   DEVICE_VENDOR := Poray
   DEVICE_MODEL := X8
@@ -1013,7 +1013,7 @@ define Device/trendnet_tew-638apb-v2
   BLOCKSIZE := 64k
   IMAGE_SIZE := 3776k
   IMAGE/sysupgrade.bin := $$(sysupgrade_bin) | umedia-header 0x026382 | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-638APB
   DEVICE_VARIANT := v2
@@ -1034,7 +1034,7 @@ define Device/unbranded_a5-v11
   SOC := rt5350
   IMAGE_SIZE := 3776k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	poray-header -B A5-V11 -F 4M
   DEVICE_VENDOR := 
   DEVICE_MODEL := A5-V11

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -51,7 +51,7 @@ define Device/edimax_br-6475nd
   IMAGE_SIZE := 7744k
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN54 -f 0x70000 -S 0x01100000 | pad-rootfs | \
-	append-metadata | check-size $$$$(IMAGE_SIZE)
+	append-metadata | check-size
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := BR-6475nD
   DEVICE_PACKAGES := swconfig
@@ -99,7 +99,7 @@ define Device/sitecom_wlr-6000
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7244k
   IMAGES += factory.dlf
-  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size | \
 	senao-header -r 0x0202 -p 0x41 -t 2
   DEVICE_VENDOR := Sitecom
   DEVICE_MODEL := WLR-6000
@@ -113,7 +113,7 @@ define Device/trendnet_tew-691gr
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	umedia-header 0x026910
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-691GR
@@ -127,7 +127,7 @@ define Device/trendnet_tew-692gr
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	umedia-header 0x026920
   DEVICE_VENDOR := TRENDnet
   DEVICE_MODEL := TEW-692GR

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -11,6 +11,7 @@ include $(INCLUDE_DIR)/image.mk
 FAT32_BLOCK_SIZE=1024
 FAT32_BLOCKS=$(shell echo $$(($(CONFIG_SUNXI_SD_BOOT_PARTSIZE)*1024*1024/$(FAT32_BLOCK_SIZE))))
 
+DEVICE_VARS := SUNXI_DTS SUNXI_DTS_DIR
 KERNEL_LOADADDR:=0x40008000
 
 define Build/sunxi-sdcard
@@ -32,7 +33,6 @@ endef
 # why \x00\x00\x00\x00 for zImage-initramfs
 define Device/Default
   PROFILES := Default
-  DEVICE_VARS := SUNXI_DTS SUNXI_DTS_DIR
   KERNEL_NAME := zImage
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz

--- a/target/linux/tegra/image/Makefile
+++ b/target/linux/tegra/image/Makefile
@@ -34,6 +34,7 @@ define Build/tegra-sdcard
 endef
 
 DEVICE_VARS += BOOT_SCRIPT UBOOT
+
 define Device/Default
   BOOT_SCRIPT := generic-bootscript
   IMAGES := sdcard.img.gz


### PR DESCRIPTION
- clean up `check-size $$$$(IMAGE_SIZE)`
- clean up `DEVICE_VARS`
- replace `${}` with `$()`
- replace `$$$$()` with `$$()`