### PR TITLE
ipq806x: provide wifi mac from dts

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -20,7 +20,6 @@ case "$FIRMWARE" in
 		;;
 	buffalo,wxr-2533dhp)
 		caldata_extract "ART" 0x1000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary ART 0x1e)
 		;;
 	edgecore,ecw5410)
 		if [ -b "$(find_mtd_part 0:art)" ]; then
@@ -38,22 +37,18 @@ case "$FIRMWARE" in
 	nec,wg2600hp |\
 	nec,wg2600hp3)
 		caldata_extract "ART" 0x1000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary PRODUCTDATA 0x12)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
 		caldata_extract "art" 0x1000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) 1)
 		;;
 	tplink,ad7200 |\
 	tplink,c2600)
 		caldata_extract "radio" 0x1000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 0x8) -1)
 		;;
 	tplink,vr2600v)
 		caldata_extract "ART" 0x1000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 0x0) -1)
 		;;
 	zyxel,nbg6817)
 		if [ -b "$(find_mtd_part 0:art)" ]; then
@@ -80,7 +75,6 @@ case "$FIRMWARE" in
 		;;
 	buffalo,wxr-2533dhp)
 		caldata_extract "ART" 0x5000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary ART 0x18)
 		;;
 	linksys,ea7500-v1 |\
 	linksys,ea8500)
@@ -90,22 +84,18 @@ case "$FIRMWARE" in
 	nec,wg2600hp |\
 	nec,wg2600hp3)
 		caldata_extract "ART" 0x5000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary PRODUCTDATA 0xc)
 		;;
 	netgear,d7800 |\
 	netgear,r7500v2 |\
 	netgear,r7800)
 		caldata_extract "art" 0x5000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) 2)
 		;;
 	tplink,ad7200 |\
 	tplink,c2600)
 		caldata_extract "radio" 0x5000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary default-mac 0x8)
 		;;
 	tplink,vr2600v)
 		caldata_extract "ART" 0x5000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary default-mac 0x0)
 		;;
 	zyxel,nbg6817)
 		if [ -b "$(find_mtd_part 0:art)" ]; then

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062-wg2600hp3.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062-wg2600hp3.dts
@@ -359,6 +359,8 @@
 			reg = <0x00010000 0 0 0 0>;
 
 			qcom,ath10k-calibration-variant = "NEC-Platforms-WG2600HP3";
+			nvmem-cells = <&macaddr_PRODUCTDATA_12>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };
@@ -379,6 +381,8 @@
 
 			ieee80211-freq-limit = <2400000 2483000>;
 			qcom,ath10k-calibration-variant = "NEC-Platforms-WG2600HP3";
+			nvmem-cells = <&macaddr_PRODUCTDATA_c>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };
@@ -450,5 +454,13 @@
 
 	macaddr_factory_6: macaddr@6 {
 		reg = <0x6 0x6>;
+	};
+
+	macaddr_PRODUCTDATA_c: macaddr@c {
+		reg = <0xc 0x6>;
+	};
+
+	macaddr_PRODUCTDATA_12: macaddr@12 {
+		reg = <0x12 0x6>;
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
@@ -249,11 +249,42 @@
 
 &pcie0 {
 	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_defaultmac_8>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(-1)>;
+		};
+	};
 };
 
 &pcie1 {
 	status = "okay";
 	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_defaultmac_8>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &mdio0 {

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -161,6 +161,22 @@
 
 	pinctrl-0 = <&usb0_pwr_en_pins>;
 	pinctrl-names = "default";
+	
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_art_6>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(1)>;
+		};
+	};
 };
 
 &usb3_1 {
@@ -168,6 +184,22 @@
 
 	pinctrl-0 = <&usb1_pwr_en_pins>;
 	pinctrl-names = "default";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_art_6>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(2)>;
+		};
+	};
 };
 
 &pcie0 {

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-r7500v2.dts
@@ -186,6 +186,22 @@
 	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&pcie0_pins>;
 	pinctrl-names = "default";
+	
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_art_6>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(1)>;
+		};
+	};
 };
 
 &pcie1 {
@@ -194,6 +210,22 @@
 	pinctrl-0 = <&pcie1_pins>;
 	pinctrl-names = "default";
 	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_art_6>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(2)>;
+		};
+	};
 };
 
 &nand_controller {

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-vr2600v.dts
@@ -284,11 +284,42 @@
 
 &pcie0 {
 	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_defaultmac_0>;
+			nvmem-cell-names = "mac-address";
+			mtd-mac-address-increment = <(-1)>;
+		};
+	};
 };
 
 &pcie1 {
 	status = "okay";
 	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_defaultmac_0>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &mdio0 {

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
@@ -320,11 +320,41 @@
 
 &pcie0 {
 	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_PRODUCTDATA_12>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &pcie1 {
 	status = "okay";
 	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_PRODUCTDATA_c>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &qcom_pinmux {
@@ -394,5 +424,13 @@
 
 	macaddr_PRODUCTDATA_6: macaddr@6 {
 		reg = <0x6 0x6>;
+	};
+
+	macaddr_PRODUCTDATA_c: macaddr@c {
+		reg = <0xc 0x6>;
+	};
+
+	macaddr_PRODUCTDATA_12: macaddr@12 {
+		reg = <0x12 0x6>;
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wxr-2533dhp.dts
@@ -395,11 +395,41 @@
 
 &pcie0 {
 	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_ART_1e>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &pcie1 {
 	status = "okay";
 	max-link-speed = <1>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "pci168c,0040";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_ART_18>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
 };
 
 &qcom_pinmux {
@@ -478,5 +508,13 @@
 
 	macaddr_ART_6: macaddr@6 {
 		reg = <0x6 0x6>;
+	};
+
+	macaddr_ART_18: macaddr@18 {
+		reg = <0x18 0x6>;
+	};
+
+	macaddr_ART_1e: macaddr@1e {
+		reg = <0x1e 0x6>;
 	};
 };


### PR DESCRIPTION
We have a dedicated patch to patch ath10k mac address. Directly use the dts to provide the mac instead of use a dedicated script.

@adschm What do you think about this? Also i wonder if we can generalize the wifi bridge (as every ipq8064 board use a qca9980 and every ipq8065 board use a qca9984 chip) and use a tag to set the mac address
