### PR TITLE
ath79: add support for Ubiquiti NanoBridge M (XM)

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_nanobridge-m.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_nanobridge-m.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7241_ubnt_xm_outdoor.dtsi"
+
+/ {
+	compatible = "ubnt,nanobridge-m", "ubnt,xm", "qca,ar7241";
+	model = "Ubiquiti NanoBridge M";
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -247,6 +247,7 @@ trendnet,tew-823dru)
 	;;
 ubnt,bullet-m|\
 ubnt,bullet-m-xw|\
+ubnt,nanobridge-m|\
 ubnt,nanostation-loco-m|\
 ubnt,nanostation-loco-m-xw|\
 ubnt,nanostation-m|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ath79_setup_interfaces()
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
+	ubnt,nanobridge-m|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-loco-m-xw|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -91,6 +91,7 @@ case "$FIRMWARE" in
 	tplink,tl-wr842n-v1|\
 	ubnt,airrouter|\
 	ubnt,bullet-m|\
+	ubnt,nanobridge-m|\
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-m|\
 	ubnt,picostation-m|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -219,6 +219,14 @@ define Device/ubnt_picostation-m
 endef
 TARGET_DEVICES += ubnt_picostation-m
 
+define Device/ubnt_nanobridge-m
+  $(Device/ubnt-xm)
+  DEVICE_MODEL := NanoBridge M
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += bullet-m
+endef
+TARGET_DEVICES += ubnt_nanobridge-m
+
 define Device/ubnt_rocket-m
   $(Device/ubnt-xm)
   DEVICE_MODEL := Rocket-M


### PR DESCRIPTION
This patch adds support for the Ubiquiti NanoBridge M (XM), a
802.11n wireless with a feed+dish form factor, with the same board
definition as the Bullet M (XM).

Specifications:
 - Atheros AR7241 SoC
 - 32 MB RAM
 - 8 MB SPI flash
 - 1x 10/100 Mbps Ethernet port, 24 Vdc PoE-in
 - Power and LAN green LEDs
 - 4x RSSI LEDs (red, orange, green, green)
 - UART (115200 8N1)

Flashing via stock GUI:
 - WARNING: flashing OpenWrt from AirOS v5.6 or newer will brick your
   device! Read the wiki for more info.
 - Downgrade to AirOS v5.5.x (latest available is 5.5.11) first.
 - Upload the factory image via AirOS web GUI.

Flashing via TFTP:
 - WARNING: flashing OpenWrt from AirOS v5.6 or newer will brick your
   device! Read the wiki for more info.
 - Downgrade to AirOS v5.5.x (latest available is 5.5.11) first.
 - Use a pointy tool (e.g., pen cap, slotted screwdriver) to keep the
   reset button pressed.
 - Power on the device (keep reset button pressed).
 - Keep pressing until LEDs flash alternatively LED1+LED3 =>
   LED2+LED4 => LED1+LED3, etc.
 - Release reset button.
 - The device starts a TFTP server at 192.168.1.20.
 - Set a static IP on the computer (e.g., 192.168.1.21/24).
 - Upload via tftp the factory image:
    $ tftp 192.168.1.20
    tftp> bin
    tftp> trace
    tftp> put openwrt-ath79-generic-xxxxx-ubnt_nanobridge-m-squashfs-factory.bin

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>