### PR TITLE
octeon: add support for Itus Shield Router

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -8,6 +8,9 @@
 board_config_update
 
 case "$(board_name)" in
+itus,shield-router)
+	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
+	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"
 	;;

--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -17,6 +17,10 @@ do_sysinfo_octeon() {
 		name="erpro"
 		;;
 
+	"ITUS_SHIELD"*)
+		name="itus,shield-router"
+		;;
+
 	*)
 		name="generic"
 		;;

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -10,6 +10,11 @@ move_config() {
 			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
 			umount /mnt
 			;;
+		itus,shield-router)
+			mount -t vfat /dev/mmcblk1p1 /mnt
+			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
+			umount /mnt
+			;;
 	esac
 }
 

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -29,6 +29,15 @@ define Device/generic
 endef
 TARGET_DEVICES += generic
 
+ITUSROUTER_CMDLINE:=console=ttyS0,115200 root=/dev/mmcblk1p2 rootfstype=squashfs,ext4,f2fs rootwait
+define Device/itus_shield-router
+  DEVICE_VENDOR := Itus Networks
+  DEVICE_MODEL := Shield Router
+  CMDLINE := $(ITUSROUTER_CMDLINE)
+  IMAGE/sysupgrade.tar/squashfs += | append-metadata
+endef
+TARGET_DEVICES += itus_shield-router
+
 ER_CMDLINE:=-mtdparts=phys_mapped_flash:640k(boot0)ro,640k(boot1)ro,64k(eeprom)ro root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait
 define Device/ubnt_edgerouter
   DEVICE_VENDOR := Ubiquiti

--- a/target/linux/octeon/patches-5.4/130-itus_shield_support.patch
+++ b/target/linux/octeon/patches-5.4/130-itus_shield_support.patch
@@ -1,0 +1,42 @@
+--- a/arch/mips/include/asm/octeon/cvmx-bootinfo.h
++++ b/arch/mips/include/asm/octeon/cvmx-bootinfo.h
+@@ -297,7 +297,7 @@ enum cvmx_board_types_enum {
+ 	CVMX_BOARD_TYPE_UBNT_E100 = 20002,
+ 	CVMX_BOARD_TYPE_UBNT_E200 = 20003,
+ 	CVMX_BOARD_TYPE_UBNT_E220 = 20005,
+-	CVMX_BOARD_TYPE_CUST_DSR1000N = 20006,
++	CVMX_BOARD_TYPE_ITUS_SHIELD = 20006,
+ 	CVMX_BOARD_TYPE_KONTRON_S1901 = 21901,
+ 	CVMX_BOARD_TYPE_CUST_PRIVATE_MAX = 30000,
+
+@@ -400,7 +400,7 @@ static inline const char *cvmx_board_typ
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E100)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E200)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E220)
+-		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_DSR1000N)
++		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_ITUS_SHIELD)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_KONTRON_S1901)
+ 		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_PRIVATE_MAX)
+ 	}
+--- a/arch/mips/cavium-octeon/octeon-platform.c
++++ b/arch/mips/cavium-octeon/octeon-platform.c
+@@ -707,7 +707,7 @@ int __init octeon_prune_device_tree(void
+ 	if (fdt_check_header(initial_boot_params))
+ 		panic("Corrupt Device Tree.");
+
+-	WARN(octeon_bootinfo->board_type == CVMX_BOARD_TYPE_CUST_DSR1000N,
++	WARN(octeon_bootinfo->board_type == CVMX_BOARD_TYPE_ITUS_SHIELD,
+ 	     "Built-in DTB booting is deprecated on %s. Please switch to use appended DTB.",
+ 	     cvmx_board_type_to_string(octeon_bootinfo->board_type));
+
+--- a/arch/mips/pci/pci-octeon.c
++++ b/arch/mips/pci/pci-octeon.c
+@@ -211,7 +211,7 @@ const char *octeon_get_pci_interrupts(vo
+ 		return "AAABAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+ 	case CVMX_BOARD_TYPE_BBGW_REF:
+ 		return "AABCD";
+-	case CVMX_BOARD_TYPE_CUST_DSR1000N:
++	case CVMX_BOARD_TYPE_ITUS_SHIELD:
+ 		return "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+ 	case CVMX_BOARD_TYPE_THUNDER:
+ 	case CVMX_BOARD_TYPE_EBH3000:


### PR DESCRIPTION
octeon: add support for Itus Shield Router

Itus Networks Shield - 1Ghz dual-core mips64 / Cavium Octeon 3 SoC, 
1Gb RAM, 4Gb eMMC,3 GbE 10/100/1000 ports

Information regarding device can be found: 
https://deviwiki.com/wiki/Itus_Networks_Shield_Pro

Installing OpenWrt on Itus Networks Shield:

1) Boot Shield
2) On device: mount /dev/mmcblk1p1 /mnt
3) scp openwrt-octeon-itus,shield-router-initramfs-kernel.bin to 
   /mnt/ItusrouterImage
3a) Optionally: scp openwrt-octeon-itus,shield-router-initramfs-kernel.bin 
    to /mnt/ItusgatewayImage to allow you to have an emergency recovery 
    boot in the GATEWAY slot - this slot will have no permament storage and 
    is used for emergency recovery only when booted in the (G)ateway 
    position
4) On device: umount /mnt
5) reboot

Once booted, run the sysupgrade via cli or luCi on the 
openwrt-octeon-itus,shield-router-squashfs-sysupgrade.tar file the mode 
you are running.

Once rebooted, the system installation is complete.  Your storage partition 
for the mode is inialized and set.

Signed-off-by: Donald Hoskins <grommish@gmail.com>
