### PR TITLE
uboot-envtools: ath79: update ubootenv partion index for gl-ar300m

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -18,10 +18,6 @@ buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,ecb1750|\
 etactica,eg200|\
-glinet,gl-ar300m-lite|\
-glinet,gl-ar300m-nand|\
-glinet,gl-ar300m-nor|\
-glinet,gl-ar300m16|\
 glinet,gl-ar750s-nor|\
 glinet,gl-ar750s-nor-nand|\
 librerouter,librerouter-v1|\
@@ -50,6 +46,14 @@ domywifi,dw33d)
 	;;
 glinet,gl-ar150)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
+	;;
+glinet,gl-ar300m-lite|\
+glinet,gl-ar300m-nand|\
+glinet,gl-ar300m-nor|\
+glinet,gl-ar300m16)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
 	;;
 netgear,wndr3700|\
 netgear,wndr3700-v2|\


### PR DESCRIPTION
The block index of u-boot-env changed from mtd1 to mtd3 after upgrading kernel to 5.4.
On a nand boot of gl-ar300m, the mtd changed as following:
Before:
```
dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00fa0000 00010000 "nor_firmware"
mtd3: 00400000 00020000 "kernel"
mtd4: 07c00000 00020000 "ubi"
mtd5: 00010000 00010000 "art"
```
Now:
```
dev:    size   erasesize  name
mtd0: 00400000 00020000 "kernel"
mtd1: 07c00000 00020000 "ubi"
mtd2: 00040000 00010000 "u-boot"
mtd3: 00010000 00010000 "u-boot-env"
mtd4: 00fa0000 00010000 "nor_firmware"
mtd5: 00010000 00010000 "art"
```

On a nor boot of gl-ar300m, the mtd changed as following:
Before:
```
dev:    size   erasesize  name
mtd0: 00040000 00010000 "u-boot"
mtd1: 00010000 00010000 "u-boot-env"
mtd2: 00fa0000 00010000 "firmware"
mtd3: 001f0000 00010000 "kernel"
mtd4: 00db0000 00010000 "rootfs"
mtd5: 00770000 00010000 "rootfs_data"
mtd6: 00010000 00010000 "art"
mtd7: 00400000 00020000 "nand_kernel"
mtd8: 07c00000 00020000 "nand_ubi"
```
Now:
```
dev:    size   erasesize  name
mtd0: 00400000 00020000 "nand_kernel"
mtd1: 07c00000 00020000 "nand_ubi"
mtd2: 00040000 00010000 "u-boot"
mtd3: 00010000 00010000 "u-boot-env"
mtd4: 00fa0000 00010000 "firmware"
mtd5: 00220000 00010000 "kernel"
mtd6: 00d80000 00010000 "rootfs"
mtd7: 00b40000 00010000 "rootfs_data"
mtd8: 00010000 00010000 "art"
```

This patch search the mtd block by label name, work as expect when perform a clean flash.
Maybe an additional patch needed to perform a sysupgrade **from old images**.

Tested:
device: gl-ar300m-nand
images: gl-ar300m-nand and gl-ar300m-nor