### PR TITLE
build: fix compatibility with python3.6

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -2,7 +2,7 @@
 
 from os import getenv, environ
 from pathlib import Path
-from subprocess import run
+from subprocess import run, PIPE
 from sys import argv
 import json
 
@@ -42,10 +42,11 @@ if output:
             "val.DEFAULT_PACKAGES",
             "val.ARCH_PACKAGES",
         ],
-        capture_output=True,
+        stdout=PIPE,
+        stderr=PIPE,
         check=True,
         env=environ.copy().update({"TOPDIR": Path().cwd()}),
-        text=True,
+        universal_newlines=True,
     ).stdout.splitlines()
 
     output["default_packages"] = default_packages.split()


### PR DESCRIPTION
On a system python3 is linked to python3.6, fail to perform json_overview_image_info
 and got `TypeError: __init__() got an unexpected keyword argument 'capture_output'`.
This patch emulate the behaviour on python 3.7+.