### PR TITLE
arm-trusted-firmware-mvebu: enable per default on buildbot 

### DIFF
--- a/package/boot/arm-trusted-firmware-mvebu/Makefile
+++ b/package/boot/arm-trusted-firmware-mvebu/Makefile
@@ -45,7 +45,7 @@ define Package/arm-trusted-firmware-mvebu-espressobin-v3-v5-1gb-1cs
   TITLE:=ARM Trusted Firmware for Marvell ESPRESSObin V3-V5 (1GB 1CS)
   DEPENDS:=+u-boot-espressobin
   UBOOT:=espressobin
-  DDR_TOPOLOGY:=2
+  DDR_TOPOLOGY:=4
   CLOCKSPRESET:=CPU_800_DDR_800
   PLAT:=a3700
 endef

--- a/package/boot/arm-trusted-firmware-mvebu/Makefile
+++ b/package/boot/arm-trusted-firmware-mvebu/Makefile
@@ -21,6 +21,9 @@ PKG_LICENSE_FILES:=docs/license.rst
 
 PKG_MAINTAINER:=Vladimir Vid <vladimir.vid@sartura.hr>
 
+PKG_TARGETS:=bin
+PKG_FLAGS:=nonshared
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/arm-trusted-firmware-mvebu
@@ -28,6 +31,10 @@ define Package/arm-trusted-firmware-mvebu
   CATEGORY:=Boot Loaders
   DEPENDS:=@TARGET_mvebu_cortexa53
   VARIANT:=$(subst arm-trusted-firmware-mvebu-,,$(1))
+
+  define Package/$(1)/install
+	$$(Package/arm-trusted-firmware-mvebu/install)
+  endef
 endef
 
 define Package/arm-trusted-firmware-mvebu-espressobin-512mb
@@ -221,10 +228,9 @@ define Build/Compile
 		fip
 endef
 
-define Build/InstallDev
-	$(INSTALL_DIR) $(BIN_DIR)/flash-image-$(BUILD_VARIANT)
-	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/flash-image.bin $(BIN_DIR)/flash-image-$(BUILD_VARIANT)/
-	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/uart-images.tgz $(BIN_DIR)/flash-image-$(BUILD_VARIANT)/
+define Package/arm-trusted-firmware-mvebu/install
+	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/flash-image.bin $(1)/
+	$(CP) $(PKG_BUILD_DIR)/build/$(PLAT)/release/uart-images.tgz $(1)/
 endef
 
 $(eval $(call BuildPackage,arm-trusted-firmware-mvebu-espressobin-512mb))

--- a/package/boot/arm-trusted-firmware-mvebu/Makefile
+++ b/package/boot/arm-trusted-firmware-mvebu/Makefile
@@ -31,6 +31,7 @@ define Package/arm-trusted-firmware-mvebu
   CATEGORY:=Boot Loaders
   DEPENDS:=@TARGET_mvebu_cortexa53
   VARIANT:=$(subst arm-trusted-firmware-mvebu-,,$(1))
+  DEFAULT:=y if BUILDBOT
 
   define Package/$(1)/install
 	$$(Package/arm-trusted-firmware-mvebu/install)

--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -38,14 +38,12 @@ endef
 
 define U-Boot/espressobin
   NAME:=Marvell ESPRESSObin
-  BUILD_DEVICES:=globalscale_espressobin globalscale_espressobin-v7
   BUILD_SUBTARGET:=cortexa53
   UBOOT_CONFIG:=mvebu_espressobin-88f3720
 endef
 
 define U-Boot/espressobin-emmc
   NAME:=Marvell ESPRESSObin
-  BUILD_DEVICES:=globalscale_espressobin-emmc globalscale_espressobin-v7-emmc
   BUILD_SUBTARGET:=cortexa53
   UBOOT_CONFIG:=mvebu_espressobin-88f3720
   UBOOT_MAKE_FLAGS+=DEVICE_TREE=armada-3720-espressobin-emmc
@@ -53,7 +51,6 @@ endef
 
 define U-Boot/uDPU
   NAME:=Methode uDPU
-  BUILD_DEVICES:=methode_udpu
   BUILD_SUBTARGET:=cortexa53
 endef
 

--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -71,6 +71,10 @@ define Build/Configure
 	$(call Build/Configure/U-Boot)
 endef
 
+define Package/u-boot/install
+	$(if $(findstring cortexa53,$(BUILD_SUBTARGET)),,$(Package/u-boot/install/default))
+endef
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
 	$(CP) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-$(UBOOT_IMAGE)


### PR DESCRIPTION
The firmware for these boards is not part of the built image, it needs to be updated independently using a binary file and flashed to NOR using the u-boot 'bubt' command.
    
Let buildbot always build firmware binaries for all boards, so that they can be found and downloaded from the "Supplementary Files" section.

See also #3360.