### PR TITLE
[RFT] ath79: add support for the TP-Link WBS210 v1

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_wbs210-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_wbs210-v1.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpe_2port.dtsi"
+
+/ {
+	compatible = "tplink,wbs210-v1", "qca,ar9344";
+	model = "TP-Link WBS210 v1";
+};
+
+&led_link4 {
+	gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -200,6 +200,7 @@ tplink,cpe210-v1|\
 tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
+tplink,wbs210-v1|\
 tplink,wbs210-v2|\
 tplink,wbs510-v1|\
 tplink,wbs510-v2)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -104,6 +104,7 @@ ath79_setup_interfaces()
 	tplink,cpe220-v2|\
 	tplink,cpe220-v3|\
 	tplink,cpe510-v1|\
+	tplink,wbs210-v1|\
 	tplink,wbs210-v2|\
 	tplink,wbs510-v1|\
 	tplink,wbs510-v2|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -58,6 +58,7 @@ tplink,cpe210-v1|\
 tplink,cpe220-v2|\
 tplink,cpe220-v3|\
 tplink,cpe510-v1|\
+tplink,wbs210-v1|\
 tplink,wbs210-v2|\
 tplink,wbs510-v1|\
 tplink,wbs510-v2)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -634,6 +634,18 @@ define Device/tplink_tl-wr902ac-v1
 endef
 TARGET_DEVICES += tplink_tl-wr902ac-v1
 
+define Device/tplink_wbs210-v1
+  $(Device/tplink-safeloader-okli)
+  SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := WBS210
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := rssileds
+  TPLINK_BOARD_ID := WBS210
+  SUPPORTED_DEVICES += wbs210
+endef
+TARGET_DEVICES += tplink_wbs210-v1
+
 define Device/tplink_wbs210-v2
   $(Device/tplink-safeloader-okli)
   SOC := ar9344


### PR DESCRIPTION
This ports support for a popular low-cost 2GHz N based AP from ar71xx

Specifications:
- SoC: Atheros AR9344
- RAM: 64MB
- Storage: 8 MB SPI NOR
- Wireless: 2.4GHz N based built into SoC
- Ethernet: 1x 10/100 Mbps with 24V POE IN, 1x 10/100 Mbps

Installation:
Flash factory image through stock firmware WEB UI
or through TFTP
To get to TFTP recovery just hold reset button while powering on for
around 4-5 seconds and release.
Rename factory image to recovery.bin
Stock TFTP server IP:192.168.0.100
Stock device TFTP adress:192.168.0.254