### PR TITLE
ath79: use rgmii-id instead of rgmii in ubnt,lap-120

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_lap-120.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_lap-120.dts
@@ -13,7 +13,6 @@
 
 	phy-mask = <4>;
 	phy4: ethernet-phy@4 {
-		phy-mode = "rgmii";
 		reg = <4>;
 	};
 };
@@ -22,11 +21,11 @@
 	status = "okay";
 
 	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x06000000 0x00000101 0x00001313>;
+	pll-data = <0x02000000 0x00000101 0x00001313>;
 
 	mtd-mac-address = <&art 0x0>;
 
-	phy-mode = "rgmii";
+	phy-mode = "rgmii-id";
 	phy-handle = <&phy4>;
 
 	gmac-config {


### PR DESCRIPTION
~~Since commit 4b2ab533d4 (ath79: disable delays on AT803X config init)~~

Since commit 6f2e1b7485 (ath79: disable delays on AT803X config init)
the incoming incoming traffic on the ubnt,lap-120 devices Ethernet
port was not making it through. After it, the working GMAC rxd and
rxdv delay values changed from 3 to 2.

Fixes [FS#2893](https://bugs.openwrt.org/index.php?do=details&task_id=2893).

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>

