### PR TITLE
target: bump minimum CPU type to pentium-mmx

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -173,8 +173,8 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_octeonplus = -march=octeon+ -mabi=64
   endif
   ifeq ($(ARCH),i386)
-    CPU_TYPE ?= pentium
-    CPU_CFLAGS_pentium = -march=pentium-mmx
+    CPU_TYPE ?= pentium-mmx
+    CPU_CFLAGS_pentium-mmx = -march=pentium-mmx
     CPU_CFLAGS_pentium4 = -march=pentium4
   endif
   ifneq ($(findstring arm,$(ARCH)),)


### PR DESCRIPTION
f4f8f4a180366ee90fd8e153213db2cb746ca361 broke ffmpeg compilation with x86

The reason is that ffmpeg's x86 assembly requires at least MMX, which the
pentium CPU_TYPE was preventing.

Fixes ffmpeg compilation on x86_legacy and x86_geode.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

From: https://patchwork.ozlabs.org/project/openwrt/patch/20200112044434.633455-1-rosenp@gmail.com/