### PR TITLE
ath79: add support for Senao Engenius EAP350 v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -24,6 +24,7 @@ arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,eap300-v2|\
+engenius,eap350-v1|\
 engenius,ecb1200|\
 engenius,ecb1750|\
 engenius,ecb350-v1|\

--- a/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7242.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,eap350-v1", "qca,ar7242";
+	model = "EnGenius EAP350 v1";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "blue:wlan";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x50000 0x50000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0xa0000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0xb0000 0xf0000>;
+			};
+
+			partition@1a0000 {
+				label = "fakeroot";
+				reg = <0x1a0000 0x10000>;
+				read-only;
+			};
+
+			firmware1: partition@1b0000 {
+				label = "firmware1";
+				reg = <0x1b0000 0x4c0000>;
+			};
+
+			partition@670000 {
+				label = "failsafe";
+				reg = <0x670000 0x180000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy4>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0 0 0 0 0>;
+		mtd-mac-address = <&art 0x0>;
+		mtd-mac-address-increment = <1>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -29,6 +29,7 @@ ath79_setup_interfaces()
 	dlink,dap-1365-a1|\
 	dlink,dir-505|\
 	engenius,eap300-v2|\
+	engenius,eap350-v1|\
 	engenius,ecb1200|\
 	engenius,ecb1750|\
 	engenius,ecb350-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -75,6 +75,7 @@ case "$FIRMWARE" in
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
 	buffalo,wzr-hp-g302h-a1a0|\
+	engenius,eap350-v1|\
 	engenius,ecb350-v1|\
 	engenius,enh202-v1)
 		caldata_extract "art" 0x1000 0xeb8

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -965,6 +965,17 @@ define Device/engenius_eap300-v2
 endef
 TARGET_DEVICES += engenius_eap300-v2
 
+define Device/engenius_eap350-v1
+  $(Device/engenius_loader_okli)
+  SOC := ar7242
+  DEVICE_MODEL := EAP350
+  DEVICE_VARIANT := v1
+  IMAGE_SIZE := 4864k
+  LOADER_FLASH_OFFS := 0x1b0000
+  ENGENIUS_IMGNAME := senao-eap350
+endef
+TARGET_DEVICES += engenius_eap350-v1
+
 define Device/engenius_ecb1200
   SOC := qca9557
   DEVICE_VENDOR := EnGenius


### PR DESCRIPTION
FCC ID: U2M-EAP350

Engenius EAP350 is a wireless access point with 1 gigabit ethernet port with POE,
2.4 GHz wireless, external ethernet switch, and 2 internal antennas.

Specification:

  - AR7242 SOC
  - AR9283 WLAN			(2.4 GHz, 2x2, PCIe on-board)
  - 40 MHz reference clock
  - 8 MB FLASH			MX25L6406E
  - 32 MB RAM			EM6AA160TSA-5G
  - UART at J2			(populated)
  - GbE port			(Atheros AR8035-A switch)
  - 3 LEDs, 1 button		(power, eth, 2.4 GHz) (reset)
  - 2 internal antennas

MAC addresses:

  MAC	  *:0c   art 0x0	(eth)
  ---	  *:0d   ???		(2.4 GHz)

  Only 1 MAC address on label and flash

Installation:

  2 ways to flash factory.bin from OEM:

  - if you get Failsafe Mode from failed flash:
      only use it to flash Original firmware from Engenius
      or risk kernel loop or halt which requires serial cable

  Method 1: Firmware upgrade page:

    OEM webpage at 192.168.10.1
    username and password "admin"
    Navigate to "Upgrade Firmware" page from left pane
    Click Browse and select the factory.bin image
    Upload and verify checksum
    Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

    After connecting to serial console and rebooting...
    Interrupt uboot with any key pressed rapidly
    execute `run failsafe_boot` OR `bootm 0x9f670000`
    wait a minute
    connect to ethernet and navigate to
    "192.168.1.1/index.htm"
    Select the factory.bin image and upload
    wait about 3 minutes

Return to OEM:

  If you have a serial cable, see Serial Failsafe instructions

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will not work
  DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

  The easiest way to return to the OEM software is the Failsafe image
  If you dont have a serial cable, you can ssh into openwrt and run

  `mtd -r erase fakeroot`

  Wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

Format of OEM firmware image:

  The OEM software of EAP350 is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names...

    openwrt-senao-eap350-uImage-lzma.bin
    openwrt-senao-eap350-root.squashfs

  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  The OEM upgrade script is at /etc/fwupgrade.sh

  Later models in the EAP series likely have a different platform
  and the upgrade and image verification process differs.

  OKLI kernel loader is required because the OEM software
  expects the kernel to be no greater than 1024k
  and the factory.bin upgrade procedure would
  overwrite part of the kernel when writing rootfs.

Note on PLL-data cells:

  The default PLL register values will not work
  because of the external AR8035-A switch between
  the SOC and the ethernet PHY chips.

  For AR724x series, the PLL register for GMAC0
  can be seen in the DTSI as 0x2c.
  Therefore the PLL register can be read from uboot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x1805002c 1`.

  uboot did not have a good value for 1 GBps
  so it was taken from other similar DTS file.

Tested from master, all link speeds functional

Signed-off-by: Michael Pratt <mpratt51@gmail.com>