### PR TITLE
kernel: rename CONFIG_NETPRIO_CGROUP to CONFIG_CGROUP_NET_PRIO for current kernels

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -766,7 +766,7 @@ if KERNEL_CGROUPS
 		bool "Control Group Classifier"
 		default y
 
-	config KERNEL_NETPRIO_CGROUP
+	config KERNEL_CGROUP_NET_PRIO
 		bool "Network priority cgroup"
 		default y
 


### PR DESCRIPTION
Compile tested: master x86-64
Run tested: master x86-64

In current kernels (5.4 on master) the config option for cgroups net_prio has been renamed so it is not being built.
