### PR TITLE
ath79: move device specific nodes to respective dts files

### DIFF
--- a/target/linux/ath79/dts/qca9558_devolo_dvl1200e.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1200e.dts
@@ -34,10 +34,35 @@
 	};
 };
 
+&eth0 {
+	pll-data = <0xae000000 0x80000101 0x80001313>;
+	phy-mode = "rgmii-rxid";
+};
+
 &mdio1 {
 	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		at803x-override-sgmii-link-check;
+	};
 };
 
 &eth1 {
 	status = "okay";
+
+	mtd-mac-address = <&art 0x00>;
+	mtd-mac-address-increment = <1>;
+
+	phy-handle = <&phy1>;
+	pll-data = <0x03000101 0x00000101 0x00001313>;
+
+	qca955x-sgmii-fixup;
+};
+
+&gmac_config {
+	rxdv-delay = <3>;
+	rxd-delay = <3>;
+	txen-delay = <0>;
+	txd-delay = <0>;
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1200i.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1200i.dts
@@ -44,5 +44,4 @@
 	rxd-delay = <3>;
 	txen-delay = <3>;
 	txd-delay = <3>;
-	rgmii-enabled = <1>;
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1750c.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1750c.dts
@@ -35,6 +35,7 @@
 };
 
 &eth0 {
+	pll-data = <0xae000000 0x80000101 0x80001313>;
 	phy-mode = "rgmii-id";
 };
 

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1750e.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1750e.dts
@@ -69,10 +69,35 @@
 	status = "okay";
 };
 
+&eth0 {
+	pll-data = <0xae000000 0x80000101 0x80001313>;
+	phy-mode = "rgmii-rxid";
+};
+
 &mdio1 {
 	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		at803x-override-sgmii-link-check;
+	};
 };
 
 &eth1 {
 	status = "okay";
+
+	mtd-mac-address = <&art 0x00>;
+	mtd-mac-address-increment = <1>;
+
+	phy-handle = <&phy1>;
+	pll-data = <0x03000101 0x00000101 0x00001313>;
+
+	qca955x-sgmii-fixup;
+};
+
+&gmac_config {
+	rxdv-delay = <3>;
+	rxd-delay = <3>;
+	txen-delay = <0>;
+	txd-delay = <0>;
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1750i.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1750i.dts
@@ -44,5 +44,4 @@
 	rxd-delay = <3>;
 	txen-delay = <3>;
 	txd-delay = <3>;
-	rgmii-enabled = <1>;
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1750x.dts
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1750x.dts
@@ -45,5 +45,4 @@
 	rxd-delay = <3>;
 	txen-delay = <3>;
 	txd-delay = <3>;
-	rgmii-enabled = <1>;
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
@@ -107,35 +107,12 @@
 
 	mtd-mac-address = <&art 0x00>;
 	phy-handle = <&phy4>;
-	phy-mode = "rgmii-rxid";
-	pll-data = <0xae000000 0x80000101 0x80001313>;
 
 	gmac_config: gmac-config {
 		device = <&gmac>;
 
-		rxdv-delay = <3>;
-		rxd-delay = <3>;
-		txen-delay = <0>;
-		txd-delay = <0>;
 		rgmii-enabled = <1>;
 	};
-};
-
-&mdio1 {
-	phy1: ethernet-phy@1 {
-		reg = <1>;
-		at803x-override-sgmii-link-check;
-	};
-};
-
-&eth1 {
-	mtd-mac-address = <&art 0x00>;
-	mtd-mac-address-increment = <1>;
-
-	phy-handle = <&phy1>;
-	pll-data = <0x03000101 0x00000101 0x00001313>;
-
-	qca955x-sgmii-fixup;
 };
 
 &wmac {


### PR DESCRIPTION
qca9558_devolo_dvl1xxx.dtsi contains device specific nodes.
To improve simplicity, move such nodes.