### PR TITLE
ath79: add support for Senao Engenius ECB350 v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -25,6 +25,7 @@ buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
 engenius,eap300-v2|\
 engenius,ecb1750|\
+engenius,ecb350-v1|\
 engenius,enh202-v1|\
 engenius,ens202ext-v1|\
 etactica,eg200|\

--- a/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7242.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,ecb350-v1", "qca,ar7242";
+	model = "EnGenius ECB350 v1";
+
+	aliases {
+		label-mac-device = &ath9k;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x4f4b4c49>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x50000 0x50000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0xa0000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@b0000 {
+				label = "firmware2";
+				reg = <0xb0000 0xf0000>;
+			};
+
+			partition@1a0000 {
+				label = "fakeroot";
+				reg = <0x1a0000 0x10000>;
+				read-only;
+			};
+
+			firmware1: partition@1b0000 {
+				label = "firmware1";
+				reg = <0x1b0000 0x4c0000>;
+			};
+
+			partition@670000 {
+				label = "failsafe";
+				reg = <0x670000 0x180000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy4>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0 0 0 0 0>;
+		mtd-mac-address = <&art 0x0>;
+		mtd-mac-address-increment = <(-1)>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -30,6 +30,7 @@ ath79_setup_interfaces()
 	dlink,dir-505|\
 	engenius,eap300-v2|\
 	engenius,ecb1750|\
+	engenius,ecb350-v1|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
 	hak5,wifi-pineapple-nano|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -74,6 +74,7 @@ case "$FIRMWARE" in
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
 	buffalo,wzr-hp-g302h-a1a0|\
+	engenius,ecb350-v1|\
 	engenius,enh202-v1)
 		caldata_extract "art" 0x1000 0xeb8
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -887,6 +887,17 @@ define Device/engenius_ecb1750
 endef
 TARGET_DEVICES += engenius_ecb1750
 
+define Device/engenius_ecb350-v1
+  $(Device/engenius_loader_okli)
+  SOC := ar7242
+  DEVICE_MODEL := ECB350
+  DEVICE_VARIANT := v1
+  IMAGE_SIZE := 4864k
+  LOADER_FLASH_OFFS := 0x1b0000
+  ENGENIUS_IMGNAME := senao-ecb350
+endef
+TARGET_DEVICES += engenius_ecb350-v1
+
 define Device/engenius_enh202-v1
   $(Device/engenius_loader_okli)
   SOC := ar7240


### PR DESCRIPTION
FCC ID: A8J-ECB350

Engenius ECB350 v1 is an indoor wireless access point with a gigabit ethernet port,
2.4 GHz wireless, external antennas, and PoE.

**Specification:**

  - AR7242			MIPS SOC
  - AR9283			2.4 GHz (2x2), PCIe on-board
  - AR8035			RGMII, GbE with 802.3af PoE
  - 40 MHz reference clock
  - 8 MB FLASH			25L6406EM2I-12G
  - 32 MB RAM
  - UART at J2			(populated)
  - 2 external antennas
  - 3 LEDs, 1 button		(power, lan, wlan) (reset)

**MAC addresses:**

  MACs are labeled as WLAN and WAN
  vendor MAC addresses in flash are duplicate

  phy0	WLAN	*:b8	---
  eth0	WAN	*:b9	art 0x0/0x6

**Installation:**

  - if you get Failsafe Mode from failed flash:
      only use it to flash Original firmware from Engenius
      or risk kernel loop or halt which requires serial cable

  Method 1: Firmware upgrade page:

  OEM webpage at 192.168.1.1
  username and password "admin"
  Navigate to "Firmware" page from left pane
  Click Browse and select the factory.bin image
  Upload and verify checksum
  Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

  After connecting to serial console and rebooting...
  Interrupt uboot with any key pressed rapidly
  execute `run failsafe_boot` OR `bootm 0x9f670000`
  wait a minute
  connect to ethernet and navigate to
  "192.168.1.1/index.htm"
  Select the factory.bin image and upload
  wait about 3 minutes

**Return to OEM:**

  If you have a serial cable, see Serial Failsafe instructions

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will not work
  DO NOT downgrade to ar71xx this way, can cause kernel loop or halt

  The easiest way to return to the OEM software is the Failsafe image
  If you dont have a serial cable, you can ssh into openwrt and run

  `mtd -r erase fakeroot`

  Wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

**TFTP recovery** (unstable / not reliable):

  rename initramfs to 'vmlinux-art-ramdisk'
  make available on TFTP server at 192.168.1.101
  power board while holding or pressing reset button repeatedly

  NOTE: for some Engenius boards TFTP is not reliable
  try setting MTU to 600 and try many times

**Format of OEM firmware image:**

  The OEM software of ECB350 v1 is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names
  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  The OEM upgrade script is at /etc/fwupgrade.sh.

  OKLI kernel loader is required because the OEM software
  expects the kernel size to be no greater than 1536k
  and otherwise the factory.bin upgrade procedure would
  overwrite part of the kernel when writing rootfs.
  The factory upgrade script follows the original mtd partitions.

**Note on PLL-data cells:**

  The default PLL register values will not work
  because of the AR8035 switch between
  the SOC and the ethernet port.

  For AR724x series, the PLL register for GMAC0
  can be seen in the DTSI as 0x2c.
  Therefore the PLL register can be read from u-boot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x1805002c 1`

  However the registers that u-boot sets are not ideal and sometimes wrong...
  the at803x driver supports setting the RGMII clock/data delay on the PHY side.
  This way the pll-data register only needs to handle invert and phase.

  for this board no extra adjustements are needed on the MAC side
  all link speeds functional

Signed-off-by: Michael Pratt <mcpratt@pm.me>