### PR TITLE
ath10k-ct-firmware: add conflicts and better provides

### DIFF
--- a/package/firmware/ath10k-ct-firmware/Makefile
+++ b/package/firmware/ath10k-ct-firmware/Makefile
@@ -226,13 +226,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca988x
+  CONFLICTS:=ath10k-firmware-qca988x
 endef
 define Package/ath10k-firmware-qca988x-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.1 full-htt-mgt fw for QCA988x
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca988x
+  PROVIDES:=ath10k-firmware-qca988x ath10k-firmware-qca988x-ct
+  CONFLICTS:=ath10k-firmware-qca988x ath10k-firmware-qca988x-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 
@@ -242,13 +244,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca9887
+  CONFLICTS:=ath10k-firmware-qca9887
 endef
 define Package/ath10k-firmware-qca9887-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.1 full-htt-mgt fw for QCA9887
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca9887
+  PROVIDES:=ath10k-firmware-qca9887 ath10k-firmware-qca9887-ct
+  CONFLICTS:=ath10k-firmware-qca9887 ath10k-firmware-qca9887-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 
@@ -258,13 +262,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca99x0
+  CONFLICTS:=ath10k-firmware-qca99x0
 endef
 define Package/ath10k-firmware-qca99x0-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.4 full-htt-mgt fw for QCA99x0
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca99x0
+  PROVIDES:=ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct
+  CONFLICTS:=ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct ath10k-firmware-qca99x0-ct-htt
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 define Package/ath10k-firmware-qca99x0-ct-htt
@@ -272,7 +278,8 @@ $(Package/ath10k-firmware-default)
   TITLE:=ath10k CT 10.4 htt-mgt fw for QCA99x0
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca99x0
+  PROVIDES:=ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct
+  CONFLICTS:=ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 
@@ -282,13 +289,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca9984
+  CONFLICTS:=ath10k-firmware-qca9984
 endef
 define Package/ath10k-firmware-qca9984-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.4 full-htt-mgt fw for QCA9984
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca9984
+  PROVIDES:=ath10k-firmware-qca9984 ath10k-firmware-qca9984-ct
+  CONFLICTS:=ath10k-firmware-qca9984 ath10k-firmware-qca9984-ct ath10k-firmware-qca9984-ct-htt
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 define Package/ath10k-firmware-qca9984-ct-htt
@@ -296,7 +305,8 @@ $(Package/ath10k-firmware-default)
   TITLE:=ath10k CT 10.4 htt-mgt fw for QCA9984
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca9984
+  PROVIDES:=ath10k-firmware-qca9984 ath10k-firmware-qca9984-ct
+  CONFLICTS:=ath10k-firmware-qca9984 ath10k-firmware-qca9984-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 
@@ -306,13 +316,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca4019
+  CONFLICTS:=ath10k-firmware-qca4019
 endef
 define Package/ath10k-firmware-qca4019-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.4 full-htt-mgt for QCA4018/9
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca4019
+  PROVIDES:=ath10k-firmware-qca4019 ath10k-firmware-qca4019-ct
+  CONFLICTS:=ath10k-firmware-qca4019 ath10k-firmware-qca4019-ct ath10k-firmware-qca4019-ct-htt
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 define Package/ath10k-firmware-qca4019-ct-htt
@@ -320,7 +332,8 @@ $(Package/ath10k-firmware-default)
   TITLE:=ath10k CT 10.4 htt-mgt for QCA4018/9
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca4019
+  PROVIDES:=ath10k-firmware-qca4019 ath10k-firmware-qca4019-ct
+  CONFLICTS:=ath10k-firmware-qca4019 ath10k-firmware-qca4019-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 
@@ -330,13 +343,15 @@ $(Package/ath10k-ct-firmware-default)
   SECTION:=firmware
   CATEGORY:=Firmware
   PROVIDES:=ath10k-firmware-qca9888
+  CONFLICTS:=ath10k-firmware-qca9888
 endef
 define Package/ath10k-firmware-qca9888-ct-full-htt
 $(Package/ath10k-ct-firmware-default)
   TITLE:=ath10k CT 10.4 full-htt-mgt fw for QCA9886/8
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca9888
+  PROVIDES:=ath10k-firmware-qca9888 ath10k-firmware-qca9888-ct
+  CONFLICTS:=ath10k-firmware-qca9888 ath10k-firmware-qca9888-ct ath10k-firmware-qca9888-ct-htt
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 define Package/ath10k-firmware-qca9888-ct-htt
@@ -344,7 +359,8 @@ $(Package/ath10k-firmware-default)
   TITLE:=ath10k CT 10.4 htt-mgt fw for QCA9886/8
   SECTION:=firmware
   CATEGORY:=Firmware
-  PROVIDES:=ath10k-firmware-qca9888
+  PROVIDES:=ath10k-firmware-qca9888 ath10k-firmware-qca9888-ct
+  CONFLICTS:=ath10k-firmware-qca9888 ath10k-firmware-qca9888-ct
   DEPENDS:=+!PACKAGE_kmod-ath10k-ct-smallbuffers:kmod-ath10k-ct
 endef
 


### PR DESCRIPTION
This expands packages to define not only provides but also conflicts.
These packages provides same files so they should specify conflicts.

Second expansion is that *-ct-htt and *-ct-full-htt firmwares can also
provide *-ct variant as that allows explicit dependency on CT variant
with various firmware modifications.