### PR TITLE
ramips: add alternative name for Buffalo WSR-2533DHP

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -196,6 +196,8 @@ define Device/buffalo_wsr-2533dhpl
   IMAGE_SIZE := 7936k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-2533DHPL
+  DEVICE_ALT0_VENDOR := Buffalo
+  DEVICE_ALT0_MODEL := WSR-2533DHP
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata
   DEVICE_PACKAGES := kmod-mt7615e wpad-basic
 endef


### PR DESCRIPTION
Buffalo WSR-2533DHP is identical to the WSR-2533DHPL, Buffalo sold it
with renaming.

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>