### PR TITLE
[RFC] ci: Use GitHub Action for pull request tests

### DIFF
--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -1,0 +1,154 @@
+name: Build OpenWrt snapshot pull request
+
+on:
+  pull_request:
+    branches: [ master ]
+
+
+jobs:
+  determine_target:
+    name: Determine target
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.set-matrix.outputs.target }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Info
+      run: |
+        git log -10 --oneline
+        env
+
+    - name: Set matrix
+      id: set-matrix
+      run: |
+        # convert case independent string `ci-target:` to target
+        # multiple targets are separated by white space
+        TARGETS="$(git log -1 --pretty=format:%b | grep -e "^CI-target" | \
+            cut -d ':' -f 2 | tr ' ' '\n' | grep -v -e '^$' | sort | uniq)"
+
+        # use `ci-target` based targets or selection of popular targets
+        TARGETS="${TARGETS:-ath79/generic x86/64 ramips/mt7621 mvebu/cortexa9}"
+
+        JSON='{"target":['
+        FIRST=1
+        for TARGET in $TARGETS; do
+          [[ $FIRST -ne 1 ]] && JSON="$JSON"','
+          JSON="$JSON"'"'"${TARGET}"'"'
+          FIRST=0
+        done
+        JSON="$JSON"']}'
+
+        echo -e "\n---- targets ----\n"
+        echo "$JSON"
+        echo -e "\n---- targets ----\n"
+        echo "::set-output name=target::$JSON"
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: determine_target
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.determine_target.outputs.target)}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+
+    - name: Cache sources
+      uses: actions/cache@v2
+      with:
+        path: dl/
+        key: Sources
+
+    - name: Initialization environment
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        sudo apt-get -y install libncurses-dev
+        TARGET=$(echo ${{ matrix.target }} | cut -d "/" -f 1)
+        SUBTARGET=$(echo ${{ matrix.target }} | cut -d "/" -f 2)
+        echo "::set-env name=CI_TARGET_BUILD_PLATFORM::$TARGET"
+        echo "::set-env name=CI_TARGET_BUILD_SUBTARGET::$SUBTARGET"
+
+    - name: Setup openwrt-ci
+      run: |
+        export CI_SOURCE_URL="https://gitlab.com/ynezz/openwrt-ci/raw/master"
+        wget -q "$CI_SOURCE_URL/Makefile" -O Makefile.ci
+        make ci-prepare -f Makefile.ci
+
+    - name: openwrt-ci prepare
+      run: |
+        CI_TARGET_BUILD_CONFIG_EXTRA="$(git log -1 --pretty=format:%b | \
+            grep -e "^CI-config" | cut -d ':' -f 2 | tr ' ' '\n' | \
+            grep -v -e '^$' | sort | uniq | tr '\n' ' ')"
+        CI_TARGET_BUILD_CONFIG_EXTRA="$CI_TARGET_BUILD_CONFIG_EXTRA +BUILD_LOG"
+        export CI_TARGET_BUILD_CONFIG_EXTRA
+        echo $CI_TARGET_BUILD_CONFIG_EXTRA
+        make ci-target-build-prepare -f Makefile.ci
+
+    - name: openwrt-ci download
+      run: |
+        make ci-target-build-download -f Makefile.ci
+
+    - name: openwrt-ci run
+      run: |
+        make ci-target-build-run -f Makefile.ci
+
+    - name: Sanitize target
+      run: echo ::set-env name=target_sani::$(echo ${{ matrix.target }} | tr "/" "-")
+
+    - name: Upload images
+      uses: actions/upload-artifact@v2
+      with:
+        name: openwrt-ci-${{ env.target_sani }}-images
+        path: |
+          bin/targets/${{ matrix.target }}/*
+          !bin/targets/${{ matrix.target }}/*.buildinfo
+          !bin/targets/${{ matrix.target }}/*.json
+          !bin/targets/${{ matrix.target }}/*.manifest
+          !bin/targets/${{ matrix.target }}/kernel-debug.*
+          !bin/targets/${{ matrix.target }}/openwrt-imagebuilder*
+          !bin/targets/${{ matrix.target }}/openwrt-sdk*
+          !bin/targets/${{ matrix.target }}/packages/*
+          !bin/targets/${{ matrix.target }}/sha256sums*
+
+    - name: Upload packages
+      uses: actions/upload-artifact@v2
+      with:
+        name: openwrt-ci-${{ env.target_sani }}-packages
+        path: |
+          bin/targets/${{ matrix.target }}/packages/
+          !bin/targets/${{ matrix.target }}/packages/kmod-*.ipk
+
+    - name: Upload kmods
+      uses: actions/upload-artifact@v2
+      with:
+        name: openwrt-ci-${{ env.target_sani }}-kmods
+        path: bin/targets/${{ matrix.target }}/packages/kmod-*.ipk
+
+    - name: Upload supplementary
+      uses: actions/upload-artifact@v2
+      with:
+        name: openwrt-ci-${{ env.target_sani }}-supplementary
+        path: |
+          bin/targets/${{ matrix.target }}/*.buildinfo
+          bin/targets/${{ matrix.target }}/*.json
+          bin/targets/${{ matrix.target }}/*.manifest
+          bin/targets/${{ matrix.target }}/kernel-debug.*
+          bin/targets/${{ matrix.target }}/openwrt-imagebuilder*
+          bin/targets/${{ matrix.target }}/openwrt-sdk*
+          bin/targets/${{ matrix.target }}/sha256sums*
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: openwrt-ci-${{ env.target_sani }}-logs
+        path: logs/


### PR DESCRIPTION
This pull request makes use of the GitHub Action CI which allows to
compile test all incoming pull requests and make both build logs and
artifacts available to other developers. Ideally this lowers the need of
human resource for reviews and also opens testing to a wider audience
as compiled artifacts are available in a, as much you trust GitHub,
trustworthy fashion, allowing to test without recompiling things.

The build process uses the `openwrt-ci` repository which allows
both tool and target wide compilation and tests. Target compilation aims
to imitate the Buildbot behaviour, meaning a successful build within the
CI likely won't break the Buildbot.

While the GitHub Action CI allows up to 60 builds in parallel, it would
not be feasible to build all targets on each pull request. Therefore it
is possible to control the CI via specific strings in the commit
message. This approach makes it agnostic to different flavors or CI
providers, so a migration to a future GitLab CI would be easily done
without developers needing to change their workflow. Ideally.

The implemented control strings are `CI-target` and `CI-config`. The
primer allows to set the desired target while the latter allows to set
specific `.config` options which should be tested.  For a better
readability boolean config options may be abbreviated via leading `+`
and `-`, expanding a `-SDK` option to `CONFIG_SDK=n`.  A illustrative
use case is to test compilation with a GCC 10 instead of 8 version, as
show in the example below:

CI-target: ath79/generic x86/64
CI-config: +DEVEL +TOOLCHAINOPTS +GCC_USE_VERSION_10

To set non boolean variable the full config options is required.

It is possible to have multiple appearances of both `CI-config` or
`CI-target` in case the message line exceeds a desired maximum length.
In this case the additional target `ramips/mt7621` will also be build:

CI-target: ramips/mt7621

Adding the same target multiple times is filtered out via a `sort |
uniq` combination to avoid unnecessary builds.

Each activated target is build in parallel and resulting artifacts are
stored as compressed ZIP files on GitHub servers. Files are separated
in five archives to allow tester only downloading required files.

openwrt-ci-x86-64-supplementary 281 MB
openwrt-ci-x86-64-packages 2.31 MB
openwrt-ci-x86-64-logs 11.5 MB
openwrt-ci-x86-64-kmods 20 MB
openwrt-ci-x86-64-images 48.8 MB

The archive names should be self explanatory. Other CIs like GitLab also
allow storage of artifacts, so a future migration should not change the
workflow to much.

Signed-off-by: Paul Spooren <mail@aparcar.org>