### PR TITLE
kirkwood: use three temperature sensors instead of one

### DIFF
--- a/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
+++ b/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
@@ -13,10 +13,16 @@ boot() {
 		;;
 	zyxel,nsa310b)
 		path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
-		echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1
-		echo 1 > "$path_to_hwmon/pwm1_auto_channels" # temp1 is the only one that changes
-		echo 23000 > "$path_to_hwmon/temp1_auto_temp_min"
-		echo 43000 > "$path_to_hwmon/temp1_auto_temp_max" # next step is 49600 millicelsius, or 50 celsius, 43 celsius is better
+		echo 123 > "$path_to_hwmon/pwm1_auto_channels" # use the max. value of (temp1) OR (temp2) OR (temp3) as an input for the PWM of the cooling fan
+		#Temperature Sensor #1 placed on mainboard
+		echo 30000 > "$path_to_hwmon/temp1_auto_temp_min"
+        	echo 49600 > "$path_to_hwmon/temp1_auto_temp_max" 
+		#Temperature Sensor #2 placed on mainboard
+		echo 30000 > "$path_to_hwmon/temp2_auto_temp_min" 	#range: 0 to 127000 in steps of 1000 [millicelsius] -> range: 0°C to 127°C in 1°C steps
+        	echo 49600 > "$path_to_hwmon/temp2_auto_temp_max" 	#range: 0 to 127000 in steps of ???? [millicelsius] -> range: 0°C to 127°C in ?°C steps 
+		#Temperature Sensor #3 placed close to a  chipset
+		echo 23000 > "$path_to_hwmon/temp3_auto_temp_min" 	#range: 0 to  60000 in steps of 1000 [millicelsius] -> range: 0°C to 60°C  in 1°C steps
+		echo 103000 > "$path_to_hwmon/temp3_auto_temp_max" 	#pre-defined steps: 103000; 122000; 143300; 170000 in [millicelsius] -> 103°C; 122°C; 143,3°C; 170°C
 		;;
 	esac
 }


### PR DESCRIPTION
temp1 -> main board temp1
temp2 -> main board temp2
temp3 -> processor temperature
All three temperatures give valid input for the PWM of the fan on NSA310. 
Change tested on two NSA310
Signed-off-by: ThBexx <thomas.beckler@hotmail.com>