### PR TITLE
bcm47xx: fix brcm-wl module loading

### DIFF
--- a/target/linux/bcm47xx/patches-5.4/999-wl_exports.patch
+++ b/target/linux/bcm47xx/patches-5.4/999-wl_exports.patch
@@ -12,10 +12,11 @@
  static int cfe_env;
 --- a/arch/mips/mm/cache.c
 +++ b/arch/mips/mm/cache.c
-@@ -62,6 +62,8 @@ void (*_dma_cache_wback_inv)(unsigned lo
+@@ -62,6 +62,9 @@ void (*_dma_cache_wback_inv)(unsigned lo
  void (*_dma_cache_wback)(unsigned long start, unsigned long size);
  void (*_dma_cache_inv)(unsigned long start, unsigned long size);
  
++EXPORT_SYMBOL(_dma_cache_wback_inv);
 +EXPORT_SYMBOL(_dma_cache_inv);
 +
  #endif /* CONFIG_DMA_NONCOHERENT */


### PR DESCRIPTION
_dma_cache_wback_inv needs to be exported to load wl module successfully.
```
root@OpenWrt:/# insmod wl
[  363.867779] wl: Unknown symbol _dma_cache_wback_inv (err -2)
failed to insert /lib/modules/5.4.40/wl.ko
```