### PR TITLE
ath79: dts: add missing 'serial0' alias for TP-Link TL-MR3040v2

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -11,6 +11,7 @@
 	compatible = "tplink,tl-mr3040-v2", "qca,ar9331";
 
 	aliases {
+		serial0 = &uart;
 		led-boot = &led_lan;
 		led-failsafe = &led_lan;
 		label-mac-device = &eth0;


### PR DESCRIPTION
Out of all devices currently supported based on AR9331 chipset,
this one had the 'serial0' alias missing. Add it to fix setting of
/dev/console and login shell on the onboard UART.

Run-tested-on: TP-Link TL-MR3040v2
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

This fix also affects 19.07 branch - I did the test on this too and backporting is trivial.
As an interesting fact, for some reason, this also fixed sysupgrade for me. It seems that /dev/console is required for it after all, without it the router would reboot instantly.