### PR TITLE
ipq806x: EA8500 fix boot partition detection

### DIFF
--- a/target/linux/ipq806x/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/linksys.sh
@@ -21,8 +21,6 @@ linksys_get_target_firmware() {
 			"${cur_boot_part}" "${mtd_ubi0}"
 	fi
 
-	cur_boot_part=$(/usr/sbin/fw_printenv -n boot_part)
-
 	case $cur_boot_part in
 	1)
 		fw_setenv -s - <<-EOF


### PR DESCRIPTION
Remove extraneous code that disabled boot partition detection.

Tested the previously inert code on my EA8500:

```
root@OpenWrt:/tmp# ./check.sh
result 1
root@OpenWrt:/tmp# fw_printenv -n boot_part
1
root@OpenWrt:/tmp# cat check.sh
#!/bin/sh
                mtd_ubi0=$(cat /sys/devices/virtual/ubi/ubi0/mtd_num)
                case $(egrep ^mtd${mtd_ubi0}: /proc/mtd | cut -d '"' -f 2) in
                kernel1|rootfs1)
                        cur_boot_part=1
                        ;;
                kernel2|rootfs2)
                        cur_boot_part=2
                        ;;
                esac
echo "result ${cur_boot_part}"
```