### PR TITLE
ramips: add support for UniElec U7621-01

### DIFF
--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01-16m.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_unielec_u7621-01.dtsi"
+
+/ {
+	compatible = "unielec,u7621-01-16m", "unielec,u7621-01", "mediatek,mt7621-soc";
+	model = "UniElec U7621-01 (16M flash)";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <14000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "unielec,u7621-01", "mediatek,mt7621-soc";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "green:status";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe000>;
+			mtd-mac-address-increment = <1>;			
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1092,6 +1092,16 @@ define Device/ubnt_unifi-nanohd
 endef
 TARGET_DEVICES += ubnt_unifi-nanohd
 
+define Device/unielec_u7621-01-16m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := UniElec
+  DEVICE_MODEL := U7621-01
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 wpad-basic-wolfssl
+endef
+TARGET_DEVICES += unielec_u7621-01-16m
+
 define Device/unielec_u7621-06-16m
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
UniElec U7621-01 is a router platform board, it is the smaller model of the U7621-06.

The device has the following specifications:

- MT7621AT (880 MHz)
- 256 of RAM (DDR3)
- 16 MB of FLASH (MX25l12805d SPI)
- 5x 1 Gbps Ethernet (MT7621 built-in switch)
- 1x 2.4Ghz MT7603E
- 1x 5Ghz MT7612
- 1x miniPCIe slots (PCIe bus only)
- 1x miniSIM slot
- 1x USB 2.0 (uses the usb 3.0 driver)
- 8x LEDs (1x GPIO-controlled)
- 1x reset button
- 1x UART header (4-pins)
- 1x GPIO header (30-pins)
- 1x DC jack for main power (12 V)

The following has been tested and is working:

- Ethernet switch
- 1x 2.4Ghz MT7603E (wifi)
- 1x 5Ghz MT7612 (wifi)
- miniPCIe slots (tested with Wi-Fi cards and LTE modem cards)
- miniSIM slot (works with normal size simcard)
- sysupgrade
- reset button

Installation:

This board has no locked down bootloader. The seller can be asked to install openwrt v18.06, so upgrades are standard
sysupgrade method.

Recovery:

This board contains a Chinese, closed-source bootloader called Breed
(Boot and Recovery Environment for Embedded Devices). Breed supports web
recovery and to enter it, you keep the reset button pressed for around
5 seconds during boot. Your machine will be assigned an IP through DHCP
and the router will use IP address 192.168.1.1. The recovery website is
in Chinese, but is easy to use. Click on the second item in the list to
access the recovery page, then the second item on the next page is where
you select the firmware. In order to start the recovery, you click the
button at the bottom.

LEDs list (left to right):

- ESW_P0_LED_0
- ESW_P1_LED_0
- ESW_P2_LED_0
- ESW_P3_LED_0
- ESW_P4_LED_0
- CTS2_N (GPIO10, configured as "status" LED)
- LED_WLAN# (connected with pin 44 in wifi1 slot)

Signed-off-by: David Bentham <db260179@gmail.com>