### PR TITLE
ath79: add support for Senao Engenius ECB600

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -27,6 +27,7 @@ engenius,eap300-v2|\
 engenius,ecb1200|\
 engenius,ecb1750|\
 engenius,ecb350-v1|\
+engenius,ecb600|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\
 engenius,enstationac-v1|\

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "EnGenius ECB600";
+	compatible = "engenius,ecb600", "qca,ar9344";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi5g {
+			label = "blue:wifi5g";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x050000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0x0a0000 0x010000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0x0b0000 0x170000>;
+			};
+
+			partition@220000 {
+				label = "fakeroot";
+				reg = <0x220000 0x010000>;
+				read-only;
+			};
+
+			firmware1: partition@230000 {
+				label = "firmware1";
+				reg = <0x230000 0xbc0000>;
+			};
+
+			partition@df0000 {
+				label = "failsafe";
+				reg = <0xdf0000 0x200000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0 0 0 0 0>;
+		qca,no-eeprom;
+		qca,disable-5ghz;
+		mtd-mac-address = <&art 0x0>;
+		mtd-mac-address-increment = <(-2)>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,disable-2ghz;
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <(-1)>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ath79_setup_interfaces()
 	engenius,ecb1200|\
 	engenius,ecb1750|\
 	engenius,ecb350-v1|\
+	engenius,ecb600|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -88,10 +88,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_mac $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1)
 		;;
-	enterasys,ws-ap3705i)
-		caldata_extract "calibrate" 0x5000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR0)
-		;;
+	engenius,ecb600|\
 	mercury,mw4530r-v1|\
 	ocedo,raccoon|\
 	tplink,tl-wdr3500-v1|\
@@ -103,6 +100,10 @@ case "$FIRMWARE" in
 	ubnt,unifi-ap-pro|\
 	winchannel,wb2000)
 		caldata_extract "art" 0x5000 0x440
+		;;
+	enterasys,ws-ap3705i)
+		caldata_extract "calibrate" 0x5000 0x440
+		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR0)
 		;;
 	netgear,wnr2200-8m|\
 	netgear,wnr2200-16m|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1002,6 +1002,16 @@ define Device/engenius_ecb350-v1
 endef
 TARGET_DEVICES += engenius_ecb350-v1
 
+define Device/engenius_ecb600
+  $(Device/engenius_loader_okli)
+  SOC := ar9344
+  DEVICE_MODEL := ECB600
+  IMAGE_SIZE := 12032k
+  LOADER_FLASH_OFFS := 0x230000
+  ENGENIUS_IMGNAME := senao-ecb600
+endef
+TARGET_DEVICES += engenius_ecb600
+
 define Device/engenius_enh202-v1
   $(Device/engenius_loader_okli)
   SOC := ar7240


### PR DESCRIPTION
FCC ID: A8J-ECB600

Engenius ECB600 is a wireless access point with 1 gigabit ethernet port,
dual-band wireless, external ethernet switch, and 4 external antennas.

Specification:

  - AR9344 SOC			(5 GHz, 2x2, WMAC)
  - AR9382 WLAN			(2.4 GHz, 2x2, PCIe on-board)
  - 40 MHz reference clock
  - 16 MB FLASH			MX25L12845EMI-10G
  - 2x 64 MB RAM		NT5TU32M16DG
  - UART at H1			(populated)
  - GbE port			(Atheros AR8035-A switch)
  - 4 LEDs, 1 button		(power, eth, 2.4 GHz, 5 GHz) (reset)
  - 4 external antennas

MAC addresses:

  MAC 1	  *:52   ???
  MAC 2	  *:53   ???
  -----	  *:54   art 0x0

  The MAC address in flash is not the one on the label

  Even though only 1 MAC representing the vendor is found on flash
  The OEM software reports these MACs for the rest of the ifconfig.

Installation:

  2 ways to flash factory.bin from OEM:

  - if you get Failsafe Mode from failed flash:
      only use it to flash Original firmware from Engenius
      or risk kernel loop or halt which requires serial cable

  Method 1: Firmware upgrade page:

    OEM webpage at 192.168.1.1
    username and password "admin"
    Navigate to "Upgrade Firmware" page from left pane
    Click Browse and select the factory.bin image
    Upload and verify checksum
    Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

    After connecting to serial console and rebooting...
    Interrupt uboot with any key pressed rapidly
    execute `run failsafe_boot` OR `bootm 0x9fdf0000`
    wait a minute
    connect to ethernet and navigate to
    "192.168.1.1/index.htm"
    Select the factory.bin image and upload
    wait about 3 minutes

Return to OEM:

  If you have a serial cable, see Serial Failsafe instructions

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will not work
  DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

  The easiest way to return to the OEM software is the Failsafe image
  If you dont have a serial cable, you can ssh into openwrt and run

  `mtd -r erase fakeroot`

  Wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

Format of OEM firmware image:

  The OEM software of ECB600 is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names...

    openwrt-senao-ecb600-uImage-lzma.bin
    openwrt-senao-ecb600-root.squashfs

  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  The OEM upgrade script is at /etc/fwupgrade.sh

  Later models in the ECB series likely have a different platform
  and the upgrade and image verification process differs.

  OKLI kernel loader is required because the OEM software
  expects the kernel to be no greater than 1536k
  and the factory.bin upgrade procedure would
  overwrite part of the kernel when writing rootfs.

Note on PLL-data cells:

  The default PLL register values will not work
  because of the external AR8035-A switch between
  the SOC and the ethernet PHY chips.

  For AR934x series, the PLL register for GMAC0
  can be seen in the DTSI as 0x2c.
  Therefore the PLL register can be read from uboot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x1805002c 1`.

  Unfortunately uboot did not have the best values
  so they were taken from other similar DTS files.

Tested from master, all link speeds functional

Signed-off-by: Michael Pratt <mpratt51@gmail.com>