### PR TITLE
ath79: update WA/XC devices UBNT_VERSION to 8.5.3

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -28,7 +28,7 @@ endef
 # UBNT_BOARD e.g. one of (XS2, XS5, RS, XM)
 # UBNT_TYPE e.g. one of (BZ, XM, XW)
 # UBNT_CHIP e.g. one of (ar7240, ar933x, ar934x)
-# UBNT_VERSION e.g. one of (6.0.0, 8.5.0)
+# UBNT_VERSION e.g. one of (6.0.0, 8.5.3)
 define Device/ubnt
   DEVICE_VENDOR := Ubiquiti
   DEVICE_PACKAGES := kmod-usb2
@@ -66,7 +66,7 @@ define Device/ubnt-wa
   UBNT_BOARD := WA
   UBNT_CHIP := ar934x
   UBNT_TYPE := WA
-  UBNT_VERSION := 8.5.0
+  UBNT_VERSION := 8.5.3
 endef
 
 define Device/ubnt-xc
@@ -75,7 +75,7 @@ define Device/ubnt-xc
   UBNT_BOARD := XC
   UBNT_CHIP := qca955x
   UBNT_TYPE := XC
-  UBNT_VERSION := 8.5.0
+  UBNT_VERSION := 8.5.3
 endef
 
 define Device/ubnt-xm


### PR DESCRIPTION
Ubiquiti WA devices with newer hw version 2011K require UBNT_VERSION
to be at least 8.5.3, otherwise the image is rejected:

   New ver: WA.ar934x.v8.5.0-42.OpenWrt-r10947-65030d81f3
   Versions: New(525568) 8.5.0, Required(525571) 8.5.3
   Invalid version 'WA.ar934x.v8.5.0-42.OpenWrt-r10947-65030d81f3'

For consistency, also increase version number for XC devices.

Tested-by: Pedro <pedrowrt@cas.cat>
Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>