### PR TITLE
imagebuilder: add package signature verification

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -57,6 +57,14 @@ else
 	find $(wildcard $(PACKAGE_SUBDIRS)) -type f -name '*.ipk' -exec $(CP) {} $(PKG_BUILD_DIR)/packages/ \;
 endif
 
+ifneq ($(CONFIG_SIGNATURE_CHECK),)
+	echo ''                                                        >> $(PKG_BUILD_DIR)/repositories.conf
+	echo 'option check_signature'                                  >> $(PKG_BUILD_DIR)/repositories.conf
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/keys
+	$(CP) -L $(STAGING_DIR_ROOT)/etc/opkg/keys/ $(PKG_BUILD_DIR)/
+	$(CP) -L $(STAGING_DIR_ROOT)/usr/sbin/opkg-key $(PKG_BUILD_DIR)/scripts/
+endif
+
 	$(CP) $(TOPDIR)/target/linux $(PKG_BUILD_DIR)/target/
 	if [ -d $(TOPDIR)/staging_dir/host/lib/grub ]; then \
 		$(CP) $(TOPDIR)/staging_dir/host/lib/grub/ $(PKG_BUILD_DIR)/staging_dir/host/lib; \

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -46,6 +46,7 @@ Building images:
 	make image BIN_DIR="<path>" # alternative output directory for the images
 	make image EXTRA_IMAGE_NAME="<string>" # Add this to the output image filename (sanitized)
 	make image DISABLED_SERVICES="<svc1> [<svc2> [<svc3> ..]]" # Which services in /etc/init.d/ should be disabled
+	make image ADD_LOCAL_KEY=1 # add locally generated siging key to image
 
 Print manifest:
 	List "all" packages which get installed into the image.
@@ -64,8 +65,10 @@ help: FORCE
 # override variables from rules.mk
 PACKAGE_DIR:=$(TOPDIR)/packages
 LISTS_DIR:=$(subst $(space),/,$(patsubst %,..,$(subst /,$(space),$(TARGET_DIR))))$(DL_DIR)
+export OPKG_KEYS:=$(TOPDIR)/keys
 OPKG:=$(call opkg,$(TARGET_DIR)) \
 	-f $(TOPDIR)/repositories.conf \
+	--verify-program $(SCRIPT_DIR)/opkg-key \
 	--cache $(DL_DIR) \
 	--lists-dir $(LISTS_DIR)
 
@@ -132,8 +135,19 @@ package_index: FORCE
 	@echo >&2
 	@echo Building package index... >&2
 	@mkdir -p $(TMP_DIR) $(TARGET_DIR)/tmp
+
+	$(if $(CONFIG_SIGNATURE_CHECK), \
+		@if [ ! -s $(BUILD_KEY) -o ! -s $(BUILD_KEY).pub ]; then \
+			echo Generate local signing keys... >&2; \
+			$(STAGING_DIR_HOST)/bin/usign -G -s $(BUILD_KEY) -p $(BUILD_KEY).pub -c "Local build key"; \
+			$(SCRIPT_DIR)/opkg-key add $(BUILD_KEY).pub; \
+		fi \
+	)
+
 	(cd $(PACKAGE_DIR); $(SCRIPT_DIR)/ipkg-make-index.sh . > Packages && \
-		gzip -9nc Packages > Packages.gz \
+		gzip -9nc Packages > Packages.gz; \
+		$(if $(CONFIG_SIGNATURE_CHECK), \
+			$(STAGING_DIR_HOST)/bin/usign -S -m Packages -s $(BUILD_KEY)); \
 	) >/dev/null 2>/dev/null
 	$(OPKG) update >&2 || true
 
@@ -162,8 +176,13 @@ prepare_rootfs: FORCE
 	@echo Finalizing root filesystem...
 
 	$(CP) $(TARGET_DIR) $(TARGET_DIR_ORIG)
+	$(if $(CONFIG_SIGNATURE_CHECK), \
+		$(if $(ADD_LOCAL_KEY), \
+			OPKG_KEYS=$(TARGET_DIR)/etc/opkg/keys/ \
+			$(SCRIPT_DIR)/opkg-key add $(BUILD_KEY).pub \
+		) \
+	)
 	$(call prepare_rootfs,$(TARGET_DIR),$(USER_FILES),$(DISABLED_SERVICES))
-
 
 build_image: FORCE
 	@echo


### PR DESCRIPTION
The ImageBuilder downloads pre-built packages and adds them to images.
This process uses `opkg` which has the capability to verify package list
signatures via `usign`, as enabled per default on running OpenWrt
devices.

Until now this was disabled for ImageBuilders because neither the `opkg`
keys nor the `opkg-add` script was present during first packagelist
update.

To harden the ImageBuilder against *drive-by-download-attacks* both keys
and verification script are added to the ImageBuilder allowing `opkg` to
verify downloaded package indices.

This commit adds `opkg-add` to the ImageBuilder scripts folder. The keys
folder is added to ImageBuilder $TOPDIR to have an obvious place for users to
store their own keys. The `option check_signature` is appended to the
repositories.conf file. All of the above only happens if the Buildbot
runs with the SIGNATURE_CHECK option.

The keys stored in the ImageBuilder keys/ folder are the same as stored
within images in `/etc/opkg/keys`.

To allow a local package feed in which the user can add additional
packages, a local set of `usign` keys is generated, similar to the
building OpenWrt from source. The private key signs the local
repository inside the packages/ folder. The local public key is
added to the keys/ folder to be considered by `opkg` when updating
repositories. This way a local package feed can be modified while
requiring `opkg` to check signatures for remote feed, making HTTPS
optional.

The new option `ADD_LOCAL_KEY` allows to add the local key inside the
created images, adding the advantage that sysupgrades can validate the
ImageBuilders local key.

Signed-off-by: Paul Spooren <mail@aparcar.org>