### PR TITLE
comgt: Add error check and retry mechanism for more robust initial communication with NCM modem

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -71,10 +71,25 @@ proto_ncm_setup() {
 		return 1
 	}
 
-	[ -n "$delay" ] && sleep "$delay"
-
-	manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
-	[ $? -ne 0 -o -z "$manufacturer" ] && {
+	start=$(date +%s)
+	while true; do
+		manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
+		[ "$manufacturer" = "error" ] && {
+			manufacturer=""
+		}
+		[ -n "$manufacturer" ] && {
+			break
+		}
+		[ -z "$delay" ] && {
+			break
+		}
+		sleep 1
+		elapsed=$(($(date +%s) - start))
+		[ "$elapsed" -gt "$delay" ] && {
+			break
+		}
+	done
+	[ -z "$manufacturer" ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED
 		return 1


### PR DESCRIPTION
This patch avoids NO_DEVICE failures by filtering out textual "error" responses when calling gcom. I have tested and seen how these responses sometimes fail NCM connections with my Huawei E3276 modem.
A retry loop is needed for the implementation  and this is giving the added benefit of being able to quit out early from any specified delay waiting, bringing the interface up sooner on a successful response even when a long delay is set for giving the modem time to init.