### PR TITLE
ramips: add support for Tenda A6 (WL0175, RT5350)

### DIFF
--- a/target/linux/ramips/dts/rt5350_tenda_a6.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_a6.dts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tenda,a6", "ralink,rt5350-soc";
+	model = "Tenda A6";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "a6:blue:power";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x3b0000>;
+			};
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uartf", "led";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&esw {
+	mediatek,portmap = <0x1>;
+	mediatek,portdisable = <0x3e>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1026,6 +1026,18 @@ define Device/tenda_3g300m
 endef
 TARGET_DEVICES += tenda_3g300m
 
+define Device/tenda_a6
+  SOC := rt5350
+  IMAGE_SIZE := 3776k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	poray-header -B A6 -F 4M
+  DEVICE_VENDOR := Tenda
+  DEVICE_MODEL := A6
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2
+endef
+TARGET_DEVICES += tenda_a6
+
 define Device/tenda_w150m
   SOC := rt3050
   IMAGE_SIZE := 3776k

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -53,6 +53,7 @@ ramips_setup_interfaces()
 	netgear,wnce2001|\
 	tenda,3g150b|\
 	tenda,3g300m|\
+	tenda,a6|\
 	tenda,w150m|\
 	unbranded,a5-v11|\
 	wansview,ncs601w|\

--- a/tools/firmware-utils/src/mkporayfw.c
+++ b/tools/firmware-utils/src/mkporayfw.c
@@ -61,6 +61,7 @@
 #define HWID_NEXX_WT1520	0x30353332
 #define HWID_NEXX_WT3020	0x30323033
 #define HWID_A5_V11		0x32473352
+#define HWID_A6			0x32473352
 
 /* Recognized XOR obfuscation keys */
 #define KEY_HAME		0
@@ -71,6 +72,7 @@
 #define KEY_NEXX_1		5
 #define KEY_NEXX_2		6
 #define KEY_A5_V11		7
+#define KEY_A6			8
 
 /* XOR key length */
 #define KEY_LEN			15
@@ -146,6 +148,11 @@ static struct board_info boards[] = {
 		.hw_id          = HWID_A5_V11,
 		.layout_id      = "4M",
 		.key            = KEY_A5_V11,
+        }, {
+		.id             = "A6",
+		.hw_id          = HWID_A6,
+		.layout_id      = "4M",
+		.key            = KEY_A6,
         }, {
 		.id		= "MPR-A1",
 		.hw_id		= HWID_HAME_MPR_A1_L8,


### PR DESCRIPTION
Hi

Small patch to include support for Tenda A6 mini wireless router

Specifications are already detailed at https://openwrt.org/toh/tenda/a6

I have published additional details at following custom build github page, which I am using/offering until device support is official: https://github.com/fragtion/openwrt-hardware/tree/master/tenda-a6

As my builds are working very well for me, it would be nice to make this more widely available/accessible to the general public

Thank you for your consideration :)

Signed-off-by: Dimitri Pappas <fragtion@gmail.com>