### PR TITLE
imagebuilder: Remove json_info_files/ before build

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -168,6 +168,7 @@ prepare_rootfs: FORCE
 build_image: FORCE
 	@echo
 	@echo Building images...
+	rm -rf $(BUILD_DIR)/json_info_files/
 	$(NO_TRACE_MAKE) -C target/linux/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
 		$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)")
 


### PR DESCRIPTION
The folder `json_info_files` contains multiple JSON files which describe
created firmware images. The folder is not removed between builds as the
ImageBuilder does not use `image.mk`.

Not removing the JSON files result in a merged `profiles.json` file
containing entries for outdated or non-existing images.

This commit adds the `json_info_files/` cleanup step to the ImageBuilder
Makefile.

Signed-off-by: Paul Spooren <mail@aparcar.org>