### PR TITLE
hostapd: fix per-BSS airtime configuration and support for static airtime policy configuration

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -102,6 +102,8 @@ hostapd_common_add_device_config() {
 	config_add_string acs_chan_bias
 	config_add_array hostapd_options
 
+	config_add_int airtime_mode
+
 	hostapd_add_log_config
 }
 

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -288,6 +288,7 @@ hostapd_common_add_bss_config() {
 	config_add_string osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
 
 	config_add_int airtime_bss_weight airtime_bss_limit
+	config_add_array airtime_sta_weight
 }
 
 hostapd_set_vlan_file() {
@@ -411,6 +412,10 @@ append_hs20_conn_capab() {
 	[ -n "$1" ] && append bss_conf "hs20_conn_capab=$1" "$N"
 }
 
+append_airtime_sta_weight() {
+	[ -n "$1" ] && append bss_conf "airtime_sta_weight=$1" "$N"
+}
+
 hostapd_set_bss_options() {
 	local var="$1"
 	local phy="$2"
@@ -432,7 +437,7 @@ hostapd_set_bss_options() {
 		acct_server acct_secret acct_port acct_interval \
 		bss_load_update_period chan_util_avg_period sae_require_mfp \
 		multi_ap multi_ap_backhaul_ssid multi_ap_backhaul_key \
-		airtime_bss_weight airtime_bss_limit
+		airtime_bss_weight airtime_bss_limit airtime_sta_weight
 
 	set_default isolate 0
 	set_default maxassoc 0
@@ -466,6 +471,7 @@ hostapd_set_bss_options() {
 
 	[ "$airtime_bss_weight" -gt 0 ] && append bss_conf "airtime_bss_weight=$airtime_bss_weight" "$N"
 	[ "$airtime_bss_limit" -gt 0 ] && append bss_conf "airtime_bss_limit=$airtime_bss_limit" "$N"
+	json_for_each_item append_airtime_sta_weight airtime_sta_weight
 
 	append bss_conf "bss_load_update_period=$bss_load_update_period" "$N"
 	append bss_conf "chan_util_avg_period=$chan_util_avg_period" "$N"


### PR DESCRIPTION
Pull request contains two commits:
```
hostapd: fix per-BSS airtime configuration

airtime_mode is always parsed as an empty string since it hasn't been
added into hostapd_common_add_device_config function.

Fixes: e289f183 ("hostapd: add support for per-BSS airtime configuration")
Signed-off-by: Dobroslaw Kijowski <dobo90@gmail.com>
```

```
hostapd: add support for static airtime policy configuration

* Add support for passing airtime_sta_weight into hostapd configuration.
* Since that commit it is possible to configure station weights. Set higher
  value for larger airtime share, lower for smaller share.

I have tested this functionality by modyfing /etc/config/wireless to:

config wifi-device 'radio0'
        ...
        option airtime_mode '1'

config wifi-iface 'default_radio0'
        ...
        list airtime_sta_weight '01:02:03:04:05:06 1024'
```

Probably @blocktrron is the best person to look at those changes.