### PR TITLE
ath79: add support for Qxwlan E600G(AC)

### DIFF
--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-16m.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600G v2 16M";
+	compatible = "qxwlan,e600g-v2-16m", "qca,qca9531";
+};
+
+&leds {
+	wlan {
+		label = "blue:wlan";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g-v2-8m.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600G v2 8M";
+	compatible = "qxwlan,e600g-v2-8m", "qca,qca9531";
+};
+
+&leds {
+	wlan {
+		label = "blue:wlan";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "blue:system";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			pridata: partition@50000 {
+				label = "pri-data";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&pridata 0x400>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	mtd-mac-address = <&pridata 0x400>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-16m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-16m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600GAC v2 16M";
+	compatible = "qxwlan,e600gac-v2-16m", "qca,qca9531";
+};
+
+&keys {
+	wps {
+		label = "wps";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
+&leds {
+	wlan2g {
+		label = "orange:wlan2g";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy1tpt";
+	};
+
+	control1 {
+		label = "green:control";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+
+	control2 {
+		label = "red:control";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+
+	control3 {
+		label = "blue:control";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0xf90000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-8m.dts
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600gac-v2-8m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_qxwlan_e600g.dtsi"
+
+/ {
+	model = "Qxwlan E600GAC v2 8M";
+	compatible = "qxwlan,e600gac-v2-8m", "qca,qca9531";
+};
+
+&keys {
+	wps {
+		label = "wps";
+		linux,code = <KEY_WPS_BUTTON>;
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		debounce-interval = <60>;
+	};
+};
+
+&leds {
+	wlan2g {
+		label = "orange:wlan2g";
+		gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		linux,default-trigger = "phy1tpt";
+	};
+
+	control1 {
+		label = "green:control";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+
+	control2 {
+		label = "red:control";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+
+	control3 {
+		label = "blue:control";
+		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&partitions {
+	partition@70000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x070000 0x790000>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -195,6 +195,10 @@ etactica,eg200)
 	ucidef_set_led_oneshot "modbus" "Modbus" "red:modbus" "100" "33"
 	;;
 glinet,gl-mifi|\
+qxwlan,e600g-v2-8m|\
+qxwlan,e600g-v2-16m|\
+qxwlan,e600gac-v2-8m|\
+qxwlan,e600gac-v2-16m|\
 qxwlan,e750a-v4-8m|\
 qxwlan,e750a-v4-16m)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -24,6 +24,8 @@ case "$FIRMWARE" in
 	devolo,magic-2-wifi|\
 	qxwlan,e1700ac-v2-8m|\
 	qxwlan,e1700ac-v2-16m|\
+	qxwlan,e600gac-v2-8m|\
+	qxwlan,e600gac-v2-16m|\
 	ubnt,unifiac-lite|\
 	ubnt,unifiac-lr|\
 	ubnt,unifiac-mesh|\

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -24,6 +24,14 @@ qxwlan,e558-v2-16m|\
 qxwlan,e558-v2-8m)
 	migrate_leds ":qss=:sig2"
 	;;
+qxwlan,e600g-v2-16m|\
+qxwlan,e600g-v2-8m)
+	migrate_leds "green:wan=green:wlan"
+	;;
+qxwlan,e600gac-v2-16m|\
+qxwlan,e600gac-v2-8m)
+	migrate_leds "orange:wan=orange:wlan2g" "green:system=blue:system"
+	;;
 qxwlan,e750a-v4-16m|\
 qxwlan,e750a-v4-8m|\
 qxwlan,e750g-v8-16m|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1519,6 +1519,48 @@ define Device/qxwlan_e558-v2-8m
 endef
 TARGET_DEVICES += qxwlan_e558-v2-8m
 
+define Device/qxwlan_e600g-v2
+  SOC := qca9531
+  DEVICE_VENDOR := Qxwlan
+  DEVICE_MODEL := E600G
+  DEVICE_PACKAGES := kmod-usb2
+  SUPPORTED_DEVICES += e600g-v2
+endef
+
+define Device/qxwlan_e600g-v2-16m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += qxwlan_e600g-v2-16m
+
+define Device/qxwlan_e600g-v2-8m
+  $(Device/qxwlan_e600g-v2-16m)
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+endef
+TARGET_DEVICES += qxwlan_e600g-v2-8m
+
+define Device/qxwlan_e600gac-v2-16m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_MODEL := E600GAC
+  DEVICE_VARIANT := v2 (16M)
+  IMAGE_SIZE := 15936k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  SUPPORTED_DEVICES += e600gac-v2
+endef
+TARGET_DEVICES += qxwlan_e600gac-v2-16m
+
+define Device/qxwlan_e600gac-v2-8m
+  $(Device/qxwlan_e600g-v2)
+  DEVICE_MODEL := E600GAC
+  DEVICE_VARIANT := v2 (8M)
+  IMAGE_SIZE := 7744k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  SUPPORTED_DEVICES += e600gac-v2
+endef
+TARGET_DEVICES += qxwlan_e600gac-v2-8m
+
 define Device/qxwlan_e750a-v4
   SOC := ar9344
   DEVICE_VENDOR := Qxwlan


### PR DESCRIPTION
E600G based on Qualcomm/Atheros QCA9531

Specification:

 - 650/600/200 MHz (CPU/DDR/AHB)
 - 128/64 MB of RAM (DDR2)
 - 8/16 MB of FLASH (SPI NOR)
 - 2T2R 2.4 GHz
 - 2 x 10/100 Mbps Ethernetï(one port with PoE support)
 - 1 x MiniPCI-e
 - 1 x SIM (3G/4G)
 - 5 x LED , 1 x Button, 1 x power input
 - UART(J100) header on PCB(115200 8N1)

E600GAC based on Qualcomm/Atheros QCA9531 + QCA9887

Specification:

  - 650/600/200 MHz (CPU/DDR/AHB)
  - 128/64 MB of RAM (DDR2)
  - 8/16 MB of FLASH (SPI NOR)
  - 2T2R 2.4 GHz
  - 1T1R 5 GHz
  - 2 x 10/100 Mbps Ethernetï(one port with PoE support)
  - 6 x LED (one three-color led), 2 x Button,1 x power input
  - UART (J100)header on PCB(115200 8N1)

Flash instruction:

   1.Using tftp mode with UART connection and original LEDE image
      - Configure PC with static IP 192.168.1.10 and tftp server.
      - Rename "openwrt-ar71xx-generic-xxx-squashfs-sysupgrade.bin"
        to "firmware.bin" and place it in tftp server directory.
      - Connect PC with one of LAN ports, power up the router and press
        key "Enter" to access U-Boot CLI.
      - Use the following commands to update the device to LEDE:
        run lfw
      - After that the device will reboot and boot to LEDE.
      - Wait until all LEDs stops flashing and use the router.

   2.Using httpd mode with Web UI connection and original LEDE image
      - Configure PC with static IP 192.168.1.xxx(2-255) and tftp server.
      - Connect PC with one of LAN ports,press the reset button, power up
        the router and keep button pressed for around 6-7 seconds, until
        leds flashing.
      - Open your browser and enter 192.168.1.1,You will see the upgrade
        interface, select "openwrt-ar71xx-generic-xxx-squashfs-
        sysupgrade.bin" and click the upgrade button.
      - After that the device will reboot and boot to LEDE.
      - Wait until all LEDs stops flashing and use the router.

Signed-off-by: 张鹏 <sd20@qxwlan.com>