### PR TITLE
refpolicy: add variant that builds modular policy

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -362,6 +362,12 @@ menu "Global build settings"
 			help
 			  SELinux Reference Policy (refpolicy)
 
+		config SELINUXTYPE_targeted-modular
+			bool "targeted-modular"
+			select PACKAGE_refpolicy-modular
+			help
+			  Modular SELinux Reference Policy (refpolicy-modular)
+
 		config SELINUXTYPE_dssp
 			bool "dssp"
 			select PACKAGE_selinux-policy

--- a/package/system/refpolicy/Makefile
+++ b/package/system/refpolicy/Makefile
@@ -24,12 +24,25 @@ TAR_OPTIONS:=--transform='s%^refpolicy%$(PKG_NAME)-$(PKG_VERSION)%' -xf -
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/refpolicy
+define Package/refpolicy/Default
   SECTION:=system
   CATEGORY:=Base system
   TITLE:=SELinux reference policy
   URL:=http://selinuxproject.org/page/Main_Page
   PKGARCH:=all
+endef
+
+define Package/refpolicy
+  $(call Package/refpolicy/Default)
+  CONFLICTS:=refpolicy-modular
+  VARIANT:=default
+endef
+
+define Package/refpolicy-modular
+  $(call Package/refpolicy/Default)
+  TITLE += (modular)
+  VARIANT:=modular
+  PROVIDES:=refpolicy
 endef
 
 define Package/refpolicy/description
@@ -56,25 +69,43 @@ endef
 # builds is a small host tool that gets run as part of the build
 # process.
 MAKE_FLAGS += \
+	DESTDIR="$(PKG_INSTALL_DIR)"
 	SETFILES="$(STAGING_DIR_HOST)/bin/setfiles" \
 	CHECKPOLICY="$(STAGING_DIR_HOSTPKG)/bin/checkpolicy" \
 	CC="$(HOSTCC)" \
 	CFLAGS="$(HOST_CFLAGS)"
 
 define Build/Configure
-	$(SED) "/MONOLITHIC/c\MONOLITHIC = y" $(PKG_BUILD_DIR)/build.conf
 	$(SED) "/NAME/c\NAME = targeted" $(PKG_BUILD_DIR)/build.conf
+ifneq ($(BUILD_VARIANT),modular)
+	$(SED) "/MONOLITHIC/c\MONOLITHIC = y" $(PKG_BUILD_DIR)/build.conf
+endif
 	$(call Build/Compile/Default,conf)
 endef
+
+ifeq ($(BUILD_VARIANT),modular)
+define Build/Install
+	$(call Build/Compile/Default,install install-headers)
+endef
+endif
 
 define Package/refpolicy/conffiles
 /etc/selinux/config
 endef
 
+Package/refpolicy-modular/conffiles = $(Package/refpolicy/conffiles)
+
 define Package/refpolicy/install
 	$(INSTALL_DIR) $(1)/etc/selinux
 	$(CP) $(PKG_INSTALL_DIR)/etc/selinux/* $(1)/etc/selinux/
 	$(CP) ./files/selinux-config $(1)/etc/selinux/config
+ifeq ($(BUILD_VARIANT),modular)
+	$(INSTALL_DIR) $(1)/usr/share/selinux
+	$(CP) $(PKG_INSTALL_DIR)/usr/share/selinux/* $(1)/usr/share/selinux/
+endif
 endef
 
+Package/refpolicy-modular/install = $(Package/refpolicy/install)
+
 $(eval $(call BuildPackage,refpolicy))
+$(eval $(call BuildPackage,refpolicy-modular))


### PR DESCRIPTION
This adds a variant of refpolicy that builds the modular version of the SELinux policy. There are a few reasons why this should not be the default case, namely the resource requirements of a modular policy along with the read-only nature of /var on OpenWrt. @doverride noted this elsewhere (https://github.com/openwrt/openwrt/pull/3472#issuecomment-705585219). Despite this, I have found the modular policy useful for experimentation.

Signed-off-by: W. Michael Petullo <mike@flyn.org>