### PR TITLE
ramips: add support for Hi-Link HLK-7688A IoT Gateway Mode

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hilink,hlk-7688a", "mediatek,mt7628an-soc";
+	model = "Hi-Link HLK-7688A";
+
+	aliases {
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wlan: wlan {
+			label = "green:wlan";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+
+	spidev@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -126,6 +126,14 @@ define Device/hilink_hlk-7628n
 endef
 TARGET_DEVICES += hilink_hlk-7628n
 
+define Device/hilink_hlk-7688a
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Hi-Link
+  DEVICE_MODEL := HLK-7688A
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += hilink_hlk-7688a
+
 define Device/hiwifi_hc5661a
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -61,6 +61,7 @@ ramips_setup_interfaces()
 			"1:lan" "0:wan" "6@eth0"
 		;;
 	hilink,hlk-7628n|\
+	hilink,hlk-7688a|\
 	hiwifi,hc5861b|\
 	skylab,skw92a|\
 	tplink,archer-c20-v4|\
@@ -152,6 +153,7 @@ ramips_setup_macs()
 		lan_mac=$wan_mac
 		;;
 	cudy,wr1000|\
+	hilink,hlk-7688a|\
 	wavlink,wl-wn577a2)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$(mtd_get_mac_binary factory 0x4)


### PR DESCRIPTION
Please can support for Hi-Link HLK-7688A in IoT Gateway Mode be added.