### PR TITLE
mediatek: cleanup and fix for mt7623

### DIFF
--- a/target/linux/mediatek/base-files/etc/uci-defaults/99-net-ps
+++ b/target/linux/mediatek/base-files/etc/uci-defaults/99-net-ps
@@ -1,16 +1,5 @@
-uci set network.globals='globals'
-uci set network.globals.packet_steering=1
-uci set network.eth0=device
-uci set network.eth0.name=eth0
-uci set network.lan0=device
-uci set network.lan0.name=lan0
-uci set network.lan1=device
-uci set network.lan1.name=lan1
-uci set network.lan2=device
-uci set network.lan2.name=lan2
-uci set network.lan3=device
-uci set network.lan3.name=lan3
-
-uci commit network
-
-exit 0
+uci -q get network.globals.packet_steering >/dev/null || {
+	uci set network.globals='globals'
+	uci set network.globals.packet_steering=1
+	uci commit network
+}

--- a/target/linux/mediatek/patches-5.4/0226-phy-phy-mtk-tphy-Add-hifsys-support.patch
+++ b/target/linux/mediatek/patches-5.4/0226-phy-phy-mtk-tphy-Add-hifsys-support.patch
@@ -1,0 +1,66 @@
+From 28f9a5e2a3f5441ab5594669ed82da11e32277a9 Mon Sep 17 00:00:00 2001
+From: Kristian Evensen <kristian.evensen@gmail.com>
+Date: Mon, 30 Apr 2018 14:38:01 +0200
+Subject: [PATCH] phy: phy-mtk-tphy: Add hifsys-support
+
+---
+ drivers/phy/mediatek/phy-mtk-tphy.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+--- a/drivers/phy/mediatek/phy-mtk-tphy.c
++++ b/drivers/phy/mediatek/phy-mtk-tphy.c
+@@ -15,6 +15,8 @@
+ #include <linux/of_device.h>
+ #include <linux/phy/phy.h>
+ #include <linux/platform_device.h>
++#include <linux/mfd/syscon.h>
++#include <linux/regmap.h>
+ 
+ /* version V1 sub-banks offset base address */
+ /* banks shared by multiple phys */
+@@ -263,6 +265,9 @@
+ #define RG_CDR_BIRLTD0_GEN3_MSK		GENMASK(4, 0)
+ #define RG_CDR_BIRLTD0_GEN3_VAL(x)	(0x1f & (x))
+ 
++#define HIF_SYSCFG1			0x14
++#define HIF_SYSCFG1_PHY2_MASK		(0x3 << 20)
++
+ enum mtk_phy_version {
+ 	MTK_PHY_V1 = 1,
+ 	MTK_PHY_V2,
+@@ -310,6 +315,7 @@ struct mtk_tphy {
+ 	struct clk *u3phya_ref;	/* reference clock of usb3 anolog phy */
+ 	const struct mtk_phy_pdata *pdata;
+ 	struct mtk_phy_instance **phys;
++	struct regmap *hif;
+ 	int nphys;
+ 	int src_ref_clk; /* MHZ, reference clock for slew rate calibrate */
+ 	int src_coef; /* coefficient for slew rate calibrate */
+@@ -629,6 +635,10 @@ static void pcie_phy_instance_init(struc
+ 	if (tphy->pdata->version != MTK_PHY_V1)
+ 		return;
+ 
++	if (tphy->hif)
++		regmap_update_bits(tphy->hif, HIF_SYSCFG1,
++				   HIF_SYSCFG1_PHY2_MASK, 0);
++
+ 	tmp = readl(u3_banks->phya + U3P_U3_PHYA_DA_REG0);
+ 	tmp &= ~(P3A_RG_XTAL_EXT_PE1H | P3A_RG_XTAL_EXT_PE2H);
+ 	tmp |= P3A_RG_XTAL_EXT_PE1H_VAL(0x2) | P3A_RG_XTAL_EXT_PE2H_VAL(0x2);
+@@ -1114,6 +1124,16 @@ static int mtk_tphy_probe(struct platfor
+ 		&tphy->src_ref_clk);
+ 	device_property_read_u32(dev, "mediatek,src-coef", &tphy->src_coef);
+ 
++	if (of_find_property(np, "mediatek,phy-switch", NULL)) {
++		tphy->hif = syscon_regmap_lookup_by_phandle(np,
++							    "mediatek,phy-switch");
++		if (IS_ERR(tphy->hif)) {
++			dev_err(&pdev->dev,
++				"missing \"mediatek,phy-switch\" phandle\n");
++			return PTR_ERR(tphy->hif);
++		}
++	}
++
+ 	port = 0;
+ 	for_each_child_of_node(np, child_np) {
+ 		struct mtk_phy_instance *instance;


### PR DESCRIPTION
- mediatek: tidy up image subtarget Makefiles
- mediatek: mt7623: enforce image metadata check
- mediatek: remove unnecessary uci-defaults script
- mediatek: mt7623: refresh kernel 5.4 config
- mediatek: re-add u3phy2 phy-switch patch