### PR TITLE
ramips: erx and erx-sfp: set ports to lan and wan default setup

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -43,10 +43,10 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
 	ubnt,edgerouter-x)
-		ucidef_set_interface_lan "eth0 eth1 eth2 eth3 eth4"
+		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;
 	ubnt,edgerouter-x-sfp)
-		ucidef_set_interface_lan "eth0 eth1 eth2 eth3 eth4 eth5"
+		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"


### PR DESCRIPTION
This commit partially reverts 5acd1ed0be0d78847cd7d9d5599526f59babaf4d.
This change was discussed in https://github.com/openwrt/openwrt/pull/2901#discussion_r407238452

There has also been some discussion at https://lists.infradead.org/pipermail/openwrt-devel/2020-April/022988.html
but has more to do with the labels of the ports (ethX, lanX, swXpY) and are
not addressed in the commit.

With commit 5acd1ed0be0d78847cd7d9d5599526f59babaf4d all the ports were put into the lan bridge, with
the arguement that the OEM Firmware does not have a WAN port enabled.  In
the default OEM setup, all of the ports except eth0 are dead and eth0 is
set to a static IP address without providing DHCP services when connected.
It is only after the wizard has been run that eth0 becomes the WAN port
and all the rest of the ports belong to LAN with DHCP enabled.

Having all of the ports set to the LAN bridge does not mirror the default
OEM setup.  To accomplish that, then only eth0 would be in the LAN bridge.
But this is not the expected behaviour of OpenWRT.

Therefore this proposal to set eth0 to WAN and eth1-N to LAN provides the
expected behaviour expected from OpenWrt, maintains the current documentation
as up-to-date, and does not require the user to manually detach eth0 from
the LAN bridge, create the WAN(6) interface(s), and set eth0 to the WAN(6)
interface(s).

Fixes: 5acd1ed0be0d ("ramips: mt7621: fix Ubiquiti ER-X ports names and MAC addresses")
Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>
