### PR TITLE
tcpdump: patch CVE-2020-8037

### DIFF
--- a/package/network/utils/tcpdump/Makefile
+++ b/package/network/utils/tcpdump/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tcpdump
 PKG_VERSION:=4.9.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \

--- a/package/network/utils/tcpdump/patches/101-CVE-2020-8037.patch
+++ b/package/network/utils/tcpdump/patches/101-CVE-2020-8037.patch
@@ -1,0 +1,47 @@
+--- a/print-ppp.c
++++ b/print-ppp.c
+@@ -1368,19 +1368,29 @@ trunc:
+ }
+ 
+ #ifndef TCPDUMP_MINI
++/*
++ * Un-escape RFC 1662 PPP in HDLC-like framing, with octet escapes.
++ * The length argument is the on-the-wire length, not the captured
++ * length; we can only un-escape the captured part.
++ */
+ static void
+ ppp_hdlc(netdissect_options *ndo,
+          const u_char *p, int length)
+ {
++	u_int caplen = ndo->ndo_snapend - p;
+ 	u_char *b, *t, c;
+ 	const u_char *s;
+-	int i, proto;
++	u_int i;
++	int proto;
+ 	const void *se;
+ 
++	if (caplen == 0)
++		return;
++
+         if (length <= 0)
+                 return;
+ 
+-	b = (u_char *)malloc(length);
++	b = (u_char *)malloc(caplen);
+ 	if (b == NULL)
+ 		return;
+ 
+@@ -1389,10 +1399,10 @@ ppp_hdlc(netdissect_options *ndo,
+ 	 * Do this so that we dont overwrite the original packet
+ 	 * contents.
+ 	 */
+-	for (s = p, t = b, i = length; i > 0 && ND_TTEST(*s); i--) {
++	for (s = p, t = b, i = caplen; i != 0; i--) {
+ 		c = *s++;
+ 		if (c == 0x7d) {
+-			if (i <= 1 || !ND_TTEST(*s))
++			if (i <= 1)
+ 				break;
+ 			i--;
+ 			c = *s++ ^ 0x20;


### PR DESCRIPTION
This PR backports upstream fix for [CVE-2020-8037](https://nvd.nist.gov/vuln/detail/CVE-2020-8037).

This fix is only relevant for tcpdump package, tcpdump-mini is not affeted by this issue.

IMHO This could be cherry-picked to 19.07




