### PR TITLE
ramips: mt7621: load compat_version from /etc/board.json

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/uci-defaults/05_fix-compat-version
@@ -2,7 +2,10 @@
 # Copyright (C) 2020 OpenWrt.org
 #
 
-uci set system.@system[0].compat_version="1.1"
+compat_version=$(cat /etc/board.json | jsonfilter -e "@['system']['compat_version']")
+[ -n "$compat_version" ] || compat_version="1.0"
+
+uci set system.@system[0].compat_version="$compat_version"
 uci commit system
 
 exit 0


### PR DESCRIPTION
It is better to load compat_version from /etc/board.json