### PR TITLE
ath79: add support for EnGenius EMR3000

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -31,6 +31,7 @@ engenius,ecb1200|\
 engenius,ecb1750|\
 engenius,ecb350-v1|\
 engenius,ecb600|\
+engenius,emr3000-v2|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\
 engenius,enstationac-v1|\

--- a/target/linux/ath79/dts/qca9558_engenius_emr3000-v2.dts
+++ b/target/linux/ath79/dts/qca9558_engenius_emr3000-v2.dts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "EnGenius EMR3000 V2";
+	compatible = "engenius,emr3000-v2", "qca,qca9558";
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_white;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_white;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_white: status_white {
+			label = "white:status";
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		status_red {
+			label = "red:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_amber {
+			label = "amber:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		bluetooth {
+			label = "blue:bluetooth";
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <1>;
+		phy-mode = "rgmii";
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <2>;
+		phy-mode = "sgmii";
+		at803x-override-sgmii-link-check;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	pll-data = <0x9a000000 0x80000101 0x80001313>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&phy1>;
+	pll-data = <0x9b000000 0x80000101 0x80001313>;
+	qca955x-sgmii-fixup;
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0x1f50000>;
+			};
+
+			partition@1fb0000 {
+				label = "userconfig";
+				reg = <0x1fb0000 0x050000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ ath79_setup_interfaces()
 	engenius,ecb1200|\
 	engenius,ecb1750|\
 	engenius,ecb600|\
+	engenius,emr3000-v2|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\
@@ -540,6 +541,13 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		label_mac=$lan_mac
 		;;
+	engenius,emr3000-v2|\
+	sitecom,wlr-7100|\
+	sitecom,wlr-8100)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
+		label_mac=$lan_mac
+		;;
 	engenius,epg5000)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
@@ -600,12 +608,6 @@ ath79_setup_macs()
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
-		;;
-	sitecom,wlr-7100|\
-	sitecom,wlr-8100)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
-		label_mac=$lan_mac
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c7-v4|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -42,6 +42,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env athaddr) +1)
 		;;
+	engenius,emr3000-v2|\
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -72,6 +72,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii u-boot-env athaddr)
 		;;
+	engenius,emr3000-v2|\
 	engenius,epg5000|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr2|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1021,6 +1021,20 @@ define Device/engenius_ecb600
 endef
 TARGET_DEVICES += engenius_ecb600
 
+define Device/engenius_emr3000-v2
+  SOC := qca9558
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := EMR3000
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
+  IMAGE_SIZE := 32064k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | \
+	senao-header -r 0x101 -p 0x83 -t 2
+endef
+TARGET_DEVICES += engenius_emr3000-v2
+
 define Device/engenius_ens202ext-v1
   $(Device/engenius_loader_okli)
   SOC := ar9341


### PR DESCRIPTION
Specifications:

* Qualcomm QCA9558 (Scorpion)
* 128 MB of RAM
* 32 MB of FLASH (SPI NOR)
* 2x 10/100/1000 Mbps Ethernet
* 2T2R 2.4 GHz (QCA9558), 802.11b/g/n
* 2T2R 5 GHz (QCA988X), 802.11ac/n/a
* 1x USB 2.0
* 4x LED, driven by GPIO
* 1x button (reset)

Flash instructions:

You can flash the factory image via the vendor GUI.
There is no "Keep settings" checkbox, so make sure to factory-reset
 after flashing by holding reset button for 10s and be able to login.
