### PR TITLE
x86: add genisoimage and xorrisofs as alternatives to mkisofs

### DIFF
--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -23,6 +23,9 @@ DEFAULT_PACKAGES += partx-utils mkf2fs e2fsprogs
 
 $(eval $(call BuildTarget))
 
-$(eval $(call $(if $(CONFIG_ISO_IMAGES),RequireCommand,Ignore),mkisofs, \
-   	Please install mkisofs. \
+$(eval $(call $(if $(CONFIG_ISO_IMAGES),SetupHostCommand,Ignore),mkisofs, \
+	Please install mkisofs. , \
+	mkisofs -v 2>&1 , \
+	genisoimage -v 2>&1 | grep genisoimage, \
+	xorrisofs -v 2>&1 | grep xorriso \
 ))


### PR DESCRIPTION
Some system not have mkisofs, but have genisoimage or
xorrisofs. They have compatable options for mkisofs,
so let them as alternatives to mkisofs.

Signed-off-by: 李国 <uxgood.org@gmail.com>
