### PR TITLE
ath79: add support for D-Link DAP-2660 A1

### DIFF
--- a/target/linux/ath79/dts/qca9557_dlink_dap-2660-a1.dts
+++ b/target/linux/ath79/dts/qca9557_dlink_dap-2660-a1.dts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+#include "qca95xx_dlink_dap-2xxx.dtsi"
+
+/ {
+	compatible = "dlink,dap-2660-a1", "qca,qca9557";
+	model = "D-Link DAP-2660 A1";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+};
+
+&partitions {
+	partition@70000 {
+		label = "firmware";
+		reg = <0x70000 0xee0000>;
+		compatible = "wrg";
+	};
+
+	partition@f50000 {
+		label = "dlink";
+		reg = <0xf50000 0xa0000>;
+		read-only;
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x10000>;
+		read-only;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@4 {
+		reg = <0x4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-id";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca95xx_dlink_dap-2xxx.dtsi
+++ b/target/linux/ath79/dts/qca95xx_dlink_dap-2xxx.dtsi
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "bdcfg";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "rgdb";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "unused";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -462,6 +462,10 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_text "mp" 0x1)
 		label_mac=$lan_mac
 		;;
+	dlink,dap-2660-a1)
+		lan_mac=$(mtd_get_mac_ascii bdcfg "lanmac")
+		label_mac=$lan_mac
+		;;
 	dlink,dap-2695-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -51,6 +51,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) -1)
 		;;
+	dlink,dap-2660-a1|\
 	dlink,dap-2695-a1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii bdcfg wlanmac_a)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -22,6 +22,10 @@ case "$board" in
 	dlink,dch-g020-a1)
 		mtd_get_mac_text "mp" 0x13 > /sys${DEVPATH}/macaddress
 		;;
+	dlink,dap-2660-a1)
+		[ "$PHYNBR" -eq 1 ] && \
+			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
+		;;
 	iodata,wn-ac1600dgr)
 		# There is no eeprom data for 5 GHz wlan in "art" partition
 		# which would allow to patch the macaddress

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
@@ -13,6 +13,7 @@ fixwrgg() {
 board=$(board_name)
 
 case "$board" in
+dlink,dap-2660-a1|\
 dlink,dap-2695-a1)
 	fixwrgg
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -708,6 +708,28 @@ define Device/dlink_dap-1365-a1
 endef
 TARGET_DEVICES += dlink_dap-1365-a1
 
+define Device/dlink_dap-2xxx
+  IMAGES += factory.img sysupgrade.bin
+  IMAGE/factory.img := append-kernel | pad-offset 6144k 160 | \
+	append-rootfs | wrgg-pad-rootfs | mkwrggimg | check-size
+  IMAGE/sysupgrade.bin := append-kernel | mkwrggimg | \
+	pad-to $$$$(BLOCKSIZE) | append-rootfs | append-metadata | check-size
+  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
+  KERNEL_INITRAMFS := $$(KERNEL) | mkwrggimg
+endef
+
+define Device/dlink_dap-2660-a1
+  $(Device/dlink_dap-2xxx)
+  SOC := qca9557
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-2660
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 15232k
+  DAP_SIGNATURE := wapac09_dkbs_dap2660
+endef
+TARGET_DEVICES += dlink_dap-2660-a1
+
 define Device/dlink_dap-2695-a1
   SOC := qca9558
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct


### PR DESCRIPTION
Specifications:
 * QCA9557, 16 MiB Flash, 128 MiB RAM, 802.11n 2T2R
 * QCA9882, 802.11ac 2T2R
 * Gigabit LAN Port (AR8035), 802.11af PoE

Installation:
 * Factory Web UI is at 192.168.0.50
   login with 'admin' and blank password, flash factory.bin
 * Recovery Web UI is at 192.168.0.50
   connect network cable, hold reset button during power-on and keep it
   pressed until uploading has started (only required when checksum is ok,
   e.g. for reverting back to oem firmware), flash factory.bin

After flashing factory.bin, additional free space can be reclaimed by
flashing sysupgrade.bin, since the factory image requires some padding
to be accepted for upgrading via OEM Web UI.

Known Issues:
 * 10BASE-T link unstable, retransmissions occur (also affects OEM fw)
 * "unknown" partition contains data, but is not declared in OEM layout

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>