### PR TITLE
ramips: add support for D-Link DIR-882 R1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -1,24 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 #include "mt7621_dlink_dir-8xx-a1.dtsi"
+#include "mt7621_dlink_dir-882-x1.dtsi"
 
 / {
 	compatible = "dlink,dir-882-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-882 A1";
-};
-
-&leds {
-	usb2 {
-		label = "green:usb2";
-		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-		trigger-sources = <&ehci_port2>;
-		linux,default-trigger = "usbport";
-	};
-
-	usb3 {
-		label = "green:usb3";
-		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		trigger-sources = <&xhci_ehci_port1>;
-		linux,default-trigger = "usbport";
-	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-r1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir-8xx-r1.dtsi"
+#include "mt7621_dlink_dir-882-x1.dtsi"
+
+/ {
+	compatible = "dlink,dir-882-r1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-882 R1";
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-x1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-x1.dtsi
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+&leds {
+	usb2 {
+		label = "green:usb2";
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&ehci_port2>;
+		linux,default-trigger = "usbport";
+	};
+
+	usb3 {
+		label = "green:usb3";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		trigger-sources = <&xhci_ehci_port1>;
+		linux,default-trigger = "usbport";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx-r1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx-r1.dtsi
@@ -29,14 +29,14 @@
 
 			factory: partition@40000 {
 				label = "factory";
-				reg = <0x40000 0x20000>;
+				reg = <0x40000 0x10000>;
 				read-only;
 			};
 
-			partition@60000 {
-				compatible = "sge,uimage";
+			partition@50000 {
+				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x60000 0xfa0000>;
+				reg = <0x50000 0xfb0000>;
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx-x1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx-x1.dtsi
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_net_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "orange:net";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		net_green {
+			label = "green:net";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -148,6 +148,11 @@ define Build/sercom-seal
 		$(1)
 endef
 
+define Build/sign-dlink-ru
+	sign_dlink_ru $@ $1 $2
+	mv $@.new $@
+endef
+
 define Build/trx
 	$(STAGING_DIR_HOST)/bin/trx $(1) \
 		-o $@ \

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -247,6 +247,17 @@ define Device/dlink_dir-8xx-a1
 	check-size
 endef
 
+define Device/dlink_dir-8xx-r1
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := D-Link
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
+  KERNEL_INITRAMFS := $$(KERNEL) 
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs |\
+	pad-rootfs | append-metadata | check-size
+endef
+
 define Device/dlink_dir-xx60-a1
   $(Device/dsa-migration)
   BLOCKSIZE := 128k
@@ -323,6 +334,17 @@ define Device/dlink_dir-882-a1
   DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += dlink_dir-882-a1
+
+define Device/dlink_dir-882-r1
+  $(Device/dlink_dir-8xx-r1)
+  DEVICE_MODEL := DIR-882
+  DEVICE_VARIANT := R1
+  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  IMAGE/factory.bin := append-kernel | append-rootfs | check-size | \
+	  sign-dlink-ru 57c5375741c30ca9ebcb36713db4ba51 \
+	  ab0dff19af8842cdb70a86b4b68d23f7
+endef
+TARGET_DEVICES += dlink_dir-882-r1
 
 define Device/d-team_newifi-d2
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -30,7 +30,8 @@ dlink,dir-2660-a1)
 dlink,dir-860l-b1|\
 dlink,dir-867-a1|\
 dlink,dir-878-a1|\
-dlink,dir-882-a1)
+dlink,dir-882-a1|\
+dlink,dir-882-r1)
 	ucidef_set_led_netdev "wan" "wan" "green:net" "wan"
 	;;
 gnubee,gb-pc1|\

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -84,6 +84,7 @@ define Host/Compile
 	$(call cc,pc1crypt)
 	$(call cc,ptgen cyg_crc32)
 	$(call cc,seama md5)
+	$(call cc,sign_dlink_ru md5,-Wall)
 	$(call cc,spw303v)
 	$(call cc,srec2bin)
 	$(call cc,tplink-safeloader md5,-Wall --std=gnu99)

--- a/tools/firmware-utils/src/sign_dlink_ru.c
+++ b/tools/firmware-utils/src/sign_dlink_ru.c
@@ -1,0 +1,225 @@
+/*
+ * This program is designed to sign firmware images so they are accepted
+ * by D-Link DIR-882 R1 WebUIs.
+ *
+ * Copyright (C) 2020 Andrew Pikler
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "md5.h"
+
+#define BUF_SIZE 4096
+#define MD5_HASH_LEN 16
+
+
+typedef struct _md5_digest_t {
+	uint8_t digest[MD5_HASH_LEN];
+} md5_digest_t;
+
+typedef struct _salt_t {
+	char* salt_ascii;
+	uint8_t* salt_bin;
+	size_t salt_bin_len;
+} salt_t;
+
+void read_file_bytes(FILE* f, MD5_CTX* md5_ctx) {
+	uint8_t buf[BUF_SIZE];
+	size_t bytes_read;
+	rewind(f);
+	
+	while (0 != (bytes_read = fread(buf, sizeof(uint8_t), BUF_SIZE, f))) {
+		MD5_Update(md5_ctx, buf, bytes_read);
+	}
+
+	if (!feof(f)) {
+		printf("Error: expected to be at EOF\n");
+		exit(-1);
+	}
+}
+
+void add_magic_bytes(FILE* f) {
+	char magic_bytes[] = { 0x00, 0xc0, 0xff, 0xee };
+	size_t magic_bytes_len = 4;
+	fwrite(magic_bytes, magic_bytes_len, 1, f);
+}
+
+/**
+ * Add the signature produced by this salt to the file
+ * The signature consists by creating an MD5 digest wht the salt bytes plus
+ * all of the bytes in the firmware file, then adding the magic bytes to the
+ * file
+ */
+void add_signature(FILE* f, salt_t* salt) {
+	md5_digest_t digest;
+	MD5_CTX md5_context;
+
+	MD5_Init(&md5_context);
+	MD5_Update(&md5_context, salt->salt_bin, salt->salt_bin_len);
+	read_file_bytes(f, &md5_context);
+	MD5_Final(digest.digest, &md5_context);
+
+	fwrite(&digest.digest, sizeof(uint8_t), MD5_HASH_LEN, f);
+	add_magic_bytes(f);
+}
+
+void add_version_suffix(FILE* f) {
+	char* version_suffix = "c0ffeef0rge";
+	fseek(f, 0, SEEK_END);
+	fwrite(version_suffix, sizeof(char), strlen(version_suffix), f);
+}
+
+int asciihex_to_int(char c) {
+	if(c >= '0' && c <= 'F')
+		return c - '0';
+
+	if(c >= 'a' && c <= 'f')
+		return 10 + c - 'a';
+	return -1;
+}
+
+/**
+ * Verify this is a valid hex string to convert
+ */
+void verify_valid_hex_str(char* s) {
+	int i;
+	int s_len = strlen(s);
+	if (s_len == 0) {
+		printf("invalid empty salt: %s\n", s);
+		exit(-1);
+	}
+
+	if (s_len % 2 != 0) {
+		printf("invalid odd len salt: %s\n", s);
+		exit(-1);
+	}
+
+	for (i = 0; i < s_len; ++i) {
+		if (asciihex_to_int(s[i]) < 0) {
+			printf("invalid salt (invalid hex char): %s\n", s);
+			exit(-1);
+		}
+	}
+}
+
+/**
+ * Convert a hex ascii string to an allocated binary array. This array must be free'd
+ */
+uint8_t* convert_hex_to_bin(char * s) {
+	int i;
+	int s_len = strlen(s);
+
+	uint8_t* ret = malloc(s_len / 2);
+	for (i = 0; i < s_len; i += 2) {
+		ret[i / 2] = (asciihex_to_int(s[i]) << 4) | asciihex_to_int(s[i + 1]);
+	}
+
+	return ret;
+}
+
+void init_salt(salt_t* salt, char * salt_ascii) {
+	salt->salt_ascii = salt_ascii;
+	salt->salt_bin = convert_hex_to_bin(salt_ascii);
+	salt->salt_bin_len = strlen(salt_ascii) / 2;
+}
+
+void free_salt(salt_t* salt) {
+	free(salt->salt_bin);
+}
+
+/**
+ * Verify that the arguments are valid, or exit with failure
+ */
+void verify_args(int argc, char** argv) {
+	int i;
+
+	if (argc < 3) {
+		printf("Usage: %s <firmware file> <signing hash1> <signing hash2> ... <signing hash n>\n", argv[0]);
+		exit(1);
+	}
+
+	for (i = 2; i < argc; i++) {
+		verify_valid_hex_str(argv[i]);
+	}
+}
+
+FILE* make_out_file(char* filename) {
+	uint8_t buf[BUF_SIZE];
+	int bytes_read;
+	char* suffix = ".new";
+	int new_filename_len = strlen(filename) + strlen(suffix) + 1;
+	char* new_filename = malloc(new_filename_len);
+	strcpy(new_filename, filename);
+	strcat(new_filename, suffix);
+
+	FILE* f = fopen(filename, "r+");
+	if (!f) {
+		printf("cannot open file %s\n", filename);
+		exit(2);
+	}
+
+	FILE* out = fopen(new_filename, "w+");
+	free(new_filename);
+	if (!out) {
+		printf("cannot open file %s\n", filename);
+		exit(2);
+	}
+
+	while (0 != (bytes_read = fread(buf, sizeof(uint8_t), BUF_SIZE, f))) {
+		fwrite(buf, sizeof(uint8_t), bytes_read, out);
+	}
+	fclose(f);
+	return out;
+}
+
+/**
+ * Sign the firmware file after all of our checks have completed
+ */
+void sign_firmware(char* filename, char** salts, int num_salts) {
+	int i;
+	salt_t salt;
+	FILE* f = make_out_file(filename);
+
+	// add a version suffix string - dlink versions do something similar before the first signature
+	add_version_suffix(f);
+
+	//for each of the salts we are supplied with
+	for (i = 0; i < num_salts; i++) {
+		char* salt_str = salts[i];
+		// convert this str to binary
+		init_salt(&salt, salt_str);
+
+		// add the signature to the firmware file produced from this salt
+		add_signature(f, &salt);
+		free_salt(&salt);
+		printf("Signed with salt: %s\n", salt_str);
+	}
+
+	fclose(f);
+}
+
+
+int main(int argc, char ** argv) {
+	verify_args(argc, argv);
+	sign_firmware(argv[1], argv+2, argc-2);
+	return 0;
+}


### PR DESCRIPTION
The R1 revision is identical to the A1 revision except
- No Config2 Parition, therefore
   - factory partition resized to 64k from 128K
   - Firmware partition offset is 0x50000 not 0x60000
   - Firmware partitions size increased by 64K
- Firmware partition type is "denx,uimage", not "sge,uimage"
- Padding of image creation "uimage-padhdr 96" removed

Installation:
- Older firmware versions: put the factory image on a USB stick, turn on
  the telnet console, and flash using the following cmd
  "fw_updater Linux /mnt/usb_X_X/firmware.bin"

- D-Link FailsafeUI:
  Sign the firmware image with the script here:
  https://pastebin.com/5wGYjTsn
  Then, power down the router, press and hold the reset button, then
  re-plug it. Keep the reset button pressed until the internet LED stops
  flashing, then jack into any lan port and manually assign a static IP
  address in 192.168.0.0/24 other than 192.168.0.0 (e.g. 192.168.0.2)
  and go to http://192.168.0.1

Signed-off-by: Andrew Pikler <andrew.pikler@gmail.com>
