### PR TITLE
brcm63xx: add support for Technicolor TG582n

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -91,6 +91,12 @@ sercomm,h500-s-lowi|\
 sercomm,h500-s-vfes)
 	ucidef_set_led_netdev "wan" "WAN" "green:internet" "eth0.2"
 	;;
+technicolor,tg582n)
+	ucidef_set_led_netdev "lan" "LAN" "green:ethernet" "eth0.1"
+	ucidef_set_led_netdev "wan" "WAN" "green:broadband" "eth0.2"
+	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
+	ucidef_set_led_usbdev "usb" "USB" "red:power" "1-1"
+	;;
 telsey,cpva502plus)
 	ucidef_set_led_netdev "lan" "LAN" "amber:link" "eth0"
 	;;

--- a/target/linux/bcm63xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm63xx/base-files/etc/board.d/02_network
@@ -15,7 +15,8 @@ netgear,cvg834g|\
 netgear,dgnd3700-v2|\
 netgear,evg2000|\
 t-com,speedport-w-303v|\
-t-com,speedport-w-500v)
+t-com,speedport-w-500v|\
+technicolor,tg582n)
 	ucidef_set_interface_lan "eth0"
 	;;
 adb,a4001n1|\

--- a/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/bcm63xx/base-files/etc/uci-defaults/09_fix_crc
@@ -33,6 +33,7 @@ case "$(board_name)" in
 	nucom,r5010un-v2|\
 	observa,vh4032n|\
 	t-com,speedport-w-303v|\
+	technicolor,tg582n|\
 	telsey,cpva502plus|\
 	telsey,cpva642|\
 	telsey,magic|\

--- a/target/linux/bcm63xx/dts/bcm6328-technicolor-tg582n.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-technicolor-tg582n.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "bcm6328.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Technicolor TG582n";
+	compatible = "technicolor,tg582n", "brcm,bcm6328";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wifi {
+			label = "wifi";
+			gpios = <&pinctrl 15 1>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 23 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 24 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led@1 {
+		reg = <1>;
+		active-low;
+		label = "green:internet";
+	};
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "red:wifi";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "green:wifi";
+	};
+
+	led_power_green: led@4 {
+		reg = <4>;
+		active-low;
+		label = "green:power";
+		default-state = "on";
+	};
+
+	led@5 {
+		reg = <5>;
+		active-low;
+		label = "green:ethernet";
+	};
+
+	led@7 {
+		reg = <7>;
+		active-low;
+		label = "red:internet";
+	};
+
+	led@8 {
+		reg = <8>;
+		active-low;
+		label = "red:power";
+	};
+
+	led@9 {
+		reg = <9>;
+		active-low;
+		label = "green:wps";
+	};
+
+	led@10 {
+		reg = <10>;
+		active-low;
+		label = "red:wps";
+	};
+
+	led@11 {
+		reg = <11>;
+		active-low;
+		label = "green:broadband";
+	};
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x000000 0x010000>;
+				label = "cfe";
+				read-only;
+
+				partition@580 {
+					label = "cfe_nvram";
+					reg = <0x000580 0x000400>;
+				};
+			};
+
+			partition@10000 {
+				reg = <0x010000 0xff0000>;
+				label = "linux";
+				compatible = "brcm,bcm963xx-imagetag";
+			};
+		};
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio1", "gpio2",
+		       "gpio3", "gpio4",
+		       "gpio5", "gpio7",
+		       "gpio8", "gpio9",
+		       "gpio10", "gpio11";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -1073,6 +1073,19 @@ define Device/t-com_speedport-w-500v
 endef
 TARGET_DEVICES += t-com_speedport-w-500v
 
+### Technicolor ###
+define Device/technicolor_tg582n
+  $(Device/bcm63xx)
+  DEVICE_VENDOR := Technicolor
+  DEVICE_MODEL := TG582n
+  IMAGES += sysupgrade.bin
+  CFE_BOARD_ID := DANT-1
+  CHIP_ID := 6328
+  FLASH_MB := 16
+  DEVICE_PACKAGES := $(USB2_PACKAGES) $(B43_PACKAGES)
+endef
+TARGET_DEVICES += technicolor_tg582n
+
 ### Tecom ###
 define Device/tecom_gw6000
   $(Device/bcm63xx-legacy)

--- a/target/linux/bcm63xx/patches-5.4/806-board_bcm6328-technicolor-tg582n.patch
+++ b/target/linux/bcm63xx/patches-5.4/806-board_bcm6328-technicolor-tg582n.patch
@@ -1,0 +1,70 @@
+Index: linux-5.4.61/arch/mips/bcm63xx/boards/board_bcm963xx.c
+===================================================================
+--- linux-5.4.61.orig/arch/mips/bcm63xx/boards/board_bcm963xx.c
++++ linux-5.4.61/arch/mips/bcm63xx/boards/board_bcm963xx.c
+@@ -1321,6 +1321,49 @@ static struct board_info __initdata boar
+ 	},
+ };
+ 
++static struct board_info __initdata board_TG582N = {
++	.name = "DANT-1",
++	.expected_cpu_id = 0x6328,
++
++	.has_pci = 1,
++	.has_ohci0 = 1,
++	.has_ehci0 = 1,
++	.num_usbh_ports = 1,
++
++	.has_enetsw = 1,
++	.enetsw = {
++		.used_ports = {
++			[0] = {
++				.used = 1,
++				.phy_id = 1,
++				.name = "Port 1",
++			},
++			[1] = {
++				.used = 1,
++				.phy_id = 2,
++				.name = "Port 2",
++			},
++			[2] = {
++				.used = 1,
++				.phy_id = 3,
++				.name = "Port 3",
++			},
++			[3] = {
++				.used = 1,
++				.phy_id = 4,
++				.name = "Port 4",
++			},
++		},
++	},
++
++	.use_fallback_sprom = 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM43225,
++		.pci_bus = 1,
++		.pci_dev = 0,
++	},
++};
++
+ static struct board_info __initdata board_96348sv = {
+ 	.name = "MAGIC",
+ 	.expected_cpu_id = 0x6348,
+@@ -2835,6 +2878,7 @@ static const struct board_info __initcon
+ 	&board_dsl_274xb_f1,
+ 	&board_FAST2704V2,
+ 	&board_R5010UNV2,
++	&board_TG582N,
+ #endif /* CONFIG_BCM63XX_CPU_6328 */
+ #ifdef CONFIG_BCM63XX_CPU_6338
+ 	&board_96338gw,
+@@ -2946,6 +2990,7 @@ static struct of_device_id const bcm963x
+ 	{ .compatible = "sagem,fast-2704-v2", .data = &board_FAST2704V2, },
+ 	{ .compatible = "sercomm,ad1018", .data = &board_AD1018, },
+ 	{ .compatible = "sercomm,ad1018-nor", .data = &board_AD1018, },
++	{ .compatible = "technicolor,tg582n", .data = &board_TG582N, },
+ #endif /* CONFIG_BCM63XX_CPU_6328 */
+ #ifdef CONFIG_BCM63XX_CPU_6338
+ 	{ .compatible = "brcm,bcm96338gw", .data = &board_96338gw, },


### PR DESCRIPTION
Technicolor TG582n has a similar PCB as the OpenWrt's ADB P.DG A4001N1
with LEDs connected to different GPIO PINs in active low configuration.

Hardware:
* Board ID: DANT-1
* SoC: Broadcom BCM6328 (rev b0) @ 320MHz, CPU BMIPS4350
* RAM DDR2: 64 Mbyte - Winbond W9751G6KB-25
* Serial flash: 16 Mbyte - MXIC MX25L6445EMI
* Ethernet: 4x Ethernet 10/100 baseT
* Wifi 2.4GHz: Broadcom Corporation BCM43227 Wireless Network Adapter (rev 30)
* LEDs: 2x Power, 1x Ethernet, 1x Broadband, 2x Wi-Fi, 2x WPS, 4x ethernet
* Buttons: 1x Reset, 1x WPS, 1x WiFi
* UART: 1x TTL 115200n8, VCC GND TX RX, on J3 connector (short R62 and R63)

Installation via CFE:
* Stock CFE has to be overwritten with a generic 6328 one that can upload
  .bin images with no signature check (cfe6328_configured.bin)
* Connect a serial port to the board
* Stop the CFE boot process after power on by pressing enter
* Set static IP 192.168.2.10 and subnet mask 255.255.255.0
* Navigate to http://192.168.2.50/
* Upload the OpenWrt image file

PCB:   |GPIO:   |TG582n:

LED2R  |488(08) |red    Power
LED2G  |484(04) |green  Power

LED10R |486(06) |
LED13G |485(05) |green  Ethernet

LED11R |494(14) |
LED14G |491(11) |green  Broadband

LED5R  |487(07) |red    Internet
LED5G  |481(01) |green  Internet

LED12R |498(18) |
LED12G |499(19) |

LED6R  |482(02) |red    Wi-Fi
LED6G  |483(03) |green  Wi-Fi

LED7R  |490(10) |red    WPS
LED7G  |489(09) |green  WPS

LED4   |508(28) |ethernet port 4
LED3   |507(27) |ethernet port 3

LED9   |506(26) |ethernet port 2
LED8   |505(25) |ethernet port 1

SW3    |503(23) |key Reset

SW5    |504(24) |key WPS

SW4    |495(15) |key Wi-Fi

SW6    |493(13) |

SW1    |492(12) |

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>