### PR TITLE
layerscape: fix linux headers install issue

### DIFF
--- a/target/linux/layerscape/patches-5.4/701-net-0408-sdk_fman-fix-CONFIG_COMPAT-leak-during-headers-insta.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0408-sdk_fman-fix-CONFIG_COMPAT-leak-during-headers-insta.patch
@@ -1,0 +1,529 @@
+From 7837219f354524f6c2c9332a6a5aa616c28f53a9 Mon Sep 17 00:00:00 2001
+From: Yangbo Lu <yangbo.lu@nxp.com>
+Date: Thu, 20 Aug 2020 18:38:49 +0800
+Subject: [PATCH] sdk_fman: fix CONFIG_COMPAT leak during headers installing
+
+This patch is to fix CONFIG_COMPAT leak during headers installing
+by replacing CONFIG_COMPAT kernel option with FM_COMPAT instead.
+
+Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
+---
+ .../net/ethernet/freescale/sdk_fman/ncsw_config.mk |  5 ++
+ include/uapi/linux/fmd/Peripherals/fm_ioctls.h     | 16 ++---
+ include/uapi/linux/fmd/Peripherals/fm_pcd_ioctls.h | 72 +++++++++++-----------
+ .../uapi/linux/fmd/Peripherals/fm_port_ioctls.h    | 14 ++---
+ .../uapi/linux/fmd/Peripherals/fm_test_ioctls.h    |  4 +-
+ 5 files changed, 58 insertions(+), 53 deletions(-)
+
+diff --git a/drivers/net/ethernet/freescale/sdk_fman/ncsw_config.mk b/drivers/net/ethernet/freescale/sdk_fman/ncsw_config.mk
+index 586f9c7..99a0b73 100644
+--- a/drivers/net/ethernet/freescale/sdk_fman/ncsw_config.mk
++++ b/drivers/net/ethernet/freescale/sdk_fman/ncsw_config.mk
+@@ -44,6 +44,11 @@ ifdef CONFIG_FMAN_ARM
+ ccflags-y += -I$(FMAN)/inc/integrations/LS1043
+ endif
+ 
++# FM_COMPAT is used in kernel headers in case of kernel option leaking
++ifeq ("$(CONFIG_COMPAT)", "y")
++ccflags-y += -DFM_COMPAT
++endif
++
+ ccflags-y += -I$(FMAN)/src/inc
+ ccflags-y += -I$(FMAN)/src/inc/system
+ ccflags-y += -I$(FMAN)/src/inc/wrapper
+diff --git a/include/uapi/linux/fmd/Peripherals/fm_ioctls.h b/include/uapi/linux/fmd/Peripherals/fm_ioctls.h
+index e0c2dd3..ff9e66b6 100644
+--- a/include/uapi/linux/fmd/Peripherals/fm_ioctls.h
++++ b/include/uapi/linux/fmd/Peripherals/fm_ioctls.h
+@@ -434,7 +434,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Retval        Handle to FM VSP object, or NULL for Failure.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_CONFIG_COMPAT                             _IOWR(FM_IOC_TYPE_BASE, FM_IOC_NUM(8), ioc_compat_fm_vsp_params_t)
+ #endif
+ #define FM_IOC_VSP_CONFIG                                    _IOWR(FM_IOC_TYPE_BASE, FM_IOC_NUM(8), ioc_fm_vsp_params_t)
+@@ -448,7 +448,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Return        E_OK on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_INIT_COMPAT                               _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(9), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_IOC_VSP_INIT                                      _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(9), ioc_fm_obj_t)
+@@ -464,7 +464,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Return        E_OK on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_FREE_COMPAT                               _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(10), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_IOC_VSP_FREE                                      _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(10), ioc_fm_obj_t)
+@@ -482,7 +482,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Cautions      Allowed only following FM_VSP_Config() and before FM_VSP_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_CONFIG_POOL_DEPLETION_COMPAT              _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(11), ioc_compat_fm_buf_pool_depletion_params_t)
+ #endif
+ #define FM_IOC_VSP_CONFIG_POOL_DEPLETION                     _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(11), ioc_fm_buf_pool_depletion_params_t)
+@@ -512,7 +512,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Cautions      Allowed only following FM_VSP_Config() and before FM_VSP_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_CONFIG_BUFFER_PREFIX_CONTENT_COMPAT       _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(12), ioc_compat_fm_buffer_prefix_content_params_t)
+ #endif
+ #define FM_IOC_VSP_CONFIG_BUFFER_PREFIX_CONTENT              _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(12), ioc_fm_buffer_prefix_content_params_t)
+@@ -530,7 +530,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Cautions      Allowed only following FM_VSP_Config() and before FM_VSP_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_CONFIG_NO_SG_COMPAT                     _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(13), ioc_compat_fm_vsp_config_no_sg_params_t)
+ #endif
+ #define FM_IOC_VSP_CONFIG_NO_SG                            _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(13), ioc_fm_vsp_config_no_sg_params_t)
+@@ -554,7 +554,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Cautions      Allowed only following FM_VSP_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_VSP_GET_BUFFER_PRS_RESULT_COMPAT            _IOWR(FM_IOC_TYPE_BASE, FM_IOC_NUM(14), ioc_compat_fm_vsp_prs_result_params_t)
+ #endif
+ #define FM_IOC_VSP_GET_BUFFER_PRS_RESULT                   _IOWR(FM_IOC_TYPE_BASE, FM_IOC_NUM(14), ioc_fm_vsp_prs_result_params_t)
+@@ -612,7 +612,7 @@ typedef struct ioc_fm_ctrl_mon_counters_params_t {
+ 
+  @Cautions      Allowed only following FM_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_IOC_CTRL_MON_GET_COUNTERS_COMPAT                _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(17), ioc_compat_fm_ctrl_mon_counters_params_t)
+ #endif
+ #define FM_IOC_CTRL_MON_GET_COUNTERS                       _IOW(FM_IOC_TYPE_BASE, FM_IOC_NUM(17), ioc_fm_ctrl_mon_counters_params_t)
+diff --git a/include/uapi/linux/fmd/Peripherals/fm_pcd_ioctls.h b/include/uapi/linux/fmd/Peripherals/fm_pcd_ioctls.h
+index d13e878..0606e80 100644
+--- a/include/uapi/linux/fmd/Peripherals/fm_pcd_ioctls.h
++++ b/include/uapi/linux/fmd/Peripherals/fm_pcd_ioctls.h
+@@ -312,7 +312,7 @@ typedef struct ioc_fm_pcd_kg_dflt_value_params_t {
+ 
+  @Cautions      Allowed only when PCD is disabled.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_PRS_LOAD_SW_COMPAT  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(3), ioc_compat_fm_pcd_prs_sw_params_t)
+ #endif
+ #define FM_PCD_IOC_PRS_LOAD_SW  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(3), ioc_fm_pcd_prs_sw_params_t)
+@@ -385,7 +385,7 @@ typedef struct ioc_fm_pcd_kg_dflt_value_params_t {
+ 
+  @Cautions      Allowed only following FM_PCD_Init() & FM_PCD_KgSchemeSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_KG_SCHEME_GET_CNTR_COMPAT  _IOR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(4), ioc_compat_fm_pcd_kg_scheme_spc_t)
+ #endif
+ #define FM_PCD_IOC_KG_SCHEME_GET_CNTR  _IOR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(4), ioc_fm_pcd_kg_scheme_spc_t)
+@@ -2413,7 +2413,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only following FM_PCD_MatchTableSet().
+ *//***************************************************************************/
+ 
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_GET_KEY_STAT_COMPAT   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(12), ioc_compat_fm_pcd_cc_tbl_get_stats_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_GET_KEY_STAT  _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(12), ioc_fm_pcd_cc_tbl_get_stats_t)
+@@ -2439,7 +2439,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only following FM_PCD_MatchTableSet().
+ *//***************************************************************************/
+ 
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_GET_MISS_STAT_COMPAT   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(13), ioc_compat_fm_pcd_cc_tbl_get_stats_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_GET_MISS_STAT  _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(13), ioc_fm_pcd_cc_tbl_get_stats_t)
+@@ -2463,7 +2463,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only following FM_PCD_HashTableSet().
+ *//***************************************************************************/
+ 
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_HASH_TABLE_GET_MISS_STAT_COMPAT   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(14), ioc_compat_fm_pcd_cc_tbl_get_stats_t)
+ #endif
+ #define FM_PCD_IOC_HASH_TABLE_GET_MISS_STAT  _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(14), ioc_fm_pcd_cc_tbl_get_stats_t)
+@@ -2511,7 +2511,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_NET_ENV_CHARACTERISTICS_SET_COMPAT   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(20), ioc_compat_fm_pcd_net_env_params_t)
+ #endif
+ #define FM_PCD_IOC_NET_ENV_CHARACTERISTICS_SET  _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(20), ioc_fm_pcd_net_env_params_t)
+@@ -2525,7 +2525,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_NET_ENV_CHARACTERISTICS_DELETE_COMPAT  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(21), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_NET_ENV_CHARACTERISTICS_DELETE   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(21), ioc_fm_obj_t)
+@@ -2544,7 +2544,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_KG_SCHEME_SET_COMPAT     _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(24), ioc_compat_fm_pcd_kg_scheme_params_t)
+ #endif
+ #define FM_PCD_IOC_KG_SCHEME_SET    _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(24), ioc_fm_pcd_kg_scheme_params_t)
+@@ -2558,7 +2558,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_KG_SCHEME_DELETE_COMPAT  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(25), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_KG_SCHEME_DELETE     _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(25), ioc_fm_obj_t)
+@@ -2575,7 +2575,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_CC_ROOT_BUILD_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(26), compat_uptr_t)
+ #endif
+ #define FM_PCD_IOC_CC_ROOT_BUILD    _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(26), void *) /* workaround ...*/
+@@ -2587,7 +2587,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Param[in]     ioc_fm_obj_t - The id of a CC tree.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_CC_ROOT_DELETE_COMPAT    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(27), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_CC_ROOT_DELETE    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(27), ioc_fm_obj_t)
+@@ -2604,7 +2604,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_SET_COMPAT    _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(28), compat_uptr_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_SET    _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(28), void *) /* workaround ...*/
+@@ -2618,7 +2618,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_DELETE_COMPAT    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(29), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_DELETE   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(29), ioc_fm_obj_t)
+@@ -2634,7 +2634,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_CcRootBuild().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_CC_ROOT_MODIFY_NEXT_ENGINE_COMPAT   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(30), ioc_compat_fm_pcd_cc_tree_modify_next_engine_params_t)
+ #endif
+ #define FM_PCD_IOC_CC_ROOT_MODIFY_NEXT_ENGINE   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(30), ioc_fm_pcd_cc_tree_modify_next_engine_params_t)
+@@ -2650,7 +2650,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_MatchTableSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_NEXT_ENGINE_COMPAT   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(31), ioc_compat_fm_pcd_cc_node_modify_next_engine_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_NEXT_ENGINE   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(31), ioc_fm_pcd_cc_node_modify_next_engine_params_t)
+@@ -2666,7 +2666,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_MatchTableSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_MISS_NEXT_ENGINE_COMPAT   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(32), ioc_compat_fm_pcd_cc_node_modify_next_engine_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_MISS_NEXT_ENGINE _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(32), ioc_fm_pcd_cc_node_modify_next_engine_params_t)
+@@ -2684,7 +2684,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only after FM_PCD_MatchTableSet() has been called for this
+                 node and for all of the nodes that lead to it.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_REMOVE_KEY_COMPAT    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(33), ioc_compat_fm_pcd_cc_node_remove_key_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_REMOVE_KEY   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(33), ioc_fm_pcd_cc_node_remove_key_params_t)
+@@ -2705,7 +2705,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only after FM_PCD_MatchTableSet() has been called for this
+                 node and for all of the nodes that lead to it.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_ADD_KEY_COMPAT   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(34), ioc_compat_fm_pcd_cc_node_modify_key_and_next_engine_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_ADD_KEY  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(34), ioc_fm_pcd_cc_node_modify_key_and_next_engine_params_t)
+@@ -2722,7 +2722,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only following FM_PCD_MatchTableSet() not only of the relevnt node but also
+                 the node that points to this node
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_KEY_AND_NEXT_ENGINE_COMPAT    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(35), ioc_compat_fm_pcd_cc_node_modify_key_and_next_engine_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_KEY_AND_NEXT_ENGINE   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(35), ioc_fm_pcd_cc_node_modify_key_and_next_engine_params_t)
+@@ -2739,7 +2739,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+  @Cautions      Allowed only after FM_PCD_MatchTableSet() has been called for this
+                 node and for all of the nodes that lead to it.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_KEY_COMPAT    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(36), ioc_compat_fm_pcd_cc_node_modify_key_params_t)
+ #endif
+ #define FM_PCD_IOC_MATCH_TABLE_MODIFY_KEY   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(36), ioc_fm_pcd_cc_node_modify_key_params_t)
+@@ -2766,7 +2766,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_HASH_TABLE_SET_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(37), ioc_compat_fm_pcd_hash_table_params_t)
+ #endif
+ #define FM_PCD_IOC_HASH_TABLE_SET _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(37), ioc_fm_pcd_hash_table_params_t)
+@@ -2784,7 +2784,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_HashTableSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_HASH_TABLE_DELETE_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(37), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_HASH_TABLE_DELETE _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(37), ioc_fm_obj_t)
+@@ -2803,7 +2803,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_HashTableSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_HASH_TABLE_ADD_KEY_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(39), ioc_compat_fm_pcd_hash_table_add_key_params_t)
+ #endif
+ #define FM_PCD_IOC_HASH_TABLE_ADD_KEY _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(39), ioc_fm_pcd_hash_table_add_key_params_t)
+@@ -2820,7 +2820,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_HashTableSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_HASH_TABLE_REMOVE_KEY_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(40), ioc_compat_fm_pcd_hash_table_remove_key_params_t)
+ #endif
+ #define FM_PCD_IOC_HASH_TABLE_REMOVE_KEY _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(40), ioc_fm_pcd_hash_table_remove_key_params_t)
+@@ -2836,7 +2836,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_PLCR_PROFILE_SET_COMPAT     _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(41), ioc_compat_fm_pcd_plcr_profile_params_t)
+ #endif
+ #define FM_PCD_IOC_PLCR_PROFILE_SET     _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(41), ioc_fm_pcd_plcr_profile_params_t)
+@@ -2851,7 +2851,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_PLCR_PROFILE_DELETE_COMPAT   _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(41), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_PLCR_PROFILE_DELETE  _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(41), ioc_fm_obj_t)
+@@ -2867,7 +2867,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        A handle to the initialized object on success; NULL code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MANIP_NODE_SET_COMPAT    _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(43), ioc_compat_fm_pcd_manip_params_t)
+ #endif
+ #define FM_PCD_IOC_MANIP_NODE_SET   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(43), ioc_fm_pcd_manip_params_t)
+@@ -2887,7 +2887,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_ManipNodeSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MANIP_NODE_REPLACE_COMPAT    FM_PCD_IOC_MANIP_NODE_SET_COMPAT
+ #endif
+ #define FM_PCD_IOC_MANIP_NODE_REPLACE           FM_PCD_IOC_MANIP_NODE_SET
+@@ -2903,7 +2903,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_ManipNodeSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MANIP_NODE_DELETE_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(44), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_MANIP_NODE_DELETE    _IOW(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(44), ioc_fm_obj_t)
+@@ -2920,7 +2920,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_ManipNodeSet().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_MANIP_GET_STATS_COMPAT  _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(50), ioc_compat_fm_pcd_manip_get_stats_t)
+ #endif
+ #define FM_PCD_IOC_MANIP_GET_STATS   _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(50), ioc_fm_pcd_manip_get_stats_t)
+@@ -2953,7 +2953,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_Init().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_FRM_REPLIC_GROUP_SET_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(46), ioc_compat_fm_pcd_frm_replic_group_params_t)
+ #endif
+ #define FM_PCD_IOC_FRM_REPLIC_GROUP_SET _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(46), ioc_fm_pcd_frm_replic_group_params_t)
+@@ -2969,7 +2969,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_FrmReplicSetGroup().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_FRM_REPLIC_GROUP_DELETE_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(47), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PCD_IOC_FRM_REPLIC_GROUP_DELETE _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(47), ioc_fm_obj_t)
+@@ -2987,7 +2987,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_FrmReplicSetGroup() of this group.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_FRM_REPLIC_MEMBER_ADD_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(48), ioc_compat_fm_pcd_frm_replic_member_params_t)
+ #endif
+ #define FM_PCD_IOC_FRM_REPLIC_MEMBER_ADD _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(48), ioc_fm_pcd_frm_replic_member_params_t)
+@@ -3004,7 +3004,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Cautions      Allowed only following FM_PCD_FrmReplicSetGroup() of this group.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_FRM_REPLIC_MEMBER_REMOVE_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(49), ioc_compat_fm_pcd_frm_replic_member_t)
+ #endif
+ #define FM_PCD_IOC_FRM_REPLIC_MEMBER_REMOVE _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(49), ioc_fm_pcd_frm_replic_member_t)
+@@ -3021,7 +3021,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ 
+  @Return        0 on success; Error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_STATISTICS_SET_NODE_COMPAT _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(45), void *)
+ #endif
+ #define FM_PCD_IOC_STATISTICS_SET_NODE _IOWR(FM_IOC_TYPE_BASE, FM_PCD_IOC_NUM(45), void *)
+@@ -3029,7 +3029,7 @@ typedef struct ioc_fm_pcd_cc_tbl_get_stats_t {
+ #endif /* FM_CAPWAP_SUPPORT */
+ 
+ #ifdef NCSW_BACKWARD_COMPATIBLE_API
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PCD_IOC_SET_NET_ENV_CHARACTERISTICS_COMPAT \
+                                                 FM_PCD_IOC_NET_ENV_CHARACTERISTICS_SET_COMPAT
+ #define FM_PCD_IOC_DELETE_NET_ENV_CHARACTERISTICS_COMPAT \
+diff --git a/include/uapi/linux/fmd/Peripherals/fm_port_ioctls.h b/include/uapi/linux/fmd/Peripherals/fm_port_ioctls.h
+index eb9bd9a..23150e5 100644
+--- a/include/uapi/linux/fmd/Peripherals/fm_port_ioctls.h
++++ b/include/uapi/linux/fmd/Peripherals/fm_port_ioctls.h
+@@ -589,7 +589,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Return        0 on success; error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_SET_PCD_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(20), ioc_compat_fm_port_pcd_params_t)
+ #endif
+ #define FM_PORT_IOC_SET_PCD _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(20), ioc_fm_port_pcd_params_t)
+@@ -674,7 +674,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Return        0 on success; error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_PCD_KG_MODIFY_INITIAL_SCHEME_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(26), ioc_compat_fm_pcd_kg_scheme_select_t)
+ #endif
+ #define FM_PORT_IOC_PCD_KG_MODIFY_INITIAL_SCHEME _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(26), ioc_fm_pcd_kg_scheme_select_t)
+@@ -691,7 +691,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Return        0 on success; error code otherwise.
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_PCD_PLCR_MODIFY_INITIAL_PROFILE_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(27), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PORT_IOC_PCD_PLCR_MODIFY_INITIAL_PROFILE _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(27), ioc_fm_obj_t)
+@@ -708,7 +708,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Cautions      Allowed only following FM_PORT_SetPCD() and FM_PORT_DetachPCD()
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_PCD_CC_MODIFY_TREE_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(28), ioc_compat_fm_obj_t)
+ #endif
+ #define FM_PORT_IOC_PCD_CC_MODIFY_TREE _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(28), ioc_fm_obj_t)
+@@ -726,7 +726,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Cautions      Allowed only following FM_PORT_SetPCD().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_PCD_KG_BIND_SCHEMES_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(30), ioc_compat_fm_pcd_port_schemes_params_t)
+ #endif
+ #define FM_PORT_IOC_PCD_KG_BIND_SCHEMES _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(30), ioc_fm_pcd_port_schemes_params_t)
+@@ -744,7 +744,7 @@ typedef struct ioc_fm_port_pcd_fqids_params_t {
+ 
+  @Cautions      Allowed only following FM_PORT_SetPCD().
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_PCD_KG_UNBIND_SCHEMES_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(31), ioc_compat_fm_pcd_port_schemes_params_t)
+ #endif
+ #define FM_PORT_IOC_PCD_KG_UNBIND_SCHEMES _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(31), ioc_fm_pcd_port_schemes_params_t)
+@@ -917,7 +917,7 @@ typedef struct ioc_fm_port_vsp_alloc_params_t {
+  @Cautions      Allowed only following FM_PORT_Init(), and before FM_PORT_SetPCD()
+                 and also before FM_PORT_Enable() (i.e. the port should be disabled).
+ *//***************************************************************************/
+-#if defined(CONFIG_COMPAT)
++#if defined(FM_COMPAT)
+ #define FM_PORT_IOC_VSP_ALLOC_COMPAT _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(38), ioc_compat_fm_port_vsp_alloc_params_t)
+ #endif
+ #define FM_PORT_IOC_VSP_ALLOC _IOW(FM_IOC_TYPE_BASE, FM_PORT_IOC_NUM(38), ioc_fm_port_vsp_alloc_params_t)
+diff --git a/include/uapi/linux/fmd/Peripherals/fm_test_ioctls.h b/include/uapi/linux/fmd/Peripherals/fm_test_ioctls.h
+index 207ed1e..2646704 100644
+--- a/include/uapi/linux/fmd/Peripherals/fm_test_ioctls.h
++++ b/include/uapi/linux/fmd/Peripherals/fm_test_ioctls.h
+@@ -90,7 +90,7 @@ typedef struct ioc_fmt_buff_context_t {
+     uint8_t         fm_time_stamp[FM_TIME_STAMP_MAX];
+ } ioc_fmt_buff_context_t;
+ 
+-#if defined(__KERNEL__) && defined(CONFIG_COMPAT)
++#if defined(__KERNEL__) && defined(FM_COMPAT)
+ typedef struct ioc_fmt_compat_buff_context_t {
+     compat_uptr_t         p_user_priv;
+     uint8_t               fm_prs_res[FM_PRS_MAX];
+@@ -109,7 +109,7 @@ typedef struct ioc_fmt_buff_desc_t {
+     ioc_fmt_buff_context_t buff_context;
+ } ioc_fmt_buff_desc_t;
+ 
+-#if defined(__KERNEL__) && defined(CONFIG_COMPAT)
++#if defined(__KERNEL__) && defined(FM_COMPAT)
+ typedef struct ioc_fmt_compat_buff_desc_t {
+     uint32_t                qid;
+     compat_uptr_t           p_data;
+-- 
+2.7.4
+


### PR DESCRIPTION
The linux upstream commit had treated config leak as error.
5967577 scripts: headers_install: Exit with error on config leak

It is causing below build issue. Provide a kernel patch to fix
it by replacing CONFIG_COMPAT kernel option with FM_COMPAT instead.

  HDRINST usr/include/linux/fmd/integrations/integration_ioctls.h
  HDRINST usr/include/linux/fmd/Peripherals/fm_port_ioctls.h
error: include/uapi/linux/fmd/Peripherals/fm_port_ioctls.h: leak
CONFIG_COMPAT to user-space
scripts/Makefile.headersinst:63: recipe for target
'usr/include/linux/fmd/Peripherals/fm_port_ioctls.h' failed
make[5]: *** [usr/include/linux/fmd/Peripherals/fm_port_ioctls.h] Error 1
Makefile:1198: recipe for target 'headers' failed
make[4]: *** [headers] Error 2

Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>

