### PR TITLE
toolchain/binutils: fix broken build of binutils 2.34 on mips64

### DIFF
--- a/toolchain/binutils/patches/2.34/500-Change-default-emulation-for-mips64-linux.patch
+++ b/toolchain/binutils/patches/2.34/500-Change-default-emulation-for-mips64-linux.patch
@@ -25,7 +25,7 @@
  			;;
 -mips64*el-*-linux-*)	targ_emul=elf32ltsmipn32
 -			targ_extra_emuls="elf32btsmipn32 elf32ltsmip elf32btsmip elf64ltsmip elf64btsmip"
-+mips64*el-*-linux-*)	targ_emul=lf64ltsmip
++mips64*el-*-linux-*)	targ_emul=elf64ltsmip
 +			targ_extra_emuls="elf32btsmipn32 elf32ltsmipn32 elf32ltsmip elf32btsmip elf64btsmip"
  			targ_extra_libpath=$targ_extra_emuls
  			;;


### PR DESCRIPTION
**Review/Distribution List**:  @hauke, @diizzyy    (based on similar fixes and commits in the repo)
**Compile tested**:  mips64-le-malta, master branch
**Run tested**:  mips64-le-malta, master branch

**Description**:
Commit 53470bdf32 ("toolchain/binutils: Add binutils 2.34") logs refreshed patches, but also added a typo causing failed builds on mipsel64 platforms, including the malta subtarget. Update the patch to fix this.

This also fixes FS#3276.

Thanks for your review and any feedback!