### PR TITLE
build: Add preferred TLS lib options

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -144,6 +144,25 @@ menu "Global build settings"
 		help
 		  Enables IPv6 support in kernel (builtin) and packages.
 
+	choice
+		prompt "Preferred SSL/TLS library"
+		default TLS_LIB_USE_WOLFSSL
+		help
+		  Select the preferred SSL/TLS library.
+
+		config TLS_LIB_USE_NONE
+			bool "None"
+
+		config TLS_LIB_USE_MBEDTLS
+			bool "MbedTLS"
+
+		config TLS_LIB_USE_OPENSSL
+			bool "OpenSSL"
+
+		config TLS_LIB_USE_WOLFSSL
+			bool "wolfSSL"
+	endchoice
+
 	comment "Stripping options"
 
 	choice

--- a/include/target.mk
+++ b/include/target.mk
@@ -21,7 +21,7 @@ DEFAULT_PACKAGES:=\
 	fstools \
 	libc \
 	libgcc \
-	libustream-wolfssl \
+	libustream-config \
 	logd \
 	mtd \
 	netifd \

--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -48,6 +48,21 @@ define Package/libustream-mbedtls
   DEFAULT_VARIANT:=1
 endef
 
+define Package/libustream-config
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=ustream SSL Library (with config)
+ifdef CONFIG_TLS_LIB_USE_MBEDTLS
+  DEPENDS := +libustream-mbedtls
+endif
+ifdef CONFIG_TLS_LIB_USE_OPENSSL
+  DEPENDS := +libustream-openssl
+endif
+ifdef CONFIG_TLS_LIB_USE_WOLFSSL
+  DEPENDS := +libustream-wolfssl
+endif
+endef
+
 ifeq ($(BUILD_VARIANT),wolfssl)
   TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/wolfssl
   CMAKE_OPTIONS += -DWOLFSSL=on
@@ -61,6 +76,11 @@ define Package/libustream/default/install
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/libustream-ssl.so $(1)/lib/
 endef
 
+define Package/libustream-config/install
+	$(INSTALL_DIR) $(1)/tmp
+	touch $(1)/tmp/.libustream-config-placeholder
+endef
+
 Package/libustream-openssl/install = $(Package/libustream/default/install)
 Package/libustream-wolfssl/install = $(Package/libustream/default/install)
 Package/libustream-mbedtls/install = $(Package/libustream/default/install)
@@ -68,3 +88,4 @@ Package/libustream-mbedtls/install = $(Package/libustream/default/install)
 $(eval $(call BuildPackage,libustream-mbedtls))
 $(eval $(call BuildPackage,libustream-wolfssl))
 $(eval $(call BuildPackage,libustream-openssl))
+$(eval $(call BuildPackage,libustream-config))


### PR DESCRIPTION
A question introduced by commit e79df3516d3e2931a2a2964cadfed0af99acef49
In order for opkg to use HTTPS, an SSL lib must be introduced.Wolfssl is selected here by default.
This means that if a package is compiled using another SSL library, users will get a compile error.
For example: 
if you use luci-ssl-openssl,will get error like.
```bash
Configuring dnsmasq-full.
Collected errors:
 * check_data_file_clashes: Package libustream-openssl20200215 wants to install file ./openwrt/build_dir/target-aarch64_generic_musl/root-rockchip/lib/libustream-ssl.so
	But that file is already provided by package  * libustream-wolfssl20200215
 * opkg_install_cmd: Cannot install package libustream-openssl20200215.
 * check_data_file_clashes: Package libustream-openssl20200215 wants to install file ./openwrt/build_dir/target-aarch64_generic_musl/root-rockchip/lib/libustream-ssl.so
	But that file is already provided by package  * libustream-wolfssl20200215
 * opkg_install_cmd: Cannot install package luci-ssl-openssl.
```
To solve this problem, I think it would be a good idea to add a compile option to allow users to select the default SSL library.

So I made the following changes
Add preferred TLS lib options to menuconfig.
Added a virtual package libustream-config.

Signed-off-by: Yuan Tao <ty@wevs.org>
