### PR TITLE
kernel/pcengines-apu2: detect apuv4 board

### DIFF
--- a/target/linux/x86/patches-5.4/012-pcengines-apu2-detect-apuv4-board.patch
+++ b/target/linux/x86/patches-5.4/012-pcengines-apu2-detect-apuv4-board.patch
@@ -1,0 +1,35 @@
+--- a/drivers/platform/x86/pcengines-apuv2.c
++++ b/drivers/platform/x86/pcengines-apuv2.c
+@@ -189,6 +189,33 @@ static const struct dmi_system_id apu_gpio_dmi_table[] __initconst = {
+ 		},
+ 		.driver_data = (void *)&board_apu2,
+ 	},
++	/* APU4 w/ legacy bios < 4.0.8 */
++	{
++		.ident        = "apu4",
++		.matches    = {
++			DMI_MATCH(DMI_SYS_VENDOR, "PC Engines"),
++			DMI_MATCH(DMI_BOARD_NAME, "APU4")
++		},
++		.driver_data = (void *)&board_apu2,
++	},
++	/* APU4 w/ legacy bios >= 4.0.8 */
++	{
++		.ident       = "apu4",
++		.matches     = {
++			DMI_MATCH(DMI_SYS_VENDOR, "PC Engines"),
++			DMI_MATCH(DMI_BOARD_NAME, "apu4")
++		},
++		.driver_data = (void *)&board_apu2,
++	},
++	/* APU4 w/ mainline bios */
++	{
++		.ident       = "apu4",
++		.matches     = {
++			DMI_MATCH(DMI_SYS_VENDOR, "PC Engines"),
++			DMI_MATCH(DMI_BOARD_NAME, "PC Engines apu4")
++		},
++		.driver_data = (void *)&board_apu2,
++	},
+ 	{}
+ };


### PR DESCRIPTION
Backports [platform/x86: pcengines-apuv2: detect apuv4 board](https://github.com/torvalds/linux/commit/3d00da1de3ea36ba44f4a7ba76c8c8b16f98204b)

Commit https://github.com/openwrt/openwrt/commit/2b550a6be198ff78ac672d654d867ff1a0a13760 removed the kernel/leds-apu2 which was an out of tree driver that supported the APUv4 platform.
