### PR TITLE
ramips: mt7621: Add support for Beeline SmartBox TURBO+

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -25,6 +25,15 @@ allnet,all0256n-8m|\
 allnet,all5002)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;
+beeline,smartbox-turbo-plus|\
+linksys,ea7300-v1|\
+linksys,ea7500-v2|\
+xiaomi,mi-router-ac2100|\
+xiaomi,mir3p|\
+xiaomi,mir3g|\
+xiaomi,redmi-router-ac2100)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\
@@ -38,14 +47,6 @@ ravpower,rp-wd03)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
-	;;
-linksys,ea7300-v1|\
-linksys,ea7500-v2|\
-xiaomi,mi-router-ac2100|\
-xiaomi,mir3p|\
-xiaomi,mir3g|\
-xiaomi,redmi-router-ac2100)
-	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 esac
 

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "beeline,smartbox-turbo-plus", "mediatek,mt7621-soc";
+	model = "Beeline SmartBox TURBO+";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+			label = "smartbox-turbo-plus:blue:status";
+		};
+
+		led_status_green: status_green {
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			label = "smartbox-turbo-plus:green:status";
+		};
+
+		led_status_red: status_red {
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			label = "smartbox-turbo-plus:red:status";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x40000>;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "crash";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "crash_syslog";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* uboot expects to find kernels at 0x200000 & 0x600000
+		 * referred to as system 1 & system 2 respectively.
+		 * a kernel is considered suitable for handing control over
+		 * if its linux magic number exists & uImage CRC are correct.
+		 * If either of those conditions fail, a matching sys'n'_fail flag
+		 * is set in uboot env & a restart performed in the hope that the
+		 * alternate kernel is okay.
+		 * if neither kernel checksums ok and both are marked failed, system 2
+		 * is booted anyway.
+		 *
+		 * Note uboot's tftp flash install writes the transferred
+		 * image to both kernel partitions.
+		 */
+
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		/* ubi partition is the result of squashing
+		 * next consecutive stock partitions:
+		 * - rootfs0 (rootfs partition for stock kernel0),
+		 * - rootfs1 (rootfs partition for stock failsafe kernel1),
+		 * - overlay (used as ubi overlay in stock fw)
+		 * resulting 117,5MiB space for packages.
+		 */
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0x7580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7615";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0x4>;
+			mtd-mac-address-increment = <1>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -202,6 +202,25 @@ define Device/asus_rt-ac85p
 endef
 TARGET_DEVICES += asus_rt-ac85p
 
+define Device/beeline_smartbox-turbo-plus
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 124416k
+  UBINIZE_OPTS := -E 5
+  IMAGES += kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Beeline
+  DEVICE_MODEL := SmartBox TURBO+
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware kmod-usb3 \
+	kmod-usb-ledtrig-usbport uboot-envtools
+endef
+TARGET_DEVICES += beeline_smartbox-turbo-plus
+
 define Device/buffalo_wsr-1166dhp
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -45,6 +45,7 @@ platform_do_upgrade() {
 	case "$board" in
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
+	beeline,smartbox-turbo-plus|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2660-a1|\
 	hiwifi,hc5962|\


### PR DESCRIPTION
Specification
=============
Power: 12 VDC, 1.5 A
Connector type: barrel
CPU1: MediaTek MT7621A (880 MHz, 4 cores)
FLA1: 128 MiB (Macronix MX30LF1G18AC-TI)
RAM1: 128 MiB (Nanya NT5CC64M16GP-DI)
WI1 chip1: MediaTek MT7603EN
WI1 802dot11 protocols: bgn
WI1 MIMO config: 2x2:2
WI1 antenna connector: MHF
WI2 chip1: MediaTek MT7615N
WI2 802dot11 protocols: an+ac
WI2 MIMO config: 4x4:4
WI2 antenna connector: MHF
ETH chip1: MediaTek MT7621A
Switch: MediaTek MT7621A
Buttons: Reset, WPS
USB ports: USB 3.0
LEDs: 2 RGB
Zigbee 3.0 chip

UART Serial, J4
[o] GND
[o] TX
[ ] VCC - Do not connect it
[o] RX
R53, R54 are absent. Install jumpers.

Flash instruction
=================

This router is supplied by the Beeline service provider only in Russia. Up-to-date installation manual and posted on the permanent link https://telegra.ph/OpenWrt-for-Beeline-SmartBox-TURBO-08-26 in the language of the country of sale and operation of the equipment

Signed-off-by: Andrew Freeman <labz56@gmail.com>
