### PR TITLE
ramips: add ZyXEL WAP6805 support, inlcuding basic Quantenna QV840 bootstrap

### DIFF
--- a/package/kernel/mt7621-qtn-rgmii/Makefile
+++ b/package/kernel/mt7621-qtn-rgmii/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=mt7621-qtn-rgmii
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+PKG_MAINTAINER:=Bjørn Mork <bjorn@mork.no>
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/mt7621-qtn-rgmii
+  SECTION:=kernel
+  SUBMENU:=Other modules
+  TITLE:=Enable RGMII connected Quantenna module on MT7621
+  DEPENDS:=@TARGET_ramips_mt7621
+  HIDDEN:=1
+  FILES:=$(PKG_BUILD_DIR)/mt7621-qtn-rgmii.ko
+  AUTOLOAD:=$(call AutoLoad,30,mt7621-qtn-rgmii,1)
+endef
+
+define KernelPackage/mt7621-qtn-rgmii/description
+  Enable RGMII connected Quantenna module on MT7621.
+
+  The Mitrastar designed ZyXEL WAP6805 has a Quantenna QV840
+  module connected to the RGMII pins of the MT7621 SoC. For
+  unknown reasons, it is necessary to change the value of
+  the register at 0x1e110008 from default (usually 0xc000c)
+  to 0x9000c for this connection wo work.
+
+  This driver simply does that without much fuzz.
+endef
+
+define Build/Compile
+        $(KERNEL_MAKE) M=$(PKG_BUILD_DIR) modules
+endef
+
+$(eval $(call KernelPackage,mt7621-qtn-rgmii))

--- a/package/kernel/mt7621-qtn-rgmii/src/Makefile
+++ b/package/kernel/mt7621-qtn-rgmii/src/Makefile
@@ -1,0 +1,1 @@
+obj-m += mt7621-qtn-rgmii.o

--- a/package/kernel/mt7621-qtn-rgmii/src/mt7621-qtn-rgmii.c
+++ b/package/kernel/mt7621-qtn-rgmii/src/mt7621-qtn-rgmii.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2020  Bjørn Mork <bjorn@mork.no>
+ */
+#include <linux/io.h>
+#include <linux/module.h>
+
+#define MODULE_NAME "mt7621-qtn-rgmii"
+#define RGMII_REG_BASE	0x1e110008
+#define RGMII_REG_SIZE	4
+#define RGMII_REG_VALUE	0x9000c
+
+static u32 oldval;
+
+static int __init mt7621_qtn_rgmii_init(void)
+{
+	void __iomem *base = ioremap(RGMII_REG_BASE, RGMII_REG_SIZE);
+
+	if (!base)
+		return -ENOMEM;
+	oldval = ioread32(base);
+	if (oldval != RGMII_REG_VALUE) {
+		iowrite32(RGMII_REG_VALUE, base);
+		pr_info(MODULE_NAME ": changed register 0x%08x value from 0x%08x to 0x%08x\n", RGMII_REG_BASE, oldval,  RGMII_REG_VALUE);
+	}
+	iounmap(base);
+	return 0;
+}
+
+static void __exit mt7621_qtn_rgmii_exit(void)
+{
+	void __iomem *base = ioremap(RGMII_REG_BASE, RGMII_REG_SIZE);
+
+	if (!base)
+		return;
+	if (oldval != RGMII_REG_VALUE) {
+		iowrite32(oldval, base);
+		pr_info(MODULE_NAME ": reset register 0x%08x back to 0x%08x\n", RGMII_REG_BASE, oldval);
+	}
+	iounmap(base);
+}
+
+module_init(mt7621_qtn_rgmii_init);
+module_exit(mt7621_qtn_rgmii_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Bjørn Mork <bjorn@mork.no>");
+MODULE_DESCRIPTION("Enable RGMII connected Quantenna module on MT7621");

--- a/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,wap6805", "mediatek,mt7621-soc";
+	model = "ZyXEL WAP6805";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "wap6805:red:status";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_blink {
+			label = "wap6805:blink:status";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: status_green {
+			label = "wap6805:green:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "MRD";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			read-only;
+		};
+
+		partition@300000 {
+			label = "Config";
+			reg = <0x300000 0x100000>;
+		};
+
+		partition@400000 {
+			label = "Kernel";
+			reg = <0x400000 0x2000000>;
+		};
+
+		partition@800000 {
+			label = "ubi";
+			reg = <0x800000 0x1c00000>;
+		};
+
+		partition@2400000 {
+			label = "Kernel2";
+			reg = <0x2400000 0x2000000>;
+		};
+
+		partition@4400000 {
+			label = "Private";
+			reg = <0x4400000 0x100000>;
+		};
+
+		partition@4500000 {
+			label = "Log";
+			reg = <0x4500000 0x1000000>;
+		};
+
+		partition@5500000 {
+			label = "App";
+			reg = <0x5500000 0x2b00000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&gmac1 {
+	status = "okay";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -105,6 +105,11 @@ define Build/ubnt-erx-factory-image
 	fi
 endef
 
+define Build/mitrastarimage
+	uimage_padhdr -l 160 -i $@ -o $@.new
+	mv $@.new $@
+endef
+
 define Device/afoundry_ew1200
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := AFOUNDRY
@@ -1119,3 +1124,17 @@ define Device/zio_freezio
 	kmod-usb-ledtrig-usbport wpad-basic
 endef
 TARGET_DEVICES += zio_freezio
+
+define Device/zyxel_wap6805
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := WAP6805
+  DEVICE_PACKAGES := kmod-mt7603 wpad-basic kmod-mt7621-qtn-rgmii
+  KERNEL := $(KERNEL_DTB) | uImage lzma | mitrastarimage
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zyxel_wap6805

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -52,6 +52,10 @@ ramips_setup_interfaces()
 	ubnt,edgerouter-x-sfp)
 		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 		;;
+	zyxel,wap6805)
+		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
+		ucidef_set_interface "qtn" ifname "eth1" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.0"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -23,6 +23,9 @@ ubnt,edgerouter-x-sfp)
 	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "403"
 	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "404"
 	;;
+zyxel,wap6805)
+	ucidef_add_gpio_switch "qtn_power" "Quantenna Module Power" "496" "1"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -70,6 +70,15 @@ platform_do_upgrade() {
 	ubnt,edgerouter-x-sfp)
 		platform_upgrade_ubnt_erx "$1"
 		;;
+	zyxel,wap6805)
+		local kernel2_mtd="$(find_mtd_part Kernel2)"
+		[ "$(hexdump -n 4 -e '"%x"' $kernel2_mtd)" = "56190527" ] &&\
+		[ "$(hexdump -n 4 -s 104 -e '"%x"' $kernel2_mtd)" != "0" ] &&\
+		dd bs=4 count=1 seek=26 conv=notrunc if=/dev/zero of=$kernel2_mtd 2>/dev/null &&\
+		echo "Kernel2 sequence number was reset to 0"
+		CI_KERNPART="Kernel"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Time to add this now that we finally have an ethernet driver with support for both MT7621 GMACs.

The Quantenna 5GHz radio is a full SoC with its own OS.  It is connected to the MT7621 RGMII port, and loads both second stage uboot and OS from the MT7621 using tftp. This reuest adds basic support for booting up the module, and communicating with it using Quantennas proporietary RPC protocol.  It does not integrate the module as a radio in OpenWrt.

The OEM GPL firmware soure for the  ZyXEL WAP6805 included this strange code, which writes a magic value to an unnamed and undocumented (AFAIK) register without any explanation:
```
# Support QTN 5G
if [ "$CONFIG_QTN_5G" = "y" ]; then
   reg s 0xbe110000
   reg w 8 0x9000c
```

This is required to enable the connection to the Quantenna module.  I do not know why.  I did not know how or where to implement it, as the correct solution obviously depends on what this actually does.  Copying the OEM method using the "io" tool would work, but I didn't really want to depend on a debug tool with access to all address space.  So I ended up creating a tiny and driver just doing that single write. Please point me in the correct direction if this is unacceptable.I realize it's ugly...

I've chosen to download the Quantenna firmware from Netgear since they provide it ready for download without registration. As an extra bonus(?), their firmware comes with no root password - making it easy to play with the OS running on the module.  The module can be configured entirely by RPC calls, but debugging and figuring out how to use it is much easier when you can log into it and watch the wifi-devices, vlan interfaces and bridges you create.