### PR TITLE
ltq-vmmc: update permission handling

### DIFF
--- a/package/kernel/lantiq/ltq-vmmc/Makefile
+++ b/package/kernel/lantiq/ltq-vmmc/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=drv_vmmc
 PKG_VERSION:=1.9.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_HASH:=707f515eb727c032418c4da67d7e86884bb56cdc2a606e8f6ded6057d8767e57
@@ -168,9 +168,10 @@ define Build/InstallDev
 endef
 
 define KernelPackage/ltq-vmmc/install
-	$(INSTALL_DIR) $(1)/etc/init.d $(1)/$(FW_DIR)
+	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/init.d $(1)/$(FW_DIR)
 	$(INSTALL_BIN) ./files/vmmc.init $(1)/etc/init.d/vmmc
-	$(CP) $(PKG_BUILD_DIR)/firmware/$(FW_SOURCE) $(1)/$(FW_DIR)/$(FW_TARGET)
+	$(INSTALL_CONF) ./files/vmmc.conf $(1)/etc/config/vmmc
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/firmware/$(FW_SOURCE) $(1)/$(FW_DIR)/$(FW_TARGET)
 	ln -s /$(FW_DIR)/$(FW_TARGET) $(1)/$(FW_DIR)/$(FW_TARGET_GENERIC)
 	$(CP) $(PKG_BUILD_DIR)/coef/$(COEF_SRC) $(1)/$(FW_DIR)/$(COEF_TARGET)
 	$(CP) $(PKG_BUILD_DIR)/coef/$(COEF_SRC_FXO) $(1)/$(FW_DIR)/$(COEF_TARGET_FXO)

--- a/package/kernel/lantiq/ltq-vmmc/files/vmmc.conf
+++ b/package/kernel/lantiq/ltq-vmmc/files/vmmc.conf
@@ -1,0 +1,6 @@
+# /dev/vmmc* nodes are by default created with ownership root:root. With
+# the below setting the group can be changed, so that software like
+# asterisk not running as root can properly access the hardware.
+
+config vmmc 'nodes'
+	#option group "asterisk"

--- a/package/kernel/lantiq/ltq-vmmc/files/vmmc.init
+++ b/package/kernel/lantiq/ltq-vmmc/files/vmmc.init
@@ -5,15 +5,18 @@
 START=31
 
 start() {
-	[ ! -c /dev/vmmc10 ] && {
-		mknod /dev/vmmc10 c 122 10
-		mknod /dev/vmmc11 c 122 11
-		mknod /dev/vmmc12 c 122 12
-		mknod /dev/vmmc13 c 122 13
-		mknod /dev/vmmc14 c 122 14
-		mknod /dev/vmmc15 c 122 15
-		mknod /dev/vmmc16 c 122 16
-		mknod /dev/vmmc17 c 122 17
-		mknod /dev/vmmc18 c 122 18
-	}
+	config_load vmmc
+	config_get GROUP nodes group ""
+
+	if [ -n "$GROUP" ]; then
+		group_exists "$GROUP" || GROUP=
+	fi
+
+	for i in 10 11 12 13 14 15 16 17 18; do
+		if ! [ -e /dev/vmmc$i ]; then
+			mknod -m 664 /dev/vmmc$i c 122 $i
+			[ -n "$GROUP" ] && [ -c /dev/vmmc$i ] && \
+				chown :"$GROUP" /dev/vmmc$i
+		fi
+	done
 }


### PR DESCRIPTION
This commit addresses two permission issues.

1. The firmware is currently just copied. It can end up with o= on the
   device (this is the case for voice_ar9_firmware.bin for instance).
   Instead of copying it the Makefile is changed to use the macro
   "$(INSTALL_DATA) in order for the file to be world-readable.
2. A configuration file /etc/config/vmmc is added and the init script
   updated accordingly, to allow changing the group of the device nodes.
   Like this applications running as non-root may access the device
   nodes after the user changes the configuration to the appropriate
   group (for instance "asterisk").

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

--

Hi all,

This was sent to patchwork already a while ago, via openwrt-devel. It's related to [this issue](https://github.com/openwrt/telephony/issues/520) raised in telephony repo.

@jospezial, care to add a Tested-by to this commit?

Maintainer: @blogic 

Thanks!
Seb