### PR TITLE
ath79: increase spi frequency on tp-link tl-wr1043nd v2

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -106,7 +106,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <33400000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
Increase SPI frequency to 33.333 MHz. It's maximum frequency supported by SPI memory ([s25fl064k](https://www.mouser.in/datasheet/2/100/spansion%20inc._s25fl064k_00-1161216.pdf)) without Fast read opcode.

Before:
$ time dd if=/dev/mtd1 of=/dev/null bs=8M
0+1 records in
0+1 records out
real	0m 3.21s
user	0m 0.00s
sys	0m 3.21s

After:
$ time dd if=/dev/mtd1 of=/dev/null bs=8M
0+1 records in
0+1 records out
real	0m 2.52s
user	0m 0.00s
sys	0m 2.52s

Tested on TP-Link TL-WR1043ND V2