### PR TITLE
kernel: drop kmod-bmp085, kmod-bmp085-i2c and kmod-bmp085-spi

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1119,53 +1119,6 @@ endef
 $(eval $(call KernelPackage,echo))
 
 
-define KernelPackage/bmp085
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=BMP085/BMP18x pressure sensor
-  DEPENDS:= +kmod-regmap-core
-  KCONFIG:= CONFIG_BMP085
-  FILES:= $(LINUX_DIR)/drivers/misc/bmp085.ko
-endef
-
-define KernelPackage/bmp085/description
- This driver adds support for Bosch Sensortec's digital pressure
- sensors BMP085 and BMP18x.
-endef
-
-$(eval $(call KernelPackage,bmp085))
-
-
-define KernelPackage/bmp085-i2c
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=BMP085/BMP18x pressure sensor I2C
-  DEPENDS:= +kmod-bmp085
-  KCONFIG:= CONFIG_BMP085_I2C
-  FILES:= $(LINUX_DIR)/drivers/misc/bmp085-i2c.ko
-  AUTOLOAD:=$(call AutoProbe,bmp085-i2c)
-endef
-define KernelPackage/bmp085-i2c/description
- This driver adds support for Bosch Sensortec's digital pressure
- sensor connected via I2C.
-endef
-
-$(eval $(call KernelPackage,bmp085-i2c))
-
-
-define KernelPackage/bmp085-spi
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=BMP085/BMP18x pressure sensor SPI
-  DEPENDS:= +kmod-bmp085
-  KCONFIG:= CONFIG_BMP085_SPI
-  FILES:= $(LINUX_DIR)/drivers/misc/bmp085-spi.ko
-  AUTOLOAD:=$(call AutoProbe,bmp085-spi)
-endef
-define KernelPackage/bmp085-spi/description
- This driver adds support for Bosch Sensortec's digital pressure
- sensor connected via SPI.
-endef
-
-$(eval $(call KernelPackage,bmp085-spi))
-
 define KernelPackage/tpm
   SUBMENU:=$(OTHER_MENU)
   TITLE:=TPM Hardware Support


### PR DESCRIPTION
CONFIG_BMP085* is replaced by CONFIG_BMP280 since 4.9[1] and this package is empty.
OpenWRT also has kmod-iio-bmp280* package and we can drop old packages.

1. [ misc: retire the old BMP085 driver ](https://github.com/torvalds/linux/commit/832c8232dd7be4977ae9fb9c7cbc4decce19a8fc#diff-5000d544d790c669405eb2a6775e5981)

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>