### PR TITLE
imx6: use device-tree compatible for board name

### DIFF
--- a/package/boot/uboot-envtools/files/imx6
+++ b/package/boot/uboot-envtools/files/imx6
@@ -14,10 +14,31 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
-apalis*)
-	ubootenv_add_uci_config $(bootdev_from_uuid)boot0 -0x2200 0x2000 0x200 10
-	;;
-*gw5*)
+gw,imx6dl-gw51xx |\
+gw,imx6dl-gw52xx |\
+gw,imx6dl-gw53xx |\
+gw,imx6dl-gw54xx |\
+gw,imx6dl-gw551x |\
+gw,imx6dl-gw552x |\
+gw,imx6dl-gw553x |\
+gw,imx6dl-gw5904 |\
+gw,imx6dl-gw5907 |\
+gw,imx6dl-gw5910 |\
+gw,imx6dl-gw5912 |\
+gw,imx6dl-gw5913 |\
+gw,imx6q-gw51xx |\
+gw,imx6q-gw52xx |\
+gw,imx6q-gw53xx |\
+gw,imx6q-gw5400-a |\
+gw,imx6q-gw54xx |\
+gw,imx6q-gw551x |\
+gw,imx6q-gw552x |\
+gw,imx6q-gw553x |\
+gw,imx6q-gw5904 |\
+gw,imx6q-gw5907 |\
+gw,imx6q-gw5910 |\
+gw,imx6q-gw5912 |\
+gw,imx6q-gw5913 )
 	if [ -c /dev/mtd1 ]; then
 		# board boots from NAND
 		ubootenv_add_uci_config /dev/mtd1 0x0 0x20000 0x40000
@@ -28,7 +49,12 @@ apalis*)
 		ubootenv_add_uci_config /dev/mmcblk0 0xd1400 0x20000
 	fi
 	;;
-wandboard)
+toradex,apalis_imx6q-eval |\
+toradex,apalis_imx6q-ixora |\
+toradex,apalis_imx6q-ixora-v1.1 )
+	ubootenv_add_uci_config $(bootdev_from_uuid)boot0 -0x2200 0x2000 0x200 10
+	;;
+wand,imx6dl-wandboard)
 	ubootenv_add_uci_config "/dev/mmcblk0" "0x60000" "0x2000" "0x2000"
 	;;
 esac

--- a/target/linux/imx6/base-files/etc/board.d/02_network
+++ b/target/linux/imx6/base-files/etc/board.d/02_network
@@ -10,22 +10,34 @@ board=$(board_name)
 board_config_update
 
 case "$board" in
-cubox-i |\
-gw51xx |\
-gw52xx |\
-gw5904 |\
-gw5907 |\
-gw5910 |\
-gw5912 |\
-gw5913)
+gw,imx6dl-gw51xx |\
+gw,imx6dl-gw52xx |\
+gw,imx6dl-gw5904 |\
+gw,imx6dl-gw5907 |\
+gw,imx6dl-gw5910 |\
+gw,imx6dl-gw5912 |\
+gw,imx6dl-gw5913 |\
+gw,imx6q-gw51xx |\
+gw,imx6q-gw52xx |\
+gw,imx6q-gw5904 |\
+gw,imx6q-gw5907 |\
+gw,imx6q-gw5910 |\
+gw,imx6q-gw5912 |\
+gw,imx6q-gw5913 |\
+solidrun,cubox-i/dl |\
+solidrun,cubox-i/q )
 	ucidef_set_interface_lan 'eth0'
 	;;
-gw53xx |\
-gw54xx |\
-gw552x)
+gw,imx6dl-gw53xx |\
+gw,imx6dl-gw54xx |\
+gw,imx6dl-gw552x |\
+gw,imx6q-gw53xx |\
+gw,imx6q-gw5400-a |\
+gw,imx6q-gw54xx |\
+gw,imx6q-gw552x )
 	ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 	;;
-wandboard)
+wand,imx6dl-wandboard )
 	ucidef_set_interface_wan 'eth0'
 	;;
 esac

--- a/target/linux/imx6/base-files/lib/imx6.sh
+++ b/target/linux/imx6/base-files/lib/imx6.sh
@@ -2,9 +2,6 @@
 # Copyright (C) 2010-2013 OpenWrt.org
 #
 
-IMX6_BOARD_NAME=
-IMX6_MODEL=
-
 rootpartuuid() {
 	local cmdline=$(cat /proc/cmdline)
 	local bootpart=${cmdline##*root=}
@@ -30,104 +27,4 @@ apalis_mount_boot() {
 	[ -f /boot/uImage ] || {
 		mount -o rw,noatime $(bootpart_from_uuid) /boot > /dev/null
 	}
-}
-
-imx6_board_detect() {
-	local machine
-	local name
-
-	machine=$(cat /proc/device-tree/model)
-
-	case "$machine" in
-	"Gateworks Ventana i.MX6 DualLite/Solo GW51XX" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW51XX")
-		name="gw51xx"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW52XX" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW52XX")
-		name="gw52xx"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW53XX" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW53XX")
-		name="gw53xx"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW54XX" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW54XX" |\
-	"Gateworks Ventana GW5400-A")
-		name="gw54xx"
-		;;
-
-	"Gateworks Ventana i.MX6 Dual/Quad GW551X" |\
-	"Gateworks Ventana i.MX6 DualLite/Solo GW551X")
-		name="gw551x"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW552X" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW552X")
-		name="gw552x"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW553X" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW553X")
-		name="gw553x"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW5904" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5904")
-		name="gw5904"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW5907" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5907")
-		name="gw5907"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW5910" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5910")
-		name="gw5910"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW5912" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5912")
-		name="gw5912"
-		;;
-
-	"Gateworks Ventana i.MX6 DualLite/Solo GW5913" |\
-	"Gateworks Ventana i.MX6 Dual/Quad GW5913")
-		name="gw5913"
-		;;
-
-	"SolidRun Cubox-i Solo/DualLite" |\
-	"SolidRun Cubox-i Dual/Quad")
-		name="cubox-i"
-		;;
-
-	"Toradex Apalis iMX6Q/D Module on Ixora Carrier Board" |\
-	"Toradex Apalis iMX6Q/D Module on Ixora Carrier Board V1.1")
-		name="apalis,ixora"
-		;;
-
-	"Toradex Apalis iMX6Q/D Module on Apalis Evaluation Board")
-		name="apalis,eval"
-		;;
-
-	"Wandboard i.MX6 Dual Lite Board")
-		name="wandboard"
-		;;
-
-	*)
-		name="generic"
-		;;
-	esac
-
-	[ -z "$IMX6_BOARD_NAME" ] && IMX6_BOARD_NAME="$name"
-	[ -z "$IMX6_MODEL" ] && IMX6_MODEL="$machine"
-
-	[ -e "/tmp/sysinfo/" ] || mkdir -p "/tmp/sysinfo/"
-
-	echo "$IMX6_BOARD_NAME" > /tmp/sysinfo/board_name
-	echo "$IMX6_MODEL" > /tmp/sysinfo/model
 }

--- a/target/linux/imx6/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/imx6/base-files/lib/preinit/01_sysinfo
@@ -1,7 +1,0 @@
-do_sysinfo_imx6() {
-	. /lib/imx6.sh
-
-	imx6_board_detect
-}
-
-boot_hook_add preinit_main do_sysinfo_imx6

--- a/target/linux/imx6/base-files/lib/preinit/79_move_config
+++ b/target/linux/imx6/base-files/lib/preinit/79_move_config
@@ -6,7 +6,9 @@ move_config() {
 	local board=$(board_name)
 
 	case "$board" in
-	apalis*)
+	toradex,apalis_imx6q-eval |\
+	toradex,apalis_imx6q-ixora |\
+	toradex,apalis_imx6q-ixora-v1.1 )
 		if [ -b $(bootpart_from_uuid) ]; then
 			apalis_mount_boot
 			[ -f "/boot/$BACKUP_FILE" ] && mv -f "/boot/$BACKUP_FILE" /

--- a/target/linux/imx6/base-files/lib/upgrade/platform.sh
+++ b/target/linux/imx6/base-files/lib/upgrade/platform.sh
@@ -8,7 +8,9 @@ RAMFS_COPY_BIN='blkid jffs2reset'
 
 enable_image_metadata_check() {
 	case "$(board_name)" in
-		apalis*)
+		toradex,apalis_imx6q-eval |\
+		toradex,apalis_imx6q-ixora |\
+		toradex,apalis_imx6q-ixora-v1.1 )
 			REQUIRE_IMAGE_METADATA=1
 			;;
 	esac
@@ -34,12 +36,38 @@ platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
-	apalis*)
-		return 0
-		;;
-	*gw5*)
+	gw,imx6dl-gw51xx |\
+	gw,imx6dl-gw52xx |\
+	gw,imx6dl-gw53xx |\
+	gw,imx6dl-gw54xx |\
+	gw,imx6dl-gw551x |\
+	gw,imx6dl-gw552x |\
+	gw,imx6dl-gw553x |\
+	gw,imx6dl-gw5904 |\
+	gw,imx6dl-gw5907 |\
+	gw,imx6dl-gw5910 |\
+	gw,imx6dl-gw5912 |\
+	gw,imx6dl-gw5913 |\
+	gw,imx6q-gw51xx |\
+	gw,imx6q-gw52xx |\
+	gw,imx6q-gw53xx |\
+	gw,imx6q-gw5400-a |\
+	gw,imx6q-gw54xx |\
+	gw,imx6q-gw551x |\
+	gw,imx6q-gw552x |\
+	gw,imx6q-gw553x |\
+	gw,imx6q-gw5904 |\
+	gw,imx6q-gw5907 |\
+	gw,imx6q-gw5910 |\
+	gw,imx6q-gw5912 |\
+	gw,imx6q-gw5913 )
 		nand_do_platform_check $board $1
 		return $?;
+		;;
+	toradex,apalis_imx6q-eval |\
+	toradex,apalis_imx6q-ixora |\
+	toradex,apalis_imx6q-ixora-v1.1 )
+		return 0
 		;;
 	esac
 
@@ -51,11 +79,37 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-	apalis*)
-		apalis_do_upgrade "$1"
-		;;
-	*gw5*)
+	gw,imx6dl-gw51xx |\
+	gw,imx6dl-gw52xx |\
+	gw,imx6dl-gw53xx |\
+	gw,imx6dl-gw54xx |\
+	gw,imx6dl-gw551x |\
+	gw,imx6dl-gw552x |\
+	gw,imx6dl-gw553x |\
+	gw,imx6dl-gw5904 |\
+	gw,imx6dl-gw5907 |\
+	gw,imx6dl-gw5910 |\
+	gw,imx6dl-gw5912 |\
+	gw,imx6dl-gw5913 |\
+	gw,imx6q-gw51xx |\
+	gw,imx6q-gw52xx |\
+	gw,imx6q-gw53xx |\
+	gw,imx6q-gw5400-a |\
+	gw,imx6q-gw54xx |\
+	gw,imx6q-gw551x |\
+	gw,imx6q-gw552x |\
+	gw,imx6q-gw553x |\
+	gw,imx6q-gw5904 |\
+	gw,imx6q-gw5907 |\
+	gw,imx6q-gw5910 |\
+	gw,imx6q-gw5912 |\
+	gw,imx6q-gw5913 )
 		nand_do_upgrade "$1"
+		;;
+	toradex,apalis_imx6q-eval |\
+	toradex,apalis_imx6q-ixora |\
+	toradex,apalis_imx6q-ixora-v1.1 )
+		apalis_do_upgrade "$1"
 		;;
 	esac
 }
@@ -64,7 +118,9 @@ platform_copy_config() {
 	local board=$(board_name)
 
 	case "$board" in
-	apalis*)
+	toradex,apalis_imx6q-eval |\
+	toradex,apalis_imx6q-ixora |\
+	toradex,apalis_imx6q-ixora-v1.1 )
 		apalis_copy_config
 		;;
 	esac
@@ -74,7 +130,9 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
-	apalis*)
+	toradex,apalis_imx6q-eval |\
+	toradex,apalis_imx6q-ixora |\
+	toradex,apalis_imx6q-ixora-v1.1 )
 		[ -z "$UPGRADE_BACKUP" ] && {
 			jffs2reset -y
 			umount /overlay


### PR DESCRIPTION
In imx6, we currently use the model from DTS to derive a board name
manually in /lib/imx6.sh.

However, if we have individual DTS files anyway, we can exploit
generic 02_sysinfo and use the compatible as board name directly.

While at it, remove the wildcards from /lib/upgrade/platform.sh as
these might make code shorter, but are quite unpleasant when grepping
for a specific device.