### PR TITLE
ath79: add support for Senao Engenius EnStationAC v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -27,6 +27,7 @@ engenius,eap300-v2|\
 engenius,ecb1750|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\
+engenius,enstationac-v1|\
 etactica,eg200|\
 glinet,gl-ar750s-nor|\
 glinet,gl-ar750s-nor-nand|\

--- a/target/linux/ath79/dts/qca9557_engenius_enstationac-v1.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_enstationac-v1.dts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,enstationac-v1", "qca,qca9557";
+	model = "EnGenius EnStationAC v1";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		rssilow {
+			label = "red:rssilow";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "amber:rssimedium";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "green:rssihigh";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x4f4b4c49>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x050000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0x0a0000 0x010000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0x0b0000 0x170000>;
+			};
+
+			partition@220000 {
+				label = "fakeroot";
+				reg = <0x220000 0x010000>;
+				read-only;
+			};
+
+			firmware1: partition@230000 {
+				label = "firmware1";
+				reg = <0x230000 0xb40000>;
+			};
+
+			partition@d70000 {
+				label = "failsafe";
+				reg = <0xd70000 0x280000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+		at803x-override-sgmii-link-check;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy1>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+
+	phy-handle = <&phy2>;
+
+	pll-data = <0x03000000 0x00000101 0x00001313>;
+
+	qca955x-sgmii-fixup;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -185,7 +185,8 @@ engenius,enh202-v1)
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "amber:rssimedium" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "67" "100"
 	;;
-engenius,ens202ext-v1)
+engenius,ens202ext-v1|\
+engenius,enstationac-v1)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan0" "1"  "100"
 	ucidef_set_led_rssi "rssimedium" "RSSIMEDIUM" "amber:rssimedium" "wlan0" "33" "100"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,6 +11,7 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
 	allnet,all-wap02860ac|\
+	engenius,enstationac-v1|\
 	glinet,gl-x750)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +2)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -56,6 +56,7 @@ endef
 define Build/engenius-tar-gz
 	-[ -f "$@" ] && \
 	mkdir -p $@.tmp && \
+	touch $@.tmp/failsafe.bin && \
 	echo '#!/bin/sh' > $@.tmp/before-upgrade.sh && \
 	echo ': > /tmp/_sys/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
 	$(CP) $(KDIR)/loader-$(DEVICE_NAME).uImage \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -911,6 +911,18 @@ define Device/engenius_ens202ext-v1
 endef
 TARGET_DEVICES += engenius_ens202ext-v1
 
+define Device/engenius_enstationac-v1
+  $(Device/engenius_loader_okli)
+  SOC := qca9557
+  DEVICE_MODEL := EnStationAC
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct rssileds
+  IMAGE_SIZE := 11520k
+  LOADER_FLASH_OFFS := 0x230000
+  ENGENIUS_IMGNAME := ar71xx-generic-enstationac
+endef
+TARGET_DEVICES += engenius_enstationac-v1
+
 define Device/engenius_epg5000
   SOC := qca9558
   DEVICE_VENDOR := EnGenius


### PR DESCRIPTION
FCC ID: A8J-ENSTAC

Engenius EnStationAC is an outdoor wireless access point/bridge with 2 gigabit ethernet ports,
5 GHz only wireless, external ethernet switch, internal antenna plates and proprietery PoE.

Specification:

  - QCA9557
  - 40 MHz reference clock
  - 16 MB FLASH			MX25L12845EMI-10G
  - 2x 64 MB RAM		NT5TU32M16FG
  - UART at J10			(unpopulated)
  - 2x GbE ports with POE	(Atheros AR8033 switch)
  - 5 GHz, 2x2, 26dBm		(QCA9882 PCI card)
  - internal antenna plates	(19 dbi, directional)
  - 7 LEDs, 1 button		(power, eth, wlan, RSSI) (reset)

MAC addresses:

  eth0	*:d3   art 0x0/0x6
  eth1	*:d4   ???
  wlan	*:d5   ???

  The device label lists first ETH MAC and WLAN 5 GHz MAC

  Even though only 1 MAC representing the vendor is found on flash
  The OEM software reports these MACs for the rest of the ifconfig.

Installation:

  2 ways to flash factory.bin from OEM:

  - Connect ethernet directly to board (the non POE port)
      this is LAN for all images
  - if you get Failsafe Mode from failed flash:
      only use it to flash Original firmware from Engenius
      or risk kernel loop or halt which requires serial cable

  Method 1: Firmware upgrade page:

    OEM webpage at 192.168.1.1
    username and password "admin"
    Navigate to "Firmware" page from left pane
    Click Browse and select the factory.bin image
    Upload and verify checksum
    Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

    After connecting to serial console and rebooting...
    Interrupt uboot with any key pressed rapidly
    execute `run failsafe_boot` OR `bootm 0x9fd70000`
    wait a minute
    connect to ethernet and navigate to
    "192.168.1.1/index.htm"
    Select the factory.bin image and upload
    wait about 3 minutes

Return to OEM:

  If you have a serial cable, see Serial Failsafe instructions

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will not work
  DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

  The easiest way to return to the OEM software is the Failsafe image
  If you dont have a serial cable, you can ssh into openwrt and run

  `mtd -r erase fakeroot`

  Wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

Format of OEM firmware image:

  The OEM software of EnStationAC is a heavily modified version
  of Openwrt Altitude Adjustment 12.09. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names...

    openwrt-ar71xx-enstationac-uImage-lzma.bin
    openwrt-ar71xx-enstationac-root.squashfs

  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  Newer EnGenius software requires more checks but their script
  includes a way to skip them, otherwise the tar must include
  a text file with the version and md5sums in a deprecated format.

  The OEM upgrade script is at /etc/fwupgrade.sh.

  OKLI kernel loader is required because the OEM software
  expects the kernel to be no greater than 1536k
  and the factory.bin upgrade procedure would otherwise
  overwrite part of the kernel when writing rootfs.

Note on PLL-data cells:

  The default PLL register values will not work
  because of the external AR8033 switch between
  the SOC and the ethernet PHY chips.

  For QCA955x series, the PLL registers for eth0 and eth1
  can be see in the DTSI as 0x28 and 0x48 respectively.
  Therefore the PLL registers can be read from uboot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x18050028 1` and `md 0x18050048 1`.

  For eth0 at 1000 speed, the value returned was
  ae000000 but that didn't work, so following
  the logical pattern from the rest of the values,
  the guessed value of a3000000 works better.

Tested from master, all link speeds functional

Signed-off-by: Michael Pratt <mpratt51@gmail.com>