### PR TITLE
[RFT] ath79: add support for TP-Link TL-WDR6500 v2

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wdr6500-v2", "qca,qca9561";
+	model = "TP-Link TL-WDR6500 v2";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth1;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan4 {
+			label = "tp-link:green:lan4";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "tp-link:green:lan3";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "tp-link:green:lan2";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "tp-link:green:lan1";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tp-link:green:wan";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system {
+			label = "tp-link:white:system";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x010000 0x7d0000>;
+			};
+
+			partition@7e0000 {
+				label = "mib0";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x0fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x0fc00>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+
+	mtd-mac-address = <&uboot 0x0fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -302,6 +302,13 @@ tplink,tl-wpa8630p-v2-eu|\
 tplink,tl-wpa8630p-v2-int)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3c"
 	;;
+tplink,tl-wdr6500-v2)
+	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
+	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "tp-link:green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "tp-link:green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "tp-link:green:lan4" "switch0" "0x10"
+	;;
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "tp-link:green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "tp-link:green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -125,7 +125,8 @@ ath79_setup_interfaces()
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
-	comfast,cf-e560ac)
+	comfast,cf-e560ac|\
+	tplink,tl-wdr6500-v2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -129,6 +129,10 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
+	tplink,tl-wdr6500-v2)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x0fc00) -2)
+		;;
 	tplink,tl-wpa8630-v1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x0fc00) +1)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -500,6 +500,21 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
+define Device/tplink_tl-wdr6500-v2
+  $(Device/tplink-8mlzma)
+  SOC := qca9561
+  DEVICE_MODEL := TL-WDR6500
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 8000k
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma | tplink-v1-header
+  TPLINK_HWID := 0x65000002
+  TPLINK_HEADER_VERSION := 2
+  SUPPORTED_DEVICES += tl-wdr6500-v2
+endef
+TARGET_DEVICES += tplink_tl-wdr6500-v2
+
 define Device/tplink_tl-wpa8630-v1
   $(Device/tplink-8mlzma)
   SOC := qca9563


### PR DESCRIPTION
This ports the TP-Link TL-WDR6500 v2 from ar71xx to ath79.

Specifications:

  SoC: QCA9561
  CPU: 750 MHz
  Flash: 8 MiB (Winbond W25Q64FVSIG)
  RAM: 128 MiB
  WiFi 2.4 GHz: QCA956X 3x3 MIMO 802.11b/g/n
  WiFi 5 GHz: QCA9882-BR4A 2x2 MIMO 802.11a/n/ac
  Ethernet: 4x LAN and 1x WAN (all 100M)
  USB: 1x Header

Flashing instructions:

  As it appears, the device does not support flashing via GUI or
  TFTP, only serial is possible.
