### PR TITLE
lantiq: xrx200 clean dts

### DIFF
--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -110,18 +110,6 @@
 			phy-mode = "rgmii";
 			phy-handle = <&phy0>;
 		};
-		ethernet@4 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <4>;
-			phy-mode = "mii";
-			phy-handle = <&phy13>;
-		};
-		ethernet@5 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <5>;
-			phy-mode = "mii";
-			phy-handle = <&phy14>;
-		};
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
@@ -133,6 +121,18 @@
 			reg = <3>;
 			phy-mode = "mii";
 			phy-handle = <&phy12>;
+		};
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "mii";
+			phy-handle = <&phy13>;
+		};
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "mii";
+			phy-handle = <&phy14>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -110,25 +110,25 @@
 			phy-mode = "rgmii";
 			phy-handle = <&phy0>;
 		};
-		ethernet@1 {
+		ethernet@4 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <4>;
 			phy-mode = "mii";
 			phy-handle = <&phy13>;
 		};
-		ethernet@2 {
+		ethernet@5 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <5>;
 			phy-mode = "mii";
 			phy-handle = <&phy14>;
 		};
-		ethernet@3 {
+		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
 			phy-mode = "mii";
 			phy-handle = <&phy11>;
 		};
-		ethernet@4 {
+		ethernet@3 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <3>;
 			phy-mode = "mii";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
@@ -3,9 +3,6 @@
 
 #include "vr9_avm_fritz736x.dtsi"
 
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
-
 / {
 	compatible = "avm,fritz7360-v2", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
 	model = "AVM FRITZ!Box 7360 V2";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
@@ -3,9 +3,6 @@
 
 #include "vr9_avm_fritz736x.dtsi"
 
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
-
 / {
 	compatible = "avm,fritz7360sl", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
 	model = "AVM FRITZ!Box 7360 SL";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -3,9 +3,6 @@
 
 #include "vr9_avm_fritz736x.dtsi"
 
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
-
 / {
 	compatible = "avm,fritz7362sl", "avm,fritz736x", "lantiq,xway", "lantiq,vr9";
 	model = "AVM FRITZ!Box 7362 SL";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -105,7 +105,7 @@
 			phy-handle = <&phy11>;
 		};
 
-		ethernet@3 {
+		ethernet@4 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <4>;
 			phy-mode = "gmii";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
@@ -162,18 +162,6 @@
 		reg = <0>;
 		lantiq,switch;
 
-		ethernet@4 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <4>;
-			phy-mode = "mii";
-			phy-handle = <&phy13>;
-		};
-		ethernet@5 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <5>;
-			phy-mode = "mii";
-			phy-handle = <&phy14>;
-		};
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
@@ -185,6 +173,18 @@
 			reg = <3>;
 			phy-mode = "mii";
 			phy-handle = <&phy12>;
+		};
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "mii";
+			phy-handle = <&phy13>;
+		};
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "mii";
+			phy-handle = <&phy14>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
@@ -162,25 +162,25 @@
 		reg = <0>;
 		lantiq,switch;
 
-		ethernet@1 {
+		ethernet@4 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <4>;
 			phy-mode = "mii";
 			phy-handle = <&phy13>;
 		};
-		ethernet@2 {
+		ethernet@5 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <5>;
 			phy-mode = "mii";
 			phy-handle = <&phy14>;
 		};
-		ethernet@3 {
+		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
 			phy-mode = "mii";
 			phy-handle = <&phy11>;
 		};
-		ethernet@4 {
+		ethernet@3 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <3>;
 			phy-mode = "mii";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -103,17 +103,11 @@
 		reg = <0>;
 		lantiq,switch;
 
-		ethernet@4 {
+		ethernet@0 {
 			compatible = "lantiq,xrx200-pdi-port";
-			reg = <4>;
-			phy-mode = "gmii";
-			phy-handle = <&phy13>;
-		};
-		ethernet@2 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <2>;
-			phy-mode = "gmii";
-			phy-handle = <&phy11>;
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
 		};
 		ethernet@1 {
 			compatible = "lantiq,xrx200-pdi-port";
@@ -121,11 +115,17 @@
 			phy-mode = "rgmii";
 			phy-handle = <&phy1>;
 		};
-		ethernet@0 {
+		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
-			reg = <0>;
-			phy-mode = "rgmii";
-			phy-handle = <&phy0>;
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -121,12 +121,6 @@
 			phy-handle = <&phy0>;
 			// gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
 		};
-		ethernet@5 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <5>;
-			phy-mode = "rgmii";
-			phy-handle = <&phy5>;
-		};
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
@@ -138,6 +132,12 @@
 			reg = <4>;
 			phy-mode = "gmii";
 			phy-handle = <&phy13>;
+		};
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy5>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -133,7 +133,7 @@
 			phy-mode = "gmii";
 			phy-handle = <&phy11>;
 		};
-		ethernet@3 {
+		ethernet@4 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <4>;
 			phy-mode = "gmii";

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -41,12 +41,6 @@
 			phy-handle = <&phy0>;
 			// gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
 		};
-		ethernet@5 {
-			compatible = "lantiq,xrx200-pdi-port";
-			reg = <5>;
-			phy-mode = "rgmii";
-			phy-handle = <&phy5>;
-		};
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
@@ -58,6 +52,12 @@
 			reg = <4>;
 			phy-mode = "gmii";
 			phy-handle = <&phy13>;
+		};
+		ethernet@5 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <5>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy5>;
 		};
 	};
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -53,7 +53,7 @@
 			phy-mode = "gmii";
 			phy-handle = <&phy11>;
 		};
-		ethernet@3 {
+		ethernet@4 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <4>;
 			phy-mode = "gmii";


### PR DESCRIPTION
This PR contains three patches that fixes small inconsistency in dts:
 - lantiq: remove duplicated include from fritzbox dts
 - lantiq: set port number corresponding to reg value
 - lantiq: sort ethernet ports in dts

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
Acked-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>