### PR TITLE
ath79: add support for Compex WPJ563

### DIFF
--- a/target/linux/ath79/dts/qca9563_compex_wpj563.dts
+++ b/target/linux/ath79/dts/qca9563_compex_wpj563.dts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	model = "Compex WPJ563";
+	compatible = "compex,wpj563", "qca,qca9563";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_sig4;
+		led-failsafe = &led_sig4;
+		led-running = &led_sig4;
+		led-upgrade = &led_sig4;
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		sig1 {
+			label = "wpj563:green:sig1";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "wpj563:green:sig2";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		sig3 {
+			label = "wpj563:green:sig4";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig4: sig4 {
+			label = "wpj563:green:sig4";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0xfc0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	mtd-mac-address = <&uboot 0x2e010>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -131,7 +131,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"
 		;;
-	compex,wpj344-16m)
+	compex,wpj344-16m|\
+	compex,wpj563)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan" "2:wan"
 		;;
@@ -370,7 +371,8 @@ ath79_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
-	compex,wpj344-16m)
+	compex,wpj344-16m|\
+	compex,wpj563)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
 		;;
 	devolo,magic-2-wifi)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -470,6 +470,18 @@ define Device/compex_wpj531-16m
 endef
 TARGET_DEVICES += compex_wpj531-16m
 
+define Device/compex_wpj563
+  SOC := qca9563
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb3
+  IMAGE_SIZE := 16128k
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := WPJ563
+  SUPPORTED_DEVICES += wpj563
+  IMAGES += cpximg-7a02.bin
+  IMAGE/cpximg-7a02.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | mkmylofw_16m 0x694 2
+endef
+TARGET_DEVICES += compex_wpj563
+
 define Device/devolo_dvl1200e
   SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
This is the last of the 3 compex devices i've prepared ports from ar71xx to ath79 for.
It's much like the WPJ531 but with three antenna-sockets for the on-board radio.