### PR TITLE
ar71xx: improve support for Arduino Yun

### DIFF
--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -217,6 +217,7 @@ platform_check_image() {
 	archer-c60-v2|\
 	archer-c7-v4|\
 	archer-c7-v5|\
+	arduino-yun|\
 	bullet-m|\
 	bullet-m-xw|\
 	c-55|\
@@ -346,7 +347,6 @@ platform_check_image() {
 	ap152|\
 	ap91-5g|\
 	ap96|\
-	arduino-yun|\
 	bhr-4grv2|\
 	bxu2000n-2-a1|\
 	db120|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
@@ -141,7 +141,7 @@ static void __init ds_setup(void)
 
 	// enable OE of level shifter
 	if (gpio_request_one(DS_GPIO_OE,
-	    GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED, "OE-1") != 0)
+	    GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED, "OE-1") != 0)
 		printk("Error setting GPIO OE\n");
 
 	if (gpio_request_one(DS_GPIO_UART_ENA,
@@ -150,7 +150,7 @@ static void __init ds_setup(void)
 
 	// enable OE of level shifter
 	if (gpio_request_one(DS_GPIO_OE2,
-	    GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED, "OE-2") != 0)
+	    GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED, "OE-2") != 0)
 		printk("Error setting GPIO OE2\n");
 }
 

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-arduino-yun.c
@@ -117,8 +117,7 @@ static void __init ds_setup(void)
 	ath79_gpio_function_disable(AR933X_GPIO_FUNC_ETH_SWITCH_LED0_EN |
 								AR933X_GPIO_FUNC_ETH_SWITCH_LED1_EN |
 								AR933X_GPIO_FUNC_ETH_SWITCH_LED2_EN |
-								AR933X_GPIO_FUNC_ETH_SWITCH_LED3_EN |
-								AR933X_GPIO_FUNC_ETH_SWITCH_LED4_EN);
+								AR933X_GPIO_FUNC_ETH_SWITCH_LED3_EN);
 
 	//Disable the Function for some pins to have GPIO functionality active
 	// GPIO6-7-8 and GPIO11

--- a/target/linux/ar71xx/patches-4.14/821-serial-core-add-support-for-boot-console-with-arbitr.patch
+++ b/target/linux/ar71xx/patches-4.14/821-serial-core-add-support-for-boot-console-with-arbitr.patch
@@ -1,0 +1,54 @@
+From 4d3c17975c7814884a721fe693b3adf5c426d759 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Tue, 10 Nov 2015 22:18:39 +0100
+Subject: [RFC] serial: core: add support for boot console with arbitrary
+ baud rates
+
+The Arduino Yun uses a baud rate of 250000 by default. The serial is
+going over the Atmel ATmega and is used to connect to this chip.
+Without this patch Linux wants to switch the console to 9600 Baud.
+
+With this patch Linux will use the configured baud rate and not a
+default one specified in uart_register_driver().
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+[rebased to 4.14, slightly reworded commit message]
+Signed-off-by: Sungbo Eo <mans0n@gorani.run>
+---
+ drivers/tty/serial/serial_core.c | 6 +++++-
+ include/linux/console.h          | 1 +
+ 2 files changed, 6 insertions(+), 1 deletions(-)
+
+--- a/drivers/tty/serial/serial_core.c
++++ b/drivers/tty/serial/serial_core.c
+@@ -232,6 +232,8 @@ static int uart_port_startup(struct tty_
+ 	if (retval == 0) {
+ 		if (uart_console(uport) && uport->cons->cflag) {
+ 			tty->termios.c_cflag = uport->cons->cflag;
++			tty->termios.c_ospeed = uport->cons->baud;
++			tty->termios.c_ispeed = uport->cons->baud;
+ 			uport->cons->cflag = 0;
+ 		}
+ 		/*
+@@ -2072,8 +2074,10 @@ uart_set_options(struct uart_port *port,
+ 	 * Allow the setting of the UART parameters with a NULL console
+ 	 * too:
+ 	 */
+-	if (co)
++	if (co) {
+ 		co->cflag = termios.c_cflag;
++		co->baud = baud;
++	}
+ 
+ 	return 0;
+ }
+--- a/include/linux/console.h
++++ b/include/linux/console.h
+@@ -145,6 +145,7 @@ struct console {
+ 	short	flags;
+ 	short	index;
+ 	int	cflag;
++	int	baud;
+ 	void	*data;
+ 	struct	 console *next;
+ };


### PR DESCRIPTION
Resubmission of https://patchwork.ozlabs.org/project/openwrt/list/?series=162629

This patchset fixes some bugs for Arduino Yun, which have been lying around for years.

* Revert "ar71xx: fix Arduino Yun enabling of level shifters outputs"
* ar71xx: fix sysupgrade for Arduino Yun
* ar71xx: enable ethernet LED of Arduino Yun
* ar71xx: restore support for boot console with arbitrary baud rates
