### PR TITLE
ipq40xx: fix reboot for compex wpj428

### DIFF
--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -32,6 +32,10 @@
 
 		mdio@90000 {
 			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+			reset-delay-us = <2000>;
 		};
 
 		ess-psgmii@98000 {
@@ -129,6 +133,20 @@
 };
 
 &tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
 	serial_pins: serial_pinmux {
 		mux {
 			pins = "gpio60", "gpio61";

--- a/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-5.4/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -32,6 +32,10 @@
 
 		mdio@90000 {
 			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+			reset-gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+			reset-delay-us = <2000>;
 		};
 
 		ess-psgmii@98000 {
@@ -129,6 +133,20 @@
 };
 
 &tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
 	serial_pins: serial_pinmux {
 		mux {
 			pins = "gpio60", "gpio61";


### PR DESCRIPTION
Reset the mdio using dedicated GPIOs.