### PR TITLE
ath79: improve status LED definitions for GL-AR750

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
@@ -11,6 +11,10 @@
 	model = "GL.iNet GL-AR750";
 
 	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 		label-mac-device = &eth0;
 	};
 
@@ -36,7 +40,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		power {
+		led_power: power {
 			label = "gl-ar750:white:power";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			default-state = "on";


### PR DESCRIPTION
Improve the status LED functionality in GL-AR750 by adding the definitions for different statuses (boot, failsafe, running, flashing).

Tested with GL-AR750 with master r12985-508462a399 
