### PR TITLE
base-files: fix backwards compatiblity of rc.common EXTRA_COMMANDS

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=236
+PKG_RELEASE:=237
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -62,15 +62,15 @@ depends() {
 	return 0
 }
 
-EXTRA_HELP=""
-EXTRA_COMMANDS="boot shutdown depends"
+ALL_HELP=""
+ALL_COMMANDS="boot shutdown depends"
 extra_command() {
 	local cmd="$1"
 	local help="$2"
 
 	local extra="$(printf "%-16s%s" "${cmd}" "${help}")"
-	EXTRA_HELP="${EXTRA_HELP}\t${extra}\n"
-	EXTRA_COMMANDS="${EXTRA_COMMANDS} ${cmd}"
+	ALL_HELP="${ALL_HELP}\t${extra}\n"
+	ALL_COMMANDS="${ALL_COMMANDS} ${cmd}"
 }
 
 help() {
@@ -79,7 +79,7 @@ Syntax: $initscript [command]
 
 Available commands:
 EOF
-	echo -e "$EXTRA_HELP"
+	echo -e "$ALL_HELP"
 }
 
 # for procd
@@ -175,6 +175,7 @@ extra_command "enabled" "Check if service is started on boot"
 	}
 }
 
-ALL_COMMANDS="${EXTRA_COMMANDS}"
+ALL_COMMANDS="${ALL_COMMANDS} ${EXTRA_COMMANDS}"
+ALL_HELP="${ALL_HELP}${EXTRA_HELP}"
 list_contains ALL_COMMANDS "$action" || action=help
 $action "$@"


### PR DESCRIPTION
Avoid needlessly breaking old initscripts that set EXTRA_COMMANDS. This
will aid in debugging (as it simplifies reverting to an older version of
a package) and unbreaks third-party feeds (and packages that maintain
their OpenWrt initscripts as part of the software's repo instead of the
OpenWrt feed like fastd).

Without this, initscripts that set EXTRA_COMMANDS become completely
unusable, as all default commands like start/stop cease working.

Fixes: 1a69f50dc627 ("base-files: fix rc.common help alignment")
Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>

PR that introduced the issue: #3246
Related: https://github.com/NeoRaider/fastd/issues/14

@feckert @dedeckeh