### PR TITLE
ath79: add support for MikroTik RouterBOARD 493AH (rb4xx series)

### DIFF
--- a/target/linux/ath79/dts/ar7161_mikrotik_routerboard-493ah.dts
+++ b/target/linux/ath79/dts/ar7161_mikrotik_routerboard-493ah.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-1.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar7100_mikrotik_routerboard-4xx.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-493ah", "qca,ar7161";
+	model = "MikroTik RouterBOARD 493AH";
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		status = "disabled";
+
+		reset_key: reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -1,5 +1,16 @@
 include ./common-mikrotik.mk
 
+define Device/mikrotik_routerboard-493ah
+  $(Device/mikrotik)
+  SOC := ar7161
+  DEVICE_MODEL := RouterBOARD 493AH
+  IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+  DEVICE_PACKAGES += nand-utils
+  SUPPORTED_DEVICES += rb-493ah
+endef
+TARGET_DEVICES += mikrotik_routerboard-493ah
+
 define Device/mikrotik_routerboard-493g
   $(Device/mikrotik)
   SOC := ar7161

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -31,6 +31,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	mikrotik,routerboard-493ah|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-922uags-5hpacd)
 		platform_do_upgrade_mikrotik_nand "$1"


### PR DESCRIPTION
This is a work in progress to extend the work of @ch6574 in PR #3026 to the RB493AH.

Right now I am unable to netboot the image this produces, so I do not get a sysupgrade capable of installing this.

The RB493AH is very similar to the RB493G. The former:

  * Does not have a USB interface
  * Does not have a micro SD interface
  * Has only 128 MB of RAM
  * Has 100/10 Mb/s Ethernet interfaces
  * Has a single switch interface that covers eight ports

There was some initial discussion about this work at the tail end of PR #3026.