### PR TITLE
ramips: mt7621: add support for NETGEAR WAC104

### DIFF
--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0 or MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,wac104", "mediatek,mt7621-soc";
+	model = "Netgear WAC104";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "wac104:green:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "wac104:green:power";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "wac104:green:wifi";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "SC PID";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x1c00000>;
+		};
+
+		factory: partition@2e00000 {
+			label = "factory";
+			reg = <0x2e00000 0x100000>;
+			read-only;
+		};
+
+		partition@4200000 {
+			label = "reserved";
+			reg = <0x4200000 0x3c00000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -676,6 +676,18 @@ define Device/netgear_r6850
 endef
 TARGET_DEVICES += netgear_r6850
 
+define Device/netgear_wac104
+  $(Device/netgear_sercomm_nand)
+  DEVICE_MODEL := WAC104
+  SERCOMM_HWNAME := WAC104
+  SERCOMM_HWID := CAY
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0006
+  IMAGE_SIZE := 28672k
+  DEVICE_PACKAGES += kmod-mt76x2
+endef
+TARGET_DEVICES += netgear_wac104
+
 define Device/netgear_wndr3700-v5
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 64k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -29,7 +29,8 @@ ramips_setup_interfaces()
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
-	linksys,re6500)
+	linksys,re6500|\
+	netgear,wac104)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	mikrotik,routerboard-m11g|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -52,6 +52,7 @@ platform_do_upgrade() {
 	netgear,r6700-v2|\
 	netgear,r6800|\
 	netgear,r6850|\
+	netgear,wac104|\
 	netis,wf2881|\
 	xiaomi,mir3g|\
 	xiaomi,mir3p|\


### PR DESCRIPTION
NETGEAR WAC104 is an AP based on castrated R6220, without WAN
port and USB.

SoC: MediaTek MT7621ST
RAM: 128M DDR3
FLASH: 128M NAND
WiFi: MediaTek MT7612EN an+ac
MediaTek MT7603EN bgn
ETH: MediaTek MT7621ST (4x LAN)
BTN: 1x Connect (WPS), 1x WLAN, 1x Reset
LED: 7x (3x GPIO controlled)

Installation:

Login to netgear webinterface and flash factory.img

Back to stock:

Use nmrpflash to revert stock image.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>