### PR TITLE
base-files: preserve user-added sysctl.d files

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=220
+PKG_RELEASE:=221
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/lib/upgrade/keep.d/base-files-essential
+++ b/package/base-files/files/lib/upgrade/keep.d/base-files-essential
@@ -8,4 +8,5 @@
 /etc/shells
 /etc/shinit
 /etc/sysctl.conf
+/etc/sysctl.d/
 /etc/rc.local


### PR DESCRIPTION
Currently we preserve /etc/sysctl.conf but not the /etc/sysctl.d/
directory.

Preserve any additional settings the user might have dumped into
the /etc/sysctl.d/ file (which is where they should be putting
changes/overrides into anyway rather than editing the top-level
file).

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>