### PR TITLE
bcm53xx: enhance support for Linksys Panamera aka EA9500 v1 or v1.1

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm53xx/base-files/etc/board.d/01_leds
@@ -5,6 +5,11 @@
 board_config_update
 
 case "$(board_name)" in
+linksys,panamera)
+	ucidef_set_led_netdev "wifi-enabled" "Wireless5G1" "bcm53xx:white:wifi-enabled" "wlan0" "link"
+	ucidef_set_led_default "logo" "Power" "bcm53xx:white:power" "1"
+	;;
+
 netgear,r8000)
 	ucidef_set_led_usbport "usb2" "USB 2.0" "bcm53xx:white:usb2" "usb1-port2" "usb2-port2"
 	ucidef_set_led_usbport "usb3" "USB 3.0" "bcm53xx:white:usb3" "usb1-port1" "usb2-port1" "usb4-port1"

--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -31,6 +31,10 @@ bcm53xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5t@eth0"
 		;;
+	linksys,panamera)
+		ucidef_add_switch "switch1" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5t@eth0"
+		;;
 	luxul,abr-4500-v1|\
 	luxul,xbr-4500-v1)
 		ucidef_add_switch "switch0" \
@@ -84,6 +88,7 @@ bcm53xx_setup_macs()
 
 	case "$board" in
 	dlink,dir-885l | \
+	linksys,panamera | \
 	netgear,r7900 | \
 	netgear,r8000 | \
 	netgear,r8500)
@@ -105,6 +110,7 @@ bcm53xx_setup_macs()
 		offset=1
 		;;
 	dlink,dir-885l | \
+	linksys,panamera | \
 	netgear,r7900 | \
 	netgear,r8000 | \
 	netgear,r8500)

--- a/target/linux/bcm53xx/base-files/etc/init.d/clear_partialboot
+++ b/target/linux/bcm53xx/base-files/etc/init.d/clear_partialboot
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=97
+boot() {
+	. /lib/functions.sh
+
+	case $(board_name) in
+		linksys,panamera)
+			# clear partialboots
+			nvram set partialboots=0 && nvram commit
+			;;
+	esac
+}

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -274,7 +274,6 @@ define Device/linksys_ea9500
   DEVICE_MODEL := EA9500
   DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
   DEVICE_DTS := bcm47094-linksys-panamera
-  BROKEN := y
 endef
 TARGET_DEVICES += linksys_ea9500
 

--- a/target/linux/bcm53xx/patches-5.4/700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
+++ b/target/linux/bcm53xx/patches-5.4/700-b53-add-hacky-CPU-port-fixes-for-devices-not-using-p.patch
@@ -21,7 +21,7 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
  
  #include "b53_regs.h"
  #include "b53_priv.h"
-@@ -1587,6 +1588,28 @@ static int b53_switch_init(struct b53_de
+@@ -1587,6 +1588,30 @@ static int b53_switch_init(struct b53_de
  			return ret;
  	}
  
@@ -44,7 +44,9 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 +	 * For some reason it doesn't work (no packets on eth2).
 +	 */
 +	if (of_machine_is_compatible("netgear,r7900") ||
-+	    of_machine_is_compatible("netgear,r8000"))
++	    of_machine_is_compatible("netgear,r8000") ||
++	    (of_machine_is_compatible("linksys,panamera") &&
++		dev->chip_id == BCM53012_DEVICE_ID))
 +		sw_dev->cpu_port = 5;
 +
  	dev->enabled_ports |= BIT(sw_dev->cpu_port);


### PR DESCRIPTION
Based on my accepted patches, we can now enable image generation for EA9500 router.

This pull request consists of:

1. Backporting accepted patches for EA9500 and BCM5301X platform
2. Add LED config, Network config and partialboot flag related patches
3. Enable image generation itself

This has been tested locally by me and several users [here](https://forum.openwrt.org/t/build-for-linksys-ea9500/1817)

**Hardware Info:**

- Processor	- Broadcom BCM4709C0KFEBG dual-core @ 1.4 GHz
- Switch		- BCM53012 in BCM4709C0KFEBG & external BCM53125
- DDR3 RAM	- 256 MB
- Flash		- 128 MB (Toshiba TC58BVG0S3HTA00)
- 2.4GHz		- BCM4366 4×4 2.4/5G single chip 802.11ac SoC
- Power Amp	- Skyworks SE2623L 2.4 GHz power amp (x4)
- 5GHz x 2	- BCM4366 4×4 2.4/5G single chip 802.11ac SoC
- Power Amp	- PLX Technology PEX8603 3-lane, 3-port PCIe switch
- Ports		- 8 Ports, 1 WAN Ports
- Antennas	- 8 Antennas
- Serial Port	- @j6 [GND,TX,RX] (VCC NC)    115200 8n1

**Flashing Instructions:**

1. Connect a USB-TTL table to J6 on the router as well as a ethernet cable to a lan port and your PC.  
2. Power-on the router. 
3. Use putty or a serial port program to view the terminal. Hit Ctrl+C and interrupt the CFE terminal terminal. 
4. Setup a TFTP server on your local machine at setup you local IP to 192.168.1.2
5. Start the TFTP Server
6. Run following commands at the CFE terminal
```
flash -noheader 192.168.1.2:/openwrt.trx nflash0.trx
flash -noheader 192.168.1.2:/openwrt.trx nflash0.trx2
nvram set bootpartition=0 && nvram set partialboots=0 && nvram commit
```
7. Reboot router to be presented by OpenWrt

Note: Only installation method via serial cable is supported at the moment. The trx firmware has to be flashed to both the partitions using following commands from CFE prompt. This will cover US and Non-US variants.

Signed-off-by: Vivek Unune <npcomplete13@gmail.com>