### PR TITLE
x86: Support Intel 10 Gigabit Ethernet Cards

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -1,7 +1,7 @@
 define Device/generic
   DEVICE_TITLE := Generic x86/64
   DEVICE_PACKAGES += kmod-bnx2 kmod-e1000e kmod-e1000 kmod-forcedeth kmod-igb \
-	kmod-r8169
+	kmod-ixgbe kmod-r8169
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
Support Intel 10 Gigabit Ethernet Cards in x86/64 images by default.
This ensures that systems with cards such as the Intel x520 will work properly.

Signed-off-by: Gregory L. Dietsche <Gregory.Dietsche@cuw.edu>