### PR TITLE
Update fs.mk: Change the description of fs-nfs-v4.

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -435,7 +435,7 @@ define KernelPackage/fs-nfs-v4
 endef
 
 define KernelPackage/fs-nfs-v4/description
- Kernel module for NFS v4 support
+ Kernel module for NFS v4 client support
 endef
 
 $(eval $(call KernelPackage,fs-nfs-v4))


### PR DESCRIPTION
TITLE is "NFS4 filesystem **_client_** support" (Line 428)
but the description is "Kernel module for NFS v4 support" (Line 438).
Maybe we can use "Kernel module for NFS v4 _**client**_ support" on line 438.

Signed-off-by: Bob Cp 1119283622@qq.com
