### PR TITLE
ramips: add support for TP-Link RE500 v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_re500-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re500-v1.dts
@@ -4,8 +4,8 @@
 #include "mt7621_tplink_rexx0-v1.dtsi"
 
 / {
-	compatible = "tplink,re650-v1", "mediatek,mt7621-soc";
-	model = "TP-Link RE650 v1";
+	compatible = "tplink,re500-v1", "mediatek,mt7621-soc";
+	model = "TP-Link RE500 v1";
 
 	aliases {
 		led-boot = &led_power;
@@ -18,39 +18,39 @@
 		compatible = "gpio-leds";
 
 		led_power: power {
-			label = "re650-v1:blue:power";
+			label = "re500-v1:blue:power";
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 		};
 
 		wifi2g {
-			label = "re650-v1:blue:wifi2G";
+			label = "re500-v1:blue:wifi2G";
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		wifi5g {
-			label = "re650-v1:blue:wifi5G";
+			label = "re500-v1:blue:wifi5G";
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
 		wps_red {
-			label = "re650-v1:red:wps";
+			label = "re500-v1:red:wps";
 			gpios = <&gpio 26 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps_blue {
-			label = "re650-v1:blue:wps";
+			label = "re500-v1:blue:wps";
 			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
 		};
 
 		eth_act {
-			label = "re650-v1:green:eth_act";
+			label = "re500-v1:green:eth_act";
 			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
 		};
 
 		eth_link {
-			label = "re650-v1:green:eth_link";
+			label = "re500-v1:green:eth_link";
 			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		power {
+			label = "power";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_POWER>;
+		};
+
+		led {
+			label = "led";
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xde0000>;
+			};
+
+			config: partition@e00000 {
+				label = "config";
+				reg = <0xe00000 0x50000>;
+				read-only;
+			};
+
+			/* range 0xe50000 to 0xff0000 is empty in vendor
+			 * firmware, so we do not use it either
+			 */
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <1>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&config 0x10008>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&config 0x10008>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -842,6 +842,16 @@ define Device/tplink_re350-v1
 endef
 TARGET_DEVICES += tplink_re350-v1
 
+define Device/tplink_re500-v1
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := RE500
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7615e wpad-basic
+  TPLINK_BOARD_ID := RE500-V1
+  IMAGE_SIZE := 14208k
+endef
+TARGET_DEVICES += tplink_re500-v1
+
 define Device/tplink_re650-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := RE650

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -68,10 +68,14 @@ netgear,r6800)
 	ucidef_set_led_netdev "lan3" "LAN3" "$boardname:white:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "$boardname:white:lan4" "lan4"
 	;;
-tplink,re350-v1|\
-tplink,re650-v1)
+tplink,re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "$boardname:blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "$boardname:blue:wifi5G" "wlan1"
+	ucidef_set_led_netdev "eth_act" "LAN act" "$boardname:green:eth_act" "lan" "tx rx"
+	ucidef_set_led_netdev "eth_link" "LAN link" "$boardname:green:eth_link" "lan" "link"
+	;;
+tplink,re500-v1|\
+tplink,re650-v1)
 	ucidef_set_led_netdev "eth_act" "LAN act" "$boardname:green:eth_act" "lan" "tx rx"
 	ucidef_set_led_netdev "eth_link" "LAN link" "$boardname:green:eth_link" "lan" "link"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ ramips_setup_interfaces()
 	netgear,ex6150|\
 	thunder,timecloud|\
 	tplink,re350-v1|\
+	tplink,re500-v1|\
 	tplink,re650-v1|\
 	ubnt,unifi-nanohd)
 		ucidef_set_interface_lan "lan"

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1858,6 +1858,43 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the RE500 */
+	{
+		.id = "RE500-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:55530000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:45550000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:4A500000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:43410000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:41550000}\r\n"
+			"{product_name:RE500,product_ver:1.0.0,special_id:41530000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0xde0000},
+			{"partition-table", 0xe00000, 0x02000},
+			{"default-mac", 0xe10000, 0x00020},
+			{"pin", 0xe10100, 0x00020},
+			{"product-info", 0xe11100, 0x01000},
+			{"soft-version", 0xe20000, 0x01000},
+			{"support-list", 0xe21000, 0x01000},
+			{"profile", 0xe22000, 0x08000},
+			{"user-config", 0xe30000, 0x10000},
+			{"default-config", 0xe40000, 0x10000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the RE650 */
 	{
 		.id     = "RE650-V1",


### PR DESCRIPTION
This device uses the same hardware as RE650 v1 which got supported in
8c51dde.

Hardware specification:

- SoC 880 MHz - MediaTek MT7621AT
- 128 MB of DDR3 RAM
- 16 MB - Winbond 25Q128FVSG
- 4T4R 2.4 GHz - MediaTek MT7615E
- 4T4R 5 GHz - MediaTek MT7615E
- 1x 1 Gbps Ethernet - MT7621AT integrated
- 7x LEDs (Power, 2G, 5G, WPS(x2), Lan(x2))
- 4x buttons (Reset, Power, WPS, LED)
- UART header (J1) - 2:GND, 3:RX, 4:TX
  Serial console @ 57600,8n1

Flash instructions:

Upload
openwrt-ramips-mt7621-tplink_re500-v1-squashfs-factory.bin
from the RE500 web interface.

TFTP recovery to stock firmware:

Unfortunately, I can't find an easy way to recover the RE
without opening the device and using modified binaries. The
TFTP upload will only work if selected from u-boot, which
means you have to open the device and attach to the serial
console. The TFTP update procedure does *not* accept the
published vendor firmware binaries. However, it allows to
flash kernel + rootfs binaries, and this works if you have
a backup of the original contents of the flash. It's probably
possible to create special image out of the vendor binaries
and use that as recovery image.