### PR TITLE
ath79: add support for Senao Engenius ENS202EXT v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -17,6 +17,7 @@ alfa-network,ap121f|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,ecb1750|\
+engenius,ens202ext-v1|\
 etactica,eg200|\
 glinet,gl-ar300m-lite|\
 glinet,gl-ar300m-nand|\

--- a/target/linux/ath79/dts/ar9341_engenius_ens202ext-v1.dts
+++ b/target/linux/ath79/dts/ar9341_engenius_ens202ext-v1.dts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9341.dtsi"
+
+/ {
+	model = "Engenius ENS202EXT v1";
+	compatible = "engenius,ens202ext-v1", "qca,ar9341";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &wmac;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "ens202ext-v1:amber:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "ens202ext-v1:amber:wlan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssilow {
+			label = "ens202ext-v1:red:rssilow";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "ens202ext-v1:amber:rssimedium";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "ens202ext-v1:green:rssihigh";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x050000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0x0a0000 0x010000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0x0b0000 0x170000>;
+			};
+
+			partition@220000 {
+				label = "fakeroot";
+				reg = <0x220000 0x010000>;
+			};
+
+			firmware1: partition@230000 {
+				label = "firmware1";
+				reg = <0x230000 0xbc0000>;
+			};
+
+			partition@df0000 {
+				label = "failsafe";
+				reg = <0xdf0000 0x200000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -129,6 +129,12 @@ compex,wpj531-16m)
 	ucidef_set_led_rssi "sig3" "SIG3" "wpj531:green:sig3" "wlan0" "65" "100"
 	ucidef_set_led_rssi "sig4" "SIG4" "wpj531:green:sig4" "wlan0" "50" "100"
 	;;
+engenius,ens202ext-v1)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:red:rssilow" "wlan0" "1"  "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:amber:rssimedium" "wlan0" "33" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "67" "100"
+	;;
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:white:dlan" "eth0.1" "rx"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -175,6 +175,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
 		;;
+	engenius,ens202ext-v1)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan"
+		;;
 	engenius,ews511ap)
 		ucidef_set_interface_lan "eth0 eth1" "dhcp"
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -124,6 +124,21 @@ define Build/wrgg-pad-rootfs
 	$(STAGING_DIR_HOST)/bin/padjffs2 $(IMAGE_ROOTFS) -c 64 >>$@
 endef
 
+define Build/engenius_ens202ext-v1-factory
+	-[ -f "$@" ] && \
+	mkdir -p $@.tmp && \
+	echo '#!/bin/sh' > $@.tmp/before-upgrade.sh && \
+	echo ': > /tmp/_sys/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
+	$(CP) $(KDIR)/loader-ens202ext-v1.uImage \
+		$@.tmp/openwrt-senao-ens202ext-uImage-lzma.bin && \
+	$(CP) $@ $@.tmp/openwrt-senao-ens202ext-root.squashfs && \
+	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
+		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-C $@.tmp . > $@ && \
+	$(Build/gzip) && \
+	rm -rf $@.tmp
+endef
+
 define Device/seama
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
   KERNEL_INITRAMFS := $$(KERNEL) | seama
@@ -711,6 +726,27 @@ define Device/engenius_ecb1750
 	append-metadata | check-size
 endef
 TARGET_DEVICES += engenius_ecb1750
+
+define Device/engenius_ens202ext-v1
+  SOC := ar9341
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ENS202EXT
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := rssileds kmod-leds-gpio
+  IMAGE_SIZE := 12032k
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x230000
+  COMPILE := loader-ens202ext-v1.bin loader-ens202ext-v1.uImage
+  COMPILE/loader-ens202ext-v1.bin := loader-okli-compile
+  COMPILE/loader-ens202ext-v1.uImage := append-loader-okli ens202ext-v1 | \
+	pad-to $$$$(BLOCKSIZE) | lzma | uImage lzma
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-squashfs-fakeroot-be | pad-to $$$$(BLOCKSIZE) | \
+	append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
+	check-size | engenius_ens202ext-v1-factory
+endef
+TARGET_DEVICES += engenius_ens202ext-v1
 
 define Device/engenius_epg5000
   SOC := qca9558


### PR DESCRIPTION
NOTE: This commit message is old, see the actual commit


Engenius ENS202EXT is an outdoor wireless access point with 2 10/100 ports,
with built-in ethernet switch, detachable antennas and proprietery PoE.

Specification:

	- Qualcomm/Atheros AR9341 v1
	- 535/400/200 MHz		(CPU/DDR/AHB)
	- 64 MB of RAM
	- 16 MB of FLASH
	- UART (J1) header on PCB	(unpopulated)
	- 2x 10/100 Mbps Ethernet	(built-in switch Atheros AR8229)
	- 2.4 GHz, up to 27dBm		(Atheros AR9340)
	- 2x external, detachable antennas
	- 7x LED (5 programmable in ath79), 1x GPIO button (Reset)

Known Issues:

	- Ath79 UART driver not functioning and therefore disabled,
		prints garbage when write enabled, prints correctly when disabled
	- Not possible to make a factory.bin in ath79, generic or tiny (see below)
	- Ethernet LEDs stay on solid when connected and are not programmable

3 ways to flash from OEM:

	- Connect ethernet directly to board (the non POE port)
	- Use ar71xx/tiny factory image first
	- Wait 3 minutes between each flash
	- if you get Failsafe Mode from failed flash:
		only use it to flash Original firmware from Engenius
		or risk kernel loop which requires soldering and serial cable

	Method 1: Firmware upgrade page:
		OEM webpage at 192.168.1.1, username and password "admin"
		In upper right select Reset
		"Restore to factory default settings"
		Wait for reboot and login again
		Navigate to "Firmware Upgrade" page from left pane
		Click Browse and select the ar71xx-tiny factory image
		Upload and verify checksum
		Click Continue to confirm
		Wait about 3 minutes

	Method 2: Serial to load Failsafe webpage:
		After connecting to serial console (need to solder pins) and rebooting...
		Interrupt boot with any key pressed rapidly
		execute `run failsafe_boot` OR `bootm 0x9fdf0000`
		wait a minute
		connect to ethernet and navigate to "192.168.1.1/index.htm" webpage
		Select the ar71xx-tiny factory image and upload and click upgrade

	Method 3: Serial command line sysupgrade:
		Connected to ethernet and serial console on OEM firmware...
		use a TFTP server and pull the ar71xx-tiny factory.bin to the board:
		`cd /tmp && tftp -r ...factory.bin -g 192.168.1.xxx`
		`sysupgrade -n -v ...factory.bin`

	*If you are unable to get network/LuCI after flashing*
	You must perform another factory reset:

		After waiting 3 minutes or when Power LED stop blinking completely:

		Hold Reset button for 15 seconds while powered on

		Power LED will blink very fast on successful start of reset
		wait 3 minutes

		OR

		Solder pins to board
		Connect to serial console
		execute command
		`mtd -r erase rootfs_data`

		and wait 3 minutes

	Proceed to sysupgrade flash to ath79 from ar71xx

Sysupgrade Flash from ar71xx in LuCI:

	- It's highly recommended to do a factory reset before and after changing kernels.
	- DO NOT allow previous settings/configuration to be saved

		In the console this can be done with
			`mtd -r erase rootfs_data`
		In LuCI this is under:
			System --> Backup/Flash Firmware --> Perform Reset
	After reboot and waiting 3 minutes (or when Power LED stops blinking)...
		Navigate to System --> Backup/Flash Firmware --> Flash Image
	Select the ath79-sysupgrade image and upload
		*UNCHECK* "Keep settings and retain the current configuration" and Flash

Return to OEM:

	If you have a serial cable, see Serial Failsafe instructions

	*DISCLAIMER*
	The Failsafe image is unique to this model, this does not apply to other boards.
	The following directions are otherwise dangerous for other boards and can brick other devices.
	DO NOT downgrade to ar71xx this way, causes kernel loop

	The only safe way to return to the OEM software is through the Failsafe image
	If you dont have a serial cable, you can ssh into openwrt and run

	`mtd -r erase firmware`
	Wait 3 minutes
	connect to ethernet and navigate to 192.168.1.1/index.htm
	select OEM firmware image from Engenius and click upgrade

Format of OEM firmware image:

	The OEM software of ENS202EXT is a heavily modified version of Openwrt Kamikaze bleeding-edge.
	One of the many modifications is to the sysupgrade program. Image verification is performed
	simply by the successful ungzip and untar of the supplied file and name check of the resulting
	contents. To form a factory.bin that is accepted by the modified OEM Openwrt build,
	the kernel and rootfs must have specific names...

		openwrt-senao-ens202ext-uImage-lzma.bin
		openwrt-senao-ens202ext-root.squashfs

	Then the files must be tarballed and gzipped. The resulting binary is actually a
	tar.gz file in disguise. This can be verified by using binwalk on the OEM firmware images,
	ungzipping then untaring.

	It's not possible to make a factory.bin for ath79 because the kernel is too large.

	the new ath79 kernel is beyond	1592k
	Even ath79-tiny is		1580k

	Checksum fails at boot because the bootloader (modified uboot) expects kernel to be 1536k.
	mtdparts variable is part of the build and saving a new uboot environment will not persist.
	For some reason this only happens when flashing from Failsafe or OEM images. Sysupgrades from
	Openwrt (ar71xx kernel) do not effect boot checksum afterward, even if it does, it would go to
	the failsafe image allowing one to install OEM firmware and restart install from OEM process
	or go back to ar71xx or OEM and stay there if you want.

	HOWEVER: one should not install older Openwrt versions from failsafe
	because it can cause rootfs to be unmountable, causing kernel loop after successful checksum.
	The only way to rescue after that is with a serial cable.

	It may also be possible that the modified sysupgrade on OEM firmware was written in a way
	that assumes the kernel will always be 1536k or less. Sysupgrade of OEM version might
	interact with uboot or with the custom OEM partition at 0x9f050000.

Note on built-in switch:

	There is two ports on the board, POE through the power supply brick, the other is on the board.
	For whatever reason, in the ar71xx target, both ports were on the built-in switch on eth1.
	In order to make use of a port for WAN or a different LAN, one would have to set each port to a VLAN.

	In ath79, eth0 and eth1 is defined in the DTS so that the built-in switch is seen as eth0,
	but only for 1 port and the other port is on eth1 without a built-in switch.

	eth0: switch0
		CPU is port 0
		board port is port 1

	eth1: POE port on the power brick

	Since there is two physical ports, it can be configured as a full router,
	with LAN for both wired and wireless.

Tested and working from v19.07.2 tag

Signed-off-by: Michael Pratt <mpratt51@gmail.com>