### PR TITLE
lantiq: switch to 5.4

### DIFF
--- a/target/linux/lantiq/Makefile
+++ b/target/linux/lantiq/Makefile
@@ -11,8 +11,7 @@ BOARDNAME:=Lantiq
 FEATURES:=squashfs
 SUBTARGETS:=xrx200 xway xway_legacy falcon ase
 
-KERNEL_PATCHVER:=4.19
-KERNEL_TESTING_PATCHVER:=5.4
+KERNEL_PATCHVER:=5.4
 
 define Target/Description
 	Build firmware images for Lantiq SoC


### PR DESCRIPTION
Runtime tested on BT Home Hub 5A and D-Link DWR-966.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
