### PR TITLE
ramips: add support for TP-Link RE220 v2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re220-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re220-v2.dts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_tplink_re200.dtsi"
+
+/ {
+	compatible = "tplink,re220-v2", "mediatek,mt7628an-soc";
+	model = "TP-Link RE220 v2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "re220-v2:green:wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "re220-v2:green:wifi";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "re220-v2:green:lan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "re220-v2:green:power";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g_green {
+			label = "re220-v2:green:wifi2g";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g_green {
+			label = "re220-v2:green:wifi5g";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g_red {
+			label = "re220-v2:red:wifi2g";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g_red {
+			label = "re220-v2:red:wifi5g";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "p4led_an", "p3led_an", "p2led_an", "p1led_an",
+				"p0led_an", "wled_an", "i2c", "wdt", "refclk";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -367,6 +367,16 @@ define Device/tplink_re200-v2
 endef
 TARGET_DEVICES += tplink_re200-v2
 
+define Device/tplink_re220-v2
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE220
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt76x0e
+  TPLINK_BOARD_ID := RE220-V2
+endef
+TARGET_DEVICES += tplink_re220-v2
+
 define Device/tplink_re305-v1
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 6016k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -68,6 +68,7 @@ tplink,archer-c50-v4)
 	ucidef_set_led_wlan "wlan5g" "wlan5g" "$boardname:green:wlan5g" "phy1tpt"
 	;;
 tplink,re200-v2|\
+tplink,re220-v2|\
 tplink,tl-mr3020-v3|\
 tplink,tl-wa801nd-v5)
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ramips_setup_interfaces()
 	ravpower,rp-wd009|\
 	tama,w06|\
 	tplink,re200-v2|\
+	tplink,re220-v2|\
 	tplink,re305-v1|\
 	tplink,tl-mr3020-v3|\
 	tplink,tl-wr802n-v4|\

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1555,6 +1555,49 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the RE220 v2 */
+	{
+		.id     = "RE220-V2",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:00000000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:41520000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:41550000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:42520000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:43410000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:45530000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:45550000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:49440000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:4a500000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:4b520000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:52550000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:54570000}\n"
+			"{product_name:RE220,product_ver:2.0.0,special_id:55530000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x7a0000},
+			{"partition-table", 0x7c0000, 0x02000},
+			{"default-mac", 0x7c2000, 0x00020},
+			{"pin", 0x7c2100, 0x00020},
+			{"product-info", 0x7c3100, 0x01000},
+			{"soft-version", 0x7c4200, 0x01000},
+			{"support-list", 0x7c5200, 0x01000},
+			{"profile", 0x7c6200, 0x08000},
+			{"config-info", 0x7ce200, 0x00400},
+			{"user-config", 0x7d0000, 0x10000},
+			{"default-config", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
   /** Firmware layout for the RE305 v1 */
 	{
 		.id     = "RE305-V1",


### PR DESCRIPTION
TP-Link RE220 v2 is a wireless range extender with Ethernet and 2.4G and 5G
WiFi with internal antennas. It's based on MediaTek MT7628AN+MT7610EN.

This port of OpenWRT leverages work done by Andreas Böhler <dev@aboehler.at>
for the TP-Link RE200 v2 as both devices share the same SoC, flash layout
and GPIO pinout.

Specifications

MediaTek MT7628AN (580 Mhz)
64 MB of RAM
8 MB of FLASH
2T2R 2.4 GHz and 1T1R 5 GHz
1x 10/100 Mbps Ethernet
UART header on PCB (57600 8n1)
8x LED (GPIO-controlled), 2x button
There are 2.4G and 5G LEDs in red and green which are controlled separately.

Web Interface Installation

It is possible to upgrade to OpenWrt via the web interface. Simply flash
the -factory.bin from OEM. In contrast to a stock firmware, this will not
overwrite U-Boot.

Signed-off-by: Rowan Border <rowanjborder@gmail.com>