### PR TITLE
iproute2: tc: fix problems related to recent upstream updates

### DIFF
--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iproute2
 PKG_VERSION:=5.7.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/net/iproute2

--- a/package/network/utils/iproute2/patches/002-configure-support-ipset-v7.patch
+++ b/package/network/utils/iproute2/patches/002-configure-support-ipset-v7.patch
@@ -1,0 +1,32 @@
+From 650591a7a70cd79d826fcdc579a20c168c987cf2 Mon Sep 17 00:00:00 2001
+From: Tony Ambardar <tony.ambardar@gmail.com>
+Date: Tue, 7 Jul 2020 00:58:33 -0700
+Subject: [PATCH] configure: support ipset version 7 with kernel version 5
+
+The configure script checks for ipset v6 availability but doesn't test
+for v7, which is backward compatible and used on kernel v5.x systems.
+Update the script to test for both ipset versions. Without this change,
+the tc ematch function em_ipset will be disabled.
+
+Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
+Signed-off-by: Stephen Hemminger <stephen@networkplumber.org>
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index f415bf49..307912aa 100755
+--- a/configure
++++ b/configure
+@@ -208,7 +208,7 @@ typedef unsigned short ip_set_id_t;
+ #include <linux/netfilter/xt_set.h>
+ 
+ struct xt_set_info info;
+-#if IPSET_PROTOCOL == 6
++#if IPSET_PROTOCOL == 6 || IPSET_PROTOCOL == 7
+ int main(void)
+ {
+ 	return IPSET_MAXNAMELEN;
+-- 
+2.17.1
+

--- a/package/network/utils/iproute2/patches/175-reduce-dynamic-syms.patch
+++ b/package/network/utils/iproute2/patches/175-reduce-dynamic-syms.patch
@@ -39,6 +39,6 @@
 +	for s in `grep -B 3 '\<dlsym' $$files | sed -n '/snprintf/{s:.*"\([^"]*\)".*:\1:;s:%s::;p}'` ; do \
 +		sed -n '/'$$s'[^ ]* =/{s:.* \([^ ]*'$$s'[^ ]*\) .*:\1;:;p}' $$files ; \
 +	done >> $@ ; \
-+	echo "show_stats; print_tm; parse_rtattr; get_u32; matches; addattr_l; addattr_nest; addattr_nest_end; };" >> $@
++	echo "show_stats; print_nl; print_tm; parse_rtattr; parse_rtattr_flags; get_u32; matches; addattr_l; addattr_nest; addattr_nest_end; };" >> $@
 +
  endif


### PR DESCRIPTION
**Maintainers/Distribution List**:  @dedeckeh, @ldir-EDB0 (based on prior commits and review)
**Compile tested**:  mips32-be-malta and armvirt-32, master branch
**Run tested**:  mips32-be-malta and armvirt-32, master branch

**Description**:
This PR address some _tc_ problems arising from recent updates to kernel v5.x, iproute2 v5.x and ipset v7.x. It includes the following changes:

1. Fix missing _em_ipset_ module when using kernel v5.x and ipset v7.x, backported after accepted upstream.
2. Fix broken "_action .. xt_", related to iproute 5.x updates which impacted a previous size optimization.
3. Bump PKG_RELEASE.

Thanks for your review and feedback.
