### PR TITLE
ath79: make LED control common for wpa8630v1/2, simplify scancodes

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
@@ -25,7 +25,7 @@
 
 		leds {
 			label = "LED control button";
-			linux,code = <BTN_0>;
+			linux,code = <KEY_LIGHTS_TOGGLE>;
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
@@ -68,6 +68,16 @@
 			label = "tp-link:green:wifi5g";
 			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		led_control {
+			gpio-export,name = "tp-link:led:control";
+			gpio-export,output = <0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.dtsi
@@ -6,15 +6,6 @@
 	aliases {
 		label-mac-device = &eth0;
 	};
-
-	gpio-export {
-		compatible = "gpio-export";
-
-		led_control {
-			gpio-export,name = "tp-link:led:control";
-			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
 &partitions {


### PR DESCRIPTION
The V1 has the same LED Control GPIO configuration according to the TP-Link GPL sources. Set the GPIO to output to make it work and set to Active Low. It defaults to LEDs on at bootup.

To turn all LEDs off:

    echo 0 > /sys/class/gpio/tp-link\:led\:control/value

To turn all LEDs on:

    echo 1 > /sys/class/gpio/tp-link\:led\:control/value

---

Change the "LED" button from BTN_0 to KEY_LIGHTS_TOGGLE to match other devices and the button guide, and to reduce the number of unintuitive "BTN_X" inputs.

Change the "Pair" button from BTN_1 to BTN_0. The user impact of this is low as this device has only been in Snapshot for ~10 days, has no wiki yet. For people with existing bindings it will just move their assigned LED button functionality to the Pair button and the LED button will do nothing until the bindings are set again.