### PR TITLE
ath79: rework ar9342 based ubnt devices

### DIFF
--- a/target/linux/ath79/dts/ar9342_ubnt_lap-120.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_lap-120.dts
@@ -1,37 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,lap-120", "ubnt,wa", "qca,ar9342";
 	model = "Ubiquiti LiteAP ac (LAP-120)";
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
-	};
 };
 
 &wmac {

--- a/target/linux/ath79/dts/ar9342_ubnt_litebeam-ac-gen2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_litebeam-ac-gen2.dts
@@ -1,37 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,litebeam-ac-gen2", "ubnt,wa", "qca,ar9342";
 	model = "Ubiquiti LiteBeam AC Gen2";
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
-	};
 };
 
 &wmac {

--- a/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac-gen2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac-gen2.dts
@@ -1,10 +1,10 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 
-#include "ar9342_ubnt_wa_1port.dtsi"
+#include "ar9342_ubnt_wa_2port.dtsi"
 
 / {
-	compatible = "ubnt,nanobeam-ac", "ubnt,wa", "qca,ar9342";
-	model = "Ubiquiti NanoBeam AC Gen1 (WA)";
+	compatible = "ubnt,nanobeam-ac-gen2", "ubnt,wa", "qca,ar9342";
+	model = "Ubiquiti NanoBeam AC Gen2 (WA)";
 
 	aliases {
 		led-boot = &led_rssi3;

--- a/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
@@ -42,7 +42,6 @@
 
 	phy-mask = <4>;
 	phy4: ethernet-phy@4 {
-		phy-mode = "rgmii";
 		reg = <4>;
 	};
 };
@@ -51,11 +50,11 @@
 	status = "okay";
 
 	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x06000000 0x00000101 0x00001313>;
+	pll-data = <0x02000000 0x00000101 0x00001313>;
 
 	mtd-mac-address = <&art 0x0>;
 
-	phy-mode = "rgmii";
+	phy-mode = "rgmii-id";
 	phy-handle = <&phy4>;
 
 	gmac-config {

--- a/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanobeam-ac.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,nanobeam-ac", "ubnt,wa", "qca,ar9342";
@@ -34,32 +34,5 @@
 			label = "blue:rssi3";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
 	};
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac-loco.dts
@@ -1,37 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,nanostation-ac-loco", "ubnt,wa", "qca,ar9342";
 	model = "Ubiquiti Nanostation AC loco (WA)";
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
-	};
 };
 
 &wmac {

--- a/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_nanostation-ac.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_2port.dtsi"
 
 / {
 	compatible = "ubnt,nanostation-ac","ubnt,wa", "qca,ar9342";
@@ -34,41 +34,6 @@
 			label = "blue:rssi3";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy0: ethernet-phy@0 {
-		phy-mode = "rgmii";
-		reg = <0>;
-
-		qca,ar8327-initvals = <
-			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
-			0x58 0xffb7ffb7 /* LED_CTRL2 */
-			0x5c 0x03ffff00 /* LED_CTRL3 */
-			0x7c 0x0000007e /* PORT0_STATUS */
-		>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x06000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii";
-	phy-handle = <&phy0>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <2>;
-		rxdv-delay = <2>;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9342_ubnt_powerbeam-5ac-gen2.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_powerbeam-5ac-gen2.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "ar9342_ubnt_wa.dtsi"
+#include "ar9342_ubnt_wa_1port.dtsi"
 
 / {
 	compatible = "ubnt,powerbeam-5ac-gen2", "ubnt,wa", "qca,ar9342";
@@ -34,32 +34,5 @@
 			label = "blue:rssi3";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
-	};
-};
-
-&mdio0 {
-	status = "okay";
-
-	phy-mask = <4>;
-	phy4: ethernet-phy@4 {
-		reg = <4>;
-	};
-};
-
-&eth0 {
-	status = "okay";
-
-	/* default for ar934x, except for 1000M and 10M */
-	pll-data = <0x02000000 0x00000101 0x00001313>;
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-mode = "rgmii-id";
-	phy-handle = <&phy4>;
-
-	gmac-config {
-		device = <&gmac>;
-		rxd-delay = <3>;
-		rxdv-delay = <3>;
 	};
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_wa_1port.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa_1port.dtsi
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9342_ubnt_wa.dtsi"
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+	};
+};

--- a/target/linux/ath79/dts/ar9342_ubnt_wa_2port.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa_2port.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9342_ubnt_wa.dtsi"
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <4>;
+	phy0: ethernet-phy@0 {
+		phy-mode = "rgmii";
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x58 0xffb7ffb7 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M and 10M */
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -358,6 +358,7 @@ ubnt,rocket-m)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100"
 	;;
 ubnt,nanobeam-ac|\
+ubnt,nanobeam-ac-gen2|\
 ubnt,nanostation-ac|\
 ubnt,powerbeam-5ac-gen2)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -248,6 +248,7 @@ ath79_setup_interfaces()
 	qxwlan,e1700ac-v2-16m|\
 	qxwlan,e750g-v8-8m|\
 	qxwlan,e750g-v8-16m|\
+	ubnt,nanobeam-ac-gen2|\
 	ubnt,nanostation-ac|\
 	yuncore,a782|\
 	yuncore,xd4200)
@@ -582,6 +583,7 @@ ath79_setup_macs()
 		label_mac=$wan_mac
 		;;
 	ubnt,litebeam-ac-gen2|\
+	ubnt,nanobeam-ac-gen2|\
 	ubnt,powerbeam-5ac-500|\
 	ubnt,powerbeam-5ac-gen2)
 		label_mac=$(mtd_get_mac_binary art 0x5006)

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -76,6 +76,7 @@ tplink,wbs510-v2)
 ubnt,aircube-isp)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "11"
 	;;
+ubnt,nanobeam-ac-gen2|\
 ubnt,nanostation-ac)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "3"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -31,6 +31,7 @@ case "$FIRMWARE" in
 	ubnt,lap-120|\
 	ubnt,litebeam-ac-gen2|\
 	ubnt,nanobeam-ac|\
+	ubnt,nanobeam-ac-gen2|\
 	ubnt,nanostation-ac|\
 	ubnt,nanostation-ac-loco|\
 	ubnt,powerbeam-5ac-500|\

--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -190,9 +190,18 @@ TARGET_DEVICES += ubnt_litebeam-ac-gen2
 define Device/ubnt_nanobeam-ac
   $(Device/ubnt-wa)
   DEVICE_MODEL := NanoBeam AC
+  DEVICE_VARIANT := Gen1
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct rssileds
 endef
 TARGET_DEVICES += ubnt_nanobeam-ac
+
+define Device/ubnt_nanobeam-ac-gen2
+  $(Device/ubnt-wa)
+  DEVICE_MODEL := NanoBeam AC
+  DEVICE_VARIANT := Gen2
+  DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct rssileds
+endef
+TARGET_DEVICES += ubnt_nanobeam-ac-gen2
 
 define Device/ubnt_nanobridge-m
   $(Device/ubnt-xm)


### PR DESCRIPTION
Please notice:
You have to apply https://github.com/openwrt/openwrt/pull/3536#pullrequestreview-516355511

... Testing all devices again ... (Draft)

- [x] Nanobeam AC Gen2
- [x] Litebeam AC Gen2
- [x] Nanostation AC Loco
- [x] Lite AP 120
- [x] Nanobeam AC
- [ ] Nanostation AC
- [x] Powerbeam AC Gen2

Images for missing devices:
[nanobeam.zip](https://github.com/openwrt/openwrt/files/5435569/nanobeam.zip)
[nanostation.zip](https://github.com/openwrt/openwrt/files/5435574/nanostation.zip)
[powerbeam.zip](https://github.com/openwrt/openwrt/files/5435576/powerbeam.zip)
[lap-120.zip](https://github.com/openwrt/openwrt/files/5435577/lap-120.zip)