### PR TITLE
ramips: add support for D-Link DIR-878 A1

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -408,6 +408,43 @@ static struct mtd_part_parser uimage_fonfxc_parser = {
 };
 
 /**************************************************
+ * SGE (T&W) Shenzhen Gongjin Electronics
+ **************************************************/
+
+#define SGE_PAD_LEN		96
+
+static ssize_t uimage_find_sge(u_char *buf, size_t len, int *extralen)
+{
+	if (uimage_verify_default(buf, len, extralen) < 0)
+		return -EINVAL;
+
+	*extralen = SGE_PAD_LEN;
+
+	return 0;
+}
+
+static int
+mtdsplit_uimage_parse_sge(struct mtd_info *master,
+			      const struct mtd_partition **pparts,
+			      struct mtd_part_parser_data *data)
+{
+	return __mtdsplit_parse_uimage(master, pparts, data,
+				       uimage_find_sge);
+}
+
+static const struct of_device_id mtdsplit_uimage_sge_of_match_table[] = {
+	{ .compatible = "sge,uimage" },
+	{},
+};
+
+static struct mtd_part_parser uimage_sge_parser = {
+	.owner = THIS_MODULE,
+	.name = "sge-fw",
+	.of_match_table = mtdsplit_uimage_sge_of_match_table,
+	.parse_fn = mtdsplit_uimage_parse_sge,
+};
+
+/**************************************************
  * OKLI (OpenWrt Kernel Loader Image)
  **************************************************/
 
@@ -470,6 +507,7 @@ static int __init mtdsplit_uimage_init(void)
 	register_mtd_parser(&uimage_netgear_parser);
 	register_mtd_parser(&uimage_edimax_parser);
 	register_mtd_parser(&uimage_fonfxc_parser);
+	register_mtd_parser(&uimage_sge_parser);
 	register_mtd_parser(&uimage_okli_parser);
 
 	return 0;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-878-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-878 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_net_orange;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "dir-878-a1:orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "dir-878-a1:green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "dir-878-a1:orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_green {
+			label = "dir-878-a1:green:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "sge,uimage";
+				label = "firmware";
+				reg = <0x60000 0xfa0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -86,6 +86,11 @@ define Build/mitrastarimage
 	mv $@.new $@
 endef
 
+define Build/sge-uimage
+	uimage_padhdr -i $@ -o $@.new -l 96
+	mv $@.new $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:7' > $(1).compat; \
@@ -240,6 +245,21 @@ define Device/dlink_dir-860l-b1
   SUPPORTED_DEVICES += dir-860l-b1
 endef
 TARGET_DEVICES += dlink_dir-860l-b1
+
+define Device/dlink_dir-878-a1
+  IMAGE_SIZE := 16000k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-878
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+  KERNEL_INITRAMFS := $$(KERNEL) | sge-uimage
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | sge-uimage |\
+	pad-rootfs | append-metadata | check-size
+  IMAGE/factory.bin := append-kernel | append-rootfs | sge-uimage |\
+	check-size
+endef
+TARGET_DEVICES += dlink_dir-878-a1
 
 define Device/d-team_newifi-d2
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,7 +26,8 @@ d-team,pbr-m1|\
 gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
-dlink,dir-860l-b1)
+dlink,dir-860l-b1|\
+dlink,dir-878-a1)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:net" "wan"
 	;;
 gnubee,gb-pc1|\


### PR DESCRIPTION
Specifications:
* SoC: MT7621AT
* RAM: 128MB
* Flash: 16MB NOR SPI flash
* WiFi: MT7615N (2.4GHz) and MT7615N (5Ghz)
* LAN: 5x1000M
* Firmware layout is Uboot with extra 96 bytes in header
* Base PCB is AP-MTKH7-0002
* LEDs Power Green,Power Orange,Internet Green,Internet Orange
* LEDs "2.4G" Green & "5G" Green connected directly to wifi module
* Buttons Reset,WPS,WIFI

Flashing instructions:

Upload image via emergency recovery mode
Push and hold reset button (on the back of the device) until power led starts flashing (about 10 secs or so) while powering the device on.
Give it ~30 seconds, to boot the recovery mode GUI
Connect your client computer to LAN1 of the device
Set your client IP address manually to 192.168.0.2 / 255.255.255.0.
Call the recovery page for the device at http://192.168.0.1
Use the provided emergency web GUI to upload and flash a new firmware to the device. Some browsers/OS combinations are known not to work, so if you don't see the percentage complete displayed and moving within a few seconds, restart the procedure from scratch and try anoher one, ot try the command line way.

Alternative method using command line on Linux:
curl -v -i -F "firmware=@openwrt-ramips-mt7621-dlink_dir-878-a1-squashfs-factory.bin" 192.168.0.1

Credit to @Lucky1openwrt for the patch. Original pull request: https://github.com/openwrt/openwrt/pull/2588/

Signed-off-by: Mathieu Martin-Borret <mathieu.mb@protonmail.com>