### PR TITLE
ramips: mt7621: use lzma-loader for ra21s & rg21s

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -249,6 +249,7 @@ endef
 TARGET_DEVICES += d-team_pbr-m1
 
 define Device/edimax_ra21s
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := RA21S
@@ -262,6 +263,7 @@ endef
 TARGET_DEVICES += edimax_ra21s
 
 define Device/edimax_rg21s
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Edimax
   DEVICE_MODEL := Gemini AC2600 RG21S


### PR DESCRIPTION
The rg21s fails to boot if the kernel is larger than about
2,376 KiB. The ra21s is virtually identical hardware.
Enabling lzma-loader resolves the issue on both the rg21s
and ra21s (see FS#3047 on the issue tracker).

Signed-off-by: Furkan Alaca <furkan.alaca@queensu.ca>
