### PR TITLE
ipq40xx: Configure MDIO pins on wpj428.

### DIFF
--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4028-wpj428.dts
@@ -32,6 +32,8 @@
 
 		mdio@90000 {
 			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
 		};
 
 		ess-psgmii@98000 {
@@ -129,6 +131,20 @@
 };
 
 &tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_mdio {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_mdc {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
 	serial_pins: serial_pinmux {
 		mux {
 			pins = "gpio60", "gpio61";


### PR DESCRIPTION
The bootloader does not always initialize the MDIO pins before booting
Linux. E.g. on version "U-Boot 2012.07 [Chaos Calmer 15.05.1,r35193] (Jul
25 2017 - 11:36:26)" this is the case when booting automatically without
activating the U-Boot console.

Without this change, the kernel boot will complain about missing PHYs:
[    0.679947] libphy: ipq40xx_mdio: probed
[    0.688129] ar40xx c000000.ess-switch: Probe failed - Missing PHYs!
[    0.688525] libphy: Fixed MDIO Bus: probed

With this change it will work as expected:
[    0.679806] libphy: ipq40xx_mdio: probed
[    0.715161] ESS reset ok!
[    0.748133] ESS reset ok!
[    1.166005] libphy: Fixed MDIO Bus: probed

Signed-off-by: Fredrik Olofsson <fredrik.olofsson@anyfinetworks.com>

This problem can be triggered by flashing and test like this. The first boot in this log works since the console in U-Boot was active. The second boot triggers this problem:
```
(IPQ40xx) # sf probe
SF: Detected MX25L25635E with page size 4 KiB, total 32 MiB
(IPQ40xx) # tftpboot 0x84000000 openwrt-ipq40xx-generic-compex_wpj428-squashfs-sysupgrade.bin
eth0 PHY0 Down Speed :10 Half duplex
eth0 PHY1 Down Speed :10 Half duplex
eth0 PHY2 Down Speed :10 Half duplex
eth0 PHY3 Down Speed :10 Half duplex
eth0 PHY4 up Speed :1000 Full duplex
Using eth0 device
TFTP from server 192.168.1.10; our IP address is 192.168.1.1
Filename 'openwrt-ipq40xx-generic-compex_wpj428-squashfs-sysupgrade.bin'.
Load address: 0x84000000
Loading: #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         ############
done
Bytes transferred = 5899015 (5a0307 hex)
(IPQ40xx) # sf erase 0x00180000 +$filesize
(IPQ40xx) # sf write 0x84000000 0x00180000 $filesize
(IPQ40xx) # bootipq
...
[    0.679806] libphy: ipq40xx_mdio: probed
[    0.715161] ESS reset ok!
[    0.748133] ESS reset ok!
[    1.166005] libphy: Fixed MDIO Bus: probed
...
root@OpenWrt:/# ping 192.168.1.10
PING 192.168.1.10 (192.168.1.10): 56 data bytes
64 bytes from 192.168.1.10: seq=0 ttl=64 time=1.017 ms
64 bytes from 192.168.1.10: seq=1 ttl=64 time=0.587 ms
root@OpenWrt:/# reboot
...
... NOT TOUCHING CONSOLE IN U-BOOT
...
[    0.679947] libphy: ipq40xx_mdio: probed
[    0.688129] ar40xx c000000.ess-switch: Probe failed - Missing PHYs!
[    0.688525] libphy: Fixed MDIO Bus: probed
...
root@OpenWrt:/# ping 192.168.1.10
PING 192.168.1.10 (192.168.1.10): 56 data bytes
^C
--- 192.168.1.10 ping statistics ---
10 packets transmitted, 0 packets received, 100% packet loss
```