### PR TITLE
lantiq/xrx200: make use of WLAN button on Fritzbox 3370

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -44,7 +44,7 @@
 
 		wifi {
 			label = "wlan";
-			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -45,7 +45,7 @@
 		wifi {
 			label = "wlan";
 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -40,7 +40,7 @@
 		wifi {
 			label = "wifi";
 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -44,7 +44,7 @@
 
 		wifi {
 			label = "wlan";
-			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
 		};
 	};

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -45,7 +45,7 @@
 		wifi {
 			label = "wlan";
 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -40,7 +40,7 @@
 		wifi {
 			label = "wifi";
 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WLAN>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 


### PR DESCRIPTION
Currently, pressing the WLAN button on the 3370 has no effect.
This submission fixes the GPIO <-> key mapping for this button:
A sequence of pressing and releasing the button will now toggle wireless activity, as would be expected.

Note:
I expect the same problem on Fritzbox 736x devices, but couldn't test this.