### PR TITLE
x86/efi: add FAT32 esp mounting support

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -110,6 +110,10 @@ get_magic_vfat() {
 	(get_image "$@" | dd bs=1 count=3 skip=54) 2>/dev/null
 }
 
+get_magic_fat32() {
+	(get_image "$@" | dd bs=1 count=5 skip=82) 2>/dev/null
+}
+
 part_magic_efi() {
 	local magic=$(get_magic_gpt "$@")
 	[ "$magic" = "EFI PART" ]
@@ -117,7 +121,8 @@ part_magic_efi() {
 
 part_magic_fat() {
 	local magic=$(get_magic_vfat "$@")
-	[ "$magic" = "FAT" ]
+	local magic_fat32=$(get_magic_fat32 "$@")
+	[ "$magic" = "FAT" -o "$magic_fat32" = "FAT32" ]
 }
 
 export_bootdevice() {


### PR DESCRIPTION
Adds a new function get_magic_fat32() in base-files to read FAT32 magic.

Now FAT32 EFI system partition can be handled in the same way as FAT12/FAT16.

Tested with both FAT16 and FAT32 ESPs.