### PR TITLE
rtl838x: Bind dnsmasq to loopback device

### DIFF
--- a/target/linux/rtl838x/base-files/etc/uci-defaults/01_dnsmasq-loopback
+++ b/target/linux/rtl838x/base-files/etc/uci-defaults/01_dnsmasq-loopback
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+uci batch <<EOF
+delete dhcp.@dnsmasq[0].interface
+add_list dhcp.@dnsmasq[0].interface=lo
+commit dhcp
+EOF


### PR DESCRIPTION
On switches, dnsmasq should not act as a public service by default.

Signed-off-by: Andreas Oberritter <obi@saftware.de>
