### PR TITLE
 ath79: add support for Buffalo WZR-600DHP

### DIFF
--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-600dhp.dts
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-600dhp.dts
@@ -4,6 +4,6 @@
 #include "ar7161_buffalo_wzr-hp-ag300h.dtsi"
 
 / {
-	compatible = "buffalo,wzr-hp-ag300h", "qca,ar7161";
-	model = "Buffalo WZR-HP-AG300H";
+	compatible = "buffalo,wzr-600dhp", "qca,ar7161";
+	model = "Buffalo WZR-600DHP";
 };

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar7100.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_diag;
+		led-failsafe = &led_diag;
+		led-upgrade = &led_diag;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_diag: diag {
+			label = "buffalo:red:diag";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		band2g_a {
+			label = "buffalo:amber:band2g";
+			gpios = <&ath9k0 1 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "buffalo:green:usb";
+			gpios = <&ath9k0 3 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&usb_ohci_port>, <&usb_ehci_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		band2g_g {
+			label = "buffalo:green:band2g";
+			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		band5g_g {
+			label = "buffalo:green:band5g";
+			gpios = <&ath9k1 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		router {
+			label = "buffalo:green:router";
+			gpios = <&ath9k1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		movie_engine {
+			label = "buffalo:blue:movie_engine";
+			gpios = <&ath9k1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		band5g_a {
+			label = "buffalo:amber:band5g";
+			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		usb {
+			linux,code = <BTN_2>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		aoss {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_auto {
+			linux,code = <BTN_6>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		router_off {
+			linux,code = <BTN_5>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		movie_engine {
+			linux,code = <BTN_7>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_usb_power {
+			gpio-export,name = "buffalo:power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	flash {
+		compatible = "mtd-concat";
+
+		devices = <&flash0 &flash1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x0040000 0x0010000>;
+				read-only;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x0050000 0x0010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0060000 0x1f90000>;
+			};
+
+			partition@1ff0000 {
+				label = "user_property";
+				reg = <0x1ff0000 0x0010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_ohci_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb2 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	usb_ehci_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 {
+		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 {
+		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <2>;
+	cs-gpios = <0>, <0>;
+
+	flash0: flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+	};
+
+	flash1: flash@1 {
+		compatible = "jedec,spi-nor";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x120c>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x520c>;
+	mtd-mac-address-increment = <1>;
+
+	phy-handle = <&phy4>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -94,6 +94,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
 		;;
+	buffalo,wzr-600dhp|\
 	buffalo,wzr-hp-ag300h|\
 	tplink,archer-c25-v1|\
 	tplink,archer-c60-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -132,6 +132,7 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:11.0.bin")
 	case $board in
+	buffalo,wzr-600dhp|\
 	buffalo,wzr-hp-ag300h|\
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\
@@ -155,6 +156,7 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:12.0.bin")
 	case $board in
+	buffalo,wzr-600dhp|\
 	buffalo,wzr-hp-ag300h|\
 	netgear,wndr3700|\
 	netgear,wndr3700-v2|\

--- a/target/linux/ath79/image/common-buffalo.mk
+++ b/target/linux/ath79/image/common-buffalo.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += BUFFALO_PRODUCT BUFFALO_HWVER
+
 define Build/buffalo-tag
 	$(eval product=$(word 1,$(1)))
 	$(eval hwver=$(word 2,$(1)))
@@ -16,4 +18,17 @@ define Build/buffalo-tftp-header
 		dd if=$@; \
 	) > $@.new
 	mv $@.new $@
+endef
+
+
+define Device/buffalo_common
+  DEVICE_VENDOR := Buffalo
+  BUFFALO_PRODUCT :=
+  BUFFALO_HWVER := 3
+  IMAGES += factory.bin tftp.bin
+  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs | check-size
+  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc $$$$(BUFFALO_PRODUCT) 1.99 | \
+	buffalo-tag $$$$(BUFFALO_PRODUCT) $$$$(BUFFALO_HWVER)
+  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
 endef

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -333,15 +333,25 @@ define Device/buffalo_bhr-4grv2
 endef
 TARGET_DEVICES += buffalo_bhr-4grv2
 
-define Device/buffalo_wzr-hp-ag300h
+define Device/buffalo_wzr_ar7161
   $(Device/buffalo_common)
   SOC := ar7161
-  DEVICE_MODEL := WZR-HP-AG300H
   BUFFALO_PRODUCT := WZR-HP-AG300H
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-leds-reset kmod-owl-loader
   IMAGE_SIZE := 32320k
   SUPPORTED_DEVICES += wzr-hp-ag300h
+endef
+
+define Device/buffalo_wzr-600dhp
+  $(Device/buffalo_wzr_ar7161)
+  DEVICE_MODEL := WZR-600DHP
+endef
+TARGET_DEVICES += buffalo_wzr-600dhp
+
+define Device/buffalo_wzr-hp-ag300h
+  $(Device/buffalo_wzr_ar7161)
+  DEVICE_MODEL := WZR-HP-AG300H
 endef
 TARGET_DEVICES += buffalo_wzr-hp-ag300h
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -315,17 +315,12 @@ endef
 TARGET_DEVICES += avm_fritzdvbc
 
 define Device/buffalo_bhr-4grv
+  $(Device/buffalo_common)
   SOC := ar7242
-  DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := BHR-4GRV
+  BUFFALO_PRODUCT := BHR-4GRV
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 32256k
-  IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc BHR-4GRV 1.99 | \
-	buffalo-tag BHR-4GRV 3
-  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
 endef
 TARGET_DEVICES += buffalo_bhr-4grv
@@ -339,51 +334,37 @@ endef
 TARGET_DEVICES += buffalo_bhr-4grv2
 
 define Device/buffalo_wzr-hp-ag300h
+  $(Device/buffalo_common)
   SOC := ar7161
-  DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-HP-AG300H
-  IMAGE_SIZE := 32320k
-  IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-AG300H 1.99 | \
-	buffalo-tag WZR-HP-AG300H 3
-  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
+  BUFFALO_PRODUCT := WZR-HP-AG300H
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
 	kmod-leds-reset kmod-owl-loader
+  IMAGE_SIZE := 32320k
   SUPPORTED_DEVICES += wzr-hp-ag300h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-ag300h
 
 define Device/buffalo_wzr-hp-g302h-a1a0
+  $(Device/buffalo_common)
   SOC := ar7242
-  DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-HP-G302H
   DEVICE_VARIANT := A1A0
+  BUFFALO_PRODUCT := WZR-HP-G302H
+  BUFFALO_HWVER := 4
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 32128k
-  IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G302H 1.99 | \
-	buffalo-tag WZR-HP-G302H 4
-  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g300nh2
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g302h-a1a0
 
 define Device/buffalo_wzr-hp-g450h
+  $(Device/buffalo_common)
   SOC := ar7242
-  DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WZR-HP-G450H/WZR-450HP
+  BUFFALO_PRODUCT := WZR-HP-G450H
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
   IMAGE_SIZE := 32256k
-  IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WZR-HP-G450H 1.99 | \
-	buffalo-tag WZR-HP-G450H 3
-  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += wzr-hp-g450h
 endef
 TARGET_DEVICES += buffalo_wzr-hp-g450h

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -1,16 +1,11 @@
 include ./common-buffalo.mk
 
 define Device/buffalo_whr-g301n
+  $(Device/buffalo_common)
   SOC := ar7240
-  DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WHR-G301N
+  BUFFALO_PRODUCT := WHR-G301N
   IMAGE_SIZE := 3712k
-  IMAGES += factory.bin tftp.bin
-  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
-	pad-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/default) | buffalo-enc WHR-G301N 1.99 | \
-	buffalo-tag WHR-G301N 3
-  IMAGE/tftp.bin := $$(IMAGE/default) | buffalo-tftp-header
   SUPPORTED_DEVICES += whr-g301n
   DEFAULT := n
 endef


### PR DESCRIPTION
    The hardware of this device seems to be identical to WZR-HP-AG300H.
    It was already implemented as a clone in ar71xx.

    Specification:
    - 680 MHz CPU (Qualcomm Atheros AR7161)
    - 128 MiB RAM
    - 32 MiB Flash
    - WiFi 5 GHz a/n
    - WiFi 2.4 GHz b/g/n
    - 5x 1000Base-T Ethernet
    - 1x USB 2.0

    Installation of OpenWRT from vendor firmware:
    - Connect to the Web-interface at http://192.168.11.1
    - Go to “Administration” → “Firmware Upgrade”
    - Upload the OpenWrt factory image
