### PR TITLE
mac80211: ath9k: enable OEM cards support on x86 by default

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -218,6 +218,7 @@ define KernelPackage/ath9k/config
 	config ATH9K_SUPPORT_PCOEM
 		bool "Support chips used in PC OEM cards"
 		depends on PACKAGE_kmod-ath9k
+		default y if (x86_64 || i386)
 
        config ATH9K_TX99
                bool "Enable TX99 support (WARNING: testing only, breaks normal operation!)"


### PR DESCRIPTION
A lot of devices running OpenWrt x86 arch (32 or 64 bit) are either "home-made routers" or devices that use PC class OEM components. This commit enables OEM cards support on those devices by default.

Signed-off-by: Rafał Dzięgiel <rafostar.github@gmail.com>