### PR TITLE
IPQ806x: add Netgear xr500

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -27,7 +27,8 @@ nec,wg2600hp)
 netgear,d7800 |\
 netgear,r7500 |\
 netgear,r7500v2 |\
-netgear,r7800)
+netgear,r7800 |\
+netgear,xr500)
 	ucidef_set_led_usbport "usb1" "USB 1" "${boardname}:white:usb1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "${boardname}:white:usb2" "usb3-port1" "usb4-port1"
 	ucidef_set_led_switch "wan" "WAN" "${boardname}:white:wan" "switch0" "0x20"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ nec,wg2600hp)
 		"2:lan" "3:lan" "4:lan" "5:lan" "6@eth1" "1:wan" "0@eth0"
 	;;
 netgear,r7800 |\
+netgear,xr500 |\
 tplink,c2600)
 	ucidef_add_switch "switch0" \
 		"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "6@eth1" "5:wan" "0@eth0"

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -23,7 +23,8 @@ case "$FIRMWARE" in
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
-	netgear,r7800)
+	netgear,r7800 |\
+	netgear,xr500)
 		caldata_extract "art" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) +1)
 		;;
@@ -57,7 +58,8 @@ case "$FIRMWARE" in
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
-	netgear,r7800)
+	netgear,r7800 |\
+	netgear,xr500)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) +2)
 		;;

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -20,6 +20,7 @@ platform_do_upgrade() {
 	netgear,r7500 |\
 	netgear,r7500v2 |\
 	netgear,r7800 |\
+	netgear,xr500 |\
 	qcom,ipq8064-ap148 |\
 	qcom,ipq8064-ap161)
 		nand_do_upgrade "$1"

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065-xr500.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8065-xr500.dts
@@ -1,0 +1,531 @@
+#include "qcom-ipq8065.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear XR500";
+	compatible = "netgear,xr500", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+
+		rsvd@5fe00000 {
+			reg = <0x5fe00000 0x200000>;
+			reusable;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+
+		led-boot = &power_white;
+		led-failsafe = &power_amber;
+		led-running = &power_white;
+		led-upgrade = &power_amber;
+		label-mac-device = &gmac2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	soc {
+		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio6", "gpio54", "gpio65";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			i2c4_pins: i2c4_pinmux {
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
+			led_pins: led_pins {
+				pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+					"gpio24","gpio26", "gpio53", "gpio64";
+				function = "gpio";
+				drive-strength = <2>;
+				bias-pull-down;
+			};
+
+			nand_pins: nand_pins {
+				disable {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+
+				pullups {
+					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+
+				clk {
+					pins = "gpio1";
+					input-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+
+				tx {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
+					input-disable;
+				};
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					bias-pull-down;
+				};
+
+				data {
+					pins = "gpio18", "gpio19";
+					drive-strength = <10>;
+				};
+
+				cs {
+					pins = "gpio20";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+
+				clk {
+					pins = "gpio21";
+					drive-strength = <12>;
+				};
+			};
+
+			spi6_pins: spi6_pins {
+				mux {
+					pins = "gpio55", "gpio56", "gpio58";
+					function = "gsbi6";
+					bias-pull-down;
+				};
+
+				mosi {
+					pins = "gpio55";
+					drive-strength = <12>;
+				};
+
+				miso {
+					pins = "gpio56";
+					drive-strength = <14>;
+				};
+
+				cs {
+					pins = "gpio57";
+					drive-strength = <12>;
+					bias-pull-up;
+				};
+
+				clk {
+					pins = "gpio58";
+					drive-strength = <12>;
+				};
+
+				reset {
+					pins = "gpio33";
+					drive-strength = <10>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				mux {
+					pins = "gpio15";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				mux {
+					pins = "gpio16", "gpio68";
+					function = "gpio";
+					drive-strength = <12>;
+					bias-pull-down;
+					output-high;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "okay";
+			serial@16340000 {
+				status = "okay";
+			};
+			/*
+			 * The i2c device on gsbi4 should not be enabled.
+			 * On ipq806x designs gsbi4 i2c is meant for exclusive
+			 * RPM usage. Turning this on in kernel manifests as
+			 * i2c failure for the RPM.
+			 */
+		};
+
+		sata-phy@1b400000 {
+			status = "okay";
+		};
+
+		sata@29000000 {
+			ports-implemented = <0x1>;
+			status = "okay";
+		};
+
+		usb3_0: usb3@110f8800 {
+			status = "okay";
+
+			pinctrl-0 = <&usb0_pwr_en_pins>;
+			pinctrl-names = "default";
+		};
+
+		usb3_1: usb3@100f8800 {
+			status = "okay";
+
+			pinctrl-0 = <&usb1_pwr_en_pins>;
+			pinctrl-names = "default";
+		};
+
+		pcie0: pci@1b500000 {
+			status = "okay";
+
+			bridge@0,0 {
+				reg = <0x00000000 0 0 0 0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				ranges;
+
+				wifi@1,0 {
+					compatible = "pci168c,0046";
+					reg = <0x00010000 0 0 0 0>;
+
+					mtd-mac-address = <&art 6>;
+					mtd-mac-address-increment = <(1)>;
+				};
+			};
+		};
+
+		pcie1: pci@1b700000 {
+			status = "okay";
+			force_gen1 = <1>;
+
+			bridge@0,0 {
+				reg = <0x00000000 0 0 0 0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				ranges;
+
+				wifi@1,0 {
+					compatible = "pci168c,0046";
+					reg = <0x00010000 0 0 0 0>;
+
+					mtd-mac-address = <&art 6>;
+					mtd-mac-address-increment = <(2)>;
+				};
+			};
+		};
+
+		nand@1ac00000 {
+			status = "okay";
+
+			pinctrl-0 = <&nand_pins>;
+			pinctrl-names = "default";
+
+			cs0 {
+				reg = <0>;
+				compatible = "qcom,nandcs";
+
+				nand-ecc-strength = <4>;
+				nand-bus-width = <8>;
+				nand-ecc-step-size = <512>;
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					qcadata@0 {
+						label = "qcadata";
+						reg = <0x0000000 0x0c80000>;
+						read-only;
+					};
+
+					APPSBL@c80000 {
+						label = "APPSBL";
+						reg = <0x0c80000 0x0500000>;
+						read-only;
+					};
+
+					APPSBLENV@1180000 {
+						label = "APPSBLENV";
+						reg = <0x1180000 0x0080000>;
+						read-only;
+					};
+
+					art: art@1200000 {
+						label = "art";
+						reg = <0x1200000 0x0140000>;
+						read-only;
+					};
+
+					artbak: art@1340000 {
+						label = "artbak";
+						reg = <0x1340000 0x0140000>;
+						read-only;
+					};
+
+					kernel@1480000 {
+						label = "kernel";
+						reg = <0x1480000 0x0400000>;
+					};
+
+					ubi@1880000 {
+						label = "ubi";
+						reg = <0x1880000 0xce00000>;
+					};
+
+					reserve@e680000 {
+						label = "reserve";
+						reg = <0xe680000 0x780000>;
+						read-only;
+					};
+				};
+			};
+		};
+
+		mdio0: mdio {
+			compatible = "virtual,mdio-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH>,
+				<&qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
+			pinctrl-0 = <&mdio0_pins>;
+			pinctrl-names = "default";
+
+
+			phy0: ethernet-phy@0 {
+				reg = <0>;
+				qca,ar8327-initvals = <
+					0x00004 0x7600000   /* PAD0_MODE */
+					0x00008 0x1000000   /* PAD5_MODE */
+					0x0000c 0x80        /* PAD6_MODE */
+					0x000e4 0xaa545     /* MAC_POWER_SEL */
+					0x000e0 0xc74164de  /* SGMII_CTRL */
+					0x0007c 0x4e        /* PORT0_STATUS */
+					0x00094 0x4e        /* PORT6_STATUS */
+					0x00970 0x1e864443  /* QM_PORT0_CTRL0 */
+					0x00974 0x000001c6  /* QM_PORT0_CTRL1 */
+					0x00978 0x19008643  /* QM_PORT1_CTRL0 */
+					0x0097c 0x000001c6  /* QM_PORT1_CTRL1 */
+					0x00980 0x19008643  /* QM_PORT2_CTRL0 */
+					0x00984 0x000001c6  /* QM_PORT2_CTRL1 */
+					0x00988 0x19008643  /* QM_PORT3_CTRL0 */
+					0x0098c 0x000001c6  /* QM_PORT3_CTRL1 */
+					0x00990 0x19008643  /* QM_PORT4_CTRL0 */
+					0x00994 0x000001c6  /* QM_PORT4_CTRL1 */
+					0x00998 0x1e864443  /* QM_PORT5_CTRL0 */
+					0x0099c 0x000001c6  /* QM_PORT5_CTRL1 */
+					0x009a0 0x1e864443  /* QM_PORT6_CTRL0 */
+					0x009a4 0x000001c6  /* QM_PORT6_CTRL1 */
+					>;
+				qca,ar8327-vlans = <
+					0x1	0x5e	    /* VLAN1 Ports 1/2/3/4/6 */
+					0x2	0x21	    /* VLAN2 Ports 0/5 */
+				>;
+			};
+
+			phy4: ethernet-phy@4 {
+				reg = <4>;
+				qca,ar8327-initvals = <
+					0x000e4 0x6a545     /* MAC_POWER_SEL */
+					0x0000c 0x80        /* PAD6_MODE */
+					>;
+			};
+		};
+
+		gmac1: ethernet@37200000 {
+			status = "okay";
+			phy-mode = "rgmii";
+			qcom,id = <1>;
+			qcom,phy_mdio_addr = <4>;
+			qcom,poll_required = <0>;
+			qcom,rgmii_delay = <1>;
+			qcom,phy_mii_type = <0>;
+			qcom,emulation = <0>;
+			qcom,irq = <255>;
+			mdiobus = <&mdio0>;
+
+			pinctrl-0 = <&rgmii2_pins>;
+			pinctrl-names = "default";
+
+			mtd-mac-address = <&art 6>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		gmac2: ethernet@37400000 {
+			status = "okay";
+			phy-mode = "sgmii";
+			qcom,id = <2>;
+			qcom,phy_mdio_addr = <0>;	/* none */
+			qcom,poll_required = <0>;	/* no polling */
+			qcom,rgmii_delay = <0>;
+			qcom,phy_mii_type = <1>;
+			qcom,emulation = <0>;
+			qcom,irq = <258>;
+			mdiobus = <&mdio0>;
+
+			mtd-mac-address = <&art 0>;
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		wifi {
+			label = "wifi";
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		power_white: power_white {
+			label = "xr500:white:power";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		power_amber: power_amber {
+			label = "xr500:amber:power";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_white {
+			label = "xr500:white:wan";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_amber {
+			label = "xr500:amber:wan";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb1 {
+			label = "xr500:white:usb1";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb2 {
+			label = "xr500:white:usb2";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		esata {
+			label = "xr500:white:esata";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "xr500:white:wifi";
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "xr500:white:wps";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-xr500.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-xr500.dts
@@ -1,0 +1,527 @@
+#include "qcom-ipq8065.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear XR500";
+	compatible = "netgear,xr500", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+
+		rsvd@5fe00000 {
+			reg = <0x5fe00000 0x200000>;
+			reusable;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+
+		led-boot = &power_white;
+		led-failsafe = &power_amber;
+		led-running = &power_white;
+		led-upgrade = &power_amber;
+		label-mac-device = &gmac2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		wifi {
+			label = "wifi";
+			gpios = <&qcom_pinmux 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		power_white: power_white {
+			label = "xr500:white:power";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		power_amber: power_amber {
+			label = "xr500:amber:power";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_white {
+			label = "xr500:white:wan";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_amber {
+			label = "xr500:amber:wan";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb1 {
+			label = "xr500:white:usb1";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb2 {
+			label = "xr500:white:usb2";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		esata {
+			label = "xr500:white:esata";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "xr500:white:wifi";
+			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "xr500:white:wps";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio6", "gpio54", "gpio65";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	i2c4_pins: i2c4_pinmux {
+		mux {
+			pins = "gpio12", "gpio13";
+			function = "gsbi4";
+			drive-strength = <12>;
+			bias-disable;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
+				"gpio24","gpio26", "gpio53", "gpio64";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	nand_pins: nand_pins {
+		disable {
+			pins = "gpio34", "gpio35", "gpio36",
+					"gpio37", "gpio38";
+			function = "nand";
+			drive-strength = <10>;
+			bias-disable;
+		};
+		pullups {
+			pins = "gpio39";
+			function = "nand";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+		hold {
+			pins = "gpio40", "gpio41", "gpio42",
+					"gpio43", "gpio44", "gpio45",
+					"gpio46", "gpio47";
+			function = "nand";
+			drive-strength = <10>;
+			bias-bus-hold;
+		};
+	};
+
+	mdio0_pins: mdio0_pins {
+		mux {
+			pins = "gpio0", "gpio1";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		clk {
+			pins = "gpio1";
+			input-disable;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		mux {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+			function = "rgmii2";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		tx {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
+			input-disable;
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			bias-pull-down;
+		};
+
+		data {
+			pins = "gpio18", "gpio19";
+			drive-strength = <10>;
+		};
+
+		cs {
+			pins = "gpio20";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+
+		clk {
+			pins = "gpio21";
+			drive-strength = <12>;
+		};
+	};
+
+	spi6_pins: spi6_pins {
+		mux {
+			pins = "gpio55", "gpio56", "gpio58";
+			function = "gsbi6";
+			bias-pull-down;
+		};
+
+		mosi {
+			pins = "gpio55";
+			drive-strength = <12>;
+		};
+
+		miso {
+			pins = "gpio56";
+			drive-strength = <14>;
+		};
+
+		cs {
+			pins = "gpio57";
+			drive-strength = <12>;
+			bias-pull-up;
+		};
+
+		clk {
+			pins = "gpio58";
+			drive-strength = <12>;
+		};
+
+		reset {
+			pins = "gpio33";
+			drive-strength = <10>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+
+	usb0_pwr_en_pins: usb0_pwr_en_pins {
+		mux {
+			pins = "gpio15";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+
+	usb1_pwr_en_pins: usb1_pwr_en_pins {
+		mux {
+			pins = "gpio16", "gpio68";
+			function = "gpio";
+			drive-strength = <12>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+};
+
+&gsbi4 {
+	qcom,mode = <GSBI_PROT_I2C_UART>;
+	status = "okay";
+
+	serial@16340000 {
+		status = "okay";
+	};
+
+	/*
+	* The i2c device on gsbi4 should not be enabled.
+	* On ipq806x designs gsbi4 i2c is meant for exclusive
+	* RPM usage. Turning this on in kernel manifests as
+	* i2c failure for the RPM.
+	*/
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			qcadata@0 {
+				label = "qcadata";
+				reg = <0x0000000 0x0c80000>;
+				read-only;
+			};
+
+			APPSBL@c80000 {
+				label = "APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+
+			APPSBLENV@1180000 {
+				label = "APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+				read-only;
+			};
+
+			art: art@1200000 {
+				label = "art";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+			};
+
+			artbak: art@1340000 {
+				label = "artbak";
+				reg = <0x1340000 0x0140000>;
+				read-only;
+			};
+
+			kernel@1480000 {
+				label = "kernel";
+				reg = <0x1480000 0x0400000>;
+			};
+
+			ubi@1880000 {
+				label = "ubi";
+				reg = <0x1880000 0xce00000>;
+			};
+
+			reserve@7900000 {
+				label = "reserve";
+				reg = <0xe680000 0x0780000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			0x00970 0x1e864443  /* QM_PORT0_CTRL0 */
+			0x00974 0x000001c6  /* QM_PORT0_CTRL1 */
+			0x00978 0x19008643  /* QM_PORT1_CTRL0 */
+			0x0097c 0x000001c6  /* QM_PORT1_CTRL1 */
+			0x00980 0x19008643  /* QM_PORT2_CTRL0 */
+			0x00984 0x000001c6  /* QM_PORT2_CTRL1 */
+			0x00988 0x19008643  /* QM_PORT3_CTRL0 */
+			0x0098c 0x000001c6  /* QM_PORT3_CTRL1 */
+			0x00990 0x19008643  /* QM_PORT4_CTRL0 */
+			0x00994 0x000001c6  /* QM_PORT4_CTRL1 */
+			0x00998 0x1e864443  /* QM_PORT5_CTRL0 */
+			0x0099c 0x000001c6  /* QM_PORT5_CTRL1 */
+			0x009a0 0x1e864443  /* QM_PORT6_CTRL0 */
+			0x009a4 0x000001c6  /* QM_PORT6_CTRL1 */
+			>;
+		qca,ar8327-vlans = <
+			0x1	0x5e	    /* VLAN1 Ports 1/2/3/4/6 */
+			0x2	0x21	    /* VLAN2 Ports 0/5 */
+		>;
+	};
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		qca,ar8327-initvals = <
+			0x000e4 0x6a545     /* MAC_POWER_SEL */
+			0x0000c 0x80        /* PAD6_MODE */
+			>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+	qcom,phy_mdio_addr = <4>;
+	qcom,poll_required = <0>;
+	qcom,rgmii_delay = <1>;
+	qcom,phy_mii_type = <0>;
+	qcom,emulation = <0>;
+	qcom,irq = <255>;
+	mdiobus = <&mdio0>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	mtd-mac-address = <&art 6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+	qcom,phy_mdio_addr = <0>;	/* none */
+	qcom,poll_required = <0>;	/* no polling */
+	qcom,rgmii_delay = <0>;
+	qcom,phy_mii_type = <1>;
+	qcom,emulation = <0>;
+	qcom,irq = <258>;
+	mdiobus = <&mdio0>;
+
+	mtd-mac-address = <&art 0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&sata_phy {
+	status = "okay";
+};
+
+&sata {
+	ports-implemented = <0x1>;
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+	
+	pinctrl-0 = <&usb0_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&usb3_1 {
+	status = "okay";
+	
+	pinctrl-0 = <&usb1_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie0 {
+	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0046";
+			reg = <0x00010000 0 0 0 0>;
+
+			mtd-mac-address = <&art 6>;
+			mtd-mac-address-increment = <(1)>;
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+	force_gen1 = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0046";
+			reg = <0x00010000 0 0 0 0>;
+
+			mtd-mac-address = <&art 6>;
+			mtd-mac-address-increment = <(2)>;
+		};
+	};
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -206,6 +206,22 @@ define Device/netgear_r7800
 endef
 TARGET_DEVICES += netgear_r7800
 
+define Device/netgear_xr500
+	$(call Device/DniImage)
+	DEVICE_VENDOR := NETGEAR
+	DEVICE_MODEL := xr500
+	SOC := qcom-ipq8065
+	KERNEL_SIZE := 4096k
+	NETGEAR_BOARD_ID := XR500
+	NETGEAR_HW_ID := 29764958+0+256+512+4x4+4x4+cascade
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	BOARD_NAME := xr500
+	SUPPORTED_DEVICES += xr500
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+endef
+TARGET_DEVICES += netgear_xr500
+
 define Device/qcom_ipq8064-ap148
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/ipq806x/patches-4.19/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-4.19/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -791,6 +791,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -791,6 +791,19 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
  	qcom-ipq8064-ap148.dtb \
@@ -26,6 +26,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-wxr-2533dhp.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
++	qcom-ipq8065-xr500.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \
  	qcom-msm8974-fairphone-fp2.dtb \

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -843,6 +843,18 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -843,6 +843,19 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
  	qcom-ipq8064-ap148.dtb \
@@ -26,6 +26,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-wxr-2533dhp.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
++	qcom-ipq8065-xr500.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \
  	qcom-msm8974-fairphone-fp2.dtb \


### PR DESCRIPTION
Adds support for 'Netgear Nighthawk Pro Gaming XR500'
Original patch from saksev from openwrt forum (https://forum.openwrt.org/t/netgear-xr500-under-dd-wrt-to-openwrt/30498/6)
Manufacturer page: https://www.netgear.com/gaming/xr500/

Specifications:
Almost identical to Netgear R7800(https://openwrt.org/toh/netgear/r7800)
Differences:
Outside casing
Bigger flash storage
Removed esata
swapped leds: (r7800 > xr500)
 usb1 (gpio 7 > 8)
 usb2 (gpio 8 > 26)
 guest/esata (gpio 26 > 7)

SoC: Qualcomm Atheros IPQ8065
RAM: 512 MB
Storage: 256 MiB
Wireless: Qualcomm Atheros QCA9984
Ethernet: 5x 1000/100/10
USB: 2x 3.0

Install via TFTP recovery:
TFTP flashing process(Same as R7800)

1.Turn off the power, push and hold the reset button (in a hole on backside) with a pin
2.Turn on the power and wait till power led starts flashing white (after it first flashes orange for a while)
3.Release the reset button and tftp the factory img in binary mode. The power led will stop flashing if you succeeded in transferring the image, and the router reboots rather quickly with the new firmware.
4.Try to ping the router (ping 192.168.1.1). If does not respond, then tftp will not work either.

Uploading the firmware image with a TFTP client
$ tftp 192.168.1.1
> bin
> put openwrt-ipq806x-netgear_xr500-squashfs-factory.img

Signed-off-by: Anthoni O'Brien <anthoniobrien@gmail.com>
Tested-by: Anthoni O'Brien <anthoniobrien@gmail.com>
