### PR TITLE
ath79: increase spi frequency on TL-WDR3500/3600/4300/4310

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -78,7 +78,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <33000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
SPI Flash chip support up to 33 MHz wihout fast read opcode.
Avaible frequencies are 112.5, 56.25, 37.5, 28.125, 22.5 etc.
This patch increases this frequency from 22.5 to 28.125 Mhz.

Formula to calculate SPI frequency:
Freq = 225 MHz / 2 / div

Before:

$ time dd if=/dev/mtd1 of=/dev/null bs=8M
0+1 records in
0+1 records out
real	0m 3.58s
user	0m 0.00s
sys	0m 3.57s

After:

$ time dd if=/dev/mtd1 of=/dev/null bs=8M
0+1 records in
0+1 records out
real	0m 2.95s
user	0m 0.00s
sys	0m 2.93s

Runtested on WDR4300.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
