### PR TITLE
hostapd: Add density_level to config data rates

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -98,6 +98,7 @@ hostapd_common_add_device_config() {
 	config_add_int local_pwr_constraint
 	config_add_string require_mode
 	config_add_boolean legacy_rates
+	config_add_int density_level
 
 	config_add_string acs_chan_bias
 	config_add_array hostapd_options
@@ -113,7 +114,7 @@ hostapd_prepare_device_config() {
 	local base_cfg=
 
 	json_get_vars country country_ie beacon_int:100 dtim_period:2 doth require_mode legacy_rates \
-		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode
+		acs_chan_bias local_pwr_constraint spectrum_mgmt_required airtime_mode density_level
 
 	hostapd_set_log_options base_cfg
 
@@ -122,8 +123,7 @@ hostapd_prepare_device_config() {
 	set_default doth 1
 	set_default legacy_rates 1
 	set_default airtime_mode 0
-
-	[ "$hwmode" = "b" ] && legacy_rates=1
+	set_default density_level 0
 
 	[ -n "$country" ] && {
 		append base_cfg "country_code=$country" "$N"
@@ -144,16 +144,46 @@ hostapd_prepare_device_config() {
 	json_get_values rate_list supported_rates
 
 	[ -n "$hwmode" ] && append base_cfg "hw_mode=$hwmode" "$N"
-	[ "$legacy_rates" -eq 0 ] && set_default require_mode g
-
-	[ "$hwmode" = "g" ] && {
-		[ "$legacy_rates" -eq 0 ] && set_default rate_list "6000 9000 12000 18000 24000 36000 48000 54000"
-		[ -n "$require_mode" ] && set_default basic_rate_list "6000 12000 24000"
-	}
-
-	case "$require_mode" in
-		n) append base_cfg "require_ht=1" "$N";;
-		ac) append base_cfg "require_vht=1" "$N";;
+	if [ "$hwmode" = "b" ]; then
+		legacy_rates=1
+	else
+		[ -n "$require_mode" ] && legacy_rates=0
+		case "$require_mode" in
+			n) append base_cfg "require_ht=1" "$N";;
+			ac) append base_cfg "require_vht=1" "$N";;
+		esac
+	fi
+	
+	[ "$legacy_rates" -ne 0 -a "$density_level" -eq 3 ] && density_level=2
+	case "$density_level" in
+		1)
+			if [ "$legacy_rates" -eq 0 ]; then
+				set_default rate_list "6000 9000 12000 18000 24000 36000 48000 54000"
+				set_default basic_rate_list "6000 12000 24000"
+			else
+				set_default rate_list "5500 6000 9000 11000 12000 18000 24000 36000 48000 54000"
+				set_default basic_rate_list "5500 11000"
+			fi
+		;;
+		2)
+			if [ "$legacy_rates" -eq 0 ]; then
+				set_default rate_list "12000 18000 24000 36000 48000 54000"
+				set_default basic_rate_list "12000 24000"
+			else
+				set_default rate_list "11000 12000 18000 24000 36000 48000 54000"
+				set_default basic_rate_list "11000"
+			fi
+		;;
+		3)
+			set_default rate_list "24000 36000 48000 54000"
+			set_default basic_rate_list "24000"
+		;;
+		*)
+			if [ "$legacy_rates" -eq 0 ]; then
+				set_default rate_list "6000 9000 12000 18000 24000 36000 48000 54000"
+				set_default basic_rate_list "6000 12000 24000"
+			fi
+		;;
 	esac
 
 	for r in $rate_list; do


### PR DESCRIPTION
Add a density_level option to configure data rates appropriately for normal, high and very high density wireless deployments.

The purpose of using a higher minimum basic/mandatory data rate than 6 Mb/s, or 5.5 Mb/s (802.11b compatible), is in carefully designed high density environments to reduce management overheads where significant co-channel interference (CCI) exists and cannot be avoided.

Caution: Without careful design and validation, configuration of a too high minimum basic/mandatory data rate can sacrifice connection stability and disrupt the ability to reliably connect and authenticate for little to no capacity benefit. This is because this configuration affects the ability of clients to hear and demodulate management, control and broadcast/multicast data frames.

A majority of deployments are best suited to use 6, 12 and 24 Mb/s as basic/mandatory data rates for radios operating either at 2.4 GHz or 5 GHz.

For the majority of deployments, the minimum basic/mandatory data rate should not be configured above 12 Mb/s.

Only configure a 12 Mb/s, or 11 Mb/s (802.11b compatible), minimum basic/mandatory rate in high density deployments that have been designed and validated for this.

For the majority of deployments, a minimum basic/mandatory data rate above 12 Mb/s must not be used, these are 18 Mb/s or 24 Mb/s. Such a configuration is only appropriate for use in very high density deployment scenarios.

A density_level of Very High (3) must only be used where a deployment has a valid use case and has been designed specifically for this use, nearly always with highly directional antennas - an example would be stadium deployments. For example, with a 24 Mb/s OFDM minimum basic/mandatory data rate, approximately a -73 dBm RSSI is required to decode frames. Most clients will not have roamed elsewhere by the time that they experience -73 dBm and, where they do, they frequently may not hear and be able to demodulate beacon, control or broadcast/multicast data frames causing connectivity issues.

There is a myth that disabling lower basic/mandatory data rates will improve roaming and avoid sticky clients. For 802.11n, 802.11ac and 802.11ax clients this is not correct as clients will shift to and use lower MCS rates and not to the 802.11b or 802.11g/802.11a rates that are able to be used as basic/mandatory data rates.

There is a myth that disabling lower basic/mandatory data rates will ensure that clients only use higher data rates and that better performance is assured. For 802.11n, 802.11ac and 802.11ax clients this is not correct as clients will shift around and use MCS rates and not the 802.11b or 802.11g/802.11a rates that able to be used as basic/mandatory data rates.

Density Levels

0 - Disabled (Default)
Setting density_level to 0 disables the configuration of data rates. This is the default.

1 - Normal Density
Setting density_level to 1 configures the basic/mandatory rates to 6, 12 and 24 Mb/s OFDM rates where legacy_rates is 0. Supported rates lower than the minimum basic/mandatory rate are not offered.
Setting density_level to 1 configures the basic/mandatory rates to the 5.5 and 11 Mb/s DSSS rates where legacy_rates is 1. Supported rates lower than the minimum basic/mandatory rate are not offered.

2 - High Density
Setting the density_level to 2 configures the basic/mandatory rates to the 12 and 24 Mb/s OFDM rates where legacy_rates is 0. Supported rates lower than the minimum basic/mandatory rate are not offered.
Setting the density_level to 2 configures the basic/mandatory rates to the 11 Mb/s DSSS rate where legacy_rates is 1. Supported rates lower than the minimum basic/mandatory rate are not offered.

3 - Very High Density
Setting the density_level to 3 configures the basic/mandatory rates to the 24 Mb/s OFDM rate where legacy_rates is 0. Supported rates lower than the minimum basic/mandatory rate are not offered.
Setting the density_level to 3 only has effect where legacy_rates is 0, this has the same effect as being configured with a density_level of 2.

Where specified, the basic_rate and supported_rates options continue to override both density_level and legacy_rates.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>