### PR TITLE
build,json: fix compatibility with Python 3.5

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -38,7 +38,7 @@ if output:
             "make",
             "--no-print-directory",
             "-C",
-            f"target/linux/{output['target'].split('/')[0]}",
+            "target/linux/{}".format(output['target'].split('/')[0]),
             "val.DEFAULT_PACKAGES",
             "val.ARCH_PACKAGES",
         ],


### PR DESCRIPTION
The f-string feature was introduced in Python 3.6. As Buildbots may run
on Debian 9, which comes per default with Python 3.5, this would cause
an issue. Instead of f-strings use the *legacy* `.format()` function.

Signed-off-by: Paul Spooren <mail@aparcar.org>