### PR TITLE
lantiq: add support for AVM FRITZ!Box 7430

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7430", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7430";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_info_red;
+		led-running = &led_power;
+		led-upgrade = &led_info_green;
+
+		led-dsl = &led_info_green;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		dect {
+			label = "dect";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "fritz7430:green:power";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_info_green: info_green {
+			label = "fritz7430:green:info";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info_red: info_red {
+			label = "fritz7430:red:info";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			label = "fritz7430:green:wifi";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		dect {
+			label = "fritz7430:green:dect";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		fon {
+			label = "fritz7430:green:fon";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <0 0x0 0x8000000>;
+		lantiq,cs = <1>;
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "urlader";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "nand-tffs";
+				reg = <0x40000 0x400000>;
+				read-only;
+			};
+
+			partition@440000 {
+				label = "kernel";
+				reg = <0x440000 0x400000>;
+			};
+
+			partition@840000 {
+				label = "ubi";
+				reg = <0x840000 0x3000000>;
+			};
+
+			partition@3840000 {
+				label = "reserved-kernel";
+				reg = <0x3840000 0x400000>;
+				read-only;
+			};
+
+			partition@3c40000 {
+				label = "reserved-filesystem";
+				reg = <0x3c40000 0x3000000>;
+				read-only;
+			};
+
+			partition@6c40000 {
+				label = "config";
+				reg = <0x6c40000 0x200000>;
+				read-only;
+			};
+
+			partition@6e40000 {
+				label = "nand-filesystem";
+				reg = <0x6e40000 0x11c0000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 11 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <2>;
+		#address-cells = <3>;
+		device_type = "pci";
+
+		wifi@168c,abcd {
+			compatible = "pci168c,abcd";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "mii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <3>;
+			phy-mode = "mii";
+			phy-handle = <&phy12>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "mii";
+			phy-handle = <&phy13>;
+		};
+
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "mii";
+			phy-handle = <&phy14>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy12: ethernet-phy@12 {
+			reg = <0x12>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy14: ethernet-phy@14 {
+			reg = <0x14>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pcie-rst {
+			lantiq,pins = "io11";
+			lantiq,open-drain = <1>;
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz7430", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7430";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_info_red;
+		led-running = &led_power;
+		led-upgrade = &led_info_green;
+
+		led-dsl = &led_info_green;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		dect {
+			label = "dect";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_PHONE>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "fritz7430:green:power";
+			gpios = <&gpio 31 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_info_green: info_green {
+			label = "fritz7430:green:info";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info_red: info_red {
+			label = "fritz7430:red:info";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			label = "fritz7430:green:wifi";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		dect {
+			label = "fritz7430:green:dect";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		fon {
+			label = "fritz7430:green:fon";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&localbus {
+	flash@0 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <0 0x0 0x8000000>;
+		lantiq,cs = <1>;
+
+		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
+		pinctrl-names = "default";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "urlader";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "nand-tffs";
+				reg = <0x40000 0x400000>;
+				read-only;
+			};
+
+			partition@440000 {
+				label = "kernel";
+				reg = <0x440000 0x400000>;
+			};
+
+			partition@840000 {
+				label = "ubi";
+				reg = <0x840000 0x3000000>;
+			};
+
+			partition@3840000 {
+				label = "reserved-kernel";
+				reg = <0x3840000 0x400000>;
+				read-only;
+			};
+
+			partition@3c40000 {
+				label = "reserved-filesystem";
+				reg = <0x3c40000 0x3000000>;
+				read-only;
+			};
+
+			partition@6c40000 {
+				label = "config";
+				reg = <0x6c40000 0x200000>;
+				read-only;
+			};
+
+			partition@6e40000 {
+				label = "nand-filesystem";
+				reg = <0x6e40000 0x11c0000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 11 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <2>;
+		#address-cells = <3>;
+		device_type = "pci";
+
+		wifi@168c,abcd {
+			compatible = "pci168c,abcd";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "mii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@3 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <3>;
+			phy-mode = "mii";
+			phy-handle = <&phy12>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "mii";
+			phy-handle = <&phy13>;
+		};
+
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "mii";
+			phy-handle = <&phy14>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy12: ethernet-phy@12 {
+			reg = <0x12>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy14: ethernet-phy@14 {
+			reg = <0x14>;
+			compatible = "lantiq,phy22f", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		pcie-rst {
+			lantiq,pins = "io11";
+			lantiq,open-drain = <1>;
+			lantiq,output = <1>;
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -148,6 +148,17 @@ define Device/avm_fritz7412
 endef
 TARGET_DEVICES += avm_fritz7412
 
+define Device/avm_fritz7430
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7430
+  BOARD_NAME := FRITZ7430
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic fritz-tffs-nand fritz-caldata
+endef
+TARGET_DEVICES += avm_fritz7430
+
 define Device/bt_homehub-v5a
   $(Device/NAND)
   DEVICE_VENDOR := British Telecom

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -43,6 +43,10 @@ lantiq_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "6t@eth0"
 		;;
+	avm,fritz7430)
+		ucidef_add_switch "switch0" \
+			"2:lan:3" "3:lan:4" "4:lan:1" "5:lan:2" "6t@eth0"
+		;;
 	bt,homehub-v5a)
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:4" "2:lan:2" "4:lan:1" "5:wan:5" "6t@eth0"
@@ -84,7 +88,8 @@ lantiq_setup_dsl()
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
-	avm,fritz7412)
+	avm,fritz7412|\
+	avm,fritz7430)
 		annex="b"
 		;;
 	esac
@@ -134,7 +139,8 @@ lantiq_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
 		;;
-	avm,fritz7412)
+	avm,fritz7412|\
+	avm,fritz7430)
 		tffsdev=$(find_mtd_chardev "nand-tffs")
 		lan_mac=$(/usr/bin/fritz_tffs_nand -d $tffsdev -n maca -o)
 		wan_mac=$(/usr/bin/fritz_tffs_nand -d $tffsdev -n macdsl -o)

--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -19,7 +19,8 @@ case "$FIRMWARE" in
 			avm,fritz7360sl)
 				caldata_extract "urlader" 0x985 0x1000
 				;;
-			avm,fritz7412)
+			avm,fritz7412|\
+			avm,fritz7430)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 4096 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
 				;;
 			bt,homehub-v5a)

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -13,6 +13,7 @@ platform_do_upgrade() {
 	avm,fritz3370-rev2-micron|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
+	avm,fritz7430|\
 	bt,homehub-v5a|\
 	zyxel,p-2812hnu-f1|\
 	zyxel,p-2812hnu-f3)


### PR DESCRIPTION
Hardware:
- SoC: Lantiq VRX 220
- CPU: 2x MIPS 34Kc 500 MHz
- RAM: 128 MiB 250 MHz
- Flash: 128 MiB NAND
- Ethernet: Built-in Fast Ethernet switch, 4 ports used
- Wifi: Atheros AR9381-AL1A b/g/n with 2 pcb/internal and 1 external antennas
- USB: 1x USB 2.0
- DSL: Built-in A/VDSL2 modem
- DECT: Dialog SC14441
- LEDs: 1 two-color, 4 one-color
- Buttons: 1x DECT, 1x WIFI
- Telephone connectors: 1 FXS port via TAE or RJ11 connector

With the exception of FXS/DECT everything works
(there are no drivers for AVM's FXS or DECT implementation),
DSL is yet untested.

Installation:
Boot up the device and wait a few seconds. Run the eva_ramboot.py script
in scripts/flashing/ to load the initramfs image on the device:
$ ./scripts/flashing/eva_ramboot.py 192.168.178.1 &lt;path to your initramfs image&gt;
If the script fails to reach the device, maybe try 169.254.120.1.

Wait until booting is complete. You should now be able to reach your device
under the default ip address 192.168.1.1.

Before flashing, check if linux_fs_start is not set to 1 in the tffs partition:
$ fritz_tffs_nand -d /dev/mtd1 -n linux_fs_start
If linux_fs_start is 1, you will need to reset it to 0, either by FTP,
upgrading FritzOS or doing a recovery.

Now you should be able to flash the device using sysupgrade.

Signed-off-by: Leon Maurice Adam &lt;leon.adam@aol.de&gt;