### PR TITLE
lantiq: enable G.INP retransmission counters & statistics

### DIFF
--- a/package/kernel/lantiq/ltq-vdsl/Makefile
+++ b/package/kernel/lantiq/ltq-vdsl/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-vr9
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_BASE_NAME:=drv_dsl_cpe_api
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
@@ -60,6 +60,8 @@ CONFIGURE_ARGS += --enable-kernel-include="$(LINUX_DIR)/include" \
 	--enable-linux-26 \
 	--enable-kernelbuild="$(LINUX_DIR)" \
 	--enable-debug-prints=no \
+	--enable-dsl-pm-retx-counters \
+	--enable-dsl-pm-retx-thresholds \
 	ARCH=mips
 
 CONFIGURE_ARGS += --enable-model=full

--- a/package/network/config/ltq-vdsl-app/Makefile
+++ b/package/network/config/ltq-vdsl-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-app
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_BASE_NAME:=dsl_cpe_control
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@OPENWRT
@@ -55,7 +55,9 @@ CONFIGURE_ARGS += \
 CONFIGURE_ARGS += \
 	--enable-model=typical \
 	--enable-dsl-pm-showtime \
-	--disable-dsl-ceoc
+	--disable-dsl-ceoc \
+	--enable-dsl-pm-retx-counters \
+	--enable-dsl-pm-retx-thresholds
 #CONFIGURE_ARGS += --enable-model=debug
 
 define Package/ltq-vdsl-app/install


### PR DESCRIPTION
Signed-off-by: Jeroen Peelaerts <jeroen.peelaerts@gmail.com>

This patch enables the ReTx counters in the VDSL drivers and adds following line 'feature' metrics.

* G.INP UP/DOWN
* Trellis encoding UP/DOWN
* Bitswap UP/DOWN
* Virtual Noise UP/DOWN

I wanted to know these settings to compare my uplink configuration with that of my Fr!tzbox 7490. Enabling bitswap/G.INP has improved my line stability quite a bit with my current firmware.
