### PR TITLE
[RFT] ramips: improve LED support for D-Link DIR-615 D series

### DIFF
--- a/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
+++ b/target/linux/ramips/dts/rt3050_dlink_dir-615-d.dts
@@ -74,23 +74,23 @@
 	leds {
 		compatible = "gpio-leds";
 
-		status {
+		status_amber {
 			label = "dir-615-d:amber:status";
 			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 		};
 
-		led_status_green: status2 {
+		led_status_green: status_green {
 			label = "dir-615-d:green:status";
 			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
-		wan {
+		wan_amber {
 			label = "dir-615-d:amber:wan";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
 		};
 
-		wan2 {
+		wan_green {
 			label = "dir-615-d:green:wan";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
@@ -33,7 +33,6 @@ dlink,dir-300-b7|\
 dlink,dir-320-b1|\
 dlink,dir-600-b1|\
 dlink,dir-610-a1|\
-dlink,dir-615-d|\
 dlink,dir-615-h1|\
 dlink,dir-620-a1|\
 engenius,esr-9753|\
@@ -65,6 +64,10 @@ asiarf,awapn2403)
 	;;
 dlink,dcs-930l-b1)
 	ucidef_set_led_netdev "wifi" "WiFi" "$boardname:blue:wps"
+	;;
+dlink,dir-615-d)
+	ucidef_set_led_netdev "wan" "WAN (green)" "$boardname:green:wan" "eth0.2"
+	set_wifi_led "rt2800soc-phy0::radio"
 	;;
 dlink,dir-620-d1|\
 trendnet,tew-714tru)


### PR DESCRIPTION
This patch adds a trigger for the WAN LED and enhances support for
the WiFi LED by enabling activity indication.

This is based on bug report feedback (see reference below).

While at it, update the LED node names in DTS file.

Fixes: FS#732

---

https://bugs.openwrt.org/index.php?do=details&task_id=732&pagenum=41

I have not tested this at all, I just implemented the working configuration from this very old bug report.

Testers would be welcome.