### PR TITLE
grub2: move grub-bios-setup and grub-editenv to none variant

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -187,6 +187,7 @@ menu "Target Images"
 		depends on TARGET_x86
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
 		select PACKAGE_grub2
+		select PACKAGE_grub2-bios-setup
 		default y
 
 	config GRUB_EFI_IMAGES
@@ -195,6 +196,7 @@ menu "Target Images"
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
 		select PACKAGE_grub2
 		select PACKAGE_grub2-efi
+		select PACKAGE_grub2-bios-setup
 		select PACKAGE_kmod-fs-vfat
 		default y
 

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -47,7 +47,7 @@ define Package/grub2-editenv
   TITLE:=Grub2 Environment editor
   URL:=http://www.gnu.org/software/grub/
   DEPENDS:=@TARGET_x86
-  VARIANT:=pc
+  VARIANT:=none
 endef
 
 define Package/grub2-editenv/description
@@ -61,7 +61,7 @@ define Package/grub2-bios-setup
   TITLE:=Grub2 BIOS boot setup tool
   URL:=http://www.gnu.org/software/grub/
   DEPENDS:=@TARGET_x86
-  VARIANT:=pc
+  VARIANT:=none
 endef
 
 define Package/grub2-bios-setup/description
@@ -99,6 +99,10 @@ HOST_MAKE_FLAGS += \
 	LIBLZMA=$(STAGING_DIR_HOST)/lib/liblzma.a
 
 TARGET_CFLAGS := $(filter-out -fno-plt,$(TARGET_CFLAGS))
+
+ifneq ($(BUILD_VARIANT),none)
+  MAKE_PATH := grub-core
+endif
 
 define Host/Configure
 	$(SED) 's,(RANLIB),(TARGET_RANLIB),' $(HOST_BUILD_DIR)/grub-core/Makefile.in

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -23,6 +23,10 @@ PKG_BUILD_DEPENDS:=grub2/host
 PKG_ASLR_PIE:=0
 PKG_SSP:=0
 
+ifneq ($(BUILD_VARIANT),none)
+  PKG_TARGETS := bin
+endif
+
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/host-build.mk

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -20,10 +20,9 @@ PKG_HASH:=e5292496995ad42dabe843a0192cf2a2c502e7ffcc7479398232b10a472df77d
 HOST_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=grub2/host
 
-PKG_ASLR_PIE:=0
-PKG_SSP:=0
-
 ifneq ($(BUILD_VARIANT),none)
+  PKG_ASLR_PIE:=0
+  PKG_SSP:=0
   PKG_TARGETS := bin
 endif
 
@@ -102,9 +101,8 @@ HOST_MAKE_FLAGS += \
 	TARGET_RANLIB=$(TARGET_RANLIB) \
 	LIBLZMA=$(STAGING_DIR_HOST)/lib/liblzma.a
 
-TARGET_CFLAGS := $(filter-out -fno-plt,$(TARGET_CFLAGS))
-
 ifneq ($(BUILD_VARIANT),none)
+  TARGET_CFLAGS := $(filter-out -fno-plt,$(TARGET_CFLAGS))
   MAKE_PATH := grub-core
 endif
 

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -18,6 +18,7 @@ PKG_SOURCE_URL:=@GNU/grub
 PKG_HASH:=e5292496995ad42dabe843a0192cf2a2c502e7ffcc7479398232b10a472df77d
 
 HOST_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DEPENDS:=grub2/host
 
 ifneq ($(BUILD_VARIANT),none)
@@ -148,6 +149,7 @@ endef
 
 define Package/grub2-efi/install
 	sed 's#msdos1#gpt1#g' ./files/grub-early.cfg >$(PKG_BUILD_DIR)/grub-early.cfg
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)/grub2
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -54,6 +54,20 @@ define Package/grub2-editenv/description
 	Edit grub2 environment files.
 endef
 
+define Package/grub2-bios-setup
+  CATEGORY:=Utilities
+  SECTION:=utils
+  SUBMENU:=Boot Loaders
+  TITLE:=Grub2 BIOS boot setup tool
+  URL:=http://www.gnu.org/software/grub/
+  DEPENDS:=@TARGET_x86
+  VARIANT:=pc
+endef
+
+define Package/grub2-bios-setup/description
+	Set up images to bootable.
+endef
+
 HOST_BUILD_PREFIX := $(STAGING_DIR_HOST)
 
 CONFIGURE_VARS += \
@@ -92,8 +106,6 @@ define Host/Configure
 endef
 
 define Package/grub2/install
-	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-bios-setup $(1)/usr/sbin/
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)/grub2
 	$(CP) $(PKG_BUILD_DIR)/grub-core/boot.img $(STAGING_DIR_IMAGE)/grub2/
 	$(CP) $(PKG_BUILD_DIR)/grub-core/cdboot.img $(STAGING_DIR_IMAGE)/grub2/
@@ -151,7 +163,13 @@ define Package/grub2-editenv/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-editenv $(1)/usr/sbin/
 endef
 
+define Package/grub2-bios-setup/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-bios-setup $(1)/usr/sbin/
+endef
+
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,grub2))
 $(eval $(call BuildPackage,grub2-efi))
 $(eval $(call BuildPackage,grub2-editenv))
+$(eval $(call BuildPackage,grub2-bios-setup))


### PR DESCRIPTION
Refactored the compilation of grub2:

    1.make grub2-bios-setup as a separate package
    
    The grub2 and grub2-efi packages should only contain boot-related code.
    grub-bios-setup is the same as grub-editenv, they are both grub2 tools
    and should be placed in a separate package.

    2.make grub2 tools built in a separate variant
    
    grub2 boot-related code and tools-related code may require different
    compilation parameters. We split them into different variants for
    compilation, so that we can accurately pass the required parameters and
    avoid causing problems.

    3.avoid generating empty grub2 and grub2-efi packages
    
    The grub2 and grub2-efi packages only compile the boot-related code,
    they are finally installed in $(STAGING_DIR_IMAGE)/grub2/, so these two
    packages become empty, so we set PKG_TARGETS := bin to avoid generating
    these two package.

    4.pass compilation parameters more accurately
    
    In order for the grub2 boot-related code to compile normally, we have
    made many adjustments to the compilation parameters. These adjustments
    are not necessary for tools-related code. We apply these parameter
    adjustments only to the boot-related code.

    5.make compilation parallel
    
    grub2 does not have any parallel compilation problems,
    we make it parallel compilation.


Compile tested: x86_64
Run tested: x86_64