### PR TITLE
kernel: make kmod-*-core selected by dependent modules

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -147,7 +147,7 @@ I2C_MUX_GPIO_MODULES:= \
 define KernelPackage/i2c-mux-gpio
   $(call i2c_defaults,$(I2C_MUX_GPIO_MODULES),51)
   TITLE:=GPIO-based I2C mux/switches
-  DEPENDS:=kmod-i2c-mux
+  DEPENDS:=+kmod-i2c-mux
 endef
 
 define KernelPackage/i2c-mux-gpio/description
@@ -163,7 +163,7 @@ I2C_MUX_PCA9541_MODULES:= \
 define KernelPackage/i2c-mux-pca9541
   $(call i2c_defaults,$(I2C_MUX_PCA9541_MODULES),51)
   TITLE:=Philips PCA9541 I2C mux/switches
-  DEPENDS:=kmod-i2c-mux
+  DEPENDS:=+kmod-i2c-mux
 endef
 
 define KernelPackage/i2c-mux-pca9541/description
@@ -178,7 +178,7 @@ I2C_MUX_PCA954x_MODULES:= \
 define KernelPackage/i2c-mux-pca954x
   $(call i2c_defaults,$(I2C_MUX_PCA954x_MODULES),51)
   TITLE:=Philips PCA954x I2C mux/switches
-  DEPENDS:=kmod-i2c-mux
+  DEPENDS:=+kmod-i2c-mux
 endef
 
 define KernelPackage/i2c-mux-pca954x/description

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -275,7 +275,7 @@ define Device/traverse-ls1043
   DEVICE_PACKAGES += \
     layerscape-fman-ls1043ardb \
     uboot-envtools \
-    kmod-i2c-mux kmod-i2c-mux-pca954x \
+    kmod-i2c-mux-pca954x \
     kmod-hwmon-core \
     kmod-gpio-pca953x kmod-input-gpio-keys-polled \
     kmod-rtc-isl1208

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -22,7 +22,7 @@ define Device/marvell_macchiatobin
   DEVICE_MODEL := MACCHIATObin
   DEVICE_ALT0_VENDOR := SolidRun
   DEVICE_ALT0_MODEL := Armada 8040 Community Board
-  DEVICE_PACKAGES += kmod-i2c-mux kmod-i2c-mux-pca954x
+  DEVICE_PACKAGES += kmod-i2c-mux-pca954x
   DEVICE_DTS := armada-8040-mcbin
   SUPPORTED_DEVICES := marvell,armada8040-mcbin
 endef

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -15,7 +15,7 @@ define Device/cznic_turris-omnia
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
-    partx-utils kmod-i2c-mux kmod-i2c-mux-pca954x
+    partx-utils kmod-i2c-mux-pca954x
   IMAGES := $$(IMAGE_PREFIX)-sysupgrade.img.gz omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz
   IMAGE/$$(IMAGE_PREFIX)-sysupgrade.img.gz := boot-img | sdcard-img | gzip | append-metadata
   IMAGE/omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz := omnia-medkit-initramfs | gzip


### PR DESCRIPTION
Currently kmod-X-* will not get into images unless kmod-X-core is added to
DEVICE_PACKAGES as well. By changing the dependencies from "depends on" to
"select", we do not have the issue anymore.

Furthermore, we can remove most occurrences of the package from DEVICE_PACKAGES
and similar variables, as it is now pulled by dependent modules.