### PR TITLE
x86: preinit: check first for board_vendor & board_name;

### DIFF
--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -10,12 +10,12 @@ sanitize_name_x86() {
 do_sysinfo_x86() {
 	local vendor product file
 
-	for file in sys_vendor board_vendor; do
+	for file in board_vendor sys_vendor; do
 		vendor="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		[ -n "$vendor" ] && break
 	done
 
-	for file in product_name board_name; do
+	for file in board_name product_name; do
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
 		"Supermicro:Super Server")


### PR DESCRIPTION
sys_vendor & product_name are set to 'To Be Filled By O.E.M.' on custom
built PCs
