### PR TITLE
config: use static Kernel user/hostname by default

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -6,21 +6,19 @@
 
 config KERNEL_BUILD_USER
 	string "Custom Kernel Build User Name"
-	default "builder" if BUILDBOT
-	default ""
+	default "builder"
 	help
 	  Sets the Kernel build user string, which for example will be returned
 	  by 'uname -a' on running systems.
-	  If not set, uses system user at build time.
+	  If not set, uses "builder" to simplify reproducibility.
 
 config KERNEL_BUILD_DOMAIN
 	string "Custom Kernel Build Domain Name"
-	default "buildhost" if BUILDBOT
-	default ""
+	default "buildhost"
 	help
 	  Sets the Kernel build domain string, which for example will be
 	  returned by 'uname -a' on running systems.
-	  If not set, uses system hostname at build time.
+	  If not set, uses "buildhost" to simplify reproducibility.
 
 config KERNEL_PRINTK
 	bool "Enable support for printk"


### PR DESCRIPTION
Using different user/hostname combinations than the buildbot changes the
Kernel magic checksum and therefore complicates reproducibility.

This commits uses the values `builder` and `buildhost` both on BUILDBOTs
and locally running machines. Reducing the number of modified  options
required to reproduce upstream images by two.

Signed-off-by: Paul Spooren <mail@aparcar.org>