### PR TITLE
[19.07] uboot-envtools: Fix compilation with new gcc

### DIFF
--- a/package/boot/uboot-envtools/patches/002-dtc-yyloc.patch
+++ b/package/boot/uboot-envtools/patches/002-dtc-yyloc.patch
@@ -1,0 +1,24 @@
+Index: u-boot-2018.03/scripts/dtc/dtc-lexer.l
+===================================================================
+--- u-boot-2018.03.orig/scripts/dtc/dtc-lexer.l
++++ u-boot-2018.03/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+Index: u-boot-2018.03/scripts/dtc/dtc-lexer.lex.c_shipped
+===================================================================
+--- u-boot-2018.03.orig/scripts/dtc/dtc-lexer.lex.c_shipped
++++ u-boot-2018.03/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,6 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
GCC 10 seems to be more picky about redefinitions, so removing redefined
symbols.

/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[5]: *** [scripts/Makefile.host:108: scripts/dtc/dtc] Error 1
make[4]: *** [scripts/Makefile.build:425: scripts/dtc] Error 2
make[3]: *** [Makefile:491: scripts] Error 2

Signed-off-by: Michal Hrusecky <michal.hrusecky@turris.com>