### PR TITLE
dnsmasq: 'ipset' config sections

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -768,6 +768,29 @@ dhcp_relay_add() {
 	fi
 }
 
+dnsmasq_ipset_add() {
+	local cfg="$1"
+	local ipsets domains
+
+	add_ipset() {
+		ipsets="${ipsets:+$ipsets,}$1"
+	}
+
+	add_domain() {
+		# leading '/' is expected
+		domains="$domains/$1"
+	}
+
+	config_list_foreach "$cfg" "name" add_ipset
+	config_list_foreach "$cfg" "domain" add_domain
+
+	if [ -z "$ipsets" ] || [ -z "$domains" ]; then
+		return 0
+	fi
+
+	xappend "--ipset=$domains/$ipsets"
+}
+
 dnsmasq_start()
 {
 	local cfg="$1"
@@ -1052,6 +1075,10 @@ dnsmasq_start()
 
 	echo >> $CONFIGFILE_TMP
 	config_foreach filter_dnsmasq cname dhcp_cname_add "$cfg"
+	echo >> $CONFIGFILE_TMP
+
+	echo >> $CONFIGFILE_TMP
+	config_foreach filter_dnsmasq ipset dnsmasq_ipset_add "$cfg"
 	echo >> $CONFIGFILE_TMP
 
 	echo >> $CONFIGFILE_TMP


### PR DESCRIPTION
Allow configuring ipsets with dedicated config sections:

    config ipset
        list name 'ss_rules_dst_forward'
        list name 'ss_rules6_dst_forward'
        list domain 't.me'
        list domain 'telegram.org'

instead of rather inconvenient (especially with a long list of domain names):

    config dnsmasq
        ...
        list ipset '/t.me/telegram.org/ss_rules_dst_forward,ss_rules6_dst_forward'

Old 'list ipset' way is still working.

Build & run tested: ipq806x/nbg6817