### PR TITLE
build: add 'make kernel_xconfig' command

### DIFF
--- a/include/kernel-build.mk
+++ b/include/kernel-build.mk
@@ -157,7 +157,7 @@ define BuildKernel
   compile: $(LINUX_DIR)/.modules
 	$(MAKE) -C image compile TARGET_BUILD=
 
-  oldconfig menuconfig nconfig: $(STAMP_PREPARED) $(STAMP_CHECKED) FORCE
+  oldconfig menuconfig nconfig xconfig: $(STAMP_PREPARED) $(STAMP_CHECKED) FORCE
 	rm -f $(LINUX_DIR)/.config.prev
 	rm -f $(STAMP_CONFIGURED)
 	$(LINUX_RECONF_CMD) > $(LINUX_DIR)/.config

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -165,12 +165,16 @@ kernel_oldconfig: prepare_kernel_conf
 ifneq ($(DISTRO_PKG_CONFIG),)
 kernel_menuconfig: export PATH:=$(dir $(DISTRO_PKG_CONFIG)):$(PATH)
 kernel_nconfig: export PATH:=$(dir $(DISTRO_PKG_CONFIG)):$(PATH)
+kernel_xconfig: export PATH:=$(dir $(DISTRO_PKG_CONFIG)):$(PATH)
 endif
 kernel_menuconfig: prepare_kernel_conf
 	$(_SINGLE)$(NO_TRACE_MAKE) -C target/linux menuconfig
 
 kernel_nconfig: prepare_kernel_conf
 	$(_SINGLE)$(NO_TRACE_MAKE) -C target/linux nconfig
+
+kernel_xconfig: prepare_kernel_conf
+	$(_SINGLE)$(NO_TRACE_MAKE) -C target/linux xconfig
 
 staging_dir/host/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp

--- a/target/linux/Makefile
+++ b/target/linux/Makefile
@@ -9,5 +9,5 @@ include $(INCLUDE_DIR)/target.mk
 
 export TARGET_BUILD=1
 
-prereq clean download prepare compile install menuconfig nconfig oldconfig update refresh: FORCE
+prereq clean download prepare compile install oldconfig menuconfig nconfig xconfig update refresh: FORCE
 	@+$(NO_TRACE_MAKE) -C $(BOARD) $@


### PR DESCRIPTION
This adds the kernel_xconfig make target.

Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>