### PR TITLE
[RFC] base-files: Add more flexibility to diag.sh mechanics (upgrade-like)

### DIFF
--- a/package/base-files/files/etc/init.d/done
+++ b/package/base-files/files/etc/init.d/done
@@ -12,6 +12,6 @@ boot() {
 	}
 
 	# set leds to normal state
-	. /etc/diag.sh
+	. /lib/diag.sh
 	set_state done
 }

--- a/package/base-files/files/etc/rc.button/reset
+++ b/package/base-files/files/etc/rc.button/reset
@@ -11,7 +11,7 @@ pressed)
 	return 5
 ;;
 timeout)
-	. /etc/diag.sh
+	. /lib/diag.sh
 	set_state failsafe
 ;;
 released)

--- a/package/base-files/files/lib/diag.sh
+++ b/package/base-files/files/lib/diag.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright (C) 2006-2019 OpenWrt.org
+
+. /lib/functions.sh
+
+include /lib/diag
+
+set_state() {
+	if type 'get_status_led_platform' >/dev/null 2>/dev/null; then
+		get_status_led_platform "$1"
+	else
+		get_status_led_default "$1"
+	fi
+
+	if type 'set_state_platform' >/dev/null 2>/dev/null; then
+		set_state_platform "$1"
+	else
+		set_state_default "$1"
+	fi
+}

--- a/package/base-files/files/lib/diag/default.sh
+++ b/package/base-files/files/lib/diag/default.sh
@@ -1,14 +1,18 @@
 #!/bin/sh
-# Copyright (C) 2006-2019 OpenWrt.org
+# Copyright (C) 2006-2020 OpenWrt.org
 
 . /lib/functions/leds.sh
 
-boot="$(get_dt_led boot)"
-failsafe="$(get_dt_led failsafe)"
-running="$(get_dt_led running)"
-upgrade="$(get_dt_led upgrade)"
+get_status_led_default() {
+	boot="$(get_dt_led boot)"
+	failsafe="$(get_dt_led failsafe)"
+	running="$(get_dt_led running)"
+	upgrade="$(get_dt_led upgrade)"
+}
 
-set_led_state() {
+set_state_default() {
+	[ -z "$boot" -a -z "$failsafe" -a -z "$running" -a -z "$upgrade" ] && return 0
+
 	status_led="$boot"
 
 	case "$1" in
@@ -37,7 +41,7 @@ set_led_state() {
 		;;
 	done)
 		status_led_off
-		[ "$status_led" != "$running" ] && \
+		[ "$boot" != "$running" ] && \
 			status_led_restore_trigger "boot"
 		[ -n "$running" ] && {
 			status_led="$running"
@@ -45,8 +49,4 @@ set_led_state() {
 		}
 		;;
 	esac
-}
-
-set_state() {
-	[ -n "$boot" -o -n "$failsafe" -o -n "$running" -o -n "$upgrade" ] && set_led_state "$1"
 }

--- a/package/base-files/files/lib/preinit/02_default_set_state
+++ b/package/base-files/files/lib/preinit/02_default_set_state
@@ -1,5 +1,5 @@
 define_default_set_state() {
-	. /etc/diag.sh
+	. /lib/diag.sh
 }
 
 boot_hook_add preinit_main define_default_set_state

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -285,7 +285,7 @@ get_partitions() { # <device> <filename>
 }
 
 indicate_upgrade() {
-	. /etc/diag.sh
+	. /lib/diag.sh
 	set_state upgrade
 }
 

--- a/target/linux/bcm27xx/base-files/lib/diag/platform.sh
+++ b/target/linux/bcm27xx/base-files/lib/diag/platform.sh
@@ -5,7 +5,7 @@
 . /lib/functions.sh
 . /lib/functions/leds.sh
 
-set_state() {
+set_state_platform() {
 	case "$(board_name)" in
 	raspberrypi,2-model-b |\
 	raspberrypi,2-model-b-rev2 |\

--- a/target/linux/bcm47xx/base-files/lib/diag/platform.sh
+++ b/target/linux/bcm47xx/base-files/lib/diag/platform.sh
@@ -3,31 +3,17 @@
 
 . /lib/functions/leds.sh
 
-get_status_led() {
+get_status_led_platform() {
 	for led in dmz power diag wps; do
 		status_led_file=$(find /sys/class/leds/ -name "*${led}*" | head -n1)
 		if [ ! -f $status_led_file ]; then
 			status_led=$(basename $status_led_file)
-			return
+			break
 		fi;
 	done
-}
 
-set_state() {
-	get_status_led
-
-	case "$1" in
-	preinit)
-		status_led_blink_preinit
-		;;
-	failsafe)
-		status_led_blink_failsafe
-		;;
-	preinit_regular)
-		status_led_blink_preinit_regular
-		;;
-	done)
-		status_led_on
-		;;
-	esac
+	boot="$status_led"
+	failsafe="$status_led"
+	running="$status_led"
+	upgrade="$status_led"
 }

--- a/target/linux/bcm53xx/base-files/lib/diag/platform.sh
+++ b/target/linux/bcm53xx/base-files/lib/diag/platform.sh
@@ -2,7 +2,7 @@
 
 . /lib/functions/leds.sh
 
-get_status_led() {
+get_status_led_platform() {
 	local status_led_file
 
 	# There may be more than one color of power LED, try to avoid amber/red
@@ -21,25 +21,9 @@ get_status_led() {
 
 	# And finally, let's also try the device-Tree aliases node
 	status_led="$(get_dt_led status)"
-}
 
-set_state() {
-	get_status_led
-
-	[ -z "$status_led" ] && return
-
-	case "$1" in
-	preinit)
-		status_led_blink_preinit
-		;;
-	failsafe)
-		status_led_blink_failsafe
-		;;
-	preinit_regular)
-		status_led_blink_preinit_regular
-		;;
-	done)
-		status_led_on
-		;;
-	esac
+	boot="$status_led"
+	failsafe="$status_led"
+	running="$status_led"
+	upgrade="$status_led"
 }

--- a/target/linux/mxs/base-files/lib/diag/platform.sh
+++ b/target/linux/mxs/base-files/lib/diag/platform.sh
@@ -4,7 +4,7 @@
 . /lib/functions.sh
 . /lib/functions/leds.sh
 
-get_status_led() {
+get_status_led_platform() {
 	case $(board_name) in
 	i2se,duckbill*)
 		status_led="duckbill:green:status"
@@ -16,23 +16,9 @@ get_status_led() {
 		status_led=$(cd /sys/class/leds && ls -1d *:status 2> /dev/null | head -n 1)
 		;;
 	esac
-}
 
-set_state() {
-	get_status_led
-
-	case "$1" in
-	preinit)
-		status_led_blink_preinit
-		;;
-	failsafe)
-		status_led_blink_failsafe
-		;;
-	preinit_regular)
-		status_led_blink_preinit_regular
-		;;
-	done)
-		status_led_on
-		;;
-	esac
+	boot="$status_led"
+	failsafe="$status_led"
+	running="$status_led"
+	upgrade="$status_led"
 }

--- a/target/linux/x86/base-files/lib/diag/platform.sh
+++ b/target/linux/x86/base-files/lib/diag/platform.sh
@@ -48,33 +48,16 @@ match_diag_led() {
 	fi
 }
 
-get_status_led() {
+get_status_led_platform() {
 	if [ -s /etc/config/system ]; then
 		config_load system
 		config_foreach match_diag_led led
 	else
 		preinit_match_diag_led
 	fi
-}
 
-set_state() {
-	get_status_led
-
-	case "$1" in
-	preinit)
-		status_led_blink_preinit
-		;;
-
-	failsafe)
-		status_led_blink_failsafe
-		;;
-
-	preinit_regular)
-		status_led_blink_preinit_regular
-		;;
-
-	done)
-		status_led_on
-		;;
-	esac
+	boot="$status_led"
+	failsafe="$status_led"
+	running="$status_led"
+	upgrade="$status_led"
 }


### PR DESCRIPTION
Generic 'diag.sh' from 'base-files' now resides in /lib. It will attempt to include '/lib/diag/*.sh' where file 'platform.sh' is expected to have 'set_state_platform' function (part of a target, this is similar to platform upgrade).

The function will be able to call original 'set_state_default' (defined in /lib/diag/default.sh, part of base-files package) and/or do something totally different.