### PR TITLE
kernel: bump 5.4 to 5.4.68

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .67
+LINUX_VERSION-5.4 = .68
 
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.67 = c175bd9c5d54c7120365d51cf235102e14d5a9a1baddd6296819839240dccaa4
+LINUX_KERNEL_HASH-5.4.68 = 0e93876c5ae8dc0c55cbe631971a46ab02b90cf7461fed3085703a5e4e3cd6dd
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/backport-5.4/737-v5.5-net-phy-add-core-phylib-sfp-support.patch
+++ b/target/linux/generic/backport-5.4/737-v5.5-net-phy-add-core-phylib-sfp-support.patch
@@ -130,7 +130,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	/* Some Ethernet drivers try to connect to a PHY device before
  	 * calling register_netdevice() -> netdev_register_kobject() and
  	 * does the dev->dev.kobj initialization. Here we only check for
-@@ -2289,6 +2352,9 @@ static int phy_remove(struct device *dev
+@@ -2290,6 +2353,9 @@ static int phy_remove(struct device *dev
  	phydev->state = PHY_DOWN;
  	mutex_unlock(&phydev->lock);
  

--- a/target/linux/generic/backport-5.4/750-v5.5-net-phy-add-support-for-clause-37-auto-negotiation.patch
+++ b/target/linux/generic/backport-5.4/750-v5.5-net-phy-add-support-for-clause-37-auto-negotiation.patch
@@ -20,7 +20,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -1681,6 +1681,40 @@ static int genphy_config_advert(struct p
+@@ -1682,6 +1682,40 @@ static int genphy_config_advert(struct p
  }
  
  /**
@@ -61,7 +61,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
   * genphy_config_eee_advert - disable unwanted eee mode advertisement
   * @phydev: target phy_device struct
   *
-@@ -1789,6 +1823,54 @@ int __genphy_config_aneg(struct phy_devi
+@@ -1790,6 +1824,54 @@ int __genphy_config_aneg(struct phy_devi
  EXPORT_SYMBOL(__genphy_config_aneg);
  
  /**
@@ -116,7 +116,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
   * genphy_aneg_done - return auto-negotiation status
   * @phydev: target phy_device struct
   *
-@@ -1960,6 +2042,63 @@ int genphy_read_status(struct phy_device
+@@ -1961,6 +2043,63 @@ int genphy_read_status(struct phy_device
  EXPORT_SYMBOL(genphy_read_status);
  
  /**

--- a/target/linux/generic/hack-5.4/702-phy_add_aneg_done_function.patch
+++ b/target/linux/generic/hack-5.4/702-phy_add_aneg_done_function.patch
@@ -15,7 +15,7 @@
  
 --- a/drivers/net/phy/phy_device.c
 +++ b/drivers/net/phy/phy_device.c
-@@ -1911,6 +1911,9 @@ int genphy_update_link(struct phy_device
+@@ -1912,6 +1912,9 @@ int genphy_update_link(struct phy_device
  	if (bmcr & BMCR_ANRESTART)
  		goto done;
  


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x, ath79/generic, bcm27xx/bcm7211
Run-tested: ipq806x (R7800)

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>