### PR TITLE
ipq806x: simplify WG2600HP MAC address calculation

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -19,7 +19,7 @@ case "$FIRMWARE" in
 		;;
 	nec,wg2600hp)
 		caldata_extract "ART" 0x1000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary PRODUCTDATA 0xc) +1)
+		ath10k_patch_mac $(mtd_get_mac_binary PRODUCTDATA 0x12)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\


### PR DESCRIPTION
WG2600HP has its WLAN MAC address at PRODUCTDATA 0xc and 0x12, so use it.

cc @musashino205
