### PR TITLE
feeds: add freifunk feed

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,6 +2,7 @@ src-git packages https://git.openwrt.org/feed/packages.git
 src-git luci https://git.openwrt.org/project/luci.git
 src-git routing https://git.openwrt.org/feed/routing.git
 src-git telephony https://git.openwrt.org/feed/telephony.git
+#src-git freifunk https://github.com/freifunk/openwrt-packages.git
 #src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git management https://github.com/openwrt-management/packages.git


### PR DESCRIPTION
@jow- @nbd168 @hnyman @blogic 

Readd the freifunk packages, that have been moved from the LuCI feed into its own feed in January 2019. 
See: https://github.com/openwrt/luci/pull/2533