### PR TITLE
ipq40xx: Support hard button for WPJ419

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-wpj419.dts
@@ -348,6 +348,16 @@
 			status = "okay";
 		};
 	};
+	
+	keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
 };
 
 &gmac0 {


### PR DESCRIPTION
Compex WPJ419 has a button on a GPIO pin.

Signed-off-by: Phi Nguyen <phind.uet@gmail.com>
