### PR TITLE
x86: fix grub-bios-setup fail during sysupgrade

### DIFF
--- a/target/linux/x86/base-files/lib/upgrade/platform.sh
+++ b/target/linux/x86/base-files/lib/upgrade/platform.sh
@@ -63,7 +63,7 @@ platform_do_bootloader_upgrade() {
 			-d "/tmp/boot/boot/grub" \
 			-r "hd0,${parttable}1" \
 			"/dev/$diskdev" \
-		&& touch /boot/grub/upgraded
+		&& touch /tmp/boot/grub/upgraded
 
 		umount /tmp/boot
 	fi

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -49,6 +49,9 @@ BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 define Build/combined
 	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/boot/vmlinuz
 	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
+	$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
+	$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \
+		$@.boot/boot/grub/core.img
 	$(if $(filter $(1),efi),
 		$(INSTALL_DIR) $@.boot/efi/boot
 		$(CP) $(STAGING_DIR_IMAGE)/grub2/boot$(if $(CONFIG_x86_64),x64,ia32).efi $@.boot/efi/boot/


### PR DESCRIPTION
grub-bios-setup requires two images (boot.img and core.img),
but they are missing. This make an error during sysupgrade:
Upgrading bootloader on /dev/sda...
grub-bios-setup: error: cannot open `/tmp/boot/boot/grub/boot.img': No
such file or directory.

Signed-off-by: 李国 <uxgood.org@gmail.com>
