### PR TITLE
tplink-safeloader: update soft_ver for TP-Link Archer C6 v2 (EU)

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -891,7 +891,7 @@ static struct device_info boards[] = {
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",
 		.support_trail = '\x00',
-		.soft_ver = "soft_ver:1.1.1\n",
+		.soft_ver = "soft_ver:1.2.1\n",
 
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},


### PR DESCRIPTION
The last couple of TP-Link firmware releases for Archer C6 v2 (EU)
have switched to version 1.2.x. Bump the soft_ver to "1.2.1" to
allow firmware updates from the vendor web interface.

TP-Link vendor firmware releases supported by this change:
* Archer C6(EU)_V2_200110: soft_ver:1.2.1 Build 20200110 rel.60119
* Archer C6(EU)_V2_191014: soft_ver:1.2.0 Build 20191014 rel.33289

Signed-off-by: Georgi Vlaev <georgi.vlaev@gmail.com>
