### PR TITLE
Support SELinux labels for built packages

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -246,7 +246,7 @@ define Image/mkfs/squashfs
 	echo "LD_LIBRARY_PATH=\$$LD_LIBRARY_PATH:$(STAGING_DIR_HOSTPKG)/lib" \
 	     "$(STAGING_DIR_HOSTPKG)/sbin/setfiles -r" \
 	     "$(call mkfs_target_dir,$(1))" \
-	     "$(call mkfs_target_dir,$(1))/etc/selinux/targeted/contexts/files/file_contexts " \
+	     "$(STAGING_DIR_HOSTPKG)/etc/selinux/targeted/contexts/files/file_contexts " \
 	     "$(call mkfs_target_dir,$(1))" > $@.fakeroot-script
 	echo "$(Image/mkfs/squashfs-common)" >> $@.fakeroot-script
 	chmod +x $@.fakeroot-script

--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -260,7 +260,12 @@ $(_endef)
     endif
 
 	$(INSTALL_DIR) $$(PDIR_$(1))
-	$(FAKEROOT) $(SCRIPT_DIR)/ipkg-build -m "$(FILE_MODES)" $$(IDIR_$(1)) $$(PDIR_$(1))
+	$(FAKEROOT) $(SCRIPT_DIR)/ipkg-build \
+		-m "$(FILE_MODES)" \
+		-c "$(if $(CONFIG_TARGET_ROOTFS_SECURITY_LABELS)\
+			,$(STAGING_DIR_HOSTPKG)/etc/selinux/targeted/contexts/files/file_contexts)" \
+		$$(IDIR_$(1)) \
+		$$(PDIR_$(1))
 	@[ -f $$(IPKG_$(1)) ]
 
     $(1)-clean:

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -14,6 +14,10 @@ PKG_LICENSE:=GPL-3.0-with-GCC-exception
 
 PKG_FLAGS:=hold essential nonshared
 
+ifdef CONFIG_TARGET_ROOTFS_SECURITY_LABELS
+  HOST_BUILD_DEPENDS += refpolicy/host
+endif
+
 include $(INCLUDE_DIR)/package.mk
 
 ifneq ($(DUMP),1)

--- a/package/system/refpolicy/Makefile
+++ b/package/system/refpolicy/Makefile
@@ -14,6 +14,8 @@ PKG_SOURCE_URL:=https://github.com/SELinuxProject/refpolicy/releases/download/RE
 PKG_HASH:=dec854512ed00cd057408f330c2cea4de7a4405f7a147458f59c994bf578e4b0
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=checkpolicy/host policycoreutils/host
+HOST_BUILD_DEPENDS:=checkpolicy/host policycoreutils/host
+
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:tresys:refpolicy
@@ -23,6 +25,7 @@ PKG_LICENSE_FILES:=COPYING
 TAR_OPTIONS:=--transform='s%^refpolicy%$(PKG_NAME)-$(PKG_VERSION)%' -xf -
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/refpolicy
   SECTION:=system
@@ -61,10 +64,24 @@ MAKE_FLAGS += \
 	CC="$(HOSTCC)" \
 	CFLAGS="$(HOST_CFLAGS)"
 
+HOST_MAKE_FLAGS += \
+	TEST_TOOLCHAIN="$(STAGING_DIR_HOSTPKG)" \
+	DESTDIR="$(STAGING_DIR_HOSTPKG)" \
+	BINDIR=/bin \
+	SBINDIR=/sbin \
+	CC="$(HOSTCC)" \
+	CFLAGS="$(HOST_CFLAGS)"
+
 define Build/Configure
 	$(SED) "/MONOLITHIC/c\MONOLITHIC = y" $(PKG_BUILD_DIR)/build.conf
 	$(SED) "/NAME/c\NAME = targeted" $(PKG_BUILD_DIR)/build.conf
 	$(call Build/Compile/Default,conf)
+endef
+
+define Host/Configure
+	$(SED) "/MONOLITHIC/c\MONOLITHIC = y" $(HOST_BUILD_DIR)/build.conf
+	$(SED) "/NAME/c\NAME = targeted" $(HOST_BUILD_DIR)/build.conf
+	$(call Host/Compile/Default,conf)
 endef
 
 define Package/refpolicy/conffiles
@@ -78,3 +95,4 @@ define Package/refpolicy/install
 endef
 
 $(eval $(call BuildPackage,refpolicy))
+$(eval $(call HostBuild))

--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -92,14 +92,16 @@ resolve_file_mode_id() {
 # ipkg-build "main"
 ###
 file_modes=""
-usage="Usage: $0 [-v] [-h] [-m] <pkg_directory> [<destination_directory>]"
-while getopts "hvm:" opt; do
+file_contexts=""
+usage="Usage: $0 [-v] [-h] [-m] [-c <file_contexts>] <pkg_directory> [<destination_directory>]"
+while getopts "hvm:c:" opt; do
     case $opt in
 	v ) echo $version
 	    exit 0
 	    ;;
 	h ) 	echo $usage  >&2 ;;
 	m )	file_modes=$OPTARG ;;
+	c )	file_contexts=$OPTARG ;;
 	\? ) 	echo $usage  >&2
 	esac
 done
@@ -179,6 +181,11 @@ for file_mode in $file_modes; do
 	chown "$uid:$gid" "$pkg_dir/$path"
 	chmod  "$mode" "$pkg_dir/$path"
 done
+
+if [ -n "$file_contexts" ]; then
+	setfiles -v -r "$pkg_dir" "$file_contexts" "$pkg_dir"
+fi
+
 $TAR -X $tmp_dir/tarX --format=gnu --sort=name -cpf - --mtime="$TIMESTAMP" . | $GZIP -n - > $tmp_dir/data.tar.gz
 
 installed_size=`stat -c "%s" $tmp_dir/data.tar.gz`

--- a/tools/tar/Makefile
+++ b/tools/tar/Makefile
@@ -15,6 +15,11 @@ PKG_SOURCE_URL:=@GNU/tar
 PKG_HASH:=d0d3ae07f103323be809bc3eac0dcc386d52c5262499fe05511ac4788af1fdd8
 
 HOST_BUILD_PARALLEL:=1
+ifdef CONFIG_TARGET_ROOTFS_SECURITY_LABELS
+  HOST_BUILD_DEPENDS:=libselinux/host
+endif
+
+PKG_CONFIG_DEPENDS:=CONFIG_TARGET_ROOTFS_SECURITY_LABELS
 
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -23,8 +28,8 @@ HOSTCXX := $(HOSTCXX_NOCACHE)
 
 HOST_CONFIGURE_ARGS += \
 	--without-posix-acls \
-	--without-selinux \
-	--without-xattrs \
+	--with$(if $(CONFIG_TARGET_ROOTFS_SECURITY_LABELS),,out)-selinux \
+	--with$(if $(CONFIG_TARGET_ROOTFS_SECURITY_LABELS),,out)-xattrs \
 	--disable-acl \
 	--disable-nls
 


### PR DESCRIPTION
This PR touches various bits, ultimately allowing to have SELinux file contexts in packages if `CONFIG_ROOTFS_SECURITY_LABELS` is enabled.