### PR TITLE
ath79: add support for MikroTik RouterBOARD 921GS-5HPacD-15s (mANTBox 15s)

### DIFF
--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-921gs-5hpacd-15s.dts
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-921gs-5hpacd-15s.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_mikrotik_routerboard-92x.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-921gs-5hpacd-15s", "qca,qca9558";
+	model = "MikroTik RouterBOARD 921GS-5HPacD-15s";
+};
+
+&pcie1 {
+	status = "okay";
+
+	ath10k: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-922uags-5hpacd.dts
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-922uags-5hpacd.dts
@@ -1,153 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "qca955x.dtsi"
+#include "qca9558_mikrotik_routerboard-92x.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-922uags-5hpacd", "qca,qca9558";
 	model = "MikroTik RouterBOARD 922UAGS-5HPacD";
 
-	aliases {
-		led-boot = &led_user;
-		led-failsafe = &led_user;
-		led-upgrade = &led_user;
-		serial0 = &uart;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_user: user {
-			label = "mikrotik:green:user";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	ath10k-leds {
-		compatible = "gpio-leds";
-
-		wlan5g {
-			label = "mikrotik:green:wlan5g";
-			gpios = <&ath10k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-
 	gpio-export {
-		compatible = "gpio-export";
-
 		gpio_usb_power {
 			gpio-export,name = "mikrotik:power:usb";
 			gpio-export,output = <0>;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
-
-		gpio_nand_power {
-			gpio-export,name = "mikrotik:power:nand";
-			gpio-export,output = <0>;
-			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
-		};
 	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	phy-handle = <&phy4>;
-	pll-data = <0x8f000000 0xa0000101 0xa0001313>;
-
-	gmac-config {
-		device = <&gmac>;
-		rgmii-enabled = <1>;
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "mikrotik,routerboot-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "routerboot";
-				reg = <0x0 0x0>;
-				read-only;
-			};
-
-			hard_config: hard_config {
-				read-only;
-			};
-
-			bios {
-				read-only;
-			};
-
-			soft_config {
-			};
-		};
-	};
-};
-
-&nand {
-	status = "okay";
-
-	nand-ecc-mode = "soft";
-	qca,nand-swap-dma;
-	qca,nand-scan-fixup;
-
-	partitions {
-		compatible = "fixed-partitions";
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "booter";
-			reg = <0x0000000 0x0040000>;
-			read-only;
-		};
-
-		partition@40000 {
-			label = "kernel";
-			reg = <0x0040000 0x03c0000>;
-		};
-
-		partition@400000 {
-			label = "ubi";
-			reg = <0x0400000 0x7c00000>;
-		};
-	};
-};
-
-&uart {
-	status = "okay";
 };
 
 &pcie0 {

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca955x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-upgrade = &led_user;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_user: user {
+			label = "mikrotik:green:user";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath10k-leds {
+		compatible = "gpio-leds";
+
+		wlan5g {
+			label = "mikrotik:green:wlan5g";
+			gpios = <&ath10k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_nand_power {
+			gpio-export,name = "mikrotik:power:nand";
+			gpio-export,output = <0>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy4>;
+	pll-data = <0x8f000000 0xa0000101 0xa0001313>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "mikrotik,routerboot-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "routerboot";
+				reg = <0x0 0x0>;
+				read-only;
+			};
+
+			hard_config: hard_config {
+				read-only;
+			};
+
+			bios {
+				read-only;
+			};
+
+			soft_config {
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	qca,nand-swap-dma;
+	qca,nand-scan-fixup;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "booter";
+			reg = <0x0000000 0x0040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "kernel";
+			reg = <0x0040000 0x03c0000>;
+		};
+
+		partition@400000 {
+			label = "ubi";
+			reg = <0x0400000 0x7c00000>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -9,6 +9,15 @@ define Device/mikrotik_routerboard-493g
 endef
 TARGET_DEVICES += mikrotik_routerboard-493g
 
+define Device/mikrotik_routerboard-921gs-5hpacd-15s
+  $(Device/mikrotik_nand)
+  SOC := qca9558
+  DEVICE_MODEL := RouterBOARD 921GS-5HPacD-15s (mANTBox 15s)
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  SUPPORTED_DEVICES += rb-921gs-5hpacd-r2
+endef
+TARGET_DEVICES += mikrotik_routerboard-921gs-5hpacd-15s
+
 define Device/mikrotik_routerboard-922uags-5hpacd
   $(Device/mikrotik_nand)
   SOC := qca9558

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
+	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		ucidef_set_interface_lan "eth0"
@@ -34,6 +35,7 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		label_mac="$mac_base"
 		lan_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,6 +11,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_sysfsload_from_file $wlan_data 0x5000 0x844
 		;;

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -32,6 +32,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	mikrotik,routerboard-493g|\
+	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd)
 		platform_do_upgrade_mikrotik_nand "$1"
 		;;


### PR DESCRIPTION
This ports the board from ar71xx.

I was only able to boot to initrd ~~, but writing to flash seems to fail. As I don't have a serial console attached, I was not able to look at this~~ and write to flash. But I already like to share for review, comments and test. @rogerpueyo

As the embedded RB921-pcb is a stripped down version of the RB922 this patch adds a common dtsi for this series and includes this to the final dts-files.

See https://mikrotik.com/product/RB921GS-5HPacD-15S for more info.

Specifications:
 - SoC: Qualcomm Atheros QCA9558 (720 MHz)
 - RAM: 128 MB
 - Storage: 128 MB NAND
 - Wireless: external QCA9892 802.11a/ac 2x2:2
 - Ethernet: 1x 1000/100/10 Mbps, integrated, via AR8031 PHY, passive PoE in
 - SFP: 1x host

Working:
 - NAND storage detection
 - Ethernet
 - Wireless
 - Sysupgrade
 - 1x user LED (blinks during boot, sysupgrade)
 - Reset button

Untested:
 - SFP cage (probably not working)
