### PR TITLE
ramips: add support for Edimax Gemini RE23S

### DIFF
--- a/target/linux/ramips/dts/mt7621_edimax_re23s.dts
+++ b/target/linux/ramips/dts/mt7621_edimax_re23s.dts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "edimax,re23s", "mediatek,mt7621-soc";
+	model = "Edimax RE23S";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_wifi_red;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "re23s:green:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi_green {
+			label = "re23s:green:wifi";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi_amber {
+			label = "re23s:amber:wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wifi_red: wifi_red {
+			label = "re23s:red:wifi";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "cimage";
+				reg = <0x50000 0x20000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "edimax,uimage";
+				label = "firmware";
+				reg = <0x70000 0xf50000>;
+			};
+
+			partition@fc0000 {
+				label = "freespace";
+				reg = <0xfc0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x8004>;
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -261,6 +261,24 @@ define Device/edimax_ra21s
 endef
 TARGET_DEVICES += edimax_ra21s
 
+define Device/edimax_re23s
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15680k
+  DEVICE_VENDOR := Edimax
+  DEVICE_MODEL := RE23S
+  DEVICE_ALT0_VENDOR := Edimax
+  DEVICE_ALT0_MODEL := Gemini RE23S
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	edimax-header -s CSYS -m RN76 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+	append-metadata | check-size
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | \
+	edimax-header -s CSYS -m RN76 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+	check-size
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+endef
+TARGET_DEVICES += edimax_re23s
+
 define Device/edimax_rg21s
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Edimax

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -19,6 +19,16 @@ ramips_setup_interfaces()
 	xiaomi,mir3g-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	edimax,re23s|\
+	mikrotik,routerboard-m11g|\
+	netgear,ex6150|\
+	thunder,timecloud|\
+	tplink,re350-v1|\
+	tplink,re500-v1|\
+	tplink,re650-v1|\
+	ubnt,unifi-nanohd)
+		ucidef_set_interface_lan "lan"
+		;;
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
 	xiaomi,mir3p|\
@@ -32,15 +42,6 @@ ramips_setup_interfaces()
 	linksys,re6500|\
 	netgear,wac104)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
-		;;
-	mikrotik,routerboard-m11g|\
-	netgear,ex6150|\
-	thunder,timecloud|\
-	tplink,re350-v1|\
-	tplink,re500-v1|\
-	tplink,re650-v1|\
-	ubnt,unifi-nanohd)
-		ucidef_set_interface_lan "lan"
 		;;
 	mikrotik,routerboard-750gr3)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"


### PR DESCRIPTION
Hardware
--------
```
SoC:   Mediatek MT7621AT (880 MHz, 2 cores 4 threads)
RAM:   128MB
FLASH: 16MB NOR (Macronix MX25L12805D)
ETH:   1x 10/100/1000 Mbps Ethernet (MT7530)
WIFI:
  - 2.4GHz: 1x MT7615 (4x4:4)
  - 5GHz:   1x MT7615 (4x4:4)
  - 4 antennas: 2 external detachable and 2 internal
BTN:
  - 1x Reset button
  - 1x WPS button
LEDS:
  - 1x Gree led (Power)
  - 1x Green-Amber-Red led (Wifi)
UART:
  - 57600-8-N-1
```

Everything works correctly.

Installation
------------
Flash the factory image directly from OEM web interface.
(You can login using these credentials: admin/1234)

Restore OEM Firmware
--------------------
Flash the OEM "bin" firmware directly from LUCI.
The firmware is downloadable from the OEM web page.
Warning: Remember to not keep settings!
Warning2: Remember to force the flash.

Restoring procedure tested with RE23_1.08.bin

Notes
-----
Since the label contains both the 2.4GHz and 5GHz mac address I decided
to set the 5GHz one as label-mac-device. Moreover it also corresponds
to the lan mac address.

The wifi led in the OEM firmware changes colour depending on the signal
strenght. This can be done in OpenWrt but just for one interface.
So for now will not be any default action for this led.

If you want to open the case, pay attention to the antenna placed on
the bottom part of the front cover.
The wire is a bit short and it breaks easily. (I broke it)

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>