### PR TITLE
ath79: add support for Meraki MR16

### DIFF
--- a/target/linux/ath79/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ath79/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+case "$(board_name)" in
+	meraki,mr16)
+		uci set system.@system[0].compat_version="2.0"
+		uci commit system
+		;;
+esac
+
+exit 0

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7100.dtsi"
+
+/ {
+	compatible = "meraki,mr16", "qca,ar7161";
+	model = "Meraki MR16";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_orange;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi1 {
+			label = "mr16:green:wifi1";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2 {
+			label = "mr16:green:wifi2";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi3 {
+			label = "mr16:green:wifi3";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi4 {
+			label = "mr16:green:wifi4";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "mr16:green:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_orange: power_orange {
+			label = "mr16:orange:power";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_power_green: power_green {
+			label = "mr16:green:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 { /* 2.4 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&config 0x66>;
+		mtd-mac-address-increment = <1>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 { /* 5 GHz */
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&config 0x66>;
+		mtd-mac-address-increment = <2>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&config 0x66>;
+
+	pll-data = <0x00110000 0x00001099 0x00991099>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x40000>;
+				read-only;
+			};
+
+			config: partition@80000 {
+				label = "config";
+				reg = <0x80000 0x20000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "firmware";
+				reg = <0xa0000 0xf40000>;
+				compatible = "denx,uimage";
+			};
+
+			art: partition@fe0000 {
+				label = "art";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -169,6 +169,9 @@ glinet,gl-mifi)
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth1"
 	;;
+meraki,mr16)
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	;;
 netgear,wnr2200-8m|\
 netgear,wnr2200-16m)
 	ucidef_set_led_netdev "wan-amber" "WAN (amber)" "netgear:amber:wan" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -30,6 +30,7 @@ ath79_setup_interfaces()
 	engenius,ecb1750|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
+	meraki,mr16|\
 	netgear,ex6400|\
 	netgear,ex7300|\
 	ocedo,koala|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -143,6 +143,9 @@ case "$FIRMWARE" in
 		caldata_extract "caldata" 0x1000 0xeb8
 		ath9k_patch_mac_crc $(mtd_get_mac_text "caldata" 0xffa0) 0x20c
 		;;
+	meraki,mr16)
+		caldata_extract "art" 0x11000 0xeb8
+		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;
@@ -162,6 +165,9 @@ case "$FIRMWARE" in
 	dlink,dir-825-b1)
 		caldata_extract "caldata" 0x5000 0xeb8
 		ath9k_patch_mac_crc $(macaddr_add $(mtd_get_mac_text "caldata" 0xffb4) 1) 0x20c
+		;;
+	meraki,mr16)
+		caldata_extract "art" 0x15000 0xeb8
 		;;
 	*)
 		caldata_die "board $board is not supported yet"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1019,6 +1019,22 @@ define Device/librerouter_librerouter-v1
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
 
+define Device/meraki_mr16
+  SOC := ar7161
+  DEVICE_VENDOR := Meraki
+  DEVICE_MODEL := MR16
+  IMAGE_SIZE := 15616k
+  DEVICE_PACKAGES := kmod-owl-loader
+  SUPPORTED_DEVICES += mr16
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partitions differ from ar71xx version of MR16. Image format is incompatible. \
+	To use sysupgrade, you must change /lib/update/common.sh::get_image to prepend 128K zeroes to this image, \
+	and change the bootcmd in u-boot to "bootm 0xbf0a0000".  Ater that, you can use "sysupgrade -F". \
+	For more details, see the OpenWrt Wiki: https://openwrt.org/toh/meraki/mr16, \
+	or the commit message of the MR16 ath79 port on git.openwrt.org.
+endef
+TARGET_DEVICES += meraki_mr16
+
 define Device/nec_wg1200cr
   SOC := qca9563
   DEVICE_VENDOR := NEC


### PR DESCRIPTION
Port device support for Meraki MR16 from the ar71xx target to ath79.

Specifications:

  * AR7161 CPU, 16 MiB Flash, 64 MiB RAM
  * One PoE-capable Gigabit Ethernet Port
  * AR9220 / AR9223 (2x2 11an / 11n) WLAN

Installation:

  * Requires TFTP server at 192.168.1.101, w/ initramfs & sysupgrade .bins
  * Open shell case and connect a USB to TTL cable to upper serial headers
  * Power on the router; connect to U-boot over 115200-baud connection
  * Interrupt U-boot process to boot Openwrt by running:
       tftpboot 0c00000 <filename-of-initramfs-kernel>.bin;
       bootm 0c00000;
  * Copy sysupgrade image to /tmp on MR16
  * sysupgrade -i /tmp/<filename-of-sysupgrade>.bin

Notes:

  - There are two separate ARTs in the partition (offset 0x1000/0x5000 and
    0x11000/0x15000) in the OEM device. I suspect this is an OEM artifact;
    possibly used to configure the radios for different regions,
    circumstances or RF frontends. We assume the first is the correct one
    as was the case with ar71xx.

  - kmod-owl-loader is still required to load the ART partition into the
    driver.

  - The manner of storing MAC addresses is identical to in ar71xx (in
    an mtd partition labeled 'mac').

  - Migrating from ar71xx has not been thorougly tested (sysupgrade
    requires --force), but partitioning is identical to 18.06 ar71xx, so it
    should not be a problem.

  - The MR12 should be able to be migrated in a nearly identical manner as
    it shares much of its hardware with the MR16.

  - Thank-you Chris B for copious help with this port.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>

