### PR TITLE
firewall: add rule for traceroute support

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -129,6 +129,19 @@ config rule
 	option proto		udp
 	option target		ACCEPT
 
+# allow interoperability with traceroute classic
+# note that traceroute uses a fixed port range, and depends on getting
+# back ICMP Unreachables.  if we're operating in DROP mode, it won't
+# work so we explicitly REJECT packets on these ports.
+config rule
+	option name		Support-UDP-Traceroute
+	option src		wan
+	option dest_port	33434:33689
+	option proto		udp
+	option family		ipv4
+	option target		REJECT
+	option enabled		false
+
 # include a file with users custom iptables rules
 config include
 	option path /etc/firewall.user


### PR DESCRIPTION
Built and tested on master HEAD with x86_64 generic image.  Installed rule, deleted the `option enabled false` line, restarted the firewall, then ran `traceroute` from an external site pointed back at my router's public address.

Traceroute got to the router but then stopped there.
