### PR TITLE
kirkwood: get rid of BOARD_NAME and tidy up DEVICE_DTS

### DIFF
--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -17,7 +17,7 @@ endef
 
 define Device/Default
   PROFILES := Default
-  DEVICE_DTS = $$(if $$(BOARD_NAME),kirkwood-$$(BOARD_NAME),)
+  DEVICE_DTS = kirkwood-$(lastword $(subst _, ,$(1)))
   KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
   KERNEL := kernel-bin | append-dtb | uImage none
   KERNEL_NAME := zImage
@@ -30,13 +30,12 @@ define Device/Default
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-ubi
-  SUPPORTED_DEVICES = $(subst _,$(comma),$(1)) $$(BOARD_NAME)
+  SUPPORTED_DEVICES = $(subst _,$(comma),$(1))
 endef
 
 define Device/checkpoint_l-50
   DEVICE_VENDOR := Check Point
   DEVICE_MODEL := L-50
-  DEVICE_DTS := kirkwood-l-50
   DEVICE_PACKAGES := kmod-ath9k kmod-gpio-button-hotplug kmod-mvsdio \
 	kmod-rtc-s35390a kmod-usb-ledtrig-usbport wpad-basic
   IMAGES := sysupgrade.bin
@@ -50,15 +49,16 @@ define Device/cisco_on100
   KERNEL_IN_UBI :=
   UBINIZE_OPTS := -E 5
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
-  BOARD_NAME := on100
   DEVICE_PACKAGES := kmod-mvsdio
+  SUPPORTED_DEVICES += on100
 endef
 TARGET_DEVICES += cisco_on100
 
 define Device/cloudengines_pogoe02
   DEVICE_VENDOR := Cloud Engines
   DEVICE_MODEL := Pogoplug E02
-  BOARD_NAME := pogo_e02
+  DEVICE_DTS := kirkwood-pogo_e02
+  SUPPORTED_DEVICES += pogo_e02
 endef
 TARGET_DEVICES += cloudengines_pogoe02
 
@@ -74,7 +74,8 @@ TARGET_DEVICES += cloudengines_pogoplugv4
 define Device/iom_iconnect-1.1
   DEVICE_VENDOR := Iomega
   DEVICE_MODEL := Iconnect
-  BOARD_NAME := iconnect
+  DEVICE_DTS := kirkwood-iconnect
+  SUPPORTED_DEVICES += iconnect
 endef
 TARGET_DEVICES += iom_iconnect-1.1
 
@@ -109,7 +110,6 @@ define Device/linksys_e4200-v2
   $(Device/dsa-migration)
   DEVICE_MODEL := E4200
   DEVICE_VARIANT := v2
-  DEVICE_DTS := kirkwood-e4200-v2
   KERNEL_SIZE := 2688k
   SUPPORTED_DEVICES += linksys,viper linksys-viper
 endef
@@ -119,7 +119,6 @@ define Device/linksys_ea3500
   $(Device/linksys)
   $(Device/dsa-migration)
   DEVICE_MODEL := EA3500
-  DEVICE_DTS := kirkwood-ea3500
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
@@ -132,7 +131,6 @@ define Device/linksys_ea4500
   $(Device/linksys)
   $(Device/dsa-migration)
   DEVICE_MODEL := EA4500
-  DEVICE_DTS := kirkwood-ea4500
   KERNEL_SIZE := 2688k
   SUPPORTED_DEVICES += linksys,viper linksys-viper
 endef
@@ -141,31 +139,32 @@ TARGET_DEVICES += linksys_ea4500
 define Device/raidsonic_ib-nas62x0
   DEVICE_VENDOR := RaidSonic
   DEVICE_MODEL := ICY BOX IB-NAS62x0
-  BOARD_NAME := ib62x0
+  DEVICE_DTS := kirkwood-ib62x0
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  SUPPORTED_DEVICES += ib62x0
 endef
 TARGET_DEVICES += raidsonic_ib-nas62x0
 
 define Device/seagate_dockstar
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := FreeAgent Dockstar
-  BOARD_NAME := dockstar
+  SUPPORTED_DEVICES += dockstar
 endef
 TARGET_DEVICES += seagate_dockstar
 
 define Device/seagate_goflexnet
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := GoFlexNet
-  BOARD_NAME := goflexnet
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  SUPPORTED_DEVICES += goflexnet
 endef
 TARGET_DEVICES += seagate_goflexnet
 
 define Device/seagate_goflexhome
   DEVICE_VENDOR := Seagate
   DEVICE_MODEL := GoFlexHome
-  BOARD_NAME := goflexhome
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4
+  SUPPORTED_DEVICES += goflexhome
 endef
 TARGET_DEVICES += seagate_goflexhome
 
@@ -174,7 +173,7 @@ define Device/zyxel_nsa310b
   DEVICE_MODEL := NSA310b
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-r8169 kmod-fs-ext4 \
 	kmod-gpio-button-hotplug kmod-hwmon-lm85
-  BOARD_NAME := nsa310b
+  SUPPORTED_DEVICES += nsa310b
 endef
 TARGET_DEVICES += zyxel_nsa310b
 
@@ -182,7 +181,6 @@ define Device/zyxel_nsa310s
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NSA310S
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 kmod-gpio-button-hotplug
-  DEVICE_DTS := kirkwood-nsa310s
 endef
 TARGET_DEVICES += zyxel_nsa310s
 
@@ -192,7 +190,7 @@ define Device/zyxel_nsa325
   DEVICE_VARIANT := v1/v2
   DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
 	kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-usb3
-  BOARD_NAME := nsa325
+  SUPPORTED_DEVICES += nsa325
 endef
 TARGET_DEVICES += zyxel_nsa325
 


### PR DESCRIPTION
Since most of the DTS file names follow a common scheme now, let's
update the automatically generated DEVICE_DTS value and get rid
of some DEVICE_DTS and all BOARD_NAME entries for individual devices.

This should specifically make the job easier for developers adding
new devices, as they are not tempted to copy over BOARD_NAME anymore.