### PR TITLE
[WIP] ath79: add support for MikroTik hAP ac lite (RB952ui-5a2nd)

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_16mb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_16mb.dtsi
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "mikrotik,16mb-nor", "qca,qca9533";
+	model = "MikroTik 16MB NOR platform";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-upgrade = &led_user;
+		led-running = &led_user;
+		serial0 = &uart;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x0>;
+					read-only;
+				};
+
+				soft_config {
+					label = "soft_config";
+				};
+			};
+
+			partition@20000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x020000 0xfe0000>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&eth0 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};

--- a/target/linux/ath79/dts/qca9533_mikrotik_lhg-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_lhg-2nd.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_mikrotik_lhg-hb.dtsi"
+
+/ {
+	compatible = "mikrotik,lhg-2nd", "qca,qca9533";
+	model = "MikroTik LHG 2nD (RBLHG-2nD)";
+};

--- a/target/linux/ath79/dts/qca9533_mikrotik_lhg-hb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_lhg-hb.dtsi
@@ -1,21 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-
-#include "qca953x.dtsi"
+#include "qca9533_mikrotik_16mb.dtsi"
 
 / {
 	compatible = "mikrotik,lhg-hb", "qca,qca9533";
 	model = "MikroTik LHG-HB platform";
-
-	aliases {
-		led-boot = &led_user;
-		led-failsafe = &led_user;
-		led-upgrade = &led_user;
-		led-running = &led_user;
-		serial0 = &uart;
-	};
 
 	leds {
 		compatible = "gpio-leds";
@@ -67,99 +56,6 @@
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 		*/
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-			debounce-interval = <60>;
-		};
-	};
-};
-
-&spi {
-	status = "okay";
-
-	num-cs = <1>;
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x20000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				bios {
-					size = <0x1000>;
-					read-only;
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0x0>;
-					read-only;
-				};
-
-				soft_config {
-					label = "soft_config";
-				};
-			};
-
-			partition@20000 {
-				compatible = "mikrotik,minor";
-				label = "firmware";
-				reg = <0x020000 0xfe0000>;
-			};
-		};
-	};
-};
-
-&uart {
-	status = "okay";
-};
-
-&wmac {
-	status = "okay";
-
-	qca,no-eeprom;
-};
-
-&eth0 {
-	compatible = "syscon", "simple-mfd";
-};
-
-&eth1 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-
-	gmac-config {
-		device = <&gmac>;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_lhg-hb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_lhg-hb.dtsi
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca953x.dtsi"
+
+/ {
+	compatible = "mikrotik,lhg-hb", "qca,qca9533";
+	model = "MikroTik LHG-HB platform";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-upgrade = &led_user;
+		led-running = &led_user;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_wan_pin>;
+
+		power {
+			label = "mikrotik:blue:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_user: user {
+			label = "mikrotik:green:user";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "mikrotik:green:lan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "mikrotik:green:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssilow {
+			label = "mikrotik:green:rssilow";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumlow {
+			label = "mikrotik:green:rssimediumlow";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimediumhigh {
+			label = "mikrotik:green:rssimediumhigh";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		/* The rssihigh LED GPIO 16 is shared with the reset button, so it remains
+		unregistered here to avoid conflict.
+
+		rssihigh {
+			label = "mikrotik:green:rssihigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+		*/
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x0>;
+					read-only;
+				};
+
+				soft_config {
+					label = "soft_config";
+				};
+			};
+
+			partition@20000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x020000 0xfe0000>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&eth0 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&pinmux {
+	led_wan_pin: pinmux_led_wan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-952ui-5a2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-952ui-5a2nd.dts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9533_mikrotik_16mb.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-952ui-5ac2nd", "qca,qca9533";
+	model = "MikroTik hAP ac lite";
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_wan_pin>;
+
+		power {
+			label = "mikrotik:green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_user: user {
+			label = "mikrotik:green:user";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinmux {
+	led_wan_pin: pinmux_led_wan_pin {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+	reg = <0 0 0 0 0>;
+	};
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -1,5 +1,13 @@
 include ./common-mikrotik.mk
 
+define Device/mikrotik_lhg-2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := LHG 2nD (RBLHG-2nD)
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_lhg-2nd
+
 define Device/mikrotik_routerboard-493g
   $(Device/mikrotik_nand)
   SOC := ar7161

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -1,5 +1,14 @@
 include ./common-mikrotik.mk
 
+define Device/mikrotik_routerboard-952ui-5a2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := hAP ac lite (RB952Ui-5ac2nD)
+  IMAGE_SIZE := 16256k
+  SUPPORTED_DEVICES += rb-952ui-5ac2nd
+endef
+TARGET_DEVICES += mikrotik_routerboard-952ui-5a2nd
+
 define Device/mikrotik_lhg-2nd
   $(Device/mikrotik_nor)
   SOC := qca9533

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+boardname="${board##*,}"
+
+case "$board" in
+mikrotik,lhg-2nd)
+	ucidef_set_led_netdev "lan" "lan" "mikrotik:green:lan" "eth0"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -8,16 +8,17 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	mikrotik,lhg-2nd|\
+	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-wap-g-5hact2hnd)
+		ucidef_set_interface_lan "eth0"
+		;;
 	mikrotik,routerboard-493g)
 		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth0.2"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:3" "4:lan:2" "5:wan"
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
-		;;
-	mikrotik,routerboard-922uags-5hpacd|\
-	mikrotik,routerboard-wap-g-5hact2hnd)
-		ucidef_set_interface_lan "eth0"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
@@ -34,6 +35,7 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,lhg-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		label_mac="$mac_base"
 		lan_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ ath79_setup_interfaces()
 	case "$board" in
 	mikrotik,lhg-2nd|\
 	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-952ui-5ac2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		ucidef_set_interface_lan "eth0"
 		;;
@@ -36,6 +37,7 @@ ath79_setup_macs()
 
 	case "$board" in
 	mikrotik,lhg-2nd|\
+	mikrotik,routerboard-952ui-5ac2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		label_mac="$mac_base"
 		lan_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,12 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	mikrotik,lhg-2nd)
+		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
+		ath9k_patch_mac $(macaddr_add "$mac_base" +1) /tmp/$FIRMWARE
+		caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 0x440
+		rm -f /tmp/$FIRMWARE
+		;;
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
 		ath9k_patch_mac $(macaddr_add "$mac_base" +2) /tmp/$FIRMWARE

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -18,6 +18,12 @@ case "$FIRMWARE" in
 		caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 0x440
 		rm -f /tmp/$FIRMWARE
 		;;
+	mikrotik,routerboard-952ui-5ac2nd)
+		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
+		ath9k_patch_mac $(macaddr_add "$mac_base" +6) /tmp/$FIRMWARE
+		caldata_sysfsload_from_file /tmp/$FIRMWARE 0x0 0x440
+		rm -f /tmp/$FIRMWARE
+		;;
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_from_file $wlan_data 0x1000 0x440 /tmp/$FIRMWARE
 		ath9k_patch_mac $(macaddr_add "$mac_base" +2) /tmp/$FIRMWARE

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,6 +11,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
+	mikrotik,routerboard-952ui-5ac2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_sysfsload_from_file $wlan_data 0x5000 0x844
 		;;


### PR DESCRIPTION
Today I got my hands on this device and had the chance to add initial support for it. As I will have no access to it for the next time, I like to share what I was able to so far.
This work is based on https://github.com/openwrt/openwrt/pull/3094 (cherry-picked from @adrianschmutzler staging-tree)

---

This is a quick port of the devices from ar71xx.

Working:
* booting to initramfs
* LAN
* Wifi (5GHZ + 2GHz)
* green user-LED
* Reset-button (Failsafe)
* MAC-adresses are setup correctly, as per label

untested:
* sysupgrade
* mii for LAN-switch (via eth0)
* PoE out on LAN5
* USB / USB-Power

to be fixed / implemented
* LEDs for LAN-ports