### PR TITLE
[RFT] ath79: add support for TP-Link TL-WDR7500 v3

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr7500-v3.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr7500-v3.dts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9558_tplink_archer-c.dtsi"
+
+/ {
+	compatible = "tplink,tl-wdr7500-v3", "qca,qca9558";
+	model = "TP-Link TL-WDR7500 v3";
+};
+
+&keys {
+	rfkill {
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		linux,code = <KEY_RFKILL>;
+		linux,input-type = <EV_SW>;
+		debounce-interval = <60>;
+	};
+};
+
+&leds {
+	wlan5g {
+		label = "tp-link:green:wlan5g";
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&mtdparts {
+	uboot: partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	partition@20000 {
+		label = "firmware";
+		compatible = "tplink,firmware";
+		reg = <0x020000 0x7d0000>;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -276,7 +276,8 @@ ath79_setup_interfaces()
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v1|\
 	tplink,archer-c7-v2|\
-	tplink,tl-wdr4900-v2)
+	tplink,tl-wdr4900-v2|\
+	tplink,tl-wdr7500-v3)
 		ucidef_add_switch "switch0" \
 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -102,7 +102,8 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		;;
 	tplink,archer-c5-v1|\
-	tplink,archer-c7-v2)
+	tplink,archer-c7-v2|\
+	tplink,tl-wdr7500-v3)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary u-boot 0x1fc00) -1)
 		;;

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -500,6 +500,18 @@ define Device/tplink_tl-wdr4900-v2
 endef
 TARGET_DEVICES += tplink_tl-wdr4900-v2
 
+define Device/tplink_tl-wdr7500-v3
+  $(Device/tplink-8mlzma)
+  SOC := qca9558
+  DEVICE_MODEL := TL-WDR7500
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
+	ath10k-firmware-qca988x-ct
+  TPLINK_HWID := 0x75000003
+  SUPPORTED_DEVICES += archer-c7
+endef
+TARGET_DEVICES += tplink_tl-wdr7500-v3
+
 define Device/tplink_tl-wpa8630-v1
   $(Device/tplink-8mlzma)
   SOC := qca9563


### PR DESCRIPTION
This ports support for the TP-Link TL-WDR7500 v3 from ar71xx to ath79.

The basic features appear to be identical to the Archer C7 v1, however
it has the (supported) QCA9880-BR4A chip of the C7 v2.

Specifications:

  SoC:       QCA9558
  CPU:       720 MHz
  Flash:     8 MiB
  RAM:       128 MiB
  WLAN:      2.4 GHz b/g/n, 5 GHz a/n/ac
             Qualcomm Atheros QCA9880-BR4A
  Ethernet:  5x Gbit ports
  USB:       2x 2.0 ports

Flashing instructions:

Upload the factory image via the OEM firmware GUI.

TFTP recovery appears to be available as well.