### PR TITLE
fakeroot: fix build errors with clang 12 on macOS

### DIFF
--- a/tools/fakeroot/patches/101-conf_darwin.patch
+++ b/tools/fakeroot/patches/101-conf_darwin.patch
@@ -1,0 +1,12 @@
+Index: fakeroot-1.24/configure
+===================================================================
+--- fakeroot-1.24.orig/configure
++++ fakeroot-1.24/configure
+@@ -12847,6 +12847,7 @@ for first in size_t int; do
+ #include <sys/types.h>
+ #endif
+ #include <unistd.h>
++#include <stdio.h>
+ #ifdef HAVE_GRP_H
+ #include <grp.h>
+ #endif


### PR DESCRIPTION
Fix build errors with clang 12 on macOS:
```
libfakeroot.c:1564:15: error: unknown type name 'unknown'
int setgroups(SETGROUPS_SIZE_TYPE size, const gid_t *list){
              ^
./config.h:262:29: note: expanded from macro 'SETGROUPS_SIZE_TYPE'
#define SETGROUPS_SIZE_TYPE unknown
```
