### PR TITLE
build: fix "dd: memory exhausted by input buffer of size" when CONFIG…

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -177,7 +177,13 @@ ifeq ($(strip $(call kernel_patchver_ge,4.18.0)),1)
 endif
 
 define Image/pad-to
-	dd if=$(1) of=$(1).new bs=$(2) conv=sync
+	if [ $(2) -gt 1048576 ]; then \
+		dd if=$(1) of=$(1).new \
+			bs=1048576 count=$(shell expr $(2) / 1048576) \
+			conv=sync ; \
+	else \
+		dd if=$(1) of=$(1).new bs=$(2) conv=sync  ; \
+	fi
 	mv $(1).new $(1)
 endef
 


### PR DESCRIPTION
…_TARGET_ROOTFS_PARTSIZE is set to a large number. e.g. 14336

      problem: dd will not be able to allocate a large bs on a build machine with a small memory
      fix: split CONFIG_TARGET_ROOTFS_PARTSIZE to bs and count.  still handles small CONFIG_TARGET_ROOTFS_PARTSIZE properly.

Signed-off-by: shir474 <shir474@users.noreply.github.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
