### PR TITLE
config: kernel: fix missed CGROUP_HUGETLB symbol

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -596,8 +596,8 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_HUGETLB
 		bool "HugeTLB controller"
-		default y if KERNEL_HUGETLB_PAGE
-		depends on KERNEL_HUGETLB_PAGE
+		default n
+		select KERNEL_HUGETLB_PAGE
 
 	config KERNEL_CGROUP_PIDS
 		bool "PIDs cgroup subsystem"


### PR DESCRIPTION
Waiting for user input during the first compile.
```
*
* Restart config...
*
*
* Control Group support
*
Control Group support (CGROUPS) [Y/n/?] y
  Memory controller (MEMCG) [Y/n/?] y
    Swap controller (MEMCG_SWAP) [Y/n/?] y
      Swap controller enabled by default (MEMCG_SWAP_ENABLED) [N/y/?] n
  IO controller (BLK_CGROUP) [Y/n/?] y
  PIDs controller (CGROUP_PIDS) [Y/n/?] y
  RDMA controller (CGROUP_RDMA) [Y/n/?] y
  Freezer controller (CGROUP_FREEZER) [N/y/?] n
  HugeTLB controller (CGROUP_HUGETLB) [N/y/?] (NEW) 

```
This problem because:
The symbol KERNEL_CGROUP_HUGETLB is always used whenever KERNEL_CGROUPS is enabled.
The absence of this notation will cause the user to be asked to enter this parameter the first time it is compiled.

This change will ensure that KERNEL_CGROUP_HUGETLB is exported and the value follows the KERNEL_HUGETLB_PAGE change.

Signed-off-by: Yuan Tao <ty@wevs.org>