### PR TITLE
x86: add led driver for PC Engines APU1

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -131,6 +131,22 @@ endef
 $(eval $(call KernelPackage,ledtrig-oneshot))
 
 
+define KernelPackage/leds-apu
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=PC Engines APU1 LED support
+  DEPENDS:= @GPIO_SUPPORT @TARGET_x86
+  KCONFIG:=CONFIG_LEDS_APU
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-apu.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-apu,1)
+endef
+
+define KernelPackage/leds-apu/description
+  Driver for the PC Engines APU1 LEDs.
+endef
+
+$(eval $(call KernelPackage,leds-apu))
+
+
 define KernelPackage/leds-pca963x
   SUBMENU:=$(LEDS_MENU)
   TITLE:=PCA963x LED support

--- a/target/linux/x86/base-files/etc/board.d/01_leds
+++ b/target/linux/x86/base-files/etc/board.d/01_leds
@@ -8,10 +8,10 @@
 board_config_update
 
 case "$(board_name)" in
-pc-engines-apu|pc-engines-apu2|pc-engines-apu3)
-	ucidef_set_led_netdev "wan" "WAN" "apu2:green:led3" "eth0"
-	ucidef_set_led_netdev "lan" "LAN" "apu2:green:led2" "br-lan"
-	ucidef_set_led_default "diag" "DIAG" "apu2:green:power" "1"
+pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
+	ucidef_set_led_netdev "wan" "WAN" "apu:green:3" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "apu:green:2" "br-lan"
+	ucidef_set_led_default "diag" "DIAG" "apu:green:1" "1"
 	;;
 traverse-technologies-geos)
 	ucidef_set_led_netdev "lan" "LAN" "geos:1" "br-lan" "tx rx"

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -9,7 +9,7 @@
 board_config_update
 
 case "$(board_name)" in
-pc-engines-apu|pc-engines-apu2|pc-engines-apu3)
+pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;
 traverse-technologies-geos)

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -18,6 +18,10 @@ do_sysinfo_x86() {
 	for file in product_name board_name; do
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
+		"PC Engines:APU")
+			product="apu1"
+			break
+			;;
 		"Supermicro:Super Server")
 			continue
 			;;

--- a/target/linux/x86/patches-5.4/300-pcengines_apu1_led.patch
+++ b/target/linux/x86/patches-5.4/300-pcengines_apu1_led.patch
@@ -1,0 +1,41 @@
+From: Andreas Eberlein <foodeas@aeberlein.de>
+Subject: x86: add LED support for PC Engines APU1 with mainline bios
+
+This adds support for the LEDs on PC Engines APU1 with the mainline bios.
+
+Signed-off-by: Andreas Eberlein <foodeas@aeberlein.de>
+---
+--- a/drivers/leds/leds-apu.c
++++ b/drivers/leds/leds-apu.c
+@@ -83,6 +83,7 @@ static const struct apu_led_profile apu1
+ };
+ 
+ static const struct dmi_system_id apu_led_dmi_table[] __initconst = {
++	/* PC Engines APU with "Legacy" bios < 4.0.8 */
+ 	{
+ 		.ident = "apu",
+ 		.matches = {
+@@ -90,6 +91,14 @@ static const struct dmi_system_id apu_le
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "APU")
+ 		}
+ 	},
++	/* PC Engines APU with "Mainline" bios >= 4.0.8 */
++	{
++		.ident = "apu",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "PC Engines"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "apu1")
++		}
++	},
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(dmi, apu_led_dmi_table);
+@@ -173,7 +182,7 @@ static int __init apu_led_init(void)
+ 	int err;
+ 
+ 	if (!(dmi_match(DMI_SYS_VENDOR, "PC Engines") &&
+-	      dmi_match(DMI_PRODUCT_NAME, "APU"))) {
++	      (dmi_match(DMI_PRODUCT_NAME, "APU") || dmi_match(DMI_PRODUCT_NAME, "apu1")))) {
+ 		pr_err("No PC Engines APUv1 board detected. For APUv2,3 support, enable CONFIG_PCENGINES_APU2\n");
+ 		return -ENODEV;
+ 	}


### PR DESCRIPTION
This driver adds the LED support for the PC Engines APU1.
This integrates the Linux kernel driver and includes a patch to support newer firmware versions. Also the default LED configuration is updated to use the correct devices.

Signed-off-by: Andreas Eberlein <foodeas@aeberlein.de>