### PR TITLE
ath79: add support for ZiKing CPE46B

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -46,6 +46,7 @@ ubnt,nanostation-m|\
 yuncore,a770|\
 yuncore,a782|\
 yuncore,xd4200|\
+ziking,cpe46b|\
 zyxel,nbg6616)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
+++ b/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9330.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+        model = "ZiKing CPE46B";
+        compatible = "ziking,cpe46b", "qca,ar9330";
+
+        aliases {
+                serial0 = &uart;
+                label-mac-device = &eth0;
+        };
+
+        leds {
+                compatible = "gpio-leds";
+
+                wlan {
+                        label = "green:wlan";
+                        gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+                        linux,default-trigger = "phy0tpt";
+                };
+
+                rssi1 {
+                        label = "green:rssi1";
+                        gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+                };
+
+                rssi2 {
+                        label = "green:rssi2";
+                        gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+                };
+        };
+
+        keys {
+                compatible = "gpio-keys";
+
+                reset {
+                        label = "reset";
+                        linux,code = <KEY_RESTART>;
+                        gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+                };
+        };
+};
+
+&uart {
+        status = "okay";
+};
+
+&spi {
+        status = "okay";
+
+        num-chipselects = <1>;
+
+        flash@0 {
+                compatible = "jedec,spi-nor";
+                spi-max-frequency = <50000000>;
+                reg = <0>;
+
+                partitions {
+                        compatible = "fixed-partitions";
+                        #address-cells = <1>;
+                        #size-cells = <1>;
+
+                        partition@0 {
+                                label = "u-boot";
+                                reg = <0x000000 0x010000>;
+                                read-only;
+                        };
+
+                        partition@10000 {
+                                label = "u-boot-env";
+                                reg = <0x010000 0x010000>;
+                        };
+
+                        partition@20000 {
+                                compatible = "denx,uimage";
+                                label = "firmware";
+                                reg = <0x020000 0x7d0000>;
+                        };
+
+                        art: partition@7f0000 {
+                                label = "art";
+                                reg = <0x7f0000 0x010000>;
+                                read-only;
+                        };
+                };
+        };
+};
+
+&eth0 {
+        status = "okay";
+
+        mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+        status = "okay";
+
+        mtd-mac-address = <&art 0x0>;
+        mtd-mac-address-increment = <2>;
+};
+
+&wmac {
+        status = "okay";
+
+        mtd-cal-data = <&art 0x1000>;
+        mtd-mac-address = <&art 0x1002>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1683,6 +1683,15 @@ define Device/yuncore_xd4200
 endef
 TARGET_DEVICES += yuncore_xd4200
 
+define Device/ziking_cpe46b
+  SOC := ar9330
+  DEVICE_VENDOR := ZiKing
+  DEVICE_MODEL := CPE46B
+  IMAGE_SIZE := 8000k
+  DEVICE_PACKAGES := kmod-i2c-gpio
+endef
+TARGET_DEVICES += ziking_cpe46b
+
 define Device/zbtlink_zbt-wd323
   SOC := ar9344
   DEVICE_VENDOR := ZBT


### PR DESCRIPTION
ZiKing CPE46B is a POE outdoor 2.4ghz device with an integrated directional
antenna. It is low cost and mostly available via Aliexpress, references can
be found at:
- https://forum.openwrt.org/t/anddear-ziking-cpe46b-ar9331-ap121/60383
- https://git.lsd.cat/g/openwrt-cpe46b

Specifications:

- Atheros AR9330
- 32MB of RAM
- 8MB of flash (SPI NOR)
- 1 * 2.4ghz integrated antenna
- 2 * 10/100/1000 ethernet ports (1 POE)
- 3 * Green LEDs controlled by the SoC
- 3 * Green LEDs controlled via GPIO
- 1 * Reset Button controlled via GPIO
- 1 * 4 pin serial header on the PCB
- Outdoor packaging

Flash instruction:
You can use sysupgrade image directly in vendor firmware which is based
on OpenWrt/LEDE. In case of issues with the vendor GUI, the vendor
Telnet console is vulnerable to command injection and can be used to gain
a shell directly on the OEM OpenWrt distribution.
Signed-off-by: Giulio Lorenzo <salveenee@mortemale.org>
