### PR TITLE
ipq806x: enable Linksys EA8500 eth1 interface

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -37,7 +37,7 @@ linksys,ea7500-v1)
 linksys,ea8500)
 	hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 	ucidef_add_switch "switch0" \
-		"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
+		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
 	ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
 	ucidef_set_interface_macaddr "wan" "$hw_mac_addr"
 	;;

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -292,6 +292,7 @@
 					0x00004 0x7600000   /* PAD0_MODE */
 					0x00008 0x1000000   /* PAD5_MODE */
 					0x0000c 0x80        /* PAD6_MODE */
+					0x00010 0x2613a0    /* PWS_REG */
 					0x000e4 0x6a545     /* MAC_POWER_SEL */
 					0x000e0 0xc74164de  /* SGMII_CTRL */
 					0x0007c 0x4e        /* PORT0_STATUS */

--- a/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-5.4/arch/arm/boot/dts/qcom-ipq8064-ea8500.dts
@@ -279,6 +279,7 @@
 			0x00004 0x7600000   /* PAD0_MODE */
 			0x00008 0x1000000   /* PAD5_MODE */
 			0x0000c 0x80        /* PAD6_MODE */
+			0x00010 0x2613a0    /* PWS_REG */
 			0x000e4 0x6a545     /* MAC_POWER_SEL */
 			0x000e0 0xc74164de  /* SGMII_CTRL */
 			0x0007c 0x4e        /* PORT0_STATUS */


### PR DESCRIPTION
At this moment Linksys EA8500 uses only eth0.

This patch change switch registers, which allow to use eth1 as lan
and eth0 as wan. The method work with similar Linksys EA7500V1
and it work with EA8500.

Suggested-by: Sungbo Eo <mans0n@gorani.run>
Tested-by: Brian Onn <brian.a.onn@gmail.com>
Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>