### PR TITLE
add dlink dir-1960-a1 and dir-2660-a1 support

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-1960-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1960-a1.dts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_dlink_dir-xx60-a1.dtsi"
+
+/ {
+	compatible = "dlink,dir-1960-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-1960 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_net_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "dir-1960-a1:orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: power_white {
+			label = "dir-1960-a1:white:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "dir-1960-a1:orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_white {
+			label = "dir-1960-a1:white:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_white {
+			label = "dir-1960-a1:white:usb";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-2660-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-2660-a1.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_dlink_dir-xx60-a1.dtsi"
+
+/ {
+	compatible = "dlink,dir-2660-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-2660 A1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_net_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "dir-2660-a1:orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: power_white {
+			label = "dir-2660-a1:white:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "dir-2660-a1:orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_white {
+			label = "dir-2660-a1:white:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2_white {
+			label = "dir-2660-a1:white:usb2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb3_white {
+			label = "dir-2660-a1:white:usb3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "config2";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+		
+		partition@180000 {
+			label = "firmware";
+			compatible = "sge,uimage";
+			reg = <0x180000 0x2800000>;
+		};
+
+		partition@2980000 {
+			label = "private";
+			reg = <0x2980000 0x2000000>;
+			read-only;
+		};
+
+		partition@4980000 {
+			label = "firmware2";
+			compatible = "sge,uimage";
+			reg = <0x4980000 0x2800000>;
+		};
+
+		partition@7180000 {
+			label = "mydlink";
+			reg = <0x7180000 0x600000>;
+			read-only;
+		};
+
+		partition@7780000 {
+			label = "reserved";
+			reg = <0x7780000 0x880000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		mtd-mac-address = <&factory 0xe000>;
+		mtd-mac-address-increment = <1>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mtd-mac-address = <&factory 0xe000>;
+		mtd-mac-address-increment = <2>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -248,6 +248,13 @@ define Device/dlink_dir-xx60-a1
 	check-size
 endef
 
+define Device/dlink_dir-1960-a1
+  $(Device/dlink_dir-xx60-a1)
+  DEVICE_MODEL := DIR-1960
+  DEVICE_VARIANT := A1
+endef
+TARGET_DEVICES += dlink_dir-1960-a1
+
 define Device/dlink_dir-2660-a1
   $(Device/dlink_dir-xx60-a1)
   DEVICE_MODEL := DIR-2660

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -232,6 +232,29 @@ define Device/dlink_dir-8xx-a1
 	check-size
 endef
 
+define Device/dlink_dir-xx60-a1
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 40960k
+  UBINIZE_OPTS := -E 5
+  DEVICE_VENDOR := D-Link
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware \
+	kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
+  KERNEL := $$(KERNEL) | uimage-padhdr 96
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+endef
+
+define Device/dlink_dir-2660-a1
+  $(Device/dlink_dir-xx60-a1)
+  DEVICE_MODEL := DIR-2660
+  DEVICE_VARIANT := A1
+endef
+TARGET_DEVICES += dlink_dir-2660-a1
+
 define Device/dlink_dir-860l-b1
   $(Device/seama)
   BLOCKSIZE := 64k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,6 +26,9 @@ d-team,pbr-m1|\
 gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
+dlink,dir-2660-a1)
+	ucidef_set_led_netdev "wan" "wan" "$boardname:white:net" "wan"
+	;;
 dlink,dir-860l-b1|\
 dlink,dir-867-a1|\
 dlink,dir-878-a1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,6 +26,7 @@ d-team,pbr-m1|\
 gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
+dlink,dir-1960-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:white:net" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -44,6 +44,7 @@ platform_do_upgrade() {
 	case "$board" in
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
+	dlink,dir-1960-a1|\
 	dlink,dir-2660-a1|\
 	hiwifi,hc5962|\
 	linksys,ea7300-v1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -44,6 +44,7 @@ platform_do_upgrade() {
 	case "$board" in
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
+	dlink,dir-2660-a1|\
 	hiwifi,hc5962|\
 	linksys,ea7300-v1|\
 	linksys,ea7500-v2|\


### PR DESCRIPTION
This continues from https://github.com/openwrt/openwrt/pull/3210 with the device trees for the dir-1960-a1 and dir-2660-a1 based on https://github.com/Lucky1openwrt/openwrt/commit/0886f9ccb629cde4add485950144f9a0e5f7567f

The only change for the existing devices (dir-867,877,882) aside the reorganization of the common device trees, is the setting of the default mac addresses for the wireless interfaces in the common device tree.