### PR TITLE
mvebu: remove ClearFog Base SUPPORTED_DEVICES

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -210,7 +210,6 @@ define Device/solidrun_clearfog-base-a1
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := boot-scr | boot-img-ext4 | sdcard-img-ext4 | gzip | append-metadata
   DEVICE_DTS := armada-388-clearfog-base armada-388-clearfog-pro
-  SUPPORTED_DEVICES += armada-388-clearfog-base
   UBOOT := clearfog-u-boot-spl.kwb
   BOOT_SCRIPT := clearfog
 endef


### PR DESCRIPTION
Only the Pro device was changed with 898969636d8, but the Base and Pro
should be kept in sync for such changes.

Signed-off-by: Joel Johnson <mrjoel@lixil.net>