### PR TITLE
uhttpd: use P-256 for certs

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -119,13 +119,13 @@ config cert defaults
 	option days		730
 
 	# key type: rsa or ec
-	option key_type		rsa
+	option key_type		ec
 
 	# RSA key size
 	option bits		2048
 
 	# EC curve name
-	# Curve names vary between mbedtls/px5g and openssl
+	# Curve names vary between px5g-{wolfssl,mbedtls} and openssl
 	# P-256 or P-384 are guaranteed to work
 	option ec_curve		P-256
 


### PR DESCRIPTION
The uhttpd package takes care of creating self-signed certificates if
px5g is installed. This improves the security of router management as it
encrypts the LuCI connection.

Once it's enabled by default the certificates should life longer than
only two years, as most OpenWrt devices run longer and sysupgrades do
not trigger certificate regeneration. For that reason bump the default
valid days to 10 years.

The EC P-256 curve is faster than RSA which which improves the user
experience on embedded devices. EC P-256 is support for as old devices
as Android 4.4.

Signed-off-by: Paul Spooren <mail@aparcar.org>