### PR TITLE
wireguard-tools: add tunlink option for hostroute

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20200513
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/

--- a/package/network/utils/wireguard-tools/files/wireguard.sh
+++ b/package/network/utils/wireguard-tools/files/wireguard.sh
@@ -112,6 +112,7 @@ proto_wireguard_setup() {
 	config_get fwmark "${config}" "fwmark"
 	config_get ip6prefix "${config}" "ip6prefix"
 	config_get nohostroute "${config}" "nohostroute"
+	config_get tunlink "${config}" "tunlink"
 
 	ip link del dev "${config}" 2>/dev/null
 	ip link add dev "${config}" type wireguard
@@ -173,7 +174,7 @@ proto_wireguard_setup() {
 		sed -E 's/\[?([0-9.:a-f]+)\]?:([0-9]+)/\1 \2/' | \
 		while IFS=$'\t ' read -r key address port; do
 			[ -n "${port}" ] || continue
-			proto_add_host_dependency "${config}" "${address}"
+			proto_add_host_dependency "${config}" "${address}" "${tunlink}"
 		done
 	fi
 


### PR DESCRIPTION
In a multi-wan setup, netifd may need guidance on which wan device to
use to create the route to the remote peer.

This commit adds a 'tunlink' parameter similar to other tunneling interfaces
such as 6in4, 6rd, gre, etc.