### PR TITLE
netifd: fix typo (timesvr) in dhcp script

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -49,7 +49,7 @@ setup_interface () {
 	proto_add_data
 	[ -n "$ZONE" ]     && json_add_string zone "$ZONE"
 	[ -n "$ntpsrv" ]   && json_add_string ntpserver "$ntpsrv"
-	[ -n "$timesvr" ]  && json_add_string timeserver "$timesvr"
+	[ -n "$timesrv" ]  && json_add_string timeserver "$timesrv"
 	[ -n "$hostname" ] && json_add_string hostname "$hostname"
 	[ -n "$message" ]  && json_add_string message "$message"
 	[ -n "$timezone" ] && json_add_int timezone "$timezone"

--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -46,6 +46,12 @@ setup_interface () {
 		proto_add_dns_search "$i"
 	done
 
+	# TODO: Deprecate timesvr in favor of timesrv
+	if [ -n "$timesvr" -a -z "$timesrv" ]; then
+		timesrv="$timesvr"
+		echo "Environment variable 'timesvr' will be deprecated; use 'timesrv' instead."
+	fi
+
 	proto_add_data
 	[ -n "$ZONE" ]     && json_add_string zone "$ZONE"
 	[ -n "$ntpsrv" ]   && json_add_string ntpserver "$ntpsrv"


### PR DESCRIPTION
Match DHCP Option 4 handling  to udhcpc's environment variable (timesrv).

Signed-off-by: Sukru Senli <sukru.senli@iopsys.eu>
