### PR TITLE
imagebuilder: add missing libfakeroot files

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -85,6 +85,7 @@ endif
 	$(CP) $(STAGING_DIR_HOST)/bin/* $(PKG_BUILD_DIR)/staging_dir/host/bin/
 	(cd $(PKG_BUILD_DIR); find staging_dir/host/bin/ $(IB_LDIR)/scripts/dtc/ -type f | \
 		$(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(PKG_BUILD_DIR)/staging_dir/host)
+	$(CP) $(TOPDIR)/staging_dir/host/lib/libfakeroot* $(PKG_BUILD_DIR)/staging_dir/host/lib
 	STRIP=sstrip $(SCRIPT_DIR)/rstrip.sh $(PKG_BUILD_DIR)/staging_dir/host/bin/
 	(cd $(BUILD_DIR); \
 		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' -cf $@ $(IB_NAME) \


### PR DESCRIPTION
The `libfakeroot` files are currently missing in the ImageBuilder. As
`fakeroot` is always built, copy those files unconditionally.

Signed-off-by: Paul Spooren <mail@aparcar.org>
