### PR TITLE
base-files: mitigate NAT Slipstreaming (CVE-2020-28041)

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=234
+PKG_RELEASE:=235
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/etc/sysctl.d/10-default.conf
+++ b/package/base-files/files/etc/sysctl.d/10-default.conf
@@ -23,5 +23,7 @@ net.ipv4.tcp_timestamps=1
 net.ipv4.tcp_sack=1
 net.ipv4.tcp_dsack=1
 
+net.netfilter.nf_conntrack_helper=0
+
 net.ipv6.conf.default.forwarding=1
 net.ipv6.conf.all.forwarding=1


### PR DESCRIPTION
The attach leverages the iptables conntrack helpers:
https://github.com/samyk/slipstream

With kernel 4.7 and up the automatic helper assignment in
kernel has been turned off by default.
https://git.kernel.org/pub/scm/linux/kernel/git/pablo/nf.git/commit/?id=3bb398d925

Since Linux 3.5, it is possible to deactivate the automatic
conntrack helper assignment in /proc/sys/net/netfilter/nf_conntrack_helper

Signed-off-by: Saverio Proto <zioproto@gmail.com>

