### PR TITLE
ramips: add support for D-Link DIR-867 A1 and DIR-882 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-867-a1.dts
@@ -4,8 +4,8 @@
 #include "mt7621_dlink_dir-8xx-a1.dtsi"
 
 / {
-	compatible = "dlink,dir-878-a1", "mediatek,mt7621-soc";
-	model = "D-Link DIR-878 A1";
+	compatible = "dlink,dir-867-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-867 A1";
 
 	aliases {
 		led-boot = &led_power_orange;
@@ -18,22 +18,22 @@
 		compatible = "gpio-leds";
 
 		led_power_orange: power_orange {
-			label = "dir-878-a1:orange:power";
+			label = "dir-867-a1:orange:power";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power_green: power_green {
-			label = "dir-878-a1:green:power";
+			label = "dir-867-a1:green:power";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		led_net_orange: net_orange {
-			label = "dir-878-a1:orange:net";
+			label = "dir-867-a1:orange:net";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
 		net_green {
-			label = "dir-878-a1:green:net";
+			label = "dir-867-a1:green:net";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -4,8 +4,8 @@
 #include "mt7621_dlink_dir-8xx-a1.dtsi"
 
 / {
-	compatible = "dlink,dir-878-a1", "mediatek,mt7621-soc";
-	model = "D-Link DIR-878 A1";
+	compatible = "dlink,dir-882-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-882 A1";
 
 	aliases {
 		led-boot = &led_power_orange;
@@ -18,23 +18,37 @@
 		compatible = "gpio-leds";
 
 		led_power_orange: power_orange {
-			label = "dir-878-a1:orange:power";
+			label = "dir-882-a1:orange:power";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power_green: power_green {
-			label = "dir-878-a1:green:power";
+			label = "dir-882-a1:green:power";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		led_net_orange: net_orange {
-			label = "dir-878-a1:orange:net";
+			label = "dir-882-a1:orange:net";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 		};
 
 		net_green {
-			label = "dir-878-a1:green:net";
+			label = "dir-882-a1:green:net";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2 {
+			label = "dir-882-a1:green:usb2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb3 {
+			label = "dir-882-a1:green:usb3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx-a1.dtsi
@@ -1,0 +1,147 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "sge,uimage";
+				label = "firmware";
+				reg = <0x60000 0xfa0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -220,6 +220,19 @@ define Device/buffalo_wsr-600dhp
 endef
 TARGET_DEVICES += buffalo_wsr-600dhp
 
+define Device/dlink_dir-8xx-a1
+  IMAGE_SIZE := 16000k
+  DEVICE_VENDOR := D-Link
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+  KERNEL_INITRAMFS := $$(KERNEL) | uimage-padhdr 96
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | uimage-padhdr 96 |\
+	pad-rootfs | append-metadata | check-size
+  IMAGE/factory.bin := append-kernel | append-rootfs | uimage-padhdr 96 |\
+	check-size
+endef
+
 define Device/dlink_dir-860l-b1
   $(Device/seama)
   BLOCKSIZE := 64k
@@ -236,20 +249,24 @@ define Device/dlink_dir-860l-b1
 endef
 TARGET_DEVICES += dlink_dir-860l-b1
 
+define Device/dlink_dir-867-a1
+  $(Device/dlink_dir-8xx-a1)
+  DEVICE_MODEL := DIR-867
+endef
+TARGET_DEVICES += dlink_dir-867-a1
+
 define Device/dlink_dir-878-a1
-  IMAGE_SIZE := 16000k
-  DEVICE_VENDOR := D-Link
+  $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-878
-  DEVICE_VARIANT := A1
-  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
-  KERNEL_INITRAMFS := $$(KERNEL) | uimage-padhdr 96
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | uimage-padhdr 96 |\
-	pad-rootfs | append-metadata | check-size
-  IMAGE/factory.bin := append-kernel | append-rootfs | uimage-padhdr 96 |\
-	check-size
 endef
 TARGET_DEVICES += dlink_dir-878-a1
+
+define Device/dlink_dir-882-a1
+  $(Device/dlink_dir-8xx-a1)
+  DEVICE_MODEL := DIR-882
+  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += dlink_dir-882-a1
 
 define Device/d-team_newifi-d2
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -27,7 +27,9 @@ gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
 dlink,dir-860l-b1|\
-dlink,dir-878-a1)
+dlink,dir-867-a1|\
+dlink,dir-878-a1|\
+dlink,dir-882-a1)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:net" "wan"
 	;;
 gnubee,gb-pc1|\


### PR DESCRIPTION
This PR continues the work started in PR #2588 and #3029 by adding support for DIR-867 A1 and DIR-882 A1. There are several other routers that are based on the same base board (DIR-1760/DIR-1960/DIR-2660 from D-Link and MR2600 from Motorola), but since they require more changes due to different flash layout and minor differences on the LEDs, and considering that AFAICT @Lucky1openwrt is already working on the DIR-1960, I focused this PR on what I can test at the moment, the DIR-867/878/882 trio.

The existing DTS for the DIR-878 was changed to a common DTS and a separate DTS with the differences were made for the three targets (DIR-867/878/882). I carefully tested all of them and the compiled images works fine, the devices are properly identified, all LEDs working as they should and the USB ports works out of the box (on DIR-882 case). DIR-867 is hardware limited to 3x3 streams but this didn't require any specific change in the DTS, as the mt76 driver seems to handle that by itself (by probing the EEPROM apparently? Not entirely sure).

Anyway, this PR is ready for review.