### PR TITLE
bcm63xx: move dts-v1 and remove devicename from LED labels

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -8,104 +8,91 @@
 board_config_update
 
 board=$(board_name)
-model="${board##*,}"
 
 case "$board" in
 actiontec,r1000h)
-	ucidef_set_led_usbport "usb" "USB" "R1000H:green:usb" "usb1-port1" "usb2-port1"
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;
-adb,a4001n)
-	ucidef_set_led_usbdev "usb" "USB" "A4001N:green:usb" "1-1"
+adb,a4001n|\
+comtrend,ar-5315u|\
+comtrend,vr-3032u|\
+huawei,hg253s-v2|\
+nucom,r5010un-v2|\
+sagem,fast-2704-v2)
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "1-1"
 	;;
 adb,a4001n1)
-	ucidef_set_led_netdev "lan" "LAN" "A4001N1:green:eth" "eth0"
-	ucidef_set_led_usbdev "usb" "USB" "A4001N1:green:3g" "1-1"
+	ucidef_set_led_netdev "lan" "LAN" "green:eth" "eth0"
+	ucidef_set_led_usbdev "usb" "USB" "green:3g" "1-1"
 	;;
 adb,pdg-a4001n-a-000-1a1-ax)
-	ucidef_set_led_netdev "lan" "LAN" "$model:green:internet" "eth0.1"
-	ucidef_set_led_netdev "wan" "WAN" "$model:green:adsl" "eth0.2"
-	ucidef_set_led_netdev "wlan0" "WIFI" "$model:green:wifi" "wlan0"
-	ucidef_set_led_usbdev "usb" "USB" "$model:green:service" "1-1"
+	ucidef_set_led_netdev "lan" "LAN" "green:internet" "eth0.1"
+	ucidef_set_led_netdev "wan" "WAN" "green:adsl" "eth0.2"
+	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
+	ucidef_set_led_usbdev "usb" "USB" "green:service" "1-1"
 	;;
 adb,av4202n)
-	ucidef_set_led_netdev "wlan0" "WLAN" "AV4202N:blue:wifi" "wlan0"
+	ucidef_set_led_netdev "wlan0" "WLAN" "blue:wifi" "wlan0"
 	;;
 bt,home-hub-2-a)
-	ucidef_set_led_netdev "lan" "LAN" "HOMEHUB2A:blue:broadband" "eth0.1"
-	ucidef_set_led_netdev "wlan0" "WIFI" "HOMEHUB2A:green:wireless" "wlan0"
-	ucidef_set_led_usbdev "usb1" "USB1" "HOMEHUB2A:blue:phone" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "HOMEHUB2A:green:phone" "2-1"
-	;;
-comtrend,ar-5315u)
-	ucidef_set_led_usbdev "usb" "USB" "AR-5315u:green:usb" "1-1"
-	;;
-comtrend,vr-3032u|\
-huawei,hg253s-v2)
-	ucidef_set_led_usbdev "usb" "USB" "$model:green:usb" "1-1"
+	ucidef_set_led_netdev "lan" "LAN" "blue:broadband" "eth0.1"
+	ucidef_set_led_netdev "wlan0" "WIFI" "green:wireless" "wlan0"
+	ucidef_set_led_usbdev "usb1" "USB1" "blue:phone" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "green:phone" "2-1"
 	;;
 huawei,echolife-hg553)
-	ucidef_set_led_netdev "lan" "LAN" "HW553:blue:lan" "eth0"
-	ucidef_set_led_usbdev "usb1" "USB1" "HW553:red:hspa" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "HW553:blue:hspa" "1-2"
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
+	ucidef_set_led_usbdev "usb1" "USB1" "red:hspa" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "blue:hspa" "1-2"
 	;;
 huawei,echolife-hg556a-a|\
 huawei,echolife-hg556a-b|\
 huawei,echolife-hg556a-c)
-	ucidef_set_led_netdev "lan" "LAN" "HW556:red:dsl" "eth0"
-	ucidef_set_led_usbdev "usb" "USB" "HW556:red:hspa" "1-2"
+	ucidef_set_led_netdev "lan" "LAN" "red:dsl" "eth0"
+	ucidef_set_led_usbdev "usb" "USB" "red:hspa" "1-2"
 	;;
-huawei,echolife-hg622)
-	ucidef_set_led_usbdev "usb" "USB" "HG622:green:usb" "1-2"
-	;;
+huawei,echolife-hg622|\
 huawei,echolife-hg655b)
-	ucidef_set_led_usbdev "usb" "USB" "HW65x:green:usb" "1-2"
+	ucidef_set_led_usbdev "usb" "USB" "green:usb" "1-2"
 	;;
 inventel,livebox-1)
-	ucidef_set_led_netdev "lan" "LAN" "Livebox1:red:traffic" "eth0"
-	ucidef_set_led_netdev "wan" "WAN" "Livebox1:red:adsl" "eth1"
-	ucidef_set_led_netdev "wlan0" "WIFI" "Livebox1:red:wifi" "wlan0"
+	ucidef_set_led_netdev "lan" "LAN" "red:traffic" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "red:adsl" "eth1"
+	ucidef_set_led_netdev "wlan0" "WIFI" "red:wifi" "wlan0"
 	;;
 netgear,dgnd3700-v1)
-	ucidef_set_led_netdev "lan" "LAN" "DGND3700v1_3800B:green:lan" "eth0.1"
-	ucidef_set_led_netdev "wan" "WAN" "DGND3700v1_3800B:green:inet" "eth0.2"
-	ucidef_set_led_netdev "wlan0" "WIFI2G" "DGND3700v1_3800B:green:wifi2g" "wlan0"
-	ucidef_set_led_netdev "wlan1" "WIFI5G" "DGND3700v1_3800B:blue:wifi5g" "wlan1"
-	ucidef_set_led_usbdev "usb1" "USB1" "DGND3700v1_3800B:green:usb-back" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "DGND3700v1_3800B:green:usb-front" "1-2"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0.1"
+	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth0.2"
+	ucidef_set_led_netdev "wlan0" "WIFI2G" "green:wifi2g" "wlan0"
+	ucidef_set_led_netdev "wlan1" "WIFI5G" "blue:wifi5g" "wlan1"
+	ucidef_set_led_usbdev "usb1" "USB1" "green:usb-back" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "green:usb-front" "1-2"
 	;;
 netgear,dgnd3700-v2)
-	ucidef_set_led_netdev "lan" "LAN" "$model:green:ethernet" "eth0"
-	ucidef_set_led_usbdev "usb1" "USB1" "$model:green:usb1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "$model:green:usb2" "1-2"
+	ucidef_set_led_netdev "lan" "LAN" "green:ethernet" "eth0"
+	ucidef_set_led_usbdev "usb1" "USB1" "green:usb1" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "green:usb2" "1-2"
 	;;
 netgear,evg2000)
-	ucidef_set_led_netdev "lan" "LAN" "EVG2000:green:lan" "eth0"
-	ucidef_set_led_netdev "wan" "WAN" "EVG2000:green:wan" "eth1"
-	ucidef_set_led_netdev "wlan0" "WIFI" "EVG2000:green:wireless" "wlan0"
-	ucidef_set_led_usbdev "usb1" "USB1" "EVG2000:green:voip1" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "EVG2000:green:voip2" "1-2"
-	;;
-nucom,r5010un-v2)
-	ucidef_set_led_usbdev "usb" "USB" "R5010UNv2:green:usb" "1-1"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_netdev "wlan0" "WIFI" "green:wireless" "wlan0"
+	ucidef_set_led_usbdev "usb1" "USB1" "green:voip1" "1-1"
+	ucidef_set_led_usbdev "usb2" "USB2" "green:voip2" "1-2"
 	;;
 sagem,fast-2704n)
-	ucidef_set_led_netdev "wan" "WAN" "F@ST2704N:green:inet" "eth0.2"
+	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth0.2"
 	;;
-sagem,fast-2704-v2)
-	ucidef_set_led_usbdev "usb" "USB" "F@ST2704V2:green:usb" "1-1"
-	;;
-sercomm,ad1018)
-	ucidef_set_led_netdev "wlan0" "WLAN" "$model:green:wifi" "wlan0"
-	;;
+sercomm,ad1018|\
 sercomm,ad1018-nor)
-	ucidef_set_led_netdev "wlan0" "WLAN" "AD1018:green:wifi" "wlan0"
+	ucidef_set_led_netdev "wlan0" "WLAN" "green:wifi" "wlan0"
 	;;
 sercomm,h500-s-lowi|\
 sercomm,h500-s-vfes)
-	ucidef_set_led_netdev "wan" "WAN" "h500-s:green:internet" "eth0.2"
+	ucidef_set_led_netdev "wan" "WAN" "green:internet" "eth0.2"
 	;;
 telsey,cpva502plus)
-	ucidef_set_led_netdev "lan" "LAN" "CPVA502+:amber:link" "eth0"
+	ucidef_set_led_netdev "lan" "LAN" "amber:link" "eth0"
 	;;
 esac
 

--- a/target/linux/bcm63xx/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/bcm63xx/base-files/etc/uci-defaults/04_led_migration
@@ -1,0 +1,12 @@
+. /lib/functions/migrations.sh
+
+board=$(board_name)
+
+case "$board" in
+esac
+
+remove_devicename_leds
+
+migrations_apply system
+
+exit 0

--- a/target/linux/bcm63xx/dts/bcm3368-netgear-cvg834g.dts
+++ b/target/linux/bcm63xx/dts/bcm3368-netgear-cvg834g.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm3368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm3368-netgear-cvg834g.dts
+++ b/target/linux/bcm63xx/dts/bcm3368-netgear-cvg834g.dts
@@ -24,7 +24,7 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "CVG834G:green:power";
+			label = "green:power";
 			gpios = <&gpio1 5 0>;
 			default-state = "on";
 		};

--- a/target/linux/bcm63xx/dts/bcm3368.dtsi
+++ b/target/linux/bcm63xx/dts/bcm3368.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s-lowi.dts
+++ b/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s-lowi.dts
@@ -4,8 +4,6 @@
  *
  * Copyright (C) 2020 Daniel González Cabanelas <dgcbueu@gmail.com>
  */
- 
-/dts-v1/;
 
 #include "bcm63167-sercomm-h500-s.dtsi"
 

--- a/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s-vfes.dts
+++ b/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s-vfes.dts
@@ -5,8 +5,6 @@
  * Copyright (C) 2020 Daniel González Cabanelas <dgcbueu@gmail.com>
  */
  
-/dts-v1/;
-
 #include "bcm63167-sercomm-h500-s.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s.dtsi
+++ b/target/linux/bcm63xx/dts/bcm63167-sercomm-h500-s.dtsi
@@ -52,58 +52,58 @@
 
 	mobile_red {
 		reg = <0>;
-		label = "h500-s:red:mobile";
+		label = "red:mobile";
 	};
 
 	mobile_green {
 		reg = <1>;
-		label = "h500-s:green:mobile";
+		label = "green:mobile";
 	};
 
 	led_power_red: power_red {
 		reg = <8>;
-		label = "h500-s:red:power";
+		label = "red:power";
 	};
 
 	wifi_green {
 		reg = <9>;
-		label = "h500-s:green:wifi";
+		label = "green:wifi";
 	};
 
 	phone_red {
 		reg = <12>;
-		label = "h500-s:red:phone";
+		label = "red:phone";
 	};
 
 	wifi_red {
 		reg = <13>;
-		label = "h500-s:red:wifi";
+		label = "red:wifi";
 	};
 
 	internet_red {
 		reg = <14>;
-		label = "h500-s:red:internet";
+		label = "red:internet";
 	};
 
 	internet_green {
 		reg = <15>;
-		label = "h500-s:green:internet";
+		label = "green:internet";
 	};
 
 	phone_green {
 		reg = <16>;
-		label = "h500-s:green:phone";
+		label = "green:phone";
 	};
 
 	led_power_green: power_green {
 		reg = <17>;
-		label = "h500-s:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	mobile_blue {
 		reg = <23>;
-		label = "h500-s:blue:mobile";
+		label = "blue:mobile";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm63168-comtrend-vr-3032u.dts
+++ b/target/linux/bcm63xx/dts/bcm63168-comtrend-vr-3032u.dts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm63168-comtrend-vr-3032u.dts
+++ b/target/linux/bcm63xx/dts/bcm63168-comtrend-vr-3032u.dts
@@ -70,31 +70,31 @@
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "vr-3032u:red:inet";
+		label = "red:inet";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "vr-3032u:green:dsl";
+		label = "green:dsl";
 	};
 
 	led@4 {
 		reg = <4>;
 		active-low;
-		label = "vr-3032u:green:usb";
+		label = "green:usb";
 	};
 
 	led@7 {
 		reg = <7>;
 		active-low;
-		label = "vr-3032u:green:wps";
+		label = "green:wps";
 	};
 
 	led@8 {
 		reg = <8>;
 		active-low;
-		label = "vr-3032u:green:inet";
+		label = "green:inet";
 	};
 
 	led@9 {
@@ -142,7 +142,7 @@
 	led_power_green: led@20 {
 		reg = <20>;
 		active-low;
-		label = "vr-3032u:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 };

--- a/target/linux/bcm63xx/dts/bcm63168-sky-sr102.dts
+++ b/target/linux/bcm63xx/dts/bcm63168-sky-sr102.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm63168-sky-sr102.dts
+++ b/target/linux/bcm63xx/dts/bcm63168-sky-sr102.dts
@@ -38,64 +38,64 @@
 		compatible = "gpio-leds";
 
 		lan1_green {
-			label = "SR102:green:lan1";
+			label = "green:lan1";
 			gpios = <&pinctrl 1 1>;
 		};
 		power_red {
-			label = "SR102:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 2 1>;
 		};
 		wifi_red {
-			label = "SR102:red:wifi";
+			label = "red:wifi";
 			gpios = <&pinctrl 3 1>;
 		};
 		inet_red {
-			label = "SR102:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 4 1>;
 		};
 		inet_white {
-			label = "SR102:white:inet";
+			label = "white:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		led_power_white: power_white {
-			label = "SR102:white:power";
+			label = "white:power";
 			gpios = <&pinctrl 6 0>;
 			default-state = "on";
 		};
 		wifi_white {
-			label = "SR102:white:wifi";
+			label = "white:wifi";
 			gpios = <&pinctrl 8 0>;
 		};
 		lan2_red {
-			label = "SR102:red:lan2";
+			label = "red:lan2";
 			gpios = <&pinctrl 9 1>;
 		};
 		lan3_red {
-			label = "SR102:red:lan3";
+			label = "red:lan3";
 			gpios = <&pinctrl 10 1>;
 		};
 		lan4_red {
-			label = "SR102:red:lan4";
+			label = "red:lan4";
 			gpios = <&pinctrl 11 1>;
 		};
 		lan1_red {
-			label = "SR102:red:lan1";
+			label = "red:lan1";
 			gpios = <&pinctrl 12 1>;
 		};
 		lan2_green {
-			label = "SR102:green:lan2";
+			label = "green:lan2";
 			gpios = <&pinctrl 13 0>;
 		};
 		lan3_green {
-			label = "SR102:green:lan3";
+			label = "green:lan3";
 			gpios = <&pinctrl 14 1>;
 		};
 		lan4_green {
-			label = "SR102:green:lan4";
+			label = "green:lan4";
 			gpios = <&pinctrl 15 1>;
 		};
 		hd_white {
-			label = "SR102:white:hd";
+			label = "white:hd";
 			gpios = <&pinctrl 18 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm63169-comtrend-vg-8050.dts
+++ b/target/linux/bcm63xx/dts/bcm63169-comtrend-vg-8050.dts
@@ -56,50 +56,50 @@
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "vg-8050:red:internet";
+		label = "red:internet";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "vg-8050:red:power";
+		label = "red:power";
 	};
 
 	led_power_green: led@6 {
 		reg = <6>;
 		active-low;
-		label = "vg-8050:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@7 {
 		reg = <7>;
 		active-low;
-		label = "vg-8050:green:wps";
+		label = "green:wps";
 	};
 
 	led@8 {
 		reg = <8>;
 		active-low;
-		label = "vg-8050:green:internet";
+		label = "green:internet";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "vg-8050:green:voip";
+		label = "green:voip";
 	};
 
 	led@12 {
 		reg = <12>;
 		active-low;
-		label = "vg-8050:red:voip";
+		label = "red:voip";
 	};
 
 	led@14 {
 		reg = <14>;
 		active-low;
-		label = "vg-8050:red:wps";
+		label = "red:wps";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm63169-comtrend-vg-8050.dts
+++ b/target/linux/bcm63xx/dts/bcm63169-comtrend-vg-8050.dts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref-p300.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref-p300.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6318.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref-p300.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref-p300.dts
@@ -38,22 +38,22 @@
 		compatible = "gpio-leds";
 
 		inet {
-			label = "96318REF_P300:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 8 1>;
 		};
 
 		inet_fail {
-			label = "96318REF_P300:red:inet-fail";
+			label = "red:inet-fail";
 			gpios = <&pinctrl 9 1>;
 		};
 
 		post_failed {
-			label = "96318REF_P300:red:post-failed";
+			label = "red:post-failed";
 			gpios = <&pinctrl 11 1>;
 		};
 
 		usb_pwron {
-			label = "96318REF_P300::usb-pwron";
+			label = ":usb-pwron";
 			gpios = <&pinctrl 13 1>;
 			default-state = "on";
 		};

--- a/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6318.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-brcm-bcm96318ref.dts
@@ -38,17 +38,17 @@
 		compatible = "gpio-leds";
 
 		inet {
-			label = "96318REF:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 8 1>;
 		};
 
 		inet_fail {
-			label = "96318REF:red:inet-fail";
+			label = "red:inet-fail";
 			gpios = <&pinctrl 9 1>;
 		};
 
 		post_failed {
-			label = "96318REF:red:post-failed";
+			label = "red:post-failed";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6318-comtrend-ar-5315u.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-comtrend-ar-5315u.dts
@@ -91,20 +91,20 @@
 	led@0 {
 		reg = <0>;
 		active-low;
-		label = "AR-5315u:green:wps";
+		label = "green:wps";
 	};
 
 	led_power_green: led@1 {
 		reg = <1>;
 		active-low;
-		label = "AR-5315u:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "AR-5315u:green:usb";
+		label = "green:usb";
 	};
 
 	led@4 {
@@ -138,25 +138,25 @@
 	led@8 {
 		reg = <8>;
 		active-low;
-		label = "AR-5315u:green:inet";
+		label = "green:inet";
 	};
 
 	led@9 {
 		reg = <9>;
 		active-low;
-		label = "AR-5315u:red:inet";
+		label = "red:inet";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "AR-5315u:green:dsl";
+		label = "green:dsl";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "AR-5315u:red:power";
+		label = "red:power";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6318-comtrend-ar-5315u.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-comtrend-ar-5315u.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6318.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-d-link-dsl-275xb-d1.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-d-link-dsl-275xb-d1.dts
@@ -52,39 +52,39 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "dsl-275xb:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 3 1>;
 			default-state = "on";
 		};
 
 		inet_green {
-			label = "dsl-275xb:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 8 1>;
 		};
 
 		inet_red {
-			label = "dsl-275xb:red:inet-fail";
+			label = "red:inet-fail";
 			gpios = <&pinctrl 9 1>;
 		};
 
 		power_red {
-			label = "dsl-275xb:red:post-failed";
+			label = "red:post-failed";
 			gpios = <&pinctrl 11 1>;
 		};
 
 		wps_blue {
-			label = "dsl-275xb:blue:wps";
+			label = "blue:wps";
 			gpios = <&pinctrl 16 1>;
 		};
 
 		dsl_green {
-			label = "dsl-275xb:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 17 1>;
 		};
 
 		usb_green {
 			/* not user controllable? */
-			label = "dsl-275xb:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 49 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6318-d-link-dsl-275xb-d1.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-d-link-dsl-275xb-d1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6318.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-sagem-fast-2704n.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-sagem-fast-2704n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6318.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6318-sagem-fast-2704n.dts
+++ b/target/linux/bcm63xx/dts/bcm6318-sagem-fast-2704n.dts
@@ -52,48 +52,48 @@
 		compatible = "gpio-leds";
 
 		wps_green {
-			label = "F@ST2704N:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 2 1>;
 		};
 		lan1_green {
-			label = "F@ST2704N:green:lan1";
+			label = "green:lan1";
 			gpios = <&pinctrl 4 1>;
 		};
 		lan2_green {
-			label = "F@ST2704N:green:lan2";
+			label = "green:lan2";
 			gpios = <&pinctrl 5 1>;
 		};
 		lan3_green {
-			label = "F@ST2704N:green:lan3";
+			label = "green:lan3";
 			gpios = <&pinctrl 6 1>;
 		};
 		lan4_green {
-			label = "F@ST2704N:green:lan4";
+			label = "green:lan4";
 			gpios = <&pinctrl 7 1>;
 		};
 		inet_green {
-			label = "F@ST2704N:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 8 1>;
 		};
 		inet_red {
-			label = "F@ST2704N:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 9 1>;
 		};
 		dsl_green {
-			label = "F@ST2704N:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 10 1>;
 		};
 		led_power_red: power_red {
-			label = "F@ST2704N:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 11 1>;
 		};
 		power_green {
-			label = "F@ST2704N:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 47 1>;
 			default-state = "on";
 		};
 		usb_green {
-			label = "F@ST2704N:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 49 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6318.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6318.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm63268-brcm-bcm963268bu-p300.dts
+++ b/target/linux/bcm63xx/dts/bcm63268-brcm-bcm963268bu-p300.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm63268-inteno-vg50.dts
+++ b/target/linux/bcm63xx/dts/bcm63268-inteno-vg50.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm63268.dtsi
+++ b/target/linux/bcm63xx/dts/bcm63268.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm63269-brcm-bcm963269bhr.dts
+++ b/target/linux/bcm63xx/dts/bcm63269-brcm-bcm963269bhr.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm63268.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm63269-brcm-bcm963269bhr.dts
+++ b/target/linux/bcm63xx/dts/bcm63269-brcm-bcm963269bhr.dts
@@ -31,12 +31,12 @@
 		compatible = "gpio-leds";
 
 		usb1 {
-			label = "963269BHR:green:usb1";
+			label = "green:usb1";
 			gpios = <&pinctrl 9 1>;
 		};
 
 		usb2 {
-			label = "963269BHR:green:usb2";
+			label = "green:usb2";
 			gpios = <&pinctrl 10 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-adb-a4001n.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-a4001n.dts
@@ -45,24 +45,24 @@
 		compatible = "gpio-leds";
 
 		inet_red {
-			label = "A4001N:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 1 0>;
 		};
 		power_red {
-			label = "A4001N:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 4 0>;
 		};
 		led_power_green: power_green {
-			label = "A4001N:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 8 0>;
 			default-state = "on";
 		};
 		usb_green {
-			label = "A4001N:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 10 1>;
 		};
 		dsl_green {
-			label = "A4001N:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-adb-a4001n.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-a4001n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-adb-a4001n1.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-a4001n1.dts
@@ -45,52 +45,52 @@
 		compatible = "gpio-leds";
 
 		inet_red {
-			label = "A4001N1:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "A4001N1:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		led_power_green: power_green {
-			label = "A4001N1:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		ppp_red {
-			label = "A4001N1:red:ppp";
+			label = "red:ppp";
 			gpios = <&pinctrl 5 1>;
 		};
 		usb_green {
-			label = "A4001N1:green:3g";
+			label = "green:3g";
 			gpios = <&pinctrl 6 1>;
 		};
 		usb_red {
-			label = "A4001N1:red:3g";
+			label = "red:3g";
 			gpios = <&pinctrl 7 1>;
 		};
 		power_red {
-			label = "A4001N1:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 8 1>;
 		};
 		wlan_green {
-			label = "A4001N1:green:wlan";
+			label = "green:wlan";
 			gpios = <&pinctrl 9 1>;
 		};
 		wlan_red {
-			label = "A4001N1:red:wlan";
+			label = "red:wlan";
 			gpios = <&pinctrl 10 1>;
 		};
 		inet_green {
-			label = "A4001N1:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 11 1>;
 		};
 		eth_red {
-			label = "A4001N1:red:eth";
+			label = "red:eth";
 			gpios = <&pinctrl 20 1>;
 		};
 		eth_green {
-			label = "A4001N1:green:eth";
+			label = "green:eth";
 			gpios = <&pinctrl 31 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-adb-a4001n1.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-a4001n1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
@@ -53,61 +53,61 @@
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:red:internet";
+		label = "red:internet";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:green:adsl";
+		label = "green:adsl";
 	};
 
 	led@5 {
 		reg = <5>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:red:adsl";
+		label = "red:adsl";
 	};
 
 	led@6 {
 		reg = <6>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:green:service";
+		label = "green:service";
 	};
 
 	led@7 {
 		reg = <7>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:red:service";
+		label = "red:service";
 	};
 
 	led@8 {
 		reg = <8>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:red:power";
+		label = "red:power";
 	};
 
 	led@9 {
 		reg = <9>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:green:wifi";
+		label = "green:wifi";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:red:wifi";
+		label = "red:wifi";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:green:internet";
+		label = "green:internet";
 	};
 
 	led_power_green: led@12 {
 		reg = <12>;
 		active-low;
-		label = "pdg-a4001n-a-000-1a1-ax:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 };

--- a/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-adb-pdg-a4001n-a-000-1a1-ax.dts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-brcm-bcm963281tan.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-brcm-bcm963281tan.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-brcm-bcm963281tan.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-brcm-bcm963281tan.dts
@@ -24,28 +24,28 @@
 		compatible = "gpio-leds";
 
 		inet {
-			label = "963281TAN::internet";
+			label = ":internet";
 			gpios = <&pinctrl 1 1>;
 		};
 		led_power: power {
-			label = "963281TAN::power";
+			label = ":power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		inet_fail {
-			label = "963281TAN::internet-fail";
+			label = ":internet-fail";
 			gpios = <&pinctrl 7 1>;
 		};
 		power_fail {
-			label = "963281TAN::power-fail";
+			label = ":power-fail";
 			gpios = <&pinctrl 8 1>;
 		};
 		wps {
-			label = "963281TAN::wps";
+			label = ":wps";
 			gpios = <&pinctrl 9 1>;
 		};
 		dsl {
-			label = "963281TAN::dsl";
+			label = ":dsl";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-brcm-bcm96328avng.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-brcm-bcm96328avng.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-brcm-bcm96328avng.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-brcm-bcm96328avng.dts
@@ -24,28 +24,28 @@
 		compatible = "gpio-leds";
 
 		inet_fail {
-			label = "96328avng::internet-fail";
+			label = ":internet-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		dsl {
-			label = "96328avng::dsl";
+			label = ":dsl";
 			gpios = <&pinctrl 3 1>;
 		};
 		led_power: power {
-			label = "96328avng::power";
+			label = ":power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		power_fail {
-			label = "96328avng::power-fail";
+			label = ":power-fail";
 			gpios = <&pinctrl 8 1>;
 		};
 		wps {
-			label = "96328avng::wps";
+			label = ":wps";
 			gpios = <&pinctrl 9 1>;
 		};
 		inet {
-			label = "96328avng::internet";
+			label = ":internet";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5381u.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5381u.dts
@@ -82,19 +82,19 @@
 	led_alarm_red: led@2 {
 		reg = <2>;
 		active-low;
-		label = "AR-5381u:red:alarm";
+		label = "red:alarm";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "AR-5381u:green:inet";
+		label = "green:inet";
 	};
 
 	led_power_green: led@4 {
 		reg = <4>;
 		active-low;
-		label = "AR-5381u:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 };

--- a/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5381u.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5381u.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5387un.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5387un.dts
@@ -81,29 +81,29 @@
 
 	led@1 {
 		reg = <1>;
-		label = "AR-5387un:red:inet";
+		label = "red:inet";
 	};
 
 	led@4 {
 		reg = <4>;
-		label = "AR-5387un:red:power";
+		label = "red:power";
 	};
 
 	led@7 {
 		reg = <7>;
-		label = "AR-5387un:green:inet";
+		label = "green:inet";
 	};
 
 	led_power_green: led@8 {
 		reg = <8>;
-		label = "AR-5387un:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "AR-5387un:green:dsl";
+		label = "green:dsl";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5387un.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-comtrend-ar-5387un.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-274xb-f1.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-274xb-f1.dts
@@ -52,28 +52,28 @@
 		compatible = "gpio-leds";
 
 		inet_red {
-			label = "dsl-274xb:red:internet";
+			label = "red:internet";
 			gpios = <&pinctrl 2 1>;
 		};
 		dsl_green {
-			label = "dsl-274xb:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 3 1>;
 		};
 		led_power_green: power_green {
-			label = "dsl-274xb:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "dsl-274xb:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 8 1>;
 		};
 		wps_blue {
-			label = "dsl-274xb:blue:wps";
+			label = "blue:wps";
 			gpios = <&pinctrl 9 1>;
 		};
 		inet_green {
-			label = "dsl-274xb:green:internet";
+			label = "green:internet";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-274xb-f1.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-d-link-dsl-274xb-f1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-nucom-r5010un-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-nucom-r5010un-v2.dts
@@ -45,32 +45,32 @@
 		compatible = "gpio-leds";
 
 		inet_green {
-			label = "R5010UNv2:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 1 1>;
 		};
 		inet_fail_red {
-			label = "R5010UNv2:red:inet-fail";
+			label = "red:inet-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		dsl_red {
-			label = "R5010UNv2:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 3 1>;
 		};
 		led_power_green: power_green {
-			label = "R5010UNv2:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		power_fail_red {
-			label = "R5010UNv2:red:power-fail";
+			label = "red:power-fail";
 			gpios = <&pinctrl 5 1>;
 		};
 		wps_green {
-			label = "R5010UNv2:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 10 1>;
 		};
 		usb_green {
-			label = "R5010UNv2:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-nucom-r5010un-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-nucom-r5010un-v2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-sagem-fast-2704-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sagem-fast-2704-v2.dts
@@ -52,32 +52,32 @@
 		compatible = "gpio-leds";
 
 		usb_green {
-			label = "F@ST2704V2:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 1 1>;
 		};
 		inet_red {
-			label = "F@ST2704V2:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 2 1>;
 		};
 		dsl_green {
-			label = "F@ST2704V2:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 3 1>;
 		};
 		led_power_green: power_green {
-			label = "F@ST2704V2:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "F@ST2704V2:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 5 1>;
 		};
 		wps_green {
-			label = "F@ST2704V2:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 10 1>;
 		};
 		inet_green {
-			label = "F@ST2704V2:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6328-sagem-fast-2704-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sagem-fast-2704-v2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018-nor.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018-nor.dts
@@ -71,56 +71,56 @@
 	inet_red@0 {
 		reg = <0>;
 		active-low;
-		label = "AD1018:red:internet";
+		label = "red:internet";
 	};
 
 	inet_green@1 {
 		reg = <1>;
 		active-low;
-		label = "AD1018:green:internet";
+		label = "green:internet";
 	};
 
 	led_power_green: power_green@8 {
 		reg = <8>;
 		active-low;
-		label = "AD1018:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	adsl_green@10 {
 		reg = <10>;
 		active-low;
-		label = "AD1018:green:adsl";
+		label = "green:adsl";
 	};
 
 	adsl_red@11 {
 		reg = <11>;
 		active-low;
-		label = "AD1018:red:adsl";
+		label = "red:adsl";
 	};
 
 	phone_green@12 {
 		reg = <12>;
 		active-low;
-		label = "AD1018:green:phone";
+		label = "green:phone";
 	};
 
 	wps_green@13 {
 		reg = <13>;
 		active-low;
-		label = "AD1018:green:wps";
+		label = "green:wps";
 	};
 
 	wifi_green@14 {
 		reg = <14>;
 		active-low;
-		label = "AD1018:green:wifi";
+		label = "green:wifi";
 	};
 
 	usb_green@15 {
 		reg = <15>;
 		active-low;
-		label = "AD1018:green:usb";
+		label = "green:usb";
 	};
 
 	ephy0_spd@17 {

--- a/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018-nor.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018-nor.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018.dts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/dts-v1/;
-
 #include "bcm6328.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018.dts
+++ b/target/linux/bcm63xx/dts/bcm6328-sercomm-ad1018.dts
@@ -66,56 +66,56 @@
 	led@0 {
 		reg = <0>;
 		active-low;
-		label = "ad1018:red:internet";
+		label = "red:internet";
 	};
 
 	led@1 {
 		reg = <1>;
 		active-low;
-		label = "ad1018:green:internet";
+		label = "green:internet";
 	};
 
 	led_power_green: led@8 {
 		reg = <8>;
 		active-low;
-		label = "ad1018:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "ad1018:green:adsl";
+		label = "green:adsl";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "ad1018:red:adsl";
+		label = "red:adsl";
 	};
 
 	led@12 {
 		reg = <12>;
 		active-low;
-		label = "ad1018:green:phone";
+		label = "green:phone";
 	};
 
 	led@13 {
 		reg = <13>;
 		active-low;
-		label = "ad1018:green:wps";
+		label = "green:wps";
 	};
 
 	led@14 {
 		reg = <14>;
 		active-low;
-		label = "ad1018:green:wifi";
+		label = "green:wifi";
 	};
 
 	led@15 {
 		reg = <15>;
 		active-low;
-		label = "ad1018:green:usb";
+		label = "green:usb";
 	};
 
 	led@17 {

--- a/target/linux/bcm63xx/dts/bcm6328.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6328.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338gw.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338gw.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96338GW:green:power";
+			label = "green:power";
 			gpios = <&gpio0 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96338GW:green:stop";
+			label = "green:stop";
 			gpios = <&gpio0 1 1>;
 		};
 		dsl_green {
-			label = "96338GW:green:adsl";
+			label = "green:adsl";
 			gpios = <&gpio0 3 1>;
 		};
 		ppp_fail_green {
-			label = "96338GW:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&gpio0 4 1>;
 		};
 		ses_green {
-			label = "96338GW:green:ses";
+			label = "green:ses";
 			gpios = <&gpio0 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338gw.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338gw.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6338.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338w.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338w.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96338W:green:power";
+			label = "green:power";
 			gpios = <&gpio0 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96338W:green:stop";
+			label = "green:stop";
 			gpios = <&gpio0 1 1>;
 		};
 		dsl_green {
-			label = "96338W:green:adsl";
+			label = "green:adsl";
 			gpios = <&gpio0 3 1>;
 		};
 		ppp_fail_green {
-			label = "96338W:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&gpio0 4 1>;
 		};
 		ses_green {
-			label = "96338W:green:ses";
+			label = "green:ses";
 			gpios = <&gpio0 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338w.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-brcm-bcm96338w.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6338.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6338-d-link-dsl-2640u.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-d-link-dsl-2640u.dts
@@ -17,18 +17,18 @@
 		compatible = "gpio-leds";
 
 		green_power {
-			label = "96338W2_E7T:green:power";
+			label = "green:power";
 			gpios = <&gpio0 0 1>;
 			default-state = "on";
 		};
 
 		green_stop {
-			label = "96338W2_E7T:green:ppp";
+			label = "green:ppp";
 			gpios = <&gpio0 4 1>;
 		};
 
 		green_adsl {
-			label = "96338W2_E7T:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&gpio0 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6338-d-link-dsl-2640u.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-d-link-dsl-2640u.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6338.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6338-dynalink-rta1320.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-dynalink-rta1320.dts
@@ -17,20 +17,20 @@
 		compatible = "gpio-leds";
 
 		green_power {
-			label = "RTA1320_16M:green:power";
+			label = "green:power";
 			gpios = <&gpio0 0 1>;
 			default-state = "on";
 		};
 		green_stop {
-			label = "RTA1320_16M:green:stop";
+			label = "green:stop";
 			gpios = <&gpio0 1 1>;
 		};
 		green_adsl {
-			label = "RTA1320_16M:green:adsl";
+			label = "green:adsl";
 			gpios = <&gpio0 3 1>;
 		};
 		green_ppp {
-			label = "RTA1320_16M:green:ppp";
+			label = "green:ppp";
 			gpios = <&gpio0 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6338-dynalink-rta1320.dts
+++ b/target/linux/bcm63xx/dts/bcm6338-dynalink-rta1320.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6338.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6338.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6338.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6345-brcm-bcm96345gw2.dts
+++ b/target/linux/bcm63xx/dts/bcm6345-brcm-bcm96345gw2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6345.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770bw.dts
+++ b/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770bw.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6345.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770bw.dts
+++ b/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770bw.dts
@@ -38,22 +38,22 @@
 		compatible = "gpio-leds";
 
 		usb {
-			label = "RTA770BW:green:usb";
+			label = "green:usb";
 			gpios = <&gpio0 7 1>;
 		};
 
 		adsl {
-			label = "RTA770BW:green:adsl";
+			label = "green:adsl";
 			gpios = <&gpio0 8 0>;
 		};
 
 		led_diag: diag {
-			label = "RTA770BW:green:diag";
+			label = "green:diag";
 			gpios = <&gpio0 10 1>;
 		};
 
 		wlan {
-			label = "RTA770BW:green:wlan";
+			label = "green:wlan";
 			gpios = <&gpio0 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770w.dts
+++ b/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770w.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6345.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770w.dts
+++ b/target/linux/bcm63xx/dts/bcm6345-dynalink-rta770w.dts
@@ -38,22 +38,22 @@
 		compatible = "gpio-leds";
 
 		usb {
-			label = "RTA770W:green:usb";
+			label = "green:usb";
 			gpios = <&gpio0 7 1>;
 		};
 
 		adsl {
-			label = "RTA770W:green:adsl";
+			label = "green:adsl";
 			gpios = <&gpio0 8 0>;
 		};
 
 		led_diag: diag {
-			label = "RTA770W:green:diag";
+			label = "green:diag";
 			gpios = <&gpio0 10 1>;
 		};
 
 		wlan {
-			label = "RTA770W:green:wlan";
+			label = "green:wlan";
 			gpios = <&gpio0 11 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6345.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6345.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6348-asmax-ar-1004g.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-asmax-ar-1004g.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-asmax-ar-1004g.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-asmax-ar-1004g.dts
@@ -38,16 +38,16 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "AR1004G:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		inet_green {
-			label = "AR1004G:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 3 1>;
 		};
 		power_red {
-			label = "AR1004G:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 6 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-belkin-f5d7633.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-belkin-f5d7633.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-belkin-f5d7633.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-belkin-f5d7633.dts
@@ -31,24 +31,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348GW-10:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW-10:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW-10:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW-10:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW-10:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-10.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-10.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-10.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-10.dts
@@ -31,24 +31,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348GW-10:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW-10:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW-10:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW-10:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW-10:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-11.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-11.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-11.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw-11.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "96348GW-11:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW-11:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW-11:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW-11:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW-11:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348gw.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "96348GW:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348r.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348r.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348r.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-brcm-bcm96348r.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348R:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348R:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348R:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348R:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348R:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2110.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2110.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2110.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2110.dts
@@ -38,23 +38,23 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "V2110:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 		};
 		power_red {
-			label = "V2110:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_green {
-			label = "V2110:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "V2110:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		wireless_green {
-			label = "V2110:green:wireless";
+			label = "green:wireless";
 			gpios = <&pinctrl 6 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2500v-bb.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2500v-bb.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2500v-bb.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-bt-voyager-2500v-bb.dts
@@ -31,23 +31,23 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "V2500V_BB:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 		};
 		power_red {
-			label = "V2500V_BB:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_green {
-			label = "V2500V_BB:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "V2500V_BB:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		wireless_green {
-			label = "V2500V_BB:green:wireless";
+			label = "green:wireless";
 			gpios = <&pinctrl 6 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-5365.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-5365.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-5365.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-5365.dts
@@ -45,16 +45,16 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348A-122:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		alarm_red {
-			label = "96348A-122:red:alarm";
+			label = "red:alarm";
 			gpios = <&pinctrl 2 1>;
 		};
 		wps_green {
-			label = "96348A-122:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 6 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-536plus.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-536plus.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-536plus.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-comtrend-ct-536plus.dts
@@ -38,12 +38,12 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "CT536_CT5621:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		adsl_fail_green {
-			label = "CT536_CT5621:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-d-link-dsl-2640b-b.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-d-link-dsl-2640b-b.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-d-link-dsl-2640b-b.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-d-link-dsl-2640b-b.dts
@@ -38,20 +38,20 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "D-4P-W:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		status {
-			label = "D-4P-W::status";
+			label = ":status";
 			gpios = <&pinctrl 3 1>;
 		};
 		inet_green {
-			label = "D-4P-W:green:internet";
+			label = "green:internet";
 			gpios = <&pinctrl 4 1>;
 		};
 		inet_red {
-			label = "D-4P-W:red:internet";
+			label = "red:internet";
 			gpios = <&pinctrl 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-davolink-dv-201amr.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-davolink-dv-201amr.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-dynalink-rta1025w.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-dynalink-rta1025w.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-inventel-livebox-1.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-inventel-livebox-1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-inventel-livebox-1.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-inventel-livebox-1.dts
@@ -45,28 +45,28 @@
 		compatible = "gpio-leds";
 
 		led_red_adsl_fail: red_adsl_fail {
-			label = "Livebox1:red:adsl-fail-power";
+			label = "red:adsl-fail-power";
 			gpios = <&pinctrl 0 0>;
 			default-state = "on";
 		};
 
 		red_adsl {
-			label = "Livebox1:red:adsl";
+			label = "red:adsl";
 			gpios = <&pinctrl 1 0>;
 		};
 
 		red_traffic {
-			label = "Livebox1:red:traffic";
+			label = "red:traffic";
 			gpios = <&pinctrl 2 0>;
 		};
 
 		red_phone {
-			label = "Livebox1:red:phone";
+			label = "red:phone";
 			gpios = <&pinctrl 3 0>;
 		};
 
 		red_wifi {
-			label = "Livebox1:red:wifi";
+			label = "red:wifi";
 			gpios = <&pinctrl 4 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-netgear-dg834g-v4.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-netgear-dg834g-v4.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-netgear-dg834g-v4.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-netgear-dg834g-v4.dts
@@ -31,20 +31,20 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348W3:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		status {
-			label = "96348W3:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 1 1>;
 		};
 		inet_green {
-			label = "96348W3::adsl";
+			label = ":adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_red {
-			label = "96348W3::internet";
+			label = ":internet";
 			gpios = <&pinctrl 3 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-netgear-dg834gt-pn.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-netgear-dg834gt-pn.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-netgear-dg834gt-pn.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-netgear-dg834gt-pn.dts
@@ -31,24 +31,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348GW-10:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW-10:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW-10:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW-10:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW-10:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2404.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2404.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2604.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2604.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2604.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-sagem-fast-2604.dts
@@ -31,20 +31,20 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "F@ST2604:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "F@ST2604:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 1 1>;
 		};
 		inet_red {
-			label = "F@ST2604:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 4 1>;
 		};
 		wps_green {
-			label = "F@ST2604:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-t-com-speedport-w-500v.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-t-com-speedport-w-500v.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-t-com-speedport-w-500v.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-t-com-speedport-w-500v.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "SPW500V:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "SPW500V:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 1 1>;
 		};
 		ppp_green {
-			label = "SPW500V:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		pstn_green {
-			label = "SPW500V:green:pstn";
+			label = "green:pstn";
 			gpios = <&pinctrl 28 1>;
 		};
 		voip_green {
-			label = "SPW500V:green:voip";
+			label = "green:voip";
 			gpios = <&pinctrl 32 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-tecom-gw6000.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-tecom-gw6000.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-tecom-gw6200.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-tecom-gw6200.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-tecom-gw6200.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-tecom-gw6200.dts
@@ -38,19 +38,19 @@
 		compatible = "gpio-leds";
 
 		led_line1_green: line1_green {
-			label = "GW6200:green:line1";
+			label = "green:line1";
 			gpios = <&pinctrl 4 1>;
 		};
 		line2_green {
-			label = "GW6200:green:line2";
+			label = "green:line2";
 			gpios = <&pinctrl 5 1>;
 		};
 		line3_green {
-			label = "GW6200:green:line3";
+			label = "green:line3";
 			gpios = <&pinctrl 6 1>;
 		};
 		tel_green {
-			label = "GW6200:green:tel";
+			label = "green:tel";
 			gpios = <&pinctrl 7 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-telsey-cpva502plus.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-telsey-cpva502plus.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-telsey-cpva502plus.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-telsey-cpva502plus.dts
@@ -31,12 +31,12 @@
 		compatible = "gpio-leds";
 
 		phone_green {
-			label = "CPVA502+:green:phone";
+			label = "green:phone";
 			gpios = <&pinctrl 0 1>;
 		};
 
 		link_amber {
-			label = "CPVA502+:amber:link";
+			label = "amber:link";
 			gpios = <&pinctrl 5 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-telsey-magic.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-telsey-magic.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-telsey-magic.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-telsey-magic.dts
@@ -17,38 +17,38 @@
 		compatible = "gpio-leds";
 
 		power {
-			label = "MAGIC:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 
 		stop {
-			label = "MAGIC:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 
 		hpna {
-			label = "MAGIC:green:hpna";
+			label = "green:hpna";
 			gpios = <&pinctrl 4 1>;
 		};
 
 		status {
-			label = "MAGIC:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 5 1>;
 		};
 
 		voip {
-			label = "MAGIC:green:voip";
+			label = "green:voip";
 			gpios = <&pinctrl 22 1>;
 		};
 
 		wifi {
-			label = "MAGIC:green:wifi";
+			label = "green:wifi";
 			gpios = <&pinctrl 28 0>;
 		};
 
 		usb {
-			label = "MAGIC:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 35 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-tp-link-td-w8900gb.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-tp-link-td-w8900gb.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-tp-link-td-w8900gb.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-tp-link-td-w8900gb.dts
@@ -31,24 +31,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96348GW-11:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 1>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96348GW-11:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 1 1>;
 		};
 		adsl_fail_green {
-			label = "96348GW-11:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96348GW-11:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 3 1>;
 		};
 		ppp_fail_green {
-			label = "96348GW-11:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 4 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348-usrobotics-usr9108.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-usrobotics-usr9108.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6348.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6348-usrobotics-usr9108.dts
+++ b/target/linux/bcm63xx/dts/bcm6348-usrobotics-usr9108.dts
@@ -17,11 +17,11 @@
 		compatible = "gpio-leds";
 
 		usb {
-			label = "96348GW-A::usb";
+			label = ":usb";
 			gpios = <&pinctrl 0 1>;
 		};
 		dsl {
-			label = "96348GW-A::adsl";
+			label = ":adsl";
 			gpios = <&pinctrl 3 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6348.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6348.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6358-alcatel-rg100a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-alcatel-rg100a.dts
@@ -17,20 +17,20 @@
 		compatible = "gpio-leds";
 
 		stop_green {
-			label = "96358VW2:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 4 1>;
 		};
 		power_green {
-			label = "96358VW2:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 5 1>;
 			default-state = "on";
 		};
 		adsl_green {
-			label = "96358VW2:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 22 1>;
 		};
 		ppp_fail_green {
-			label = "96358VW2:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 23 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-alcatel-rg100a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-alcatel-rg100a.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "96358VW:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 0>;
 			default-state = "on";
 		};
 		stop_green {
-			label = "96358VW:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 5 0>;
 		};
 		adsl_fail_green {
-			label = "96358VW:green:adsl-fail";
+			label = "green:adsl-fail";
 			gpios = <&pinctrl 15 1>;
 		};
 		ppp_green {
-			label = "96358VW:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 22 1>;
 		};
 		ppp_fail_green {
-			label = "96358VW:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 23 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw2.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw2.dts
@@ -17,20 +17,20 @@
 		compatible = "gpio-leds";
 
 		stop_green {
-			label = "96358VW2:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 4 1>;
 		};
 		power_green {
-			label = "96358VW2:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 5 1>;
 			default-state = "on";
 		};
 		adsl_green {
-			label = "96358VW2:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 22 1>;
 		};
 		ppp_fail_green {
-			label = "96358VW2:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 23 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw2.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-brcm-bcm96358vw2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-bt-home-hub-2-a.dts
@@ -58,92 +58,92 @@
 	led@0 {
 		reg = <0>;
 		active-low;
-		label = "HOMEHUB2A:red:power";
+		label = "red:power";
 	};
 
 	led_power_green: led@1 {
 		reg = <0>;
 		active-low;
-		label = "HOMEHUB2A:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "HOMEHUB2A:blue:power";
+		label = "blue:power";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "HOMEHUB2A:red:broadband";
+		label = "red:broadband";
 	};
 
 	led@4 {
 		reg = <4>;
 		active-low;
-		label = "HOMEHUB2A:green:broadband";
+		label = "green:broadband";
 	};
 
 	led@5 {
 		reg = <5>;
 		active-low;
-		label = "HOMEHUB2A:blue:broadband";
+		label = "blue:broadband";
 	};
 
 	led@6 {
 		reg = <6>;
 		active-low;
-		label = "HOMEHUB2A:red:wireless";
+		label = "red:wireless";
 	};
 
 	led@7 {
 		reg = <7>;
 		active-low;
-		label = "HOMEHUB2A:green:wireless";
+		label = "green:wireless";
 	};
 
 	led@8 {
 		reg = <8>;
 		active-low;
-		label = "HOMEHUB2A:blue:wireless";
+		label = "blue:wireless";
 	};
 
 	led@9 {
 		reg = <9>;
 		active-low;
-		label = "HOMEHUB2A:red:phone";
+		label = "red:phone";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "HOMEHUB2A:green:phone";
+		label = "green:phone";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "HOMEHUB2A:blue:phone";
+		label = "blue:phone";
 	};
 
 	led@12 {
 		reg = <12>;
 		active-low;
-		label = "HOMEHUB2A:red:upgrading";
+		label = "red:upgrading";
 	};
 
 	led_upgrading_green: led@13 {
 		reg = <13>;
 		active-low;
-		label = "HOMEHUB2A:green:upgrading";
+		label = "green:upgrading";
 	};
 
 	led@14 {
 		reg = <14>;
 		active-low;
-		label = "HOMEHUB2A:blue:upgrading";
+		label = "blue:upgrading";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6358-comtrend-ct-6373.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-comtrend-ct-6373.dts
@@ -31,16 +31,16 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "CT6373-1:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 0>;
 			default-state = "on";
 		};
 		usb_green {
-			label = "CT6373-1:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 3 1>;
 		};
 		wlan_green {
-			label = "CT6373-1:green:wlan";
+			label = "green:wlan";
 			gpios = <&pinctrl 9 1>;
 		};
 	};
@@ -55,25 +55,25 @@
 	led@0 {
 		reg = <0>;
 		active-low;
-		label = "CT6373-1:green:adsl";
+		label = "green:adsl";
 	};
 
 	led@1 {
 		reg = <1>;
 		active-low;
-		label = "CT6373-1:green:line";
+		label = "green:line";
 	};
 
 	led@2 {
 		reg = <2>;
 		active-low;
-		label = "CT6373-1:green:fxs1";
+		label = "green:fxs1";
 	};
 
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "CT6373-1:green:fxs2";
+		label = "green:fxs2";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6358-comtrend-ct-6373.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-comtrend-ct-6373.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-2650u.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-2650u.dts
@@ -17,20 +17,20 @@
 		compatible = "gpio-leds";
 
 		stop_green {
-			label = "96358VW2:green:stop";
+			label = "green:stop";
 			gpios = <&pinctrl 4 1>;
 		};
 		power_green {
-			label = "96358VW2:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 5 1>;
 			default-state = "on";
 		};
 		adsl_green {
-			label = "96358VW2:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 22 1>;
 		};
 		ppp_fail_green {
-			label = "96358VW2:green:ppp-fail";
+			label = "green:ppp-fail";
 			gpios = <&pinctrl 23 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-2650u.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-2650u.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-274xb-c2.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-274xb-c2.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		inet_green {
-			label = "dsl-274xb:green:internet";
+			label = "green:internet";
 			gpios = <&pinctrl 2 0>;
 		};
 		power_red {
-			label = "dsl-274xb:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 4 1>;
 		};
 		led_power_green: power_green {
-			label = "dsl-274xb:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 5 1>;
 			default-state = "on";
 		};
 		dsl_green {
-			label = "dsl-274xb:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 9 1>;
 		};
 		inet_red {
-			label = "dsl-274xb:red:internet";
+			label = "red:internet";
 			gpios = <&pinctrl 10 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-274xb-c2.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dsl-274xb-c2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dva-g3810bn-tl.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dva-g3810bn-tl.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-d-link-dva-g3810bn-tl.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-d-link-dva-g3810bn-tl.dts
@@ -31,24 +31,24 @@
 		compatible = "gpio-leds";
 
 		voip {
-			label = "DVAG3810BN::voip";
+			label = ":voip";
 			gpios = <&pinctrl 1 0>;
 		};
 		power {
-			label = "DVAG3810BN::power";
+			label = ":power";
 			gpios = <&pinctrl 4 0>;
 			default-state = "on";
 		};
 		stop {
-			label = "DVAG3810BN::stop";
+			label = ":stop";
 			gpios = <&pinctrl 5 0>;
 		};
 		dsl {
-			label = "DVAG3810BN::dsl";
+			label = ":dsl";
 			gpios = <&pinctrl 22 1>;
 		};
 		inet {
-			label = "DVAG3810BN::internet";
+			label = ":internet";
 			gpios = <&pinctrl 23 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg553.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg553.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-a.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-a.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-a.dts
@@ -1,153 +1,45 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {
 	model = "Huawei EchoLife HG556a (version A)";
 	compatible = "huawei,echolife-hg556a-a", "brcm,bcm6358";
+};
 
-	aliases {
-		led-boot = &led_power_red;
-		led-failsafe = &led_power_red;
-		led-running = &led_power_red;
-		led-upgrade = &led_power_red;
-	};
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		help {
-			label = "help";
-			gpios = <&pinctrl 8 1>;
-			linux,code = <KEY_HELP>;
-			debounce-interval = <60>;
-		};
-
-		wlan {
-			label = "wlan";
-			gpios = <&pinctrl 9 1>;
-			linux,code = <KEY_WLAN>;
-			debounce-interval = <60>;
-		};
-
-		restart {
-			label = "restart";
-			gpios = <&pinctrl 10 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 11 1>;
-			linux,code = <KEY_CONFIG>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		message_red {
-			label = "HW556:red:message";
-			gpios = <&pinctrl 0 1>;
-		};
-		hspa_red {
-			label = "HW556:red:hspa";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_red {
-			label = "HW556:red:dsl";
-			gpios = <&pinctrl 2 1>;
-		};
-		led_power_red: power_red {
-			label = "HW556:red:power";
-			gpios = <&pinctrl 3 1>;
-			default-state = "on";
-		};
-		all_red {
-			label = "HW556:red:all";
-			gpios = <&pinctrl 6 1>;
-			default-state = "on";
-		};
-		lan1_green {
-			label = "HW556:green:lan1";
-			gpios = <&pinctrl 12 1>;
-		};
-		lan1_red {
-			label = "HW556:red:lan1";
-			gpios = <&pinctrl 13 1>;
-		};
-		lan2_green {
-			label = "HW556:green:lan2";
-			gpios = <&pinctrl 15 1>;
-		};
-		lan2_red {
-			label = "HW556:red:lan2";
-			gpios = <&pinctrl 22 1>;
-		};
-		lan3_green {
-			label = "HW556:green:lan3";
-			gpios = <&pinctrl 23 1>;
-		};
-		lan3_red {
-			label = "HW556:red:lan3";
-			gpios = <&pinctrl 26 1>;
-		};
-		lan4_green {
-			label = "HW556:green:lan4";
-			gpios = <&pinctrl 27 1>;
-		};
-		lan4_red {
-			label = "HW556:red:lan4";
-			gpios = <&pinctrl 28 1>;
-		};
+&gpiokeys {
+	help {
+		label = "help";
+		gpios = <&pinctrl 8 1>;
+		linux,code = <KEY_HELP>;
+		debounce-interval = <60>;
 	};
 };
 
-&pflash {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		cfe@0 {
-			label = "CFE";
-			reg = <0x000000 0x020000>;
-			read-only;
-		};
-
-		linux@20000 {
-			label = "linux";
-			reg = <0x020000 0xec0000>;
-			compatible = "brcm,bcm963xx-imagetag";
-		};
-
-		cal_data@ee0000 {
-			label = "cal_data";
-			reg = <0xee0000 0x100000>;
-			read-only;
-		};
-
-		nvram@fe0000 {
-			label = "nvram";
-			reg = <0xfe0000 0x020000>;
-		};
+&gpioleds {
+	message_red {
+		label = "red:message";
+		gpios = <&pinctrl 0 1>;
 	};
-};
 
-&uart0 {
-	status = "okay";
+	hspa_red {
+		label = "red:hspa";
+		gpios = <&pinctrl 1 1>;
+	};
+
+	all_red {
+		label = "red:all";
+		gpios = <&pinctrl 6 1>;
+		default-state = "on";
+	};
+
+	lan1_green {
+		label = "green:lan1";
+		gpios = <&pinctrl 12 1>;
+	};
+
+	lan2_green {
+		label = "green:lan2";
+		gpios = <&pinctrl 15 1>;
+	};
 };

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-b.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-b.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-b.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-b.dts
@@ -1,153 +1,45 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {
 	model = "Huawei EchoLife HG556a (version B)";
 	compatible = "huawei,echolife-hg556a-b", "brcm,bcm6358";
+};
 
-	aliases {
-		led-boot = &led_power_red;
-		led-failsafe = &led_power_red;
-		led-running = &led_power_red;
-		led-upgrade = &led_power_red;
-	};
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		help {
-			label = "help";
-			gpios = <&pinctrl 8 1>;
-			linux,code = <KEY_HELP>;
-			debounce-interval = <60>;
-		};
-
-		wlan {
-			label = "wlan";
-			gpios = <&pinctrl 9 1>;
-			linux,code = <KEY_WLAN>;
-			debounce-interval = <60>;
-		};
-
-		restart {
-			label = "restart";
-			gpios = <&pinctrl 10 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 11 1>;
-			linux,code = <KEY_CONFIG>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		message_red {
-			label = "HW556:red:message";
-			gpios = <&pinctrl 0 1>;
-		};
-		hspa_red {
-			label = "HW556:red:hspa";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_red {
-			label = "HW556:red:dsl";
-			gpios = <&pinctrl 2 1>;
-		};
-		led_power_red: power_red {
-			label = "HW556:red:power";
-			gpios = <&pinctrl 3 1>;
-			default-state = "on";
-		};
-		all_red {
-			label = "HW556:red:all";
-			gpios = <&pinctrl 6 1>;
-			default-state = "on";
-		};
-		lan1_green {
-			label = "HW556:green:lan1";
-			gpios = <&pinctrl 12 1>;
-		};
-		lan1_red {
-			label = "HW556:red:lan1";
-			gpios = <&pinctrl 13 1>;
-		};
-		lan2_green {
-			label = "HW556:green:lan2";
-			gpios = <&pinctrl 15 1>;
-		};
-		lan2_red {
-			label = "HW556:red:lan2";
-			gpios = <&pinctrl 22 1>;
-		};
-		lan3_green {
-			label = "HW556:green:lan3";
-			gpios = <&pinctrl 23 1>;
-		};
-		lan3_red {
-			label = "HW556:red:lan3";
-			gpios = <&pinctrl 26 1>;
-		};
-		lan4_green {
-			label = "HW556:green:lan4";
-			gpios = <&pinctrl 27 1>;
-		};
-		lan4_red {
-			label = "HW556:red:lan4";
-			gpios = <&pinctrl 28 1>;
-		};
+&gpiokeys {
+	help {
+		label = "help";
+		gpios = <&pinctrl 8 1>;
+		linux,code = <KEY_HELP>;
+		debounce-interval = <60>;
 	};
 };
 
-&pflash {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		cfe@0 {
-			label = "CFE";
-			reg = <0x000000 0x020000>;
-			read-only;
-		};
-
-		linux@20000 {
-			label = "linux";
-			reg = <0x020000 0xec0000>;
-			compatible = "brcm,bcm963xx-imagetag";
-		};
-
-		cal_data@ee0000 {
-			label = "cal_data";
-			reg = <0xee0000 0x100000>;
-			read-only;
-		};
-
-		nvram@fe0000 {
-			label = "nvram";
-			reg = <0xfe0000 0x020000>;
-		};
+&gpioleds {
+	message_red {
+		label = "red:message";
+		gpios = <&pinctrl 0 1>;
 	};
-};
 
-&uart0 {
-	status = "okay";
+	hspa_red {
+		label = "red:hspa";
+		gpios = <&pinctrl 1 1>;
+	};
+
+	all_red {
+		label = "red:all";
+		gpios = <&pinctrl 6 1>;
+		default-state = "on";
+	};
+
+	lan1_green {
+		label = "green:lan1";
+		gpios = <&pinctrl 12 1>;
+	};
+
+	lan2_green {
+		label = "green:lan2";
+		gpios = <&pinctrl 15 1>;
+	};
 };

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-c.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-c.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-c.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a-c.dts
@@ -1,148 +1,39 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-huawei-echolife-hg556a.dtsi"
 
 / {
 	model = "Huawei EchoLife HG556a (version C)";
 	compatible = "huawei,echolife-hg556a-c", "brcm,bcm6358";
+};
 
-	aliases {
-		led-boot = &led_power_red;
-		led-failsafe = &led_power_red;
-		led-running = &led_power_red;
-		led-upgrade = &led_power_red;
-	};
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		help {
-			label = "help";
-			gpios = <&pinctrl 36 1>;
-			linux,code = <KEY_HELP>;
-			debounce-interval = <60>;
-		};
-
-		wlan {
-			label = "wlan";
-			gpios = <&pinctrl 9 1>;
-			linux,code = <KEY_WLAN>;
-			debounce-interval = <60>;
-		};
-
-		restart {
-			label = "restart";
-			gpios = <&pinctrl 10 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 11 1>;
-			linux,code = <KEY_CONFIG>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		lan1_green {
-			label = "HW556:green:lan1";
-			gpios = <&pinctrl 0 1>;
-		};
-		lan2_green {
-			label = "HW556:green:lan2";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_red {
-			label = "HW556:red:dsl";
-			gpios = <&pinctrl 2 1>;
-		};
-		led_power_red: power_red {
-			label = "HW556:red:power";
-			gpios = <&pinctrl 3 1>;
-			default-state = "on";
-		};
-		message_red {
-			label = "HW556:red:message";
-			gpios = <&pinctrl 12 1>;
-		};
-		lan1_red {
-			label = "HW556:red:lan1";
-			gpios = <&pinctrl 13 1>;
-		};
-		hspa_red {
-			label = "HW556:red:hspa";
-			gpios = <&pinctrl 15 1>;
-		};
-		lan2_red {
-			label = "HW556:red:lan2";
-			gpios = <&pinctrl 22 1>;
-		};
-		lan3_green {
-			label = "HW556:green:lan3";
-			gpios = <&pinctrl 23 1>;
-		};
-		lan3_red {
-			label = "HW556:red:lan3";
-			gpios = <&pinctrl 26 1>;
-		};
-		lan4_green {
-			label = "HW556:green:lan4";
-			gpios = <&pinctrl 27 1>;
-		};
-		lan4_red {
-			label = "HW556:red:lan4";
-			gpios = <&pinctrl 28 1>;
-		};
+&gpiokeys {
+	help {
+		label = "help";
+		gpios = <&pinctrl 36 1>;
+		linux,code = <KEY_HELP>;
+		debounce-interval = <60>;
 	};
 };
 
-&pflash {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		cfe@0 {
-			label = "CFE";
-			reg = <0x000000 0x020000>;
-			read-only;
-		};
-
-		linux@20000 {
-			label = "linux";
-			reg = <0x020000 0xec0000>;
-			compatible = "brcm,bcm963xx-imagetag";
-		};
-
-		cal_data@ee0000 {
-			label = "cal_data";
-			reg = <0xee0000 0x100000>;
-			read-only;
-		};
-
-		nvram@fe0000 {
-			label = "nvram";
-			reg = <0xfe0000 0x020000>;
-		};
+&gpioleds {
+	lan1_green {
+		label = "green:lan1";
+		gpios = <&pinctrl 0 1>;
 	};
-};
 
-&uart0 {
-	status = "okay";
+	lan2_green {
+		label = "green:lan2";
+		gpios = <&pinctrl 1 1>;
+	};
+
+	message_red {
+		label = "red:message";
+		gpios = <&pinctrl 12 1>;
+	};
+
+	hspa_red {
+		label = "red:hspa";
+		gpios = <&pinctrl 15 1>;
+	};
 };

--- a/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6358-huawei-echolife-hg556a.dtsi
@@ -1,18 +1,13 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Huawei EchoLife HG553";
-	compatible = "huawei,echolife-hg553", "brcm,bcm6358";
-
 	aliases {
-		led-boot = &led_power_blue;
-		led-failsafe = &led_power_blue;
-		led-running = &led_power_blue;
-		led-upgrade = &led_power_blue;
+		led-boot = &led_power_red;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_red;
+		led-upgrade = &led_power_red;
 	};
 
 	chosen {
@@ -20,66 +15,76 @@
 		stdout-path = "serial0:115200n8";
 	};
 
-	keys {
+	gpiokeys: keys {
 		compatible = "gpio-keys-polled";
 		#address-cells = <1>;
 		#size-cells = <0>;
 		poll-interval = <20>;
 
-		rfkill {
-			label = "rfkill";
+		wlan {
+			label = "wlan";
 			gpios = <&pinctrl 9 1>;
-			linux,code = <KEY_RFKILL>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		restart {
+			label = "restart";
+			gpios = <&pinctrl 10 1>;
+			linux,code = <KEY_RESTART>;
 			debounce-interval = <60>;
 		};
 
 		reset {
 			label = "reset";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_RESTART>;
+			gpios = <&pinctrl 11 1>;
+			linux,code = <KEY_CONFIG>;
 			debounce-interval = <60>;
 		};
 	};
 
-	leds {
+	gpioleds: leds {
 		compatible = "gpio-leds";
 
-		led_power_blue: power_blue {
-			label = "blue:power";
-			gpios = <&pinctrl 4 1>;
+		dsl_red {
+			label = "red:dsl";
+			gpios = <&pinctrl 2 1>;
+		};
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&pinctrl 3 1>;
 			default-state = "on";
 		};
-		power_red {
-			label = "red:power";
-			gpios = <&pinctrl 5 1>;
-		};
-		hspa_red {
-			label = "red:hspa";
-			gpios = <&pinctrl 12 1>;
-		};
-		hspa_blue {
-			label = "blue:hspa";
+
+		lan1_red {
+			label = "red:lan1";
 			gpios = <&pinctrl 13 1>;
 		};
-		lan_red {
-			label = "red:lan";
+
+		lan2_red {
+			label = "red:lan2";
 			gpios = <&pinctrl 22 1>;
 		};
-		lan_blue {
-			label = "blue:lan";
+
+		lan3_green {
+			label = "green:lan3";
 			gpios = <&pinctrl 23 1>;
 		};
-		wifi_red {
-			label = "red:wifi";
-			gpios = <&pinctrl 25 1>;
+
+		lan3_red {
+			label = "red:lan3";
+			gpios = <&pinctrl 26 1>;
 		};
-		dsl_red {
-			label = "red:adsl";
-			gpios = <&pinctrl 34 1>;
+
+		lan4_green {
+			label = "green:lan4";
+			gpios = <&pinctrl 27 1>;
 		};
-		dsl_blue {
-			label = "blue:adsl";
-			gpios = <&pinctrl 35 1>;
+
+		lan4_red {
+			label = "red:lan4";
+			gpios = <&pinctrl 28 1>;
 		};
 	};
 };
@@ -100,8 +105,14 @@
 
 		linux@20000 {
 			label = "linux";
-			reg = <0x020000 0xfc0000>;
+			reg = <0x020000 0xec0000>;
 			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		cal_data@ee0000 {
+			label = "cal_data";
+			reg = <0xee0000 0x100000>;
+			read-only;
 		};
 
 		nvram@fe0000 {

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226.dtsi
@@ -1,0 +1,93 @@
+#include "bcm6358.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 34 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 37 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		voip_red {
+			label = "red:VoIP";
+			gpios = <&pinctrl 0 1>;
+		};
+		eth_red {
+			label = "red:ethernet";
+			gpios = <&pinctrl 1 1>;
+		};
+		dsl_green {
+			label = "green:ADSL";
+			gpios = <&pinctrl 2 1>;
+		};
+		usb_green {
+			label = "green:USB";
+			gpios = <&pinctrl 3 1>;
+		};
+		power_green {
+			label = "green:power";
+			gpios = <&pinctrl 4 1>;
+			default-state = "on";
+		};
+		power_red {
+			label = "red:power";
+			gpios = <&pinctrl 5 1>;
+		};
+		inet_red {
+			label = "red:internet";
+			gpios = <&pinctrl 6 1>;
+		};
+		inet_green {
+			label = "green:internet";
+			gpios = <&pinctrl 7 1>;
+		};
+		eth_green {
+			label = "green:ethernet";
+			gpios = <&pinctrl 8 1>;
+		};
+		voip_green {
+			label = "green:VoIP";
+			gpios = <&pinctrl 9 1>;
+		};
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&pinctrl 10 1>;
+		};
+		usb_red {
+			label = "red:USB";
+			gpios = <&pinctrl 11 1>;
+		};
+		dsl_red {
+			label = "red:ADSL";
+			gpios = <&pinctrl 12 1>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226g.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226g.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-pirelli-a226.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226g.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226g.dts
@@ -1,96 +1,10 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-pirelli-a226.dtsi"
 
 / {
 	model = "Pirelli A226G";
 	compatible = "pirelli,a226g", "brcm,bcm6358";
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		wps {
-			label = "wps";
-			gpios = <&pinctrl 34 1>;
-			linux,code = <KEY_WPS_BUTTON>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		voip_red {
-			label = "DWV-S0:red:VoIP";
-			gpios = <&pinctrl 0 1>;
-		};
-		eth_red {
-			label = "DWV-S0:red:ethernet";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_green {
-			label = "DWV-S0:green:ADSL";
-			gpios = <&pinctrl 2 1>;
-		};
-		usb_green {
-			label = "DWV-S0:green:USB";
-			gpios = <&pinctrl 3 1>;
-		};
-		power_green {
-			label = "DWV-S0:green:power";
-			gpios = <&pinctrl 4 1>;
-			default-state = "on";
-		};
-		power_red {
-			label = "DWV-S0:red:power";
-			gpios = <&pinctrl 5 1>;
-		};
-		inet_red {
-			label = "DWV-S0:red:internet";
-			gpios = <&pinctrl 6 1>;
-		};
-		inet_green {
-			label = "DWV-S0:green:internet";
-			gpios = <&pinctrl 7 1>;
-		};
-		eth_green {
-			label = "DWV-S0:green:ethernet";
-			gpios = <&pinctrl 8 1>;
-		};
-		voip_green {
-			label = "DWV-S0:green:VoIP";
-			gpios = <&pinctrl 9 1>;
-		};
-		wifi_red {
-			label = "DWV-S0:red:wifi";
-			gpios = <&pinctrl 10 1>;
-		};
-		usb_red {
-			label = "DWV-S0:red:USB";
-			gpios = <&pinctrl 11 1>;
-		};
-		dsl_red {
-			label = "DWV-S0:red:ADSL";
-			gpios = <&pinctrl 12 1>;
-		};
-	};
 };
 
 &pflash {
@@ -118,8 +32,4 @@
 			reg = <0x7f0000 0x010000>;
 		};
 	};
-};
-
-&uart0 {
-	status = "okay";
 };

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m-fwb.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m-fwb.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-pirelli-a226.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m-fwb.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m-fwb.dts
@@ -1,96 +1,10 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-pirelli-a226.dtsi"
 
 / {
 	model = "Pirelli A226M-FWB";
 	compatible = "pirelli,a226m-fwb", "brcm,bcm6358";
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		wps {
-			label = "wps";
-			gpios = <&pinctrl 34 1>;
-			linux,code = <KEY_WPS_BUTTON>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		voip_red {
-			label = "DWV-S0:red:VoIP";
-			gpios = <&pinctrl 0 1>;
-		};
-		eth_red {
-			label = "DWV-S0:red:ethernet";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_green {
-			label = "DWV-S0:green:ADSL";
-			gpios = <&pinctrl 2 1>;
-		};
-		usb_green {
-			label = "DWV-S0:green:USB";
-			gpios = <&pinctrl 3 1>;
-		};
-		power_green {
-			label = "DWV-S0:green:power";
-			gpios = <&pinctrl 4 1>;
-			default-state = "on";
-		};
-		power_red {
-			label = "DWV-S0:red:power";
-			gpios = <&pinctrl 5 1>;
-		};
-		inet_red {
-			label = "DWV-S0:red:internet";
-			gpios = <&pinctrl 6 1>;
-		};
-		inet_green {
-			label = "DWV-S0:green:internet";
-			gpios = <&pinctrl 7 1>;
-		};
-		eth_green {
-			label = "DWV-S0:green:ethernet";
-			gpios = <&pinctrl 8 1>;
-		};
-		voip_green {
-			label = "DWV-S0:green:VoIP";
-			gpios = <&pinctrl 9 1>;
-		};
-		wifi_red {
-			label = "DWV-S0:red:wifi";
-			gpios = <&pinctrl 10 1>;
-		};
-		usb_red {
-			label = "DWV-S0:red:USB";
-			gpios = <&pinctrl 11 1>;
-		};
-		dsl_red {
-			label = "DWV-S0:red:ADSL";
-			gpios = <&pinctrl 12 1>;
-		};
-	};
 };
 
 &pflash {
@@ -118,8 +32,4 @@
 			reg = <0xfe0000 0x020000>;
 		};
 	};
-};
-
-&uart0 {
-	status = "okay";
 };

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-pirelli-a226.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-a226m.dts
@@ -1,96 +1,10 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-pirelli-a226.dtsi"
 
 / {
 	model = "Pirelli A226M";
 	compatible = "pirelli,a226m", "brcm,bcm6358";
-
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		wps {
-			label = "wps";
-			gpios = <&pinctrl 34 1>;
-			linux,code = <KEY_WPS_BUTTON>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		voip_red {
-			label = "DWV-S0:red:VoIP";
-			gpios = <&pinctrl 0 1>;
-		};
-		eth_red {
-			label = "DWV-S0:red:ethernet";
-			gpios = <&pinctrl 1 1>;
-		};
-		dsl_green {
-			label = "DWV-S0:green:ADSL";
-			gpios = <&pinctrl 2 1>;
-		};
-		usb_green {
-			label = "DWV-S0:green:USB";
-			gpios = <&pinctrl 3 1>;
-		};
-		power_green {
-			label = "DWV-S0:green:power";
-			gpios = <&pinctrl 4 1>;
-			default-state = "on";
-		};
-		power_red {
-			label = "DWV-S0:red:power";
-			gpios = <&pinctrl 5 1>;
-		};
-		inet_red {
-			label = "DWV-S0:red:internet";
-			gpios = <&pinctrl 6 1>;
-		};
-		inet_green {
-			label = "DWV-S0:green:internet";
-			gpios = <&pinctrl 7 1>;
-		};
-		eth_green {
-			label = "DWV-S0:green:ethernet";
-			gpios = <&pinctrl 8 1>;
-		};
-		voip_green {
-			label = "DWV-S0:green:VoIP";
-			gpios = <&pinctrl 9 1>;
-		};
-		wifi_red {
-			label = "DWV-S0:red:wifi";
-			gpios = <&pinctrl 10 1>;
-		};
-		usb_red {
-			label = "DWV-S0:red:USB";
-			gpios = <&pinctrl 11 1>;
-		};
-		dsl_red {
-			label = "DWV-S0:red:ADSL";
-			gpios = <&pinctrl 12 1>;
-		};
-	};
 };
 
 &pflash {
@@ -118,8 +32,4 @@
 			reg = <0x7f0000 0x010000>;
 		};
 	};
-};
-
-&uart0 {
-	status = "okay";
 };

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-agpf-s0.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-agpf-s0.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-pirelli-agpf-s0.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-pirelli-agpf-s0.dts
@@ -38,60 +38,60 @@
 		compatible = "gpio-leds";
 
 		power_green {
-			label = "AGPF-S0:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 4 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "AGPF-S0:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 5 1>;
 		};
 		service_green {
-			label = "AGPF-S0:green:service";
+			label = "green:service";
 			gpios = <&pinctrl 6 1>;
 		};
 		service_red {
-			label = "AGPF-S0:red:service";
+			label = "red:service";
 			gpios = <&pinctrl 7 1>;
 		};
 		dsl_green {
-			label = "AGPF-S0:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 9 1>;
 		};
 		dsl_red {
-			label = "AGPF-S0:red:adsl";
+			label = "red:adsl";
 			gpios = <&pinctrl 10 1>;
 		};
 		wifi_green {
-			label = "AGPF-S0:green:wifi";
+			label = "green:wifi";
 			gpios = <&pinctrl 22 1>;
 		};
 		wifi_red {
-			label = "AGPF-S0:red:wifi";
+			label = "red:wifi";
 			gpios = <&pinctrl 23 1>;
 		};
 		inet_red {
-			label = "AGPF-S0:red:internet";
+			label = "red:internet";
 			gpios = <&pinctrl 24 1>;
 		};
 		inet_green {
-			label = "AGPF-S0:green:internet";
+			label = "green:internet";
 			gpios = <&pinctrl 25 1>;
 		};
 		usr1_green {
-			label = "AGPF-S0:green:usr1";
+			label = "green:usr1";
 			gpios = <&pinctrl 26 1>;
 		};
 		usr1_red {
-			label = "AGPF-S0:red:usr1";
+			label = "red:usr1";
 			gpios = <&pinctrl 27 1>;
 		};
 		usr2_green {
-			label = "AGPF-S0:green:usr2";
+			label = "green:usr2";
 			gpios = <&pinctrl 29 1>;
 		};
 		usr2_red {
-			label = "AGPF-S0:red:usr2";
+			label = "red:usr2";
 			gpios = <&pinctrl 30 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-foxconn-r1.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-foxconn-r1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-sfr-neufbox-4.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-foxconn-r1.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-foxconn-r1.dts
@@ -1,118 +1,33 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-sfr-neufbox-4.dtsi"
 
 / {
 	model = "SFR Neufbox 4 (Foxconn)";
 	compatible = "sfr,neufbox-4-foxconn-r1", "brcm,bcm6358";
 
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		service {
-			label = "service";
-			gpios = <&pinctrl 27 1>;
-			linux,code = <BTN_0>;
-			debounce-interval = <60>;
-		};
-
-		clip {
-			label = "clip";
-			gpios = <&pinctrl 31 1>;
-			linux,code = <BTN_1>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 34 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_WPS_BUTTON>;
-			debounce-interval = <60>;
-		};
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
 		traffic_white {
-			label = "NB4-FXC-r1:white:traffic";
+			label = "white:traffic";
 			gpios = <&pinctrl 2 0>;
 		};
 		service_blue {
-			label = "NB4-FXC-r1:blue:service";
+			label = "blue:service";
 			gpios = <&pinctrl 4 0>;
 		};
 		wifi_white {
-			label = "NB4-FXC-r1:white:wifi";
+			label = "white:wifi";
 			gpios = <&pinctrl 15 0>;
 		};
 		service_red {
-			label = "NB4-FXC-r1:red:service";
+			label = "red:service";
 			gpios = <&pinctrl 29 0>;
 		};
 		service_green {
-			label = "NB4-FXC-r1:green:service";
+			label = "green:service";
 			gpios = <&pinctrl 30 0>;
 		};
 	};
-};
-
-&leds {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_serial_led>;
-
-	led@0 {
-		reg = <0>;
-		active-low;
-		label = "NB4-FXC-r1:white:alarm";
-	};
-
-	led@2 {
-		reg = <2>;
-		active-low;
-		label = "NB4-FXC-r1:white:tv";
-	};
-
-	led@3 {
-		reg = <3>;
-		active-low;
-		label = "NB4-FXC-r1:white:tel";
-	};
-
-	led@4 {
-		reg = <4>;
-		active-low;
-		label = "NB4-FXC-r1:white:adsl";
-	};
-};
-
-&pflash {
-	status = "okay";
-
-	partitions {
-		compatible = "brcm,bcm963xx-cfe-nor-partitions";
-	};
-};
-
-&uart0 {
-	status = "okay";
 };

--- a/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-sercomm-r0.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-sercomm-r0.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358-sfr-neufbox-4.dtsi"
 
 / {

--- a/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-sercomm-r0.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4-sercomm-r0.dts
@@ -1,118 +1,33 @@
 /dts-v1/;
 
-#include "bcm6358.dtsi"
-
-#include <dt-bindings/input/input.h>
+#include "bcm6358-sfr-neufbox-4.dtsi"
 
 / {
 	model = "SFR Neufbox 4 (Sercomm)";
 	compatible = "sfr,neufbox-4-sercomm-r0", "brcm,bcm6358";
 
-	chosen {
-		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
-		stdout-path = "serial0:115200n8";
-	};
-
-	keys {
-		compatible = "gpio-keys-polled";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		poll-interval = <20>;
-
-		service {
-			label = "service";
-			gpios = <&pinctrl 27 1>;
-			linux,code = <BTN_0>;
-			debounce-interval = <60>;
-		};
-
-		clip {
-			label = "clip";
-			gpios = <&pinctrl 31 1>;
-			linux,code = <BTN_1>;
-			debounce-interval = <60>;
-		};
-
-		reset {
-			label = "reset";
-			gpios = <&pinctrl 34 1>;
-			linux,code = <KEY_RESTART>;
-			debounce-interval = <60>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&pinctrl 37 1>;
-			linux,code = <KEY_WPS_BUTTON>;
-			debounce-interval = <60>;
-		};
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
 		traffic_white {
-			label = "NB4-SER-r0:white:traffic";
+			label = "white:traffic";
 			gpios = <&pinctrl 2 1>;
 		};
 		service_blue {
-			label = "NB4-SER-r0:blue:service";
+			label = "blue:service";
 			gpios = <&pinctrl 4 1>;
 		};
 		wifi_white {
-			label = "NB4-SER-r0:white:wifi";
+			label = "white:wifi";
 			gpios = <&pinctrl 15 1>;
 		};
 		service_red {
-			label = "NB4-SER-r0:red:service";
+			label = "red:service";
 			gpios = <&pinctrl 29 1>;
 		};
 		service_green {
-			label = "NB4-SER-r0:green:service";
+			label = "green:service";
 			gpios = <&pinctrl 30 1>;
 		};
 	};
-};
-
-&leds {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_serial_led>;
-
-	led@0 {
-		reg = <0>;
-		active-low;
-		label = "NB4-SER-r0:white:alarm";
-	};
-
-	led@2 {
-		reg = <2>;
-		active-low;
-		label = "NB4-SER-r0:white:tv";
-	};
-
-	led@3 {
-		reg = <3>;
-		active-low;
-		label = "NB4-SER-r0:white:tel";
-	};
-
-	led@4 {
-		reg = <4>;
-		active-low;
-		label = "NB4-SER-r0:white:adsl";
-	};
-};
-
-&pflash {
-	status = "okay";
-
-	partitions {
-		compatible = "brcm,bcm963xx-cfe-nor-partitions";
-	};
-};
-
-&uart0 {
-	status = "okay";
 };

--- a/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6358-sfr-neufbox-4.dtsi
@@ -1,0 +1,88 @@
+#include "bcm6358.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	chosen {
+		bootargs = "rootfstype=squashfs,jffs2 noinitrd console=ttyS0,115200";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		poll-interval = <20>;
+
+		service {
+			label = "service";
+			gpios = <&pinctrl 27 1>;
+			linux,code = <BTN_0>;
+			debounce-interval = <60>;
+		};
+
+		clip {
+			label = "clip";
+			gpios = <&pinctrl 31 1>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&pinctrl 34 1>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pinctrl 37 1>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_serial_led>;
+
+	led@0 {
+		reg = <0>;
+		active-low;
+		label = "white:alarm";
+	};
+
+	led@2 {
+		reg = <2>;
+		active-low;
+		label = "white:tv";
+	};
+
+	led@3 {
+		reg = <3>;
+		active-low;
+		label = "white:tel";
+	};
+
+	led@4 {
+		reg = <4>;
+		active-low;
+		label = "white:adsl";
+	};
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "brcm,bcm963xx-cfe-nor-partitions";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
@@ -45,28 +45,28 @@
 		compatible = "gpio-leds";
 
 		ses_green {
-			label = "spw303v:green:ses";
+			label = "green:ses";
 			gpios = <&pinctrl 0 1>;
 		};
 		power_adsl_red {
-			label = "spw303v:red:power+adsl";
+			label = "red:power+adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "spw303v:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 5 1>;
 		};
 		led_power_adsl_green: power_adsl_green {
-			label = "spw303v:green:power+adsl";
+			label = "green:power+adsl";
 			gpios = <&pinctrl 22 1>;
 			default-state = "on";
 		};
 		voip_green {
-			label = "spw303v:green:voip";
+			label = "green:voip";
 			gpios = <&pinctrl 27 1>;
 		};
 		pots_green {
-			label = "spw303v:green:pots";
+			label = "green:pots";
 			gpios = <&pinctrl 31 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358-telsey-cpva642.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-telsey-cpva642.dts
@@ -45,44 +45,44 @@
 		compatible = "gpio-leds";
 
 		eth_green {
-			label = "CPVA642:green:ether";
+			label = "green:ether";
 			gpios = <&pinctrl 1 1>;
 		};
 		phone2_green {
-			label = "CPVA642:green:phone2";
+			label = "green:phone2";
 			gpios = <&pinctrl 2 1>;
 		};
 		usb_green {
-			label = "CPVA642:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 3 1>;
 		};
 		phone1_green {
-			label = "CPVA642:green:phone1";
+			label = "green:phone1";
 			gpios = <&pinctrl 4 1>;
 		};
 		wifi_red {
-			label = "CPVA642:red:wifi";
+			label = "red:wifi";
 			gpios = <&pinctrl 6 1>;
 		};
 		link_red {
-			label = "CPVA642:red:link";
+			label = "red:link";
 			gpios = <&pinctrl 9 1>;
 		};
 		link_green {
-			label = "CPVA642:green:link";
+			label = "green:link";
 			gpios = <&pinctrl 10 1>;
 		};
 		led_power_green: power_green {
-			label = "CPVA642:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 11 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "CPVA642:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 14 1>;
 		};
 		wifi_green {
-			label = "CPVA642:green:wifi";
+			label = "green:wifi";
 			gpios = <&pinctrl 28 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6358-telsey-cpva642.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-telsey-cpva642.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6358.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6358.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6359-huawei-echolife-hg520v.dts
+++ b/target/linux/bcm63xx/dts/bcm6359-huawei-echolife-hg520v.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6358.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6359-huawei-echolife-hg520v.dts
+++ b/target/linux/bcm63xx/dts/bcm6359-huawei-echolife-hg520v.dts
@@ -38,7 +38,7 @@
 		compatible = "gpio-leds";
 
 		led_inet_green: inet_green {
-			label = "HW520:green:net";
+			label = "green:net";
 			gpios = <&pinctrl 32 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6361-sfr-neufbox-6-sercomm-r0.dts
+++ b/target/linux/bcm63xx/dts/bcm6361-sfr-neufbox-6-sercomm-r0.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6362.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6362-huawei-hg253s-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-huawei-hg253s-v2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6362.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6362-huawei-hg253s-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-huawei-hg253s-v2.dts
@@ -51,12 +51,12 @@
 		compatible = "gpio-leds";
 
 		led_phone_green: led@28 {
-			label = "hg253s-v2:green:phone";
+			label = "green:phone";
 			gpios = <&pinctrl 28 1>;
 		};
 
 		led@30 {
-			label = "hg253s-v2:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 30 1>;
 		};
 	};
@@ -71,13 +71,13 @@
 	led@3 {
 		reg = <3>;
 		active-low;
-		label = "hg253s-v2:green:internet";
+		label = "green:internet";
 	};
 
 	led@5 {
 		reg = <5>;
 		active-low;
-		label = "hg253s-v2:green:wifi";
+		label = "green:wifi";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/dts-v1/;
-
 #include "bcm6362.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-netgear-dgnd3700-v2.dts
@@ -54,12 +54,12 @@
 		compatible = "gpio-leds";
 
 		led@28 {
-			label = "dgnd3700-v2:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 28 1>;
 		};
 
 		led@34 {
-			label = "dgnd3700-v2:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 34 1>;
 		};
 	};
@@ -78,67 +78,67 @@
 	led@1 {
 		reg = <1>;
 		active-low;
-		label = "dgnd3700-v2:green:internet";
+		label = "green:internet";
 	};
 
 	led_power_green: led@8 {
 		reg = <8>;
-		label = "dgnd3700-v2:green:power";
+		label = "green:power";
 		default-state = "on";
 	};
 
 	led@9 {
 		reg = <9>;
 		active-low;
-		label = "dgnd3700-v2:green:wps";
+		label = "green:wps";
 	};
 
 	led@10 {
 		reg = <10>;
 		active-low;
-		label = "dgnd3700-v2:green:usb1";
+		label = "green:usb1";
 	};
 
 	led@11 {
 		reg = <11>;
 		active-low;
-		label = "dgnd3700-v2:green:usb2";
+		label = "green:usb2";
 	};
 
 	led@12 {
 		reg = <12>;
 		active-low;
-		label = "dgnd3700-v2:amber:internet";
+		label = "amber:internet";
 	};
 
 	led@13 {
 		reg = <13>;
 		active-low;
-		label = "dgnd3700-v2:green:ethernet";
+		label = "green:ethernet";
 	};
 
 	led@14 {
 		reg = <14>;
 		active-low;
-		label = "dgnd3700-v2:amber:dsl";
+		label = "amber:dsl";
 	};
 
 	led@16 {
 		reg = <16>;
 		active-low;
-		label = "dgnd3700-v2:amber:usb1";
+		label = "amber:usb1";
 	};
 
 	led@17 {
 		reg = <17>;
 		active-low;
-		label = "dgnd3700-v2:amber:usb2";
+		label = "amber:usb2";
 	};
 
 	led@18 {
 		reg = <18>;
 		active-low;
-		label = "dgnd3700-v2:amber:ethernet";
+		label = "amber:ethernet";
 	};
 };
 

--- a/target/linux/bcm63xx/dts/bcm6362-sagem-fast-2504n.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-sagem-fast-2504n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6362.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6362-sagem-fast-2504n.dts
+++ b/target/linux/bcm63xx/dts/bcm6362-sagem-fast-2504n.dts
@@ -45,28 +45,28 @@
 		compatible = "gpio-leds";
 
 		power_orange {
-			label = "fast2504n:orange:power";
+			label = "orange:power";
 			gpios = <&pinctrl 2 1>;
 		};
 		power_green {
-			label = "fast2504n:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 10 1>;
 			default-state = "on";
 		};
 		inet_red {
-			label = "fast2504n:red:internet";
+			label = "red:internet";
 			gpios = <&pinctrl 26 1>;
 		};
 		led_ok_green: ok_green {
-			label = "fast2504n:green:ok";
+			label = "green:ok";
 			gpios = <&pinctrl 28 1>;
 		};
 		ok_orange {
-			label = "fast2504n:orange:ok";
+			label = "orange:ok";
 			gpios = <&pinctrl 29 1>;
 		};
 		wlan_orangee {
-			label = "fast2504n:orange:wlan";
+			label = "orange:wlan";
 			gpios = <&pinctrl 30 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6362.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6362.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6368-actiontec-r1000h.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-actiontec-r1000h.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-actiontec-r1000h.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-actiontec-r1000h.dts
@@ -45,38 +45,38 @@
 		compatible = "gpio-leds";
 
 		inet_green {
-			label = "R1000H:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 
 		usb_green {
-			label = "R1000H:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 21 1>;
 		};
 
 		led_power_green: power_green {
-			label = "R1000H:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 
 		wps_green {
-			label = "R1000H:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 23 1>;
 		};
 
 		power_red {
-			label = "R1000H:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 
 		wps_red {
-			label = "R1000H:red:wps";
+			label = "red:wps";
 			gpios = <&pinctrl 30 1>;
 		};
 
 		inet_red {
-			label = "R1000H:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-adb-av4202n.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-adb-av4202n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>

--- a/target/linux/bcm63xx/dts/bcm6368-adb-av4202n.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-adb-av4202n.dts
@@ -46,32 +46,32 @@
 		compatible = "gpio-leds";
 
 		led_power_white: power_white {
-			label = "AV4202N:white:power";
+			label = "white:power";
 			gpios = <&pinctrl 10 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 		power_red {
-			label = "AV4202N:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 11 GPIO_ACTIVE_LOW>;
 		};
 		wan_white {
-			label = "AV4202N:white:wan";
+			label = "white:wan";
 			gpios = <&pinctrl 26 GPIO_ACTIVE_LOW>;
 		};
 		wan_red {
-			label = "AV4202N:red:wan";
+			label = "red:wan";
 			gpios = <&pinctrl 27 GPIO_ACTIVE_LOW>;
 		};
 		phone_white {
-			label = "AV4202N:white:phone";
+			label = "white:phone";
 			gpios = <&pinctrl 24 GPIO_ACTIVE_LOW>;
 		};
 		phone_red {
-			label = "AV4202N:red:phone";
+			label = "red:phone";
 			gpios = <&pinctrl 25 GPIO_ACTIVE_LOW>;
 		};
 		wifi {
-			label = "AV4202N:blue:wifi";
+			label = "blue:wifi";
 			gpios = <&pinctrl 22 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvngr.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvngr.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvngr.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvngr.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "96368MVNgr:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_fail_green {
-			label = "96368MVNgr:green:inet-fail";
+			label = "green:inet-fail";
 			gpios = <&pinctrl 3 0>;
 		};
 		inet_green {
-			label = "96368MVNgr:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		power_green {
-			label = "96368MVNgr:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		wps_green {
-			label = "96368MVNgr:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 23 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvwg.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvwg.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvwg.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-brcm-bcm96368mvwg.dts
@@ -17,24 +17,24 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "96368MVWG:green:adsl";
+			label = "green:adsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		ppp_green {
-			label = "96368MVWG:green:ppp";
+			label = "green:ppp";
 			gpios = <&pinctrl 5 0>;
 		};
 		power_green {
-			label = "96368MVWG:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		wps_green {
-			label = "96368MVWG:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 23 1>;
 		};
 		ppp_fail_red {
-			label = "96368MVWG:red:ppp-fail";
+			label = "red:ppp-fail";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025u.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025u.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "VR-3025u:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_green {
-			label = "VR-3025u:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		led_power_green: power_green {
-			label = "VR-3025u:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		power_red {
-			label = "VR-3025u:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 		inet_red {
-			label = "VR-3025u:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025u.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025u.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025un.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025un.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "VR-3025un:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_green {
-			label = "VR-3025un:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		led_power_green: power_green {
-			label = "VR-3025un:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		power_red {
-			label = "VR-3025un:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 		inet_red {
-			label = "VR-3025un:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025un.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3025un.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3026e.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3026e.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3026e.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-comtrend-vr-3026e.dts
@@ -38,24 +38,24 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "VR-3026e:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_green {
-			label = "VR-3026e:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		led_power_green: power_green {
-			label = "VR-3026e:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		power_red {
-			label = "VR-3026e:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 		inet_red {
-			label = "VR-3026e:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg622.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg622.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg622.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg622.dts
@@ -32,19 +32,19 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "HG622:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_green {
-			label = "HG622:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 1>;
 		};
 		usb_green {
-			label = "HG622:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 11 1>;
 		};
 		power_green {
-			label = "HG622:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 1>;
 			default-state = "on";
 		};

--- a/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg655b.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg655b.dts
@@ -52,29 +52,29 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "HW65x:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		internet_green {
-			label = "HW65x:green:internet";
+			label = "green:internet";
 			gpios = <&pinctrl 5 1>;
 		};
 
 		usb_green {
-			label = "HW65x:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 14 1>;
 		};
 		led_power_green: power_green {
-			label = "HW65x:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 1>;
 			default-state = "on";
 		};
 		voip_green {
-			label = "HW65x:green:voip";
+			label = "green:voip";
 			gpios = <&pinctrl 25 1>;
 		};
 		wps_green {
-			label = "HW65x:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 27 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg655b.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-huawei-echolife-hg655b.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-netgear-dgnd3700-v1.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-netgear-dgnd3700-v1.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-netgear-dgnd3700-v1.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-netgear-dgnd3700-v1.dts
@@ -52,48 +52,48 @@
 		compatible = "gpio-leds";
 
 		dsl_green {
-			label = "DGND3700v1_3800B:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_red {
-			label = "DGND3700v1_3800B:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 4 1>;
 		};
 		inet_green {
-			label = "DGND3700v1_3800B:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 1>;
 		};
 		wps_green {
-			label = "DGND3700v1_3800B:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 11 1>;
 		};
 		usbfront_green {
-			label = "DGND3700v1_3800B:green:usb-front";
+			label = "green:usb-front";
 			gpios = <&pinctrl 13 1>;
 		};
 		usbback_green {
-			label = "DGND3700v1_3800B:green:usb-back";
+			label = "green:usb-back";
 			gpios = <&pinctrl 14 1>;
 		};
 		power_red {
-			label = "DGND3700v1_3800B:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 22 1>;
 		};
 		lan_green {
-			label = "DGND3700v1_3800B:green:lan";
+			label = "green:lan";
 			gpios = <&pinctrl 23 1>;
 		};
 		led_power_green: power_green {
-			label = "DGND3700v1_3800B:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 24 1>;
 			default-state = "on";
 		};
 		wifi2g_green {
-			label = "DGND3700v1_3800B:green:wifi2g";
+			label = "green:wifi2g";
 			gpios = <&pinctrl 26 1>;
 		};
 		wifi5g_blue {
-			label = "DGND3700v1_3800B:blue:wifi5g";
+			label = "blue:wifi5g";
 			gpios = <&pinctrl 27 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-observa-vh4032n.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-observa-vh4032n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368-observa-vh4032n.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-observa-vh4032n.dts
@@ -45,36 +45,36 @@
 		compatible = "gpio-leds";
 
 		dsl_blue {
-			label = "VH4032N:blue:dsl";
+			label = "blue:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		dsl_red {
-			label = "VH4032N:red:dsl";
+			label = "red:dsl";
 			gpios = <&pinctrl 5 1>;
 		};
 		hspa_blue {
-			label = "VH4032N:blue:hspa";
+			label = "blue:hspa";
 			gpios = <&pinctrl 11 1>;
 		};
 		hspa_red {
-			label = "VH4032N:red:hspa";
+			label = "red:hspa";
 			gpios = <&pinctrl 12 1>;
 		};
 		led_power_blue: power_blue {
-			label = "VH4032N:blue:power";
+			label = "blue:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		power_red {
-			label = "VH4032N:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 		voice_blue {
-			label = "VH4032N:blue:voice";
+			label = "blue:voice";
 			gpios = <&pinctrl 25 1>;
 		};
 		voice_red {
-			label = "VH4032N:red:voice";
+			label = "red:voice";
 			gpios = <&pinctrl 26 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-zyxel-p870hw-51a-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-zyxel-p870hw-51a-v2.dts
@@ -45,24 +45,24 @@
 		compatible = "gpio-leds";
 
 		led_power_green: power_green {
-			label = "P870HW-51a:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 0 0>;
 			default-state = "on";
 		};
 		dsl_green {
-			label = "P870HW-51a:green:dsl";
+			label = "green:dsl";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_green {
-			label = "P870HW-51a:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 22 1>;
 		};
 		wps_orange {
-			label = "P870HW-51a:orange:wps";
+			label = "orange:wps";
 			gpios = <&pinctrl 24 1>;
 		};
 		inet_red {
-			label = "P870HW-51a:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 33 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6368-zyxel-p870hw-51a-v2.dts
+++ b/target/linux/bcm63xx/dts/bcm6368-zyxel-p870hw-51a-v2.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6368.dtsi
+++ b/target/linux/bcm63xx/dts/bcm6368.dtsi
@@ -1,3 +1,5 @@
+/dts-v1/;
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;

--- a/target/linux/bcm63xx/dts/bcm6369-comtrend-wap-5813n.dts
+++ b/target/linux/bcm63xx/dts/bcm6369-comtrend-wap-5813n.dts
@@ -52,24 +52,24 @@
 		compatible = "gpio-leds";
 
 		inet_green {
-			label = "WAP-5813n:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 0>;
 		};
 		led_power_green: power_green {
-			label = "WAP-5813n:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 0>;
 			default-state = "on";
 		};
 		wps_green {
-			label = "WAP-5813n:green:wps";
+			label = "green:wps";
 			gpios = <&pinctrl 23 1>;
 		};
 		power_red {
-			label = "WAP-5813n:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 24 0>;
 		};
 		inet_red {
-			label = "WAP-5813n:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 31 0>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6369-comtrend-wap-5813n.dts
+++ b/target/linux/bcm63xx/dts/bcm6369-comtrend-wap-5813n.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>

--- a/target/linux/bcm63xx/dts/bcm6369-netgear-evg2000.dts
+++ b/target/linux/bcm63xx/dts/bcm6369-netgear-evg2000.dts
@@ -45,44 +45,44 @@
 		compatible = "gpio-leds";
 
 		voip1_green {
-			label = "EVG2000:green:voip1";
+			label = "green:voip1";
 			gpios = <&pinctrl 14 1>;
 		};
 		voip2_green {
-			label = "EVG2000:green:voip2";
+			label = "green:voip2";
 			gpios = <&pinctrl 2 1>;
 		};
 		inet_red {
-			label = "EVG2000:red:inet";
+			label = "red:inet";
 			gpios = <&pinctrl 4 1>;
 		};
 		inet_green {
-			label = "EVG2000:green:inet";
+			label = "green:inet";
 			gpios = <&pinctrl 5 1>;
 		};
 		usb_green {
-			label = "EVG2000:green:usb";
+			label = "green:usb";
 			gpios = <&pinctrl 15 1>;
 		};
 		led_power_green: power_green {
-			label = "EVG2000:green:power";
+			label = "green:power";
 			gpios = <&pinctrl 22 1>;
 			default-state = "on";
 		};
 		power_red {
-			label = "EVG2000:red:power";
+			label = "red:power";
 			gpios = <&pinctrl 23 1>;
 		};
 		lan_green {
-			label = "EVG2000:green:lan";
+			label = "green:lan";
 			gpios = <&pinctrl 24 1>;
 		};
 		wireless_green {
-			label = "EVG2000:green:wireless";
+			label = "green:wireless";
 			gpios = <&pinctrl 26 1>;
 		};
 		wan_green {
-			label = "EVG2000:green:wan";
+			label = "green:wan";
 			gpios = <&pinctrl 27 1>;
 		};
 	};

--- a/target/linux/bcm63xx/dts/bcm6369-netgear-evg2000.dts
+++ b/target/linux/bcm63xx/dts/bcm6369-netgear-evg2000.dts
@@ -1,5 +1,3 @@
-/dts-v1/;
-
 #include "bcm6368.dtsi"
 
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
1. This drops the useless devicename part of the LED labels (which I started for ath79/ramips recently) across the target
2. This moves the dts-v1 identifier to the shared SoC DTSI files, so they don't have to be copy-pasted into each DTS file.

Do we actually need the 04_led_migration script for this target? How is the upgrade process working here?

@Noltari 