### PR TITLE
ath79/mikrotik: Use base mac on lan interface for RBwAPG-5HacT2HnD

### DIFF
--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -34,6 +34,10 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,routerboard-wap-g-5hact2hnd)
+		label_mac="$mac_base"
+		lan_mac="$mac_base"
+		;;
 	*)
 		label_mac="$mac_base"
 		wan_mac="$mac_base"


### PR DESCRIPTION
Since the Mikrotik RBwAPG-5HacT2HnD has only a single ethernet interface
(lan), it makes sense to use the device base mac on the label for the
lan interface.
