### PR TITLE
mvebu: image: add check for fdt_add_r and kernel_addr_r variables

### DIFF
--- a/target/linux/mvebu/image/generic-arm64.bootscript
+++ b/target/linux/mvebu/image/generic-arm64.bootscript
@@ -10,6 +10,14 @@ elif mmc dev 1; then
 	setenv mmcdev 1
 fi
 
+if test -n "${fdt_addr_r}"; then
+       setenv fdt_addr ${fdt_addr_r}
+fi
+
+if test -n "${kernel_addr_r}"; then
+       setenv kernel_addr ${kernel_addr_r}
+fi
+
 load mmc ${mmcdev}:1 ${fdt_addr} @DTB@.dtb
 load mmc ${mmcdev}:1 ${kernel_addr} Image
 


### PR DESCRIPTION
fdt_addr and kernel_addr variables are getting obsolete in the mainline
u-boot in favor of fdt_addr_r and kernel_addr_r.

By checking if the new variables exist, we can make sure that devices with newer
version of u-boot will work while not breaking support for the existing ones.