### PR TITLE
u-boot: switch download to https

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -3,7 +3,8 @@ PKG_NAME ?= u-boot
 ifndef PKG_SOURCE_PROTO
 PKG_SOURCE = $(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL = \
-	https://sources.openwrt.org \
+	https://mirror.cyberbits.eu/u-boot \
+	https://ftp.denx.de/pub/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
 endif
 


### PR DESCRIPTION
ftp can cause problems on some networks switch download location to https

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>
