### PR TITLE
ramips: fix ethernet/failsafe on mt7620/mt76x8 devices

### DIFF
--- a/target/linux/ramips/mt7620/base-files/lib/preinit/07_set_preinit_iface_ramips
+++ b/target/linux/ramips/mt7620/base-files/lib/preinit/07_set_preinit_iface_ramips
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+ramips_switchdev_from_soc() {
+	# The ethernet switch driver enables VLAN by default, but
+	# failsafe uses eth0, making the device unreachable:
+	# https://dev.openwrt.org/ticket/18768
+
+	local switchdev
+	local RT3X5X=$(grep -E "(RT3.5|RT5350|MT7628|MT7688|MT7620|MT7621)" /proc/cpuinfo)
+
+	[ -n "$RT3X5X" ] || return 1
+
+	case "$RT3X5X" in
+	*MT7620*)
+		switchdev=mt7620
+		;;
+	*MT7621*)
+		switchdev=mt7530
+		;;
+	*)
+		switchdev=rt305x
+		;;
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_switchdev_from_board() {
+	# For these devices, external ethernet switch should be used
+	# instead of the SoC internal switch.
+
+	local switchdev
+	local board=$(board_name)
+
+	case "$board" in
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_set_preinit_iface() {
+	local switchdev=$(ramips_switchdev_from_board)
+	[ -n "$switchdev" ] || switchdev=$(ramips_switchdev_from_soc)
+
+	if [ -n "$switchdev" ]; then
+		swconfig dev $switchdev set reset 1
+		swconfig dev $switchdev set enable_vlan 0
+		swconfig dev $switchdev set apply 1
+	fi
+
+	ifname=eth0
+}
+
+boot_hook_add preinit_main ramips_set_preinit_iface

--- a/target/linux/ramips/mt76x8/base-files/lib/preinit/07_set_preinit_iface_ramips
+++ b/target/linux/ramips/mt76x8/base-files/lib/preinit/07_set_preinit_iface_ramips
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+ramips_switchdev_from_soc() {
+	# The ethernet switch driver enables VLAN by default, but
+	# failsafe uses eth0, making the device unreachable:
+	# https://dev.openwrt.org/ticket/18768
+
+	local switchdev
+	local RT3X5X=$(grep -E "(RT3.5|RT5350|MT7628|MT7688|MT7620|MT7621)" /proc/cpuinfo)
+
+	[ -n "$RT3X5X" ] || return 1
+
+	case "$RT3X5X" in
+	*MT7620*)
+		switchdev=mt7620
+		;;
+	*MT7621*)
+		switchdev=mt7530
+		;;
+	*)
+		switchdev=rt305x
+		;;
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_switchdev_from_board() {
+	# For these devices, external ethernet switch should be used
+	# instead of the SoC internal switch.
+
+	local switchdev
+	local board=$(board_name)
+
+	case "$board" in
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_set_preinit_iface() {
+	local switchdev=$(ramips_switchdev_from_board)
+	[ -n "$switchdev" ] || switchdev=$(ramips_switchdev_from_soc)
+
+	if [ -n "$switchdev" ]; then
+		swconfig dev $switchdev set reset 1
+		swconfig dev $switchdev set enable_vlan 0
+		swconfig dev $switchdev set apply 1
+	fi
+
+	ifname=eth0
+}
+
+boot_hook_add preinit_main ramips_set_preinit_iface


### PR DESCRIPTION
Commit https://github.com/openwrt/openwrt/commit/a8d62a4eb1ce53beb901b212ce7e474eb70341ca removed disabling VLAN in preinit. This led to non-working ethernet on the RE2x0 devices (in both, failsafe and operation), because the switch is not reconfigured in the network setup. 

This moves the preinit files to the target subdirectories.