### PR TITLE
sunxi: add support for Libre Computer ALL-H3-CC H5

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -226,6 +226,14 @@ define U-Boot/pangolin
   UENV:=pangolin
 endef
 
+define U-Boot/libretech_all_h3_cc_h5
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=Libre Computer ALL-H3-CC H5
+  BUILD_DEVICES:=libretech_all-h3-cc-h5
+  DEPENDS:=+PACKAGE_u-boot-libretech_all_h3_cc_h5:arm-trusted-firmware-sunxi
+  UENV:=a64
+endef
+
 define U-Boot/nanopi_neo_plus2
   BUILD_SUBTARGET:=cortexa53
   NAME:=NanoPi NEO Plus2 (H5)
@@ -328,7 +336,8 @@ UBOOT_TARGETS := \
 	pangolin \
 	pine64_plus \
 	sopine_baseboard \
-	orangepi_zero_plus
+	orangepi_zero_plus \
+	libretech_all_h3_cc_h5
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -38,6 +38,15 @@ define Device/friendlyarm_nanopi-neo2
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
 
+define Device/libretech_all-h3-cc-h5
+  DEVICE_VENDOR := Libre Computer
+  DEVICE_MODEL := ALL-H3-CC
+  DEVICE_VARIANT := H5
+  $(Device/sun50i-h5)
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-libretech-all-h3-cc
+endef
+TARGET_DEVICES += libretech_all-h3-cc-h5
+
 define Device/olimex_a64-olinuxino
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A64-Olinuxino


### PR DESCRIPTION
Specification:

- CPU: Allwinner H5, Quad-core Cortex-A53 Up to 1GHz
- DDR3 RAM: 2GB
- Network:
    10/100M Ethernet x 1
- IR: x1 (Receive)
- USB (Host) Type-A x3
- USB (OTG) Type-A x1
- MicroSD Slot x 1
- eMMC Slot x1
- MicroUSB power input
- GPIO 40pin header
- UART 3pin header
- Leds:
    - librecomputer:blue:status
    - librecomputer:green:pwr
- Buttons:
    - uboot button (used to enter fel mode)
    - power button (can trigger power on)
- Power Supply via MicroUSB or GPIO 5V/2A

Installation:

- Write the image to SD Card with dd
- Boot from the SD Card

Signed-off-by: Roman Kuzmitskii damex.pp@icloud.com
