### PR TITLE
openvpn: Allow override of interface name

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -112,6 +112,7 @@ define Package/openvpn-$(BUILD_VARIANT)/install
 		$(1)/etc/init.d \
 		$(1)/etc/config \
 		$(1)/etc/openvpn \
+		$(1)/lib/functions \
 		$(1)/lib/upgrade/keep.d \
 		$(1)/usr/libexec \
 		$(1)/etc/hotplug.d/openvpn
@@ -127,6 +128,10 @@ define Package/openvpn-$(BUILD_VARIANT)/install
 	$(INSTALL_BIN) \
 		files/usr/libexec/openvpn-hotplug \
 		$(1)/usr/libexec/openvpn-hotplug
+
+	$(INSTALL_DATA) \
+		files/lib/functions/openvpn.sh \
+		$(1)/lib/functions/openvpn.sh
 
 	$(INSTALL_DATA) \
 		files/etc/hotplug.d/openvpn/01-user \

--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/package/network/services/openvpn/files/etc/hotplug.d/openvpn/01-user
+++ b/package/network/services/openvpn/files/etc/hotplug.d/openvpn/01-user
@@ -1,17 +1,6 @@
 #!/bin/sh
 
-get_option() {
-	local variable="$1"
-	local option="$2"
-
-	local value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+(([^ \t\\]|\\.)+)[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
-	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+'"'([^']+)'"'[ \t]*$/\1/p' "$config" | tail -n1)"
-	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+"(([^"\\]|\\.)+)"[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
-	[ -n "$value" ] || return 1
-
-	export -n "$variable=$value"
-	return 0
-}
+. /lib/functions/openvpn.sh
 
 [ -e "/etc/openvpn.user" ] && {
 	env -i ACTION="$ACTION" INSTANCE="$INSTANCE" \
@@ -23,7 +12,7 @@ get_option() {
 # Wrap user defined scripts on up/down events
 case "$ACTION" in
 	up|down)
-		if get_option command "$ACTION"; then
+		if get_openvpn_option "$config" command "$ACTION"; then
 			exec /bin/sh -c "$command $ACTION $INSTANCE $*"
 		fi
 	;;

--- a/package/network/services/openvpn/files/lib/functions/openvpn.sh
+++ b/package/network/services/openvpn/files/lib/functions/openvpn.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+get_openvpn_option() {
+	local config="$1"
+	local variable="$2"
+	local option="$3"
+
+	local value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+(([^ \t\\]|\\.)+)[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+'"'([^']+)'"'[ \t]*$/\1/p' "$config" | tail -n1)"
+	[ -n "$value" ] || value="$(sed -rne 's/^[ \t]*'"$option"'[ \t]+"(([^"\\]|\\.)+)"[ \t]*$/\1/p' "$config" | tail -n1 | sed -re 's/\\(.)/\1/g')"
+	[ -n "$value" ] || return 1
+
+	export -n "$variable=$value"
+	return 0
+}
+

--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -69,6 +69,40 @@ section_enabled() {
 	[ $enable -gt 0 ] || [ $enabled -gt 0 ]
 }
 
+openvpn_get_dev() {
+	local dev dev_type
+	local name="$1"
+	local conf="$2"
+
+	# Do override only for configurations with config_file
+	config_get config_file "$name" config
+	[ -n "$config_file" ] || return
+
+	# Check there is someething to override
+	config_get dev "$name" dev
+	config_get dev_type "$name" dev_type
+	[ -n "$dev" ] || return
+
+	# If there is a no dev_type, try to guess it
+	if [ -z "$dev_type" ]; then
+		. /lib/functions/openvpn.sh
+
+		local odev odev_type
+		get_openvpn_option "$conf" odev dev
+		get_openvpn_option "$conf" odev_type dev-type
+		[ -n "$odev_type" ] || odev_type="$odev"
+
+		case "$odev_type" in
+			tun*) dev_type="tun" ;;
+			tap*) dev_type="tap" ;;
+			*) return;;
+		esac
+	fi
+
+	# Return overrides
+	echo "--dev-type $dev_type --dev $dev"
+}
+
 openvpn_add_instance() {
 	local name="$1"
 	local dir="$2"
@@ -83,7 +117,8 @@ openvpn_add_instance() {
 		--config "$conf" \
 		--up "/usr/libexec/openvpn-hotplug up $name" \
 		--down "/usr/libexec/openvpn-hotplug down $name" \
-		--script-security "${security:-2}"
+		--script-security "${security:-2}" \
+		$(openvpn_get_dev "$name" "$conf")
 	procd_set_param file "$dir/$conf"
 	procd_set_param term_timeout 15
 	procd_set_param respawn


### PR DESCRIPTION
If using a configuration file for OpenVPN, allow overriding name of the
interface. The reason is that then people could use configuration file
provided by VPN provider directly and override the name of the interface
to include it in correct firewall zone without need to alter the
configuration file.

Signed-off-by: Michal Hrusecky <michal@hrusecky.net>