### PR TITLE
kernel: Support Aquantia 10 Gigabit Ethernet Cards

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -642,6 +642,36 @@ endef
 
 $(eval $(call KernelPackage,e1000e))
 
+define KernelPackage/aquantia
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=aQuantia device support
+  DEPENDS:=@PCI_SUPPORT +kmod-i2c-core +kmod-i2c-algo-bit +kmod-ptp +kmod-hwmon-core +LINUX_5_4:kmod-libphy
+  KCONFIG:=CONFIG_AQUANTIA_PHY
+  FILES:=$(LINUX_DIR)/drivers/net/phy/aquantia.ko
+  AUTOLOAD:=$(call AutoLoad,35,aquantia)
+endef
+
+define KernelPackage/aquantia/description
+ Kernel modules for aQuantia Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,aquantia))
+
+define KernelPackage/atlantic
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=aQuantia AQtion(tm) Support
+  DEPENDS:=@PCI_SUPPORT @TARGET_x86 +kmod-i2c-core +kmod-i2c-algo-bit +kmod-ptp
+  KCONFIG:=CONFIG_AQUANTIA_PHY \
+    CONFIG_AQTION=m
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/aquantia/atlantic/atlantic.ko
+  AUTOLOAD:=$(call AutoLoad,35,atlantic)
+endef
+
+define KernelPackage/atlantic/description
+ Kernel modules for the aQuantia AQtion(tm) Ethernet card
+endef
+
+$(eval $(call KernelPackage,atlantic))
 
 define KernelPackage/igb
   SUBMENU:=$(NETWORK_DEVICES_MENU)


### PR DESCRIPTION
I've built an X86 gateway running OpenWrt with an ASUS XG-C100C PCI-E (actually `Aquantia Corp. AQC107 NBase-T/IEEE 802.3bz Ethernet Controller [AQtion] (rev 02)`).

I based this off of 7e0e5110bc90a8d6e709b9a070eb2aa82d46f15d so the dependencies may not be 100% correct. I'm really pleased with the result so far and would like to thank all of the OpenWrt developers working on this great project.