### PR TITLE
ath79: add support for TP-Link TL-WPA8630P (EU) v2.1

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.1-eu.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630p-v2.1-eu.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "qca9563_tplink_tl-wpa8630.dtsi"
+
+/ {
+	compatible = "tplink,tl-wpa8630p-v2.1-eu", "qca,qca9563";
+	model = "TP-Link WPA8630P v2.1 (EU)";
+
+	aliases {
+		label-mac-device = &eth0;
+	};
+};
+
+&partitions {
+	partition@0 {
+		label = "factory-uboot";
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	partition@20000 {
+		label = "u-boot";
+		reg = <0x020000 0x020000>;
+		read-only;
+	};
+
+	partition@40000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x040000 0x5e0000>;
+	};
+
+	partition@680000 {
+		label = "tplink";
+		reg = <0x680000 0x170000>;
+		read-only;
+	};
+
+	partition@6a0000 {
+		label = "partition-table";
+		reg = <0x6a0000 0x010000>;
+		read-only;
+	};
+
+	info: partition@7e0000 {
+		label = "info";
+		reg = <0x7e0000 0x010000>;
+		read-only;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&info 0x8>;
+};
+
+&wmac {
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -316,7 +316,8 @@ tplink,tl-mr6400-v1)
 	;;
 tplink,tl-wpa8630-v1|\
 tplink,tl-wpa8630p-v2-eu|\
-tplink,tl-wpa8630p-v2-int)
+tplink,tl-wpa8630p-v2-int|\
+tplink,tl-wpa8630p-v2.1-eu)
 	ucidef_set_led_switch "lan" "LAN" "tp-link:green:lan" "switch0" "0x3c"
 	;;
 tplink,tl-wr842n-v2)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -198,7 +198,8 @@ case "$FIRMWARE" in
 		;;
 	tplink,eap225-wall-v2|\
 	tplink,tl-wpa8630p-v2-eu|\
-	tplink,tl-wpa8630p-v2-int)
+	tplink,tl-wpa8630p-v2-int|\
+	tplink,tl-wpa8630p-v2.1-eu)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -564,6 +564,13 @@ define Device/tplink_tl-wpa8630p-v2-int
 endef
 TARGET_DEVICES += tplink_tl-wpa8630p-v2-int
 
+define Device/tplink_tl-wpa8630p-v2.1-eu
+  $(Device/tplink_tl-wpa8630p-v2)
+  DEVICE_VARIANT := v2.1 (EU)
+  TPLINK_BOARD_ID := TL-WPA8630P-V2.1-EU
+endef
+TARGET_DEVICES += tplink_tl-wpa8630p-v2.1-eu
+
 define Device/tplink_tl-wr1043nd-v1
   $(Device/tplink-8m)
   SOC := ar9132

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1513,6 +1513,41 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the TL-WPA8630P v2.1 (EU)*/
+	{
+		.id     = "TL-WPA8630P-V2.1-EU",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WPA8630P,product_ver:2.1.0,special_id:45550000}\n",
+		.support_trail = '\x00',
+		.soft_ver = NULL,
+
+		.partitions = {
+			{"factory-uboot", 0x00000, 0x20000},
+			{"fs-uboot", 0x20000, 0x20000},
+			{"firmware", 0x40000, 0x5e0000},
+			{"extra-para", 0x680000, 0x01000},
+			{"product-info", 0x690000, 0x01000},
+			{"partition-table", 0x6a0000, 0x02000},
+			{"soft-version", 0x6b0000, 0x01000},
+			{"support-list", 0x6b1000, 0x01000},
+			{"profile", 0x6b2000, 0x08000},
+			{"user-config", 0x6c0000, 0x10000},
+			{"default-config", 0x6d0000, 0x10000},
+			{"default-nvm", 0x6e0000, 0xc0000},
+			{"default-pib", 0x7a0000, 0x40000},
+			{"default-mac", 0x7e0000, 0x00020},
+			{"pin", 0x7e0100, 0x00020},
+			{"device-id", 0x7e0200, 0x00030},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the TL-WR1043 v5 */
 	{
 		.id     = "TLWR1043NV5",


### PR DESCRIPTION
The only unique aspect for the firmware compared to v2 layout is the
partition layout. Support for the (AU) v2.1 model was already added in
ab74def ("ath79: add support for TP-Link TL-WPA8630P v2").

---------------------

So far the only released firmware (and partition layout) for this model is `wpa8630pv2_uk-up-ver2-1-0-P1-20171117-rel42724-APPLC.bin` from https://www.tp-link.com/en/support/download/tl-wpa8630p/v2.1/#Firmware , so it is safe for users to upgrade like the other supported models.