### PR TITLE
Rockchip:nanopi-r2s improve boot failed

### DIFF
--- a/package/boot/uboot-rockchip/patches/101-rockchip-rk3328-nanopi-r2s-improve-boot-failed.patch
+++ b/package/boot/uboot-rockchip/patches/101-rockchip-rk3328-nanopi-r2s-improve-boot-failed.patch
@@ -1,0 +1,37 @@
+From: Yuan Tao <ty@wevs.org>
+Date: Sun, 9 Aug 2020 09:02:55 +0800
+Subject: rockchip:nanopi-r2s-improve-boot-failed
+
+Issues:
+When booting on some SD cards an error message appears as:
+"spl: mmc init failed with error: -95"
+
+Solutions:
+Add regulator-boot-on parameters to vcc_sd.
+Add startup-delay-us parameters to vcc_sdio.
+This will improve the problem that in some SD cards are failing to boot up.
+
+Tested environment:
+SD Card: Netac Extreme P500 Pro 32GB
+
+Signed-off-by: Yuan Tao <ty@wevs.org>
+---
+
+--- a/arch/arm/dts/rk3328-nanopi-r2s.dts
++++ b/arch/arm/dts/rk3328-nanopi-r2s.dts
+@@ -32,6 +32,7 @@
+ 		regulator-name = "vcc_sd";
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
+ 		vin-supply = <&vcc_io>;
+ 	};
+ 
+@@ -49,6 +50,7 @@
+ 		regulator-name = "vcc_sdio";
+ 		regulator-settling-time-us = <5000>;
+ 		regulator-type = "voltage";
++		startup-delay-us = <2000>;
+ 		vin-supply = <&vcc_io>;
+ 	};
+ 


### PR DESCRIPTION
NanoPi-R2S boots with mmc init failed issue on some MicroSD cards.
Just like that.
```
U-Boot TPL 2020.07 (Aug 03 2020 - 21:34:34)
DDR4, 333MHz
BW=32 Col=10 Bk=4 BG=2 CS0 Row=15 CS=1 Die BW=16 Size=1024MB
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2020.07 (Aug 03 2020 - 21:34:34 +0000)
Trying to boot from MMC1
spl: mmc init failed with error: -95
SPL: failed to boot from all boot devices
### ERROR ### Please RESET the board ###
```

After testing it was found that the initialization failed because the initialization wait time was too short, so I added startup-delay-us to fix the problem.
After my own NanoPi R2S test additions it has been able to boot properly from a specific MicroSD card.

Signed-off-by: Yuan Tao <ty@wevs.org>
