### PR TITLE
ramips: reduce spi-max-frequency for ipTIME A8004T

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -65,8 +65,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
-		m25p,fast-read;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
A8004T uses `en25qh128` for the MTD.
This flash memory would allow 80MHz, sometimes kernel received
wrong id value in initramfs installed router.
(kernel expected `1c 70 18 1c 70 18`, but one of cases, it
was `9c 70 18 1c 70 18`)

In this case, openwrt can't detect the partition information,
it would write the inccorect data to the firmware partition &
also it would occur the bootlooping after sysupgrade.

Signed-off-by: Sunguk Lee <d3m3vilurr@gmail.com>