### PR TITLE
brcm63xx: add support for ADB P.DG A4101N A-000-1A1-AE

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -33,6 +33,10 @@ adb,pdg-a4001n-a-000-1a1-ax)
 	ucidef_set_led_usbdev "usb1" "USB1" "green:service" "1-1"
 	ucidef_set_led_usbdev "usb2" "USB2" "red:service" "2-1"
 	;;
+adb,pdg-a4101n-a-000-1a1-ae)
+	ucidef_set_led_netdev "wan" "WAN" "green:internet" "eth0.2"
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "1-1"
+	;;
 adb,av4202n)
 	ucidef_set_led_netdev "wlan0" "WLAN" "blue:wifi" "wlan0"
 	;;

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -18,6 +18,11 @@ t-com,speedport-w-303v|\
 t-com,speedport-w-500v)
 	ucidef_set_interface_lan "eth0"
 	;;
+adb,pdg-a4101n-a-000-1a1-ae)
+	ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"
+	ucidef_add_switch "switch0" \
+		"0:lan" "1:lan" "2:lan" "3:wan" "8t@eth0"
+	;;
 adb,a4001n1|\
 adb,a4001n|\
 adb,pdg-a4001n-a-000-1a1-ax|\

--- a/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
@@ -13,6 +13,7 @@ case "$(board_name)" in
 	adb,a4001n|\
 	adb,a4001n1|\
 	adb,pdg-a4001n-a-000-1a1-ax|\
+	adb,pdg-a4101n-a-000-1a1-ae|\
 	brcm,bcm96328avng|\
 	brcm,bcm963281tan|\
 	bt,voyager-2110|\

--- a/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4101n-a-000-1a1-ae.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4101n-a-000-1a1-ae.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "ADB P.DG A4101N A-000-1A1-AE";
+	compatible = "adb,pdg-a4101n-a-000-1a1-ae", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_dsl_green;
+		led-failsafe = &led_dsl_green;
+		led-upgrade = &led_dsl_green;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wifi {
+			label = "wifi";
+			gpios = <&pinctrl 12 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wifi-led";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led@31 {
+			label = "green:tel";
+			gpios = <&pinctrl 31 1>;
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led_dsl_green: led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:dsl";
+		default-state = "off";
+	};
+
+	led@9 {
+		reg = <9>;
+		active-low;
+		label = "green:wps";
+	};
+
+	led@10 {
+		reg = <10>;
+		active-low;
+		label = "green:usb";
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:internet";
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+			};
+
+			partition@10000 {
+				reg = <0x010000 0xff0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio3", "gpio9", "gpio10",
+		       "gpio11";
+	};
+
+	green_internet_switch {
+		gpio-hog;
+		gpios = <2 1>;
+		output-low;
+		line-name = "green:internet-switch";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -237,6 +237,18 @@ define Device/adb_pdg-a4001n-a-000-1a1-ax
 endef
 TARGET_DEVICES += adb_pdg-a4001n-a-000-1a1-ax
 
+define Device/adb_pdg-a4101n-a-000-1a1-ae
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := ADB
+  DEVICE_MODEL := P.DG A4101N A-000-1A1-AE
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := 96328avngv
+  CHIP_ID := 6328
+  FLASH_MB := 16
+  DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += adb_pdg-a4101n-a-000-1a1-ae
+
 define Device/adb_av4202n
   $(Device/bcm63xx)
   DEVICE_VENDOR := ADB

--- a/target/linux/bcm63xx/patches-5.4/512-board_bcm6328.patch
+++ b/target/linux/bcm63xx/patches-5.4/512-board_bcm6328.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -348,6 +348,482 @@ static struct board_info __initdata boar
+@@ -348,6 +348,525 @@ static struct board_info __initdata boar
  		},
  	},
  };
@@ -438,6 +438,49 @@
 +	},
 +};
 +
++static struct board_info __initdata board_PDG_A4101N_A_000_1A1_AE = {
++	.name = "96328avngv",
++	.expected_cpu_id = 0x6328,
++
++	.has_pci = 1,
++	.has_ohci0 = 1,
++	.has_ehci0 = 1,
++	.num_usbh_ports = 1,
++
++	.has_enetsw = 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used = 1,
++				.phy_id = 1,
++				.name = "Port 1",
++			},
++			[1] = {
++				.used = 1,
++				.phy_id = 2,
++				.name = "Port 2",
++			},
++			[2] = {
++				.used = 1,
++				.phy_id = 3,
++				.name = "Port 3",
++			},
++			[3] = {
++				.used = 1,
++				.phy_id = 4,
++				.name = "Port 4",
++			},
++		},
++	},
++
++	.use_fallback_sprom = 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM43225,
++		.pci_bus = 1,
++		.pci_dev = 0,
++	},
++};
++
 +static struct board_info __initdata board_R5010UNV2 = {
 +	.name = "96328ang",
 +	.expected_cpu_id = 0x6328,
@@ -483,7 +526,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6328 */
  
  /*
-@@ -703,6 +1179,16 @@ static const struct board_info __initcon
+@@ -703,6 +1222,17 @@ static const struct board_info __initcon
  #endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
  	&board_96328avng,
@@ -496,17 +539,19 @@
 +	&board_dsl_274xb_f1,
 +	&board_FAST2704V2,
 +	&board_PDG_A4001N_A_000_1A1_AX,
++	&board_PDG_A4101N_A_000_1A1_AE,
 +	&board_R5010UNV2,
  #endif /* CONFIG_BCM63XX_CPU_6328 */
  #ifdef CONFIG_BCM63XX_CPU_6338
  	&board_96338gw,
-@@ -742,7 +1228,19 @@ static struct of_device_id const bcm963x
+@@ -742,7 +1272,20 @@ static struct of_device_id const bcm963x
  	{ .compatible = "sagem,fast-2704n", .data = &board_FAST2704N, },
  #endif /* CONFIG_BCM63XX_CPU_6318 */
  #ifdef CONFIG_BCM63XX_CPU_6328
 +	{ .compatible = "adb,a4001n", .data = &board_A4001N, },
 +	{ .compatible = "adb,a4001n1", .data = &board_A4001N1, },
 +	{ .compatible = "adb,pdg-a4001n-a-000-1a1-ax", .data = &board_PDG_A4001N_A_000_1A1_AX, },
++	{ .compatible = "adb,pdg-a4101n-a-000-1a1-ae", .data = &board_PDG_A4101N_A_000_1A1_AE, },
  	{ .compatible = "brcm,bcm96328avng", .data = &board_96328avng, },
 +	{ .compatible = "brcm,bcm963281tan", .data = &board_963281TAN, },
 +	{ .compatible = "comtrend,ar-5381u", .data = &board_AR5381u, },

--- a/target/linux/bcm63xx/patches-5.4/513-board-bcm6338.patch
+++ b/target/linux/bcm63xx/patches-5.4/513-board-bcm6338.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -857,6 +857,32 @@ static struct board_info __initdata boar
+@@ -900,6 +900,32 @@ static struct board_info __initdata boar
  		.force_duplex_full	= 1,
  	},
  };
@@ -33,7 +33,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  
  /*
-@@ -1193,6 +1219,8 @@ static const struct board_info __initcon
+@@ -1237,6 +1263,8 @@ static const struct board_info __initcon
  #ifdef CONFIG_BCM63XX_CPU_6338
  	&board_96338gw,
  	&board_96338w,
@@ -42,7 +42,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	&board_96345gw2,
-@@ -1245,6 +1273,8 @@ static struct of_device_id const bcm963x
+@@ -1290,6 +1318,8 @@ static struct of_device_id const bcm963x
  #ifdef CONFIG_BCM63XX_CPU_6338
  	{ .compatible = "brcm,bcm96338gw", .data = &board_96338gw, },
  	{ .compatible = "brcm,bcm96338w", .data = &board_96338w, },

--- a/target/linux/bcm63xx/patches-5.4/514-board_bcm6345.patch
+++ b/target/linux/bcm63xx/patches-5.4/514-board_bcm6345.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -893,6 +893,19 @@ static struct board_info __initdata boar
+@@ -936,6 +936,19 @@ static struct board_info __initdata boar
  	.name				= "96345GW2",
  	.expected_cpu_id		= 0x6345,
  };
@@ -20,7 +20,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  
  /*
-@@ -1224,6 +1237,7 @@ static const struct board_info __initcon
+@@ -1268,6 +1281,7 @@ static const struct board_info __initcon
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	&board_96345gw2,
@@ -28,7 +28,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  #ifdef CONFIG_BCM63XX_CPU_6348
  	&board_96348r,
-@@ -1278,6 +1292,8 @@ static struct of_device_id const bcm963x
+@@ -1323,6 +1337,8 @@ static struct of_device_id const bcm963x
  #endif /* CONFIG_BCM63XX_CPU_6338 */
  #ifdef CONFIG_BCM63XX_CPU_6345
  	{ .compatible = "brcm,bcm96345gw2", .data = &board_96345gw2, },

--- a/target/linux/bcm63xx/patches-5.4/515-board-bcm6348.patch
+++ b/target/linux/bcm63xx/patches-5.4/515-board-bcm6348.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -1092,6 +1092,275 @@ static struct board_info __initdata boar
+@@ -1135,6 +1135,275 @@ static struct board_info __initdata boar
  
  	.has_ohci0 = 1,
  };
@@ -276,7 +276,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6348 */
  
  /*
-@@ -1248,6 +1517,19 @@ static const struct board_info __initcon
+@@ -1292,6 +1561,19 @@ static const struct board_info __initcon
  	&board_DV201AMR,
  	&board_96348gw_a,
  	&board_rta1025w_16,
@@ -296,7 +296,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6348 */
  #ifdef CONFIG_BCM63XX_CPU_6358
  	&board_96358vw,
-@@ -1296,15 +1578,29 @@ static struct of_device_id const bcm963x
+@@ -1341,15 +1623,29 @@ static struct of_device_id const bcm963x
  	{ .compatible = "dynalink,rta770w", .data = &board_rta770w, },
  #endif /* CONFIG_BCM63XX_CPU_6345 */
  #ifdef CONFIG_BCM63XX_CPU_6348

--- a/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
+++ b/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
@@ -8,7 +8,7 @@
  #include <asm/addrspace.h>
  #include <bcm63xx_board.h>
  #include <bcm63xx_cpu.h>
-@@ -1445,6 +1446,88 @@ static struct board_info __initdata boar
+@@ -1488,6 +1489,88 @@ static struct board_info __initdata boar
  	.has_ehci0 = 1,
  };
  
@@ -97,7 +97,7 @@
  static struct board_info __initdata board_DWVS0 = {
  	.name				= "DWV-S0",
  	.expected_cpu_id		= 0x6358,
-@@ -1469,6 +1552,238 @@ static struct board_info __initdata boar
+@@ -1512,6 +1595,238 @@ static struct board_info __initdata boar
  	.has_ohci0			= 1,
  	.has_ehci0			= 1,
  };
@@ -336,7 +336,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
  /*
-@@ -1535,7 +1850,20 @@ static const struct board_info __initcon
+@@ -1579,7 +1894,20 @@ static const struct board_info __initcon
  	&board_96358vw,
  	&board_96358vw2,
  	&board_AGPFS0,
@@ -357,7 +357,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  };
  
-@@ -1608,11 +1936,24 @@ static struct of_device_id const bcm963x
+@@ -1653,11 +1981,24 @@ static struct of_device_id const bcm963x
  	{ .compatible = "alcatel,rg100a", .data = &board_96358vw2, },
  	{ .compatible = "brcm,bcm96358vw", .data = &board_96358vw, },
  	{ .compatible = "brcm,bcm96358vw2", .data = &board_96358vw2, },

--- a/target/linux/bcm63xx/patches-5.4/517-board_bcm6362.patch
+++ b/target/linux/bcm63xx/patches-5.4/517-board_bcm6362.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -1786,6 +1786,117 @@ static struct board_info __initdata boar
+@@ -1829,6 +1829,117 @@ static struct board_info __initdata boar
  };
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
@@ -118,7 +118,7 @@
  /*
   * all boards
   */
-@@ -1865,6 +1976,12 @@ static const struct board_info __initcon
+@@ -1909,6 +2020,12 @@ static const struct board_info __initcon
  	&board_nb4_fxc_r1,
  	&board_spw303v,
  #endif /* CONFIG_BCM63XX_CPU_6358 */
@@ -131,7 +131,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -1956,6 +2073,10 @@ static struct of_device_id const bcm963x
+@@ -2001,6 +2118,10 @@ static struct of_device_id const bcm963x
  	{ .compatible = "telsey,cpva642", .data = &board_CPVA642, },
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  #ifdef CONFIG_BCM63XX_CPU_6362

--- a/target/linux/bcm63xx/patches-5.4/518-board_bcm6368.patch
+++ b/target/linux/bcm63xx/patches-5.4/518-board_bcm6368.patch
@@ -9,7 +9,7 @@
  #include <asm/addrspace.h>
  #include <bcm63xx_board.h>
  #include <bcm63xx_cpu.h>
-@@ -1898,6 +1900,648 @@ static struct board_info __initdata boar
+@@ -1941,6 +1943,648 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_6362 */
  
  /*
@@ -658,7 +658,7 @@
   * all boards
   */
  static const struct board_info __initconst *bcm963xx_boards[] = {
-@@ -1982,6 +2626,22 @@ static const struct board_info __initcon
+@@ -2026,6 +2670,22 @@ static const struct board_info __initcon
  	&board_hg253s_v2,
  	&board_nb6,
  #endif /* CONFIG_BCM63XX_CPU_6362 */
@@ -681,7 +681,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2079,6 +2739,20 @@ static struct of_device_id const bcm963x
+@@ -2124,6 +2784,20 @@ static struct of_device_id const bcm963x
  	{ .compatible = "sfr,neufbox-6-sercomm-r0", .data = &board_nb6, },
  #endif /* CONFIG_BCM63XX_CPU_6362 */
  #ifdef CONFIG_BCM63XX_CPU_6368

--- a/target/linux/bcm63xx/patches-5.4/519-board_bcm63268.patch
+++ b/target/linux/bcm63xx/patches-5.4/519-board_bcm63268.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -2542,6 +2542,273 @@ static struct board_info __initdata boar
+@@ -2585,6 +2585,273 @@ static struct board_info __initdata boar
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  
  /*
@@ -274,7 +274,7 @@
   * all boards
   */
  static const struct board_info __initconst *bcm963xx_boards[] = {
-@@ -2642,6 +2909,15 @@ static const struct board_info __initcon
+@@ -2686,6 +2953,15 @@ static const struct board_info __initcon
  	&board_VR3026e,
  	&board_WAP5813n,
  #endif /* CONFIG_BCM63XX_CPU_6368 */
@@ -290,7 +290,7 @@
  };
  
  static struct of_device_id const bcm963xx_boards_dt[] = {
-@@ -2755,6 +3031,14 @@ static struct of_device_id const bcm963x
+@@ -2800,6 +3076,14 @@ static struct of_device_id const bcm963x
  	{ .compatible = "zyxel,p870hw-51a-v2", .data = &board_P870HW51A_V2, },
  #endif /* CONFIG_BCM63XX_CPU_6368 */
  #ifdef CONFIG_BCM63XX_CPU_63268

--- a/target/linux/bcm63xx/patches-5.4/531-board_bcm6348-bt-voyager-2500v-bb.patch
+++ b/target/linux/bcm63xx/patches-5.4/531-board_bcm6348-bt-voyager-2500v-bb.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/bcm63xx/boards/board_bcm963xx.c
 +++ b/arch/mips/bcm63xx/boards/board_bcm963xx.c
-@@ -3067,6 +3067,22 @@ void __init board_bcm963xx_init(void)
+@@ -3112,6 +3112,22 @@ void __init board_bcm963xx_init(void)
  		val &= MPI_CSBASE_BASE_MASK;
  	}
  	boot_addr = (u8 *)KSEG1ADDR(val);


### PR DESCRIPTION
ADB P.DG A4101N A-000-1A1-AE has a similar PCB as the OpenWrt's ADB P.DG A4001N1
with LEDs connected to different GPIO PINs in active low configuration.

Hardware:
* Board ID: 96328avngv
* SoC: Broadcom BCM6328 (rev b0) @ 320MHz, CPU BMIPS4350
* RAM DDR2: 64 Mbyte - Winbond W9751G6KB-25
* Serial flash: 16 Mbyte - Winbond 25Q128BVFG
* Ethernet: 4x Ethernet 10/100 baseT
* Wifi 2.4GHz: Broadcom Corporation BCM43225 Wireless Network Adapter (rev 23)
* LEDs: 1x Power, 1x DSL, 1x Internet, 4x ETH, 1x USB, 1x WLAN, 1x WPS, 1x TEL
* Buttons: 1x Reset, 1x WPS, 1x unnamed
* UART: 1x TTL 115200n8, VCC RX TX GND, on J502 connector

Installation via CFE:
* Stock CFE has to be overwritten with a generic 6328 one that can upload
  .bin images with no signature check (cfe6328_configured.bin)
* Connect a serial port to the board
* Stop the cfe boot process after power on by pressing enter
* Set static IP 192.168.2.10 and subnet mask 255.255.255.0
* Navigate to http://192.168.2.50/
* Upload the OpenWrt image file

A4101N GPIO LAYOUT:

Power            always on
DSL              GPIO483(03)
Internet         GPIO491(11)
ETH1             GPIO505(25)
ETH2             GPIO506(26)
ETH3             GPIO507(27)
ETH4             GPIO508(28)
USB              GPIO490(10)
WLAN             controlled by BCM43225
WPS              GPIO489(09)
TEL              GPIO511(31)

Key RESET        GPIO503(23)
Key WPS          GPIO504(24)
Key unnamed      GPIO492(12)

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>