### PR TITLE
libnetfilter-log: Backport kernel header syncs

### DIFF
--- a/package/libs/libnetfilter-log/Makefile
+++ b/package/libs/libnetfilter-log/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_log
 PKG_VERSION:=1.0.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/libs/libnetfilter-log/patches/0007-include-Sync-with-current-kernel-headers.patch
+++ b/package/libs/libnetfilter-log/patches/0007-include-Sync-with-current-kernel-headers.patch
@@ -1,0 +1,108 @@
+From 614d8b6cfb969c6102ef320de22b1eb199efce2a Mon Sep 17 00:00:00 2001
+From: Felix Janda <felix.janda@posteo.de>
+Date: Sat, 16 May 2015 13:37:53 +0200
+Subject: include: Sync with current kernel headers
+
+Signed-off-by: Felix Janda <felix.janda@posteo.de>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/libnetfilter_log/linux_nfnetlink_log.h | 51 +++++++++++++-------------
+ 1 file changed, 25 insertions(+), 26 deletions(-)
+
+diff --git a/include/libnetfilter_log/linux_nfnetlink_log.h b/include/libnetfilter_log/linux_nfnetlink_log.h
+index 4c802c8..9f38277 100644
+--- a/include/libnetfilter_log/linux_nfnetlink_log.h
++++ b/include/libnetfilter_log/linux_nfnetlink_log.h
+@@ -20,33 +20,31 @@ enum nfulnl_msg_types {
+ };
+ 
+ struct nfulnl_msg_packet_hdr {
+-	u_int16_t	hw_protocol;	/* hw protocol (network order) */
+-	u_int8_t	hook;		/* netfilter hook */
+-	u_int8_t	_pad;
+-} __attribute__ ((packed));
++	__be16		hw_protocol;	/* hw protocol (network order) */
++	__u8	hook;		/* netfilter hook */
++	__u8	_pad;
++};
+ 
+ struct nfulnl_msg_packet_hw {
+-	u_int16_t	hw_addrlen;
+-	u_int16_t	_pad;
+-	u_int8_t	hw_addr[8];
+-} __attribute__ ((packed));
++	__be16		hw_addrlen;
++	__u16	_pad;
++	__u8	hw_addr[8];
++};
+ 
+ struct nfulnl_msg_packet_timestamp {
+-	aligned_u64	sec;
+-	aligned_u64	usec;
+-} __attribute__ ((packed));
+-
+-#define NFULNL_PREFIXLEN	30	/* just like old log target */
++	__aligned_be64	sec;
++	__aligned_be64	usec;
++};
+ 
+ enum nfulnl_attr_type {
+ 	NFULA_UNSPEC,
+ 	NFULA_PACKET_HDR,
+-	NFULA_MARK,			/* u_int32_t nfmark */
++	NFULA_MARK,			/* __u32 nfmark */
+ 	NFULA_TIMESTAMP,		/* nfulnl_msg_packet_timestamp */
+-	NFULA_IFINDEX_INDEV,		/* u_int32_t ifindex */
+-	NFULA_IFINDEX_OUTDEV,		/* u_int32_t ifindex */
+-	NFULA_IFINDEX_PHYSINDEV,	/* u_int32_t ifindex */
+-	NFULA_IFINDEX_PHYSOUTDEV,	/* u_int32_t ifindex */
++	NFULA_IFINDEX_INDEV,		/* __u32 ifindex */
++	NFULA_IFINDEX_OUTDEV,		/* __u32 ifindex */
++	NFULA_IFINDEX_PHYSINDEV,	/* __u32 ifindex */
++	NFULA_IFINDEX_PHYSOUTDEV,	/* __u32 ifindex */
+ 	NFULA_HWADDR,			/* nfulnl_msg_packet_hw */
+ 	NFULA_PAYLOAD,			/* opaque data payload */
+ 	NFULA_PREFIX,			/* string prefix */
+@@ -71,23 +69,23 @@ enum nfulnl_msg_config_cmds {
+ };
+ 
+ struct nfulnl_msg_config_cmd {
+-	u_int8_t	command;	/* nfulnl_msg_config_cmds */
++	__u8	command;	/* nfulnl_msg_config_cmds */
+ } __attribute__ ((packed));
+ 
+ struct nfulnl_msg_config_mode {
+-	u_int32_t	copy_range;
+-	u_int8_t	copy_mode;
+-	u_int8_t	_pad;
++	__be32		copy_range;
++	__u8	copy_mode;
++	__u8	_pad;
+ } __attribute__ ((packed));
+ 
+ enum nfulnl_attr_config {
+ 	NFULA_CFG_UNSPEC,
+ 	NFULA_CFG_CMD,			/* nfulnl_msg_config_cmd */
+ 	NFULA_CFG_MODE,			/* nfulnl_msg_config_mode */
+-	NFULA_CFG_NLBUFSIZ,		/* u_int32_t buffer size */
+-	NFULA_CFG_TIMEOUT,		/* u_int32_t in 1/100 s */
+-	NFULA_CFG_QTHRESH,		/* u_int32_t */
+-	NFULA_CFG_FLAGS,		/* u_int16_t */
++	NFULA_CFG_NLBUFSIZ,		/* __u32 buffer size */
++	NFULA_CFG_TIMEOUT,		/* __u32 in 1/100 s */
++	NFULA_CFG_QTHRESH,		/* __u32 */
++	NFULA_CFG_FLAGS,		/* __u16 */
+ 	__NFULA_CFG_MAX
+ };
+ #define NFULA_CFG_MAX (__NFULA_CFG_MAX -1)
+@@ -95,6 +93,7 @@ enum nfulnl_attr_config {
+ #define NFULNL_COPY_NONE	0x00
+ #define NFULNL_COPY_META	0x01
+ #define NFULNL_COPY_PACKET	0x02
++/* 0xff is reserved, don't use it for new copy modes. */
+ 
+ #define NFULNL_CFG_F_SEQ	0x0001
+ #define NFULNL_CFG_F_SEQ_GLOBAL	0x0002
+-- 
+2.11.0
+

--- a/package/libs/libnetfilter-log/patches/0008-include-Sync-with-current-kernel-headers.patch
+++ b/package/libs/libnetfilter-log/patches/0008-include-Sync-with-current-kernel-headers.patch
@@ -1,0 +1,52 @@
+From 721ea5ec049e12afdd7c182f2899ab6d92914e68 Mon Sep 17 00:00:00 2001
+From: Ken-ichirou MATSUZAWA <chamaken@gmail.com>
+Date: Fri, 11 Sep 2015 12:12:11 +0900
+Subject: include: Sync with kernel headers
+
+Signed-off-by: Ken-ichirou MATSUZAWA <chamas@h4.dion.ne.jp>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ include/libnetfilter_log/linux_nfnetlink_log.h | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/include/libnetfilter_log/linux_nfnetlink_log.h b/include/libnetfilter_log/linux_nfnetlink_log.h
+index 9f38277..081e7f9 100644
+--- a/include/libnetfilter_log/linux_nfnetlink_log.h
++++ b/include/libnetfilter_log/linux_nfnetlink_log.h
+@@ -1,16 +1,12 @@
+ #ifndef _NFNETLINK_LOG_H
+ #define _NFNETLINK_LOG_H
+ 
+-#ifndef aligned_u64
+-#define aligned_u64 unsigned long long __attribute__((aligned(8)))
+-#endif
+-
+ /* This file describes the netlink messages (i.e. 'protocol packets'),
+  * and not any kind of function definitions.  It is shared between kernel and
+  * userspace.  Don't put kernel specific stuff in here */
+ 
+ #include <linux/types.h>
+-#include <libnfnetlink/linux_nfnetlink.h>
++#include <linux/netfilter/nfnetlink.h>
+ 
+ enum nfulnl_msg_types {
+ 	NFULNL_MSG_PACKET,		/* packet from kernel to userspace */
+@@ -55,6 +51,8 @@ enum nfulnl_attr_type {
+ 	NFULA_HWTYPE,			/* hardware type */
+ 	NFULA_HWHEADER,			/* hardware header */
+ 	NFULA_HWLEN,			/* hardware header length */
++	NFULA_CT,			/* nf_conntrack_netlink.h */
++	NFULA_CT_INFO,			/* enum ip_conntrack_info */
+ 
+ 	__NFULA_MAX
+ };
+@@ -97,5 +95,6 @@ enum nfulnl_attr_config {
+ 
+ #define NFULNL_CFG_F_SEQ	0x0001
+ #define NFULNL_CFG_F_SEQ_GLOBAL	0x0002
++#define NFULNL_CFG_F_CONNTRACK	0x0004
+ 
+ #endif /* _NFNETLINK_LOG_H */
+-- 
+2.11.0
+


### PR DESCRIPTION
Backport upstream commits that sync the local kernel header
copies in this library, with up to date copies

Signed-off-by: Brett Mastbergen <bmastbergen@untangle.com>