### PR TITLE
dnsmasq: skip dnssec option if not compiled in

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -43,6 +43,7 @@ dnsmasq_ignore_opt() {
 		pxe-*)
 			[ -z "$dnsmasq_has_dhcp" ] ;;
 		dnssec-*|\
+		dnssec|\
 		trust-anchor)
 			[ -z "$dnsmasq_has_dnssec" ] ;;
 		tftp-*)
@@ -960,7 +961,7 @@ dnsmasq_start()
 	}
 
 	config_get_bool dnssec "$cfg" dnssec 0
-	[ "$dnssec" -gt 0 ] && {
+	[ "$dnssec" -gt 0 ] && ! dnsmasq_ignore_opt "dnssec" && {
 		xappend "--conf-file=$TRUSTANCHORSFILE"
 		xappend "--dnssec"
 		[ -x /etc/init.d/sysntpd ] && {


### PR DESCRIPTION
Filtering out unavailable options was introduced in commit 0299a4b73e729504dfdc5c4563535db082bdf941 by @yousong, but did not deal with `--dnssec` or the trust anchor file. This patch adds `--dnssec` to the list of options requiring DNSSEC and checks for its availability before adding the trust anchor file option.

I've tested this patch on OpenWRT 19.07.3, but the relevant code is unchanged on master. 