### PR TITLE
build: find_md5 list with mod time and sorted

### DIFF
--- a/include/depends.mk
+++ b/include/depends.mk
@@ -13,7 +13,7 @@
 
 DEP_FINDPARAMS := -x "*/.svn*" -x ".*" -x "*:*" -x "*\!*" -x "* *" -x "*\\\#*" -x "*/.*_check" -x "*/.*.swp" -x "*/.pkgdir*"
 
-find_md5=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) | mkhash md5
+find_md5=find $(wildcard $(1)) -type f $(patsubst -x,-and -not -path,$(DEP_FINDPARAMS) $(2)) -printf "%p%T@\n" | sort | mkhash md5
 
 define rdep
   .PRECIOUS: $(2)


### PR DESCRIPTION
It was observed that the MD5 would not change after source files had been
modified, looking deeper into the build process it was discovered that
find_md5 build function makes a list of the files being built and then
passes the list to a summing utility on stdin.  The resultant MD5 is of
the file list, not the contents of the files.

The MD5 would change if the ordering of the list changed, or items were
removed or deleted. Causing inconsistent and intermittent behaviour.

The proposed fix is to add the modification time after the filename and
then sort the list to prevent find returning files in a different order
falsely re-triggering a rebuild. The MD5 will now change when a file is
modified or files are added/removed from the list.

Signed-off-by: John Beckett <john.beckett@net2edge.com>