### PR TITLE
ath79: Add support for WNDRMAC, WNDRMACv2

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -199,7 +199,9 @@ ath79_setup_interfaces()
 		;;
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
+	netgear,wndrmac|\
 	netgear,wndr3800|\
+	netgear,wndrmacv2|\
 	netgear,wndr3800ch)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -118,7 +118,9 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h|\
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
+	netgear,wndrmac|\
 	netgear,wndr3800|\
+	netgear,wndrmacv2|\
 	netgear,wndr3800ch)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
@@ -136,7 +138,9 @@ case "$FIRMWARE" in
 	buffalo,wzr-hp-ag300h|\
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
+	netgear,wndrmac|\
 	netgear,wndr3800|\
+	netgear,wndrmacv2|\
 	netgear,wndr3800ch)
 		caldata_extract "art" 0x5000 0xeb8
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -903,6 +903,24 @@ define Device/netgear_wndr3800
 endef
 TARGET_DEVICES += netgear_wndr3800
 
+define Device/netgear_wndrmac
+  $(Device/netgear_wndr3700-v2)
+  DEVICE_MODEL := WNDRMAC
+  DEVICE_VARIANT := v1
+  NETGEAR_BOARD_ID := WNDRMAC
+  SUPPORTED_DEVICES += wndrmac
+endef
+TARGET_DEVICES += netgear_wndrmac
+
+define Device/netgear_wndrmacv2
+  $(Device/netgear_wndr3800)
+  DEVICE_MODEL := WNDRMAC
+  DEVICE_VARIANT := v2
+  NETGEAR_BOARD_ID := WNDRMACv2
+  SUPPORTED_DEVICES += wndrmacv2
+endef
+TARGET_DEVICES += netgear_wndrmacv2
+
 define Device/netgear_wndr3800ch
   $(Device/netgear_wndr3x00)
   DEVICE_MODEL := WNDR3800CH


### PR DESCRIPTION
Adding router support for two devices
* The Netgear WNDRMAC is a variant of the WNDR3700v1
* The Netgear WNDRMACv2 is a variant of the Netgear WNDR3800

Specification: see as above

(wip)