### PR TITLE
base-files: fix rc.common help alignment

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=233
+PKG_RELEASE:=234
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -62,20 +62,24 @@ depends() {
 	return 0
 }
 
+EXTRA_HELP=""
+EXTRA_COMMANDS="boot shutdown depends"
+extra_command() {
+	local cmd="$1"
+	local help="$2"
+
+	local extra="$(printf "%-16s%s" "${cmd}" "${help}")"
+	EXTRA_HELP="${EXTRA_HELP}\t${extra}\n"
+	EXTRA_COMMANDS="${EXTRA_COMMANDS} ${cmd}"
+}
+
 help() {
 	cat <<EOF
 Syntax: $initscript [command]
 
 Available commands:
-	start	Start the service
-	stop	Stop the service
-	restart	Restart the service
-	reload	Reload configuration files (or restart if service does not implement reload)
-	enable	Enable service autostart
-	disable	Disable service autostart
-	enabled	Check if service is started on boot
-$EXTRA_HELP
 EOF
+	echo -e "$EXTRA_HELP"
 }
 
 # for procd
@@ -103,14 +107,20 @@ service_running() {
 
 ${INIT_TRACE:+set -x}
 
+extra_command "start" "Start the service"
+extra_command "stop" "Stop the service"
+extra_command "restart" "Restart the service"
+extra_command "reload" "Reload configuration files (or restart if service does not implement reload)"
+extra_command "enable" "Enable service autostart"
+extra_command "disable" "Disable service autostart"
+extra_command "enabled" "Check if service is started on boot"
+
 . "$initscript"
 
 [ -n "$USE_PROCD" ] && {
-	EXTRA_COMMANDS="${EXTRA_COMMANDS} running status trace"
-	EXTRA_HELP="\
-	running	Check if service is running
-	status	Service status
-${EXTRA_HELP}"
+	extra_command "running" "Check if service is running"
+	extra_command "status" "Service status"
+	extra_command "trace" "Start with syscall trace"
 
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")
@@ -165,6 +175,6 @@ ${EXTRA_HELP}"
 	}
 }
 
-ALL_COMMANDS="start stop reload restart boot shutdown enable disable enabled depends ${EXTRA_COMMANDS}"
+ALL_COMMANDS="${EXTRA_COMMANDS}"
 list_contains ALL_COMMANDS "$action" || action=help
 $action "$@"

--- a/package/network/config/ltq-adsl-app/Makefile
+++ b/package/network/config/ltq-adsl-app/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dsl_cpe_control_danube
 PKG_VERSION:=3.24.4.4
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/dsl_cpe_control-$(PKG_VERSION)
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources/

--- a/package/network/config/ltq-adsl-app/files/dsl_control
+++ b/package/network/config/ltq-adsl-app/files/dsl_control
@@ -4,9 +4,8 @@
 START=97
 USE_PROCD=1
 
-EXTRA_COMMANDS="dslstat lucistat"
-EXTRA_HELP="	dslstat Get DSL status information
-	lucistat Get status information in lua friendly format"
+extra_command "dslstat" "Get DSL status information"
+extra_command "lucistat" "Get status information in lua friendly format"
 
 . /lib/functions/lantiq_dsl.sh
 

--- a/package/network/config/ltq-vdsl-app/Makefile
+++ b/package/network/config/ltq-vdsl-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-app
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 PKG_BASE_NAME:=dsl_cpe_control
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://mirror2.openwrt.org/sources

--- a/package/network/config/ltq-vdsl-app/files/dsl_control
+++ b/package/network/config/ltq-vdsl-app/files/dsl_control
@@ -4,9 +4,8 @@
 START=97
 USE_PROCD=1
 
-EXTRA_COMMANDS="dslstat lucistat"
-EXTRA_HELP="	dslstat Get DSL status information
-	lucistat Get status information in lua friendly format"
+extra_command "dslstat" "Get DSL status information"
+extra_command "lucistat" "Get status information in lua friendly format"
 
 . /lib/functions/lantiq_dsl.sh
 

--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2020.80
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -9,8 +9,8 @@ USE_PROCD=1
 PROG=/usr/sbin/dropbear
 NAME=dropbear
 PIDCOUNT=0
-EXTRA_COMMANDS="killclients"
-EXTRA_HELP="	killclients Kill ${NAME} processes except servers and yourself"
+
+extra_command "killclients" "Kill ${NAME} processes except servers and yourself"
 
 _dropbearkey()
 {

--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zram-swap
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -2,9 +2,8 @@
 
 START=15
 
-EXTRA_COMMANDS="compact status"
-EXTRA_HELP="        compact trigger compaction for all Z-RAM swap dev's
-        status  print out status information & statistics about Z-RAM swap devices"
+extra_command "compact" "Trigger compaction for all Z-RAM swap dev's"
+extra_command "status" "Print out information & statistics about Z-RAM swap devices"
 
 ram_getsize()
 {


### PR DESCRIPTION
Add a new function `extra_command` to encapsulate the `EXTRA_HELP` and `EXTRA_COMMANDS` handling. 

**All init scripts in the package feed have to be adjusted as well.**