### PR TITLE
rockchip: Fix for WAN interface on FriendlyElec NanoPi R2S

### DIFF
--- a/package/boot/uboot-rockchip/patches/100-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/package/boot/uboot-rockchip/patches/100-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -104,7 +104,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	gmac_clk: gmac-clock {
 +		compatible = "fixed-clock";
 +		clock-frequency = <125000000>;
-+		clock-output-names = "gmac_clk";
++		clock-output-names = "gmac_clkin";
 +		#clock-cells = <0>;
 +	};
 +

--- a/target/linux/rockchip/patches-5.4/001-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-5.4/001-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -56,7 +56,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 +	gmac_clk: gmac-clock {
 +		compatible = "fixed-clock";
 +		clock-frequency = <125000000>;
-+		clock-output-names = "gmac_clk";
++		clock-output-names = "gmac_clkin";
 +		#clock-cells = <0>;
 +	};
 +


### PR DESCRIPTION
Fix clockname for gmac in DT (the clock provided in drivers/clk/rockchip/clk-rk3328.c is gmac_clkin, not gmac_clk)
Fix OID for PHY in compatible tag in DT for rt8211e PHY

Signed-off-by: Tobias Waldvogel <tobias.waldvogel@gmail.com>