### PR TITLE
ramips: add support for WAVLINK WL-WN577A2 (aka Maginon WLR-755)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -36,6 +36,16 @@
 	leds {
 		compatible = "gpio-leds";
 
+		led_lan: lan {
+			label = "wl-wn577a2:green:lan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wan: wan {
+			label = "wl-wn577a2:green:wan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
 		led_wps: wps {
 			label = "wl-wn577a2:green:wps";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
@@ -45,7 +55,7 @@
 
 &state_default {
 	gpio {
-		groups = "i2c", "wdt", "p0led_an";
+		groups = "i2c", "wdt", "p0led_an", "p3led_an", "p4led_an";
 		function = "gpio";
 	};
 };
@@ -112,4 +122,16 @@
 
 &esw {
 	mediatek,portmap = <0x2f>;
+};
+
+&usbphy {
+    status = "disabled";
+};
+
+&ehci {
+    status = "disabled";
+};
+
+&ohci {
+    status = "disabled";
 };

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -1,0 +1,117 @@
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn577a2", "maginon,wlr-755", "mediatek,mt7628an-soc";
+	model = "WAVLINK WL-WN577A2";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+    };
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "wl-wn577a2:green:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+        groups = "i2c", "wled_an", "gpio", "refclk", "wdt", "p0led_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -1,4 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
+
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
 
@@ -8,16 +10,12 @@
 	compatible = "wavlink,wl-wn577a2", "maginon,wlr-755", "mediatek,mt7628an-soc";
 	model = "WAVLINK WL-WN577A2";
 
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	aliases {
 		led-boot = &led_wps;
 		led-failsafe = &led_wps;
 		led-running = &led_wps;
 		led-upgrade = &led_wps;
-    };
+	};
 
 	keys {
 		compatible = "gpio-keys";
@@ -47,7 +45,7 @@
 
 &state_default {
 	gpio {
-        groups = "i2c", "wled_an", "gpio", "refclk", "wdt", "p0led_an";
+		groups = "i2c", "wdt", "p0led_an";
 		function = "gpio";
 	};
 };
@@ -70,7 +68,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -537,6 +537,17 @@ define Device/wavlink_wl-wn575a3
 endef
 TARGET_DEVICES += wavlink_wl-wn575a3
 
+define Device/wavlink_wl-wn577a2
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN577A2
+  DEVICE_ALT0_VENDOR := Maginon
+  DEVICE_ALT0_MODEL := WLR-755
+  DEVICE_PACKAGES := kmod-mt76x0e
+  SUPPORTED_DEVICES += wl-wn577a2
+endef
+TARGET_DEVICES += wavlink_wl-wn577a2
+
 define Device/widora_neo-16m
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Widora

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -544,7 +544,6 @@ define Device/wavlink_wl-wn577a2
   DEVICE_ALT0_VENDOR := Maginon
   DEVICE_ALT0_MODEL := WLR-755
   DEVICE_PACKAGES := kmod-mt76x0e
-  SUPPORTED_DEVICES += wl-wn577a2
 endef
 TARGET_DEVICES += wavlink_wl-wn577a2
 

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -125,6 +125,10 @@ wavlink,wl-wn575a3)
 	ucidef_set_led_rssi "wifi-med" "wifi-med" "$boardname:green:wifi-med" "wlan1" "50" "84"
 	ucidef_set_led_rssi "wifi-high" "wifi-high" "$boardname:green:wifi-high" "wlan1" "85" "100"
 	;;
+wavlink,wl-wn577a2)
+	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x8"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
+	;;
 zbtlink,zbt-we1226)
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_switch "lan1" "LAN1" "$boardname:green:lan1" "switch0" "0x01"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -38,8 +38,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
-	wavlink,wl-wn577a2|\
-	buffalo,wcr-1166ds)
+	buffalo,wcr-1166ds|\
+	wavlink,wl-wn577a2)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
 		;;
@@ -187,7 +187,6 @@ ramips_setup_macs()
 		;;
 	wavlink,wl-wn577a2)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
-		lan_mac=$(mtd_get_mac_binary factory 0x28)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	skylab,skw92a|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	wavlink,wl-wn577a2|\
 	buffalo,wcr-1166ds)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
@@ -183,6 +184,11 @@ ramips_setup_macs()
 	wavlink,wl-wn575a3|\
 	wiznet,wizfi630s)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
+		;;
+	wavlink,wl-wn577a2)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
+		lan_mac=$(mtd_get_mac_binary factory 0x28)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	skylab,skw92a|\
 	totolink,lr1200)


### PR DESCRIPTION
This commit adds support for the Wavlink WL-WN577A2 (black case). In Germany this dual-band wall-plug
wireless router is sold under the brand name Maginon WL-755 (white case):

- CPU: MediaTek MT7628AN (580MHz)
- Flash: 8MB
- RAM: 64MB
- Bootloader: U-Boot
- Ethernet: 2x 10/100 Mbps (Ralink RT3050)
- 2.4 GHz: 802.11b/g/n SoC
- 5 GHz: 802.11a/n/ac MT7610E
- Antennas: internal
- 4 green LEDs: 1 programmable (WPS) + LAN, WAN, POWER
- Buttons: Reset, WPS
- Small sliding power switch

Flashing instructions (U-boot):

- Configure a TFTP server on your PC/Laptop and set its IP to 192.168.10.100
- Rename the OpenWrt image as firmware.bin and place it in the root folder of the TFTP server
- Power off the device and connect an Ethernet cable from its LAN or WAN port to your PC/Laptop
- Press the WPS button (and keep it pressed)
- Power on the device (using the small sliding power switch)
- After a few seconds, when the WAN/LAN LED stops blinking very fast, release the WPS button
- Flashing takes about a minute
- WPS LED will indicate OpenWrt device status