### PR TITLE
ath79: add support for Belkin AC1750 DB Wi-Fi (F9J1108v2)

### DIFF
--- a/target/linux/ath79/dts/qca9558_belkin_f9j1108-v2.dts
+++ b/target/linux/ath79/dts/qca9558_belkin_f9j1108-v2.dts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Belkin F9J1108v2 (AC1750 DB Wi-Fi)";
+	compatible = "belkin,f9j1108-v2", "qca,qca9558";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth0;
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+		
+		usb {
+			label = "green:usb2";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+		
+		status {
+			label = "amber:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps-amber {
+			label = "amber:wps";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps-blue {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system {
+			label = "blue:system";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb2_power {
+			gpio-export,name = "usb2:power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+		
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+	
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwpart1 &fwpart2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+			
+			fwpart1: partition@50000 {
+				label = "fwpart1";
+				reg = <0x050000 0xe20000>;
+			};
+			
+			partition@e70000 {
+				label = "loader";
+				reg = <0xe70000 0x10000>;
+				read-only;
+			};
+			
+			fwpart2: partition@e80000 {
+				label = "fwpart2";
+				reg = <0xe80000 0x170000>;
+			};
+			
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x50 0xc737c737 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x0030c300 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&phy0>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <(-1)>;
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+	
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -100,6 +100,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
 		;;
+	belkin,f9j1108-v2)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+		;;
 	buffalo,bhr-4grv|\
 	buffalo,wzr-hp-g450h)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -50,6 +50,24 @@ define Build/cybertan-trx
 	-rm $@-empty.bin
 endef
 
+define Build/edimax-headers
+	$(eval edimax_magic=$(word 1,$(1)))
+	$(eval edimax_model=$(word 2,$(1)))
+
+	$(STAGING_DIR_HOST)/bin/edimax_fw_header -M $(edimax_magic) -m $(edimax_model)\
+		-v $(VERSION_DIST)$(firstword $(subst +, , $(firstword $(subst -, ,$(REVISION))))) \
+		-n "uImage" \
+		-i $(KDIR)/loader-$(DEVICE_NAME).uImage \
+		-o $@.uImage
+	$(STAGING_DIR_HOST)/bin/edimax_fw_header -M $(edimax_magic) -m $(edimax_model)\
+		-v $(VERSION_DIST)$(firstword $(subst +, , $(firstword $(subst -, ,$(REVISION))))) \
+		-n "rootfs" \
+		-i $@ \
+		-o $@.rootfs
+	cat $@.uImage $@.rootfs > $@
+	rm -rf $@.uImage $@.rootfs
+endef
+
 # This needs to make /tmp/_sys/sysupgrade.tgz an empty file prior to
 # sysupgrade, as otherwise it will implant the old configuration from
 # OEM firmware when writing rootfs from factory.bin
@@ -362,6 +380,26 @@ define Device/avm_fritzdvbc
 	ath10k-firmware-qca988x-ct -swconfig
 endef
 TARGET_DEVICES += avm_fritzdvbc
+
+define Device/belkin_f9j1108-v2
+  SOC := qca9558
+  DEVICE_VENDOR := Belkin
+  DEVICE_MODEL := F9J1108 v2 (AC1750 DB Wi-Fi)
+  IMAGE_SIZE := 14464k
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2 \
+	kmod-usb3 kmod-usb-ledtrig-usbport
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x50000
+  COMPILE := loader-$(1).bin loader-$(1).uImage
+  COMPILE/loader-$(1).bin := loader-okli-compile
+  COMPILE/loader-$(1).uImage := append-loader-okli $(1) | pad-to 64k | lzma | \
+	uImage lzma
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs | check-size | edimax-headers F9J1108v1 BR-6679BAC | pad-to $$$$(BLOCKSIZE)
+endef
+TARGET_DEVICES += belkin_f9j1108-v2
 
 define Device/buffalo_bhr-4grv
   $(Device/buffalo_common)


### PR DESCRIPTION
This device is the non-US build of the F9K1115 v2, with a different firmware magic.

Specifications:

SoC: QCA9558
CPU: 720 MHz
Flash: 16 MiB NOR
RAM: 128 MiB
WiFi 2.4 GHz: QCA9558-AT4A 3x3 MIMO 802.11b/g/n
WiFi 5 GHz: QCA9880-2R4E 3x3 MIMO 802.11a/n/ac
Ethernet: 4x LAN and 1x WAN (all 1gbps)
USB: 2x USB 3.0

Flashing instructions:

The factory.bin can be flashed via the Belkin web UI or via the uboot http upgrade page.
Once the factory.bin has been written, it is possible to sysupgrade -F the sysupgrade image.

Signed-off-by: Damien Mascord <tusker@tusker.org>