### PR TITLE
build: fixup 9534357 typo

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/feeds.mk
 include $(INCLUDE_DIR)/rootfs.mk
 
 -include $(TMP_DIR)/.packagedeps
-package-y += kernel/linux
+package-y += linux
 $(curdir)/autoremove:=1
 $(curdir)/builddirs:=$(sort $(package-) $(package-y) $(package-m))
 $(curdir)/builddirs-default:=. $(sort $(package-y) $(package-m))


### PR DESCRIPTION
Fixup 9534357 which added a non existing packages to the packages-y
list.

Reported-by: Jonas Albrecht <plonkbong100@protonmail.com>
Reported-by: Rosen Penev <rosenp@gmail.com>
Signed-off-by: Paul Spooren <mail@aparcar.org>