### PR TITLE
ipq40xx: add Yinuolink Q418 support

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -10,6 +10,11 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+yinuolink,yn-q418)
+	ucidef_set_led_wlan "wlan" "WLAN" "${boardname}:blue:wlan" "phy1tpt" "phy0tpt"
+	ucidef_set_led_usbport "usb2" "USB2" "${boardname}:blue:usb2" "usb3-port1"
+	ucidef_set_led_usbport "usb3" "USB3" "${boardname}:blue:usb3" "usb 2-1-port3"
+	;;
 alfa-network,ap120c-ac)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "eth1"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -63,7 +63,7 @@ ipq40xx_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
                 ucidef_add_switch "switch0" \
                         "0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "0u@eth1" "5:wan"
-                ;;
+		;;
 	avm,fritzbox-7530)
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -59,6 +59,11 @@ ipq40xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
+	yinuolink,yn-q418)
+		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+                ucidef_add_switch "switch0" \
+                        "0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "0u@eth1" "5:wan"
+                ;;
 	avm,fritzbox-7530)
 		ucidef_add_switch "switch0" \
 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -130,7 +130,7 @@ case "$FIRMWARE" in
 		;;
 	yinuolink,yn-q418)
 	        caldata_extract "ART" 0x1000 0x2f20
-                ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
+                ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
                 ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x1000 0x2f20
@@ -231,7 +231,7 @@ case "$FIRMWARE" in
 		;;
 	yinuolink,yn-q418)
 	        caldata_extract "ART" 0x5000 0x2f20
-                $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
+                $(macaddr_add "$(cat /sys/class/net/eth0/address)" 4)
                 ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -40,6 +40,7 @@ case "$FIRMWARE" in
 		caldata_extract "0:ART" 0x9000 0x2f20
 		;;
 	linksys,ea8300 |\
+	yinuolink,yn-q418 |\
 	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
@@ -71,8 +72,10 @@ case "$FIRMWARE" in
 		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
 	asus,rt-ac58u)
-		CI_UBIPART=UBI_DEV
-		caldata_extract_ubi "Factory" 0x1000 0x2f20
+#		CI_UBIPART=UBI_DEV
+#		caldata_extract_ubi "Factory" 0x1000 0x2f20
+		caldata_extract "ART" 0x1000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_binary mfginfo 0x1D)
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -127,6 +130,10 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
+	yinuolink,yn-q418)
+	        caldata_extract "ART" 0x1000 0x2f20
+                ath10k_patch_mac $(macaddr_add "$(hexdump -v -n 6 -s 0x1006 -e '5/1 "%02x:" 1/1 "%02x"' /dev/mtd7)" 0)
+                ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x1000 0x2f20
 		caldata_valid "202f" || caldata_extract "ART" 0x1000 0x2f20
@@ -168,8 +175,7 @@ case "$FIRMWARE" in
 		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	asus,rt-ac58u)
-		CI_UBIPART=UBI_DEV
-		caldata_extract_ubi "Factory" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -224,6 +230,10 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
 		;;
+	yinuolink,yn-q418)
+	        caldata_extract "ART" 0x5000 0x2f20
+                ath10k_patch_mac $(macaddr_add "$(hexdump -v -n 6 -s 0x5006 -e '5/1 "%02x:" 1/1 "%02x"' /dev/mtd7)" 2)
+                ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x5000 0x2f20
 		caldata_valid "202f" || caldata_extract "ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -72,10 +72,8 @@ case "$FIRMWARE" in
 		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
 	asus,rt-ac58u)
-#		CI_UBIPART=UBI_DEV
-#		caldata_extract_ubi "Factory" 0x1000 0x2f20
-		caldata_extract "ART" 0x1000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_binary mfginfo 0x1D)
+		CI_UBIPART=UBI_DEV
+		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -173,7 +173,8 @@ case "$FIRMWARE" in
 		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	asus,rt-ac58u)
-		caldata_extract "ART" 0x5000 0x2f20
+		CI_UBIPART=UBI_DEV
+		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -130,7 +130,7 @@ case "$FIRMWARE" in
 		;;
 	yinuolink,yn-q418)
 	        caldata_extract "ART" 0x1000 0x2f20
-                ath10k_patch_mac $(macaddr_add "$(hexdump -v -n 6 -s 0x1006 -e '5/1 "%02x:" 1/1 "%02x"' /dev/mtd7)" 0)
+                ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
                 ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x1000 0x2f20
@@ -173,8 +173,7 @@ case "$FIRMWARE" in
 		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;
 	asus,rt-ac58u)
-		CI_UBIPART=UBI_DEV
-		caldata_extract_ubi "Factory" 0x5000 0x2f20
+		caldata_extract "ART" 0x5000 0x2f20
 		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
@@ -231,7 +230,7 @@ case "$FIRMWARE" in
 		;;
 	yinuolink,yn-q418)
 	        caldata_extract "ART" 0x5000 0x2f20
-                ath10k_patch_mac $(macaddr_add "$(hexdump -v -n 6 -s 0x5006 -e '5/1 "%02x:" 1/1 "%02x"' /dev/mtd7)" 2)
+                $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
                 ;;
 	meraki,mr33)
 		caldata_extract_ubi "ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -71,6 +71,7 @@ platform_do_upgrade() {
 	engenius,eap2200 |\
 	luma,wrtq-329acn |\
 	mobipromo,cm520-79f |\
+	yinuolink,yn-q418 |\
 	qxwlan,e2600ac-c2)
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "YiNuoLink YN-Q418";
+	compatible = "yinuolink,yn-q418";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x8000000>;
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 rootfstype=squashfs";
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		mdio@90000 {
+			status = "okay";
+
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+			reset-gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+			reset-delay-us = <2000>;
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+
+		usb3@8af8800 {
+			status = "okay";
+
+			dwc3@8a00000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+		//		usb3_port1: port@1 {
+		//			reg = <1>;
+		//			#trigger-source-cells = <0>;
+		//		};
+
+				usb3_port1: port@1 {
+					reg = <3>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		usb2: usb2@60f8800 {
+			status = "okay";
+
+			dwc3@6000000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				usb2_port3: port@3 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: wlan {
+			label = "yn-q418:blue:wlan";
+			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb3 {
+			label = "yn-q418:blue:usb3";
+			gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&usb3_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb2 {
+			label = "yn-q418:blue:usb2";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&usb2_port3>;
+			linux,default-trigger = "usbport";
+		};
+	};
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	mdio_pins: mdio_pinmux {
+		pinmux_1 {
+			pins = "gpio53";
+			function = "mdio";
+		};
+
+		pinmux_2 {
+			pins = "gpio52";
+			function = "mdc";
+		};
+
+		pinconf {
+			pins = "gpio52", "gpio53";
+			bias-pull-up;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		mux {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		mux_cs {
+			function = "gpio";
+			pins = "gpio54", "gpio59";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&blsp1_spi1 { /* BLSP1 QUP1 */
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
+		   <&tlmm 59 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		/*
+		 * U-boot looks for "n25q128a11" node,
+		 * if we don't have it, it will spit out the following warning:
+		 * "ipq: fdt fixup unable to find compatible node".
+		 */
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		linux,modalias = "m25p80", "mx25l1606e", "n25q128a11";
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+			partition@60000 {
+				label = "QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+			partition@c0000 {
+				label = "CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+			partition@d0000 {
+				label = "DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "APPSBLENV"; /* uboot env*/
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+			partition@f0000 {
+				label = "APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+			partition@170000 {
+				label = "ART";
+				reg = <0x00170000 0x00010000>;
+			};
+			/* 0x00180000 - 0x00200000 unused */
+		};
+	};
+
+	spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <30000000>;
+
+		/*
+		 * U-boot looks for "spinand,mt29f" node,
+		 * if we don't have it, it will spit out the following warning:
+		 * "ipq: fdt fixup unable to find compatible node".
+		 */
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs";
+				reg = <0x00000000 0x04000000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "YN-Q418";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "YN-Q418";
+};

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
@@ -75,11 +75,6 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-		//		usb3_port1: port@1 {
-		//			reg = <1>;
-		//			#trigger-source-cells = <0>;
-		//		};
-
 				usb3_port1: port@1 {
 					reg = <3>;
 					#trigger-source-cells = <0>;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
@@ -126,7 +126,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_power: wlan {
+		led_wlan: wlan {
 			label = "yn-q418:blue:wlan";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy0tpt";

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-yn-q418.dts
@@ -127,20 +127,20 @@
 		compatible = "gpio-leds";
 
 		led_wlan: wlan {
-			label = "yn-q418:blue:wlan";
+			label = "blue:wlan";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy0tpt";
 		};
 
 		usb3 {
-			label = "yn-q418:blue:usb3";
+			label = "blue:usb3";
 			gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
 			trigger-sources = <&usb3_port1>;
 			linux,default-trigger = "usbport";
 		};
 
 		usb2 {
-			label = "yn-q418:blue:usb2";
+			label = "blue:usb2";
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
 			trigger-sources = <&usb2_port3>;
 			linux,default-trigger = "usbport";

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -592,6 +592,19 @@ define Device/mobipromo_cm520-79f
 endef
 TARGET_DEVICES += mobipromo_cm520-79f
 
+define Device/yinuolink_yn-q418
+	$(call Device/FitzImage)
+	$(call Device/UbiFit)
+	DEVICE_DTS_CONFIG := config@5
+	DEVICE_VENDOR := YiNuoLink
+	DEVICE_MODEL := YN-Q418
+	SOC := qcom-ipq4018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += yinuolink_yn-q418
+
 define Device/netgear_ex61x0v2
 	$(call Device/DniImage)
 	DEVICE_DTS_CONFIG := config@4

--- a/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -837,11 +837,54 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -837,11 +837,55 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -27,6 +27,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4018-ex6100v2.dtb \
 +	qcom-ipq4018-ex6150v2.dtb \
 +	qcom-ipq4018-fritzbox-4040.dtb \
++	qcom-ipq4018-yn-q418.dtb \
 +	qcom-ipq4018-jalapeno.dtb \
 +	qcom-ipq4018-meshpoint-one.dtb \
 +	qcom-ipq4018-nbg6617.dtb \


### PR DESCRIPTION
Adds support for the Yinuo-link Q418 series boards.

Specifications are:

CPU: Qualcomm IPQ40x9 (4x ARMv7A Cortex A7) at 716 MHz
RAM:256 MB
Storage: 2MB of SPI-NOR, 128 MB of parallel NAND
1 * USB 3.0 TypeA port
1 * USB 2.0 port
2 * MiniPCI-E for LTE modems with only USB2.0 link
2 SIM card slots
Ethernet: 5x GBe Ethernet
DC Jack
UART header
WLAN: In-SoC 2x2 802.11b/g/n and 2x2 802.11a/n/ac
4x MMCX connectors for WLAN
Reset button
6x LED-s
Installation instructions:

UART Settings are 115200 8n1

Using httpd mode with Web UI connection and Openwrt image
- Configure PC with static IP 192.168.1.xxx(2-255) and tftp server.
- Connect PC with one of LAN ports,press the reset button , power up
the router and keep button pressed for around 9-10 seconds, until
leds flashing.
- Open your browser and enter 192.168.1.1,You will see the upgrade
interface, select "openwrt-ipq40xx-generic-yinuolink_yn-q418-squashfs-nand-factory.ubi" and click the upgrade button.
- After that the device will reboot and boot to openwrt.
- Wait until all LEDs stops flashing and use the router.


Signed-off-by: OUBO oja520@126.com
