### PR TITLE
hostapd: add support for custom per-BSS options

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -286,6 +286,8 @@ hostapd_common_add_bss_config() {
 	config_add_string osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
 
 	config_add_int airtime_bss_weight airtime_bss_limit
+	
+	config_add_array hostapd_bss_options
 }
 
 hostapd_set_vlan_file() {
@@ -879,6 +881,11 @@ hostapd_set_bss_options() {
 		json_for_each_item append_osu_provider osu_provider
 		json_for_each_item append_operator_icon operator_icon
 	fi
+	
+	json_get_values opts hostapd_bss_options
+	for val in $opts; do
+		append bss_conf "$val" "$N"
+	done
 
 	bss_md5sum=$(echo $bss_conf | md5sum | cut -d" " -f1)
 	append bss_conf "config_id=$bss_md5sum" "$N"


### PR DESCRIPTION
This adds an option "hostapd_bss_options" that does the same as
"hostapd_options" but on a per-BSS level, instead of a per-device level.

This can be used, for example, to configure different per-STA sae_passwords
per BSS or to augment some of the existing per-BSS options.