### PR TITLE
sunxi: add support for FriendlyArm Zeropi

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -154,6 +154,12 @@ define U-Boot/nanopi_m1_plus
   BUILD_DEVICES:=friendlyarm_nanopi-m1-plus
 endef
 
+define U-Boot/zeropi
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=ZeroPi (H3)
+  BUILD_DEVICES:=friendlyarm_zeropi
+endef
+
 define U-Boot/nanopi_neo_air
   BUILD_SUBTARGET:=cortexa7
   NAME:=U-Boot for NanoPi NEO Air (H3)
@@ -299,6 +305,7 @@ UBOOT_TARGETS := \
 	Linksprite_pcDuino3 \
 	Lamobo_R1 \
 	nanopi_m1_plus \
+	zeropi \
 	nanopi_neo \
 	nanopi_neo_air \
 	nanopi_neo_plus2 \

--- a/package/boot/uboot-sunxi/patches/250-sun8i-h3-zeropi-add-device-tree.patch
+++ b/package/boot/uboot-sunxi/patches/250-sun8i-h3-zeropi-add-device-tree.patch
@@ -1,0 +1,76 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+@@ -540,6 +540,7 @@
+ 	sun8i-h3-orangepi-plus2e.dtb \
+ 	sun8i-h3-orangepi-zero-plus2.dtb \
+-	sun8i-h3-rervision-dvk.dtb
++	sun8i-h3-rervision-dvk.dtb \
++	sun8i-h3-zeropi.dtb
+ dtb-$(CONFIG_MACH_SUN8I_R40) += \
+ 	sun8i-r40-bananapi-m2-ultra.dtb \
+ 	sun8i-v40-bananapi-m2-berry.dtb
+diff --git a/arch/arm/dts/sun8i-h3-zeropi.dts b/arch/arm/dts/sun8i-h3-zeropi.dts
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h3-zeropi.dts
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "sun8i-h3-nanopi.dtsi"
++
++/ {
++	model = "FriendlyElec ZeroPi";
++	compatible = "friendlyarm,zeropi", "allwinner,sun8i-h3";
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&gmac_power_pin_nanopi>;
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&pio {
++	gmac_power_pin_nanopi: gmac_power_pin@0 {
++		pins = "PD6";
++		function = "gpio_out";
++	};
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&usb_otg {
++	status = "okay";
++	dr_mode = "peripheral";
++};
++
++&usbphy {
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++};

--- a/package/boot/uboot-sunxi/patches/251-sun8i-h3-zeropi-add-defconfig.patch
+++ b/package/boot/uboot-sunxi/patches/251-sun8i-h3-zeropi-add-defconfig.patch
@@ -1,0 +1,27 @@
+diff --git a/configs/zeropi_defconfig b/configs/zeropi_defconfig
+new file mode 100644
+index 0000000..1e51018
+--- /dev/null
++++ b/configs/zeropi_defconfig
+@@ -0,0 +1,21 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_MACH_SUN8I_H3=y
++CONFIG_DRAM_CLK=408
++CONFIG_DRAM_ZQ=3881979
++CONFIG_DRAM_ODT_EN=y
++CONFIG_MACPWR="PD6"
++# CONFIG_VIDEO_DE2 is not set
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-zeropi"
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_CONSOLE_MUX=y
++CONFIG_SPL=y
++CONFIG_SYS_CLK_FREQ=480000000
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -47,6 +47,14 @@ define Device/friendlyarm_nanopi-neo-air
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
 
+define Device/friendlyarm_zeropi
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := ZeroPi
+  DEVICE_PACKAGES:=kmod-rtc-sunxi
+  SOC := sun8i-h3
+endef
+TARGET_DEVICES += friendlyarm_zeropi
+
 define Device/lamobo_lamobo-r1
   DEVICE_VENDOR := Lamobo
   DEVICE_MODEL := Lamobo R1

--- a/target/linux/sunxi/patches-5.4/062-add-sun8i-h3-zeropi-support.patch
+++ b/target/linux/sunxi/patches-5.4/062-add-sun8i-h3-zeropi-support.patch
@@ -1,0 +1,79 @@
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+@@ -1118,6 +1118,7 @@
+ 	sun8i-h3-orangepi-plus2e.dtb \
+ 	sun8i-h3-orangepi-zero-plus2.dtb \
+ 	sun8i-h3-rervision-dvk.dtb \
++	sun8i-h3-zeropi.dtb \
+ 	sun8i-r16-bananapi-m2m.dtb \
+ 	sun8i-r16-nintendo-nes-classic.dtb \
+ 	sun8i-r16-nintendo-super-nes-classic.dtb \
+diff --git a/arch/arm/boot/dts/sun8i-h3-zeropi.dts b/arch/arm/boot/dts/sun8i-h3-zeropi.dts
+--- /dev/null
++++ b/arch/arm/boot/dts/sun8i-h3-zeropi.dts
+@@ -0,0 +1,62 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "sun8i-h3-nanopi.dtsi"
++
++/ {
++	model = "FriendlyElec ZeroPi";
++	compatible = "friendlyarm,zeropi", "allwinner,sun8i-h3";
++
++	aliases {
++		ethernet0 = &emac;
++	};
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&gmac_power_pin_nanopi>;
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&pio {
++	gmac_power_pin_nanopi: gmac_power_pin@0 {
++		pins = "PD6";
++		function = "gpio_out";
++	};
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&usb_otg {
++	status = "okay";
++	dr_mode = "peripheral";
++};
++
++&usbphy {
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++};


### PR DESCRIPTION
Specification
* CPU: Allwinner H3, Quad-core Cortex-A7 Up to 1.2GHz
* DDR3 RAM: 256MB/512MB
* Connectivity: 10/100/1000Mbps Ethernet
* USB Host: Type-A x 1
* MicroSD Slot x 1
* MicroUSB: for power input only
* Debug Serial Port: 4Pin, 2.54 mm pitch pin header
* Power Supply: DC 5V/2A
* PCB Dimension: 40 x 40 x 1.2mm

Installation:
* Burn the image file to an SD Card with dd or any image burning tool
* Boot ZeroPi from the SD Card

The following features are working and tested:

* Ethernet port 10/100/1000M Ethernet

Remarks: SBC is mostly compatible and boots with FriendlyARM NanoPI M1 plus DTS also (zeropi has no working hdmi)

Signed-off-by: Arturas Moskvinas <arturas.moskvinas@gmail.com>