### PR TITLE
ramips/mt7628: fix portmap based on board.d port assignment

### DIFF
--- a/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
+++ b/target/linux/ramips/dts/mt7628an_duzun_dm06.dts
@@ -72,7 +72,7 @@
 };
 
 &esw {
-	mediatek,portmap = <0x3>;
+	mediatek,portmap = <0x3e>;
 	mediatek,portdisable = <0x3c>;
 };
 

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mir4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mir4a-100m.dts
@@ -130,7 +130,7 @@
 };
 
 &esw {
-	mediatek,portmap = <0x2f>;
+	mediatek,portmap = <0x3e>;
 	mediatek,portdisable = <0x2a>;
 };
 


### PR DESCRIPTION
When comparing to the port assignment in board.d/02_network, a few
devices seem to use the wrong setup of mediatek,portmap.

The corrects the values for mt76x8 subtarget based on the location
of the wan port.

A previous cleanup of obviously wrong values has already been done in
7a387bf9a0d7 ("ramips: mt76x8: fix bogus mediatek,portmap")