### PR TITLE
ath79: add support for GL.iNet GL-USB150

### DIFF
--- a/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9331.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "glinet,gl-usb150", "qca,ar9331";
+	model = "GL.iNet GL-USB150";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_lan_reset {
+			gpio-export,name = "lan:reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	compatible = "syscon", "simple-mfd";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <33000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ath79_setup_interfaces()
 	engenius,ecb1750|\
 	enterasys,ws-ap3705i|\
 	glinet,gl-ar300m-lite|\
+	glinet,gl-usb150|\
 	hak5,wifi-pineapple-nano|\
 	meraki,mr16|\
 	netgear,ex6400|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1030,6 +1030,15 @@ define Device/glinet_gl-mifi
 endef
 TARGET_DEVICES += glinet_gl-mifi
 
+define Device/glinet_gl-usb150
+  SOC := ar9331
+  DEVICE_VENDOR := GL.iNET
+  DEVICE_MODEL := GL-USB150
+  IMAGE_SIZE := 16000k
+  SUPPORTED_DEVICES += gl-usb150
+endef
+TARGET_DEVICES += glinet_gl-usb150
+
 define Device/glinet_gl-x750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
Add support for the ar71xx supported GL.iNet GL-USB150 to ath79.

GL.iNet GL-USB150 is an USB dongle WiFi router, based on Atheros AR9331.

Specification:

- 400/400/200 MHz (CPU/DDR/AHB)
- 64 MB of RAM (DDR2)
- 16 MB of FLASH (SPI NOR)
- Realtek RTL8152B USB to Ethernet bridge (connected with AR9331 PHY4)
- 1T1R 2.4 GHz
- 2x LED, 1x button
- UART header on PCB

Flash instruction:

Vendor software is based on openwrt so you can flash the sysupgrade
image via the vendor GUI or using command line sysupgrade utility.
Make sure to not save configuration over reflash as uci settings
differ between versions.
