### PR TITLE
ramips: fix ethernet bugs

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1401,7 +1401,7 @@ static int __init fe_init(struct net_device *dev)
 	fe_reset_phy(priv);
 
 	mac_addr = of_get_mac_address(priv->dev->of_node);
-	if (mac_addr)
+	if (!IS_ERR_OR_NULL(mac_addr))
 		ether_addr_copy(dev->dev_addr, mac_addr);
 
 	/* If the mac address is invalid, use random mac address  */

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -202,8 +202,6 @@ ramips_setup_macs()
 	nexx,wt1520-8m|\
 	nixcore,x1-16m|\
 	nixcore,x1-8m|\
-	olimex,rt5350f-olinuxino|\
-	olimex,rt5350f-olinuxino-evb|\
 	omnima,miniembplug|\
 	planex,mzk-w300nh2|\
 	sitecom,wl-351|\
@@ -226,6 +224,8 @@ ramips_setup_macs()
 	huawei,d105|\
 	hilink,hlk-rm04|\
 	nexaira,bc2|\
+	olimex,rt5350f-olinuxino|\
+	olimex,rt5350f-olinuxino-evb|\
 	petatel,psr-680w|\
 	skyline,sl-r7205)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")


### PR DESCRIPTION
ramips: 5.4: handle ERR_PTR properly
ramips: fix MAC address setup for Olimex RT5350F-OLinuXino devices
ramips: explicitly disable built-in switch for lan-only devices
ramips: remove default interface setup for some subtargets
ramips: rt305x: reset switch before probe
ramips: re-add set_preinit_iface script for rt305x and mt7620