### PR TITLE
ath79: re-enable image generation for GL-AR750S

### DIFF
--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s-nor-nand.dts
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s-nor-nand.dts
@@ -9,8 +9,21 @@
 	model = "GL.iNet GL-AR750S (NOR/NAND)";
 };
 
-&nor_kernel {
-	label = "kernel";
+&nor_partitions {
+	partition@60000 {
+		label = "kernel";
+		reg = <0x060000 0x400000>;
+
+		/*
+		 * U-Boot bootcmd is "bootm 0x9f060000".
+		 * So this might be possible to resize in the future.
+		 */
+	};
+
+	parition@460000 {
+		label = "nor_reserved";
+		reg = <0x460000 0xba0000>;
+	};
 };
 
 &nand_ubi {

--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s-nor.dts
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s-nor.dts
@@ -9,10 +9,10 @@
 	model = "GL.iNet GL-AR750S (NOR)";
 };
 
-/delete-node/ &nor_kernel;
-/delete-node/ &nor_reserved;
-
-&nor_firmware {
-	compatible = "denx,uimage";
-	label = "firmware";
+&nor_partitions {
+	partition@60000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x060000 0xfa0000>;
+	};
 };

--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dtsi
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dtsi
@@ -99,20 +99,7 @@
 				read-only;
 			};
 
-			nor_firmware: partition@60000 {
-				label = "nor_firmware";
-				reg = <0x060000 0xfa0000>;
-			};
-
-			nor_kernel: partition_alt@60000 {
-				label = "nor_kernel";
-				reg = <0x060000 0x400000>;
-			};
-
-			nor_reserved: parition_alt@460000 {
-				label = "nor_reserved";
-				reg = <0x460000 0xba0000>;
-			};
+			/* Firmware / Kernel flash type specific */
 		};
 	};
 

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -117,24 +117,15 @@ define Device/glinet_gl-ar750s-common
   DEVICE_MODEL := GL-AR750S
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2 \
 	kmod-usb-storage block-mount
-  KERNEL_SIZE := 2048k
   IMAGE_SIZE := 16000k
-  PAGESIZE := 2048
-  VID_HDR_OFFSET := 2048
 endef
 
-# NB: The kernel size is intentionally restricted at this time; see commit message
 define Device/glinet_gl-ar750s-nor-nand
   $(Device/glinet_gl-ar750s-common)
   DEVICE_VARIANT := NOR/NAND
-  BLOCKSIZE := 128k
-  GL_UBOOT_UBI_OFFSET := 2048k
-  IMAGES += factory.img
-  IMAGE/factory.img := append-kernel | pad-to $$$$(GL_UBOOT_UBI_OFFSET) | \
-	append-ubi | check-kernel-size $$$$(GL_UBOOT_UBI_OFFSET)
+  KERNEL_SIZE := 4096k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   SUPPORTED_DEVICES += glinet,gl-ar750s-nor
-  DEFAULT := n
 endef
 TARGET_DEVICES += glinet_gl-ar750s-nor-nand
 
@@ -143,7 +134,6 @@ define Device/glinet_gl-ar750s-nor
   DEVICE_VARIANT := NOR
   BLOCKSIZE := 64k
   SUPPORTED_DEVICES += gl-ar750s glinet,gl-ar750s glinet,gl-ar750s-nor-nand
-  DEFAULT := n
 endef
 TARGET_DEVICES += glinet_gl-ar750s-nor
 


### PR DESCRIPTION
The bootloader only writes the first 2MB of the image to the NOR flash
when installing the NAND factory image. The bootloader is capable of
booting larger kernels as it boots from the memory mapped SPI flash.

Disable the NAND factory image. The NAND can be bootstrapped by writing
the NAND initramfs image using the NOR upgrade method in the bootloader
web-recovery and sysupgrading from there. The NOR variant is not
affected.

Also refactor the partition definitions in the DTS to make them less
annoying to read.