### PR TITLE
lantiq: dts: Move the &usb_vbus nodes out of &gpio

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
@@ -96,18 +96,6 @@
 			gpios = <&gpio 50 GPIO_ACTIVE_HIGH>;
 		};
 	};
-};
-
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		exin {
-			lantiq,groups = "exin1";
-			lantiq,function = "exin";
-		};
-	};
 
 	usb_vbus: regulator-usb-vbus {
 		compatible = "regulator-fixed";
@@ -119,6 +107,18 @@
 
 		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+	};
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		exin {
+			lantiq,groups = "exin1";
+			lantiq,function = "exin";
+		};
 	};
 };
 

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
@@ -73,6 +73,18 @@
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -101,18 +113,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
@@ -105,6 +105,18 @@
 			gpios = <&gpiomm 6 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -131,18 +143,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -108,6 +108,18 @@
 			gpios = <&gpiomm 9 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -141,18 +153,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
@@ -96,18 +96,6 @@
 			gpios = <&gpio 50 GPIO_ACTIVE_HIGH>;
 		};
 	};
-};
-
-&gpio {
-	pinctrl-names = "default";
-	pinctrl-0 = <&state_default>;
-
-	state_default: pinmux {
-		exin {
-			lantiq,groups = "exin1";
-			lantiq,function = "exin";
-		};
-	};
 
 	usb_vbus: regulator-usb-vbus {
 		compatible = "regulator-fixed";
@@ -119,6 +107,18 @@
 
 		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+	};
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		exin {
+			lantiq,groups = "exin1";
+			lantiq,function = "exin";
+		};
 	};
 };
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
@@ -73,6 +73,18 @@
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -101,18 +113,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
@@ -105,6 +105,18 @@
 			gpios = <&gpiomm 6 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -131,18 +143,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -108,6 +108,18 @@
 			gpios = <&gpiomm 9 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -141,18 +153,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 


### PR DESCRIPTION
Move the USB VBUS regulator nodes out of the GPIO controller node. This
fixes a problem where the "regulator-fixed" driver wasn't probed for
these regulators because the GPIO driver doesn't scan the child-nodes
and based on the dt-bindings documentation it's not supposed to.

This fixed the following error reported by Luca Olivetti:
  ...
  dwc2 1e101000.usb: DWC OTG Controller
  dwc2 1e101000.usb: new USB bus registered, assigned bus number 1
  dwc2 1e101000.usb: irq 62, io mem 0x1e101000
  dwc2 1e101000.usb: startup error -517
  dwc2 1e101000.usb: USB bus 1 deregistered
  dwc2 1e101000.usb: dwc2_hcd_init() FAILED, returning -517

Cc: @olivluca