### PR TITLE
Backport 18.06: scripts/config: fix *c_shipped build depency tracking

### DIFF
--- a/scripts/config/Makefile
+++ b/scripts/config/Makefile
@@ -31,7 +31,7 @@ lxdialog-objs := \
 	lxdialog/checklist.o lxdialog/util.o lxdialog/inputbox.o \
 	lxdialog/textbox.o lxdialog/yesno.o lxdialog/menubox.o
 
-clean-files	:= zconf.tab.c lex.zconf.c zconf.hash.c
+clean-files	:= zconf.tab.c zconf.lex.c zconf.hash.c
 # Remove qconf junk files
 clean-files	+= $(qconf-cxxobjs) qconf.moc .tmp_qtcheck qconf
 
@@ -55,9 +55,9 @@ zconf.tab.o: zconf.lex.c zconf.hash.c confdata.c
 
 kconfig_load.o: lkc_defs.h
 
-zconf.tab.c: zconf.y
-zconf.lex.c: zconf.l
-zconf.hash.c: zconf.gperf
+zconf.tab.c: zconf.y $(wildcard zconf.tab.c_shipped)
+zconf.lex.c: zconf.l $(wildcard zconf.lex.c_shipped)
+zconf.hash.c: zconf.gperf $(wildcard zconf.hash.c_shipped)
 
 %.tab.c: %.y
 	cp $@_shipped $@ || bison -l -b $* -p $(notdir $*) $<


### PR DESCRIPTION
In commit 9d5510a500a1804484152adb8951dda3688658bc the file `lex.zconf.c` was renamed to `zconf.lex.c`, but the `clean-files` variable was not updated accordingly. Because of this, the generated file is not correctly cleaned by the top level `config-clean` target.

This was later fixed in master as 0096a1cf0015e483b99e51c74f2f0bbae7247342 and in branch 19.07 as f79e6e01bd78b84316418f9981d7d1b6c3900e8c. This PR backports the fix to the 18.06 branch.

This fixes some very annoying warnings:

    tmp/.config-package.in:718:warning: ignoring unsupported character '@'

Manually deleting the `zconf.lex.c` solves the problem by letting it regenerate.

I know that the openwrt-18.06 branch should be EOL, but in case other people are still using it, it is a nice fix to have.
