### PR TITLE
ramips: add support to Linksys EA7300 v1 & v2 boards

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -33,6 +33,8 @@ xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
+linksys,ea7300-v1|\
+linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 xiaomi,mi-router-ac2100|\
 xiaomi,mir3p|\

--- a/target/linux/ramips/dts/mt7621_linksys_ea7300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7300-v1.dts
@@ -4,10 +4,9 @@
 #include "mt7621.dtsi"
 #include "mt7621_linksys_ea7xxx.dtsi"
 
-
 / {
-	compatible = "linksys,ea7500-v2", "mediatek,mt7621-soc";
-	model = "Linksys EA7500 v2";
+	compatible = "linksys,ea7300-v1", "mediatek,mt7621-soc";
+	model = "Linksys EA7300 v1";
 
 	aliases {
 		led-boot = &led_power;
@@ -20,38 +19,39 @@
 		compatible = "gpio-leds";
 
 		wan_green {
-			label = "ea7500-v2:green:wan";
+			label = "ea7300-v1:green:wan";
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 		};
 
 		lan1_green {
-			label = "ea7500-v2:green:lan1";
+			label = "ea7300-v1:green:lan1";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
 		lan2_green {
-			label = "ea7500-v2:green:lan2";
+			label = "ea7300-v1:green:lan2";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 		};
 
 		lan3_green {
-			label = "ea7500-v2:green:lan3";
+			label = "ea7300-v1:green:lan3";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		lan4_green {
-			label = "ea7500-v2:green:lan4";
+			label = "ea7300-v1:green:lan4";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "ea7500-v2:white:power";
+			label = "ea7300-v1:white:power";
 			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
-			label = "ea7500-v2:green:wps";
+			label = "ea7300-v1:green:wps";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
+

--- a/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7300-v2.dts
@@ -4,10 +4,9 @@
 #include "mt7621.dtsi"
 #include "mt7621_linksys_ea7xxx.dtsi"
 
-
 / {
-	compatible = "linksys,ea7500-v2", "mediatek,mt7621-soc";
-	model = "Linksys EA7500 v2";
+	compatible = "linksys,ea7300-v2", "mediatek,mt7621-soc";
+	model = "Linksys EA7300 v2";
 
 	aliases {
 		led-boot = &led_power;
@@ -20,38 +19,39 @@
 		compatible = "gpio-leds";
 
 		wan_green {
-			label = "ea7500-v2:green:wan";
+			label = "ea7300-v2:green:wan";
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 		};
 
 		lan1_green {
-			label = "ea7500-v2:green:lan1";
+			label = "ea7300-v2:green:lan1";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
 		lan2_green {
-			label = "ea7500-v2:green:lan2";
+			label = "ea7300-v2:green:lan2";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 		};
 
 		lan3_green {
-			label = "ea7500-v2:green:lan3";
+			label = "ea7300-v2:green:lan3";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		lan4_green {
-			label = "ea7500-v2:green:lan4";
+			label = "ea7300-v2:green:lan4";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		led_power: power {
-			label = "ea7500-v2:white:power";
+			label = "ea7300-v2:white:power";
 			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		};
 
 		wps {
-			label = "ea7500-v2:green:wps";
+			label = "ea7300-v2:green:wps";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
+

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+        #address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u_env";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@c0000 {
+			label = "factory";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "s_env";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "devinfo";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		partition@580000 {
+			label = "ubi";
+			reg = <0x580000 0x2400000>;
+		};
+
+		partition@2980000 {
+			label = "alt_kernel";
+			reg = <0x2980000 0x400000>;
+			read-only;
+		};
+
+		partition@2d80000 {
+			label = "alt_rootfs";
+			reg = <0x2d80000 0x2400000>;
+			read-only;
+		};
+
+		partition@5180000 {
+			label = "sysdiag";
+			reg = <0x5180000 0x100000>;
+			read-only;
+		};
+
+		partition@5280000 {
+			label = "syscfg";
+			reg = <0x5280000 0x2d00000>;
+			read-only;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -526,21 +526,43 @@ define Device/lenovo_newifi-d1
 endef
 TARGET_DEVICES += lenovo_newifi-d1
 
-define Device/linksys_ea7500-v2
+define Device/linksys_ea7xxx
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 36864k
   DEVICE_VENDOR := Linksys
-  DEVICE_MODEL := EA7500
-  DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware wpad-basic uboot-envtools
   UBINIZE_OPTS := -E 5
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
-	append-ubi | check-size | linksys-image type=EA7500v2
+	append-ubi | check-size | linksys-image type=$$$$(DEVICE_HWNAME)
+endef
+
+define Device/linksys_ea7300-v1
+  $(Device/linksys_ea7xxx)
+  DEVICE_MODEL := EA7300
+  DEVICE_VARIANT := v1
+  DEVICE_HWNAME := EA7300
+endef
+TARGET_DEVICES += linksys_ea7300-v1
+
+define Device/linksys_ea7300-v2
+  $(Device/linksys_ea7xxx)
+  DEVICE_MODEL := EA7300
+  DEVICE_VARIANT := v2
+  DEVICE_HWNAME := EA7300v2
+  DEVICE_PACKAGES += kmod-mt7603
+endef
+TARGET_DEVICES += linksys_ea7300-v2
+
+define Device/linksys_ea7500-v2
+  $(Device/linksys_ea7xxx)
+  DEVICE_MODEL := EA7500
+  DEVICE_VARIANT := v2
+  DEVICE_HWNAME := EA7500v2
 endef
 TARGET_DEVICES += linksys_ea7500-v2
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -35,6 +35,8 @@ gnubee,gb-pc2)
 	ucidef_set_led_netdev "lan1" "lan1" "$boardname:green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "$boardname:green:lan2" "lan2"
 	;;
+linksys,ea7300-v1|\
+linksys,ea7300-v2|\
 linksys,ea7500-v2)
 	ucidef_set_led_netdev "lan1" "lan1 link" "$boardname:green:lan1" "lan1" "link"
 	ucidef_set_led_netdev "lan2" "lan2 link" "$boardname:green:lan2" "lan2" "link"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -100,6 +100,8 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
 		;;
+	linksys,ea7300-v1|\
+	linksys,ea7300-v2|\
 	linksys,ea7500-v2)
 		lan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		wan_mac=$lan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,8 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	linksys,ea7300-v1|\
+	linksys,ea7300-v2|\
 	linksys,ea7500-v2)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -8,7 +8,9 @@ boot() {
 		[ -n "$(fw_printenv bootcount bootchanged 2>/dev/null)" ] &&\
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
-	linksys,ea7500-v2)
+	linksys,ea7300-v1|\
+	linksys,ea7300-v2|\
+	linksys,ea7500)
 		mtd resetbc s_env || true
 		;;
 	samknows,whitebox-v8)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -45,6 +45,8 @@ platform_do_upgrade() {
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
 	hiwifi,hc5962|\
+	linksys,ea7300-v1|\
+	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
 	netgear,r6220|\
 	netgear,r6260|\


### PR DESCRIPTION
### Overview

This PR adds support for Linksys EA7300 boards. Given their similarities to the already-supported EA7500 (they are basically the same router) this was surprisingly easy. Support for both versions is included under the same device given that they only differ in their 2.4 GHz radio. Both radios are supported by the same driver so this should not be a problem.

### Specifications

* SoC:  MediaTek MT7621A                (880 MHz 2c/4t)
* RAM:
  * v1: Nanya NT5CC128M16IP-DIT     (256M DDR3-1600)
  * v2: Winbond W632GG6MB-12        (256M DDR3-1600)
* Flash:
  * v1: Macronix MX30LF1G18AC-TI    (128M NAND)
  * v2: Winbond W29N01HVSINA        (128M NAND)
* Eth:  MediaTek MT7621A                (10/100/1000 Mbps x5)
* Radio:
  * v1: MT7615N                     (2.4 GHz & 5 GHz)
  * v2:
    * MT7603E                     (2.4 GHz)
    * MT7615N                     (5 GHz)
  * 4 antennae: 1 internal and 3 non-deatachable
* USB:  3.0 (x1)
* LEDs:
  * White   (x1 logo)
  * Green   (x6 eth + wps)
  * Orange  (x5, hardware-bound)
* Buttons:
  * Reset   (x1)
  * WPS     (x1)

Everything works! Been running it for a couple weeks now and haven't had
any problems.

### Installation

Flash factory image through GUI.

This might fail due to the A/B nature of this device. When flashing, OEM
firmware writes over the non-booted partition. If booted from 'A',
flashing over 'B' won't work. To get around this, you should flash the
OEM image over itself. This will then boot the router from 'B' and
allow you to flash OpenWRT without problems.

### Reverting to factory firmware

Hard-reset the router three times to force it to boot from 'B.' This is
where the stock firmware resides. To remove any traces of OpenWRT from
your router simply flash the OEM image at this point.