### PR TITLE
ramips: add support for Zyxel Keenetic 4G

### DIFF
--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-4g.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-4g.dts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,keenetic-4g", "mediatek,mt7628an-soc";
+	model = "Zyxel Keenetic 4G";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		internet {
+			label = "keenetic-4g:green:internet";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "keenetic-4g:green:wifi";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "p0led_an", "wled_an", "refclk", "wdt";
+		function = "gpio";
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -657,6 +657,18 @@ define Device/zbtlink_zbt-we1226
 endef
 TARGET_DEVICES += zbtlink_zbt-we1226
 
+define Device/zyxel_keenetic-4g
+  IMAGE_SIZE := 16064k
+  BLOCKSIZE := 64k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_TITLE := Keenetic 4G
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size | zyimage -d 4624 -v "KN-4G"
+endef
+TARGET_DEVICES += zyxel_keenetic-4g
+
 define Device/zyxel_keenetic-extra-ii
   IMAGE_SIZE := 14912k
   BLOCKSIZE := 64k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -133,6 +133,9 @@ zbtlink,zbt-we1226)
 	ucidef_set_led_switch "lan2" "LAN2" "$boardname:green:lan2" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "WAN" "$boardname:green:wan" "switch0" "0x10"
 	;;
+zyxel,keenetic-4g)
+	ucidef_set_led_switch "internet" "internet" "$boardname:green:internet" "switch0" "0x01"
+	;;
 zyxel,keenetic-extra-ii)
 	set_wifi_led "$boardname:green:wifi"
 	ucidef_set_led_switch "internet" "internet" "$boardname:green:internet" "switch0" "0x01"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -129,6 +129,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "1:lan:1" "4:wan" "6@eth0"
 		;;
+	zyxel,keenetic-4g)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "0:wan" "6@eth0"
+		;;
 	esac
 }
 


### PR DESCRIPTION
Specifications:

Model - KN-1210
CPU - MediaTek MT7628N (MIPS24Kc) @ 575MHz
RAM - Winbond W9751G6KB-25 64 MB (DDR2)
Flash memory-Winbond W25Q128CSIG 16 MB (Dual Boot, SPI)
Wi-Fi 2.4
Wi-Fi class-MediaTek MT7603 2T2R/300Mbps (2.4 GHz)
Antennas - 2x5dBi
Ethernet ports - 4x FE (10/100)
USB - USB 2.0 ports (modems Only)
3G/4G connection Via a compatible USB modem

Flash instruction:

Configure PC with static IP 192.168.1.2/24 and start TFTP server.
Rename "openwrt-ramips-mt76x8-zyxel_keenetic-4g-squashfs-sysupgrade.bin"
to "KN-1210_recovery.bin" and place it in TFTP server directory.
Connect PC with one of LAN ports, press the reset button, power up
the router and keep button pressed until power LED start blinking.
Router will download file from TFTP server, write it to flash and reboot.