### PR TITLE
ipq806x: add patch to fix broken buttons

### DIFF
--- a/target/linux/generic/pending-5.4/001-v5.4-pinctrl-qcom-fix-wrong-write-in-update_dual_edge.patch.patch
+++ b/target/linux/generic/pending-5.4/001-v5.4-pinctrl-qcom-fix-wrong-write-in-update_dual_edge.patch.patch
@@ -1,0 +1,31 @@
+From 17d4771b9740e0c504067b18d527cc29ba490e16 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 14 Apr 2020 02:28:00 +0200
+Subject: [PATCH] pinctrl: qcom: fix wrong write in update_dual_edge
+
+Fix a typo in the readl/writel accessor conversion where val is used
+instead of pol changing the behavior of the original code.
+
+Fixes: 6c73698904aa pinctrl: qcom: Introduce readl/writel accessors
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/pinctrl/qcom/pinctrl-msm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/qcom/pinctrl-msm.c b/drivers/pinctrl/qcom/pinctrl-msm.c
+index 1a948c3f54b7..9f1c9951949e 100644
+--- a/drivers/pinctrl/qcom/pinctrl-msm.c
++++ b/drivers/pinctrl/qcom/pinctrl-msm.c
+@@ -692,7 +692,7 @@ static void msm_gpio_update_dual_edge_pos(struct msm_pinctrl *pctrl,
+ 
+ 		pol = msm_readl_intr_cfg(pctrl, g);
+ 		pol ^= BIT(g->intr_polarity_bit);
+-		msm_writel_intr_cfg(val, pctrl, g);
++		msm_writel_intr_cfg(pol, pctrl, g);
+ 
+ 		val2 = msm_readl_io(pctrl, g) & BIT(g->in_bit);
+ 		intstat = msm_readl_intr_status(pctrl, g);
+-- 
+2.25.1
+


### PR DESCRIPTION
From kernel 4.20 msm-gpio driver is broken and cause the malfunction of the buttons on every ipq806x target. Add a patch to fix this.

@ynezz can you merge this?

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>