### PR TITLE
rockchip: fix slow SD booting issue on FriendlyARM NanoPI R2S

### DIFF
--- a/target/linux/rockchip/patches-5.4/104-slow-sd-card-fail-to-boot-on-NanoPI-R2S.patch
+++ b/target/linux/rockchip/patches-5.4/104-slow-sd-card-fail-to-boot-on-NanoPI-R2S.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
+@@ -37,6 +37,7 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&sdmmc0m1_gpio>;
+ 		regulator-name = "vcc_sd";
++		regulator-boot-on;
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vcc_io>;


### PR DESCRIPTION
NanoPI R2S fails too boot when Class 4 SD Card is used. It is crashing with:
```
[    0.599245] Waiting for root device PARTUUID=5452574f-02...
[    1.496765] usb 4-1: new SuperSpeed Gen 1 USB device number 2 using xhci-hcd
[    1.810225] mmc0: card never left busy state
[    1.810626] mmc0: error -110 whilst initialising SD card
[    1.825959] mmc_host mmc0: Bus speed (slot 0) = 300000Hz (slot req 300000Hz, actual 300000HZ div = 0)
[    3.193357] mmc0: card never left busy state
[    3.193747] mmc0: error -110 whilst initialising SD card
[    3.209291] mmc_host mmc0: Bus speed (slot 0) = 200000Hz (slot req 200000Hz, actual 200000HZ div = 0)
[    4.620761] mmc0: card never left busy state
[    4.621150] mmc0: error -110 whilst initialising SD card
[    4.637285] mmc_host mmc0: Bus speed (slot 0) = 100000Hz (slot req 100000Hz, actual 100000HZ div = 0)
[    6.180747] mmc0: card never left busy state
[    6.181138] mmc0: error -110 whilst initialising SD card
```

When armbian DTB is used instead of one provided by OpenWRT - boot is successful.
`regulator-boot-on` is the only meaningful change which made NanoPI R2S to load on Class 4 SD Card.
Tested loading on Class 4 and Class 10 SD Cards - both were successful

Signed-off-by: Arturas Moskvinas <arturas.moskvinas@gmail.com>