### PR TITLE
ath79: fix led_power GPIO for D-Link DIR-842

### DIFF
--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
@@ -37,12 +37,13 @@
 
 &spi {
 	status = "okay";
+
 	num-cs = <1>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <30000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
@@ -25,14 +25,6 @@
 			debounce-interval = <60>;
 		};
 	};
-
-	// Pull up on boot - otherwise the reset button won't work
-	reset-button {
-		gpio-hog;
-		output-high;
-		gpios = <11 GPIO_ACTIVE_LOW>;
-		line-name = "reset-button";
-	};
 };
 
 &uart {
@@ -116,6 +108,7 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		qca,mib-poll-interval = <500>;
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 
 		qca,ar8327-initvals = <
 			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
@@ -140,5 +133,6 @@
 
 &wmac {
 	status = "okay";
+
 	qca,no-eeprom;
 };

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c1.dts
@@ -17,19 +17,14 @@
 	leds {
 		compatible = "gpio-leds";
 
+		led_power: power {
+			label = "dir-842-c1:green:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
 		wps {
 			label = "dir-842-c1:green:wps";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		led_power: power {
-			label = "dir-842-c1:green:power";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		internet {
-			label = "dir-842-c1:green:internet";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c2.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c2.dts
@@ -17,19 +17,14 @@
 	leds {
 		compatible = "gpio-leds";
 
+		led_power: power {
+			label = "dir-842-c2:green:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
 		wps {
 			label = "dir-842-c2:green:wps";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		led_power: power {
-			label = "dir-842-c2:green:power";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		internet {
-			label = "dir-842-c2:green:internet";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c3.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c3.dts
@@ -17,19 +17,14 @@
 	leds {
 		compatible = "gpio-leds";
 
+		led_power: power {
+			label = "dir-842-c3:green:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
 		wps {
 			label = "dir-842-c3:green:wps";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		led_power: power {
-			label = "dir-842-c3:green:power";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-
-		internet {
-			label = "dir-842-c3:green:internet";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -101,9 +101,6 @@ engenius,ecb1750)
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "devolo:white:dlan" "eth0.1" "rx"
 	;;
-dlink,dir-842-c1|\
-dlink,dir-842-c2|\
-dlink,dir-842-c3|\
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;


### PR DESCRIPTION
The device has a total of 8 LEDs, 5 of which are controlled by the switch
(LAN 1-4, WAN). Only power, wifi and wps are controlled by the SoC.

 * led_power is on GPIO 5 (not 15), boot flashing sequence is now visible
 * remove led 'internet', since it is only connected to the switch
 * remove ucidef_set_led_switch for WAN from 01_leds, as it has no effect
 * replace gpio-hog on GPIO 11 with phy0 reset-gpios (for external switch)
 * increase spi-max-frequency to 50 MHz

Tested on revisions C1 and C3.

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>