### PR TITLE
add suport for Ubiquiti AirCube AC

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_acb-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_acb-ac.dts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9342_ubnt_wa.dtsi"
+
+/ {
+	compatible = "ubnt,acb-ac","ubnt,wa", "qca,ar9342";
+	model = "Ubiquiti airCube AC";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "cfg";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			eeprom: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+  status = "okay";
+
+  phy-mask = <4>;
+  phy0: ethernet-phy@0 {
+    phy-mode = "rgmii";
+    reg = <0>;
+
+    qca,ar8327-initvals = <
+      0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+      0x7c 0x0000007e /* PORT0_STATUS */
+    >;
+  };
+};
+
+&eth0 {
+  status = "okay";
+
+  pll-data = <0x06000000 0x00000101 0x00001616>;
+
+  mtd-mac-address = <&eeprom 0x0>;
+
+  phy-mode = "rgmii";
+  phy-handle = <&phy0>;
+
+  gmac-config {
+    device = <&gmac>;
+    rxd-delay = <2>;
+    rxdv-delay = <2>;
+  };
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&eeprom 0x1000>;
+	mtd-mac-address = <&eeprom 0x1002>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -354,6 +354,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2"
 		;;
+	ubnt,acb-ac)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2" "4:wan" "5:lan:3"
+		;;
 	ubnt,edgeswitch-5xp)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -82,7 +82,8 @@ ubnt,nanostation-m)
 ubnt,nanostation-m-xw)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "2"
 	;;
-ubnt,acb-isp)
+ubnt,acb-isp|\
+ubnt,acb-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
 	;;
 zbtlink,zbt-wd323)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -34,6 +34,7 @@ case "$FIRMWARE" in
 	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2|\
 	ubnt,unifiac-pro|\
+  ubnt,acb-ac|\
 	yuncore,a770)
 		caldata_extract "art" 0x5000 0x844
 		;;

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -122,6 +122,17 @@ define Device/ubnt_acb-isp
 endef
 TARGET_DEVICES += ubnt_acb-isp
 
+define Device/ubnt_acb-ac
+  $(Device/ubnt)
+  SOC := ar9342
+  DEVICE_MODEL := airCube AC
+  IMAGE_SIZE := 15744k
+  UBNT_BOARD := ACB-AC
+  UBNT_CHIP := ar9342
+  UBNT_TYPE := ACB
+endef
+TARGET_DEVICES += ubnt_acb-ac
+
 define Device/ubnt_airrouter
   $(Device/ubnt-xm)
   SOC := ar7241

--- a/tools/firmware-utils/src/mkfwimage.c
+++ b/tools/firmware-utils/src/mkfwimage.c
@@ -157,6 +157,15 @@ struct fw_info fw_info[] = {
 		.sign = true,
 	},
 	{
+		.name = "ACB-AC",
+		.fw_layout = {
+			.kern_start = 0x9f050000,
+			.kern_entry = 0x80002000,
+			.firmware_max_length= 0x00F60000,
+		},
+		.sign = true,
+	},
+	{
 		.name = "",
 	},
 };


### PR DESCRIPTION
This device is based on ar9342 soc. It is capable of 802.11gbn and ac.
There are 4 gigabytes ethernet ports, 3 for local network and 1 wan.
The device have 1 LED, but as for Ubiquiti AirCube ISP (a 802.11gbn
only device), I was unable to make it works. It continuously blinks
slowly

Signed-off-by: David Barbion <davidb@230ruedubac.fr>