### PR TITLE
[19.07] ar71xx: change u-boot-env to read-write for ZyXEL NBG6616

### DIFF
--- a/package/boot/uboot-envtools/files/ar71xx
+++ b/package/boot/uboot-envtools/files/ar71xx
@@ -47,6 +47,7 @@ mr600v2|\
 mr900|\
 mr900v2|\
 n5q|\
+nbg6616|\
 nbg6716|\
 om5p|\
 om5p-ac|\

--- a/target/linux/ar71xx/image/generic.mk
+++ b/target/linux/ar71xx/image/generic.mk
@@ -1067,7 +1067,7 @@ define Device/NBG6616
   BOARDNAME := NBG6616
   KERNEL_SIZE := 2048k
   IMAGE_SIZE := 15323k
-  MTDPARTS := spi0.0:192k(u-boot)ro,64k(env)ro,64k(RFdata)ro,384k(zyxel_rfsd),384k(romd),64k(header),2048k(kernel),13184k(rootfs),15232k@0x120000(firmware)
+  MTDPARTS := spi0.0:192k(u-boot)ro,64k(env),64k(RFdata)ro,384k(zyxel_rfsd),384k(romd),64k(header),2048k(kernel),13184k(rootfs),15232k@0x120000(firmware)
   CMDLINE += mem=128M
   RAS_BOARD := NBG6616
   RAS_ROOTFS_SIZE := 14464k


### PR DESCRIPTION
As the ath79 port of this device uses a combined kernel + root
partition the uboot bootcmd variable needs to be changed. As using
cli/luci is more convenient than opening up the case and using a uart
connection, lets unlock the uboot-env partition for write access.