### PR TITLE
ar71xx: fix ZyXEL NBG6616 wifi switch

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-nbg6716.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-nbg6716.c
@@ -203,11 +203,11 @@ static struct gpio_keys_button nbg6616_gpio_keys[] __initdata = {
 	},
 	{
 		.desc		= "RFKILL button",
-		.type		= EV_KEY,
+		.type		= EV_SW,
 		.code		= KEY_RFKILL,
 		.debounce_interval = NBG6716_KEYS_DEBOUNCE_INTERVAL,
 		.gpio		= NBG6716_GPIO_BTN_RFKILL,
-		.active_low	= 1,
+		.active_low	= 0,
 	},
 	{
 		.desc		= "WPS button",


### PR DESCRIPTION
The device uses a rf-kill switch instead of a button. Furthermore the
GPIO is active high.