### PR TITLE
imagebuilder: fix partition signature

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -81,6 +81,8 @@ endif
 		$(CP) -L $(LINUX_DIR)/arch/$(LINUX_KARCH)/boot/dts/* $(IB_DTSDIR); \
 	fi
 	$(SED) 's,^# REVISION:=.*,REVISION:=$(REVISION),g' $(PKG_BUILD_DIR)/include/version.mk
+	$(SED) 's,^# SOURCE_DATE_EPOCH:=.*,SOURCE_DATE_EPOCH:=$(SOURCE_DATE_EPOCH),g' $(PKG_BUILD_DIR)/include/version.mk
+	$(SED) '/LINUX_VERMAGIC:=/ { s,unknown,$(LINUX_VERMAGIC),g }' $(PKG_BUILD_DIR)/include/kernel.mk
 	find $(PKG_BUILD_DIR) -name CVS -o -name .git -o -name .svn \
 	  | $(XARGS) rm -rf
 	$(INSTALL_DIR) $(IB_IDIR)


### PR DESCRIPTION
When building images with the imagebuilder, the partition signature
never changes. The signature is generated by hashing SOURCE_DATE_EPOCH
and LINUX_VERMAGIC which are undefined. Prepopulate these variables, as
done by the SDK.

Signed-off-by: Matthew Gyurgyik <matthew@gyurgyik.io>
