### PR TITLE
prereq-build: test for perl's Data::Dumper

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -62,6 +62,10 @@ else
   zlib_link_flags := -lz
 endif
 
+$(eval $(call TestHostCommand,perl-data-dumper, \
+	Please install the Perl Data::Dumper module, \
+	perl -MData::Dumper -e 1))
+
 $(eval $(call TestHostCommand,perl-thread-queue, \
 	Please install the Perl Thread::Queue module, \
 	perl -MThread::Queue -e 1))


### PR DESCRIPTION
Required for installation of autoconf:

make[5]: Entering directory `/openwrt/build_dir/host/autoconf-2.69'
Making all in bin
make[6]: Entering directory `/openwrt/build_dir/host/autoconf-2.69/bin'
autom4te_perllibdir='..'/lib AUTOM4TE_CFG='../lib/autom4te.cfg'
../bin/autom4te -B '..'/lib -B '..'/lib         --language M4sh --cache
 '' --melt ./autoconf.as -o autoconf.in

Can't locate Data/Dumper.pm in @INC (@INC contains: ../lib
/usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl
/usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at
../lib/Autom4te/C4che.pm line 33.
BEGIN failed--compilation aborted at ../lib/Autom4te/C4che.pm line 33.
Compilation failed in require at ../bin/autom4te line 40.
BEGIN failed--compilation aborted at ../bin/autom4te line 40.
make[6]: *** [autoconf.in] Error 2

Signed-off-by: Rosen Penev <rosenp@gmail.com>

From: https://patchwork.ozlabs.org/project/openwrt/patch/20200330011356.3058801-1-rosenp@gmail.com/