### PR TITLE
ath79: add support for TP-Link TL-WR802N V1 and V2

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr802n.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr802n.c
@@ -24,7 +24,7 @@
 #include "machtypes.h"
 
 #define TL_WR802N_GPIO_LED_SYSTEM	13
-#define TL_WR802N_GPIO_BTN_RESET	11
+#define TL_WR802N_GPIO_BTN_RESET	12
 
 #define TL_WR802N_KEYS_POLL_INTERVAL		20 /* msecs */
 #define TL_WR802N_KEYS_DEBOUNCE_INTERVAL	(3 * TL_WR802N_KEYS_POLL_INTERVAL)
@@ -61,7 +61,7 @@ static struct gpio_keys_button tl_wr802n_gpio_keys[] __initdata = {
 		.code		= KEY_RESTART,
 		.debounce_interval = TL_WR802N_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= TL_WR802N_GPIO_BTN_RESET,
-		.active_low	= 0,
+		.active_low	= 1,
 	}
 };
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr802n-v1.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr802n-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_tplink_tl-wr802n.dtsi"
+
+/ {
+	model = "TP-Link TL-WR802N v1";
+	compatible = "tplink,tl-wr802n-v1", "qca,qca9533";
+};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr802n-v2.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr802n-v2.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_tplink_tl-wr802n.dtsi"
+
+/ {
+	model = "TP-Link TL-WR802N v2";
+	compatible = "tplink,tl-wr802n-v2", "qca,qca9533";
+};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr802n.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr802n.dtsi
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &wmac;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "tp-link:green:system";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0x3d0000>;
+				compatible = "tplink,firmware";
+			};
+
+			art: partition@3f0000 {
+				label = "art";
+				reg = <0x3f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -272,6 +272,30 @@ define Device/tplink_tl-wr743nd-v1
 endef
 TARGET_DEVICES += tplink_tl-wr743nd-v1
 
+define Device/tplink_tl-wr802n-v1
+  $(Device/tplink-4mlzma)
+  SOC := qca9533
+  DEVICE_MODEL := TL-WR802N
+  DEVICE_VARIANT := v1
+  TPLINK_HWID := 0x08020001
+  SUPPORTED_DEVICES += tl-wr802n-v1
+endef
+TARGET_DEVICES += tplink_tl-wr802n-v1
+
+define Device/tplink_tl-wr802n-v2
+  $(Device/tplink-4mlzma)
+  SOC := qca9533
+  DEVICE_MODEL := TL-WR802N
+  DEVICE_VARIANT := v2
+  TPLINK_HWID := 0x08020002
+  SUPPORTED_DEVICES += tl-wr802n-v2
+  TPLINK_HWREV := 2
+  IMAGES += factory-us.bin factory-eu.bin
+  IMAGE/factory-us.bin := tplink-v1-image factory -C US
+  IMAGE/factory-eu.bin := tplink-v1-image factory -C EU
+endef
+TARGET_DEVICES += tplink_tl-wr802n-v2
+
 define Device/tplink_tl-wr841-v5
   $(Device/tplink-4m)
   SOC := ar7240

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -43,7 +43,9 @@ ath79_setup_interfaces()
 	tplink,tl-wa901nd-v2|\
 	tplink,tl-wa901nd-v4|\
 	tplink,tl-wa901nd-v5|\
-	tplink,tl-wr703n)
+	tplink,tl-wr703n|\
+	tplink,tl-wr802n-v1|\
+	tplink,tl-wr802n-v2)
 		ucidef_set_interface_lan "eth0"
 		;;
 	tplink,tl-mr3220-v1|\

--- a/target/linux/ath79/tiny/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/tiny/base-files/etc/uci-defaults/04_led_migration
@@ -1,0 +1,18 @@
+. /lib/functions.sh
+. /lib/functions/migrations.sh
+
+board=$(board_name)
+boardonly="${board##*,}"
+
+case "$board" in
+tplink,tl-wr802n-v1)
+	migrate_leds ":blue:=:green:"
+	;;
+tplink,tl-wr802n-v2)
+	migrate_leds "^$boardonly:=tp-link:"
+	;;
+esac
+
+migrations_apply system
+
+exit 0


### PR DESCRIPTION
ath79: add support for TP-Link TL-WR802N V1 and V2

Specification:
- SoC: Qualcomm Atheros QCA9533 (560 MHz, MIPS 24Kc)
- RAM: 32 MiB
- Storage: 4 MiB of Flash on board
- Wireless: Built into QCA9533 (Honey Bee), PHY modes b/g/n
- Ethernet: 1x100M (port0)

Installation through OEM Web Interface:
- Connect to TL-WR802N by Ethernet or Wi-Fi
- Go to web interface:
  [V1] http://192.168.0.1
  [V2] http://192.168.0.254
  Default user is "admin" & password is "admin".
  On V2, there is no DHCP server running by default, so remember to set
  IP manually.
- Go to "System Tools -> Firmware Upgrade"
- Browse for firmware:
  [V1] "*.factory.bin"
  [V2] "*.factory-us.bin" or  "*.factory-eu.bin" for eu model
  Web interface may complain if filename is too long. In such case,
  rename .bin to something shorter.
- Click upgrade

Installation through tftp:
Note: T_OUT, T_IN and GND on the board must be connected to USB TTL
      Serial Configuration 115200 8n1

- Boot the TL-WR802N
- When "Autobooting in 1 seconds" appears type "tpl" followed by enter
- Connect to the board Ethernet port
    (IPADDR: 192.168.1.1, ServerIP: 192.168.1.10)
- tftpboot 0x80000000 <Firmware Image Name>
- Record the result of "printenv bootcmd"
- Enter "erase <Result of 'printenv bootcmd'> +0x3c0000"
    (e.g erase 0x9f020000 +0x3c0000)
- Enter "cp.b 0x80000000 <Result of 'printenv bootcmd'> 0x3c0000"
    (e.g cp.b 0x80000000 0x9f020000 0x3c0000)
- Enter "bootm <Result of 'printenv bootcmd'>"
    (e.g bootm 0x9f020000)

When porting from ar71xx target to ath79, I found out that on V2,
reset button is on GPIO12 and active low, instead of GPIO11 and
acticve high. By cross-flashing V1 firmware to V2, I confirmed
the same is true for V1.
Also according to manual of V1, this one also has green
LED instead of blue - both of those issues were fixed accordingly.

Installation manual based on ar71xx support by Thomas Roberts

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

Compile-tested-on: TP-Link TL-WR802N v1/v2
Runtime-tested-on: TP-Link TL-WR802N v2

I have a backport for 19.07 ready and tested as well, pushed on tl-wr802n-ath79_19.07 branch on my Github.