### PR TITLE
ath79: add support for TP-Link CPE610-v2

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_cpe610-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe610-v2.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_tplink_cpe.dtsi"
+
+/ {
+	model = "TP-Link CPE610 v2";
+	compatible = "tplink,cpe610-v2", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lan: lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "tp-link:green:wlan5g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -243,6 +243,9 @@ tplink,cpe510-v3)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "76" "100" "-75" "13"
 	;;
 tplink,cpe610-v1|\
+tplink,cpe610-v2)
+	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
+	;;
 tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "tp-link:green:internet" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ ath79_setup_interfaces()
 	tplink,cpe510-v2|\
 	tplink,cpe510-v3|\
 	tplink,cpe610-v1|\
+	tplink,cpe610-v2|\
 	tplink,re350k-v1|\
 	tplink,re355-v1|\
 	tplink,re450-v1|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -352,6 +352,16 @@ define Device/tplink_cpe610-v1
 endef
 TARGET_DEVICES += tplink_cpe610-v1
 
+define Device/tplink_cpe610-v2
+  $(Device/tplink-safeloader-okli)
+  SOC := ar9344
+  IMAGE_SIZE := 7680k
+  DEVICE_MODEL := CPE610
+  DEVICE_VARIANT := v2
+  TPLINK_BOARD_ID := CPE610V2
+endef
+TARGET_DEVICES += tplink_cpe610-v2
+
 define Device/tplink_re350k-v1
   $(Device/tplink-safeloader)
   SOC := qca9558

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -474,6 +474,46 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "support-list",
 	},
 
+	/** Firmware layout for the CPE610V2 */
+	{
+		.id     = "CPE610V2",
+		.vendor = "CPE610(TP-LINK|UN|N300-5|00000000):2.0\r\n",
+		.support_list =
+			"SupportList:\r\n"
+			"CPE610(TP-LINK|EU|N300-5|00000000):2.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5|45550000):2.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5|55530000):2.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|00000000):2.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|45550000):2.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5|55530000):2.0\r\n"
+			"CPE610(TP-LINK|US|N300-5|55530000):2.0\r\n"
+			"CPE610(TP-LINK|UN|N300-5):2.0\r\n"
+			"CPE610(TP-LINK|EU|N300-5):2.0\r\n"
+			"CPE610(TP-LINK|US|N300-5):2.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x00020},
+			{"product-info", 0x31100, 0x00100},
+			{"signature", 0x32000, 0x00400},
+			{"os-image", 0x40000, 0x200000},
+			{"file-system", 0x240000, 0x570000},
+			{"soft-version", 0x7b0000, 0x00100},
+			{"support-list", 0x7b1000, 0x00400},
+			{"user-config", 0x7c0000, 0x10000},
+			{"default-config", 0x7d0000, 0x10000},
+			{"log", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "support-list",
+	},
+
 	{
 		.id     = "WBS210",
 		.vendor = "CPE510(TP-LINK|UN|N300-5):1.0\r\n",


### PR DESCRIPTION
TP-Link CPE610-v2 is an outdoor wireless CPE for 5 GHz with
one Ethernet port based on Atheros AR9344

Specifications:
 - 560/450/225 MHz (CPU/DDR/AHB)
 - 1x 10/100 Mbps Ethernet
 - 64 MB of DDR2 RAM
 - 8 MB of SPI-NOR Flash
 - 23dBi high-gain directional 2×2 MIMO antenna and a dedicated metal reflector
 - Power, LAN, WLAN5G green LEDs
 - 3x green RSSI LEDs

Flashing instructions:
 Flash factory image through stock firmware WEB UI
 or through TFTP
 To get to TFTP recovery just hold reset button while powering on for
 around 4-5 seconds and release.
 Rename factory image to recovery.bin
 Stock TFTP server IP:192.168.0.100
 Stock device TFTP adress:192.168.0.254

Signed-off-by: Andrew Cameron <apcameron@softhome.net>

