### PR TITLE
mediatek: remove condition in Device/Default

### DIFF
--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -21,21 +21,17 @@ endef
 # default all platform image(fit) build 
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)
-  KERNEL_NAME := zImage
+  KERNEL_NAME := Image
+  KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   FILESYSTEMS := squashfs
   DEVICE_DTS_DIR := $(DTS_DIR)
   IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | \
+	pad-rootfs | append-metadata
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
-ifeq ($(SUBTARGET),mt7623)
-  KERNEL_NAME := zImage
-  KERNEL := kernel-bin | append-dtb | uImage none
-  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
-else
-  KERNEL_NAME := Image
-  KERNEL = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-endif
 endef
 
 include $(SUBTARGET).mk

--- a/target/linux/mediatek/image/mt7623.mk
+++ b/target/linux/mediatek/image/mt7623.mk
@@ -29,14 +29,15 @@ define Device/bpi_bananapi-r2
   DEVICE_VENDOR := Bpi
   DEVICE_MODEL := Banana Pi R2
   DEVICE_DTS := mt7623n-bananapi-bpi-r2
-  SUPPORTED_DEVICES := bananapi,bpi-r2
+  KERNEL_NAME := zImage
+  KERNEL := kernel-bin | fit none $$(DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL_INITRAMFS :=
   DEVICE_PACKAGES := kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 kmod-mmc \
 	mkf2fs e2fsprogs kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
   UBOOT_TARGET := mt7623n_bpir2
   IMAGES := img.gz
   IMAGE/img.gz := banana-pi-sdcard | gzip | append-metadata
-  KERNEL := kernel-bin | fit none $$(DTS_DIR)/$$(DEVICE_DTS).dtb
-  KERNEL_INITRAMFS :=
+  SUPPORTED_DEVICES := bananapi,bpi-r2
 endef
 TARGET_DEVICES += bpi_bananapi-r2
 
@@ -45,9 +46,12 @@ define Device/unielec_u7623-02-emmc-512m
   DEVICE_MODEL := U7623-02
   DEVICE_VARIANT := eMMC/512MB RAM
   DEVICE_DTS := mt7623a-unielec-u7623-02-emmc-512m
-  IMAGES := sysupgrade-emmc.bin.gz
-  IMAGE/sysupgrade-emmc.bin.gz := sysupgrade-emmc | gzip | append-metadata
+  KERNEL_NAME := zImage
+  KERNEL := kernel-bin | append-dtb | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
   DEVICE_PACKAGES := kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 kmod-mmc \
 	mkf2fs e2fsprogs kmod-usb-ohci kmod-usb2 kmod-usb3 kmod-ata-ahci-mtk
+  IMAGES := sysupgrade-emmc.bin.gz
+  IMAGE/sysupgrade-emmc.bin.gz := sysupgrade-emmc | gzip | append-metadata
 endef
 TARGET_DEVICES += unielec_u7623-02-emmc-512m


### PR DESCRIPTION
The current condition with part of the variables set dependent on
the subtarget in Device/Default isn't really nice to read and also
defeats the purpose of having a default node.

This removes the special settings for mt7623 and moves them to the
individual devices, which is not much of a problem as there are
actually just two of them and they partly use different settings
anyway.

While at it, slightly adjust the order of variables and wrap some
long lines.