### PR TITLE
ar71xx: enable strip to save space in tiny images

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -175,6 +175,7 @@ menu "Global build settings"
 
 	config STRIP_KERNEL_EXPORTS
 		bool "Strip unnecessary exports from the kernel image"
+		default y if SMALL_FLASH
 		help
 		  Reduces kernel size by stripping unused kernel exports from the kernel
 		  image.  Note that this might make the kernel incompatible with any kernel
@@ -182,6 +183,7 @@ menu "Global build settings"
 
 	config USE_MKLIBS
 		bool "Strip unnecessary functions from libraries"
+		default y if SMALL_FLASH
 		help
 		  Reduces libraries to only those functions that are necessary for using all
 		  selected packages (including those selected as <M>).  Note that this will


### PR DESCRIPTION
This patch makes more of the ar71xx tiny device images buildable by default; in particular, most of the TP-Link images.

19.07.4 can be built for 4MB ar71xx devices without any particular difficulty, but most images for this target are no longer being released by buildbot, since they've become slightly too big ([only 20-80k over](http://buildbot.openwrt.org/openwrt-19.07/images/builders/ar71xx%2Ftiny/builds/177/steps/images/logs/stdio)) in their default config.

By stripping kernel exports and library functions, enough space is saved so that some of the images will build again. These strips create no real detriment in practice, as it's basically impossible to add kmods or packages to a 4MB device after compilation anyway (due to lack of available space).