### PR TITLE
ath79: add support for the Netgear WNDRMAC series

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -52,7 +52,8 @@ glinet,gl-ar150)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
 	;;
 netgear,wndr3700|\
-netgear,wndr3700-v2)
+netgear,wndr3700-v2|\
+netgear,wndrmac-v2)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x10000"
 	;;
 netgear,wndr3700-v4|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -53,6 +53,7 @@ glinet,gl-ar150)
 	;;
 netgear,wndr3700|\
 netgear,wndr3700-v2|\
+netgear,wndrmac-v1|\
 netgear,wndrmac-v2)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x10000"
 	;;

--- a/target/linux/ath79/dts/ar7161_netgear_wndrmac-v1.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndrmac-v1.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7161_netgear_wndr3700.dtsi"
+
+/ {
+	compatible = "netgear,wndrmac-v1", "qca,ar7161";
+	model = "Netgear WNDRMAC v1";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x050000>;
+		read-only;
+	};
+
+	partition@50000 {
+		label = "u-boot-env";
+		reg = <0x050000 0x020000>;
+	};
+
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0xf80000>;
+		compatible = "netgear,uimage";
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/dts/ar7161_netgear_wndrmac-v2.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndrmac-v2.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7161_netgear_wndr3700.dtsi"
+
+/ {
+	compatible = "netgear,wndrmac-v2", "qca,ar7161";
+	model = "Netgear WNDRMAC v2";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x050000>;
+		read-only;
+	};
+
+	partition@50000 {
+		label = "u-boot-env";
+		reg = <0x050000 0x020000>;
+		read-only;
+	};
+
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0xf80000>;
+		compatible = "netgear,uimage";
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -205,6 +205,7 @@ ath79_setup_interfaces()
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
 	netgear,wndr3800ch|\
+	netgear,wndrmac-v1|\
 	netgear,wndrmac-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -432,6 +433,7 @@ ath79_setup_macs()
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
+	netgear,wndrmac-v1|\
 	netgear,wndrmac-v2)
 		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0x0)")
 		;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -204,7 +204,8 @@ ath79_setup_interfaces()
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
-	netgear,wndr3800ch)
+	netgear,wndr3800ch|\
+	netgear,wndrmac-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5u@eth0"
@@ -430,7 +431,8 @@ ath79_setup_macs()
 		;;
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
-	netgear,wndr3800)
+	netgear,wndr3800|\
+	netgear,wndrmac-v2)
 		lan_mac=$(macaddr_setbit_la "$(mtd_get_mac_binary art 0x0)")
 		;;
 	phicomm,k2t)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -127,7 +127,8 @@ case "$FIRMWARE" in
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
-	netgear,wndr3800ch)
+	netgear,wndr3800ch|\
+	netgear,wndrmac-v2)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
 	dlink,dir-825-b1)
@@ -145,7 +146,8 @@ case "$FIRMWARE" in
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
-	netgear,wndr3800ch)
+	netgear,wndr3800ch|\
+	netgear,wndrmac-v2)
 		caldata_extract "art" 0x5000 0xeb8
 		;;
 	dlink,dir-825-b1)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -128,6 +128,7 @@ case "$FIRMWARE" in
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
 	netgear,wndr3800ch|\
+	netgear,wndrmac-v1|\
 	netgear,wndrmac-v2)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
@@ -147,6 +148,7 @@ case "$FIRMWARE" in
 	netgear,wndr3700-v2|\
 	netgear,wndr3800|\
 	netgear,wndr3800ch|\
+	netgear,wndrmac-v1|\
 	netgear,wndrmac-v2)
 		caldata_extract "art" 0x5000 0xeb8
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -932,6 +932,18 @@ define Device/netgear_wndr3800ch
 endef
 TARGET_DEVICES += netgear_wndr3800ch
 
+define Device/netgear_wndrmac-v2
+  $(Device/netgear_wndr3x00)
+  DEVICE_MODEL := WNDRMAC
+  DEVICE_VARIANT := v2
+  NETGEAR_KERNEL_MAGIC := 0x33373031
+  NETGEAR_BOARD_ID := WNDRMACv2
+  NETGEAR_HW_ID := 29763654+16+128
+  IMAGE_SIZE := 15872k
+  SUPPORTED_DEVICES += wndr3700
+endef
+TARGET_DEVICES += netgear_wndrmac-v2
+
 define Device/netgear_wnr2200_common
   SOC := ar7241
   DEVICE_MODEL := WNR2200

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -932,6 +932,18 @@ define Device/netgear_wndr3800ch
 endef
 TARGET_DEVICES += netgear_wndr3800ch
 
+define Device/netgear_wndrmac-v1
+  $(Device/netgear_wndr3x00)
+  DEVICE_MODEL := WNDRMAC
+  DEVICE_VARIANT := v1
+  NETGEAR_KERNEL_MAGIC := 0x33373031
+  NETGEAR_BOARD_ID := WNDRMAC
+  NETGEAR_HW_ID := 29763654+16+64
+  IMAGE_SIZE := 15872k
+  SUPPORTED_DEVICES += wndr3700
+endef
+TARGET_DEVICES += netgear_wndrmac-v1
+
 define Device/netgear_wndrmac-v2
   $(Device/netgear_wndr3x00)
   DEVICE_MODEL := WNDRMAC


### PR DESCRIPTION
## Hardware support - WNDRMAC series

The Netgear WNDRMAC series are hardware variants of specific Netgear routers.

* The WNDRMAC v1 is a hardware variant of the Netgear WNDR3700v2 
  * See [commit](https://github.com/cybik/openwrt/commit/2db75642a25e2bc439baeb94974d73fb43633152) for the full spec, flash and information write-up
* The WNDRMAC v2 is a hardware variant of the Netgear WNDR3800 
  * See [commit](https://github.com/cybik/openwrt/commit/0a438f32d97199eeae0fbfb6266ed54131604ad1) for the full spec, flash and information write-up

They are considered near-clones of their "siblings", and there have been reports of being able to run the matching sibling firmware on the right target (wndr3700v2 on wndrmacv1, and wndr3800 on wndrmacv2).

## Test Report
* Latest binaries and config in use: [rel-2749971dd7 on my fork](https://github.com/cybik/openwrt/releases/tag/rel-2749971dd7)

### Tested
* Kernel: 5.4.42
* Latest source version: [r13521-2749971dd7](https://github.com/cybik/openwrt/commit/2749971dd789daa5ca6f77044a4bf600188aa8d6)
* Previously tested source versions:
  * [r13420-5971ca78ec](https://github.com/cybik/openwrt/commit/5971ca78ece8450b6d89c0e6fb9f5c182f98e3a7)

#### Wireless
* WiFi 2.4ghz Scan: *works* [as of r13521]
* WiFi 5ghz Scan: *works* [as of r13521]
* WiFi 2.4ghz Client into LAN and 5gHz as Master (relay mode): *worked once?* [as of r13521]

#### Buttons
* WiFi button "switcher"
  * With WiFi active, hitting button once disables WiFi [as of r13521]
  * With WiFi disabled, hitting button once enables WiFi [as of r13521]

#### LEDs
* Power LED: *works* [as of r13521]
* USB LED
  * USB port unused: powered down // *works as expected* [as of r13521]
  * USB port in use: lit up // *works as expected* [as of r13521]
* WiFi LED: *works* [as of r13521]
* WAN LED: *works* [as of r13521]
* Network activity LED: *works* [as of r13521]

