### PR TITLE
ramips: add support for Winstars WS-WN583A6

### DIFF
--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "winstars,ws-wn583a6", "mediatek,mt7621-soc";
+	model = "Winstars WS-WN583A6";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		night_light_white {
+			label = "ws-wn583a6:white:night_light";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "ws-wn583a6:blue:status";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		status_amber {
+			label = "ws-wn583a6:amber:status";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			label = "ws-wn583a6:red:status";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+		
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1020,6 +1020,18 @@ define Device/wevo_w2914ns-v2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
 
+define Device/winstars_ws-wn583a6
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Winstars
+  DEVICE_MODEL := WS-WN583A6
+  DEVICE_ALT0_VENDOR := Gemeita
+  DEVICE_ALT0_MODEL := AC2100
+  KERNEL_INITRAMFS_SUFFIX := -WN583A6$$(KERNEL_SUFFIX)
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware wpad-basic
+endef
+TARGET_DEVICES += winstars_ws-wn583a6
+
 define Device/xiaomi-ac2100
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -9,7 +9,8 @@ ramips_setup_interfaces()
 	local board="$1"
 
 	case $board in
-	asiarf,ap7621-001)
+	asiarf,ap7621-001|\
+	winstars,ws-wn583a6)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	asiarf,ap7621-nv1|\
@@ -113,6 +114,7 @@ ramips_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
 		;;
+	winstars,ws-wn583a6|\
 	zbtlink,zbt-we1326|\
 	zbtlink,zbt-wg3526-16m|\
 	zbtlink,zbt-wg3526-32m)


### PR DESCRIPTION
The Winstars WS-WN583A6 is a wireless repeater with 2 gigabit ethernet
ports. Even if mine is branded as "Gemeita AC2100", the sticker on the
back says WS-WN583A6. So I will refer to it as Winstars WS-WN583A6.
Probably the real product name is the Wavlink WL-WN583A6 because of
the many references to Wavlink in the OEM firmware and bootlog.

Hardware
--------
```
SoC:   Mediatek MT7621AT (880 MHz, 2 cores 4 threads)
RAM:   128MB
FLASH: 8MB NOR (GigaDevice GD25Q64B)
ETH:   2x 10/100/1000 Mbps Ethernet (MT7530)
WIFI:
  - 2.4GHz: 1x MT7603E (2x2:2)
  - 5GHz:   1x MT7615E (4x4:4)
  - 6 internal antennas
BTN:
  - 1x Reset button
  - 1x WPS button
  - 1x ON/OFF switch (working but unmodifiable)
  - 1x Auto/Schedule switch (working but unmodifiable. Read Note #3)
LEDS:
  - 1x White led
  - 1x Red led
  - 1x Amber led
  - 1x Blue led
  - 2x Blue leds (lan and wan port status: working but unmodifiable)
UART:
  - 57600-8-N-1
```

Everything works correctly.

Currently there is no firmware update available. Because of this, in
order to restore the OEM firmware, you must firstly dump the OEM
firmware from your router before you flash the OpenWrt image.

Backup the OEM Firmware
-----------------------
The following steps are to be intended for users having little to none
experience in linux. Obviously there are many ways to backup the OEM
firmware, but probably this is the easiest way for this router.
Procedure tested on M83A6.V5030.191210 firmware version.

1) Go to http://192.168.10.1/webcmd.shtml

2) Type the following line in the "Command" input box:
	`mkdir /etc_ro/lighttpd/www/dev; for i in /dev/mtd*ro; do dd if=${i} of=/etc_ro/lighttpd/www${i}; done`

3) Click "Apply"

4) After few seconds, in the textarea should appear this output:
```
		16384+0 records in
	16384+0 records out
	8388608 bytes (8.0MB) copied, 4.038820 seconds, 2.0MB/s
	384+0 records in
	384+0 records out
	196608 bytes (192.0KB) copied, 0.095180 seconds, 2.0MB/s
	128+0 records in
	128+0 records out
	65536 bytes (64.0KB) copied, 0.032020 seconds, 2.0MB/s
	128+0 records in
	128+0 records out
	65536 bytes (64.0KB) copied, 0.031760 seconds, 2.0MB/s
	15744+0 records in
	15744+0 records out
	8060928 bytes (7.7MB) copied, 3.885280 seconds, 2.0MB/s
	dd: can't open '/dev/mtd5ro': No such device
	dd: can't open '/dev/mtd6ro': No such device
	dd: can't open '/dev/mtd7ro': No such device
```
   Excluding the "X.XXXXXX seconds" part, you should get the same
   exact output. If your output doesn't match mine, stop reading
   and ask for help in the forum.

5) Open the following links to download the partitions of the OEM FW:
	http://192.168.10.1/dev/mtd0ro
	http://192.168.10.1/dev/mtd1ro
	http://192.168.10.1/dev/mtd2ro
	http://192.168.10.1/dev/mtd3ro
	http://192.168.10.1/dev/mtd4ro

   If one (or more) of these files weight 0 byte, stop reading and ask
   for help in the forum.

6) Store these downloaded files in a safe place.

7) Reboot your router to remove any temporary file from your router.

Installation
------------
Flash the initramfs image in the OEM firmware interface.
When openwrt boots, flash the sysupgrade image otherwise you won't be
able to keep configuration between reboots.

Restore OEM Firmware
--------------------
Flash the "mtd4ro" file you previously backed-up directly from LUCI.
Warning: Remember to not keep settings!
Warning2: Remember to force the flash.

Notes
-----
1) The "System Command" page allows to run every command as root.
   For example you can use "dd" and "nc" to backup the OEM firmware.
   PC (SERVER):
	`nc -l 5555 > ./mtdXro`
   ROUTER (CLIENT):
	`dd if=/dev/mtdXro | nc PC_IP_ADDRESS 5555`

2) The OEM web interface accepts only images containing the string
   "WN583A6" in the filename.
   Currently the OEM interface accepts only the initramfs image
   probably because it checks if the ih_size in the image header is
   equal to the whole image size (instead of the kernel size)
   Read more here:
   https://forum.openwrt.org/t/support-for-strong-1200/22768/19

3) The white led (namely "Smart Night Light") can be controller by the
   user only if the side switch is set to "Schedule" otherwise it will
   be activated by the light condition (there is a photodiode on the
   top side of the router)

4) Router mac addresses:

   LAN		XX:XX:XX:XX:XX:8F
   WAN		XX:XX:XX:XX:XX:90
   WIFI 2G	XX:XX:XX:XX:XX:91
   WIFI 5G	XX:XX:XX:XX:XX:92

   LABEL		XX:XX:XX:XX:XX:91

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>