### PR TITLE
ath79: Add support for Senao Engenius ENH202 v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -19,6 +19,7 @@ arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,ecb1750|\
+engenius,enh202-v1|\
 etactica,eg200|\
 glinet,gl-ar750s-nor|\
 glinet,gl-ar750s-nor-nand|\

--- a/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
+++ b/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7240.dtsi"
+
+/ {
+	compatible = "engenius,enh202-v1", "qca,ar7240";
+	model = "EnGenius ENH202 v1";
+
+	aliases {
+		led-boot = &led_rssihigh;
+		led-failsafe = &led_rssihigh;
+		led-running = &led_rssihigh;
+		led-upgrade = &led_rssihigh;
+		label-mac-device = &ath9k;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &switch_led_disable_pins &clks_disable_pins>;
+
+		rssilow {
+			label = "enh202-v1:red:rssilow";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "enh202-v1:amber:rssimedium";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_rssihigh: rssihigh {
+			label = "enh202-v1:green:rssihigh";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "enh202-v1:amber:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "enh202-v1:green:wan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "enh202-v1:green:wlan";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <20000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x50000 0x50000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0xa0000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0xb0000 0xf0000>;
+			};
+
+			partition@1a0000 {
+				label = "fakeroot";
+				reg = <0x1a0000 0x10000>;
+			};
+
+			firmware1: partition@1b0000 {
+				label = "firmware1";
+				reg = <0x1b0000 0x4c0000>;
+			};
+
+			partition@670000 {
+				label = "failsafe";
+				reg = <0x670000 0x180000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -144,6 +144,14 @@ dlink,dap-1365-a1)
 dlink,dir-859-a1)
 	ucidef_set_led_switch "internet" "WAN" "$boardname:green:internet" "switch0" "0x20"
 	;;
+engenius,enh202-v1)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "$boardname:red:rssilow" "wlan0" "1"  "100"
+	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "$boardname:amber:rssimedium" "wlan0" "33" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "$boardname:green:rssihigh" "wlan0" "67" "100"
+	ucidef_set_led_switch "lan" "LAN" "$boardname:amber:lan" "switch0" "0x10"
+	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
+	;;
 engenius,ews511ap)
 	ucidef_set_led_netdev "lan1" "LAN1" "$boardname:blue:lan1" "eth1"
 	ucidef_set_led_netdev "lan2" "LAN2" "$boardname:blue:lan2" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -186,6 +186,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
 		;;
+	engenius,enh202-v1)
+		ucidef_set_interface_wan "eth0"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "4:lan:1"
+		;;
 	engenius,ews511ap)
 		ucidef_set_interface_lan "eth0 eth1" "dhcp"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -74,7 +74,8 @@ case "$FIRMWARE" in
 	avm,fritz300e)
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
-	buffalo,wzr-hp-g302h-a1a0)
+	buffalo,wzr-hp-g302h-a1a0|\
+	engenius,enh202-v1)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
 	buffalo,wzr-hp-g450h)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -135,6 +135,21 @@ define Build/wrgg-pad-rootfs
 	$(STAGING_DIR_HOST)/bin/padjffs2 $(IMAGE_ROOTFS) -c 64 >>$@
 endef
 
+define Build/engenius_enh202-v1-factory
+	-[ -f "$@" ] && \
+	mkdir -p $@.tmp && \
+	echo '#!/bin/sh' > $@.tmp/before-upgrade.sh && \
+	echo ': > /tmp/_sys/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
+	$(CP) $(KDIR)/loader-enh202-v1.uImage \
+		$@.tmp/openwrt-senao-enh202-uImage-lzma.bin && \
+	$(CP) $@ $@.tmp/openwrt-senao-enh202-root.squashfs && \
+	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
+		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-C $@.tmp . > $@ && \
+	$(Build/gzip) && \
+	rm -rf $@.tmp
+endef
+
 define Device/seama
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
   KERNEL_INITRAMFS := $$(KERNEL) | seama
@@ -804,6 +819,27 @@ define Device/engenius_ecb1750
 	append-metadata | check-size
 endef
 TARGET_DEVICES += engenius_ecb1750
+
+define Device/engenius_enh202-v1
+  SOC := ar7240
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ENH202
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := rssileds
+  IMAGE_SIZE := 4864k
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x1b0000
+  COMPILE := loader-enh202-v1.bin loader-enh202-v1.uImage
+  COMPILE/loader-enh202-v1.bin := loader-okli-compile
+  COMPILE/loader-enh202-v1.uImage := append-loader-okli enh202-v1 | \
+	pad-to $$$$(BLOCKSIZE) | lzma | uImage lzma
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-squashfs-fakeroot-be | pad-to $$$$(BLOCKSIZE) | append-kernel | \
+	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | pad-to 4928k | \
+	engenius_enh202-v1-factory
+endef
+TARGET_DEVICES += engenius_enh202-v1
 
 define Device/engenius_epg5000
   SOC := qca9558


### PR DESCRIPTION
FCC ID: U2M-ENH200

Engenius ENH202 is an outdoor wireless access point with 2 10/100 ports,
built-in ethernet switch, internal antenna plates and proprietery PoE.

Specification:

	- Qualcomm/Atheros AR7240 rev 2
	- 40 MHz reference clock
	- 8 MB FLASH			ST25P64V6P (aka ST M25P64)
	- 32 MB RAM
	- UART at J3			(populated)
	- 2x 10/100 Mbps Ethernet	(built-in switch at gmac1)
	- 2.4 GHz, 2x2, 29dBm		(Atheros AR9280 rev 2)
	- internal antenna plates	(10 dbi, semi-directional)
	- 5 LEDs, 1x reset button	(LAN, WAN, RSSI)

Known Issues:

	- Sysupgrade from ar71xx no longer possible
	- Power LED not controllable, or unknown gpio

2 ways to flash factory.bin from OEM:

	- Connect ethernet directly to board (the non POE port)
		this is LAN for all images
	- if you get Failsafe Mode from failed flash:
		only use it to flash Original firmware from Engenius
		or risk kernel loop or halt which requires serial cable

	Method 1: Firmware upgrade page:
		OEM webpage at 192.168.1.1
		username and password "admin"
		In upper right select Reset
		"Restore to factory default settings"
		Wait for reboot and login again
		Navigate to "Firmware Upgrade" page from left pane
		Click Browse and select the factory.bin image
		Upload and verify checksum
		Click Continue to confirm and wait 3 minutes

	Method 2: Serial to load Failsafe webpage:
		After connecting to serial console and rebooting...
		Interrupt boot with any key pressed rapidly
		execute `run failsafe_boot` OR `bootm 0x9f670000`
		wait a minute
		connect to ethernet and navigate to
		"192.168.1.1/index.htm"
		Select the factory.bin image and upload
		wait about 3 minutes

Return to OEM:

	If you have a serial cable, see Serial Failsafe instructions

	*DISCLAIMER*
	The Failsafe image is unique to Engenius boards.
	If the failsafe image is missing or damaged this will not work
	DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

	The easiest way to return to the OEM software is the Failsafe image
	If you dont have a serial cable, you can ssh into openwrt and run

	`mtd -r erase fakeroot`

	Wait 3 minutes
	connect to ethernet and navigate to 192.168.1.1/index.htm
	select OEM firmware image from Engenius and click upgrade

Format of OEM firmware image:

	The OEM software of ENH202 is a heavily modified version
	of Openwrt Kamikaze bleeding-edge. One of the many modifications
	is to the sysupgrade program. Image verification is performed
	simply by the successful ungzip and untar of the supplied file
	and name check and header verification of the resulting contents.
	To form a factory.bin that is accepted by OEM Openwrt build,
	the kernel and rootfs must have specific names...

		openwrt-senao-enh202-uImage-lzma.bin
		openwrt-senao-enh202-root.squashfs

	and begin with the respective headers (uImage, squashfs).
	Then the files must be tarballed and gzipped.
	The resulting binary is actually a tar.gz file in disguise.
	This can be verified by using binwalk on the OEM firmware images,
	ungzipping then untaring, and by swapping headers to see
	what the OEM upgrade utility accepts and rejects.

Note on built-in switch:

	ENH202 is originally configured to be an access point,
	but with two ethernet ports, both WAN and LAN is possible.

	the POE port is gmac0 which is preferred to be
	the port for WAN because it gives link status
	where swconfig does not.

Tested and working on master

Signed-off-by: Michael Pratt <mpratt51@gmail.com>