### PR TITLE
ath79: Add support for D-Link DCH-G020 Rev. A1

### DIFF
--- a/target/linux/ath79/dts/qca9531_dlink_dch-g020-a1.dts
+++ b/target/linux/ath79/dts/qca9531_dlink_dch-g020-a1.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "dlink,dch-g020-a1", "qca,qca9531";
+	model = "D-Link DCH-G020 A1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	i2c {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		sda-gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+
+		gpio_ext: gpio_ext@38 {
+			compatible = "nxp,pca9554";
+			reg = <0x38 0x1>;
+
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		rtc@30 {
+			compatible = "pericom,pt7c43390";
+			reg = <0x30 0x8>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		usb_power {
+			label = "d-link:power:usb";
+			gpio-export,name = "d-link:power:usb";
+			gpio-export,output = <0>;
+			gpios = <&gpio_ext 3 GPIO_ACTIVE_LOW>;
+		};
+
+		zwave_power {
+			label = "d-link:power:zwave";
+			gpio-export,name = "d-link:power:zwave";
+			gpio-export,output = <0>;
+			gpios = <&gpio_ext 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "d-link:green:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		status {
+			label = "d-link:red:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x10000 0x10000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "mp";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "bootarg";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xe70000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@ec0000 {
+				label = "dlink";
+				reg = <0xec0000 0x140000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -147,6 +147,10 @@ ath79_setup_interfaces()
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" "0@eth0" "2:lan" "3:wan" "6@eth1"
 		;;
+	dlink,dch-g020-a1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:2" "2:lan:1"
+		;;
 	dlink,dir-825-b1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -378,6 +382,10 @@ ath79_setup_macs()
 		;;
 	dlink,dap-2695-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
+		;;
+	dlink,dch-g020-a1)
+		lan_mac=$(mtd_get_mac_text "mp" 0x1)
+		label_mac=$lan_mac
 		;;
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,6 +17,9 @@ case "$board" in
 	adtran,bsap1840)
 		macaddr_add "$(mtd_get_mac_binary 'Board data' 2)" $(($PHYNBR * 8 + 1)) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dch-g020-a1)
+		mtd_get_mac_text "mp" 0x13 > /sys${DEVPATH}/macaddress
+		;;
 	iodata,wn-ac1600dgr)
 		# There is no eeprom data for 5 GHz wlan in "art" partition
 		# which would allow to patch the macaddress

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -50,6 +50,17 @@ define Build/cybertan-trx
 	-rm $@-empty.bin
 endef
 
+define Build/mkdapimg2
+	$(STAGING_DIR_HOST)/bin/mkdapimg2 \
+		-i $@ -o $@.new \
+		-s $(DAP_SIGNATURE) \
+		-v $(VERSION_DIST)-$(firstword $(subst +, , \
+			$(firstword $(subst -, ,$(REVISION))))) \
+		-r Default \
+		$(if $(1),-k $(1))
+	mv $@.new $@
+endef
+
 define Build/mkmylofw_16m
 	$(eval device_id=$(word 1,$(1)))
 	$(eval revision=$(word 2,$(1)))
@@ -562,6 +573,20 @@ define Device/dlink_dap-2695-a1
   SUPPORTED_DEVICES += dap-2695-a1
 endef
 TARGET_DEVICES += dlink_dap-2695-a1
+
+define Device/dlink_dch-g020-a1
+  SOC := qca9531
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DCH-G020
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-gpio-pca953x kmod-i2c-gpio kmod-usb2 kmod-usb-acm
+  IMAGES += factory.bin
+  IMAGE_SIZE := 14784k
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | mkdapimg2 0x20000
+  DAP_SIGNATURE := HONEYBEE-FIRMWARE-DCH-G020
+endef
+TARGET_DEVICES += dlink_dch-g020-a1
 
 define Device/dlink_dir-505
   SOC := ar9330


### PR DESCRIPTION
The DCH-G020 is a Smart Home Gateway for Z-Wave devices.

Specifications:

 * QCA9531, 16 MiB Flash, 64 MiB RAM
 * On-Board USB SD3503A Z-Wave dongle
 * GL850 USB 2.0 Hub (one rear port, internal Z-Wave) controlled by PCA9554
 * Two Ethernet Ports (10/100)

Known issues:

 * MAC addresses are in 17 bytes ASCII format,
   there is currently no dts binding for this;
   workaround using lan_mac and ifconfig in /board.d/02_network
   The device actually uses one MAC address, which is stored twice in the flash
 * Real-Time-Clock is not working as there is currently no driver available,
   but is included in the dts as compatible = "pericom,pt7c43390";
 * openzwave was tested on v19.07 (running MinOZW as a proof-of-concept),
   but the package now grew too big as lots of device pictures were included,
   thus any Z-Wave functionality is left to the user (e.g. extroot and domoticz)

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>