### PR TITLE
ath79: merge ar9342 dts files

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_litebeam-ac-gen2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_litebeam-ac-gen2.dts
@@ -1,35 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,litebeam-ac-gen2", "ubnt,wa", "qca,ar9342";
 	model = "Ubiquiti LiteBeam AC Gen2";
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
-	};
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
@@ -1,36 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,nanostation-ac-loco", "ubnt,wa", "qca,ar9342";
 	model = "Ubiquiti Nanostation AC loco (WA)";
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		phy-mode = "rgmii";
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x06000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
-	};
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_2port.dtsi"
 
 / {
 	compatible = "ubnt,nanostation-ac","ubnt,wa", "qca,ar9342";
@@ -34,41 +34,6 @@
 			label = "blue:rssi3";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy0: ethernet-phy@0 {
-		phy-mode = "rgmii";
-		reg = <0>;
-
-		qca,ar8327-initvals = <
-			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
-			0x58 0xffb7ffb7 /* LED_CTRL2 */
-			0x5c 0x03ffff00 /* LED_CTRL3 */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x06000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii";
-	phy-handle = <&phy0>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <2>;
-		rxdv-delay = <2>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9342_ubnt_wa_1port.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa_1port.dtsi
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9342_ubnt_wa.dtsi"
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa_2port.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa_2port.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9342_ubnt_wa.dtsi"
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy0: ethernet-phy@0 {
+		phy-mode = "rgmii";
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x58 0xffb7ffb7 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+	};
+};


### PR DESCRIPTION
Most ubnt-wa devices differ only in the number of ethernet ports.
Therefore we introduce another 1port, or 2port definition.

In addition, this fixes the nanostation ac loco, because we use the dts file for the litebeam ac gen2. The ethernet interface of the nanostation ac loco does not work with 5.4 kernel. Changing the dts file to the litebeam ac gen2 fixes the issue.