### PR TITLE
ath79: fix block protection clearing

### DIFF
--- a/target/linux/ath79/patches-5.4/450-fix-block-protection-clearing.patch
+++ b/target/linux/ath79/patches-5.4/450-fix-block-protection-clearing.patch
@@ -1,0 +1,28 @@
+From: Nick Hainke <vincent@systemli.org>
+Date: Sun, 25 Oct 2020 00:52:47 +0200
+Subject: [PATCH] ath79: fix block protection clearing
+
+The block protection bits of macronix do not match the implementation.
+The chip has 3 BP bits. Bit 5 is actually the third BP but here the
+5th bit is SR_TB. Therefore the patch adds SR_TB to the mask. In the
+4.19er kernel the whole register was simply set to 0.
+
+The wrong implementation did not remove the block protection. This led
+to jffs2 errors in the form of:
+"jffs2: Newly-erased block contained word 0x19852003 at offset 0x..."
+This caused inconsistent memory and other errors.
+
+Suggested-by: David Bauer <mail@david-bauer.net>
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1981,7 +1981,7 @@ static int sr2_bit7_quad_enable(struct s
+ static int spi_nor_clear_sr_bp(struct spi_nor *nor)
+ {
+ 	int ret;
+-	u8 mask = SR_BP2 | SR_BP1 | SR_BP0;
++	u8 mask = SR_TB | SR_BP2 | SR_BP1 | SR_BP0;
+ 
+ 	ret = read_sr(nor);
+ 	if (ret < 0) {


### PR DESCRIPTION
The block protection bits of macronix do not match the implementation. The chip has 3 BP bits. Bit 5 is actually the third BP but here the 5th bit is SR_TB. Therefore the patch adds SR_TB to the mask. In the 4.19er kernel the whole register was simply set to 0.

The wrong implementation did not remove the block protection. This led to jffs2 errors in the form of:
"jffs2: Newly-erased block contained word 0x19852003 at offset 0x..."
This caused inconsistent memory and other errors.
