### PR TITLE
config: Support legacy cgroups for docker-ce on LARGE_MEMORY  devices

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -538,7 +538,7 @@ endif
 
 config KERNEL_KEYS
     bool "Enable kernel access key retention support"
-    default n
+    default y if LARGE_MEMORY
 
 config KERNEL_PERSISTENT_KEYRINGS
     bool "Enable kernel persistent keyrings"
@@ -578,7 +578,7 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_FREEZER
 		bool "legacy Freezer cgroup subsystem"
-		default n
+		default y if LARGE_MEMORY
 		select KERNEL_FREEZER
 		help
 		  Provides a way to freeze and unfreeze all tasks in a
@@ -588,7 +588,7 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_DEVICE
 		bool "legacy Device controller for cgroups"
-		default n
+		default y if LARGE_MEMORY
 		help
 		  Provides a cgroup implementing whitelists for devices which
 		  a process in the cgroup can mknod or open.
@@ -596,7 +596,7 @@ if KERNEL_CGROUPS
 
 	config KERNEL_CGROUP_HUGETLB
 		bool "HugeTLB controller"
-		default n
+		default y if LARGE_MEMORY
 		select KERNEL_HUGETLB_PAGE
 
 	config KERNEL_CGROUP_PIDS
@@ -720,7 +720,7 @@ if KERNEL_CGROUPS
 	config KERNEL_CGROUP_PERF
 		bool "Enable perf_event per-cpu per-container group (cgroup) monitoring"
 		select KERNEL_PERF_EVENTS
-		default n
+		default y if LARGE_MEMORY
 		help
 		  This option extends the per-cpu mode to restrict monitoring to
 		  threads which belong to the cgroup specified and run on the
@@ -785,6 +785,7 @@ if KERNEL_CGROUPS
 
 		config KERNEL_CFQ_GROUP_IOSCHED
 			bool "Proportional weight of disk bandwidth in CFQ"
+			default y if LARGE_MEMORY
 
 		config KERNEL_BLK_DEV_THROTTLING
 			bool "Enable throttling policy"
@@ -805,15 +806,15 @@ if KERNEL_CGROUPS
 
 	config KERNEL_NET_CLS_CGROUP
 		bool "legacy Control Group Classifier"
-		default n
+		default y if LARGE_MEMORY
 
 	config KERNEL_CGROUP_NET_CLASSID
 		bool "legacy Network classid cgroup"
-		default n
+		default y if LARGE_MEMORY
 
 	config KERNEL_CGROUP_NET_PRIO
 		bool "legacy Network priority cgroup"
-		default n
+		default y if LARGE_MEMORY
 
 endif
 

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -20,7 +20,7 @@ sub target_config_features(@) {
 		/^usb$/ and $ret .= "\tselect USB_SUPPORT\n";
 		/^usbgadget$/ and $ret .= "\tselect USB_GADGET_SUPPORT\n";
 		/^pcmcia$/ and $ret .= "\tselect PCMCIA_SUPPORT\n";
-		/^pwm$/ and $ret .= "\select PWM_SUPPORT\n";
+		/^pwm$/ and $ret .= "\tselect PWM_SUPPORT\n";
 		/^rtc$/ and $ret .= "\tselect RTC_SUPPORT\n";
 		/^squashfs$/ and $ret .= "\tselect USES_SQUASHFS\n";
 		/^jffs2$/ and $ret .= "\tselect USES_JFFS2\n";
@@ -38,6 +38,7 @@ sub target_config_features(@) {
 		/^mips16$/ and $ret .= "\tselect HAS_MIPS16\n";
 		/^rfkill$/ and $ret .= "\tselect RFKILL_SUPPORT\n";
 		/^low_mem$/ and $ret .= "\tselect LOW_MEMORY_FOOTPRINT\n";
+		/^large_mem$/ and $ret .= "\tselect LARGE_MEMORY\n";
 		/^small_flash$/ and $ret .= "\tselect SMALL_FLASH\n";
 		/^nand$/ and $ret .= "\tselect NAND_SUPPORT\n";
 		/^virtio$/ and $ret .= "\tselect VIRTIO_SUPPORT\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -79,6 +79,9 @@ config USES_UBIFS
 config LOW_MEMORY_FOOTPRINT
 	bool
 
+config LARGE_MEMORY
+	bool
+
 config SMALL_FLASH
 	bool
 

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=i386
 BOARD:=x86
 BOARDNAME:=x86
-FEATURES:=squashfs ext4 vdi vmdk pcmcia targz fpu boot-part rootfs-part
+FEATURES:=squashfs ext4 vdi vmdk pcmcia targz fpu boot-part rootfs-part large_mem
 SUBTARGETS:=generic legacy geode 64
 
 KERNEL_PATCHVER:=5.4


### PR DESCRIPTION
Docker-ce still does not support cgroups v2. This should make it posible to run docker-ce from package repository on current snapshot builds.

Enabled Flags:

KERNEL_KEYS
KERNEL_CGROUP_FREEZER
KERNEL_CGROUP_DEVICE
KERNEL_CGROUP_HUGETLB
KERNEL_CGROUP_PERF
KERNEL_CFQ_GROUP_IOSCHED
KERNEL_NET_CLS_CGROUP
KERNEL_CGROUP_NET_CLASSID
KERNEL_CGROUP_NET_PRIO

Signed-off-by: Najdanović Ivan <najdanovicivan@gmail.com>