### PR TITLE
[19.07]Backport latest JSON patches

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -536,6 +536,7 @@ define Device/Build/image
 	IMAGE_TYPE=$(word 1,$(subst ., ,$(2))) \
 	IMAGE_PREFIX="$(IMAGE_PREFIX)" \
 	DEVICE_TITLE="$(DEVICE_TITLE)" \
+	DEVICE_PACKAGES="$(DEVICE_PACKAGES)" \
 	TARGET="$(BOARD)" \
 	SUBTARGET="$(if $(SUBTARGET),$(SUBTARGET),generic)" \
 	VERSION_NUMBER="$(VERSION_NUMBER)" \

--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -41,6 +41,7 @@ image_info = {
                     "sha256": image_hash,
                 }
             ],
+            "device_packages": getenv("DEVICE_PACKAGES").split(),
             "supported_devices": getenv("SUPPORTED_DEVICES").split(),
             "titles": get_titles(),
         }

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -33,19 +33,22 @@ for json_file in work_dir.glob("*.json"):
             )
 
 
-output["default_packages"] = run(
+default_packages, output["arch_packages"] = run(
     [
         "make",
         "--no-print-directory",
         "-C",
         f"target/linux/{output['target'].split('/')[0]}",
         "val.DEFAULT_PACKAGES",
+        "val.ARCH_PACKAGES",
     ],
     capture_output=True,
     check=True,
     env=environ.copy().update({"TOPDIR": Path().cwd()}),
     text=True,
-).stdout.split()
+).stdout.splitlines()
+
+output["default_packages"] = default_packages.split()
 
 if output:
     output_path.write_text(json.dumps(output, sort_keys=True, separators=(",", ":")))

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -38,7 +38,7 @@ if output:
             "make",
             "--no-print-directory",
             "-C",
-            f"target/linux/{output['target'].split('/')[0]}",
+            "target/linux/{}".format(output['target'].split('/')[0]),
             "val.DEFAULT_PACKAGES",
             "val.ARCH_PACKAGES",
         ],

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -2,7 +2,7 @@
 
 from os import getenv, environ
 from pathlib import Path
-from subprocess import run
+from subprocess import run, PIPE
 from sys import argv
 import json
 
@@ -42,10 +42,11 @@ if output:
             "val.DEFAULT_PACKAGES",
             "val.ARCH_PACKAGES",
         ],
-        capture_output=True,
+        stdout=PIPE,
+        stderr=PIPE,
         check=True,
         env=environ.copy().update({"TOPDIR": Path().cwd()}),
-        text=True,
+        universal_newlines=True,
     ).stdout.splitlines()
 
     output["default_packages"] = default_packages.split()

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -32,25 +32,23 @@ for json_file in work_dir.glob("*.json"):
                 image_info["profiles"][device_id]["images"][0]
             )
 
-
-default_packages, output["arch_packages"] = run(
-    [
-        "make",
-        "--no-print-directory",
-        "-C",
-        f"target/linux/{output['target'].split('/')[0]}",
-        "val.DEFAULT_PACKAGES",
-        "val.ARCH_PACKAGES",
-    ],
-    capture_output=True,
-    check=True,
-    env=environ.copy().update({"TOPDIR": Path().cwd()}),
-    text=True,
-).stdout.splitlines()
-
-output["default_packages"] = default_packages.split()
-
 if output:
+    default_packages, output["arch_packages"] = run(
+        [
+            "make",
+            "--no-print-directory",
+            "-C",
+            f"target/linux/{output['target'].split('/')[0]}",
+            "val.DEFAULT_PACKAGES",
+            "val.ARCH_PACKAGES",
+        ],
+        capture_output=True,
+        check=True,
+        env=environ.copy().update({"TOPDIR": Path().cwd()}),
+        text=True,
+    ).stdout.splitlines()
+
+    output["default_packages"] = default_packages.split()
     output_path.write_text(json.dumps(output, sort_keys=True, separators=(",", ":")))
 else:
     print("JSON info file script could not find any JSON files for target")

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-import json
+from os import getenv, environ
 from pathlib import Path
-from os import getenv
+from subprocess import run
 from sys import argv
+import json
 
 if len(argv) != 2:
     print("JSON info files script requires ouput file as argument")
@@ -30,6 +31,21 @@ for json_file in work_dir.glob("*.json"):
             output["profiles"][device_id]["images"].append(
                 image_info["profiles"][device_id]["images"][0]
             )
+
+
+output["default_packages"] = run(
+    [
+        "make",
+        "--no-print-directory",
+        "-C",
+        f"target/linux/{output['target'].split('/')[0]}",
+        "val.DEFAULT_PACKAGES",
+    ],
+    capture_output=True,
+    check=True,
+    env=environ.copy().update({"TOPDIR": Path().cwd()}),
+    text=True,
+).stdout.split()
 
 if output:
     output_path.write_text(json.dumps(output, sort_keys=True, separators=(",", ":")))

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -168,6 +168,7 @@ prepare_rootfs: FORCE
 build_image: FORCE
 	@echo
 	@echo Building images...
+	rm -rf $(BUILD_DIR)/json_info_files/
 	$(NO_TRACE_MAKE) -C target/linux/$(BOARD)/image install TARGET_BUILD=1 IB=1 EXTRA_IMAGE_NAME="$(EXTRA_IMAGE_NAME)" \
 		$(if $(USER_PROFILE),PROFILE="$(USER_PROFILE)")
 


### PR DESCRIPTION
The patch series adds `arch_packages` to the `profiles.json` file and fixes the compilation with Python3.6 and before, important as the Buildbots are likely using Debian 9 with Python3.5.

Tested with ath79/generic, ramips/mt7621and x86/64. The latter doesn't use `image.mk` yet, so simply no `profiles.json` is created. Both other targets work fine, find theath79 JSON output [here](http://sprunge.us/YkDadp) (the real `profils.json` isn't *prettified*)