### PR TITLE
ramips: add support for TP-Link TL-WR850N v2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr850n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr850n-v2.dts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7628an_tplink_8m.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr850n-v2", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-WR850N v2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "tl-wr850n-v2:green:power";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "tl-wr850n-v2:green:wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "tl-wr850n-v2:green:lan";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "tl-wr850n-v2:green:wan";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "tl-wr850n-v2:green:wlan";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "p0led_an", "p2led_an", "perst", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -553,6 +553,19 @@ define Device/tplink_tl-wr842n-v5
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v5
 
+define Device/tplink_tl-wr850n-v2
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := TL-WR850N
+  DEVICE_VARIANT := v2
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x08500002
+  TPLINK_HWREVADD := 0x2
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_tl-wr850n-v2
+
 define Device/tplink_tl-wr902ac-v3
   $(Device/tplink-v2)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -94,7 +94,8 @@ tplink,tl-wr841n-v13)
 	ucidef_set_led_switch "lan4" "lan4" "$boardname:green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
-tplink,tl-wr841n-v14)
+tplink,tl-wr841n-v14|\
+tplink,tl-wr850n-v2)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -73,6 +73,7 @@ ramips_setup_interfaces()
 	tplink,tl-wr841n-v13|\
 	tplink,tl-wr841n-v14|\
 	tplink,tl-wr842n-v5|\
+	tplink,tl-wr850n-v2|\
 	unielec,u7628-01-16m|\
 	wrtnode,wrtnode2p|\
 	wrtnode,wrtnode2r|\
@@ -203,7 +204,8 @@ ramips_setup_macs()
 	tplink,tl-wr840n-v5|\
 	tplink,tl-wr841n-v13|\
 	tplink,tl-wr841n-v14|\
-	tplink,tl-wr842n-v5)
+	tplink,tl-wr842n-v5|\
+	tplink,tl-wr850n-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xf100)" 1)
 		;;
 	tplink,archer-c20-v5|\


### PR DESCRIPTION
This patch adds support for the TP-Link TL-WR850N v2, ported from the ramips target.
This router is very similar to TP-Link TL-WR840 v4 and TP-Link TL-WR841 v13

Specifications:
SOC: MediaTek MT7628NN
Flash: 8 MiB SPI
RAM: 64 MiB
WLAN: MediaTek MT7628NN
Ethernet: 5 ports (100M)

**Installation:**
* Using the integrated tftp capability of the router:
* Turn off the router.
* Connect pc to one of the router LAN ports.
* Set your PC IPv4 address to 192.168.0.66/24.
* Run any TFTP server on the PC.
* Put the recovery firmware on the root directory of TFTP server and name the file tp_recovery.bin
* Start the router by pressing power button while holding the WPS/Reset button (or both WPS/Reset and WIFI buttons)
* Router connects to your PC with IPv4 address 192.168.0.2, downloads the firmware, installs it and reboots. LEDs are flashing. Now you have OpenWrt installed.
* Change your IPv4 PC address to something in 192.168.1.0/24 network or use DHCP to get an address from your OpenWrt router.
* Done! You can login to your router via ssh.


Forum link https://forum.openwrt.org/t/add-support-for-tp-link-tl-wr850n-v2/66899

Note: This PR is with reference to https://github.com/openwrt/openwrt/pull/3113 which was closed by the author due to some git issues. So I did some tidying up and fixing


Signed-off-by: Andrew Freeman <labz56@gmail.com>