### PR TITLE
ath79: add support for compex WPJ344

### DIFF
--- a/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
+++ b/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	compatible = "compex,wpj344-16m", "qca,ar9344";
+	model = "Compex WPJ344 (16MB flash)";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "wpj344:green:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		sig1 {
+			label = "wpj344:red:sig1";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "wpj344:yellow:sig2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		sig3 {
+			label = "wpj344:green:sig3";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		sig4 {
+			label = "wpj344:green:sig4";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "firmware";
+				reg = <0x030000 0xfc0000>;
+				compatible = "denx,uimage";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+    };
+	};
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0x80000080 /* POWER_ON_STRIP */
+			0x50 0x00000000 /* LED_CTRL0 */
+			0x54 0xc737c737 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x00c30c00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&uboot 0x2e010>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -115,6 +115,13 @@ engenius,ecb1750|\
 enterasys,ws-ap3705i)
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:blue:lan" "eth0"
 	;;
+compex,wpj344-16m)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "sig1" "SIG1" "wpj344:red:sig1" "wlan0" "85" "100"
+	ucidef_set_led_rssi "sig2" "SIG2" "wpj344:yellow:sig2" "wlan0" "75" "100"
+	ucidef_set_led_rssi "sig3" "SIG3" "wpj344:green:sig3" "wlan0" "65" "100"
+	ucidef_set_led_rssi "sig4" "SIG4" "wpj344:green:sig4" "wlan0" "50" "100"
+	;;
 compex,wpj531-16m)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "sig1" "SIG1" "wpj531:red:sig1" "wlan0" "85" "100"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -126,6 +126,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
+	compex,wpj344-16m)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "3:lan" "2:wan"
+		;;
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2)
 		ucidef_add_switch "switch0" \
@@ -365,6 +369,9 @@ ath79_setup_macs()
 	avm,fritz4020)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
+		;;
+	compex,wpj344-16m)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
 		;;
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -441,6 +441,19 @@ define Device/comfast_cf-wr752ac-v1
 endef
 TARGET_DEVICES += comfast_cf-wr752ac-v1
 
+define Device/compex_wpj344-16m
+  SOC := ar9344
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 16128k
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := WPJ344
+  DEVICE_VARIANT := 16M
+  SUPPORTED_DEVICES += wpj344
+  IMAGES += cpximg-6a08.bin cpximg-6a06a.bin
+  IMAGE/cpximg-6a08.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | mkmylofw_16m 0x690 3
+endef
+TARGET_DEVICES += compex_wpj344-16m
+
 define Device/compex_wpj531-16m
   SOC := qca9531
   DEVICE_PACKAGES := kmod-usb2


### PR DESCRIPTION
The WPJ344 is functionally very similar to the WPJ531.
Major differences:
- eth0 is wired to an internal switch that connects both ethernet ports, eth1 doesn't appear to do anything useful
- AR9344

There is a customisation option to reduce the flash size to 8MB but i've only ever seen that with a preview board from 2014.
I've adjusted the rssiled initialisation for the WPJ531, allowing it to be shared with the WPJ344.

I'm not sure whether to include the variant 6a06a. It's unclear to me whether it was ever commercially available.