### PR TITLE
bcm63xx: use model part of board name as variable in 01_leds

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -7,7 +7,10 @@
 
 board_config_update
 
-case "$(board_name)" in
+board=$(board_name)
+model="${board##*,}"
+
+case "$board" in
 actiontec,r1000h)
 	ucidef_set_led_usbport "usb" "USB" "R1000H:green:usb" "usb1-port1" "usb2-port1"
 	;;
@@ -30,8 +33,9 @@ bt,home-hub-2-a)
 comtrend,ar-5315u)
 	ucidef_set_led_usbdev "usb" "USB" "AR-5315u:green:usb" "1-1"
 	;;
-comtrend,vr-3032u)
-	ucidef_set_led_usbdev "usb" "USB" "vr-3032u:green:usb" "1-1"
+comtrend,vr-3032u|\
+huawei,hg253s-v2)
+	ucidef_set_led_usbdev "usb" "USB" "$model:green:usb" "1-1"
 	;;
 huawei,echolife-hg553)
 	ucidef_set_led_netdev "lan" "LAN" "HW553:blue:lan" "eth0"
@@ -50,9 +54,6 @@ huawei,echolife-hg622)
 huawei,echolife-hg655b)
 	ucidef_set_led_usbdev "usb" "USB" "HW65x:green:usb" "1-2"
 	;;
-huawei,hg253s-v2)
-	ucidef_set_led_usbdev "usb" "USB" "hg253s-v2:green:usb" "1-1"
-	;;
 inventel,livebox-1)
 	ucidef_set_led_netdev "lan" "LAN" "Livebox1:red:traffic" "eth0"
 	ucidef_set_led_netdev "wan" "WAN" "Livebox1:red:adsl" "eth1"
@@ -67,9 +68,9 @@ netgear,dgnd3700-v1)
 	ucidef_set_led_usbdev "usb2" "USB2" "DGND3700v1_3800B:green:usb-front" "1-2"
 	;;
 netgear,dgnd3700-v2)
-	ucidef_set_led_netdev "lan" "LAN" "dgnd3700-v2:green:ethernet" "eth0"
-	ucidef_set_led_usbdev "usb1" "USB1" "dgnd3700-v2:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "dgnd3700-v2:green:usb2" "1-2"
+	ucidef_set_led_netdev "lan" "LAN" "$model:green:ethernet" "eth0"
+	ucidef_set_led_usbdev "usb1" "USB1" "$model:green:usb1" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "$model:green:usb2" "1-2"
 	;;
 netgear,evg2000)
 	ucidef_set_led_netdev "lan" "LAN" "EVG2000:green:lan" "eth0"
@@ -88,7 +89,7 @@ sagem,fast-2704-v2)
 	ucidef_set_led_usbdev "usb" "USB" "F@ST2704V2:green:usb" "1-1"
 	;;
 sercomm,ad1018)
-	ucidef_set_led_netdev "wlan0" "WLAN" "ad1018:green:wifi" "wlan0"
+	ucidef_set_led_netdev "wlan0" "WLAN" "$model:green:wifi" "wlan0"
 	;;
 sercomm,ad1018-nor)
 	ucidef_set_led_netdev "wlan0" "WLAN" "AD1018:green:wifi" "wlan0"


### PR DESCRIPTION
This extracts the model part of the board name and uses it for the
LED string identifiers in 01_leds. As this makes statements more
generic, it will allow to merge more cases in the future.