### PR TITLE
ath10k-ct: Support AQL on ath10k CT_KVER-5.4

### DIFF
--- a/package/kernel/ath10k-ct/patches/205-ath10k-Add-NL80211_EXT_FEATURE_AQL-flag.patch
+++ b/package/kernel/ath10k-ct/patches/205-ath10k-Add-NL80211_EXT_FEATURE_AQL-flag.patch
@@ -1,0 +1,10 @@
+--- a/ath10k-5.4/mac.c
++++ b/ath10k-5.4/mac.c
+@@ -10180,6 +10180,7 @@ int ath10k_mac_register(struct ath10k *a
+ 	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_VHT_IBSS);
+ 	wiphy_ext_feature_set(ar->hw->wiphy,
+ 			      NL80211_EXT_FEATURE_SET_SCAN_DWELL);
++	wiphy_ext_feature_set(ar->hw->wiphy, NL80211_EXT_FEATURE_AQL);
+ 
+ 	if (test_bit(WMI_SERVICE_TX_DATA_ACK_RSSI, ar->wmi.svc_map) ||
+ 	    test_bit(WMI_SERVICE_HTT_MGMT_TX_COMP_VALID_FLAGS, ar->wmi.svc_map))


### PR DESCRIPTION
Commit ea50780 backported Airtime Queue Limits (AQL) from Linux 5.5
to OpenWrt's backports 5.4. However, this only enabled AQL for the
vanilla ath10k driver. This patch also enables it for ath10k-ct, the default 
driver for OpenWrt.

Tested on:
* 2xTP-Link Archer A7v5 (QCA9563/QCA988X)
* Backports version 5.4-rc8 & 5.4.27
* ath10k-ct and ath10k-ct-htt firmware version 014 to 017
* ath10k-ct driver versions dc025dc to 3d173a4 (CT_KVER-5.4)
* WPA2, 802.11krv

Tested since: _January 25, 2020_.

Signed-off-by: Jose Olivera <oliverajeo@gmail.com>

Additional notes for GitHub:
I am not pulling this into @greearb's repository since this is an OpenWrt specific patch, to enable a feature that is backported to 5.4 by another OpenWrt patch.

To check that it is working, in the shell:
`cat /sys/kernel/debug/ieee80211/phy0/netdev:wlan0/stations/*/aql`
