### PR TITLE
sunxi: fix board.d/01_leds permissions and board name handling

### DIFF
--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -1,14 +1,10 @@
 #!/bin/sh
 
-. /lib/functions/leds.sh
 . /lib/functions/uci-defaults.sh
-
-board=$(board_name)
-boardname="${board##*,}"
 
 board_config_update
 
-case $board in
+case $(board_name) in
 friendlyarm,nanopi-r1)
 	ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"


### PR DESCRIPTION
The file lacks executable permissions, which makes it not being applied during the first boot. Stripping of the board name is also unnecessary.