### PR TITLE
build: multiple improvements around mkhash

### DIFF
--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -218,8 +218,8 @@ $(_endef)
     ifneq ($$(CONFIG_IPK_FILES_CHECKSUMS),)
 	(cd $$(IDIR_$(1)); \
 		( \
-			find . -type f \! -path ./CONTROL/\* -exec sha256sum \{\} \; 2> /dev/null | \
-			sed 's|\([[:blank:]]\)\./|\1/|' > $$(IDIR_$(1))/CONTROL/files-sha256sum \
+			find . -type f \! -path ./CONTROL/\* -exec mkhash sha256 -n \{\} \; 2> /dev/null | \
+			sed 's|\([[:blank:]]\)\./| \1/|' > $$(IDIR_$(1))/CONTROL/files-sha256sum \
 		) || true \
 	)
     endif

--- a/scripts/mkhash.c
+++ b/scripts/mkhash.c
@@ -736,7 +736,10 @@ static int usage(const char *progname)
 {
 	int i;
 
-	fprintf(stderr, "Usage: %s <hash type> [<file>...]\n"
+	fprintf(stderr, "Usage: %s <hash type> [options] [<file>...]\n"
+		"Options:\n"
+		"	-n		Print filename(s)\n"
+		"\n"
 		"Supported hash types:", progname);
 
 	for (i = 0; i < ARRAY_SIZE(types); i++)

--- a/scripts/mkhash.c
+++ b/scripts/mkhash.c
@@ -823,8 +823,11 @@ int main(int argc, char **argv)
 	if (argc < 2)
 		return hash_file(t, NULL, add_filename);
 
-	for (i = 0; i < argc - 1; i++)
-		hash_file(t, argv[1 + i], add_filename);
+	for (i = 0; i < argc - 1; i++) {
+		int ret =  hash_file(t, argv[1 + i], add_filename);
+		if (ret)
+			return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
These patches where initially submitted via mailing list, however where separately updated which became hard to track.

This PR combines the patches:
9fc46f6d4e build: use mkhash for IPK metadata checksums
e54d6c1e47 scripts: mkhash fail on hashing a folder
4e7575346f scripts: mkhash fix return code handling
15082b2344 scripts: mkhash show -n option in usage
