### PR TITLE
ramips: Add support for Xiaomi Mi Router(Black,R2100)

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,6 +34,7 @@ zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 linksys,ea7500-v2|\
+xiaomi,mi-router-ac2100|\
 xiaomi,mir3p|\
 xiaomi,mir3g|\
 xiaomi,redmi-router-ac2100)

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_xiaomi_router-ac2100.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-ac2100", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router AC2100";
+
+	aliases {
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_yellow;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan_yellow {
+			label = "mi-router-ac2100:yellow:wan";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "mi-router-ac2100:blue:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_yellow: status_yellow {
+			label = "mi-router-ac2100:yellow:status";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "mi-router-ac2100:blue:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7621_xiaomi_router-ac2100.dtsi"
 
 / {
 	compatible = "xiaomi,redmi-router-ac2100", "mediatek,mt7621-soc";
@@ -16,10 +13,6 @@
 		led-running = &led_status_white;
 		led-upgrade = &led_status_white;
 		label-mac-device = &gmac0;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
 	};
 
 	leds {
@@ -44,140 +37,5 @@
 			label = "redmi-router-ac2100:white:wan";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-};
-
-
-&nand {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "Bootloader";
-			reg = <0x0 0x80000>;
-			read-only;
-		};
-
-		partition@80000 {
-			label = "Config";
-			reg = <0x80000 0x40000>;
-		};
-
-		partition@c0000 {
-			label = "Bdata";
-			reg = <0xc0000 0x40000>;
-			read-only;
-		};
-
-		factory: partition@100000 {
-			label = "factory";
-			reg = <0x100000 0x40000>;
-			read-only;
-		};
-
-		partition@140000 {
-			label = "crash";
-			reg = <0x140000 0x40000>;
-		};
-
-		partition@180000 {
-			label = "crash_syslog";
-			reg = <0x180000 0x40000>;
-		};
-
-		partition@1c0000 {
-			label = "reserved0";
-			reg = <0x1c0000 0x40000>;
-			read-only;
-		};
-
-		/* We keep stock xiaomi firmware (kernel0) here */
-		partition@200000 {
-			label = "kernel_stock";
-			reg = <0x200000 0x400000>;
-		};
-
-		partition@600000 {
-			label = "kernel";
-			reg = <0x600000 0x400000>;
-		};
-
-		partition@a00000 {
-			label = "ubi";
-			reg = <0xa00000 0x7580000>;
-		};
-	};
-};
-
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&pcie1 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		ieee80211-freq-limit = <2400000 2500000>;
-	};
-};
-
-&gmac0 {
-	mtd-mac-address = <&factory 0xe000>;
-};
-
-&switch0 {
-	ports {
-		port@0 {
-			status = "okay";
-			label = "wan";
-			mtd-mac-address = <&factory 0xe006>;
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan1";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "lan3";
-		};
-	};
-};
-
-&state_default {
-	gpio {
-		groups = "uart2", "uart3", "wdt";
-		function = "gpio";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x40000>;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "crash";
+			reg = <0x140000 0x40000>;
+		};
+
+		partition@180000 {
+			label = "crash_syslog";
+			reg = <0x180000 0x40000>;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* We keep stock xiaomi firmware (kernel0) here */
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0x7580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -891,6 +891,23 @@ define Device/wevo_w2914ns-v2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
 
+define Device/xiaomi_mi-router-ac2100
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 120320k
+  UBINIZE_OPTS := -E 5
+  IMAGES += kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router AC2100
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e wpad-basic uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_mi-router-ac2100
+
 define Device/xiaomi_mir3g
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k
@@ -947,7 +964,7 @@ define Device/xiaomi_redmi-router-ac2100
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
-  IMAGE_SIZE := 124416k
+  IMAGE_SIZE := 120320k
   UBINIZE_OPTS := -E 5
   IMAGES += kernel1.bin rootfs0.bin
   IMAGE/kernel1.bin := append-kernel

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -77,6 +77,9 @@ tplink,re650-v1)
 xzwifi,creativebox-v1)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
+xiaomi,mi-router-ac2100)
+	ucidef_set_led_netdev "wan-blue" "WAN (blue)" "$boardname:blue:wan" "wan"
+	;;
 xiaomi,redmi-router-ac2100)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -21,6 +21,7 @@ ramips_setup_interfaces()
 		;;
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
+	xiaomi,mi-router-ac2100|\
 	xiaomi,mir3p|\
 	xiaomi,redmi-router-ac2100)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,7 @@ platform_do_upgrade() {
 	netgear,r6800|\
 	netgear,r6850|\
 	netis,wf2881|\
+	xiaomi,mi-router-ac2100|\
 	xiaomi,mir3g|\
 	xiaomi,mir3p|\
 	xiaomi,redmi-router-ac2100)


### PR DESCRIPTION
The Xiaomi Mi Router AC2100 is a *black* cylindrical router that shares many
characteristics (apart from its looks and the GPIO ports) with the 6-antenna
*white* "Xiaomi Redmi Router AC2100"

See the visual comparison of the two routers here:
https://github.com/emirefek/openwrt-R2100/raw/imgcdn/rm2100-r2100.jpg

Specification of R2100:
- CPU: MediaTek MT7621A
- RAM: 128 MB DDR3
- FLASH: 128 MB ESMT NAND
- WIFI: 2x2 802.11bgn (MT7603)
- WIFI: 4x4 802.11ac (MT7615)
- ETH: 3xLAN+1xWAN 1000base-T
- LED: Power, WAN in Yellow and Blue
- UART: On board (Don't know where is should be confirmed by anybody else)
- Modified u-boot

Hacking of official firmware process is same at both RM2100 and R2100. Thanks to @namidairo
Here is the detailed guide for Hacking:
https://github.com/impulse/ac2100-openwrt-guide
Guide is written for MacOS but it will work at linux. needed packages: python3(with scapy), netcat, http server, telnet client

1. Run PPPoE dummy and exploit to get netcat and wget busybox, get telnet and wget the firmware over
2. mtd write openwrt-ramips-mt7621-xiaomi_mi-router-ac2100-squashfs-kernel1.bin kernel1
3. nvram set uart_en=1
4. nvram set bootdelay=5
5. nvram set flag_try_sys1_failed=1
6. nvram commit
7. mtd -r write openwrt-ramips-mt7621-xiaomi_mi-router-ac2100-squashfs-rootfs0.bin rootfs0

other than these I specified in here. Everything is same with:
https://github.com/openwrt/openwrt/commit/f3792690c4f0567a8965d82898295b9d50c3bb7e
Thanks for all community and especially for this device:
 @Ilyas @scp07 @namidairo @Percy @thorsten97 @impulse (names at forum.openwrt.com)

MAC Locations:
WAN *:b5 = factory 0xe006
LAN *:b6 = factory 0xe000
WIFI 5ghz *:b8 = factory 0x8004
WIFI 2.4ghz *:b7 = factory 0x0004

Tested-by: Emir Efe Kucuk <emirefek@gmail.com>
Signed-off-by: Emir Efe Kucuk <emirefek@gmail.com>