### PR TITLE
lantiq: FRITZ!Box 7412 change PHY mode to mii

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
@@ -195,7 +195,7 @@
 		ethernet@2 {
 			compatible = "lantiq,xrx200-pdi-port";
 			reg = <2>;
-			phy-mode = "gmii";
+			phy-mode = "mii";
 			phy-handle = <&phy11>;
 		};
 	};


### PR DESCRIPTION
FRITZ!Box 7412 loads the firmware for fast ethernet PHY and mii is more accurate in this case.
Gmii is used by Gigabit ethernet PHYs.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>