### PR TITLE
brcm63xx: add USB status LED in 01_leds for ADP P.DG A4001N

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -29,7 +29,8 @@ adb,pdg-a4001n-a-000-1a1-ax)
 	ucidef_set_led_netdev "lan" "LAN" "green:internet" "eth0.1"
 	ucidef_set_led_netdev "wan" "WAN" "green:adsl" "eth0.2"
 	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
-	ucidef_set_led_usbdev "usb" "USB" "green:service" "1-1"
+	ucidef_set_led_usbdev "usb1" "USB1" "green:service" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "red:service" "2-1"
 	;;
 adb,av4202n)
 	ucidef_set_led_netdev "wlan0" "WLAN" "blue:wifi" "wlan0"


### PR DESCRIPTION
Add a status LED in 01_leds for USB 2-1 connected devices.

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>