### PR TITLE
[RFT] kirkwood: increase kernel size of Linksys EA3500

### DIFF
--- a/target/linux/kirkwood/files-5.4/arch/arm/boot/dts/kirkwood-linksys-audi.dts
+++ b/target/linux/kirkwood/files-5.4/arch/arm/boot/dts/kirkwood-linksys-audi.dts
@@ -165,22 +165,22 @@
 
 		partition@200000 {
 			label = "kernel1";
-			reg = <0x200000 0x290000>;
+			reg = <0x200000 0x300000>;
 		};
 
-		partition@490000 {
+		partition@500000 {
 			label = "rootfs1";
-			reg = <0x490000 0x1170000>;
+			reg = <0x500000 0x1100000>;
 		};
 
 		partition@1600000 {
 			label = "kernel2";
-			reg = <0x1600000 0x290000>;
+			reg = <0x1600000 0x300000>;
 		};
 
-		partition@1890000 {
+		partition@1900000 {
 			label = "rootfs2";
-			reg = <0x1890000 0x1170000>;
+			reg = <0x1900000 0x1100000>;
 		};
 
 		partition@2a00000 {

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -86,12 +86,11 @@ define Device/linksys_audi
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
-  KERNEL_SIZE := 2624k
+  KERNEL_SIZE := 3072k
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
   BOARD_NAME := linksys-audi
-  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_audi
 


### PR DESCRIPTION
Linksys Audi EA3500 after DSA enable have to small kernel partition
size. This patch change kernel partition to maksimum size allowed by
u-boot.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>

I don't have this device. Could anyone test it?
