### PR TITLE
ramips: add support for Wavlink WL-WN531A6

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,wl-wn531a6", "mediatek,mt7621-soc";
+	model = "Wavlink WL-WN531A6";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		touch { /* RH6015C touch sensor -> GPIO 14 */
+			label = "Touch Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		turbo {
+			label = "Turbo Button";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "WPS Button";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "wl-wn531a6:blue:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "wl-wn531a6:red:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi2g {
+			label = "wl-wn531a6:blue:wifi2g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xeb0000>;
+			};
+
+			partition@f00000 {
+				label = "vendor";
+				reg = <0xf00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&uartlite2 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1093,6 +1093,15 @@ define Device/unielec_u7621-06-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
 
+define Device/wavlink_wl-wn531a6
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN531A6
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+  IMAGE_SIZE := 15040k
+endef
+TARGET_DEVICES += wavlink_wl-wn531a6
+
 define Device/wevo_11acnas
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -118,6 +118,7 @@ ramips_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
 		;;
+	wavlink,wl-wn531a6|\
 	winstars,ws-wn583a6|\
 	zbtlink,zbt-we1326|\
 	zbtlink,zbt-wg3526-16m|\


### PR DESCRIPTION
This patch adds support for Wavlink WL-WN531A6 (Quantum D6).

Specifications:
--------------

* SoC: Mediatek MT7621AT 2C2T, 880MHz
* RAM: 128MB DDR3, Nanya NT5CB64M16GP-EK
* Flash: 16MB SPI NOR flash, GigaDevice GD25Q127CSIG
* WiFi 5GHz: Mediatek MT7615N (4x4:4) on mini PCIE slot.
* WiFi 2.4GHz: Mediatek MT7603EN (2x2:2) on mini PCIE slot.
* Ethernet: MT7630, 5x 1000Base-T
* LED: Power, WAN, LAN(x4), WiFi, WPS, dual color
       "WAVLINK" LED logo on the top cover.
* Buttons: Reset, WPS, "Turbo", touch button on the top
           cover via RH6015C touch sensor.
* UART: UART1: serial console (57600 8n1) on the J4 header
               located below the top heatsink.
        UART2: J12 header, located on the right side of
               the board.
* USB: One USB3 port.
* I2C: J9 header, located below the top heatsink.

Backup the OEM Firmware:
-----------------------

There isn't any firmware released for the WL-WN531A6 on
the Wavlink web site. Reverting back to the OEM firmware is
not possible unless we have a backup of the original OEM
firmware.

The OEM firmware is stored on /dev/mtd4 ("Kernel").

  1) Plug a FAT32 formatted USB flash drive into the USB port.
  2) Navigate to "Setup->USB Storage". Under the "Available
     Network folder" you can see part of the mount point of
     the newly mounted flash drive filesystem - e.g "sda1".
     The full mount point is prefixed with "/media", so in
     this case the mount point becomes "/media/sda1".
  3) Go to http://192.168.10.1/webcmd.shtml .
  4) Type the following line in the "Command" input box:

     dd if=/dev/mtd4ro of=/media/sda1/firmware.bin

  5) Click "Apply"
  6) After few seconds, in the text area should appear this
     output:

        30080+0 records in
      30080+0 records out

  7) Type "sync" in the "Command" input box and click "Apply".
  8) At this point the OEM firmware is stored on the flash
     drive as "firmware.bin". The size of the file is 15040 KB.

Installation:
------------

* Flashing instructions (OEM web interface):
The OEM web interface accepts only files with names containing
"WN531A6". It's also impossible to flash the *-sysupgrade.bin
image, so we have to flash the *-initramfs-kernel.bin first and
use the OpenWrt's upgrade interface to write the sysupgrade
image.

  1) Rename openwrt-ramips-mt7621-wavlink_wl-wn531a6-initramfs-kernel.bin
     to WN531A6.bin.
  2) Connect your computer to the one of the LAN ports of the
     router with an Ethernet cable and open http://192.168.10.1
  3) Browse to Setup -> Firmware Upgrade interface.
  4) Upload the (renamed) OpenWrt image - WN531A6.bin.
  5) Proceed with the firmware installation and give the device
     a few minutes to finish and reboot.
  6) After reboot wait for the "WAVLINK" logo on the top cover
     to turn solid blue, and open http://192.168.1.1
  7) Use the OpenWrt's "Flash Firmware" interface to write the
     OpenWrt sysupgrade image:
     openwrt-ramips-mt7621-wavlink_wl-wn531a6-squashfs-sysupgrade.bin

* Flashing instructions (u-boot TFTP):
  1) Configure a TFTP server on your computer and set its IP
     to 192.168.10.100
  2) Rename the OpenWrt sysupgrade image to firmware.bin and
     place it in the root folder of the TFTP server.
  3) Power off the device and connect an Ethernet cable from
     one of its LAN ports your computer.
  4) Press the "Reset" button (and keep it pressed)
  5) Power on the device.
  6) After a few seconds, when the connected port LAN LED stops
     blinking fast, release the "Reset" button.
  7) Flashing OpenWrt takes less than a minute, system will
     reboot automatically.
  8) After reboot the WAVLINK logo on the top cover will indicate
     the current OpenWrt running status (wait until the logo tunrs
     solid blue).

Revert to the OEM Firmware:
--------------------------
* U-boot TFTP:
  Follow "Flashing instructions (u-boot TFTP)" and use the
  "firmware.bin" backup image.

* OpenWrt "Flash Firmware" interface:
  Upload the "firmware.bin" backup image and select "Force update"
  before continuing.

Notes:
-----
* The MAC address shown on the label at the back of the device
is assigned to the 2.4G WiFi adapter.

* The I2C bus and UART2 are fully functional. The headers are
not populated.

Signed-off-by: Georgi Vlaev <georgi.vlaev@konsulko.com>
