### PR TITLE
ath79/mikrotik: remove bootloader2 location for SXT 5n

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5n.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5n.dtsi
@@ -122,13 +122,13 @@
 					read-only;
 				};
 
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0x0>;
-					read-only;
+				soft_config {
 				};
 
-				soft_config {
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x10000>;
+					read-only;
 				};
 			};
 		};


### PR DESCRIPTION
Setting the offset of the bootloader2 partition makes the RouterBoot platform driver fail to fetch the soft_config:

	partition@10000 {
		label = "bootloader2";
		reg = <0x10000 0x0>;
		read-only;
	};

By removing the "reg = <0x10000 0x0>;" line, the driver detects and enables the soft_config partition correctly.

Fixes [FS#3314](https://bugs.openwrt.org/index.php?do=details&task_id=3314&order=dateopened&sort=desc).

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>



Before the commit:
```
[    0.567415] 3 fixed-partitions partitions found on MTD device ar934x-nand
[    0.574448] Creating 3 MTD partitions on "ar934x-nand":
[    0.579885] 0x000000000000-0x000000040000 : "booter"
[    0.586206] 0x000000040000-0x000000400000 : "kernel"
[    0.592487] 0x000000400000-0x000008000000 : "ubi"
[    0.613702] spi-nor spi0.0: w25x10 (128 Kbytes)
[    0.618452] 1 fixed-partitions partitions found on MTD device spi0.0
[    0.625029] Creating 1 MTD partitions on "spi0.0":
[    0.630003] 0x000000000000-0x000000020000 : "RouterBoot"
[    0.638556] RouterBoot: routerboot partition /ahb/spi@1f000000/flash@0/partitions/partition@0/soft_config (/ahb/spi@1f000000/flash@0/partitions/partition@0) "soft_config" overlaps with previous partition "bootloader2".
[    0.658644] RouterBoot: error parsing routerboot partition /ahb/spi@1f000000/flash@0/partitions/partition@0/soft_config (/ahb/spi@1f000000/flash@0/partitions/partition@0)
[    0.674395] 2 fixed-partitions partitions found on MTD device RouterBoot
[    0.681324] Creating 2 MTD partitions on "RouterBoot":
[    0.686658] 0x000000000000-0x000000020000 : "bootloader1"
[    0.693477] 0x000000010000-0x000000020000 : "bootloader2"

root@OpenWrt:/# cat /proc/mtd 
dev:    size   erasesize  name
mtd0: 00040000 00020000 "booter"
mtd1: 003c0000 00020000 "kernel"
mtd2: 07c00000 00020000 "ubi"
mtd3: 00020000 00001000 "RouterBoot"
mtd4: 00020000 00001000 "bootloader1"
mtd5: 00010000 00001000 "bootloader2"
```

After the commit:
```
[    4.431839] 3 fixed-partitions partitions found on MTD device ar934x-nand
[    4.438871] Creating 3 MTD partitions on "ar934x-nand":
[    4.444295] 0x000000000000-0x000000040000 : "booter"
[    4.450557] 0x000000040000-0x000000400000 : "kernel"
[    4.456881] 0x000000400000-0x000008000000 : "ubi"
[    4.478200] spi-nor spi0.0: w25x10 (128 Kbytes)
[    4.483491] 1 routerbootpart partitions found on MTD device spi0.0
[    4.489898] Creating 1 MTD partitions on "spi0.0":
[    4.494890] 0x000000000000-0x000000020000 : "partitions"
[    4.503362] 5 routerbootpart partitions found on MTD device partitions
[    4.510174] Creating 5 MTD partitions on "partitions":
[    4.515514] 0x000000000000-0x00000000c000 : "routerboot1"
[    4.522238] 0x00000000c000-0x00000000d000 : "hard_config"
[    4.529015] 0x00000000d000-0x00000000e000 : "bios"
[    4.535209] 0x00000000e000-0x000000020000 : "routerboot2"
[    4.541950] 0x00000000e000-0x00000000f000 : "soft_config"

root@OpenWrt:/# cat /proc/mtd 
dev:    size   erasesize  name
mtd0: 00040000 00020000 "booter"
mtd1: 003c0000 00020000 "kernel"
mtd2: 07c00000 00020000 "ubi"
mtd3: 00020000 00001000 "partitions"
mtd4: 0000c000 00001000 "routerboot1"
mtd5: 00001000 00001000 "hard_config"
mtd6: 00001000 00001000 "bios"
mtd7: 00012000 00001000 "routerboot2"
mtd8: 00001000 00001000 "soft_config"
```