### PR TITLE
ramips: add support for ELECOM WRC-2533GST2

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
@@ -7,3 +7,35 @@
 	compatible = "elecom,wrc-1900gst", "mediatek,mt7621-soc";
 	model = "ELECOM WRC-1900GST";
 };
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xb00000>;
+	};
+
+	partition@b50000 {
+		label = "tm_pattern";
+		reg = <0xb50000 0x380000>;
+		read-only;
+	};
+
+	partition@ed0000 {
+		label = "tm_key";
+		reg = <0xed0000 0x80000>;
+		read-only;
+	};
+
+	partition@f50000 {
+		label = "art_block";
+		reg = <0xf50000 0x30000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "user_data";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
@@ -6,3 +6,35 @@
 	compatible = "elecom,wrc-2533gst", "mediatek,mt7621-soc";
 	model = "ELECOM WRC-2533GST";
 };
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xb00000>;
+	};
+
+	partition@b50000 {
+		label = "tm_pattern";
+		reg = <0xb50000 0x380000>;
+		read-only;
+	};
+
+	partition@ed0000 {
+		label = "tm_key";
+		reg = <0xed0000 0x80000>;
+		read-only;
+	};
+
+	partition@f50000 {
+		label = "art_block";
+		reg = <0xf50000 0x30000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "user_data";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_elecom_wrc-gst.dtsi"
+
+/ {
+	compatible = "elecom,wrc-2533gst2", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-2533GST2";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1800000>;
+	};
+
+	partition@1850000 {
+		label = "tm_pattern";
+		reg = <0x1850000 0x400000>;
+		read-only;
+	};
+
+	partition@1c50000 {
+		label = "tm_key";
+		reg = <0x1c50000 0x100000>;
+		read-only;
+	};
+
+	partition@1d50000 {
+		label = "nvram";
+		reg = <0x1d50000 0xb0000>;
+		read-only;
+	};
+
+	partition@1e00000 {
+		label = "user_data";
+		reg = <0x1e00000 0x200000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
@@ -129,7 +129,7 @@
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -149,36 +149,6 @@
 			factory: partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0xb00000>;
-			};
-
-			partition@b50000 {
-				label = "tm_pattern";
-				reg = <0xb50000 0x380000>;
-				read-only;
-			};
-
-			partition@ed0000 {
-				label = "tm_key";
-				reg = <0xed0000 0x80000>;
-				read-only;
-			};
-
-			partition@f50000 {
-				label = "art_block";
-				reg = <0xf50000 0x30000>;
-				read-only;
-			};
-
-			partition@f80000 {
-				label = "user_data";
-				reg = <0xf80000 0x80000>;
 				read-only;
 			};
 		};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
@@ -194,7 +194,34 @@
 
 &pcie {
 	status = "okay";
-	/* WRC-xxxxGST has MT7615 for 2.4/5 GHz wifi, but it's not supported */
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
 };
 
 &xhci {

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gst.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_power_green;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_green;
+		label-mac-device = &wan;
 	};
 
 	chosen {
@@ -92,7 +93,7 @@
 
 &switch0 {
 	ports {
-		port@0 {
+		wan: port@0 {
 			status = "okay";
 			label = "wan";
 			mtd-mac-address = <&factory 0xe006>;
@@ -126,7 +127,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -291,6 +291,7 @@ define Device/elecom_wrc-1900gst
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-gst-factory WRC-1900GST 0.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
 endef
 TARGET_DEVICES += elecom_wrc-1900gst
 
@@ -302,6 +303,7 @@ define Device/elecom_wrc-2533gst
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-gst-factory WRC-2533GST 0.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
 endef
 TARGET_DEVICES += elecom_wrc-2533gst
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -307,6 +307,18 @@ define Device/elecom_wrc-2533gst
 endef
 TARGET_DEVICES += elecom_wrc-2533gst
 
+define Device/elecom_wrc-2533gst2
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 24576k
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-2533GST2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	elecom-gst-factory WRC-2533GST2 0.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+endef
+TARGET_DEVICES += elecom_wrc-2533gst2
+
 define Device/firefly_firewrt
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Firefly


### PR DESCRIPTION
- update dts for ELECOM WRC-GST devices
  - increase SPI frequency to 40 MHz
  - add label-mac-device alias

- add MT7615 wireless support for ELECOM WRC-GST devices

- add support for ELECOM WRC-2533GST2