### PR TITLE
ramips: add support for Dlink DIR-853 A3

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-853-a3", "mediatek,mt7621-soc";
+	model = "D-Link DIR-853 A3";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_net_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "orange:net";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		net_blue {
+			label = "blue:net";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_blue {
+			label = "blue:usb";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "config2";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "firmware";
+			compatible = "openwrt,uimage", "denx,uimage";
+			openwrt,padding = <96>;
+			reg = <0x180000 0x2800000>;
+		};
+
+		partition@2980000 {
+			label = "private";
+			reg = <0x2980000 0x2000000>;
+			read-only;
+		};
+
+		partition@4980000 {
+			label = "firmware2";
+			reg = <0x4980000 0x2800000>;
+		};
+
+		partition@7180000 {
+			label = "mydlink";
+			reg = <0x7180000 0x600000>;
+			read-only;
+		};
+
+		partition@7780000 {
+			label = "reserved";
+			reg = <0x7780000 0x880000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mtd-mac-address = <&factory 0x4>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -342,6 +342,13 @@ define Device/dlink_dir-2660-a1
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 
+define Device/dlink_dir-853-a3
+  $(Device/dlink_dir-xx60-a1)
+  DEVICE_MODEL := DIR-853
+  DEVICE_VARIANT := A3
+endef
+TARGET_DEVICES += dlink_dir-853-a3
+
 define Device/dlink_dir-860l-b1
   $(Device/dsa-migration)
   $(Device/seama)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -34,6 +34,9 @@ dlink,dir-2640-a1|\
 dlink,dir-2660-a1)
 	ucidef_set_led_netdev "wan" "wan" "white:net" "wan"
 	;;
+dlink,dir-853-a3)
+	ucidef_set_led_netdev "wan" "wan" "blue:net" "wan"
+	;;
 dlink,dir-860l-b1|\
 dlink,dir-867-a1|\
 dlink,dir-878-a1|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,13 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	dlink,dir-853-a3)
+		[ "$PHYNBR" = "0" ] && \
+			base_mac=$(mtd_get_mac_binary factory 0x4)
+			base_mac=$(macaddr_setbit $base_mac 26)
+			base_mac=$(macaddr_unsetbit $base_mac 27)
+			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
+		;;
 	glinet,gl-mt1300)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -56,6 +56,7 @@ platform_do_upgrade() {
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
+	dlink,dir-853-a3|\
 	hiwifi,hc5962|\
 	jcg,q20|\
 	linksys,e5600|\


### PR DESCRIPTION
Specifications:
* SoC: MT7621AT
* RAM: 256MB
* Flash: 128MB NAND flash
* WiFi: MT7615DN (2.4GHz+5Ghz) with DBDC
* LAN: 5x1000M
* Firmware layout is Uboot with extra 96 bytes in header
* Base PCB is DIR-1360 REV1.0
* LEDs Power Blue+Orange,Wan Blue+Orange,WPS Blue,"2.4G"Blue, "5G" Blue,
 USB Blue
* Buttons Reset,WPS, Wifi


lan      factory 0xe000              (label - same as stock firmware)
wan      factory 0xe006            (same as stock)
2.4 GHz  factory 0x4+bitswap (same as stock)
5.0 GHz  factory 0x4                 (Same as stock)

Flashing instruction:

The Dlink "Emergency Room" cannot be accessed through the reset
button on this device. You can either use console or use the
encrypted factory image availble in the openwrt forum [or here](https://www.mediafire.com/file/z8jmmfz6nwbw1ys/openwrt-21.02.0-rc2-ramips-mt7621-dlink_dir-853-a3-squashfs-factory-enc.bin/file)
The image is 21.02-rc2 encrypted ready to be flashed.

Once the encrypted image is flashed throuh the stock Dlink web
interface, the sysupgrade images can be used.

Header pins needs to be soldered near the WPS and Wifi buttons.

The layout for the pins is (VCC,RX,TX,GND). No need to connect the VCC.

the settings are:

Bps/Par/Bits          : 57600 8N1
Hardware Flow Control : No
Software Flow Control : No

Connect your client computer to LAN1 of the device
Set your client IP address manually to 192.168.0.101 / 255.255.255.0.
Call the recovery page or tftp for the device at http://192.168.0.1
Use the provided emergency web GUI to upload and flash a new firmware to
the device

At the time of writing the the wireless config need to be setup by
editing the wireless config file. A sample wireless config file can
be found on the openwrt forum as well.

Signed-off-by: Karim Dehouche <karimdplay@gmail.com>