### PR TITLE
brcm63xx: add support for Technicolor TG582n Telecom Italia branded

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -94,6 +94,12 @@ sercomm,h500-s-lowi|\
 sercomm,h500-s-vfes)
 	ucidef_set_led_netdev "wan" "WAN" "green:internet" "eth0.2"
 	;;
+technicolor,tg582n-telecom-italia)
+	ucidef_set_led_netdev "lan" "LAN" "green:internet" "eth0.1"
+	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
+	ucidef_set_led_usbdev "usb1" "USB1" "green:service" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "red:service" "2-1"
+	;;
 telsey,cpva502plus)
 	ucidef_set_led_netdev "lan" "LAN" "amber:link" "eth0"
 	;;

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -15,9 +15,8 @@ netgear,cvg834g|\
 netgear,dgnd3700-v2|\
 netgear,evg2000|\
 t-com,speedport-w-303v|\
-t-com,speedport-w-500v)
-	ucidef_set_interface_lan "eth0"
-	;;
+t-com,speedport-w-500v|\
+technicolor,tg582n-telecom-italia|\
 adb,a4001n1|\
 adb,a4001n|\
 adb,pdg-a4001n-a-000-1a1-ax|\

--- a/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
@@ -34,6 +34,7 @@ case "$(board_name)" in
 	nucom,r5010un-v2|\
 	observa,vh4032n|\
 	t-com,speedport-w-303v|\
+	technicolor,tg582n-telecom-italia|\
 	telsey,cpva502plus|\
 	telsey,cpva642|\
 	telsey,magic|\

--- a/target/linux/bcm63xx/dts/bcm6328-technicolor-tg582n-telecom-italia.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-technicolor-tg582n-telecom-italia.dts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Technicolor TG582n Telecom Italia";
+	compatible = "technicolor,tg582n-telecom-italia", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wifi-led";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led@1 {
+		reg = <1>;
+		active-low;
+		label = "green:wifi";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:power";
+		default-state = "on";
+	};
+
+	led@5 {
+		reg = <5>;
+		active-low;
+		label = "green:adsl";
+	};
+
+	led@7 {
+		reg = <7>;
+		active-low;
+		label = "red:wifi";
+	};
+
+	led@8 {
+		reg = <8>;
+		active-low;
+		label = "red:power";
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@14 {
+		reg = <14>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@18 {
+		reg = <18>;
+		active-low;
+		label = "red:service";
+	};
+
+	led@19 {
+		reg = <19>;
+		active-low;
+		label = "green:service";
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			partition@10000 {
+				reg = <0x010000 0xff0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio4",
+		       "gpio5", "gpio7",
+		       "gpio8", "gpio11",
+		       "gpio14", "gpio18",
+		       "gpio19";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -1098,6 +1098,19 @@ define Device/t-com_speedport-w-500v
 endef
 TARGET_DEVICES += t-com_speedport-w-500v
 
+### Technicolor ###
+define Device/technicolor_tg582n-telecom-italia
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := Technicolor
+  DEVICE_MODEL := TG582n Telecom Italia
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := DANT-V
+  CHIP_ID := 6328
+  FLASH_MB := 16
+  DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += technicolor_tg582n-telecom-italia
+
 ### Tecom ###
 define Device/tecom_gw6000
   $(Device/bcm63xx-legacy)

--- a/target/linux/bcm63xx/patches-5.4/512-board_bcm6328.patch
+++ b/target/linux/bcm63xx/patches-5.4/512-board_bcm6328.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -348,6 +348,525 @@ static struct board_info __initdata boar
+@@ -348,6 +348,568 @@ static struct board_info __initdata boar
  		},
  	},
  };
@@ -523,10 +523,53 @@
 +		.pci_dev = 0,
 +	},
 +};
++
++static struct board_info __initdata board_TG582N_TELECOM_ITALIA = {
++	.name = "DANT-V",
++	.expected_cpu_id = 0x6328,
++
++	.has_pci = 1,
++	.has_ohci0 = 1,
++	.has_ehci0 = 1,
++	.num_usbh_ports = 1,
++
++	.has_enetsw = 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used = 1,
++				.phy_id = 1,
++				.name = "Port 1",
++			},
++			[1] = {
++				.used = 1,
++				.phy_id = 2,
++				.name = "Port 2",
++			},
++			[2] = {
++				.used = 1,
++				.phy_id = 3,
++				.name = "Port 3",
++			},
++			[3] = {
++				.used = 1,
++				.phy_id = 4,
++				.name = "Port 4",
++			},
++		},
++	},
++
++	.use_fallback_sprom = 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM43225,
++		.pci_bus = 1,
++		.pci_dev = 0,
++	},
++};
  #endif /* CONFIG_BCM63XX_CPU_6328 */
  
  /*
-@@ -703,6 +1222,17 @@ static const struct board_info __initcon
+@@ -703,6 +1265,18 @@ static const struct board_info __initcon
  #endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
  	&board_96328avng,
@@ -540,11 +583,12 @@
 +	&board_FAST2704V2,
 +	&board_PDG_A4001N_A_000_1A1_AX,
 +	&board_PDG_A4101N_A_000_1A1_AE,
++	&board_TG582N_TELECOM_ITALIA,
 +	&board_R5010UNV2,
  #endif /* CONFIG_BCM63XX_CPU_6328 */
  #ifdef CONFIG_BCM63XX_CPU_6338
  	&board_96338gw,
-@@ -742,7 +1272,20 @@ static struct of_device_id const bcm963x
+@@ -742,7 +1316,21 @@ static struct of_device_id const bcm963x
  	{ .compatible = "sagem,fast-2704n", .data = &board_FAST2704N, },
  #endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
@@ -562,6 +606,7 @@
 +	{ .compatible = "sagem,fast-2704-v2", .data = &board_FAST2704V2, },
 +	{ .compatible = "sercomm,ad1018", .data = &board_AD1018, },
 +	{ .compatible = "sercomm,ad1018-nor", .data = &board_AD1018, },
++	{ .compatible = "technicolor,tg582n-telecom-italia", .data = &board_TG582N_TELECOM_ITALIA, },
  #endif /* CONFIG_BCM63XX_CPU_6328 */
  #ifdef CONFIG_BCM63XX_CPU_6338
  	{ .compatible = "brcm,bcm96338gw", .data = &board_96338gw, },

--- a/target/linux/bcm63xx/patches-5.4/513-board-bcm6338.patch
+++ b/target/linux/bcm63xx/patches-5.4/513-board-bcm6338.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -900,6 +900,32 @@ static struct board_info __initdata boar
+@@ -943,6 +943,32 @@ static struct board_info __initdata boar
  		.force_duplex_full	= 1,
  	},
  };
@@ -33,7 +33,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  
  /*
-@@ -1237,6 +1263,8 @@ static const struct board_info __initcon
+@@ -1281,6 +1307,8 @@ static const struct board_info __initcon
  #ifdef CONFIG_BCM63XX_CPU_6338
  	&board_96338gw,
  	&board_96338w,
@@ -42,7 +42,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	&board_96345gw2,
-@@ -1290,6 +1318,8 @@ static struct of_device_id const bcm963x
+@@ -1335,6 +1363,8 @@ static struct of_device_id const bcm963x
  #ifdef CONFIG_BCM63XX_CPU_6338
  	{ .compatible = "brcm,bcm96338gw", .data = &board_96338gw, },
  	{ .compatible = "brcm,bcm96338w", .data = &board_96338w, },

--- a/target/linux/bcm63xx/patches-5.4/514-board_bcm6345.patch
+++ b/target/linux/bcm63xx/patches-5.4/514-board_bcm6345.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -936,6 +936,19 @@ static struct board_info __initdata boar
+@@ -979,6 +979,19 @@ static struct board_info __initdata boar
  	.name				= "96345GW2",
  	.expected_cpu_id		= 0x6345,
  };
@@ -20,7 +20,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  
  /*
-@@ -1268,6 +1281,7 @@ static const struct board_info __initcon
+@@ -1312,6 +1325,7 @@ static const struct board_info __initcon
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	&board_96345gw2,
@@ -28,7 +28,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  #ifdef CONFIG_BCM63XX_CPU_6348
  	&board_96348r,
-@@ -1323,6 +1337,8 @@ static struct of_device_id const bcm963x
+@@ -1368,6 +1382,8 @@ static struct of_device_id const bcm963x
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	{ .compatible = "brcm,bcm96345gw2", .data = &board_96345gw2, },

--- a/target/linux/bcm63xx/patches-5.4/515-board-bcm6348.patch
+++ b/target/linux/bcm63xx/patches-5.4/515-board-bcm6348.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -1135,6 +1135,275 @@ static struct board_info __initdata boar
+@@ -1178,6 +1178,275 @@ static struct board_info __initdata boar
  
  	.has_ohci0 = 1,
  };
@@ -276,7 +276,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6348 */
  
  /*
-@@ -1292,6 +1561,19 @@ static const struct board_info __initcon
+@@ -1336,6 +1605,19 @@ static const struct board_info __initcon
  	&board_DV201AMR,
  	&board_96348gw_a,
  	&board_rta1025w_16,
@@ -296,7 +296,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6348 */
  #ifdef CONFIG_BCM63XX_CPU_6358
  	&board_96358vw,
-@@ -1341,15 +1623,29 @@ static struct of_device_id const bcm963x
+@@ -1386,15 +1668,29 @@ static struct of_device_id const bcm963x
  	{ .compatible = "dynalink,rta770w", .data = &board_rta770w, },
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  #ifdef CONFIG_BCM63XX_CPU_6348

--- a/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
+++ b/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
@@ -8,7 +8,7 @@
  #include <asm/addrspace.h>
  #include <bcm63xx_board.h>
  #include <bcm63xx_cpu.h>
-@@ -1488,6 +1489,88 @@ static struct board_info __initdata boar
+@@ -1531,6 +1532,88 @@ static struct board_info __initdata boar
  	.has_ehci0 = 1,
  };
  
@@ -97,7 +97,7 @@
  static struct board_info __initdata board_DWVS0 = {
  	.name				= "DWV-S0",
  	.expected_cpu_id		= 0x6358,
-@@ -1512,6 +1595,238 @@ static struct board_info __initdata boar
+@@ -1555,6 +1638,238 @@ static struct board_info __initdata boar
  	.has_ohci0			= 1,
  	.has_ehci0			= 1,
  };
@@ -336,7 +336,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
  /*
-@@ -1579,7 +1894,20 @@ static const struct board_info __initcon
+@@ -1623,7 +1938,20 @@ static const struct board_info __initcon
  	&board_96358vw,
  	&board_96358vw2,
  	&board_AGPFS0,
@@ -357,7 +357,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  };
  
-@@ -1653,11 +1981,24 @@ static struct of_device_id const bcm963x
+@@ -1698,11 +2026,24 @@ static struct of_device_id const bcm963x
  	{ .compatible = "alcatel,rg100a", .data = &board_96358vw2, },
  	{ .compatible = "brcm,bcm96358vw", .data = &board_96358vw, },
  	{ .compatible = "brcm,bcm96358vw2", .data = &board_96358vw2, },

--- a/target/linux/bcm63xx/patches-5.4/517-board_bcm6362.patch
+++ b/target/linux/bcm63xx/patches-5.4/517-board_bcm6362.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -1829,6 +1829,117 @@ static struct board_info __initdata boar
+@@ -1872,6 +1872,117 @@ static struct board_info __initdata boar
  };
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
@@ -118,7 +118,7 @@
  /*
   * all boards
   */
-@@ -1909,6 +2020,12 @@ static const struct board_info __initcon
+@@ -1953,6 +2064,12 @@ static const struct board_info __initcon
  	&board_nb4_fxc_r1,
  	&board_spw303v,
  #endif /* CONFIG_BCM63XX_CPU_6358 */
@@ -131,7 +131,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2001,6 +2118,10 @@ static struct of_device_id const bcm963x
+@@ -2046,6 +2163,10 @@ static struct of_device_id const bcm963x
  	{ .compatible = "telsey,cpva642", .data = &board_CPVA642, },
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  #ifdef CONFIG_BCM63XX_CPU_6362

--- a/target/linux/bcm63xx/patches-5.4/518-board_bcm6368.patch
+++ b/target/linux/bcm63xx/patches-5.4/518-board_bcm6368.patch
@@ -9,7 +9,7 @@
  #include <asm/addrspace.h>
  #include <bcm63xx_board.h>
  #include <bcm63xx_cpu.h>
-@@ -1941,6 +1943,648 @@ static struct board_info __initdata boar
+@@ -1984,6 +1986,648 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_6362 */
  
  /*
@@ -658,7 +658,7 @@
   * all boards
   */
  static const struct board_info __initconst *bcm963xx_boards[] = {
-@@ -2026,6 +2670,22 @@ static const struct board_info __initcon
+@@ -2070,6 +2714,22 @@ static const struct board_info __initcon
  	&board_hg253s_v2,
  	&board_nb6,
  #endif /* CONFIG_BCM63XX_CPU_6362 */
@@ -681,7 +681,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2124,6 +2784,20 @@ static struct of_device_id const bcm963x
+@@ -2169,6 +2829,20 @@ static struct of_device_id const bcm963x
  	{ .compatible = "sfr,neufbox-6-sercomm-r0", .data = &board_nb6, },
  #endif /* CONFIG_BCM63XX_CPU_6362 */
  #ifdef CONFIG_BCM63XX_CPU_6368

--- a/target/linux/bcm63xx/patches-5.4/519-board_bcm63268.patch
+++ b/target/linux/bcm63xx/patches-5.4/519-board_bcm63268.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -2585,6 +2585,273 @@ static struct board_info __initdata boar
+@@ -2628,6 +2628,273 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  
  /*
@@ -274,7 +274,7 @@
   * all boards
   */
  static const struct board_info __initconst *bcm963xx_boards[] = {
-@@ -2686,6 +2953,15 @@ static const struct board_info __initcon
+@@ -2730,6 +2997,15 @@ static const struct board_info __initcon
  	&board_VR3026e,
  	&board_WAP5813n,
  #endif /* CONFIG_BCM63XX_CPU_6368 */
@@ -290,7 +290,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2800,6 +3076,14 @@ static struct of_device_id const bcm963x
+@@ -2845,6 +3121,14 @@ static struct of_device_id const bcm963x
  	{ .compatible = "zyxel,p870hw-51a-v2", .data = &board_P870HW51A_V2, },
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  #ifdef CONFIG_BCM63XX_CPU_63268

--- a/target/linux/bcm63xx/patches-5.4/531-board_bcm6348-bt-voyager-2500v-bb.patch
+++ b/target/linux/bcm63xx/patches-5.4/531-board_bcm6348-bt-voyager-2500v-bb.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -3112,6 +3112,22 @@ void __init board_bcm963xx_init(void)
+@@ -3157,6 +3157,22 @@ void __init board_bcm963xx_init(void)
  		val &= MPI_CSBASE_BASE_MASK;
  	}
  	boot_addr = (u8 *)KSEG1ADDR(val);


### PR DESCRIPTION
Technicolor TG582n Telecom Italia branded a.k.a.
Telecom Italia ADSL2+ Wi-Fi N (AGTWI)
has the same PCB as the unbranded Technicolor TG582n with LEDs
connected to different GPIO PINs in active low configuration and
different LED names. It has a PCB similar to the OpenWrt's ADB P.DG A4001N1 one.

Hardware:
* Board ID: DANT-V
* SoC: Broadcom BCM6328 (rev b0) @ 320MHz, CPU BMIPS4350
* RAM DDR2: 64 Mbyte - EtronTech EM68B16CWQD-25H
* Serial flash: 16 Mbyte - Spansion FL 128SAIF00
* Ethernet: 4x Ethernet 10/100 baseT
* Wifi 2.4GHz: Broadcom Corporation BCM43227 Wireless Network Adapter (rev 30)
* LEDs: 2x Power, 1x ADSL, 2x Internet, 2x Wi-Fi, 2x Service, 4x ethernet
* Buttons: 1x Reset, 1x WPS (named WiFi/LED)
* UART: 1x TTL 115200n8, VCC GND TX RX, on J3 connector (short R62 and R63)

Installation via CFE:
* Stock CFE has to be overwritten with a generic 6328 one that can upload
  .bin images with no signature check (cfe6328_configured.bin)
* Connect a serial port to the board
* Stop the CFE boot process after power on by pressing enter
* Set static IP 192.168.2.10 and subnet mask 255.255.255.0
* Navigate to http://192.168.2.50/
* Upload the OpenWrt image file

PCB:   |GPIO:   |TG582n:          |AGTWI:

LED2R  |488(08) |red    Power     |red   Power
LED2G  |484(04) |green  Power     |green Power

LED10R |486(06) |                 |missing R85 end LED
LED13G |485(05) |green  Ethernet  |green ADSL

LED11R |494(14) |                 |red   Internet
LED14G |491(11) |green  Broadband |green Internet

LED5R  |487(07) |red    Internet  |red   Wi-Fi
LED5G  |481(01) |green  Internet  |green Wi-Fi

LED12R |498(18) |                 |red   Service
LED12G |499(19) |                 |green Service

LED6R  |482(02) |red    Wi-Fi     |missing R108 end LED
LED6G  |483(03) |green  Wi-Fi     |missing R107 end LED

LED7R  |490(10) |red    WPS       |missing R91 end LED
LED7G  |489(09) |green  WPS       |missing R92 end LED

LED4   |508(28) |ethernet port 4  |ethernet port 4
LED3   |507(27) |ethernet port 3  |ethernet port 3

LED9   |506(26) |ethernet port 2  |ethernet port 2
LED8   |505(25) |ethernet port 1  |ethernet port 1

SW3    |503(23) |key Reset        |key Reset

SW5    |504(24) |key WPS          |key Wi-Fi/LED

SW4    |495(15) |key Wi-Fi        |missing R127 end key

SW6    |493(13) |                 |missing R171 end key

SW1    |492(12) |                 |missing R1 end key

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>