### PR TITLE
ramips: Add support for Wavlink WL-WN530HG4

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,wl-wn530hg4", "ralink,mt7620a-soc";
+	model = "Wavlink WL-WN530HG4";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		serial0 = &uartlite;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "wl-wn530hg4:blue:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		status_yellow {
+			label = "wl-wn530hg4:yellow:status";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+
+		status_red {
+			label = "wl-wn530hg4:red:status";
+			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii2_pins &mdio_pins>;
+
+	mtd-mac-address = <&factory 0x28>;
+
+	mediatek,portmap = "llllw";
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1078,6 +1078,15 @@ define Device/vonets_var11n-300
 endef
 TARGET_DEVICES += vonets_var11n-300
 
+define Device/wavlink_wl-wn530hg4
+  SOC := mt7620a
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN530HG4
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += wavlink_wl-wn530hg4
+
 define Device/wrtnode_wrtnode
   SOC := mt7620n
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -193,7 +193,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "0:wan" "6@eth0"
 		;;
-	phicomm,k2g)
+	phicomm,k2g|\
+	wavlink,wl-wn530hg4)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5:wan" "6@eth0"
 		;;
@@ -334,7 +335,8 @@ ramips_setup_macs()
 	lenovo,newifi-y1|\
 	lenovo,newifi-y1s|\
 	ohyeah,oy-0001|\
-	phicomm,k2g)
+	phicomm,k2g|\
+	wavlink,wl-wn530hg4)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	linksys,e1700)


### PR DESCRIPTION
ramips: Add support for Wavlink WL-WN530HG4

Same hardware as Phicomm K2G but different flash layout.

Specification:
- SoC: MediaTek MT7620A
- Flash: 8 MB
- RAM: 64 MB
- Ethernet: 4 FE ports and 1 GE port (RTL8211F on port 5)
- Wireless radio: MT7620 for 2.4G and MT7612E for 5G, both equipped with external PA.
- UART: 1 x UART on PCB - 57600 8N1

Flash instruction:
To avoid requiring UART for TFTP a dual flash procedure is suggested to install the squashfs image:
1. Rename openwrt-ramips-mt7620-wavlink_wl-wn530hg4-initramfs-kernel.bin to WN530HG4-WAVLINK.
2. Flash this file with the factory web interface.
3. With OpenWRT now running use standard sysupgrade to install the squashfs image.