### PR TITLE
ath79: add support for AVM FRITZ!WLAN Repeater DVB-C

### DIFF
--- a/target/linux/ath79/dts/qca9556_avm_fritzdvbc.dts
+++ b/target/linux/ath79/dts/qca9556_avm_fritzdvbc.dts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9556_avm_fritz-repeater.dtsi"
+
+/ {
+	compatible = "avm,fritzdvbc", "qca,qca9556";
+	model = "AVM FRITZ!WLAN Repeater DVB-C";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		num-chipselects = <0>;
+
+		spi_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <10000000>;
+
+			gpio_latch_bit {
+				gpio-hog;
+				gpios = <16 GPIO_ACTIVE_HIGH>;
+				output-high;
+				line-name = "gpio-latch-bit";
+			};
+		};
+	};
+
+	// The GPIO pins 100 or greater are redirected to the shift register
+	// So OEM source pin 100 becomes 0, 101 becomes 1, ...
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			// OEM source pin 106
+			label = "fritzdvbc:green:power";
+			gpios = <&spi_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			// OEM source pin 107
+			label = "fritzdvbc:green:wlan";
+			gpios = <&spi_gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		tv {
+			// OEM source pin 105
+			label = "fritzdvbc:green:tv";
+			gpios = <&spi_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			// OEM source pin 100 or 101
+			// Testing showed pin 1 ("101")
+			label = "fritzdvbc:green:rssihigh";
+			gpios = <&spi_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			// OEM source pin 102 or 104
+			// Testing showed pin 2 ("102")
+			label = "fritzdvbc:green:rssimediumhigh";
+			gpios = <&spi_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			// OEM source pin 103
+			label = "fritzdvbc:green:rssimedium";
+			gpios = <&spi_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			// OEM source pin 102 or 104
+			// Testing showed pin 4 ("104")
+			label = "fritzdvbc:green:rssimediumlow";
+			gpios = <&spi_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow {
+			// OEM source pin 100 or 101
+			// Testing showed pin 0 ("100")
+			label = "fritzdvbc:green:rssilow";
+			gpios = <&spi_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&gpio {
+	reset-pcie-ep {
+		gpio-hog;
+		gpios = <109 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "PCIE EP reset";
+	};
+
+	reset-pcie {
+		gpio-hog;
+		gpios = <110 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "PCIE Bus reset";
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -38,6 +38,14 @@ avm,fritz4020)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x1E"
 	;;
+avm,fritzdvbc)
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:green:rssilow" "wlan1" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "$boardname:green:rssimediumlow" "wlan1" "20" "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:green:rssimedium" "wlan1" "40" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "$boardname:green:rssimediumhigh" "wlan1" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan1" "80" "100"
+	;;
 comfast,cf-e110n-v2)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 	alfa-network,ap121f|\
 	aruba,ap-105|\
 	avm,fritz1750e|\
+	avm,fritzdvbc|\
 	avm,fritz300e|\
 	comfast,cf-wr752ac-v1|\
 	devolo,dvl1200i|\
@@ -341,9 +342,7 @@ ath79_setup_macs()
 		label_mac=$(mtd_get_mac_binary art 0x1002)
 		;;
 	avm,fritz1750e|\
-	avm,fritz450e)
-		label_mac=$(fritz_tffs -n macwlan -i $(find_mtd_part "tffs (1)"))
-		;;
+	avm,fritz450e|\
 	avm,fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		label_mac=$(fritz_tffs -n macwlan -i $(find_mtd_part "tffs (1)"))
@@ -351,6 +350,9 @@ ath79_setup_macs()
 	avm,fritz4020)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
+		;;
+	avm,fritzdvbc)
+		label_mac=$(fritz_tffs -n macwlan -i $(find_mtd_part "tffs (1)"))
 		;;
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -11,7 +11,8 @@ case "$FIRMWARE" in
 	case $board in
 	avm,fritz1750e|\
 	avm,fritz4020|\
-	avm,fritz450e)
+	avm,fritz450e|\
+	avm,fritzdvbc)
 		caldata_extract_reverse "urlader" 0x1541 0x440
 		;;
 	dlink,dir-505|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -10,7 +10,8 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
-	avm,fritz1750e)
+	avm,fritz1750e|\
+	avm,fritzdvbc)
 		caldata_extract "urlader" 0x198a 0x844
 		;;
 	comfast,cf-wr650ac-v1|\

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -5,7 +5,8 @@
 preinit_set_mac_address() {
 	case $(board_name) in
 	avm,fritz1750e|\
-	avm,fritz450e)
+	avm,fritz450e|\
+	avm,fritzdvbc)
 		ip link set dev eth0 address $(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
 	siemens,ws-ap3610)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -210,6 +210,16 @@ define Device/avm_fritz450e
 endef
 TARGET_DEVICES += avm_fritz450e
 
+define Device/avm_fritzdvbc
+  $(Device/avm)
+  SOC := qca9556
+  IMAGE_SIZE := 15232k
+  DEVICE_MODEL := FRITZ!WLAN Repeater DVB-C
+  DEVICE_PACKAGES += rssileds kmod-ath10k-ct-smallbuffers \
+	ath10k-firmware-qca988x-ct -swconfig
+endef
+TARGET_DEVICES += avm_fritzdvbc
+
 define Device/buffalo_bhr-4grv
   SOC := ar7242
   DEVICE_VENDOR := Buffalo


### PR DESCRIPTION
 ath79: add support for AVM FRITZ!WLAN Repeater DVB-C

This commit adds support for the AVM FRITZ!WLAN Repeater DVB-C

SOC: Qualcomm Atheros QCA9556 720/600/200MHz MIPS 74Kc
RAM: 64 MiB (0x4000000)
FLASH: 16 MB NOR (WINBOND Uniform-Flash, 256 Bytes WriteBuffer)
WLAN: 2.4 GHZ b/g/n and 5 GHz n/ac
Ethernet: Gigabit
DVB-C: em28174 with MxL251 tuner
INPUT: 1x WPS Button (used for reset in OEM firmware by 15 seconds hold)
LED: Power, WLAN, TV, RSSI0-4
Serial: Yes

Tested and working:
 - Ethernet (correct MAC, gigabit, iperf3 about 200 Mbit/s)
 - 2.4 GHz Wi-Fi (correct MAC)
 - 5 GHz Wi-Fi (correct MAC)
 - WPS Button (tested using wifitoggle)
 - LEDs
 - Installation via EVA bootloader (FTP recovery)
 - OpenWrt sysupgrade (both CLI and LuCI)
 - Download of "urlader" (mtd0)

Not working:
 - Internal USB
 - DVB-C em28174+MxL251 (depends on internal USB)

Installation via EVA bootloader (FTP recovery):
Set NIC to 192.168.178.3/24 gateway 192.168.178.1 and power on the device,
connect to 192.168.178.1 through FTP and sign in with adam2/adam2:

ftp> quote USER adam2
ftp> quote PASS adam2
ftp> binary
ftp> debug
ftp> passive
ftp> quote MEDIA FLSH
ftp> put openwrt-sysupgrade.bin mtd1

Wait for "Transfer complete" together with the transfer details.
Wait two minutes to make sure flash is complete (just to be safe).
Then restart the device (power off and on) to boot into OpenWrt.
Revert your NIC settings to reach OpenWrt at 192.168.1.1

Signed-off-by: Natalie Kagelmacher <nataliek@pm.me>