### PR TITLE
ath79: rearrange nand node by register address

### DIFF
--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -148,24 +148,6 @@
 			};
 		};
 
-		nand: nand@1b000200 {
-			compatible = "qca,ar934x-nand";
-			reg = <0x1b000200 0xb8>;
-
-			interrupts = <21>;
-			interrupt-parent = <&miscintc>;
-
-			resets = <&rst 14>;
-			reset-names = "nand";
-
-			nand-ecc-mode = "hw";
-
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			status = "disabled";
-		};
-
 		gmac: gmac@18070000 {
 			compatible = "qca,ar9340-gmac";
 			reg = <0x18070000 0x14>;
@@ -191,6 +173,24 @@
 
 			phy-names = "usb-phy";
 			phys = <&usb_phy>;
+
+			status = "disabled";
+		};
+
+		nand: nand@1b000200 {
+			compatible = "qca,ar934x-nand";
+			reg = <0x1b000200 0xb8>;
+
+			interrupts = <21>;
+			interrupt-parent = <&miscintc>;
+
+			resets = <&rst 14>;
+			reset-names = "nand";
+
+			nand-ecc-mode = "hw";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			status = "disabled";
 		};

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -182,24 +182,6 @@
 			};
 		};
 
-		nand: nand@1b800200 {
-			compatible = "qca,ar934x-nand";
-			reg = <0x1b800200 0xb8>;
-
-			interrupts = <21>;
-			interrupt-parent = <&miscintc>;
-
-			resets = <&rst 14>;
-			reset-names = "nand";
-
-			nand-ecc-mode = "hw";
-
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			status = "disabled";
-		};
-
 		gmac: gmac@18070000 {
 			compatible = "qca,qca9550-gmac";
 			reg = <0x18070000 0x58>;
@@ -297,6 +279,24 @@
 
 			phy-names = "usb-phy1";
 			phys = <&usb_phy1>;
+
+			status = "disabled";
+		};
+
+		nand: nand@1b800200 {
+			compatible = "qca,ar934x-nand";
+			reg = <0x1b800200 0xb8>;
+
+			interrupts = <21>;
+			interrupt-parent = <&miscintc>;
+
+			resets = <&rst 14>;
+			reset-names = "nand";
+
+			nand-ecc-mode = "hw";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			status = "disabled";
 		};


### PR DESCRIPTION
All other nodes in the DTS are placed in order of address space. Harmonize
the nand nodes as well.

Tested on qca9557. This should be purely cosmetic.