### PR TITLE
ramips: mt7621: add support for Xiaomi Mi Router 4 

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,7 +34,8 @@ zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 xiaomi,mir3p|\
-xiaomi,mir3g)
+xiaomi,mir3g|\
+xiaomi,mir4)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 esac

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir4.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir4.dts
@@ -53,7 +53,7 @@
 
 		minet {
 			label = "minet";
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir4.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir4.dts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,mir4", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router 4";
+
+	aliases {
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_yellow;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "mir4:red:status";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "mir4:blue:status";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_yellow: status_yellow {
+			label = "mir4:yellow:status";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		minet {
+			label = "minet";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x40000>;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "crash";
+			reg = <0x140000 0x40000>;
+		};
+
+		partition@180000 {
+			label = "crash_syslog";
+			reg = <0x180000 0x40000>;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* uboot expects to find kernels at 0x200000 & 0x600000
+		 * referred to as system 1 & system 2 respectively.
+		 * a kernel is considered suitable for handing control over
+		 * if its linux magic number exists & uImage CRC are correct.
+		 * If either of those conditions fail, a matching sys'n'_fail flag
+		 * is set in uboot env & a restart performed in the hope that the
+		 * alternate kernel is okay.
+		 * if neither kernel checksums ok and both are marked failed, system 2
+		 * is booted anyway.
+		 *
+		 * Note uboot's tftp flash install writes the transferred
+		 * image to both kernel partitions.
+		 */
+
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		/* ubi partition is the result of squashing
+		 * next consecutive stock partitions:
+		 * - rootfs0 (rootfs partition for stock kernel0),
+		 * - rootfs1 (rootfs partition for stock failsafe kernel1),
+		 * - overlay (used as ubi overlay in stock fw)
+		 * resulting 117,5MiB space for packages.
+		 */
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0x7580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe006>;
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -889,6 +889,22 @@ define Device/xiaomi_mir3p
 endef
 TARGET_DEVICES += xiaomi_mir3p
 
+define Device/xiaomi_mir4
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 124416k
+  UBINIZE_OPTS := -E 5
+  IMAGES += kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router 4
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_mir4
+
 define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ ramips_setup_interfaces()
 	lenovo,newifi-d1|\
 	mikrotik,rbm33g|\
 	xiaomi,mir3g|\
-	xiaomi,mir3g-v2)
+	xiaomi,mir3g-v2|\
+	xiaomi.mir4)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	gehua,ghl-r-001|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,7 +53,8 @@ platform_do_upgrade() {
 	netgear,r6850|\
 	netis,wf2881|\
 	xiaomi,mir3g|\
-	xiaomi,mir3p)
+	xiaomi,mir3p|\
+	xiaomi,mir4)
 		nand_do_upgrade "$1"
 		;;
 	iodata,wn-ax1167gr2|\


### PR DESCRIPTION
### **Hardware**
Power: 12 VDC, 1.5 A
Connector type: barrel
CPU1: MediaTek MT7621A (880 MHz, 4 cores)
FLA1: 128 MiB (ESMT F59L1G81MA)
RAM1: 128 MiB (ESMT M15T1G1664A)
WI1 chip1: MediaTek MT7603EN
WI1 802dot11 protocols: bgn
WI1 MIMO config: 2x2:2
WI1 antenna connector: U.FL
WI2 chip1: MediaTek MT7612EN
WI2 802dot11 protocols: an+ac
WI2 MIMO config: 2x2:2
WI2 antenna connector: U.FL
ETH chip1: MediaTek MT7621A
Switch: MediaTek MT7621A
LAN speed: 10/100/1000
LAN ports: 2
WAN speed: 10/100/1000
WAN ports: 1
Default IP address: 192.168.31.1
TTL Serial
[o] TX
[o] GND
[o] RX
[ ] VCC - Do not connect it

### **Flash instructions:**
1.Create a simple http server using caddy V1.0
2.set ttl enable
To enable writing to the console, you must reset to factory settings
Then you see uboot boot, press the keyboard 4 button (enter uboot command line)
If it is not successful, repeat the above operation of restoring the factory settings.
After entering the uboot command line, type:

setenv uart_en 1
saveenv
boot

3.use shell in ttl
cd /tmp
wget http://"your computerip:80"/openwrt-ramips-mt7621-xiaomi_mir4-squashfs-kernel1.bin
wget http://"your computer ip:80"/openwrt-ramips-mt7621-xiaomi_mir4-squashfs-rootfs0.bin
mtd write openwrt-ramips-mt7621-xiaomi_mir4-squashfs-kernel1.bin kernel1
mtd write openwrt-ramips-mt7621-xiaomi_mir4-squashfs-rootfs0.bin rootfs0
nvram set flag_try_sys1_failed=1
nvram commit
reboot
4.login to the router http://192.168.1.1/


### **Recovery**
download [MIWIFIRepairTool.x86.zip](http://bigota.miwifi.com/xiaoqiang/tools/MIWIFIRepairTool.x86.zip)
Follow the prompts [XiaoMi community](https://www.xiaomi.cn/post/5289432)