### PR TITLE
octeon: cleanup base-files

### DIFF
--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -2,31 +2,27 @@ do_sysinfo_octeon() {
 	local machine
 	local name
 
-	machine=$(grep "^system type" /proc/cpuinfo | sed "s/system type.*: \(.*\)/\1/g")
+	machine="$(awk '/^system type/ {print $4}' /proc/cpuinfo)"
 
 	case "$machine" in
-	"UBNT_E100"*)
-		name="erlite"
-		;;
-
-	"UBNT_E200"*)
-		name="er"
-		;;
-
-	"UBNT_E220"*)
-		name="erpro"
-		;;
-
-	"ITUS_SHIELD"*)
-		name="itus,shield-router"
-		;;
-
-	*)
-		name="generic"
-		;;
+		"UBNT_E100")
+			name="erlite"
+			;;
+		"UBNT_E200")
+			name="er"
+			;;
+		"UBNT_E220")
+			name="erpro"
+			;;
+		"ITUS_SHIELD")
+			name="itus,shield-router"
+			;;
+		*)
+			name="generic"
+			;;
 	esac
 
-	[ -e "/tmp/sysinfo/" ] || mkdir -p "/tmp/sysinfo/"
+	mkdir -p "/tmp/sysinfo"
 
 	echo "$name" > /tmp/sysinfo/board_name
 	echo "$machine" > /tmp/sysinfo/model

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -1,24 +1,25 @@
 # Copyright (C) 2014 OpenWrt.org
 
-move_config() {
-	. /lib/functions.sh
-	local device
-	case "$(board_name)" in
-		erlite)
-			device="/dev/sda1"
-			;;
-		itus,shield-router)
-			device="/dev/mmcblk1p1"
-			;;
-	esac
-
-	if [ -n "$device" ] && [ -b "$device" ] ; then
-		. /lib/upgrade/common.sh
+octeon_move_config() {
+	. /lib/upgrade/common.sh
+	local device="$1"
+	[ -n "$device" ] && [ -b "$device" ] && {
 		mount -t vfat "$device" /mnt
 		[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
 		umount /mnt
-	fi
-	return 0
+	}
+}
+
+move_config() {
+	. /lib/functions.sh
+	case "$(board_name)" in
+		erlite)
+			octeon_move_config "/dev/sda1"
+			;;
+		itus,shield-router)
+			octeon_move_config "/dev/mmcblk1p1"
+			;;
+	esac
 }
 
 boot_hook_add preinit_mount_root move_config

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -2,20 +2,23 @@
 
 move_config() {
 	. /lib/functions.sh
-	. /lib/upgrade/common.sh
-
+	local device
 	case "$(board_name)" in
 		erlite)
-			mount -t vfat /dev/sda1 /mnt
-			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
-			umount /mnt
+			device="/dev/sda1"
 			;;
 		itus,shield-router)
-			mount -t vfat /dev/mmcblk1p1 /mnt
-			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
-			umount /mnt
+			device="/dev/mmcblk1p1"
 			;;
 	esac
+
+	if [ -n "$device" ] && [ -b "$device" ] ; then
+		. /lib/upgrade/common.sh
+		mount -t vfat "$device" /mnt
+		[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
+		umount /mnt
+	fi
+	return 0
 }
 
 boot_hook_add preinit_mount_root move_config

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -1,116 +1,110 @@
-#
-# Copyright (C) 2014 OpenWrt.org
-#
-
-platform_get_rootfs() {
-	local rootfsdev
-
-	if read cmdline < /proc/cmdline; then
-		case "$cmdline" in
-			*root=*)
-				rootfsdev="${cmdline##*root=}"
-				rootfsdev="${rootfsdev%% *}"
-			;;
-		esac
-
-		echo "${rootfsdev}"
-	fi
-}
-
 platform_copy_config() {
+	local device
+
 	case "$(board_name)" in
-	erlite)
-		mount -t vfat /dev/sda1 /mnt
-		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
-		umount /mnt
-		;;
-	itus,shield-router)
-		mount -t vfat /dev/mmcblk1p1 /mnt
-		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
-		umount /mnt
-		;;
+		erlite)
+			device="/dev/sda1"
+			;;
+		itus,shield-router)
+			device="/dev/mmcblk1p1"
+			;;
 	esac
+
+	if [ -n "$device}" ] && [ -b "$device" ] ; then
+		mount -t "vfat" "$device" "/mnt"
+		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
+		umount "/mnt"
+	fi
+	return 0
 }
 
 platform_do_flash() {
-	local tar_file=$1
-	local board=$2
-	local kernel=$3
-	local rootfs=$4
+	local sysupgrade_file="$1"
+	local kernel_file="$2"
+	local kernel_checksum_file="$kernel_file.md5"
+	local boot_device="$3"
+	local root_device="$4"
+	# find a sysupgrade directory by looking inside sysupgrade file
+	local sysupgrade_directory="$(tar tf $sysupgrade_file | awk -F '/' '/^sysupgrade/ {print $1; exit}')"
+	[ -n "$sysupgrade_directory" ] || return 1
 
-	local board_dir=$(tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$')
-	board_dir=${board_dir%/}
-	[ -n "$board_dir" ] || return 1
-
-	mkdir -p /boot
-
-	if [ $board = "itus,shield-router" ]; then
-		# mmcblk1p1 (fat) contains all ELF-bin images for the Shield
-		mount /dev/mmcblk1p1 /boot
-
-		echo "flashing Itus Kernel to /boot/$kernel (/dev/mmblk1p1)"
-		tar -Oxf $tar_file "$board_dir/kernel" > /boot/$kernel
-	else
-		mount -t vfat /dev/$kernel /boot
-
-		[ -f /boot/vmlinux.64 -a ! -L /boot/vmlinux.64 ] && {
-			mv /boot/vmlinux.64 /boot/vmlinux.64.previous
-			mv /boot/vmlinux.64.md5 /boot/vmlinux.64.md5.previous
-		}
-
-		echo "flashing kernel to /dev/$kernel"
-		tar xf $tar_file $board_dir/kernel -O > /boot/vmlinux.64
-		md5sum /boot/vmlinux.64 | cut -f1 -d " " > /boot/vmlinux.64.md5
+	if [ ! -f "$sysupgrade_file" ] && \
+		[ ! -b "$boot_device" ] && \
+		[ ! -b "$root_device" ] ; then
+		return 1
 	fi
 
-	echo "flashing rootfs to ${rootfs}"
-	tar xf $tar_file $board_dir/root -O | dd of="${rootfs}" bs=4096
+	local boot_directory="/boot"
+	mkdir -p "$boot_directory"
+	mount -t "vfat" "$boot_device" "$boot_directory"
+	# backups current kernel file to a kernel file with .previous postfix
+	if [ -f "$boot_directory/$kernel_file" ] && \
+		[ ! -L "$boot_directory/$kernel_file" ] && \
+		[ -f "$boot_directory/$kernel_checksum_file" ] && \
+		[ ! -L "$boot_directory/$kernel_checksum_file" ] ; then
+		mv "$kernel_file" "$kernel_file.previous"
+		mv "$kernel_checksum_file" "$kernel_checksum_file.previous"
+	fi
+
+	echo "copying kernel to $boot_directory/$kernel_file"
+	tar xf "$sysupgrade_file" "$board_dir/kernel" -O > "$kernel_file"
+	md5sum "$kernel_file" | cut -f1 -d " " > "$kernel_checksum_file"
+
+	echo "flashing rootfs to $root_device"
+	tar xf "$sysupgrade_file" "$board_dir/root" -O | dd of="$root_device" bs=4096
 
 	sync
-	umount /boot
+	umount "$boot_directory"
+	return 0
 }
 
 platform_do_upgrade() {
-	local tar_file="$1"
-	local board=$(board_name)
-	local rootfs="$(platform_get_rootfs)"
-	local kernel=
+	local sysupgrade_file="$1"
+	local kernel_file="vmlinux.64"
+	local boot_device
+	local root_device
 
-	[ -b "${rootfs}" ] || return 1
-	case "$board" in
-	er)
-		kernel=mmcblk0p1
-		;;
-	erlite)
-		kernel=sda1
-		;;
-	itus,shield-router)
-		kernel=ItusrouterImage
-		;;
-	*)
-		return 1
+	case "$(board_name)" in
+		er)
+			boot_device="/dev/mmcblk0p1"
+			root_device="/dev/mmcblk0p2"
+			;;
+		erlite)
+			boot_device="/dev/sda1"
+			root_device="/dev/sda2"
+			;;
+		itus,shield-router)
+			kernel_file="ItusrouterImage"
+			boot_device="/dev/mmcblk1p1"
+			root_device="/dev/mmcblk1p2"
+			;;
+		*)
+			return 1
 	esac
 
-	platform_do_flash $tar_file $board $kernel $rootfs
+	if [ -n "$boot_device" ] && \
+		[ -b "$boot_device" ] && \
+		[ -n "$root_device" ] && \
+		[ -b "$root_device" ] ; then
+		platform_do_flash "$sysupgrade_file" "$kernel_file" "$boot_device" "$root_device"
+	fi
 
 	return 0
 }
 
 platform_check_image() {
-	local board=$(board_name)
-	local tar_file="$1"
+	local sysupgrade_file="$1"
+	# find a sysupgrade directory by looking inside sysupgrade file
+	local sysupgrade_directory="$(tar tf $sysupgrade_file | awk -F '/' '/^sysupgrade/ {print $1; exit}')"
+	[ -n "$sysupgrade_directory" ] || return 1
 
-	local board_dir=$(tar tf "$tar_file" | grep -m 1 '^sysupgrade-.*/$')
-	board_dir=${board_dir%/}
-	[ -n "$board_dir" ] || return 1
-
-	case "$board" in
+	case "$(board_name)" in
 	er | \
 	erlite | \
 	itus,shield-router)
-		local kernel_length=$(tar xf $tar_file $board_dir/kernel -O | wc -c 2> /dev/null)
-		local rootfs_length=$(tar xf $tar_file $board_dir/root -O | wc -c 2> /dev/null)
-		[ "$kernel_length" = 0 -o "$rootfs_length" = 0 ] && {
+		local kernel_length="$(tar xf $sysupgrade_file $sysupgrade_directory/kernel -O | wc -c 2> /dev/null)"
+		local rootfs_length="$(tar xf $sysupgrade_file $sysupgrade_directory/root -O | wc -c 2> /dev/null)"
+		[ "$kernel_length" = 0 ] || [ "$rootfs_length" = 0 ] && {
 			echo "The upgrade image is corrupt."
 			return 1
 		}

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -1,21 +1,21 @@
-platform_copy_config() {
-	local device
-
-	case "$(board_name)" in
-		erlite)
-			device="/dev/sda1"
-			;;
-		itus,shield-router)
-			device="/dev/mmcblk1p1"
-			;;
-	esac
-
-	if [ -n "$device}" ] && [ -b "$device" ] ; then
+platform_octeon_copy_config() {
+	local device="$1"
+	[ -n "$device}" ] && [ -b "$device" ] && {
 		mount -t "vfat" "$device" "/mnt"
 		cp -af "$UPGRADE_BACKUP" "/mnt/$BACKUP_FILE"
 		umount "/mnt"
-	fi
-	return 0
+	}
+}
+
+platform_copy_config() {
+	case "$(board_name)" in
+		erlite)
+			platform_octeon_copy_config "/dev/sda1"
+			;;
+		itus,shield-router)
+			platform_octeon_copy_config "/dev/mmcblk1p1"
+			;;
+	esac
 }
 
 platform_do_flash() {


### PR DESCRIPTION
improvements:
 - use single awk (busybox version works well)
   command to find board name in 01_sysinfo and
   to find sysupgrade directory inside sysupgrade tar
 - use tabs and curly brackets for variables everywhere
   helps with not making a mistake in the future and
   to keep code clean-er
 - use separate condition logic to make statements certain
 - add checks for devices being block devices and that files
   are actually exist before doing anything with them.
   we need to be certainly sure that environment is right
   before doing anything to the device.
 - stop guessing which device we need to use for flashing
   since we already know that information.
 - get rid of exception in logic during flash for itus and
   make it follow same pattern with a kernel partition backup.
   we add kernel image name for it follow the same pattern.
 - reuse the code and add comments

tldr: actualized code, reuse and document it.

tested on:
  - ubnt_edgerouter-lite
  - ubnt_edgerouter
  - generic board

what tested:
  - sysupgrade with keeping configuration
  - sysupgrade without keeping configuration
  - new install
    (not applicable to ubnt_edgerouter-lite since it is done from pc)
  - generic octeon booting on generic octeonplus or higher board

Signed-off-by: Roman Kuzmitskii damex.pp@icloud.com
