### PR TITLE
images: Fix sysupgrade.tar for devices with NOR flash

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -5,6 +5,19 @@ get_magic_word() {
 	dd if=$1 bs=4 count=1 2>/dev/null | od -A n -N 4 -t x1 | tr -d ' '
 }
 
+get_post_padding_word() {
+	local rootfs_length="$(stat -c%s "$1")"
+	[ "$rootfs_length" -ge 4 ] || return
+	rootfs_length=$((rootfs_length-4))
+
+	# the JFFS2 end marker must be on a 4K boundary (often 64K or 256K)
+	local unaligned_bytes=$((rootfs_length%4096))
+	[ "$unaligned_bytes" = 0 ] || return
+
+	# skip rootfs data except the potential EOF marker
+	dd if="$1" bs=1 skip="$rootfs_length" 2>/dev/null | od -A n -N 4 -t x1 | tr -d ' '
+}
+
 get_fs_type() {
 	local magic_word="$(get_magic_word "$1")"
 
@@ -13,7 +26,16 @@ get_fs_type() {
 		echo "ubifs"
 		;;
 	"68737173")
-		echo "squashfs"
+		local post_padding_word="$(get_post_padding_word "$1")"
+
+		case "$post_padding_word" in
+		"deadc0de")
+			echo "squashfs-jffs2"
+			;;
+		*)
+			echo "squashfs"
+			;;
+		esac
 		;;
 	*)
 		echo "unknown"


### PR DESCRIPTION
@KanjiMonster https://github.com/openwrt/openwrt/commit/ee76bd11bbe75bf57cccd84bbeea245ee7a2893b#commitcomment-44425547

The NOR flash rootfs images stored in a sysupgrade.tar must end with the JFFS2 marker. Otherwise, devices like OpenMesh A42/A62 are not able to calculate the md5sum of the fixed squashfs part and store it inside the u-boot-env.

But the commit ee76bd11bbe7 ("images: fix boot failures on NAND with small sub pages") adds up to 1020 0x00 bytes after the 0xdead0de EOF marker. The calculated md5sum will be wrong due do this change and u-boot will fail to boot the newly flashed device with a message like:

    Validating MD5Sum of 'vmlinux'...
    Passed!
    Validating MD5Sum of 'rootfs'...
    Failed!
        583a1b7b54b8601efa64ade42742459b != 8850ee812dfd7638e94083329d5d2781
  
    Data validation failed!

and boot the old image again.

Since the original change should not change the behavior of NOR images, just check for the deadc0de marker at the end of the squashfs-jffs2 image do avoid the problematic behavior for these images.

Fixes: ee76bd11bbe7 ("images: fix boot failures on NAND with small sub pages")