### PR TITLE
mvebu: espressobin: add support for mainline firmware

### DIFF
--- a/package/boot/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-envtools/files/mvebu
@@ -23,7 +23,14 @@ glinet,gl-mv1000)
 globalscale,espressobin|\
 globalscale,espressobin-emmc|\
 globalscale,espressobin-v7|\
-globalscale,espressobin-v7-emmc|\
+globalscale,espressobin-v7-emmc)
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"
+	else
+		ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
+	fi
+	;;
 marvell,armada8040-mcbin-doubleshot|\
 marvell,armada8040-mcbin-singleshot)
 	ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -15,6 +15,7 @@ define Device/globalscale_espressobin
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := Non-eMMC
   SOC := armada-3720
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin
 
@@ -27,6 +28,7 @@ define Device/globalscale_espressobin-emmc
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := eMMC
   SOC := armada-3720
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-emmc
 
@@ -39,6 +41,7 @@ define Device/globalscale_espressobin-v7
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := V7 Non-eMMC
   SOC := armada-3720
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-v7
 
@@ -51,6 +54,7 @@ define Device/globalscale_espressobin-v7-emmc
   DEVICE_ALT0_MODEL := Armada 3700 Community Board
   DEVICE_ALT0_VARIANT := V7 eMMC
   SOC := armada-3720
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-v7-emmc
 

--- a/target/linux/mvebu/image/espressobin.bootscript
+++ b/target/linux/mvebu/image/espressobin.bootscript
@@ -1,0 +1,34 @@
+# Bootscript for Globalscale ESPRESSOBin Board
+
+# Set distro variables if necessary for compability with downstream firmware
+if test -z "${kernel_addr_r}"; then
+	setenv kernel_addr_r 0x7000000
+fi
+
+if test -z "${fdt_add_r}"; then
+	setenv fdt_addr_r 0x6f00000
+fi
+
+if test -z "${devtype}"; then
+	setenv devtype mmc
+fi
+
+if test -z "${devnum}"; then
+	if mmc dev 0; then
+		setenv devnum 0
+	elif mmc dev 1; then
+		setenv devnum 1
+	fi
+fi
+
+# figure out partition uuid to pass to the kernel as root=
+part uuid ${devtype} ${devnum}:2 uuid
+
+setenv console "console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000"
+setenv bootargs "root=PARTUUID=${uuid} rw rootwait ${console}"
+
+echo "Booting Linux from ${devtype} ${devnum} with args: ${bootargs}"
+load ${devtype} ${devnum}:1 ${fdt_addr_r} @DTB@.dtb
+load ${devtype} ${devnum}:1 ${kernel_addr_r} Image
+
+booti ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
This fixes booting OpenWRT with a firmware built from #3360:
* adds a bootscript to support downstream and mainline firmware
* fixes uboot-envtools for mainline u-boot

As a bonus, with a mainline firmware, this allows booting OpenWRT off USB and SATA thanks to distro boot.

Tested with downloads from http://espressobin.net/tech-spec/ and #3360.

Using downstream `U-Boot 2017.03-armada-17.06`:
```
NOTICE:  Booting Trusted Firmware
NOTICE:  BL1: v1.3(release):armada-17.06.2:a37c108
NOTICE:  BL1: Built : 14:30:53, Jul  5 2NOTICE:  BL2: v1.3(release):armada-17.06
.2:a37c108
NOTICE:  BL2: Built : 14:30:55, Jul  5 20NOTICE:  BL31: v1.3(release):armada-17.
06.2:a37c108
NOTICE:  BL31:

U-Boot 2017.03-armada-17.06.3-ga33ecb8 (Jul 05 2017 - 14:30:47 +0800)

Model: Marvell Armada 3720 Community Board ESPRESSOBin
       CPU    @ 1000 [MHz]
       L2     @ 800 [MHz]
       TClock @ 200 [MHz]
       DDR    @ 800 [MHz]
DRAM:  1 GiB
U-Boot DComphy-0: USB3          5 Gbps
Comphy-1: PEX0          2.5 Gbps
Comphy-2: SATA0         6 Gbps
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq led only pmp fbss pio slum part sxs
PCIE-0: Link up
MMC:   sdhci@d0000: 0
SF: Detected w25q32dw with page size 256 Bytes, erase size 4 KiB, total 4 MiB
Net:
Warning: neta@30000 (eth0) using random MAC address - 0a:22:46:ee:87:b0
eth0: neta@30000 [PRIME]
Hit any key to stop autoboot:  0
starting USB...
USB0:   Register 2000104 NbrPorts 2
Starting the controller
USB XHCI 1.00
USB1:   USB EHCI 1.00
scanning bus 0 for devices... ERROR: Configure Endpoint command returned complet
ion code 17.
Failed to configure xHCI endpoint
failed to set default configuration len 34, status 80000000
1 USB Device(s) found
scanning bus 1 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
/
** Bad device usb 0 **
## Executing script at 06d00000
Wrong image format for "source" command
/boot/
** Bad device usb 0 **
## Executing script at 06d00000
Wrong image format for "source" command
scanning bus for devices...
switch to partitions #0, OK
mmc0 is current device
Booting Linux from mmc 0 with args: root=PARTUUID=9b37be97-02 rw rootwait consol
e=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000
```

Using downstream `U-Boot 2017.03-armada-17.10`:
```
TIM-1.0
WTMI-armada-17.10.1-b90dbf0
ENTER init_ddrgen
DDR_TOPOLOGY is 2 :     DDR3, 2CS 512M + 512M
WTMI_CLOCK=2

Fill memory before self refresh...done

Fill memory before self refresh...done

Now in Self-refresh Mode
Restore CAS Read and Write Latency
Restore termination values to original values
Exited self-refresh ...

DLL TUNING
==============
   DLL 0xc0001050[21:16]: [1,2a,15]
   DLL 0xc0001050[29:24]: [5,33,1c]
   DLL 0xc0001054[21:16]: [4,29,16]
   DLL 0xc0001054[29:24]: [5,2e,19]
   DLL 0xc0001074[21:16]: [0,3f,1f]
   DLL 0xc0001074NOTICE:  Booting Trusted Firmware
NOTICE:  BL1: v1.3(release):armada-17.10.3:a3306ab
NOTICE:  BL1: Built : 18:22:33, Jan 29 2NOTICE:  BL2: v1.3(release):armada-17.10
.3:a3306ab
NOTICE:  BL2: Built : 18:22:35, Jan 29 2018NOTICE:  BL31: v1.3(release):armada-1
7.10.3:a3306ab
NOTICE:  BL31:

U-Boot 2017.03-armada-17.10.1-gaee49fc (Jan 29 2018 - 18:21:49 +0800)

Model: Marvell Armada 3720 Community Board ESPRESSOBin
       CPU    @ 1000 [MHz]
       L2     @ 800 [MHz]
       TClock @ 200 [MHz]
       DDR    @ 800 [MHz]
DRAM:  1 GiB
U-Boot DT blob at : 000000003f7161b8
Comphy-0: USB3          5 Gbps
Comphy-1: PEX0          2.5 Gbps
Comphy-2: SATA0         6 Gbps
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq led only pmp fbss pio slum part sxs
PCIE-0: Link up
MMC:   sdhci@d0000: 0, sdhci@d8000: 1
SF: Detected w25q32dw with page size 256 Bytes, erase size 4 KiB, total 4 MiB
Net:   eth0: neta@30000 [PRIME]
Hit any key to stop autoboot:  0
starting USB...
USB0:   Register 2000104 NbrPorts 2
Starting the controller
USB XHCI 1.00
USB1:   USB EHCI 1.00
scanning bus 0 for devices... ERROR: Configure Endpoint command returned complet
ion code 17.
Failed to configure xHCI endpoint
failed to set default configuration len 34, status 80000000
1 USB Device(s) found
scanning bus 1 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
/
** Bad device usb 0 **
## Executing script at 06d00000
switch to partitions #0, OK
mmc0 is current device
Booting Linux from mmc 0 with args: root=PARTUUID=9b37be97-02 rw rootwait consol
e=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000
```

Using flash-image.bin from #3360:
```
TIM-1.0
WTMI-devel-18.12.1-
WTMI: system early-init
CPU VDD voltage default value: 1.108V
NOTICE:  Booting Trusted Firmware
NOTICE:  BL1: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL1: Built : 05:17:03, Sep 12 2020
NOTICE:  BL1: Booting BL2
NOTICE:  BL2: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL2: Built : 05:17:03, Sep 12 2020
NOTICE:  BL1: Booting BL31
NOTICE:  BL31: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL31: Built : 05:17:03

U-Boot 2020.10-rc4 (Sep 12 2020 - 05:17:03 +0000)

DRAM:  1 GiB
Comphy-0: USB3_HOST0    5 Gbps
Comphy-1: PEX0          2.5 Gbps
Comphy-2: SATA0         5 Gbps
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq led only pmp fbss pio slum part sxs
PCIE-0: Link up
MMC:   sdhci@d0000: 0
Loading Environment from SPIFlash... SF: Detected w25q32dw with page size 256 By
tes, erase size 4 KiB, total 4 MiB
OK
Model: Globalscale Marvell ESPRESSOBin Board
Net:   eth0: neta@30000
Hit any key to stop autoboot:  0
MMC Device 1 not found
no mmc device at slot 1
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
1045 bytes read in 10 ms (101.6 KiB/s)
## Executing script at 06d00000
switch to partitions #0, OK
mmc0 is current device
Booting Linux from mmc 0 with args: root=PARTUUID=9b37be97-02 rw rootwait consol
e=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000
```

Using flash-image.bin from #3360, with OpenWRT on attached usb stick:
```
TIM-1.0
WTMI-devel-18.12.1-
WTMI: system early-init
CPU VDD voltage default value: 1.108V
NOTICE:  Booting Trusted Firmware
NOTICE:  BL1: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL1: Built : 05:17:03, Sep 12 2020
NOTICE:  BL1: Booting BL2
NOTICE:  BL2: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL2: Built : 05:17:03, Sep 12 2020
NOTICE:  BL1: Booting BL31
NOTICE:  BL31: v2.3(): (Marvell-devel-18.12.0)
NOTICE:  BL31: Built : 05:17:03

U-Boot 2020.10-rc4 (Sep 12 2020 - 05:17:03 +0000)

DRAM:  1 GiB
Comphy-0: USB3_HOST0    5 Gbps
Comphy-1: PEX0          2.5 Gbps
Comphy-2: SATA0         5 Gbps
Target spinup took 0 ms.
AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl SATA mode
flags: ncq led only pmp fbss pio slum part sxs
PCIE-0: Link up
MMC:   sdhci@d0000: 0
Loading Environment from SPIFlash... SF: Detected w25q32dw with page size 256 By
tes, erase size 4 KiB, total 4 MiB
OK
Model: Globalscale Marvell ESPRESSOBin Board
Net:   eth0: neta@30000
Hit any key to stop autoboot:  0
MMC Device 1 not found
no mmc device at slot 1
MMC: no card present
starting USB...
Bus usb@58000: Register 2000104 NbrPorts 2
Starting the controller
USB XHCI 1.00
Bus usb@5e000: USB EHCI 1.00
scanning bus usb@58000 for devices... 2 USB Device(s) found
scanning bus usb@5e000 for devices... 2 USB Device(s) found
       scanning usb for storage devices... 1 Storage Device(s) found

Device 0: Vendor: SanDisk  Rev: 0001 Prod: Extreme
            Type: Removable Hard Disk
            Capacity: 29923.1 MB = 29.2 GB (61282631 x 512)
... is now current device
Scanning usb 0:1...
Found U-Boot script /boot.scr
1045 bytes read in 7 ms (145.5 KiB/s)
## Executing script at 06d00000
MMC: no card present
MMC Device 1 not found
no mmc device at slot 1
Booting Linux from usb 0 with args: root=PARTUUID=9b37be97-02 rw rootwait consol
e=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000
```