### PR TITLE
ramips: mt7621: use lzma-loader for wg3526

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1286,6 +1286,7 @@ TARGET_DEVICES += zbtlink_zbt-wg2626
 
 define Device/zbtlink_zbt-wg3526-16m
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG3526
@@ -1298,6 +1299,7 @@ TARGET_DEVICES += zbtlink_zbt-wg3526-16m
 
 define Device/zbtlink_zbt-wg3526-32m
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG3526


### PR DESCRIPTION
use lzma-loader for  wg3526

The wg3526 fails to boot if the kernel is large
Enabling lzma-loader resolves the issue on both the wg3526-16
and wg3526-32 (see FS#3143 on the issue tracker).

Signed-off-by: Rustam Gaptulin rascal6@gmail.com