### PR TITLE
ath79: mikrotik: fix network setup for lhg-hb platform

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-lhg-hb.dtsi
@@ -67,10 +67,19 @@
 	};
 };
 
-&eth1 {
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
 	gmac-config {
 		device = <&gmac>;
+		switch-phy-swap = <1>;
 	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
 };
 
 &pinmux {


### PR DESCRIPTION
Link speed for eth0 on MikroTik LHG 2 (LHG HB platform) was not being reported correctly; fixed link at 1000 Mbps was shown, as the Ethernet port was connected to the internal switch.

See https://bugs.openwrt.org/index.php?do=details&task_id=3309 for more details

The network configuration in this patch connects the physical Ethernet port directly, avoiding the switch, so link speed is correctly attributed to the `eth0` interface. Incidentally, this is the same network setup as for the [MikroTik SXT Lite 5](https://github.com/openwrt/openwrt/blob/master/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5n.dtsi#L172).