### PR TITLE
tools/xz: Update to 5.2.5

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.2.4
+PKG_VERSION:=5.2.5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@SF/lzmautils \
 		http://tukaani.org/xz
-PKG_HASH:=3313fd2a95f43d88e44264e6b015e7d03053e681860b0d5d3f9baca79c57b7bf
+PKG_HASH:=5117f930900b341493827d63aa910ff5e011e0b994197c3b71c08a20228a42df
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 HOST_BUILD_PARALLEL:=1
@@ -26,6 +26,7 @@ HOST_CONFIGURE_ARGS += \
 	--enable-static=yes \
 	--enable-shared=no \
 	--disable-doc \
+	--disable-nls \
 	--with-pic
 
 define Host/Install


### PR DESCRIPTION
Update xz to 5.2.5
Disable NLS support to be consistent with other tools such as bison, e2fsprogs
and sed.
Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>