### PR TITLE
ramips: fix kernel oops in `mt7621_nfc_write_page_hwecc`

### DIFF
--- a/target/linux/ramips/patches-5.4/0300-mtd-rawnand-add-driver-support-for-MT7621-nand-flash.patch
+++ b/target/linux/ramips/patches-5.4/0300-mtd-rawnand-add-driver-support-for-MT7621-nand-flash.patch
@@ -23,7 +23,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 @@ -391,6 +391,14 @@ config MTD_NAND_QCOM
  	  Enables support for NAND flash chips on SoCs containing the EBI2 NAND
  	  controller. This controller is found on IPQ806x SoC.
- 
+
 +config MTD_NAND_MT7621
 +	tristate "MT7621 NAND controller"
 +	depends on SOC_MT7621 || COMPILE_TEST
@@ -47,7 +47,7 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
  obj-$(CONFIG_MTD_NAND_TEGRA)		+= tegra_nand.o
 --- /dev/null
 +++ b/drivers/mtd/nand/raw/mt7621_nand.c
-@@ -0,0 +1,1348 @@
+@@ -0,0 +1,1350 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * MediaTek MT7621 NAND Flash Controller driver
@@ -1155,9 +1155,11 @@ Signed-off-by: Weijie Gao <weijie.gao@mediatek.com>
 +	uint32_t i, j;
 +	u8 *oobptr;
 +
-+	for (i = 0; i < mtd->writesize; i++)
-+		if (buf[i] != 0xff)
-+			return 0;
++	if (buf) {
++		for (i = 0; i < mtd->writesize; i++)
++			if (buf[i] != 0xff)
++				return 0;
++	}
 +
 +	for (i = 0; i < nand->ecc.steps; i++) {
 +		oobptr = oob_fdm_ptr(nand, i);


### PR DESCRIPTION
https://bugs.openwrt.org/index.php?do=details&task_id=3416

`mt7621_nfc_write_page_hwecc` may be called with `buf=NULL`, but `mt7621_nfc_check_empty_page` always tries to read it
That caused Oops `Unable to handle kernel paging request at virtual address 00000000`.

I'm not sure about potential corner cases of that solution, but that worked for me, marked block successfully.