### PR TITLE
lantiq:dts: Set correct gphy pins for ethernetports  (solves bug #3188)

### DIFF
--- a/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files-4.19/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -112,7 +112,7 @@
 
 &eth0 {
 	pinctrl-0 = <&mdio_pins>,
-		    <&gphy0_led0_pins>, <&gphy0_led2_pins>,
+		    <&gphy0_led1_pins>, <&gphy0_led2_pins>,
 		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
 	pinctrl-names = "default";
 

--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -112,7 +112,7 @@
 
 &eth0 {
 	pinctrl-0 = <&mdio_pins>,
-		    <&gphy0_led0_pins>, <&gphy0_led2_pins>,
+		    <&gphy0_led1_pins>, <&gphy0_led2_pins>,
 		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
 	pinctrl-names = "default";
 


### PR DESCRIPTION
Signed-off-by: W. van den Akker <wvdakker@wilsoft.nl>

See bug: #3188 
Fix fix_gphy_pins.patch  supplied by: Mathias Kresin dev@kresin.me

