### PR TITLE
lantiq/xrx200: Enable use of WLAN button on AVM Fritzbox 3370 & 736x

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ3370-REV2.dtsi
@@ -45,8 +45,8 @@
 
 		wifi {
 			label = "wlan";
-			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ736X.dtsi
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/FRITZ736X.dtsi
@@ -40,7 +40,7 @@
 		wifi {
 			label = "wifi";
 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 


### PR DESCRIPTION
**Problem**
1. The 'WLAN' button doesn't have an effect on the Fritzbox 3370 (and presumably also on 736x boxen).
Pressing the button should enable/disable wireless activity.
Apparently, OpenWRT reacts to events from the 'rfkill' `KEY_RFKILL` button, but the .dtsi file defines the button as 'wlan' `KEY_WLAN` instead.
2. Also, the button actions 'pressed' and 'released' are reversed (at least on Fritzbox 3370)
The button's behavior can easily be tested by adding
`logger -t button_action "$BUTTON $ACTION"`
as the second line of `/etc/rc.button/rfkill`, and using `logread` to read the events.

**Fix**
1. Change GPIO binding for WLAN button from KEY_WLAN to KEY_RFKILL.
This is the gpio <-> key mapping almost all other devices use (except some brcm63xx devices).
2. Change GPIO pin to ACTIVE_LOW for AVM 3370.
I couldn't test this on a AVM 736x, so I didn't change the corresponing gpio line.
