### PR TITLE
ath79: fix input type for TP-Link TL-WR902AC v1 mode switch

### DIFF
--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
@@ -77,12 +77,14 @@
 
 		sw1 {
 			label = "Mode switch 1";
+			linux,input-type = <EV_SW>;
 			linux,code = <BTN_0>;
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 		};
 
 		sw2 {
 			label = "Mode switch 2";
+			linux,input-type = <EV_SW>;
 			linux,code = <BTN_1>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
Inputs assigned to "mode select" switch on the side of the device
were missing linux,input-type property.
This would cause them do incorrectly generate EV_KEY events.
Fix this by setting the linux,input-type = <EV_SW> property on them.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>

Compile- and run-tested on: TP-Link TL-WR902AC v1