### PR TITLE
lantiq: xrx200net-legacy: remove auto-enable routine in set_vlan_ports()

### DIFF
--- a/target/linux/lantiq/patches-5.4/0025-NET-MIPS-lantiq-adds-xrx200-legacy.patch
+++ b/target/linux/lantiq/patches-5.4/0025-NET-MIPS-lantiq-adds-xrx200-legacy.patch
@@ -209,7 +209,7 @@ Subject: NET: MIPS: lantiq: adds xrx200 ethernet and switch driver
 +};
 --- /dev/null
 +++ b/drivers/net/ethernet/lantiq_xrx200_legacy.c
-@@ -0,0 +1,1927 @@
+@@ -0,0 +1,1913 @@
 +/*
 + *   This program is free software; you can redistribute it and/or modify it
 + *   under the terms of the GNU General Public License version 2 as published
@@ -816,20 +816,6 @@ Subject: NET: MIPS: lantiq: adds xrx200 ethernet and switch driver
 +
 +	tem.index = val->port_vlan;
 +	xrx200_pce_table_entry_read(&tem);
-+
-+	// auto-enable this vlan if not enabled already
-+	if (tem.val[0] == 0)
-+	{
-+		struct switch_val v;
-+		v.port_vlan = val->port_vlan;
-+		v.value.i = val->port_vlan;
-+		if(xrx200sw_set_vlan_vid(dev, NULL, &v))
-+			return -EINVAL;
-+
-+		//read updated tem
-+		tem.index = val->port_vlan;
-+		xrx200_pce_table_entry_read(&tem);
-+	}
 +
 +	tem.val[1] = portmap;
 +	tem.val[2] = tagmap;


### PR DESCRIPTION
This auto-enabling leads to problems when you try to set up some vlan
config and do set the ports before setting the vid of the vlan table
entries.

example:

swconfig dev switch0 vlan 2 set ports "2t 6t"
swconfig dev switch0 vlan 2 set vid 3

swconfig dev switch0 vlan 3 set ports "3t 6t"
-> Error, because the auto-enable routine in xrx200sw_set_vlan_ports()
will then try to implicitly set vid to "3" (the table index) which is
already used by vlan 2 and therefore results in an error.

As the swconfig load command also reads the options line by line from
/etc/config/network, this problem could also occur when the order of the
options of a switch_vlan section is ports before vid.

Also, I can't imagine any reason why we would need this auto-enable
"feature".

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
