### PR TITLE
mac80211: select the first available channel for 5GHz interfaces

### DIFF
--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -82,9 +82,9 @@ detect_mac80211() {
 
 		iw phy "$dev" info | grep -q 'Capabilities:' && htmode=HT20
 
-		iw phy "$dev" info | grep -q '5180 MHz' && {
+		iw phy "$dev" info | grep -q '\* 5... MHz \[' && {
 			mode_band="a"
-			channel="36"
+			channel=$(iw phy "$dev" info | grep '\* 5... MHz \[' | grep '(disabled)' -v -m 1 | sed 's/[^[]*\[\|\].*//g')
 			iw phy "$dev" info | grep -q 'VHT Capabilities' && htmode="VHT80"
 		}
 


### PR DESCRIPTION
Some 5GHz wifi interfaces, especially in Tri-band routers, can't use
channel 36. In these cases, the default configuration for 5GHz
interfaces, once enabled, doesn't work.

This patch selects the first non-disabled channel for 5GHz interfaces.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>