### PR TITLE
kernel: add Aquantia AQtion USB-to-5GbE adapters

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1104,6 +1104,21 @@ define AddDepends/usb-net
 endef
 
 
+define KernelPackage/usb-net-aqc111
+  TITLE:=Support for USB-to-Ethernet Aquantia AQtion 5/2.5GbE
+  KCONFIG:=CONFIG_USB_NET_AQC111
+  FILES:=$(LINUX_DIR)/drivers/$(USBNET_DIR)/aqc111.ko
+  AUTOLOAD:=$(call AutoProbe,aqc111)
+  $(call AddDepends/usb-net)
+endef
+
+define KernelPackage/usb-net-aqc111/description
+ Support for USB-to-Ethernet Aquantia AQtion 5/2.5GbE
+endef
+
+$(eval $(call KernelPackage,usb-net-aqc111))
+
+
 define KernelPackage/usb-net-asix
   TITLE:=Kernel module for USB-to-Ethernet Asix convertors
   DEPENDS:=+kmod-libphy


### PR DESCRIPTION
This add support for USB-to-Ethernet Aquantia AQtion
5/2.5GbE adapters based on the AQC111U controllers.

Run-tested: x86
Adapter-tested: Sabrent NT-SS5G
