### PR TITLE
ramips: rt3883: use lzma-loader for DIR-645

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -33,6 +33,7 @@ TARGET_DEVICES += belkin_f9k1109v1
 
 define Device/dlink_dir-645
   $(Device/seama)
+  $(Device/uimage-lzma-loader)
   SOC := rt3662
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7872k


### PR DESCRIPTION
The DIR-645 fails to boot if the kernel is large.
Enabling lzma-loader resolves the issue.

Run-tested on D-Link DIR-645.

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>
