### PR TITLE
ath79: add support for TP-Link TL-WPA8630P v2

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2-de.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2-de.dts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_tl-wpa8630p-v2.dtsi"
+
+/ {
+	compatible = "tplink,tl-wpa8630p-v2-de", "qca,qca9563";
+	model = "TP-Link WPA8630P v2 (DE)";
+};
+
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x040000 0x5e0000>;
+			};
+
+			partition@620000 {
+				label = "partition-table";
+				reg = <0x620000 0x010000>;
+				read-only;
+			};
+
+			partition@630000 {
+				label = "tplink";
+				reg = <0x630000 0x1b0000>;
+				read-only;
+			};
+
+			mac: partition@7e0000 {
+				label = "mac";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2-eu.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2-eu.dts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_tl-wpa8630p-v2.dtsi"
+
+/ {
+	compatible = "tplink,tl-wpa8630p-v2-eu", "qca,qca9563";
+	model = "TP-Link WPA8630P v2 (EU)";
+};
+
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "u-boot";
+				reg = <0x020000 0x020000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x040000 0x5e0000>;
+			};
+
+			partition@620000 {
+				label = "partition-table";
+				reg = <0x620000 0x010000>;
+				read-only;
+			};
+
+			mac: partition@630000 {
+				label = "mac";
+				reg = <0x630000 0x010000>;
+				read-only;
+			};
+
+			partition@640000 {
+				label = "tplink";
+				reg = <0x640000 0x1b0000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "tp-link:green:wifi2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "tp-link:green:wifi5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		led_control {
+			gpio-export,name = "tp-link:led:control";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		pair {
+			label = "Pair button";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		leds {
+			label = "LED control button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	phy-mode = "sgmii";
+	mtd-mac-address = <&mac 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&mac 0x8>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -296,6 +296,10 @@ tplink,tl-mr6400-v1)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:white:wan" "eth1"
 	ucidef_set_led_netdev "4g" "4G" "tp-link:white:4g" "usb0"
 	;;
+tplink,tl-wpa8630p-v2-de|\
+tplink,tl-wpa8630p-v2-eu)
+	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3c"
+	;;
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -291,6 +291,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:3" "3:lan:2"
 		;;
+	tplink,tl-wpa8630p-v2-de|\
+	tplink,tl-wpa8630p-v2-eu)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "5:lan:4"
+		;;
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -187,7 +187,9 @@ case "$FIRMWARE" in
 	tplink,archer-c60-v2|\
 	tplink,archer-c60-v3|\
 	tplink,archer-c6-v2|\
-	tplink,archer-c6-v2-us)
+	tplink,archer-c6-v2-us|\
+	tplink,tl-wpa8630p-v2-de|\
+	tplink,tl-wpa8630p-v2-eu)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary mac 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -500,6 +500,28 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
+define Device/tplink_tl-wpa8630p-v2-de
+  $(Device/tplink-safeloader)
+  SOC := qca9563
+  DEVICE_MODEL := TL-WPA8630P
+  DEVICE_VARIANT := v2 (DE)
+  IMAGE_SIZE := 6016k
+  TPLINK_BOARD_ID := TLWPA8630PV2DE
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_tl-wpa8630p-v2-de
+
+define Device/tplink_tl-wpa8630p-v2-eu
+  $(Device/tplink-safeloader)
+  SOC := qca9563
+  DEVICE_MODEL := TL-WPA8630P
+  DEVICE_VARIANT := v2 (EU)
+  IMAGE_SIZE := 6016k
+  TPLINK_BOARD_ID := TLWPA8630PV2EU
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_tl-wpa8630p-v2-eu
+
 define Device/tplink_tl-wr1043nd-v1
   $(Device/tplink-8m)
   SOC := ar9132

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1373,6 +1373,78 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the TL-WPA8630P v2 (DE)*/
+	{
+		.id     = "TLWPA8630PV2DE",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WPA8630P,product_ver:2.0.0,special_id:44450000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"factory-uboot", 0x00000, 0x20000},
+			{"fs-uboot", 0x20000, 0x20000},
+			{"firmware", 0x40000, 0x5e0000}, /* Stock: name os-image base 0x40000 size 0x100000 */
+											 /* Stock: name file-system base 0x140000 size 0x4e0000 */
+			{"partition-table", 0x620000, 0x02000},
+			{"extra-para", 0x632100, 0x01000},
+			{"soft-version", 0x640000, 0x01000},
+			{"support-list", 0x641000, 0x01000},
+			{"profile", 0x642000, 0x08000},
+			{"user-config", 0x650000, 0x10000},
+			{"default-config", 0x660000, 0x10000},
+			{"default-nvm", 0x670000, 0xc0000},
+			{"default-pib", 0x730000, 0x40000},
+			{"default-mac", 0x7e0000, 0x00020},
+			{"pin", 0x7e0100, 0x00020},
+			{"device-id", 0x7e0200, 0x00030},
+			{"product-info", 0x7e1100, 0x01000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
+	/** Firmware layout for the TL-WPA8630P v2 (EU)*/
+	{
+		.id     = "TLWPA8630PV2EU",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WPA8630P,product_ver:2.0.0,special_id:45550000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"factory-uboot", 0x00000, 0x20000},
+			{"fs-uboot", 0x20000, 0x20000},
+			{"firmware", 0x40000, 0x5e0000}, /* Stock: name os-image base 0x40000 size 0x100000 */
+											 /* Stock: name file-system base 0x140000 size 0x4e0000 */
+			{"partition-table", 0x620000, 0x02000},
+			{"default-mac", 0x630000, 0x00020},
+			{"pin", 0x630100, 0x00020},
+			{"device-id", 0x630200, 0x00030},
+			{"product-info", 0x631100, 0x01000},
+			{"extra-para", 0x632100, 0x01000},
+			{"soft-version", 0x640000, 0x01000},
+			{"support-list", 0x641000, 0x01000},
+			{"profile", 0x642000, 0x08000},
+			{"user-config", 0x650000, 0x10000},
+			{"default-config", 0x660000, 0x10000},
+			{"default-nvm", 0x670000, 0xc0000},
+			{"default-pib", 0x730000, 0x40000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the TL-WR1043 v5 */
 	{
 		.id     = "TLWR1043NV5",


### PR DESCRIPTION
The TL-WPA8630P v2 is a HomePlug AV2 compatible device with a QCA9563 SoC
and 2.4GHz and 5GHz WiFi modules.

Specifications
--------------

  - QCA9563 750MHz, 2.4GHz WiFi
  - QCA9888 5GHz WiFi
  - 8MiB SPI Flash
  - 128MiB RAM
  - 3 GBit Ports (QCA8337)
  - PLC (QCA7550)

MAC address assignment
----
LAN and 2.4GHz WiFi share the same MAC address as printed on the label. The 5GHz WiFi uses LAN-1, this is based on assumptions from similar devices. Unfortunately, I cannot go back to stock on my device to check this.

LAN Port assignment
----
While there are 3 physical LAN ports on the device, there will be 4 visible ports in OpenWrt. The fourth port is used by the PowerLine Communication SoC and thus treated like a regular LAN port.

Versions
--------
There are different versions of the TL-WPA8630(P) v2 devices that sometimes differ in the firmware layout. So far, I only implemented the one device I have, which is based on a EU firmware edition plus the DE version based on the OEM firmware layout. The flash layout is also different for the non-P version (so just TL-WPA8630 v2). 
When flashing back to stock, make sure to flash the correct version! I accidentally flashed the non-P firmware to my P device and now it always overwrites the boot loader when doing a firmware upgrade from the stock web interface.

Installation
------------

Installation is possible from the OEM web interface. Make sure to
install the latest OEM firmware first, so that the PLC firmware is
at the latest version.

Notes
-----

I cannot test installation from the OEM interface, because I messed up my stock firmware while trying to go back to stock. My device **always** overwrites the bootloader, even when doing stock -> stock firmware upgrades. Since I do not have a full backup, I cannot resolve this situation. 