### PR TITLE
bc fakeroot libelf gdb: corrected build errors with clang 12 on macOS

### DIFF
--- a/toolchain/gdb/patches/130-conf_darwin.patch
+++ b/toolchain/gdb/patches/130-conf_darwin.patch
@@ -1,0 +1,59 @@
+Index: gdb-8.3.1/readline/rltty.c
+===================================================================
+--- gdb-8.3.1.orig/readline/rltty.c
++++ gdb-8.3.1/readline/rltty.c
+@@ -37,9 +37,9 @@
+ 
+ #include "rldefs.h"
+ 
+-#if defined (GWINSZ_IN_SYS_IOCTL)
++#if defined (HAVE_SYS_IOCTL_H)
+ #  include <sys/ioctl.h>
+-#endif /* GWINSZ_IN_SYS_IOCTL */
++#endif /* HAVE_SYS_IOCTL_H */
+ 
+ #include "rltty.h"
+ #include "readline.h"
+Index: gdb-8.3.1/readline/terminal.c
+===================================================================
+--- gdb-8.3.1.orig/readline/terminal.c
++++ gdb-8.3.1/readline/terminal.c
+@@ -51,9 +51,9 @@
+ /* System-specific feature definitions and include files. */
+ #include "rldefs.h"
+ 
+-#if defined (GWINSZ_IN_SYS_IOCTL) && !defined (TIOCGWINSZ)
++#if defined (HAVE_SYS_IOCTL_H)
+ #  include <sys/ioctl.h>
+-#endif /* GWINSZ_IN_SYS_IOCTL && !TIOCGWINSZ */
++#endif /* HAVE_SYS_IOCTL_H */
+ 
+ #ifdef __MSDOS__
+ # include <pc.h>
+Index: gdb-8.3.1/readline/config.h.in
+===================================================================
+--- gdb-8.3.1.orig/readline/config.h.in
++++ gdb-8.3.1/readline/config.h.in
+@@ -142,6 +142,9 @@
+ /* Define if you have the <fcntl.h> header file.  */
+ #undef HAVE_FCNTL_H
+ 
++/* Define if you have the <sys/ioctl.h> header file.  */
++#undef HAVE_SYS_IOCTL_H
++
+ /* Define if you have the <langinfo.h> header file.  */
+ #undef HAVE_LANGINFO_H
+ 
+Index: gdb-8.3.1/readline/configure
+===================================================================
+--- gdb-8.3.1.orig/readline/configure
++++ gdb-8.3.1/readline/configure
+@@ -4580,7 +4580,7 @@ $as_echo "#define HAVE_STRCOLL 1" >>conf
+ fi
+ 
+ 
+-for ac_header in fcntl.h unistd.h stdlib.h varargs.h stdarg.h string.h strings.h \
++for ac_header in fcntl.h sys/ioctl.h unistd.h stdlib.h varargs.h stdarg.h string.h strings.h \
+ 		limits.h locale.h pwd.h memory.h termcap.h termios.h termio.h
+ do :
+   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`

--- a/tools/bc/patches/002-conf_darwin.patch
+++ b/tools/bc/patches/002-conf_darwin.patch
@@ -1,0 +1,14 @@
+Index: bc-1.06.95/configure
+===================================================================
+--- bc-1.06.95.orig/configure
++++ bc-1.06.95/configure
+@@ -288,6 +288,9 @@ ac_includes_default="\
+ # if HAVE_STDLIB_H
+ #  include <stdlib.h>
+ # endif
++# if HAVE_STDDEF_H
++#  include <stddef.h>
++# endif
+ #endif
+ #if HAVE_STRING_H
+ # if !STDC_HEADERS && HAVE_MEMORY_H

--- a/tools/fakeroot/patches/101-conf_darwin.patch
+++ b/tools/fakeroot/patches/101-conf_darwin.patch
@@ -1,0 +1,12 @@
+Index: fakeroot-1.24/configure
+===================================================================
+--- fakeroot-1.24.orig/configure
++++ fakeroot-1.24/configure
+@@ -12847,6 +12847,7 @@ for first in size_t int; do
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
++#include <stdio.h>
+ #ifdef HAVE_GRP_H
+ #include <grp.h>
+ #endif

--- a/tools/libelf/patches/901-conf_darwin.patch
+++ b/tools/libelf/patches/901-conf_darwin.patch
@@ -1,0 +1,56 @@
+Index: libelf-0.8.13/config.h.in
+===================================================================
+--- libelf-0.8.13.orig/config.h.in
++++ libelf-0.8.13/config.h.in
+@@ -141,6 +141,9 @@
+ /* Define if you have the <stdint.h> header file.  */
+ #undef HAVE_STDINT_H
+ 
++/* Define if you have the <stdlib.h> header file.  */
++#undef HAVE_STDLIB_H
++
+ /* Define if you have the <sys/elf.h> header file.  */
+ #undef HAVE_SYS_ELF_H
+ 
+Index: libelf-0.8.13/configure
+===================================================================
+--- libelf-0.8.13.orig/configure
++++ libelf-0.8.13/configure
+@@ -1146,7 +1146,7 @@ EOF
+ 
+ fi
+ 
+-for ac_hdr in unistd.h stdint.h fcntl.h
++for ac_hdr in unistd.h stdint.h stdlib.h fcntl.h
+ do
+ ac_safe=`echo "$ac_hdr" | sed 'y%./+-%__p_%'`
+ echo $ac_n "checking for $ac_hdr""... $ac_c" 1>&6
+@@ -1186,6 +1186,13 @@ else
+ fi
+ done
+ 
++cat >> confdefs.h <<EOF
++
++#ifdef HAVE_STDLIB_H
++# include <stdlib.h>
++#endif
++EOF
++
+ for ac_hdr in elf.h sys/elf.h link.h sys/link.h
+ do
+ ac_safe=`echo "$ac_hdr" | sed 'y%./+-%__p_%'`
+Index: libelf-0.8.13/lib/private.h
+===================================================================
+--- libelf-0.8.13.orig/lib/private.h
++++ libelf-0.8.13/lib/private.h
+@@ -37,6 +37,10 @@
+ #endif
+ #include <sys/types.h>
+ 
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
++
+ #if STDC_HEADERS
+ # include <stdlib.h>
+ # include <string.h>


### PR DESCRIPTION
Corrected build errors for bc fakeroot libelf gdb, with clang 12 on macOS
