### PR TITLE
[OpenWrt 19.07] curl: patch CVE-2020-8169

### DIFF
--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=curl
 PKG_VERSION:=7.66.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://dl.uxnr.de/mirror/curl/ \

--- a/package/network/utils/curl/patches/101-CVE-2020-8169.patch
+++ b/package/network/utils/curl/patches/101-CVE-2020-8169.patch
@@ -1,0 +1,38 @@
+From 600a8cded447cd7118ed50142c576567c0cf5158 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 14 May 2020 14:37:12 +0200
+Subject: [PATCH] url: make the updated credentials URL-encoded in the URL
+
+Found-by: Gregory Jefferis
+Reported-by: Jeroen Ooms
+Added test 1168 to verify. Bug spotted when doing a redirect.
+Bug: https://github.com/jeroen/curl/issues/224
+Closes #5400
+---
+ lib/url.c               |  6 ++--
+ tests/data/Makefile.inc |  1 +
+ tests/data/test1168     | 78 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 83 insertions(+), 2 deletions(-)
+ create mode 100644 tests/data/test1168
+
+diff --git a/lib/url.c b/lib/url.c
+index f250f2ff20a..9b8b2bdde64 100644
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -2788,12 +2788,14 @@ static CURLcode override_login(struct Curl_easy *data,
+ 
+   /* for updated strings, we update them in the URL */
+   if(user_changed) {
+-    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp, 0);
++    uc = curl_url_set(data->state.uh, CURLUPART_USER, *userp,
++                      CURLU_URLENCODE);
+     if(uc)
+       return Curl_uc_to_curlcode(uc);
+   }
+   if(passwd_changed) {
+-    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp, 0);
++    uc = curl_url_set(data->state.uh, CURLUPART_PASSWORD, *passwdp,
++                      CURLU_URLENCODE);
+     if(uc)
+       return Curl_uc_to_curlcode(uc);
+   }


### PR DESCRIPTION
This PR patches CVE-2020-8169

Affected versions: curl 7.62.0 to and including 7.70.0
https://curl.haxx.se/docs/CVE-2020-8169.html

Run tested on Omnia with OpenWrt 19.07