### PR TITLE
perf: add libcap dependency

### DIFF
--- a/package/devel/perf/Makefile
+++ b/package/devel/perf/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/nls.mk
 define Package/perf
   SECTION:=devel
   CATEGORY:=Development
-  DEPENDS:= +libelf +libdw +PACKAGE_libunwind:libunwind +libpthread +librt +objdump @!IN_SDK @!TARGET_arc770 @KERNEL_PERF_EVENTS
+  DEPENDS:= +libelf +libdw +PACKAGE_libunwind:libunwind +libpthread +librt +libcap +objdump @!IN_SDK @!TARGET_arc770 @KERNEL_PERF_EVENTS
   TITLE:=Linux performance monitoring tool
   VERSION:=$(LINUX_VERSION)-$(PKG_RELEASE)
   URL:=http://www.kernel.org


### PR DESCRIPTION
Add libcap dependency for perf. This resolves build issue.

Package perf is missing dependencies for the following libraries:
libcap.so.2

Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>

