### PR TITLE
build: store SOURCE_DATE_EPOCH in JSON info files

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -563,6 +563,7 @@ define Device/Build/image
 	@mkdir -p $$(shell dirname $$@)
 	DEVICE_ID="$(DEVICE_NAME)" \
 	BIN_DIR="$(BIN_DIR)" \
+	SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
 	IMAGE_NAME="$(IMAGE_NAME)" \
 	IMAGE_TYPE=$(word 1,$(subst ., ,$(2))) \
 	IMAGE_PREFIX="$(IMAGE_PREFIX)" \

--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -44,6 +44,7 @@ image_info = {
     "target": "{}/{}".format(getenv("TARGET"), getenv("SUBTARGET")),
     "version_code": getenv("VERSION_CODE"),
     "version_number": getenv("VERSION_NUMBER"),
+    "source_date_epoch": getenv("SOURCE_DATE_EPOCH"),
     "profiles": {
         device_id: {
             "image_prefix": getenv("IMAGE_PREFIX"),


### PR DESCRIPTION
The source date epoch is the only reproducible date close to the actual
build date. It can be used for tooling like the firmware wizard to show
the image age.

Signed-off-by: Paul Spooren <mail@aparcar.org>