### PR TITLE
ath79: Add support for Ubiquiti NanoBeam AC Gen2

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac-gen2-wa.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac-gen2-wa.dts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,nanobeam-ac-gen2-wa", "ubnt,wa", "qca,ar9342";
+	model = "Ubiquiti NanoBeam AC Gen2 (WA)";
+
+	aliases {
+		led-boot = &led_rssi3;
+		led-failsafe = &led_rssi3;
+		led-upgrade = &led_rssi3;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		rssi0 {
+			label = "ubnt:blue:rssi0";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi1 {
+			label = "ubnt:blue:rssi1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "ubnt:blue:rssi2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_rssi3: rssi3 {
+			label = "ubnt:blue:rssi3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy0: ethernet-phy@0 {
+		phy-mode = "rgmii";
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x58 0xffb7ffb7 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -324,6 +324,7 @@ ubnt,rocket-m)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "ubnt:green:link4" "wlan0" "76" "100"
 	;;
 ubnt,nanobeam-ac|\
+ubnt,nanobeam-ac-gen2-wa|\
 ubnt,nanostation-ac|\
 ubnt,powerbeam-5ac-gen2)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ ath79_setup_interfaces()
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
+	ubnt,nanobeam-ac-gen2-wa|\
 	ubnt,nanobridge-m|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,nanostation-loco-m|\
@@ -522,6 +523,7 @@ ath79_setup_macs()
 		label_mac=$(cat /sys/class/ieee80211/phy0/macaddress)
 		;;
 	ubnt,litebeam-ac-gen2|\
+	ubnt,nanobeam-ac-gen2-wa|\
 	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2)
 		label_mac=$(mtd_get_mac_binary art 0x5006)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -24,6 +24,7 @@ case "$FIRMWARE" in
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
+	ubnt,nanobeam-ac-gen2-wa|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,powerbeam-5ac-500|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -185,6 +185,15 @@ define Device/ubnt_nanobeam-ac
 endef
 TARGET_DEVICES += ubnt_nanobeam-ac
 
+define Device/ubnt_nanobeam-ac-gen2-wa
+  $(Device/ubnt-wa)
+  DEVICE_MODEL := NanoBeam AC
+  DEVICE_VARIANT := Gen2
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct rssileds
+  IMAGE/factory.bin := $$(IMAGE/factory.bin) | pad-to 15744K
+endef
+TARGET_DEVICES += ubnt_nanobeam-ac-gen2-wa
+
 define Device/ubnt_nanobridge-m
   $(Device/ubnt-xm)
   SOC := ar7241


### PR DESCRIPTION
CPU:         Atheros AR9342 rev 3 SoC
RAM:         64 MB DDR2
Flash:       16 MB NOR SPI
WLAN 2.4GHz: Atheros AR9342 rev 3 (ath9k)
WLAN 5.0GHz: QCA988X
Ports:       2x GbE

Flashing procedure is identical to other ubnt devices.
https://openwrt.org/toh/ubiquiti/common

Flashing through factory firmware
1. Ensure firmware version v8.7.0 is installed.
   Up/downgrade to this exact version.
2. Patch fwupdate.real binary using
   `hexdump -Cv /bin/ubntbox | sed 's/14 40 fe 27/00 00 00 00/g' | hexdump -R > /tmp/fwupdate.real`
3. Make the patched fwupdate.real binary executable using
   `chmod +x /tmp/fwupdate.real`
4. Copy the squashfs factory image to /tmp on the device
5. Flash OpenWRT using `/tmp/fwupdate.real -m <squashfs-factory image>`
6. Wait for the device to reboot
(copied from Ubiquiti NanoBeam AC and modified)

Signed-off-by: Nick Hainke <vincent@systemli.org>

--- 

This is my first PR that adds a new device.
I'm not sure why many ubnt devices are using `kmod-ath10k-ct-smallbuffers`. Should I use that, too?

I'm not sure if this is correct (like nanobeam ac)
```
rxd-delay = <3>;
rxdv-delay = <3>;
```
or this (nanostation ac)
```
rxd-delay = <2>;
rxdv-delay = <2>;
```

The station has the similar dts for the network since it has now two network ports like the nanostation ac.