### PR TITLE
buildroot: per-subtarget patches

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -19,7 +19,11 @@ endif
 export HOST_EXTRACFLAGS=-I$(STAGING_DIR_HOST)/include
 
 # defined in quilt.mk
+ifeq ($(PLATFORM_DIR),$(PLATFORM_SUBDIR))
 Kernel/Patch:=$(Kernel/Patch/Default)
+else
+Kernel/Patch:=$(Kernel/Patch/Subtarget)
+endif
 
 ifneq (,$(findstring .xz,$(LINUX_SOURCE)))
   LINUX_CAT:=xzcat

--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -92,6 +92,17 @@ define Build/Patch/Default
 	$(if $(QUILT),touch $(PKG_BUILD_DIR)/.quilt_used)
 endef
 
+define Kernel/Patch/Subtarget
+	find $(PLATFORM_DIR) -type l -xtype f -lname "*patches*" -delete
+	for pdir in $$$$(find $(PLATFORM_SUBDIR) -name "patches*" -xtype d -printf "%f\n"); do \
+		mkdir -p $(PLATFORM_DIR)/$$$$pdir ; \
+		for p in $$$$(find -L $(PLATFORM_SUBDIR) -wholename "*/$$$$pdir/*" -type f); do \
+			ln -sf $$$$p $(PLATFORM_DIR)/$$$$pdir/ ; \
+		done ; \
+	done
+	$(call Kernel/Patch/Default)
+endef
+
 kernel_files=$(foreach fdir,$(GENERIC_FILES_DIR) $(FILES_DIR),$(fdir)/.)
 define Kernel/Patch/Default
 	$(if $(QUILT),rm -rf $(LINUX_DIR)/patches; mkdir -p $(LINUX_DIR)/patches)


### PR DESCRIPTION
I recently implemented this into an old chaos calmer buildroot to support a specific scenario. I would like to share this for proper review from openwrt community. I don't know if this could be of any general interest or if this is already implemented in current master in different ways.
Assuming each subtarget's kernel builds to a different build_dir subdirectory (ie. linux-*target*_*subtarget*), this patchset allows each subtarget to bring specific kernel patches into regular target's patches directories as symlinks. Then everything gets copied into quilt's platform as usual when kernel patching stage is reached.

Subtargets families sharing the same kernel patches have their patches-* folder symlinked to that one of their main family member.

I had to patch CC's buildroot and define `$(SUBTARGET)` in `rules.mk` to also get bin outputs to go into different subdirectories, but it looks like current master can do this already since that var is there already.

This could eventually be extended to files-* as well. Also, a proper make clean target is missing..

This was my first valid idea to easily manage subtargets of different cpu arch (eg. mips and arm brcm63xx). Having multiple clones of the same target for each board equiring different kernel patches was not convenient to me, and I preferred to have them all under a single target.

Please, take this as a concept. Of course, I will squash everything to a well-done single commit with proper commit message once reviewed in case.