### PR TITLE
x86: add nforce eth to default packages

### DIFF
--- a/target/linux/x86/64/target.mk
+++ b/target/linux/x86/64/target.mk
@@ -1,6 +1,7 @@
 ARCH:=x86_64
 BOARDNAME:=x86_64
-DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 kmod-igb kmod-bnx2
+DEFAULT_PACKAGES += kmod-button-hotplug kmod-e1000e kmod-e1000 kmod-r8169 \
+	kmod-igb kmod-bnx2 forcedeth
 
 define Target/Description
         Build images for 64 bit systems including virtualized guests.

--- a/target/linux/x86/image/generic.mk
+++ b/target/linux/x86/image/generic.mk
@@ -2,7 +2,7 @@ define Device/generic
   DEVICE_TITLE := Generic x86
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-natsemi \
 	kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 \
-	kmod-via-rhine kmod-via-velocity
+	kmod-via-rhine kmod-via-velocity forcedeth
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/legacy.mk
+++ b/target/linux/x86/image/legacy.mk
@@ -2,7 +2,7 @@ define Device/generic
   DEVICE_TITLE := Generic x86/legacy
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 \
 	kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 \
-	kmod-tg3 kmod-via-rhine kmod-via-velocity
+	kmod-tg3 kmod-via-rhine kmod-via-velocity forcedeth
   GRUB2_VARIANT := legacy
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
forcedeth is necessary to use the integrated
ethernet controller of Nvidia nForce chipset.

There are PC motherboards with this chipset
from 2001 that run 32bit Athlon XP CPUs and
more modern ones up to 2009 that can run Intel
and AMD 64bit processors, so add this to
all non-geode x86 targets.

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>

tested on a nForce motherboard with an Athlon XP, legacy target.