### PR TITLE
base-files: sysfixtime: Fix time on the fake RTC

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -8,23 +8,33 @@ RTC_DEV=/dev/rtc0
 HWCLOCK=/sbin/hwclock
 
 boot() {
-	start && exit 0
-
-	local maxtime="$(maxtime)"
+	hwclock_load
+	local maxtime="$(find_max_time)"
 	local curtime="$(date +%s)"
-	[ $curtime -lt $maxtime ] && date -s @$maxtime
+	if [ $curtime -lt $maxtime ]; then
+		date -s @$maxtime
+		hwclock_save
+	fi
 }
 
 start() {
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -s -u -f $RTC_DEV
+	hwclock_load
 }
 
 stop() {
+	hwclock_save
+}
+
+hwclock_load() {
+	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -s -u -f $RTC_DEV
+}
+
+hwclock_save(){
 	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV && \
 		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
 }
 
-maxtime() {
+find_max_time() {
 	local file newest
 
 	for file in $( find /etc -type f ) ; do


### PR DESCRIPTION
On some devices the chip has RTC but no battery save time.
This leads back to getting the wrong time and skipping the check of the last file modification date.

This commit ensures that the file time is checked even if the RTC exists.
which would ordinarily return an approbiate system time used for e.g. certificate generation.