### PR TITLE
kirkwood: add support for Seagate BlackArmor NAS220

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -59,6 +59,11 @@ define U-Boot/l-50
   BUILD_DEVICES:=checkpoint_l-50
 endef
 
+define U-Boot/nas220
+  NAME:=Seagate Blackarmor NAS220
+  BUILD_DEVICES:=seagate_blackarmor-nas220
+endef
+
 define U-Boot/nsa310
   NAME:=Zyxel NSA310
   BUILD_DEVICES:=zyxel_nsa310b
@@ -95,6 +100,7 @@ UBOOT_TARGETS := \
 	ib62x0 ib62x0_second_stage \
 	iconnect iconnect_second_stage \
 	l-50 \
+	nas220 \
 	nsa310 \
 	nsa310s \
 	nsa325 \

--- a/package/boot/uboot-kirkwood/patches/201-blackarmor-nas220.patch
+++ b/package/boot/uboot-kirkwood/patches/201-blackarmor-nas220.patch
@@ -1,0 +1,29 @@
+--- a/include/configs/nas220.h
++++ b/include/configs/nas220.h
+@@ -54,17 +54,22 @@
+ /*
+  * Default environment variables
+  */
+-#define CONFIG_BOOTCOMMAND ""
++#define CONFIG_BOOTCOMMAND \
++	"ubi part ubi; " \
++	"ubi read 0x800000 kernel; " \
++	"bootm 0x800000"
+ 
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+ 	"bootargs=console=ttyS0,115200\0" \
+ 	"mtdparts=mtdparts=orion_nand:0xa0000@0x0(uboot),"\
+ 	"0x010000@0xa0000(env),"\
+-	"0x500000@0xc0000(uimage),"\
+-	"0x1a40000@0x5c0000(rootfs)\0" \
++	"0x1e80000@0xc0000(ubi)\0"\
+ 	"mtdids=nand0=orion_nand\0"\
+ 	"autostart=no\0"\
+-	"autoload=no\0"
++	"autoload=no\0"\
++	"ipaddr=10.4.50.165\0"\
++	"serverip=10.4.50.5\0"\
++	"bootdelay=3"
+ 
+ /*
+  * Ethernet Driver configuration

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -22,6 +22,7 @@ case "$board" in
 "iom,iconnect-1.1"|\
 "iom,ix2-200"|\
 "raidsonic,ib-nas62x0"|\
+"seagate,blackarmor-nas220"|\
 "seagate,dockstar"|\
 "seagate,goflexhome"|\
 "seagate,goflexnet"|\

--- a/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
+++ b/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
@@ -11,6 +11,20 @@ boot() {
 		path_to_hwmon='/sys/class/hwmon/hwmon0'
 		echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1
 		;;
+	seagate,blackarmor-nas220)
+		path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
+		# adt7476 fan control chip. 3 temp sensors. Set to 1/4 speed at 35C and max speed at 48C.
+		echo 7 > "$path_to_hwmon/pwm1_auto_channels_temp"
+		echo 64 > "$path_to_hwmon/pwm1_auto_point1_pwm"
+		echo 255 > "$path_to_hwmon/pwm1_auto_point2_pwm"
+		echo 35000 > "$path_to_hwmon/temp1_auto_point1_temp"
+		echo 48000 > "$path_to_hwmon/temp1_auto_point2_temp"
+		echo 35000 > "$path_to_hwmon/temp2_auto_point1_temp"
+		echo 48000 > "$path_to_hwmon/temp2_auto_point2_temp"
+		echo 35000 > "$path_to_hwmon/temp3_auto_point1_temp"
+		echo 48000 > "$path_to_hwmon/temp3_auto_point2_temp"
+		echo 2 > "$path_to_hwmon/pwm1_enable"
+		;;
 	zyxel,nsa310b)
 		path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-002e/hwmon/hwmon0'
 		echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -145,6 +145,18 @@ define Device/raidsonic_ib-nas62x0
 endef
 TARGET_DEVICES += raidsonic_ib-nas62x0
 
+define Device/seagate_blackarmor-nas220
+  DEVICE_VENDOR := Seagate
+  DEVICE_MODEL := Blackarmor NAS220
+  DEVICE_PACKAGES := kmod-hwmon-adt7475 kmod-fs-ext4 kmod-ata-marvell-sata \
+	mdadm kmod-gpio-button-hotplug
+  PAGESIZE := 512
+  SUBPAGESIZE := 256
+  BLOCKSIZE := 16k
+  UBINIZE_OPTS := -e 1
+endef
+TARGET_DEVICES += seagate_blackarmor-nas220
+
 define Device/seagate_dockstar
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := FreeAgent Dockstar

--- a/target/linux/kirkwood/patches-5.4/203-blackarmor-nas220.patch
+++ b/target/linux/kirkwood/patches-5.4/203-blackarmor-nas220.patch
@@ -1,0 +1,99 @@
+--- a/arch/arm/boot/dts/kirkwood-blackarmor-nas220.dts
++++ b/arch/arm/boot/dts/kirkwood-blackarmor-nas220.dts
+@@ -17,6 +17,13 @@
+ 	compatible = "seagate,blackarmor-nas220","marvell,kirkwood-88f6192",
+ 		     "marvell,kirkwood";
+ 
++	aliases {
++		led-boot = &led_status_amber;
++		led-failsafe = &led_status_amber;
++		led-running = &led_status_blue;
++		led-upgrade = &led_status_amber;
++	};
++
+ 	memory { /* 128 MB */
+ 		device_type = "memory";
+ 		reg = <0x00000000 0x8000000>;
+@@ -36,14 +43,14 @@
+ 		compatible = "gpio-keys";
+ 
+ 		reset {
+-			label = "Reset";
+-			linux,code = <KEY_POWER>;
++			label = "Reset Button";
++			linux,code = <KEY_RESTART>;
+ 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+ 		};
+ 
+-		button {
+-			label = "Power";
+-			linux,code = <KEY_SLEEP>;
++		power {
++			label = "Power Button";
++			linux,code = <KEY_POWER>;
+ 			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+ 		};
+ 	};
+@@ -51,11 +58,27 @@
+ 	gpio-leds {
+ 		compatible = "gpio-leds";
+ 
+-		blue-power {
++		led_power_blue: power_blue {
+ 			label = "nas220:blue:power";
+ 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "default-on";
+ 		};
++
++		disk_blue {
++			label = "nas220:blue:disk";
++			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "disk-activity";
++		};
++
++		led_status_blue: status_blue {
++			label = "nas220:blue:status";
++			gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
++		};
++
++		led_status_amber: status_amber {
++			label = "nas220:amber:status";
++			gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
++		};
+ 	};
+ 
+ 	regulators {
+@@ -153,6 +176,33 @@
+ 
+ &nand {
+ 	status = "okay";
++
++	partitions {
++		compatible = "fixed-partitions";
++
++		partition@0 {
++			label = "uboot";
++			reg = <0x0 0xa0000>;
++			read-only;
++		};
++
++		partition@a0000 {
++			label = "uboot-env";
++			reg = <0xa0000 0x10000>;
++			read-only;
++		};
++
++		partition@b0000 {
++			label = "reserved";
++			reg = <0xb0000 0x10000>;
++			read-only;
++		};
++
++		partition@c0000 {
++			label = "ubi";
++			reg = <0xc0000 0x1e80000>;
++		};
++	};
+ };
+ 
+ &mdio {


### PR DESCRIPTION
The Seagate BlackArmor NAS220 is a consumer NAS
with two internal drive bays. The stock OS runs
RAID 1 over the disks via mdadm.

Device specification:
- SoC: Marvell 88F6192 800 MHz
- RAM: 128 MB
- Flash: 32 MB
- 2 x internal SATA II drives
- Ethernet: 10/100/1000 Mbps (single port, no switch)
- WLAN: None
- LED: Power, Status, Sata Activity
- Key: Power, Reset
- Serial: 10 pin header, (115200,8,N,1), 3.3V TTL
	9|x  -   x|10
	7|x  -   x|8
	5|x  - GND|6
	3|x  -  RX|4
	1|TX -   x|2
	front of case
- USB ports: 2 x USB 2.0

Flash instruction:

NOTE: this process uses a serial connection. It will upgrade the
bootloader and reset the bootloader environment variables

TFTP server setup
- Setup PC with TFTP server set the PC IP to 10.4.50.5 as TFTP server
- Copy these files to TFTP server location
    - u-boot.kwb
    - seagate_blackarmor-nas220-initramfs-uImage
    - seagate_blackarmor-nas220-squashfs-sysupgrade.bin
    - seagate_blackarmor-nas220-squashfs-factory.bin

Seagate NAS setup
- Connect LAN cable between PC and seagate device
- Connect to serial to seagate device

Install u-boot
- Boot seagate device and stop in bootloader by pressing any key
- run 'printenv' from u-boot and save the values
- tftpboot 0x2000000 u-boot.kwb
- nand erase.part uboot
- nand write 0x2000000 0x0 ${filesize}
- reset

Update MAC address in u-boot env
- Stop in u-boot by pressing any key
- Get your MAC address from your saved printenv. Is also on chassis
- setenv ethaddr <your MAC>
- saveenv

Option 1 (recommended) - Install OpenWrt via initramfs and sysupgrade
- tftpboot 0x2000000 seagate_blackarmor-nas220-initramfs-uImage
- bootm 0x2000000
- *OpenWrt should be running now, however it is not written to flash yet*
- From the running instance of OpenWrt use Luci's "flash image" feature
    from the web site or use sysupgrade from the console to write
    seagate_blackarmor-nas220-squashfs-sysupgrade.bin to flash

Option 2 - Install OpenWrt by flashing factory image from u-boot
- nand erase.part ubi
- tftpboot 0x2000000 seagate_blackarmor-nas220-squashfs-factory.bin
- nand write 0x2000000 ubi ${filesize}
- reset

Signed-off-by: Kip Porterfield <kip.porterfield@gmail.com>