### PR TITLE
ath79: remove DTS from ATH79 target name

### DIFF
--- a/target/linux/ath79/Makefile
+++ b/target/linux/ath79/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 ARCH:=mips
 BOARD:=ath79
-BOARDNAME:=Atheros ATH79 (DTS)
+BOARDNAME:=Atheros ATH79
 CPU_TYPE:=24kc
 SUBTARGETS:=generic mikrotik nand tiny
 


### PR DESCRIPTION
The legacy ar71xx target is removed and multiple targets use DTS now, so
there is no need to point that out for ATH79 specifically.

Signed-off-by: Paul Spooren <mail@aparcar.org>