### PR TITLE
lantiq: dts: Move the &usb_vbus nodes out of &gpio

### DIFF
--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV7510PW22.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV7510PW22.dts
@@ -74,6 +74,18 @@
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -114,18 +126,6 @@
 			lantiq,pull = <2>;
 			lantiq,output = <0>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV7518PW.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV7518PW.dts
@@ -106,6 +106,18 @@
 			gpios = <&gpiomm 6 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -145,18 +157,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV752DPW.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/ARV752DPW.dts
@@ -107,6 +107,18 @@
 			gpios = <&gpiomm 9 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -152,18 +164,6 @@
 			lantiq,pull = <2>;
 			lantiq,open-drain = <1>;
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpiomm 0 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 

--- a/target/linux/lantiq/files-4.14/arch/mips/boot/dts/P2601HNFX.dts
+++ b/target/linux/lantiq/files-4.14/arch/mips/boot/dts/P2601HNFX.dts
@@ -97,6 +97,18 @@
 			gpios = <&gpio 50 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &gpio {
@@ -128,18 +140,6 @@
 			lantiq,groups = "mdio";
 			lantiq,function = "mdio";
 		};
-	};
-
-	usb_vbus: regulator-usb-vbus {
-		compatible = "regulator-fixed";
-
-		regulator-name = "USB_VBUS";
-
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&gpio 9 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
 	};
 };
 


### PR DESCRIPTION
Move the USB VBUS regulator nodes out of the GPIO controller node. This
fixes a problem where the "regulator-fixed" driver wasn't probed for
these regulators because the GPIO driver doesn't scan the child-nodes
and based on the dt-bindings documentation it's not supposed to.

Similar to #3174 but for the openwrt-19.07 branch.