### PR TITLE
hostapd: add BGSCAN and AUTOSCAN option

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -278,6 +278,8 @@ hostapd_common_add_bss_config() {
 	config_add_int airtime_bss_weight airtime_bss_limit
 
 	config_add_string roam_rssi_threshold
+
+	config_add_string autoscan_periodic_interval
 }
 
 hostapd_set_vlan_file() {
@@ -897,10 +899,16 @@ wpa_supplicant_prepare_interface() {
 		[ -e "$multiap_flag_file" ] && rm "$multiap_flag_file"
 	fi
 	wpa_supplicant_teardown_interface "$ifname"
+
+	local autoscan_periodic_interval
+	json_get_var autoscan_periodic_interval autoscan_periodic_interval
+	[ -n "$autoscan_periodic_interval" ] && autoscan_periodic_interval="autoscan=periodic:${autoscan_periodic_interval}"
+
 	cat > "$_config" <<EOF
 ${scan_list:+freq_list=$scan_list}
 $ap_scan
 $country_str
+$autoscan_periodic_interval
 EOF
 	return 0
 }

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -276,6 +276,8 @@ hostapd_common_add_bss_config() {
 	config_add_string osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
 
 	config_add_int airtime_bss_weight airtime_bss_limit
+
+	config_add_string roam_rssi_threshold
 }
 
 hostapd_set_vlan_file() {
@@ -1188,6 +1190,10 @@ wpa_supplicant_add_network() {
 
 	[ -n "$bssid_blacklist" ] && append network_data "bssid_blacklist=$bssid_blacklist" "$N$T"
 	[ -n "$bssid_whitelist" ] && append network_data "bssid_whitelist=$bssid_whitelist" "$N$T"
+
+	local roam_rssi_threshold
+	json_get_var roam_rssi_threshold roam_rssi_threshold
+	[ -n "$roam_rssi_threshold" ] && append network_data "bgscan=\"simple:120:${roam_rssi_threshold}:600\"" "$N$T"
 
 	[ -n "$basic_rate" ] && {
 		local br rate_list=

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -600,10 +600,10 @@ CONFIG_IBSS_RSN=y
 # operations for roaming within an ESS (same SSID). See the bgscan parameter in
 # the wpa_supplicant.conf file for more details.
 # Periodic background scans based on signal strength
-#CONFIG_BGSCAN_SIMPLE=y
+CONFIG_BGSCAN_SIMPLE=y
 # Learn channels used by the network and try to avoid bgscans on other
 # channels (experimental)
-#CONFIG_BGSCAN_LEARN=y
+CONFIG_BGSCAN_LEARN=y
 
 # Opportunistic Wireless Encryption (OWE)
 # Experimental implementation of draft-harkins-owe-07.txt

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -527,9 +527,9 @@ CONFIG_WNM=y
 #
 # Enabling directly a module will enable autoscan support.
 # For exponential module:
-#CONFIG_AUTOSCAN_EXPONENTIAL=y
+CONFIG_AUTOSCAN_EXPONENTIAL=y
 # For periodic module:
-#CONFIG_AUTOSCAN_PERIODIC=y
+CONFIG_AUTOSCAN_PERIODIC=y
 
 # Password (and passphrase, etc.) backend for external storage
 # These optional mechanisms can be used to add support for storing passwords


### PR DESCRIPTION
With this change the following option gets enabled on wpa_supplicant full.
* BGSCAN:
This compile option allows the connection to search for a new access point when the signal strength of this becomes weaker. This functionality only works if a connection to this access point SSID already exists. This option is especially useful when the router is used in a mobile scenario where it is not used as an access point but as a client. This is the patch https://lists.openwrt.org/pipermail/openwrt-devel/2020-October/031632.html that was already send via mailinglist.
* AUTOSCAN:
This compile option allows the router to automatically connect to another client connections when a connection is no longer available. Without this option the other connection must to be restarted to establish the connection.