### PR TITLE
mvebu: armada-37xx: Backport PCI aardvark patches

### DIFF
--- a/target/linux/mvebu/patches-5.4/402-PCI-aardvark-Wait-for-endpoint-to-be-ready-before-tr.patch
+++ b/target/linux/mvebu/patches-5.4/402-PCI-aardvark-Wait-for-endpoint-to-be-ready-before-tr.patch
@@ -1,0 +1,50 @@
+From f4c7d053d7f77cd5c1a1ba7c7ce085ddba13d1d7 Mon Sep 17 00:00:00 2001
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Wed, 22 May 2019 23:33:50 +0200
+Subject: [PATCH] PCI: aardvark: Wait for endpoint to be ready before training
+ link
+
+When configuring pcie reset pin from gpio (e.g. initially set by
+u-boot) to pcie function this pin goes low for a brief moment
+asserting the PERST# signal. Thus connected device enters fundamental
+reset process and link configuration can only begin after a minimal
+100ms delay (see [1]).
+
+Because the pin configuration comes from the "default" pinctrl it is
+implicitly configured before the probe callback is called:
+
+driver_probe_device()
+  really_probe()
+    ...
+    pinctrl_bind_pins() /* Here pin goes from gpio to PCIE reset
+                           function and PERST# is asserted */
+    ...
+    drv->probe()
+
+[1] "PCI Express Base Specification", REV. 4.0
+    PCI Express, February 19 2014, 6.6.1 Conventional Reset
+
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -337,6 +337,14 @@ static void advk_pcie_setup_hw(struct ad
+ 	reg |= PIO_CTRL_ADDR_WIN_DISABLE;
+ 	advk_writel(pcie, reg, PIO_CTRL);
+ 
++	/*
++	 * PERST# signal could have been asserted by pinctrl subsystem before
++	 * probe() callback has been called, making the endpoint going into
++	 * fundamental reset. As required by PCI Express spec a delay for at
++	 * least 100ms after such a reset before link training is needed.
++	 */
++	msleep(PCI_PM_D3COLD_WAIT);
++
+ 	/* Start link training */
+ 	reg = advk_readl(pcie, PCIE_CORE_LINK_CTRL_STAT_REG);
+ 	reg |= PCIE_CORE_LINK_TRAINING;

--- a/target/linux/mvebu/patches-5.4/403-PCI-aardvark-Don-t-rely-on-jiffies-while-holding-spi.patch
+++ b/target/linux/mvebu/patches-5.4/403-PCI-aardvark-Don-t-rely-on-jiffies-while-holding-spi.patch
@@ -1,0 +1,54 @@
+From 7fbcb5da811be7d47468417c7795405058abb3da Mon Sep 17 00:00:00 2001
+From: Remi Pommarel <repk@triplefau.lt>
+Date: Fri, 27 Sep 2019 10:55:02 +0200
+Subject: [PATCH] PCI: aardvark: Don't rely on jiffies while holding spinlock
+
+advk_pcie_wait_pio() can be called while holding a spinlock (from
+pci_bus_read_config_dword()), then depends on jiffies in order to
+timeout while polling on PIO state registers. In the case the PIO
+transaction failed, the timeout will never happen and will also cause
+the cpu to stall.
+
+This decrements a variable and wait instead of using jiffies.
+
+Signed-off-by: Remi Pommarel <repk@triplefau.lt>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Andrew Murray <andrew.murray@arm.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -175,7 +175,8 @@
+ 	(PCIE_CONF_BUS(bus) | PCIE_CONF_DEV(PCI_SLOT(devfn))	| \
+ 	 PCIE_CONF_FUNC(PCI_FUNC(devfn)) | PCIE_CONF_REG(where))
+ 
+-#define PIO_TIMEOUT_MS			1
++#define PIO_RETRY_CNT			500
++#define PIO_RETRY_DELAY			2 /* 2 us*/
+ 
+ #define LINK_WAIT_MAX_RETRIES		10
+ #define LINK_WAIT_USLEEP_MIN		90000
+@@ -400,17 +401,16 @@ static void advk_pcie_check_pio_status(s
+ static int advk_pcie_wait_pio(struct advk_pcie *pcie)
+ {
+ 	struct device *dev = &pcie->pdev->dev;
+-	unsigned long timeout;
++	int i;
+ 
+-	timeout = jiffies + msecs_to_jiffies(PIO_TIMEOUT_MS);
+-
+-	while (time_before(jiffies, timeout)) {
++	for (i = 0; i < PIO_RETRY_CNT; i++) {
+ 		u32 start, isr;
+ 
+ 		start = advk_readl(pcie, PIO_START);
+ 		isr = advk_readl(pcie, PIO_ISR);
+ 		if (!start && isr)
+ 			return 0;
++		udelay(PIO_RETRY_DELAY);
+ 	}
+ 
+ 	dev_err(dev, "config read/write timed out\n");

--- a/target/linux/mvebu/patches-5.4/404-PCI-aardvark-Train-link-immediately-after-enabling-t.patch
+++ b/target/linux/mvebu/patches-5.4/404-PCI-aardvark-Train-link-immediately-after-enabling-t.patch
@@ -1,0 +1,60 @@
+From 6964494582f56a3882c2c53b0edbfe99eb32b2e1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 30 Apr 2020 10:06:14 +0200
+Subject: [PATCH] PCI: aardvark: Train link immediately after enabling training
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Adding even 100ms (PCI_PM_D3COLD_WAIT) delay between enabling link
+training and starting link training causes detection issues with some
+buggy cards (such as Compex WLE900VX).
+
+Move the code which enables link training immediately before the one
+which starts link traning.
+
+This fixes detection issues of Compex WLE900VX card on Turris MOX after
+cold boot.
+
+Link: https://lore.kernel.org/r/20200430080625.26070-2-pali@kernel.org
+Fixes: f4c7d053d7f7 ("PCI: aardvark: Wait for endpoint to be ready...")
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Rob Herring <robh@kernel.org>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -300,11 +300,6 @@ static void advk_pcie_setup_hw(struct ad
+ 	reg |= LANE_COUNT_1;
+ 	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
+ 
+-	/* Enable link training */
+-	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
+-	reg |= LINK_TRAINING_EN;
+-	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
+-
+ 	/* Enable MSI */
+ 	reg = advk_readl(pcie, PCIE_CORE_CTRL2_REG);
+ 	reg |= PCIE_CORE_CTRL2_MSI_ENABLE;
+@@ -346,7 +341,15 @@ static void advk_pcie_setup_hw(struct ad
+ 	 */
+ 	msleep(PCI_PM_D3COLD_WAIT);
+ 
+-	/* Start link training */
++	/* Enable link training */
++	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
++	reg |= LINK_TRAINING_EN;
++	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
++
++	/*
++	 * Start link training immediately after enabling it.
++	 * This solves problems for some buggy cards.
++	 */
+ 	reg = advk_readl(pcie, PCIE_CORE_LINK_CTRL_STAT_REG);
+ 	reg |= PCIE_CORE_LINK_TRAINING;
+ 	advk_writel(pcie, reg, PCIE_CORE_LINK_CTRL_STAT_REG);

--- a/target/linux/mvebu/patches-5.4/405-PCI-aardvark-Improve-link-training.patch
+++ b/target/linux/mvebu/patches-5.4/405-PCI-aardvark-Improve-link-training.patch
@@ -1,0 +1,208 @@
+From 43fc679ced18006b12d918d7a8a4af392b7fbfe7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Thu, 30 Apr 2020 10:06:17 +0200
+Subject: [PATCH] PCI: aardvark: Improve link training
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently the aardvark driver trains link in PCIe gen2 mode. This may
+cause some buggy gen1 cards (such as Compex WLE900VX) to be unstable or
+even not detected. Moreover when ASPM code tries to retrain link second
+time, these cards may stop responding and link goes down. If gen1 is
+used this does not happen.
+
+Unconditionally forcing gen1 is not a good solution since it may have
+performance impact on gen2 cards.
+
+To overcome this, read 'max-link-speed' property (as defined in PCI
+device tree bindings) and use this as max gen mode. Then iteratively try
+link training at this mode or lower until successful. After successful
+link training choose final controller gen based on Negotiated Link Speed
+from Link Status register, which should match card speed.
+
+Link: https://lore.kernel.org/r/20200430080625.26070-5-pali@kernel.org
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Rob Herring <robh@kernel.org>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 114 ++++++++++++++++++++------
+ 1 file changed, 89 insertions(+), 25 deletions(-)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -39,6 +39,7 @@
+ #define PCIE_CORE_LINK_CTRL_STAT_REG				0xd0
+ #define     PCIE_CORE_LINK_L0S_ENTRY				BIT(0)
+ #define     PCIE_CORE_LINK_TRAINING				BIT(5)
++#define     PCIE_CORE_LINK_SPEED_SHIFT				16
+ #define     PCIE_CORE_LINK_WIDTH_SHIFT				20
+ #define PCIE_CORE_ERR_CAPCTL_REG				0x118
+ #define     PCIE_CORE_ERR_CAPCTL_ECRC_CHK_TX			BIT(5)
+@@ -201,6 +202,7 @@ struct advk_pcie {
+ 	struct mutex msi_used_lock;
+ 	u16 msi_msg;
+ 	int root_bus_nr;
++	int link_gen;
+ 	struct pci_bridge_emul bridge;
+ };
+ 
+@@ -225,20 +227,16 @@ static int advk_pcie_link_up(struct advk
+ 
+ static int advk_pcie_wait_for_link(struct advk_pcie *pcie)
+ {
+-	struct device *dev = &pcie->pdev->dev;
+ 	int retries;
+ 
+ 	/* check if the link is up or not */
+ 	for (retries = 0; retries < LINK_WAIT_MAX_RETRIES; retries++) {
+-		if (advk_pcie_link_up(pcie)) {
+-			dev_info(dev, "link up\n");
++		if (advk_pcie_link_up(pcie))
+ 			return 0;
+-		}
+ 
+ 		usleep_range(LINK_WAIT_USLEEP_MIN, LINK_WAIT_USLEEP_MAX);
+ 	}
+ 
+-	dev_err(dev, "link never came up\n");
+ 	return -ETIMEDOUT;
+ }
+ 
+@@ -253,6 +251,85 @@ static void advk_pcie_wait_for_retrain(s
+ 	}
+ }
+ 
++static int advk_pcie_train_at_gen(struct advk_pcie *pcie, int gen)
++{
++	int ret, neg_gen;
++	u32 reg;
++
++	/* Setup link speed */
++	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
++	reg &= ~PCIE_GEN_SEL_MSK;
++	if (gen == 3)
++		reg |= SPEED_GEN_3;
++	else if (gen == 2)
++		reg |= SPEED_GEN_2;
++	else
++		reg |= SPEED_GEN_1;
++	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
++
++	/*
++	 * Enable link training. This is not needed in every call to this
++	 * function, just once suffices, but it does not break anything either.
++	 */
++	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
++	reg |= LINK_TRAINING_EN;
++	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
++
++	/*
++	 * Start link training immediately after enabling it.
++	 * This solves problems for some buggy cards.
++	 */
++	reg = advk_readl(pcie, PCIE_CORE_LINK_CTRL_STAT_REG);
++	reg |= PCIE_CORE_LINK_TRAINING;
++	advk_writel(pcie, reg, PCIE_CORE_LINK_CTRL_STAT_REG);
++
++	ret = advk_pcie_wait_for_link(pcie);
++	if (ret)
++		return ret;
++
++	reg = advk_readl(pcie, PCIE_CORE_LINK_CTRL_STAT_REG);
++	neg_gen = (reg >> PCIE_CORE_LINK_SPEED_SHIFT) & 0xf;
++
++	return neg_gen;
++}
++
++static void advk_pcie_train_link(struct advk_pcie *pcie)
++{
++	struct device *dev = &pcie->pdev->dev;
++	int neg_gen = -1, gen;
++
++	/*
++	 * Try link training at link gen specified by device tree property
++	 * 'max-link-speed'. If this fails, iteratively train at lower gen.
++	 */
++	for (gen = pcie->link_gen; gen > 0; --gen) {
++		neg_gen = advk_pcie_train_at_gen(pcie, gen);
++		if (neg_gen > 0)
++			break;
++	}
++
++	if (neg_gen < 0)
++		goto err;
++
++	/*
++	 * After successful training if negotiated gen is lower than requested,
++	 * train again on negotiated gen. This solves some stability issues for
++	 * some buggy gen1 cards.
++	 */
++	if (neg_gen < gen) {
++		gen = neg_gen;
++		neg_gen = advk_pcie_train_at_gen(pcie, gen);
++	}
++
++	if (neg_gen == gen) {
++		dev_info(dev, "link up at gen %i\n", gen);
++		return;
++	}
++
++err:
++	dev_err(dev, "link never came up\n");
++}
++
+ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ {
+ 	u32 reg;
+@@ -288,12 +365,6 @@ static void advk_pcie_setup_hw(struct ad
+ 		PCIE_CORE_CTRL2_TD_ENABLE;
+ 	advk_writel(pcie, reg, PCIE_CORE_CTRL2_REG);
+ 
+-	/* Set GEN2 */
+-	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
+-	reg &= ~PCIE_GEN_SEL_MSK;
+-	reg |= SPEED_GEN_2;
+-	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
+-
+ 	/* Set lane X1 */
+ 	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
+ 	reg &= ~LANE_CNT_MSK;
+@@ -341,20 +412,7 @@ static void advk_pcie_setup_hw(struct ad
+ 	 */
+ 	msleep(PCI_PM_D3COLD_WAIT);
+ 
+-	/* Enable link training */
+-	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
+-	reg |= LINK_TRAINING_EN;
+-	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
+-
+-	/*
+-	 * Start link training immediately after enabling it.
+-	 * This solves problems for some buggy cards.
+-	 */
+-	reg = advk_readl(pcie, PCIE_CORE_LINK_CTRL_STAT_REG);
+-	reg |= PCIE_CORE_LINK_TRAINING;
+-	advk_writel(pcie, reg, PCIE_CORE_LINK_CTRL_STAT_REG);
+-
+-	advk_pcie_wait_for_link(pcie);
++	advk_pcie_train_link(pcie);
+ 
+ 	reg = advk_readl(pcie, PCIE_CORE_CMD_STATUS_REG);
+ 	reg |= PCIE_CORE_CMD_MEM_ACCESS_EN |
+@@ -1036,6 +1094,12 @@ static int advk_pcie_probe(struct platfo
+ 		return ret;
+ 	}
+ 
++	ret = of_pci_get_max_link_speed(dev->of_node);
++	if (ret <= 0 || ret > 3)
++		pcie->link_gen = 3;
++	else
++		pcie->link_gen = ret;
++
+ 	advk_pcie_setup_hw(pcie);
+ 
+ 	advk_sw_pci_bridge_init(pcie);

--- a/target/linux/mvebu/patches-5.4/406-PCI-aardvark-Issue-PERST-via-GPIO.patch
+++ b/target/linux/mvebu/patches-5.4/406-PCI-aardvark-Issue-PERST-via-GPIO.patch
@@ -1,0 +1,123 @@
+From 5169a9851daaa2782a7bd2bb83d5b1bd224b2879 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 30 Apr 2020 10:06:18 +0200
+Subject: [PATCH] PCI: aardvark: Issue PERST via GPIO
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for issuing PERST via GPIO specified in 'reset-gpios'
+property (as described in PCI device tree bindings).
+
+Some buggy cards (e.g. Compex WLE900VX or WLE1216) are not detected
+after reboot when PERST is not issued during driver initialization.
+
+If bootloader already enabled link training then issuing PERST has no
+effect for some buggy cards (e.g. Compex WLE900VX) and these cards are
+not detected. We therefore clear the LINK_TRAINING_EN register before.
+
+It was observed that Compex WLE900VX card needs to be in PERST reset
+for at least 10ms if bootloader enabled link training.
+
+Tested on Turris MOX.
+
+Link: https://lore.kernel.org/r/20200430080625.26070-6-pali@kernel.org
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 43 ++++++++++++++++++++++++++-
+ 1 file changed, 42 insertions(+), 1 deletion(-)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <linux/delay.h>
++#include <linux/gpio.h>
+ #include <linux/interrupt.h>
+ #include <linux/irq.h>
+ #include <linux/irqdomain.h>
+@@ -17,6 +18,7 @@
+ #include <linux/init.h>
+ #include <linux/platform_device.h>
+ #include <linux/of_address.h>
++#include <linux/of_gpio.h>
+ #include <linux/of_pci.h>
+ 
+ #include "../pci.h"
+@@ -204,6 +206,7 @@ struct advk_pcie {
+ 	int root_bus_nr;
+ 	int link_gen;
+ 	struct pci_bridge_emul bridge;
++	struct gpio_desc *reset_gpio;
+ };
+ 
+ static inline void advk_writel(struct advk_pcie *pcie, u32 val, u64 reg)
+@@ -330,10 +333,31 @@ err:
+ 	dev_err(dev, "link never came up\n");
+ }
+ 
++static void advk_pcie_issue_perst(struct advk_pcie *pcie)
++{
++	u32 reg;
++
++	if (!pcie->reset_gpio)
++		return;
++
++	/* PERST does not work for some cards when link training is enabled */
++	reg = advk_readl(pcie, PCIE_CORE_CTRL0_REG);
++	reg &= ~LINK_TRAINING_EN;
++	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
++
++	/* 10ms delay is needed for some cards */
++	dev_info(&pcie->pdev->dev, "issuing PERST via reset GPIO for 10ms\n");
++	gpiod_set_value_cansleep(pcie->reset_gpio, 1);
++	usleep_range(10000, 11000);
++	gpiod_set_value_cansleep(pcie->reset_gpio, 0);
++}
++
+ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ {
+ 	u32 reg;
+ 
++	advk_pcie_issue_perst(pcie);
++
+ 	/* Set to Direct mode */
+ 	reg = advk_readl(pcie, CTRL_CONFIG_REG);
+ 	reg &= ~(CTRL_MODE_MASK << CTRL_MODE_SHIFT);
+@@ -406,7 +430,8 @@ static void advk_pcie_setup_hw(struct ad
+ 
+ 	/*
+ 	 * PERST# signal could have been asserted by pinctrl subsystem before
+-	 * probe() callback has been called, making the endpoint going into
++	 * probe() callback has been called or issued explicitly by reset gpio
++	 * function advk_pcie_issue_perst(), making the endpoint going into
+ 	 * fundamental reset. As required by PCI Express spec a delay for at
+ 	 * least 100ms after such a reset before link training is needed.
+ 	 */
+@@ -1094,6 +1119,22 @@ static int advk_pcie_probe(struct platfo
+ 		return ret;
+ 	}
+ 
++	pcie->reset_gpio = devm_gpiod_get_from_of_node(dev, dev->of_node,
++						       "reset-gpios", 0,
++						       GPIOD_OUT_LOW,
++						       "pcie1-reset");
++	ret = PTR_ERR_OR_ZERO(pcie->reset_gpio);
++	if (ret) {
++		if (ret == -ENOENT) {
++			pcie->reset_gpio = NULL;
++		} else {
++			if (ret != -EPROBE_DEFER)
++				dev_err(dev, "Failed to get reset-gpio: %i\n",
++					ret);
++			return ret;
++		}
++	}
++
+ 	ret = of_pci_get_max_link_speed(dev->of_node);
+ 	if (ret <= 0 || ret > 3)
+ 		pcie->link_gen = 3;

--- a/target/linux/mvebu/patches-5.4/407-PCI-aardvark-Add-PHY-support.patch
+++ b/target/linux/mvebu/patches-5.4/407-PCI-aardvark-Add-PHY-support.patch
@@ -1,0 +1,152 @@
+From 366697018c9a2aa67d457bfdc495115cface6ae8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Thu, 30 Apr 2020 10:06:20 +0200
+Subject: [PATCH] PCI: aardvark: Add PHY support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With recent proposed changes for U-Boot it is possible that bootloader
+won't initialize the PHY for this controller (currently the PHY is
+initialized regardless whether PCI is used in U-Boot, but with these
+proposed changes the PHY is initialized only on request).
+
+Since the mvebu-a3700-comphy driver by Miquèl Raynal supports enabling
+PCIe PHY, and since Linux' functionality should be independent on what
+bootloader did, add code for enabling generic PHY if found in device OF
+node.
+
+The mvebu-a3700-comphy driver does PHY powering via SMC calls to ARM
+Trusted Firmware. The corresponding code in ARM Trusted Firmware skips
+one register write which U-Boot does not: step 7 ("Enable TX"), see [1].
+Instead ARM Trusted Firmware expects PCIe driver to do this step,
+probably because the register is in PCIe controller address space,
+instead of PHY address space. We therefore add this step into the
+advk_pcie_setup_hw function.
+
+[1] https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/tree/drivers/marvell/comphy/phy-comphy-3700.c?h=v2.3-rc2#n836
+
+Link: https://lore.kernel.org/r/20200430080625.26070-8-pali@kernel.org
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Rob Herring <robh@kernel.org>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Cc: Miquèl Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 69 +++++++++++++++++++++++++++
+ 1 file changed, 69 insertions(+)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -16,6 +16,7 @@
+ #include <linux/kernel.h>
+ #include <linux/pci.h>
+ #include <linux/init.h>
++#include <linux/phy/phy.h>
+ #include <linux/platform_device.h>
+ #include <linux/of_address.h>
+ #include <linux/of_gpio.h>
+@@ -103,6 +104,8 @@
+ #define     PCIE_CORE_CTRL2_STRICT_ORDER_ENABLE	BIT(5)
+ #define     PCIE_CORE_CTRL2_OB_WIN_ENABLE	BIT(6)
+ #define     PCIE_CORE_CTRL2_MSI_ENABLE		BIT(10)
++#define PCIE_CORE_REF_CLK_REG			(CONTROL_BASE_ADDR + 0x14)
++#define     PCIE_CORE_REF_CLK_TX_ENABLE		BIT(1)
+ #define PCIE_MSG_LOG_REG			(CONTROL_BASE_ADDR + 0x30)
+ #define PCIE_ISR0_REG				(CONTROL_BASE_ADDR + 0x40)
+ #define PCIE_MSG_PM_PME_MASK			BIT(7)
+@@ -207,6 +210,7 @@ struct advk_pcie {
+ 	int link_gen;
+ 	struct pci_bridge_emul bridge;
+ 	struct gpio_desc *reset_gpio;
++	struct phy *phy;
+ };
+ 
+ static inline void advk_writel(struct advk_pcie *pcie, u32 val, u64 reg)
+@@ -358,6 +362,11 @@ static void advk_pcie_setup_hw(struct ad
+ 
+ 	advk_pcie_issue_perst(pcie);
+ 
++	/* Enable TX */
++	reg = advk_readl(pcie, PCIE_CORE_REF_CLK_REG);
++	reg |= PCIE_CORE_REF_CLK_TX_ENABLE;
++	advk_writel(pcie, reg, PCIE_CORE_REF_CLK_REG);
++
+ 	/* Set to Direct mode */
+ 	reg = advk_readl(pcie, CTRL_CONFIG_REG);
+ 	reg &= ~(CTRL_MODE_MASK << CTRL_MODE_SHIFT);
+@@ -1084,6 +1093,62 @@ out_release_res:
+ 	return err;
+ }
+ 
++static void __maybe_unused advk_pcie_disable_phy(struct advk_pcie *pcie)
++{
++	phy_power_off(pcie->phy);
++	phy_exit(pcie->phy);
++}
++
++static int advk_pcie_enable_phy(struct advk_pcie *pcie)
++{
++	int ret;
++
++	if (!pcie->phy)
++		return 0;
++
++	ret = phy_init(pcie->phy);
++	if (ret)
++		return ret;
++
++	ret = phy_set_mode(pcie->phy, PHY_MODE_PCIE);
++	if (ret) {
++		phy_exit(pcie->phy);
++		return ret;
++	}
++
++	ret = phy_power_on(pcie->phy);
++	if (ret) {
++		phy_exit(pcie->phy);
++		return ret;
++	}
++
++	return 0;
++}
++
++static int advk_pcie_setup_phy(struct advk_pcie *pcie)
++{
++	struct device *dev = &pcie->pdev->dev;
++	struct device_node *node = dev->of_node;
++	int ret = 0;
++
++	pcie->phy = devm_of_phy_get(dev, node, NULL);
++	if (IS_ERR(pcie->phy) && (PTR_ERR(pcie->phy) == -EPROBE_DEFER))
++		return PTR_ERR(pcie->phy);
++
++	/* Old bindings miss the PHY handle */
++	if (IS_ERR(pcie->phy)) {
++		dev_warn(dev, "PHY unavailable (%ld)\n", PTR_ERR(pcie->phy));
++		pcie->phy = NULL;
++		return 0;
++	}
++
++	ret = advk_pcie_enable_phy(pcie);
++	if (ret)
++		dev_err(dev, "Failed to initialize PHY (%d)\n", ret);
++
++	return ret;
++}
++
+ static int advk_pcie_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -1141,6 +1206,10 @@ static int advk_pcie_probe(struct platfo
+ 	else
+ 		pcie->link_gen = ret;
+ 
++	ret = advk_pcie_setup_phy(pcie);
++	if (ret)
++		return ret;
++
+ 	advk_pcie_setup_hw(pcie);
+ 
+ 	advk_sw_pci_bridge_init(pcie);

--- a/target/linux/mvebu/patches-5.4/408-PCI-aardvark-Don-t-touch-PCIe-registers-if-no-card-c.patch
+++ b/target/linux/mvebu/patches-5.4/408-PCI-aardvark-Don-t-touch-PCIe-registers-if-no-card-c.patch
@@ -1,0 +1,50 @@
+From 70e380250c3621c55ff218cbaf2272830d9dbb1d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 2 Jul 2020 10:30:36 +0200
+Subject: [PATCH] PCI: aardvark: Don't touch PCIe registers if no card
+ connected
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When there is no PCIe card connected and advk_pcie_rd_conf() or
+advk_pcie_wr_conf() is called for PCI bus which doesn't belong to emulated
+root bridge, the aardvark driver throws the following error message:
+
+  advk-pcie d0070000.pcie: config read/write timed out
+
+Obviously accessing PCIe registers of disconnected card is not possible.
+
+Extend check in advk_pcie_valid_device() function for validating
+availability of PCIe bus. If PCIe link is down, then the device is marked
+as Not Found and the driver does not try to access these registers.
+
+This is just an optimization to prevent accessing PCIe registers when card
+is disconnected. Trying to access PCIe registers of disconnected card does
+not cause any crash, kernel just needs to wait for a timeout. So if card
+disappear immediately after checking for PCIe link (before accessing PCIe
+registers), it does not cause any problems.
+
+Link: https://lore.kernel.org/r/20200702083036.12230-1-pali@kernel.org
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+---
+ drivers/pci/controller/pci-aardvark.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -640,6 +640,13 @@ static bool advk_pcie_valid_device(struc
+ 	if ((bus->number == pcie->root_bus_nr) && PCI_SLOT(devfn) != 0)
+ 		return false;
+ 
++	/*
++	 * If the link goes down after we check for link-up, nothing bad
++	 * happens but the config access times out.
++	 */
++	if (bus->number != pcie->root_bus_nr && !advk_pcie_link_up(pcie))
++		return false;
++
+ 	return true;
+ }
+ 

--- a/target/linux/mvebu/patches-5.4/409-phy-marvell-comphy-Convert-internal-SMCC-firmware-re.patch
+++ b/target/linux/mvebu/patches-5.4/409-phy-marvell-comphy-Convert-internal-SMCC-firmware-re.patch
@@ -1,0 +1,106 @@
+From ea17a0f153af2cd890e4ce517130dcccaa428c13 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 2 Sep 2020 16:43:43 +0200
+Subject: [PATCH] phy: marvell: comphy: Convert internal SMCC firmware return
+ codes to errno
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Driver ->power_on and ->power_off callbacks leaks internal SMCC firmware
+return codes to phy caller. This patch converts SMCC error codes to
+standard linux errno codes. Include file linux/arm-smccc.h already provides
+defines for SMCC error codes, so use them instead of custom driver defines.
+Note that return value is signed 32bit, but stored in unsigned long type
+with zero padding.
+
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Link: https://lore.kernel.org/r/20200902144344.16684-2-pali@kernel.org
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Rob Herring <robh@kernel.org>
+---
+ drivers/phy/marvell/phy-mvebu-a3700-comphy.c | 14 +++++++++++---
+ drivers/phy/marvell/phy-mvebu-cp110-comphy.c | 14 +++++++++++---
+ 2 files changed, 22 insertions(+), 6 deletions(-)
+
+--- a/drivers/phy/marvell/phy-mvebu-a3700-comphy.c
++++ b/drivers/phy/marvell/phy-mvebu-a3700-comphy.c
+@@ -26,7 +26,6 @@
+ #define COMPHY_SIP_POWER_ON			0x82000001
+ #define COMPHY_SIP_POWER_OFF			0x82000002
+ #define COMPHY_SIP_PLL_LOCK			0x82000003
+-#define COMPHY_FW_NOT_SUPPORTED			(-1)
+ 
+ #define COMPHY_FW_MODE_SATA			0x1
+ #define COMPHY_FW_MODE_SGMII			0x2
+@@ -112,10 +111,19 @@ static int mvebu_a3700_comphy_smc(unsign
+ 				  unsigned long mode)
+ {
+ 	struct arm_smccc_res res;
++	s32 ret;
+ 
+ 	arm_smccc_smc(function, lane, mode, 0, 0, 0, 0, 0, &res);
++	ret = res.a0;
+ 
+-	return res.a0;
++	switch (ret) {
++	case SMCCC_RET_SUCCESS:
++		return 0;
++	case SMCCC_RET_NOT_SUPPORTED:
++		return -EOPNOTSUPP;
++	default:
++		return -EINVAL;
++	}
+ }
+ 
+ static int mvebu_a3700_comphy_get_fw_mode(int lane, int port,
+@@ -220,7 +228,7 @@ static int mvebu_a3700_comphy_power_on(s
+ 	}
+ 
+ 	ret = mvebu_a3700_comphy_smc(COMPHY_SIP_POWER_ON, lane->id, fw_param);
+-	if (ret == COMPHY_FW_NOT_SUPPORTED)
++	if (ret == -EOPNOTSUPP)
+ 		dev_err(lane->dev,
+ 			"unsupported SMC call, try updating your firmware\n");
+ 
+--- a/drivers/phy/marvell/phy-mvebu-cp110-comphy.c
++++ b/drivers/phy/marvell/phy-mvebu-cp110-comphy.c
+@@ -123,7 +123,6 @@
+ 
+ #define COMPHY_SIP_POWER_ON	0x82000001
+ #define COMPHY_SIP_POWER_OFF	0x82000002
+-#define COMPHY_FW_NOT_SUPPORTED	(-1)
+ 
+ /*
+  * A lane is described by the following bitfields:
+@@ -273,10 +272,19 @@ static int mvebu_comphy_smc(unsigned lon
+ 			    unsigned long lane, unsigned long mode)
+ {
+ 	struct arm_smccc_res res;
++	s32 ret;
+ 
+ 	arm_smccc_smc(function, phys, lane, mode, 0, 0, 0, 0, &res);
++	ret = res.a0;
+ 
+-	return res.a0;
++	switch (ret) {
++	case SMCCC_RET_SUCCESS:
++		return 0;
++	case SMCCC_RET_NOT_SUPPORTED:
++		return -EOPNOTSUPP;
++	default:
++		return -EINVAL;
++	}
+ }
+ 
+ static int mvebu_comphy_get_mode(bool fw_mode, int lane, int port,
+@@ -819,7 +827,7 @@ static int mvebu_comphy_power_on(struct
+ 	if (!ret)
+ 		return ret;
+ 
+-	if (ret == COMPHY_FW_NOT_SUPPORTED)
++	if (ret == -EOPNOTSUPP)
+ 		dev_err(priv->dev,
+ 			"unsupported SMC call, try updating your firmware\n");
+ 

--- a/target/linux/mvebu/patches-5.4/410-PCI-aardvark-Fix-initialization-with-old-Marvell-s-A.patch
+++ b/target/linux/mvebu/patches-5.4/410-PCI-aardvark-Fix-initialization-with-old-Marvell-s-A.patch
@@ -1,0 +1,44 @@
+From b0c6ae0f8948a2be6bf4e8b4bbab9ca1343289b6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 2 Sep 2020 16:43:44 +0200
+Subject: [PATCH] PCI: aardvark: Fix initialization with old Marvell's Arm
+ Trusted Firmware
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Old ATF automatically power on pcie phy and does not provide SMC call for
+phy power on functionality which leads to aardvark initialization failure:
+
+[    0.330134] mvebu-a3700-comphy d0018300.phy: unsupported SMC call, try updating your firmware
+[    0.338846] phy phy-d0018300.phy.1: phy poweron failed --> -95
+[    0.344753] advk-pcie d0070000.pcie: Failed to initialize PHY (-95)
+[    0.351160] advk-pcie: probe of d0070000.pcie failed with error -95
+
+This patch fixes above failure by ignoring 'not supported' error in
+aardvark driver. In this case it is expected that phy is already power on.
+
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Link: https://lore.kernel.org/r/20200902144344.16684-3-pali@kernel.org
+Fixes: 366697018c9a ("PCI: aardvark: Add PHY support")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Reviewed-by: Rob Herring <robh@kernel.org>
+Cc: <stable@vger.kernel.org> # 5.8+: ea17a0f153af: phy: marvell: comphy: Convert internal SMCC firmware return codes to errno
+---
+ drivers/pci/controller/pci-aardvark.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1124,7 +1124,9 @@ static int advk_pcie_enable_phy(struct a
+ 	}
+ 
+ 	ret = phy_power_on(pcie->phy);
+-	if (ret) {
++	if (ret == -EOPNOTSUPP) {
++		dev_warn(&pcie->pdev->dev, "PHY unsupported by firmware\n");
++	} else if (ret) {
+ 		phy_exit(pcie->phy);
+ 		return ret;
+ 	}

--- a/target/linux/mvebu/patches-5.4/552-arm64-dts-marvell-armada-37xx-Set-pcie_reset_pin-to-.patch
+++ b/target/linux/mvebu/patches-5.4/552-arm64-dts-marvell-armada-37xx-Set-pcie_reset_pin-to-.patch
@@ -1,0 +1,93 @@
+From 715878016984b2617f6c1f177c50039e12e7bd5b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Thu, 30 Apr 2020 10:06:23 +0200
+Subject: [PATCH] arm64: dts: marvell: armada-37xx: Set pcie_reset_pin to gpio
+ function
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We found out that we are unable to control the PERST# signal via the
+default pin dedicated to be PERST# pin (GPIO2[3] pin) on A3700 SOC when
+this pin is in EP_PCIE1_Resetn mode. There is a register in the PCIe
+register space called PERSTN_GPIO_EN (D0088004[3]), but changing the
+value of this register does not change the pin output when measuring
+with voltmeter.
+
+We do not know if this is a bug in the SOC, or if it works only when
+PCIe controller is in a certain state.
+
+Commit f4c7d053d7f7 ("PCI: aardvark: Wait for endpoint to be ready
+before training link") says that when this pin changes pinctrl mode
+from EP_PCIE1_Resetn to GPIO, the PERST# signal is asserted for a brief
+moment.
+
+So currently the situation is that on A3700 boards the PERST# signal is
+asserted in U-Boot (because the code in U-Boot issues reset via this pin
+via GPIO mode), and then in Linux by the obscure and undocumented
+mechanism described by the above mentioned commit.
+
+We want to issue PERST# signal in a known way, therefore this patch
+changes the pcie_reset_pin function from "pcie" to "gpio" and adds the
+reset-gpios property to the PCIe node in device tree files of
+EspressoBin and Armada 3720 Dev Board (Turris Mox device tree already
+has this property and uDPU does not have a PCIe port).
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+Cc: Remi Pommarel <repk@triplefau.lt>
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-db.dts           | 3 +++
+ arch/arm64/boot/dts/marvell/armada-3720-espressobin.dtsi | 1 +
+ arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts   | 4 ----
+ arch/arm64/boot/dts/marvell/armada-37xx.dtsi             | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-db.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-db.dts
+@@ -128,6 +128,9 @@
+ 
+ /* CON15(V2.0)/CON17(V1.4) : PCIe / CON15(V2.0)/CON12(V1.4) :mini-PCIe */
+ &pcie0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_reset_pins &pcie_clkreq_pins>;
++	reset-gpios = <&gpiosb 3 GPIO_ACTIVE_LOW>;
+ 	status = "okay";
+ };
+ 
+--- a/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
+@@ -55,6 +55,7 @@
+ 	phys = <&comphy1 0>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie_reset_pins &pcie_clkreq_pins>;
++	reset-gpios = <&gpiosb 3 GPIO_ACTIVE_LOW>;
+ };
+ 
+ /* J6 */
+--- a/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
+@@ -120,10 +120,6 @@
+ 	};
+ };
+ 
+-&pcie_reset_pins {
+-	function = "gpio";
+-};
+-
+ &pcie0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie_reset_pins &pcie_clkreq_pins>;
+--- a/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
++++ b/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
+@@ -318,7 +318,7 @@
+ 
+ 				pcie_reset_pins: pcie-reset-pins {
+ 					groups = "pcie1";
+-					function = "pcie";
++					function = "gpio";
+ 				};
+ 
+ 				pcie_clkreq_pins: pcie-clkreq-pins {

--- a/target/linux/mvebu/patches-5.4/553-arm64-dts-marvell-armada-37xx-Move-PCIe-comphy-handl.patch
+++ b/target/linux/mvebu/patches-5.4/553-arm64-dts-marvell-armada-37xx-Move-PCIe-comphy-handl.patch
@@ -1,0 +1,57 @@
+From df749cdb015011e9ed8b60ebb84b4e76a9f35735 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Thu, 30 Apr 2020 10:06:24 +0200
+Subject: [PATCH] arm64: dts: marvell: armada-37xx: Move PCIe comphy handle
+ property
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Move the comphy handle property of the PCIe node from board specific
+device tree files (EspressoBin and Turris Mox) to the generic
+armada-37xx.dtsi.
+
+This is correct since this is the only possible PCIe PHY configuration
+on Armada 37xx, so when PCIe is enabled on any board, this handle is
+correct.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-espressobin.dtsi | 1 -
+ arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts   | 1 -
+ arch/arm64/boot/dts/marvell/armada-37xx.dtsi             | 1 +
+ 3 files changed, 1 insertion(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
+@@ -52,7 +52,6 @@
+ /* J9 */
+ &pcie0 {
+ 	status = "okay";
+-	phys = <&comphy1 0>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie_reset_pins &pcie_clkreq_pins>;
+ 	reset-gpios = <&gpiosb 3 GPIO_ACTIVE_LOW>;
+--- a/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
+@@ -126,7 +126,6 @@
+ 	status = "okay";
+ 	max-link-speed = <2>;
+ 	reset-gpios = <&gpiosb 3 GPIO_ACTIVE_LOW>;
+-	phys = <&comphy1 0>;
+ 
+ 	/* enabled by U-Boot if PCIe module is present */
+ 	status = "disabled";
+--- a/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
++++ b/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
+@@ -494,6 +494,7 @@
+ 					<0 0 0 2 &pcie_intc 1>,
+ 					<0 0 0 3 &pcie_intc 2>,
+ 					<0 0 0 4 &pcie_intc 3>;
++			phys = <&comphy1 0>;
+ 			pcie_intc: interrupt-controller {
+ 				interrupt-controller;
+ 				#interrupt-cells = <1>;

--- a/target/linux/mvebu/patches-5.4/554-arm64-dts-marvell-armada-37xx-Move-PCIe-max-link-spe.patch
+++ b/target/linux/mvebu/patches-5.4/554-arm64-dts-marvell-armada-37xx-Move-PCIe-max-link-spe.patch
@@ -1,0 +1,44 @@
+From 1b5a2dd9e266d78d5fddd7e6b116e47ba9577b5e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 30 Apr 2020 10:06:25 +0200
+Subject: [PATCH] arm64: dts: marvell: armada-37xx: Move PCIe max-link-speed
+ property
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Move the max-link-speed property of the PCIe node from board specific
+device tree files to the generic armada-37xx.dtsi.
+
+Armada 37xx supports only PCIe gen2 speed so max-link-speed property
+should be in the generic armada-37xx.dtsi file.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Tested-by: Tomasz Maciej Nowak <tmn505@gmail.com>
+Acked-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Signed-off-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts | 1 -
+ arch/arm64/boot/dts/marvell/armada-37xx.dtsi           | 1 +
+ 2 files changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-turris-mox.dts
+@@ -124,7 +124,6 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie_reset_pins &pcie_clkreq_pins>;
+ 	status = "okay";
+-	max-link-speed = <2>;
+ 	reset-gpios = <&gpiosb 3 GPIO_ACTIVE_LOW>;
+ 
+ 	/* enabled by U-Boot if PCIe module is present */
+--- a/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
++++ b/arch/arm64/boot/dts/marvell/armada-37xx.dtsi
+@@ -494,6 +494,7 @@
+ 					<0 0 0 2 &pcie_intc 1>,
+ 					<0 0 0 3 &pcie_intc 2>,
+ 					<0 0 0 4 &pcie_intc 3>;
++			max-link-speed = <2>;
+ 			phys = <&comphy1 0>;
+ 			pcie_intc: interrupt-controller {
+ 				interrupt-controller;


### PR DESCRIPTION
This commit contains patches for PCI aardvark driver and relevant DTS
changes for Turris MOX and EspressoBin backported from mainline kernel.
It fixes support for old ATF, various wifi cards, mainly Compex WLE900VX.