### PR TITLE
imagebuilder: pass IB=1 on checking requirements

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -84,7 +84,7 @@ PROFILE_LIST = $(foreach p,$(PROFILE_NAMES), \
 
 staging_dir/host/.prereq-build: include/prereq-build.mk
 	mkdir -p tmp
-	@$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/prereq-build.mk prereq 2>/dev/null || { \
+	@$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f $(TOPDIR)/include/prereq-build.mk prereq IB=1 2>/dev/null || { \
 		echo "Prerequisite check failed. Use FORCE=1 to override."; \
 		false; \
 	}


### PR DESCRIPTION
The patch 4a1a58a3  build, imagebuilder: Do not require libncurses-dev
was supposed to remove libncurses as a requirement for the ImageBuilder.
However as the IB=1 is only exported during building, not for checking
requirements, it did never actually work.

This commit export IB=1 to the requirement check.

Signed-off-by: Paul Spooren <mail@aparcar.org>