### PR TITLE
ramips: Add suport for COMFAST CF-WR617AC

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -471,6 +471,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "0:wan" "6@eth0"
 		;;
+  comfast,cf-wr617ac)
+    ucidef_add_switch "switch0" \
+      "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+    ;;
 	zbtlink,zbt-we1226|\
 	y1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/dts/CF-WR617AC.dts
+++ b/target/linux/ramips/dts/CF-WR617AC.dts
@@ -1,0 +1,94 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+/ {
+  compatible = "comfast,cf-wr617ac", "mediatek,mt7628an-soc";
+  model = "Comfast CF-WR617AC";
+
+  chosen {
+    bootargs = "console=ttyS0,115200";
+  };
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+};
+
+&pinctrl {
+  state_default: pinctrl0 {
+    gpio {
+      ralink,group = "i2c";
+      ralink,function = "gpio";
+    };
+  };
+};
+
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			ubootenv: partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x760000>;
+			};
+		};
+	};
+};
+
+
+&pcie {
+  status = "okay";
+};
+
+&pcie0 {
+  wifi@0,0 {
+    compatible = "mediatek,mt76";
+    reg = <0x0000 0 0 0 0>;
+    mediatek,mtd-eeprom = <&factory 0x8000>;
+    ieee80211-freq-limit = <5000000 6000000>;
+  };
+};
+
+&ethernet {
+  mtd-mac-address = <&factory 0x4>;
+  mtd-mac-address-increment = <(-1)>;
+};
+
+&esw {
+  mediatek,portmap = <0x2f>;
+};
+
+&wmac {
+  status = "okay";
+};

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr617ac.dts
@@ -1,0 +1,86 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+/ {
+  compatible = "comfast,cf-wr617ac", "mediatek,mt7628an-soc";
+  model = "Comfast CF-WR617AC";
+
+  chosen {
+    bootargs = "console=ttyS0,115200";
+  };
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	m25p80@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			ubootenv: partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x760000>;
+			};
+		};
+	};
+};
+
+
+&pcie {
+  status = "okay";
+};
+
+&pcie0 {
+  wifi@0,0 {
+    compatible = "mediatek,mt76";
+    reg = <0x0000 0 0 0 0>;
+    mediatek,mtd-eeprom = <&factory 0x8000>;
+    ieee80211-freq-limit = <5000000 6000000>;
+  };
+};
+
+&ethernet {
+  mtd-mac-address = <&factory 0x4>;
+  mtd-mac-address-increment = <(-1)>;
+};
+
+&esw {
+  mediatek,portmap = <0x2f>;
+  mediatek,portdisable = <0x2a>;
+};
+
+&wmac {
+  status = "okay";
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -485,3 +485,14 @@ define Device/zyxel_keenetic-extra-ii
 	check-size $$$$(IMAGE_SIZE) | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii
+
+define Device/comfast_cf-wr617ac
+  IMAGE_SIZE := $(ralink_default_fw_size_32M)
+  DTS := CF-WR617AC
+  DEVICE_VENDOR := Comfast
+  DEVICE_MODEL := CF-WR617AC
+  DEVICE_TITLE := Comfast CF-WR617AC
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-rt2800-pci
+  SUPPORTED_DEVICES += cf-wr617ac
+endef
+TARGET_DEVICES += comfast_cf-wr617ac


### PR DESCRIPTION
COMFAST CF-WR617AC is a dual-radio wireless router with a 4 fast ethernet port.
It has 4*5dBi antennas

Specifications:
Chipset:MT7628DA+MT7612E
Antenna : 2.4Ghz:2*5dbi Antenna + 5.8Ghz:2*5dbi Antenna 
Wireless Rate:2.4Ghz 300Mbps , 5.8Ghz 867Mbps 
Output Power :100mW(20dbm)
Physical port:1*10/100Mbps RJ45 WAN Port , 3*10/100Mbps RJ45 LAN Port 

Signed-off-by: Sergei Iudin <tsipa740@gmail.com>