### PR TITLE
[RFT] lantiq: use entire available memory on vr200

### DIFF
--- a/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -6,7 +6,7 @@
 / {
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0 0x7f00000>;
+		reg = <0x0 0x8000000>;
 	};
 
 	usb_vbus: regulator-usb-vbus {


### PR DESCRIPTION
there are two variants of vr200:
- vr200 - without FXS support (SMP)
- vr200v - with FXS support

vr200v use 2MB reserved memory for vpe1 (FXS). This memory is already
excluded by bootargs. On vr200 (without FXS) we can use entire memory.
It was found only on vr200. Other boards that use reserved memory
doesn't exclude this in memory node.

It should be tested on device.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>