### PR TITLE
[19.07] mvebu: backport ClearFog SPI enablement

### DIFF
--- a/target/linux/mvebu/patches-4.14/529-armada388-clearfog-enable-spi-flash.patch
+++ b/target/linux/mvebu/patches-4.14/529-armada388-clearfog-enable-spi-flash.patch
@@ -1,0 +1,56 @@
+From bb683d7ad9d53442586cfdd0a79a6d6c1fec344e Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Thu, 28 Jun 2018 10:13:35 +0300
+Subject: [PATCH] ARM: dts: armada388-clearfog: enable spi flash
+
+The SolidRun Armada 388 SOM has the SPI flash populated by default
+unless the customer explicitly asks otherwise. Enable support by
+default.
+
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Acked-by: Russell King <rmk+kernel@armlinux.org.uk>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm/boot/dts/armada-388-clearfog.dts           | 2 +-
+ arch/arm/boot/dts/armada-388-clearfog.dtsi          | 2 +-
+ arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi | 1 -
+ 3 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/boot/dts/armada-388-clearfog.dts b/arch/arm/boot/dts/armada-388-clearfog.dts
+index 5fd0f6f61e776..af76b6cafc639 100644
+--- a/arch/arm/boot/dts/armada-388-clearfog.dts
++++ b/arch/arm/boot/dts/armada-388-clearfog.dts
+@@ -235,7 +235,7 @@
+ &spi1 {
+ 	/*
+ 	 * Add SPI CS pins for clearfog:
+-	 * CS0: W25Q32 (not populated on uSOM)
++	 * CS0: W25Q32
+ 	 * CS1:
+ 	 * CS2: mikrobus
+ 	 */
+diff --git a/arch/arm/boot/dts/armada-388-clearfog.dtsi b/arch/arm/boot/dts/armada-388-clearfog.dtsi
+index 0d9dfdfe977e2..e7618e6c5ad50 100644
+--- a/arch/arm/boot/dts/armada-388-clearfog.dtsi
++++ b/arch/arm/boot/dts/armada-388-clearfog.dtsi
+@@ -230,7 +230,7 @@
+ &spi1 {
+ 	/*
+ 	 * Add SPI CS pins for clearfog:
+-	 * CS0: W25Q32 (not populated on uSOM)
++	 * CS0: W25Q32
+ 	 * CS1: PIC microcontroller (Pro models)
+ 	 * CS2: mikrobus
+ 	 */
+diff --git a/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi b/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
+index 2d1cea131e71c..c990d502d9a40 100644
+--- a/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
++++ b/arch/arm/boot/dts/armada-38x-solidrun-microsom.dtsi
+@@ -99,7 +99,6 @@
+ 		compatible = "w25q32", "jedec,spi-nor";
+ 		reg = <0>; /* Chip select 0 */
+ 		spi-max-frequency = <3000000>;
+-		status = "disabled";
+ 	};
+ };
+ 


### PR DESCRIPTION
Backport Device Tree change first added in kernel 4.19 to enable the SPI
device on ClearFog devices by default. This is tested and working in
snapshot builds with kernel 5.4+, include the change in future 19.07
patch releases.