### PR TITLE
ramips: update board support for WIZnet WizFi630S

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -145,7 +145,7 @@
 };
 
 &ethernet {
-	mtd-mac-address = <&factory 0x28>;
+	mtd-mac-address = <&factory 0x2e>;
 };
 
 &esw {

--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -28,7 +28,7 @@
 
 		led_run: run {
 			label = "wizfi630s:green:run";
-			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
 		};
 
 		ledwps {
@@ -61,47 +61,29 @@
 
 		wps {
 			label = "wps";
-			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 
 		scm1 {
 			label = "SCM1";
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
 		};
 
 		scm2 {
 			label = "SCM2";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_2>;
+			linux,input-type = <EV_SW>;
 		};
 	};
 };
 
 &state_default {
 	gpio {
-		groups = "gpio";
-		function = "gpio";
-	};
-
-	i2s {
-		groups = "i2s";
-		function = "gpio";
-	};
-
-	wdt {
-		groups = "wdt";
-		function = "gpio";
-	};
-
-	i2c {
-		groups = "i2c";
-		function = "gpio";
-	};
-
-	refclk {
-		groups = "refclk";
+		groups = "gpio", "i2s", "i2c", "wdt", "refclk", "p1led_an", "p2led_an";
 		function = "gpio";
 	};
 };
@@ -150,11 +132,11 @@
 	};
 };
 
-&i2c {
+&uart1 {
 	status = "okay";
 };
 
-&uart1 {
+&uart2 {
 	status = "okay";
 };
 

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -658,6 +658,7 @@ define Device/wiznet_wizfi630s
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := WIZnet
   DEVICE_MODEL := WizFi630S
+  SUPPORTED_DEVICES += wizfi630s
 endef
 TARGET_DEVICES += wiznet_wizfi630s
 

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -199,9 +199,12 @@ ramips_setup_macs()
 		;;
 	rakwireless,rak633|\
 	unielec,u7628-01-16m|\
-	wavlink,wl-wn575a3|\
-	wiznet,wizfi630s)
+	wavlink,wl-wn575a3)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
+		;;
+	wiznet,wizfi630s)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
+		wan_mac=$(mtd_get_mac_binary factory 0x28)
 		;;
 	tplink,archer-c20-v4|\
 	tplink,archer-c50-v3|\


### PR DESCRIPTION
This PR is needed as in the release version of WizFi630S some pins had changed that where not yet updated in master. Also in the factory image a different board name is used, which caused a incompatibility warning when using sysupgrade. This PR is correcting the pin map and is updating the supported device list to avoid the error. There's also some cosmetics (removing a doublet). WizFi630S also has three mac adresses preprogrammed in the factory partion, but did not use it by now.