### PR TITLE
kernel: add KERNEL_IO_URING option

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -345,6 +345,11 @@ config KERNEL_AIO
 	bool "Compile the kernel with asynchronous IO support"
 	default y if !SMALL_FLASH
 
+config KERNEL_IO_URING
+	bool "Compile the kernel with io_uring support"
+	default y if !SMALL_FLASH
+	depends on LINUX_5_4 
+
 config KERNEL_FHANDLE
 	bool "Compile the kernel with support for fhandle syscalls"
 	default y if !SMALL_FLASH


### PR DESCRIPTION
Adds configurable support for the `io_uring` interface (CONFIG_IO_URING) via `KERNEL_IO_URING` option.

_The compressed `zImage` grows by about 5-9KB (mips/arm)_

I would like to enable this by default for all 5.4 kernels, so i can use the new [io_uring](https://www.samba.org/samba/docs/4.12/man-html/vfs_io_uring.8.html) samba-4.12.x vfs module by default.

The associated [liburing](https://git.kernel.dk/cgit/liburing/) is also already submitted and merged.
The kernel + liburing was tested on ARM/mvebu via samba4 `vfs_io_uring` module and i have no issues so far.

Some extra reads on it and why we should enable it by default, since i expect more packages to use this in the future.
https://wiki.samba.org/index.php/Samba_4.12_Features_added/changed#.27io_uring.27_vfs_module
https://lwn.net/Articles/810414/
https://kernel.dk/io_uring.pdf
https://www.phoronix.com/scan.php?page=news_item&px=Linux-5.6-IO-uring-Tests
