### PR TITLE
feeds: add freifunk feed

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,3 +2,4 @@ src-git packages https://git.openwrt.org/feed/packages.git;openwrt-19.07
 src-git luci https://git.openwrt.org/project/luci.git;openwrt-19.07
 src-git routing https://git.openwrt.org/feed/routing.git;openwrt-19.07
 src-git telephony https://git.openwrt.org/feed/telephony.git;openwrt-19.07
+src-git freifunk https://github.com/freifunk/openwrt-packages.git;openwrt-19.07


### PR DESCRIPTION
Read the freifunk packages, that have been moved from the LuCI feed
into its own feed in January 2019.

Signed-off-by: Paul Spooren <mail@aparcar.org>