### PR TITLE
ath79: add support for TP-Link CPE510 V3.20

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -416,7 +416,10 @@ static struct device_info boards[] = {
 			"CPE510(TP-LINK|US|N300-5|55530000):3.0\r\n"
 			"CPE510(TP-LINK|UN|N300-5):3.0\r\n"
 			"CPE510(TP-LINK|EU|N300-5):3.0\r\n"
-			"CPE510(TP-LINK|US|N300-5):3.0\r\n",
+			"CPE510(TP-LINK|US|N300-5):3.0\r\n"
+			"CPE510(TP-LINK|UN|N300-5|00000000):3.20\r\n"
+			"CPE510(TP-LINK|US|N300-5|55530000):3.20\r\n"
+			"CPE510(TP-LINK|EU|N300-5|45550000):3.20\r\n",
 		.support_trail = '\xff',
 		.soft_ver = NULL,
 


### PR DESCRIPTION
TP-Link CPE510-v3.20 is an outdoor wireless CPE for 5 GHz with
one Ethernet port based on Atheros AR9344

Specifications:

    Based on the same underlying hardware as the TP-Link CPE510
    Power, LAN, and 4 green LEDs
    1 10/100Mbps Shielded Ethernet Port (Passive PoE in)
    Built-in 13dBi 2x2 dual-polarized directional MIMO antenna
    Adjustable transmission power from 0 to 23dBm/200mw

Flashing instructions:
Flash factory image through stock firmware WEB UI
or through TFTP
To get to TFTP recovery just hold reset button while powering on for
around 4-5 seconds and release.
Rename factory image to recovery.bin
Stock TFTP server IP:192.168.0.100
Stock device TFTP adress:192.168.0.254

Signed-off-by: Ulf Cramme <<ulf@cramme.org>>