### PR TITLE
ath79: add support for MikroTik SXT Lite5 (RBSXT5nDr2)

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_mikrotik_sxt5n.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-sxt-5nd-r2", "qca,ar9344";
+	model = "MikroTik SXT Lite5 (RouterBOARD SXT 5nD r2)";
+};

--- a/target/linux/ath79/dts/ar9344_mikrotik_sxt5n.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_sxt5n.dtsi
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "mikrotik,sxt5n", "qca,ar9344";
+	model = "MikroTik SXT5N platform";
+
+	aliases {
+		label-mac-device = &eth1;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "sxt5n:green:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssilow {
+			label = "sxt5n:green:rssilow";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "sxt5n:green:rssimediumlow";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "sxt5n:green:rssimedium";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "sxt5n:green:rssimediumhigh";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		led_rssihigh: rssihigh {
+			label = "sxt5n:green:rssihigh";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_user: user {
+			label = "sxt5n:green:user";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_nand_power {
+			gpio-export,name = "sxt5n:power:nand";
+			gpio-export,output = <0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	qca,nand-swap-dma;
+	qca,nand-scan-fixup;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "booter";
+			reg = <0x0000000 0x0040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "kernel";
+			reg = <0x0040000 0x03c0000>;
+		};
+
+		partition@400000 {
+			label = "ubi";
+			reg = <0x0400000 0x7c00000>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -35,3 +35,18 @@ define Device/mikrotik_routerboard-wap-g-5hact2hnd
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef
 TARGET_DEVICES += mikrotik_routerboard-wap-g-5hact2hnd
+
+define Device/mikrotik_sxt5n
+  $(Device/mikrotik)
+  SOC := ar9344
+  IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+  DEVICE_PACKAGES += nand-utils rssileds kmod-gpio-beeper
+endef
+
+define Device/mikrotik_routerboard-sxt-5nd-r2
+  $(Device/mikrotik_sxt5n)
+  DEVICE_MODEL := SXT Lite5 (RouterBOARD SXT 5nD r2)
+  SUPPORTED_DEVICES += rb-sxt5n
+endef
+TARGET_DEVICES += mikrotik_routerboard-sxt-5nd-r2

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+boardname="${board##*,}"
+
+case "$board" in
+mikrotik,routerboard-sxt-5nd-r2)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "rssilow" "sxt5n:green:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "rssimediumlow" "sxt5n:green:rssimediumlow" "wlan0" "20" "100"
+	ucidef_set_led_rssi "rssimedium" "rssimedium" "sxt5n:green:rssimedium" "wlan0" "40" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "sxt5n:green:rssimediumhigh" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "rssihigh" "sxt5n:green:rssihigh" "wlan0" "80" "100"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -16,7 +16,8 @@ ath79_setup_interfaces()
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
 	mikrotik,routerboard-922uags-5hpacd|\
-	mikrotik,routerboard-wap-g-5hact2hnd)
+	mikrotik,routerboard-wap-g-5hact2hnd|\
+	mikrotik,routerboard-sxt-5nd-r2)
 		ucidef_set_interface_lan "eth0"
 		;;
 	*)
@@ -34,6 +35,10 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,routerboard-sxt-5nd-r2)
+		label_mac="$mac_base"
+		lan_mac="$mac_base"
+		;;
 	*)
 		label_mac="$mac_base"
 		wan_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,12 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	mikrotik,routerboard-sxt-5nd-r2)
+		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
+		ath9k_patch_mac $(macaddr_add "$mac_base" +1) /tmp/$FIRMWARE
+		caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 0x440
+		rm -f /tmp/$FIRMWARE
+		;;
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
 		ath9k_patch_mac $(macaddr_add "$mac_base" +2) /tmp/$FIRMWARE

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -32,7 +32,8 @@ platform_do_upgrade() {
 
 	case "$board" in
 	mikrotik,routerboard-493g|\
-	mikrotik,routerboard-922uags-5hpacd)
+	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-sxt-5nd-r2)
 		platform_do_upgrade_mikrotik_nand "$1"
 		;;
 	*)


### PR DESCRIPTION
This commit adds support for the MikroTik SXT Lite5, an outdoor 802.11a/n CPE based on the AR9344 SoC. The support code is mostly targeted at the "sxt5n" board platform, with support for this actual device depending on it, so that similar ones can be easily added later.

The device was already supported in ar71xx, but the network configuration was slightly different::
```
        ath79_setup_ar934x_eth_cfg(AR934X_ETH_CFG_SW_ONLY_MODE);

        ath79_register_mdio(1, 0x0);

        /* GMAC0 is left unused */

        /* MAC1 is connected to MAC0 on the internal switch */
        /* The ethernet port connects to PHY P0, which connects to MAC1
           on the internal switch */
        ath79_init_mac(ath79_eth1_data.mac_addr, ath79_mac_base, 0);
        ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
        ath79_register_eth(1);
```
Link detection was available there, but reported speed was fixed at GMII's 1000 Mbps. In ath79, by switching to GMAC0, link detection and correct speed/duplex are reported.

---

The MikroTik SXT Lite5 (product code RBSXT5nDr2, also SXT 5nD r2) is
an outdoor 5GHz CPE with a 16 dBi integrated antenna built around the
Atheros AR9344 SoC. It is based on the "sxt5n" board platform.

Specifications:
 - SoC: Atheros AR9344
 - RAM: 64 MB
 - Storage: 128 MB NAND
 - Wireless: Atheros AR9340 (SoC) 802.11a/n 2x2:2
 - Ethernet: Atheros AR8229 switch (SoC), 1x 10/100 port,
    8-32 Vdc PoE in
 - 6 user-controllable LEDs:
  · 1x power (blue)
  · 1x wlan (green)
  · 4x rssi (green)
 - 1 GPIO-controlled buzzer

 See https://mikrotik.com/product/RBSXT5nDr2 for more details.

Notes:
 The device was already supported in the ar71xx target. There, the
 Ethernet port was handled by GMAC1. Here in ath79 it is handled by
 GMAC0, which allows to get link information (loss, speed, duplex) on
 the eth0 interface.

Flashing:
 TFTP boot initramfs image and then perform sysupgrade. Follow common
 MikroTik procedure as in https://openwrt.org/toh/mikrotik/common.

Acknowledgments:
 Michael Pratt (@mpratt14) for helping on the network settings.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>