### PR TITLE
[RFC]x86/64: Add PC Engines APU2 board

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -5,3 +5,16 @@ define Device/generic
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic
+
+define Device/pcengines_apu2
+  DEVICE_TITLE := PC Engines APU 2
+  DEVICE_PACKAGES += amd64-microcode flashrom fstrim irqbalance kmod-bnx2 \
+	kmod-crypto-hw-ccp kmod-crypto-hw-ccp kmod-e1000 kmod-e1000e \
+	kmod-forcedeth kmod-gpio kmod-gpio-button-hotplug kmod-gpio-nct5104d \
+	kmod-igb kmod-leds-apu2 kmod-leds-gpio kmod-pcspkr kmod-r8169 \
+	kmod-sound-core kmod-sp5100_tco kmod-usb-core kmod-usb-ohci kmod-usb2 \
+	kmod-usb3
+  GRUB2_VARIANT := generic
+  SUPPORTED_DEVICES += pcengines,apu2
+endef
+TARGET_DEVICES += pcengines_apu2


### PR DESCRIPTION
The APU2 board is a popular board to be used with OpenWrt. However to
work well, it requires some extra packages. This should be reflected in
an available profile instead of requiring the user to manually figure
out missing packages.

Signed-off-by: Paul Spooren <mail@aparcar.org>