### PR TITLE
ramips: Add support for Netgear EX6120

### DIFF
--- a/target/linux/ramips/dts/mt7620a_netgear_ex6120.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex6120.dts
@@ -1,0 +1,58 @@
+/* This file is released into the public domain */
+
+/dts-v1/;
+
+#include "mt7620a_netgear_ex3700_ex6130.dtsi"
+
+/ {
+	compatible = "netgear,ex6120", "ralink,mt7620a-soc";
+	model = "Netgear EX6120";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_g {
+			label = "ex6120:green:power";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_a {
+			label = "ex6120:amber:power";
+			gpios = <&gpio2 28 GPIO_ACTIVE_LOW>;
+		};
+
+		router_g {
+			label = "ex6120:green:router";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		router_r {
+			label = "ex6120:red:router";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		device_g {
+			label = "ex6120:green:device";
+			gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+		};
+
+		device_r {
+			label = "ex6120:red:device";
+			gpios = <&gpio2 21 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "ex6120:green:wps";
+			gpios = <&gpio2 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -630,6 +630,20 @@ define Device/netgear_ex3700
 endef
 TARGET_DEVICES += netgear_ex3700
 
+define Device/netgear_ex6120
+  SOC := mt7620a
+  NETGEAR_BOARD_ID := U12H319T30_NETGEAR
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGES += factory.chk
+  IMAGE/factory.chk := $$(sysupgrade_bin) | check-size | \
+        netgear-chk
+  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := EX6120
+endef
+TARGET_DEVICES += netgear_ex6120
+
 define Device/netgear_ex6130
   SOC := mt7620a
   NETGEAR_BOARD_ID := U12H319T50_NETGEAR

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -154,6 +154,7 @@ netgear,wn3000rp-v3)
 	set_wifi_led "$boardname:green:router"
 	;;
 netgear,ex3700|\
+netgear,ex6120|\
 netgear,ex6130)
 	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "$boardname:green:router" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "$boardname:green:device" "wlan1"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -44,6 +44,7 @@ ramips_setup_interfaces()
 	kimax,u25awf-h1|\
 	netgear,ex2700|\
 	netgear,ex3700|\
+	netgear,ex6120|\
 	netgear,ex6130|\
 	netgear,wn3000rp-v3|\
 	planex,cs-qr10|\


### PR DESCRIPTION
This device is nearly identical to EX6130, requiring only
a different NETGEAR_BOARD_ID.

Signed-off-by: Adam Serbinski <adam@serbinski.com>