### PR TITLE
ramips: add support for ASUS RT-N56U B1

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-n56u-b1", "mediatek,mt7621-soc";
+	model = "ASUS RT-N56U B1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x8004>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0x4>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -202,6 +202,17 @@ define Device/asus_rt-ac85p
 endef
 TARGET_DEVICES += asus_rt-ac85p
 
+define Device/asus_rt-n56u-b1
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-N56U
+  DEVICE_VARIANT := B1
+  IMAGE_SIZE := 15040k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += asus_rt-n56u-b1
+
 define Device/buffalo_wsr-1166dhp
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -8,6 +8,10 @@ board=$(board_name)
 board_config_update
 
 case $board in
+asus,rt-n56u-b1)
+	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
+	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"
+	;;
 d-team,newifi-d2)
 	ucidef_set_led_netdev "internet" "internet" "amber:internet" "wan"
 	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "blue:wlan2g" "wlan0"


### PR DESCRIPTION
SoC:      MediaTek MT7621ST (880 MHz)
FLASH: 16 MiB (Macronix MX25L12835FM2I-10G)
RAM:     128 MiB (Nanya NT5CB64M16FP-DH)
WiFi:      MediaTek MT7603EN bgn 2x2:2
WiFi:      MediaTek MT7612EN an 2x2:2
BTN:      Reset, WPS
LED:     - Power
             - WiFi 2.4 GHz
             - WiFi 5 GHz
             - WAN
             - LAN {1-4}
             - USB {1-2}
UART:   UART is present as pin hole next to the aluminium capacitor.
              3V3 - RX - GND - TX / 115200-8N1
              3V3 is the nearest on the aluminium capacitor and nut hole (pin1).
USB:     2 ports
POWER: 12VDC, 1.5A (Barrel 5.5x2.1)

Installation
------------
Via TFTP:
1. Set your computers IP-Address to 192.168.1.75
2. Power up the Router with the Reset button pressed.
3. Release the Reset button after 5 seconds.
4. Upload OpenWRT sysupgrade image via TFTP:
 > tftp -4 -v -m binary 192.168.1.1 -c put IMAGE

Signed-off-by: Pavel Chervontsev <cherpash@gmail.com>
