### PR TITLE
dnsmasq: Add /etc/nsswitch.conf to jail

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1065,6 +1065,8 @@ dnsmasq_start()
 		done
 	}
 
+	[ -e /etc/nsswitch.conf ] && append EXTRA_MOUNT "/etc/nsswitch.conf /lib/libnss*"
+
 	procd_open_instance $cfg
 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
 	procd_set_param file $CONFIGFILE


### PR DESCRIPTION
If nsswitch is used /etc/nsswitch.conf and /lib/libnss* must be added
to the jail, otherwise user and group dnsmasq cannot be resolved
and dnsmasq does not start

Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>

