### PR TITLE
build: add optimization flags for MIPS 4KEc

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -199,6 +199,7 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_mips32 = -mips32 -mtune=mips32
     CPU_CFLAGS_mips64 = -mips64 -mtune=mips64 -mabi=64
     CPU_CFLAGS_mips64r2 = -mips64r2 -mtune=mips64r2 -mabi=64
+    CPU_CFLAGS_4kec = -mips32r2 -mtune=4kec
     CPU_CFLAGS_24kc = -mips32r2 -mtune=24kc
     CPU_CFLAGS_74kc = -mips32r2 -mtune=74kc
     CPU_CFLAGS_octeonplus = -march=octeon+ -mabi=64


### PR DESCRIPTION
The rtl838x target uses 4KEc processor cores. This fixes
illegal instructions observed in delay slots when an
intermixed MIPS16 function directly followed a MIPS32
function with a branch or jump as last instruction.

Signed-off-by: Andreas Oberritter <obi@saftware.de>
