### PR TITLE
mac80211 ath10k: increase rx buffer size to 2048

### DIFF
--- a/package/kernel/mac80211/patches/ath/922-ath10k-increase-rx-buffer-size-to-2048.patch
+++ b/package/kernel/mac80211/patches/ath/922-ath10k-increase-rx-buffer-size-to-2048.patch
@@ -1,0 +1,37 @@
+From: Linus Lüssing <ll@simonwunderlich.de>
+Date: Wed, 5 Feb 2020 20:10:43 +0100
+Subject: ath10k: increase rx buffer size to 2048
+
+Before, only frames with a maximum size of 1528 bytes could be
+transmitted between two 802.11s nodes.
+
+For batman-adv for instance, which adds its own header to each frame,
+we typically need an MTU of at least 1532 bytes to be able to transmit
+without fragmentation.
+
+This patch now increases the maxmimum frame size from 1528 to 1656
+bytes.
+
+Tested with two ath10k devices in 802.11s mode, as well as with
+batman-adv on top of 802.11s with forwarding disabled.
+
+Fix originally found and developed by Ben Greear.
+
+Link: https://github.com/greearb/ath10k-ct/issues/89
+Link: https://github.com/greearb/ath10k-ct/commit/9e5ab25027e0971fa24ccf93373324c08c4e992d
+Cc: Ben Greear <greearb@candelatech.com>
+Signed-off-by: Linus Lüssing <ll@simonwunderlich.de>
+
+Forwarded: https://patchwork.kernel.org/patch/11367055/
+
+--- a/drivers/net/wireless/ath/ath10k/htt.h
++++ b/drivers/net/wireless/ath/ath10k/htt.h
+@@ -2219,7 +2219,7 @@ struct htt_rx_chan_info {
+  * Should be: sizeof(struct htt_host_rx_desc) + max rx MSDU size,
+  * rounded up to a cache line size.
+  */
+-#define HTT_RX_BUF_SIZE 1920
++#define HTT_RX_BUF_SIZE 2048
+ #define HTT_RX_MSDU_SIZE (HTT_RX_BUF_SIZE - (int)sizeof(struct htt_rx_desc))
+ 
+ /* Refill a bunch of RX buffers for each refill round so that FW/HW can handle


### PR DESCRIPTION
Before, only frames with a maximum size of 1528 bytes could be transmitted between two 802.11s nodes.

For batman-adv for instance, which adds its own header to each frame, we typically need an MTU of at least 1532 bytes to be able to transmit without fragmentation.

This patch now increases the maxmimum frame size from 1528 to 1656 bytes.

Tested with two ath10k devices in 802.11s mode, as well as with batman-adv on top of 802.11s with forwarding disabled.

Fix originally found and developed by @greearb and is already part of ath10k-ct

Link: https://github.com/greearb/ath10k-ct/issues/89
Link: https://github.com/greearb/ath10k-ct/commit/9e5ab25027e0971fa24ccf93373324c08c4e992d
Forwarded: https://patchwork.kernel.org/patch/11367055/

----

If this is accepted, please consider also adding it to openwrt-19.07. @T-X detected this problem while working on OpenWrt 19.07.x