### PR TITLE
[19.07]scripts: Add Buildbot dump-target-info.pl script

### DIFF
--- a/scripts/dump-target-info.pl
+++ b/scripts/dump-target-info.pl
@@ -1,0 +1,91 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Cwd;
+
+my (%targets, %architectures);
+
+$ENV{'TOPDIR'} = Cwd::getcwd();
+
+
+sub parse_targetinfo {
+	my ($target_dir, $subtarget) = @_;
+
+	if (open M, "make -C '$target_dir' --no-print-directory DUMP=1 TARGET_BUILD=1 SUBTARGET='$subtarget' |") {
+		my ($target_name, $target_arch, @target_features);
+		while (defined(my $line = readline M)) {
+			chomp $line;
+
+			if ($line =~ /^Target: (.+)$/) {
+				$target_name = $1;
+			}
+			elsif ($line =~ /^Target-Arch-Packages: (.+)$/) {
+				$target_arch = $1;
+			}
+			elsif ($line =~ /^Target-Features: (.+)$/) {
+				@target_features = split /\s+/, $1;
+			}
+			elsif ($line =~ /^@\@$/) {
+				if ($target_name && $target_arch &&
+				    !grep { $_ eq 'broken' or $_ eq 'source-only' } @target_features) {
+					$targets{$target_name} = $target_arch;
+					$architectures{$target_arch} ||= [];
+					push @{$architectures{$target_arch}}, $target_name;
+				}
+
+				undef $target_name;
+				undef $target_arch;
+				@target_features = ();
+			}
+		}
+		close M;
+	}
+}
+
+sub get_targetinfo {
+	foreach my $target_makefile (glob "target/linux/*/Makefile") {
+		my ($target_dir) = $target_makefile =~ m!^(.+)/Makefile$!;
+		my @subtargets;
+
+		if (open M, "make -C '$target_dir' --no-print-directory DUMP=1 TARGET_BUILD=1 val.FEATURES V=s 2>/dev/null |") {
+			if (defined(my $line = readline M)) {
+				chomp $line;
+				if (grep { $_ eq 'broken' or $_ eq 'source-only' } split /\s+/, $line) {
+					next;
+				}
+			}
+		}
+
+		if (open M, "make -C '$target_dir' --no-print-directory DUMP=1 TARGET_BUILD=1 val.SUBTARGETS V=s 2>/dev/null |") {
+			if (defined(my $line = readline M)) {
+				chomp $line;
+				@subtargets = split /\s+/, $line;
+			}
+			close M;
+		}
+
+		push @subtargets, 'generic' if @subtargets == 0;
+
+		foreach my $subtarget (@subtargets) {
+			parse_targetinfo($target_dir, $subtarget);
+		}
+	}
+}
+
+if (@ARGV == 1 && $ARGV[0] eq 'targets') {
+	get_targetinfo();
+	foreach my $target_name (sort keys %targets) {
+		printf "%s %s\n", $target_name, $targets{$target_name};
+	}
+}
+elsif (@ARGV == 1 && $ARGV[0] eq 'architectures') {
+	get_targetinfo();
+	foreach my $target_arch (sort keys %architectures) {
+		printf "%s %s\n", $target_arch, join ' ', @{$architectures{$target_arch}};
+	}
+}
+else {
+	print "Usage: $0 targets\n";
+	print "Usage: $0 architectures\n";
+}


### PR DESCRIPTION
The script comes from buildbot.git[0] and is used to print available
targets and architectures, which are then build.

As the buildbot clones openwrt.git anyway, the script might as well live
here to be used for other cases as well, e.g. determining what
architectures are available when building Docker containers or show
developers an overview which architectures are used by which target.

It's called with either the parameter `architectures` or `targets`,
showing architectures followed by supported targets or targets, followed
by the supported architectures:

$ ./scripts/dump-target-info.pl architectures
aarch64_cortex-a53 bcm27xx/bcm2710 mediatek/mt7622 mvebu/cortexa53 sunxi/cortexa53
aarch64_cortex-a72 bcm27xx/bcm2711 mvebu/cortexa72
...

$ ./scripts/dump-target-info.pl targets
apm821xx/nand powerpc_464fp
apm821xx/sata powerpc_464fp
...

In the future the the script could be removed from the buildbot
repository and maintained only here.

Rename `dumpinfo.pl` to `dump-target-info.pl` to improve verbosity of
filename.

[0]: https://git.openwrt.org/?p=buildbot.git;a=blob;f=scripts/dumpinfo.pl;h=aa97f8d60379076a41b968402e9337cea824ece5;hb=HEAD

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit 656b562aff36d92b0e8586833b59896a55b8a993)

Removed the accidentality added checkpatch.sh script. As we build 19.07.x docker containers, this should be backported. 