### PR TITLE
dnsmasq: add client id support

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.82
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=http://thekelleys.org.uk/dnsmasq

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -161,7 +161,7 @@ append_server() {
 }
 
 append_rev_server() {
-        xappend "--rev-server=$1"
+	xappend "--rev-server=$1"
 }
 
 append_address() {
@@ -335,6 +335,7 @@ dhcp_host_add() {
 
 	config_get mac "$cfg" mac
 	config_get duid "$cfg" duid
+	config_get clientid "$cfg" client_id
 	config_get tag "$cfg" tag
 
 	if [ -n "$mac" ]; then
@@ -349,7 +350,11 @@ dhcp_host_add() {
 		duids="id:${duid// */}"
 	fi
 
-	if [ -z "$macs" ] && [ -z "$duids" ]; then
+	if [ -n "$clientid" ]; then
+		clientid="id:${clientid},"
+	fi
+
+	if [ -z "$macs" ] && [ -z "$duids" ] && [ -z "$clientid" ]; then
 		# --dhcp-host=lap,192.168.0.199,[::beef]
 		[ -n "$name" ] || return 0
 		macs="$name"
@@ -376,7 +381,7 @@ dhcp_host_add() {
 		addrs="${ip:+,$ip}${hostid:+,[::$hostid]}"
 		xappend "--dhcp-host=$macs${duids:+,$duids}$hosttag$addrs$nametime"
 	else
-		xappend "--dhcp-host=$macs$hosttag${ip:+,$ip}$nametime"
+		xappend "--dhcp-host=$clientid$macs$hosttag${ip:+,$ip}$nametime"
 	fi
 }
 


### PR DESCRIPTION
This adds client_id host option for config/dhcp static leases.

Signed-off-by: Sergio E. Nemirowski <sergio@outerface.net>