### PR TITLE
bpftools: support NLS building and update to 5.8.9

### DIFF
--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bpftools
-PKG_VERSION:=5.8.3
+PKG_VERSION:=5.8.9
 PKG_RELEASE:=1
 
 PKG_SOURCE:=linux-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/v5.x
-PKG_HASH:=8ea27e1ed38981f772cc6d5f16ab8dbb8052c3800ba0494bd798fbb95dcc1779
+PKG_HASH:=99d8bc1b82f17d7d79f9af4a94af4c0e3772159e9e6e278761bde8569f93e15f
 
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
 
@@ -32,6 +32,7 @@ TAR_OPTIONS+= \
 	$(addprefix $(LINUX_TLD)/,$(BPF_FILES))
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/nls.mk
 
 define Package/bpftool/Default
   SECTION:=net
@@ -92,6 +93,10 @@ ifneq ($(BUILD_VARIANT),lib)
   TARGET_LDFLAGS += -Wl,--gc-sections
 endif
 
+ifneq ($(INTL_FULL),)
+  TARGET_LDFLAGS += -Wl,-lintl
+endif
+
 MAKE_FLAGS += \
 	EXTRA_CFLAGS="$(TARGET_CFLAGS) $(TARGET_CPPFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
@@ -125,9 +130,9 @@ define Build/Configure
 		$(MAKE_FLAGS) FEATURES_DUMP= $(PKG_BUILD_DIR)//libbpf/libbpf.a
 	(cd $(PKG_BUILD_DIR); cat FEATURE-DUMP.bpftool libbpf/FEATURE-DUMP.libbpf \
 		| sort | uniq > FEATURE-DUMP.openwrt)
-	$(SED) 's/feature-libbfd=[01]/feature-libbfd=$(HAVE_LIBBFD)/' \
-		-e 's/feature-libcap=[01]/feature-libcap=$(HAVE_LIBCAP)/' \
-		-e 's/feature-clang-bpf-global-var=[01]/feature-clang-bpf-global-var=$(HAVE_CLANG)/' \
+	$(SED) 's/feature-libbfd=1/feature-libbfd=$(HAVE_LIBBFD)/' \
+		-e 's/feature-libcap=1/feature-libcap=$(HAVE_LIBCAP)/' \
+		-e 's/feature-clang-bpf-global-var=1/feature-clang-bpf-global-var=$(HAVE_CLANG)/' \
 		$(PKG_BUILD_DIR)/FEATURE-DUMP.openwrt
 endef
 

--- a/package/network/utils/bpftools/patches/001-libbpf-ensure-no-local-symbols-counted-in-ABI-check.patch
+++ b/package/network/utils/bpftools/patches/001-libbpf-ensure-no-local-symbols-counted-in-ABI-check.patch
@@ -11,11 +11,9 @@ Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
  tools/lib/bpf/Makefile | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/tools/lib/bpf/Makefile b/tools/lib/bpf/Makefile
-index bf8ed134cb8a..c820b0be9d63 100644
 --- a/tools/lib/bpf/Makefile
 +++ b/tools/lib/bpf/Makefile
-@@ -152,6 +152,7 @@ GLOBAL_SYM_COUNT = $(shell readelf -s --wide $(BPF_IN_SHARED) | \
+@@ -152,6 +152,7 @@ GLOBAL_SYM_COUNT = $(shell readelf -s --
  			   awk '/GLOBAL/ && /DEFAULT/ && !/UND/ {print $$NF}' | \
  			   sort -u | wc -l)
  VERSIONED_SYM_COUNT = $(shell readelf --dyn-syms --wide $(OUTPUT)libbpf.so | \
@@ -31,6 +29,3 @@ index bf8ed134cb8a..c820b0be9d63 100644
  		    grep -Eo '[^ ]+@LIBBPF_' | cut -d@ -f1 |		 \
  		    sort -u > $(OUTPUT)libbpf_versioned_syms.tmp; 	 \
  		diff -u $(OUTPUT)libbpf_global_syms.tmp			 \
--- 
-2.25.1
-

--- a/package/network/utils/bpftools/patches/002-libbpf-fix-build-failure-from-uninitialized-variable.patch
+++ b/package/network/utils/bpftools/patches/002-libbpf-fix-build-failure-from-uninitialized-variable.patch
@@ -27,12 +27,10 @@ Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
  tools/lib/bpf/libbpf.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/tools/lib/bpf/libbpf.c b/tools/lib/bpf/libbpf.c
-index 11e4725b8b1c..a72296797357 100644
 --- a/tools/lib/bpf/libbpf.c
 +++ b/tools/lib/bpf/libbpf.c
-@@ -5028,8 +5028,8 @@ static int bpf_object__collect_map_relos(struct bpf_object *obj,
- 	int i, j, nrels, new_sz, ptr_sz = sizeof(void *);
+@@ -5030,8 +5030,8 @@ static int bpf_object__collect_map_relos
+ 	int i, j, nrels, new_sz;
  	const struct btf_var_secinfo *vi = NULL;
  	const struct btf_type *sec, *var, *def;
 +	struct bpf_map *map = NULL, *targ_map;
@@ -41,6 +39,3 @@ index 11e4725b8b1c..a72296797357 100644
  	const char *name, *mname;
  	Elf_Data *symbols;
  	unsigned int moff;
--- 
-2.25.1
-

--- a/package/network/utils/bpftools/patches/003-bpftool-allow-passing-BPFTOOL_VERSION-to-make.patch
+++ b/package/network/utils/bpftools/patches/003-bpftool-allow-passing-BPFTOOL_VERSION-to-make.patch
@@ -8,8 +8,6 @@ Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
  tools/bpf/bpftool/Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/tools/bpf/bpftool/Makefile b/tools/bpf/bpftool/Makefile
-index 9e85f101be85..d9d821736c31 100644
 --- a/tools/bpf/bpftool/Makefile
 +++ b/tools/bpf/bpftool/Makefile
 @@ -25,7 +25,7 @@ endif
@@ -21,6 +19,3 @@ index 9e85f101be85..d9d821736c31 100644
  
  $(LIBBPF): FORCE
  	$(if $(LIBBPF_OUTPUT),@mkdir -p $(LIBBPF_OUTPUT))
--- 
-2.25.1
-

--- a/package/network/utils/bpftools/patches/004-v5.9-bpftool-use-only-ftw-for-file-tree-parsing.patch
+++ b/package/network/utils/bpftools/patches/004-v5.9-bpftool-use-only-ftw-for-file-tree-parsing.patch
@@ -26,8 +26,6 @@ Link: https://lore.kernel.org/bpf/20200721024817.13701-1-Tony.Ambardar@gmail.com
  tools/bpf/bpftool/main.h   |   4 +-
  2 files changed, 82 insertions(+), 59 deletions(-)
 
-diff --git a/tools/bpf/bpftool/common.c b/tools/bpf/bpftool/common.c
-index 88264abaa738..d8bb4dd18c8a 100644
 --- a/tools/bpf/bpftool/common.c
 +++ b/tools/bpf/bpftool/common.c
 @@ -1,10 +1,11 @@
@@ -86,7 +84,7 @@ index 88264abaa738..d8bb4dd18c8a 100644
  {
  	enum bpf_obj_type type;
  	int fd;
-@@ -353,71 +365,82 @@ void print_hex_data_json(uint8_t *data, size_t len)
+@@ -330,71 +342,82 @@ void print_hex_data_json(uint8_t *data,
  	jsonw_end_array(json_wtr);
  }
  
@@ -218,11 +216,9 @@ index 88264abaa738..d8bb4dd18c8a 100644
  }
  
  void delete_pinned_obj_table(struct pinned_obj_table *tab)
-diff --git a/tools/bpf/bpftool/main.h b/tools/bpf/bpftool/main.h
-index af9ad56c303a..b02e763f1e9c 100644
 --- a/tools/bpf/bpftool/main.h
 +++ b/tools/bpf/bpftool/main.h
-@@ -140,8 +140,8 @@ int cmd_select(const struct cmd *cmds, int argc, char **argv,
+@@ -196,8 +196,8 @@ int cmd_select(const struct cmd *cmds, i
  int get_fd_type(int fd);
  const char *get_fd_type_name(enum bpf_obj_type type);
  char *get_fdinfo(int fd, const char *key);
@@ -231,8 +227,5 @@ index af9ad56c303a..b02e763f1e9c 100644
 +int open_obj_pinned(const char *path, bool quiet);
 +int open_obj_pinned_any(const char *path, enum bpf_obj_type exp_type);
  int mount_bpffs_for_pin(const char *name);
- int do_pin_any(int argc, char **argv, int (*get_fd_by_id)(__u32));
+ int do_pin_any(int argc, char **argv, int (*get_fd_by_id)(int *, char ***));
  int do_pin_fd(int fd, const char *name);
--- 
-2.17.1
-

--- a/package/network/utils/bpftools/patches/005-tools-arch-powerpc-fix-EDEADLOCK-redefinition-errors.patch
+++ b/package/network/utils/bpftools/patches/005-tools-arch-powerpc-fix-EDEADLOCK-redefinition-errors.patch
@@ -1,0 +1,56 @@
+From afe3f4c765b17ced23811fe652c7f7adf7a0c0cf Mon Sep 17 00:00:00 2001
+From: Tony Ambardar <Tony.Ambardar@gmail.com>
+Date: Mon, 14 Sep 2020 23:05:26 -0700
+Subject: [PATCH] tools/arch/powerpc: fix EDEADLOCK redefinition errors in
+ errno.h
+
+A few archs like powerpc have different errno.h values for macros
+EDEADLOCK and EDEADLK. In code including both libc and linux versions of
+errno.h, this can result in multiple definitions of EDEADLOCK in the
+include chain. Definitions to the same value (e.g. seen with mips) do
+not raise warnings, but on powerpc there are redefinitions changing the
+value, which raise warnings and errors (with "-Werror").
+
+Guard against these redefinitions to avoid build errors like the following,
+first seen cross-compiling libbpf v5.8.9 for powerpc using GCC 8.4.0 with
+musl 1.1.24:
+
+  In file included from ../../arch/powerpc/include/uapi/asm/errno.h:5,
+                   from ../../include/linux/err.h:8,
+                   from libbpf.c:29:
+  ../../include/uapi/asm-generic/errno.h:40: error: "EDEADLOCK" redefined [-Werror]
+   #define EDEADLOCK EDEADLK
+
+  In file included from toolchain-powerpc_8540_gcc-8.4.0_musl/include/errno.h:10,
+                   from libbpf.c:26:
+  toolchain-powerpc_8540_gcc-8.4.0_musl/include/bits/errno.h:58: note: this is the location of the previous definition
+   #define EDEADLOCK       58
+
+  cc1: all warnings being treated as errors
+  make[5]: *** [target-powerpc_8540_musl/bpftools-5.8.9/tools/build/Makefile.build:97: /home/kodidev/openwrt-project/build_dir/target-powerpc_8540_musl/bpftools-minimal/bpftools-5.8.9//libbpf/staticobjs/libbpf.o] Error 1
+
+Fixes: 95f28190aa01 ("tools include arch: Grab a copy of errno.h for arch's
+                      supported by perf")
+Fixes: c3617f72036c ("UAPI: (Scripted) Disintegrate arch/powerpc/include/asm")
+
+Reported-by: Rosen Penev <rosenp@gmail.com>
+Signed-off-by: Tony Ambardar <Tony.Ambardar@gmail.com>
+---
+ tools/arch/powerpc/include/uapi/asm/errno.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/arch/powerpc/include/uapi/asm/errno.h b/tools/arch/powerpc/include/uapi/asm/errno.h
+index cc79856896a1..4ba87de32be0 100644
+--- a/tools/arch/powerpc/include/uapi/asm/errno.h
++++ b/tools/arch/powerpc/include/uapi/asm/errno.h
+@@ -2,6 +2,7 @@
+ #ifndef _ASM_POWERPC_ERRNO_H
+ #define _ASM_POWERPC_ERRNO_H
+ 
++#undef	EDEADLOCK
+ #include <asm-generic/errno.h>
+ 
+ #undef	EDEADLOCK
+-- 
+2.25.1
+


### PR DESCRIPTION
**Review/Distribution List**:  @dangowrt @tchebb @robimarko @zorun
**Compile tested**:  mips{32,64}-{be,le}-malta, master branch
**Run tested**:  mips{32,64}-{be,le}-malta, master branch (using QEMU)

**Description**: Use upstream stable kernel 5.8.6, and fix overriding feature detection to
only allow/hide detected features.

With global nls support enabled (CONFIG_BUILD_NLS), the linked libelf.so
and libbfd.so libraries will depend on libintl.so. Import the nls.mk helper
to set library prefixes and flags accordingly, and also conditionally add
"-lintl" as link-time library.

Fixes: 2f0d672088 ("bpftools: add utility and library packages supporting
eBPF usage")

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
