### PR TITLE
ramips: add support for ELECOM WRC-1750GS

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_elecom_wrc-gst.dtsi"
+
+/ {
+	compatible = "elecom,wrc-1750gs", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-1750GS";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xb00000>;
+	};
+
+	partition@b50000 {
+		label = "tm_pattern";
+		reg = <0xb50000 0x380000>;
+		read-only;
+	};
+
+	partition@ed0000 {
+		label = "tm_key";
+		reg = <0xed0000 0x80000>;
+		read-only;
+	};
+
+	partition@f50000 {
+		label = "art_block";
+		reg = <0xf50000 0x30000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "user_data";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_elecom_wrc-gst.dtsi"
+
+/ {
+	compatible = "elecom,wrc-1750gsv", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-1750GSV";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xb00000>;
+	};
+
+	partition@b50000 {
+		label = "tm_pattern";
+		reg = <0xb50000 0x380000>;
+		read-only;
+	};
+
+	partition@ed0000 {
+		label = "tm_key";
+		reg = <0xed0000 0x80000>;
+		read-only;
+	};
+
+	partition@f50000 {
+		label = "nvram";
+		reg = <0xf50000 0x30000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "user_data";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -326,6 +326,30 @@ define Device/elecom_wrc-1167ghbk2-s
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
 
+define Device/elecom_wrc-1750gs
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 11264k
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-1750GS
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	elecom-gst-factory WRC-1750GS 0.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+endef
+TARGET_DEVICES += elecom_wrc-1750gs
+
+define Device/elecom_wrc-1750gsv
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 11264k
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-1750GSV
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
+	elecom-gst-factory WRC-1750GSV 0.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware wpad-basic
+endef
+TARGET_DEVICES += elecom_wrc-1750gsv
+
 define Device/elecom_wrc-1900gst
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 11264k


### PR DESCRIPTION
ELECOM WRC-1750GS is a 2.4/5 GHz band 11ac (Wi-Fi 5) router, based on
MT7621A.

WRC-1750GSV has the same hardware with WRC-1750GS.

Specification:

- SoC		: MediaTek MT7621A
- RAM		: DDR3 128 MiB
- Flash		: SPI-NOR 16 MiB
- WLAN		: 2.4/5 GHz 3T3R (2x MediaTek MT7615)
- Ethernet	: 10/100/1000 Mbps x5
  - Switch	: MediaTek MT7530 (SoC)
- LED/keys	: 4x/6x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J4: 3.3V, GND, TX, RX from ethernet port side
  - 57600n8
- Power		: 12VDC, 1.5A

Flash instruction using factory image:

1. Boot WRC-1750GS (or WRC-1750GSV) normally
2. Access to "http://192.168.2.1/" and open firmware update page
   ("ファームウェア更新")
3. Select the OpenWrt factory image and click apply ("適用") button
   for WRC-1750GS : factory-gs.bin
   for WRC-1750GSV: factory-gsv.bin
4. Wait ~120 seconds to complete flashing

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>