### PR TITLE
kernel: mips: self-decompressing ELF kernel direct boot (Mikrotik mt7621 & ath79)

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -142,6 +142,13 @@ define Build/append-dtb
 	cat $(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb >> $@
 endef
 
+define Build/append-dtb-elf
+	$(TARGET_CROSS)objcopy \
+		--set-section-flags=.appended_dtb=alloc,contents \
+		--update-section \
+		.appended_dtb=$(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb $@
+endef
+
 define Build/install-dtb
 	$(call locked, \
 		$(foreach dts,$(DEVICE_DTS), \

--- a/target/linux/ath79/image/common-mikrotik.mk
+++ b/target/linux/ath79/image/common-mikrotik.mk
@@ -1,8 +1,8 @@
 define Device/mikrotik
 	DEVICE_VENDOR := MikroTik
-	LOADER_TYPE := elf
-	KERNEL := kernel-bin | append-dtb | lzma | loader-kernel
-	KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel
+	KERNEL_NAME := vmlinuz
+	KERNEL := kernel-bin | append-dtb-elf
+	KERNEL_INITRAMFS := kernel-bin | append-dtb-elf
 endef
 
 define Device/mikrotik_nor

--- a/target/linux/ath79/mikrotik/target.mk
+++ b/target/linux/ath79/mikrotik/target.mk
@@ -1,5 +1,7 @@
 BOARDNAME := MikroTik devices
 FEATURES += minor nand squashfs
+KERNELNAME := vmlinux vmlinuz
+IMAGES_DIR := ../../..
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 

--- a/target/linux/generic/backport-5.4/200-v5.10-mips-ralink-enable-zboot-support.patch
+++ b/target/linux/generic/backport-5.4/200-v5.10-mips-ralink-enable-zboot-support.patch
@@ -1,0 +1,31 @@
+From 1f0400d0e2c410b04f246aefb2e9b5155eb4b0bf Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Tue, 13 Oct 2020 10:05:47 +0800
+Subject: [PATCH] mips: ralink: enable zboot support
+
+Some of these ralink devices come with an ancient u-boot which can't
+extract LZMA properly when image gets too big.
+Enable zboot support to get a self-extracting kernel instead of relying
+on broken u-boot support.
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/mips/Kconfig b/arch/mips/Kconfig
+index 99091b059c0b..6e75f02ca6fb 100644
+--- a/arch/mips/Kconfig
++++ b/arch/mips/Kconfig
+@@ -616,6 +616,7 @@ config RALINK
+ 	select SYS_SUPPORTS_32BIT_KERNEL
+ 	select SYS_SUPPORTS_LITTLE_ENDIAN
+ 	select SYS_SUPPORTS_MIPS16
++	select SYS_SUPPORTS_ZBOOT
+ 	select SYS_HAS_EARLY_PRINTK
+ 	select CLKDEV_LOOKUP
+ 	select ARCH_HAS_RESET_CONTROLLER
+-- 
+2.29.0
+

--- a/target/linux/generic/pending-5.4/206-MIPS-zboot-put-appended-dtb-into-a-section.patch
+++ b/target/linux/generic/pending-5.4/206-MIPS-zboot-put-appended-dtb-into-a-section.patch
@@ -1,0 +1,41 @@
+From 7d1531c81c0fb4c93bea8dc316043ad0e4d0c270 Mon Sep 17 00:00:00 2001
+From: Chuanhong Guo <gch981213@gmail.com>
+Date: Sun, 25 Oct 2020 23:19:40 +0800
+Subject: [PATCH] MIPS: zboot: put appended dtb into a section
+
+This will make a separated section for dtb appear in ELF, and we can
+then use objcopy to patch a dtb into vmlinuz when RAW_APPENDED_DTB
+is set in kernel config.
+
+command to patch a dtb:
+objcopy --set-section-flags=.appended_dtb=alloc,contents \
+        --update-section=.appended_dtb=<target>.dtb vmlinuz vmlinuz-dtb
+
+Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
+---
+ arch/mips/boot/compressed/ld.script | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/arch/mips/boot/compressed/ld.script b/arch/mips/boot/compressed/ld.script
+index 2ed08fbef8e7..0ebb667274d6 100644
+--- a/arch/mips/boot/compressed/ld.script
++++ b/arch/mips/boot/compressed/ld.script
+@@ -31,9 +31,12 @@ SECTIONS
+ 		CONSTRUCTORS
+ 		. = ALIGN(16);
+ 	}
+-	__appended_dtb = .;
+-	/* leave space for appended DTB */
+-	. += 0x100000;
++
++	.appended_dtb : {
++		__appended_dtb = .;
++		/* leave space for appended DTB */
++		. += 0x100000;
++	}
+ 
+ 	_edata = .;
+ 	/* End of data section */
+-- 
+2.26.2
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -708,8 +708,8 @@ define Device/MikroTik
   BLOCKSIZE := 64k
   IMAGE_SIZE := 16128k
   DEVICE_PACKAGES := kmod-usb3
-  LOADER_TYPE := elf
-  KERNEL := $(KERNEL_DTB) | loader-kernel
+  KERNEL_NAME := vmlinuz
+  KERNEL := kernel-bin | append-dtb-elf
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | \
 	check-size

--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -6,6 +6,9 @@ SUBTARGET:=mt7621
 BOARDNAME:=MT7621 based boards
 FEATURES+=nand ramdisk rtc usb minor
 CPU_TYPE:=24kc
+KERNELNAME:=vmlinux vmlinuz
+# make Kernel/CopyImage use $LINUX_DIR/vmlinuz
+IMAGES_DIR:=../../..
 
 DEFAULT_PACKAGES += wpad-basic-wolfssl
 


### PR DESCRIPTION
Boot self-decompressing ELF kernel with ELF appended DTB directly from MikroTik RouterBoot.

PR for discussion and testing MIPS ralink. Tested on MikroTik 760iGS.

Following inconsistent behaviour of the Openwrt loader, this PR removes it and uses the kernel's in-built self-decompressing image vmlinuz (from zBoot).
[Openwrt issue](https://bugs.openwrt.org/index.php?do=details&task_id=3354)
[760iGS discussion](https://github.com/openwrt/openwrt/pull/3103#issuecomment-698097701)

On MIPS, the direct vmlinux.elf kernel boot with CONFIG_ELF_APPENDED_DTB is straightforward, but produces a large file for a minimal build ~11MiB.
A self-decompressing minimal build is ~4.3MiB, and on a 760iGS decompression takes ~6 seconds.
There are some kernel patches needed to allow the compressed booted (vmlinuz) to use ELF_APPENDED_DTB_VMLINUZ, when the vmlinux.bin it packs uses RAW_APPENDED_DTB.