### PR TITLE
ramips: add DTS triggers to USB LEDs for F9K1109v1

### DIFF
--- a/target/linux/ramips/dts/rt3883_belkin_f9k1109v1.dts
+++ b/target/linux/ramips/dts/rt3883_belkin_f9k1109v1.dts
@@ -30,11 +30,15 @@
 		usb1 {
 			label = "f9k1109v1:green:usb1";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
 		};
 
 		usb2 {
 			label = "f9k1109v1:green:usb2";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port2>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
 		};
 
 		wps_amber {
@@ -63,5 +67,19 @@
 			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
+	};
+};
+
+&ehci {
+	ehci_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&ohci {
+	ohci_port2: port@2 {
+		reg = <2>;
+		#trigger-source-cells = <0>;
 	};
 };

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -23,7 +23,7 @@ define Device/belkin_f9k1109v1
   DEVICE_VENDOR := Belkin
   DEVICE_MODEL := F9K1109
   DEVICE_VARIANT := Version 1.0
-  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 swconfig
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport swconfig
   IMAGE_SIZE := 7808k
   KERNEL := kernel-bin | append-dtb | lzma -d16 | uImage lzma
   # Stock firmware checks for this uImage image name during upload.

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/01_leds
@@ -18,7 +18,6 @@ led_wlan="$(get_dt_led wlan)"
 
 case $board in
 belkin,f9k1109v1)
-	ucidef_set_led_usbport "usb" "USB" "$boardname:green:usb1" "usb1-port1"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:blue:wps" "eth0"
 	;;
 edimax,br-6475nd)


### PR DESCRIPTION
Alter DTS for Belkin F9K1109v1 to trigger USB leds from the echi/ochi
ports. Also include ledtrig package and minor cleanup of the uci
defs of the LEDs

This is a long overdue correction from the discussion with @mans0n and @adrianschmutzler in this PR #2543

Signed-off-by: Kip Porterfield <kip.porterfield@gmail.com>