### PR TITLE
ath79: add support for 8devices Lima board

### DIFF
--- a/target/linux/ath79/dts/qca9531_8dev_lima.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_lima.dts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "8dev,lima", "qca,qca9531";
+	model = "8devices Lima";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux-code = "KEY_RESTART";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+
+	dr_mode = "host";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wdt {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	/* Winbond W25Q256 SPI flash */
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <45000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x040000>;
+			};
+
+			art: partition@80000 {
+				label = "art";
+				reg = <0x080000 0x040000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0c0000 0xf40000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+	mtd-mac-address = <&art 0x6>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <1>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,6 +9,10 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	8dev,lima|\
+	ubnt,unifi)
+		caldata_extract "art" 0x1000 0x800
+		;;
 	avm,fritz1750e|\
 	avm,fritz4020|\
 	avm,fritz450e|\
@@ -109,9 +113,6 @@ case "$FIRMWARE" in
 	ubnt,picostation-m|\
 	ubnt,rocket-m)
 		caldata_extract "art" 0x1000 0x1000
-		;;
-	ubnt,unifi)
-		caldata_extract "art" 0x1000 0x800
 		;;
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -129,6 +129,16 @@ define Device/8dev_carambola2
 endef
 TARGET_DEVICES += 8dev_carambola2
 
+define Device/8dev_lima
+  SOC := qca9531
+  DEVICE_VENDOR := 8devices
+  DEVICE_MODEL := Lima
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 15616k
+  SUPPORTED_DEVICES += lima
+endef
+TARGET_DEVICES += 8dev_lima
+
 define Device/adtran_bsap1880
   SOC := ar7161
   DEVICE_VENDOR := Adtran/Bluesocket


### PR DESCRIPTION
Specification:

 - 650/600/216 MHz (CPU/DDR/AHB)
 - 64 MB of RAM (DDR2)
 - 32 MB of FLASH
 - 2T2R 2.4 GHz
 - 2x 10/100 Mbps Ethernet
 - 1x USB 2.0 Host socket
 - 1x miniPCIe slot
 - UART for serial console
 - 14x GPIO

Flash instructions:

Upgrading from ar71xx target:
 - Upload image into the board:
    scp openwrt-ath79-generic-8dev_lima-squashfs-sysupgrade.bin \
        root@192.168.1.1/tmp/
 - Run sysupgrade
    sysupgrade -F /tmp/openwrt-ath79-generic-8dev_lima-squashfs-sysupgrade.bin

Upgrading from u-boot:
 - Set up tftp server with openwrt-ath79-generic-8dev_lima-initramfs-kernel.bin
 - Go to u-boot (reboot and press ESC when prompted)
 - Set TFTP server IP
    setenv serverip 192.168.1.254
 - Set device ip from the same subnet
    setenv ipaddr 192.168.1.1
 - Copy new firmware to board
    tftpboot 0x82000000 initramfs.bin
 - Boot OpenWRT
    bootm 0x82000000
 - Upload image openwrt-ath79-generic-8dev_lima-squashfs-sysupgrade.bin into the board
 - Run sysupgrade.

Signed-off-by: Andrey Bondar <a.bondar@8devices.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
