### PR TITLE
lantiq: switch-setup, wifi mac fix for ARV752DPW

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -21,6 +21,8 @@
 		led-dsl = &internet_red;
 		led-usb = &umts;
 		led-wifi = &wifi;
+
+		label-mac-device = &wifi0;
 	};
 
 	memory@0 {
@@ -217,9 +219,10 @@
 	interrupt-map = <0x7000 0 0 1 &icu0 135>;
 	req-mask = <0x3>;
 
-	wifi@1814,0601 {
+	wifi0: wifi@1814,0601 {
 		compatible = "pci1814,0601";
 		reg = <0x7000 0 0 0 0>;
+		mtd-mac-address = <&boardconfig 0x16>;
 		ralink,mtd-eeprom = <&boardconfig 0x410>;
 		ralink,mtd-eeprom-swap;
 	};

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -21,6 +21,8 @@
 		led-dsl = &internet_red;
 		led-usb = &umts;
 		led-wifi = &wifi;
+
+		label-mac-device = &wifi0;
 	};
 
 	memory@0 {
@@ -217,9 +219,10 @@
 	interrupt-map = <0x7000 0 0 1 &icu0 135>;
 	req-mask = <0x3>;
 
-	wifi@1814,0601 {
+	wifi0: wifi@1814,0601 {
 		compatible = "pci1814,0601";
 		reg = <0x7000 0 0 0 0>;
+		mtd-mac-address = <&boardconfig 0x16>;
 		ralink,mtd-eeprom = <&boardconfig 0x410>;
 		ralink,mtd-eeprom-swap;
 	};

--- a/target/linux/lantiq/xway/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xway/base-files/etc/board.d/02_network
@@ -36,6 +36,7 @@ lantiq_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4t@eth0"
 		;;
+	arcadyan,arv752dpw|\
 	bt,homehub-v2b)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5t@eth0"


### PR DESCRIPTION
Few fixes for Arcadyan ARV752DPW (aka Easybox 802):

- set wifi mac from flash partition 'board_config' to match the label
on the device; currently wifi mac is always set to 00:0c:43:28:60:00
and eth0 is configured with preset mac from 'board_config'
- set eth0 mac address to be an increment of wifi mac
- add missing switch config (4 LAN-Ports + CPU)