### PR TITLE
[18.06] fstools: backport: fix ntfs uuid

### DIFF
--- a/package/system/fstools/Makefile
+++ b/package/system/fstools/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fstools
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/fstools.git

--- a/package/system/fstools/patches/000-fix-ntfs-uuid.patch
+++ b/package/system/fstools/patches/000-fix-ntfs-uuid.patch
@@ -1,0 +1,61 @@
+From d05276dc1d6de119da518d62930b9a8ef55ef7e9 Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Fri, 25 Oct 2019 10:48:47 +0000
+Subject: [PATCH] libblkid-tiny: ntfs: fix use-after-free
+
+The memory pointed to by ns can be reallocated when checking mft records
+
+Fixes FS#2129
+
+Signed-off-by: Yousong Zhou <yszhou4tech@gmail.com>
+---
+ libblkid-tiny/ntfs.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/libblkid-tiny/ntfs.c b/libblkid-tiny/ntfs.c
+index 3a9d5cb..2426e70 100644
+--- a/libblkid-tiny/ntfs.c
++++ b/libblkid-tiny/ntfs.c
+@@ -88,6 +88,7 @@ static int probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag)
+ 
+ 	uint32_t sectors_per_cluster, mft_record_size;
+ 	uint16_t sector_size;
++	uint64_t volume_serial;
+ 	uint64_t nr_clusters, off; //, attr_off;
+ 	unsigned char *buf_mft;
+ 
+@@ -148,15 +149,16 @@ static int probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag)
+ 		return 1;
+ 
+ 
++	volume_serial = ns->volume_serial;
+ 	off = le64_to_cpu(ns->mft_cluster_location) * sector_size *
+ 		sectors_per_cluster;
+ 
+ 	DBG(LOWPROBE, ul_debug("NTFS: sector_size=%"PRIu16", mft_record_size=%"PRIu32", "
+ 			"sectors_per_cluster=%"PRIu32", nr_clusters=%"PRIu64" "
+-			"cluster_offset=%"PRIu64"",
++			"cluster_offset=%"PRIu64", volume_serial=%"PRIu64"",
+ 			sector_size, mft_record_size,
+ 			sectors_per_cluster, nr_clusters,
+-			off));
++			off, volume_serial));
+ 
+ 	buf_mft = blkid_probe_get_buffer(pr, off, mft_record_size);
+ 	if (!buf_mft)
+@@ -207,9 +209,9 @@ static int probe_ntfs(blkid_probe pr, const struct blkid_idmag *mag)
+ #endif
+ 
+ 	blkid_probe_sprintf_uuid(pr,
+-			(unsigned char *) &ns->volume_serial,
+-			sizeof(ns->volume_serial),
+-			"%016" PRIX64, le64_to_cpu(ns->volume_serial));
++			(unsigned char *) &volume_serial,
++			sizeof(volume_serial),
++			"%016" PRIX64, le64_to_cpu(volume_serial));
+ 	return 0;
+ }
+ 
+-- 
+2.23.0
+


### PR DESCRIPTION
Just backport from fstools:

[PATCH] libblkid-tiny: ntfs: fix use-after-free

The memory pointed to by ns can be reallocated when checking mft records

Fixes FS#2129