### PR TITLE
sunxi: add support for FriendlyARM NanoPi R1

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -172,6 +172,12 @@ define U-Boot/nanopi_neo
   BUILD_DEVICES:=friendlyarm_nanopi-neo
 endef
 
+define U-Boot/nanopi_r1
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=U-Boot for NanoPi R1 (H3)
+  BUILD_DEVICES:=friendlyarm_nanopi-r1
+endef
+
 define U-Boot/orangepi_r1
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi R1 (H2+)
@@ -310,6 +316,7 @@ UBOOT_TARGETS := \
 	nanopi_neo_air \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
+	nanopi_r1 \
 	orangepi_zero \
 	orangepi_r1 \
 	orangepi_one \

--- a/package/boot/uboot-sunxi/patches/252-sunxi-h3-add-support-for-nanopi-r1.patch
+++ b/package/boot/uboot-sunxi/patches/252-sunxi-h3-add-support-for-nanopi-r1.patch
@@ -1,0 +1,206 @@
+From 0e8043aff1aae95d1f7b7422b91b57d9569860d3 Mon Sep 17 00:00:00 2001
+From: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+Date: Mon, 12 Oct 2020 18:39:53 +0000
+Subject: [PATCH] sunxi: add support for FriendlyARM NanoPi R1
+
+Signed-off-by: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+---
+ arch/arm/dts/Makefile               |   1 +
+ arch/arm/dts/sun8i-h3-nanopi-r1.dts | 146 ++++++++++++++++++++++++++++
+ configs/nanopi_r1_defconfig         |  22 +++++
+ 3 files changed, 169 insertions(+)
+ create mode 100644 arch/arm/dts/sun8i-h3-nanopi-r1.dts
+ create mode 100644 configs/nanopi_r1_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index c3d4a44d040..86a7c0455e8 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -531,6 +531,7 @@ dtb-$(CONFIG_MACH_SUN8I_H3) += \
+ 	sun8i-h3-nanopi-m1-plus.dtb \
+ 	sun8i-h3-nanopi-neo.dtb \
+ 	sun8i-h3-nanopi-neo-air.dtb \
++	sun8i-h3-nanopi-r1.dtb \
+ 	sun8i-h3-orangepi-2.dtb \
+ 	sun8i-h3-orangepi-lite.dtb \
+ 	sun8i-h3-orangepi-one.dtb \
+diff --git a/arch/arm/dts/sun8i-h3-nanopi-r1.dts b/arch/arm/dts/sun8i-h3-nanopi-r1.dts
+new file mode 100644
+index 00000000000..df7c9f91f8b
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h3-nanopi-r1.dts
+@@ -0,0 +1,146 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2019 Igor Pecovnik <igor@armbian.com>
++ * Copyright (C) 2020 Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
++ */
++
++/* NanoPi R1 is based on the NanoPi-H3 design from FriendlyARM */
++#include "sun8i-h3-nanopi.dtsi"
++
++/ {
++	model = "FriendlyARM NanoPi R1";
++	compatible = "friendlyarm,nanopi-r1", "allwinner,sun8i-h3";
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		pinctrl-names = "default";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>;
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
++	};
++
++	leds {
++		/delete-node/ pwr;
++		status {
++			label = "nanopi:red:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		wan {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++
++		lan {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r_gpio_keys {
++		pinctrl-names = "default";
++		pinctrl-0 = <&sw_r_npi>;
++
++		/delete-node/ k1;
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	sdio_wifi: sdio_wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&r_pio {
++	sw_r_npi: key_pins {
++		pins = "PL3";
++		function = "gpio_in";
++	};
++};
+diff --git a/configs/nanopi_r1_defconfig b/configs/nanopi_r1_defconfig
+new file mode 100644
+index 00000000000..e028b41a46e
+--- /dev/null
++++ b/configs/nanopi_r1_defconfig
+@@ -0,0 +1,22 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_SPL=y
++CONFIG_MACH_SUN8I_H3=y
++CONFIG_DRAM_CLK=408
++CONFIG_DRAM_ZQ=3881979
++CONFIG_DRAM_ODT_EN=y
++CONFIG_MACPWR="PD6"
++# CONFIG_VIDEO_DE2 is not set
++CONFIG_NR_DRAM_BANKS=1
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_CONSOLE_MUX=y
++CONFIG_SYS_CLK_FREQ=480000000
++# CONFIG_CMD_FLASH is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-r1"
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2

--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+. /lib/functions/leds.sh
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+boardname="${board##*,}"
+
+board_config_update
+
+case $board in
+friendlyarm,nanopi-r1)
+	ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/sunxi/base-files/etc/board.d/02_network
+++ b/target/linux/sunxi/base-files/etc/board.d/02_network
@@ -8,6 +8,9 @@
 board_config_update
 
 case $(board_name) in
+friendlyarm,nanopi-r1)
+	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	;;
 lamobo,lamobo-r1)
 	ucidef_add_switch "switch0" \
 		"4:lan:1" "0:lan:2" "1:lan:3" "2:lan:4" "3:wan" "8@eth0"

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -47,6 +47,16 @@ define Device/friendlyarm_nanopi-neo-air
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
 
+define Device/friendlyarm_nanopi-r1
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R1
+  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb2 kmod-usb-net-rtl8152 \
+	kmod-brcmfmac kmod-leds-gpio kmod-ledtrig-heartbeat wpad-basic-wolfssl \
+	brcmfmac-firmware-43430-sdio
+  SOC := sun8i-h3
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r1
+
 define Device/friendlyarm_zeropi
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := ZeroPi

--- a/target/linux/sunxi/patches-5.4/100-sunxi-h3-add-support-for-nanopi-r1.patch
+++ b/target/linux/sunxi/patches-5.4/100-sunxi-h3-add-support-for-nanopi-r1.patch
@@ -1,0 +1,193 @@
+From 5aee0b1272cd5b42933ef629d66b677669e2e8d2 Mon Sep 17 00:00:00 2001
+From: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+Date: Mon, 12 Oct 2020 05:24:51 +0000
+Subject: [PATCH] sunxi: add support for friendlyarm nanopi r1
+
+Signed-off-by: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+---
+ .../devicetree/bindings/arm/sunxi.yaml        |   5 +
+ arch/arm/boot/dts/Makefile                    |   1 +
+ arch/arm/boot/dts/sun8i-h3-nanopi-r1.dts      | 146 ++++++++++++++++++
+ 3 files changed, 152 insertions(+)
+ create mode 100644 arch/arm/boot/dts/sun8i-h3-nanopi-r1.dts
+
+diff --git a/Documentation/devicetree/bindings/arm/sunxi.yaml b/Documentation/devicetree/bindings/arm/sunxi.yaml
+index 972b1e9ee80..048a2a08806 100644
+--- a/Documentation/devicetree/bindings/arm/sunxi.yaml
++++ b/Documentation/devicetree/bindings/arm/sunxi.yaml
+@@ -241,6 +241,11 @@ properties:
+           - const: friendlyarm,nanopi-neo-plus2
+           - const: allwinner,sun50i-h5
+ 
++      - description: FriendlyARM NanoPi R1
++        items:
++          - const: friendlyarm,nanopi-r1
++          - const: allwinner,sun8i-h3
++
+       - description: Gemei G9 Tablet
+         items:
+           - const: gemei,g9
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index f0069eea70f..c4c1356a06b 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -1109,6 +1109,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h3-nanopi-m1-plus.dtb \
+ 	sun8i-h3-nanopi-neo.dtb \
+ 	sun8i-h3-nanopi-neo-air.dtb \
++	sun8i-h3-nanopi-r1.dtb \
+ 	sun8i-h3-orangepi-2.dtb \
+ 	sun8i-h3-orangepi-lite.dtb \
+ 	sun8i-h3-orangepi-one.dtb \
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-r1.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-r1.dts
+new file mode 100644
+index 00000000000..df7c9f91f8b
+--- /dev/null
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-r1.dts
+@@ -0,0 +1,146 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2019 Igor Pecovnik <igor@armbian.com>
++ * Copyright (C) 2020 Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
++ */
++
++/* NanoPi R1 is based on the NanoPi-H3 design from FriendlyARM */
++#include "sun8i-h3-nanopi.dtsi"
++
++/ {
++	model = "FriendlyARM NanoPi R1";
++	compatible = "friendlyarm,nanopi-r1", "allwinner,sun8i-h3";
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		pinctrl-names = "default";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>;
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
++	};
++
++	leds {
++		/delete-node/ pwr;
++		status {
++			label = "nanopi:red:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		wan {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++
++		lan {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r_gpio_keys {
++		pinctrl-names = "default";
++		pinctrl-0 = <&sw_r_npi>;
++
++		/delete-node/ k1;
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	sdio_wifi: sdio_wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&r_pio {
++	sw_r_npi: key_pins {
++		pins = "PL3";
++		function = "gpio_in";
++	};
++};

--- a/target/linux/sunxi/patches-5.4/300-sunxi-h3-suppress-clock-frequency-warning.patch
+++ b/target/linux/sunxi/patches-5.4/300-sunxi-h3-suppress-clock-frequency-warning.patch
@@ -1,0 +1,56 @@
+From 110a7e180c605022cbc9a7be541f734c7b7789f3 Mon Sep 17 00:00:00 2001
+From: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+Date: Mon, 12 Oct 2020 18:20:51 +0000
+Subject: [PATCH] sunxi: add clock-frequency property to sun8i-h3
+
+This patch suppresses the warning of missing clock-frequency
+property for sun8i h3 based boards.
+
+dmesg:
+
+[    0.002860] /cpus/cpu@0 missing clock-frequency property
+[    0.002895] /cpus/cpu@1 missing clock-frequency property
+[    0.002926] /cpus/cpu@2 missing clock-frequency property
+[    0.002956] /cpus/cpu@3 missing clock-frequency property
+
+Signed-off-by: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>
+---
+ arch/arm/boot/dts/sun8i-h3.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index 6056f206c9e..307a25b01d7 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -78,6 +78,7 @@
+ 			clock-names = "cpu";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 			#cooling-cells = <2>;
++			clock-frequency = <1296000000>;
+ 		};
+ 
+ 		cpu1: cpu@1 {
+@@ -88,6 +89,7 @@
+ 			clock-names = "cpu";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 			#cooling-cells = <2>;
++			clock-frequency = <1296000000>;
+ 		};
+ 
+ 		cpu2: cpu@2 {
+@@ -98,6 +100,7 @@
+ 			clock-names = "cpu";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 			#cooling-cells = <2>;
++			clock-frequency = <1296000000>;
+ 		};
+ 
+ 		cpu3: cpu@3 {
+@@ -108,6 +111,7 @@
+ 			clock-names = "cpu";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 			#cooling-cells = <2>;
++			clock-frequency = <1296000000>;
+ 		};
+ 	};
+ 


### PR DESCRIPTION
Specification:
- CPU: Allwinner H3, Quad-core Cortex-A7 Up to 1.2GHz
- DDR3 RAM: 512MB/1GB
- Network:
    - 10/100/1000M Ethernet x 1，
    - 10/100M Ethernet x 1
- WiFi: 802.11b/g/n, with SMA antenna interface
- USB Host: Type-A x2
- MicroSD Slot x 1
- MicroUSB: for OTG and power input
- Debug Serial Port: 3Pin 2.54mm pitch pin-header
- Power Supply: DC 5V/2A

Installation:
- Write the image file to an SD Card with dd or any image burning tool
- Boot NanoPi from the SD Card

The following features are working and tested:
- Ethernet ports
    - 10/100/1000M Ethernet
    - 10/100M Ethernet
- LED:
    - nanopi:red:status
    - nanopi:green:wan
    - nanopi:green:lan
- KEY:
    - reset

Signed-off-by: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>