### PR TITLE
kernel: use skb_list_del_init in NF_HOOK_LIST

### DIFF
--- a/target/linux/generic/hack-4.19/951-must-call-skb_list_del_init-in-NF_HOOK_LIST.patch
+++ b/target/linux/generic/hack-4.19/951-must-call-skb_list_del_init-in-NF_HOOK_LIST.patch
@@ -1,0 +1,26 @@
+From daadc14ea0f4e39103d719af5042167a6eb71113 Mon Sep 17 00:00:00 2001
+From: Chen Minqiang <ptpt52@gmail.com>
+Date: Thu, 27 Feb 2020 02:28:50 +0800
+Subject: [PATCH] must call skb_list_del_init in NF_HOOK_LIST
+
+Signed-off-by: Chen Minqiang <ptpt52@gmail.com>
+---
+ include/linux/netfilter.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 72cb19c..9460a56 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -300,7 +300,7 @@ NF_HOOK_LIST(uint8_t pf, unsigned int hook, struct net *net, struct sock *sk,
+ 
+ 	INIT_LIST_HEAD(&sublist);
+ 	list_for_each_entry_safe(skb, next, head, list) {
+-		list_del(&skb->list);
++		skb_list_del_init(skb);
+ 		if (nf_hook(pf, hook, net, sk, skb, in, out, okfn) == 1)
+ 			list_add_tail(&skb->list, &sublist);
+ 	}
+-- 
+2.17.1
+

--- a/target/linux/generic/hack-5.4/951-must-call-skb_list_del_init-in-NF_HOOK_LIST.patch
+++ b/target/linux/generic/hack-5.4/951-must-call-skb_list_del_init-in-NF_HOOK_LIST.patch
@@ -1,0 +1,13 @@
+diff --git a/include/linux/netfilter.h b/include/linux/netfilter.h
+index 77ebb61..4c0e653 100644
+--- a/include/linux/netfilter.h
++++ b/include/linux/netfilter.h
+@@ -316,7 +316,7 @@ NF_HOOK_LIST(uint8_t pf, unsigned int hook, struct net *net, struct sock *sk,
+ 
+ 	INIT_LIST_HEAD(&sublist);
+ 	list_for_each_entry_safe(skb, next, head, list) {
+-		list_del(&skb->list);
++		skb_list_del_init(skb);
+ 		if (nf_hook(pf, hook, net, sk, skb, in, out, okfn) == 1)
+ 			list_add_tail(&skb->list, &sublist);
+ 	}


### PR DESCRIPTION
list_del is invalid use for skb
it cannot make sure skb->next=NULL