### PR TITLE
[RFC] base-files: Add more flexibility to diag.sh mechanics

### DIFF
--- a/package/base-files/files/etc/init.d/done
+++ b/package/base-files/files/etc/init.d/done
@@ -12,6 +12,6 @@ boot() {
 	}
 
 	# set leds to normal state
-	. /etc/diag.sh
+	. /lib/functions/diag.sh
 	set_state done
 }

--- a/package/base-files/files/etc/rc.button/reset
+++ b/package/base-files/files/etc/rc.button/reset
@@ -11,7 +11,7 @@ pressed)
 	return 5
 ;;
 timeout)
-	. /etc/diag.sh
+	. /lib/functions/diag.sh
 	set_state failsafe
 ;;
 released)

--- a/package/base-files/files/lib/functions/diag.sh
+++ b/package/base-files/files/lib/functions/diag.sh
@@ -50,3 +50,5 @@ set_led_state() {
 set_state() {
 	[ -n "$boot" -o -n "$failsafe" -o -n "$running" -o -n "$upgrade" ] && set_led_state "$1"
 }
+
+[ -f /etc/diag.sh ] && . /etc/diag.sh

--- a/package/base-files/files/lib/preinit/02_default_set_state
+++ b/package/base-files/files/lib/preinit/02_default_set_state
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 define_default_set_state() {
-	. /etc/diag.sh
+	. /lib/functions/diag.sh
 }
 
 boot_hook_add preinit_main define_default_set_state

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -268,7 +268,7 @@ get_partitions() { # <device> <filename>
 }
 
 indicate_upgrade() {
-	. /etc/diag.sh
+	. /lib/functions/diag.sh
 	set_state upgrade
 }
 


### PR DESCRIPTION
Generic `diag.sh` from `base-files` package now resides in `/lib/functions`. It will attempt to source '/etc/diag.sh' if it exists, which action would override default `set_state` function. The function will be able to call original `set_led_state` and/or do something totally different.

Any sub-target with `base-files/etc/diag.sh` could be able to call generic `set_led_state` in its `set_state` function, without introducing a copy of it for the whole sub-target because of some pesky board.

For example:
```shell
# /etc/diag.sh
set_state() {
   case $(board_name) in
   acme,weirdo)
      some_weirdo_stuff "$1"
      ;;
   *)
      # This function is from /lib/functions/diag.sh
      set_led_state "$1"
      ;;
   esac
}
```
