### PR TITLE
ramips: add support for ASUS RT-AC54U

### DIFF
--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-ac54u", "ralink,mt7620a-soc";
+	model = "Asus RT-AC54U";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "rt-ac54u:blue:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "rt-ac54u:blue:usb";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wifi2g {
+			label = "rt-ac54u:blue:wifi2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0{
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&gpio0 {
+	enable-leds {
+		gpio-hog;
+		line-name = "enable-leds";
+		output-low;
+		gpios = <10 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+	
+	mtd-mac-address = <&factory 0x22>;
+	mediatek,portmap = "wllll";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wled", "uartf";
+		function = "gpio";
+	};
+};
+	
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		
+		led {
+			led-sources = <2>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -86,6 +86,16 @@ define Device/asus_rt-ac51u
 endef
 TARGET_DEVICES += asus_rt-ac51u
 
+define Device/asus_rt-ac54u
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Asus
+  DEVICE_MODEL := RT-AC54U
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += asus_rt-ac54u
+
 define Device/asus_rt-n12p
   SOC := mt7620n
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -70,7 +70,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
-	asus,rt-ac51u)
+	asus,rt-ac51u|\
+	asus,rt-ac54u)
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
@@ -343,6 +344,7 @@ ramips_setup_macs()
 	zbtlink,zbt-we1026-5g-16m)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
+	asus,rt-ac54u|\
 	zyxel,keenetic-omni|\
 	zyxel,keenetic-omni-ii|\
 	zyxel,keenetic-viva)


### PR DESCRIPTION
Specification:
- CPU: MTK MT7620A
- RAM: 64MB
- ROM: 16MB SPI Flash Macronix MX25L12835E
- WiFi1: MediaTek MT7620A
- WiFi2: MediaTek MT7612E
- Button: reset, wps
- LED: 9 LEDs:Power, WiFi 2.4G,WiFi 5G, USB, LAN1, LAN2, LAN3, LAN4, WAN
- Ethernet: 5 ports, 4 LAN + 1 WAN
- Other: 1x UART 1x USB2.0

Installation:
  Update using ASUS Firmware Restoration Tool:
  1. Download the ASUS Firmware Restoration Tool but don't open it yet
  2. Unplug your computer from the router
  3. Put the router into Rescue Mode by: turning the power off, using a pin
to press and hold the reset button, then turning the router back on while
keeping the reset button pressed for ~5 secs until the power LED starts
flashing slowly (which indicates the router has entered Rescue Mode)
  4. Important (if you don't do this next step the Asus Firmware
Restoration Tool will wrongly assume that the router is not in Rescue Mode
and will refuse to flash it): go to the Windows Control Panel and
temporarily disable ALL other network adapters except the one you will use
to connect your computer to the router
  5. For the single adapter you left enabled, temporarily give it the
static IP 192.168.1.10 and the subnet mask 255.255.255.0
  6. Connect a LAN cable between your computer (make sure to use the
Ethernet port of the adapter you've just set up) and port 1 of the router
(not the router's WAN port)
  7. Rename sysupgrade.bin to factory.trx
  8. Open the Asus Firmware Restoration Tool, locate factory.trx and click
upload (if Windows shows a compatibility prompt, confirm that the tool worked fine)
  9. Flashing and reboot is finished when the power LED stops blinking and
stays on

MAC assignment based on vendor firmware:

2g    0x4	label
5g    0x8004	label + 4
lan   0x22	label + 4
wan   0x28	label

Signed-off-by: Zhijun You <hujy652@gmail.com>