### PR TITLE
[RETRACTED]; compressed-memory: available only via patches for projects that actively use it

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -809,3 +809,18 @@ endef
 
 $(eval $(call KernelPackage,crypto-xts))
 
+
+define KernelPackage/crypto-zstd
+  TITLE:=zstd compression CryptoAPI module
+  DEPENDS:=+kmod-lib-zstd +kmod-crypto-acompress
+  KCONFIG:=CONFIG_CRYPTO_ZSTD
+  FILES:=$(LINUX_DIR)/crypto/zstd.ko
+  AUTOLOAD:=$(call AutoLoad,09,zstd)
+  $(call AddDepends/crypto)
+endef
+
+define KernelPackage/crypto-zstd/description
+ Kernel module for the CryptoAPI to support Zstandard
+endef
+
+$(eval $(call KernelPackage,crypto-zstd))

--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -166,6 +166,27 @@ endef
 $(eval $(call KernelPackage,lib-lz4))
 
 
+define KernelPackage/lib-lz4hc
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=LZ4HC support
+  DEPENDS:=+kmod-lib-lz4 +kmod-crypto-acompress
+  HIDDEN:=1
+  KCONFIG:= \
+	CONFIG_CRYPTO_LZ4HC \
+	CONFIG_LZ4HC_COMPRESS
+  FILES:= \
+	$(LINUX_DIR)/crypto/lz4hc.ko \
+	$(LINUX_DIR)/lib/lz4/lz4hc_compress.ko
+  AUTOLOAD:=$(call AutoProbe,lz4hc lz4hc_compress)
+endef
+
+define KernelPackage/lib-lz4hc/description
+ Kernel module for LZ4HC compression/decompression support
+endef
+
+$(eval $(call KernelPackage,lib-lz4hc))
+
+
 define KernelPackage/lib-raid6
   SUBMENU:=$(LIB_MENU)
   TITLE:=RAID6 algorithm support

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -869,6 +869,85 @@ endef
 $(eval $(call KernelPackage,zram))
 
 
+define KernelPackage/zsmalloc
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=ZSMALLOC support
+  DEPENDS:=+kmod-crypto-deflate \
+	+kmod-lib-lz4 \
+	@!PACKAGE_kmod-zram
+  KCONFIG:= \
+	CONFIG_ZSMALLOC \
+	CONFIG_ZSMALLOC_STAT=n
+  FILES:= $(LINUX_DIR)/mm/zsmalloc.ko
+  AUTOLOAD:=$(call AutoLoad,19,zsmalloc)
+endef
+
+define KernelPackage/zsmalloc/description
+ Special purpose memory allocator for compressed memory pages
+endef
+
+define KernelPackage/zsmalloc/config
+	if PACKAGE_kmod-zsmalloc
+		config KERNEL_PGTABLE_MAPPING
+			bool "zsmalloc: enable CONFIG_PGTABLE_MAPPING"
+			default y if arm
+			default n
+			help
+	  Enable CONFIG_PGTABLE_MAPPING in the kernel for faster memory
+	  allocations when using ZSMALLOC, in some architectures. Enabled
+	  by default for the ARM architecture because it may be a huge
+	  performance boost.
+	endif
+endef
+
+$(eval $(call KernelPackage,zsmalloc))
+
+
+define KernelPackage/zram-writeback
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=zram with writeback support
+  DEPENDS:=+kmod-zsmalloc
+  KCONFIG:= \
+	CONFIG_ZRAM \
+	CONFIG_ZRAM_DEBUG=n \
+	CONFIG_ZRAM_MEMORY_TRACKING=n \
+	CONFIG_ZRAM_WRITEBACK=y
+  FILES:= \
+	$(LINUX_DIR)/drivers/block/zram/zram.ko
+  AUTOLOAD:=$(call AutoLoad,20,zram)
+endef
+
+define KernelPackage/zram-writeback/description
+ Compressed RAM disk with support for page writeback
+endef
+
+$(eval $(call KernelPackage,zram-writeback))
+
+
+define KernelPackage/zswap
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=zswap compressed swapping cache
+  DEPENDS:=+kmod-zsmalloc
+  KCONFIG:= \
+	CONFIG_FRONTSWAP=y \
+	CONFIG_Z3FOLD \
+	CONFIG_ZBUD \
+	CONFIG_ZPOOL \
+	CONFIG_ZSWAP=y
+  FILES:= \
+	$(LINUX_DIR)/mm/z3fold.ko \
+	$(LINUX_DIR)/mm/zbud.ko \
+	$(LINUX_DIR)/mm/zpool.ko
+  AUTOLOAD:=$(call AutoLoad,20,z3fold zbud zpool)
+endef
+
+define KernelPackage/zswap/description
+ Compressed swap cache and compressed memory allocator support
+endef
+
+$(eval $(call KernelPackage,zswap))
+
+
 define KernelPackage/pps
   SUBMENU:=$(OTHER_MENU)
   TITLE:=PPS support

--- a/package/system/compressed-memory/Makefile
+++ b/package/system/compressed-memory/Makefile
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2019-2020 Oever González <notengobattery@gmail.com>
+#
+# Licensed to the public under the Apache License 2.0.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=compressed-memory
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/compressed-memory
+  SECTION:=utils
+  CATEGORY:=Base system
+  DEPENDS:= \
+	+kmod-crypto-deflate \
+	+kmod-crypto-zstd \
+	+kmod-lib-lz4 \
+	+kmod-lib-lz4hc \
+	+kmod-lib-lzo \
+	+!(BUSYBOX_DEFAULT_MKSWAP||BUSYBOX_CONFIG_MKSWAP):swap-utils \
+	+!((BUSYBOX_DEFAULT_SWAPON||BUSYBOX_CONFIG_SWAPON)&&(BUSYBOX_DEFAULT_SWAPOFF||BUSYBOX_CONFIG_SWAPOFF)):block-mount
+  HIDDEN:=1
+  TITLE:=Configuration files for compressed-memory
+  MAINTAINER:=Oever Gonzalez <notengobattery@gmail.com>
+  PKGARCH:=all
+endef
+
+define Package/compressed-memory/description
+ Installs a UCI file which contains pre-computed values for packages that belong
+ to compressed-memory.
+endef
+
+define Package/swap-zram-writeback
+  SECTION:=utils
+  CATEGORY:=Base system
+  DEPENDS:= +compressed-memory \
+	+kmod-zram-writeback \
+	+losetup
+  TITLE:=Script to manage compressed memory for swap
+  MAINTAINER:=Oever Gonzalez <notengobattery@gmail.com>
+  PKGARCH:=all
+endef
+
+define Package/swap-zram-writeback/description
+ A script to activate compressed memory for a swap device. This can increase
+ the total available memory by compressing the memory that is not accessed
+ often (by using an algorith called LRU).
+
+ Most programs allocate memory that they do not use after the startup.
+ Allowing the system to compress that memory reduces the memory pressure as a
+ trade-off for CPU cycles.
+endef
+
+define Package/swap-zswap-cache
+  SECTION:=utils
+  CATEGORY:=Base system
+  DEPENDS:= +compressed-memory \
+	+kmod-zswap
+  TITLE:=Script to manage compressed cache for swap
+  MAINTAINER:=Oever Gonzalez <notengobattery@gmail.com>
+  PKGARCH:=all
+endef
+
+define Package/swap-zswap-cache/description
+ A script to activate compressed memory cache. This compressed cache will be
+ depleted before it begins to evict memory pages to a slow (real) swap device.
+
+ This can save good amounts of I/O to the swap device at the cost of CPU cycles
+ and a percentage of the memory. As compressing memory may be cheaper than
+ performing I/O, the system may run smoother under memory pressure.
+
+ If the pool is depleted and the system begins to starve, it will freeze as it
+ does when swapping normally. The point of this package is to delay the point
+ where it happens.
+endef
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/compressed-memory/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/compressed_memory.uci $(1)/etc/config/compressed_memory
+endef
+
+define Package/swap-zram-writeback/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/zram.init $(1)/etc/init.d/zram
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) ./files/zram.script $(1)/bin/zram
+endef
+
+define Package/swap-zswap-cache/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/zswap.init $(1)/etc/init.d/zswap
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) ./files/zswap.script $(1)/bin/zswap
+endef
+
+$(eval $(call BuildPackage,compressed-memory))
+$(eval $(call BuildPackage,swap-zram-writeback))
+$(eval $(call BuildPackage,swap-zswap-cache))

--- a/package/system/compressed-memory/files/compressed_memory.uci
+++ b/package/system/compressed-memory/files/compressed_memory.uci
@@ -1,0 +1,93 @@
+
+config params 'zram'
+	# This is the main switch for the zram script
+	option enabled	'1'
+	# The compression algorithm to use for the zram device
+	option algorithm	'lz4'
+	# Base pool % which is scaled by the expected compression ratio
+	option pool_base	'40.00'
+	# Hard pool % which clamp the maximum size of the zram device
+	#   This value is scaled by the worst expected compression ratio
+	option pool_limit	'96.6183575'
+	# The worst ratio that is expected by the worst compression algorithm
+	#   This value should never be less than 1.00
+	option worst_ratio	'1.035'
+	# zram can evict pages that are hard to compress to a backing storage,
+	#  which must have to be a block device, or a file in a loop device
+#	option backing_file	'/data/zram.img'
+
+config params 'zswap'
+	# This is the main switch for the zswap script
+	option enabled	'1'
+	# Default compression algorithm, the same options for zram
+	#   There is no gain in selecting a better one, because the zpool limits
+	#   the compression ratio of the data
+	option algorithm	'lz4'
+	# Size of the memory pool for zswap (if zram is not enabled)
+	option pool	'30.00'
+	# This is the zpool, z3fold guarantees a compression ratio of 3.00
+	#   while zbud guarantees a compression ratio of 2.00
+	option zpool	'z3fold'
+	# Adjust the system swappiness to this value when zswap is enabled
+	option swappiness	'100'
+	# zswap will be adjusted in the presence of zram, and also will modify zram
+	# parameters in order to provide better interoperability and to prevent
+	# excesive memory usage.
+
+	# The compressor to set the scale, this should be the higher compression
+	option compressor_scale	'deflate'
+	# The target underestimate compression ratio for the above compressor
+	option compressor_factor	'0.725'
+	# This will scale the zswap pool to a percentage of the zram pool
+	option zwap_scale_pool	'30.00'
+
+# Define the compression algorithms:
+#  The expected ratio is what defines the capacity to save RAM, where higher
+#   is better. Generally, higher compression ration leads lo more latency.
+#  The streams factor defines the maximum CPU cores to be used. Where 100 is
+#   to use all CPUs. The lower it is, the faster that the compression algorithm
+#   is, so it doesn't need to use too much CPU to do it's job. This is also
+#   known as the "cost".
+
+config compress 'deflate'
+	# Deflate has the best compression ratio but is really slow
+	option driver	'deflate'
+	option expected_ratio	'4.713'
+	option streams_factor	'100.000'
+
+config compress 'zstd'
+	option driver	'zstd'
+	option expected_ratio	'4.699'
+	option streams_factor	'96.535'
+
+config compress 'lz4hc'
+	option driver	'lz4hc'
+	option expected_ratio	'4.047'
+	option streams_factor	'45.835'
+
+config compress 'lzo'
+	option driver	'lzo'
+	option expected_ratio	'4.276'
+	option streams_factor	'26.475'
+
+config compress 'lzo_rle'
+	option driver	'lzo-rle'
+	option expected_ratio	'4.266'
+	option streams_factor	'24.105'
+
+config compress 'lz4'
+	# lz4 is the faster of all and offers good saving
+	option driver	'lz4'
+	option expected_ratio	'4.232'
+	option streams_factor	'21.735'
+
+# Define the zpools:
+#  These zpools will limit the maximum compression ratio of zswap
+
+config zpool 'zbud'
+	# zbud guarantees a 2.00 compression ratio
+	option expected_ratio	'2.000'
+
+config zpool 'z3fold'
+	# zbud guarantees a 3.00 compression ratio
+	option expected_ratio	'3.000'

--- a/package/system/compressed-memory/files/zram.init
+++ b/package/system/compressed-memory/files/zram.init
@@ -1,0 +1,47 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2019-2020 Oever González <notengobattery@gmail.com>
+#
+# Licensed to the public under the Apache License 2.0.
+#
+
+START=15
+USE_PROCD=1
+NAME="zram"
+PROG="/bin/zram"
+EXTRA_COMMANDS="stats compact"
+
+start_service() {
+	procd_open_instance "zram"
+	procd_set_param command "$PROG"
+	procd_append_param command start
+	procd_set_param env RUNNABLE=$RUNNABLE ZSWAP_OK=$ZSWAP_OK
+	procd_set_param stdout 0
+	procd_set_param stderr 0
+	procd_close_instance
+}
+
+stop_service() {
+	rc_procd "$PROG" stop
+}
+
+reload_service() {
+	echo "Explicitly restarting the '$NAME' service..."
+	stop; start
+}
+
+restart_service() {
+	reload_service
+}
+
+service_triggers() {
+	procd_add_reload_trigger "compressed_memory"
+}
+
+stats() {
+	rc_procd "$PROG" status
+}
+
+compact() {
+	rc_procd "$PROG" compact
+}

--- a/package/system/compressed-memory/files/zram.script
+++ b/package/system/compressed-memory/files/zram.script
@@ -1,0 +1,387 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2019-2020 Oever González <notengobattery@gmail.com>
+#
+# Licensed to the public under the Apache License 2.0.
+#
+
+KIB=1024
+MIB=1048576
+EXTRA_COMMANDS="compact status"
+CONFIG=compressed_memory
+
+config_load $CONFIG
+config_get ALGORITHM zram algorithm 'lz4'
+config_get DRIVER $ALGORITHM driver "$ALGORITHM"
+config_get EXPECTED_RATIO $ALGORITHM expected_ratio '3.000'
+config_get_bool ZSWAP_ENABLED zswap enabled '1'
+ZSWAP_SCALE=1; ZSWAP_POOL=0; ZPOOL_RATIO=1
+
+log_msg() {
+	local MESSAGE="$1"
+	logger -s -t zram -p user.info "$MESSAGE"
+}
+
+_zram_mounted() {
+	if [ $(grep -cs zram /proc/swaps) -ne 0 ]; then
+		log_msg "info: a zram device is already enabled"
+		return 1
+	fi
+	return 0
+}
+
+_do_math() {
+	local decimals="$1"
+	local expression="$2"
+	echo | awk 'BEGIN { f = "%.'"$decimals"'f" }
+	  { printf f, '"$expression"'}'
+}
+
+_do_compare() {
+	local expression="$1"
+	_do_math 0 "($expression)?1:0"
+}
+
+ram_getsize() {
+	local kib=$(grep 'MemTotal' /proc/meminfo | xargs | cut -d' ' -f2)
+	_do_math 3 "$kib * 1.024"
+}
+
+check_zswap() {
+	if [ -x '/bin/zswap' ] && /etc/init.d/zswap enabled; then
+	if [ "x$ZSWAP_OK" = "xno" ]; then return 200; fi
+	config_get_bool ZSWAP_ENABLED zswap enabled '1'; export ZSWAP_ENABLED
+	if [ "x$ZSWAP_ENABLED" = "x1" ]; then
+		config_get ALGORITHM zswap compressor_scale 'deflate'; export ALGORITHM
+		config_get ZSWAP_SCALE zswap compressor_factor '0.725'; export ZSWAP_SCALE
+		config_get ZSWAP_POOL zswap zwap_scale_pool '30.00'; export ZSWAP_POOL
+		config_get ZSWAP_ZPOOL zswap zpool 'z3fold'; export ZSWAP_ZPOOL
+		config_get ZPOOL_RATIO $ZSWAP_ZPOOL expected_ratio '3.000'; export ZPOOL_RATIO
+		config_get DRIVER $ALGORITHM driver "$ALGORITHM"; export DRIVER
+		config_get EXPECTED_RATIO $ALGORITHM expected_ratio '3.000'; export EXPECTED_RATIO
+		return 0
+	else export RUNNABLE=yes; return 201; fi
+	else export RUNNABLE=yes; return 202; fi
+}
+check_zswap
+
+zram_getsize() {
+	local ram_size="$(ram_getsize)"
+	log_msg "detected RAM size: $ram_size kb"
+	log_msg "compression algorithm: '$ALGORITHM', driver: '$DRIVER'"
+	log_msg "expected compression ratio for '$ALGORITHM': $EXPECTED_RATIO"
+	log_msg "zswap factor for compression ratio: $(printf '%.2f' $ZSWAP_SCALE)"
+	local zswap_scaled=$(_do_math 9 "$ZSWAP_SCALE * $EXPECTED_RATIO")
+	log_msg "scaled compression ratio': $zswap_scaled"
+	local pool_base; config_get pool_base zram pool_base '40.00'
+	log_msg "memory pool base: $pool_base%"
+	local pool_base_b=$(_do_math 0 \
+	  "$ram_size * $zswap_scaled * $pool_base * 10")
+	log_msg "calculated memory pool: $pool_base_b bytes"
+	local pool_limit; config_get pool_limit zram pool_limit '96.6183575'
+	log_msg "memory pool limit for zram: $pool_limit%"
+	local worst_ratio; config_get worst_ratio zram worst_ratio '1.035'
+	log_msg "worst expected compression ratio: $worst_ratio"
+	local zswap_pool=$(_do_math 0 "$pool_limit * $ZSWAP_POOL * $worst_ratio / ($ZPOOL_RATIO * 100)")
+	log_msg "zswap memory pool: $ZSWAP_POOL% uncompressed of zram ($zswap_pool%)"
+	local pool_clamp_b=$(_do_math 0 \
+	  "$ram_size * ($pool_limit * $worst_ratio - $zswap_pool) * 10")
+	log_msg "maximum memory pool allowed for zram: $pool_clamp_b bytes"
+	_clamp=$(_do_compare "$pool_base_b >= $pool_clamp_b")
+	if [ "0$_clamp" -eq 1 ]; then
+		log_msg "warning: base memory pool exceeds the pool limit"
+		printf $pool_clamp_b
+	else
+		printf $pool_base_b
+	fi
+}
+
+zram_dev() {
+	local idx="$1"; printf "/dev/zram${idx:-0}"
+}
+
+zram_getdev() {
+	local zdev="$(zram_dev)"
+	if [ "x$(mount | grep $zdev)" != "x" ]; then
+		local idx=$(cat /sys/class/zram-control/hot_add)
+		zdev="$(zram_dev $idx)"
+	fi
+	printf $zdev
+}
+
+zram_available() {
+	local zram_dev="$1"
+	if [ ! -e $zram_dev ]; then
+		log_msg "error: device '$zram_dev' not found"
+		return 1
+	fi
+	local enabled; config_get_bool enabled zram enabled '1'
+	if [ "0$enabled" -eq "0" ] && [ "x$UCI_RUN" != "xyes" ]; then
+		log_msg "warning: zram is not enabled in UCI"
+		return 100
+	fi
+	local zswap_enabled; config_get_bool zswap_enabled zswap enabled '1'
+	if [ "0$zswap_enabled" -eq "1" ] && [ "x$RUNNABLE" != "xyes" ]; then
+		log_msg "warning: zram was not allowed to run"
+		return 101
+	fi
+	if [ "x$(which awk)" = "x" ]; then
+		log_msg "error: command 'awk' not found"; return 2
+	fi
+	if [ "x$(which /sbin/mkswap)" = "x" ]; then
+		log_msg "error: command '/sbin/mkswap' not found"; return 2
+	fi
+	if [ "x$(which /sbin/swapon)" = "x" ]; then
+		log_msg "error: command '/sbin/swapon' not found"; return 2
+	fi
+	if [ "x$(which /sbin/swapoff)" = "x" ]; then
+		log_msg "error: command '/sbin/swapoff' not found"; return 2
+	fi
+	if [ "x$(which /usr/sbin/losetup)" = "x" ]; then
+		log_msg "error: command '/usr/sbin/losetup' not found"; return 2
+	fi
+}
+
+zram_reset() {
+	local dev="$1"
+	local base="$(basename "$dev")"
+	local block_entry=/sys/block/$base/reset
+	log_msg "resetting device '$base' to defaults"
+	printf "1" > $block_entry
+}
+
+zram_algorithm() {
+	local dev="$1"
+	local base="$(basename "$dev")"
+	local block_entry=/sys/block/$base/comp_algorithm
+	printf "$DRIVER" > $block_entry
+	local real_algorithm=$(cat $block_entry)
+	if [ "0$(grep -c "\[$DRIVER\]" $block_entry)" -ne 0 ]; then
+		log_msg "compression algorithm for '$base': $real_algorithm"
+	else
+		printf "deflate" > $block_entry
+		local curr=$(grep -o '\[.*\]' /sys/block/zram0/comp_algorithm | \
+		  awk -F[[] '{print $2}' | awk -F[]] '{print $1}')
+		log_msg "error: compression driver '$DRIVER' not supported"
+		uci set ${CONFIG}.zram.algorithm="$curr";
+		uci set ${CONFIG}.zswap.compressor_scale="$curr"; uci commit
+		log_msg "warning: changed compression driver to '$curr'"
+		env - RUNNABLE=$RUNNABLE /etc/init.d/zram restart
+		return 4
+	fi
+}
+
+zram_streams() {
+	local dev="$1"
+	local base="$(basename "$dev")"
+	local block_entry=/sys/block/$base/max_comp_streams
+	local cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || \
+	  sysctl -n hw.ncpu || \
+	  printf "$NUMBER_OF_PROCESSORS")
+	log_msg "available cores/CPUs for compression: $cores"
+	if [ "0$cores" -le 1 ]; then return 0; fi
+	local streams_factor; config_get streams_factor $ALGORITHM streams_factor '100.00'
+	log_msg "CPU streams factor for '$ALGORITHM': $streams_factor"
+	local streams=$(_do_math 0 "($cores * $streams_factor / 100) + 0.5")
+	_clamp=$(_do_compare "$streams >= $cores")
+	if [ "0$_clamp" -eq 1 ]; then streams=$cores; fi
+	log_msg "calculated compression streams: $streams"
+	printf "$streams" > $block_entry
+	log_msg "compression streams for '$base': $(cat $block_entry)"
+}
+
+zram_backing_add() {
+	local dev="$1"
+	local base="$(basename "$dev")"
+	local block_entry=/sys/block/$base/backing_dev
+	local ok="NO"
+	local backing_file; config_get backing_file zram backing_file
+	if [ -f "$backing_file" ]; then
+		/usr/sbin/losetup -f "$backing_file"
+		local lo=$(losetup | grep "$backing_file" | xargs | cut -f1 -d' ')
+		local fi=$(losetup | grep "$backing_file" | xargs | cut -f6 -d' ')
+		printf "$lo" > $block_entry; local _lo=$(cat $block_entry)
+		if [ "x$lo" = "x$_lo" ]; then
+			log_msg "backing device for '$base': '$_lo', file: '$fi'"
+			ok="YES"
+		else
+			log_msg "error: setting up backing file for '$base' failed"
+			printf "none" > $block_entry
+		fi
+	elif [ -b "$backing_file" ]; then
+		printf "$backing_file" > $block_entry; local _dev=$(cat $block_entry)
+		if [ "x$backing_file" = "x$_dev" ]; then
+			log_msg "backing block device for '$base': $block";
+			ok="YES"
+		else
+			log_msg "error: setting up backing device for '$base' failed";
+			printf "none" > $block_entry
+		fi
+	else
+		log_msg "backing file for '$base' is not set or does not exist"
+	fi
+	if [ "$ok" = "YES" ]; then
+		printf "all" > /sys/block/$base/idle
+		printf "idle" > /sys/block/$base/writeback
+		printf "huge" > /sys/block/$base/writeback
+	fi
+}
+
+ap_if_no_ma_in() {
+	local MATCH="$1"
+	local LINE="$2"
+	local FILE="$3"
+	(grep -qF "$MATCH" "$FILE"  || echo "$LINE" | tee -a "$FILE") > /dev/null 2>&1
+}
+
+start() {
+	_zram_mounted || exit 0
+	local zram_dev=$(zram_getdev)
+	zram_available $zram_dev || exit $?
+	local ram_size=$(ram_getsize)
+	local zram_size=$(zram_getsize)
+	local zram_pte=$(_do_math 2 "$zram_size / ($ram_size * 10)")
+	log_msg "maximum pool size for zram: $zram_size bytes ($zram_pte%)"
+	local pool_limit; config_get pool_limit zram pool_limit '96.6183575'
+	local worst_ratio; config_get worst_ratio zram worst_ratio '1.035'
+	local zswap_pool=$(_do_math 0 "$pool_limit * $worst_ratio * $ZSWAP_POOL / ($ZPOOL_RATIO * 100)")
+	log_msg "info: total memory for compression (assuming worst case): $zram_pte% +  $(printf '%.2f' $zswap_pool)%"
+	zram_reset $zram_dev || exit $?
+	zram_algorithm $zram_dev || exit $?
+	zram_streams $zram_dev || exit $?
+	zram_backing_add $zram_dev
+	local base="$(basename $zram_dev)"
+	local block_entry=/sys/block/$base/disksize
+	printf "$zram_size" > $block_entry
+	local rsize=$(_do_math 2 "$(cat $block_entry) / ($MIB)")
+	/sbin/mkswap $zram_dev || exit $?
+	/sbin/swapon -d -p 1000 $zram_dev && \
+		{ log_msg "activated '$zram_dev' for swapping ($rsize MiB)"; } || \
+		{ log_msg "error: cannot enable swap inside the device '$zram_dev'"; exit 6; }
+	ap_if_no_ma_in "/bin/zram compact" "0 */6 * * * /bin/zram compact" "/etc/crontabs/root"
+}
+
+zram_backing_remove() {
+	local dev="$1"
+	local base="$(basename "$dev")"
+	local block_entry=/sys/block/$base/backing_dev
+	local backing_dev="$(cat $block_entry)"
+	local fi=$(losetup | grep $backing_dev | xargs | cut -f6 -d' ')
+	if [ -f "$fi" ]; then
+		local lo=$(losetup | grep $backing_dev | xargs | cut -f1 -d' ')
+		losetup -d "$lo" && \
+			{ log_msg "detached loop device '$lo' for '$fi'"; } || \
+			{ log_msg "warning: could not deatach device '$lo' for '$fi'"; }
+	elif [ -d "$backing_dev" ]; then
+		log_msg "block device will be released on zram reset"
+	fi
+}
+
+stop() {
+	local zram_dev
+	for zram_dev in $(grep zram /proc/swaps | cut -d' ' -f1); do
+		RUNNABLE=yes UCI_RUN=yes zram_available $zram_dev || exit $?
+		log_msg "deactivating swap device '$zram_dev'"
+		/sbin/swapoff $zram_dev &> /dev/null || \
+			{ log_msg "swap cannot be disabled for '$zram_dev'"; exit 6; }
+		log_msg "swap disabled for '$zram_dev'"
+		zram_backing_remove $zram_dev
+		zram_reset $zram_dev
+		local dev_index="$(echo $zram_dev | grep -o "[0-9]*$")"
+		if [ "0$dev_index" -ne 0 ]; then
+			log_msg  "removing zram device '$zram_dev'"
+			printf $dev_index > /sys/class/zram-control/hot_remove
+		fi
+	done
+}
+
+zram_compact() {
+	local base="$(basename "$1")"
+	local block_entry=/sys/block/$base
+	local old_mem_used=$(cat $block_entry/mm_stat | xargs | cut -d' ' -f3)
+	local old_size=$(cat $block_entry/mm_stat | xargs | cut -d' ' -f2)
+	local old_overhead=$(_do_math 0 "$old_mem_used - $old_size")
+	printf "1" > $block_entry/compact
+	printf "all" > $block_entry/idle
+	printf "idle" > $block_entry/writeback
+	printf "huge" > $block_entry/writeback
+	local new_mem_used=$(cat $block_entry/mm_stat | xargs | cut -d' ' -f3)
+	log_msg "Compacting zram device '$base'..."
+	log_msg "Memory usage reduced by $(_do_math 2 \
+	  "($old_mem_used - $new_mem_used)/($MIB)") MiB"
+	local new_size=$(cat $block_entry/mm_stat | xargs | cut -d' ' -f2)
+	local new_overhead=$(_do_math 0 "$new_mem_used - $new_size")
+	log_msg "Memory overhead reduced by $(_do_math 2 \
+	  "($old_overhead+1-$new_overhead)*100/($old_overhead+1)")%"
+}
+
+compact() {
+	for zram_dev in $(grep zram /proc/swaps | cut -d' ' -f1); do
+		RUNNABLE=yes UCI_RUN=yes zram_available $zram_dev || exit $?
+		zram_compact $zram_dev
+	done
+}
+
+zram_stats() {
+	local base="$(basename "$1")"
+	local ram_size="$(ram_getsize)"
+	local block_entry=/sys/block/$base
+	local backing=$(cat $block_entry/backing_dev)
+	local streams=$(cat $block_entry/max_comp_streams)
+	local driver=$(cat $block_entry/comp_algorithm)
+	local zswap_scaled=$(_do_math 2 "$EXPECTED_RATIO * $ZSWAP_SCALE")
+	local backing_file=$(losetup | grep "$backing" | xargs | cut -f6 -d' ')
+	local discarded=$(cat /sys/block/zram0/io_stat | xargs | cut -f4 -d' ')
+	awk -v mib="$MIB" \
+		-v mb="1000000" \
+		-v kib="$KIB" \
+		-v kb="1000" \
+		-v base="$base" \
+		-v ram="$ram_size" \
+		-v block="$block_entry" \
+		-v backing="$backing" \
+		-v streams="$streams" \
+		-v cratio="$zswap_scaled" \
+		-v file="$backing_file" \
+		-v disc="$discarded" \
+		-v algo="$ALGORITHM" \
+		-v driver="$driver" \
+		'BEGIN { f = "%-35s - %.2f %s\n"
+		  f2 = "%-35s - %d %s\n"
+		  f3 = "%-35s - %s\n"
+		  f4 = "%-35s - %.2f %s (%.2f %s)\n"}
+		{ printf "Gathering stats info for zram device <%s>\n", base
+		  print "\nZRAM\n----"
+		  printf f3, "Block device", block
+		  printf f3, "Backing loop device", backing
+		  printf f3, "Backing file of loop dev", file
+		  printf f3, "Compression algorithm", algo
+		  printf f3, "Compression driver", driver
+		  printf f3, "Max. compression streams", streams
+		  print "\nDATA\n----"
+		  printf f4, "Original data size", $1/mib, "MiB", $1/(ram*10), "%"
+		  printf f4, "Compressed data size", $2/mib, "MiB", $2/(ram*10), "%"
+		  printf f4, "Estimated savings", ($1-$3)/mib, "MiB", ($1-$3)/(ram*10), "%"
+		  printf f, "Compression ratio (absolute)", $1/($3+1), ""
+		  printf f, "Compression ratio", $1/($2+1), ""
+		  printf f, "Expected compression ratio", cratio, ""
+		  print "\nMEMORY\n------"
+		  printf f4, "System memory", ram/kib, "MiB", ram/kb, "MB"
+		  printf f4, "Memory used (current)", $3/mib, "MiB", $3/(ram*10), "%"
+		  printf f4, "Allocator overhead", ($3-$2)/mib, "MiB", ($3-$2)/(ram*10), "%"
+		  printf f4, "Max. memory ever used", $5/mib, "MiB", $5/(ram*10), "%"
+		  printf f, "Allocator efficiency", ($2+1)*100/($3+1), "%"
+		  print "\nPAGES\n-----"
+		  printf f2, "Same pages count", $6, ""
+		  printf f2, "Compacted pages count", $7, ""
+		  printf f2, "Uncompressible pages count", $8, ""
+		  printf f2, "Pages discarded count", disc, ""
+		  print "" }' < $block_entry/mm_stat
+}
+
+status() {
+	for zram_dev in $(grep zram /proc/swaps | cut -d' ' -f1); do
+		RUNNABLE=yes UCI_RUN=yes zram_available $zram_dev || exit $?
+		zram_stats $zram_dev
+	done
+}

--- a/package/system/compressed-memory/files/zswap.init
+++ b/package/system/compressed-memory/files/zswap.init
@@ -1,0 +1,42 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2019-2020 Oever González <notengobattery@gmail.com>
+#
+# Licensed to the public under the Apache License 2.0.
+#
+
+START=16
+USE_PROCD=1
+NAME="zswap"
+PROG="/bin/zswap"
+EXTRA_COMMANDS="stats"
+
+start_service() {
+  procd_open_instance "zswap"
+  procd_set_param command "$PROG"
+  procd_append_param command start
+  procd_set_param stdout 0
+  procd_set_param stderr 0
+  procd_close_instance
+}
+
+stop_service() {
+  rc_procd "$PROG" stop
+}
+
+reload_service() {
+  echo "Explicitly restarting the '$NAME' service..."
+  stop; start
+}
+
+restart_service() {
+  reload_service
+}
+
+service_triggers() {
+	procd_add_reload_trigger "compressed_memory"
+}
+
+stats() {
+  rc_procd "$PROG" status
+}

--- a/package/system/compressed-memory/files/zswap.script
+++ b/package/system/compressed-memory/files/zswap.script
@@ -1,0 +1,210 @@
+#!/bin/sh /etc/rc.common
+#
+# Copyright (C) 2019-2020 Oever González <notengobattery@gmail.com>
+#
+# Licensed to the public under the Apache License 2.0.
+#
+
+KIB=1024
+MIB=1048576
+EXTRA_COMMANDS="status"
+CONFIG=compressed_memory
+ZSWAP_SYSFS=/sys/module/zswap/parameters
+ZSWAP_DEBUGFS=/sys/kernel/debug/zswap
+
+config_load $CONFIG
+config_get_bool ZRAM_ENABLED zram enabled '1'
+
+log_msg() {
+	local MESSAGE="$1"
+	logger -s -t zswap -p user.info "$MESSAGE"
+}
+
+_do_math() {
+	local decimals="$1"
+	local expression="$2"
+	echo | awk 'BEGIN { f = "%.'"$decimals"'f" }
+	  { printf f, '"$expression"'}'
+}
+
+ram_getsize() {
+	local kib=$(grep MemTotal /proc/meminfo | xargs | cut -d' ' -f2)
+	_do_math 3 "$kib * 1.024"
+}
+
+_zswap_factor() {
+	local ratio_scale; config_get ratio_scale zswap compressor_factor '0.725'
+	log_msg "compression ratio scale: $(printf '%.2f' $ratio_scale)"
+	printf $ratio_scale
+}
+
+_zswap_pool() {
+	local pool; config_get pool zram pool_limit '96.6183575'
+	log_msg "pool limit for zram: $pool%"
+	local worst; config_get worst zram worst_ratio '1.035'
+	log_msg "worst case compression ratio for zram: $worst"
+	local max_pool=$(_do_math 12 "$worst * $pool")
+	log_msg "absolute maximum memory pool: $(printf '%.2f' "$max_pool")%"
+	local zpool; config_get zpool zswap zpool 'z3fold'
+	local ratio; config_get ratio $zpool expected_ratio '3.000'
+	log_msg "expected compression ratio for $zpool: $ratio"
+	local scale; config_get scale zswap zwap_scale_pool '30.00'
+	log_msg "zswap scale for zram pool: $scale%"
+	local zswap_pool=$(_do_math 0 "$max_pool * $scale / ($ratio * 100)")
+	log_msg "adjusted zswap pool: $zswap_pool%"
+	printf $zswap_pool
+}
+
+check_zram() {
+	if [ -x '/bin/zram' ] && /etc/init.d/zram enabled; then
+	config_get_bool ZRAM_ENABLED zram enabled '1'; export ZSWAP_ENABLED
+	if [ "x$ZRAM_ENABLED" = "x1" ]; then return 0
+	else return 1; fi
+	else return 2; fi
+}
+check_zram
+
+_launch_zram() {
+	local success="$1"
+	if check_zram; then /etc/init.d/zram stop
+		if [ "x$success" = "xyes" ]; then
+			log_msg "trying to enable zram on success..."
+			env - RUNNABLE=yes ZSWAP_OK=yes /bin/zram restart && \
+			{ printf "$(_zswap_pool)" > $ZSWAP_SYSFS/max_pool_percent; \
+			  pool=$(cat $ZSWAP_SYSFS/max_pool_percent); \
+			  ram_size=$(ram_getsize); pool_b=$(_do_math 0 "$pool * $ram_size * 10"); \
+			  log_msg "maximum pool for zswap: $pool% ($pool_b bytes)"; }
+		else
+			log_msg "trying to enable zram on failure..."
+			env - RUNNABLE=yes ZSWAP_OK=no /etc/init.d/zram restart
+		fi
+	else log_msg "info: zram is not enabled or not available"
+	fi
+}
+
+zswap_available() {
+	if [ ! -d "$ZSWAP_SYSFS" ]; then
+		log_msg "error: zswap module is not loaded!"
+		return 1
+	fi
+	local enabled; config_get_bool enabled zswap enabled '1'
+	if [ "0$enabled" -eq "0" ] && [ "x$UCI_RUN" != "xyes" ]; then
+		log_msg "warning: zswap is not enabled in UCI"
+		return 100
+	fi
+	if [ "x$(which awk)" = "x" ]; then
+		log_msg "error: command 'awk' not found"; return 2
+	fi
+	if [ "x$(which block)" = "x" ]; then
+		log_msg "error: command 'block' not found"; return 2
+	fi
+	if [ "x$(which /sbin/swapoff)" = "x" ]; then
+		log_msg "error: command '/sbin/swapoff' not found"; return 2
+	fi
+}
+
+start() {
+	zswap_available || exit $?
+	local zpool; config_get zpool zswap zpool 'z3fold'
+	printf "$zpool" > $ZSWAP_SYSFS/zpool
+	local zpool_is=$(cat $ZSWAP_SYSFS/zpool)
+	log_msg "zpool for zswap: '$zpool'"
+	if [ "x$zpool_is" != "x$zpool" ]; then
+		log_msg "unsupported zpool $zpool, using $zpool_is instead"
+		printf "$zpool_is" > $ZSWAP_SYSFS/zpool
+		uci set ${CONFIG}.zswap.zpool="$zpool_is"
+		uci commit; env - /etc/init.d/zswap restart; exit 200
+	fi
+	local algorithm; config_get algorithm zswap algorithm 'lz4'
+	local driver; config_get driver $algorithm driver "$algorithm"
+	printf "$driver" > $ZSWAP_SYSFS/compressor
+	local driver_is=$(cat $ZSWAP_SYSFS/compressor)
+	log_msg "driver for zswap: '$driver_is'"
+	if [ "x$driver_is" != "x$driver" ]; then
+		printf "deflate" > $ZSWAP_SYSFS/compressor
+		driver_is=$(cat $ZSWAP_SYSFS/compressor)
+		log_msg "unsupported driver $driver, using $driver_is instead"
+		printf "$driver_is" > $ZSWAP_SYSFS/compressor
+		uci set ${CONFIG}.zswap.algorithm="$driver_is"
+		uci commit; env - /etc/init.d/zswap restart; exit 201
+	fi
+	local pool; config_get pool zswap pool '30.00'
+	printf '%.0f' "$pool" > $ZSWAP_SYSFS/max_pool_percent
+	pool=$(cat $ZSWAP_SYSFS/max_pool_percent)
+	local ram_size=$(ram_getsize)
+	local pool_b=$(_do_math 0 "$pool * $ram_size * 10")
+	log_msg "maximum pool for zswap: $pool% ($pool_b bytes)"
+	printf "Y" > $ZSWAP_SYSFS/enabled
+	local enabled=$(cat $ZSWAP_SYSFS/enabled)
+	if [ "x$enabled" = "xY" ]; then
+		log_msg "zswap was successfully enabled"
+	else
+		log_msg "error: could not enable the zswap pool"
+		_launch_zram no; exit 3
+	fi
+	local swapiness; config_get swapiness zswap swappiness '100'
+	sysctl -w vm.swappiness="$(printf '%.0f' "$swapiness")" > /dev/null
+	swapiness=$(sysctl vm.swappiness)
+	log_msg "system swapiness is $swapiness"
+	_launch_zram yes
+}
+
+stop() {
+	UCI_RUN=yes zswap_available || exit $?
+	printf "N" > $ZSWAP_SYSFS/enabled
+	printf "1" > $ZSWAP_SYSFS/max_pool_percent
+	enabled=$(cat $ZSWAP_SYSFS/enabled)
+	if [ "x$enabled" = "xN" ]; then
+		log_msg "info: successfully disabled"
+	else
+		log_msg "error: could not disable the zswap pool"
+		exit 4
+	fi
+}
+
+status() {
+	UCI_RUN=yes zswap_available || exit $?
+	local max_pool=$(cat $ZSWAP_SYSFS/max_pool_percent)
+	local compressor=$(cat $ZSWAP_SYSFS/compressor)
+	local enabled=$(cat $ZSWAP_SYSFS/enabled)
+	local zpool=$(cat $ZSWAP_SYSFS/zpool)
+	local ram_size="$(ram_getsize)"
+	local page_size=4096
+	cat $ZSWAP_DEBUGFS/* | xargs | awk -v mib="$MIB" \
+		-v mb="1000000" \
+		-v kib="$KIB" \
+		-v kb="1000" \
+		-v max_pool="$max_pool" \
+		-v compressor="$compressor" \
+		-v enabled="$enabled" \
+		-v zpool="$zpool" \
+		-v ram="$ram_size" \
+		-v pgsz="$page_size" \
+		'BEGIN { f = "%-35s - %.2f %s\n"
+		  f2 = "%-35s - %d %s\n"
+		  f3 = "%-35s - %s\n"
+		  f4 = "%-35s - %.2f %s (%.2f %s)\n"}
+		{ print "Gathering stats info for zswap subsystem"
+		  print "\nZSWAP\n-----"
+		  printf f3, "Currently enabled", enabled
+		  printf f3, "Compression algorithm", compressor
+		  printf f3, "Memory allocator (zpool)", zpool
+		  printf f4, "Max. memory pool", max_pool, "%", ram*max_pool*10/mib, "MiB"
+		  print "\nSTATS\n-----"
+		  printf f3, "Duplicate entry", $1
+		  printf f3, "Pool limit hit (times)", $2
+		  printf f3, "Rejected due to alloc. fail", $4
+		  printf f3, "Rejected due to bad compression", $5
+		  printf f3, "Rejected due to kmemcache fail", $6
+		  printf f3, "Rejected due to reclaim failed", $7
+		  printf f3, "Same filled pages (identical)", $8
+		  printf f3, "Pages currently in the pool", $9
+		  printf f3, "Written-back pages to storage", $10
+		  print "\nDATA\n----"
+		  printf f4, "System memory", ram/kib, "MiB", ram/kb, "MB"
+		  printf f4, "Pool total size", $3/mib, "MiB", $3/(ram*10), "%"
+		  printf f4, "Original data size", $9*pgsz/mib, "MiB", $9*pgsz/(ram*10), "%"
+		  printf f4, "Estimated savings", ($9*pgsz-$3)/mib, "MiB", ($9*pgsz-$3)/(ram*10), "%"
+		  printf f, "Compression ratio", ($9*pgsz+1)/($3+1), ""
+		  print "" }'
+}


### PR DESCRIPTION
[RETRACTED]

Even when rejected by OpenWrt, this pull request is being actively used by several projects and builds. They include my own builds and builds from other users/brands with a wider spread. Even when retracted, these projects will still benefit from the changes by pulling the latest changes by comparing my master branch against OpenWrt master.

This means that this project will work, always, against the OpenWrt master branch. I'll keep it updated, but you may find it unreliable with older versions. I do not recommend relying on this pull request anymore. It is officially retracted now. All developers should pull the changes from my master branch or directly from the link below.

More information available here: https://forum.openwrt.org/t/49076