### PR TITLE
ramips: add m25p,fast-read to fix race condition for Xiaomi Mi Router 4A Gigabit

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-gigabit.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-gigabit.dts
@@ -6,3 +6,14 @@
 	compatible = "xiaomi,mi-router-4a-gigabit", "mediatek,mt7621-soc";
 	model = "Xiaomi Mi Router 4A Gigabit Edition";
 };
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+	};
+};


### PR DESCRIPTION
The Xiaomi Mi Router 4A Gigabit model has a race condition on bootup causing the SQUASHFS data errors to appear and create a bootloop scenario.

By adding the m25p,fast-read in its dtsi, will resolves this issue.

Signed-off-by: David Bentham <db260179@gmail.com>