### PR TITLE
ipq40xx: Add support for Linksys MR8300 (Dallas)

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -43,7 +43,8 @@ buffalo,wtr-m2133hp)
 linksys,ea6350v3)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x20000"
 	;;
-linksys,ea8300)
+linksys,ea8300 |\
+linksys,mr8300)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x40000" "0x20000"
 	;;
 zyxel,nbg6617)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -50,7 +50,8 @@ ipq40xx_setup_interfaces()
 		;;
 	avm,fritzbox-4040|\
 	linksys,ea6350v3|\
-	linksys,ea8300)
+	linksys,ea8300|\
+	linksys,mr8300)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -39,7 +39,8 @@ case "$FIRMWARE" in
 	openmesh,a62)
 		caldata_extract "0:ART" 0x9000 0x2f20
 		;;
-	linksys,ea8300)
+	linksys,ea8300 |\
+	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
 		ath10k_patch_mac $(macaddr_setbit_la $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4))
@@ -118,7 +119,8 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +2)
 		;;
-	linksys,ea8300)
+	linksys,ea8300 |\
+	linksys,mr8300)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
@@ -211,7 +213,8 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +3)
 		;;
-	linksys,ea8300)
+	linksys,ea8300 |\
+	linksys,mr8300)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
 		;;

--- a/target/linux/ipq40xx/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq40xx/base-files/etc/init.d/bootcount
@@ -8,8 +8,9 @@ boot() {
 		[ -n "$(fw_printenv bootcount changed 2>/dev/null)" ] &&\
 			echo -e "bootcount\nchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
-	linksys,ea6350v3|\
-	linksys,ea8300)
+	linksys,ea6350v3 |\
+	linksys,ea8300 |\
+	linksys,mr8300)
 		mtd resetbc s_env || true
 		;;
 	esac

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -15,7 +15,8 @@ preinit_set_mac_address() {
 		base_mac=$(cat /sys/class/net/eth0/address)
 		ip link set dev eth1 address $(macaddr_add "${base_mac}" +1)
 		;;
-	linksys,ea8300)
+	linksys,ea8300 |\
+	linksys,mr8300)
 		base_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ip link set dev eth0 address "${base_mac}"
 		ip link set dev eth1 address $(macaddr_add "${base_mac}" 1)

--- a/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh
@@ -8,6 +8,7 @@ set_preinit_iface() {
 	ezviz,cs-w3-wd1200g-eup| \
 	glinet,gl-b1300| \
 	linksys,ea8300| \
+	linksys,mr8300| \
 	meraki,mr33| \
 	zyxel,nbg6617)
 		ifname=eth0

--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -16,7 +16,7 @@ linksys_get_target_firmware() {
 			"${cur_boot_part}" "${mtd_ubi0}"
 	fi
 
-	# OEM U-Boot for EA6350v3 and EA8300; bootcmd=
+	# OEM U-Boot for EA6350v3, EA8300 and MR8300; bootcmd=
 	#  if test $auto_recovery = no;
 	#      then bootipq;
 	#  elif test $boot_part = 1;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -99,7 +99,8 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	linksys,ea6350v3 |\
-	linksys,ea8300)
+	linksys,ea8300 |\
+	linksys,mr8300)
 		platform_do_upgrade_linksys "$1"
 		;;
 	meraki,mr33)

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mr8300.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-mr8300.dts
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/*
+ * Device Tree Source for Linksys MR8300 (Dallas)
+ *
+ * Copyright (C) 2019 Jeff Kletsky
+ * Updated 2020 Hans Geiblinger (support for mr8300)
+ *
+ */
+
+/dts-v1/;
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Linksys MR8300 (Dallas)";
+	compatible = "linksys,mr8300", "qcom,ipq4019";
+
+
+	aliases {
+		led-boot = &led_wps_amber;
+		led-failsafe = &led_wps;
+		led-running = &led_linksys;
+		led-upgrade = &led_world;
+		serial0 = &blsp1_uart1;
+	};
+
+
+	leds {
+		compatible = "gpio-leds";
+
+		// Retain node names from running OEM on MR8300
+
+		// Front panel LEDs, top to bottom
+
+		led_plug: diag {
+			label = "mr8300:amber:plug";
+			gpios = <&tlmm 47 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_world: internet {
+			label = "mr8300:amber:world";
+			gpios = <&tlmm 49 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wps: wps {
+			label = "mr8300:white:wps";
+			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_wps_amber: wps_amber {
+			label = "mr8300:amber:wps";
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led_linksys: pwr {
+			label = "mr8300:white:linksys";
+			gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
+		};
+
+		// On back panel, above USB socket
+
+		led_usb: usb {
+			label = "mr8300:green:usb";
+			gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&usb3_port1>, <&usb3_port2>,
+					  <&usb2_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+
+		button@0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+		};
+
+		button@1 {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+
+	//
+	// OEM U-Boot provides either
+	// init=/sbin/init rootfstype=ubifs ubi.mtd=11,2048 \
+	//                 root=ubi0:ubifs rootwait rw
+	// or the same with ubi.mtd=13,2048
+	//
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_0 rootfstype=squashfs ro";
+	};
+
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		usb2@60f8800 {
+			status = "okay";
+
+			dwc3@6000000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				usb2_port1: port@1 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		usb3@8af8800 {
+			status = "okay";
+
+			dwc3@8a00000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				usb3_port1: port@1 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+
+				usb3_port2: port@2 {
+					reg = <2>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+};
+
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&nand {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "sbl1";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "mibib";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "qsee";
+				reg = <0x200000 0x100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "cdt";
+				reg = <0x300000 0x80000>;
+				read-only;
+			};
+
+			partition@380000 {
+				label = "appsblenv";
+				reg = <0x380000 0x80000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "ART";
+				reg = <0x400000 0x80000>;
+				read-only;
+			};
+
+			partition@480000 {
+				label = "appsbl";
+				reg = <0x480000 0x200000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "u_env";
+				reg = <0x680000 0x80000>;
+				// writable -- U-Boot environment
+			};
+
+			partition@700000 {
+				label = "s_env";
+				reg = <0x700000 0x40000>;
+				// writable -- Boot counter records
+			};
+
+			partition@740000 {
+				label = "devinfo";
+				reg = <0x740000 0x40000>;
+				read-only;
+			};
+
+			partition@780000 {
+				label = "kernel";
+				reg = <0x780000 0x5800000>;
+			};
+
+			partition@a80000 {
+				label = "rootfs";
+				reg = <0xa80000 0x5500000>;
+			};
+
+			partition@5f80000 {
+				label = "alt_kernel";
+				reg = <0x5f80000 0x5800000>;
+			};
+
+			partition@6280000 {
+				label = "alt_rootfs";
+				reg = <0x6280000 0x5500000>;
+			};
+
+			partition@b780000 {
+				label = "sysdiag";
+				reg = <0xb780000 0x100000>;
+				read-only;
+			};
+
+			partition@b880000 {
+				label = "syscfg";
+				reg = <0xb880000 0x4680000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi2: wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	serial_0_pins: serial0-pinmux {
+		pins = "gpio16", "gpio17";
+		function = "blsp_uart0";
+		bias-disable;
+	};
+
+	nand_pins: nand_pins {
+		pullups {
+			pins = "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		// gpio61 controls led_usb
+
+		pulldowns {
+			pins =  "gpio55", "gpio56", "gpio57",
+				"gpio60", "gpio62", "gpio63",
+				"gpio64", "gpio65", "gpio66",
+				"gpio67", "gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "linksys-ea8300-fcc";
+};
+
+&wifi1 {
+	status = "okay";
+	ieee80211-freq-limit = <5170000 5330000>;
+	qcom,ath10k-calibration-variant = "linksys-ea8300-fcc";
+};
+
+&wifi2 {
+	status = "okay";
+	ieee80211-freq-limit = <5490000 5835000>;
+	qcom,ath10k-calibration-variant = "linksys-ea8300-fcc";
+};

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -515,6 +515,22 @@ define Device/linksys_ea8300
 endef
 TARGET_DEVICES += linksys_ea8300
 
+define Device/linksys_mr8300
+	$(call Device/FitzImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := MR8300
+	SOC := qcom-ipq4019
+	KERNEL_SIZE := 3072k
+	IMAGE_SIZE := 87040k
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
+	IMAGES += factory.bin
+	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MR8300
+	DEVICE_PACKAGES := uboot-envtools ath10k-firmware-qca9888-ct ipq-wifi-linksys_ea8300 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += linksys_mr8300
+
 define Device/meraki_mr33
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Cisco Meraki

--- a/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-4.19/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -785,11 +785,49 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -785,11 +785,50 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -42,6 +42,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4019-fritzrepeater-1200.dtb \
 +	qcom-ipq4019-fritzrepeater-3000.dtb \
 +	qcom-ipq4019-ea8300.dtb \
++	qcom-ipq4019-mr8300.dtb \
 +	qcom-ipq4019-habanero-dvk.dtb \
 +	qcom-ipq4019-map-ac2200.dtb \
 +	qcom-ipq4019-e2600ac-c1.dtb \

--- a/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -837,11 +837,50 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -837,11 +837,51 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -39,6 +39,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4019-a62.dtb \
 +	qcom-ipq4019-cm520-79f.dtb \
 +	qcom-ipq4019-ea8300.dtb \
++	qcom-ipq4019-mr8300.dtb \
 +	qcom-ipq4019-eap2200.dtb \
 +	qcom-ipq4019-fritzbox-7530.dtb \
 +	qcom-ipq4019-fritzrepeater-1200.dtb \


### PR DESCRIPTION
The Linksys MR8300 is based on QCA4019 and QCA9888 and provides three,
independent radios. NAND provides two, alternate kernel/firmware
images with fail-over provided by the OEM U-Boot.

Support is based on the already supported EA8300. Only difference is
EA8300 has 256MB RAM where MR8300 has 512MB RAM.

Installation:

  "Factory" images may be installed directly through the OEM GUI using
   URL: https://<IP of router>/fwupdate.html

Hardware Highlights:

  * IPQ4019 at 717 MHz (4 CPUs)
  * 256 MB NAND (Winbond W29N02GV, 8-bit parallel)
  * 512 MB RAM
  * Three, fully-functional radios; `iw phy` reports (FCC/US, -CT):
      * 2.4 GHz radio at 30 dBm
      * 5 GHz radio on ch. 36-64 at 23 dBm
      * 5 GHz radio on ch. 100-144 at 23 dBm (DFS), 149-165 at 30 dBm
      #{ managed } <= 16, #{ AP, mesh point } <= 16, #{ IBSS } <= 1
      * All two-stream, MCS 0-9
  * 4x GigE LAN, 1x GigE Internet Ethernet jacks with port lights
  * USB3, single port on rear with LED
  * WPS and reset buttons
  * Four status lights on top
  * Serial pads internal (unpopulated)

Signed-off-by: Hans Geiblinger <cybrnook2002@yahoo.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
