### PR TITLE
[RFC] Dualboot for EFI GPT x86 systems

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -241,13 +241,21 @@ menu "Target Images"
 		bool "Build GRUB EFI images"
 		depends on TARGET_x86 || TARGET_armsr || TARGET_loongarch64
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
-		select PACKAGE_grub2 if TARGET_x86
 		select PACKAGE_grub2-efi if TARGET_x86
-		select PACKAGE_grub2-bios-setup if TARGET_x86
 		select PACKAGE_grub2-efi-arm if TARGET_armsr
 		select PACKAGE_grub2-efi-loongarch64 if TARGET_loongarch64
+		select PACKAGE_kmod-fs-ext4 if TARGET_x86
 		select PACKAGE_kmod-fs-vfat
 		default y
+
+	config GRUB_EFI_HYBRID
+		bool "Build Hybrid EFI/BIOS GRUB images"
+		depends on GRUB_EFI_IMAGES && TARGET_x86
+		select PACKAGE_grub2
+		select PACKAGE_grub2-bios-setup
+		default y
+		help
+		  Retain hybrid BIOS boot partition on EFI images. Disable for strictly native EFI dual-boot setups.
 
 	config GRUB_CONSOLE
 		bool "Use Console Terminal (in addition to Serial)"
@@ -359,7 +367,7 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_PARTNAME
 		string "Root partition on target device"
-		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
+		depends on GRUB_IMAGES
 		help
 		  Override the root partition on the final device. If left empty,
 		  it will be mounted by PARTUUID which makes the kernel find the

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -241,6 +241,7 @@ menu "Target Images"
 		bool "Build GRUB EFI images"
 		depends on TARGET_x86 || TARGET_armsr || TARGET_loongarch64
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
+		select PACKAGE_grub2-editenv if TARGET_x86
 		select PACKAGE_grub2-efi if TARGET_x86
 		select PACKAGE_grub2-efi-arm if TARGET_armsr
 		select PACKAGE_grub2-efi-loongarch64 if TARGET_loongarch64

--- a/package/base-files/files/etc/init.d/done
+++ b/package/base-files/files/etc/init.d/done
@@ -12,6 +12,20 @@ boot() {
 		sh /etc/rc.local
 	}
 
+	if grep -q "openwrt_rootfs" /proc/cmdline; then
+		. /lib/upgrade/common.sh
+		if is_gpt_dualboot && export_partdevice_label bootpart openwrt_boot; then
+			mkdir -p /tmp/boot
+			mount "/dev/$bootpart" -o rw,noatime /tmp/boot
+			if grep -q openwrt_rootfs_alt /proc/cmdline; then
+				grub-editenv /tmp/boot/boot/grub/grubenv set attempt=0 target_slot=1
+			else
+				grub-editenv /tmp/boot/boot/grub/grubenv set attempt=0 target_slot=0
+			fi
+			umount /tmp/boot
+		fi
+	fi
+
 	# set leds to normal state
 	. /etc/diag.sh
 	set_state done

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -154,6 +154,10 @@ identify_magic_long() {
 	esac
 }
 
+is_gpt_dualboot() {
+	grep -q 'PARTNAME=openwrt_boot' /sys/class/block/*/uevent 2>/dev/null
+}
+
 part_magic_efi() {
 	local magic=$(get_magic_gpt "$@")
 	[ "$magic" = "EFI PART" ]
@@ -240,6 +244,31 @@ export_partdevice() {
 	done
 
 	return 1
+}
+
+export_partdevice_label() {
+	local var="$1" label="$2"
+	local found uevent line MAJOR MINOR DEVNAME DEVTYPE PARTN PARTNAME
+
+	found=
+	for uevent in /sys/class/block/*/uevent; do
+		DEVTYPE= DEVNAME= PARTNAME=
+		while read line; do
+			export -n "$line"
+		done < "$uevent"
+		if [ "$DEVTYPE" = "partition" -a "$label" = "$PARTNAME" -a -b "/dev/$DEVNAME" ]; then
+			[ -n "$found" ] && {
+				echo "$label found more than once, remove duplicate partitions and try again" >&2
+				return 1
+			}
+			echo "Found $label @ /dev/$DEVNAME"
+			found="$DEVNAME"
+		fi
+	done
+	[ -n "$found" ] || return 1
+
+	export "$var=$found"
+	return 0
 }
 
 hex_le32_to_cpu() {

--- a/package/base-files/files/lib/upgrade/do_stage2
+++ b/package/base-files/files/lib/upgrade/do_stage2
@@ -18,6 +18,10 @@ fi
 v "Upgrade completed"
 sleep 1
 
+if [ "${INTERACTIVE:-0}" -eq 1 ] && ! ask_bool $(( ! ${EFI_DUALBOOT:-0} )) "Reboot now?"; then
+	return 0
+fi
+
 v "Rebooting system..."
 umount -a
 reboot -f

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -431,6 +431,12 @@ if [ $TEST -eq 1 ]; then
 	exit 0
 fi
 
+if is_gpt_dualboot; then
+	ask_bool 1 "Proceed with upgrade?" && { export EFI_DUALBOOT=1 IMAGE; . "$COMMAND"; }
+	rm -f /tmp/sysupgrade.*
+	exit 0
+fi
+
 install_bin /sbin/upgraded
 v "Commencing upgrade. Closing all shell sessions."
 

--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -154,14 +154,16 @@ define Package/grub2/install
 endef
 
 define Package/grub2-efi/install
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)/grub2
 	sed 's#msdos1#gpt1#g' ./files/grub-early.cfg >$(PKG_BUILD_DIR)/grub-early.cfg
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \
 		-O $(CONFIG_ARCH)-efi \
-		-c $(PKG_BUILD_DIR)/grub-early.cfg \
+		-c $(if $(CONFIG_GRUB_EFI_HYBRID),$(PKG_BUILD_DIR)/grub-early,./files/grub-early-efi).cfg \
 		-o $(STAGING_DIR_IMAGE)/grub2/boot$(if $(CONFIG_x86_64),x64,ia32).efi \
-		at_keyboard boot chain configfile fat linux ls part_gpt reboot serial test efi_gop efi_uga
+		at_keyboard boot chain configfile ext2 fat linux loadenv ls part_gpt \
+		reboot search_label serial test usb_keyboard efi_gop efi_uga
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \

--- a/package/boot/grub2/files/grub-early-efi.cfg
+++ b/package/boot/grub2/files/grub-early-efi.cfg
@@ -1,0 +1,3 @@
+search.fs_label openwrt_boot root --hint (hd0)
+
+configfile /boot/grub/grub.cfg

--- a/scripts/gen_image_generic.sh
+++ b/scripts/gen_image_generic.sh
@@ -20,13 +20,30 @@ rm -f "$OUTPUT"
 head=16
 sect=63
 
-# create partition table
-set $(ptgen -o "$OUTPUT" -h $head -s $sect ${GUID:+-g} -t "${KERNELPARTTYPE}" -p "${KERNELSIZE}m${PARTOFFSET:+@$PARTOFFSET}" -t "${ROOTFSPARTTYPE}" -p "${ROOTFSSIZE}m" ${ALIGN:+-l $ALIGN} ${SIGNATURE:+-S 0x$SIGNATURE} ${GUID:+-G $GUID})
+[ -n "$EFI_DUALBOOT" ] && ESPPARTTYPE="ef" KERNELPARTTYPE="ea"
 
-KERNELOFFSET="$(($1 / 512))"
-KERNELSIZE="$2"
-ROOTFSOFFSET="$(($3 / 512))"
-ROOTFSSIZE="$(($4 / 512))"
+# create partition table
+set $(ptgen -o "$OUTPUT" -h $head -s $sect ${GUID:+-g} \
+    ${EFI_DUALBOOT:+-d 0 -u} \
+    ${EFI_DUALBOOT:+-r -N "EFI system partition" -t "${ESPPARTTYPE}"    -p 1m} \
+    ${EFI_DUALBOOT:+-r -N "openwrt_boot"}        -t "${KERNELPARTTYPE}" -p "${KERNELSIZE}m${PARTOFFSET:+@$PARTOFFSET}" \
+    ${EFI_DUALBOOT:+-r -N "openwrt_rootfs"}      -t "${ROOTFSPARTTYPE}" -p "${ROOTFSSIZE}m" \
+    ${EFI_DUALBOOT:+-r -N "openwrt_rootfs_alt"   -t "${ROOTFSPARTTYPE}" -p "${ROOTFSSIZE}m"} \
+    ${ALIGN:+-l $ALIGN} ${SIGNATURE:+-S 0x$SIGNATURE} ${GUID:+-G $GUID})
+
+if [ -n "$EFI_DUALBOOT" ]; then
+    ESPOFFSET="$(($1 / 512))"
+    ESPSIZE="$(($2 / 512))"
+    KERNELOFFSET="$(($3 / 512))"
+    KERNELSIZE="$4"
+    ROOTFSOFFSET="$(($5 / 512))"
+    ROOTFSSIZE="$(($6 / 512))"
+else
+    KERNELOFFSET="$(($1 / 512))"
+    KERNELSIZE="$2"
+    ROOTFSOFFSET="$(($3 / 512))"
+    ROOTFSSIZE="$(($4 / 512))"
+fi
 
 # Using mcopy -s ... is using READDIR(3) to iterate through the directory
 # entries, hence they end up in the FAT filesystem in traversal order which
@@ -47,9 +64,12 @@ dos_dircopy() {
 }
 
 [ -n "$PADDING" ] && dd if=/dev/zero of="$OUTPUT" bs=512 seek="$ROOTFSOFFSET" conv=notrunc count="$ROOTFSSIZE"
+[ -n "$EFI_DUALBOOT" ] && dd if="$OUTPUT.grub.img" of="$OUTPUT" bs=512 seek="$ESPOFFSET" conv=notrunc count="$ESPSIZE"
 dd if="$ROOTFSIMAGE" of="$OUTPUT" bs=512 seek="$ROOTFSOFFSET" conv=notrunc
 
-if [ -n "$GUID" ]; then
+if [ -n "$EFI_DUALBOOT" ]; then
+    make_ext4fs -J -L openwrt_boot -l "$KERNELSIZE" ${SOURCE_DATE_EPOCH:+-T ${SOURCE_DATE_EPOCH}} "$OUTPUT.kernel" "$KERNELDIR"
+elif [ -n "$GUID" ]; then
     [ -n "$PADDING" ] && dd if=/dev/zero of="$OUTPUT" bs=512 seek="$((ROOTFSOFFSET + ROOTFSSIZE))" conv=notrunc count="$sect"
     mkfs.fat --invariant -n kernel -C "$OUTPUT.kernel" -S 512 "$((KERNELSIZE / 1024))"
     LC_ALL=C dos_dircopy "$KERNELDIR" /

--- a/target/linux/x86/base-files/lib/upgrade/platform.sh
+++ b/target/linux/x86/base-files/lib/upgrade/platform.sh
@@ -96,6 +96,35 @@ platform_check_image() {
 		return 0
 	fi
 
+	if is_gpt_dualboot; then
+		# extract boot sector from image
+		get_image_dd "$1" of=/tmp/image.bs count=63 bs=512b
+
+		if part_magic_efi /tmp/image.bs; then
+			get_partitions /tmp/image.bs image
+			local img_parts="$(wc -l < /tmp/partmap.image)"
+			rm -f /tmp/image.bs /tmp/partmap.image
+
+			if [ "$img_parts" -lt 4 ]; then
+				v "Invalid image: expected 4 partitions for dual-boot, found $img_parts"
+				return 1
+			fi
+
+			export_partdevice_label esppart "EFI system partition" && \
+				export_partdevice_label bootpart openwrt_boot && \
+				export_partdevice_label partdev openwrt_rootfs && \
+				export_partdevice_label partdevalt openwrt_rootfs_alt || {
+					v "Unable to determine upgrade device"
+					return 1
+				}
+			return 0
+		else
+			v "Invalid image type"
+			rm -f /tmp/image.bs
+			return 1
+		fi
+	fi
+
 	case "$(get_magic_word "$1")" in
 		eb48|eb63) ;;
 		*)
@@ -134,11 +163,12 @@ platform_copy_config() {
 	# ONIE upgrade bundles sysupgrade.tgz into the installer itself.
 	is_onie_install && return 0
 
-	if export_partdevice partdev 1; then
+	if (is_gpt_dualboot && export_partdevice_label partdev openwrt_boot) || export_partdevice partdev 1; then
+		mkdir -p /tmp/boot
 		part_magic_fat "/dev/$partdev" && parttype=vfat
-		mount -t $parttype -o rw,noatime "/dev/$partdev" /mnt
-		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
-		umount /mnt
+		mount -t $parttype -o rw,noatime "/dev/$partdev" /tmp/boot
+		cp -af "$UPGRADE_BACKUP" "/tmp/boot/$BACKUP_FILE"
+		umount /tmp/boot
 	fi
 }
 
@@ -146,7 +176,38 @@ platform_do_bootloader_upgrade() {
 	local bootpart parttable=msdos
 	local diskdev="$1"
 
-	if export_partdevice bootpart 1; then
+	if is_gpt_dualboot; then
+		export_partdevice_label esppart "EFI system partition" || {
+			v "Unable to find 'EFI system partition'"
+			return 1
+		}
+
+		mkdir -p /tmp/.esp /tmp/.tmp
+		mount -o ro,loop $diskdev /tmp/.tmp
+		mount -o rw,noatime "/dev/$esppart" /tmp/.esp
+
+		set -- /tmp/.tmp/efi/boot/boot???.efi
+		new=$1; old="${new/\/tmp\/.tmp//tmp/.esp}"
+		[ -f "$new" ] || v "Unable to find EFI bootloader in the update image"
+		[ -f "$old" ] || v "Unable to find EFI bootloader on /dev/$esppart"
+		[ -f "$new" ] && [ -f "$old" ] || {
+			umount /tmp/.esp /tmp/.tmp
+			return 1
+		}
+
+		if ! cmp -s "$old" "$new"; then
+			v "Bootloader on /dev/$esppart needs to be updated"
+			mkdir -p "$(dirname "$old")"
+			ask_bool 0 "Skip" || {
+				v "Upgrading bootloader on /dev/$esppart..."
+				cp -a "$new" "$old"
+			}
+		else
+			v "Bootloader on /dev/$esppart does not need to be updated"
+		fi
+
+		umount /tmp/.esp /tmp/.tmp
+	elif export_partdevice bootpart 1; then
 		mkdir -p /tmp/boot
 		mount -o rw,noatime "/dev/$bootpart" /tmp/boot
 		echo "(hd0) /dev/$diskdev" > /tmp/device.map
@@ -164,7 +225,54 @@ platform_do_bootloader_upgrade() {
 }
 
 platform_do_upgrade() {
-	local diskdev partdev diff
+	local _alt bootpart defboot diff diskdev partdev partdevalt part size start
+
+	if is_gpt_dualboot; then
+		# extract the boot sector from the image
+		get_image_dd "$1" of=/tmp/image.bs count=63 bs=512b
+
+		export_partdevice_label esppart "EFI system partition" && \
+			export_partdevice_label bootpart openwrt_boot && \
+			export_partdevice_label partdev openwrt_rootfs && \
+			export_partdevice_label partdevalt openwrt_rootfs_alt || {
+				v "Unable to determine upgrade device"
+				return 1
+			}
+
+		grep -q 'root=PARTLABEL=openwrt_rootfs_alt' /proc/cmdline && _alt= || _alt=_alt
+		get_partitions /tmp/image.bs image
+		while read part start size; do
+			case "$part" in
+			1)
+				v "Extracting bootloader from image..."
+				get_image_dd "$1" of=/tmp/.grub.img ibs="512" obs=1M skip="$start" count="$size"
+			;;
+			2)
+				v "Writing new kernel to /boot/vmlinuz$_alt..."
+				if [ -n "$_alt" ]; then defboot=1; else defboot=0; fi
+				get_image_dd "$1" of=/tmp/.bootkernel.img ibs="512" obs=1M skip="$start" count="$size"
+				mkdir -p /tmp/boot /tmp/.bootkernel && \
+					mount -o rw,noatime "/dev/$bootpart" /tmp/boot && \
+					mount -o ro,loop /tmp/.bootkernel.img /tmp/.bootkernel && \
+					cp -af /tmp/.bootkernel/boot/vmlinuz /tmp/boot/boot/vmlinuz$_alt && \
+					grub-editenv /tmp/boot/boot/grub/grubenv set attempt=0 target_slot=$defboot
+				umount /tmp/boot /tmp/.bootkernel; rm -f /tmp/.bootkernel.img
+				sync
+			;;
+			3)
+				[ -n "$_alt" ] && partdev=$partdevalt
+				v "Writing new rootfs to /dev/$partdev..."
+				get_image_dd "$1" of="/dev/$partdev" ibs="512" obs=1M skip="$start" count="$size" conv=fsync
+			;;
+			esac
+		done < /tmp/partmap.image
+
+		platform_do_bootloader_upgrade /tmp/.grub.img
+		rm -f /tmp/.grub.img /tmp/image.bs /tmp/partmap.image /tmp/sysupgrade.*
+		sync
+
+		return 0
+	fi
 
 	if is_onie_install; then
 		platform_do_upgrade_onie "$1"

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -76,6 +76,9 @@ define Build/grub-config
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@TITLE@#$(GRUB_TITLE)#g' \
 		./grub-$(1).cfg > $@.boot/boot/grub/grub.cfg
+	$(if $(filter $(1),efidualboot),
+		$(STAGING_DIR_HOST)/bin/grub-editenv $@.boot/boot/grub/grubenv create
+		$(STAGING_DIR_HOST)/bin/grub-editenv $@.boot/boot/grub/grubenv set attempt=0 target_slot=0)
 endef
 
 define Build/grub-install

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -36,16 +36,28 @@ BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
 define Build/combined
 	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/boot/vmlinuz
-	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
-	$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
-	$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \
-		$@.boot/boot/grub/core.img
+	$(if $(filter $(1),efidualboot),,
+		-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
+		$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
+		$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \
+			$@.boot/boot/grub/core.img
+	)
 	$(if $(filter $(1),efi),
 		$(INSTALL_DIR) $@.boot/efi/boot
 		$(CP) $(STAGING_DIR_IMAGE)/grub2/boot$(if $(CONFIG_x86_64),x64,ia32).efi $@.boot/efi/boot/
 	)
+	$(if $(filter $(1),efidualboot),
+		rm -f $@.grub.img
+		mkfs.fat -n ESP -C $@.grub.img -S 512 1024
+		mmd -i $@.grub.img ::/efi ::/efi/boot
+		mcopy -i $@.grub.img \
+			$(STAGING_DIR_IMAGE)/grub2/boot$(if $(CONFIG_x86_64),x64,ia32).efi \
+			::/efi/boot/boot$(if $(CONFIG_x86_64),x64,ia32).efi
+	)
 	PADDING="1" SIGNATURE="$(IMG_PART_SIGNATURE)" \
-		$(if $(filter $(1),efi),GUID="$(IMG_PART_DISKGUID)") $(SCRIPT_DIR)/gen_image_generic.sh \
+		$(if $(filter $(1),efi efidualboot),GUID="$(IMG_PART_DISKGUID)") \
+		$(if $(filter $(1),efidualboot),EFI_DUALBOOT=1) \
+		$(SCRIPT_DIR)/gen_image_generic.sh \
 		$@ \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -138,6 +138,11 @@ define Build/iso
 endef
 
 DEVICE_VARS += GRUB2_VARIANT
+ifeq ($(CONFIG_GRUB_EFI_HYBRID),y)
+  EFI_TARGET := efi
+else
+  EFI_TARGET := efidualboot
+endif
 define Device/Default
   ARTIFACT/image.iso := grub-config iso | iso
   IMAGE/combined.img := grub-config pc | combined | grub-install | append-metadata
@@ -148,11 +153,11 @@ define Device/Default
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | libdeflate-gzip
   ARTIFACT/image-efi.iso := grub-config iso | iso efi
-  IMAGE/combined-efi.img := grub-config efi | combined efi | grub-install efi | append-metadata
-  IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | libdeflate-gzip | append-metadata
-  IMAGE/combined-efi.vdi := grub-config efi | combined efi | grub-install efi | qemu-image vdi
-  IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
-  IMAGE/combined-efi.vhdx := grub-config efi | combined efi | grub-install efi | qemu-image vhdx -o subformat=dynamic
+  IMAGE/combined-efi.img := grub-config $(EFI_TARGET) | combined $(EFI_TARGET) $(if $(CONFIG_GRUB_EFI_HYBRID),| grub-install efi )| append-metadata
+  IMAGE/combined-efi.img.gz := grub-config $(EFI_TARGET) | combined $(EFI_TARGET) $(if $(CONFIG_GRUB_EFI_HYBRID),| grub-install efi )| libdeflate-gzip | append-metadata
+  IMAGE/combined-efi.vdi := grub-config $(EFI_TARGET) | combined $(EFI_TARGET) $(if $(CONFIG_GRUB_EFI_HYBRID),| grub-install efi )| qemu-image vdi
+  IMAGE/combined-efi.vmdk := grub-config $(EFI_TARGET) | combined $(EFI_TARGET) $(if $(CONFIG_GRUB_EFI_HYBRID),| grub-install efi )| qemu-image vmdk
+  IMAGE/combined-efi.vhdx := grub-config $(EFI_TARGET) | combined $(EFI_TARGET) $(if $(CONFIG_GRUB_EFI_HYBRID),| grub-install efi )| qemu-image vhdx -o subformat=dynamic
   ARTIFACT/onie-installer.bin := onie-installer
   ifeq ($(CONFIG_TARGET_IMAGES_GZIP),y)
     IMAGES-y := rootfs.img.gz

--- a/target/linux/x86/image/grub-efidualboot.cfg
+++ b/target/linux/x86/image/grub-efidualboot.cfg
@@ -1,0 +1,46 @@
+@SERIAL_CONFIG@
+@TERMINAL_CONFIG@
+
+load_env -f /boot/grub/grubenv
+
+if [ -z "$target_slot" ]; then
+	set target_slot="0"
+fi
+
+if [ -z "$attempt" ]; then
+	set attempt="0"
+fi
+
+if [ "$target_slot" = "0" ]; then
+	set default="0"
+	set fallback="1"
+else
+	set default="1"
+	set fallback="0"
+fi
+
+set timeout=@TIMEOUT@
+search.fs_label openwrt_boot root --hint (hd0)
+
+if [ "$attempt" = "0+1+1" ]; then
+	set attempt="0"
+	set default="$fallback"
+	set target_slot="$fallback"
+	save_env -f /boot/grub/grubenv attempt target_slot
+else
+	set attempt="$attempt+1"
+	save_env -f /boot/grub/grubenv attempt
+fi
+
+menuentry "@TITLE@" {
+	linux /boot/vmlinuz root=PARTLABEL=openwrt_rootfs rootwait @CMDLINE@ noinitrd
+}
+menuentry "@TITLE@ alternate partition" {
+	linux /boot/vmlinuz_alt root=PARTLABEL=openwrt_rootfs_alt rootwait @CMDLINE@ noinitrd
+}
+menuentry "@TITLE@ (failsafe)" {
+	linux /boot/vmlinuz failsafe=true root=PARTLABEL=openwrt_rootfs rootwait @CMDLINE@ noinitrd
+}
+menuentry "@TITLE@ alternate partition (failsafe)" {
+	linux /boot/vmlinuz_alt failsafe=true root=PARTLABEL=openwrt_rootfs_alt rootwait @CMDLINE@ noinitrd
+}

--- a/tools/firmware-utils/patches/0001-firmware-utils-ptgen-add-FreeDesktop-boot-partition-.patch
+++ b/tools/firmware-utils/patches/0001-firmware-utils-ptgen-add-FreeDesktop-boot-partition-.patch
@@ -1,0 +1,37 @@
+From 5db39cdecbf1f22669c97b303c10b394afe83dd3 Mon Sep 17 00:00:00 2001
+From: Javier Marcet <javier@marcet.info>
+Date: Tue, 16 Jun 2026 00:00:13 +0200
+Subject: [PATCH 1/2] firmware-utils: ptgen: add FreeDesktop boot partition
+ GUID
+
+Add the FreeDesktop boot partition GUID (0xea) to ptgen for GPT
+dual-boot layouts.
+
+Signed-off-by: Javier Marcet <javier@marcet.info>
+---
+ src/ptgen.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/src/ptgen.c
++++ b/src/ptgen.c
+@@ -67,6 +67,10 @@ typedef struct {
+ 	GUID_INIT( 0xEBD0A0A2, 0xB9E5, 0x4433, \
+ 			0x87, 0xC0, 0x68, 0xB6, 0xB7, 0x26, 0x99, 0xC7)
+ 
++#define GUID_PARTITION_FREEDESKTOP_BOOT \
++	GUID_INIT( 0xBC13C2FF, 0x59E6, 0x4262, \
++			0xA3, 0x52, 0xB2, 0x75, 0xFD, 0x6F, 0x71, 0x72)
++
+ #define GUID_PARTITION_BIOS_BOOT \
+ 	GUID_INIT( 0x21686148, 0x6449, 0x6E6F, \
+ 			0x74, 0x4E, 0x65, 0x65, 0x64, 0x45, 0x46, 0x49)
+@@ -670,6 +674,9 @@ static guid_t type_to_guid_and_name(unsi
+ 				*name = "EFI System Partition";
+ 			guid = GUID_PARTITION_SYSTEM;
+ 			break;
++		case 0xea:
++			guid = GUID_PARTITION_FREEDESKTOP_BOOT;
++			break;
+ 		case 0x83:
+ 			guid = GUID_PARTITION_LINUX_FS_GUID;
+ 			break;

--- a/tools/firmware-utils/patches/0002-firmware-utils-ptgen-add-flag-to-disable-BIOS-boot-s.patch
+++ b/tools/firmware-utils/patches/0002-firmware-utils-ptgen-add-flag-to-disable-BIOS-boot-s.patch
@@ -1,0 +1,69 @@
+From ea6ede5ba5afff466e662563ddbe25e8c4e829a4 Mon Sep 17 00:00:00 2001
+From: Javier Marcet <javier@marcet.info>
+Date: Tue, 16 Jun 2026 00:00:37 +0200
+Subject: [PATCH 2/2] firmware-utils: ptgen: add flag to disable BIOS boot stub
+
+Introduce a new `--disable-bios-boot-stub` / `-u` option to optionally
+prevent the creation of the 1MB BIOS boot stub partition. This is
+required for generating strictly native EFI layouts for GPT dual-boot
+images when legacy hybrid mode is disabled.
+
+Signed-off-by: Javier Marcet <javier@marcet.info>
+---
+ src/ptgen.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/src/ptgen.c
++++ b/src/ptgen.c
+@@ -177,6 +177,7 @@ int kb_align = 0;
+ bool ignore_null_sized_partition = false;
+ bool use_guid_partition_table = false;
+ bool allow_stub_partition = true;
++bool disable_bios_boot_stub = false;
+ struct partinfo parts[GPT_ENTRY_MAX];
+ bool entry_used[GPT_ENTRY_MAX] = { false };
+ char *filename = NULL;
+@@ -500,7 +501,7 @@ static int gen_gptable(uint32_t signatur
+ 		printf("%" PRIu64 "\n", (sect - start) * DISK_SECTOR_SIZE);
+ 	}
+ 
+-	if (parts[0].actual_start > gpt_first_entry_sector + GPT_SIZE &&
++	if (!disable_bios_boot_stub && parts[0].actual_start > gpt_first_entry_sector + GPT_SIZE &&
+ 	    allow_stub_partition && !entry_used[GPT_ENTRY_MAX - 1]) {
+ 		gpte[GPT_ENTRY_MAX - 1].start = cpu_to_le64(gpt_first_entry_sector + GPT_SIZE);
+ 		gpte[GPT_ENTRY_MAX - 1].end = cpu_to_le64(parts[0].actual_start - 1);
+@@ -638,6 +639,7 @@ static void usage(char *prog)
+ 			"  -v, --verbose                   enable vervose output\n"
+ 			"  -l, --alignment=SIZE            align partition boundaries to SIZE Kbytes\n"
+ 			"  -n, --ignore-null-sized-parts   do not create null sized partitions\n"
++			"  -u, --disable-bios-boot-stub    do not create 1MB BIOS boot stub partition\n"
+ 			"  -D, --disable-gpt-stub-part     do not fill a gap before 1-st GPT partition\n"
+ 			"  -o, --output=FILENAME           write an image to a file FILENAME\n"
+ 			"  -h, --heads=COUNT               use CHS scheme, defines heads number\n"
+@@ -709,6 +711,7 @@ int main (int argc, char **argv)
+ 			{"verbose",			no_argument,		0,	'v'},
+ 			{"kb_alignment",		required_argument,	0,	'l'},
+ 			{"ignore-null-sized-parts",	no_argument,		0,	'n'},
++			{"disable-bios-boot-stub",	no_argument,		0,	'u'},
+ 			{"disable-gpt-stub-part",	no_argument,		0,	'D'},
+ 			{"output",			required_argument,	0,	'o'},
+ 			{"heads",			required_argument,	0,	'h'},
+@@ -731,7 +734,7 @@ int main (int argc, char **argv)
+ 			{NULL,				0,			0,	 0 },
+ 		};
+ 
+-		ch = getopt_long(argc, argv, "?h:s:p:a:t:T:o:DvnbHN:gl:rBS:G:e:d:i:",
++		ch = getopt_long(argc, argv, "?h:s:p:a:t:T:o:DvnbHN:gl:rBS:G:e:d:i:u",
+ 				 long_options, &option_index);
+ 		if (ch == -1)
+ 			break;
+@@ -743,6 +746,9 @@ int main (int argc, char **argv)
+ 		case 'v':
+ 			verbose++;
+ 			break;
++		case 'u':
++			disable_bios_boot_stub = true;
++			break;
+ 		case 'D':
+ 			allow_stub_partition = false;
+ 			break;


### PR DESCRIPTION
This PR implements robust A/B (dual-slot) `sysupgrade` support for **EFI GPT x86 systems**, providing an automatic fallback mechanism if a new firmware build fails to boot. It has been tested and run in production for several years.

**Key Architectural Changes:**
1. **A/B Partition Layout:** Transitions to a 4-partition layout via `ptgen` utilizing `PARTLABEL`s on `GPT` instead of UUIDs:
   - `openwrt_boot`: Shared boot partition holding both `vmlinuz` and `vmlinuz_alt`.
   - `openwrt_rootfs`: The primary root filesystem.
   - `openwrt_rootfs_alt`: The alternate fallback slot.
   *(Note: This intentionally drops `TARGET_ROOTFS_PARTNAME` override support for `EFI` builds, as the A/B state machine requires this predictable label pairing).*
2. **State Tracking & Automatic Fallback:** Eliminates `sed` string-replacements. It leverages `grub2-editenv` to track the `target_slot` and boot `attempt` counters. After consecutive failed boots, GRUB automatically falls back to the alternate partition. The counter is safely reset to 0 by `/etc/init.d/done` upon a successful boot.
3. **Native EFI Focus:** The dual-boot layout is strictly designed for native `EFI` hardware. Legacy BIOS and Hybrid setups safely bypass this logic and continue to use the standard OpenWrt 2-partition layout.
4. **Optional Legacy Hybrid Support:** Introduced `CONFIG_GRUB_EFI_HYBRID` to `menuconfig`. This allows users to explicitly toggle whether legacy `BIOS` `MBR` boot code is included on standard `EFI` images.
5. **Live Sysupgrade UX & Interactive Prompts:** Because the dual-boot layout writes to the offline alternate partition, `sysupgrade` performs the update live without dropping shell sessions or killing active processes. Additionally, for interactive upgrades (`sysupgrade -i`), this PR introduces a final `Reboot now?` prompt across all platforms. The default dynamically adapts: it defaults to 'No' for dual-boot setups (allowing users to inspect the live system before switching) and 'Yes' for standard setups. Non-interactive/headless upgrades remain 100% untouched and execute/reboot automatically.
6. **Zero Impact on Non-x86 Targets:** Shared scripts (`gen_image_generic.sh`, `do_stage2`) dynamically detect the architecture. Non-x86 `EFI` targets (like `armsr`) completely bypass the A/B logic and safely fall back to their legacy 2-partition FAT32 setups.