### PR TITLE
ramips: fix initramfs image for I-O DATA mt7621 devices

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -386,8 +386,8 @@ define Device/iodata_wn-ax1167gr2
   $(Device/iodata_nand)
   UIMAGE_MAGIC := 0x434f4d42
   DEVICE_MODEL := WN-AX1167GR2
-  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XBC.1)b10 | \
-	iodata-mstc-header
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	custom-initramfs-uimage 3.10(XBC.1)b10 | iodata-mstc-header
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr2
@@ -396,8 +396,8 @@ define Device/iodata_wn-ax2033gr
   $(Device/iodata_nand)
   UIMAGE_MAGIC := 0x434f4d42
   DEVICE_MODEL := WN-AX2033GR
-  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(VST.1)C10 | \
-	iodata-mstc-header
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	custom-initramfs-uimage 3.10(VST.1)C10 | iodata-mstc-header
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e wpad-basic
 endef
 TARGET_DEVICES += iodata_wn-ax2033gr
@@ -406,8 +406,8 @@ define Device/iodata_wn-dx1167r
   $(Device/iodata_nand)
   UIMAGE_MAGIC := 0x434f4d43
   DEVICE_MODEL := WN-DX1167R
-  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XIK.1)b10 | \
-	iodata-mstc-header
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	custom-initramfs-uimage 3.10(XIK.1)b10 | iodata-mstc-header
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef
 TARGET_DEVICES += iodata_wn-dx1167r


### PR DESCRIPTION
This is additional fix of c998ae7f0e9bd51be4935055efbc3834a92698b1.

The sysupgrade image of I-O DATA MT7621 devices manufactured by MSTC
(MitraStar Technology Corp.) faced to the booting issue. This was caused
by imcomplete extraction of large kernel image by U-Boot, and this issue
is occurred in initramfs image after fixing of sysupgrade image.
So, use lzma-loader for initramfs image to fix the issue.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
Co-developed-by: Yanase Yuki <dev@zpc.sakura.ne.jp>
Signed-off-by: Yanase Yuki <dev@zpc.sakura.ne.jp>
Tested-by: Yanase Yuki <dev@zpc.sakura.ne.jp> [wn-ax2033gr]

I've tested the official initramfs image when working to fix sysupgrade, the image works and I've fixed only sysupgrade image. But after being merged, the lzma extraction issue is reported by zpc and I tested the new initramfs image on WN-AX1167GR2, the same issue occurred...