### PR TITLE
[WIP] treewide: prepare to drop deprecated LED label property

### DIFF
--- a/package/base-files/files/lib/functions/leds.sh
+++ b/package/base-files/files/lib/functions/leds.sh
@@ -12,6 +12,18 @@ get_dt_led_path() {
 	echo "$ledpath"
 }
 
+get_dt_led_name() {
+	local dtname=$(basename "$1")
+	local dtparent=$(basename $(dirname $1))
+	local ledpath
+	local ledname
+
+	[ -n "$dtname" ] && ledpath=$(grep -rl '^OF_NAME='$dtname'$' /sys/devices/platform/$dtparent/leds/*/uevent)
+	[ -n "$ledpath" ] && ledname=$(echo $ledpath | sed 's#.*/\([^/]*\)/uevent#\1#')
+
+	[ -n "$ledname" ] && echo "$ledname" || echo "$dtname"
+}
+
 get_dt_led() {
 	local label
 	local ledpath=$(get_dt_led_path $1)
@@ -19,7 +31,7 @@ get_dt_led() {
 	[ -n "$ledpath" ] && \
 		label=$(cat "$ledpath/label" 2>/dev/null) || \
 		label=$(cat "$ledpath/chan-name" 2>/dev/null) || \
-		label=$(basename "$ledpath")
+		label=$(get_dt_led_name "$ledpath")
 
 	echo "$label"
 }

--- a/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 #include "ar9344.dtsi"
 

--- a/target/linux/ath79/dts/ar9344_tplink_cpe610-v1.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe610-v1.dts
@@ -17,7 +17,8 @@
 		compatible = "gpio-leds";
 
 		led_lan: lan {
-			label = "tp-link:green:lan";
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 

--- a/target/linux/ath79/dts/ar9344_tplink_cpe610-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe610-v2.dts
@@ -17,7 +17,8 @@
 		compatible = "gpio-leds";
 
 		led_lan: lan {
-			label = "tp-link:green:lan";
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 

--- a/target/linux/ath79/dts/ar9344_tplink_cpe_1port.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe_1port.dtsi
@@ -14,27 +14,36 @@
 		compatible = "gpio-leds";
 
 		lan {
-			label = "tp-link:green:lan";
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
 		link1 {
-			label = "tp-link:green:link1";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		link2 {
-			label = "tp-link:green:link2";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		link3 {
-			label = "tp-link:green:link3";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		led_system: link4 {
-			label = "tp-link:green:link4";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
@@ -14,32 +14,44 @@
 		compatible = "gpio-leds";
 
 		lan0 {
-			label = "tp-link:green:lan0";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
 		lan1 {
-			label = "tp-link:green:lan1";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 
 		link1 {
-			label = "tp-link:green:link1";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		link2 {
-			label = "tp-link:green:link2";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		link3 {
-			label = "tp-link:green:link3";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		led_link4: link4 {
-			label = "tp-link:green:link4";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdr4300.dtsi
@@ -38,14 +38,18 @@
 
 &leds {
 	usb1 {
-		label = "tp-link:green:usb1";
+		function = LED_FUNCTION_USB;
+		function-enumerator = <1>;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&hub_port1>;
 		linux,default-trigger = "usbport";
 	};
 
 	usb2 {
-		label = "tp-link:green:usb2";
+		function = LED_FUNCTION_USB;
+		function-enumerator = <2>;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&hub_port2>;
 		linux,default-trigger = "usbport";

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 #include "ar9344.dtsi"
 
@@ -23,13 +24,15 @@
 		};
 
 		led_system: system {
-			label = "tp-link:green:system";
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		qss {
-			label = "tp-link:green:qss";
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe210.dtsi
@@ -4,7 +4,8 @@
 
 &leds {
 	lan {
-		label = "tp-link:green:lan";
+		function = LED_FUNCTION_LAN;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/ath79/dts/qca9533_tplink_cpe220-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_cpe220-v3.dts
@@ -10,12 +10,16 @@
 
 &leds {
 	lan0 {
-		label = "tp-link:green:lan0";
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <0>;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 	};
 
 	lan1 {
-		label = "tp-link:green:lan1";
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <1>;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 #include "qca953x.dtsi"
 
@@ -18,22 +19,30 @@
 		compatible = "gpio-leds";
 
 		link1 {
-			label = "tp-link:green:link1";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
 		link2 {
-			label = "tp-link:green:link2";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		link3 {
-			label = "tp-link:green:link3";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		led_link4: link4 {
-			label = "tp-link:green:link4";
+			function = LED_FUNCTION_RSSI;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n.dtsi
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 #include "qca956x.dtsi"
 
@@ -18,7 +19,8 @@
 		compatible = "gpio-leds";
 
 		led_system: system {
-			label = "tp-link:green:system";
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "heartbeat";
 		};
@@ -30,37 +32,48 @@
 		};
 
 		wifi_wps {
-			label = "tp-link:green:wps";
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
 		};
 
 		wan {
-			label = "tp-link:green:wan";
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_fail {
-			label = "tp-link:orange:wan";
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
 		lan1 {
-			label = "tp-link:green:lan1";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
 		};
 
 		lan2 {
-			label = "tp-link:green:lan2";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
 		lan3 {
-			label = "tp-link:green:lan3";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 		};
 
 		lan4 {
-			label = "tp-link:green:lan4";
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -81,7 +81,8 @@
 
 &leds {
 	usb {
-		label = "tp-link:green:usb";
+		function = LED_FUNCTION_USB;
+		color = <LED_COLOR_ID_GREEN>;
 		gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 		trigger-sources = <&hub_port0>;
 		linux,default-trigger = "usbport";

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -370,6 +370,10 @@ zbtlink,zbt-wd323)
 	ucidef_set_led_switch "lan1" "LAN1" "zbt-wd323:orange:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "zbt-wd323:orange:lan2" "switch0" "0x08"
 	;;
+# for testing only
+tplink,tl-wdr4300-v1)
+	ucidef_set_led_netdev "wan" "WAN" "green:wps" "eth0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/generic/backport-5.4/101-dt-bindings-leds-add-LED_FUNCTION-for-wlan2g-wlan.patch
+++ b/target/linux/generic/backport-5.4/101-dt-bindings-leds-add-LED_FUNCTION-for-wlan2g-wlan.patch
@@ -1,0 +1,31 @@
+From bc2745ac8927ab3694781285831afbe5349f270f Mon Sep 17 00:00:00 2001
+From: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+Date: Sat, 19 Sep 2020 19:05:51 +0200
+Subject: [PATCH v2 1/2] dt-bindings: leds: add LED_FUNCTION for wlan2g/wlan5g
+
+Many consumer "routers" have dedicated LEDs for specific WiFi bands,
+e.g. one for 2.4 GHz and one for 5 GHz. These LEDs specifically
+indicate the state of the relevant band, so the latter should be
+included in the function name. LED_FUNCTION_WLAN will remain for
+general cases or when the LED is used for more than one band.
+
+This essentially is equivalent to how we use LED_FUNCTION_LAN and
+LED_FUNCTION_WAN instead of just having LED_FUNCTION_ETHERNET.
+
+Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+
+---
+ include/dt-bindings/leds/common.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -70,6 +70,8 @@
+ #define LED_FUNCTION_USB "usb"
+ #define LED_FUNCTION_WAN "wan"
+ #define LED_FUNCTION_WLAN "wlan"
++#define LED_FUNCTION_WLAN2G "wlan2g"
++#define LED_FUNCTION_WLAN5G "wlan5g"
+ #define LED_FUNCTION_WPS "wps"
+ 
+ #endif /* __DT_BINDINGS_LEDS_H */

--- a/target/linux/generic/backport-5.4/102-dt-bindings-leds-add-LED_FUNCTION_RSSI.patch
+++ b/target/linux/generic/backport-5.4/102-dt-bindings-leds-add-LED_FUNCTION_RSSI.patch
@@ -1,0 +1,28 @@
+From 332e26c4b5edf64d897329ed0b994e7378eab4ad Mon Sep 17 00:00:00 2001
+From: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+Date: Sat, 19 Sep 2020 19:10:54 +0200
+Subject: [PATCH v2 2/2] dt-bindings: leds: add LED_FUNCTION_RSSI
+
+Several consumer "routers" and CPE devices have dedicated LEDs to
+show the received signal strength indicator (RSSI). This is
+different from the "WLAN" LEDs that just show enabled/disabled
+state and sometimes rx/tx activity.
+
+Add a LED function for these LEDs.
+
+Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+
+---
+ include/dt-bindings/leds/common.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/dt-bindings/leds/common.h
++++ b/include/dt-bindings/leds/common.h
+@@ -60,6 +60,7 @@
+ #define LED_FUNCTION_PANIC "panic"
+ #define LED_FUNCTION_PROGRAMMING "programming"
+ #define LED_FUNCTION_POWER "power"
++#define LED_FUNCTION_RSSI "rssi"
+ #define LED_FUNCTION_RX "rx"
+ #define LED_FUNCTION_SD "sd"
+ #define LED_FUNCTION_SCROLLLOCK "scrolllock"


### PR DESCRIPTION
This PR is in very early WIP state, and I'm actually just posting it here to collect the discussion on it in a common place.

The choice of "migrated" devices is mainly based on what seems helpful for illustration and test.

Currently, status LEDs via aliases are broken, and much else probably is as well.

The kernel patches have been submitted upstream.

Don't worry: This is a project for after the 20.xx branch (we should also have dropped kernel 4.19 by then).