### PR TITLE
build: allow names in PKG_FILE_MODES instead of numeric values

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -92,6 +92,7 @@ prepare-tmpinfo: FORCE
 	./scripts/package-metadata.pl mk tmp/.packageinfo > tmp/.packagedeps || { rm -f tmp/.packagedeps; false; }
 	./scripts/package-metadata.pl pkgaux tmp/.packageinfo > tmp/.packageauxvars || { rm -f tmp/.packageauxvars; false; }
 	touch $(TOPDIR)/tmp/.build
+	grep "Require-User" tmp/.packageinfo | cut -d ' ' -f 2- | grep "=" | sort -u > tmp/userids
 
 .config: ./scripts/config/conf $(if $(CONFIG_HAVE_DOT_CONFIG),,prepare-tmpinfo)
 	@+if [ \! -e .config ] || ! grep CONFIG_HAVE_DOT_CONFIG .config >/dev/null; then \

--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -68,6 +68,40 @@ pkg_appears_sane() {
 	return $PKG_ERROR
 }
 
+resolve_file_mode_id() {
+	type="$1"
+	name="$2"
+	position=1
+	if [ "$type" = "group" ]; then
+		position=2
+	fi
+
+	# root is always 0
+	if [ "$name" = "root" ]; then
+		echo 0
+		exit 0
+	fi
+
+	# return numeric names
+	if [ "$name" -eq "$name" 2>/dev/null ]; then
+		echo "$name"
+		exit 0
+	fi
+
+	ids=$(grep "$name" "$TOPDIR/tmp/userids")
+	for id in $ids; do
+		resolved_name=$(echo "$id" | cut -d ":" -f "$position" | cut -d "=" -f 1)
+		resolved_id=$(echo "$id" | cut -d ":" -f "$position" | cut -d "=" -f 2)
+		if [ "$resolved_name" = "$name" ]; then
+			echo "$resolved_id"
+			exit 0
+		fi
+	done
+
+	>&2 echo "No $type ID found for $name"
+	exit 1
+}
+
 ###
 # ipkg-build "main"
 ###
@@ -142,10 +176,14 @@ for file_mode in $file_modes; do
 	    ;;
 	esac
 	path=$(echo "$file_mode" | cut -d ':' -f 1)
-	user_group=$(echo "$file_mode" | cut -d ':' -f 2-3)
+	user=$(echo "$file_mode" | cut -d ':' -f 2)
+	group=$(echo "$file_mode" | cut -d ':' -f 3)
 	mode=$(echo "$file_mode" | cut -d ':' -f 4)
 
-	chown "$user_group" "$pkg_dir/$path"
+	uid=$(resolve_file_mode_id user "$user")
+	gid=$(resolve_file_mode_id group "$group")
+
+	chown "$uid:$gid" "$pkg_dir/$path"
 	chmod  "$mode" "$pkg_dir/$path"
 done
 $TAR -X $tmp_dir/tarX --format=gnu --sort=name -cpf - --mtime="$TIMESTAMP" . | $GZIP -n - > $tmp_dir/data.tar.gz


### PR DESCRIPTION
This should improve the usability/readability of patches like 
https://github.com/openwrt/packages/pull/13378 and https://github.com/openwrt/packages/pull/13377