### PR TITLE
mbedtls: enable session tickets

### DIFF
--- a/package/libs/mbedtls/patches/200-config.patch
+++ b/package/libs/mbedtls/patches/200-config.patch
@@ -126,15 +126,6 @@
  
  /**
   * \def MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
-@@ -1690,7 +1690,7 @@
-  *
-  * Comment this macro to disable support for SSL session tickets
-  */
--#define MBEDTLS_SSL_SESSION_TICKETS
-+//#define MBEDTLS_SSL_SESSION_TICKETS
- 
- /**
-  * \def MBEDTLS_SSL_EXPORT_KEYS
 @@ -1720,7 +1720,7 @@
   *
   * Comment this macro to disable support for truncated HMAC in SSL
@@ -216,15 +207,6 @@
  
  /**
   * \def MBEDTLS_RSA_C
-@@ -2913,7 +2913,7 @@
-  *
-  * Requires: MBEDTLS_CIPHER_C
-  */
--#define MBEDTLS_SSL_TICKET_C
-+//#define MBEDTLS_SSL_TICKET_C
- 
- /**
-  * \def MBEDTLS_SSL_CLI_C
 @@ -3013,7 +3013,7 @@
   *
   * This module provides run-time version information.


### PR DESCRIPTION
mbedtls: enable session tickets

session tickets are a feature of TLSv1.2 and require less memory
and overhead on the server than does managing a session cache

Building mbedtls with support for session tickets will allow the
feature to be used with an upcoming release of lighttpd-1.4.56.