### PR TITLE
ath79: add support for TP-Link RE450 v3

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
@@ -1,194 +1,47 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "qca956x.dtsi"
+#include "qca9563_tplink_re450.dtsi"
 
 / {
 	compatible = "tplink,re450-v2", "qca,qca9563";
 	model = "TP-Link RE450 v2";
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
-	};
-
-	aliases {
-		led-boot = &led_power;
-		led-failsafe = &led_power;
-		led-running = &led_power;
-		led-upgrade = &led_power;
-		mdio-gpio0 = &mdio2;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_power: power {
-			label = "tp-link:blue:power";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-		};
-
-		wlan2g {
-			label = "tp-link:blue:wlan2g";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wlan5g {
-			label = "tp-link:blue:wlan5g";
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		lan_link {
-			label = "tp-link:green:lan_link";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-		};
-
-		lan_data {
-			label = "tp-link:green:lan_data";
-			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
-		};
-
-		wps_blue {
-			label = "tp-link:blue:wps";
-			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		};
-
-		wps_red {
-			label = "tp-link:red:wps";
-			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		power {
-			label = "Power button";
-			linux,code = <KEY_POWER>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		leds {
-			label = "LED control button";
-			linux,code = <BTN_0>;
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "WPS button";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-
-	mdio2: mdio {
-		compatible = "virtual,mdio-gpio";
-
-		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>, /* MDC */
-			<&gpio 4 GPIO_ACTIVE_HIGH>; /* MDIO */
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		phy4: ethernet-phy@4 {
-			reg = <4>;
-			device_type = "ethernet-phy";
-			reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-		};
-	};
 };
 
-&pcie {
-	status = "okay";
-};
-
-&uart {
-	status = "okay";
-};
-
-&gpio {
-	status = "okay";
-};
-
-&spi {
-	status = "okay";
-
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x020000 0x5e0000>;
-			};
-
-			partition@600000 {
-				label = "partition-table";
-				reg = <0x600000 0x010000>;
-				read-only;
-			};
-
-			info: partition@610000 {
-				label = "info";
-				reg = <0x610000 0x020000>;
-				read-only;
-			};
-
-			partition@630000 {
-				label = "config";
-				reg = <0x630000 0x020000>;
-				read-only;
-			};
-
-			art: partition@7f0000 {
-				label = "art";
-				reg = <0x7f0000 0x010000>;
-				read-only;
-			};
-		};
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x020000>;
+		read-only;
 	};
-};
 
-&eth0 {
-	status = "okay";
+	partition@20000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x020000 0x5e0000>;
+	};
 
-	phy-mode = "sgmii";
-	phy-handle = <&phy4>;
+	partition@600000 {
+		label = "partition-table";
+		reg = <0x600000 0x010000>;
+		read-only;
+	};
 
-	mtd-mac-address = <&info 0x8>;
-};
+	info: partition@610000 {
+		label = "info";
+		reg = <0x610000 0x020000>;
+		read-only;
+	};
 
-&wmac {
-	status = "okay";
+	partition@630000 {
+		label = "config";
+		reg = <0x630000 0x020000>;
+		read-only;
+	};
 
-	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&info 0x8>;
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
 };

--- a/target/linux/ath79/dts/qca9563_tplink_re450-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re450-v3.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_re450.dtsi"
+
+/ {
+	compatible = "tplink,re450-v3", "qca,qca9563";
+	model = "TP-Link RE450 v3";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	info: partition@20000 {
+		label = "info";
+		reg = <0x020000 0x002000>;
+		read-only;
+	};
+
+	partition@22000 {
+		label = "partition-table";
+		reg = <0x022000 0x002000>;
+		read-only;
+	};
+
+	partition@24000 {
+		label = "info2";
+		reg = <0x024000 0x00a000>;
+		read-only;
+	};
+
+	partition@2e000 {
+		label = "config";
+		reg = <0x02e000 0x022000>;
+		read-only;
+	};
+
+	partition@50000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x050000 0x7a0000>;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/dts/qca9563_tplink_re450.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_re450.dtsi
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "qca,qca9563";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		mdio-gpio0 = &mdio2;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tp-link:blue:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "tp-link:blue:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "tp-link:blue:wlan5g";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan_link {
+			label = "tp-link:green:lan_link";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_data {
+			label = "tp-link:green:lan_data";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "tp-link:blue:wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps_red {
+			label = "tp-link:red:wps";
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		power {
+			label = "Power button";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		leds {
+			label = "LED control button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	mdio2: mdio {
+		compatible = "virtual,mdio-gpio";
+
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>, /* MDC */
+			<&gpio 4 GPIO_ACTIVE_HIGH>; /* MDIO */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			device_type = "ethernet-phy";
+			reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy4>;
+
+	mtd-mac-address = <&info 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -244,7 +244,8 @@ tplink,tl-wr902ac-v1)
 	;;
 tplink,re355-v1|\
 tplink,re450-v1|\
-tplink,re450-v2)
+tplink,re450-v2|\
+tplink,re450-v3)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "tp-link:green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "tp-link:green:lan_link" "eth0" "link"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -42,6 +42,7 @@ ath79_setup_interfaces()
 	tplink,re355-v1|\
 	tplink,re450-v1|\
 	tplink,re450-v2|\
+	tplink,re450-v3|\
 	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-m-ar7240|\
 	ubnt,bullet-m-ar7241|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -118,7 +118,8 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
-	tplink,re450-v2)
+	tplink,re450-v2|\
+	tplink,re450-v3)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -400,6 +400,18 @@ define Device/tplink_re450-v2
 endef
 TARGET_DEVICES += tplink_re450-v2
 
+define Device/tplink_re450-v3
+  $(Device/tplink-safeloader)
+  SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE450
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  TPLINK_BOARD_ID := RE450-V3
+  LOADER_TYPE := elf
+endef
+TARGET_DEVICES += tplink_re450-v3
+
 define Device/tplink_tl-mr6400-v1
   $(Device/tplink-8mlzma)
   SOC := qca9531

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1728,7 +1728,46 @@ static struct device_info boards[] = {
 			{"user-config", 0x630000, 0x10000},
 			{"default-config", 0x640000, 0x10000},
 			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
 
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
+	/** Firmware layout for the RE450 v3 */
+	{
+		.id     = "RE450-V3",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:00000000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:55530000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:45550000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:4A500000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:43410000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:41550000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:41530000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:4B520000}\r\n"
+			"{product_name:RE450,product_ver:3.0.0,special_id:42520000}\r\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00020},
+			{"pin", 0x20020, 0x00020},
+			{"product-info", 0x21000, 0x01000},
+			{"partition-table", 0x22000, 0x02000},
+			{"soft-version", 0x24000, 0x01000},
+			{"support-list", 0x25000, 0x01000},
+			{"profile", 0x26000, 0x08000},
+			{"user-config", 0x2e000, 0x10000},
+			{"default-config", 0x3e000, 0x10000},
+			{"config-info", 0x4e000, 0x00400},
+			{"firmware", 0x50000, 0x7a0000},
+			{"radio", 0x7f0000, 0x10000},
 			{NULL, 0, 0}
 		},
 


### PR DESCRIPTION
TP-Link RE450 v3 is a dual band router/range-extender based on
Qualcomm/Atheros QCA9563 + QCA9880.

This device is nearly identical to RE450 v2 besides a modified flash
layout (hence I think force-flashing a RE450v2 image will lead to at
least loss of MAC address).  RE450 v3 didn't even get its own FCC-ID.

Copied from 781ad462 "ath79: add support for TP-Link RE450 v2":

  Specification:

  - 775 MHz CPU
  - 64 MB of RAM (DDR2)
  - 8 MB of FLASH (SPI NOR)
  - 3T3R 2.4 GHz
  - 3T3R 5 GHz
  - 1x 10/100/1000 Mbps Ethernet (AR8033 PHY)
  - 7x LED, 4x button
  - UART header on PCB (needs unmounted R64 & R69 0201 resistors/jumpers)

  Flash instruction:
  Apply factory image in OEM firmware web-gui.

  U-Boot does not seem to have any recovery functions, so
  debricking requires connection via UART.

Signed-off-by: Andreas Wiese <aw-openwrt@meterriblecrew.net>