### PR TITLE
ramips: add support for TP-Link RE200 v4

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re200-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200-v4.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_re200.dtsi"
+
+/ {
+	compatible = "tplink,re200-v4", "mediatek,mt7628an-soc";
+	model = "TP-Link RE200 v4";
+
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -413,6 +413,16 @@ define Device/tplink_re200-v3
 endef
 TARGET_DEVICES += tplink_re200-v3
 
+define Device/tplink_re200-v4
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE200
+  DEVICE_VARIANT := v4
+  DEVICE_PACKAGES := kmod-mt76x0e
+  TPLINK_BOARD_ID := RE200-V4
+endef
+TARGET_DEVICES += tplink_re200-v4
+
 define Device/tplink_re220-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -62,6 +62,7 @@ tplink,archer-c50-v4)
 	;;
 tplink,re200-v2|\
 tplink,re200-v3|\
+tplink,re200-v4|\
 tplink,re220-v2|\
 tplink,tl-mr3020-v3|\
 tplink,tl-wa801nd-v5)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ ramips_setup_interfaces()
 	tama,w06|\
 	tplink,re200-v2|\
 	tplink,re200-v3|\
+	tplink,re200-v4|\
 	tplink,re220-v2|\
 	tplink,re305-v1|\
 	tplink,tl-mr3020-v3|\

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1739,6 +1739,50 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+  /** Firmware layout for the RE200 v4 */
+	{
+		.id     = "RE200-V4",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:00000000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:45550000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:4A500000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:4B520000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:43410000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:41550000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:42520000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:55530000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:41520000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:52550000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:54570000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:45530000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:49440000}\n"
+			"{product_name:RE200,product_ver:4.0.0,special_id:45470000}\n",
+		.support_trail = '\x00',
+		.soft_ver = "soft_ver:1.1.0\n",
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x7a0000},
+			{"partition-table", 0x7c0000, 0x02000},
+			{"default-mac", 0x7c2000, 0x00020},
+			{"pin", 0x7c2100, 0x00020},
+			{"product-info", 0x7c3100, 0x01000},
+			{"soft-version", 0x7c4200, 0x01000},
+			{"support-list", 0x7c5200, 0x01000},
+			{"profile", 0x7c6200, 0x08000},
+			{"config-info", 0x7ce200, 0x00400},
+			{"user-config", 0x7d0000, 0x10000},
+			{"default-config", 0x7e0000, 0x10000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the RE220 v2 */
 	{
 		.id     = "RE220-V2",


### PR DESCRIPTION
TP-Link RE200 v4 is a wireless range extender with Ethernet and 2.4G and 5G
WiFi with internal antennas. It's based on MediaTek MT7628AN+MT7610EN like the v2/v3.

Specifications
--------------

- MediaTek MT7628AN (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 1x 10/100 Mbps Ethernet
- 8x LED (GPIO-controlled), 2x button
- UART connection holes on PCB (57600 8n1)

There are 2.4G and 5G LEDs in red and green which are controlled
separately.

MAC addresses
-------------

The MAC address assignment matches stock firmware, i.e.:

LAN : *:8E
2.4G: *:8D
5G  : *:8C

MAC address assignment has been done according to the RE200 v2.

The label MAC address matches the OpenWrt ethernet address.

Installation
------------

Web Interface
-------------

It is possible to upgrade to OpenWrt via the web interface. Simply flash
the -factory.bin from OEM. In contrast to a stock firmware, this will not
overwrite U-Boot.

Recovery
--------

Unfortunately, this devices does not offer a recovery mode or a tftp
installation method. If the web interface upgrade fails, you have to open
your device and attach serial console.

Instructions for serial console
and recovery may be checked out in commit 6d6f36a ("ramips: add support
for TP-Link RE200 v2") or on the device's Wiki page.

Signed-off-by: Richard Fröhning <misanthropos@gmx.de>
