### PR TITLE
Fix /lib/netifd/hostapd.sh 's "auth_secret" config option

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -196,7 +196,7 @@ hostapd_common_add_bss_config() {
 	config_add_int eapol_version
 
 	config_add_string 'auth_server:host' 'server:host'
-	config_add_string auth_secret
+	config_add_string auth_secret key
 	config_add_int 'auth_port:port' 'port:port'
 
 	config_add_string acct_server


### PR DESCRIPTION
https://openwrt.org/docs/guide-user/network/wifi/basic documents that "auth_secret" is the option to use when specifying the radius secret for wpa2 enterprise, but it does not work.

auth_server and auth_port work, as aliases of port and server, respectively, but "auth_secret" does not, and netifd fails to start hostapd with no notice to the user of what the problem is.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
