### PR TITLE
treewide: consistent use of MikroTik productnames

### DIFF
--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "mikrotik,routerboard-wap-g-5hact2hnd", "qca,qca9556";
-	model = "MikroTik RouterBOARD wAP G-5HacT2HnD";
+	model = "MikroTik wAP ac";
 
 	aliases {
 		mdio-gpio1 = &mdio2;

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -9,6 +9,15 @@ define Device/mikrotik_routerboard-493g
 endef
 TARGET_DEVICES += mikrotik_routerboard-493g
 
+define Device/mikrotik_routerboard-921gs-5hpacd-15s
+  $(Device/mikrotik_nand)
+  SOC := qca9558
+  DEVICE_MODEL := RouterBOARD mANTBox 15s
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  SUPPORTED_DEVICES += rb-921gs-5hpacd-r2
+endef
+TARGET_DEVICES += mikrotik_routerboard-921gs-5hpacd-15s
+
 define Device/mikrotik_routerboard-922uags-5hpacd
   $(Device/mikrotik_nand)
   SOC := qca9558
@@ -21,7 +30,7 @@ TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 define Device/mikrotik_routerboard-wap-g-5hact2hnd
   $(Device/mikrotik_nor)
   SOC := qca9556
-  DEVICE_MODEL := RouterBOARD wAP G-5HacT2HnD (wAP AC)
+  DEVICE_MODEL := RouterBOARD wAP ac (BE)
   IMAGE_SIZE := 16256k
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
@@ -8,7 +8,7 @@
 
 / {
 	compatible = "mikrotik,routerboard-750gr3", "mediatek,mt7621-soc";
-	model = "MikroTik RouterBOARD 750Gr3";
+	model = "MikroTik hEX";
 
 	aliases {
 		led-boot = &led_usr;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -653,7 +653,7 @@ endef
 
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
-  DEVICE_MODEL := RouterBOARD 750Gr3
+  DEVICE_MODEL := RouterBOARD hEX
   DEVICE_PACKAGES += kmod-gpio-beeper
   SUPPORTED_DEVICES += mikrotik,rb750gr3
 endef


### PR DESCRIPTION
This PR needs #3140 merged first.

This change makes consistent use of the marketing name in the DEVICE_MODEL.
Marketing name is the "handy" name by which each device is called on the web-page (https://mikrotik.com/products/).

This PR is based on https://github.com/openwrt/openwrt/pull/3140#discussion_r447134565 and https://github.com/openwrt/openwrt/pull/3140#issuecomment-667558444.