### PR TITLE
mac80211/hostapd: Fix setting radio htmode when using mesh mode

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -782,6 +782,7 @@ mac80211_setup_vif() {
 	case "$mode" in
 		mesh)
 			wireless_vif_parse_encryption
+			[ -z "$htmode" ] && htmode="NOHT";
 			freq="$(get_freq "$phy" "$channel")"
 			if [ "$wpa" -gt 0 -o "$auto_channel" -gt 0 ] || chan_is_dfs "$phy" "$channel"; then
 				mac80211_setup_supplicant $vif_enable || failed=1

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -772,7 +772,8 @@ wpa_supplicant_set_fixed_freq() {
 	case "$htmode" in
 		VHT80) append network_data "max_oper_chwidth=1" "$N$T";;
 		VHT160) append network_data "max_oper_chwidth=2" "$N$T";;
-		*) append network_data "max_oper_chwidth=0" "$N$T";;
+		VHT20|VHT40) append network_data "max_oper_chwidth=0" "$N$T";;
+		*) append network_data "disable_vht=1" "$N$T";;
 	esac
 }
 


### PR DESCRIPTION
When configuring the radio in legacy mode from luci, the htmode is not set correctly to NOHT, causing the radio in mesh mode to be set to HT40. 
Also, disable_vht parameter needs to be set when using wpa_supplicant NOHT/HT20/HT40 modes.