### PR TITLE
[v2] ramips: add support for MikroTik RouterBOARD 760iGS

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
@@ -52,14 +52,16 @@
 		};
 	};
 
-	beeper {
-		compatible = "gpio-beeper";
-		gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
-	};
-
 	gpio_export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
+
+		buzzer {
+			/* Beeper requires PWM for frequency selection */
+			gpio-export,name = "buzzer";
+			gpio-export,output = <0>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
 
 		usb_power {
 			gpio-export,name = "usb_power";

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7621_mikrotik_routerboard-7xx.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-750gr3", "mediatek,mt7621-soc";
@@ -15,10 +12,6 @@
 		led-failsafe = &led_usr;
 		led-running = &led_usr;
 		led-upgrade = &led_usr;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
 	};
 
 	leds {
@@ -35,135 +28,12 @@
 			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		mode {
-			label = "mode";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		buzzer {
-			/* Beeper requires PWM for frequency selection */
-			gpio-export,name = "buzzer";
-			gpio-export,output = <0>;
-			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
-		};
-
-		usb_power {
-			gpio-export,name = "usb_power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		};
-	};
-};
-
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <20000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x40000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0xf000>;
-					read-only;
-				};
-
-				soft_config {
-				};
-
-				partition@30000 {
-					label = "bios";
-					reg = <0x30000 0x1000>;
-					read-only;
-				};
-			};
-
-			partition@40000 {
-				compatible = "mikrotik,minor";
-				label = "firmware";
-				reg = <0x040000 0xfc0000>;
-			};
-		};
-	};
-};
-
-&switch0 {
-	ports {
-		port@0 {
-			status = "okay";
-			label = "wan";
-		};
-
-		port@1 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan3";
-		};
-
-		port@3 {
-			status = "okay";
-			label = "lan4";
-		};
-
-		port@4 {
-			status = "okay";
-			label = "lan5";
-		};
-	};
 };
 
 &state_default {
 	gpio {
-		/* via gpio7 (uart3 group) the PoE status can be read */
+		/* on 760iGS via gpio7 (uart3 group) the PoE status can be read */
 		groups = "uart2", "uart3", "jtag", "wdt";
 		function = "gpio";
 	};
-};
-
-&sdhci {
-	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-760igs.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_mikrotik_routerboard-7xx.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-760igs", "mediatek,mt7621-soc";
+	model = "MikroTik RouterBOARD 760iGS";
+
+	aliases {
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_pwr: pwr {
+			label = "routerboard-760igs:blue:pwr";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		sfp {
+			label = "routerboard-760igs:blue:sfp";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp1: sfp1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c>;
+		los-gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1000>;
+	};
+};
+
+&mdio {
+	ephy7: ethernet-phy@7 {
+		reg = <7>;
+		sfp = <&sfp1>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "sfp";
+	phy-handle = <&ephy7>;
+};
+
+&i2c {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		/* gpio7 (uart3 group) goes high when
+		 * port5 (PoE out) is cabled to a
+		 * Mikrotik PoE-in capable port,
+		 * such as port1 on another rb760iGS */
+		groups = "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "mode";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		buzzer {
+			/* Beeper requires PWM for frequency selection */
+			gpio-export,name = "buzzer";
+			gpio-export,output = <0>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0xf000>;
+					read-only;
+				};
+
+				soft_config {
+				};
+
+				partition@30000 {
+					label = "bios";
+					reg = <0x30000 0x1000>;
+					read-only;
+				};
+			};
+
+			partition@40000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x040000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan5";
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -708,6 +708,13 @@ define Device/mikrotik_routerboard-750gr3
 endef
 TARGET_DEVICES += mikrotik_routerboard-750gr3
 
+define Device/mikrotik_routerboard-760igs
+  $(Device/MikroTik)
+  DEVICE_MODEL := RouterBOARD 760iGS
+  DEVICE_PACKAGES += kmod-sfp -wpad-basic
+endef
+TARGET_DEVICES += mikrotik_routerboard-760igs
+
 define Device/mikrotik_routerboard-m11g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M11G

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -703,7 +703,7 @@ endef
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 750Gr3
-  DEVICE_PACKAGES += kmod-gpio-beeper -wpad-basic
+  DEVICE_PACKAGES += -wpad-basic
   SUPPORTED_DEVICES += mikrotik,rb750gr3
 endef
 TARGET_DEVICES += mikrotik_routerboard-750gr3

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -48,6 +48,9 @@ linksys,ea7500-v2)
 	ucidef_set_led_netdev "lan4" "lan4 link" "$boardname:green:lan4" "lan4" "link"
 	ucidef_set_led_netdev "wan" "wan link" "$boardname:green:wan" "wan" "link"
 	;;
+mikrotik,routerboard-760igs)
+	ucidef_set_led_netdev "sfp" "SFP" "$boardname:blue:sfp" "sfp"
+	;;
 mikrotik,routerboard-m11g)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:green:rssi0" "wlan0" "1" "100"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -48,6 +48,9 @@ ramips_setup_interfaces()
 	mikrotik,routerboard-750gr3)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
+	mikrotik,routerboard-760igs)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan sfp"
+		;;
 	ubnt,edgerouter-x)
 		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;
@@ -108,6 +111,7 @@ ramips_setup_macs()
 		label_mac=$lan_mac
 		;;
 	mikrotik,routerboard-750gr3|\
+	mikrotik,routerboard-760igs|\
 	mikrotik,routerboard-m11g|\
 	mikrotik,routerboard-m33g)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -7,6 +7,9 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+mikrotik,routerboard-760igs)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "497"
+	;;
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "16"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,7 @@ platform_do_upgrade() {
 		}
 		;;
 	mikrotik,routerboard-750gr3|\
+	mikrotik,routerboard-760igs|\
 	mikrotik,routerboard-m11g|\
 	mikrotik,routerboard-m33g)
 		[ -z "$(rootfs_type)" ] && mtd erase firmware


### PR DESCRIPTION
Continued work of openwrt#2761, as original PR submitter cannot currently improve their PR.

~~Still WIP.~~
Open to any suggestions.

- [x] Attribute / sign-off
  - ~~Is Author, and / or Co-authored-by suitable?~~
  - @vgrassia
  - @llogar
- [x] squash commits to:
  - ~~share 750gr3 DTS~~
  - add 760igs support
  - ~~add 760igs SFP support~~ SFP working fine, included in main support commit
- [ ] additional testing
  - Confirm 750gr3 is not broken
    dwdiff on the compiled 750gr3 DTB shows no meaningful differences (only leds node position shifted).
- ~~Additional GPIO pins (poe_status): mentioned in DTS state_default, introduced https://github.com/openwrt/openwrt/commit/6ba58b7b020c4b793e6fb7a43c8adef070579d8d?~~