### PR TITLE
ath79: add support for Ubiquiti airCube AC

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ubnt,aircube-ac", "qca,ar9342";
+	model = "Ubiquiti airCube AC";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy0: ethernet-phy@0 {
+		phy-mode = "rgmii";
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -364,6 +364,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
+	ubnt,aircube-ac)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2" "5:lan:3" "4:wan"
+		;;
 	ubnt,aircube-isp)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -73,6 +73,7 @@ tplink,wbs510-v1|\
 tplink,wbs510-v2)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;
+ubnt,aircube-ac|\
 ubnt,aircube-isp)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -26,6 +26,7 @@ case "$FIRMWARE" in
 	qxwlan,e1700ac-v2-16m|\
 	qxwlan,e600gac-v2-8m|\
 	qxwlan,e600gac-v2-16m|\
+	ubnt,aircube-ac|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -110,15 +110,28 @@ define Device/ubnt-xw
   UBNT_VERSION := 6.0.4
 endef
 
-define Device/ubnt_aircube-isp
+define Device/ubnt-acb
   $(Device/ubnt)
-  SOC := qca9533
-  DEVICE_MODEL := airCube ISP
   IMAGE_SIZE := 15744k
-  UBNT_BOARD := ACB-ISP
-  UBNT_CHIP := qca9533
+  UBNT_BOARD := ACB
   UBNT_TYPE := ACB
   UBNT_VERSION := 2.5.0
+endef
+
+define Device/ubnt_aircube-ac
+  $(Device/ubnt-acb)
+  SOC := ar9342
+  DEVICE_MODEL := airCube AC
+  UBNT_CHIP := ar9342
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += ubnt_aircube-ac
+
+define Device/ubnt_aircube-isp
+  $(Device/ubnt-acb)
+  SOC := qca9533
+  DEVICE_MODEL := airCube ISP
+  UBNT_CHIP := qca9533
   SUPPORTED_DEVICES += ubnt,acb-isp
 endef
 TARGET_DEVICES += ubnt_aircube-isp

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -148,7 +148,7 @@ struct fw_info fw_info[] = {
 		.sign = true,
 	},
 	{
-		.name = "ACB-ISP",
+		.name = "ACB",
 		.fw_layout = {
 			.kern_start	=	0x9f050000,
 			.kern_entry	=	0x80002000,


### PR DESCRIPTION
The Ubiquiti Network airCube AC is a cube shaped device supporting
2.4 GHz and 5 GHz with internal 2x2 MIMO antennas.

It can be powered with either one of:
 - 24v power supply with 3.0mm x 1.0mm barrel plug
 - 24v passive PoE on first LAN port

There are four 10/100/1000 Mbps ports (1 * WAN + 3 * LAN).
First LAN port have optional PoE passthrough to the WAN port.

SoC: Qualcomm / Atheros AR9342
RAM: 64 MB DDR2
Flash: 16 MB SPI NOR
Ethernet: 4x 10/100/1000 Mbps (1 WAN + 3 LAN)
LEDS: 1x via a SPI controller (not yet supported)
Buttons: 1x Reset
Serial: 1x (only RX and TX); 115200 baud, 8N1

Missing features:
 - LED control is not supported

Physical to internal switch port mapping:
 - physical port #1 (poe in) = switchport 2
 - physical port #2 = switchport 3
 - physical port #3 = switchport 5
 - physical port #4 (wan/poe out) = switchport 4

Factory update is tested and is the same as for Ubiquiti AirCube ISP
hence the shared configuration between that devices.

Signed-off-by: Roman Kuzmitskii <damex.pp@icloud.com>
