### PR TITLE
x86: select pciutils and usbutils by default

### DIFF
--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -19,7 +19,8 @@ KERNELNAME:=bzImage
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += partx-utils mkf2fs e2fsprogs kmod-button-hotplug
+DEFAULT_PACKAGES += partx-utils mkf2fs e2fsprogs pciutils usbutils \
+	kmod-button-hotplug
 
 $(eval $(call BuildTarget))
 


### PR DESCRIPTION
These package are useful by all subtargets, therefore add them to default
packages selection.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>
