### PR TITLE
ramips: add support for LB-Link BL-W1200

### DIFF
--- a/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
+++ b/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "lb-link,bl-w1200", "ralink,mt7620a-soc";
+	model = "LB-Link BL-W1200";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset_wps {
+			label = "reset_wps";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "bl-w1200:green:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "spi refclk";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&factory 0x28>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+	mediatek,portmap = "wllll";
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1 {
+			reg = <1>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@2 {
+			reg = <2>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@3 {
+			reg = <3>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		ethernet-phy@1f {
+			reg = <0x1f>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -580,6 +580,15 @@ define Device/lava_lr-25g001
 endef
 TARGET_DEVICES += lava_lr-25g001
 
+define Device/lb-link_bl-w1200
+  SOC := mt7620a
+  DEVICE_VENDOR := LB-Link
+  DEVICE_MODEL := BL-W1200
+  IMAGE_SIZE := 7872k
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-mt76x2
+endef
+TARGET_DEVICES += lb-link_bl-w1200
+
 define Device/lenovo_newifi-y1
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -116,6 +116,7 @@ ramips_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "5:lan" "0:wan" "6@eth0"
 		;;
 	edimax,br-6478ac-v2|\
+	lb-link,bl-w1200|\
 	tplink,archer-c2-v1)
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "false"
@@ -318,6 +319,10 @@ ramips_setup_macs()
 		;;
 	iptime,a104ns)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary u-boot 0x1fc20)" 2)
+		;;
+	lb-link,bl-w1200)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
+		label_mac=$wan_mac
 		;;
 	lenovo,newifi-y1|\
 	lenovo,newifi-y1s|\

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/03_gpio_switches
@@ -22,6 +22,9 @@ head-weblink,hdrm200)
 	ucidef_add_gpio_switch "io4" "I/O 4" "14"
 	ucidef_add_gpio_switch "power_mpcie" "mPCIe power" "21" "1"
 	;;
+lb-link,bl-w1200)
+	ucidef_add_gpio_switch "eth_leds_enable" "ETH LEDs enable" "10" "1"
+	;;
 zbtlink,zbt-we826-e)
 	ucidef_add_gpio_switch "sim_switch" "SIM slot switch" "13"
 	ucidef_add_gpio_switch "power_mpcie" "mPCIe power" "14" "1"


### PR DESCRIPTION
The BL-W1200 Wireless Router is based on the MT7620A SoC.

Specification:

- MediaTek MT7620A (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 1x 802.11bgn radio
- 1x 802.11ac radio (MT7612E)
- 5x 10/100/1000 Mbps Ethernet (MT7530)
- 2x external, non-detachable antennas (Wifi 2.4G/5G)
- 1x USB 2.0
- UART (R2) on PCB (57600 8n1)
- 9x LED (1 GPIO controlled), 1x button
- u-Boot bootloader

Known issues:
- No status LED. Used WPS LED durring boot/failsafe/sysupgrade.

Installation:
1. Apply initramfs image via factory web-gui.
2. Install sysupgrade image.

How to revert to OEM firmware:
- sysupgrade -n -F stock_firmware.bin

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
