### PR TITLE
ipq40xx: Update coding style for OpenMesh devices

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-a42.dts
@@ -1,18 +1,6 @@
+// SPDX-License-Identifier: ISC
 /* Copyright (c) 2015, The Linux Foundation. All rights reserved.
  * Copyright (c) 2017, Sven Eckelmann <sven.eckelmann@openmesh.com>
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
  */
 
 #include "qcom-ipq4019.dtsi"
@@ -95,30 +83,28 @@
 	};
 
 	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		red {
+		status_red {
 			label = "red:status";
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-off";
 		};
 
-		power: green {
+		led_status_green: status_green {
 			label = "green:status";
 			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
 		};
 
-		blue {
+		status_blue {
 			label = "blue:status";
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-off";
 		};
 	};
 
@@ -168,7 +154,7 @@
 	status = "okay";
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
 
-	m25p80@0 {
+	flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-a62.dts
@@ -1,18 +1,6 @@
+// SPDX-License-Identifier: ISC
 /* Copyright (c) 2015, The Linux Foundation. All rights reserved.
  * Copyright (c) 2017-2018, Sven Eckelmann <sven.eckelmann@openmesh.com>
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
  */
 
 #include "qcom-ipq4019.dtsi"
@@ -98,30 +86,28 @@
 	};
 
 	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		red {
+		status_red {
 			label = "red:status";
 			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-off";
 		};
 
-		power: green {
+		led_status_green: status_green {
 			label = "green:status";
 			gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
 		};
 
-		blue {
+		status_blue {
 			label = "blue:status";
 			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-off";
 		};
 	};
 
@@ -178,7 +164,7 @@
 	status = "okay";
 	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
 
-	m25p80@0 {
+	flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -647,7 +647,6 @@ define Device/openmesh_a62
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct uboot-envtools
 endef
-
 TARGET_DEVICES += openmesh_a62
 
 define Device/qcom_ap-dk01.1-c1


### PR DESCRIPTION
The OpenMesh related files were not updated since a while and the new coding style requirements weren't integrated. This can cause problems for new devices when an author uses these files as starting point.

Following changes were requested for #3617

* use SPDX-License-Identifier's instead of full license texts
* drop linux,default-trigger with value default-off for LEDs
* led nodes with label "abc:xyz" should have name "xyz_abc"
* led labels for "xyz_abc" should be "led_xyz_abc"
* "m25p80@0" flash node should be renamed to "flash@0"
* drop unnecessary empty lines