### PR TITLE
ppp: Support pre-up and post-down

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -231,6 +231,8 @@ define Package/ppp/install
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-up $(1)/lib/netifd/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp6-up $(1)/lib/netifd/
 	$(INSTALL_BIN) ./files/lib/netifd/ppp-down $(1)/lib/netifd/
+	$(INSTALL_BIN) ./files/lib/netifd/ppp-pre-up $(1)/lib/netifd/
+	$(INSTALL_BIN) ./files/lib/netifd/ppp-post-down $(1)/lib/netifd/
 endef
 Package/ppp-multilink/install=$(Package/ppp/install)
 

--- a/package/network/services/ppp/files/lib/netifd/ppp-post-down
+++ b/package/network/services/ppp/files/lib/netifd/ppp-post-down
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[ -d /etc/ppp/ip-post-down.d ] && {
+	for SCRIPT in /etc/ppp/ip-post-down.d/*
+	do
+		[ -x "$SCRIPT" ] && "$SCRIPT" "$@"
+	done
+}

--- a/package/network/services/ppp/files/lib/netifd/ppp-pre-up
+++ b/package/network/services/ppp/files/lib/netifd/ppp-pre-up
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[ -d /etc/ppp/ip-pre-up.d ] && {
+	for SCRIPT in /etc/ppp/ip-pre-up.d/*
+	do
+		[ -x "$SCRIPT" ] && "$SCRIPT" "$@"
+	done
+}

--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -134,6 +134,8 @@ ppp_generic_setup() {
 	[ -n "$connect" ] || json_get_var connect connect
 	[ -n "$disconnect" ] || json_get_var disconnect disconnect
 
+	/lib/netifd/ppp-pre-up "$config"
+
 	proto_run_command "$config" /usr/sbin/pppd \
 		nodetach ipparam "$config" \
 		ifname "$pppname" \
@@ -182,6 +184,8 @@ ppp_generic_teardown() {
 	esac
 
 	proto_kill_command "$interface"
+
+	/lib/netifd/ppp-post-down "$interface"
 }
 
 # PPP on serial device


### PR DESCRIPTION
Run scripts from /etc/ppp/ip-pre-up.d when starting initiating the
connection, and ones from /etc/ppp/ip-post-down.d after finally
terminating it, i.e. not after temporary network failures that lead to
disconnects, but when the interface is finally brought down.

One of the use cases is scripting a two-colored LED to blink orange when
the connection is being initiated (or being restored after an
intermittent failure) and turn white when the connection is active. A
pre-up hook is needed to set the orange LED to blink, and a post-down
hook is needed to distinguish a final connection teardown from an
intermittent failure.