### PR TITLE
ramips: mt7530 fix

### DIFF
--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
@@ -186,6 +186,22 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
 	mt7530_mdio_w32(gsw, 0x7a74, 0x44);
 	mt7530_mdio_w32(gsw, 0x7a7c, 0x44);
 
+	/* Disable EEE */
+	for (i = 0; i <= 4; i++) {
+		_mt7620_mii_write(gsw, i, 13, 0x7);
+		_mt7620_mii_write(gsw, i, 14, 0x3C);
+		_mt7620_mii_write(gsw, i, 13, 0x4007);
+		_mt7620_mii_write(gsw, i, 14, 0x0);
+	}
+
+	/* Disable EEE 10Base-Te */
+	for (i = 0; i <= 4; i++) {
+		_mt7620_mii_write(gsw, i, 13, 0x1f);
+		_mt7620_mii_write(gsw, i, 14, 0x027b);
+		_mt7620_mii_write(gsw, i, 13, 0x401f);
+		_mt7620_mii_write(gsw, i, 14, 0x1177);
+	}
+
 	/* turn on all PHYs */
 	for (i = 0; i <= 4; i++) {
 		val = _mt7620_mii_read(gsw, i, 0);

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
@@ -98,9 +98,15 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
 	mt7530_mdio_w32(gsw, 0x7000, 0x3);
 	usleep_range(10, 20);
 
-	/* (GE1, Force 1000M/FD, FC OFF, MAX_RX_LENGTH 1536) */
-	mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
-	mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
+	if ((rt_sysc_r32(SYSC_REG_CHIP_REV_ID) & 0xFFFF) == 0x0101) {
+		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
+		mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
+		mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
+	} else {
+		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
+		mtk_switch_w32(gsw, 0x2305e33b, GSW_REG_MAC_P0_MCR);
+		mt7530_mdio_w32(gsw, 0x3600, 0x5e33b);
+	}
 
 	/* (GE2, Link down) */
 	mtk_switch_w32(gsw, 0x8000, GSW_REG_MAC_P1_MCR);

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
@@ -565,7 +565,7 @@ static inline u32 fe_empty_txd(struct fe_tx_ring *ring)
 	barrier();
 	return (u32)(ring->tx_ring_size -
 			((ring->tx_next_idx - ring->tx_free_idx) &
-			 (ring->tx_ring_size - 1)));
+			 (ring->tx_ring_size - 1)) - 1);
 }
 
 struct fe_map_state {


### PR DESCRIPTION
1. Fix the mt7530 tx timeout issue
I think the tx timeout is caused by the wrong implement of fe_empty_txd() function
for hours test no tx timeout

2. Disable eee to fix the link down/up problem
https://bugs.openwrt.org/index.php?do=details&task_id=1449
tested ok and sure fixed
