### PR TITLE
bzip2: build also _static_  libbz2 library

### DIFF
--- a/package/utils/bzip2/Makefile
+++ b/package/utils/bzip2/Makefile
@@ -64,13 +64,14 @@ MAKE_FLAGS += \
 	-f Makefile-libbz2_so \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
-	all
+	all libbz2.a
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_BUILD_DIR)/bzlib.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_BUILD_DIR)/libbz2.so.$(PKG_VERSION) $(1)/usr/lib/
+	$(CP) $(PKG_BUILD_DIR)/libbz2.a $(1)/usr/lib/
 	$(LN) libbz2.so.$(PKG_VERSION) $(1)/usr/lib/libbz2.so.1.0
 	$(LN) libbz2.so.$(PKG_VERSION) $(1)/usr/lib/libbz2.so
 endef

--- a/package/utils/bzip2/patches/030-add-static-lib.patch
+++ b/package/utils/bzip2/patches/030-add-static-lib.patch
@@ -1,0 +1,20 @@
+Index: bzip2-1.0.8/Makefile-libbz2_so
+===================================================================
+--- bzip2-1.0.8.orig/Makefile-libbz2_so
++++ bzip2-1.0.8/Makefile-libbz2_so
+@@ -40,6 +40,15 @@ all: $(OBJS)
+ 	rm -f libbz2.so.1.0
+ 	ln -s libbz2.so.1.0.8 libbz2.so.1.0
+ 
++libbz2.a: $(OBJS)
++	rm -f libbz2.a
++	$(AR) cq libbz2.a $(OBJS)
++	@if ( test -f $(RANLIB) -o -f /usr/bin/ranlib -o \
++		-f /bin/ranlib -o -f /usr/ccs/bin/ranlib ) ; then \
++		echo $(RANLIB) libbz2.a ; \
++		$(RANLIB) libbz2.a ; \
++	fi
++
+ clean: 
+ 	rm -f $(OBJS) bzip2.o libbz2.so.1.0.8 libbz2.so.1.0 bzip2-shared
+ 


### PR DESCRIPTION
This patch adds a few lines from the regular Makefile into the separate Makefile that is used to build the shared library.

The motivation behind this patch is to ease the testing of binaries on other (likely more performant) Linux machines that are likely to e.g. miss the musl C library. 