### PR TITLE
[19.07] mvebu: espressobin: add support for mainline firmware

### DIFF
--- a/package/boot/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-envtools/files/mvebu
@@ -20,7 +20,14 @@ cznic,turris-omnia)
 globalscale,espressobin|\
 globalscale,espressobin-emmc|\
 globalscale,espressobin-v7|\
-globalscale,espressobin-v7-emmc|\
+globalscale,espressobin-v7-emmc)
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"
+	else
+		ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
+	fi
+	;;
 marvell,armada8040-mcbin)
 	ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
 	;;

--- a/target/linux/mvebu/image/cortex-a53.mk
+++ b/target/linux/mvebu/image/cortex-a53.mk
@@ -4,6 +4,7 @@ define Device/globalscale_espressobin
   $(call Device/Default-arm64)
   DEVICE_TITLE := ESPRESSObin (Marvell Armada 3700 Community Board)
   DEVICE_DTS := armada-3720-espressobin
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin
 
@@ -11,6 +12,7 @@ define Device/globalscale_espressobin-emmc
   $(call Device/Default-arm64)
   DEVICE_TITLE := ESPRESSObin eMMC (Marvell Armada 3700 Community Board)
   DEVICE_DTS := armada-3720-espressobin-emmc
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-emmc
 
@@ -18,6 +20,7 @@ define Device/globalscale_espressobin-v7
   $(call Device/Default-arm64)
   DEVICE_TITLE := ESPRESSObin V7 (Marvell Armada 3700 Community Board)
   DEVICE_DTS := armada-3720-espressobin-v7
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-v7
 
@@ -25,6 +28,7 @@ define Device/globalscale_espressobin-v7-emmc
   $(call Device/Default-arm64)
   DEVICE_TITLE := ESPRESSObin V7 eMMC (Marvell Armada 3700 Community Board)
   DEVICE_DTS := armada-3720-espressobin-v7-emmc
+  BOOT_SCRIPT := espressobin
 endef
 TARGET_DEVICES += globalscale_espressobin-v7-emmc
 

--- a/target/linux/mvebu/image/espressobin.bootscript
+++ b/target/linux/mvebu/image/espressobin.bootscript
@@ -1,0 +1,34 @@
+# Bootscript for Globalscale ESPRESSOBin Board
+
+# Set distro variables if necessary for compability with downstream firmware
+if test -z "${kernel_addr_r}"; then
+	setenv kernel_addr_r 0x7000000
+fi
+
+if test -z "${fdt_add_r}"; then
+	setenv fdt_addr_r 0x6f00000
+fi
+
+if test -z "${devtype}"; then
+	setenv devtype mmc
+fi
+
+if test -z "${devnum}"; then
+	if mmc dev 0; then
+		setenv devnum 0
+	elif mmc dev 1; then
+		setenv devnum 1
+	fi
+fi
+
+# figure out partition uuid to pass to the kernel as root=
+part uuid ${devtype} ${devnum}:2 uuid
+
+setenv console "console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000"
+setenv bootargs "root=PARTUUID=${uuid} rw rootwait ${console}"
+
+echo "Booting Linux from ${devtype} ${devnum} with args: ${bootargs}"
+load ${devtype} ${devnum}:1 ${fdt_addr_r} @DTB@.dtb
+load ${devtype} ${devnum}:1 ${kernel_addr_r} Image
+
+booti ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
Backport of #3405.
Required when running a mainline firmware, which is flashed to NOR and is not part of the OpenWRT image.

/cc @tmn505 