### PR TITLE
hostapd: fix not parsing skip_inactivity_poll from /etc/config/wireless

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -181,7 +181,7 @@ hostapd_common_add_bss_config() {
 	config_add_boolean wds wmm uapsd hidden utf8_ssid
 
 	config_add_int maxassoc max_inactivity
-	config_add_boolean disassoc_low_ack isolate short_preamble
+	config_add_boolean disassoc_low_ack isolate short_preamble skip_inactivity_poll
 
 	config_add_int \
 		wep_rekey eap_reauth_period \
@@ -315,13 +315,14 @@ hostapd_set_bss_options() {
 		iapp_interface eapol_version dynamic_vlan ieee80211w nasid \
 		acct_server acct_secret acct_port acct_interval \
 		bss_load_update_period chan_util_avg_period sae_require_mfp \
-		multi_ap multi_ap_backhaul_ssid multi_ap_backhaul_key
+		multi_ap multi_ap_backhaul_ssid multi_ap_backhaul_key skip_inactivity_poll
 
 	set_default isolate 0
 	set_default maxassoc 0
 	set_default max_inactivity 0
 	set_default short_preamble 1
 	set_default disassoc_low_ack 1
+	set_default skip_inactivity_poll 0
 	set_default hidden 0
 	set_default wmm 1
 	set_default uapsd 1
@@ -348,6 +349,7 @@ hostapd_set_bss_options() {
 	append bss_conf "bss_load_update_period=$bss_load_update_period" "$N"
 	append bss_conf "chan_util_avg_period=$chan_util_avg_period" "$N"
 	append bss_conf "disassoc_low_ack=$disassoc_low_ack" "$N"
+	append bss_conf "skip_inactivity_poll=$skip_inactivity_poll" "$N"
 	append bss_conf "preamble=$short_preamble" "$N"
 	append bss_conf "wmm_enabled=$wmm" "$N"
 	append bss_conf "ignore_broadcast_ssid=$hidden" "$N"


### PR DESCRIPTION
hostapd.sh does not parse skip_inactivity_poll boolean from /etc/config/wireless despite being mentioned in the documentation[1]

[1] https://openwrt.org/docs/guide-user/network/wifi/basic

Signed-off-by: Nadim Atiya <nadim.atiya@gmail.com>
