### PR TITLE
bcm27xx: label to boot partition

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -18,7 +18,7 @@ endef
 ### Image scripts ###
 define Build/boot-common
 	rm -f $@.boot
-	mkfs.fat -C $@.boot $(FAT32_BLOCKS)
+	mkfs.fat -n boot -C $@.boot $(FAT32_BLOCKS)
 	mcopy -i $@.boot $(KDIR)/COPYING.linux ::
 	mcopy -i $@.boot $(KDIR)/LICENCE.broadcom ::
 	mcopy -i $@.boot cmdline.txt ::


### PR DESCRIPTION
Get fat partition name allow easy partition identification for user.
After flashing sd card user may need change values at config.txt.
This patch allow easy identify target volume on host system.
