### PR TITLE
 ath79: add support for Teltonika RUT230

### DIFF
--- a/target/linux/ath79/dts/ar9330_teltonika_rut230.dts
+++ b/target/linux/ath79/dts/ar9330_teltonika_rut230.dts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9330.dtsi"
+
+/ {
+	compatible = "teltonika,rut230", "qca,ar9330";
+	model = "Teltonika RUT230";
+
+	chosen {
+		bootargs = "console=ttyATH0,115200 root=31:05 rootfstype=squashfs";
+	};
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_signal5;
+		led-failsafe = &led_signal5;
+		led-upgrade = &led_signal5;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		input {
+			label = "input";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		sim {
+			label = "SIM holder";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		signal1 {
+			label = "rut230:green:signal1";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "rut230:green:signal2";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "rut230:green:signal3";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		signal4 {
+			label = "rut230:green:signal4";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led_signal5: signal5 {
+			label = "rut230:green:signal5";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		status_2g {
+			label = "rut230:green:status_2g";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_3g {
+			label = "rut230:green:status_3g";
+			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan {
+			label = "rut230:green:lan";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "rut230:green:wan";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			config: partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "config";
+				read-only;
+			};
+
+			art: partition@30000 {
+				reg = <0x30000 0x10000>;
+				label = "art";
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "tplink,firmware";
+				reg = <0x40000 0xf30000>;
+				label = "firmware";
+			};
+
+			partition@f70000 {
+				reg = <0xf70000 0x90000>;
+				label = "event-log";
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&config 0x0>;
+	mtd-mac-address-increment = <1>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&config 0x0>;
+};
+
+&gpio {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-mac-address = <&config 0x0>;
+	mtd-mac-address-increment = <2>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -163,6 +163,10 @@ pcs,cr3000)
 qihoo,c301)
 	ucidef_set_led_wlan "wlan" "WLAN" "$boardname:green:wlan" "phy0tpt"
 	;;
+teltonika,rut230)
+       ucidef_set_led_netdev "lan" "LAN" "rut230:green:lan" "eth0"
+       ucidef_set_led_netdev "wan" "WAN" "rut230:green:wan" "eth1"
+       ;;
 tplink,archer-a7-v5|\
 tplink,archer-c7-v4|\
 tplink,archer-c7-v5)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1182,6 +1182,29 @@ define Device/teltonika_rut955-h7v3c0
 endef
 TARGET_DEVICES += teltonika_rut955-h7v3c0
 
+define Device/teltonika_rut230
+  SOC := ar9330
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT230
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 \
+       -uboot-envtools kmod-usb-serial-option comgt usb-modeswitch
+  IMAGE_SIZE := 15552k
+  KERNEL := kernel-bin | append-dtb | lzma | tplink-v1-header
+  KERNEL_INITRAMFS := $$(KERNEL)
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs |\
+       pad-rootfs | teltonika-fw-fake-checksum |\
+       append-string RUT200019999master |\
+       append-md5sum-bin | check-size 
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) |\
+       append-rootfs | pad-rootfs | append-metadata |\
+       check-size 
+  TPLINK_HWID := 0x32200002
+  TPLINK_HWREV := 0x1
+  TPLINK_HEADER_VERSION := 1
+endef
+TARGET_DEVICES += teltonika_rut230
+
 define Device/trendnet_tew-823dru
   SOC := qca9558
   DEVICE_VENDOR := Trendnet


### PR DESCRIPTION
Commit adds support for teltonika rut2xx routers.

Specification:
- 400 MHz CPU
- 64 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- 2x RJ45 10/100 Mbps Ethernet ports
- 2T2R 2,4 GHz (AR9330)
- built-in 4G/3G module Quectel UC20-E
- 11x LED
- 1 x SMA for 3G,  1x RP-SMA for WiFi antenna connectors
- 1x button (reset)
- DC jack for main power input (9-30 V)

Flash instruction:

Vendor firmware is based on OpenWrt CC release. Use the "factory" image
directly in GUI (make sure to uncheck "keep settings") or in U-Boot web
based recovery.

Signed-off-by: Artūras Paulius <arturas.paulius@gmail.com>