### PR TITLE
uboot-kirkwood: enable sata in nsa310 uboot

### DIFF
--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -505,7 +505,7 @@ NOTE: this patch is ready for upstream, LEDE-specific parts are in
 +#endif /* __NSA310_H */
 --- /dev/null
 +++ b/configs/nsa310_defconfig
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,50 @@
 +CONFIG_ARM=y
 +CONFIG_SYS_DCACHE_OFF=y
 +CONFIG_ARCH_CPU_INIT=y
@@ -554,6 +554,8 @@ NOTE: this patch is ready for upstream, LEDE-specific parts are in
 +CONFIG_LZMA=y
 +CONFIG_LZO=y
 +CONFIG_SYS_LONGHELP=y
++CONFIG_SATA_MV=y
++CONFIG_CMD_IDE=y
 --- /dev/null
 +++ b/include/configs/nsa310.h
 @@ -0,0 +1,103 @@


### PR DESCRIPTION
the uboot of nsa310 cannot use the network chip
as it is a realtek on the PCIe lanes and not a 
Marvell ethernet from the SoC.

Therefore tftp is not possible on this device
and the only way to install is by loading files 
from a USB drive.
If the USB subsystem is dead there is no way to
install OpenWrt.
Enable sata support and commands so it can be
used as a fallback in case of USB issues.

Signed-off-by Alberto Bursi <bobafetthotmail@gmail.com>

An example of nsa310 where the USB is dead and needed Sata support for a successful installation is in this post in the forum https://forum.openwrt.org/t/serial-install-problems-on-nsa310/37306/32?u=bobafetthotmail
I helped him by providing a custom built uboot with these options enabled