### PR TITLE
linux-firmware: update to 20201118

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20201022
+PKG_VERSION:=20201118
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=bf586e0beb4c65f22bf0a79811f259aa0a5a7cc9f70eebecb260525b6914cef7
+PKG_HASH:=863d5a31da725b856a917280d1e3014929b3bc3d4e6e5faecf530c13afb7e2b9
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
git log --pretty=oneline --abbrev-commit 20201022..20201118
2ea8667 (tag: 20201118) rtlwifi: v88.2 firmware files for RTL8192CU
e850cf3 Merge https://github.com/rjliao-qca/qca-btfw into main
65370db rtw88: RTL8822C: Update firmware to v9.9.4
e371b7c Revert "rtw88: RTL8822C: Update firmware to v9.9.4"
51d2c81 vpdma: Move firmware to ti directory
d7a24c9 Merge branch 'master' of https://github.com/shahasit/video-linux-firmware into main
9ee1543 Merge branch 'master' of https://github.com/shahasit/bt-linux-firmware into main
3bcc4c1 amdgpu: update picasso VCN firmware
b6b4542 amdgpu: update raven2 VCN firmware
79aa335 amdgpu: update raven VCN firmware
c93834e rtw88: RTL8822C: Update firmware to v9.9.4
3ef6c93 rtl_bt: Update RTL8822C BT(USB I/F) FW to 0x099A_281A
b503c96 Merge branch 'ath10k-20201023' of git://git.kernel.org/pub/scm/linux/kernel/git/kvalo/linux-firmware into main
463fdea QCA: Update Bluetooth firmware for QCA6390
8a46c32 qcom : updated venus firmware files for v5.4
d7793e5 QCA : Fixed BT SSR due to command timeout / IO fatal error
d842d8c ath11k: QCA6390 hw2.0: add to WLAN.HST.1.0.1-01740-QCAHSTSWPLZ_V2_TO_X86-1
8fb1a6e ath11k: QCA6390 hw2.0: add board-2.bin
34cb5fc ath11k: IPQ8074 hw2.0: add to WLAN.HK.2.1.0.1-01238-QCAHKSWPL_SILICONZ-2
c0a8efd ath11k: IPQ8074 hw2.0: add board-2.bin
ac7f5e9 ath11k: IPQ6018 hw1.0: add to WLAN.HK.2.1.0.1-01238-QCAHKSWPL_SILICONZ-2
2594e51 ath11k: IPQ6018 hw1.0: add board-2.bin
d8f10d4 ath10k: QCA6174 hw3.0: add firmware-sdio-6.bin version WLAN.RMH.4.4.1-00077
6652297 ath10k: QCA9984 hw1.0: update firmware-5.bin to 10.4-3.9.0.2-00131
36059aa ath10k: QCA9888 hw2.0: update firmware-5.bin to 10.4-3.9.0.2-00131
1e5629d ath10k: QCA6174 hw3.0: update board-2.bin
e315d1a ath10k: QCA6174 hw3.0: update firmware-6.bin to WLAN.RM.4.4.1-00157-QCARMSWPZ-1
```

Signed-off-by: John Audia <graysky@archlinux.us>