### PR TITLE
[18.06] tools/squashfs4: fix bugs of xz compress options

### DIFF
--- a/tools/squashfs4/patches/160-expose_lzma_xz_options.patch
+++ b/tools/squashfs4/patches/160-expose_lzma_xz_options.patch
@@ -370,9 +370,9 @@
 +	if (options.preset == 6 &&
 +			options.extreme == 0 &&
 +			options.lc == LZMA_OPT_LC_DEFAULT &&
-+			options.lp == LZMA_OPT_LC_DEFAULT &&
++			options.lp == LZMA_OPT_LP_DEFAULT &&
 +			options.pb == LZMA_OPT_PB_DEFAULT &&
-+			options.fb == 0 &&
++			options.fb == LZMA_OPT_FB_DEFAULT &&
 +			options.dict_size == block_size &&
 +			flags == 0)
 +		return NULL;
@@ -405,7 +405,7 @@
 +		options.preset = 6;
 +		options.extreme = 0;
 +		options.lc = LZMA_OPT_LC_DEFAULT;
-+		options.lp = LZMA_OPT_LC_DEFAULT;
++		options.lp = LZMA_OPT_LP_DEFAULT;
 +		options.pb = LZMA_OPT_PB_DEFAULT;
 +		options.fb = LZMA_OPT_FB_DEFAULT;
 +		options.dict_size = block_size;


### PR DESCRIPTION
lzma_xz_dump_options never return NULL,
should compare real options with default options

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>

squashfs4 was removed from master, so just patch to 18.06