### PR TITLE
octeon: use dedicated function to move config backup

### DIFF
--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -1,21 +1,27 @@
 # Copyright (C) 2014 OpenWrt.org
 
 move_config() {
-	. /lib/functions.sh
 	. /lib/upgrade/common.sh
+
+	local device="$1"
+	[ -n "$device" ] && [ -b "$device" ] && {
+		mount -t vfat "$device" /mnt
+		[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
+		umount /mnt
+	}
+}
+
+octeon_move_config() {
+	. /lib/functions.sh
 
 	case "$(board_name)" in
 		erlite)
-			mount -t vfat /dev/sda1 /mnt
-			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
-			umount /mnt
+			move_config "/dev/sda1"
 			;;
 		itus,shield-router)
-			mount -t vfat /dev/mmcblk1p1 /mnt
-			[ -f "/mnt/$BACKUP_FILE" ] && mv -f "/mnt/$BACKUP_FILE" /
-			umount /mnt
+			move_config "/dev/mmcblk1p1"
 			;;
 	esac
 }
 
-boot_hook_add preinit_mount_root move_config
+boot_hook_add preinit_mount_root octeon_move_config


### PR DESCRIPTION
all octeons use the same or very similar way to
backup and restore configuration.
we're expecting to have more devices added and to
stop repeating yourself move repeatable logic to
a separate function.

Signed-off-by: Roman Kuzmitskii damex.pp@icloud.com
