### PR TITLE
treewide: use unique profile names

### DIFF
--- a/target/linux/ath25/image/Makefile
+++ b/target/linux/ath25/image/Makefile
@@ -60,7 +60,7 @@ define Device/Default
   FILESYSTEMS := squashfs
 endef
 
-define Device/generic
+define Device/generic_ath25
   DEVICE_VENDOR := Atheros
   DEVICE_MODEL := Generic AR2xxx board
   IMAGES := kernel.lzma kernel.elf kernel.gz rootfs.bin sysupgrade.bin
@@ -71,7 +71,7 @@ define Device/generic
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 128k | combined-image
   IMAGE_NAME = $$(IMAGE_PREFIX)-$$(if $$(findstring kernel,$$(2)),,$$(1)-)$$(2)
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_ath25
 
 define Device/ubnt2-pico2
   DEVICE_VENDOR := Ubiquiti

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -22,12 +22,12 @@ define Device/Default
   IMAGE/sysupgrade.tar := sysupgrade-tar
 endef
 
-define Device/generic
+define Device/generic_octeon
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := Octeon
   FILESYSTEMS := ext4
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_octeon
 
 ER_CMDLINE:=-mtdparts=phys_mapped_flash:640k(boot0)ro,640k(boot1)ro,64k(eeprom)ro root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
 define Device/ubnt_edgerouter

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -1,7 +1,7 @@
-define Device/generic
-  DEVICE_TITLE := Generic x86/64
+define Device/generic_x86-64
+  DEVICE_TITLE := Generic x86 (64 Bit)
   DEVICE_PACKAGES += kmod-bnx2 kmod-e1000e kmod-e1000 kmod-forcedeth kmod-igb \
 	kmod-r8169
   GRUB2_VARIANT := generic
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_x86-64

--- a/target/linux/x86/image/generic.mk
+++ b/target/linux/x86/image/generic.mk
@@ -1,8 +1,8 @@
-define Device/generic
-  DEVICE_TITLE := Generic x86
+define Device/generic_x86-32
+  DEVICE_TITLE := Generic x86 (32 Bit)
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-natsemi \
 	kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 \
 	kmod-via-rhine kmod-via-velocity kmod-forcedeth
   GRUB2_VARIANT := generic
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_x86-32

--- a/target/linux/x86/image/geode.mk
+++ b/target/linux/x86/image/geode.mk
@@ -1,13 +1,13 @@
-define Device/generic
-  DEVICE_TITLE := Generic x86/Geode
+define Device/generic_x86-geode
+  DEVICE_TITLE := Generic x86 (Geode)
   DEVICE_PACKAGES += kmod-crypto-cbc kmod-crypto-hw-geode kmod-ledtrig-gpio \
 	kmod-ledtrig-heartbeat kmod-ledtrig-netdev
   GRUB2_VARIANT := legacy
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_x86-geode
 
 define Device/geos
-  $(call Device/generic)
+  $(call Device/generic_x86-geode)
   DEVICE_TITLE := Traverse Technologies Geos
   DEVICE_PACKAGES += br2684ctl flashrom kmod-hwmon-lm90 kmod-mppe kmod-pppoa \
 	kmod-usb-ohci-pci linux-atm ppp-mod-pppoa pppdump pppstats soloscli tc

--- a/target/linux/x86/image/legacy.mk
+++ b/target/linux/x86/image/legacy.mk
@@ -1,8 +1,8 @@
-define Device/generic
-  DEVICE_TITLE := Generic x86/legacy
+define Device/generic_x86-legacy
+  DEVICE_TITLE := Generic x86 (legacy)
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 \
 	kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 \
 	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth
   GRUB2_VARIANT := legacy
 endef
-TARGET_DEVICES += generic
+TARGET_DEVICES += generic_x86-legacy


### PR DESCRIPTION
Currently the targets ath25, oceon and x86 use non unique profile names
called `generic`, which makes them indistinguishable.

This commit adds the target name to the generic profile names.

Example for x86/64
generic -> generic_x86-64

Signed-off-by: Paul Spooren <mail@aparcar.org>