### PR TITLE
cznic_turris-omnia: fix initramfs and kernel image

### DIFF
--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -32,8 +32,7 @@ define Device/cznic_turris-omnia
   DEVICE_VENDOR := CZ.NIC
   DEVICE_MODEL := Turris Omnia
   KERNEL_INSTALL := 1
-  KERNEL := kernel-bin
-  KERNEL_INITRAMFS := kernel-bin
+  KERNEL := kernel-bin | append-dtb
   DEVICE_PACKAGES :=  \
     mkf2fs e2fsprogs kmod-fs-vfat kmod-nls-cp437 kmod-nls-iso8859-1 \
     wpad-basic-wolfssl kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \


### PR DESCRIPTION
This adds DTB to kernel and that way makes it possible to easily boot
initramfs image and also kernel.

The sequence to boot initramfs on Omnia is then just:
  env set bootargs earlyprintk console=ttyS0,115200
  dhcp 0x1000000 192.168.1.1:openwrt-mvebu-cortexa9-cznic_turris-omnia-initramfs-kernel.bin
  bootz 0x1000000

Without this change kernel boot won't proceed and is stuck on "Starting
kernel".