### PR TITLE
WIP hostapd: remove trailing || (19.07)

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -361,7 +361,7 @@ define Package/hostapd-utils
   CATEGORY:=Network
   TITLE:=IEEE 802.1x Authenticator (utils)
   URL:=http://hostap.epitest.fi/
-  DEPENDS:=@$(subst $(space),||,$(foreach pkg,$(HOSTAPD_PROVIDERS),PACKAGE_$(pkg)))
+  DEPENDS:=@$(patsubst %||,%,$(subst $(space),||,$(foreach pkg,$(HOSTAPD_PROVIDERS),PACKAGE_$(pkg))))
 endef
 
 define Package/hostapd-utils/description
@@ -372,7 +372,7 @@ endef
 define Package/wpa-cli
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=@$(subst $(space),||,$(foreach pkg,$(SUPPLICANT_PROVIDERS),PACKAGE_$(pkg)))
+  DEPENDS:=@$(subst " ",||,$(foreach pkg,$(SUPPLICANT_PROVIDERS),PACKAGE_$(pkg)))
   TITLE:=WPA Supplicant command line control utility
 endef
 


### PR DESCRIPTION
hostapd-utils uses this to compile dependencies:
  `DEPENDS:=@$(subst $(space),||,$(foreach pkg,$(HOSTAPD_PROVIDERS),PACKAGE_$(pkg)))`

that expands to
`PACKAGE_hostapd PACKAGE_hostapd-basic PACKAGE_hostapd-mini PACKAGE_hostapd-openssl PACKAGE_hostapd-wolfssl PACKAGE_wpad PACKAGE_wpad-mesh-openssl PACKAGE_wpad-mesh-wolfssl PACKAGE_wpad-basic PACKAGE_wpad-mini PACKAGE_wpad-openssl PACKAGE_wpad-wolfssl||`

notice the `||` at the end.

in tmp/.config-package.in, this results in a syntax error:

```
    depends on PACKAGE_PACKAGE_wpad-openssl
    depends on PACKAGE_PACKAGE_wpad-wolfssl||
    depends on PACKAGE_PACKAGE_hostapd-basic
```

wpa-cli uses the same mechanism and it also produces an error

i assume this happens because the newline also matches `$(space)`.
this commit offers two options for fixing the issue:
1 - remove the `||` at the end (`a||b||c||` -> `a||b||c`)
2 - use `" "` to match only `\x20` (i don't know whether there's a reason to use `$(space)`)

i'll edit the commit once a solution has been chosen.