### PR TITLE
ath79: add support for MikroTik RouterBOARD LHG 2nD

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-2nd.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-lhg-2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD LHG 2nD";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-upgrade = &led_user;
+		led-running = &led_user;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_wan_pin>;
+
+		power {
+			label = "mikrotik:blue:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_user: user {
+			label = "mikrotik:green:user";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "mikrotik:green:lan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "mikrotik:green:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssilow {
+			label = "mikrotik:green:rssilow";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "mikrotik:green:rssimediumlow";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "mikrotik:green:rssimediumhigh";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		/* The rssihigh LED GPIO 16 is shared with the reset button, so it remains
+		unregistered here to avoid conflict.
+
+		rssihigh {
+			label = "mikrotik:green:rssihigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+		*/
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x0>;
+					read-only;
+				};
+
+				soft_config {
+					label = "soft_config";
+				};
+			};
+
+			partition@20000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x020000 0xfe0000>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&eth0 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&pinmux {
+	led_wan_pin: pinmux_led_wan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -23,6 +23,18 @@ define Device/mikrotik_routerboard-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
+define Device/mikrotik_routerboard-lhg-2nd
+  $(Device/mikrotik)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD LHG 2nD
+  IMAGE_SIZE := 16256k
+  IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | \
+	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
+	append-metadata | check-size
+  DEVICE_PACKAGES += rssileds
+endef
+TARGET_DEVICES += mikrotik_routerboard-lhg-2nd
+
 define Device/mikrotik_routerboard-wap-g-5hact2hnd
   $(Device/mikrotik)
   SOC := qca9556

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+boardname="${board##*,}"
+
+case "$board" in
+mikrotik,routerboard-lhg-2nd)
+	ucidef_set_led_netdev "lan" "lan" "mikrotik:green:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "rssilow" "mikrotik:green:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "rssimediumlow" "mikrotik:green:rssimediumlow" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "mikrotik:green:rssimediumhigh" "wlan0" "51" "100"
+	# The rssihigh LED is disabled, as it shares GPIO 16 with the reset button
+	# ucidef_set_led_rssi "rssihigh" "rssihigh" "mikrotik:green:rssihigh" "wlan0" "76" "100"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ ath79_setup_interfaces()
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		ucidef_set_interface_lan "eth0"
 		;;
@@ -34,6 +35,10 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,routerboard-lhg-2nd)
+		label_mac="$mac_base"
+		lan_mac="$mac_base"
+		;;
 	*)
 		label_mac="$mac_base"
 		wan_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,12 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	mikrotik,routerboard-lhg-2nd)
+		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
+		ath9k_patch_mac $(macaddr_add "$mac_base" +1) /tmp/$FIRMWARE
+		caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 0x440
+		rm -f /tmp/$FIRMWARE
+		;;
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
 		ath9k_patch_mac $(macaddr_add "$mac_base" +2) /tmp/$FIRMWARE


### PR DESCRIPTION
The MikroTik RouterBOARD LHG 2nD (sold as LHG 2) is a 2.4 GHz 802.11b/g/n device with a feed and an integrated dual polarization grid dish antenna.

See https://mikrotik.com/product/lhg_2 for more info.

Specifications:
 - SoC: Qualcomm Atheros QCA9533
 - RAM: 64 MB
 - Storage: 16 MB NOR
 - Wireless: Atheros AR9531 (SoC) 802.11b/g/n 2x2:2, 18 dBi antenna
 - Ethernet: Atheros AR8229 (SoC), 1x 10/100 port, 12-28 Vdc PoE in
 - 8 LEDs, 1x Ethernet (green) + 7x  user-controllable:
   · 1x power (blue)
   · 1x user (green)
   · 1x wlan (green)
   · 4x rssi (green)

Flashing:
 TFTP boot initramfs image and then perform sysupgrade. Follow common
 MikroTik procedure as in https://openwrt.org/toh/mikrotik/common.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>