### PR TITLE
ath79: add support for D-Link DAP-1330/DAP-1365 A1

### DIFF
--- a/target/linux/ath79/dts/qca9533_dlink_dap-1330-a1.dts
+++ b/target/linux/ath79/dts/qca9533_dlink_dap-1330-a1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_dlink_dap-13xx.dtsi"
+
+/ {
+	compatible = "dlink,dap-1330-a1", "qca,qca9533";
+	model = "D-Link DAP-1330 A1";
+};

--- a/target/linux/ath79/dts/qca9533_dlink_dap-1365-a1.dts
+++ b/target/linux/ath79/dts/qca9533_dlink_dap-1365-a1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_dlink_dap-13xx.dtsi"
+
+/ {
+	compatible = "dlink,dap-1365-a1", "qca,qca9533";
+	model = "D-Link DAP-1365 A1";
+};

--- a/target/linux/ath79/dts/qca9533_dlink_dap-13xx.dtsi
+++ b/target/linux/ath79/dts/qca9533_dlink_dap-13xx.dtsi
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_status;
+		led-running = &led_power;
+		led-upgrade = &led_status;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "d-link:green:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: status {
+			label = "d-link:red:status";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow {
+			label = "d-link:red:rssilow";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "d-link:green:rssimediumlow";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "d-link:green:rssimediumhigh";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "d-link:green:rssihigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x10000 0x10000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "mp";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x40000 0x7c0000>;
+				compatible = "denx,uimage";
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -132,6 +132,14 @@ compex,wpj531-16m)
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:white:dlan" "eth0.1" "rx"
 	;;
+dlink,dap-1330-a1|\
+dlink,dap-1365-a1)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "d-link:red:rssilow" "wlan0" "1" "25"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "d-link:green:rssimediumlow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "d-link:green:rssimediumhigh" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "d-link:green:rssihigh" "wlan0" "76" "100"
+	;;
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -23,6 +23,8 @@ ath79_setup_interfaces()
 	devolo,dvl1750c|\
 	devolo,dvl1750i|\
 	devolo,dvl1750x|\
+	dlink,dap-1330-a1|\
+	dlink,dap-1365-a1|\
 	dlink,dir-505|\
 	engenius,ecb1750|\
 	enterasys,ws-ap3705i|\
@@ -386,12 +388,14 @@ ath79_setup_macs()
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
 		;;
-	dlink,dap-2695-a1)
-		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
-		;;
+	dlink,dap-1330-a1|\
+	dlink,dap-1365-a1|\
 	dlink,dch-g020-a1)
 		lan_mac=$(mtd_get_mac_text "mp" 0x1)
 		label_mac=$lan_mac
+		;;
+	dlink,dap-2695-a1)
+		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
 		;;
 	dlink,dir-825-b1)
 		lan_mac=$(mtd_get_mac_text "caldata" 0xffa0)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,6 +17,8 @@ case "$board" in
 	adtran,bsap1840)
 		macaddr_add "$(mtd_get_mac_binary 'Board data' 2)" $(($PHYNBR * 8 + 1)) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dap-1330-a1|\
+	dlink,dap-1365-a1|\
 	dlink,dch-g020-a1)
 		mtd_get_mac_text "mp" 0x13 > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -8,6 +8,13 @@ case "$board" in
 arduino,yun)
 	migrate_leds "arduino:=yun:"
 	;;
+dlink,dap-1330-a1)
+	migrate_leds ":red:power=:red:status" \
+		":red:wifi=:red:rssilow" \
+		":green:wifi=:green:rssimediumlow" \
+		":green:signal1=:green:rssimediumhigh" \
+		":green:signal2=:green:rssihigh"
+	;;
 engenius,epg5000)
 	migrate_leds ":wlan-2g=:wlan2g" ":wlan-5g=:wlan5g"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -565,6 +565,33 @@ define Device/devolo_magic-2-wifi
 endef
 TARGET_DEVICES += devolo_magic-2-wifi
 
+define Device/dlink_dap-13xx
+  SOC := qca9533
+  DEVICE_VENDOR := D-Link
+  DEVICE_PACKAGES += rssileds
+  IMAGE_SIZE := 7936k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | mkdapimg2 0xE0000
+endef
+
+define Device/dlink_dap-1330-a1
+  $(Device/dlink_dap-13xx)
+  DEVICE_MODEL := DAP-1330
+  DEVICE_VARIANT := A1
+  DAP_SIGNATURE := HONEYBEE-FIRMWARE-DAP-1330
+  SUPPORTED_DEVICES += dap-1330-a1
+endef
+TARGET_DEVICES += dlink_dap-1330-a1
+
+define Device/dlink_dap-1365-a1
+  $(Device/dlink_dap-13xx)
+  DEVICE_MODEL := DAP-1365
+  DEVICE_VARIANT := A1
+  DAP_SIGNATURE := HONEYBEE-FIRMWARE-DAP-1365
+endef
+TARGET_DEVICES += dlink_dap-1365-a1
+
 define Device/dlink_dap-2695-a1
   SOC := qca9558
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct


### PR DESCRIPTION
Port device support for DAP-1330 from the ar71xx target to ath79.

Additionally, images are generated for the European through-socket
case variant DAP-1365. Both devices run the same vendor firmware, the
only difference being the `DAP_SIGNATURE` field in the factory header.
The vendor's Web UI will display a model string stored in the flash.

Specifications:

 * QCA9533, 8 MiB Flash, 64 MiB RAM
 * One Ethernet Port (10/100)
 * Wall-plug style case (DAP-1365 with additional socket)
 * LED bargraph RSSI indicator

Installation:

 * Web UI: http://192.168.0.50 (or different address obtained via DHCP)
   There is no password set by default
 * Recovery Web UI: Keep reset button pressed during power-on
   until LED starts flashing red, upgrade via http://192.168.0.50
 * Some modern browsers may have problems flashing via the Web UI,
   if this occurs consider booting to recovery mode and flashing via:
   curl -F \
     files=@openwrt-ath79-generic-dlink_dap-1330-a1-squashfs-factory.bin \
     http://192.168.0.50/cgi/index

The device will use the same MAC address for both wired and wireless
interfaces, however it is stored at two different locations in the flash.

Factory image generation is based on `mkdapimg2` from ar71xx, which might
already be introduced to ath79 by DCH-G020 from PR #2998.
Also these devices share the same MAC layout, thus the corresponding
base-files entries (in `02_network` and `10_fix_wifi_mac`) could be merged.

LED naming is a little awkward, but compatible to ar71xx.

Apparently using a .dtsi is currently the best method to include
identical devices which only differ in the model name. Makefile entries
are also hierarchical to keep `SUPPORTED_DEVICES` out of DAP-1365 metadata.

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>