### PR TITLE
ath79: add support for COMFAST CF-E375AC

### DIFF
--- a/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
+++ b/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "COMFAST CF-E375AC";
+	compatible = "comfast,cf-e375ac", "qca,qca9563";
+
+	aliases {
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-running = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_lan: lan {
+			label = "green:lan";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan {
+			label = "red:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <500>;
+		always-running;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			art: partition@40000 {
+				label = "art";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <10>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -132,6 +132,10 @@ comfast,cf-e314n-v2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+comfast,cf-e375ac)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
+	ucidef_set_led_switch "wan" "WAN" "red:wan" "switch0" "0x02"
+	;;
 comfast,cf-e5)
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -186,6 +186,10 @@ ath79_setup_interfaces()
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
+	comfast,cf-e375ac)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:wan" "2:lan"
+		;;
 	comfast,cf-e560ac)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
@@ -487,6 +491,9 @@ ath79_setup_macs()
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macb -i $(find_mtd_part "tffs (1)"))
 		;;
+	comfast,cf-e375ac)
+		wan_mac=$(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
+		;; 	
 	compex,wpj344-16m|\
 	compex,wpj563)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -173,6 +173,7 @@ case "$FIRMWARE" in
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 		;;
+	comfast,cf-e375ac|\
 	comfast,cf-e560ac|\
 	comfast,cf-ew72|\
 	comfast,cf-wr752ac-v1)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -553,6 +553,16 @@ define Device/comfast_cf-e314n-v2
 endef
 TARGET_DEVICES += comfast_cf-e314n-v2
 
+define Device/comfast_cf-e375ac
+  SOC := qca9563
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E375AC
+  DEVICE_PACKAGES := kmod-ath10k-ct \
+	ath10k-firmware-qca9888-ct -uboot-envtools
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += comfast_cf-e375ac
+
 define Device/comfast_cf-e5
   SOC := qca9531
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
COMFAST CF-E375AC is a ceiling mount AP with PoE support, based on Qualcomm/Atheros QCA9563 + QCA9886 + QCA8337.

Short specification:

    2x 10/100/1000 Mbps Ethernet, with PoE support
    128MB of RAM (DDR2)
    16 MB of FLASH
    3T3R 2.4 GHz, 802.11b/g/n
    2T2R 5 GHz, 802.11ac/n/a, wave 2
    built-in 5x 3 dBi antennas
    output power (max): 500 mW (27 dBm)
    1x RGB LED, 1x button
    built-in watchdog chipset

Flash instruction:
1) Original firmware is based on OpenWrt.
Use sysupgrade image directly in vendor GUI.

2) TFTP
2.1) Set a tftp server on your machine with a fixed IP address of 192.168.1.10. A place the sysupgrade as firmware_auto.bin.
2.2) boot the device with an ethernet connection on fixed ip route
2.3) wait a few seconds and try to login via ssh

3) TFTP trough Bootloader
3.1) open the device case and get a uart connection working
3.2) stop the autoboot process and test connection with serverip
3.3) name the sysupgrade image firmware.bin and run firmware_upg


Signed-off-by:
Joao Henrique Albuquerque <joaohccalbu@gmail.com>

