### PR TITLE
uboot-envtools: support more Xiaomi devices

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -29,6 +29,7 @@ buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
+xiaomi,mir3g-v2|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"


### PR DESCRIPTION
- Xiaomi Mi Wi-Fi Router 3G v2
- Xiaomi Mi Router 4A Gigabit Edition

Signed-off-by: Antonis Kanouras <antonis@metadosis.eu>