### PR TITLE
brcm63xx: remove PSI (nvram) partition, add cfe's NVRAM partition

### DIFF
--- a/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
@@ -132,17 +132,17 @@
 				reg = <0x000000 0x010000>;
 				label = "cfe";
 				read-only;
+
+				partition@580 {
+					label = "cfe_nvram";
+					reg = <0x000580 0x000400>;
+				};
 			};
 
 			partition@10000 {
-				reg = <0x010000 0xfe0000>;
+				reg = <0x010000 0xff0000>;
 				label = "linux";
 				compatible = "brcm,bcm963xx-imagetag";
-			};
-
-			partition@ff0000 {
-				reg = <0xff0000 0x010000>;
-				label = "nvram";
 			};
 		};
 	};


### PR DESCRIPTION
ADB P.DG A4001N A-000-1A1-AX a.k.a. Telecom Italia ADSL2+ Wi-Fi N (AGPWI)
is a Telecom Italia braded router and it seems that there are no public
available unbranded versions of this router.

The stock Telecom Italia braded firmware has many partitions and the
partition layout changes with every firmware relase.

The PSI nvram partition is present in the stock firmware under the
"UNKNOWN" name but it's empty, full of FFs. Since removing partitions
does not cause problems with the stock firmware reflashing procedure,
I removed from the dts the PSI nvram partition from OpenWrt, expanded
the rootfs one and added the NVRAM partition contained in the
cfe bootloader.

Furthermore this router's flash needs to be entirely reprogrammed
and a new generic bcm6328 cfe must be flashed to boot OpenWrt. The
same process takes place when reflashing the stock firmware.

Here follows the original flash layout for AGPWI_1.1.0_013, the last
stock Telecom Italia braded firmware for which we have root
credenctials (admin/riattizzati).

Flash layout:

Section 00 Type BOOT       Range 0x00000000-0x00020000 MaxSize 0x00020000
        No more information.

Section 01 Type IMAGE      Range 0x00020000-0x007C0000 MaxSize 0x0079FF6C
        Uninitialized.

Section 02 Type IMAGE      Range 0x00800000-0x00FA0000 MaxSize 0x0079FF6C
        Uninitialized.

Section 03 Type CONF       Range 0x00FA0000-0x00FC0000 MaxSize 0x0001FF6C
        Size 0x0000841E Name 'rg_conf'
        Checksum 0x0041E03B Counter 0x0000051F Start Offset 0x00000000

Section 04 Type CONF       Range 0x00FC0000-0x00FE0000 MaxSize 0x0001FF6C
        Size 0x0000838E Name 'rg_conf'
        Checksum 0x00419A5A Counter 0x00000522 Start Offset 0x00000000

Section 05 Type FACTORY    Range 0x00FE0000-0x00FF0000 MaxSize 0x0000FF6C
        Size 0x00000554 Name 'rg_factory'
        Checksum 0x0001255E Counter 0x000004D3 Start Offset 0x00000000

Section 06 Type UNKNOWN    Range 0x00FF0000-0x01000000 MaxSize 0x00010000
        No more information.

Total 7 sections found.

The last AGPWI firmware relase should be AGPWI_4.0.6 and it has much more
partitions than AGPWI_1.1.0_013.

The cfe partition in the stock firmware is 0x00020000 bytes long unlike the
OpenWrt dts in wich it's 0x00010000 bytes long because from 0x00010000 to
0x00020000 in the stock cfe there are only 00s and also because the cfe must
anyway be reflashed with a generic bcm6328 cfe 0x00010000 bytes long to
run OpenWrt.

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>