### PR TITLE
[RFC] ipq40xx: fix port 1 status for IPQ40xx switches

### DIFF
--- a/target/linux/ipq40xx/patches-4.19/705-net-add-qualcomm-ar40xx-phy.patch
+++ b/target/linux/ipq40xx/patches-4.19/705-net-add-qualcomm-ar40xx-phy.patch
@@ -1858,7 +1858,7 @@
 +static int
 +ar40xx_phy_read_status(struct phy_device *phydev)
 +{
-+	if (phydev->mdio.addr != 0)
++	if(phydev->mdio.bus != NULL)
 +		return genphy_read_status(phydev);
 +
 +	return 0;
@@ -1867,7 +1867,7 @@
 +static int
 +ar40xx_phy_config_aneg(struct phy_device *phydev)
 +{
-+	if (phydev->mdio.addr == 0)
++	if(phydev->mdio.bus == NULL)
 +		return 0;
 +
 +	return genphy_config_aneg(phydev);

--- a/target/linux/ipq40xx/patches-5.4/705-net-add-qualcomm-ar40xx-phy.patch
+++ b/target/linux/ipq40xx/patches-5.4/705-net-add-qualcomm-ar40xx-phy.patch
@@ -1879,7 +1879,7 @@
 +static int
 +ar40xx_phy_read_status(struct phy_device *phydev)
 +{
-+	if (phydev->mdio.addr != 0)
++	if(phydev->mdio.bus != NULL)
 +		return genphy_read_status(phydev);
 +
 +	return 0;
@@ -1888,7 +1888,7 @@
 +static int
 +ar40xx_phy_config_aneg(struct phy_device *phydev)
 +{
-+	if (phydev->mdio.addr == 0)
++	if(phydev->mdio.bus == NULL)
 +		return 0;
 +
 +	return genphy_config_aneg(phydev);


### PR DESCRIPTION
Currently in ar40xx_phy_read_status and ar40xx_phy_config_aneg
functions there is a check which, presumably, should fail if the port
doesn't exists.

However in the current implementation, this check seems to be pointless
and moreover prevents the port 1 of the switch to be correctly enabled
if polling is required.

This commit fixes the last issue.

Even if these changes are more or less acked by other developers in [this](https://forum.openwrt.org/t/netgear-orbi-pro-support-booting-from-mmc/14208/217) thread and should be even safe to completely remove the `ar40xx_phy_read_status` and `ar40xx_phy_config_aneg` functions, I can't be 100% sure that won't negatively impact other ipq40xx devices. Because of this I am marking this PR with RFC.

This commit fixes the "wan port" problem for [this](https://github.com/openwrt/openwrt/pull/3469) device.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>