### PR TITLE
bcm63xx: alloc RX SKB with NET_IP_ALIGN

### DIFF
--- a/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-alloc_rx_skb_ip_align.patch
+++ b/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-alloc_rx_skb_ip_align.patch
@@ -6,7 +6,7 @@
  		if (!priv->rx_skb[desc_idx]) {
 -			skb = netdev_alloc_skb(dev, priv->rx_skb_size);
 +			if (priv->enet_is_sw)
-+				skb = napi_alloc_skb(&priv->napi, priv->rx_skb_size);
++				skb = netdev_alloc_skb_ip_align(dev, priv->rx_skb_size);
 +			else
 +				skb = netdev_alloc_skb(dev, priv->rx_skb_size);
  			if (!skb)

--- a/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-bulk_alloc_rx_skb.patch
+++ b/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-bulk_alloc_rx_skb.patch
@@ -1,11 +1,14 @@
 --- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c
 +++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
-@@ -252,7 +252,7 @@ static int bcm_enet_refill_rx(struct net_device *dev)
+@@ -252,7 +252,10 @@ static int bcm_enet_refill_rx(struct net_device *dev)
  		desc = &priv->rx_desc_cpu[desc_idx];
  
  		if (!priv->rx_skb[desc_idx]) {
 -			skb = netdev_alloc_skb(dev, priv->rx_skb_size);
-+			skb = napi_alloc_skb(&priv->napi, priv->rx_skb_size);
++			if (priv->enet_is_sw)
++				skb = napi_alloc_skb(&priv->napi, priv->rx_skb_size);
++			else
++				skb = netdev_alloc_skb(dev, priv->rx_skb_size);
  			if (!skb)
  				break;
  			priv->rx_skb[desc_idx] = skb;

--- a/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-bulk_alloc_rx_skb.patch
+++ b/target/linux/bcm63xx/patches-5.4/441-bcm63xx_enet-bulk_alloc_rx_skb.patch
@@ -1,0 +1,11 @@
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+@@ -252,7 +252,7 @@ static int bcm_enet_refill_rx(struct net_device *dev)
+ 		desc = &priv->rx_desc_cpu[desc_idx];
+ 
+ 		if (!priv->rx_skb[desc_idx]) {
+-			skb = netdev_alloc_skb(dev, priv->rx_skb_size);
++			skb = napi_alloc_skb(&priv->napi, priv->rx_skb_size);
+ 			if (!skb)
+ 				break;
+ 			priv->rx_skb[desc_idx] = skb;


### PR DESCRIPTION
Use netdev_alloc_skb_ip_align on newer SoC when refilling RX. Increases packet
processing performance by 30%.

Tested on BCM6328 320 MHz and iperf3 -M 512 to measure packet/sec performance.

Before:
[ ID] Interval           Transfer     Bandwidth       Retr
[  4]   0.00-30.00  sec   120 MBytes  33.7 Mbits/sec  277             sender
[  4]   0.00-30.00  sec   120 MBytes  33.5 Mbits/sec                  receiver

After:
[  4]   0.00-30.00  sec   155 MBytes  43.3 Mbits/sec  354             sender
[  4]   0.00-30.00  sec   154 MBytes  43.1 Mbits/sec                  receiver
