### PR TITLE
[RFT] ath79: port support for TP-Link TL-WA901ND v3-v5 from ar71xx

### DIFF
--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa901nd-v3.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa901nd-v3.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9341_tplink_tl-wa.dtsi"
+
+/ {
+	model = "TP-Link TL-WA901ND v3";
+	compatible = "tplink,tl-wa901nd-v3", "qca,ar9341";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd-v4.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd-v4.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wa901nd.dtsi"
+
+/ {
+	compatible = "tplink,tl-wa901nd-v4", "qca,tp9343";
+	model = "TP-Link TL-WA901ND v4";
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd-v5.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd-v5.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "tp9343_tplink_tl-wa901nd.dtsi"
+
+/ {
+	compatible = "tplink,tl-wa901nd-v5", "qca,tp9343";
+	model = "TP-Link TL-WA901ND v5";
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wa901nd.dtsi
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "tp9343_tplink_tl-wr94x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		qss {
+			label = "tp-link:green:qss";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v3.dtsi
@@ -62,6 +62,14 @@
 	};
 };
 
+&keys {
+	wifi {
+		label = "WiFi button";
+		linux,code = <KEY_RFKILL>;
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+	};
+};
+
 &eth1 {
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <(-1)>;

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v4.dts
@@ -66,6 +66,14 @@
 	};
 };
 
+&keys {
+	wifi {
+		label = "WiFi button";
+		linux,code = <KEY_RFKILL>;
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+	};
+};
+
 &eth1 {
 	mtd-mac-address = <&uboot 0x1fc00>;
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr940n-v6.dts
@@ -30,6 +30,14 @@
 	};
 };
 
+&keys {
+	wifi {
+		label = "WiFi button";
+		linux,code = <KEY_RFKILL>;
+		gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+	};
+};
+
 &eth1 {
 	mtd-mac-address = <&uboot 0x1fc00>;
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr94x.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr94x.dtsi
@@ -14,14 +14,8 @@
 		label-mac-device = &wmac;
 	};
 
-	keys {
+	keys: keys {
 		compatible = "gpio-keys";
-
-		wifi {
-			label = "WiFi button";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-		};
 
 		reset {
 			label = "Reset button";

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -180,6 +180,28 @@ define Device/tplink_tl-wa901nd-v3
 endef
 TARGET_DEVICES += tplink_tl-wa901nd-v3
 
+define Device/tplink_tl-wa901nd-v4
+  $(Device/tplink-4mlzma)
+  SOC := tp9343
+  DEVICE_MODEL := TL-WA901ND
+  DEVICE_VARIANT := v4
+  TPLINK_HWID := 0x09010004
+  SUPPORTED_DEVICES += tl-wa901nd-v4
+  IMAGE/factory.bin := tplink-v1-image factory -C EU
+endef
+TARGET_DEVICES += tplink_tl-wa901nd-v4
+
+define Device/tplink_tl-wa901nd-v5
+  $(Device/tplink-4mlzma)
+  SOC := tp9343
+  DEVICE_MODEL := TL-WA901ND
+  DEVICE_VARIANT := v5
+  TPLINK_HWID := 0x09010005
+  SUPPORTED_DEVICES += tl-wa901nd-v5
+  IMAGE/factory.bin := tplink-v1-image factory -C EU
+endef
+TARGET_DEVICES += tplink_tl-wa901nd-v5
+
 define Device/tplink_tl-wr703n
   $(Device/tplink-4mlzma)
   SOC := ar9331

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -170,6 +170,16 @@ define Device/tplink_tl-wa901nd-v2
 endef
 TARGET_DEVICES += tplink_tl-wa901nd-v2
 
+define Device/tplink_tl-wa901nd-v3
+  $(Device/tplink-4mlzma)
+  SOC := ar9341
+  DEVICE_MODEL := TL-WA901ND
+  DEVICE_VARIANT := v3
+  TPLINK_HWID := 0x09010003
+  SUPPORTED_DEVICES += tl-wa901nd-v3
+endef
+TARGET_DEVICES += tplink_tl-wa901nd-v3
+
 define Device/tplink_tl-wr703n
   $(Device/tplink-4mlzma)
   SOC := ar9331

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -48,7 +48,9 @@ tplink,tl-wa801nd-v1|\
 tplink,tl-wa830re-v1|\
 tplink,tl-wa860re-v1|\
 tplink,tl-wa901nd-v1|\
-tplink,tl-wa901nd-v3)
+tplink,tl-wa901nd-v3|\
+tplink,tl-wa901nd-v4|\
+tplink,tl-wa901nd-v5)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -47,7 +47,8 @@ tplink,tl-wa730re-v1|\
 tplink,tl-wa801nd-v1|\
 tplink,tl-wa830re-v1|\
 tplink,tl-wa860re-v1|\
-tplink,tl-wa901nd-v1)
+tplink,tl-wa901nd-v1|\
+tplink,tl-wa901nd-v3)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	;;
 tplink,tl-mr3420-v2|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -41,6 +41,7 @@ ath79_setup_interfaces()
 	tplink,tl-wa860re-v1|\
 	tplink,tl-wa901nd-v1|\
 	tplink,tl-wa901nd-v2|\
+	tplink,tl-wa901nd-v3|\
 	tplink,tl-wr703n)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -42,6 +42,8 @@ ath79_setup_interfaces()
 	tplink,tl-wa901nd-v1|\
 	tplink,tl-wa901nd-v2|\
 	tplink,tl-wa901nd-v3|\
+	tplink,tl-wa901nd-v4|\
+	tplink,tl-wa901nd-v5|\
 	tplink,tl-wr703n)
 		ucidef_set_interface_lan "eth0"
 		;;


### PR DESCRIPTION
This ports support for the TP-Link TL-WA901ND v3-v5 from ar71xx, as they share board with already existing devices and thus porting is quite straightforward.

** Don't have the devices, testers are required! **