### PR TITLE
[RFC/WIP] ath79: add support for TP-Link TL-WPA8630 v1

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630-v1.dts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_tl-wpa8630.dtsi"
+
+/ {
+	compatible = "tplink,tl-wpa8630-v1", "qca,qca9563";
+	model = "TP-Link TL-WPA8630 v1";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+};
+
+&keys {
+	wifi {
+		label = "WiFi button";
+		linux,code = <KEY_RFKILL>;
+		gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
+&partitions {
+	uboot: partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x010000>;
+		read-only;
+	};
+
+	partition@10000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x010000 0x7d0000>;
+	};
+
+	partition@7e0000 {
+		label = "mib0";
+		reg = <0x7e0000 0x010000>;
+		read-only;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&uboot 0x0fc00>;
+};
+
+&wmac {
+	mtd-mac-address = <&uboot 0x0fc00>;
+};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		leds {
+			label = "LED control button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		pair {
+			label = "Pair button";
+			linux,code = <BTN_1>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tp-link:green:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "tp-link:green:wifi2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "tp-link:green:wifi5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	phy-mode = "sgmii";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
@@ -1,43 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "qca956x.dtsi"
+#include "qca9563_tplink_tl-wpa8630.dtsi"
 
 / {
 	aliases {
-		led-boot = &led_power;
-		led-failsafe = &led_power;
-		led-running = &led_power;
-		led-upgrade = &led_power;
 		label-mac-device = &eth0;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_power: power {
-			label = "tp-link:green:power";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-		};
-
-		wifi2g {
-			label = "tp-link:green:wifi2g";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
-		wifi5g {
-			label = "tp-link:green:wifi5g";
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		lan {
-			label = "tp-link:green:lan";
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	gpio-export {
@@ -48,118 +15,47 @@
 			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
 		};
 	};
+};
 
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "Reset button";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		pair {
-			label = "Pair button";
-			linux,code = <BTN_1>;
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		leds {
-			label = "LED control button";
-			linux,code = <BTN_0>;
-			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "WPS button";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
+&keys {
+	wps {
+		label = "WPS button";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
 	};
 };
 
-&spi {
-	status = "okay";
-
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions: partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "factory-uboot";
-				reg = <0x000000 0x020000>;
-				read-only;
-			};
-
-			partition@20000 {
-				label = "u-boot";
-				reg = <0x020000 0x020000>;
-				read-only;
-			};
-
-			partition@40000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
-				reg = <0x040000 0x5e0000>;
-			};
-
-			partition@620000 {
-				label = "partition-table";
-				reg = <0x620000 0x010000>;
-				read-only;
-			};
-		};
+&partitions {
+	partition@0 {
+		label = "factory-uboot";
+		reg = <0x000000 0x020000>;
+		read-only;
 	};
-};
 
-&pcie {
-	status = "okay";
-};
+	partition@20000 {
+		label = "u-boot";
+		reg = <0x020000 0x020000>;
+		read-only;
+	};
 
-&uart {
-	status = "okay";
-};
+	partition@40000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x040000 0x5e0000>;
+	};
 
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <0>;
-
-	phy0: ethernet-phy@0 {
-		reg = <0>;
-		phy-mode = "sgmii";
-		qca,mib-poll-interval = <500>;
-
-		qca,ar8327-initvals = <
-			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
+	partition@620000 {
+		label = "partition-table";
+		reg = <0x620000 0x010000>;
+		read-only;
 	};
 };
 
 &eth0 {
-	status = "okay";
-
-	phy-handle = <&phy0>;
-	phy-mode = "sgmii";
 	mtd-mac-address = <&mac 0x8>;
 };
 
 &wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
 	mtd-mac-address = <&mac 0x8>;
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -297,6 +297,7 @@ tplink,tl-mr6400-v1)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:white:wan" "eth1"
 	ucidef_set_led_netdev "4g" "4G" "tp-link:white:4g" "usb0"
 	;;
+tplink,tl-wpa8630-v1|\
 tplink,tl-wpa8630p-v2-eu|\
 tplink,tl-wpa8630p-v2-int)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3c"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -294,6 +294,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:3" "3:lan:2"
 		;;
+	tplink,tl-wpa8630-v1|\
 	tplink,tl-wpa8630p-v2-eu|\
 	tplink,tl-wpa8630p-v2-int)
 		# port 5 (internal) is the power-line port

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -129,6 +129,10 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
+	tplink,tl-wpa8630-v1)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x0fc00) +1)
+		;;
 	tplink,tl-wr902ac-v1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary tplink 0x8) -1)

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -45,6 +45,10 @@ tplink,re355-v1)
 tplink,re450-v1)
 	migrate_leds "re450:=tp-link:"
 	;;
+tplink,tl-wpa8630-v1)
+	migrate_leds "^tl-wpa8630:=tp-link:" \
+		':wlan$=:wifi2g' ':wlan5$=:wifi5g'
+	;;
 wd,mynet-n750)
 	migrate_leds "wd:=mynet-n750:"
 	;;

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -500,6 +500,17 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
+define Device/tplink_tl-wpa8630-v1
+  $(Device/tplink-8mlzma)
+  SOC := qca9563
+  DEVICE_MODEL := TL-WPA8630
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  TPLINK_HWID := 0x86300001
+  SUPPORTED_DEVICES += tl-wpa8630
+endef
+TARGET_DEVICES += tplink_tl-wpa8630-v1
+
 define Device/tplink_tl-wpa8630p-v2
   $(Device/tplink-safeloader)
   SOC := qca9563


### PR DESCRIPTION
This ports the TP-Link TL-WPA8630 v1 from ar71xx to ath79.

Specifications:

SoC: QCA9563
CPU: 750 MHz
Flash/RAM: 8 / 128 MiB
Ethernet: 3x 1G ports (QCA8337 switch)
WLAN: 2.4 GHz b/g/n, 5 GHz a/n/ac (ath10k)

Powerline interface connected to switch port 5 (Label LAN4)

Installation:

TBD (please tell)

Recovery:

TBD (Please tell)

---

This is an RFC and should _not_ be used on a device yet.

I don't have the device myself.

Current problems:

1. The device uses "tp-link-64k" partitioning, and I don't know how to support that properly in DTS (I've put the correct partitions, but I don't know what to change beyond that):

```
static const char *tl_wpa8630_part_probes[] = {
	"tp-link-64k",
	NULL,
};

static struct flash_platform_data tl_wpa8630_flash_data = {
	.part_probes	= tl_wpa8630_part_probes,
	.type		= "s25fl064k",
};
```

2. The device sets phy_mask to `~BIT(4)`. Which reg do I have to use for phy-handle/mdio then?

```
	/* GMAC0 is connected to an AR8337 switch */
	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
	ath79_eth0_data.phy_mask = ~BIT(4);
	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
```

The remaining network config is identical to the TL-WR1043ND v4 and has been copied from there (ar8327-initvals should also be correct/the same).

3. The use of the "$" sign for marking the end of string for grep needs to be verified/tested in led migration (to make sure it's not mistaken for a variable).