### PR TITLE
ramips/mt7621: create common DTSI for Mikrotik devices

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik.dtsi
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <33000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x40000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0xf000>;
+					read-only;
+				};
+
+				soft_config {
+				};
+
+				partition@30000 {
+					label = "bios";
+					reg = <0x30000 0x1000>;
+					read-only;
+				};
+			};
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-750gr3.dts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7621_mikrotik.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-750gr3", "mediatek,mt7621-soc";
@@ -15,10 +12,6 @@
 		led-failsafe = &led_usr;
 		led-running = &led_usr;
 		led-upgrade = &led_usr;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
 	};
 
 	leds {
@@ -33,22 +26,6 @@
 		led_usr: usr {
 			label = "routerboard-750gr3:green:usr";
 			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		mode {
-			label = "mode";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,code = <BTN_0>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
 		};
 	};
 
@@ -69,59 +46,19 @@
 	};
 };
 
-&spi0 {
-	status = "okay";
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
 
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <20000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x40000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0xf000>;
-					read-only;
-				};
-
-				soft_config {
-				};
-
-				partition@30000 {
-					label = "bios";
-					reg = <0x30000 0x1000>;
-					read-only;
-				};
-			};
-
-			partition@40000 {
-				compatible = "mikrotik,minor";
-				label = "firmware";
-				reg = <0x040000 0xfc0000>;
-			};
-		};
+&partitions {
+	partition@40000 {
+		compatible = "mikrotik,minor";
+		label = "firmware";
+		reg = <0x040000 0xfc0000>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m11g.dts
@@ -1,9 +1,6 @@
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7621_mikrotik.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-m11g", "mediatek,mt7621-soc";
@@ -14,10 +11,6 @@
 		led-failsafe = &led_usr;
 		led-running = &led_usr;
 		led-upgrade = &led_usr;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200";
 	};
 
 	leds {
@@ -54,16 +47,6 @@
 		};
 	};
 
-	keys {
-		compatible = "gpio-keys";
-
-		res {
-			label = "reset";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
 	pcie0_vcc_reg {
 		compatible = "regulator-fixed";
 		regulator-name = "pcie0_vcc";
@@ -77,59 +60,11 @@
 	};
 };
 
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <33000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x40000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0xf000>;
-					read-only;
-				};
-
-				soft_config {
-				};
-
-				partition@30000 {
-					label = "bios";
-					reg = <0x30000 0x1000>;
-					read-only;
-				};
-			};
-
-			partition@40000 {
-				compatible = "mikrotik,minor";
-				label = "firmware";
-				reg = <0x040000 0xFC0000>;
-			};
-		};
+&partitions {
+	partition@40000 {
+		compatible = "mikrotik,minor";
+		label = "firmware";
+		reg = <0x040000 0xfc0000>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -1,9 +1,6 @@
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7621_mikrotik.dtsi"
 
 / {
 	compatible = "mikrotik,routerboard-m33g", "mediatek,mt7621-soc";
@@ -16,26 +13,12 @@
 		led-upgrade = &led_usr;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,115200";
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
 		led_usr: usr {
 			label = "routerboard-m33g:green:usr";
 			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		res {
-			label = "res";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
 		};
 	};
 
@@ -88,54 +71,6 @@
 };
 
 &spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <33000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x40000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0xf000>;
-					read-only;
-				};
-
-				soft_config {
-				};
-
-				partition@30000 {
-					label = "bios";
-					reg = <0x30000 0x1000>;
-					read-only;
-				};
-			};
-		};
-	};
-
 	flash@1 {
 		compatible = "jedec,spi-nor";
 		reg = <1>;
@@ -151,7 +86,7 @@
 			partition@40000 {
 				compatible = "mikrotik,minor";
 				label = "firmware";
-				reg = <0x040000 0xFC0000>;
+				reg = <0x040000 0xfc0000>;
 			};
 		};
 	};


### PR DESCRIPTION
This moves some common definitions for Mikrotik devices, mainly
routerboot partitions and reset key, to a common DTSI file.

If somebody has a better idea to name the "partitions" DT label, please tell me.

@f00b4r0 