### PR TITLE
wpa_supplicant: disable CONFIG_WRITE functionality

### DIFF
--- a/package/network/services/hostapd/files/wpa_supplicant-basic.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-basic.config
@@ -264,7 +264,7 @@ CONFIG_BACKEND=file
 # configuration can still be changed, the changes are just not going to be
 # persistent over restarts. This option can be used to reduce code size by
 # about 3.5 kB.
-#CONFIG_NO_CONFIG_WRITE=y
+CONFIG_NO_CONFIG_WRITE=y
 
 # Remove support for configuration blobs to reduce code size by about 1.5 kB.
 #CONFIG_NO_CONFIG_BLOBS=y

--- a/package/network/services/hostapd/files/wpa_supplicant-mini.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-mini.config
@@ -264,7 +264,7 @@ CONFIG_BACKEND=file
 # configuration can still be changed, the changes are just not going to be
 # persistent over restarts. This option can be used to reduce code size by
 # about 3.5 kB.
-#CONFIG_NO_CONFIG_WRITE=y
+CONFIG_NO_CONFIG_WRITE=y
 
 # Remove support for configuration blobs to reduce code size by about 1.5 kB.
 #CONFIG_NO_CONFIG_BLOBS=y


### PR DESCRIPTION
CONFIG_WRITE functionality is not used and could be removed. Looks helpful for devices with small flash because wpad is also affected.

Little testing shows that about 3-6 KB could be saved.
 
$ ls -lh
-rw-r--r--  1 evilwirelessman evilwirelessman 437K мар 24 15:04 wpa-supplicant-openssl_2019-08-08-ca8c2bd2-8_x86_64_CONFIG_WRITE_OPENSSL.ipk
-rw-r--r--  1 evilwirelessman evilwirelessman 431K мар 24 23:48 wpa-supplicant-openssl_2019-08-08-ca8c2bd2-8_x86_64_NO_CONFIG_WRITE_OPENSSL.ipk

-rw-r--r--  1 evilwirelessman evilwirelessman 321K мар 25 00:40 wpad-basic_2019-08-08-ca8c2bd2-8_mips_24kc_CONFIG_WRITE.ipk
-rw-r--r--  1 evilwirelessman evilwirelessman 318K мар 25 00:47 wpad-basic_2019-08-08-ca8c2bd2-8_mips_24kc_NO_CONFIG_WRITE.ipk

Signed-off-by: Kirill Lukonin klukonin@gmail.com
