### PR TITLE
uhttpd: make organization (O=) of the cert configurable via uci

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -35,13 +35,14 @@ generate_keys() {
 	local cfg="$1"
 	local key="$2"
 	local crt="$3"
-	local days bits country state location commonname
+	local days bits country state location organization commonname
 
 	config_get days       "$cfg" days
 	config_get bits       "$cfg" bits
 	config_get country    "$cfg" country
 	config_get state      "$cfg" state
 	config_get location   "$cfg" location
+	config_get organization "$cfg" organization
 	config_get commonname "$cfg" commonname
 	config_get key_type   "$cfg" key_type
 	config_get ec_curve   "$cfg" ec_curve
@@ -56,7 +57,7 @@ generate_keys() {
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${commonname:-OpenWrt}$UNIQUEID"/CN="${commonname:-OpenWrt}"
+			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt}"/CN="${commonname:-OpenWrt}"/UID="$UNIQUEID"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"


### PR DESCRIPTION
... and move the UNIQUEID to the UID (userID) field.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
