### PR TITLE
rtl838x: Use DHCP client by default

### DIFF
--- a/target/linux/rtl838x/base-files/etc/board.d/02_network
+++ b/target/linux/rtl838x/base-files/etc/board.d/02_network
@@ -57,7 +57,7 @@ rtl838x_setup_switch()
 	done
 	json_select ..
 	lan_list=$(echo $lan_list | xargs -n1 | sort -V | xargs)
-	ucidef_set_interface_lan "$lan_list"
+	ucidef_set_interface_lan "$lan_list" dhcp
 }
 
 rtl838x_setup_macs()


### PR DESCRIPTION
For a platform primarily being used for switches, DHCP seems
to be a sensible default. As a positive side-effect, this
disables DHCPv6 and RA for odhcpd by default.

Signed-off-by: Andreas Oberritter <obi@saftware.de>