### PR TITLE
Add GL.iNet 6416A

### DIFF
--- a/target/linux/ath79/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/base-files/etc/board.d/01_leds
@@ -74,6 +74,10 @@ etactica,eg200)
 	ucidef_set_led_oneshot "modbus" "Modbus" "$boardname:red:modbus" "100" "33"
 	ucidef_set_led_default "etactica" "etactica" "$boardname:red:etactica" "ignore"
 	;;
+glinet,6416a)
+	ucidef_set_led_netdev "lan" "LAN" "gl-inet:green:lan" "eth1"
+	ucidef_set_led_wlan "wlan" "WLAN" "gl-inet:red:wlan" "phy0tpt"
+	;;
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor)
 	ucidef_set_led_netdev "lan" "LAN" "gl-ar300m:green:lan" "eth0"

--- a/target/linux/ath79/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/base-files/etc/board.d/02_network
@@ -115,6 +115,7 @@ ath79_setup_interfaces()
 		;;
 	comfast,cf-e110n-v2|\
 	comfast,cf-e120a-v3|\
+	glinet,6416a|\
 	tplink,cpe220-v3|\
 	ubnt,nanostation-m|\
 	ubnt,routerstation)

--- a/target/linux/ath79/dts/ar9331_glinet_6416a.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6416a.dts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "ar9331.dtsi"
+
+/ {
+	model = "GL.iNet 6416A";
+	compatible = "glinet,6416a", "qca,ar9331";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &wlan;
+		led-failsafe = &wlan;
+		led-upgrade = &wlan;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_disable_pins>;
+
+		wlan: wlan {
+			label = "gl-inet:red:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "gl-inet:green:lan";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&gpio {
+	status = "okay";
+};
+
+&usb {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	num-cs = <1>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <25000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <1>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -370,6 +370,17 @@ define Device/etactica_eg200
 endef
 TARGET_DEVICES += etactica_eg200
 
+define Device/glinet_6416a
+  $(Device/tplink-16mlzma)
+  ATH_SOC := ar9331
+  DEVICE_TITLE := GL.iNet 6416A
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-chipidea2
+  TPLINK_HWID := 0x08000001
+  IMAGE_SIZE := 16000k
+  SUPPORTED_DEVICES += gl-inet
+endef
+TARGET_DEVICES += glinet_6416a
+
 define Device/glinet_gl-ar150
   ATH_SOC := ar9330
   DEVICE_TITLE := GL.iNet GL-AR150


### PR DESCRIPTION
Add the DTS and image config to support the GL.iNet 6416A which
is a simple AR9331 based device with 64MB RAM and 16MB flash.
