### PR TITLE
build,ImageBuilder: use kmod archive

### DIFF
--- a/include/feeds.mk
+++ b/include/feeds.mk
@@ -36,6 +36,8 @@ define FeedSourcesAppend
   echo 'src/gz %d_core %U/targets/%S/packages'; \
   $(strip $(if $(CONFIG_PER_FEED_REPO), \
 	echo 'src/gz %d_base %U/packages/%A/base'; \
+	$(if $(filter %SNAPSHOT-y,$(VERSION_NUMBER)-$(CONFIG_BUILDBOT)), \
+		echo 'src/gz %d_kmods %U/targets/%S/kmods/$(LINUX_VERSION)-$(LINUX_RELEASE)-$(LINUX_VERMAGIC)';) \
 	$(foreach feed,$(FEEDS_AVAILABLE), \
 		$(if $(CONFIG_FEED_$(feed)), \
 			echo '$(if $(filter m,$(CONFIG_FEED_$(feed))),# )src/gz %d_$(feed) %U/packages/%A/$(feed)';)))) \

--- a/package/system/opkg/patches/0001-pkg_hash-don-t-suggest-incompatible-packages.patch
+++ b/package/system/opkg/patches/0001-pkg_hash-don-t-suggest-incompatible-packages.patch
@@ -1,0 +1,66 @@
+From aa9c5817b8fb470eb72f7c235237e010e7af8f66 Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Fri, 16 Oct 2020 09:56:31 -1000
+Subject: [PATCH] pkg_hash: don't suggest incompatible packages
+
+Up until now opkg would suggest packages with unsatisfied dependencies
+as installable candidates. This is a frequent issue for the kmod feed in
+snapshot images. In these cases opkg suggest a newer kmod version than
+compatible with the installed kernel, because the same package is
+available both in the kmods archive and the target specific packages
+feed.
+
+This commit fixes the issue by dropping all package candidates by
+checking if all their dependencies could be installed.
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ libopkg/pkg_hash.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/libopkg/pkg_hash.c b/libopkg/pkg_hash.c
+index 52c64ff..0d9b55b 100644
+--- a/libopkg/pkg_hash.c
++++ b/libopkg/pkg_hash.c
+@@ -20,6 +20,7 @@
+ #include "hash_table.h"
+ #include "pkg.h"
+ #include "opkg_message.h"
++#include "pkg_depends.h"
+ #include "pkg_vec.h"
+ #include "pkg_hash.h"
+ #include "parse_util.h"
+@@ -373,14 +374,27 @@ pkg_t *pkg_hash_fetch_best_installation_candidate(abstract_pkg_t * apkg,
+ 					 arch_priority, pkg_get_string(maybe, PKG_VERSION));
+ 				/* We make sure not to add the same package twice. Need to search for the reason why
+ 				   they show up twice sometimes. */
+-				if ((arch_priority > 0)
+-				    &&
+-				    (!pkg_vec_contains(matching_pkgs, maybe))) {
++				char **unresolved = NULL;
++				pkg_vec_t *depends = pkg_vec_alloc();
++				pkg_hash_fetch_unsatisfied_dependencies(maybe, depends,
++					&unresolved);
++
++				if (!unresolved &&
++						(arch_priority > 0) &&
++						(!pkg_vec_contains(matching_pkgs, maybe))) {
+ 					max_count++;
+ 					abstract_pkg_vec_insert(matching_apkgs,
+ 								maybe->parent);
+ 					pkg_vec_insert(matching_pkgs, maybe);
+ 				}
++
++				if (unresolved) {
++					char **tmp = unresolved;
++					while (*tmp)
++						free(*(tmp++));
++					free(unresolved);
++				}
++				pkg_vec_free(depends);
+ 			}
+ 
+ 			if (vec->len > 0 && matching_pkgs->len < 1)
+-- 
+2.25.1
+

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -38,23 +38,27 @@ $(BIN_DIR)/$(IB_NAME).tar.xz: clean
 ifeq ($(CONFIG_IB_STANDALONE),)
 	echo '## Remote package repositories' >> $(PKG_BUILD_DIR)/repositories.conf
 	$(call FeedSourcesAppend,$(PKG_BUILD_DIR)/repositories.conf)
+	$(VERSION_SED_SCRIPT) $(PKG_BUILD_DIR)/repositories.conf
 endif
 
+ifeq ($(CONFIG_BUILDBOT),)
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/packages
 	echo ''                                                        >> $(PKG_BUILD_DIR)/repositories.conf
 	echo '## This is the local package repository, do not remove!' >> $(PKG_BUILD_DIR)/repositories.conf
 	echo 'src imagebuilder file:packages'                          >> $(PKG_BUILD_DIR)/repositories.conf
 
-	$(VERSION_SED_SCRIPT) $(PKG_BUILD_DIR)/repositories.conf
-
-ifeq ($(CONFIG_IB_STANDALONE),)
-	(cd $(call FeedPackageDir,libc); $(FIND) -type f -name 'libc_*.ipk' -or -name 'kernel_*.ipk' -or -name 'kmod-*.ipk') | \
-		while read path; do \
-			mkdir -p "$(PKG_BUILD_DIR)/packages/$${path%/*}"; \
-			cp "$(call FeedPackageDir,libc)/$$path" "$(PKG_BUILD_DIR)/packages/$$path"; \
-		done
+  ifeq ($(CONFIG_IB_STANDALONE),)
+	$(FIND) $(call FeedPackageDir,libc) -type f \
+		\( -name 'libc_*.ipk' -or -name 'kernel_*.ipk' -or -name 'kmod-*.ipk' \) \
+		-exec $(CP) -t $(PKG_BUILD_DIR)/packages {} +
+  else
+	$(FIND) $(wildcard $(PACKAGE_SUBDIRS)) -type f -name '*.ipk' \
+		-exec $(CP) -t $(PKG_BUILD_DIR)/packages/ {} +
+  endif
 else
-	$(INSTALL_DIR) $(PKG_BUILD_DIR)/packages
-	find $(wildcard $(PACKAGE_SUBDIRS)) -type f -name '*.ipk' -exec $(CP) {} $(PKG_BUILD_DIR)/packages/ \;
+	$(FIND) $(call FeedPackageDir,libc) -type f \
+		\( -name 'libc_*.ipk' -or -name 'kernel_*.ipk' \) \
+		-exec $(CP) -t $(IB_LDIR)/ {} +
 endif
 
 	$(CP) $(TOPDIR)/target/linux $(PKG_BUILD_DIR)/target/

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -153,8 +153,8 @@ package_list: FORCE
 package_install: FORCE
 	@echo
 	@echo Installing packages...
-	$(OPKG) install $(firstword $(wildcard $(PACKAGE_DIR)/libc_*.ipk $(PACKAGE_DIR)/base/libc_*.ipk))
-	$(OPKG) install $(firstword $(wildcard $(PACKAGE_DIR)/kernel_*.ipk $(PACKAGE_DIR)/base/kernel_*.ipk))
+	$(OPKG) install $(firstword $(wildcard $(LINUX_DIR)/libc_*.ipk $(PACKAGE_DIR)/libc_*.ipk))
+	$(OPKG) install $(firstword $(wildcard $(LINUX_DIR)/kernel_*.ipk $(PACKAGE_DIR)/kernel_*.ipk))
 	$(OPKG) install $(BUILD_PACKAGES)
 
 prepare_rootfs: FORCE

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -138,7 +138,10 @@ package_index: FORCE
 	$(OPKG) update >&2 || true
 
 package_reload:
-	if [ ! -f "$(PACKAGE_DIR)/Packages" ] || [ ! -f "$(PACKAGE_DIR)/Packages.gz" ] || [ "`find $(PACKAGE_DIR) -cnewer $(PACKAGE_DIR)/Packages.gz`" ]; then \
+	if [ -d "$(PACKAGE_DIR)" ] && ( \
+			[ ! -f "$(PACKAGE_DIR)/Packages" ] || \
+			[ ! -f "$(PACKAGE_DIR)/Packages.gz" ] || \
+			[ "`find $(PACKAGE_DIR) -cnewer $(PACKAGE_DIR)/Packages.gz`" ] ); then \
 		echo "Package list missing or not up-to-date, generating it." >&2 ;\
 		$(MAKE) package_index; \
 	else \


### PR DESCRIPTION
Use kmod archive created by the Buildbots instead of storing them locally, this saves about 10MB per ImageBuilder.

The referenced step in `buildbot.git` should be removed.