### PR TITLE
ath79: fix GbE on WD My Net Wi-Fi Range Extender

### DIFF
--- a/target/linux/ath79/dts/ar9344_wd_mynet-wifi-rangeextender.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-wifi-rangeextender.dts
@@ -144,10 +144,10 @@
 &eth0 {
 	status = "okay";
 
-	pll-data = <0x0e000000 0x3c000101 0x3c001313>;
+	pll-data = <0x02000000 0x00000101 0x00001313>;
 
 	/* ethernet MAC is stored in nvram */
-	phy-mode = "rgmii";
+	phy-mode = "rgmii-id";
 	phy-handle = <&phy4>;
 
 	gmac-config {


### PR DESCRIPTION
Adjusts MAC config to more closely match ar71xx port for this device.
Makes eth0 work at 1000Mbps.  Prior code only was working with a two-
pair network cable at 10/100Mbps link speeds.

Signed-off-by: Jonathan A. Kollasch <jakllsch@kollasch.net>