### PR TITLE
apm821xx: fix WNDR4700 boot

### DIFF
--- a/target/linux/apm821xx/image/nand.mk
+++ b/target/linux/apm821xx/image/nand.mk
@@ -106,7 +106,7 @@ define Device/netgear_wndr4700
   KERNEL_SIZE := 3584k
   # append a fake/empty rootfs to fool netgear's uboot
   # CHECK_DNI_FIRMWARE_ROOTFS_INTEGRITY in do_chk_dniimg()
-  KERNEL := kernel-bin | lzma | uImage lzma | pad-offset $$(BLOCKSIZE) 64 | \
+  KERNEL := kernel-bin | lzma -d16 | uImage lzma | pad-offset $$(BLOCKSIZE) 64 | \
 	    append-uImage-fakehdr filesystem | dtb | create-uImage-dtb | prepend-dtb
   KERNEL_INITRAMFS := kernel-bin | gzip | dtb | MuImage-initramfs gzip
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
@@ -117,6 +117,5 @@ define Device/netgear_wndr4700
   NETGEAR_HW_ID := 29763875+128+256
   UBINIZE_OPTS := -E 5
   SUPPORTED_DEVICES += wndr4700
-  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_wndr4700


### PR DESCRIPTION
This fixes issue [FS#3258](https://bugs.openwrt.org/index.php?do=details&task_id=3258) reported by me (or at least workarounds it)

Similar additional argument for lzma is used in Belkin F9K1109 build definition.
I've give it a try and it worked. Tested higher values and -d18 found to be the last working.

CC: @chunkeey