### PR TITLE
generic: spi-nor: fix 4-byte opcode support for w25q256

### DIFF
--- a/target/linux/generic/pending-5.4/482-mtd-spi-nor-fix-4-byte-opcode-support-for-w25q256.patch
+++ b/target/linux/generic/pending-5.4/482-mtd-spi-nor-fix-4-byte-opcode-support-for-w25q256.patch
@@ -1,0 +1,60 @@
+From: Mantas Pucka <mantas@8devices.com>
+To: linux-mtd@lists.infradead.org
+Subject: [PATCH] mtd: spi-nor: fix 4-byte opcode support for w25q256
+Date: Wed, 15 Apr 2020 16:48:30 +0300
+Message-ID: <1586958510-24012-1-git-send-email-mantas@8devices.com>
+
+There are 2 different chips (w25q256fv and w25q256jv) that share
+the same JEDEC ID. Only w25q256jv fully supports 4-byte opcodes.
+Use SFDP header version to differentiate between them.
+
+for OpenWRT only: rebased to linux-v5.4
+
+Signed-off-by: Mantas Pucka <mantas@8devices.com>
+---
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -2170,6 +2170,32 @@ static struct spi_nor_fixups gd25q256_fi
+ 	.default_init = gd25q256_default_init,
+ };
+ 
++static int
++w25q256_post_bfpt_fixups(struct spi_nor *nor,
++			 const struct sfdp_parameter_header *bfpt_header,
++			 const struct sfdp_bfpt *bfpt,
++			 struct spi_nor_flash_parameter *params)
++{
++	/*
++	 * W25Q256JV supports 4B opcodes but W25Q256FV does not.
++	 * Unfortunately, Winbond has re-used the same JEDEC ID for both
++	 * variants which prevents us from defining a new entry in the parts
++	 * table.
++	 * To differentiate between W25Q256JV and W25Q256FV check SFDP header
++	 * version: only JV has JESD216A compliant structure (version 5)
++	 */
++
++	if (bfpt_header->major == SFDP_JESD216_MAJOR &&
++	    bfpt_header->minor == SFDP_JESD216A_MINOR)
++		nor->flags |= SNOR_F_4B_OPCODES;
++
++	return 0;
++}
++
++static struct spi_nor_fixups w25q256_fixups = {
++	.post_bfpt = w25q256_post_bfpt_fixups,
++};
++
+ /* NOTE: double check command sets and memory organization when you add
+  * more nor chips.  This current list focusses on newer chips, which
+  * have been converging on command sets which including JEDEC ID.
+@@ -2508,7 +2534,8 @@ static const struct flash_info spi_nor_i
+ 	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
+ 	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },
+-	{ "w25q256", INFO(0xef4019, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "w25q256", INFO(0xef4019, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ)
++			  .fixups = &w25q256_fixups },
+ 	{ "w25q256jvm", INFO(0xef7019, 0, 64 * 1024, 512,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024,

--- a/target/linux/ipq40xx/patches-5.4/304-mtd-spi-nor-Add-support-for-mx25r3235f.patch
+++ b/target/linux/ipq40xx/patches-5.4/304-mtd-spi-nor-Add-support-for-mx25r3235f.patch
@@ -15,7 +15,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2313,6 +2313,8 @@ static const struct flash_info spi_nor_i
+@@ -2339,6 +2339,8 @@ static const struct flash_info spi_nor_i
  	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },


### PR DESCRIPTION
There are 2 different chips (w25q256fv and w25q256jv) that share
the same JEDEC ID. Only w25q256jv fully supports 4-byte opcodes.
Use SFDP header version to differentiate between them.

Fixes broken reboot on 8devices Habanero since f0f35fdac
This patch has been sent upstream.

Signed-off-by: Mantas Pucka <mantas@8devices.com>