### PR TITLE
px5g-wolfssl: cleanup Makefile and SPDX license

### DIFF
--- a/package/utils/px5g-wolfssl/Makefile
+++ b/package/utils/px5g-wolfssl/Makefile
@@ -1,9 +1,6 @@
-#
 # Copyright (C) 2020 Paul Spooren <mail@aparcar.org>
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 include $(TOPDIR)/rules.mk
 
@@ -21,7 +18,7 @@ define Package/px5g-wolfssl
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Encryption
-  TITLE:=X.509 certificate generator (using wolfssl)
+  TITLE:=X.509 certificate generator (using WolfSSL)
   DEPENDS:=+libwolfssl
   PROVIDES:=px5g
   VARIANT:=wolfssl
@@ -33,17 +30,14 @@ define Package/px5g-wolfssl/description
  and PEM format for use with stunnel, uhttpd and others.
 endef
 
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-endef
-
 TARGET_LDFLAGS += -lwolfssl
 
 
 TARGET_CFLAGS += -Wl,--gc-sections
 
 define Build/Compile
-	$(TARGET_CC) $(TARGET_CPPFLAGS) $(TARGET_CFLAGS) -o $(PKG_BUILD_DIR)/px5g px5g-wolfssl.c $(TARGET_LDFLAGS)
+	$(TARGET_CC) $(TARGET_CPPFLAGS) $(TARGET_CFLAGS) \
+		-o $(PKG_BUILD_DIR)/px5g px5g-wolfssl.c $(TARGET_LDFLAGS)
 endef
 
 define Package/px5g-wolfssl/install

--- a/package/utils/px5g-wolfssl/px5g-wolfssl.c
+++ b/package/utils/px5g-wolfssl/px5g-wolfssl.c
@@ -1,3 +1,7 @@
+// Copyright 2020 Paul Spooren <mail@aparcar.org>
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 #define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdint.h>


### PR DESCRIPTION
Minor cosmetic cleanups of the Makefile and add a SPDX compatible
license headers.