### PR TITLE
ramips: cosmetic changes for dts and makefile

### DIFF
--- a/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
+++ b/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
@@ -54,7 +54,7 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		reg = <0 0>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
+++ b/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -133,7 +133,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
@@ -99,7 +99,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
@@ -57,7 +57,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-1166d.dts
@@ -93,7 +93,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-300hp2.dts
@@ -93,7 +93,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
+++ b/target/linux/ramips/dts/mt7620a_buffalo_whr-600d.dts
@@ -93,7 +93,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dch-m225.dts
@@ -101,7 +101,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -66,7 +66,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -89,7 +89,7 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		reg = <0 0>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
@@ -83,7 +83,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
@@ -78,7 +78,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -78,7 +78,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -53,7 +53,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_hnet_c108.dts
+++ b/target/linux/ramips/dts/mt7620a_hnet_c108.dts
@@ -115,7 +115,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q128@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
+++ b/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
@@ -36,7 +36,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
+++ b/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
@@ -60,7 +60,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
+++ b/target/linux/ramips/dts/mt7620a_microduino_microwrt.dts
@@ -41,7 +41,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_netgear_ex2700_wn3000rp-v3.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex2700_wn3000rp-v3.dtsi
@@ -32,7 +32,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3700_ex6130.dtsi
@@ -36,7 +36,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;

--- a/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
+++ b/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
@@ -56,7 +56,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
@@ -50,7 +50,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
@@ -24,7 +24,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_cs-qr10.dts
@@ -71,7 +71,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_db-wrt01.dts
@@ -43,7 +43,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
@@ -63,7 +63,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
@@ -78,7 +78,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -83,7 +83,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-evb.dts
@@ -29,7 +29,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7530-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7530-evb.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
@@ -33,7 +33,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <1000000>;

--- a/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
+++ b/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
@@ -117,7 +117,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q128@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c2-v1.dts
@@ -79,7 +79,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -118,7 +118,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer.dtsi
@@ -40,7 +40,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -67,7 +67,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -72,7 +72,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "mx25l25635f", "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
+++ b/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
@@ -94,7 +94,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -72,7 +72,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-16m.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-16m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q128@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-32m.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-32m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q128@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zte_q7.dts
+++ b/target/linux/ramips/dts/mt7620a_zte_q7.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -91,7 +91,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
@@ -70,7 +70,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
@@ -75,7 +75,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
+++ b/target/linux/ramips/dts/mt7620n_buffalo_wmr-300.dts
@@ -59,7 +59,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
+++ b/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
@@ -69,7 +69,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
+++ b/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
@@ -67,7 +67,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
+++ b/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_nexx_wt3020-4m.dts
+++ b/target/linux/ramips/dts/mt7620n_nexx_wt3020-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_nexx_wt3020-8m.dts
+++ b/target/linux/ramips/dts/mt7620n_nexx_wt3020-8m.dts
@@ -18,7 +18,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_ravpower_wd03.dts
+++ b/target/linux/ramips/dts/mt7620n_ravpower_wd03.dts
@@ -53,7 +53,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
+++ b/target/linux/ramips/dts/mt7620n_vonets_var11n-300.dts
@@ -43,7 +43,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
+++ b/target/linux/ramips/dts/mt7620n_wrtnode_wrtnode.dts
@@ -40,7 +40,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-cpe102.dts
@@ -63,7 +63,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q64@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
@@ -67,7 +67,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q64@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
@@ -56,7 +56,7 @@
 &spi0 {
 	status = "okay";
 
-	en25q64@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
@@ -59,7 +59,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -87,7 +87,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -87,7 +87,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
+++ b/target/linux/ramips/dts/mt7621_afoundry_ew1200.dts
@@ -54,7 +54,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -116,7 +116,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -116,7 +116,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -93,7 +93,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <45000000>;

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -106,7 +106,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -65,7 +65,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -109,7 +109,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
@@ -123,7 +123,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
+++ b/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
@@ -53,7 +53,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc1.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
@@ -72,7 +72,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -68,7 +68,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
@@ -68,7 +68,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -76,7 +76,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <45000000>;

--- a/target/linux/ramips/dts/mt7621_linksys_re6500.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re6500.dts
@@ -54,7 +54,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
@@ -77,7 +77,7 @@
 &spi0 {
 	status = "okay";
 
-	mx25l6405d@0 {
+	flash@0 {
 		compatible = "mx25l6405d","jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_ap-mt7621a-v60.dts
@@ -79,7 +79,7 @@
 
 	flash@0 {
 		compatible = "mx25l6405d","jedec,spi-nor";
-		reg = <0 0>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
@@ -80,7 +80,7 @@
 &spi0 {
 	status = "okay";
 
-	w25q128@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		// XXX empiric value to obtain actual 10MHz SCK at the chip

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -90,7 +90,7 @@
 &spi0 {
 	status = "okay";
 
-	w25q40@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <3125000>;
@@ -136,7 +136,7 @@
 		};
 	};
 
-	w25q128@1 {
+	flash@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
 		// XXX empiric value to obtain actual 10MHz SCK at the chip

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
@@ -41,7 +41,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -53,7 +53,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_planex_vr500.dts
+++ b/target/linux/ramips/dts/mt7621_planex_vr500.dts
@@ -43,7 +43,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -55,7 +55,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
+++ b/target/linux/ramips/dts/mt7621_storylink_sap-g3200u3.dts
@@ -44,7 +44,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
+++ b/target/linux/ramips/dts/mt7621_thunder_timecloud.dts
@@ -58,7 +58,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -91,7 +91,7 @@
 &spi0 {
 	status = "okay";
 
-	w25q64@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re650-v1.dts
@@ -97,7 +97,7 @@
 &spi0 {
 	status = "okay";
 
-	w25q64@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
@@ -123,7 +123,7 @@
 	 */
 	status = "disabled";
 
-	m25p80@1 {
+	flash@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06-16m.dts
@@ -44,7 +44,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <14000000>;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mir3g-v2.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mir3g-v2.dts
@@ -50,7 +50,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -65,7 +65,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we1326.dts
@@ -38,7 +38,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-we3526.dts
@@ -35,7 +35,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -51,7 +51,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -49,7 +49,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
+++ b/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
@@ -113,7 +113,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
@@ -119,7 +119,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
+++ b/target/linux/ramips/dts/mt7628an_d-team_pbr-d1.dts
@@ -93,7 +93,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
+++ b/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
@@ -94,7 +94,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <60000000>;

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -93,7 +93,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -88,7 +88,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_mt7628an-eval-board.dts
@@ -21,7 +21,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -35,7 +35,7 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		reg = <0 0>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 
 		partitions {

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -33,7 +33,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
@@ -94,7 +94,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -61,7 +61,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -117,7 +117,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_8m.dtsi
@@ -16,7 +16,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -34,7 +34,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -79,7 +79,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v5.dts
@@ -49,7 +49,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01-16m.dts
@@ -44,7 +44,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <12000000>;

--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2-lite.dts
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2-lite.dts
@@ -26,7 +26,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2.dts
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2.dts
@@ -26,7 +26,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_widora_neo-16m.dts
+++ b/target/linux/ramips/dts/mt7628an_widora_neo-16m.dts
@@ -13,7 +13,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_widora_neo-32m.dts
+++ b/target/linux/ramips/dts/mt7628an_widora_neo-32m.dts
@@ -13,7 +13,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
@@ -24,7 +24,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -64,7 +64,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -84,7 +84,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar670w.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@bdc00000 {
+	flash@bdc00000 {
 		compatible = "cfi-flash";
 		reg = <0xbc400000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
+++ b/target/linux/ramips/dts/rt2880_airlink101_ar725w.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@bdc00000 {
+	flash@bdc00000 {
 		compatible = "cfi-flash";
 		reg = <0xbc400000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
+++ b/target/linux/ramips/dts/rt2880_asus_rt-n15.dts
@@ -18,7 +18,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
+++ b/target/linux/ramips/dts/rt2880_belkin_f5d8235-v1.dts
@@ -16,7 +16,7 @@
 		led-failsafe = &led_wired_blue;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0xbc400000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wli-tx4-ag300n.dts
@@ -18,7 +18,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
+++ b/target/linux/ramips/dts/rt2880_buffalo_wzr-agl300nh.dts
@@ -18,7 +18,7 @@
 		led-upgrade = &led_router;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
+++ b/target/linux/ramips/dts/rt2880_dlink_dap-1522-a1.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	cfi@bc400000 {
+	flash@bc400000 {
 		compatible = "cfi-flash";
 		reg = <0xbc400000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
+++ b/target/linux/ramips/dts/rt2880_ralink_v11st-fe.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_8devices_carambola.dts
+++ b/target/linux/ramips/dts/rt3050_8devices_carambola.dts
@@ -13,7 +13,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_allnet_all0256n-4m.dts
+++ b/target/linux/ramips/dts/rt3050_allnet_all0256n-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_allnet_all0256n-8m.dts
+++ b/target/linux/ramips/dts/rt3050_allnet_all0256n-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-16m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
+++ b/target/linux/ramips/dts/rt3050_arcwireless_freestation5.dts
@@ -13,7 +13,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-g32-b1.dts
@@ -30,7 +30,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
+++ b/target/linux/ramips/dts/rt3050_asus_rt-n10-plus.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n.dts
@@ -51,7 +51,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
+++ b/target/linux/ramips/dts/rt3050_asus_wl-330n3g.dts
@@ -56,7 +56,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dcs-930.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x400000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-300-b1.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status_green;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-600-b1.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status_green;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
@@ -17,7 +17,7 @@
 		label-mac-device = &wmac;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-620-a1.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status_green;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_internet;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_huawei_d105.dts
+++ b/target/linux/ramips/dts/rt3050_huawei_d105.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
+++ b/target/linux/ramips/dts/rt3050_jcg_jhr-n805r.dts
@@ -47,7 +47,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_netcore_nw718.dts
+++ b/target/linux/ramips/dts/rt3050_netcore_nw718.dts
@@ -58,7 +58,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
+++ b/target/linux/ramips/dts/rt3050_sparklan_wcr-150gn.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
+++ b/target/linux/ramips/dts/rt3050_teltonika_rut5xx.dts
@@ -40,7 +40,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3050_tenda_w150m.dts
+++ b/target/linux/ramips/dts/rt3050_tenda_w150m.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_ap;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
+++ b/target/linux/ramips/dts/rt3050_trendnet_tew-638apb-v2.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps_green;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x400000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_accton_wr6202.dts
+++ b/target/linux/ramips/dts/rt3052_accton_wr6202.dts
@@ -44,7 +44,7 @@
 		};
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
+++ b/target/linux/ramips/dts/rt3052_alfa-network_w502u.dts
@@ -20,7 +20,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
+++ b/target/linux/ramips/dts/rt3052_argus_atp-52b.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_run;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
+++ b/target/linux/ramips/dts/rt3052_asiarf_awapn2403.dts
@@ -40,7 +40,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
+++ b/target/linux/ramips/dts/rt3052_asus_rt-n13u.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
+++ b/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
+++ b/target/linux/ramips/dts/rt3052_aztech_hw550-3g.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
+++ b/target/linux/ramips/dts/rt3052_belkin_f5d8235-v2.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_router;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
+++ b/target/linux/ramips/dts/rt3052_buffalo_whr-g300n.dts
@@ -15,7 +15,7 @@
 		led-upgrade = &led_diag;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
+++ b/target/linux/ramips/dts/rt3052_dlink_dap-1350.dts
@@ -20,7 +20,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
+++ b/target/linux/ramips/dts/rt3052_engenius_esr-9753.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
+++ b/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
+++ b/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
@@ -9,7 +9,7 @@
 	compatible = "hauppauge,broadway", "ralink,rt3052-soc";
 	model = "Hauppauge Broadway";
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
+++ b/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x1000000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n825r.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_system;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_system;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
+++ b/target/linux/ramips/dts/rt3052_mofinetwork_mofi3500-3gn.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_status;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
+++ b/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
@@ -77,7 +77,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
+++ b/target/linux/ramips/dts/rt3052_nexaira_bc2.dts
@@ -9,7 +9,7 @@
 	compatible = "nexaira,bc2", "ralink,rt3052-soc";
 	model = "NexAira BC2";
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
+++ b/target/linux/ramips/dts/rt3052_omnima_miniembwifi.dts
@@ -41,7 +41,7 @@
 		};
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
+++ b/target/linux/ramips/dts/rt3052_petatel_psr-680w.dts
@@ -20,7 +20,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-wdpr.dts
@@ -12,7 +12,7 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 

--- a/target/linux/ramips/dts/rt3052_poray_ip2202.dts
+++ b/target/linux/ramips/dts/rt3052_poray_ip2202.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_run;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
+++ b/target/linux/ramips/dts/rt3052_prolink_pwh2004.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
+++ b/target/linux/ramips/dts/rt3052_ralink_v22rw-2x2.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_security;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
+++ b/target/linux/ramips/dts/rt3052_sitecom_wl-351.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
+++ b/target/linux/ramips/dts/rt3052_skyline_sl-r7205.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wifi;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_3g300m.dts
@@ -73,7 +73,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
+++ b/target/linux/ramips/dts/rt3052_tenda_w306r-v2.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_sys;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-4m.dts
@@ -6,7 +6,7 @@
 	compatible = "unbranded,wr512-3gn-4m", "unbranded,wr512-3gn", "ralink,rt3052-soc";
 	model = "WR512-3GN (4M)";
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_wr512-3gn-8m.dts
@@ -6,7 +6,7 @@
 	compatible = "unbranded,wr512-3gn-8m", "unbranded,wr512-3gn", "ralink,rt3052-soc";
 	model = "WR512-3GN (8M)";
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
+++ b/target/linux/ramips/dts/rt3052_unbranded_xdx-rn502j.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-326n4g.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
+++ b/target/linux/ramips/dts/rt3052_upvel_ur-336un.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_keenetic.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
+++ b/target/linux/ramips/dts/rt3052_zyxel_nbg-419n.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	cfi@1f000000 {
+	flash@1f000000 {
 		compatible = "cfi-flash";
 		reg = <0x1f000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3352_allnet_all5002.dts
+++ b/target/linux/ramips/dts/rt3352_allnet_all5002.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-615-h1.dts
@@ -68,7 +68,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
@@ -45,7 +45,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
+++ b/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
@@ -64,7 +64,7 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		reg = <0 0>;
+		reg = <0>;
 		spi-max-frequency = <10000000>;
 
 		partitions {

--- a/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
+++ b/target/linux/ramips/dts/rt3352_zyxel_nbg-419n-v2.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0 0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -73,7 +73,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -53,7 +53,7 @@
 		};
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
+++ b/target/linux/ramips/dts/rt3662_loewe_wmdr-143n.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;

--- a/target/linux/ramips/dts/rt3662_omnima_hpm.dts
+++ b/target/linux/ramips/dts/rt3662_omnima_hpm.dts
@@ -89,7 +89,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <25000000>;
 		reg = <0>;

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_power;
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -99,7 +99,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <8600000>;

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-691gr.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps;
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
@@ -16,7 +16,7 @@
 		led-upgrade = &led_wps_green;
 	};
 
-	nor-flash@1c000000 {
+	flash@1c000000 {
 		compatible = "cfi-flash";
 		reg = <0x1c000000 0x800000>;
 		bank-width = <2>;

--- a/target/linux/ramips/dts/rt5350_7links_px-4885-4m.dts
+++ b/target/linux/ramips/dts/rt5350_7links_px-4885-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_7links_px-4885-8m.dts
+++ b/target/linux/ramips/dts/rt5350_7links_px-4885-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
+++ b/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
@@ -44,7 +44,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_allnet_all5003.dts
+++ b/target/linux/ramips/dts/rt5350_allnet_all5003.dts
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_asiarf_awm002-evb-4m.dts
+++ b/target/linux/ramips/dts/rt5350_asiarf_awm002-evb-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80: m25p80@0 {
+	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_asiarf_awm002-evb-8m.dts
+++ b/target/linux/ramips/dts/rt5350_asiarf_awm002-evb-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80: m25p80@0 {
+	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
+++ b/target/linux/ramips/dts/rt5350_belkin_f7c027.dts
@@ -67,7 +67,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
@@ -51,7 +51,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-300-b7.dts
@@ -51,7 +51,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
@@ -73,7 +73,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-610-a1.dts
@@ -51,7 +51,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
+++ b/target/linux/ramips/dts/rt5350_easyacc_wizard-8800.dts
@@ -18,7 +18,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
@@ -62,7 +62,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
+++ b/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
@@ -55,7 +55,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
+++ b/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
@@ -56,7 +56,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
+++ b/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
@@ -55,7 +55,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_nexx_wt1520-4m.dts
+++ b/target/linux/ramips/dts/rt5350_nexx_wt1520-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_nexx_wt1520-8m.dts
+++ b/target/linux/ramips/dts/rt5350_nexx_wt1520-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_nixcore_x1-16m.dts
+++ b/target/linux/ramips/dts/rt5350_nixcore_x1-16m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_nixcore_x1-8m.dts
+++ b/target/linux/ramips/dts/rt5350_nixcore_x1-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
+++ b/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino.dtsi
@@ -12,7 +12,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
+++ b/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
@@ -69,7 +69,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
+++ b/target/linux/ramips/dts/rt5350_planex_mzk-dp150n.dts
@@ -44,7 +44,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_poray_m3.dts
+++ b/target/linux/ramips/dts/rt5350_poray_m3.dts
@@ -47,7 +47,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_poray_m4-4m.dts
+++ b/target/linux/ramips/dts/rt5350_poray_m4-4m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_poray_m4-8m.dts
+++ b/target/linux/ramips/dts/rt5350_poray_m4-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_poray_x5.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x5.dts
@@ -79,7 +79,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_poray_x8.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x8.dts
@@ -40,7 +40,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
@@ -58,7 +58,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
+++ b/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
@@ -61,7 +61,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -63,7 +63,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_vocore_vocore-16m.dts
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore-16m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_vocore_vocore-8m.dts
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore-8m.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
+++ b/target/linux/ramips/dts/rt5350_wansview_ncs601w.dts
@@ -10,7 +10,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
+++ b/target/linux/ramips/dts/rt5350_wiznet_wizfi630a.dts
@@ -81,7 +81,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
+++ b/target/linux/ramips/dts/rt5350_zorlik_zl5900v2.dts
@@ -45,7 +45,7 @@
 &spi0 {
 	status = "okay";
 
-	m25p80@0 {
+	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;


### PR DESCRIPTION
ramips: use hex notation for *-mtd-eeprom property
ramips: use generic node name for flash
ramips: fix incorrect flash reg property
ramips: simplify palmbus/{i2c,spi} in device DTS files
ramips: tidy up image Makefile