### PR TITLE
kernel: add module support Solarflare network adapter

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1234,3 +1234,41 @@ define KernelPackage/igc/description
 endef
 
 $(eval $(call KernelPackage,igc))
+
+define KernelPackage/sfc
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Solarflare SFC9000/SFC9100/EF100-family support
+  DEPENDS:=@PCI_SUPPORT +kmod-mdio +kmod-lib-crc32c +kmod-ptp +kmod-hwmon-core
+  KCONFIG:= \
+	CONFIG_SFC \
+	CONFIG_SFC_MTD \
+	CONFIG_SFC_MCDI_MON \
+	CONFIG_SFC_MCDI_LOGGING \
+	CONFIG_SFC_SRIOV
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/sfc/sfc.ko
+  AUTOLOAD:=$(call AutoProbe,sfc)
+endef
+
+define KernelPackage/sfc/description
+  Solarflare SFC9000/SFC9100/EF100-family support
+  Solarflare EF100 support requires at least kernel version 5.9
+endef
+
+$(eval $(call KernelPackage,sfc))
+
+define KernelPackage/sfc-falcon
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Solarflare SFC4000 support
+  DEPENDS:=@PCI_SUPPORT +kmod-mdio +kmod-lib-crc32c +kmod-i2c-algo-bit
+  KCONFIG:= \
+	CONFIG_SFC_FALCON \
+	CONFIG_SFC_FALCON_MTD
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/sfc/falcon/sfc-falcon.ko
+  AUTOLOAD:=$(call AutoProbe,sfc-falcon)
+endef
+
+define KernelPackage/sfc-falcon/description
+  Solarflare SFC4000 support
+endef
+
+$(eval $(call KernelPackage,sfc-falcon))


### PR DESCRIPTION
According to Solarflare user guide
it is recommended to install lm-sensors and
use the following command to obtain adapter health info

$ sensors | grep sfc
sfc pci 0400
sfc pci 0401

$ sensors sfc pci 0400
sfc pci 0400
Adapter: PCI adapter
1.2V supply:                        N/A
3.3V supply:                    +3.22 V  (min =  +3.00 V, max =  +3.60 V)
12.0V supply:                  +12.14 V  (min = +11.04 V, max = +12.96 V)
0.9V supply (ext. ADC):         +1.03 V  (min =  +0.50 V, max =  +1.10 V)
                                         (crit max =  +1.15 V)
0.9V phase A supply:                N/A
PHY overcurrent:                    N/A
ERROR: Can't get value of subfeature temp1_alarm: Can't read
PHY temp.:                          N/A
AOE FPGA temp.:                 +68.0°C  (low  =  +0.0°C, high = +95.0°C)
                                         (crit = +105.0°C)
Ambient temp.:                  +56.0°C  (low  =  +0.0°C, high = +75.0°C)
                                         (crit = +85.0°C)
Controller die (TDIODE) temp.:  +77.0°C  (low  =  +0.0°C, high = +95.0°C)
                                         (crit = +105.0°C)
Board front temp.:              +59.0°C  (low  =  +0.0°C, high = +75.0°C)
                                         (crit = +85.0°C)
Board back temp.:               +62.0°C  (low  =  +0.0°C, high = +75.0°C)
                                         (crit = +85.0°C)
1.2V supply current:                N/A
0.9V phase A supply current:        N/A
3.3V supply current:                N/A
12V supply current:                 N/A

Signed-off-by: Tan Zien <nabsdh9@gmail.com>

build test: x86-64 ipq40xx mt7621
run test: x86-64