### PR TITLE
uqmi: set plmn to 'auto' if necessary

### DIFF
--- a/package/network/utils/uqmi/Makefile
+++ b/package/network/utils/uqmi/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uqmi
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uqmi.git

--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -30,7 +30,7 @@ proto_qmi_init_config() {
 
 proto_qmi_setup() {
 	local interface="$1"
-	local dataformat connstat
+	local dataformat connstat plmn_mode mcc mnc
 	local device apn auth username password pincode delay modes pdptype
 	local profile dhcp dhcpv6 autoconnect plmn timeout mtu $PROTO_DEFAULT_OPTIONS
 	local ip4table ip6table
@@ -152,24 +152,36 @@ proto_qmi_setup() {
 		esac
 	fi
 
-	[ -n "$plmn" ] && {
-		local mcc mnc
-		if [ "$plmn" = 0 ]; then
+	json_load "$(uqmi -s -d "$device" --get-plmn)"
+	json_get_var plmn_mode mode
+	json_get_vars mcc mnc || {
+		mcc=0
+		mnc=0
+	}
+
+	if [ -z "$plmn" -o "$plmn" = 0 ]; then
+		if [ "$plmn_mode" != "automatic" ]; then
 			mcc=0
 			mnc=0
 			echo "Setting PLMN to auto"
-		else
-			mcc=${plmn:0:3}
-			mnc=${plmn:3}
-			echo "Setting PLMN to $plmn"
 		fi
+	elif [ "$mcc" -ne "${plmn:0:3}" -o "$mnc" -ne "${plmn:3}" ]; then
+		mcc=${plmn:0:3}
+		mnc=${plmn:3}
+		echo "Setting PLMN to $plmn"
+	else
+		mcc=""
+		mnc=""
+	fi
+
+	if [ -n "$mcc" -a -n "$mnc" ]; then
 		uqmi -s -d "$device" --set-plmn --mcc "$mcc" --mnc "$mnc" > /dev/null 2>&1 || {
 			echo "Unable to set PLMN"
 			proto_notify_error "$interface" PLMN_FAILED
 			proto_block_restart "$interface"
 			return 1
 		}
-	}
+	fi
 
 	# Cleanup current state if any
 	uqmi -s -d "$device" --stop-network 0xffffffff --autoconnect > /dev/null 2>&1


### PR DESCRIPTION
@dangowrt (Since you have merged the underlying patch on uqmi)

Setting the plmn to 'auto' will implicitly lead to a (delayed)
network re-registration, which could further lead to some timing
related issues in the qmi proto handler.

On the other hand, if you switch back from manual plmn selection
to auto mode you have to set it to 'auto', because this setting
is permanently "saved" in the wwan module.

Conclusion:
If plmn is not configured or configured as 'auto', check if it is
already set to 'auto'. If so, do nothing. Otherwise set it to 'auto'.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>

