### PR TITLE
ramips: add support for Netgear JWNR2010 v5

### DIFF
--- a/target/linux/ramips/dts/mt7620n_netgear_jwnr2010-v5.dts
+++ b/target/linux/ramips/dts/mt7620n_netgear_jwnr2010-v5.dts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,jwnr2010-v5", "ralink,mt7620n-soc";
+	model = "Netgear JWNR2010 v5";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "jwnr2010-v5:green:power";
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "jwnr2010-v5:green:wan";
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "jwnr2010-v5:green:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		lan1 {
+			label = "jwnr2010-v5:green:lan1";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "jwnr2010-v5:green:lan2";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "jwnr2010-v5:green:lan3";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "jwnr2010-v5:green:lan4";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x20000 0x3c0000>;
+			};
+
+			partition@3e0000 {
+				label = "nvram";
+				reg = <0x3e0000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@3f0000 {
+				label = "factory";
+				reg = <0x3f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x4>;
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	default {
+		groups = "pa", "ephy", "wled";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -696,6 +696,27 @@ define Device/netgear_ex6130
 endef
 TARGET_DEVICES += netgear_ex6130
 
+define Device/netgear_jwnr2010-v5
+  SOC := mt7620n
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 3840k
+  DEVICE_VENDOR := NETGEAR
+  DEVICE_MODEL := JWNR2010
+  DEVICE_VARIANT := v5
+  SERCOMM_HWNAME := N300
+  SERCOMM_HWID := ASW
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0040
+  IMAGES += factory.img
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size
+  IMAGE/factory.img := pad-extra 128k | $$(IMAGE/default) | \
+	pad-to $$$$(BLOCKSIZE) | sercom-footer | pad-to 128 | \
+	zip $$$$(SERCOMM_HWNAME).bin | sercom-seal
+endef
+TARGET_DEVICES += netgear_jwnr2010-v5
+
 define Device/netgear_wn3000rp-v3
   SOC := mt7620a
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -165,6 +165,13 @@ netgear,ex6130)
 	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "$boardname:green:router" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "$boardname:green:device" "wlan1"
 	;;
+netgear,jwnr2010-v5)
+	ucidef_set_led_switch "lan1" "lan1" "$boardname:green:lan1" "switch0" "0x08"
+	ucidef_set_led_switch "lan2" "lan2" "$boardname:green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "lan3" "$boardname:green:lan3" "switch0" "0x02"
+	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x01"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
+	;;
 phicomm,psg1208)
 	set_wifi_led "$boardname:white:wlan2g"
 	;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -108,6 +108,7 @@ ramips_setup_interfaces()
 			"0:lan" "6@eth0"
 		;;
 	dlink,dir-810l|\
+	netgear,jwnr2010-v5|\
 	trendnet,tew-810dr|\
 	zbtlink,zbt-we2026)
 		ucidef_add_switch "switch0" \
@@ -240,6 +241,7 @@ ramips_setup_macs()
 	edimax,ew-7478apc|\
 	fon,fon2601|\
 	head-weblink,hdrm200|\
+	netgear,jwnr2010-v5|\
 	nexx,wt3020-4m|\
 	nexx,wt3020-8m|\
 	phicomm,psg1208|\


### PR DESCRIPTION
Specification:
 - CPU: MediaTek MT7620N (580 MHz)
 - Flash size: 4 MB NOR SPI
 - RAM size: 32 MB DDR1
 - Bootloader: U-Boot
 - Wireless: MT7620N 2x2 MIMO 802.11b/g/n (2.4 GHz)
 - Switch: MT7620 built-in 10/100 switch with vlan support
 - Ports: 4x LAN, 1x WAN
 - Others: 7x LED, Reset button, UART header on PCB (57600 8N1)

MAC addresses from stock firmware:
LAN     **:28   0x4
WAN     **:29
WLAN    **:28   0x80B0
No MAC found on 0x28 and 0x2e.

Flash instructions:
 1. Use ethernet cable to connect router with PC/Laptop, any router
    LAN port will work.
 2. To flash openwrt we are using nmrpflash[1].
 3. Flash commands:
      First we need to identify the correct Ethernet id.

        nmrpflash -L

        nmrpflash -i net* -f openwrt-ramips-mt7620-netgear_jwnr2010-v5-squashfs-factory.img

      This will show something like "Advertising NMRP server on net*..." (net*, *=1,2,3... etc.)

 4. Now remove the power cable from router back side and immediately connect it again.
    You will see flash notification in CMD window, once it says reboot the device just
    plug off the router and plug in again.

Revert to stock:
 1. Download the stock firmware from official netgear support[2].
 2. Follow the same nmrpflash procedure like above, this time just use the stock firmware.

        nmrpflash -i net* -f N300-V1.1.0.54_1.0.1.img

Special Note:
 This openwrt firmware will also support other netgear N300 routers like below as they
 share same stock firmware[3].
 JNR1010v2 / WNR614 / WNR618 / JWNR2000v5 / WNR2020 / WNR1000v4 / WNR2020v2 / WNR2050

[1] https://github.com/jclehner/nmrpflash
[2] https://www.netgear.com/support/product/JWNR2010v5.aspx
[3] http://kb.netgear.com/000059663

Signed-off-by: Shibajee Roy <ador250@protonmail.com>
