### PR TITLE
kernel: Add kmod-sch-cake-virtual package to resolve dependency errors

### DIFF
--- a/package/kernel/kmod-sched-cake-oot/Makefile
+++ b/package/kernel/kmod-sched-cake-oot/Makefile
@@ -29,14 +29,26 @@ define KernelPackage/sched-cake-oot
   DEPENDS:=@LINUX_4_14 +kmod-sched-core +kmod-ipt-conntrack
 endef
 
-include $(INCLUDE_DIR)/kernel-defaults.mk
-
-define KernelPackage/sched-cake/description
+define KernelPackage/sched-cake-oot/description
   O(ut) O(f) T(ree) Common Applications Kept Enhanced fq_codel/blue derived shaper
 endef
+
+define KernelPackage/sched-cake-virtual
+  SUBMENU:=Network Support
+  TITLE:=Virtual package for sched-cake
+  URL:=https://github.com/dtaht/sch_cake
+  DEPENDS:=+!LINUX_4_14:kmod-sched-cake +LINUX_4_14:kmod-sched-cake-oot
+endef
+
+define KernelPackage/sched-cake-virtual/description
+  Virtual package for resolving sch_cake dependencies
+endef
+
+include $(INCLUDE_DIR)/kernel-defaults.mk
 
 define Build/Compile
 	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" modules
 endef
 
 $(eval $(call KernelPackage,sched-cake-oot))
+$(eval $(call KernelPackage,sched-cake-virtual))


### PR DESCRIPTION
As reported in https://github.com/openwrt/packages/issues/12072, the
imagebuilder fails due to a dependency resolution error when the userspace
packages are built using a target that has a different kernel version than
that which is being run. To resolve this, add a virtual kernel package with
the conditional dependency currently used in sqm-scripts. The idea is to
move the sqm-scripts dependency to this virtual package, which hopefully
should be consistent with the actual kernel module being built.



This was already posted to openwrt-devel (see
https://patchwork.ozlabs.org/project/openwrt/patch/mailman.10417.1588795819.2542.openwrt-devel@lists.openwrt.org/)
but opening a PR here in the hope that this will lead it to actually
getting merged...