### PR TITLE
ipq806x: fix pci broken on bootm command

### DIFF
--- a/target/linux/ipq806x/patches-5.4/096-PCI-qcom-Make-sure-PCIe-is-reset-before-init-for-rev.patch
+++ b/target/linux/ipq806x/patches-5.4/096-PCI-qcom-Make-sure-PCIe-is-reset-before-init-for-rev.patch
@@ -1,0 +1,51 @@
+From 1960d75e3251659be8276529e4d01cf6993d9f4a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 1 Sep 2020 14:21:44 +0200
+Subject: [PATCH] PCI: qcom: Make sure PCIe is reset before init for rev 2.1.0
+
+Qsdk U-Boot can incorrectly leave the PCIe interface in an undefined
+state if bootm command is used instead of bootipq. This is caused by the
+not deinit of PCIe when bootm is called. Reset the PCIe before init
+anyway to fix this U-Boot bug.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Fixes: 82a823833f4e ("PCI: qcom: Add Qualcomm PCIe controller driver")
+Cc: stable@vger.kernel.org # v4.19+
+---
+ drivers/pci/controller/dwc/pcie-qcom.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/pcie-qcom.c b/drivers/pci/controller/dwc/pcie-qcom.c
+index 3aac77a295ba..82336bbaf8dc 100644
+--- a/drivers/pci/controller/dwc/pcie-qcom.c
++++ b/drivers/pci/controller/dwc/pcie-qcom.c
+@@ -302,6 +302,9 @@ static void qcom_pcie_deinit_2_1_0(struct qcom_pcie *pcie)
+ 	reset_control_assert(res->por_reset);
+ 	reset_control_assert(res->ext_reset);
+ 	reset_control_assert(res->phy_reset);
++
++	writel(1, pcie->parf + PCIE20_PARF_PHY_CTRL);
++
+ 	regulator_bulk_disable(ARRAY_SIZE(res->supplies), res->supplies);
+ }
+ 
+@@ -314,6 +317,16 @@ static int qcom_pcie_init_2_1_0(struct qcom_pcie *pcie)
+ 	u32 val;
+ 	int ret;
+ 
++	/* reset the PCIe interface as uboot can leave it undefined state */
++	reset_control_assert(res->pci_reset);
++	reset_control_assert(res->axi_reset);
++	reset_control_assert(res->ahb_reset);
++	reset_control_assert(res->por_reset);
++	reset_control_assert(res->ext_reset);
++	reset_control_assert(res->phy_reset);
++
++	writel(1, pcie->parf + PCIE20_PARF_PHY_CTRL);
++
+ 	ret = regulator_bulk_enable(ARRAY_SIZE(res->supplies), res->supplies);
+ 	if (ret < 0) {
+ 		dev_err(dev, "cannot enable regulators\n");
+-- 
+2.27.0
+


### PR DESCRIPTION
Pci is broken when bootm is used instead of the custom bootipq. This is caused by the lack of reset by the bootloader. Make the driver do the reset to fix this specific problem.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>