### PR TITLE
layerscape: support sysupgrade

### DIFF
--- a/package/boot/uboot-layerscape/files/ls1012ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1012ardb-uEnv.txt
@@ -3,6 +3,6 @@ loadaddr=0x81000000
 fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock8 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(pfe),2m(reserved-2),1m(dtb),16m(kernel),32m(rootfs)
+bootargs=root=/dev/mtdblock8 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(pfe),2m(reserved-2),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware)
 bootcmd=echo starting openwrt ...;pfe stop;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1012ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1012ardb-uEnv.txt
@@ -3,6 +3,6 @@ loadaddr=0x81000000
 fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=ubi.mtd=8 root=ubi0:rootfs rw rootfstype=ubifs noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(pfe),2m(reserved-2),1m(dtb),16m(kernel),32m(ubifs)
+bootargs=root=/dev/mtdblock8 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(pfe),2m(reserved-2),1m(dtb),16m(kernel),32m(rootfs)
 bootcmd=echo starting openwrt ...;pfe stop;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1021atwr-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1021atwr-uEnv.txt
@@ -3,6 +3,6 @@ loadaddr=0x81000000
 fdt_high=0xffffffff
 initrd_high=0xffffffff
 nor_boot=cp.b 60f00000 $fdtaddr 100000;cp.b 61000000 $loadaddr 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock6 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=60000000.nor:1m(rcw),2m(u-boot),1m(u-boot-env),11m(reserved-1),1m(dtb),16m(kernel),32m(rootfs) cma=64M@0x0-0xb0000000
+bootargs=root=/dev/mtdblock6 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=60000000.nor:1m(rcw),2m(u-boot),1m(u-boot-env),11m(reserved-1),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware) cma=64M@0x0-0xb0000000
 bootcmd=echo starting openwrt ...;run nor_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1043ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1043ardb-uEnv.txt
@@ -4,6 +4,6 @@ fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 nor_boot=cp.b 60f00000 $fdtaddr 100000;cp.b 61000000 $loadaddr 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock8 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=60000000.nor:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(rootfs)
+bootargs=root=/dev/mtdblock8 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=60000000.nor:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware)
 bootcmd=echo starting openwrt ...;run nor_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1046ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1046ardb-uEnv.txt
@@ -4,6 +4,6 @@ fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock9 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(rootfs)
+bootargs=root=/dev/mtdblock9 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware)
 bootcmd=echo starting openwrt ...;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1046ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1046ardb-uEnv.txt
@@ -4,6 +4,6 @@ fdt_high=0xffffffffffffffff
 initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=ubi.mtd=9 root=ubi0:rootfs rw rootfstype=ubifs noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(ubifs)
+bootargs=root=/dev/mtdblock9 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=1550000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),3m(reserved-1),256k(fman),5888k(reserved-2),1m(dtb),16m(kernel),32m(rootfs)
 bootcmd=echo starting openwrt ...;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1088ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1088ardb-uEnv.txt
@@ -5,6 +5,6 @@ initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 mc_init=sf probe 0:0;sf read 80000000 a00000 300000;sf read 80300000 e00000 100000;fsl_mc start mc 80000000 80300000;sf read 80400000 d00000 100000;fsl_mc apply dpl 80400000
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=ubi.mtd=10 root=ubi0:rootfs rw rootfstype=ubifs noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=20c0000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(ubifs)
+bootargs=root=/dev/mtdblock10 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=20c0000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(rootfs)
 bootcmd=echo starting openwrt ...;run mc_init;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls1088ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls1088ardb-uEnv.txt
@@ -5,6 +5,6 @@ initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 mc_init=sf probe 0:0;sf read 80000000 a00000 300000;sf read 80300000 e00000 100000;fsl_mc start mc 80000000 80300000;sf read 80400000 d00000 100000;fsl_mc apply dpl 80400000
 qspi_boot=sf probe 0:0;sf read $fdtaddr f00000 100000;sf read $loadaddr 1000000 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock10 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=20c0000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(rootfs)
+bootargs=root=/dev/mtdblock10 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS0,115200 mtdparts=20c0000.spi-0:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware)
 bootcmd=echo starting openwrt ...;run mc_init;run qspi_boot
 bootdelay=3

--- a/package/boot/uboot-layerscape/files/ls2088ardb-uEnv.txt
+++ b/package/boot/uboot-layerscape/files/ls2088ardb-uEnv.txt
@@ -5,6 +5,6 @@ initrd_high=0xffffffffffffffff
 hwconfig=fsl_ddr:bank_intlv=auto
 mc_init=fsl_mc start mc 580a00000 580e00000;fsl_mc apply dpl 580d00000
 nor_boot=cp.b 580f00000 $fdtaddr 100000;cp.b 581000000 $loadaddr 1000000;bootm $loadaddr - $fdtaddr
-bootargs=root=/dev/mtdblock9 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS1,115200 mtdparts=580000000.nor:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(rootfs)
+bootargs=root=/dev/mtdblock9 rootfstype=squashfs,jffs2 noinitrd earlycon=uart8250,mmio,0x21c0500 console=ttyS1,115200 mtdparts=580000000.nor:1m(bl2),4m(fip),1m(u-boot-env),4m(reserved-1),3m(mc),1m(dpl),1m(dpc),1m(dtb),16m(kernel),32m(rootfs),48m@0x1000000(firmware)
 bootcmd=echo starting openwrt ...;run mc_init;run nor_boot
 bootdelay=3

--- a/target/linux/layerscape/Makefile
+++ b/target/linux/layerscape/Makefile
@@ -18,6 +18,7 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += kmod-usb3 kmod-usb-dwc3 kmod-usb-storage
+DEFAULT_PACKAGES += kmod-usb3 kmod-usb-dwc3 kmod-usb-storage \
+  partx-utils
 
 $(eval $(call BuildTarget))

--- a/target/linux/layerscape/base-files/lib/preinit/02_sysinfo_fixup
+++ b/target/linux/layerscape/base-files/lib/preinit/02_sysinfo_fixup
@@ -1,0 +1,13 @@
+do_sysinfo_layerscape_fixup() {
+	[ -e /tmp/sysinfo/board_name ] || return
+	[ -e /proc/cmdline ] || return
+	cmdline=$(strings /proc/cmdline)
+	case "${cmdline}" in
+		*root=/dev/mmcblk*)
+			board="$(strings /tmp/sysinfo/board_name)-sdboot"
+			echo ${board} > /tmp/sysinfo/board_name
+		;;
+	esac
+}
+
+boot_hook_add preinit_main do_sysinfo_layerscape_fixup

--- a/target/linux/layerscape/base-files/lib/upgrade/platform.sh
+++ b/target/linux/layerscape/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,85 @@ RAMFS_COPY_DATA="/etc/fw_env.config /var/lock/fw_printenv.lock"
 
 REQUIRE_IMAGE_METADATA=1
 
+platform_check_image_sdboot() {
+	local diskdev partdev diff
+
+	export_bootdevice && export_partdevice diskdev 0 || {
+		echo "Unable to determine upgrade device"
+		return 1
+	}
+
+	# get partitions table from boot device
+	get_partitions "/dev/$diskdev" bootdisk
+
+	# get partitions table from sysupgrade.bin
+	dd if="$1" of=/tmp/image.bs bs=512b count=1 > /dev/null 2>&1
+	sync
+	get_partitions /tmp/image.bs image
+
+	# compare tables
+	diff="$(grep -F -x -v -f /tmp/partmap.bootdisk /tmp/partmap.image)"
+
+	rm -f /tmp/image.bs /tmp/partmap.bootdisk /tmp/partmap.image
+
+	if [ -n "$diff" ]; then
+		echo "Partition layout has changed. Full image will be written."
+		ask_bool 0 "Abort" && exit 1
+		return 0
+	fi
+}
+platform_do_upgrade_sdboot() {
+	local diskdev partdev diff
+
+	export_bootdevice && export_partdevice diskdev 0 || {
+		echo "Unable to determine upgrade device"
+		return 1
+	}
+
+	if [ "$UPGRADE_OPT_SAVE_PARTITIONS" = "1" ]; then
+		# get partitions table from boot device
+		get_partitions "/dev/$diskdev" bootdisk
+
+		# get partitions table from sysupgrade.bin
+		dd if="$1" of=/tmp/image.bs bs=512b count=1 > /dev/null 2>&1
+		sync
+		get_partitions /tmp/image.bs image
+
+		# compare tables
+		diff="$(grep -F -x -v -f /tmp/partmap.bootdisk /tmp/partmap.image)"
+	else
+		diff=1
+	fi
+
+	if [ -n "$diff" ]; then
+		dd if="$1" of="/dev/$diskdev" bs=1024 count=4 > /dev/null 2>&1
+		dd if="$1" of="$diskdev" bs=1024 skip=4 seek=16384 > /dev/null 2>&1
+		sync
+
+		# Separate removal and addtion is necessary; otherwise, partition 1
+		# will be missing if it overlaps with the old partition 2
+		partx -d - "/dev/$diskdev"
+		partx -a - "/dev/$diskdev"
+
+		return 0
+	fi
+
+	# write kernel image
+	dd if="$1" of="$diskdev" bs=1024 skip=4 seek=16384 count=16384 > /dev/null 2>&1
+	sync
+
+	# iterate over each partition from the image and write it to the boot disk
+	while read part start size; do
+		if export_partdevice partdev $part; then
+			echo "Writing image to /dev/$partdev..."
+			dd if="$1" of="/dev/$partdev" bs=512 skip="$start" count="$size" > /dev/null 2>&1
+			sync
+		else
+			echo "Unable to find partition $part device, skipped."
+		fi
+	done < /tmp/partmap.image
+
+}
 platform_do_upgrade_traverse_nandubi() {
 	bootsys=$(fw_printenv bootsys | awk -F= '{{print $2}}')
 	newbootsys=2
@@ -26,6 +105,15 @@ platform_do_upgrade_traverse_nandubi() {
 	nand_do_upgrade "$1" || (echo "Upgrade failed, setting bootsys ${bootsys}" && fw_setenv bootsys $bootsys)
 
 }
+platform_copy_config() {
+	local partdev parttype=ext4
+
+	if export_partdevice partdev 1; then
+		mount -t $parttype -o rw,noatime "/dev/$partdev" /mnt
+		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
+		umount /mnt
+	fi
+}
 platform_check_image() {
 	local board=$(board_name)
 
@@ -42,6 +130,14 @@ platform_check_image() {
 	fsl,ls1046a-rdb | \
 	fsl,ls1088a-rdb | \
 	fsl,ls2088a-rdb)
+		return 0
+		;;
+	fsl,ls1012a-frwy-sdboot | \
+	fsl,ls1021a-twr-sdboot | \
+	fsl,ls1043a-rdb-sdboot | \
+	fsl,ls1046a-rdb-sdboot | \
+	fsl,ls1088a-rdb-sdboot)
+		platform_check_image_sdboot "$1"
 		return 0
 		;;
 	*)
@@ -72,6 +168,14 @@ platform_do_upgrade() {
 	fsl,ls2088a-rdb)
 		PART_NAME=firmware
 		default_do_upgrade "$1"
+		;;
+	fsl,ls1012a-frwy-sdboot | \
+	fsl,ls1021a-twr-sdboot | \
+	fsl,ls1043a-rdb-sdboot | \
+	fsl,ls1046a-rdb-sdboot | \
+	fsl,ls1088a-rdb-sdboot)
+		platform_do_upgrade_sdboot "$1"
+		return 0
 		;;
 	*)
 		echo "Sysupgrade is not currently supported on $board"

--- a/target/linux/layerscape/base-files/lib/upgrade/platform.sh
+++ b/target/linux/layerscape/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright 2015-2019 Traverse Technologies
+# Copyright 2020 NXP
 #
 
 RAMFS_COPY_BIN="/usr/sbin/fw_printenv /usr/sbin/fw_setenv /usr/sbin/ubinfo /bin/echo"
@@ -34,7 +35,13 @@ platform_check_image() {
 		nand_do_platform_check "traverse-ls1043" $1
 		return $?
 		;;
-	fsl,ls1012a-frdm)
+	fsl,ls1012a-frdm | \
+	fsl,ls1012a-rdb | \
+	fsl,ls1021a-twr | \
+	fsl,ls1043a-rdb | \
+	fsl,ls1046a-rdb | \
+	fsl,ls1088a-rdb | \
+	fsl,ls2088a-rdb)
 		return 0
 		;;
 	*)
@@ -56,7 +63,13 @@ platform_do_upgrade() {
 	traverse,ls1043s)
 		platform_do_upgrade_traverse_nandubi "$1"
 		;;
-	fsl,ls1012a-frdm)
+	fsl,ls1012a-frdm | \
+	fsl,ls1012a-rdb | \
+	fsl,ls1021a-twr | \
+	fsl,ls1043a-rdb | \
+	fsl,ls1046a-rdb | \
+	fsl,ls1088a-rdb | \
+	fsl,ls2088a-rdb)
 		PART_NAME=firmware
 		default_do_upgrade "$1"
 		;;

--- a/target/linux/layerscape/image/Makefile
+++ b/target/linux/layerscape/image/Makefile
@@ -11,6 +11,9 @@ LS_SD_ROOTFSPART_OFFSET = 64
 LS_SD_IMAGE_SIZE = $(shell echo $$((($(LS_SD_ROOTFSPART_OFFSET) + \
 	$(CONFIG_TARGET_ROOTFS_PARTSIZE)) * 1024 * 1024)))
 
+# The limitation of flash sysupgrade.bin is 16MB kernel + 32MB rootfs
+LS_SYSUPGRADE_IMAGE_SIZE = 48m
+
 define Build/ls-clean
 	rm -f $@
 endef

--- a/target/linux/layerscape/image/armv7.mk
+++ b/target/linux/layerscape/image/armv7.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 NXP
+# Copyright 2018-2020 NXP
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,11 +8,13 @@
 define Device/Default
   PROFILES := Default
   FILESYSTEMS := squashfs
-  IMAGES := firmware.bin
+  IMAGES := firmware.bin sysupgrade.bin
   KERNEL := kernel-bin | uImage none
   KERNEL_NAME := zImage
   KERNEL_LOADADDR := 0x80008000
   KERNEL_ENTRY_POINT := 0x80008000
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 16M | \
+    append-rootfs | pad-rootfs | check-size 50331649 | append-metadata
 endef
 
 define Device/ls1021atwr
@@ -29,6 +31,7 @@ define Device/ls1021atwr
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls1021a-twr
 endef
 TARGET_DEVICES += ls1021atwr
 

--- a/target/linux/layerscape/image/armv7.mk
+++ b/target/linux/layerscape/image/armv7.mk
@@ -41,7 +41,7 @@ define Device/ls1021atwr-sdboot
   DEVICE_VARIANT := SD Card Boot
   DEVICE_DTS := ls1021a-twr
   FILESYSTEMS := ext4
-  IMAGES := sdcard.img
+  IMAGES := sdcard.img sysupgrade.bin
   IMAGE/sdcard.img := \
     ls-clean | \
     ls-append-sdhead $(1) | pad-to 4K | \
@@ -50,6 +50,12 @@ define Device/ls1021atwr-sdboot
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
     append-rootfs | check-size $(LS_SD_IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := \
+    ls-clean | \
+    ls-append-sdhead $(1) | pad-to 16M | \
+    append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
+    append-rootfs | check-size $(LS_SD_IMAGE_SIZE) | append-metadata
+  SUPPORTED_DEVICES := fsl,ls1021a-twr-sdboot
 endef
 TARGET_DEVICES += ls1021atwr-sdboot
 

--- a/target/linux/layerscape/image/armv7.mk
+++ b/target/linux/layerscape/image/armv7.mk
@@ -13,8 +13,10 @@ define Device/Default
   KERNEL_NAME := zImage
   KERNEL_LOADADDR := 0x80008000
   KERNEL_ENTRY_POINT := 0x80008000
+  IMAGE_SIZE := 64m
   IMAGE/sysupgrade.bin := append-kernel | pad-to 16M | \
-    append-rootfs | pad-rootfs | check-size 50331649 | append-metadata
+    append-rootfs | pad-rootfs | \
+    check-size $(LS_SYSUPGRADE_IMAGE_SIZE) | append-metadata
 endef
 
 define Device/ls1021atwr
@@ -30,7 +32,7 @@ define Device/ls1021atwr
     ls-append $(1)-uboot-env.bin | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls1021a-twr
 endef
 TARGET_DEVICES += ls1021atwr

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 NXP
+# Copyright 2018-2020 NXP
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,11 +7,13 @@
 
 define Device/Default
   PROFILES := Default
-  IMAGES := firmware.bin
+  IMAGES := firmware.bin sysupgrade.bin
   FILESYSTEMS := squashfs
   KERNEL := kernel-bin | gzip | uImage gzip
   KERNEL_LOADADDR := 0x80080000
   KERNEL_ENTRY_POINT := 0x80080000
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 16M | \
+    append-rootfs | pad-rootfs | check-size 50331649 | append-metadata
 endef
 
 define Device/ls1012afrdm
@@ -23,7 +25,6 @@ define Device/ls1012afrdm
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-frdm
   BLOCKSIZE := 256KiB
-  IMAGES += sysupgrade.bin
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -58,6 +59,7 @@ define Device/ls1012ardb
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls1012a-rdb
 endef
 TARGET_DEVICES += ls1012ardb
 
@@ -105,6 +107,7 @@ define Device/ls1043ardb
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls1043a-rdb
 endef
 TARGET_DEVICES += ls1043ardb
 
@@ -150,6 +153,7 @@ define Device/ls1046ardb
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls1046a-rdb
 endef
 TARGET_DEVICES += ls1046ardb
 
@@ -198,6 +202,7 @@ define Device/ls1088ardb
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls1088a-rdb
 endef
 TARGET_DEVICES += ls1088ardb
 
@@ -248,6 +253,7 @@ define Device/ls2088ardb
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
     append-rootfs | pad-rootfs | check-size 67108865
+  SUPPORTED_DEVICES := fsl,ls2088a-rdb
 endef
 TARGET_DEVICES += ls2088ardb
 

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -8,8 +8,7 @@
 define Device/Default
   PROFILES := Default
   IMAGES := firmware.bin
-  FILESYSTEMS := ubifs
-  MKUBIFS_OPTS := -m 1 -e 262016 -c 128
+  FILESYSTEMS := squashfs
   KERNEL := kernel-bin | gzip | uImage gzip
   KERNEL_LOADADDR := 0x80080000
   KERNEL_ENTRY_POINT := 0x80080000
@@ -24,7 +23,6 @@ define Device/ls1012afrdm
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-frdm
   BLOCKSIZE := 256KiB
-  FILESYSTEMS := squashfs
   IMAGES += sysupgrade.bin
   IMAGE/firmware.bin := \
     ls-clean | \
@@ -51,9 +49,6 @@ define Device/ls1012ardb
     tfa-ls1012ardb \
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-rdb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 256KiB
-  PAGESIZE := 1
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -62,7 +57,7 @@ define Device/ls1012ardb
     ls-append pfe.itb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-ubi | check-size 67108865
+    append-rootfs | pad-rootfs | check-size 67108865
 endef
 TARGET_DEVICES += ls1012ardb
 
@@ -101,7 +96,6 @@ define Device/ls1043ardb
     tfa-ls1043ardb \
     fmc fmc-eth-config
   DEVICE_DTS := freescale/fsl-ls1043a-rdb-sdk
-  FILESYSTEMS := squashfs
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -147,9 +141,6 @@ define Device/ls1046ardb
     tfa-ls1046ardb \
     fmc fmc-eth-config
   DEVICE_DTS := freescale/fsl-ls1046a-rdb-sdk
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 256KiB
-  PAGESIZE := 1
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -158,7 +149,7 @@ define Device/ls1046ardb
     ls-append $(1)-fman.bin | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-ubi | check-size 67108865
+    append-rootfs | pad-rootfs | check-size 67108865
 endef
 TARGET_DEVICES += ls1046ardb
 
@@ -196,9 +187,6 @@ define Device/ls1088ardb
     tfa-ls1088ardb \
     restool
   DEVICE_DTS := freescale/fsl-ls1088a-rdb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 256KiB
-  PAGESIZE := 1
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -209,7 +197,7 @@ define Device/ls1088ardb
     ls-append $(1)-dpc.dtb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-ubi | check-size 67108865
+    append-rootfs | pad-rootfs | check-size 67108865
 endef
 TARGET_DEVICES += ls1088ardb
 
@@ -249,7 +237,6 @@ define Device/ls2088ardb
     tfa-ls2088ardb \
     restool
   DEVICE_DTS := freescale/fsl-ls2088a-rdb
-  FILESYSTEMS := squashfs
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -272,6 +259,7 @@ define Device/traverse-ls1043
   KERNEL_INSTALL := 1
   FDT_LOADADDR = 0x90000000
   FILESYSTEMS := ubifs
+  MKUBIFS_OPTS := -m 1 -e 262016 -c 128
   DEVICE_PACKAGES += \
     layerscape-fman \
     uboot-envtools \

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -12,8 +12,10 @@ define Device/Default
   KERNEL := kernel-bin | gzip | uImage gzip
   KERNEL_LOADADDR := 0x80080000
   KERNEL_ENTRY_POINT := 0x80080000
+  IMAGE_SIZE := 64m
   IMAGE/sysupgrade.bin := append-kernel | pad-to 16M | \
-    append-rootfs | pad-rootfs | check-size 50331649 | append-metadata
+    append-rootfs | pad-rootfs | \
+    check-size $(LS_SYSUPGRADE_IMAGE_SIZE) | append-metadata
 endef
 
 define Device/ls1012afrdm
@@ -33,9 +35,10 @@ define Device/ls1012afrdm
     ls-append pfe.itb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $$(BLOCKSIZE) | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size 50331648 | append-metadata
+	append-rootfs | pad-rootfs | \
+        check-size $(LS_SYSUPGRADE_IMAGE_SIZE) | append-metadata
   KERNEL := kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(DEVICE_DTS).dtb
   KERNEL_INITRAMFS := kernel-bin | fit none $$(DTS_DIR)/$$(DEVICE_DTS).dtb
   SUPPORTED_DEVICES := fsl,ls1012a-frdm
@@ -58,7 +61,7 @@ define Device/ls1012ardb
     ls-append pfe.itb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls1012a-rdb
 endef
 TARGET_DEVICES += ls1012ardb
@@ -112,7 +115,7 @@ define Device/ls1043ardb
     ls-append $(1)-fman.bin | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls1043a-rdb
 endef
 TARGET_DEVICES += ls1043ardb
@@ -164,7 +167,7 @@ define Device/ls1046ardb
     ls-append $(1)-fman.bin | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls1046a-rdb
 endef
 TARGET_DEVICES += ls1046ardb
@@ -219,7 +222,7 @@ define Device/ls1088ardb
     ls-append $(1)-dpc.dtb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls1088a-rdb
 endef
 TARGET_DEVICES += ls1088ardb
@@ -276,7 +279,7 @@ define Device/ls2088ardb
     ls-append $(1)-dpc.dtb | pad-to 15M | \
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to 32M | \
-    append-rootfs | pad-rootfs | check-size 67108865
+    append-rootfs | pad-rootfs | check-size
   SUPPORTED_DEVICES := fsl,ls2088a-rdb
 endef
 TARGET_DEVICES += ls2088ardb

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -72,7 +72,7 @@ define Device/ls1012afrwy
     kmod-ppfe
   DEVICE_DTS := freescale/fsl-ls1012a-frwy
   FILESYSTEMS := ext4
-  IMAGES := firmware.bin sdcard.img
+  IMAGES := firmware.bin sdcard.img sysupgrade.bin
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 128K | \
@@ -86,6 +86,12 @@ define Device/ls1012afrwy
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
     append-rootfs | check-size $(LS_SD_IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := \
+    ls-clean | \
+    ls-append-sdhead $(1) | pad-to 16M | \
+    append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
+    append-rootfs | check-size $(LS_SD_IMAGE_SIZE) | append-metadata
+  SUPPORTED_DEVICES := fsl,ls1012a-frwy-sdboot
 endef
 TARGET_DEVICES += ls1012afrwy
 
@@ -121,7 +127,7 @@ define Device/ls1043ardb-sdboot
     fmc fmc-eth-config
   DEVICE_DTS := freescale/fsl-ls1043a-rdb-sdk
   FILESYSTEMS := ext4
-  IMAGES := sdcard.img
+  IMAGES := sdcard.img sysupgrade.bin
   IMAGE/sdcard.img := \
     ls-clean | \
     ls-append-sdhead $(1) | pad-to 4K | \
@@ -132,6 +138,12 @@ define Device/ls1043ardb-sdboot
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
     append-rootfs | check-size $(LS_SD_IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := \
+    ls-clean | \
+    ls-append-sdhead $(1) | pad-to 16M | \
+    append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
+    append-rootfs | check-size $(LS_SD_IMAGE_SIZE) | append-metadata
+  SUPPORTED_DEVICES := fsl,ls1043a-rdb-sdboot
 endef
 TARGET_DEVICES += ls1043ardb-sdboot
 
@@ -167,7 +179,7 @@ define Device/ls1046ardb-sdboot
     fmc fmc-eth-config
   DEVICE_DTS := freescale/fsl-ls1046a-rdb-sdk
   FILESYSTEMS := ext4
-  IMAGES := sdcard.img
+  IMAGES := sdcard.img sysupgrade.bin
   IMAGE/sdcard.img := \
     ls-clean | \
     ls-append-sdhead $(1) | pad-to 4K | \
@@ -178,6 +190,12 @@ define Device/ls1046ardb-sdboot
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
     append-rootfs | check-size $(LS_SD_IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := \
+    ls-clean | \
+    ls-append-sdhead $(1) | pad-to 16M | \
+    append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
+    append-rootfs | check-size $(LS_SD_IMAGE_SIZE) | append-metadata
+  SUPPORTED_DEVICES := fsl,ls1046a-rdb-sdboot
 endef
 TARGET_DEVICES += ls1046ardb-sdboot
 
@@ -217,7 +235,7 @@ define Device/ls1088ardb-sdboot
     restool
   DEVICE_DTS := freescale/fsl-ls1088a-rdb
   FILESYSTEMS := ext4
-  IMAGES := sdcard.img
+  IMAGES := sdcard.img sysupgrade.bin
   IMAGE/sdcard.img := \
     ls-clean | \
     ls-append-sdhead $(1) | pad-to 4K | \
@@ -230,6 +248,12 @@ define Device/ls1088ardb-sdboot
     ls-append-dtb $$(DEVICE_DTS) | pad-to 16M | \
     append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
     append-rootfs | check-size $(LS_SD_IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := \
+    ls-clean | \
+    ls-append-sdhead $(1) | pad-to 16M | \
+    append-kernel | pad-to $(LS_SD_ROOTFSPART_OFFSET)M | \
+    append-rootfs | check-size $(LS_SD_IMAGE_SIZE) | append-metadata
+  SUPPORTED_DEVICES := fsl,ls1088a-rdb-sdboot
 endef
 TARGET_DEVICES += ls1088ardb-sdboot
 

--- a/target/linux/layerscape/patches-5.4/302-v5.7-dts-0119-arm64-dts-ls1043a-rdb-add-compatible-for-board.patch
+++ b/target/linux/layerscape/patches-5.4/302-v5.7-dts-0119-arm64-dts-ls1043a-rdb-add-compatible-for-board.patch
@@ -1,0 +1,28 @@
+From fa578d4e9fbef8928a45edd904dafb1e3334417e Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 30 Apr 2020 10:56:46 +0800
+Subject: [PATCH] arm64: dts: ls1043a-rdb: add compatible for board
+
+Add compatible for board to identify.
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb.dts b/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb.dts
+index dde50c8..9a93e9a 100644
+--- a/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb.dts
++++ b/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb.dts
+@@ -13,6 +13,7 @@
+ 
+ / {
+ 	model = "LS1043A RDB Board";
++	compatible = "fsl,ls1043a-rdb", "fsl,ls1043a";
+ 
+ 	aliases {
+ 		serial0 = &duart0;
+-- 
+2.7.4
+


### PR DESCRIPTION
This patch-set is to support sysupgrade for both squashfs rootfs on flash, and ext4 rootfs on SD card.
Please help to review and merge.
Thanks a lot!

