### PR TITLE
rockchip: add support for Radxa Rock Pi 4

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,16 @@ endef
 
 # RK3399 boards
 
+define U-Boot/rock-pi-4-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=Rock Pi 4
+  BUILD_DEVICES:= \
+    radxa_rock-pi-4
+  DEPENDS:=+PACKAGE_u-boot-rock-pi-4-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rockpro64-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=RockPro64
@@ -49,6 +59,7 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   nanopi-r2s-rk3328
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -23,3 +23,12 @@ define Device/pine64_rockpro64
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
 endef
 TARGET_DEVICES += pine64_rockpro64
+
+define Device/radxa_rock-pi-4
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := Rock Pi 4
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := rock-pi-4-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+endef
+TARGET_DEVICES += radxa_rock-pi-4


### PR DESCRIPTION
This PR add support for Radxa Rock Pi 4
The only part not yet working is the wifi chip BCM43456c5-AP6256.
[Rock Pi 4 boot log](https://gist.github.com/mj22226/f12347dd4467d7a7a13867b87f7478c6)
