### PR TITLE
ramips: mt7620: fix missplaced line in 01_leds

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -90,6 +90,7 @@ dlink,dwr-922-e2)
 dlink,dwr-960)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x2e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	;;
 dovado,tiny-ac)
 	set_wifi_led "$boardname:orange:wifi"
 	;;


### PR DESCRIPTION
This patch adds missed line in 01_leds and fix error:

"/bin/board_detect: /etc/board.d/01_leds: line 93:
syntax error: unexpected ")" (expecting ";;")"

Fixes: c948a47 ("ramips: add support for D-Link DWR-960")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>

@adrianschmutzler 
@dangowrt 
