### PR TITLE
kernel: backport GD25Q256 support from 4.15

### DIFF
--- a/target/linux/bcm53xx/patches-4.14/400-mtd-spi-nor-detect-JEDEC-incompatible-w25q128-using-.patch
+++ b/target/linux/bcm53xx/patches-4.14/400-mtd-spi-nor-detect-JEDEC-incompatible-w25q128-using-.patch
@@ -13,7 +13,7 @@ Signed-off-by: Rafał Miłecki <zajec5@gmail.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1227,6 +1227,18 @@ static const struct flash_info *spi_nor_
+@@ -1237,6 +1237,18 @@ static const struct flash_info *spi_nor_
  	}
  	dev_err(nor->dev, "unrecognized JEDEC id bytes: %02x, %02x, %02x\n",
  		id[0], id[1], id[2]);

--- a/target/linux/generic/backport-4.14/373-netfilter_actual_sk.patch
+++ b/target/linux/generic/backport-4.14/373-netfilter_actual_sk.patch
@@ -52,28 +52,28 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 @@ -16,7 +16,7 @@ struct ip_rt_info {
  	u_int32_t mark;
  };
-
+ 
 -int ip_route_me_harder(struct net *net, struct sk_buff *skb, unsigned addr_type);
 +int ip_route_me_harder(struct net *net, struct sock *sk, struct sk_buff *skb, unsigned addr_type);
-
+ 
  struct nf_queue_entry;
-
+ 
 --- a/include/linux/netfilter_ipv6.h
 +++ b/include/linux/netfilter_ipv6.h
 @@ -41,7 +41,7 @@ struct nf_ipv6_ops {
  };
-
+ 
  #ifdef CONFIG_NETFILTER
 -int ip6_route_me_harder(struct net *net, struct sk_buff *skb);
 +int ip6_route_me_harder(struct net *net, struct sock *sk, struct sk_buff *skb);
  __sum16 nf_ip6_checksum(struct sk_buff *skb, unsigned int hook,
  			unsigned int dataoff, u_int8_t protocol);
-
+ 
 --- a/net/ipv4/netfilter.c
 +++ b/net/ipv4/netfilter.c
 @@ -17,17 +17,19 @@
  #include <net/netfilter/nf_queue.h>
-
+ 
  /* route_me_harder function, used by iptable_nat, iptable_mangle + ip_queue */
 -int ip_route_me_harder(struct net *net, struct sk_buff *skb, unsigned int addr_type)
 +int ip_route_me_harder(struct net *net, struct sock *sk, struct sk_buff *skb, unsigned int addr_type)
@@ -87,7 +87,7 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 +	__u8 flags;
  	struct net_device *dev = skb_dst(skb)->dev;
  	unsigned int hh_len;
-
+ 
 +	sk = sk_to_full_sk(sk);
 +	flags = sk ? inet_sk_flowi_flags(sk) : 0;
 +
@@ -106,13 +106,13 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 --- a/net/ipv4/netfilter/ipt_SYNPROXY.c
 +++ b/net/ipv4/netfilter/ipt_SYNPROXY.c
 @@ -53,7 +53,7 @@ synproxy_send_tcp(struct net *net,
-
+ 
  	skb_dst_set_noref(nskb, skb_dst(skb));
  	nskb->protocol = htons(ETH_P_IP);
 -	if (ip_route_me_harder(net, nskb, RTN_UNSPEC))
 +	if (ip_route_me_harder(net, nskb->sk, nskb, RTN_UNSPEC))
  		goto free_nskb;
-
+ 
  	if (nfct) {
 --- a/net/ipv4/netfilter/iptable_mangle.c
 +++ b/net/ipv4/netfilter/iptable_mangle.c
@@ -128,7 +128,7 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 --- a/net/ipv4/netfilter/nf_nat_l3proto_ipv4.c
 +++ b/net/ipv4/netfilter/nf_nat_l3proto_ipv4.c
 @@ -397,7 +397,7 @@ nf_nat_ipv4_local_fn(void *priv, struct
-
+ 
  		if (ct->tuplehash[dir].tuple.dst.u3.ip !=
  		    ct->tuplehash[!dir].tuple.src.u3.ip) {
 -			err = ip_route_me_harder(state->net, skb, RTN_UNSPEC);
@@ -141,11 +141,11 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 @@ -129,7 +129,7 @@ void nf_send_reset(struct net *net, stru
  				   ip4_dst_hoplimit(skb_dst(nskb)));
  	nf_reject_ip_tcphdr_put(nskb, oldskb, oth);
-
+ 
 -	if (ip_route_me_harder(net, nskb, RTN_UNSPEC))
 +	if (ip_route_me_harder(net, nskb->sk, nskb, RTN_UNSPEC))
  		goto free_nskb;
-
+ 
  	niph = ip_hdr(nskb);
 --- a/net/ipv4/netfilter/nft_chain_route_ipv4.c
 +++ b/net/ipv4/netfilter/nft_chain_route_ipv4.c
@@ -163,7 +163,7 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 @@ -18,10 +18,10 @@
  #include <net/ip6_checksum.h>
  #include <net/netfilter/nf_queue.h>
-
+ 
 -int ip6_route_me_harder(struct net *net, struct sk_buff *skb)
 +int ip6_route_me_harder(struct net *net, struct sock *sk_partial, struct sk_buff *skb)
  {
@@ -196,7 +196,7 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 --- a/net/ipv6/netfilter/nf_nat_l3proto_ipv6.c
 +++ b/net/ipv6/netfilter/nf_nat_l3proto_ipv6.c
 @@ -414,7 +414,7 @@ nf_nat_ipv6_local_fn(void *priv, struct
-
+ 
  		if (!nf_inet_addr_cmp(&ct->tuplehash[dir].tuple.dst.u3,
  				      &ct->tuplehash[!dir].tuple.src.u3)) {
 -			err = ip6_route_me_harder(state->net, skb);
@@ -219,7 +219,7 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 +++ b/net/netfilter/ipvs/ip_vs_core.c
 @@ -713,12 +713,12 @@ static int ip_vs_route_me_harder(struct
  		struct dst_entry *dst = skb_dst(skb);
-
+ 
  		if (dst->dev && !(dst->dev->flags & IFF_LOOPBACK) &&
 -		    ip6_route_me_harder(ipvs->net, skb) != 0)
 +		    ip6_route_me_harder(ipvs->net, skb->sk, skb) != 0)
@@ -230,5 +230,5 @@ Signed-off-by: Aaron Goodman <aaronjg@stanford.edu>
 -		    ip_route_me_harder(ipvs->net, skb, RTN_LOCAL) != 0)
 +		    ip_route_me_harder(ipvs->net, skb->sk, skb, RTN_LOCAL) != 0)
  			return 1;
-
+ 
  	return 0;

--- a/target/linux/generic/backport-4.14/403-v4.15-0001-mtd-spi-nor-add-a-quad_enable-callback-in-struct-fla.patch
+++ b/target/linux/generic/backport-4.14/403-v4.15-0001-mtd-spi-nor-add-a-quad_enable-callback-in-struct-fla.patch
@@ -1,0 +1,47 @@
+From e27072851bf7d706c592fc528549b52023b17a09 Mon Sep 17 00:00:00 2001
+From: Andy Yan <andy.yan@rock-chips.com>
+Date: Mon, 28 Aug 2017 09:58:29 +0800
+Subject: [PATCH 1/2] mtd: spi-nor: add a quad_enable callback in struct
+ flash_info
+
+Some manufacturers may use different bit to set QE on different
+memories.
+
+The GD25Q256 from GigaDevice is an example, which uses S6(bit 6
+of the Status Register-1) to set QE, which is different with
+other supported memories from GigaDevice that use S9(bit 1 of
+the Status Register-2). This makes it is impossible to select
+the quad enable method by distinguishing the MFR. This patch
+introduce a quad_enable function which can be set per memory
+in the flash_info list table.
+
+Signed-off-by: Andy Yan <andy.yan@rock-chips.com>
+Signed-off-by: Cyrille Pitchen <cyrille.pitchen@wedev4u.fr>
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -89,6 +89,8 @@ struct flash_info {
+ #define NO_CHIP_ERASE		BIT(12) /* Chip does not support chip erase */
+ #define SPI_NOR_SKIP_SFDP	BIT(13)	/* Skip parsing of SFDP tables */
+ #define USE_CLSR		BIT(14)	/* use CLSR command */
++
++	int	(*quad_enable)(struct spi_nor *nor);
+ };
+ 
+ #define JEDEC_MFR(info)	((info)->id[0])
+@@ -2433,6 +2435,15 @@ static int spi_nor_init_params(struct sp
+ 			params->quad_enable = spansion_quad_enable;
+ 			break;
+ 		}
++
++		/*
++		 * Some manufacturer like GigaDevice may use different
++		 * bit to set QE on different memories, so the MFR can't
++		 * indicate the quad_enable method for this case, we need
++		 * set it in flash info list.
++		 */
++		if (info->quad_enable)
++			params->quad_enable = info->quad_enable;
+ 	}
+ 
+ 	/* Override the parameters with data read from SFDP tables. */

--- a/target/linux/generic/backport-4.14/403-v4.15-0002-mtd-spi-nor-add-support-for-GD25Q256.patch
+++ b/target/linux/generic/backport-4.14/403-v4.15-0002-mtd-spi-nor-add-support-for-GD25Q256.patch
@@ -1,0 +1,35 @@
+From 65153846b18c486ce3c90477c467d53915114e3f Mon Sep 17 00:00:00 2001
+From: Andy Yan <andy.yan@rock-chips.com>
+Date: Mon, 28 Aug 2017 10:00:46 +0800
+Subject: [PATCH 2/2] mtd: spi-nor: add support for GD25Q256
+
+Add support for GD25Q256, a 32MiB SPI Nor flash
+from GigaDevice.
+
+Signed-off-by: Andy Yan <andy.yan@rock-chips.com>
+Signed-off-by: Cyrille Pitchen <cyrille.pitchen@wedev4u.fr>
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -872,6 +872,8 @@ static int spi_nor_is_locked(struct mtd_
+ 	return ret;
+ }
+ 
++static int macronix_quad_enable(struct spi_nor *nor);
++
+ /* Used when the "_ext_id" is two bytes at most */
+ #define INFO(_jedec_id, _ext_id, _sector_size, _n_sectors, _flags)	\
+ 		.id = {							\
+@@ -999,6 +1001,12 @@ static const struct flash_info spi_nor_i
+ 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
+ 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 	},
++	{
++		"gd25q256", INFO(0xc84019, 0, 64 * 1024, 512,
++			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
++			SPI_NOR_4B_OPCODES | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
++			.quad_enable = macronix_quad_enable,
++	},
+ 
+ 	/* Intel/Numonyx -- xxxs33b */
+ 	{ "160s33b",  INFO(0x898911, 0, 64 * 1024,  32, 0) },

--- a/target/linux/generic/pending-4.14/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
+++ b/target/linux/generic/pending-4.14/450-mtd-spi-nor-allow-NOR-driver-to-write-fewer-bytes-th.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1377,7 +1377,7 @@ static int spi_nor_write(struct mtd_info
+@@ -1387,7 +1387,7 @@ static int spi_nor_write(struct mtd_info
  
  		write_enable(nor);
  		ret = nor->write(nor, addr, page_remain, buf + i);
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  			goto write_err;
  		written = ret;
  
-@@ -1386,13 +1386,6 @@ static int spi_nor_write(struct mtd_info
+@@ -1396,13 +1396,6 @@ static int spi_nor_write(struct mtd_info
  			goto write_err;
  		*retlen += written;
  		i += written;

--- a/target/linux/generic/pending-4.14/465-m25p80-mx-disable-software-protection.patch
+++ b/target/linux/generic/pending-4.14/465-m25p80-mx-disable-software-protection.patch
@@ -8,7 +8,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2714,6 +2714,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2733,6 +2733,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  
  	if (JEDEC_MFR(info) == SNOR_MFR_ATMEL ||
  	    JEDEC_MFR(info) == SNOR_MFR_INTEL ||

--- a/target/linux/generic/pending-4.14/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
+++ b/target/linux/generic/pending-4.14/466-Revert-mtd-spi-nor-fix-Spansion-regressions-aliased-.patch
@@ -17,7 +17,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2716,6 +2716,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2735,6 +2735,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	    JEDEC_MFR(info) == SNOR_MFR_INTEL ||
  	    JEDEC_MFR(info) == SNOR_MFR_MACRONIX ||
  	    JEDEC_MFR(info) == SNOR_MFR_SST ||
@@ -25,7 +25,7 @@ Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
  	    info->flags & SPI_NOR_HAS_LOCK) {
  		write_enable(nor);
  		write_sr(nor, 0);
-@@ -2734,7 +2735,8 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2753,7 +2754,8 @@ int spi_nor_scan(struct spi_nor *nor, co
  
  	/* NOR protection support for STmicro/Micron chips and similar */
  	if (JEDEC_MFR(info) == SNOR_MFR_MICRON ||

--- a/target/linux/generic/pending-4.14/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
+++ b/target/linux/generic/pending-4.14/470-mtd-spi-nor-support-limiting-4K-sectors-support-base.patch
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	depends on ARCH_AT91 || (ARM && COMPILE_TEST && !ARCH_EBSA110)
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2561,10 +2561,12 @@ static int spi_nor_select_erase(struct s
+@@ -2580,10 +2580,12 @@ static int spi_nor_select_erase(struct s
  
  #ifdef CONFIG_MTD_SPI_NOR_USE_4K_SECTORS
  	/* prefer "small sector" erase if possible */

--- a/target/linux/generic/pending-4.14/475-mtd-spi-nor-Add-Winbond-w25q128jv-support.patch
+++ b/target/linux/generic/pending-4.14/475-mtd-spi-nor-Add-Winbond-w25q128jv-support.patch
@@ -20,7 +20,7 @@ Changes in v2:
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1165,6 +1165,11 @@ static const struct flash_info spi_nor_i
+@@ -1175,6 +1175,11 @@ static const struct flash_info spi_nor_i
  			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
  			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
  	},

--- a/target/linux/generic/pending-4.14/476-mtd-spi-nor-add-eon-en25q128.patch
+++ b/target/linux/generic/pending-4.14/476-mtd-spi-nor-add-eon-en25q128.patch
@@ -8,7 +8,7 @@ Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -954,6 +954,7 @@ static const struct flash_info spi_nor_i
+@@ -958,6 +958,7 @@ static const struct flash_info spi_nor_i
  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },

--- a/target/linux/generic/pending-4.14/477-mtd-add-spi-nor-add-mx25u3235f.patch
+++ b/target/linux/generic/pending-4.14/477-mtd-add-spi-nor-add-mx25u3235f.patch
@@ -8,7 +8,7 @@ Signed-off-by: André Valentin <avalentin@marcant.net>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1022,6 +1022,7 @@ static const struct flash_info spi_nor_i
+@@ -1032,6 +1032,7 @@ static const struct flash_info spi_nor_i
  	{ "mx25l3205d",  INFO(0xc22016, 0, 64 * 1024,  64, SECT_4K) },
  	{ "mx25l3255e",  INFO(0xc29e16, 0, 64 * 1024,  64, SECT_4K) },
  	{ "mx25l6405d",  INFO(0xc22017, 0, 64 * 1024, 128, SECT_4K) },

--- a/target/linux/generic/pending-4.14/478-mtd-spi-nor-Add-support-for-XM25QH64A-and-XM25QH128A.patch
+++ b/target/linux/generic/pending-4.14/478-mtd-spi-nor-Add-support-for-XM25QH64A-and-XM25QH128A.patch
@@ -17,7 +17,7 @@ Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1192,6 +1192,10 @@ static const struct flash_info spi_nor_i
+@@ -1202,6 +1202,10 @@ static const struct flash_info spi_nor_i
  	{ "3S400AN", S3AN_INFO(0x1f2400, 256, 264) },
  	{ "3S700AN", S3AN_INFO(0x1f2500, 512, 264) },
  	{ "3S1400AN", S3AN_INFO(0x1f2600, 512, 528) },

--- a/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh32.patch
+++ b/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh32.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -955,6 +955,7 @@ static const struct flash_info spi_nor_i
+@@ -959,6 +959,7 @@ static const struct flash_info spi_nor_i
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
  	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },

--- a/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
+++ b/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -956,6 +956,7 @@ static const struct flash_info spi_nor_i
+@@ -960,6 +960,7 @@ static const struct flash_info spi_nor_i
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
  	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
  	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },

--- a/target/linux/generic/pending-4.14/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
+++ b/target/linux/generic/pending-4.14/481-mtd-spi-nor-add-support-for-Gigadevice-GD25D05.patch
@@ -10,7 +10,7 @@ Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -976,6 +976,11 @@ static const struct flash_info spi_nor_i
+@@ -980,6 +980,11 @@ static const struct flash_info spi_nor_i
  
  	/* GigaDevice */
  	{

--- a/target/linux/generic/pending-4.14/499-mtd-parser-cmdline-Fix-parsing-of-part-names-with-co.patch
+++ b/target/linux/generic/pending-4.14/499-mtd-parser-cmdline-Fix-parsing-of-part-names-with-co.patch
@@ -23,11 +23,9 @@ Forwarded: https://patchwork.ozlabs.org/project/linux-mtd/patch/20201122001533.9
 Fixes: eb13fa022741 ("mtd: parser: cmdline: Support MTD names containing one or more colons")
 Signed-off-by: Sven Eckelmann <sven@narfation.org>
 
-diff --git a/drivers/mtd/cmdlinepart.c b/drivers/mtd/cmdlinepart.c
-index 0625b25620ca766318ea4646a6e3761ff4d3a4cc..22881ea4c132ea5a5ba7aebd025d91bf1cd023af 100644
 --- a/drivers/mtd/cmdlinepart.c
 +++ b/drivers/mtd/cmdlinepart.c
-@@ -218,7 +218,7 @@ static int mtdpart_setup_real(char *s)
+@@ -228,7 +228,7 @@ static int mtdpart_setup_real(char *s)
  		struct cmdline_mtd_partition *this_mtd;
  		struct mtd_partition *parts;
  		int mtd_id_len, num_parts;
@@ -36,7 +34,7 @@ index 0625b25620ca766318ea4646a6e3761ff4d3a4cc..22881ea4c132ea5a5ba7aebd025d91bf
  
  		/*
  		 * Replace the first ';' by a NULL char so strrchr can work
-@@ -228,6 +228,13 @@ static int mtdpart_setup_real(char *s)
+@@ -238,6 +238,13 @@ static int mtdpart_setup_real(char *s)
  		if (semicol)
  			*semicol = '\0';
  
@@ -50,7 +48,7 @@ index 0625b25620ca766318ea4646a6e3761ff4d3a4cc..22881ea4c132ea5a5ba7aebd025d91bf
  		mtd_id = s;
  
  		/*
-@@ -237,6 +244,10 @@ static int mtdpart_setup_real(char *s)
+@@ -247,6 +254,10 @@ static int mtdpart_setup_real(char *s)
  		 */
  		p = strrchr(s, ':');
  

--- a/target/linux/ipq40xx/patches-4.14/303-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
+++ b/target/linux/ipq40xx/patches-4.14/303-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1037,6 +1037,7 @@ static const struct flash_info spi_nor_i
+@@ -1047,6 +1047,7 @@ static const struct flash_info spi_nor_i
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },
  	{ "mx25l25635e", INFO(0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
@@ -8,7 +8,7 @@
  	{ "mx25u25635f", INFO(0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },
  	{ "mx25l25655e", INFO(0xc22619, 0, 64 * 1024, 512, 0) },
  	{ "mx66l51235l", INFO(0xc2201a, 0, 64 * 1024, 1024, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | SPI_NOR_4B_OPCODES) },
-@@ -1206,11 +1207,12 @@ static const struct flash_info spi_nor_i
+@@ -1216,11 +1217,12 @@ static const struct flash_info spi_nor_i
  	{ },
  };
  
@@ -23,7 +23,7 @@
  
  	tmp = nor->read_reg(nor, SPINOR_OP_RDID, id, SPI_NOR_MAX_ID_LEN);
  	if (tmp < 0) {
-@@ -1221,10 +1223,16 @@ static const struct flash_info *spi_nor_
+@@ -1231,10 +1233,16 @@ static const struct flash_info *spi_nor_
  	for (tmp = 0; tmp < ARRAY_SIZE(spi_nor_ids) - 1; tmp++) {
  		info = &spi_nor_ids[tmp];
  		if (info->id_len) {
@@ -42,7 +42,7 @@
  	dev_err(nor->dev, "unrecognized JEDEC id bytes: %02x, %02x, %02x\n",
  		id[0], id[1], id[2]);
  	return ERR_PTR(-ENODEV);
-@@ -2684,7 +2692,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2703,7 +2711,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  		info = spi_nor_match_id(name);
  	/* Try to auto-detect if chip name wasn't specified or not found */
  	if (!info)
@@ -51,7 +51,7 @@
  	if (IS_ERR_OR_NULL(info))
  		return -ENOENT;
  
-@@ -2695,7 +2703,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2714,7 +2722,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	if (name && info->id_len) {
  		const struct flash_info *jinfo;
  

--- a/target/linux/ipq806x/patches-4.14/105-mtd-nor-add-mx25l25635f.patch
+++ b/target/linux/ipq806x/patches-4.14/105-mtd-nor-add-mx25l25635f.patch
@@ -11,7 +11,7 @@ the ubi volume created by the other.
 ---
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1036,7 +1036,7 @@ static const struct flash_info spi_nor_i
+@@ -1046,7 +1046,7 @@ static const struct flash_info spi_nor_i
  	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },

--- a/target/linux/layerscape/patches-4.14/812-flexspi-support-layerscape.patch
+++ b/target/linux/layerscape/patches-4.14/812-flexspi-support-layerscape.patch
@@ -1504,7 +1504,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
 +MODULE_LICENSE("GPL v2");
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -269,6 +269,7 @@ static inline int set_4byte(struct spi_n
+@@ -271,6 +271,7 @@ static inline int set_4byte(struct spi_n
  	u8 cmd;
  
  	switch (JEDEC_MFR(info)) {
@@ -1512,7 +1512,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
  	case SNOR_MFR_MICRON:
  		/* Some Micron need WREN command; all will accept it */
  		need_wren = true;
-@@ -1044,7 +1045,7 @@ static const struct flash_info spi_nor_i
+@@ -1054,7 +1055,7 @@ static const struct flash_info spi_nor_i
  	{ "mx66l1g45g",  INFO(0xc2201b, 0, 64 * 1024, 2048, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
  	{ "mx66l1g55g",  INFO(0xc2261b, 0, 64 * 1024, 2048, SPI_NOR_QUAD_READ) },
  
@@ -1521,7 +1521,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
  	{ "n25q016a",	 INFO(0x20bb15, 0, 64 * 1024,   32, SECT_4K | SPI_NOR_QUAD_READ) },
  	{ "n25q032",	 INFO(0x20ba16, 0, 64 * 1024,   64, SPI_NOR_QUAD_READ) },
  	{ "n25q032a",	 INFO(0x20bb16, 0, 64 * 1024,   64, SPI_NOR_QUAD_READ) },
-@@ -1059,6 +1060,12 @@ static const struct flash_info spi_nor_i
+@@ -1069,6 +1070,12 @@ static const struct flash_info spi_nor_i
  	{ "n25q00",      INFO(0x20ba21, 0, 64 * 1024, 2048, SECT_4K | USE_FSR | SPI_NOR_QUAD_READ | NO_CHIP_ERASE) },
  	{ "n25q00a",     INFO(0x20bb21, 0, 64 * 1024, 2048, SECT_4K | USE_FSR | SPI_NOR_QUAD_READ | NO_CHIP_ERASE) },
  
@@ -1534,7 +1534,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
  	/* PMC */
  	{ "pm25lv512",   INFO(0,        0, 32 * 1024,    2, SECT_4K_PMC) },
  	{ "pm25lv010",   INFO(0,        0, 32 * 1024,    4, SECT_4K_PMC) },
-@@ -2436,6 +2443,7 @@ static int spi_nor_init_params(struct sp
+@@ -2446,6 +2453,7 @@ static int spi_nor_init_params(struct sp
  			params->quad_enable = macronix_quad_enable;
  			break;
  
@@ -1542,7 +1542,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
  		case SNOR_MFR_MICRON:
  			break;
  
-@@ -2754,7 +2762,8 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2773,7 +2781,8 @@ int spi_nor_scan(struct spi_nor *nor, co
  	mtd->_read = spi_nor_read;
  
  	/* NOR protection support for STmicro/Micron chips and similar */

--- a/target/linux/layerscape/patches-4.14/818-qspi-support-layerscape.patch
+++ b/target/linux/layerscape/patches-4.14/818-qspi-support-layerscape.patch
@@ -718,7 +718,7 @@ Signed-off-by: Yogesh Gaur <yogeshnarayan.gaur@nxp.com>
  
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1159,6 +1159,11 @@ static const struct flash_info spi_nor_i
+@@ -1169,6 +1169,11 @@ static const struct flash_info spi_nor_i
  	{ "w25x40", INFO(0xef3013, 0, 64 * 1024,  8,  SECT_4K) },
  	{ "w25x80", INFO(0xef3014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25x16", INFO(0xef3015, 0, 64 * 1024,  32, SECT_4K) },

--- a/target/linux/pistachio/patches-4.14/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/pistachio/patches-4.14/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -10,7 +10,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2668,6 +2668,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2687,6 +2687,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	struct device *dev = nor->dev;
  	struct mtd_info *mtd = &nor->mtd;
  	struct device_node *np = spi_nor_get_flash_node(nor);
@@ -18,7 +18,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
  	int ret;
  	int i;
  
-@@ -2743,7 +2744,12 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2762,7 +2763,12 @@ int spi_nor_scan(struct spi_nor *nor, co
  		spi_nor_wait_till_ready(nor);
  	}
  

--- a/target/linux/ramips/patches-4.14/0053-mtd-spi-nor-add-w25q256-3b-mode-switch.patch
+++ b/target/linux/ramips/patches-4.14/0053-mtd-spi-nor-add-w25q256-3b-mode-switch.patch
@@ -21,10 +21,10 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +					 * Like SPI_NOR_4B_OPCODES, but for read
 +					 * op code only.
 +					 */
- };
  
- #define JEDEC_MFR(info)	((info)->id[0])
-@@ -240,6 +244,15 @@ static inline u8 spi_nor_convert_3to4_er
+ 	int	(*quad_enable)(struct spi_nor *nor);
+ };
+@@ -242,6 +246,15 @@ static inline u8 spi_nor_convert_3to4_er
  				      ARRAY_SIZE(spi_nor_3to4_erase));
  }
  
@@ -40,7 +40,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static void spi_nor_set_4byte_opcodes(struct spi_nor *nor,
  				      const struct flash_info *info)
  {
-@@ -467,6 +480,36 @@ static int spi_nor_erase_sector(struct s
+@@ -469,6 +482,36 @@ static int spi_nor_erase_sector(struct s
  	return nor->write_reg(nor, nor->erase_opcode, buf, nor->addr_width);
  }
  
@@ -77,7 +77,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /*
   * Erase an address range on the nor chip.  The address range may extend
   * one or more erase sectors.  Return an error is there is a problem erasing.
-@@ -492,6 +535,10 @@ static int spi_nor_erase(struct mtd_info
+@@ -494,6 +537,10 @@ static int spi_nor_erase(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -88,7 +88,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	/* whole-chip erase? */
  	if (len == mtd->size && !(nor->flags & SNOR_F_NO_OP_CHIP_ERASE)) {
  		unsigned long timeout;
-@@ -542,6 +589,7 @@ static int spi_nor_erase(struct mtd_info
+@@ -544,6 +591,7 @@ static int spi_nor_erase(struct mtd_info
  	write_disable(nor);
  
  erase_err:
@@ -96,7 +96,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_ERASE);
  
  	instr->state = ret ? MTD_ERASE_FAILED : MTD_ERASE_DONE;
-@@ -834,7 +882,9 @@ static int spi_nor_lock(struct mtd_info
+@@ -836,7 +884,9 @@ static int spi_nor_lock(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -106,7 +106,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_UNLOCK);
  	return ret;
-@@ -849,7 +899,9 @@ static int spi_nor_unlock(struct mtd_inf
+@@ -851,7 +901,9 @@ static int spi_nor_unlock(struct mtd_inf
  	if (ret)
  		return ret;
  
@@ -116,7 +116,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_LOCK);
  	return ret;
-@@ -1182,7 +1234,7 @@ static const struct flash_info spi_nor_i
+@@ -1192,7 +1244,7 @@ static const struct flash_info spi_nor_i
  	{ "w25q80", INFO(0xef5014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q80bl", INFO(0xef4014, 0, 64 * 1024,  16, SECT_4K) },
  	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },
@@ -125,7 +125,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	{ "w25m512jv", INFO(0xef7119, 0, 64 * 1024, 1024,
  			SECT_4K | SPI_NOR_QUAD_READ | SPI_NOR_DUAL_READ) },
  
-@@ -1242,6 +1294,9 @@ static int spi_nor_read(struct mtd_info
+@@ -1252,6 +1304,9 @@ static int spi_nor_read(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -135,7 +135,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	while (len) {
  		loff_t addr = from;
  
-@@ -1266,6 +1321,18 @@ static int spi_nor_read(struct mtd_info
+@@ -1276,6 +1331,18 @@ static int spi_nor_read(struct mtd_info
  	ret = 0;
  
  read_err:
@@ -154,7 +154,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_READ);
  	return ret;
  }
-@@ -1367,6 +1434,10 @@ static int spi_nor_write(struct mtd_info
+@@ -1377,6 +1444,10 @@ static int spi_nor_write(struct mtd_info
  	if (ret)
  		return ret;
  
@@ -165,7 +165,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	for (i = 0; i < len; ) {
  		ssize_t written;
  		loff_t addr = to + i;
-@@ -1407,6 +1478,7 @@ static int spi_nor_write(struct mtd_info
+@@ -1417,6 +1488,7 @@ static int spi_nor_write(struct mtd_info
  	}
  
  write_err:
@@ -173,7 +173,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	spi_nor_unlock_and_unprep(nor, SPI_NOR_OPS_WRITE);
  	return ret;
  }
-@@ -2823,8 +2895,10 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2842,8 +2914,10 @@ int spi_nor_scan(struct spi_nor *nor, co
  	} else if (mtd->size > 0x1000000) {
  		/* enable 4-byte addressing if the device exceeds 16MiB */
  		nor->addr_width = 4;

--- a/target/linux/ramips/patches-4.14/0054-mtd-spi-nor-w25q256-respect-default-mode.patch
+++ b/target/linux/ramips/patches-4.14/0054-mtd-spi-nor-w25q256-respect-default-mode.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -142,20 +142,29 @@ static int read_fsr(struct spi_nor *nor)
+@@ -144,20 +144,29 @@ static int read_fsr(struct spi_nor *nor)
   * location. Return the configuration register value.
   * Returns negative if error occurred.
   */
@@ -33,7 +33,7 @@
  /*
   * Write status register 1 byte
   * Returns negative if error occurred.
-@@ -2895,9 +2904,16 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2914,9 +2923,16 @@ int spi_nor_scan(struct spi_nor *nor, co
  	} else if (mtd->size > 0x1000000) {
  		/* enable 4-byte addressing if the device exceeds 16MiB */
  		nor->addr_width = 4;

--- a/target/linux/ramips/patches-4.14/302-spi-nor-add-gd25q512.patch
+++ b/target/linux/ramips/patches-4.14/302-spi-nor-add-gd25q512.patch
@@ -1,8 +1,8 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1066,6 +1066,11 @@ static const struct flash_info spi_nor_i
- 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
- 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+@@ -1076,6 +1076,11 @@ static const struct flash_info spi_nor_i
+ 			SPI_NOR_4B_OPCODES | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+ 			.quad_enable = macronix_quad_enable,
  	},
 +	{
 +		"gd25q512", INFO(0xc84020, 0, 64 * 1024, 1024,

--- a/target/linux/ramips/patches-4.14/304-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
+++ b/target/linux/ramips/patches-4.14/304-spi-nor-enable-4B-opcodes-for-mx25l25635f.patch
@@ -10,7 +10,7 @@ For reference see:
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1103,6 +1103,7 @@ static const struct flash_info spi_nor_i
+@@ -1113,6 +1113,7 @@ static const struct flash_info spi_nor_i
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },
  	{ "mx25l25635e", INFO(0xc22019, 0, 64 * 1024, 512, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
@@ -18,7 +18,7 @@ For reference see:
  	{ "mx25u25635f", INFO(0xc22539, 0, 64 * 1024, 512, SECT_4K | SPI_NOR_4B_OPCODES) },
  	{ "mx25l25655e", INFO(0xc22619, 0, 64 * 1024, 512, 0) },
  	{ "mx66l51235l", INFO(0xc2201a, 0, 64 * 1024, 1024, SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ | SPI_NOR_4B_OPCODES) },
-@@ -1272,11 +1273,12 @@ static const struct flash_info spi_nor_i
+@@ -1282,11 +1283,12 @@ static const struct flash_info spi_nor_i
  	{ },
  };
  
@@ -33,7 +33,7 @@ For reference see:
  
  	tmp = nor->read_reg(nor, SPINOR_OP_RDID, id, SPI_NOR_MAX_ID_LEN);
  	if (tmp < 0) {
-@@ -1287,10 +1289,16 @@ static const struct flash_info *spi_nor_
+@@ -1297,10 +1299,16 @@ static const struct flash_info *spi_nor_
  	for (tmp = 0; tmp < ARRAY_SIZE(spi_nor_ids) - 1; tmp++) {
  		info = &spi_nor_ids[tmp];
  		if (info->id_len) {
@@ -52,7 +52,7 @@ For reference see:
  	dev_err(nor->dev, "unrecognized JEDEC id bytes: %02x, %02x, %02x\n",
  		id[0], id[1], id[2]);
  	return ERR_PTR(-ENODEV);
-@@ -2770,7 +2778,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2789,7 +2797,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  		info = spi_nor_match_id(name);
  	/* Try to auto-detect if chip name wasn't specified or not found */
  	if (!info)
@@ -61,7 +61,7 @@ For reference see:
  	if (IS_ERR_OR_NULL(info))
  		return -ENOENT;
  
-@@ -2781,7 +2789,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -2800,7 +2808,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	if (name && info->id_len) {
  		const struct flash_info *jinfo;
  


### PR DESCRIPTION
Backport below changes for GigaDevice GD25Q256 support from v4.15:

  e27072851bf7 mtd: spi-nor: add a quad_enable callback in struct flash_info
  65153846b18c mtd: spi-nor: add support for GD25Q256

This chip is used on newer Quad-E4G boards.

Before:

[    2.366493] m25p80 spi0.0: unrecognized JEDEC id bytes: c8, 40, 19
[    2.372853] m25p80: probe of spi0.0 failed with error -2

After:

[    2.371722] m25p80 spi0.0: gd25q256 (32768 Kbytes)
[    2.376694] 5 fixed-partitions partitions found on MTD device spi0.0
[    2.383043] Creating 5 MTD partitions on "spi0.0":
[    2.387824] 0x000000000000-0x000000030000 : "u-boot"
[    2.394138] 0x000000030000-0x000000031000 : "u-boot-env"
[    2.400608] 0x000000031000-0x000000040000 : "config"
[    2.406830] 0x000000040000-0x000000050000 : "factory"
[    2.413169] 0x000000050000-0x000002000000 : "firmware"

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>