### PR TITLE
[RFT] ath79/mikrotik: minor cleanup

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-e130n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e130n-v2.dts
@@ -122,18 +122,9 @@
 
 &uart {
 	status = "okay";
-
-};
-
-&eth0 {
-	compatible = "syscon", "simple-mfd";
 };
 
 &eth1 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-
 	mtd-mac-address = <&art 0x0>;
 
 	gmac-config {

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
@@ -67,15 +67,7 @@
 	};
 };
 
-&eth0 {
-	compatible = "syscon", "simple-mfd";
-};
-
 &eth1 {
-	status = "okay";
-
-	phy-handle = <&swphy0>;
-
 	gmac-config {
 		device = <&gmac>;
 	};


### PR DESCRIPTION
This does minor cleanup to the mikrotik subtarget:
- Fix the network setup on qca953x
- Introduce a function for setting ath9k caldata

@rogerpueyo @f00b4r0 @SvenRoederer 