### PR TITLE
ath79: ag71xx: add support for QCA955x SGMII setup

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_gmac.c
@@ -82,6 +82,14 @@ static void ag71xx_setup_gmac_955x(struct device_node *np, void __iomem *base)
 	ag71xx_of_set(np, "rxd-delay", &val, QCA955X_ETH_CFG_RXD_DELAY_SHIFT, 0x3);
 
 	__raw_writel(val, base + QCA955X_GMAC_REG_ETH_CFG);
+
+	val = __raw_readl(base + QCA955X_GMAC_REG_SGMII_CONFIG);
+
+	ag71xx_of_set(np, "sgmii-mode", &val, QCA955X_SGMII_CONFIG_MODE_CTRL_SHIFT, 0x7);
+	ag71xx_of_bit(np, "sgmii-force-speed", &val, QCA955X_SGMII_CONFIG_FORCE_SPEED);
+	ag71xx_of_set(np, "sgmii-speed", &val, QCA955X_SGMII_CONFIG_SPEED_SHIFT, 0x3);
+
+	__raw_writel(val, base + QCA955X_GMAC_REG_SGMII_CONFIG);
 }
 
 static void ag71xx_setup_gmac_956x(struct device_node *np, void __iomem *base)


### PR DESCRIPTION
Currently there is no way to configure SGMII_CONFIG register in ag71xx.
This patch adds more gmac-config properties to make it possible.

---

This driver patch is submitted without a device support patch, so I wouldn't mind if this is eventually not merged.
But I was surprised that ag71xx does not provide any way to manually configure SGMII (except for the reset fix), which was essential for my device to enable eth1 successfully.
So I open this PR in a hope that this might help for other devices. I'm sure my approach is not an optimal way to configure it, please leave a comment if interested.