### PR TITLE
ath79: Add support for Buffalo WZR-HP-G300NH

### DIFF
--- a/package/kernel/gpio-nxp-74hc153/Makefile
+++ b/package/kernel/gpio-nxp-74hc153/Makefile
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2020 Mauri Sandberg <sandberg@mailfence.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=gpio-nxp-74hc153
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/gpio-nxp-74hc153
+  SUBMENU:=Other modules
+  TITLE:= NXP 74HC153 GPIO expander
+  FILES:=$(PKG_BUILD_DIR)/gpio-nxp-74hc153.ko
+  AUTOLOAD:=$(call AutoLoad,30,gpio-nxp-74hc153,1)
+  KCONFIG:=
+  DEPENDS:= @GPIO_SUPPORT @TARGET_ath79
+endef
+
+define KernelPackage/gpio-nxp-74hc153/description
+  Platform driver for NXP 74HC153 Dual 4-input Multiplexer.
+  This provides a GPIO interface supporting input mode only.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M=$(PKG_BUILD_DIR) modules
+endef
+
+$(eval $(call KernelPackage,gpio-nxp-74hc153))

--- a/package/kernel/gpio-nxp-74hc153/src/Makefile
+++ b/package/kernel/gpio-nxp-74hc153/src/Makefile
@@ -1,0 +1,1 @@
+obj-m += gpio-nxp-74hc153.o

--- a/package/kernel/gpio-nxp-74hc153/src/gpio-nxp-74hc153.c
+++ b/package/kernel/gpio-nxp-74hc153/src/gpio-nxp-74hc153.c
@@ -1,0 +1,291 @@
+/*
+ *  NXP 74HC153 - Dual 4-input multiplexer GPIO driver
+ *
+ *  Copyright (C) 2010 Gabor Juhos <juhosg@openwrt.org>
+ *  Copyright (C) 2020 Mauri Sandberg <sandberg@mailfence.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  Example device tree definition:
+ *
+ *  gpio-extender {
+ *    compatible = "nxp,74hc153-gpio";
+ *    gpio-controller;
+ *    #gpio-cells = <2>;
+ *
+ *    // GPIOs used by this node
+ *    gpio-s0 = <&gpio 9 GPIO_ACTIVE_HIGH>;
+ *    gpio-s1 = <&gpio 11 GPIO_ACTIVE_HIGH>;
+ *    gpio-1y = <&gpio 12 GPIO_ACTIVE_HIGH>;
+ *    gpio-2y = <&gpio 14 GPIO_ACTIVE_HIGH>;
+ *  };
+ *
+ */
+
+#include <linux/version.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/gpio.h>
+#include <linux/slab.h>
+#include <linux/platform_device.h>
+#include <linux/of_gpio.h>
+
+#define NXP_74HC153_NUM_GPIOS   8
+#define NXP_74HC153_S0_MASK     0x1
+#define NXP_74HC153_S1_MASK     0x2
+#define NXP_74HC153_BANK_MASK   0x4
+
+#define NXP_74HC153_DRIVER_NAME "nxp-74hc153"
+
+struct nxp_74hc153_config {
+	unsigned gpio_pin_s0;
+	unsigned gpio_pin_s1;
+	unsigned gpio_pin_1y;
+	unsigned gpio_pin_2y;
+};
+
+struct nxp_74hc153_chip {
+	struct device             *parent;
+	struct gpio_chip          gpio_chip;
+	struct mutex              lock;
+	struct nxp_74hc153_config config;
+};
+
+static struct nxp_74hc153_chip *gpio_to_nxp(struct gpio_chip *gc)
+{
+	return container_of(gc, struct nxp_74hc153_chip, gpio_chip);
+}
+
+static int nxp_74hc153_direction_input(struct gpio_chip *gc, unsigned offset)
+{
+	return 0;
+}
+
+static int nxp_74hc153_direction_output(struct gpio_chip *gc,
+					unsigned offset, int val)
+{
+	return -EINVAL;
+}
+
+static int nxp_74hc153_get_value(struct gpio_chip *gc, unsigned offset)
+{
+	struct nxp_74hc153_chip *nxp;
+	struct nxp_74hc153_platform_data *pdata;
+	unsigned s0;
+	unsigned s1;
+	unsigned pin;
+	int ret;
+
+	nxp = gpio_to_nxp(gc);
+	pdata = nxp->parent->platform_data;
+
+	s0 = !!(offset & NXP_74HC153_S0_MASK);
+	s1 = !!(offset & NXP_74HC153_S1_MASK);
+	pin = (offset & NXP_74HC153_BANK_MASK) ? nxp->config.gpio_pin_2y
+	                                       : nxp->config.gpio_pin_1y;
+
+	mutex_lock(&nxp->lock);
+	gpio_set_value(nxp->config.gpio_pin_s0, s0);
+	gpio_set_value(nxp->config.gpio_pin_s1, s1);
+	ret = gpio_get_value(pin);
+	mutex_unlock(&nxp->lock);
+
+	return ret;
+}
+
+static void nxp_74hc153_set_value(struct gpio_chip *gc,
+	unsigned offset, int val)
+{
+	/* not supported */
+}
+
+static int nxp_74hc153_probe(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	struct nxp_74hc153_chip *nxp;
+	struct gpio_chip *gc;
+	int err;
+	unsigned gpio_s0;
+	unsigned gpio_s1;
+	unsigned gpio_1y;
+        unsigned gpio_2y;
+
+	nxp = kzalloc(sizeof(struct nxp_74hc153_chip), GFP_KERNEL);
+	if (nxp == NULL) {
+		dev_err(&pdev->dev, "no memory for private data\n");
+		return -ENOMEM;
+	}
+
+	gpio_s0 = of_get_named_gpio(np, "gpio-s0", 0);
+	gpio_s1 = of_get_named_gpio(np, "gpio-s1", 0);
+	gpio_1y = of_get_named_gpio(np, "gpio-1y", 0);
+	gpio_2y = of_get_named_gpio(np, "gpio-2y", 0);
+
+	if (!gpio_is_valid(gpio_s0) || !gpio_is_valid(gpio_s1) ||
+  	    !gpio_is_valid(gpio_1y) || !gpio_is_valid(gpio_2y)) {
+
+		dev_err(&pdev->dev, "control GPIO(s) are missing\n");
+		err = -EINVAL;
+		goto err_free_nxp;
+	} else {
+		nxp->config.gpio_pin_s0 = gpio_s0;
+		nxp->config.gpio_pin_s1 = gpio_s1;
+		nxp->config.gpio_pin_1y = gpio_1y;
+		nxp->config.gpio_pin_2y = gpio_2y;
+	}
+
+	// apply pin configuration
+	err = gpio_request(nxp->config.gpio_pin_s0, dev_name(&pdev->dev));
+	if (err) {
+		dev_err(&pdev->dev, "unable to claim gpio %u, err=%d\n",
+			nxp->config.gpio_pin_s0, err);
+		goto err_free_nxp;
+	}
+
+	err = gpio_request(nxp->config.gpio_pin_s1, dev_name(&pdev->dev));
+	if (err) {
+		dev_err(&pdev->dev, "unable to claim gpio %u, err=%d\n",
+			nxp->config.gpio_pin_s1, err);
+		goto err_free_s0;
+	}
+
+	err = gpio_request(nxp->config.gpio_pin_1y, dev_name(&pdev->dev));
+	if (err) {
+		dev_err(&pdev->dev, "unable to claim gpio %u, err=%d\n",
+			nxp->config.gpio_pin_1y, err);
+		goto err_free_s1;
+	}
+
+	err = gpio_request(nxp->config.gpio_pin_2y, dev_name(&pdev->dev));
+	if (err) {
+		dev_err(&pdev->dev, "unable to claim gpio %u, err=%d\n",
+			nxp->config.gpio_pin_2y, err);
+		goto err_free_1y;
+	}
+
+	err = gpio_direction_output(nxp->config.gpio_pin_s0, 0);
+	if (err) {
+		dev_err(&pdev->dev,
+			"unable to set direction of gpio %u, err=%d\n",
+			nxp->config.gpio_pin_s0, err);
+		goto err_free_2y;
+	}
+
+	err = gpio_direction_output(nxp->config.gpio_pin_s1, 0);
+	if (err) {
+		dev_err(&pdev->dev,
+			"unable to set direction of gpio %u, err=%d\n",
+			nxp->config.gpio_pin_s1, err);
+		goto err_free_2y;
+	}
+
+	err = gpio_direction_input(nxp->config.gpio_pin_1y);
+	if (err) {
+		dev_err(&pdev->dev,
+			"unable to set direction of gpio %u, err=%d\n",
+			nxp->config.gpio_pin_1y, err);
+		goto err_free_2y;
+	}
+
+	err = gpio_direction_input(nxp->config.gpio_pin_2y);
+	if (err) {
+		dev_err(&pdev->dev,
+			"unable to set direction of gpio %u, err=%d\n",
+			nxp->config.gpio_pin_2y, err);
+		goto err_free_2y;
+	}
+
+	nxp->parent = &pdev->dev;
+	mutex_init(&nxp->lock);
+
+	gc = &nxp->gpio_chip;
+
+	gc->direction_input  = nxp_74hc153_direction_input;
+	gc->direction_output = nxp_74hc153_direction_output;
+	gc->get = nxp_74hc153_get_value;
+	gc->set = nxp_74hc153_set_value;
+	gc->can_sleep = 1;
+
+	gc->base = -1;
+	gc->ngpio = NXP_74HC153_NUM_GPIOS;
+	gc->label = dev_name(nxp->parent);
+	gc->parent = nxp->parent;
+	gc->owner = THIS_MODULE;
+	gc->of_node = np;
+
+	err = gpiochip_add(&nxp->gpio_chip);
+	if (err) {
+		dev_err(&pdev->dev, "unable to add gpio chip, err=%d\n", err);
+		goto err_free_2y;
+	}
+
+	platform_set_drvdata(pdev, nxp);
+	return 0;
+
+err_free_2y:
+	gpio_free(nxp->config.gpio_pin_2y);
+err_free_1y:
+	gpio_free(nxp->config.gpio_pin_1y);
+err_free_s1:
+	gpio_free(nxp->config.gpio_pin_s1);
+err_free_s0:
+	gpio_free(nxp->config.gpio_pin_s0);
+err_free_nxp:
+	kfree(nxp);
+	return err;
+}
+
+static int nxp_74hc153_remove(struct platform_device *pdev)
+{
+	struct nxp_74hc153_chip *nxp = platform_get_drvdata(pdev);
+
+	if (nxp) {
+		gpiochip_remove(&nxp->gpio_chip);
+		gpio_free(nxp->config.gpio_pin_2y);
+		gpio_free(nxp->config.gpio_pin_1y);
+		gpio_free(nxp->config.gpio_pin_s1);
+		gpio_free(nxp->config.gpio_pin_s0);
+
+		kfree(nxp);
+		platform_set_drvdata(pdev, NULL);
+	}
+
+	return 0;
+}
+
+static struct of_device_id nxp_74hc153_id[] = {
+	{
+		.compatible = "nxp,74hc153-gpio",
+		.data = NULL,
+	}, { /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, nxp_74hc153_id);
+
+static struct platform_driver nxp_74hc153_driver = {
+	.probe          = nxp_74hc153_probe,
+	.remove         = nxp_74hc153_remove,
+	.driver = {
+		.name   = NXP_74HC153_DRIVER_NAME,
+		.owner  = THIS_MODULE,
+		.of_match_table = nxp_74hc153_id,
+	},
+};
+
+static int __init nxp_74hc153_init(void)
+{
+	return platform_driver_register(&nxp_74hc153_driver);
+}
+subsys_initcall(nxp_74hc153_init);
+
+static void __exit nxp_74hc153_exit(void)
+{
+	platform_driver_unregister(&nxp_74hc153_driver);
+}
+module_exit(nxp_74hc153_exit);
+
+MODULE_AUTHOR("Gabor Juhos <juhosg@openwrt.org>");
+MODULE_DESCRIPTION("GPIO expander driver for NXP 74HC153");
+MODULE_LICENSE("GPL v2");
+MODULE_ALIAS("platform:" NXP_74HC153_DRIVER_NAME);

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh-rb.dts
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh-rb.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9132_buffalo_wzr-hp-g300nh.dtsi"
+
+/ {
+	compatible = "buffalo,wzr-hp-g300nh-rb", "qca,ar9132";
+	model = "Buffalo WZR-HP-G300NH (rtl8366rb)";
+};
+
+&switch {
+	status = "okay";
+
+	compatible = "realtek,rtl8366rb";
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x1f000000 0x13000a44 0x00441099>;
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x100 0x13000a44 0x00441099>;
+};

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh-s.dts
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh-s.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9132_buffalo_wzr-hp-g300nh.dtsi"
+
+/ {
+	compatible = "buffalo,wzr-hp-g300nh-s", "qca,ar9132";
+	model = "Buffalo WZR-HP-G300NH (rtl8366s)";
+};
+
+&switch {
+	status = "okay";
+
+	compatible = "realtek,rtl8366s";
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x1e000100 0x13000a44 0x00441099>;
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x1e000100 0x13000a44 0x00441099>;
+};

--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9132.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_diag;
+		led-failsafe = &led_security;
+		led-upgrade = &led_diag;
+	};
+
+	clock40mhz: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <40000000>;
+	};
+
+	gpio2: gpio-extender {
+		compatible = "nxp,74hc153-gpio";
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		// GPIOs used by this node
+		gpio-s0 = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		gpio-s1 = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		gpio-1y = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		gpio-2y = <&gpio 14 GPIO_ACTIVE_HIGH>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		aoss {
+			label = "aoss";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_on {
+			label = "router_on";
+			linux,code = <BTN_5>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		movie_off {
+			label = "movie_off";
+			linux,code = <BTN_3>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		usb {
+			label = "usb";
+			linux,code = <BTN_2>;
+			gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_auto {
+			label = "router_auto";
+			linux,code = <BTN_6>;
+			gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		movie_on {
+			label = "movie_on";
+			linux,code = <BTN_4>;
+			gpios = <&gpio2 7 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	flash@1e000000 {
+		compatible = "cfi-flash";
+		reg = <0x1e000000 0x2000000>;
+		bank-width = <2>;
+		device-width = <2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x0040000 0x0020000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0060000 0x1f60000>;
+			};
+
+			partition@1fc0000 {
+				label = "user_property";
+				reg = <0x1fc0000 0x0020000>;
+				read-only;
+			};
+
+			art: partition@1fe0000 {
+				label = "art";
+				reg = <0x1fe0000 0x020000>;
+				read-only;
+			};
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		led_diag: diag {
+			label = "red:diag";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wireless {
+			label = "green:wireless";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_security: security {
+			label = "amber:security";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		router {
+			label = "green:router";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	switch: switch {
+		status = "disabled";
+
+		gpio-sda = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		mii-bus = <&mdio0>;
+
+		mdio-bus {
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			phy-mask = <0x10>;
+
+			phy4: ethernet-phy@4 {
+				reg = <4>;
+				phy-mode = "rgmii";
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&eth0 {
+	status = "disabled";
+
+	phy-mode = "rgmii";
+	mtd-mac-address = <&art 0x1120c>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&mdio1 {
+	status = "okay";
+};
+
+&eth1 {
+	status = "disabled";
+
+	compatible = "qca,ar9130-eth", "syscon";
+	reg = <0x1a000000 0x200
+		0x18070004 0x4>;
+
+	pll-reg = <0x4 0x18 22>;
+	pll-handle = <&pll>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy4>;
+	resets = <&rst 13>;
+	reset-names = "mac";
+	qca,mac-idx = <1>;
+	mtd-mac-address = <&art 0x1120c>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x11000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&pll {
+	clocks = <&clock40mhz>;
+};
+
+&usb {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -83,6 +83,10 @@ avm,fritzdvbc)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan1" "60" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "80" "100"
 	;;
+buffalo,wzr-hp-g300nh-rb|\
+buffalo,wzr-hp-g300nh-s)
+        ucidef_set_led_netdev "router" "Router" "green:router" "eth1"
+        ;;
 comfast,cf-e110n-v2)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -155,6 +155,13 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
 		;;
+	buffalo,wzr-hp-g300nh-rb|\
+	buffalo,wzr-hp-g300nh-s|\
+	dlink,dir-825-b1)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
+		;;
 	buffalo,wzr-hp-g302h-a1a0)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
@@ -210,11 +217,6 @@ ath79_setup_interfaces()
 	dlink,dch-g020-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:2" "2:lan:1"
-		;;
-	dlink,dir-825-b1)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0:lan" "1:lan" "2:lan" "3:lan" "5@eth0"
 		;;
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -453,6 +453,29 @@ define Device/buffalo_wzr-hp-ag300h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-ag300h
 
+define Device/buffalo_wzr-hp-g300nh
+  $(Device/buffalo_common)
+  SOC := ar9132
+  BUFFALO_PRODUCT := WZR-HP-G300NH
+  BUFFALO_HWVER := 1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-gpio-nxp-74hc153
+  BLOCKSIZE := 128k
+  IMAGE_SIZE := 32128k
+  SUPPORTED_DEVICES += wzr-hp-g300nh
+endef
+
+define Device/buffalo_wzr-hp-g300nh-rb
+  $(Device/buffalo_wzr-hp-g300nh)
+  DEVICE_MODEL := WZR-HP-G300NH (RTL8366RB switch)
+endef
+TARGET_DEVICES += buffalo_wzr-hp-g300nh-rb
+
+define Device/buffalo_wzr-hp-g300nh-s
+  $(Device/buffalo_wzr-hp-g300nh)
+  DEVICE_MODEL := WZR-HP-G300NH (RTL8366S switch)
+endef
+TARGET_DEVICES += buffalo_wzr-hp-g300nh-s
+
 define Device/buffalo_wzr-hp-g302h-a1a0
   $(Device/buffalo_common)
   SOC := ar7242

--- a/target/linux/ath79/patches-5.4/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
+++ b/target/linux/ath79/patches-5.4/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
@@ -1,0 +1,58 @@
+From f1f811410af297c848e9ec17eaa280d190fdce10 Mon Sep 17 00:00:00 2001
+From: Mauri Sandberg <sandberg@mailfence.com>
+Date: Tue, 23 Feb 2021 18:09:31 +0200
+Subject: [PATCH] mtd: cfi_cmdset_0002: AMD chip 0x2201 - write words
+
+Buffer writes do not work with AMD chip 0x2201. The chip in question
+is a AMD/Spansion/Cypress Semiconductor S29GL256N and datasheet [1]
+talks about writing buffers being possible. While waiting for a neater
+solution resort to writing word-sized chunks only.
+
+Without the patch kernel logs will be flooded with entries like below:
+
+jffs2_scan_eraseblock(): End of filesystem marker found at 0x0
+jffs2_build_filesystem(): unlocking the mtd device...
+done.
+jffs2_build_filesystem(): erasing all blocks after the end marker...
+MTD do_write_buffer_wait(): software timeout, address:0x01ec000a.
+jffs2: Write clean marker to block at 0x01920000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01e2000a.
+jffs2: Write clean marker to block at 0x01880000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01e0000a.
+jffs2: Write clean marker to block at 0x01860000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01dc000a.
+jffs2: Write clean marker to block at 0x01820000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01da000a.
+jffs2: Write clean marker to block at 0x01800000 failed: -5
+...
+
+Tested on a Buffalo wzr-hp-g300nh running kernel 5.10.16.
+
+[1] https://www.cypress.com/file/219941/download
+or  https://datasheetspdf.com/pdf-file/565708/SPANSION/S29GL256N/1
+
+Signed-off-by: Mauri Sandberg <sandberg@mailfence.com>
+---
+ drivers/mtd/chips/cfi_cmdset_0002.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/mtd/chips/cfi_cmdset_0002.c b/drivers/mtd/chips/cfi_cmdset_0002.c
+index a1f3e1031c3d..28b6f3583f8a 100644
+--- a/drivers/mtd/chips/cfi_cmdset_0002.c
++++ b/drivers/mtd/chips/cfi_cmdset_0002.c
+@@ -272,6 +272,10 @@ static void fixup_use_write_buffers(struct mtd_info *mtd)
+ {
+ 	struct map_info *map = mtd->priv;
+ 	struct cfi_private *cfi = map->fldrv_priv;
++
++	if ((cfi->mfr == CFI_MFR_AMD) && (cfi->id == 0x2201))
++		return;
++
+ 	if (cfi->cfiq->BufWriteTimeoutTyp) {
+ 		pr_debug("Using buffer write method\n");
+ 		mtd->_write = cfi_amdstd_write_buffers;
+
+base-commit: 5de15b610f785f0e188fefb707f0b19de156968a
+-- 
+2.25.1
+


### PR DESCRIPTION
This device is a wireless router working on 2.4GHz band based on
Qualcom/Atheros AR9132 rev 2 SoC and accompanied by Atheros AR9103
wireless chip and Realtek RTL8366SR switch. This PR consists of two different
patches, one creates a kernel module for NXP 74HC153 GPIO expander and
the other adds the device itself.

  Specification:
  - 400 MHz CPU
  - 64 MB of RAM
  - 32 MB of FLASH (NOR)
  - 3x3 2.4 GHz 802.11bgn
  - 5x 10/100/1000 Mbps Ethernet
  - 4x LED, 3x button, On/Off slider, Auto/On/Off slider
  - 1x USB 2.0
  - bare UART header place on PCB

  Flash instruction:
   - Apply factory image in OEM firmware web-gui.
   - Sysupgrade on top of existing OpenWRT image
   - U-Boot TFPT recovery for both stock or OpenWRT images

  Differences to ar71xx platform
  - GPIOs for a sliding On/Off switch, marked 'Movie engine' on the device
    cover, were the wrong way around and were renamed qos_on -> movie_off,
    qos_off -> movie_on. Associated key codes remained the same they were.

The device tree source code is mostly based on musashino's work.