### PR TITLE
opkg: fix md5sum calculation

### DIFF
--- a/package/system/opkg/patches/010-fix_md5sum_calc.patch
+++ b/package/system/opkg/patches/010-fix_md5sum_calc.patch
@@ -1,0 +1,11 @@
+--- a/libopkg/file_util.c
++++ b/libopkg/file_util.c
+@@ -153,7 +153,7 @@
+ 
+ 	len = md5sum(file_name, md5sum_bin);
+ 
+-	if (len) {
++	if (len < 0) {
+ 		opkg_msg(ERROR, "Could't compute md5sum for %s.\n", file_name);
+ 		return NULL;
+ 	}


### PR DESCRIPTION
Maintainer: @jow- 
Compile tested: Clean Debian 10 host, Entware repo ([commit](https://github.com/Entware/Entware/commit/673a6b248d0610656edca789d28072761c991a3a)).
Run tested: Entware, mipsel feed.

Description: fixes regression introduced [here](https://git.openwrt.org/?p=project/opkg-lede.git;a=blobdiff;f=libopkg/file_util.c;h=1f89541420afdf6092c04e098df68e0271144a92;hp=1a98df6a102bc0a9d9495b57328a16a9cac02b85;hb=33f7b80aa32583ed41a9bb88612f8ec6a959987b;hpb=77dae8e058210d64a67b3bab37c1044f3c66cc52). Can be discovered if package index still contains `MD5Sum` field:
```
$ opkg install <something>
...
Configuring zoneinfo-asia.
Configuring libstdcpp.
Configuring findutils.
Collected errors:
...
 * file_md5sum_alloc: Could't compute md5sum for /opt/tmp/opkg-nz7AYD/zoneinfo-asia_2020a-1_mipsel-3.4.ipk.
 * file_md5sum_alloc: Could't compute md5sum for /opt/tmp/opkg-nz7AYD/zoneinfo-europe_2020a-1_mipsel-3.4.ipk.
 * file_md5sum_alloc: Could't compute md5sum for /opt/tmp/opkg-nz7AYD/findutils_4.7.0-1_mipsel-3.4.ipk.
 * file_md5sum_alloc: Could't compute md5sum for /opt/tmp/opkg-nz7AYD/terminfo_6.2-1_mipsel-3.4.ipk.
 * file_md5sum_alloc: Could't compute md5sum for /opt/tmp/opkg-nz7AYD/libpcre_8.43-2_mipsel-3.4.ipk.
 ```
I know OpenWrt using `SHA256sum` for now, just reporting about broken `MD5Sum` support. Discovered by @themiron.