### PR TITLE
sunxi: add text to Makefiles referencing Allwinner H3 and H5 CPUs

### DIFF
--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 ARCH:=arm
 BOARD:=sunxi
-BOARDNAME:=Allwinner A1x/A20/A3x/R40
+BOARDNAME:=Allwinner A1x/A20/A3x/H3/H5/R40
 FEATURES:=fpu usb ext4 display rtc squashfs
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 

--- a/target/linux/sunxi/cortexa53/target.mk
+++ b/target/linux/sunxi/cortexa53/target.mk
@@ -8,6 +8,6 @@
 include $(TOPDIR)/rules.mk
 
 ARCH:=aarch64
-BOARDNAME:=Allwinner A64
+BOARDNAME:=Allwinner A64/H5
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs

--- a/target/linux/sunxi/cortexa7/target.mk
+++ b/target/linux/sunxi/cortexa7/target.mk
@@ -7,6 +7,6 @@
 
 include $(TOPDIR)/rules.mk
 
-BOARDNAME:=Allwinner A20/A3x/R40
+BOARDNAME:=Allwinner A20/A3x/H3/R40
 CPU_TYPE:=cortex-a7
 CPU_SUBTYPE:=neon-vfpv4


### PR DESCRIPTION
This makes it a little easier to figure out which options to choose.