### PR TITLE
mt7621: Make ER-X-SFP factory image compatible with EP-R6

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -89,7 +89,7 @@ endef
 
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
-		echo '21001:6' > $(1).compat; \
+		echo '21001:7' > $(1).compat; \
 		$(TAR) -cf $(1) --transform='s/^.*/compat/' $(1).compat; \
 		\
 		$(TAR) -rf $(1) --transform='s/^.*/vmlinux.tmp/' $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE); \


### PR DESCRIPTION
The version inside the compat file determines, if a firmware supports
a specific device. I have not yet fully understood, how this is checked,
but it only seems to indicate which devices are supported by a specific
version of the combined vendor firmware. Devices assume that subsequent
versions, starting with the version that initially added support for a
specific device, are always compatible.

The first compat version that added support for the EP-R6 was '21001:7',
but OpenWrt did use '21001:6' before. This is why the factory image could
not be flashed using the vendor software, but only using TFTP.

The compat version has been bumped by the vendor a few times, but more
devices have been added since (e.g. ER-10X). Because OpenWrt currently
only supports the ER-X, ER-X-SFP and EP-R6, the compat version is
incremented to the version that first supported the EP-R6, which is
'21001:7'.

This allows the factory image to be flashed on EP-R6 without TFTP.

Signed-off-by: Fabian Bläse <fabian@blaese.de>