### PR TITLE
sunxi: Fix WiFi on Sinovoip Banana Pi M2 Ultra

### DIFF
--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -66,7 +66,8 @@ TARGET_DEVICES += lemaker_bananapi
 define Device/lemaker_bananapi-m2-ultra
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi M2 Ultra
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
+	brcmfmac-firmware-43430a0-sdio wpad-basic
   SOC := sun8i-r40
 endef
 TARGET_DEVICES += lemaker_bananapi-m2-ultra

--- a/target/linux/sunxi/image/cortex-a7.mk
+++ b/target/linux/sunxi/image/cortex-a7.mk
@@ -63,14 +63,15 @@ define Device/lemaker_bananapi
 endef
 TARGET_DEVICES += lemaker_bananapi
 
-define Device/lemaker_bananapi-m2-ultra
-  DEVICE_VENDOR := LeMaker
+define Device/sinovoip_bananapi-m2-ultra
+  DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
 	brcmfmac-firmware-43430a0-sdio wpad-basic
+  SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
   SOC := sun8i-r40
 endef
-TARGET_DEVICES += lemaker_bananapi-m2-ultra
+TARGET_DEVICES += sinovoip_bananapi-m2-ultra
 
 define Device/lemaker_bananapro
   DEVICE_VENDOR := LeMaker


### PR DESCRIPTION
This enables onboard WiFi (AP6212) out of the box

Suggestion from @juanesf. Tested on trunk, onboard WiFi is now working.

Signed-off-by: Hal Martin <hal.martin@gmail.com>