### PR TITLE
linux-firmware: update to 20201022

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20200918
+PKG_VERSION:=20201022
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=e2787907e0892e0b1a3c06f1def6fd3cdc0eff850b0919c7f21b5bda7563d2d8
+PKG_HASH:=bf586e0beb4c65f22bf0a79811f259aa0a5a7cc9f70eebecb260525b6914cef7
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
git log --pretty=oneline --abbrev-commit 20200918..20201022
dae4b4c (HEAD -> main, tag: 20201022, origin/master, origin/main, origin/HEAD) Merge branch 'v1.1.5' of https://github.com/irui-wang/linux_fw_vpu_v1.1.5 into main
04f71fe cypress: add Cypress firmware and clm_blob files
4d0755b Merge https://github.com/shahasit/bt-linux-firmware into main
2a262bb Merge https://github.com/shahasit/video-linux-firmware into main
c024640 Merge tag 'iwlwifi-fw-2020-10-14' of git://git.kernel.org/pub/scm/linux/kernel/git/iwlwifi/linux-firmware into main
09e8cff rtl_bt: Update RTL8821C BT FW to 0xAA6C_A99E
d7904d5 ath10k: add SDIO firmware for QCA9377 WiFi
ecdc272 Merge branch 'dg1_dmc_v2_02' of git://anongit.freedesktop.org/drm/drm-firmware into main
c86361d ice: update package file to 1.3.16.0
76ceac8 mediatek: separate venc service thread
8877322 QCA : Updated firmware file for WCN3991
4f41e9d iwlwifi: update and add new FWs from core56-54 release
346057d iwlwifi: update 3168, 7265D, 8000C and 8265 firmwares
a140ef3 i915: Add DG1 DMC v2.02
a09b728 qcom : updated venus firmware files for v5.4
58d41d0 ice: Add comms package file for Intel E800 series driver
c1bef9e copy-firmware: Always write Link: entries
b95e230 Merge commit 'ad1da95d52f1a9206da3ef52f3484f3b89ec6615' of https://github.com/shahasit/linux-firmware-bt into main
0b884ec amdgpu: update vega20 firmware for 20.40
bca0233 amdgpu: update vega12 firmware for 20.40
8652e02 amdgpu: update vega10 firmware for 20.40
9f46d48 amdgpu: update renoir firmware for 20.40
e667605 amdgpu: update raven2 firmware for 20.40
a487f2f amdgpu: update raven firmware for 20.40
aa7b732 amdgpu: update picasso firmware for 20.40
a18981e amdgpu: update navi14 firmware for 20.40
1696e2e amdgpu: update navi12 firmware for 20.40
6b8a6ea amdgpu: update navi10 firmware for 20.40
5b30b38 linux-firmware: Add new VPDMA firmware 1b8.bin
ad1da95 QCA : Updated firmware files for WCN3991
b78a66c linux-firmware: Update firmware for Cadence MHDP8546 DP bridge
afbfb5f linux-firmware: Update firmware patch for Intel Bluetooth 7265 (D1)
a38b8ed Mellanox: Add new mlxsw_spectrum firmware xx.2008.1312
1487a8a linux-firmware: nvidia: move firmware symlinks to WHENCE
bdd5617 linux-firmware: move i915 firmware symlinks to WHENCE
ab69b57 linux-firmware: move iwlwifi-7265D-10.ucode symlink to WHENCE
49c4ff5 Merge branch 'mrvl-prestera' of https://github.com/PLVision/linux-firmware into main
7a02212 linux-firmware: Update Marvell Switchdev firmware with ABI changes
```
Signed-off-by: John Audia <graysky@archlinux.us>