### PR TITLE
mvebu: fix regulatory country on wrt3200acm

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/03_wireless
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/03_wireless
@@ -14,6 +14,7 @@ linksys,wrt1200ac|\
 linksys,wrt1900ac-v1|\
 linksys,wrt1900ac-v2|\
 linksys,wrt1900acs|\
+linksys,wrt3200acm|\
 linksys,wrt32x)
 	SKU=$(strings /dev/mtd3|sed -ne 's/^cert_region=//p')
 	WIFIMAC2G=$(macaddr_add $(cat /sys/class/net/eth0/address) +1)

--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/03_wireless
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/03_wireless
@@ -17,7 +17,7 @@ linksys,wrt1900acs|\
 linksys,wrt3200acm|\
 linksys,wrt32x)
 	SKU=$(strings /dev/mtd3|sed -ne 's/^cert_region=//p')
-	WIFIMAC2G=$(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+	WIFIMAC2G=$(macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) +1)
 	WIFIMAC5G=$(macaddr_add $WIFIMAC2G +1)
 	case "$SKU" in
 		AP)


### PR DESCRIPTION
correct oversight on setting regulatory country and mac address for device wrt3200acm wireless configuration: FS#3307

Signed-off-by: Kabuli Chana <newtownBuild@gmail.com>
