### PR TITLE
dnsmasq: support tftp_unique_root in /etc/config/dhcp

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.82
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -904,6 +904,7 @@ dnsmasq_start()
 	append_parm "$cfg" "min_cache_ttl" "--min-cache-ttl"
 	append_parm "$cfg" "max_cache_ttl" "--max-cache-ttl"
 	append_parm "$cfg" "pxe_prompt" "--pxe-prompt"
+	append_parm "$cfg" "tftp_unique_root" "--tftp-unique-root"
 	config_list_foreach "$cfg" "pxe_service" append_pxe_service
 	config_get DOMAIN "$cfg" domain
 


### PR DESCRIPTION
The TFTP server provided by dnsmasq supports serving a select boot image
based on the client's MAC or IP address. This allows an administrator
to activate this feature in /etc/config/dhcp. Here is an example
/etc/config/dhcp that configures dnsmasq with --tftp-unique-root=mac:
```
...

config dnsmasq
	option enable_tftp 1
	option tftp_root /usr/libexec/tftpboot
	option tftp_unique_root mac

config boot router
	option serveraddress 192.168.1.1
	option servername tftp.example.com
	option filename openwrt-initramfs-kernel.bin

...
```
With this configuration, dnsmasq will serve
/usr/libexec/tftpboot/00-11-22-33-44-55/openwrt-initramfs-kernel.bin to
the client with MAC address 00:11:22:33:44:55.

Signed-off-by: W. Michael Petullo <mike@flyn.org>