### PR TITLE
lantiq: add SPDX identifier

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_allnet_all0333cj.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_allnet_all0333cj.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "amazonse.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_netgear_dgn1000b.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_netgear_dgn1000b.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "amazonse.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9_netgear_dgn3500.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500b.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500b.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9_netgear_dgn3500.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "ar9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4510pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4510pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube_arcadyan_arv4518pwr01.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4518pwr01a.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube_arcadyan_arv4518pwr01.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4519pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4519pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4520pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4520pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4525pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv4525pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7506pw11.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7506pw11.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7510pw22.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7518pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv8539pw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv8539pw22.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_audiocodes_mp-252.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_audiocodes_mp-252.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_bt_homehub-v2b.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_bt_homehub-v2b.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_lantiq_easy50712.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_lantiq_easy50712.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "danube.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy88388.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy88388.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy88444.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy88444.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-nand.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-nand.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon_lantiq_easy98000.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-nor.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-nor.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon_lantiq_easy98000.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-sflash.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000-sflash.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon_lantiq_easy98000.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98000.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 
 #include <dt-bindings/interrupt-controller/irq.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98020-v18.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98020-v18.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98020.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98020.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98021.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98021.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98035synce.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98035synce.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98035synce1588.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98035synce1588.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_falcon-mdu.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_falcon-mdu.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_falcon-sfp.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_falcon-sfp.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "falcon.dtsi"
 #include "falcon_sflash-16m.dtsi"
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_sflash-16m.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_sflash-16m.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 &ebu_cs0 {
 	#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
 #include <dt-bindings/gpio/gpio.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vg3503j.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vg3503j.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22-brn.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22-brn.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_arcadyan_vgv7510kw22.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22-nor.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22-nor.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_arcadyan_vgv7510kw22.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519-brn.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519-brn.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_arcadyan_vgv7519.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519-nor.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519-nor.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_arcadyan_vgv7519.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-hynix.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-hynix.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_avm_fritz3370-rev2.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-micron.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_avm_fritz3370-rev2.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nand.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nand.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_lantiq_easy80920.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nor.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nor.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_lantiq_easy80920.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8970.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8970.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_tplink_tdw89x0.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8980.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw8980.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_tplink_tdw89x0.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_tplink_vr200.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200v.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200v.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_tplink_vr200.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_zyxel_p-2812hnu-fx.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f3.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f3.dts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9_zyxel_p-2812hnu-fx.dtsi"
 
 / {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 #include "vr9.dtsi"
 
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
Fixes some warnings found by checkpatch.pl:
- missing SPDX license identifier,
~~- trailing whitespaces.~~

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>