### PR TITLE
ath79: rename acb-isp to aircube-isp

### DIFF
--- a/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
+++ b/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "ubnt,acb-isp", "qca,qca9533";
+	compatible = "ubnt,aircube-isp", "qca,qca9533";
 	model = "Ubiquiti airCube ISP";
 
 	aliases {

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -348,7 +348,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
-	ubnt,acb-isp)
+	ubnt,aircube-isp)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:3" "4:lan:2"

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -73,6 +73,9 @@ tplink,wbs510-v1|\
 tplink,wbs510-v2)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
 	;;
+ubnt,aircube-isp)
+	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
+	;;
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;
@@ -81,9 +84,6 @@ ubnt,nanostation-m)
 	;;
 ubnt,nanostation-m-xw)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "2"
-	;;
-ubnt,acb-isp)
-	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
 	;;
 zbtlink,zbt-wd323)
 	ucidef_add_gpio_switch "io0" "IO#0" "0"

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -110,7 +110,7 @@ define Device/ubnt-xw
   UBNT_VERSION := 6.0.4
 endef
 
-define Device/ubnt_acb-isp
+define Device/ubnt_aircube-isp
   $(Device/ubnt)
   SOC := qca9533
   DEVICE_MODEL := airCube ISP
@@ -119,8 +119,9 @@ define Device/ubnt_acb-isp
   UBNT_CHIP := qca9533
   UBNT_TYPE := ACB
   UBNT_VERSION := 2.5.0
+  SUPPORTED_DEVICES += ubnt,acb-isp
 endef
-TARGET_DEVICES += ubnt_acb-isp
+TARGET_DEVICES += ubnt_aircube-isp
 
 define Device/ubnt_airrouter
   $(Device/ubnt-xm)


### PR DESCRIPTION
ath79: rename acb-isp to aircube-isp
    
renaming Ubiquiti airCube ISP from short name acb-isp
to a full name aircube-isp
    
Signed-off-by: Roman Kuzmitskii damex.pp@icloud.com