### PR TITLE
ipq806x: add support for Askey RT4230W REV6

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -30,6 +30,9 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+askey,rt4230w-rev6)
+	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"
+	;;
 edgecore,ecw5410)
 	ubootenv_add_uci_config "/dev/mtd11" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+askey,rt4230w-rev6 |\
 asrock,g10 |\
 nec,wg2600hp)
 	ucidef_add_switch "switch0" \

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -9,6 +9,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
+	askey,rt4230w-rev6 |\
 	asrock,g10)
 		if [ -b "$(find_mtd_part 0:art)" ]; then
 			caldata_extract "0:art" 0x1000 0x2f20
@@ -68,6 +69,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
+	askey,rt4230w-rev6 |\
 	asrock,g10)
 		if [ -b "$(find_mtd_part 0:art)" ]; then
 			caldata_extract "0:art" 0x5000 0x2f20

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -10,15 +10,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
-	asrock,g10)
-		asrock_upgrade_prepare
-		nand_do_upgrade "$1"
-		;;
-	buffalo,wxr-2533dhp)
-		buffalo_upgrade_prepare_ubi
-		CI_ROOTPART="ubi_rootfs"
-		nand_do_upgrade "$1"
-		;;
+	askey,rt4230w-rev6 |\
 	compex,wpq864|\
 	netgear,d7800 |\
 	netgear,r7500 |\
@@ -26,6 +18,15 @@ platform_do_upgrade() {
 	netgear,r7800 |\
 	qcom,ipq8064-ap148 |\
 	qcom,ipq8064-ap161)
+		nand_do_upgrade "$1"
+		;;
+	asrock,g10)
+		asrock_upgrade_prepare
+		nand_do_upgrade "$1"
+		;;
+	buffalo,wxr-2533dhp)
+		buffalo_upgrade_prepare_ubi
+		CI_ROOTPART="ubi_rootfs"
 		nand_do_upgrade "$1"
 		;;
 	edgecore,ecw5410)

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq8065.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Askey RT4230W REV6";
+	compatible = "askey,rt4230w-rev6", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x3e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		led-boot = &ledctrl3;
+		led-failsafe = &ledctrl1;
+		led-running = &ledctrl2;
+		led-upgrade = &ledctrl3;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs noinitrd";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		ledctrl1: ledctrl1 {
+			label = "ledctrl1";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+		
+		ledctrl2: ledctrl2 {
+			label = "ledctrl2";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+		
+		ledctrl3: ledctrl3 {
+			label = "ledctrl3";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio54", "gpio68";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio22", "gpio23", "gpio24";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		mux {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31",
+				"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+			function = "rgmii2";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		tx {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
+			input-disable;
+		};
+	};
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x0040000 0x0140000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "0:SBL2";
+				reg = <0x0180000 0x0140000>;
+				read-only;
+			};
+			partition@2c0000 {
+				label = "0:SBL3";
+				reg = <0x02c0000 0x0280000>;
+				read-only;
+			};
+			partition@540000 {
+				label = "0:DDRCONFIG";
+				reg = <0x0540000 0x0120000>;
+				read-only;
+			};
+			partition@660000 {
+				label = "0:SSD";
+				reg = <0x0660000 0x0120000>;
+				read-only;
+			};
+			partition@780000 {
+				label = "0:TZ";
+				reg = <0x0780000 0x0280000>;
+				read-only;
+			};
+			partition@a00000 {
+				label = "0:RPM";
+				reg = <0x0a00000 0x0280000>;
+				read-only;
+			};
+			partition@c80000 {
+				label = "0:APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+			partition@1180000 {
+				label = "0:APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+			};
+			ART: partition@1200000 {
+				label = "0:ART";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+			};
+			partition@1340000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x1340000 0x0060000>;
+				read-only;
+			};
+			partition@13a0000 {
+				label = "0:SBL2_1";
+				reg = <0x13a0000 0x0140000>;
+				read-only;
+			};
+			partition@14e0000 {
+				label = "0:SBL3_1";
+				reg = <0x14e0000 0x0280000>;
+				read-only;
+			};
+			partition@1760000 {
+				label = "0:DDRCONFIG_1";
+				reg = <0x1760000 0x0120000>;
+				read-only;
+			};
+			partition@1880000 {
+				label = "0:SSD_1";
+				reg = <0x1880000 0x0120000>;
+				read-only;
+			};
+			partition@19a0000 {
+				label = "0:TZ_1";
+				reg = <0x19a0000 0x0280000>;
+				read-only;
+			};
+			partition@1c20000 {
+				label = "0:RPM_1";
+				reg = <0x1c20000 0x0280000>;
+				read-only;
+			};
+			partition@1ea0000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x1ea0000 0x0060000>;
+				read-only;
+			};
+			partition@1f00000 {
+				label = "0:APPSBL_1";
+				reg = <0x1f00000 0x0500000>;
+				read-only;
+			};
+			partition@2400000 {
+				label = "ubi";
+				reg = <0x2400000 0x1a000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+		qca,ar8327-initvals = < 
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			0x00050 0xcf02cf02  /* LED_CTRL_0 */
+			0x00054 0xc832c832  /* LED_CTRL_1 */
+			>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <0>;
+
+	mtd-mac-address = <&ART 0x0>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <1>;
+
+	mtd-mac-address = <&ART 0x6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+	clocks = <&gcc USB30_1_MASTER_CLK>;
+};
+
+&usb3_1 {
+	status = "okay";
+	clocks = <&gcc USB30_0_MASTER_CLK>;
+};
+
+&pcie0 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
+	/delete-property/ perst-gpios;
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
+	/delete-property/ perst-gpios;
+	force_gen1 = <1>;
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -90,6 +90,19 @@ define Device/ZyXELImage
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
+define Device/askey_rt4230w-rev6
+	$(call Device/LegacyImage)
+	DEVICE_VENDOR := Askey
+	DEVICE_MODEL := RT4230W
+	DEVICE_VARIANT := REV6
+	SOC := qcom-ipq8065
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	KERNEL_IN_UBI := 1
+endef
+TARGET_DEVICES += askey_rt4230w-rev6
+
 define Device/asrock_g10
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,24 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,25 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -29,6 +29,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-wg2600hp.dtb \
 +	qcom-ipq8064-wpq864.dtb \
 +	qcom-ipq8064-wxr-2533dhp.dtb \
++	qcom-ipq8065-rt4230w-rev6.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8068-ecw5410.dtb \


### PR DESCRIPTION
This adds support for the Askey RT4230W REV6 (Branded by Spectrum/Charter as RAC2V1K)
At this time, there's no way to reinstall the stock firmware so don't install this on a router that's being rented.

Specifications:

    Qualcomm IPQ8065
    1 GB of RAM (DDR3)
    512 MB Flash (NAND)
    2x Wave 2 WiFi cards (QCA9984)
    5x 10/100/1000 Mbps Ethernet (Switch: QCA8337)
    1x LED (Controlled by a microcontroller that switches it between red and blue with different patterns)
    1x USB 3.0 Type-A
    12V DC Power Input
    UART header on PCB
        On ethernet port side; pinout from top to bottom is RX, TX, GND, 5V
        Port settings are 115200n8

More information: https://forum.openwrt.org/t/askey-rac2v1k-support/15830 https://deviwiki.com/wiki/Askey_RAC2V1K

To check what revision your router is, restore one of these config backups through the stock firmware to get ssh access then run "cat /proc/device-tree/model". https://forum.openwrt.org/t/askey-rac2v1k-support/15830/17
The revision number on the board doesn't seem to be very consistent, so that's why this is needed. You can also run printenv in the uboot console and if machid is set to 177d, that means your router is rev6.

Note: Don't install this if the router is being rented from an ISP. The defined partition layout is different from the OEM one and even if you redefined the layout to match, backing up and restoring the OEM firmware breaks /overlay so nothing will save and the router will likely enter a bootloop.

How to install:

<details>
<summary>Method 1: Install without opening the case using SSH and tftp</summary>
    
    You'll need:
    RAC2V1K-SSH.zip: https://github.com/lmore377/openwrt-rt4230w/blob/master/RAC2V1K-SSH.zip
    initramfs and sysupgrade images
    
    Connect to one of the router's LAN ports

    Download the RAC2V1K-SSH.zip file and restore the config file that corresponds to your router's firmware (If you're firmware is newer than what's in the zip file, just restore the 1.1.16 file)

    After a reboot, you should be able to ssh into the router with username: "4230w" and password: "linuxbox" or "admin". Run the following commannds
     fw_setenv ipaddr 10.42.0.10 #IP of router, can be anything
     fw_setenv serverip 10.42.0.1# #IP of tftp server that's set up in next steps
     fw_setenv bootdelay 8
     fw_setenv bootcmd "tftpboot initramfs.bin; bootm; bootipq"

    Don't reboot the router yet.

    Install and set up a tftp server on your computer

    Set a static ip on the ethernet interface of your computer (use this for serverip in the above commands)

    Rename the initramfs image to initramfs.bin, and host it with the tftp server

    Reboot the router. If you set up everything right, the router led should switch over to a slow blue glow which means openwrt is booted. If for some reason the file doesn't get loaded into ram properly, it should still boot to the OEM fw
    After openwrt boots, ssh into it and run these commands:
    fw_setenv bootcmd "setenv mtdids nand0=nand0 && setenv mtdparts mtdparts=nand0:0x1A000000@0x2400000(firmware) && ubi part firmware && ubi read 0x44000000 kernel 0x6e0000 && bootm"
    fw_setenv bootdelay 2

    After openwrt boots up, figure out a way to get the sysupgrade file onto it (scp, custom build with usb kernel module included, wget, etc.) then flash it with sysupgrade. After it finishes flashing, it should reboot, the light should go red for a bit then switch over to a blinking blue, then when the light starts "breathing" blue that means openwrt is booted.
</details>

<details>
<summary>Method 2: Install with serial access (Do this if something fails and you can't boot after using method 1) </summary>
    
    You'll need:
    initramfs and sysupgrade images
    Serial access: Instructions can be found here: https://openwrt.org/inbox/toh/askey/askey_rt4230w_rev6#opening_the_case

    Install and set up a tftp server

    Set a static ip on the ethernet interface of your computer

    Download the initramfs image, rename it to initramfs.bin, and host it with the tftp server

    Connect the wan port of the router to your computer

    Interrupt U-Boot and run these commands:
    setenv serverip 10.42.0.1 (You can use whatever ip you set for the computer)
    setenv ipaddr 10.42.0.10 (Can be any ip as long as it's in the same subnet)
    setenv bootcmd "setenv mtdids nand0=nand0 && set mtdparts mtdparts=nand0:0x1A000000@0x2400000(firmware) && ubi part firmware && ubi read 0x44000000 kernel 0x6e0000 && bootm"

    saveenv
    tftpboot initramfs.bin
    bootm
    
    After openwrt boots up, figure out a way to get the sysupgrade file onto it (scp, custom build with usb kernel module included, wget, etc.) then flash it with sysupgrade. After it finishes flashing, it should reboot, the light should go red for a bit then switch over to a blinking blue, then when the light starts "breathing" blue that means openwrt is booted.
</details>