### PR TITLE
ath79: reduce spi-max-frequency for Mikrotik wAP G-5HacT2HnD

### DIFF
--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -73,7 +73,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
The previous spi-max-frequency value did not work with all the CPU speed
settings (configurable with rbcfg or from the stock firmware); the new
one does for the three of them.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>