### PR TITLE
ath79: add support for Senao Engenius EAP300 v2

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -23,6 +23,7 @@ allnet,all-wap02860ac|\
 arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
+engenius,eap300-v2|\
 engenius,ecb1750|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\

--- a/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
+++ b/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9341.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Engenius EAP300 v2";
+	compatible = "engenius,eap300-v2", "qca,ar9341";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			label = "blue:wlan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	num-cs = <1>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x050000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0x0a0000 0x010000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0x0b0000 0x170000>;
+			};
+
+			partition@220000 {
+				label = "fakeroot";
+				reg = <0x220000 0x010000>;
+				read-only;
+			};
+
+			firmware1: partition@230000 {
+				label = "firmware1";
+				reg = <0x230000 0xbc0000>;
+			};
+
+			partition@df0000 {
+				label = "failsafe";
+				reg = <0xdf0000 0x200000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -150,6 +150,7 @@ telco,t1)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	;;
 comfast,cf-wr752ac-v1|\
+engenius,eap300-v2|\
 engenius,ecb1750|\
 enterasys,ws-ap3705i)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ath79_setup_interfaces()
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\
 	dlink,dir-505|\
+	engenius,eap300-v2|\
 	engenius,ecb1750|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
@@ -424,6 +425,7 @@ ath79_setup_macs()
 	alfa-network,n5q|\
 	alfa-network,pi-wifi4|\
 	alfa-network,r36a|\
+	engenius,eap300-v2|\
 	engenius,ens202ext-v1)
 		label_mac=$(mtd_get_mac_binary art 0x1002)
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -862,6 +862,17 @@ define Device/engenius_loader_okli
 	check-size | engenius-tar-gz $$$$(ENGENIUS_IMGNAME)
 endef
 
+define Device/engenius_eap300-v2
+  $(Device/engenius_loader_okli)
+  SOC := ar9341
+  DEVICE_MODEL := EAP300
+  DEVICE_VARIANT := v2
+  IMAGE_SIZE := 12032k
+  LOADER_FLASH_OFFS := 0x230000
+  ENGENIUS_IMGNAME := senao-eap300v2
+endef
+TARGET_DEVICES += engenius_eap300-v2
+
 define Device/engenius_ecb1750
   SOC := qca9558
   DEVICE_VENDOR := EnGenius


### PR DESCRIPTION
FCC ID: A8J-EAP300A

Engenius EAP300 v2 is an indoor wireless access point with a 100/10-BaseT ethernet port,
2.4 GHz wireless, internal antennas, and 802.3af PoE.

**Specification:**

  - AR9341
  - 40 MHz reference clock
  - 16 MB FLASH			MX25L12845EMI-10G
  - 64 MB RAM
  - UART at J1			(populated)
  - Ethernet port with POE
  - internal antennas
  - 3 LEDs, 1 button		(power, eth, wlan) (reset)

**MAC addresses:**

  The device label lists MAC that is -1 of the one found in flash

  MAC	*:d3   art 0x1002
  ---	*:d4   art 0x0/0x6

**Installation:**

  - if you get Failsafe Mode from failed flash:
      only use it to flash Original firmware from Engenius
      or risk kernel loop or halt which requires serial cable

  Method 1: Firmware upgrade page:

  OEM webpage at 192.168.1.1
  username and password "admin"
  Navigate to "Firmware" page from left pane
  Click Browse and select the factory.bin image
  Upload and verify checksum
  Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

  After connecting to serial console and rebooting...
  Interrupt uboot with any key pressed rapidly
  execute `run failsafe_boot` OR `bootm 0x9fdf0000`
  wait a minute
  connect to ethernet and navigate to
  "192.168.1.1/index.htm"
  Select the factory.bin image and upload
  wait about 3 minutes

**Return to OEM:**

  If you have a serial cable, see Serial Failsafe instructions

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will not work
  DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

  The easiest way to return to the OEM software is the Failsafe image
  If you dont have a serial cable, you can ssh into openwrt and run

  `mtd -r erase fakeroot`

  Wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

**TFTP recovery** (unstable / not reliable):

  rename initramfs to 'vmlinux-art-ramdisk'
  make available on TFTP server at 192.168.1.101
  power board while holding or pressing reset button repeatedly

  NOTE: for some Engenius boards TFTP is not reliable
  try setting MTU to 600 and try many times

**Format of OEM firmware image:**

  The OEM software of EAP300 v2 is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names
  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  The OEM upgrade script is at /etc/fwupgrade.sh.

  OKLI kernel loader is required because the OEM software
  expects the kernel size to be no greater than 1536k
  and otherwise the factory.bin upgrade procedure would
  overwrite part of the kernel when writing rootfs.

Signed-off-by: Michael Pratt <mcpratt@pm.me>