### PR TITLE
bc: fix build errors with clang 12 on macOS

### DIFF
--- a/tools/bc/patches/002-conf_darwin.patch
+++ b/tools/bc/patches/002-conf_darwin.patch
@@ -1,0 +1,14 @@
+Index: bc-1.06.95/configure
+===================================================================
+--- bc-1.06.95.orig/configure
++++ bc-1.06.95/configure
+@@ -288,6 +288,9 @@ ac_includes_default="\
+ # if HAVE_STDLIB_H
+ #  include <stdlib.h>
+ # endif
++# if HAVE_STDDEF_H
++#  include <stddef.h>
++# endif
+ #endif
+ #if HAVE_STRING_H
+ # if !STDC_HEADERS && HAVE_MEMORY_H


### PR DESCRIPTION
Fix build errors with clang 12 on macOS:
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/12.0.0/include/stddef.h:35:26: error: typedef redefinition with different types ('long' vs '__darwin_size_t' (aka 'unsigned long'))
typedef __PTRDIFF_TYPE__ ptrdiff_t;
                         ^
../config.h:121:19: note: expanded from macro 'ptrdiff_t'
#define ptrdiff_t size_t
                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/_types/_size_t.h:31:32: note: previous definition is here
typedef __darwin_size_t        size_t;
              
```
