### PR TITLE
vxlan: allow creation without local address

### DIFF
--- a/package/network/config/vxlan/Makefile
+++ b/package/network/config/vxlan/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vxlan
-PKG_VERSION:=2
+PKG_VERSION:=3
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/vxlan/files/vxlan.sh
+++ b/package/network/config/vxlan/files/vxlan.sh
@@ -71,8 +71,10 @@ proto_vxlan_setup() {
 		fi
 
 		if ! network_get_ipaddr ipaddr "$wanif"; then
-			proto_notify_error "$cfg" "NO_WAN_LINK"
-			exit
+			if [ -z "$tunlink" ]; then
+				proto_notify_error "$cfg" "NO_WAN_LINK"
+				exit
+			fi
 		fi
 	}
 
@@ -101,8 +103,10 @@ proto_vxlan6_setup() {
 		fi
 
 		if ! network_get_ipaddr6 ip6addr "$wanif"; then
-			proto_notify_error "$cfg" "NO_WAN_LINK"
-			exit
+			if [ -z "$tunlink" ]; then
+				proto_notify_error "$cfg" "NO_WAN_LINK"
+				exit
+			fi
 		fi
 	}
 


### PR DESCRIPTION
If no local address was specified for the interface to create and none was
found on the specified lower layer interface (tunlink), the interface will
be created by binding directly to the lower layer interface.