### PR TITLE
ramips: use default lzma dictionary size for DIR-645

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -37,7 +37,7 @@ define Device/dlink_dir-645
   SOC := rt3662
   BLOCKSIZE := 4k
   IMAGE_SIZE := 7872k
-  KERNEL := kernel-bin | append-dtb | lzma -d10
+  KERNEL := $(KERNEL_DTB)
   SEAMA_SIGNATURE := wrgn39_dlob.hans_dir645
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-645


### PR DESCRIPTION
Commit 09faa73c53bd097666cbbe68176dd46cfcf80ee8 added the lzma-loader
to the DIR-645 build recipe, thus enabling the use of large kernels
without the workaround introduced in commit
6fba88de1913301f11163aa05298e4fb488b3640.

This now obsolete workaround causes the image to take up more space,
so this commit removes it, effectively reverting commit
6fba88de1913301f11163aa05298e4fb488b3640.

Image size before this commit: 4338474 bytes
Image size after this commit:  3908394 bytes (-9.9%/-430080 bytes)

Both images were built using the default settings in the master branch.

This was run-tested on a D-Link DIR-645 device.