### PR TITLE
bcm63xx: add BQL and xmit_more support

### DIFF
--- a/target/linux/bcm63xx/patches-5.4/442-bcm63xx_enet-add_bql_support.patch
+++ b/target/linux/bcm63xx/patches-5.4/442-bcm63xx_enet-add_bql_support.patch
@@ -1,0 +1,71 @@
+From 3c0e8e1259d223a1493c47f7e277d05b93909b6b Mon Sep 17 00:00:00 2001
+From: Sieng Piaw Liew <liew.s.piaw@gmail.com>
+Date: Mon, 2 Nov 2020 11:34:06 +0800
+Subject: [PATCH 1/2] bcm63xx: add BQL support
+
+Add Byte Queue Limits support to reduce/remove bufferbloat in bcm63xx target.
+
+Signed-off-by: Sieng Piaw Liew <liew.s.piaw@gmail.com>
+---
+ bcm63xx_enet.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/net/ethernet/broadcom/bcm63xx_enet.c b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+index 2ba9f87..f07b7ae 100644
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+@@ -432,9 +432,11 @@ static int bcm_enet_tx_reclaim(struct net_device *dev, int force)
+ {
+ 	struct bcm_enet_priv *priv;
+ 	int released;
++	unsigned int bytes;
+ 
+ 	priv = netdev_priv(dev);
+ 	released = 0;
++	bytes = 0;
+ 
+ 	while (priv->tx_desc_count < priv->tx_ring_size) {
+ 		struct bcm_enet_desc *desc;
+@@ -470,10 +472,13 @@ static int bcm_enet_tx_reclaim(struct net_device *dev, int force)
+ 		if (desc->len_stat & DMADESC_UNDER_MASK)
+ 			dev->stats.tx_errors++;
+ 
++		bytes += skb->len;
+ 		dev_kfree_skb(skb);
+ 		released++;
+ 	}
+ 
++	netdev_completed_queue(dev, released, bytes);
++
+ 	if (netif_queue_stopped(dev) && released)
+ 		netif_wake_queue(dev);
+ 
+@@ -640,6 +645,8 @@ bcm_enet_start_xmit(struct sk_buff *skb, struct net_device *dev)
+ 	desc->len_stat = len_stat;
+ 	wmb();
+ 
++	netdev_sent_queue(dev, skb->len);
++
+ 	/* kick tx dma */
+ 	enet_dmac_writel(priv, priv->dma_chan_en_mask,
+ 				 ENETDMAC_CHANCFG, priv->tx_chan);
+@@ -1060,6 +1067,8 @@ static int bcm_enet_open(struct net_device *dev)
+ 	else
+ 		bcm_enet_adjust_link(dev);
+ 
++	netdev_reset_queue(dev);
++
+ 	netif_start_queue(dev);
+ 	return 0;
+ 
+@@ -2304,6 +2313,8 @@ static int bcm_enetsw_open(struct net_device *dev)
+ 	enet_dmac_writel(priv, ENETDMAC_IR_PKTDONE_MASK,
+ 			 ENETDMAC_IRMASK, priv->tx_chan);
+ 
++	netdev_reset_queue(dev);
++
+ 	netif_carrier_on(dev);
+ 	netif_start_queue(dev);
+ 
+-- 
+2.17.1

--- a/target/linux/bcm63xx/patches-5.4/443-bcm63xx_enet-support_xmit_more_in_bql.patch
+++ b/target/linux/bcm63xx/patches-5.4/443-bcm63xx_enet-support_xmit_more_in_bql.patch
@@ -1,0 +1,39 @@
+From 79bfb73319098bc4cb701139a6677dcdec99182f Mon Sep 17 00:00:00 2001
+From: Sieng Piaw Liew <liew.s.piaw@gmail.com>
+Date: Tue, 3 Nov 2020 08:14:35 +0800
+Subject: [PATCH 2/2] bcm63xx: support xmit_more in BQL
+
+Support bulking hardware TX queue by using xmit_more.
+
+Signed-off-by: Sieng Piaw Liew <liew.s.piaw@gmail.com>
+---
+ bcm63xx_enet.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/broadcom/bcm63xx_enet.c b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+index f07b7ae..8830d33 100644
+--- a/drivers/net/ethernet/broadcom/bcm63xx_enet.c
++++ b/drivers/net/ethernet/broadcom/bcm63xx_enet.c
+@@ -647,14 +647,16 @@ bcm_enet_start_xmit(struct sk_buff *skb, struct net_device *dev)
+ 
+ 	netdev_sent_queue(dev, skb->len);
+ 
+-	/* kick tx dma */
+-	enet_dmac_writel(priv, priv->dma_chan_en_mask,
+-				 ENETDMAC_CHANCFG, priv->tx_chan);
+-
+ 	/* stop queue if no more desc available */
+ 	if (!priv->tx_desc_count)
+ 		netif_stop_queue(dev);
+ 
++	/* kick tx dma */
++	if(!netdev_xmit_more() || !priv->tx_desc_count)
++		enet_dmac_writel(priv, priv->dma_chan_en_mask,
++					ENETDMAC_CHANCFG, priv->tx_chan);
++
++
+ 	dev->stats.tx_bytes += skb->len;
+ 	dev->stats.tx_packets++;
+ 	ret = NETDEV_TX_OK;
+-- 
+2.17.1


### PR DESCRIPTION
This patch series add Byte Queue Limits and subsequently xmit_more support to the bcm63xx target. BQL aims to reduce/remove bufferbloat while xmit_more relies on BQL to allow bulking of hardware TX queue.