### PR TITLE
mediatek: move Device/Default to subtargets

### DIFF
--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -18,26 +18,6 @@ define Build/sysupgrade-emmc
 		$(IMAGE_ROOTFS)
 endef
 
-# default all platform image(fit) build 
-define Device/Default
-  PROFILES = Default $$(DEVICE_NAME)
-  KERNEL_NAME := zImage
-  FILESYSTEMS := squashfs
-  DEVICE_DTS_DIR := $(DTS_DIR)
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
-  SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
-ifeq ($(SUBTARGET),mt7623)
-  KERNEL_NAME := zImage
-  KERNEL := kernel-bin | append-dtb | uImage none
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
-else
-  KERNEL_NAME := Image
-  KERNEL = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-endif
-endef
-
 include $(SUBTARGET).mk
 
 define Image/Build

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -1,10 +1,21 @@
 KERNEL_LOADADDR := 0x44080000
 
+define Device/Default
+  PROFILES = Default $$(DEVICE_NAME)
+  FILESYSTEMS := squashfs
+  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
+  KERNEL_NAME := Image
+  KERNEL = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+endef
+
 define Device/bpi_bananapi-r64
   DEVICE_VENDOR := Bpi
   DEVICE_MODEL := Banana Pi R64
   DEVICE_DTS := mt7622-bananapi-bpi-r64
-  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
   SUPPORTED_DEVICES := bananapi,bpi-r64
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
 endef
@@ -14,7 +25,6 @@ define Device/bpi_bananapi-r64-rootdisk
   DEVICE_VENDOR := Bpi
   DEVICE_MODEL := Banana Pi R64 (rootdisk)
   DEVICE_DTS := mt7622-bananapi-bpi-r64-rootdisk
-  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
   SUPPORTED_DEVICES := bananapi,bpi-r64
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
   IMAGES := sysupgrade-emmc.bin.gz
@@ -26,7 +36,6 @@ define Device/elecom_wrc-2533gent
   DEVICE_VENDOR := Elecom
   DEVICE_MODEL := WRC-2533GENT
   DEVICE_DTS := mt7622-elecom-wrc-2533gent
-  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-mt7615e \
 	kmod-mt7615-firmware mt7622bt-firmware swconfig
 endef
@@ -36,7 +45,6 @@ define Device/mediatek_mt7622-rfb1
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MTK7622 rfb1 AP
   DEVICE_DTS := mt7622-rfb1
-  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
 endef
 TARGET_DEVICES += mediatek_mt7622-rfb1
@@ -45,7 +53,6 @@ define Device/mediatek_mt7622-ubi
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MTK7622 AP (UBI)
   DEVICE_DTS := mt7622-rfb1-ubi
-  DEVICE_DTS_DIR := $(DTS_DIR)/mediatek
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -53,7 +60,7 @@ define Device/mediatek_mt7622-ubi
   IMAGE_SIZE := 32768k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-                check-size $$$$(IMAGE_SIZE)
+	check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := sysupgrade-tar
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
 endef

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -25,6 +25,18 @@ define Build/banana-pi-sdcard
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE)
 endef
 
+define Device/Default
+  PROFILES = Default $$(DEVICE_NAME)
+  FILESYSTEMS := squashfs
+  DEVICE_DTS_DIR := $(DTS_DIR)
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
+  KERNEL_NAME := zImage
+  KERNEL := kernel-bin | append-dtb | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+endef
+
 define Device/bpi_bananapi-r2
   DEVICE_VENDOR := Bpi
   DEVICE_MODEL := Banana Pi R2

--- a/target/linux/mediatek/image/mt7629.mk
+++ b/target/linux/mediatek/image/mt7629.mk
@@ -1,5 +1,17 @@
 KERNEL_LOADADDR := 0x40008000
 
+define Device/Default
+  PROFILES = Default $$(DEVICE_NAME)
+  FILESYSTEMS := squashfs
+  DEVICE_DTS_DIR := $(DTS_DIR)
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
+  KERNEL_NAME := Image
+  KERNEL = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+endef
+
 define Device/mediatek_mt7629-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7629 rfb AP


### PR DESCRIPTION
For mediatek target, parts of the image defaults are set up differently
based on the subtarget already. To enhance readability and provide
better adjustment for the demands of the subtargets, the Device/Default
node is moved to the subtarget files.

While at it, fix a single indent on the way.