### PR TITLE
ramips: add support for the Hak5 WiFi Pineapple Mark 7

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hak5,wifi-pineapple-mk7", "mediatek,mt7628an-soc";
+	model = "Hak5 WiFi Pineapple Mark 7";
+
+	aliases {
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_blue;
+		led-upgrade = &led_system_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		system_red {
+			label = "red:system";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		system_green {
+			label = "green:system";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_blue: system_blue {
+			label = "blue:system";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb-power {
+			gpio-export,name = "usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	sdhci@10130000 {
+		compatible = "ralink,mt7620-sdhci";
+		reg = <0x10130000 4000>;
+
+		interrupt-parent = <&intc>;
+		interrupts = <14>;
+
+		status = "okay";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p4led_an", "p0led_an", "p1led_an",
+			 "p2led_an", "p3led_an", "wdt", "refclk", "i2s";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	status = "okay";
+
+	mtd-mac-address = <&factory 0x4>;
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -119,6 +119,15 @@ define Device/glinet_vixmini
 endef
 TARGET_DEVICES += glinet_vixmini
 
+define Device/hak5_wifi-pineapple-mk7
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Hak5
+  DEVICE_MODEL := WiFi Pineapple Mark 7
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  SUPPORTED_DEVICES += wifi-pineapple-mk7
+endef
+TARGET_DEVICES += hak5_wifi-pineapple-mk7
+
 define Device/hilink_hlk-7628n
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := HILINK

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ramips_setup_interfaces()
 	d-team,pbr-d1|\
 	glinet,microuter-n300|\
 	glinet,vixmini|\
+	hak5,wifi-pineapple-mk7|\
 	mediatek,linkit-smart-7688|\
 	onion,omega2p|\
 	onion,omega2|\


### PR DESCRIPTION
This patch adds support for the WiFi Pineapple Mark 7, a wireless
penetration testing tool.

Specifications:
    * SoC: MediaTek MT7628 (580MHz)
    * RAM: 256MiB (DDR2)
    * Storage 1: 32MiB NOR (SPI)
    * Storage 2: 2GB eMMC
    * Wireless 1: 802.11b/g/n 2.4GHz (Built In)
    * Wireless 2: 802.11b/g/n 2.4GHz (MT7601U)
    * Wireless 3: 802.11b/g/n 2.4GHz (MT7601U)
    * USB: 1x USB Type-A 2.0 Host Port
    * Ethernet: 1x USB Type-C AX88772C Ethernet
    * UART: 57600 8N1 on PCB
    * Inputs: 1x Reset Button
    * Outputs: 1x RGB LED

Flash Instructions:
    Original firmware is based on OpenWRT.
    Use sysupgrade via SSH to flash.

Signed-off-by: Marc Egerton <foxtrot@realloc.me>