### PR TITLE
wireguard-tools: fix category/description in menuconfig

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -30,13 +30,22 @@ MAKE_PATH:=src
 MAKE_VARS += PLATFORM=linux
 
 define Package/wireguard-tools
-  $(call Package/wireguard/Default)
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=VPN
+  URL:=https://www.wireguard.com
+  MAINTAINER:=Jason A. Donenfeld <Jason@zx2c4.com>
   TITLE:=WireGuard userspace control program (wg)
   DEPENDS:=+@BUSYBOX_CONFIG_IP +@BUSYBOX_CONFIG_FEATURE_IP_LINK
 endef
 
 define Package/wireguard-tools/description
-  $(call Package/wireguard/Default/description)
+  WireGuard is a novel VPN that runs inside the Linux Kernel and utilizes
+  state-of-the-art cryptography. It aims to be faster, simpler, leaner, and       
+  more useful than IPSec, while avoiding the massive headache. It intends to        
+  be considerably more performant than OpenVPN.  WireGuard is designed as a       
+  general purpose VPN for running on embedded interfaces and super computers        
+  alike, fit for many different circumstances. It uses UDP.
 
   This package provides the userspace control program for WireGuard,
   `wg(8)`, a netifd protocol helper, and a re-resolve watchdog script.


### PR DESCRIPTION
wireguard-tools is trying to import the menuconfig section
from the wireguard package, but since it's not anymore in 
the same makefile this seems to fail and wireguard-tools 
ends up in "extra packages" category instead with other 
odds and ends.

Same for the description, it's trying to import it from the
wireguard package but it fails so it only shows the line
written in this makefile.

remove the broken imports and add manually the entries
and description they were supposed to load

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>
