### PR TITLE
kernel: mtd: parser: cmdline: Fix parsing of part-names with colons

### DIFF
--- a/target/linux/generic/pending-5.4/499-mtd-parser-cmdline-Fix-parsing-of-part-names-with-co.patch
+++ b/target/linux/generic/pending-5.4/499-mtd-parser-cmdline-Fix-parsing-of-part-names-with-co.patch
@@ -1,0 +1,63 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 22 Nov 2020 00:48:33 +0100
+Subject: [PATCH RFC] mtd: parser: cmdline: Fix parsing of part-names with colons
+
+Some devices (especially QCA ones) are already using hardcoded partition
+names with colons in it. The OpenMesh A62 for example provides following
+mtd relevant information via cmdline:
+
+  root=31:11 mtdparts=spi0.0:256k(0:SBL1),128k(0:MIBIB),384k(0:QSEE),64k(0:CDT),64k(0:DDRPARAMS),64k(0:APPSBLENV),512k(0:APPSBL),64k(0:ART),64k(custom),64k(0:KEYS),0x002b0000(kernel),0x00c80000(rootfs),15552k(inactive) rootfsname=rootfs rootwait
+
+The change to split only on the last colon between mtd-id and partitions
+will cause newpart to see following string for the first partition:
+
+  KEYS),0x002b0000(kernel),0x00c80000(rootfs),15552k(inactive)
+
+Such a partition list cannot be parsed and thus the device fails to boot.
+
+Avoid this behavior by making sure that the start of the first part-name
+("(") will also be the last byte the mtd-id split algorithm is using for
+its colon search.
+
+Forwarded: https://patchwork.ozlabs.org/project/linux-mtd/patch/20201122001533.985641-1-sven@narfation.org/
+Fixes: eb13fa022741 ("mtd: parser: cmdline: Support MTD names containing one or more colons")
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+diff --git a/drivers/mtd/parsers/cmdlinepart.c b/drivers/mtd/parsers/cmdlinepart.c
+index 0625b25620ca766318ea4646a6e3761ff4d3a4cc..22881ea4c132ea5a5ba7aebd025d91bf1cd023af 100644
+--- a/drivers/mtd/parsers/cmdlinepart.c
++++ b/drivers/mtd/parsers/cmdlinepart.c
+@@ -218,7 +218,7 @@ static int mtdpart_setup_real(char *s)
+ 		struct cmdline_mtd_partition *this_mtd;
+ 		struct mtd_partition *parts;
+ 		int mtd_id_len, num_parts;
+-		char *p, *mtd_id, *semicol;
++		char *p, *mtd_id, *semicol, *open_parenth;
+ 
+ 		/*
+ 		 * Replace the first ';' by a NULL char so strrchr can work
+@@ -228,6 +228,13 @@ static int mtdpart_setup_real(char *s)
+ 		if (semicol)
+ 			*semicol = '\0';
+ 
++		/* make sure that part-names with ":" will not be handled as
++		 * part of the mtd-id with an ":"
++		 */
++		open_parenth = strchr(s, '(');
++		if (open_parenth)
++			*open_parenth = '\0';
++
+ 		mtd_id = s;
+ 
+ 		/*
+@@ -237,6 +244,10 @@ static int mtdpart_setup_real(char *s)
+ 		 */
+ 		p = strrchr(s, ':');
+ 
++		/* Restore the '(' now. */
++		if (open_parenth)
++			*open_parenth = '(';
++
+ 		/* Restore the ';' now. */
+ 		if (semicol)
+ 			*semicol = ';';


### PR DESCRIPTION
**This problem also affects older OpenWrt version which are updated to Linux 4.9.238/4.14.200/4.19.149 or newer - patch should therefore also be added to OpenWrt 18.06.x and OpenWrt 19.07.x.** A backport for OpenWrt 19.07 can be found in https://github.com/FreifunkVogtland/gluon/blob/plasmacloud/patches/openwrt/0018-kernel-mtd-parser-cmdline-Fix-parsing-of-part-names-with-colons.patch

Some devices (especially QCA ones) are already using hardcoded partition names with colons in it. The OpenMesh A62 for example provides following mtd relevant information via cmdline:

    root=31:11 mtdparts=spi0.0:256k(0:SBL1),128k(0:MIBIB),384k(0:QSEE),64k(0:CDT),64k(0:DDRPARAMS),64k(0:APPSBLENV),512k(0:APPSBL),64k(0:ART),64k(custom),64k(0:KEYS),0x002b0000(kernel),0x00c80000(rootfs),15552k(inactive) rootfsname=rootfs rootwait

The change to split only on the last colon between mtd-id and partitions
will cause newpart to see following string for the first partition:

    KEYS),0x002b0000(kernel),0x00c80000(rootfs),15552k(inactive)

Such a partition list cannot be parsed and thus the device fails to boot.

Avoid this behavior by making sure that the start of the first part-name ("(") will also be the last byte the mtd-id split algorithm is using for its colon search.

Fixes: d6a9a92e3217 ("kernel: bump 5.4 to 5.4.69")
