### PR TITLE
curl: properly handle zstd support rather than just shutting it off

### DIFF
--- a/package/network/utils/curl/Config.in
+++ b/package/network/utils/curl/Config.in
@@ -133,6 +133,10 @@ config LIBCURL_ZLIB
 	bool "Enable zlib support"
 	default n
 
+config LIBCURL_ZSTD
+	bool "Enable zstd support"
+	default n
+
 config LIBCURL_UNIX_SOCKETS
 	bool "Enable unix domain socket support"
 	default n

--- a/package/network/utils/curl/Makefile
+++ b/package/network/utils/curl/Makefile
@@ -37,6 +37,7 @@ PKG_CONFIG_DEPENDS:= \
   CONFIG_LIBCURL_LIBIDN2 \
   CONFIG_LIBCURL_SSH2 \
   CONFIG_LIBCURL_ZLIB \
+  CONFIG_LIBCURL_ZSTD \
   \
   CONFIG_LIBCURL_DICT \
   CONFIG_LIBCURL_FILE \
@@ -91,8 +92,8 @@ define Package/libcurl
   SECTION:=libs
   CATEGORY:=Libraries
   DEPENDS:= +LIBCURL_WOLFSSL:libwolfssl +LIBCURL_OPENSSL:libopenssl +LIBCURL_GNUTLS:libgnutls +LIBCURL_MBEDTLS:libmbedtls
-  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap +LIBCURL_LIBIDN2:libidn2
-  DEPENDS += +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
+  DEPENDS += +LIBCURL_ZLIB:zlib +LIBCURL_ZSTD:libzstd +LIBCURL_THREADED_RESOLVER:libpthread +LIBCURL_LDAP:libopenldap
+  DEPENDS += +LIBCURL_LIBIDN2:libidn2 +LIBCURL_SSH2:libssh2 +LIBCURL_NGHTTP2:libnghttp2 +ca-bundle
   TITLE:=A client-side URL transfer library
   MENU:=1
   ABI_VERSION:=4
@@ -131,6 +132,7 @@ CONFIGURE_ARGS += \
 	$(if $(CONFIG_LIBCURL_LIBIDN2),--with-libidn2="$(STAGING_DIR)/usr",--without-libidn2) \
 	$(if $(CONFIG_LIBCURL_SSH2),--with-libssh2="$(STAGING_DIR)/usr",--without-libssh2) \
 	$(if $(CONFIG_LIBCURL_ZLIB),--with-zlib="$(STAGING_DIR)/usr",--without-zlib) \
+	$(if $(CONFIG_LIBCURL_ZSTD),--with-zstd="$(STAGING_DIR)/usr",--without-zstd) \
 	$(if $(CONFIG_LIBCURL_NGHTTP2),--with-nghttp2="$(STAGING_DIR)/usr",--without-nghttp2) \
 	\
 	$(call autoconf_bool,CONFIG_LIBCURL_DICT,dict) \


### PR DESCRIPTION
Fixes package libcurl build issue :
```
Package libcurl is missing dependencies for the following libraries:
libzstd.so.1
```

Previous patch by Hans Dedecker <dedeckeh@gmail.com> took the easy way out :)

Suggested-by: Syrone Wong <wong.syrone@gmail.com>
Signed-off-by: Tony Butler <spudz76@gmail.com>