### PR TITLE
 ath79: add support for Ubiquiti PowerBeam 5AC 500

### DIFF
--- a/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
+++ b/target/linux/ath79/dts/qca9558_ubnt_powerbeam-5ac-500.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include "qca955x_ubnt_xc.dtsi"
+
+/ {
+	compatible = "ubnt,powerbeam-5ac-500", "ubnt,xc", "qca,qca9558";
+	model = "Ubiquiti PowerBeam 5AC 500";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		phy-mode = "sgmii";
+		reg = <4>;
+		at803x-override-sgmii-link-check;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy4>;
+};

--- a/target/linux/ath79/dts/qca955x_ubnt_xc.dtsi
+++ b/target/linux/ath79/dts/qca955x_ubnt_xc.dtsi
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca955x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -53,6 +53,7 @@ ath79_setup_interfaces()
 	ubnt,nanostation-loco-m|\
 	ubnt,nanostation-loco-m-xw|\
 	ubnt,picostation-m|\
+	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,rocket-m|\
 	ubnt,unifiac-lite|\
@@ -470,6 +471,7 @@ ath79_setup_macs()
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	ubnt,litebeam-ac-gen2|\
+	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2)
 		label_mac=$(mtd_get_mac_binary art 0x5006)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,6 +25,7 @@ case "$FIRMWARE" in
 	ubnt,nanobeam-ac|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
+	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,unifiac-pro|\
 	yuncore,a770)

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -69,6 +69,15 @@ define Device/ubnt-wa
   UBNT_VERSION := 8.5.0
 endef
 
+define Device/ubnt-xc
+  $(Device/ubnt)
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := XC
+  UBNT_CHIP := qca955x
+  UBNT_TYPE := XC
+  UBNT_VERSION := 8.5.0
+endef
+
 define Device/ubnt-xm
   $(Device/ubnt)
   DEVICE_VARIANT := XM
@@ -242,6 +251,15 @@ define Device/ubnt_picostation-m
   SUPPORTED_DEVICES += bullet-m
 endef
 TARGET_DEVICES += ubnt_picostation-m
+
+define Device/ubnt_powerbeam-5ac-500
+  $(Device/ubnt-xc)
+  SOC := qca9558
+  DEVICE_MODEL := PowerBeam 5AC
+  DEVICE_VARIANT := 500
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += ubnt_powerbeam-5ac-500
 
 define Device/ubnt_powerbeam-5ac-gen2
   $(Device/ubnt-wa)

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -138,6 +138,15 @@ struct fw_info fw_info[] = {
 		.sign = true,
 	},
 	{
+		.name = "XC",
+		.fw_layout = {
+			.kern_start	=	0x9f050000,
+			.kern_entry	=	0x80002000,
+			.firmware_max_length=	0x00F60000,
+		},
+		.sign = true,
+	},
+	{
 		.name = "ACB-ISP",
 		.fw_layout = {
 			.kern_start	=	0x9f050000,


### PR DESCRIPTION
These two commits add support for the Ubiquiti PowerBeam 5AC 500 devices. The first one adds the XC board type to mkfwimage and the second one supports the device itself. It depends on https://github.com/openwrt/openwrt/pull/2955, as the names are consecutive.

The RSSI LEDs seem to be connected to a 74HC595 chip according to pictures but, since I couldn't open the device and trace the pins, they are unsupported.

Procedure for flashing is at https://openwrt.org/toh/ubiquiti/common

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>