### PR TITLE
ramips:mt7621 ubnt fix interface setup problem

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -48,10 +48,10 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
 	ubnt,edgerouter-x)
-		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4" "eth0"
+		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
 		;;
 	ubnt,edgerouter-x-sfp)
-		ucidef_set_interface_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
+		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 		;;
 	zyxel,wap6805)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"


### PR DESCRIPTION
ucidef_set_interface_lan_wan -> ucidef_set_interfaces_lan_wan

the function name is missing a ‘s’ and makes interface setup could not complete

Fixes: 22468cc40c8b (ramips: erx and erx-sfp: fix missing WAN interface)
Signed-off-by: Nelson Cai niphor@gmail.com
