### PR TITLE
octeon: add support for Unifi Security Gateway 3P

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -8,7 +8,8 @@
 board_config_update
 
 case "$(board_name)" in
-itus,shield-router)
+itus,shield-router | \
+ubnt,unifi-security-gateway-3p)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;
 *)

--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -9,6 +9,10 @@ do_sysinfo_octeon() {
 		name="erlite"
 		;;
 
+	"UBNT_E120"*)
+		name="ubnt,unifi-security-gateway-3p"
+		;;
+
 	"UBNT_E200"*)
 		name="er"
 		;;

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -15,7 +15,8 @@ octeon_move_config() {
 	. /lib/functions.sh
 
 	case "$(board_name)" in
-		erlite)
+		erlite | \
+		ubnt,unifi-security-gateway-3p)
 			move_config "/dev/sda1"
 			;;
 		itus,shield-router)

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -19,7 +19,8 @@ platform_get_rootfs() {
 
 platform_copy_config() {
 	case "$(board_name)" in
-	erlite)
+	erlite | \
+	ubnt,unifi-security-gateway-3p)
 		mount -t vfat /dev/sda1 /mnt
 		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
 		umount /mnt
@@ -81,7 +82,8 @@ platform_do_upgrade() {
 	er)
 		kernel=mmcblk0p1
 		;;
-	erlite)
+	erlite | \
+	ubnt,unifi-security-gateway-3p)
 		kernel=sda1
 		;;
 	itus,shield-router)
@@ -107,7 +109,8 @@ platform_check_image() {
 	case "$board" in
 	er | \
 	erlite | \
-	itus,shield-router)
+	itus,shield-router \
+	ubnt,unifi-security-gateway-3p)
 		local kernel_length=$(tar xf $tar_file $board_dir/kernel -O | wc -c 2> /dev/null)
 		local rootfs_length=$(tar xf $tar_file $board_dir/root -O | wc -c 2> /dev/null)
 		[ "$kernel_length" = 0 -o "$rootfs_length" = 0 ] && {

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -57,4 +57,13 @@ define Device/ubnt_edgerouter-lite
 endef
 TARGET_DEVICES += ubnt_edgerouter-lite
 
+USG3P_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0)ro,512k(boot1)ro,64k(eeprom)ro root=/dev/sda2 rootfstype=squashfs,ext4 rootwait
+define Device/ubnt_unifi-security-gateway-3p
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi Security Gateway 3P
+  DEVICE_PACKAGES := kmod-leds-gpio kmod-ledtrig-gpio
+  CMDLINE := $(USG3P_CMDLINE)
+endef
+TARGET_DEVICES += ubnt_unifi-security-gateway-3p
+
 $(eval $(call BuildImage))

--- a/target/linux/octeon/patches-5.4/140-ubnt_usg_erlite_support.patch
+++ b/target/linux/octeon/patches-5.4/140-ubnt_usg_erlite_support.patch
@@ -1,0 +1,107 @@
+--- a/arch/mips/boot/dts/cavium-octeon/ubnt_e100.dts
++++ b/arch/mips/boot/dts/cavium-octeon/ubnt_e100.dts
+@@ -5,10 +5,26 @@
+  * Written by: Aaro Koskinen <aaro.koskinen@iki.fi>
+  */
+
++#include <dt-bindings/gpio/gpio.h>
++
+ /include/ "octeon_3xxx.dtsi"
+
+ / {
+-	model = "ubnt,e100";
++	compatible = "ubnt,e100", "ubnt,e120";
++
++	leds {
++		compatible = "gpio-leds";
++
++		white {
++			label = "ubnt:white:dome";
++			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
++		};
++
++		blue {
++			label = "ubnt:blue:dome";
++			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
++		};
++	};
+
+ 	soc@0 {
+ 		smi0: mdio@1180000001800 {
+--- a/arch/mips/boot/dts/cavium-octeon/Makefile
++++ b/arch/mips/boot/dts/cavium-octeon/Makefile
+@@ -1,2 +1,2 @@
+ # SPDX-License-Identifier: GPL-2.0
+-dtb-$(CONFIG_CAVIUM_OCTEON_SOC)	+= octeon_3xxx.dtb octeon_68xx.dtb
++dtb-$(CONFIG_CAVIUM_OCTEON_SOC)	+= octeon_3xxx.dtb octeon_68xx.dtb ubnt_e100.dtb
+--- a/arch/mips/include/asm/octeon/cvmx-bootinfo.h
++++ b/arch/mips/include/asm/octeon/cvmx-bootinfo.h
+@@ -295,6 +295,7 @@ enum cvmx_board_types_enum {
+	 */
+	CVMX_BOARD_TYPE_CUST_PRIVATE_MIN = 20001,
+	CVMX_BOARD_TYPE_UBNT_E100 = 20002,
++	CVMX_BOARD_TYPE_UBNT_E120 = 20004,
+	CVMX_BOARD_TYPE_UBNT_E200 = 20003,
+	CVMX_BOARD_TYPE_UBNT_E220 = 20005,
+	CVMX_BOARD_TYPE_CUST_DSR1000N = 20006,
+@@ -398,6 +399,7 @@ static inline const char *cvmx_board_type_to_string(enum
+		    /* Customer private range */
+		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_PRIVATE_MIN)
+		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E100)
++		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E120)
+		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E200)
+		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_UBNT_E220)
+		ENUM_BRD_TYPE_CASE(CVMX_BOARD_TYPE_CUST_DSR1000N)
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
+@@ -169,6 +169,7 @@ int cvmx_helper_board_get_mii_address(int ipd_port)
+		else
+			return -1;
+	case CVMX_BOARD_TYPE_UBNT_E100:
++	case CVMX_BOARD_TYPE_UBNT_E120:
+		if (ipd_port >= 0 && ipd_port <= 2)
+			return 7 - ipd_port;
+		else
+@@ -413,6 +416,7 @@ enum cvmx_helper_board_usb_clock_types __cvmx_helper_board_usb_get_clock_type(vo
+	case CVMX_BOARD_TYPE_LANAI2_G:
+	case CVMX_BOARD_TYPE_NIC10E_66:
+	case CVMX_BOARD_TYPE_UBNT_E100:
++	case CVMX_BOARD_TYPE_UBNT_E120:
+		return USB_CLOCK_TYPE_CRYSTAL_12;
+	case CVMX_BOARD_TYPE_NIC10E:
+		return USB_CLOCK_TYPE_REF_12;
+--- a/arch/mips/cavium-octeon/octeon-platform.c
++++ b/arch/mips/cavium-octeon/octeon-platform.c
+@@ -387,7 +388,8 @@ static void __init octeon_rx_tx_delay(int eth, int iface, int port)
+			}
+		}
+		break;
+	case CVMX_BOARD_TYPE_UBNT_E100:
++	case CVMX_BOARD_TYPE_UBNT_E120:
+		if (iface == 0 && port <= 2) {
+			_octeon_rx_tx_delay(eth, 0x0, 0x10);
+			return;
+--- a/arch/mips/include/asm/octeon/octeon.h
++++ b/arch/mips/include/asm/octeon/octeon.h
+@@ -284,6 +284,7 @@ int octeon_prune_device_tree(void);
+ extern const char __appended_dtb;
+ extern const char __dtb_octeon_3xxx_begin;
+ extern const char __dtb_octeon_68xx_begin;
++extern const char __dtb_ubnt_e100_begin;
+
+ /**
+  * Write a 32bit value to the Octeon NPI register space
+--- a/arch/mips/cavium-octeon/setup.c
++++ b/arch/mips/cavium-octeon/setup.c
+@@ -1206,6 +1208,11 @@ void __init device_tree_init(void)
+		fdt = &__dtb_octeon_68xx_begin;
+		do_prune = true;
+		fill_mac = true;
++	} else if ((octeon_bootinfo->board_type == CVMX_BOARD_TYPE_UBNT_E100) ||
++			(octeon_bootinfo->board_type == CVMX_BOARD_TYPE_UBNT_E120)) {
++		fdt = &__dtb_ubnt_e100_begin;
++		do_prune = false;
++		fill_mac = true;
+	} else {
+		fdt = &__dtb_octeon_3xxx_begin;
+		do_prune = true;


### PR DESCRIPTION
The Unifi Security Gateway is almost identical to the Ubiquiti EdgeRouter Lite, which is already supported.

Specifications:
- 2x 500MHz Cavium CN5020 cores
- 4MB Flash / 512MB RAM
- 3 Gbit Ethernet Ports
- Blue/white Unifi Dome LEDs
- USB 2.0 port (internal)

As the USG boots off of an internal 4G usb stick, flashing procedure is the same as for the ERL:
1. Take out the internal usb stick (as /dev/sdc)
2. `mkfs.vfat /dev/sdc1; mount /dev/sdc1 /mnt`
3. `tar xf openwrt-octeon-usg3p-sysupgrade.tar --strip 1`
4. `cp ./kernel /mnt/vmlinux.64`
5. `dd if=./root of=/dev/sdc2`

This PR is based on the work of MartB (see [forum](https://forum.openwrt.org/t/lede-on-ubiquiti-unifi-security-gateway/3685/4), [abandoned LEDE PR](https://github.com/lede-project/source/pull/1370)). His [contribution](https://gist.github.com/MartB/99e30df35cb41af7f8f9130cb41c6ddd) works on my USG:
- verbatim with `openwrt-19.07`;
- slightly modified with [master 68bf5a](https://github.com/openwrt/openwrt/tree/68bf5a96595a8a0983842c8ff0eaa8af290adc51) using both kernels (4.19 and 5.4).

Also, it would be nice to make a toh wiki page for Ubiquiti octeon devices with installation instructions.

Signed-off-by: Jacob Bernhardt <31599460+bernhardtj@users.noreply.github.com>
