### PR TITLE
ramips: add support for D-Link DWR-960 

### DIFF
--- a/package/kernel/mt76/patches/0001-mt76-mt76x0-pci-add-mt7610-PCI-ID.patch
+++ b/package/kernel/mt76/patches/0001-mt76-mt76x0-pci-add-mt7610-PCI-ID.patch
@@ -1,0 +1,30 @@
+From 9b082c3fd3fc954937444220995cb05662ab2e82 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Wed, 25 Mar 2020 06:51:29 +0100
+Subject: [PATCH] mt76: mt76x0: pci: add mt7610 PCI ID
+
+Add mt7610 PCI id found on D-Link DWR-960 to pci_device_id table.
+
+Run-tested on D-Link DWR-960 with no-name half-size mPCIE card
+with mt7610e.
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ mt76x0/pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mt76x0/pci.c b/mt76x0/pci.c
+index e2974e0ae1fc..3bd753cda190 100644
+--- a/mt76x0/pci.c
++++ b/mt76x0/pci.c
+@@ -215,6 +215,7 @@ mt76x0e_remove(struct pci_dev *pdev)
+ }
+
+ static const struct pci_device_id mt76x0e_device_table[] = {
++	{ PCI_DEVICE(0x14c3, 0x7610) },
+ 	{ PCI_DEVICE(0x14c3, 0x7630) },
+ 	{ PCI_DEVICE(0x14c3, 0x7650) },
+ 	{ },
+--
+2.20.1
+

--- a/target/linux/generic/backport-4.14/183-net-qmi_wwan-add-Wistron-Neweb-D19Q1.patch
+++ b/target/linux/generic/backport-4.14/183-net-qmi_wwan-add-Wistron-Neweb-D19Q1.patch
@@ -1,0 +1,54 @@
+From eb5a26bcaddb35fd42a978ad37831e58b1118853 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Tue, 17 Apr 2018 19:53:59 +0200
+Subject: [PATCH] net: qmi_wwan: add Wistron Neweb D19Q1
+
+This modem is embedded on dlink dwr-960 router.
+The oem configuration states:
+
+T: Bus=01 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#= 2 Spd=480 MxCh= 0
+D: Ver= 2.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs= 1
+P: Vendor=1435 ProdID=d191 Rev=ff.ff
+S: Manufacturer=Android
+S: Product=Android
+S: SerialNumber=0123456789ABCDEF
+C:* #Ifs= 6 Cfg#= 1 Atr=80 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)
+E: Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E: Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=84(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=86(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E: Ad=88(I) Atr=03(Int.) MxPS= 8 Ivl=32ms
+E: Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 5 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+E: Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/net/usb/qmi_wwan.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/usb/qmi_wwan.c
++++ b/drivers/net/usb/qmi_wwan.c
+@@ -1142,6 +1142,7 @@ static const struct usb_device_id produc
+ 	{QMI_FIXED_INTF(0x1435, 0xd181, 3)},	/* Wistron NeWeb D18Q1 */
+ 	{QMI_FIXED_INTF(0x1435, 0xd181, 4)},	/* Wistron NeWeb D18Q1 */
+ 	{QMI_FIXED_INTF(0x1435, 0xd181, 5)},	/* Wistron NeWeb D18Q1 */
++	{QMI_FIXED_INTF(0x1435, 0xd191, 4)},	/* Wistron NeWeb D19Q1 */
+ 	{QMI_QUIRK_SET_DTR(0x1508, 0x1001, 4)},	/* Fibocom NL668 series */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6003, 0)},	/* CMOTech 6003 */
+ 	{QMI_FIXED_INTF(0x16d8, 0x6007, 0)},	/* CMOTech CHE-628S */

--- a/target/linux/generic/pending-4.14/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
+++ b/target/linux/generic/pending-4.14/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
@@ -1,0 +1,55 @@
+From 9d2e23253eb5fabff02a7ce4be9c4a7fc23562e8 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Fri, 20 Mar 2020 22:56:28 +0100
+Subject: [PATCH v2 3/3] USB: serial: option: add Wistron Neweb D19Q1
+
+This modem is embedded on dlink dwr-960 router.
+The oem configuration states:
+
+T: Bus=01 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#= 2 Spd=480 MxCh= 0
+D: Ver= 2.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs= 1
+P: Vendor=1435 ProdID=d191 Rev=ff.ff
+S: Manufacturer=Android
+S: Product=Android
+S: SerialNumber=0123456789ABCDEF
+C:* #Ifs= 6 Cfg#= 1 Atr=80 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)
+E: Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E: Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=84(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=86(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E: Ad=88(I) Atr=03(Int.) MxPS= 8 Ivl=32ms
+E: Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 5 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+E: Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/usb/serial/option.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -1993,6 +1993,8 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e01, 0xff, 0xff, 0xff) },	/* D-Link DWM-152/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e02, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x7e11, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/A3 */
++	{ USB_DEVICE_INTERFACE_CLASS(0x1435, 0xd191, 0xff),			/* Wistron Neweb D19Q1 */
++	  .driver_info = RSVD(1) | RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2031, 0xff),			/* Olicard 600 */
+ 	  .driver_info = RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2060, 0xff),			/* BroadMobi BM818 */

--- a/target/linux/generic/pending-4.19/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
+++ b/target/linux/generic/pending-4.19/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
@@ -1,0 +1,55 @@
+From 9d2e23253eb5fabff02a7ce4be9c4a7fc23562e8 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Fri, 20 Mar 2020 22:56:28 +0100
+Subject: [PATCH v2 3/3] USB: serial: option: add Wistron Neweb D19Q1
+
+This modem is embedded on dlink dwr-960 router.
+The oem configuration states:
+
+T: Bus=01 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#= 2 Spd=480 MxCh= 0
+D: Ver= 2.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs= 1
+P: Vendor=1435 ProdID=d191 Rev=ff.ff
+S: Manufacturer=Android
+S: Product=Android
+S: SerialNumber=0123456789ABCDEF
+C:* #Ifs= 6 Cfg#= 1 Atr=80 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)
+E: Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E: Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=84(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=86(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E: Ad=88(I) Atr=03(Int.) MxPS= 8 Ivl=32ms
+E: Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 5 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+E: Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/usb/serial/option.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -1990,6 +1990,8 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e01, 0xff, 0xff, 0xff) },	/* D-Link DWM-152/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e02, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x7e11, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/A3 */
++	{ USB_DEVICE_INTERFACE_CLASS(0x1435, 0xd191, 0xff),			/* Wistron Neweb D19Q1 */
++	  .driver_info = RSVD(1) | RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2031, 0xff),			/* Olicard 600 */
+ 	  .driver_info = RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2060, 0xff),			/* BroadMobi BM818 */

--- a/target/linux/generic/pending-5.4/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
+++ b/target/linux/generic/pending-5.4/184-USB-serial-option-add-Wistron-Neweb-D19Q1.patch
@@ -1,0 +1,55 @@
+From 9d2e23253eb5fabff02a7ce4be9c4a7fc23562e8 Mon Sep 17 00:00:00 2001
+From: Pawel Dembicki <paweldembicki@gmail.com>
+Date: Fri, 20 Mar 2020 22:56:28 +0100
+Subject: [PATCH v2 3/3] USB: serial: option: add Wistron Neweb D19Q1
+
+This modem is embedded on dlink dwr-960 router.
+The oem configuration states:
+
+T: Bus=01 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#= 2 Spd=480 MxCh= 0
+D: Ver= 2.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs= 1
+P: Vendor=1435 ProdID=d191 Rev=ff.ff
+S: Manufacturer=Android
+S: Product=Android
+S: SerialNumber=0123456789ABCDEF
+C:* #Ifs= 6 Cfg#= 1 Atr=80 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=(none)
+E: Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E: Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=84(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=83(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=(none)
+E: Ad=86(I) Atr=03(Int.) MxPS= 10 Ivl=32ms
+E: Ad=85(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E: Ad=88(I) Atr=03(Int.) MxPS= 8 Ivl=32ms
+E: Ad=87(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 5 Alt= 0 #EPs= 2 Cls=08(stor.) Sub=06 Prot=50 Driver=(none)
+E: Ad=89(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E: Ad=06(O) Atr=02(Bulk) MxPS= 512 Ivl=125us
+
+Tested on openwrt distribution
+
+Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
+---
+ drivers/usb/serial/option.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -1990,6 +1990,8 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e01, 0xff, 0xff, 0xff) },	/* D-Link DWM-152/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x3e02, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/C1 */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x7e11, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/A3 */
++	{ USB_DEVICE_INTERFACE_CLASS(0x1435, 0xd191, 0xff),			/* Wistron Neweb D19Q1 */
++	  .driver_info = RSVD(1) | RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2031, 0xff),			/* Olicard 600 */
+ 	  .driver_info = RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2060, 0xff),			/* BroadMobi BM818 */

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "dlink,dwr-960", "ralink,mt7620a-soc";
+	model = "D-Link DWR-960";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "dwr-960:green:status";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "dwr-960:green:wan";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "dwr-960:green:lan";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		sms {
+			label = "dwr-960:green:sms";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		signal_green {
+			label = "dwr-960:green:signal";
+			gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		signal_red {
+			label = "dwr-960:red:signal";
+			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		4g {
+			label = "dwr-960:green:4g";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		3g {
+			label = "dwr-960:green:3g";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "dwr-960:green:wlan5g";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g {
+			label = "dwr-960:green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+	mediatek,portmap = "wllll";
+
+	port@5 {
+		status = "okay";
+		phy-mode = "rgmii-txid";
+		phy-handle = <&phy7>;
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy7: ethernet-phy@7 {
+			reg = <7>;
+			phy-mode = "rgmii-id";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "amit,jimage";
+				label = "firmware";
+				reg = <0x10000 0xfe0000>;
+			};
+
+			config: partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&config 0xe08e>;
+		mtd-mac-address = <&config 0xe50e>;
+		mtd-mac-address-increment = <2>;
+	};
+};
+
+&state_default {
+	default {
+		ralink,group = "i2c", "wled", "spi refclk", "uartf", "ephy";
+		ralink,function = "gpio";
+	};
+};

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.h
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.h
@@ -46,6 +46,10 @@
 #define GSW_REG_IMR		0x7008
 #define GSW_REG_ISR		0x700c
 #define GSW_REG_GPC1		0x7014
+#define GSW_REG_GPC2		0x701c
+
+#define GSW_REG_GPCx_TXDELAY	BIT(3)
+#define GSW_REG_GPCx_RXDELAY	BIT(2)
 
 #define GSW_REG_MAC_P0_MCR	0x100
 #define GSW_REG_MAC_P1_MCR	0x200

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -279,6 +279,20 @@ define Device/dlink_dwr-922-e2
 endef
 TARGET_DEVICES += dlink_dwr-922-e2
 
+define Device/dlink_dwr-960
+  $(Device/amit_jboot)
+  SOC := mt7620a
+  IMAGE_SIZE := 16256k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DWR-960
+  DLINK_ROM_ID := DLK6E2429001
+  DLINK_FAMILY_MEMBER := 0x6E24
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi \
+	kmod-mt76x0e
+endef
+TARGET_DEVICES += dlink_dwr-960
+
 define Device/dovado_tiny-ac
   SOC := mt7620a
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -87,6 +87,9 @@ dlink,dwr-922-e2)
 	ucidef_set_led_netdev "signalstrength" "signalstrength" "$boardname:green:sigstrength" "wwan0" "link"
 	ucidef_set_led_netdev "4g" "4g" "$boardname:green:4g" "wwan0" "tx rx"
 	;;
+dlink,dwr-960)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x2e"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 dovado,tiny-ac)
 	set_wifi_led "$boardname:orange:wifi"
 	;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -100,6 +100,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:2" "2:lan:1" "3:lan:3" "4:lan" "0:wan" "6@eth0"
 		;;
+	dlink,dwr-960)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "5:lan" "0:wan" "6@eth0"
+		;;
 	edimax,br-6478ac-v2|\
 	tplink,archer-c2-v1)
 		ucidef_add_switch "switch1" \
@@ -273,6 +277,7 @@ ramips_setup_macs()
 	dlink,dwr-118-a2|\
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
+	dlink,dwr-960|\
 	lava,lr-25g001)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		lan_mac=$(macaddr_add "$wan_mac" 1)

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
@@ -11,6 +11,9 @@ dlink,dir-510l)
 	ucidef_add_gpio_switch "usb_enable1" "USB 1A enable" "12" "0"
 	ucidef_add_gpio_switch "usb_enable05" "USB 0.5A enable" "13" "1"
 	;;
+dlink,dwr-960)
+	ucidef_add_gpio_switch "power_mpcie" "mPCIe power" "0" "1"
+	;;
 head-weblink,hdrm200)
 	ucidef_add_gpio_switch "sim_switch" "SIM slot switch" "0"
 	ucidef_add_gpio_switch "io1" "I/O 1" "1"

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -28,6 +28,7 @@ case "$FIRMWARE" in
 	dlink,dwr-118-a2|\
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
+	dlink,dwr-960|\
 	lava,lr-25g001)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)


### PR DESCRIPTION
The DWR-960 Wireless Router is based on the MT7620A SoC.

Specification:

- MediaTek MT7620A (580 Mhz)
- 128 MB of RAM
- 16 MB of FLASH
- 1x 802.11bgn radio
- 1x 802.11ac radio (MT7610 mpcie card)
- 4x 10/100 Mbps Ethernet (1 WAN and 3 LAN)
- 1x 10/100/1000 Mbps Ethernet (1 LAN) (AR8035)
- 2x internal, non-detachable antennas (Wifi 2.4G)
- 3x external, detachable antennas (2x LTE, 1x Wifi 5G)
- 1x LTE modem
- UART (J4) header on PCB (57600 8n1)
- 9x LED, 2x button
- JBOOT bootloader

Known issues:
- Flash is extremely slow.

Installation:
Apply factory image via http web-gui or JBOOT recovery page

How to revert to OEM firmware:
- push the reset button and turn on the power. Wait until LED start
  blinking (~10sec.)
- upload original factory image via JBOOT http (IP: 192.168.123.254)

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>