### PR TITLE
kernel: bump 5.4 to 5.4.72

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .71
+LINUX_VERSION-5.4 = .72
 
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.71 = 737049ef3cf38d46ee3b377354336cdbc1c4dd95b4e54975a70716f96c8d6cc7
+LINUX_KERNEL_HASH-5.4.72 = 0e24645bd56fe5b55a7a662895f5562c103d71b54d097281f0c9c71ff22c1172
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.4/950-0199-Bluetooth-Check-key-sizes-only-when-Secure-Simple-Pa.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0199-Bluetooth-Check-key-sizes-only-when-Secure-Simple-Pa.patch
@@ -21,8 +21,8 @@ Cc: stable@vger.kernel.org
 
 --- a/net/bluetooth/hci_conn.c
 +++ b/net/bluetooth/hci_conn.c
-@@ -1285,8 +1285,13 @@ int hci_conn_check_link_mode(struct hci_
- 			return 0;
+@@ -1302,8 +1302,13 @@ int hci_conn_check_link_mode(struct hci_
+ 		return 0;
  	}
  
 -	if (hci_conn_ssp_enabled(conn) &&

--- a/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
+++ b/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
@@ -199,10 +199,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 + * @duplex: link duplex
 + * @tx_pause: link transmit pause enablement status
 + * @rx_pause: link receive pause enablement status
-  *
-- * If @mode is not an in-band negotiation mode (as defined by
-- * phylink_autoneg_inband()), allow the link to come up. If @phy
-- * is non-%NULL, configure Energy Efficient Ethernet by calling
++ *
 + * Configure the MAC for an established link.
 + *
 + * @speed, @duplex, @tx_pause and @rx_pause indicate the finalised link
@@ -214,7 +211,10 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 + * Note that when 802.3z in-band negotiation is in use, it is possible
 + * that the user wishes to override the pause settings, and this should
 + * be allowed when considering the implementation of this method.
-+ *
+  *
+- * If @mode is not an in-band negotiation mode (as defined by
+- * phylink_autoneg_inband()), allow the link to come up. If @phy
+- * is non-%NULL, configure Energy Efficient Ethernet by calling
 + * If in-band negotiation mode is disabled, allow the link to come up. If
 + * @phy is non-%NULL, configure Energy Efficient Ethernet by calling
   * phy_init_eee() and perform appropriate MAC configuration for EEE.


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>