### PR TITLE
ath79: add support for TP-Link TL-MR3420v3

### DIFF
--- a/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,tl-mr3420-v3", "qca,qca9531";
+	model = "TP-Link TL-MR3420 v3";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &wmac;
+
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_shift_register_oe {
+			gpio-export,name = "tp-link:oe:sr";
+			gpio-export,output = <0>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_shift_register_reset {
+			gpio-export,name = "tp-link:reset:sr";
+			gpio-export,output = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "tp-link:orange:wan";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "tp-link:green:usb";
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "RF kill button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+				
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -66,6 +66,17 @@ define Device/tplink_tl-mr3420-v2
 endef
 TARGET_DEVICES += tplink_tl-mr3420-v2
 
+define Device/tplink_tl-mr3420-v3
+  $(Device/tplink-4mlzma)
+  SOC := qca9531
+  DEVICE_MODEL := TL-MR3420
+  DEVICE_VARIANT := v3
+  TPLINK_HWID := 0x34200003
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += tl-mr3420-v3
+endef
+TARGET_DEVICES += tplink_tl-mr3420-v3
+
 define Device/tplink_tl-wa701nd-v1
   $(Device/tplink-4m)
   SOC := ar7240

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -83,6 +83,7 @@ tplink,tl-wr941-v4)
 	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
 	;;
+tplink,tl-mr3420-v3|\
 tplink,tl-wr841-v9|\
 tplink,tl-wr841-v10|\
 tplink,tl-wr841-v11|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ath79_setup_interfaces()
 		;;
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
+	tplink,tl-mr3420-v3|\
 	tplink,tl-wr841-v7|\
 	tplink,tl-wr841-v9|\
 	tplink,tl-wr841-v10|\


### PR DESCRIPTION
This adds support for the TP-Link TL-WR3420v3, a later revision of the
v2 with an external gpiochip similar to TP-Link Archer C7 v4

Specifications:

SOC: Qualcomm Atheros QCA9531
CPU: 650MHz
Flash: 4 MiB
RAM: 32 MiB
WLAN: Qualcomm Atheros QCA9531 bgn 2T2R 2.4 GHz
Ethernet: 5 ports (100M)

Flashing instructions:

- Flash factory image from OEM WebUI:
  openwrt-ath79-tiny-tplink_tl-mr3420-v3-squashfs-factory.bin
- Sysupgrade from ath79 image:
  openwrt-ath79-tiny-tplink_tl-mr3420-v3-squashfs-sysupgrade.bin

Signed-off-by: Lim Guo Wei \<limguowei@gmail.com\>