### PR TITLE
ath79: add support for GL.iNet GL-MIFI

### DIFF
--- a/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	compatible = "glinet,gl-mifi", "qca,ar9331";
+	model = "GL.iNet GL-MiFi";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "gl-mifi:green:wlan";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "gl-mifi:green:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "gl-mifi:green:wan";
+			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		3g4g {
+			label = "gl-mifi:green:3g4g";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 6 GPIO_ACTIVE_LOW>;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		minipcie {
+			gpio-export,name = "minipcie";
+			gpio-export,output = <0>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+
+	dr_mode = "host";
+	vbus-supply = <&reg_usb_vbus>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-chipselects = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <33000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -146,6 +146,10 @@ glinet,gl-ar300m-lite)
 glinet,gl-ar300m16)
 	ucidef_set_led_netdev "lan" "LAN" "gl-ar300m:green:lan" "eth0"
 	;;
+glinet,gl-mifi)
+	ucidef_set_led_switch "lan" "LAN" "$boardname:green:lan" "switch0" "0x02"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
+	;;
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -8,6 +8,9 @@ case "$board" in
 engenius,epg5000)
 	migrate_leds ":wlan-2g=:wlan2g" ":wlan-5g=:wlan5g"
 	;;
+glinet,gl-mifi)
+	migrate_leds ":net=:3g4g"
+	;;
 tplink,archer-c25-v1|\
 tplink,archer-c58-v1|\
 tplink,archer-c59-v1|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -808,6 +808,16 @@ define Device/glinet_gl-ar750
 endef
 TARGET_DEVICES += glinet_gl-ar750
 
+define Device/glinet_gl-mifi
+  SOC := ar9331
+  DEVICE_VENDOR := GL.iNET
+  DEVICE_MODEL := GL-MiFi
+  DEVICE_PACKAGES := kmod-usb-chipidea2
+  IMAGE_SIZE := 16000k
+  SUPPORTED_DEVICES += gl-mifi
+endef
+TARGET_DEVICES += glinet_gl-mifi
+
 define Device/glinet_gl-x750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
Add support for the ar71xx supported GL.iNet GL-MIFI to ath79.

Specifications:
 - Atheros AR9331
 - 64 MB of RAM
 - 16 MB of FLASH (SPI NOR)
 - 2x 10/100/1000 Mbps Ethernet
 - 2.4GHz (AR9330), 802.11b/g/n
 - 1x USB 2.0 (vbus driven by GPIO)
 - 4x LED, driven by GPIO
 - 1x button (reset)
 - 1x mini pci-e slot (vcc driven by GPIO)

Flash instructions:

Vendor software is based on openwrt so you can flash the sysupgrade
image via the vendor GUI or using command line sysupgrade utility.
Make sure to not save configuration over reflash as uci settings
differ between versions.

This patch is based on earlier work[1] done by Kyson Lok. Since the
initial mailing-list submission the patch has been modified to comply
with current openwrt naming schemes and dts conventions.

[1] http://lists.openwrt.org/pipermail/openwrt-devel/2018-September/019576.html

Signed-off-by: Antti Seppälä <a.seppala@gmail.com>
