### PR TITLE
build: mkhash on FreeBSD

### DIFF
--- a/scripts/mkhash.c
+++ b/scripts/mkhash.c
@@ -79,7 +79,12 @@
 
 
 
+#ifndef __FreeBSD__
 #include <endian.h>
+#else
+#include <sys/endian.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -88,6 +93,7 @@
 
 #define ARRAY_SIZE(_n) (sizeof(_n) / sizeof((_n)[0]))
 
+#ifndef __FreeBSD__
 static void
 be32enc(void *buf, uint32_t u)
 {
@@ -98,6 +104,7 @@ be32enc(void *buf, uint32_t u)
 	p[2] = ((uint8_t) ((u >> 8) & 0xff));
 	p[3] = ((uint8_t) (u & 0xff));
 }
+#endif
 
 static void
 be64enc(void *buf, uint64_t u)


### PR DESCRIPTION
Apply patch from
https://bugs.openwrt.org/index.php?do=details&task_id=971
in order to make it easier to build OpenWRT on FreeBSD.