### PR TITLE
[RFT] ramips: fix MikroTik 750Gr3 ports MAC addresses

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_usr;
 		led-running = &led_usr;
 		led-upgrade = &led_usr;
+		label-mac-device = &gmac0;
 	};
 
 	chosen {
@@ -131,7 +132,6 @@
 
 &gmac0 {
 	mtd-mac-address = <&hard_config 0x0010>;
-	mtd-mac-address-increment = <1>;
 };
 
 &switch0 {
@@ -139,28 +139,34 @@
 		port@0 {
 			status = "okay";
 			label = "wan";
-			mtd-mac-address = <&hard_config 0x0010>;
-			mtd-mac-address-increment = <2>;
 		};
 
 		port@1 {
 			status = "okay";
 			label = "lan2";
+			mtd-mac-address = <&hard_config 0x0010>;
+			mtd-mac-address-increment = <1>;
 		};
 
 		port@2 {
 			status = "okay";
 			label = "lan3";
+			mtd-mac-address = <&hard_config 0x0010>;
+			mtd-mac-address-increment = <2>;
 		};
 
 		port@3 {
 			status = "okay";
 			label = "lan4";
+			mtd-mac-address = <&hard_config 0x0010>;
+			mtd-mac-address-increment = <3>;
 		};
 
 		port@4 {
 			status = "okay";
 			label = "lan5";
+			mtd-mac-address = <&hard_config 0x0010>;
+			mtd-mac-address-increment = <4>;
 		};
 	};
 };


### PR DESCRIPTION
According to a user in OpenWrt forum, on RouterOS the MAC addresses are
ether1(WAN) = MAC
ether2(LAN2) = MAC+1
ether3(LAN3) = MAC+2
etc.

Fix the MAC addresses in OpenWrt.

Ref: https://forum.openwrt.org/t/few-dumb-question-about-mt7530-rb750gr3-dsa/61608