### PR TITLE
ath79: add support for PowerBeam 5AC Gen2

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_powerbeam-5ac-gen2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_powerbeam-5ac-gen2.dts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,powerbeam-5ac-gen2", "ubnt,wa", "qca,ar9342";
+	model = "Ubiquiti PowerBeam 5AC Gen2";
+
+	aliases {
+		led-boot = &led_rssi3;
+		led-failsafe = &led_rssi3;
+		led-upgrade = &led_rssi3;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		rssi0 {
+			label = "ubnt:blue:rssi0";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "ubnt:blue:rssi1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "ubnt:blue:rssi2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_rssi3: rssi3 {
+			label = "ubnt:blue:rssi3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -282,7 +282,8 @@ ubnt,rocket-m)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100"
 	;;
 ubnt,nanobeam-ac|\
-ubnt,nanostation-ac)
+ubnt,nanostation-ac|\
+ubnt,powerbeam-5ac-gen2)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "ubnt:blue:rssi0" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "ubnt:blue:rssi1" "wlan0" "26" "100"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -53,6 +53,7 @@ ath79_setup_interfaces()
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-loco-m-xw|\
 	ubnt,picostation-m|\
+	ubnt,powerbeam-5ac-gen2|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
@@ -468,7 +469,8 @@ ath79_setup_macs()
 	ubnt,unifi)
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
-	ubnt,litebeam-ac-gen2)
+	ubnt,litebeam-ac-gen2|\
+	ubnt,powerbeam-5ac-gen2)
 		label_mac=$(mtd_get_mac_binary art 0x5006)
 		;;
 	ubnt,routerstation|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,6 +25,7 @@ case "$FIRMWARE" in
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
+	ubnt,powerbeam-5ac-gen2|\
 	ubnt,unifiac-pro|\
 	yuncore,a770)
 		caldata_extract "art" 0x5000 0x844

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -243,6 +243,14 @@ define Device/ubnt_picostation-m
 endef
 TARGET_DEVICES += ubnt_picostation-m
 
+define Device/ubnt_powerbeam-5ac-gen2
+  $(Device/ubnt-wa)
+  DEVICE_MODEL := PowerBeam 5AC
+  DEVICE_VARIANT := Gen2
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct rssileds
+endef
+TARGET_DEVICES += ubnt_powerbeam-5ac-gen2
+
 define Device/ubnt_rocket-m
   $(Device/ubnt-xm)
   SOC := ar7241


### PR DESCRIPTION
The Ubiquiti PowerBeam 5AC Gen 2 (PBE-5AC-Gen2) is an outdoor 802.11ac 5 GHz bridge with a radio feed and a dish antenna. The device is hardware-compatible with the LiteBeam AC Gen2, plus the 4 extra LEDs.

Specifications:
 - SoC: Qualcomm Atheros AR9342 rev 2
 - RAM: 64 MB DDR2
 - Flash: 16 MB SPI NOR (mx25l12805d)
 - Ethernet: 1x 10/100/1000 Mbps Atheros 8035, 24 Vdc PoE-in
 - WiFi 5 GHz: QCA988x HW2.0 Ubiquiti target 0x4100016c chip_id 0x043222ff
 - WiFi 2.4 GHz: Atheros AR9340 (SoC-based)
 - Buttons: 1x (reset)
 - LEDs: 1x power, 1x Ethernet, 4x RSSI via GPIO. All blue.
 - UART: not tested

Installation from stock airOS firmware:
 - Follow instructions for WA-type Ubiquiti devices on OpenWrt wiki

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>