### PR TITLE
Fixes and Extended Support for SolidRun i.MX6 Devices

### DIFF
--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -34,6 +34,15 @@ define Package/brcmfmac-firmware-4329-sdio/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-4329-sdio))
 
+Package/brcmfmac-firmware-4330-sdio = $(call Package/firmware-default,Broadcom BCM4330 FullMac SDIO firmware)
+define Package/brcmfmac-firmware-4330-sdio/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcm/brcmfmac4330-sdio.bin \
+		$(1)/lib/firmware/brcm/brcmfmac4330-sdio.bin
+endef
+$(eval $(call BuildPackage,brcmfmac-firmware-4330-sdio))
+
 Package/brcmfmac-firmware-43362-sdio = $(call Package/firmware-default,Broadcom BCM43362 FullMac SDIO firmware)
 define Package/brcmfmac-firmware-43362-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm

--- a/package/firmware/solidrun-firmware/Makefile
+++ b/package/firmware/solidrun-firmware/Makefile
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2020 Josua Mayer <josua@solid-run.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=solidrun-firmware
+PKG_SOURCE_DATE:=2019-09-05
+PKG_SOURCE_VERSION:=3ff92e688187d39b694f4e5a5cefe9d5e366ea81
+PKG_MIRROR_HASH:=2e504e071c3f896d629c4cfffe7ff4b5f1acdb4fecd3f01e8ff8c73e87a67cc7
+PKG_RELEASE:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/SolidRun/deb-pkg_cuboxi-firmware-wireless.git
+PKG_MAINTAINER:=Josua Mayer <josua@solid-run.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/brcmfmac-firmware-4329-sdio-cubox-i
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  URL:=$(PKG_SOURCE_URL)
+  DEPENDS:=
+  TITLE:=BCM4329 NVRAM for Cubox-i
+endef
+
+define Package/brcmfmac-firmware-4330-sdio-cubox-i
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  URL:=$(PKG_SOURCE_URL)
+  DEPENDS:=
+  TITLE:=BCM4330 NVRAM for Cubox-i
+endef
+
+define Package/wl18xx-firmware-cubox-i
+  SECTION:=firmware
+  CATEGORY:=Firmware
+  URL:=$(PKG_SOURCE_URL)
+  DEPENDS:=
+  TITLE:=WL1835 NVRAM for Cubox-i
+endef
+
+define Build/Compile
+
+endef
+
+define Package/brcmfmac-firmware-4329-sdio-cubox-i/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcmfmac4329-sdio.txt \
+		$(1)/lib/firmware/brcm/brcmfmac4329-sdio.txt
+endef
+
+define Package/brcmfmac-firmware-4330-sdio-cubox-i/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcmfmac4330-sdio.txt \
+		$(1)/lib/firmware/brcm/brcmfmac4330-sdio.txt
+endef
+
+define Package/wl18xx-firmware-cubox-i/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ti-connectivity
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/wl18xx-conf.bin \
+		$(1)/lib/firmware/ti-connectivity/wl18xx-conf.bin
+endef
+
+$(eval $(call BuildPackage,brcmfmac-firmware-4329-sdio-cubox-i))
+$(eval $(call BuildPackage,brcmfmac-firmware-4330-sdio-cubox-i))
+$(eval $(call BuildPackage,wl18xx-firmware-cubox-i))

--- a/package/firmware/solidrun-firmware/Makefile
+++ b/package/firmware/solidrun-firmware/Makefile
@@ -50,14 +50,22 @@ define Package/brcmfmac-firmware-4329-sdio-cubox-i/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/brcmfmac4329-sdio.txt \
-		$(1)/lib/firmware/brcm/brcmfmac4329-sdio.txt
+		$(1)/lib/firmware/brcm/brcmfmac4329-sdio.solidrun,cubox-i.txt
+	ln -s brcmfmac4329-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4329-sdio.solidrun,cubox-i-dl.txt
+	ln -s brcmfmac4329-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4329-sdio.solidrun,cubox-i-q.txt
+	ln -s brcmfmac4329-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4329-sdio.solidrun,hummingboard-dl.txt
+	ln -s brcmfmac4329-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4329-sdio.solidrun,hummingboard-q.txt
 endef
 
 define Package/brcmfmac-firmware-4330-sdio-cubox-i/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/brcmfmac4330-sdio.txt \
-		$(1)/lib/firmware/brcm/brcmfmac4330-sdio.txt
+		$(1)/lib/firmware/brcm/brcmfmac4330-sdio.solidrun,cubox-i.txt
+	ln -s brcmfmac4330-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4330-sdio.solidrun,cubox-i-dl.txt
+	ln -s brcmfmac4330-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4330-sdio.solidrun,cubox-i-q.txt
+	ln -s brcmfmac4330-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4330-sdio.solidrun,hummingboard-dl.txt
+	ln -s brcmfmac4330-sdio.solidrun,cubox-i.txt $(1)/lib/firmware/brcm/brcmfmac4330-sdio.solidrun,hummingboard-q.txt
 endef
 
 define Package/wl18xx-firmware-cubox-i/install

--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -451,6 +451,7 @@ define KernelPackage/brcmfmac/config
 		bool "Enable SDIO bus interface support"
 		default y if TARGET_bcm27xx
 		default y if TARGET_sunxi
+		default y if TARGET_imx6_DEVICE_cubox-i
 		default n
 		help
 		  Enable support for cards attached to an SDIO bus.

--- a/target/linux/imx6/base-files/etc/board.d/02_network
+++ b/target/linux/imx6/base-files/etc/board.d/02_network
@@ -25,7 +25,11 @@ gw,imx6q-gw5910 |\
 gw,imx6q-gw5912 |\
 gw,imx6q-gw5913 |\
 solidrun,cubox-i/dl |\
-solidrun,cubox-i/q )
+solidrun,cubox-i/q |\
+solidrun,hummingboard/dl |\
+solidrun,hummingboard/q |\
+solidrun,hummingboard2/dl |\
+solidrun,hummingboard2/q )
 	ucidef_set_interface_lan 'eth0'
 	;;
 gw,imx6dl-gw53xx |\

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -206,7 +206,10 @@ define Device/cubox-i
   UBOOT := mx6cuboxi
   BOOT_SCRIPT = bootscript-cubox
   DEVICE_NAME := cubox
-  DEVICE_PACKAGES := kmod-drm-imx kmod-drm-imx-hdmi kmod-usb-hid
+  DEVICE_PACKAGES := \
+	kmod-drm-imx kmod-drm-imx-hdmi \
+	kmod-brcmfmac brcmfmac-firmware-4329-sdio brcmfmac-firmware-4329-sdio-cubox-i brcmfmac-firmware-4330-sdio brcmfmac-firmware-4330-sdio-cubox-i \
+	kmod-wl18xx wl18xx-firmware wl18xx-firmware-cubox-i
   DEVICE_DTS := \
 	imx6dl-cubox-i \
 	imx6dl-cubox-i-emmc-som-v15 \

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -99,10 +99,9 @@ endef
 
 define Build/imx6-sdcard
 	$(Build/imx6-combined-image-prepare)
-
-	$(CP) $(STAGING_DIR_IMAGE)/$(UBOOT)-u-boot.img $@.boot/u-boot.img
 	$(Build/imx6-combined-image)
 	dd if=$(STAGING_DIR_IMAGE)/$(UBOOT)-SPL of=$@ bs=1024 seek=1 conv=notrunc
+	dd if=$(STAGING_DIR_IMAGE)/$(UBOOT)-u-boot.img of=$@ bs=1024 seek=69 conv=notrunc
 
 	$(Build/imx6-combined-image-clean)
 endef

--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -207,7 +207,25 @@ define Device/cubox-i
   BOOT_SCRIPT = bootscript-cubox
   DEVICE_NAME := cubox
   DEVICE_PACKAGES := kmod-drm-imx kmod-drm-imx-hdmi kmod-usb-hid
-  DEVICE_DTS := imx6q-cubox-i imx6dl-cubox-i imx6q-hummingboard imx6dl-hummingboard
+  DEVICE_DTS := \
+	imx6dl-cubox-i \
+	imx6dl-cubox-i-emmc-som-v15 \
+	imx6dl-cubox-i-som-v15 \
+	imx6dl-hummingboard \
+	imx6dl-hummingboard-emmc-som-v15 \
+	imx6dl-hummingboard-som-v15 \
+	imx6dl-hummingboard2 \
+	imx6dl-hummingboard2-emmc-som-v15 \
+	imx6dl-hummingboard2-som-v15 \
+	imx6q-cubox-i \
+	imx6q-cubox-i-emmc-som-v15 \
+	imx6q-cubox-i-som-v15 \
+	imx6q-hummingboard \
+	imx6q-hummingboard-emmc-som-v15 \
+	imx6q-hummingboard-som-v15 \
+	imx6q-hummingboard2 \
+	imx6q-hummingboard2-emmc-som-v15 \
+	imx6q-hummingboard2-som-v15
   IMAGES := combined.bin dtb
   FILESYSTEMS := squashfs
   IMAGE/combined.bin := append-rootfs | pad-extra 128k | imx6-sdcard

--- a/target/linux/imx6/image/bootscript-cubox
+++ b/target/linux/imx6/image/bootscript-cubox
@@ -1,31 +1,16 @@
-echo "CuBox OpenWrt Boot script"
+echo "Generic Distro-Boot Boot-Script"
 
-# Set console variable for both UART and HDMI
-setenv console console=ttymxc0,115200 video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32
+# rootfs is always on the next partition
+setexpr openwrt_rootpart ${distro_bootpart} + 1
 
-# Find correct dtb
-if test ${board_rev} = MX6DL; then
-	setenv fdt_soc_type imx6dl;
-elif test ${board_rev} = MX6Q; then
-	setenv fdt_soc_type imx6q;
-fi
-if test ${board_name} = CUBOXI; then
-	setenv fdt_name ${fdt_soc_type}-cubox-i.dtb;
-elif test ${board_name} = HUMMINGBOARD; then
-	setenv fdt_name ${fdt_soc_type}-hummingboard.dtb;
-fi
+# figure out partition uuid to pass to the kernel as root=
+part uuid ${devtype} ${devnum}:${openwrt_rootpart} uuid
 
-# Set correct devtype and partition
-if test ${devtype} != mmc; then setenv devtype mmc; fi
-if mmc dev 0; then
-	setenv mmcdev 0
-elif mmc dev 1; then
-	setenv mmcdev 1
-fi
+# generate bootargs
+setenv bootargs ${bootargs} console=${console} root=PARTUUID=${uuid} ro rootwait
 
-# Boot from the SD card is supported at the moment
-setenv bootargs "${console} root=/dev/mmcblk1p2 rw rootwait"
-mmc dev ${mmcdev}
-load ${devtype} ${mmcdev}:${devplist} ${kernel_addr_r} /uImage
-load ${devtype} ${mmcdev}:${devplist} ${fdt_addr_r} /${fdt_name}
+# Boot
+echo "Booting Linux with ${bootargs}"
+load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${fdtfile}
+load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} uImage
 bootz ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
1. Fix an issue where SPL fails to load u-boot.img from the first partition (tested on HummingBoard 2)

2. Add **all the DTBs** - especially all the SoM rev 1.5 variants

3. simplify boot-script a lot so that it uses all of U-Boots knowledge in place of custom device identification logic