### PR TITLE
uboot-envtools: fix domywifi_dw33d Bad CRC error

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -16,7 +16,6 @@ case "$board" in
 alfa-network,ap121f|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
-domywifi,dw33d|\
 engenius,ecb1750|\
 etactica,eg200|\
 glinet,gl-ar300m-lite|\
@@ -45,6 +44,9 @@ yuncore,xd4200)
 	;;
 buffalo,wzr-hp-ag300h)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
+	;;
+domywifi,dw33d)
+	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
 	;;
 glinet,gl-ar150)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"


### PR DESCRIPTION
The current dw33d partition index has changed, this patch solves
this problem.

old partition layout
dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00fa0000 00010000 "oem-firmware"
mtd3: 00010000 00010000 "art"
mtd4: 00500000 00020000 "kernel"
mtd5: 05b00000 00020000 "ubi"
mtd6: 02000000 00020000 "oem-backup"

new partition layout
dev:    size   erasesize  name
mtd0: 00500000 00020000 "kernel"
mtd1: 05b00000 00020000 "ubi"
mtd2: 02000000 00020000 "oem-backup"
mtd3: 00040000 00010000 "u-boot"
mtd4: 00010000 00010000 "u-boot-env"
mtd5: 00fa0000 00010000 "oem-firmware"
mtd6: 00010000 00010000 "art"

Signed-off-by: weidong jia <jwdsccd@gmail.com>
