### PR TITLE
ramips: add support for Netgear R6020

### DIFF
--- a/target/linux/ramips/dts/mt7628an_netgear_r6020.dts
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6020.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,r6020", "mediatek,mt7628an-soc";
+	model = "Netgear R6020";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "r6020:green:lan";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "r6020:green:power";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_green {
+			label = "r6020:green:wlan2g";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g_orange {
+			label = "r6020:orange:wlan2g";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_green {
+			label = "r6020:green:wan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "r6020:orange:wan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "p0led_an", "p1led_an", "p2led_an",
+			       "p3led_an", "p4led_an", "wdt",
+			       "wled_an";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <86000000>;
+		m25p,fast-read;
+		
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "nvram";
+				reg = <0x60000 0x30000>;
+				read-only;
+			};
+
+			partition@90000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x90000 0x6f0000>;
+			};
+
+			partition@780000 {
+				label = "ML";
+				reg = <0x780000 0x20000>;
+				read-only;
+			};
+
+			partition@7a0000 {
+				label = "ML1";
+				reg = <0x7a0000 0x20000>;
+				read-only;
+			};
+
+			partition@7c0000 {
+				label = "ML2";
+				reg = <0x7c0000 0x20000>;
+				read-only;
+			};
+		
+			partition@7e0000 {
+				label = "POT";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "reserved";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -189,6 +189,25 @@ define Device/mercury_mac1200r-v2
 endef
 TARGET_DEVICES += mercury_mac1200r-v2
 
+define Device/netgear_r6020
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 7104k
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := R6020
+  DEVICE_PACKAGES := kmod-mt76x2
+  SERCOMM_HWID := CFR
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0040
+  IMAGES += factory.img
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size
+  IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | \
+	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | zip R6020.bin | \
+	sercom-seal
+endef
+TARGET_DEVICES += netgear_r6020
+
 define Device/netgear_r6080
   BLOCKSIZE := 64k
   IMAGE_SIZE := 7552k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -23,6 +23,7 @@ alfa-network,awusfree1)
 asus,rt-n10p-v3|\
 asus,rt-n11p-b1|\
 asus,rt-n12-vp-b1|\
+netgear,r6020|\
 netgear,r6080|\
 netgear,r6120)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0xf"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -95,6 +95,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
+	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120)
 		ucidef_add_switch "switch0" \
@@ -151,6 +152,7 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	duzun,dm06|\
+	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120|\
 	wrtnode,wrtnode2p|\


### PR DESCRIPTION
This adds support for the Netgear R6020, aka Netgear AC750.

The R6020 appears to be the same hardware as the Netgear R6080,
aka Netgear AC1000, but it has a slightly different flash layout.

Specification:

SoC: MediaTek MT7628 (580 MHz)
Flash: 8 MiB
RAM: 64 MiB
Wireless: 2.4Ghz (builtin) and 5Ghz (MT7612E)
LAN speed: 10/100
LAN ports: 4
WAN speed: 10/100
WAN ports: 1
UART (57600 8N1) on PCB

Installation:

Flashing OpenWRT from stock firmware requires nmrpflash. Use an ethernet
cable to connect to LAN port 1 of the R6020, and power the R6020 off.
From the connected workstation, run
`nmrpflash -i eth0 -f openwrt-ramips-mt76x8-netgear_r6020-squashfs-factory.img`,
replacing eth0 with the appropriate interface (can be identified by
running `nmrpflash -L`). Then power on the R6020. After flashing has finished,
power cycle the R6020, and it will boot into OpenWRT. Once OpenWRT has been
installed, subsequent flashes can use the web interface and sysupgrade files.

Signed-off-by: Tim Thorpe <timfthorpe@gmail.com>
