### PR TITLE
ramips: mt7621: use lzma-loader for U7621-06

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1088,6 +1088,7 @@ TARGET_DEVICES += ubnt_unifi-nanohd
 
 define Device/unielec_u7621-06-16m
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
@@ -1099,6 +1100,7 @@ TARGET_DEVICES += unielec_u7621-06-16m
 
 define Device/unielec_u7621-06-64m
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06


### PR DESCRIPTION
The U7621-06 fails to boot if the kernel is large.
Enabling lzma-loader resolves the issue.

Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>