### PR TITLE
ramips: mt7621: refactor set affinity script

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
@@ -2,30 +2,18 @@
 
 START=99
 
-get_irq() {
-	local name="$1"
-	grep -m 1 "$name" /proc/interrupts | cut -d: -f1 | sed 's, *,,'
-}
-
-set_irq_affinity() {
-	local name="$1"
-	local val="$2"
-	local irq="$(get_irq "$name")"
-	[ -n "$irq" ] || return
-	echo "$val" > "/proc/irq/$irq/smp_affinity"
-}
-
 start() {
 	if grep -q 'processor.*: 2' /proc/cpuinfo; then
-		mask1=4
-		mask2=8
+		mask=4
 	elif grep -q 'processor.*: 1' /proc/cpuinfo; then
-		mask1=2
-		mask2=2
+		mask=2
 	else
 		return
 	fi
 
-	set_irq_affinity mt76x2e $mask1
-	set_irq_affinity mt7603e $mask2
+	for irq in $(grep "mt76..e" /proc/interrupts | cut -d: -f1 | sed 's, *,,')
+	do
+		echo "$mask" > "/proc/irq/$irq/smp_affinity"
+		[ $mask = 4 ] && mask=8
+	done
 }


### PR DESCRIPTION
The current one only looks for mt76x2e and mt7603e, and
does not work for 2 or more same Wi-Fi chips.
Refactor the script to cover those cases.

ping @nbd168