### PR TITLE
busybox: Add cpio applet support

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -381,10 +381,10 @@ config BUSYBOX_DEFAULT_FEATURE_BZIP2_DECOMPRESS
 	default y
 config BUSYBOX_DEFAULT_CPIO
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_CPIO_O
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_CPIO_P
 	bool
 	default n


### PR DESCRIPTION
Add busybox cpio -o functionality which is needed in order to be
able to create initramfs images on an OpenWRT system.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>