### PR TITLE
ar71xx: fix status led for GL.iNet GL-AR750S

### DIFF
--- a/target/linux/ar71xx/base-files/etc/diag.sh
+++ b/target/linux/ar71xx/base-files/etc/diag.sh
@@ -75,6 +75,7 @@ get_status_led() {
 	fritz300e|\
 	fritz4020|\
 	fritz450e|\
+	gl-ar750s|\
 	gl-usb150|\
 	mr12|\
 	mr16|\


### PR DESCRIPTION
- use power led for device status

This has already been fixed in ath79 when porting the device to the new target. I'm fixing this for ar71xx to prepare a backport for 19.07. Since there are no conflicts with 19.07, it would be great if this commit could be cherry-picked directly. Already tested my changes with builds from master and 19.07, both working as expected.