### PR TITLE
[RFC]build: Use signify instead of usign

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -402,9 +402,9 @@ metadata_json = \
 
 define Build/append-metadata
 	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json,$(SUPPORTED_DEVICES)) | fwtool -I - $@)
-	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
+	[ ! -s "$(BUILD_KEY).sec" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
-		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\
+		signify -S -m "$@" -s "$(BUILD_KEY).sec" -x "$@.sig" ;\
 		ucert -A -c "$@.ucert" -x "$@.sig" ;\
 		fwtool -S "$@.ucert" "$@" ;\
 	}

--- a/package/Makefile
+++ b/package/Makefile
@@ -96,7 +96,7 @@ ifdef CONFIG_SIGNED_PACKAGES
 	@for d in $(PACKAGE_SUBDIRS); do ( \
 		[ -d $$d ] && \
 			cd $$d || continue; \
-		$(STAGING_DIR_HOST)/bin/usign -S -m Packages -s $(BUILD_KEY); \
+		$(STAGING_DIR_HOST)/bin/signify -S -m Packages -s $(BUILD_KEY).sec; \
 	); done
 endif
 

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,11 +12,11 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=218
+PKG_RELEASE:=219
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/
-PKG_BUILD_DEPENDS:=usign/host ucert/host
+PKG_BUILD_DEPENDS:=signify/host ucert/host
 PKG_LICENSE:=GPL-2.0
 
 # Extend depends from version.mk
@@ -37,7 +37,7 @@ endif
 define Package/base-files
   SECTION:=base
   CATEGORY:=Base system
-  DEPENDS:=+netifd +libc +procd +jsonfilter +SIGNED_PACKAGES:usign +SIGNED_PACKAGES:openwrt-keyring +NAND_SUPPORT:ubi-utils +fstools +fwtool
+  DEPENDS:=+netifd +libc +procd +jsonfilter +SIGNED_PACKAGES:signify +SIGNED_PACKAGES:openwrt-keyring +NAND_SUPPORT:ubi-utils +fstools +fwtool
   TITLE:=Base filesystem for OpenWrt
   URL:=http://openwrt.org/
   VERSION:=$(PKG_RELEASE)-$(REVISION)
@@ -110,18 +110,18 @@ Build/Compile = $(Build/Compile/Default)
 
 ifdef CONFIG_SIGNED_PACKAGES
   define Build/Configure
-	[ -s $(BUILD_KEY) -a -s $(BUILD_KEY).pub ] || \
-		$(STAGING_DIR_HOST)/bin/usign -G -s $(BUILD_KEY) -p $(BUILD_KEY).pub -c "Local build key"
+	[ -s $(BUILD_KEY).sec -a -s $(BUILD_KEY).pub ] || \
+		$(STAGING_DIR_HOST)/bin/signify -G -n -s $(BUILD_KEY).sec -p $(BUILD_KEY).pub -c "Local build key"
 
 	[ -s $(BUILD_KEY).ucert ] || \
-		$(STAGING_DIR_HOST)/bin/ucert -I -c $(BUILD_KEY).ucert -p $(BUILD_KEY).pub -s $(BUILD_KEY)
+		$(STAGING_DIR_HOST)/bin/ucert -I -c $(BUILD_KEY).ucert -p $(BUILD_KEY).pub -s $(BUILD_KEY).sec
 
   endef
 
 ifndef CONFIG_BUILDBOT
   define Package/base-files/install-key
 	mkdir -p $(1)/etc/opkg/keys
-	$(CP) $(BUILD_KEY).pub $(1)/etc/opkg/keys/`$(STAGING_DIR_HOST)/bin/usign -F -p $(BUILD_KEY).pub`
+	$(CP) $(BUILD_KEY).pub $(1)/etc/opkg/keys/`$(STAGING_DIR_HOST)/bin/signify -F -p $(BUILD_KEY).pub`
 
   endef
 endif

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -110,6 +110,11 @@ Build/Compile = $(Build/Compile/Default)
 
 ifdef CONFIG_SIGNED_PACKAGES
   define Build/Configure
+	#migrating key-build over to key-build.sec
+	[ -s $(BUILD_KEY).sec -a ! -s $(BUILD_KEY) ] || \
+		echo "Migrate $(BUILD_KEY) to $(BUILD_KEY).sec to work with signify"
+		mv $(BUILD_KEY) $(BUILD_KEY).sec
+
 	[ -s $(BUILD_KEY).sec -a -s $(BUILD_KEY).pub ] || \
 		$(STAGING_DIR_HOST)/bin/signify -G -n -s $(BUILD_KEY).sec -p $(BUILD_KEY).pub -c "Local build key"
 

--- a/package/libs/libbsd/Makefile
+++ b/package/libs/libbsd/Makefile
@@ -14,6 +14,7 @@ PKG_LICENSE_FILES:=COPYING
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libbsd
@@ -42,4 +43,4 @@ define Package/libbsd/install
 endef
 
 $(eval $(call BuildPackage,libbsd))
-
+$(eval $(call HostBuild))

--- a/package/system/opkg/files/opkg-key
+++ b/package/system/opkg/files/opkg-key
@@ -15,28 +15,29 @@ EOF
 opkg_key_verify() {
 	local sigfile="$1"
 	local msgfile="$2"
+	local sigfile_pubkey="/etc/opkg/keys/$(signify -F -x $sigfile).pub"
 
 	(
 		zcat "$msgfile" 2>/dev/null ||
 		cat "$msgfile" 2>/dev/null
-	) | usign -V -P /etc/opkg/keys -q -x "$sigfile" -m -
+	) | signify -V -p "$sigfile_pubkey" -q -x "$sigfile" -m -
 }
 
 opkg_key_add() {
 	local key="$1"
 	[ -n "$key" ] || usage
 	[ -f "$key" ] || echo "Cannot open file $1"
-	local fingerprint="$(usign -F -p "$key")"
+	local fingerprint="$(signify -F -p "$key")"
 	mkdir -p "/etc/opkg/keys"
-	cp "$key" "/etc/opkg/keys/$fingerprint"
+	cp "$key" "/etc/opkg/keys/${fingerprint}.pub"
 }
 
 opkg_key_remove() {
 	local key="$1"
 	[ -n "$key" ] || usage
 	[ -f "$key" ] || echo "Cannot open file $1"
-	local fingerprint="$(usign -F -p "$key")"
-	rm -f "/etc/opkg/keys/$fingerprint"
+	local fingerprint="$(signify -F -p "$key")"
+	rm -f "/etc/opkg/keys/${fingerprint}.pub"
 }
 
 case "$1" in

--- a/package/system/signify/Makefile
+++ b/package/system/signify/Makefile
@@ -1,0 +1,67 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=signify
+PKG_VERSION:=29
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/aperezdc/$(PKG_NAME)/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=8d255ad88290c9b675711f47cc7336b736f6a7adcccd822a0c1a03e3d53de41c
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=ISC
+PKG_LICENSE_FILES:=COPYING
+
+PKG_BUILD_PARALLEL:=1
+HOST_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+HOST_BUILD_DEPENDS:=libbsd/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_LDFLAGS += -Wl,--gc-sections
+
+define Package/signify-full
+  SECTION:=base
+  CATEGORY:=Base system
+  DEPENDS:=+libbsd
+  TITLE:=OpenWrt signature generation and verification utility
+  PROVIDES:=signify
+  VARIANT:=full
+endef
+
+define Package/signify
+  SECTION:=base
+  CATEGORY:=Base system
+  DEPENDS:=
+  TITLE:=OpenWrt signature verification utility
+  PROVIDES:=signify
+  CONFLICTS:=signify-full
+  VARIANT:=tiny
+endef
+
+define Package/signify/description
+  OpenBSD tool to signs and verify signatures on files. Portable version.
+endef
+
+ifeq ($(BUILD_VARIANT),tiny)
+  MAKE_VARS += VERIFY_ONLY=1
+endif
+
+define Package/signify/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/signify $(1)/usr/bin/signify
+endef
+
+Package/signify-full/install = $(Package/signify/install)
+
+define Host/Install
+	$(INSTALL_BIN) $(HOST_BUILD_DIR)/signify $(STAGING_DIR_HOST)/bin/signify
+endef
+
+$(eval $(call BuildPackage,signify))
+$(eval $(call BuildPackage,signify-full))
+$(eval $(call HostBuild))

--- a/package/system/signify/patches/0001-Fix-compilation-with-VERIFY_ONLY-1.patch
+++ b/package/system/signify/patches/0001-Fix-compilation-with-VERIFY_ONLY-1.patch
@@ -1,0 +1,53 @@
+From 3a4ed347be236d76b516ada8deeb3d058b4082e4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20=C5=A0tetiar?= <ynezz@true.cz>
+Date: Fri, 17 Apr 2020 14:35:47 +0200
+Subject: [PATCH 1/5] Fix compilation with VERIFY_ONLY=1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently the compilation doesnt work as the C code expect VERIFYONLY
+set, so fix this by setting proper C define VERIFYONLY. Disable as well
+use of zverify which seems only available in the full signify variant.
+
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ Makefile  | 4 ++--
+ signify.c | 2 ++
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index f908451..e94b536 100644
+--- a/Makefile
++++ b/Makefile
+@@ -172,11 +172,11 @@ endif
+ ifeq ($(strip $(VERIFY_ONLY)),)
+ S += ohash.c
+ else
+-     CPPFLAGS += -DVERIFY_ONLY=1
++     CPPFLAGS += -DVERIFYONLY=1
+      $(warning )
+      $(warning ******************************************************)
+      $(warning )
+-     $(warning Building with VERIFY_ONLY enabled is unsupported, YMMV)
++     $(warning Building with VERIFYONLY enabled is unsupported, YMMV)
+      $(warning )
+      $(warning ******************************************************)
+      $(warning )
+diff --git a/signify.c b/signify.c
+index 8e54737..2da4a38 100644
+--- a/signify.c
++++ b/signify.c
+@@ -901,7 +901,9 @@ main(int argc, char **argv)
+ 				err(1, "pledge");
+ 		}
+ 		if (gzip) {
++#ifndef VERIFYONLY
+ 			zverify(pubkeyfile, msgfile, sigfile, keytype);
++#endif
+ 		} else {
+ 			if (!msgfile)
+ 				usage("must specify message");
+-- 
+2.25.1
+

--- a/package/system/signify/patches/0002-signify-Fix-compiler-warnings-building-with-VERIFY_O.patch
+++ b/package/system/signify/patches/0002-signify-Fix-compiler-warnings-building-with-VERIFY_O.patch
@@ -1,0 +1,89 @@
+From 308788f65e17f66a1a12adffc79a185affb3a0ec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20=C5=A0tetiar?= <ynezz@true.cz>
+Date: Fri, 17 Apr 2020 16:53:58 +0200
+Subject: [PATCH 2/5] signify: Fix compiler warnings building with
+ VERIFY_ONLY=1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes following compiler warnings when compiling with VERIFY_ONLY=1:
+
+ signify.c:763:6: error: variable ‘none’ set but not used [-Werror=unused-but-set-variable]
+ signify.c:760:14: error: variable ‘comment’ set but not used [-Werror=unused-but-set-variable]
+ signify.c:757:34: error: variable ‘seckeyfile’ set but not used [-Werror=unused-but-set-variable]
+
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ signify.c | 26 ++++++++++++++------------
+ 1 file changed, 14 insertions(+), 12 deletions(-)
+
+diff --git a/signify.c b/signify.c
+index 2da4a38..c4369fd 100644
+--- a/signify.c
++++ b/signify.c
+@@ -754,13 +754,15 @@ verifyzdata(uint8_t *zdata, unsigned long long zdatalen,
+ int
+ main(int argc, char **argv)
+ {
+-	const char *pubkeyfile = NULL, *seckeyfile = NULL, *msgfile = NULL,
+-	    *sigfile = NULL;
++	const char *pubkeyfile = NULL, *msgfile = NULL, *sigfile = NULL;
+ 	char sigfilebuf[PATH_MAX];
+-	const char *comment = "signify";
+ 	char *keytype = NULL;
+ 	int ch;
++#ifndef VERIFYONLY
+ 	int none = 0;
++	const char *comment = "signify";
++	const char *seckeyfile = NULL;
++#endif
+ 	int embedded = 0;
+ 	int quiet = 0;
+ 	int gzip = 0;
+@@ -796,33 +798,33 @@ main(int argc, char **argv)
+ 		case 'z':
+ 			gzip = 1;
+ 			break;
++		case 'n':
++			none = 1;
++			break;
++		case 's':
++			seckeyfile = optarg;
++			break;
++		case 'c':
++			comment = optarg;
++			break;
+ #endif
+ 		case 'V':
+ 			if (verb)
+ 				usage(NULL);
+ 			verb = VERIFY;
+ 			break;
+-		case 'c':
+-			comment = optarg;
+-			break;
+ 		case 'e':
+ 			embedded = 1;
+ 			break;
+ 		case 'm':
+ 			msgfile = optarg;
+ 			break;
+-		case 'n':
+-			none = 1;
+-			break;
+ 		case 'p':
+ 			pubkeyfile = optarg;
+ 			break;
+ 		case 'q':
+ 			quiet = 1;
+ 			break;
+-		case 's':
+-			seckeyfile = optarg;
+-			break;
+ 		case 't':
+ 			keytype = optarg;
+ 			break;
+-- 
+2.25.1
+

--- a/package/system/signify/patches/0003-bcrypt_pbkdf-disable-build-with-VERIFY_ONLY-1.patch
+++ b/package/system/signify/patches/0003-bcrypt_pbkdf-disable-build-with-VERIFY_ONLY-1.patch
@@ -1,0 +1,36 @@
+From a981c9953b43f55de03da0b7236a4356b54fd4f8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20=C5=A0tetiar?= <ynezz@true.cz>
+Date: Fri, 17 Apr 2020 18:29:04 +0200
+Subject: [PATCH 3/5] bcrypt_pbkdf: disable build with VERIFY_ONLY=1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Otherwise this drags in dependency on `arc4random_buf` which isnt needed
+in the stripped down version of signify.
+
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ bcrypt_pbkdf.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/bcrypt_pbkdf.c b/bcrypt_pbkdf.c
+index 26dba81..05f6f2f 100644
+--- a/bcrypt_pbkdf.c
++++ b/bcrypt_pbkdf.c
+@@ -15,6 +15,7 @@
+  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+  */
+ 
++#ifndef VERIFYONLY
+ #include <sys/types.h>
+ 
+ #include <stdint.h>
+@@ -174,3 +175,4 @@ bad:
+ 	arc4random_buf(key, keylen);
+ 	return -1;
+ }
++#endif
+-- 
+2.25.1
+

--- a/package/system/signify/patches/0004-Allow-compilation-of-VERIFY_ONLY-1-without-libbsd.patch
+++ b/package/system/signify/patches/0004-Allow-compilation-of-VERIFY_ONLY-1-without-libbsd.patch
@@ -1,0 +1,254 @@
+From 7bc3581753640546868480913ef4671f19754d0b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20=C5=A0tetiar?= <ynezz@true.cz>
+Date: Sat, 18 Apr 2020 09:02:39 +0200
+Subject: [PATCH 4/5] Allow compilation of VERIFY_ONLY=1 without libbsd
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Stripped down version of signify built with VERIFY_ONLY=1 needs just
+`getprogname` and `strlcpy` from libbsd so just provide the dependencies
+directly in the tree and allow compilation without libbsd.
+
+Signed-off-by: Petr Štetiar <ynezz@true.cz>
+---
+ Makefile     | 11 +++++++++-
+ crypto_api.h |  3 +++
+ progname.c   | 62 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ sha2.c       |  5 +++++
+ signify.c    | 13 +++++++++++
+ strlcpy.c    | 50 ++++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 143 insertions(+), 1 deletion(-)
+ create mode 100644 progname.c
+ create mode 100644 strlcpy.c
+
+diff --git a/Makefile b/Makefile
+index e94b536..49f6b8b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -29,7 +29,14 @@ S := crypto_api.c \
+ 	 sha512hl.c \
+ 	 sha512_256hl.c \
+ 	 signify.c \
+-	 zsig.c
++	 zsig.c \
++
++ifeq ($(strip $(VERIFY_ONLY)),1)
++CFLAGS += -DHAVE___PROGNAME
++S += \
++	progname.c \
++	strlcpy.c
++endif
+ 
+ define SED_LAST_LINE
+ sed -n -e '/^[a-zA-Z_-]\+$$/p' | sed -n '$$p'
+@@ -140,6 +147,7 @@ $S: $(libbsd_INCLUDE)/bsd/bsd.h
+ 
+ else
+ 
++ifneq ($(strip $(VERIFY_ONLY)),1)
+ LIBBSD_PKG_VERSION := 0.7
+ LIBBSD_PKG_CHECK   := $(shell pkg-config libbsd --atleast-version=$(LIBBSD_PKG_VERSION) && echo ok)
+ ifneq ($(strip $(LIBBSD_PKG_CHECK)),ok)
+@@ -148,6 +156,7 @@ endif
+ LIBBSD_DEPS    :=
+ LIBBSD_CFLAGS  := $(shell pkg-config libbsd --cflags)
+ LIBBSD_LDFLAGS := $(shell pkg-config libbsd --libs)
++endif
+ 
+ endif
+ 
+diff --git a/crypto_api.h b/crypto_api.h
+index 3eeb91c..be388e0 100644
+--- a/crypto_api.h
++++ b/crypto_api.h
+@@ -10,7 +10,10 @@
+ 
+ #include <stdint.h>
+ #include <stdlib.h>
++
++#ifndef VERIFYONLY
+ #include <bsd/stdlib.h>
++#endif
+ 
+ typedef int32_t crypto_int32;
+ typedef uint32_t crypto_uint32;
+diff --git a/progname.c b/progname.c
+new file mode 100644
+index 0000000..816505d
+--- /dev/null
++++ b/progname.c
+@@ -0,0 +1,62 @@
++/*
++ * Copyright © 2006 Robert Millan
++ * Copyright © 2010-2012 Guillem Jover <guillem@hadrons.org>
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. The name of the author may not be used to endorse or promote products
++ *    derived from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
++ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
++ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
++ * THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
++ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
++ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
++ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
++ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
++ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ */
++
++/*
++ * Rejected in glibc
++ * <https://sourceware.org/ml/libc-alpha/2006-03/msg00125.html>.
++ */
++
++#include <errno.h>
++#include <string.h>
++#include <stdlib.h>
++
++#if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
++#define LIBBSD_IS_PATHNAME_SEPARATOR(c) ((c) == '/' || (c) == '\\')
++#else
++#define LIBBSD_IS_PATHNAME_SEPARATOR(c) ((c) == '/')
++#endif
++
++#ifdef HAVE___PROGNAME
++extern const char *__progname;
++#else
++static const char *__progname = NULL;
++#endif
++
++const char *
++getprogname(void)
++{
++#if defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME)
++	if (__progname == NULL)
++		__progname = program_invocation_short_name;
++#elif defined(HAVE_GETEXECNAME)
++	/* getexecname(3) returns an absolute pathname, normalize it. */
++	if (__progname == NULL)
++		setprogname(getexecname());
++#endif
++
++	return __progname;
++}
+diff --git a/sha2.c b/sha2.c
+index da609c6..e27c82c 100644
+--- a/sha2.c
++++ b/sha2.c
+@@ -36,7 +36,12 @@
+ 
+ #include <sys/types.h>
+ 
++#ifndef VERIFYONLY
+ #include <bsd/string.h>
++#else
++#include <string.h>
++#endif
++
+ #include "sha2.h"
+ 
+ /*
+diff --git a/signify.c b/signify.c
+index c4369fd..2ecfd98 100644
+--- a/signify.c
++++ b/signify.c
+@@ -22,7 +22,13 @@
+ #include <limits.h>
+ #include <stdint.h>
+ #include <fcntl.h>
++
++#ifndef VERIFYONLY
+ #include <bsd/string.h>
++#else
++#include <string.h>
++#endif
++
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <stddef.h>
+@@ -30,9 +36,16 @@
+ #include <err.h>
+ #include <unistd.h>
+ #include <errno.h>
++
++#ifndef VERIFYONLY
+ #include <bsd/readpassphrase.h>
+ #include <bsd/libutil.h>
+ #include <bsd/stdlib.h>
++#else
++const char* getprogname(void);
++size_t strlcpy(char *dst, const char *src, size_t dsize);
++#endif
++
+ #include "sha2.h"
+ 
+ #include "crypto_api.h"
+diff --git a/strlcpy.c b/strlcpy.c
+new file mode 100644
+index 0000000..e9a7fe4
+--- /dev/null
++++ b/strlcpy.c
+@@ -0,0 +1,50 @@
++/*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
++
++/*
++ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
++ *
++ * Permission to use, copy, modify, and distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++
++#include <sys/types.h>
++#include <string.h>
++
++/*
++ * Copy string src to buffer dst of size dsize.  At most dsize-1
++ * chars will be copied.  Always NUL terminates (unless dsize == 0).
++ * Returns strlen(src); if retval >= dsize, truncation occurred.
++ */
++size_t
++strlcpy(char *dst, const char *src, size_t dsize)
++{
++	const char *osrc = src;
++	size_t nleft = dsize;
++
++	/* Copy as many bytes as will fit. */
++	if (nleft != 0) {
++		while (--nleft != 0) {
++			if ((*dst++ = *src++) == '\0')
++				break;
++		}
++	}
++
++	/* Not enough room in dst, add NUL and traverse rest of src. */
++	if (nleft == 0) {
++		if (dsize != 0)
++			*dst = '\0';		/* NUL-terminate dst */
++		while (*src++)
++			;
++	}
++
++	return(src - osrc - 1);	/* count does not include NUL */
++}
+-- 
+2.25.1
+

--- a/package/system/signify/patches/0005-Add-print-fingerprint-via-F-feature.patch
+++ b/package/system/signify/patches/0005-Add-print-fingerprint-via-F-feature.patch
@@ -1,0 +1,108 @@
+From d6987af53a00137eb5b4e68e0beea6857d26ce7a Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Thu, 9 Apr 2020 13:27:42 -1000
+Subject: [PATCH] Add print fingerprint via -F feature
+
+To know the fingerprint used for a public key or signature the option
+`-F` is added which works in combination with `-p` or `-x`. It will load
+the file and and print the used fingerprint in hex.
+
+This feature was ported over from OpenWrt's usign[0], which is a slimmed
+simpler implementation of `signify`.
+
+[0]: git@github.com:aparcar/signify.git
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ signify.c | 42 +++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 39 insertions(+), 3 deletions(-)
+
+diff --git a/signify.c b/signify.c
+index 2ecfd98..1a6999c 100644
+--- a/signify.c
++++ b/signify.c
+@@ -97,7 +97,8 @@ usage(const char *error)
+ 	    "\t%1$s -G [-n] [-c comment] -p pubkey -s seckey\n"
+ 	    "\t%1$s -S [-enz] [-x sigfile] -s seckey -m message\n"
+ #endif
+-	    "\t%1$s -V [-eqz] [-p pubkey] [-t keytype] [-x sigfile] -m message\n",
++	    "\t%1$s -V [-eqz] [-p pubkey] [-t keytype] [-x sigfile] -m message\n"
++	    "\t%1$s -F [-q] [-p pubkey] [-x sigfile]\n",
+ 	    getprogname());
+ 	exit(1);
+ }
+@@ -560,6 +561,31 @@ verifysimple(const char *pubkeyfile, const char *msgfile, const char *sigfile,
+ 	free(msg);
+ }
+ 
++static int
++fingerprint(const char *pubkeyfile, const char *sigfile)
++{
++	struct sig sig;
++	struct pubkey pubkey;
++	uint8_t *fp;
++
++	if (pubkeyfile) {
++		readb64file(pubkeyfile, &pubkey, sizeof(pubkey), NULL);
++		fp = pubkey.keynum;
++	} else if (sigfile) {
++		readb64file(sigfile, &sig, sizeof(sig), NULL);
++		fp = sig.keynum;
++	} else
++		return 1;
++
++	int i;
++	for (i = 0; i < KEYNUMLEN; i++)
++	{
++	    printf("%02x", fp[i]);
++	}
++	printf("\n");
++	return 0;
++}
++
+ static uint8_t *
+ verifyembedded(const char *pubkeyfile, const char *sigfile,
+     int quiet, unsigned long long *msglenp, const char *keytype)
+@@ -784,13 +810,14 @@ main(int argc, char **argv)
+ 		CHECK,
+ 		GENERATE,
+ 		SIGN,
+-		VERIFY
++		VERIFY,
++		FINGERPRINT
+ 	} verb = NONE;
+ 
+ 	if (pledge("stdio rpath wpath cpath tty", NULL) == -1)
+ 		err(1, "pledge");
+ 
+-	while ((ch = getopt(argc, argv, "CGSVzc:em:np:qs:t:x:")) != -1) {
++	while ((ch = getopt(argc, argv, "CGSVFzc:em:np:qs:t:x:")) != -1) {
+ 		switch (ch) {
+ #ifndef VERIFYONLY
+ 		case 'C':
+@@ -826,6 +853,11 @@ main(int argc, char **argv)
+ 				usage(NULL);
+ 			verb = VERIFY;
+ 			break;
++		case 'F':
++			if (verb)
++				usage(NULL);
++			verb = FINGERPRINT;
++			break;
+ 		case 'e':
+ 			embedded = 1;
+ 			break;
+@@ -926,6 +958,10 @@ main(int argc, char **argv)
+ 			    quiet, keytype);
+ 		}
+ 		break;
++	case FINGERPRINT:
++		if (!!pubkeyfile + !!sigfile != 1)
++			usage("Need one public key or signature");
++		return fingerprint(pubkeyfile, sigfile);
+ 	default:
+ 		if (pledge("stdio", NULL) == -1)
+ 			err(1, "pledge");
+-- 
+2.25.1
+


### PR DESCRIPTION
Instead of using `usign` and `signify` (on build hosts) in parallel, this patch series replace `usign` with (currently patched) `signify`.

The `signify` patch adds a fingerprint printing arg via `-F`. 

Signify requires keys to be called either `.sec` or `.pub`, so no more `key-build` without a suffix anymore. Maybe this needs a migration step.

Tested:

- [x] Run/Compile on x86/64 for host and target
- [x] `make package/index` with activated signing
- [x] `signify -F -x sigfile.sig` fingerprint printing
- [x] Image signing
- [ ] `opkg-key` script
  - [x] opkg_key_verify
- [ ] `ucert` compatibility via symlink `ln -s signify usign`
- [ ] usage with `fwtool` aka on device upgrades

The package size is currently pretty bad (+50kb), likely because it requires `libbsd`. Maybe this can be linked in a smarter way, any C magic is above my degree.

Also the compile option `VERIFY_ONLY` could be interesting for the targets as they don't need any signing capabilities. Sadly the command seems broken for now (at least I'm getting some compile errors), so this should get some more attentation.
