### PR TITLE
kernel: add iscsi-initator support

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -276,9 +276,9 @@ define KernelPackage/iscsi-initiator
   DEPENDS:=+kmod-scsi-core +kmod-crypto-hash
   KCONFIG:= \
 	CONFIG_INET \
-	CONFIG_SCSI_LOWLEVEL \
+	CONFIG_SCSI_LOWLEVEL=y \
 	CONFIG_ISCSI_TCP \
-	CONFIG_SCSI_ISCSI_ATTRS
+	CONFIG_SCSI_ISCSI_ATTRS=y
   FILES:= \
 	$(LINUX_DIR)/drivers/scsi/iscsi_tcp.ko \
 	$(LINUX_DIR)/drivers/scsi/libiscsi.ko \


### PR DESCRIPTION
Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Kernel drivers needed for open-iscsi package https://github.com/openwrt/packages/pull/11831
