### PR TITLE
ramips: add support for TOTOLINK A3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_totolink_a3.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_a3.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_iptime.dtsi"
+
+/ {
+	compatible = "totolink,a3", "mediatek,mt7628an-soc";
+	model = "TOTOLINK A3";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			label = "a3:blue:cpu";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "a3:blue:wlan";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x32>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -229,6 +229,15 @@ define Device/tama_w06
 endef
 TARGET_DEVICES += tama_w06
 
+define Device/totolink_a3
+  IMAGE_SIZE := 7936k
+  UIMAGE_NAME := za3
+  DEVICE_VENDOR := TOTOLINK
+  DEVICE_MODEL := A3
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += totolink_a3
+
 define Device/totolink_lr1200
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := TOTOLINK

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -72,7 +72,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "4:wan" "6@eth0"
 		;;
-	iptime,a3)
+	iptime,a3|\
+	totolink,a3)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "0:wan" "6@eth0"
 		;;
@@ -166,7 +167,8 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	iptime,a3|\
-	iptime,a604m)
+	iptime,a604m|\
+	totolink,a3)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
 	mediatek,linkit-smart-7688|\


### PR DESCRIPTION
TOTOLINK A3 is a clone of ipTIME A3. The only difference is the model name.

Specifications:
- SoC: MT7628AN
- RAM: DDR2 64MB
- Flash: SPI NOR 8MB
- WiFi:
  - 2.4GHz: SoC internal
  - 5GHz: MT7612EN
- Ethernet: 3x 10/100Mbps
  - Switch: SoC internal

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.

Tested on device by JasonHCH