### PR TITLE
mac80211: set default SSID based on base band

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -79,6 +79,7 @@ detect_mac80211() {
 		channel="11"
 		htmode=""
 		ht_capab=""
+		ssid="OpenWrt"
 
 		iw phy "$dev" info | grep -q 'Capabilities:' && htmode=HT20
 
@@ -86,6 +87,7 @@ detect_mac80211() {
 			mode_band="a"
 			channel="36"
 			iw phy "$dev" info | grep -q 'VHT Capabilities' && htmode="VHT80"
+			ssid="Op5nWrt"
 		}
 
 		[ -n "$htmode" ] && ht_capab="set wireless.radio${devidx}.htmode=$htmode"
@@ -110,7 +112,7 @@ detect_mac80211() {
 			set wireless.default_radio${devidx}.device=radio${devidx}
 			set wireless.default_radio${devidx}.network=lan
 			set wireless.default_radio${devidx}.mode=ap
-			set wireless.default_radio${devidx}.ssid=OpenWrt
+			set wireless.default_radio${devidx}.ssid=${ssid}
 			set wireless.default_radio${devidx}.encryption=none
 EOF
 		uci -q commit wireless


### PR DESCRIPTION
A quality of life change, because it is annoying to edit SSID
when one is testing wireless for every image.

Signed-off-by: Michael Pratt <mpratt51@gmail.com>