### PR TITLE
ramips: routerboard 750gr3 cut unused gpio switch poe_passthrough

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -7,9 +7,6 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-mikrotik,routerboard-750gr3)
-	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "17"
-	;;
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "16"
 	;;


### PR DESCRIPTION
This device does not support PoE out,
and GPIO 17 without an additional base does not exist.

```
cat /sys/firmware/mikrotik/hard_config/hw_options
raw		: 0x084a4007
has POE out	: false

logread: export_store: invalid GPIO 17
```
Edit: ~~The DTS label-mac-device alias should no longer be required,
now that MAC addresses are determined by rbsysfs, and assigned in 02_network~~ Commited in 5549b843885fb984bf1ec8c771c4598140eb3b6e 

This was identified while implementing support for 760igs, https://github.com/openwrt/openwrt/pull/3103,
which shares very similar hardware.

Has not been tested on 750gr3.

On the 760igs, the GPIO base is 480.

~~Still WIP~~