### PR TITLE
[RFT] ath79: fix WiFi switch for TL-WR841ND v8 (affects TL-WR842ND v2 and TL-MR3420 v2)

### DIFF
--- a/target/linux/ath79/dts/ar9341_tplink.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink.dtsi
@@ -15,17 +15,6 @@
 		label-mac-device = &wmac;
 	};
 
-	keys: keys {
-		compatible = "gpio-keys";
-
-		rfkill {
-			label = "WiFi";
-			linux,code = <KEY_RFKILL>;
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-			debounce-interval = <60>;
-		};
-	};
-
 	leds: leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -6,14 +6,23 @@
 / {
 	model = "TP-Link TL-MR3420 v2";
 	compatible = "tplink,tl-mr3420-v2", "qca,ar9341";
-};
 
-&keys {
-	reset {
-		label = "Reset";
-		linux,code = <KEY_RESTART>;
-		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		debounce-interval = <60>;
+	keys {
+		compatible = "gpio-keys";
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "Reset/WPS";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -6,14 +6,24 @@
 / {
 	model = "TP-Link TL-WR841N/ND v8";
 	compatible = "tplink,tl-wr841-v8", "qca,ar9341";
-};
 
-&keys {
-	reset {
-		label = "Reset";
-		linux,code = <KEY_RESTART>;
-		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-		debounce-interval = <60>;
+	keys {
+		compatible = "gpio-keys";
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -7,6 +7,24 @@
 	model = "TP-Link TL-WR842N/ND v2";
 	compatible = "tplink,tl-wr842n-v2", "qca,ar9341";
 
+	keys {
+		compatible = "gpio-keys";
+
+		rfkill {
+			label = "WiFi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
 	gpio-export {
 		compatible = "gpio-export";
 
@@ -15,15 +33,6 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
 		};
-	};
-};
-
-&keys {
-	reset {
-		label = "Reset";
-		linux,code = <KEY_RESTART>;
-		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-		debounce-interval = <60>;
 	};
 };
 


### PR DESCRIPTION
The TL-WR841ND v8 feature a WiFi switch instead of a button.
This adds the corresponding input-type to prevent booting into
failsafe regularly.

This has been defined correctly in ar71xx, but was overlooked
when migrating to ath79. In contrast, the TL-WR842ND v2, which
has the key set up as switch in ar71xx, actually has a button.
The TL-MR3420 v2 has a button as well and is set up correctly
for both targets. (Information based on TP-Link user guide)

Fixes: FS#2733
Fixes: 9601d94138de ("add support for TP-Link TL-WR841N/ND v8")

---

While looking into this, I found that support PR for TL-MR3420 v2 switched reset button to active_high. I'd be interested whether the setup for the other devices (active_low) is actually correct.

Despite, if you own one of the devices, please report back whether it's really a switch or a button.