### PR TITLE
ath79: support for TP-Link EAP225-Wall v2

### DIFF
--- a/target/linux/ath79/dts/qca9561_tplink_eap225-wall-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_eap225-wall-v2.dts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,eap225-wall-v2", "qca,qca9561";
+	model = "TP-Link EAP225-Wall v2";
+
+	aliases {
+		label-mac-device = &eth1;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		led {
+			label = "LED button";
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "tp-link:white:status";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		poe_passthrough {
+			gpio-export,name = "tp-link:poe-passthrough:enable";
+			gpio-export,output = <0>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "partition-table";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			info: partition@30000 {
+				label = "info";
+				reg = <0x030000 0x010000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "openwrt,elf";
+				label = "firmware";
+				reg = <0x040000 0xd80000>;
+			};
+
+			partition@dc0000 {
+				label = "config";
+				reg = <0xdc0000 0x030000>;
+				read-only;
+			};
+
+			/* df0000-f30000 undefined in vendor firmware */
+
+			partition@f30000 {
+				label = "mutil-log";
+				reg = <0xf30000 0x080000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "oops";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -301,6 +301,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "3:lan:3" "4:lan:2" "5:lan:1" "6@eth0" "2:wan:4" "1:wan:5"
 		;;
+	tplink,eap225-wall-v2)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+		;;
 	tplink,eap245-v3)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "5:lan:2"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -206,6 +206,12 @@ case "$FIRMWARE" in
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		;;
+	tplink,eap225-wall-v2)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	tplink,eap245-v3)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -364,7 +364,6 @@ TARGET_DEVICES += tplink_cpe610-v2
 
 define Device/tplink-eap2x5
   $(Device/tplink-safeloader)
-  SOC := qca9563
   LOADER_TYPE := elf
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel
   KERNEL_INITRAMFS := $$(KERNEL)
@@ -372,8 +371,20 @@ define Device/tplink-eap2x5
 	pad-extra 128
 endef
 
+define Device/tplink_eap225-wall-v2
+  $(Device/tplink-eap2x5)
+  SOC := qca9561
+  IMAGE_SIZE := 15104k
+  DEVICE_MODEL := EAP225-Wall
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  TPLINK_BOARD_ID := EAP225-WALL-V2
+endef
+TARGET_DEVICES += tplink_eap225-wall-v2
+
 define Device/tplink_eap245-v3
   $(Device/tplink-eap2x5)
+  SOC := qca9563
   IMAGE_SIZE := 14592k
   DEVICE_MODEL := EAP245
   DEVICE_VARIANT := v3

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1298,6 +1298,35 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the EAP225-Wall v2 */
+	{
+		.id     = "EAP225-WALL-V2",
+		.support_list =
+			"SupportList:\r\n"
+			"EAP225-Wall(TP-Link|UN|AC1200-D):2.0\r\n",
+		.support_trail = '\xff',
+		.soft_ver = NULL,
+		.soft_ver_compat_level = 1,
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"partition-table", 0x20000, 0x02000},
+			{"default-mac", 0x30000, 0x01000},
+			{"support-list", 0x31000, 0x00100},
+			{"product-info", 0x31100, 0x00400},
+			{"soft-version", 0x32000, 0x00100},
+			{"firmware", 0x40000, 0xd80000},
+			{"user-config", 0xdc0000, 0x30000},
+			{"mutil-log", 0xf30000, 0x80000},
+			{"oops", 0xfb0000, 0x40000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the EAP245 v3 */
 	{
 		.id     = "EAP245-V3",


### PR DESCRIPTION
TP-Link EAP225-Wall v2 is an AC1200 (802.11ac Wave-2) wall plate access point. UART access and debricking require fine soldering. 

The device was kindly provided for porting by Stijn Segers.

I just managed to destroy the device, but the patches were tested earlier.