### PR TITLE
ramips: fix booting issue for several Japanese mt7621 devices

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -377,6 +377,8 @@ define Device/iodata_wn-ax1167gr2
   IMAGE_SIZE := 51200k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AX1167GR2
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | lzma | uImage lzma
   KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XBC.1)b10 | \
 	iodata-mstc-header
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
@@ -393,6 +395,8 @@ define Device/iodata_wn-ax2033gr
   IMAGE_SIZE := 51200k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-AX2033GR
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | lzma | uImage lzma
   KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(VST.1)C10 | \
 	iodata-mstc-header
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
@@ -409,6 +413,8 @@ define Device/iodata_wn-dx1167r
   IMAGE_SIZE := 51200k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-DX1167R
+  LOADER_TYPE := bin
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | lzma | uImage lzma
   KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XIK.1)b10 | \
 	iodata-mstc-header
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -187,6 +187,7 @@ endef
 TARGET_DEVICES += asus_rt-ac85p
 
 define Device/buffalo_wsr-1166dhp
+  $(Device/uimage-lzma-loader)
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata
   IMAGE_SIZE := 15936k
   DEVICE_VENDOR := Buffalo
@@ -197,6 +198,7 @@ endef
 TARGET_DEVICES += buffalo_wsr-1166dhp
 
 define Device/buffalo_wsr-2533dhpl
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 7936k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-2533DHPL
@@ -284,6 +286,7 @@ endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
 
 define Device/elecom_wrc-1900gst
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 11264k
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-1900GST
@@ -294,6 +297,7 @@ endef
 TARGET_DEVICES += elecom_wrc-1900gst
 
 define Device/elecom_wrc-2533gst
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 11264k
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-2533GST
@@ -354,6 +358,7 @@ endef
 TARGET_DEVICES += hiwifi_hc5962
 
 define Device/iodata_wn-ax1167gr
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 15552k
   KERNEL_INITRAMFS := $$(KERNEL) | \
 	iodata-factory 7864320 4 0x1055 $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.bin
@@ -412,6 +417,7 @@ endef
 TARGET_DEVICES += iodata_wn-dx1167r
 
 define Device/iodata_wn-gx300gr
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 7616k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-GX300GR
@@ -420,6 +426,7 @@ endef
 TARGET_DEVICES += iodata_wn-gx300gr
 
 define Device/iodata_wnpr2600g
+  $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WNPR2600G
   IMAGE_SIZE := 13952k
@@ -716,6 +723,7 @@ endef
 TARGET_DEVICES += phicomm_k2p
 
 define Device/planex_vr500
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500


### PR DESCRIPTION
After switching Kernel 5.4 in ramips/mt7621, several devices fails to boot the official sysupgrade image. These commit fix this issue by using lzma-loader.

I've reported for some devices in these affected devices as "kernel 5.4 works fine" on the mailing list, but I didn't test with the same configuration of official build and the uncompressed kernel size I've compiled is smaller, sorry...