### PR TITLE
firewall: make uci scripting friendlier

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -1,4 +1,4 @@
-config defaults
+config defaults			defaults
 	option syn_flood	1
 	option input		ACCEPT
 	option output		ACCEPT
@@ -6,30 +6,30 @@ config defaults
 # Uncomment this line to disable ipv6 rules
 #	option disable_ipv6	1
 
-config zone
+config zone			lan
 	option name		lan
-	list   network		'lan'
+	list   network		lan
 	option input		ACCEPT
 	option output		ACCEPT
 	option forward		ACCEPT
 
-config zone
+config zone			wan
 	option name		wan
-	list   network		'wan'
-	list   network		'wan6'
+	list   network		wan
+	list   network		wan6
 	option input		REJECT
 	option output		ACCEPT
 	option forward		REJECT
 	option masq		1
 	option mtu_fix		1
 
-config forwarding
+config forwarding		lan_wan
 	option src		lan
 	option dest		wan
 
 # We need to accept udp packets on port 68,
 # see https://dev.openwrt.org/ticket/4108
-config rule
+config rule			dhcpc
 	option name		Allow-DHCP-Renew
 	option src		wan
 	option proto		udp
@@ -38,7 +38,7 @@ config rule
 	option family		ipv4
 
 # Allow IPv4 ping
-config rule
+config rule			icmp
 	option name		Allow-Ping
 	option src		wan
 	option proto		icmp
@@ -46,7 +46,7 @@ config rule
 	option family		ipv4
 	option target		ACCEPT
 
-config rule
+config rule			igmp
 	option name		Allow-IGMP
 	option src		wan
 	option proto		igmp
@@ -55,7 +55,7 @@ config rule
 
 # Allow DHCPv6 replies
 # see https://dev.openwrt.org/ticket/10381
-config rule
+config rule			dhcp6c
 	option name		Allow-DHCPv6
 	option src		wan
 	option proto		udp
@@ -65,23 +65,23 @@ config rule
 	option family		ipv6
 	option target		ACCEPT
 
-config rule
+config rule			mld
 	option name		Allow-MLD
 	option src		wan
 	option proto		icmp
 	option src_ip		fe80::/10
-	list icmp_type		'130/0'
-	list icmp_type		'131/0'
-	list icmp_type		'132/0'
-	list icmp_type		'143/0'
+	list icmp_type		130/0
+	list icmp_type		131/0
+	list icmp_type		132/0
+	list icmp_type		143/0
 	option family		ipv6
 	option target		ACCEPT
 
 # Allow essential incoming IPv6 ICMP traffic
-config rule
+config rule			icmp6
 	option name		Allow-ICMPv6-Input
 	option src		wan
-	option proto	icmp
+	option proto		icmp
 	list icmp_type		echo-request
 	list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
@@ -98,7 +98,7 @@ config rule
 	option target		ACCEPT
 
 # Allow essential forwarded IPv6 ICMP traffic
-config rule
+config rule			icmp6_fwd
 	option name		Allow-ICMPv6-Forward
 	option src		wan
 	option dest		*
@@ -114,14 +114,14 @@ config rule
 	option family		ipv6
 	option target		ACCEPT
 
-config rule
+config rule			esp_fwd
 	option name		Allow-IPSec-ESP
 	option src		wan
 	option dest		lan
 	option proto		esp
 	option target		ACCEPT
 
-config rule
+config rule			isakmp_fwd
 	option name		Allow-ISAKMP
 	option src		wan
 	option dest		lan
@@ -133,7 +133,7 @@ config rule
 # note that traceroute uses a fixed port range, and depends on getting
 # back ICMP Unreachables.  if we're operating in DROP mode, it won't
 # work so we explicitly REJECT packets on these ports.
-config rule
+config rule			trace
 	option name		Support-UDP-Traceroute
 	option src		wan
 	option dest_port	33434:33689
@@ -143,7 +143,7 @@ config rule
 	option enabled		false
 
 # include a file with users custom iptables rules
-config include
+config include			custom
 	option path /etc/firewall.user
 
 
@@ -151,28 +151,28 @@ config include
 # do not allow a specific ip to access wan
 #config rule
 #	option src		lan
-#	option src_ip	192.168.45.2
+#	option src_ip		192.168.45.2
 #	option dest		wan
-#	option proto	tcp
-#	option target	REJECT
+#	option proto		tcp
+#	option target		REJECT
 
 # block a specific mac on wan
 #config rule
 #	option dest		wan
-#	option src_mac	00:11:22:33:44:66
-#	option target	REJECT
+#	option src_mac		00:11:22:33:44:66
+#	option target		REJECT
 
 # block incoming ICMP traffic on a zone
 #config rule
 #	option src		lan
-#	option proto	ICMP
-#	option target	DROP
+#	option proto		ICMP
+#	option target		DROP
 
 # port redirect port coming in on wan to lan
 #config redirect
-#	option src			wan
+#	option src		wan
 #	option src_dport	80
-#	option dest			lan
+#	option dest		lan
 #	option dest_ip		192.168.16.235
 #	option dest_port	80
 #	option proto		tcp
@@ -188,21 +188,21 @@ config include
 ### FULL CONFIG SECTIONS
 #config rule
 #	option src		lan
-#	option src_ip	192.168.45.2
-#	option src_mac	00:11:22:33:44:55
-#	option src_port	80
+#	option src_ip		192.168.45.2
+#	option src_mac		00:11:22:33:44:55
+#	option src_port		80
 #	option dest		wan
-#	option dest_ip	194.25.2.129
+#	option dest_ip		194.25.2.129
 #	option dest_port	120
-#	option proto	tcp
-#	option target	REJECT
+#	option proto		tcp
+#	option target		REJECT
 
 #config redirect
 #	option src		lan
-#	option src_ip	192.168.45.2
-#	option src_mac	00:11:22:33:44:55
+#	option src_ip		192.168.45.2
+#	option src_mac		00:11:22:33:44:55
 #	option src_port		1024
 #	option src_dport	80
-#	option dest_ip	194.25.2.129
+#	option dest_ip		194.25.2.129
 #	option dest_port	120
-#	option proto	tcp
+#	option proto		tcp


### PR DESCRIPTION
Make UCI scripting for firewall configuration friendlier.
It's much easier to analyze configuration as well as set up firewall via CLI using named sections.
The default configuration should provide simple and easy to distinguish names for UCI sections.
In addition, unify the indentation for the example sections.