### PR TITLE
ath10k-ct-firmware: fix hash values and update to latest version

### DIFF
--- a/package/firmware/ath10k-ct-firmware/Makefile
+++ b/package/firmware/ath10k-ct-firmware/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct-firmware
-PKG_VERSION:=2020-07-02
-PKG_RELEASE:=2
+PKG_VERSION:=2020-10-07
+PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -95,120 +95,120 @@ define Download/ct-firmware-htt
   URL_FILE:=$($(1)_FIRMWARE_FILE_CT_HTT)
 endef
 
-QCA988X_FIRMWARE_FILE_CT:=firmware-2-ct-full-community-22.bin.lede.019
+QCA988X_FIRMWARE_FILE_CT:=firmware-2-ct-full-community-22.bin.lede.021
 define Download/ath10k-firmware-qca988x-ct
   $(call Download/ct-firmware,QCA988X,)
-  HASH:=072fafbd4d741ba77f5d92b60a644c7360af0c21a3a9ec06f1c299484bf41688
+  HASH:=40ea2842bdb492ed3ccc123c59c0ba7aca99b77a7cb1cee3d7ce6078a39a0cb5
 endef
 $(eval $(call Download,ath10k-firmware-qca988x-ct))
 
-QCA988X_FIRMWARE_FILE_CT_FULL_HTT:=firmware-2-ct-full-htt-mgt-community-22.bin.lede.019
+QCA988X_FIRMWARE_FILE_CT_FULL_HTT:=firmware-2-ct-full-htt-mgt-community-22.bin.lede.021
 define Download/ath10k-firmware-qca988x-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA988X,)
-  HASH:=031ee5eb9704a5df51d7fa25f326e334205f7bae8bfcf34327ee82d7671ee7a4
+  HASH:=4491fd27697430cd9ae0bd18d231af53db216adc04ce7e05de1b39be5088f9eb
 endef
 $(eval $(call Download,ath10k-firmware-qca988x-ct-full-htt))
 
 
-QCA9887_FIRMWARE_FILE_CT:=firmware-2-ct-full-community-22.bin.lede.019
+QCA9887_FIRMWARE_FILE_CT:=firmware-2-ct-full-community-22.bin.lede.021
 define Download/ath10k-firmware-qca9887-ct
   $(call Download/ct-firmware,QCA9887,ath10k-9887)
-  HASH:=459692deb186a63ab8eeddb7ad5d54779266e68ca686e7c46062554db6dca12b
+  HASH:=71b496b2071957fed8bd5b12a1e8032cafe7fc61a3d8615eec34a28c75358371
 endef
 $(eval $(call Download,ath10k-firmware-qca9887-ct))
 
-QCA9887_FIRMWARE_FILE_CT_FULL_HTT:=firmware-2-ct-full-htt-mgt-community-22.bin.lede.019
+QCA9887_FIRMWARE_FILE_CT_FULL_HTT:=firmware-2-ct-full-htt-mgt-community-22.bin.lede.021
 define Download/ath10k-firmware-qca9887-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA9887,ath10k-9887)
-  HASH:=fd126a457d0927d0c8ea10d66ef5b67d5e1e0741f8692bb3016bb602d0af3098
+  HASH:=32413f512a6e114fba72ecb1e336f9adcae4a17dda99f39a3a75fb25b0f8112c
 endef
 $(eval $(call Download,ath10k-firmware-qca9887-ct-full-htt))
 
 
-QCA99X0_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
+QCA99X0_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.021
 define Download/ath10k-firmware-qca99x0-ct
   $(call Download/ct-firmware,QCA99X0,ath10k-10-4b)
-  HASH:=4abdc7c63abb19a54b5021fc5b077cf33f97743e73ac2c0d3c6befa84e86f81a
+  HASH:=f231a40959c71ae95afea0c226979eb906cf52779fad5b57f0b64eed8a8f0c03
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct))
 
-QCA99X0_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
+QCA99X0_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca99x0-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA99X0,ath10k-10-4b)
-  HASH:=ac3aa9a932f4afcdbf065b1214151593b2ff59e3bd5779bdea530a6380307193
+  HASH:=348d282913de201068d3dfda9cd10759c035302262ade23ab2c83996a8b934e5
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct-full-htt))
 
-QCA99X0_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
+QCA99X0_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca99x0-ct-htt
   $(call Download/ct-firmware-htt,QCA99X0,ath10k-10-4b)
-  HASH:=8344a95b6e82a261120e3ed1f0af28807475ca4342756f4721a654690e598287
+  HASH:=0a282fa1e0e4f8a7ba99fa029e79836785224a24e131b1b1ff6aa28103c82f72
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct-htt))
 
 
-QCA9984_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
+QCA9984_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9984-ct
   $(call Download/ct-firmware,QCA9984,ath10k-9984-10-4b)
-  HASH:=dfa2a6fe4fbcc481abd014c15876afee526ffbc29a7a73af5a86ddaa161cabcf
+  HASH:=947f7e95cbac54e5eecb80254176c146a32abc13ae249ae22468646bda75442f
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct))
 
-QCA9984_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
+QCA9984_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9984-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA9984,ath10k-9984-10-4b)
-  HASH:=0a44560ad2ee0cf22547ec3e2abfd5820446b6fb9d03a8effd2717885f6700e9
+  HASH:=efdcdb2cdd72c96652c3a76136b17a0f86f5718c4477b2c61fd4c4459b0466c9
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct-full-htt))
 
-QCA9984_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
+QCA9984_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9984-ct-htt
   $(call Download/ct-firmware-htt,QCA9984,ath10k-9984-10-4b)
-  HASH:=6082ad677d3b7e7c8598a76170c1f0005aa6363df9191fbe5086d1d12f713d3b
+  HASH:=ef9372398542530e44e02b845e79fd39806dc552772105c29ae786c1f303ae39
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct-htt))
 
 
-QCA4019_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
+QCA4019_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.021
 define Download/ath10k-firmware-qca4019-ct
   $(call Download/ct-firmware,QCA4019,ath10k-4019-10-4b)
-  HASH:=7d9df54167b3feb770f967091ec6f33e7bec79be47df09bea36a2d55d6a661d9
+  HASH:=6b75c6924743d3d860c292ddea03c0ba67612ef2c51182a13d5caca897432d5c
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct))
 
-QCA4019_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
+QCA4019_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca4019-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA4019,ath10k-4019-10-4b)
-  HASH:=98fb0b2168c14e1ed8bce1c0f30bc42fa137cc00be38caf32a55b1cfa9334b05
+  HASH:=9187beaa83d13537370985bbb68d8cedbf067121cb2af76fe97281ae4833a2a3
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct-full-htt))
 
-QCA4019_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
+QCA4019_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca4019-ct-htt
   $(call Download/ct-firmware-htt,QCA4019,ath10k-4019-10-4b)
-  HASH:=978038b2dc17c57fbf8f2372ace60d98e686576ae9108c2729b35806c998cee6
+  HASH:=67384e1476490187a1c7d702372ed9973e109a1a2955461cb6f381be4102dfd7
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct-htt))
 
 
-QCA9888_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
+QCA9888_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9888-ct
   $(call Download/ct-firmware,QCA9888,ath10k-9888-10-4b)
-  HASH:=94d8902bf09cab73b768938a1947de4703ed0267a333219ceec4fe852f53527f
+  HASH:=43fa49cf4ac870c0187155b02d19a9a577981f6a5ac84a142e89a5b2c9694872
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct))
 
-QCA9888_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
+QCA9888_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9888-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA9888,ath10k-9888-10-4b)
-  HASH:=99e58cb63d150b456bc70e77665fe64d8a7193a96ee11ec0ef55b6f8c32ea39f
+  HASH:=d227f1ed431757b93a2d25f4b544d50449991fdb6b8b58e4a9e261ac42d9081e
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct-full-htt))
 
-QCA9888_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
+QCA9888_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.021
 define Download/ath10k-firmware-qca9888-ct-htt
   $(call Download/ct-firmware-htt,QCA9888,ath10k-9888-10-4b)
-  HASH:=6b54b639a215d25b96ecfce1af0998e4bf955cfe74c84d5cfe8c971c403f8498
+  HASH:=1e8a6e548330c76fea2aff92690576f827d06096b710c19789dbca206c54bd13
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct-htt))
 

--- a/package/firmware/ath10k-ct-firmware/Makefile
+++ b/package/firmware/ath10k-ct-firmware/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ath10k-ct-firmware
 PKG_VERSION:=2020-07-02
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -98,14 +98,14 @@ endef
 QCA988X_FIRMWARE_FILE_CT:=firmware-2-ct-full-community-22.bin.lede.019
 define Download/ath10k-firmware-qca988x-ct
   $(call Download/ct-firmware,QCA988X,)
-  HASH:=8b4c99253aa309d35f2e060c190091b8db1b84dbda06a6a15c83ac0f9a938126
+  HASH:=072fafbd4d741ba77f5d92b60a644c7360af0c21a3a9ec06f1c299484bf41688
 endef
 $(eval $(call Download,ath10k-firmware-qca988x-ct))
 
 QCA988X_FIRMWARE_FILE_CT_FULL_HTT:=firmware-2-ct-full-htt-mgt-community-22.bin.lede.019
 define Download/ath10k-firmware-qca988x-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA988X,)
-  HASH:=a7168916d6aa5e4d7858f8b620c0c980c76d03f390929db6f4077685ce2051e7
+  HASH:=031ee5eb9704a5df51d7fa25f326e334205f7bae8bfcf34327ee82d7671ee7a4
 endef
 $(eval $(call Download,ath10k-firmware-qca988x-ct-full-htt))
 
@@ -128,21 +128,21 @@ $(eval $(call Download,ath10k-firmware-qca9887-ct-full-htt))
 QCA99X0_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
 define Download/ath10k-firmware-qca99x0-ct
   $(call Download/ct-firmware,QCA99X0,ath10k-10-4b)
-  HASH:=7dc934f934bc4973c9273a4f22cfead8e26ec6f579647af31b718a860eca0a4b
+  HASH:=4abdc7c63abb19a54b5021fc5b077cf33f97743e73ac2c0d3c6befa84e86f81a
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct))
 
 QCA99X0_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca99x0-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA99X0,ath10k-10-4b)
-  HASH:=71a27b245a382fe009938d2826d5c97a90dceb10ddf638325268df91837ea302
+  HASH:=ac3aa9a932f4afcdbf065b1214151593b2ff59e3bd5779bdea530a6380307193
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct-full-htt))
 
 QCA99X0_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca99x0-ct-htt
   $(call Download/ct-firmware-htt,QCA99X0,ath10k-10-4b)
-  HASH:=9ed4fe41e5b0f30172f71ae0fe382dc0aab8aa4f8a898417af4f7ee936575ef6
+  HASH:=8344a95b6e82a261120e3ed1f0af28807475ca4342756f4721a654690e598287
 endef
 $(eval $(call Download,ath10k-firmware-qca99x0-ct-htt))
 
@@ -150,21 +150,21 @@ $(eval $(call Download,ath10k-firmware-qca99x0-ct-htt))
 QCA9984_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9984-ct
   $(call Download/ct-firmware,QCA9984,ath10k-9984-10-4b)
-  HASH:=32d13f432691fe759ded7d027052e925233adb436cd8f729f85ec3d19ccd1dfd
+  HASH:=dfa2a6fe4fbcc481abd014c15876afee526ffbc29a7a73af5a86ddaa161cabcf
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct))
 
 QCA9984_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9984-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA9984,ath10k-9984-10-4b)
-  HASH:=e8ab69777bd00b5fc6b1b7acccb55b903553a99932a5b0351602b5f690106588
+  HASH:=0a44560ad2ee0cf22547ec3e2abfd5820446b6fb9d03a8effd2717885f6700e9
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct-full-htt))
 
 QCA9984_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9984-ct-htt
   $(call Download/ct-firmware-htt,QCA9984,ath10k-9984-10-4b)
-  HASH:=74449b303b626e0713b3fd4f2d6103d65859403b2dd7bdd8882aa772b69b59c7
+  HASH:=6082ad677d3b7e7c8598a76170c1f0005aa6363df9191fbe5086d1d12f713d3b
 endef
 $(eval $(call Download,ath10k-firmware-qca9984-ct-htt))
 
@@ -172,21 +172,21 @@ $(eval $(call Download,ath10k-firmware-qca9984-ct-htt))
 QCA4019_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
 define Download/ath10k-firmware-qca4019-ct
   $(call Download/ct-firmware,QCA4019,ath10k-4019-10-4b)
-  HASH:=4b89763087c7ed9b56046c4e621b7f045e452436d8d9b430a5d171179e313592
+  HASH:=7d9df54167b3feb770f967091ec6f33e7bec79be47df09bea36a2d55d6a661d9
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct))
 
 QCA4019_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca4019-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA4019,ath10k-4019-10-4b)
-  HASH:=fba591e5777c53b82542ba16cae69d9bb4684837f2fa4cee1b9b26f648096748
+  HASH:=98fb0b2168c14e1ed8bce1c0f30bc42fa137cc00be38caf32a55b1cfa9334b05
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct-full-htt))
 
 QCA4019_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca4019-ct-htt
   $(call Download/ct-firmware-htt,QCA4019,ath10k-4019-10-4b)
-  HASH:=0d534c3c424184b8ec2773f15c8933bdab0d39b6f664d2578c6602b0eb7035d1
+  HASH:=978038b2dc17c57fbf8f2372ace60d98e686576ae9108c2729b35806c998cee6
 endef
 $(eval $(call Download,ath10k-firmware-qca4019-ct-htt))
 
@@ -194,21 +194,21 @@ $(eval $(call Download,ath10k-firmware-qca4019-ct-htt))
 QCA9888_FIRMWARE_FILE_CT:=firmware-5-ct-full-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9888-ct
   $(call Download/ct-firmware,QCA9888,ath10k-9888-10-4b)
-  HASH:=048f4300725e6ebbf94a6bf4f3f4e4592c446fcdbe1d801aaac024b15e89e0c9
+  HASH:=94d8902bf09cab73b768938a1947de4703ed0267a333219ceec4fe852f53527f
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct))
 
 QCA9888_FIRMWARE_FILE_CT_FULL_HTT:=firmware-5-ct-full-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9888-ct-full-htt
   $(call Download/ct-firmware-full-htt,QCA9888,ath10k-9888-10-4b)
-  HASH:=d2a7e9fea6bd854721b3fc03a3a00d379d303b2bce339377ee87a1c14a60312d
+  HASH:=99e58cb63d150b456bc70e77665fe64d8a7193a96ee11ec0ef55b6f8c32ea39f
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct-full-htt))
 
 QCA9888_FIRMWARE_FILE_CT_HTT:=firmware-5-ct-htt-mgt-community-12.bin-lede.019
 define Download/ath10k-firmware-qca9888-ct-htt
   $(call Download/ct-firmware-htt,QCA9888,ath10k-9888-10-4b)
-  HASH:=e52a6db33347c641ee791fd9a3a57a2503cdda1adc6b8d943e336431528b9d2a
+  HASH:=6b54b639a215d25b96ecfce1af0998e4bf955cfe74c84d5cfe8c971c403f8498
 endef
 $(eval $(call Download,ath10k-firmware-qca9888-ct-htt))
 


### PR DESCRIPTION
Suddenly all hash values are different (2020-11-07).

ToDo: Update to newest version.