### PR TITLE
crond: Let procd respawn process if crashed

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.31.1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -32,6 +32,7 @@ start_service() {
 	for crontab in /etc/crontabs/*; do
 		 procd_set_param file "$crontab"
 	done
+	procd_set_param respawn
 	procd_close_instance
 }
 


### PR DESCRIPTION
On some systems I see the issue that crond dies after a few days.
Simply letting procd respawn the process is a simple safety-net.

Signed-off-by: Bruno Randolf <br1@einfach.org>
