### PR TITLE
Kernel: Fix miss config and module for mlx driver

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1095,12 +1095,15 @@ define KernelPackage/mlx4-core
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Mellanox ConnectX(R) mlx4 core Network Driver
   DEPENDS:=@PCI_SUPPORT +kmod-ptp
-  FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_core.ko
+  FILES:= \
+	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_core.ko \
+	$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx4/mlx4_en.ko
   KCONFIG:= CONFIG_MLX4_EN \
+	CONFIG_MLX4_EN_DCB=n \
 	CONFIG_MLX4_CORE=y \
-	CONFIG_MLX4_CORE_GEN2=y \
-	CONFIG_MLX4_DEBUG=n
-  AUTOLOAD:=$(call AutoProbe,mlx4_core)
+	CONFIG_MLX4_DEBUG=n \
+	CONFIG_MLX4_CORE_GEN2=y
+  AUTOLOAD:=$(call AutoProbe,mlx4_core mlx4_en)
 endef
 
 define KernelPackage/mlx4-core/description
@@ -1116,7 +1119,11 @@ define KernelPackage/mlx5-core
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko
   KCONFIG:= CONFIG_MLX5_CORE \
 	CONFIG_MLX5_CORE_EN=y \
-	CONFIG_MLX5_EN_RXNFC=y
+	CONFIG_MLX5_EN_RXNFC=y \
+	CONFIG_MLX5_FPGA=n \
+	CONFIG_MLX5_MPFS=n \
+	CONFIG_MLX5_EN_ARFS=n \
+	CONFIG_MLX5_CORE_IPOIB=n
   AUTOLOAD:=$(call AutoProbe,mlx5_core)
 endef
 


### PR DESCRIPTION
Miss config possible cause kernel 4.14/4.19 build fail

Signed-off-by: Tan Zien <nabsdh9@gmail.com>