### PR TITLE
rtl838x: do not default to the router profile

### DIFF
--- a/target/linux/rtl838x/Makefile
+++ b/target/linux/rtl838x/Makefile
@@ -7,6 +7,7 @@ ARCH:=mips
 CPU_TYPE:=4kec
 BOARD:=rtl838x
 BOARDNAME:=Realtek MIPS
+DEVICE_TYPE:=basic
 FEATURES:=ramdisk squashfs
 
 KERNEL_PATCHVER:=5.4


### PR DESCRIPTION
```
The router profile installs many packages unnecessary for
the operation of a typical ethernet switch. Instead of creating
an empty switch profile upfront, use the basic profile until
a set of common packages crystallizes.

Signed-off-by: Andreas Oberritter <obi@saftware.de>
```
--
This is an alternative to https://github.com/openwrt/openwrt/pull/3476.