### PR TITLE
ipq40xx: Update 02_network for avm fritzrepeater-3000

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -59,7 +59,11 @@ ipq40xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
-	avm,fritzrepeater-3000|\
+	avm,fritzrepeater-3000)
+                ucidef_set_interface_lan "eth0 eth1"
+                ucidef_add_switch "switch0" \
+                        "0u@eth0" "4:lan" "5:lan"
+                ;;
 	compex,wpj419|\
 	compex,wpj428|\
 	engenius,eap2200)


### PR DESCRIPTION
Without the changes I always get the following error message under "Network->Switch":
"Switch switch0 has unknown topology - VLAN setings might not be accurate"

https://forum.openwrt.org/t/avm-fritz-repeater-1200-vlan-setup/57843/4

