### PR TITLE
base-files: coreutil-sha256sum breaks status code

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -127,7 +127,7 @@ list_changed_conffiles() {
 	list_conffiles | while read file csum; do
 		[ -r "$file" ] || continue
 
-		echo "${csum}  ${file}" | sha256sum -sc - || echo "$file"
+		echo "${csum}  ${file}" | busybox sha256sum -sc - || echo "$file"
 	done
 }
 


### PR DESCRIPTION
"coreutil-sha256sum" package from the packages feed replaces the Busybox sha256sum
applet by symlinking /usr/bin/gnu-sha256sum to /usr/bin/sha256sum. This leads sysupgrade script
list all configuration files the GNU sha256sum utility does not provide such functionality:

	root@OpenWrt:~# sha256sum -s
	sha256sum: invalid option -- 's'
	Try 'sha256sum --help' for more information.

Signed-off-by: Huangbin Zhan <zhanhb88@gmail.com>