### PR TITLE
elfutils: aarch64 fix build on musl

### DIFF
--- a/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
+++ b/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
@@ -1,0 +1,59 @@
+From 578f370c7e7a9f056aefa062b34590b0aa13bce5 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:27:30 +0800
+Subject: [PATCH] Fix build on aarch64/musl
+
+Errors
+
+invalid operands to binary & (have 'long double' and 'unsigned int')
+
+error: redefinition
+ of 'struct iovec'
+ struct iovec { void *iov_base; size_t iov_len; };
+        ^
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Rebase to 0.170
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+
+---
+ backends/aarch64_initreg.c | 4 ++--
+ backends/arm_initreg.c     | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/backends/aarch64_initreg.c b/backends/aarch64_initreg.c
+index daf6f37..6445276 100644
+--- a/backends/aarch64_initreg.c
++++ b/backends/aarch64_initreg.c
+@@ -33,7 +33,7 @@
+ #include "system.h"
+ #include <assert.h>
+ #if defined(__aarch64__) && defined(__linux__)
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */
+@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t tid __attribute__ ((unused)),
+ 
+   Dwarf_Word dwarf_fregs[32];
+   for (int r = 0; r < 32; r++)
+-    dwarf_fregs[r] = fregs.vregs[r] & 0xFFFFFFFF;
++    dwarf_fregs[r] = (unsigned int)fregs.vregs[r] & 0xFFFFFFFF;
+ 
+   if (! setfunc (64, 32, dwarf_fregs, arg))
+     return false;
+diff --git a/backends/arm_initreg.c b/backends/arm_initreg.c
+index efcabaf..062bb9e 100644
+--- a/backends/arm_initreg.c
++++ b/backends/arm_initreg.c
+@@ -38,7 +38,7 @@
+ #endif
+ 
+ #ifdef __aarch64__
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */


### PR DESCRIPTION
aarch64_initreg.c: In function 'aarch64_set_initial_registers_tid':
aarch64_initreg.c:85:37: error: invalid operands to binary & (have 'long double' and 'unsigned int')
     dwarf_fregs[r] = fregs.vregs[r] & 0xFFFFFFFF;
                      ~~~~~~~~~~~~~~ ^

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>

Tested on rk3328 Rock64 board
The patch is taken from openembedded.org