### PR TITLE
pxa: remove slave

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -210,7 +210,6 @@ $(eval $(call KernelPackage,i2c-piix4))
 
 
 I2C_PXA_MODULES:= \
-  CONFIG_I2C_PXA_SLAVE=y \
   CONFIG_I2C_PXA:drivers/i2c/busses/i2c-pxa
 
 define KernelPackage/i2c-pxa


### PR DESCRIPTION
Removing i2c pxa slave

There are no devices that use slave mode. This should not be set.

Signed-off-by: Scott Roberts ttocsr@gmail.com