### PR TITLE
ath79/nand: add support for Netgear WNDR4300TN

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -64,6 +64,7 @@ netgear,wndrmac-v1)
 	;;
 netgear,wndr3700-v4|\
 netgear,wndr4300|\
+netgear,wndr4300tn|\
 netgear,wndr4300sw)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
 	;;

--- a/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
@@ -57,16 +57,6 @@
 			default-state = "keep";
 		};
 
-		wan_green {
-			label = "netgear:green:wan";
-			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "netgear:amber:wan";
-			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
 		wlan2g_green {
 			label = "netgear:green:wlan2g";
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
@@ -87,13 +77,6 @@
 		wps_amber {
 			label = "netgear:amber:wps";
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
-		};
-
-		usb_green {
-			label = "netgear:green:usb";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&hub_port>;
-			linux,default-trigger = "usbport";
 		};
 	};
 
@@ -272,28 +255,6 @@
 		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
-
-		usb_power {
-			gpio-hog;
-			line-name = "netgear:power:usb";
-			gpios = <0 GPIO_ACTIVE_HIGH>;
-			output-high;
-		};
-	};
-};
-
-&usb_phy {
-	status = "okay";
-};
-
-&usb {
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	hub_port: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_netgear_wndr3700-v4.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr3700-v4.dts
@@ -2,6 +2,8 @@
 /dts-v1/;
 
 #include "ar9344_netgear_wndr.dtsi"
+#include "ar9344_netgear_wndr_wan.dtsi"
+#include "ar9344_netgear_wndr_usb.dtsi"
 
 / {
 	compatible = "netgear,wndr3700-v4", "qca,ar9344";

--- a/target/linux/ath79/dts/ar9344_netgear_wndr4300.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr4300.dts
@@ -2,6 +2,8 @@
 /dts-v1/;
 
 #include "ar9344_netgear_wndr.dtsi"
+#include "ar9344_netgear_wndr_wan.dtsi"
+#include "ar9344_netgear_wndr_usb.dtsi"
 
 / {
 	compatible = "netgear,wndr4300", "qca,ar9344";

--- a/target/linux/ath79/dts/ar9344_netgear_wndr4300sw.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr4300sw.dts
@@ -2,6 +2,8 @@
 /dts-v1/;
 
 #include "ar9344_netgear_wndr.dtsi"
+#include "ar9344_netgear_wndr_wan.dtsi"
+#include "ar9344_netgear_wndr_usb.dtsi"
 
 / {
 	compatible = "netgear,wndr4300sw", "qca,ar9344";

--- a/target/linux/ath79/dts/ar9344_netgear_wndr4300tn.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr4300tn.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "ar9344_netgear_wndr.dtsi"
+
+/ {
+	compatible = "netgear,wndr4300tn", "qca,ar9344";
+	model = "Netgear WNDR4300TN";
+};

--- a/target/linux/ath79/dts/ar9344_netgear_wndr_usb.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr_usb.dtsi
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	leds {
+		usb_green {
+			label = "netgear:green:usb";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+
+&ath9k {
+	usb_power {
+		gpio-hog;
+		line-name = "netgear:power:usb";
+		gpios = <0 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_netgear_wndr_wan.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr_wan.dtsi
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	leds {
+		wan_green {
+			label = "netgear:green:wan";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "netgear:amber:wan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -206,6 +206,16 @@ define Device/netgear_wndr4300sw
 endef
 TARGET_DEVICES += netgear_wndr4300sw
 
+define Device/netgear_wndr4300tn
+  SOC := ar9344
+  DEVICE_MODEL := WNDR4300TN
+  NETGEAR_KERNEL_MAGIC := 0x33373033
+  NETGEAR_BOARD_ID := WNDR4300TN
+  NETGEAR_HW_ID := 29763948+0+128+128+2x2+3x3
+  $(Device/netgear_ath79_nand)
+endef
+TARGET_DEVICES += netgear_wndr4300tn
+
 define Device/netgear_wndr4300-v2
   SOC := qca9563
   DEVICE_MODEL := WNDR4300

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -29,6 +29,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
+	netgear,wndr4300tn)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	zyxel,nbg6716)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -15,6 +15,7 @@ case "$FIRMWARE" in
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\
+	netgear,wndr4300tn|\
 	netgear,wndr4300-v2|\
 	netgear,wndr4500-v3)
 		caldata_extract "caldata" 0x1000 0x440
@@ -29,6 +30,7 @@ case "$FIRMWARE" in
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\
+	netgear,wndr4300tn|\
 	netgear,wndr4300-v2|\
 	netgear,wndr4500-v3)
 		caldata_extract "caldata" 0x5000 0x440


### PR DESCRIPTION
This patch adds support for the WNDR4300TN, marketed by Belgian ISP
Telenet. The hardware is the same as the WNDR4300 v1, without the
fifth ethernet port (WAN) and the USB port. The circuit board has
the traces, but the components are missing.

Signed-off-by: Davy Hollevoet <github@natox.be>