### PR TITLE
busybox: enable find -mmin support by default

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -1105,7 +1105,7 @@ config BUSYBOX_DEFAULT_FEATURE_FIND_MTIME
 	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_MMIN
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_FIND_PERM
 	bool
 	default y


### PR DESCRIPTION
Enable busybox's find -mmin time support, which is extremely small, however also very useful in scripts:

https://github.com/mirror/busybox/commit/72d1a2357d2168f241458e4d6cebb7589ac82f4f
