### PR TITLE
kernel: netfilter.mk: fix kmod-ipt-nat6 installation on 5.4

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -196,7 +196,6 @@ $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT,CONFIG_NETFILTER_XT_NAT, $(P_XT)xt_
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT,CONFIG_IP_NF_NAT, $(P_V4)iptable_nat),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_NAT, $(P_V6)ip6table_nat),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_TARGET_MASQUERADE, $(P_V6)ip6t_MASQUERADE, lt 5.2),))
-$(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_TARGET_MASQUERADE, $(P_XT)xt_MASQUERADE, ge 5.2),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_NAT6,CONFIG_IP6_NF_TARGET_NPT, $(P_V6)ip6t_NPT),))
 
 # userland only


### PR DESCRIPTION
xt_MASQUERADE.ko is picked up by both kmod-ipt-nat and kmod-ipt-nat6, causing
conflict
As kmod-ipt-nat6 already depends on kmod-ipt-nat, remove xt_MASQUERADE from it

Fixes: [FS#2924](https://bugs.openwrt.org/index.php?do=details&task_id=2924)
Fixes: 0fad8af85158 ("kernel: Include xt_MASQUERADE for kernel 5.2 and later")