### PR TITLE
oxnas: enable sata on Pogoplug V3/Pro

### DIFF
--- a/target/linux/oxnas/files/arch/arm/boot/dts/ox820-cloudengines-pogoplugpro.dts
+++ b/target/linux/oxnas/files/arch/arm/boot/dts/ox820-cloudengines-pogoplugpro.dts
@@ -118,6 +118,10 @@
 	pinctrl-0 = <&pinctrl_etha_mdio>;
 };
 
+&sata {
+	status = "okay";
+};
+
 &pcie_phy {
 	status = "okay";
 };

--- a/target/linux/oxnas/image/ox820.mk
+++ b/target/linux/oxnas/image/ox820.mk
@@ -50,8 +50,8 @@ define Device/cloudengines_pogoplugpro
   DEVICE_VENDOR := Cloud Engines
   DEVICE_MODEL := PogoPlug Pro (with mPCIe)
   SUPPORTED_DEVICES += pogoplug-pro
-  DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport kmod-rt2800-pci \
-	wpad-basic
+  DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport \
+	kmod-ata-oxnas-sata kmod-rt2800-pci wpad-basic
 endef
 TARGET_DEVICES += cloudengines_pogoplugpro
 
@@ -59,7 +59,8 @@ define Device/cloudengines_pogoplug-series-3
   DEVICE_VENDOR := Cloud Engines
   DEVICE_MODEL := PogoPlug Series V3 (without mPCIe)
   SUPPORTED_DEVICES += cloudengines,pogoplugv3 pogoplug-v3
-  DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-usb2-oxnas kmod-usb-ledtrig-usbport \
+	kmod-ata-oxnas-sata
 endef
 TARGET_DEVICES += cloudengines_pogoplug-series-3
 

--- a/target/linux/oxnas/patches-5.4/500-oxnas-sata.patch
+++ b/target/linux/oxnas/patches-5.4/500-oxnas-sata.patch
@@ -47,3 +47,13 @@
 +
  	};
  };
+--- a/arch/arm/boot/dts/ox820-cloudengines-pogoplug-series-3.dts
++++ b/arch/arm/boot/dts/ox820-cloudengines-pogoplug-series-3.dts
+@@ -111,3 +111,7 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_etha_mdio>;
+ };
++
++&sata {
++	status = "okay";
++};


### PR DESCRIPTION
Pogoplug V3/Pro has an interanl SATA port. To use it, DTS sata node should be
enabled, and kmod-ata-oxnas-sata package needs to be installed.

Fixes: [FS#2542](https://bugs.openwrt.org/index.php?do=details&task_id=2542)

I was planning a bigger PR, but it will take more time and it seems many people want this feature, so I decided to open a separate PR for this.