### PR TITLE
lantiq: fix the WAN port on the ARV7519RW22 (Orange Livebox 2.1)

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -18,7 +18,7 @@ lantiq_setup_interfaces()
 		;;
 	arcadyan,arv7519rw22)
 		ucidef_add_switch "switch0" \
-			"0:lan:5" "2:lan:3" "3:lan:4" "4:lan:1" "5:lan:2" "6t@eth0"
+			"2:lan:3" "3:lan:4" "4:lan:1" "5:lan:2" "0:wan" "6t@eth0"
 		;;
 	arcadyan,vg3503j)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
According to the OpenWrt wiki the ARV7519RW22 has four 10/100Mbit/s LAN
ports and one Gbit/s WAN port. Ethernet switch port 0 is connected to
&phy0 in "rgmii" mode - so this must be the actual WAN port. Switch the
port which was previously labelled as"lan5" to be the "wan" port so the
UCI default configuration matches what's documented for this board on
the wiki page.

This is split from PR #3085 based on the suggestion from @adrianschmutzler
It is un-tested because I don't have the relevant hardware.