### PR TITLE
bcm63xx: Add support for D-Link DSL-2750u rev C1

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -40,6 +40,7 @@ comtrend,ar-5315u)
 	ucidef_set_led_usbdev "usb" "USB" "AR-5315u:green:usb" "1-1"
 	;;
 comtrend,vr-3032u|\
+d-link,dsl-2750u-c1|\
 huawei,hg253s-v2)
 	ucidef_set_led_usbdev "usb" "USB" "$model:green:usb" "1-1"
 	;;

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -31,6 +31,7 @@ comtrend,vr-3025u|\
 comtrend,vr-3025un|\
 comtrend,vr-3026e|\
 d-link,dsl-274xb-f1|\
+d-link,dsl-2750u-c1|\
 d-link,dsl-275xb-d1|\
 huawei,echolife-hg622|\
 huawei,echolife-hg655b|\

--- a/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-2750u-c1.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-2750u-c1.dts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "D-Link DSL-2750U rev C1";
+	compatible = "d-link,dsl-2750u-c1", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wifi {
+			label = "wifi";
+			gpios = <&pinctrl 12 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		inet_green {
+			label = "dsl-2750u-c1:green:inet";
+			gpios = <&pinctrl 1 1>;
+		};
+
+		led_power_green: power_green {
+			label = "dsl-2750u-c1:green:power";
+			gpios = <&pinctrl 4 1>;
+			default-state = "on";
+		};
+
+		inet_red {
+			label = "dsl-2750u-c1:red:inet";
+			gpios = <&pinctrl 7 1>;
+		};
+
+		power_red {
+			label = "dsl-2750u-c1:red:power";
+			gpios = <&pinctrl 8 1>;
+		};
+
+		wps_green {
+			label = "dsl-2750u-c1:green:wps";
+			gpios = <&pinctrl 9 1>;
+		};
+
+		usb_green {
+			label = "dsl-2750u-c1:green:usb";
+			gpios = <&pinctrl 10 1>;
+		};
+
+		dsl_green {
+			label = "dsl-2750u-c1:green:dsl";
+			gpios = <&pinctrl 11 1>;
+		};
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			cfe@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			linux@10000 {
+				reg = <0x010000 0x7e0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+
+			nvram@7f0000 {
+				reg = <0x7f0000 0x010000>;
+				label = "nvram";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -571,6 +571,19 @@ define Device/d-link_dsl-274xb-f1
 endef
 TARGET_DEVICES += d-link_dsl-274xb-f1
 
+define Device/d-link_dsl-2750u-c1
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DSL-2750U
+  DEVICE_VARIANT := C1
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := 963281TAVNG
+  CHIP_ID := 6328
+  FLASH_MB := 8
+  DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += d-link_dsl-2750u-c1
+
 define Device/d-link_dsl-275xb-d1
   $(Device/bcm63xx)
   DEVICE_VENDOR := D-Link

--- a/target/linux/bcm63xx/patches-5.4/532-board-bcm6328-dsl-2750u-c1.patch
+++ b/target/linux/bcm63xx/patches-5.4/532-board-bcm6328-dsl-2750u-c1.patch
@@ -1,0 +1,10 @@
+--- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -1236,6 +1236,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },
+ 	{ .compatible = "comtrend,ar-5387un", .data = &board_AR5387un, },
+ 	{ .compatible = "d-link,dsl-274xb-f1", .data = &board_dsl_274xb_f1, },
++	{ .compatible = "d-link,dsl-2750u-c1", .data = &board_A4001N, },
+ 	{ .compatible = "nucom,r5010un-v2", .data = &board_R5010UNV2, },
+ 	{ .compatible = "sagem,fast-2704-v2", .data = &board_FAST2704V2, },
+ 	{ .compatible = "sercomm,ad1018", .data = &board_AD1018, },


### PR DESCRIPTION
This adds support for the D-Link DSL-2750u rev C1.
(https://deviwiki.com/wiki/D-Link_DSL-2750U_rev_C1)

It uses the same hardware as ADB P.DG A4001N.
CPU:   Broadcom BCM63281 (320 MHz)
RAM:   32M (Winbond W9725G6JB)
Flash:   8M (MXIC MX25L6445E)
Ethernet:   4x 100 Mbps
Wireless:   802.11b/g/n: BCM43225
USB:   1x 2.0

Flash instructions:

1.  Assign static IP 192.168.1.100 to PC
2.  Unplug the power source
3.  Press the RESET button at the router, don't release it yet!
4.  Plug the power source.Wait some seconds
5.  Release the RESET button
6.  Browse to http://192.168.1.1
7.  Send the openwrt-bcm63xx-generic-DSL2750U-C1-squashfs-cfe.bin and
    wait some minutes until the firmware upgrade finish.