### PR TITLE
ath79: add support for Qxwlan E1700AC/E600G/E600GAC/E750A/E750G/E558

### DIFF
--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-16m.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_qxwlan_e750x.dtsi"
+
+/ {
+	model = "Qxwlan E750A v4 16M";
+	compatible = "qxwlan,e750a-v4-16m", "qca,ar9344";
+};
+
+&leds {
+	lan {
+		label = "green:lan";
+		gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+	};
+
+	wan {
+		label = "green:wan";
+		gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&pridata 0x400>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750a-v4-8m.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_qxwlan_e750x.dtsi"
+
+/ {
+	model = "Qxwlan E750A v4 8M";
+	compatible = "qxwlan,e750a-v4-8m", "qca,ar9344";
+};
+
+&leds {
+	lan {
+		label = "green:lan";
+		gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+	};
+
+	wan {
+		label = "green:wan";
+		gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&pridata 0x400>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-16m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_qxwlan_e750x.dtsi"
+
+/ {
+	model = "Qxwlan E750G v8 16M";
+	compatible = "qxwlan,e750g-v8-16m", "qca,ar9344";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&pridata 0x400>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750g-v8-8m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_qxwlan_e750x.dtsi"
+
+/ {
+	model = "Qxwlan E750G v8 8M";
+	compatible = "qxwlan,e750g-v8-8m", "qca,ar9344";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&pridata 0x400>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		sig1 {
+			label = "green:sig1";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "green:sig2";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			pridata: partition@50000 {
+				label = "pri-data";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-16m.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600G v2 16M";
+	compatible = "qxwlan,e600g-v2-16m", "qca,qca9531";
+
+};
+
+&leds {
+	wlan {
+		label = "blue:wlan";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-8m.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600G v2 8M";
+	compatible = "qxwlan,e600g-v2-8m", "qca,qca9531";
+};
+
+&leds {
+	wlan {
+		label = "blue:wlan";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "blue:system";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			pridata: partition@50000 {
+				label = "pri-data";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	mtd-mac-address = <&pridata 0x400>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-16m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600GAC v2 16M";
+	compatible = "qxwlan,e600gac-v2-16m", "qca,qca9531";
+};
+
+&keys {
+	wps {
+		label = "wps";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
+&leds {
+	wlan2g {
+		label = "orange:wlan2g";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy1tpt";
+	};
+
+	control1 {
+		label = "green:control";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+
+	control2 {
+		label = "red:control";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+
+	control3 {
+		label = "blue:control";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-8m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600GAC v2 8M";
+	compatible = "qxwlan,e600gac-v2-8m", "qca,qca9531";
+};
+
+&keys {
+	wps {
+		label = "wps";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
+&leds {
+	wlan2g {
+		label = "orange:wlan2g";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy1tpt";
+	};
+
+	control1 {
+		label = "green:control";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+
+	control2 {
+		label = "red:control";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+
+	control3 {
+		label = "blue:control";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_qxwlan_e558-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9558_qxwlan_e558-v2-16m.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_qxwlan_e558.dtsi"
+
+/ {
+	model = "Qxwlan E558 v2 16M";
+	compatible = "qxwlan,e558-v2-16m", "qca,qca9558";
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_qxwlan_e558-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9558_qxwlan_e558-v2-8m.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_qxwlan_e558.dtsi"
+
+/ {
+	model = "Qxwlan E558 v2 8M";
+	compatible = "qxwlan,e558-v2-8m", "qca,qca9558";
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_qxwlan_e558.dtsi
+++ b/target/linux/ath79/dts/qca9558_qxwlan_e558.dtsi
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		sig1 {
+			label = "green:sig1";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "green:sig2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			pridata: partition@50000 {
+				label = "pri-data";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	mtd-mac-address-increment = <1>;
+	phy-handle = <&phy0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&pridata 0x400>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+        status = "okay";
+};
+
+&usb1 {
+        status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9563_qxwlan_e1700ac-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9563_qxwlan_e1700ac-v2-16m.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_qxwlan_e1700ac.dtsi"
+
+/ {
+	model = "Qxwlan E1700AC v2 16M";
+	compatible = "qxwlan,e1700ac-v2-16m", "qca,qca9563";
+
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9563_qxwlan_e1700ac-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9563_qxwlan_e1700ac-v2-8m.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_qxwlan_e1700ac.dtsi"
+
+/ {
+	model = "Qxwlan E1700AC v2 8M";
+	compatible = "qxwlan,e1700ac-v2-8m", "qca,qca9563";
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
+++ b/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port0>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			pridata: partition@50000 {
+				label = "pri-data";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -229,6 +229,15 @@ pcs,cr3000)
 qihoo,c301)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+qxwlan,e600g-v2-8m|\
+qxwlan,e600g-v2-16m|\
+qxwlan,e600gac-v2-8m|\
+qxwlan,e600gac-v2-16m|\
+qxwlan,e750a-v4-8m|\
+qxwlan,e750a-v4-16m)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x02"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	;;
 samsung,wam250)
 	ucidef_set_led_netdev "lan" "LAN" "white:lan" "eth0"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -243,6 +243,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
+	qxwlan,e1700ac-v2-8m|\
+	qxwlan,e1700ac-v2-16m|\
+	qxwlan,e750g-v8-8m|\
+	qxwlan,e750g-v8-16m|\
 	nec,wg1200cr|\
 	ubnt,nanostation-ac|\
 	yuncore,a782|\
@@ -282,6 +286,11 @@ ath79_setup_interfaces()
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan"
+		;;
+	qxwlan,e558-v2-8m|\
+	qxwlan,e558-v2-16m)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "4:lan" "5:lan" "6@eth0"  "3:wan"
 		;;
 	rosinson,wr818)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -22,6 +22,10 @@ case "$FIRMWARE" in
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	devolo,magic-2-wifi|\
+	qxwlan,e1700ac-v2-8m|\
+	qxwlan,e1700ac-v2-16m|\
+	qxwlan,e600gac-v2-8m|\
+	qxwlan,e600gac-v2-16m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1475,6 +1475,129 @@ define Device/qihoo_c301
 endef
 TARGET_DEVICES += qihoo_c301
 
+define Device/qxwlan_e1700ac-v2
+  SOC := qca9563
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_MODEL := E1700AC
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct -swconfig
+endef
+
+define Device/qxwlan_e1700ac-v2-16m
+  $(Device/qxwlan_e1700ac-v2)
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e1700ac-v2-16m
+
+define Device/qxwlan_e1700ac-v2-8m
+  $(Device/qxwlan_e1700ac-v2)
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e1700ac-v2-8m
+
+define Device/qxwlan_e558-v2
+  SOC := qca9558
+  DEVICE_MODEL := E558
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_PACKAGES := kmod-usb2 -swconfig
+endef
+
+define Device/qxwlan_e558-v2-16m
+  $(Device/qxwlan_e558-v2)
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e558-v2-16m
+
+define Device/qxwlan_e558-v2-8m
+  $(Device/qxwlan_e558-v2)
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e558-v2-8m
+
+define Device/qxwlan_e600g-v2
+  SOC := qca9531
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_MODEL := E600G
+  DEVICE_PACKAGES := kmod-usb2
+endef
+
+define Device/qxwlan_e600g-v2-16m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e600g-v2-16m
+
+define Device/qxwlan_e600g-v2-8m
+  $(Device/qxwlan_e600g-v2-16m)
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e600g-v2-8m
+
+define Device/qxwlan_e600gac-v2-16m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_MODEL := E600GAC
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+endef
+TARGET_DEVICES += qxwlan_e600gac-v2-16m
+
+define Device/qxwlan_e600gac-v2-8m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_MODEL := E600GAC
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+endef
+TARGET_DEVICES += qxwlan_e600gac-v2-8m
+
+define Device/qxwlan_e750a-v4
+  SOC := ar9344
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_MODEL := E750A
+  DEVICE_PACKAGES := kmod-usb2
+endef
+
+define Device/qxwlan_e750a-v4-16m
+  $(Device/qxwlan_e750a-v4)
+  DEVICE_VARIANT := v4 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e750a-v4-16m
+
+define Device/qxwlan_e750a-v4-8m
+  $(Device/qxwlan_e750a-v4)
+  DEVICE_VARIANT := v4 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e750a-v4-8m
+
+define Device/qxwlan_e750g-v8
+  SOC := ar9344
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_MODEL := E750G
+  DEVICE_PACKAGES := kmod-usb2 -swconfig
+endef
+
+define Device/qxwlan_e750g-v8-16m
+  $(Device/qxwlan_e750g-v8)
+  DEVICE_VARIANT := v8 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e750g-v8-16m
+
+define Device/qxwlan_e750g-v8-8m
+  $(Device/qxwlan_e750g-v8)
+  DEVICE_VARIANT := v8 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e750g-v8-8m
+
 define Device/rosinson_wr818
   SOC := qca9563
   DEVICE_VENDOR := Rosinson


### PR DESCRIPTION
E1700AC v2 based on Qualcomm/Atheros QCA9563 + QCA9880

Specification:

 - 750/400/250 MHz (CPU/DDR/AHB)
 - 128 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 3T3R 2.4 GHz
 - 3T3R 5 GHz
 - 2 x 10/1000M Mbps Ethernet (RJ45)
 - 1 x MiniPCI-e
 - 1 x SIM (3G/4G)
 - 1 x USB 2.0 Port
 - 5 x LED , 2 x Button(S8-Reset Buttun), 1 x power input
 - UART (J5) header on PCB (115200 8N1)

E600G v2 based on Qualcomm/Atheros QCA9531

Specification:

 - 650/600/200 MHz (CPU/DDR/AHB)
 - 128/64 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 2T2R 2.4 GHz
 - 2 x 10/100 Mbps Ethernet(RJ45)
 - 1 x MiniPCI-e
 - 1 x SIM (3G/4G)
 - 5 x LED , 1 x Button(SW2-Reset Buttun), 1 x power input
 - UART(J100) header on PCB(115200 8N1)

E600GAC v2 based on Qualcomm/Atheros QCA9531 + QCA9887

Specification:

  - 650/600/200 MHz (CPU/DDR/AHB)
  - 128/64 MB of RAM (DDR2)
  - 8/16 MB of FLASH (SPI NOR)
  - 2T2R 2.4 GHz
  - 1T1R 5 GHz
  - 2 x 10/100 Mbps Ethernet(RJ45)
  - 6 x LED (a three-color led), 2 x Button(SW2-Reset Buttun),1 x power input
  - UART (J100)header on PCB(115200 8N1)

Qxwlan E750A v4 is based on Qualcomm QCA9344.

Specification:

 - 560/450/225 MHz (CPU/DDR/AHB)
 - 128 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 2T2R 5G GHz (AR9344)
 - 2x 10/100 Mbps Ethernet (one port with PoE support)
 - 1x miniPCIe slot (USB 2.0 bus only)
 - 7x LED (6 driven by GPIO)
 - 1x button (reset)
 - 1x DC jack for main power input (9-48 V)
 - UART (J23) and LEDs (J2) headers on PCB

Qxwlan E750G v8 is based on Qualcomm QCA9344 + QCA8334.

Specification:

 - 560/450/225 MHz (CPU/DDR/AHB)
 - 128 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 2T2R 2.4G GHz (AR9344)
 - 2x 10/100 Mbps Ethernet (PoE support)
 - 2x 10/100/1000 Mbps Ethernet
 - 7x LED (6 driven by GPIO)
 - 1x button (reset)
 - 1x DC jack for main power input (9-48 V)
 - UART (J23) and LEDs (J2) headers on PCB

Qxwlan E558 v2 is based on Qualcomm QCA9558 + AR8327.

Specification:

 - 720/600/200 MHz (CPU/DDR/AHB)
 - 128 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 2T2R 2.4 GHz (QCA9558)
 - 3x 10/100/1000 Mbps Ethernet (one port with PoE support)
 - 4x miniPCIe slot (USB 2.0 bus only)
 - 1x microSIM slot
 - 5x LED (4 driven by GPIO)
 - 1x button (reset)
 - 1x 3-pos switch
 - 1x DC jack for main power input (9-48 V)
 - UART (JP5) and LEDs (J8) headers on PCB

Flash instruction:

   1.Using tftp mode with UART connection and original LEDE image
      - Configure PC with static IP 192.168.1.10 and tftp server.
      - Rename "openwrt-ar71xx-generic-xxx-squashfs-sysupgrade.bin"
        to "firmware.bin" and place it in tftp server directory.
      - Connect PC with one of LAN ports, power up the router and press
        key "Enter" to access U-Boot CLI.
      - Use the following commands to update the device to LEDE:
        run lfw
      - After that the device will reboot and boot to LEDE.
      - Wait until all LEDs stops flashing and use the router.

   2.Using httpd mode with Web UI connection and original LEDE image
      - Configure PC with static IP 192.168.1.xxx(2-255) and tftp server.
      - Connect PC with one of LAN ports,press the reset button, power up
        the router and keep button pressed for around 6-7 seconds, until
        leds flashing.
      - Open your browser and enter 192.168.1.1,You will see the upgrade
        interface, select "openwrt-ar71xx-generic-xxx-squashfs-
        sysupgrade.bin" and click the upgrade button.
      - After that the device will reboot and boot to LEDE.
      - Wait until all LEDs stops flashing and use the router.

Signed-off-by:张鹏 <sd20@qxwlan.com>