### PR TITLE
kernel: bump 5.4 to 5.4.67

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .66
+LINUX_VERSION-5.4 = .67
 
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.66 = ff1930376774f4c1fc884d82184b5ebea6628f0a37ed9be781c0b119c4cfdab2
+LINUX_KERNEL_HASH-5.4.67 = c175bd9c5d54c7120365d51cf235102e14d5a9a1baddd6296819839240dccaa4
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.4/950-0653-spi-Force-CS_HIGH-if-GPIO-descriptors-are-used.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0653-spi-Force-CS_HIGH-if-GPIO-descriptors-are-used.patch
@@ -23,7 +23,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 
 --- a/drivers/spi/spi.c
 +++ b/drivers/spi/spi.c
-@@ -3053,6 +3053,7 @@ static int __spi_validate_bits_per_word(
+@@ -3058,6 +3058,7 @@ static int __spi_validate_bits_per_word(
   */
  int spi_setup(struct spi_device *spi)
  {
@@ -31,7 +31,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
  	unsigned	bad_bits, ugly_bits;
  	int		status;
  
-@@ -3070,6 +3071,14 @@ int spi_setup(struct spi_device *spi)
+@@ -3075,6 +3076,14 @@ int spi_setup(struct spi_device *spi)
  		(SPI_TX_DUAL | SPI_TX_QUAD | SPI_TX_OCTAL |
  		 SPI_RX_DUAL | SPI_RX_QUAD | SPI_RX_OCTAL)))
  		return -EINVAL;

--- a/target/linux/bcm27xx/patches-5.4/950-0672-spi-use_gpio_descriptor-fixup-moved-to-spi_setup.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0672-spi-use_gpio_descriptor-fixup-moved-to-spi_setup.patch
@@ -37,7 +37,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 
 --- a/drivers/spi/spi.c
 +++ b/drivers/spi/spi.c
-@@ -1787,15 +1787,6 @@ static int of_spi_parse_dt(struct spi_co
+@@ -1792,15 +1792,6 @@ static int of_spi_parse_dt(struct spi_co
  	}
  	spi->chip_select = value;
  

--- a/target/linux/bcm27xx/patches-5.4/950-0697-SQUASH-spi-Demote-SPI_CS_HIGH-warning-to-KERN_DEBUG.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0697-SQUASH-spi-Demote-SPI_CS_HIGH-warning-to-KERN_DEBUG.patch
@@ -15,7 +15,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 
 --- a/drivers/spi/spi.c
 +++ b/drivers/spi/spi.c
-@@ -3065,8 +3065,8 @@ int spi_setup(struct spi_device *spi)
+@@ -3070,8 +3070,8 @@ int spi_setup(struct spi_device *spi)
  
  	if (ctlr->use_gpio_descriptors && ctlr->cs_gpiods &&
  	    ctlr->cs_gpiods[spi->chip_select] && !(spi->mode & SPI_CS_HIGH)) {

--- a/target/linux/bcm63xx/patches-5.4/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
+++ b/target/linux/bcm63xx/patches-5.4/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -665,6 +665,10 @@ int ehci_setup(struct usb_hcd *hcd)
+@@ -666,6 +666,10 @@ int ehci_setup(struct usb_hcd *hcd)
  
  	/* cache this readonly data; minimize chip reads */
  	ehci->hcs_params = ehci_readl(ehci, &ehci->caps->hcs_params);

--- a/target/linux/generic/hack-5.4/301-mips_image_cmdline_hack.patch
+++ b/target/linux/generic/hack-5.4/301-mips_image_cmdline_hack.patch
@@ -10,7 +10,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
 
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -1157,6 +1157,10 @@ config SYNC_R4K
+@@ -1158,6 +1158,10 @@ config SYNC_R4K
  config MIPS_MACHINE
  	def_bool n
  

--- a/target/linux/generic/hack-5.4/647-netfilter-flow-acct.patch
+++ b/target/linux/generic/hack-5.4/647-netfilter-flow-acct.patch
@@ -1,6 +1,6 @@
 --- a/include/net/netfilter/nf_flow_table.h
 +++ b/include/net/netfilter/nf_flow_table.h
-@@ -158,6 +158,8 @@ struct nf_flow_table_hw {
+@@ -160,6 +160,8 @@ struct nf_flow_table_hw {
  int nf_flow_table_hw_register(const struct nf_flow_table_hw *offload);
  void nf_flow_table_hw_unregister(const struct nf_flow_table_hw *offload);
  

--- a/target/linux/generic/hack-5.4/650-netfilter-add-xt_OFFLOAD-target.patch
+++ b/target/linux/generic/hack-5.4/650-netfilter-add-xt_OFFLOAD-target.patch
@@ -576,7 +576,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +#endif /* _XT_FLOWOFFLOAD_H */
 --- a/include/net/netfilter/nf_flow_table.h
 +++ b/include/net/netfilter/nf_flow_table.h
-@@ -128,6 +128,10 @@ static inline void flow_offload_dead(str
+@@ -130,6 +130,10 @@ static inline void flow_offload_dead(str
  	flow->flags |= FLOW_OFFLOAD_DYING;
  }
  

--- a/target/linux/generic/pending-5.4/110-ehci_hcd_ignore_oc.patch
+++ b/target/linux/generic/pending-5.4/110-ehci_hcd_ignore_oc.patch
@@ -17,7 +17,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -638,7 +638,7 @@ static int ehci_run (struct usb_hcd *hcd
+@@ -639,7 +639,7 @@ static int ehci_run (struct usb_hcd *hcd
  		"USB %x.%x started, EHCI %x.%02x%s\n",
  		((ehci->sbrn & 0xf0)>>4), (ehci->sbrn & 0x0f),
  		temp >> 8, temp & 0xff,
@@ -28,7 +28,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
  		    &ehci->regs->intr_enable); /* Turn On Interrupts */
 --- a/drivers/usb/host/ehci-hub.c
 +++ b/drivers/usb/host/ehci-hub.c
-@@ -641,7 +641,7 @@ ehci_hub_status_data (struct usb_hcd *hc
+@@ -640,7 +640,7 @@ ehci_hub_status_data (struct usb_hcd *hc
  	 * always set, seem to clear PORT_OCC and PORT_CSC when writing to
  	 * PORT_POWER; that's surprising, but maybe within-spec.
  	 */
@@ -37,7 +37,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
  		mask = PORT_CSC | PORT_PEC | PORT_OCC;
  	else
  		mask = PORT_CSC | PORT_PEC;
-@@ -1011,7 +1011,7 @@ int ehci_hub_control(
+@@ -1010,7 +1010,7 @@ int ehci_hub_control(
  		if (temp & PORT_PEC)
  			status |= USB_PORT_STAT_C_ENABLE << 16;
  

--- a/target/linux/generic/pending-5.4/300-mips_expose_boot_raw.patch
+++ b/target/linux/generic/pending-5.4/300-mips_expose_boot_raw.patch
@@ -9,7 +9,7 @@ Acked-by: Rob Landley <rob@landley.net>
 ---
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -1067,9 +1067,6 @@ config FW_ARC
+@@ -1068,9 +1068,6 @@ config FW_ARC
  config ARCH_MAY_HAVE_PC_FDC
  	bool
  
@@ -19,7 +19,7 @@ Acked-by: Rob Landley <rob@landley.net>
  config CEVT_BCM1480
  	bool
  
-@@ -3041,6 +3038,18 @@ choice
+@@ -3042,6 +3039,18 @@ choice
  		bool "Extend builtin kernel arguments with bootloader arguments"
  endchoice
  

--- a/target/linux/lantiq/patches-5.4/0152-lantiq-VPE.patch
+++ b/target/linux/lantiq/patches-5.4/0152-lantiq-VPE.patch
@@ -1,6 +1,6 @@
 --- a/arch/mips/Kconfig
 +++ b/arch/mips/Kconfig
-@@ -2376,6 +2376,12 @@ config MIPS_VPE_LOADER
+@@ -2377,6 +2377,12 @@ config MIPS_VPE_LOADER
  	  Includes a loader for loading an elf relocatable object
  	  onto another VPE and running it.
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0013-MLK-9785-1-usb-host-ehci-hcd-enable-park-mode.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0013-MLK-9785-1-usb-host-ehci-hcd-enable-park-mode.patch
@@ -27,7 +27,7 @@ Signed-off-by: Peter Chen <peter.chen@freescale.com>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -80,7 +80,7 @@ module_param (log2_irq_thresh, int, S_IR
+@@ -81,7 +81,7 @@ module_param (log2_irq_thresh, int, S_IR
  MODULE_PARM_DESC (log2_irq_thresh, "log2 IRQ latency, 1-64 microframes");
  
  /* initial park setting:  slower than hw default */

--- a/target/linux/layerscape/patches-5.4/820-usb-0014-MLK-17380-3-usb-move-EH-SINGLE_STEP_SET_FEATURE-impl.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0014-MLK-17380-3-usb-move-EH-SINGLE_STEP_SET_FEATURE-impl.patch
@@ -163,7 +163,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -1232,6 +1232,10 @@ static const struct hc_driver ehci_hc_dr
+@@ -1233,6 +1233,10 @@ static const struct hc_driver ehci_hc_dr
  	 * device support
  	 */
  	.free_dev =		ehci_remove_device,
@@ -176,7 +176,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  void ehci_init_driver(struct hc_driver *drv,
 --- a/drivers/usb/host/ehci-hub.c
 +++ b/drivers/usb/host/ehci-hub.c
-@@ -725,145 +725,6 @@ ehci_hub_descriptor (
+@@ -724,145 +724,6 @@ ehci_hub_descriptor (
  }
  
  /*-------------------------------------------------------------------------*/

--- a/target/linux/mediatek/patches-5.4/0001-v5.7-spi-make-spi-max-frequency-optional.patch
+++ b/target/linux/mediatek/patches-5.4/0001-v5.7-spi-make-spi-max-frequency-optional.patch
@@ -20,7 +20,7 @@ Signed-off-by: Mark Brown <broonie@kernel.org>
 
 --- a/drivers/spi/spi.c
 +++ b/drivers/spi/spi.c
-@@ -1797,13 +1797,8 @@ static int of_spi_parse_dt(struct spi_co
+@@ -1802,13 +1802,8 @@ static int of_spi_parse_dt(struct spi_co
  		spi->mode |= SPI_CS_HIGH;
  
  	/* Device speed */

--- a/target/linux/mediatek/patches-5.4/0700-arm-dts-mt7623-add-missing-pause-for-switchport.patch
+++ b/target/linux/mediatek/patches-5.4/0700-arm-dts-mt7623-add-missing-pause-for-switchport.patch
@@ -11,11 +11,9 @@ Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
  arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts b/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
-index 2b760f90f38c..5375c6699843 100644
 --- a/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
 +++ b/arch/arm/boot/dts/mt7623n-bananapi-bpi-r2.dts
-@@ -192,6 +192,7 @@ port@6 {
+@@ -193,6 +193,7 @@
  					fixed-link {
  						speed = <1000>;
  						full-duplex;
@@ -23,5 +21,3 @@ index 2b760f90f38c..5375c6699843 100644
  					};
  				};
  			};
--- 
-2.25.1


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x/R7800 and ath79/generic
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>