### PR TITLE
ipq806x: move common pinmux nodes to SoC DTSI

### DIFF
--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ap148.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ap148.dts
@@ -29,59 +29,6 @@
 	};
 };
 
-&qcom_pinmux {
-	i2c4_pins: i2c4_pinmux {
-		pins = "gpio12", "gpio13";
-		function = "gsbi4";
-		bias-disable;
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-			       "gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-			       "gpio43", "gpio44", "gpio45",
-			       "gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-			       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-};
-
 &adm_dma {
 	status = "okay";
 };

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ap161.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ap161.dts
@@ -30,65 +30,13 @@
 };
 
 &qcom_pinmux {
-	i2c4_pins: i2c4_pinmux {
-		pins = "gpio12", "gpio13";
-		function = "gsbi4";
-		bias-disable;
-	};
-
-	spi_pins: spi_pins {
-		mux {
-			pins = "gpio18", "gpio19", "gpio21";
-			function = "gsbi5";
-			drive-strength = <10>;
-			bias-none;
-		};
-	};
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
 	rgmii2_pins: rgmii2_pins {
 		mux {
-			pins = "gpio2", "gpio27", "gpio28",
-				"gpio29", "gpio30", "gpio31",
-				"gpio32", "gpio51", "gpio52",
-				"gpio59", "gpio60", "gpio61",
-				"gpio62" , "gpio66";
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
+			pins = "gpio27", "gpio28", "gpio29",
+			       "gpio30", "gpio31", "gpio32",
+			       "gpio51", "gpio52", "gpio59",
+			       "gpio60", "gpio61", "gpio62",
+			       "gpio2", "gpio66";
 		};
 	};
 };

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-c2600.dts
@@ -124,15 +124,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio26", "gpio33",
@@ -165,25 +156,6 @@
 		clk {
 			pins = "gpio21";
 			drive-strength = <12>;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -123,15 +123,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
@@ -139,51 +130,6 @@
 			function = "gpio";
 			drive-strength = <2>;
 			bias-pull-up;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-db149.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-db149.dts
@@ -25,30 +25,6 @@
 };
 
 &qcom_pinmux {
-	i2c4_pins: i2c4_pinmux {
-		pins = "gpio12", "gpio13";
-		function = "gsbi4";
-		bias-disable;
-	};
-
-	spi_pins: spi_pins {
-		mux {
-			pins = "gpio18", "gpio19", "gpio21";
-			function = "gsbi5";
-			drive-strength = <10>;
-			bias-none;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
 	rgmii0_pins: rgmii0_pins {
 		mux {
 			pins = "gpio2", "gpio66";

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -94,66 +94,12 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio6", "gpio53", "gpio54";
 			function = "gpio";
 			drive-strength = <2>;
 			bias-pull-up;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 };

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-r7500.dts
@@ -124,15 +124,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
@@ -140,51 +131,6 @@
 			function = "gpio";
 			drive-strength = <2>;
 			bias-pull-up;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 };

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -132,15 +132,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
@@ -148,51 +139,6 @@
 			function = "gpio";
 			drive-strength = <2>;
 			bias-pull-up;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
@@ -135,15 +135,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	button_pins: button_pins {
 		mux {
 			pins = "gpio54", "gpio64", "gpio65", "gpio67", "gpio68";
@@ -174,25 +165,6 @@
 		clk {
 			pins = "gpio21";
 			drive-strength = <12>;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 };

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
@@ -347,15 +347,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio14",
@@ -388,25 +379,6 @@
 		clk {
 			pins = "gpio21";
 			drive-strength = <12>;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-			       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
 		};
 	};
 

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wpq864.dts
@@ -494,51 +494,6 @@
 			bias-pull-up;
 		};
 	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36", "gpio37",
-			       "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42", "gpio43",
-			       "gpio44", "gpio45", "gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30",
-			       "gpio31", "gpio32", "gpio51", "gpio52",
-			       "gpio59", "gpio60", "gpio61", "gpio62";
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
 };
 
 &usb3_0 {

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
@@ -458,51 +458,6 @@
 		};
 	};
 
-	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-			       "gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-			       "gpio43", "gpio44", "gpio45",
-			       "gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
-	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-			       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-	};
-
 	usb_pwr_en_pins: usb_pwr_en_pins {
 		mux{
 			pins = "gpio68";

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064.dtsi
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064.dtsi
@@ -704,12 +704,68 @@
 				};
 			};
 
+			i2c4_pins: i2c4_pinmux {
+				mux {
+					pins = "gpio12", "gpio13";
+					function = "gsbi4";
+					drive-strength = <12>;
+					bias-disable;
+				};
+			};
+
 			spi_pins: spi_pins {
 				mux {
 					pins = "gpio18", "gpio19", "gpio21";
 					function = "gsbi5";
 					drive-strength = <10>;
 					bias-none;
+				};
+			};
+
+			nand_pins: nand_pins {
+				disable {
+					pins = "gpio34", "gpio35", "gpio36",
+					       "gpio37", "gpio38";
+					function = "nand";
+					drive-strength = <10>;
+					bias-disable;
+				};
+
+				pullups {
+					pins = "gpio39";
+					function = "nand";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+
+				hold {
+					pins = "gpio40", "gpio41", "gpio42",
+					       "gpio43", "gpio44", "gpio45",
+					       "gpio46", "gpio47";
+					function = "nand";
+					drive-strength = <10>;
+					bias-bus-hold;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "mdio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29",
+					       "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59",
+					       "gpio60", "gpio61", "gpio62";
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
 				};
 			};
 

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts
@@ -105,15 +105,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio9", "gpio26", "gpio33", "gpio64";
@@ -124,13 +115,6 @@
 	};
 
 	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-
 		clk {
 			pins = "gpio1";
 			input-disable;
@@ -138,14 +122,6 @@
 	};
 
 	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-
 		tx {
 			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
 			input-disable;
@@ -153,13 +129,6 @@
 	};
 
 	spi_pins: spi_pins {
-		mux {
-			pins = "gpio18", "gpio19", "gpio21";
-			function = "gsbi5";
-			drive-strength = <10>;
-			bias-none;
-		};
-
 		cs {
 			pins = "gpio20";
 			drive-strength = <12>;

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8065-r7800.dts
@@ -134,15 +134,6 @@
 		};
 	};
 
-	i2c4_pins: i2c4_pinmux {
-		mux {
-			pins = "gpio12", "gpio13";
-			function = "gsbi4";
-			drive-strength = <12>;
-			bias-disable;
-		};
-	};
-
 	led_pins: led_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
@@ -153,38 +144,7 @@
 		};
 	};
 
-	nand_pins: nand_pins {
-		disable {
-			pins = "gpio34", "gpio35", "gpio36",
-					"gpio37", "gpio38";
-			function = "nand";
-			drive-strength = <10>;
-			bias-disable;
-		};
-		pullups {
-			pins = "gpio39";
-			function = "nand";
-			drive-strength = <10>;
-			bias-pull-up;
-		};
-		hold {
-			pins = "gpio40", "gpio41", "gpio42",
-					"gpio43", "gpio44", "gpio45",
-					"gpio46", "gpio47";
-			function = "nand";
-			drive-strength = <10>;
-			bias-bus-hold;
-		};
-	};
-
 	mdio0_pins: mdio0_pins {
-		mux {
-			pins = "gpio0", "gpio1";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-disable;
-		};
-
 		clk {
 			pins = "gpio1";
 			input-disable;
@@ -192,14 +152,6 @@
 	};
 
 	rgmii2_pins: rgmii2_pins {
-		mux {
-			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
-					"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
-			function = "rgmii2";
-			drive-strength = <8>;
-			bias-disable;
-		};
-
 		tx {
 			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
 			input-disable;


### PR DESCRIPTION
As almost same pinmux nodes are repeated in each device dts,
let's define them once in the ipq8064 dtsi and remove the rest.

---

For now I only moved `nand_pins` to be safe. My goal is to unify all these pinmux nodes:

* uart0_pins
* i2c4_pins
* spi_pins
* nand_pins
* mdio0_pins
* rgmii2_pins

The other nodes are slightly different for each device dts, I'll add them under your approval.