### PR TITLE
kernel: bump 5.4 to 5.4.65

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .64
+LINUX_VERSION-5.4 = .65
 
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.64 = b9d3c2938466f388a70fd190fd6691baa8b757393b267e9f7b06c4730d85d5ef
+LINUX_KERNEL_HASH-5.4.65 = f514834417d09de1667836e443e085bf37952603f23572b69ef0fcfda16cac69
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/hack-5.4/902-debloat_proc.patch
+++ b/target/linux/generic/hack-5.4/902-debloat_proc.patch
@@ -341,7 +341,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
 --- a/net/ipv4/fib_trie.c
 +++ b/net/ipv4/fib_trie.c
-@@ -2847,11 +2847,13 @@ static const struct seq_operations fib_r
+@@ -2848,11 +2848,13 @@ static const struct seq_operations fib_r
  
  int __net_init fib_proc_init(struct net *net)
  {
@@ -357,7 +357,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  			fib_triestat_seq_show, NULL))
  		goto out2;
  
-@@ -2862,17 +2864,21 @@ int __net_init fib_proc_init(struct net
+@@ -2863,17 +2865,21 @@ int __net_init fib_proc_init(struct net
  	return 0;
  
  out3:

--- a/target/linux/generic/pending-5.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
+++ b/target/linux/generic/pending-5.4/670-ipv6-allow-rejecting-with-source-address-failed-policy.patch
@@ -66,7 +66,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
  static void rt_fibinfo_free(struct rtable __rcu **rtp)
 --- a/net/ipv4/fib_trie.c
 +++ b/net/ipv4/fib_trie.c
-@@ -2595,6 +2595,7 @@ static const char *const rtn_type_names[
+@@ -2596,6 +2596,7 @@ static const char *const rtn_type_names[
  	[RTN_THROW] = "THROW",
  	[RTN_NAT] = "NAT",
  	[RTN_XRESOLVE] = "XRESOLVE",

--- a/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
+++ b/target/linux/generic/pending-5.4/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
@@ -42,7 +42,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (netif_elide_gro(skb->dev))
  		goto normal;
  
-@@ -7262,6 +7265,48 @@ static void __netdev_adjacent_dev_unlink
+@@ -7263,6 +7266,48 @@ static void __netdev_adjacent_dev_unlink
  					   &upper_dev->adj_list.lower);
  }
  
@@ -91,7 +91,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static int __netdev_upper_dev_link(struct net_device *dev,
  				   struct net_device *upper_dev, bool master,
  				   void *upper_priv, void *upper_info,
-@@ -7312,6 +7357,7 @@ static int __netdev_upper_dev_link(struc
+@@ -7313,6 +7358,7 @@ static int __netdev_upper_dev_link(struc
  	if (ret)
  		return ret;
  
@@ -99,7 +99,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	ret = call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  					    &changeupper_info.info);
  	ret = notifier_to_errno(ret);
-@@ -7405,6 +7451,7 @@ void netdev_upper_dev_unlink(struct net_
+@@ -7406,6 +7452,7 @@ void netdev_upper_dev_unlink(struct net_
  
  	__netdev_adjacent_dev_unlink_neighbour(dev, upper_dev);
  
@@ -107,7 +107,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	call_netdevice_notifiers_info(NETDEV_CHANGEUPPER,
  				      &changeupper_info.info);
  
-@@ -8135,6 +8182,7 @@ int dev_set_mac_address(struct net_devic
+@@ -8136,6 +8183,7 @@ int dev_set_mac_address(struct net_devic
  	if (err)
  		return err;
  	dev->addr_assign_type = NET_ADDR_SET;

--- a/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
+++ b/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
@@ -196,15 +196,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  void netif_napi_add(struct net_device *dev, struct napi_struct *napi,
  		    int (*poll)(struct napi_struct *, int), int weight)
  {
-@@ -6238,6 +6327,7 @@ void netif_napi_add(struct net_device *d
+@@ -6237,6 +6326,7 @@ void netif_napi_add(struct net_device *d
  #ifdef CONFIG_NETPOLL
  	napi->poll_owner = -1;
  #endif
 +	INIT_WORK(&napi->work, napi_workfn);
  	set_bit(NAPI_STATE_SCHED, &napi->state);
- 	napi_hash_add(napi);
- }
-@@ -6276,6 +6366,7 @@ static void flush_gro_hash(struct napi_s
+ 	set_bit(NAPI_STATE_NPSVC, &napi->state);
+ 	list_add_rcu(&napi->dev_list, &dev->napi_list);
+@@ -6277,6 +6367,7 @@ static void flush_gro_hash(struct napi_s
  void netif_napi_del(struct napi_struct *napi)
  {
  	might_sleep();
@@ -212,7 +212,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (napi_hash_del(napi))
  		synchronize_net();
  	list_del_init(&napi->dev_list);
-@@ -6288,50 +6379,18 @@ EXPORT_SYMBOL(netif_napi_del);
+@@ -6289,50 +6380,18 @@ EXPORT_SYMBOL(netif_napi_del);
  
  static int napi_poll(struct napi_struct *n, struct list_head *repoll)
  {
@@ -267,7 +267,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	/* Some drivers may have called napi_schedule
  	 * prior to exhausting their budget.
-@@ -10264,6 +10323,10 @@ static int __init net_dev_init(void)
+@@ -10265,6 +10324,10 @@ static int __init net_dev_init(void)
  		sd->backlog.weight = weight_p;
  	}
  


### PR DESCRIPTION
All modifications made by update_kernel.sh/no manual intervention needed

Build-tested: x86_64
Run-tested: ipq806x (R7800)

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>