### PR TITLE
elfutils: powerpc build fix

### DIFF
--- a/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
+++ b/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
@@ -1,0 +1,34 @@
+From http://cgit.openembedded.org/openembedded-core/plain/meta/recipes-devtools/elfutils/files/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
+
+From 2e2232d0935bf8ef6e66ebffba3be68a73b5b3e5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 8 Sep 2019 15:57:59 -0700
+Subject: [PATCH] ppc_initreg.c: Incliude asm/ptrace.h for pt_regs definition
+
+Fixes
+| ../../elfutils-0.176/backends/ppc_initreg.c:79:22: error: field 'r' has incomplete type
+|       struct pt_regs r;
+|                      ^
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ backends/ppc_initreg.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/backends/ppc_initreg.c b/backends/ppc_initreg.c
+index 0e0d359..e5cca7e 100644
+--- a/backends/ppc_initreg.c
++++ b/backends/ppc_initreg.c
+@@ -33,6 +33,7 @@
+ #include <stdlib.h>
+ #if defined(__powerpc__) && defined(__linux__)
+ # include <sys/ptrace.h>
++# include <asm/ptrace.h>
+ # include <sys/user.h>
+ #endif
+ 
+-- 
+2.23.0
+


### PR DESCRIPTION
 ppc_initreg.c: In function 'ppc_set_initial_registers_tid':
 ppc_initreg.c:79:22: error: field 'r' has incomplete type
        struct pt_regs r;

Fixes: FS#2924

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>