### PR TITLE
 ramips: mt7621: Ubiquiti ER-X and ER-X-SFP: fix gpio numbers for POE enable gpios

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -17,11 +17,11 @@ ubnt,edgerouter-x)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "480"
 	;;
 ubnt,edgerouter-x-sfp)
-	ucidef_add_gpio_switch "poe_power_port0" "PoE Power Port0" "496"
-	ucidef_add_gpio_switch "poe_power_port1" "PoE Power Port1" "497"
-	ucidef_add_gpio_switch "poe_power_port2" "PoE Power Port2" "498"
-	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "499"
-	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "500"
+	ucidef_add_gpio_switch "poe_power_port0" "PoE Power Port0" "400"
+	ucidef_add_gpio_switch "poe_power_port1" "PoE Power Port1" "401"
+	ucidef_add_gpio_switch "poe_power_port2" "PoE Power Port2" "402"
+	ucidef_add_gpio_switch "poe_power_port3" "PoE Power Port3" "403"
+	ucidef_add_gpio_switch "poe_power_port4" "PoE Power Port4" "404"
 	;;
 esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -14,7 +14,7 @@ telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "16"
 	;;
 ubnt,edgerouter-x)
-	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "0"
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "480"
 	;;
 ubnt,edgerouter-x-sfp)
 	ucidef_add_gpio_switch "poe_power_port0" "PoE Power Port0" "496"


### PR DESCRIPTION
ramips: mt7621: Ubiquiti ER-X and ER-X-SFP: fix gpio numbers for POE enable gpios

With b5.4 kernel a new gpio driver is used.
GPIO numbering has changed so update 03_gpio_switches too.

GPIO numbering now looks like this on a Ubiquiti ER-X-SFP with v5.4 kernel.
```
root@OpenWrt:/# cat /sys/kernel/debug/gpio
gpiochip3: GPIOs 400-415, parent: i2c/0-0025, 0-0025, can sleep:
 gpio-400 (                    |sysfs               ) out lo
 gpio-401 (                    |sysfs               ) out lo
 gpio-402 (                    |sysfs               ) out lo
 gpio-403 (                    |sysfs               ) out lo
 gpio-404 (                    |sysfs               ) out lo
 gpio-405 (                    |mod-def0            ) in  lo ACTIVE LOW

gpiochip2: GPIOs 416-447, parent: platform/1e000600.gpio, 1e000600.gpio-bank2:

gpiochip1: GPIOs 448-479, parent: platform/1e000600.gpio, 1e000600.gpio-bank1:

gpiochip0: GPIOs 480-511, parent: platform/1e000600.gpio, 1e000600.gpio-bank0:
 gpio-487 (                    |sfp_i2c_clk_gate    ) out lo ACTIVE LOW
 gpio-492 (                    |reset               ) in  hi IRQ
```

`Signed-off-by: René van Dorst <opensource@vdorst.com>`