### PR TITLE
ath79: add support for TP-Link TL-WR841HP v3

### DIFF
--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -18,11 +18,11 @@
 		led-upgrade = &led_pwr;
 	};
 
-	leds: leds {
+	leds {
 		compatible = "gpio-leds";
 
 		wifi {
-			label = "tp-link:green:wlan";
+			label = "tp-link:green:wifi";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
@@ -38,8 +38,8 @@
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 
-		wan_red {
-			label = "tp-link:red:wan";
+		wan_amber {
+			label = "tp-link:amber:wan";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
@@ -51,6 +51,11 @@
 		wps {
 			label = "tp-link:green:wps";
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		re {
+			label = "tp-link:green:re";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -64,8 +69,8 @@
 			debounce-interval = <60>;
 		};
 
-		rfkill {
-			label = "RFKILL button";
+		wifi {
+			label = "WiFi button";
 			linux,code = <KEY_RFKILL>;
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
@@ -77,6 +82,13 @@
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
+
+		re {
+			label = "RE button";
+			linux,code = <KEY_RE_BUTTON>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
 	};
 };
 
@@ -86,7 +98,9 @@
 
 &spi {
 	status = "okay";
+
 	num-cs = <1>;
+
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
@@ -124,13 +138,16 @@
 
 &eth0 {
 	status = "okay";
+
 	phy-handle = <&swphy4>;
+
 	mtd-mac-address = <&uboot 0x1fc00>;
 	mtd-mac-address-increment = <1>;
 };
 
 &wmac {
 	status = "okay";
+
 	mtd-cal-data = <&art 0x1000>;
 	mtd-mac-address = <&uboot 0x1fc00>;
 };

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr841hp-v3", "qca,qca9533";
+	model = "TP-Link TL-WR841HP v3";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "tp-link:green:wlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_pwr: pwr {
+			label = "tp-link:green:pwr";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_red {
+			label = "tp-link:red:wan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tp-link:green:lan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tp-link:green:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		rfkill {
+			label = "RFKILL button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&eth0 {
+	status = "okay";
+	phy-handle = <&swphy4>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -296,6 +296,11 @@ tplink,tl-mr6400-v1)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:white:wan" "eth1"
 	ucidef_set_led_netdev "4g" "4G" "tp-link:white:4g" "usb0"
 	;;
+tplink,tl-wr841hp-v3)
+	ucidef_set_netdev "wan" "WAN Data" "tp-link:green:wan" "eth1" "tx rx"
+	ucidef_set_netdev "wan_red" "WAN Link" "tp-link:red:wan" "eth1" "link"
+	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
+	;;
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -229,7 +229,8 @@ tplink,archer-c59-v1|\
 tplink,archer-c59-v2|\
 tplink,archer-c60-v1|\
 tplink,archer-c60-v2|\
-tplink,archer-c60-v3)
+tplink,archer-c60-v3|\
+tplink,tl-wr841hp-v3)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	;;
@@ -295,11 +296,6 @@ tplink,tl-mr6400-v1)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:white:lan" "switch0" "0x0e"
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:white:wan" "eth1"
 	ucidef_set_led_netdev "4g" "4G" "tp-link:white:4g" "usb0"
-	;;
-tplink,tl-wr841hp-v3)
-	ucidef_set_netdev "wan" "WAN Data" "tp-link:green:wan" "eth1" "tx rx"
-	ucidef_set_netdev "wan_red" "WAN Link" "tp-link:red:wan" "eth1" "link"
-	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x1E"
 	;;
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -292,6 +292,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:3" "3:lan:2"
 		;;
+	tplink,tl-wr841hp-v3)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
+		;;
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -125,7 +125,8 @@ ath79_setup_interfaces()
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
-	comfast,cf-e560ac)
+	comfast,cf-e560ac|\
+	tplink,tl-wr841hp-v3)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
@@ -291,11 +292,6 @@ ath79_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "eth0.1 eth1" "usb0"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:3" "3:lan:2"
-		;;
-	tplink,tl-wr841hp-v3)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
 		;;
 	tplink,tl-wr842n-v2)
 		ucidef_set_interface_wan "eth1"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -613,6 +613,16 @@ define Device/tplink_tl-wr810n-v2
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
+define Device/tplink_tl-wr841hp-v3
+  $(Device/tplink-8mlzma)
+  SOC := qca9533
+  DEVICE_MODEL := TL-WR841HP
+  DEVICE_VARIANT := v3
+  TPLINK_HWID := 0x08411003
+  SUPPORTED_DEVICES += tl-wr841hp-v3
+endef
+TARGET_DEVICES += tplink_tl-wr841hp-v3
+
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   SOC := ar7241

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -619,7 +619,6 @@ define Device/tplink_tl-wr841hp-v3
   DEVICE_MODEL := TL-WR841HP
   DEVICE_VARIANT := v3
   TPLINK_HWID := 0x08411003
-  SUPPORTED_DEVICES += tl-wr841hp-v3
 endef
 TARGET_DEVICES += tplink_tl-wr841hp-v3
 


### PR DESCRIPTION
Specifications:
- QCA9533 SoC, 8 MiB nor flash, 64 MiB DDR2 RAM
- 4x Ethernet LAN 10/100, 1x Ethernet WAN 10/100
- 1x LAN, WAN, Wifi, PWR, WPS, RE Leds
- Reset, Wifi on/off, WPS, RE buttons
- Serial UART at J4 onboard: 3.3v GND RX TX, 1152008N1

Installation:

Upload openwrt-ath79-generic-tplink_tl-wr841hp-v3-squashfs-factory.bin
from stock firmware webgui

Revert back to stock firmware instructions:

- set your PC to static IP address 192.168.0.66 netmask 255.255.255.0
- download stock firmware from Tp-link website
- put it in the root directory of tftp server
- rename it to wr841hpv3_tp_recovery.bin
- power on while pressing reset button until any LED is lighting up
- wait for the router to reboot. done

This port has been tested by many people, see here
https://forum.openwrt.org/t/support-for-tp-link-tl-wr841hp-v3-router

Signed-off-by: Andy Lee <ykienyco@gmail.com>
