### PR TITLE
gdb: disable gdbserver for arc

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -44,6 +44,7 @@ endef
 define Package/gdbserver
 $(call Package/gdb/Default)
   TITLE:=Remote server for GNU Debugger
+  DEPENDS=@!arc
 endef
 
 define Package/gdbserver/description


### PR DESCRIPTION
Although gdb is supported, gdbserver is still not.

 checking whether gdbserver is supported on this host... no

Build breaks as gdbserver executable is not found during packaging.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

@neheb, @chunkeey