### PR TITLE
openvpn: Drop up&down from config file

### DIFF
--- a/package/network/services/openvpn/Makefile
+++ b/package/network/services/openvpn/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=openvpn
 
 PKG_VERSION:=2.4.9
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_SOURCE_URL:=\
 	https://build.openvpn.net/downloads/releases/ \

--- a/package/network/services/openvpn/files/openvpn.config
+++ b/package/network/services/openvpn/files/openvpn.config
@@ -9,6 +9,9 @@ config openvpn custom_config
 	# Set to 1 to enable this instance:
 	option enabled 0
 
+	# Set to 1 not to use provided up & down scripts
+	option drop_scripts 0
+
 	# Include OpenVPN configuration
 	option config /etc/openvpn/my-vpn.conf
 

--- a/package/network/services/openvpn/files/openvpn.init
+++ b/package/network/services/openvpn/files/openvpn.init
@@ -146,7 +146,15 @@ start_instance() {
 
 	if [ ! -z "$config" ]; then
 		append UCI_STARTED "$config" "$LIST_SEP"
-		openvpn_add_instance "$s" "${config%/*}" "$config" "$script_security"
+		# Allow to ignore up & down scripts as we have hotplug
+		config_get_bool drop_scripts "$s" 'drop_scripts' 0
+		if [ "$drop_scripts" -gt 0 ]; then
+			create_temp_file "/var/etc/openvpn-$s.conf"
+			sed -e 's|^[[:blank:]]*up|;up|' -e 's|^[[:blank:]]*down|;down|' "$config" > "/var/etc/openvpn-$s.conf"
+			openvpn_add_instance "$s" "${config%/*}" "/var/etc/openvpn-$s.conf" "$script_security"
+		else
+			openvpn_add_instance "$s" "${config%/*}" "$config" "$script_security"
+		fi
 		return
 	fi
 


### PR DESCRIPTION
Reasonable expectation is that up&down scripts are not tailored for
OpenWrt as in OpenWrt we use hotplug events. So dropping up&down command
from config files as they are most likely relict from some other
distribution and would effectively prevent openvpn from starting as
those scripts will most likely not exist on OpenWrt. This makes it
easier to start using some VPN providers without the need to modify
configuration file provided by them (well, the correct way would be to
teach them not to include it, but can't change the world, so adding work
around).

Little controversial, so I'm interested in opinions.