### PR TITLE
ath79: add support for MikroTik RouterBOARD wAPR-2nD (wAP R)

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-wapr-2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD wAPR-2nD (wAP R)";
+
+	aliases {
+		led-boot = &led_rssilow;
+		led-failsafe = &led_rssilow;
+		led-upgrade = &led_rssilow;
+		led-running = &led_rssilow;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+
+		led_rssilow: rssilow {
+			label = "green:rssilow";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "green:rssimedium";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssihigh {
+			label = "green:rssihigh";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		minipcie {
+			gpio-export,name = "minipcie";
+			gpio-export,output = <1>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -53,3 +53,12 @@ define Device/mikrotik_routerboard-wap-g-5hact2hnd
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef
 TARGET_DEVICES += mikrotik_routerboard-wap-g-5hact2hnd
+
+define Device/mikrotik_routerboard-wapr-2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD wAPR-2nD (wAP R)
+  DEVICE_PACKAGES += rssileds
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_routerboard-wapr-2nd

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -10,6 +10,12 @@ case "$board" in
 mikrotik,routerboard-lhg-2nd)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+mikrotik,routerboard-wapr-2nd)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimedium" "rssimedium" "green:rssimedium" "wlan0" "33" "100"
+	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "66" "100"
+	;;
 mikrotik,routerboard-sxt-5nd-r2)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -19,7 +19,8 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-922uags-5hpacd|\
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
-	mikrotik,routerboard-wap-g-5hact2hnd)
+	mikrotik,routerboard-wap-g-5hact2hnd|\
+	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
 		;;
 	*)
@@ -40,7 +41,8 @@ ath79_setup_macs()
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
-	mikrotik,routerboard-wap-g-5hact2hnd)
+	mikrotik,routerboard-wap-g-5hact2hnd|\
+	mikrotik,routerboard-wapr-2nd)
 		label_mac="$mac_base"
 		lan_mac="$mac_base"
 		;;

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -24,7 +24,8 @@ case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
 	mikrotik,routerboard-lhg-2nd|\
-	mikrotik,routerboard-sxt-5nd-r2)
+	mikrotik,routerboard-sxt-5nd-r2|\
+	mikrotik,routerboard-wapr-2nd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" +1)
 		;;
 	mikrotik,routerboard-wap-g-5hact2hnd)


### PR DESCRIPTION
This patch adds support for the MikroTik RouterBOARD wAPR-2nD (wAP R) router, a weatherproof 2.4 GHz access point with a  miniPCI-e slot and a SIM card slot.

Specifications:

 - SoC: Qualcomm Atheros QCA9531
 - Flash: 16 MB (SPI)
 - RAM: 64 MB
 - Ethernet: 1x 10/100 Mbps (PoE in)
 - WiFi: 2T2R 2.4 GHz
 - miniPCI-e slot
 - 4x green LEDs (1x WiFi, 3x RSSI)
 - 1x reset button

 See https://mikrotik.com/product/RBwAPR-2nD for more details.

Flashing:
 TFTP boot initramfs image and then perform sysupgrade. Follow common  MikroTik procedure as in https://openwrt.org/toh/mikrotik/common.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>