### PR TITLE
ath79: add support for Meraki MR12

### DIFF
--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7242.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "meraki,mr12", "qca,ar7242";
+	model = "Meraki MR12";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_orange;
+	};
+
+	extosc: ref {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-output-names = "ref";
+		clock-frequency = <40000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		link1 {
+			label = "green:link1";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		link2 {
+			label = "green:link2";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		link3 {
+			label = "green:link3";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		link4 {
+			label = "green:link4";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&config 0x66>;
+		mtd-mac-address-increment = <1>;
+	};
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	mtd-mac-address = <&config 0x66>;
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+};
+
+&mdio1 {
+	status = "okay";
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&config 0x66>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x40000>;
+				read-only;
+			};
+
+			config: partition@80000 {
+				label = "config";
+				reg = <0x80000 0x20000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "firmware";
+				reg = <0xa0000 0xf40000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fe0000 {
+				label = "art";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -221,6 +221,16 @@ glinet,gl-x750)
 hak5,lan-turtle)
 	ucidef_set_led_netdev "wan" "WAN" "orange:system" "eth1"
 	;;
+meraki,mr12|\
+tplink,cpe210-v2|\
+tplink,cpe210-v3)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "green:link1" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:link2" "wlan0" "30" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "60" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "80" "100"
+	;;
 meraki,mr16)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
 	;;
@@ -304,15 +314,6 @@ tplink,wbs510-v1|\
 tplink,wbs510-v2)
 	ucidef_set_led_netdev "lan0" "LAN0" "green:lan0" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x10"
-	ucidef_set_rssimon "wlan0" "200000" "1"
-	ucidef_set_led_rssi "rssilow" "RSSILOW" "green:link1" "wlan0" "1" "100"
-	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:link2" "wlan0" "30" "100"
-	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "60" "100"
-	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "80" "100"
-	;;
-tplink,cpe210-v2|\
-tplink,cpe210-v3)
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "green:link1" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:link2" "wlan0" "30" "100"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -259,6 +259,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:wan" "6@eth1" "4:lan"
 		;;
+	meraki,mr12)
+		ucidef_set_interface_lan "eth0"
+		ucidef_add_switch "switch0" \
+			"0@eth1" "1:lan"
+		;;
 	mercury,mw4530r-v1|\
 	tplink,archer-a7-v5|\
 	tplink,archer-c6-v2|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -56,6 +56,9 @@ case "$FIRMWARE" in
 		caldata_extract "calibrate" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR1)
 		;;
+	meraki,mr12)
+		caldata_extract "art" 0x11000 0xeb8
+		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_text board_data 0x680)

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,6 +1,7 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+	meraki,mr12|\
 	meraki,mr16)
 		uci set system.@system[0].compat_version="2.0"
 		uci commit system

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1333,6 +1333,22 @@ define Device/librerouter_librerouter-v1
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
 
+define Device/meraki_mr12
+  SOC := ar7242
+  DEVICE_VENDOR := Meraki
+  DEVICE_MODEL := MR12
+  IMAGE_SIZE := 15616k
+  DEVICE_PACKAGES := kmod-owl-loader rssileds
+  SUPPORTED_DEVICES += mr12
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partitions differ from ar71xx version of MR12. Image format is incompatible. \
+	To use sysupgrade, you must change /lib/update/common.sh::get_image to prepend 128K zeroes to this image, \
+	and change the bootcmd in u-boot to "bootm 0xbf0a0000". After that, you can use "sysupgrade -F". \
+	For more details, see the OpenWrt Wiki: https://openwrt.org/toh/meraki/MR12, \
+	or the commit message of the MR12 ath79 port on git.openwrt.org.
+endef
+TARGET_DEVICES += meraki_mr12
+
 define Device/meraki_mr16
   SOC := ar7161
   DEVICE_VENDOR := Meraki


### PR DESCRIPTION
Port device support for Meraki MR12 from the ar71xx target to ath79.

Specifications:

  - SoC: AR7242-AH1A CPU
  - RAM: 64MiB (NANYA NT5DS32M16DS-5T)
  - NOR Flash: 16MiB (MXIC MX25L12845EMI-10G)
  - Ethernet: 1 x PoE Gigabit Ethernet Port (SoC MAC + AR8021-BL1E PHY)
  - Ethernet: 1 x 100Mbit port (SoC MAC+PHY)
  - Wi-Fi: Atheros AR9283-AL1A (2T2R, 11n)

Installation:

  1. Requires TFTP server at 192.168.1.101, w/ initramfs & sysupgrade .bins
  2. Open shell case
  3. Connect a USB->TTL cable to headers furthest from the RF shield
  4. Power on the router; connect to U-boot over 115200-baud connection
  5. Interrupt U-boot process to boot Openwrt by running:
       setenv bootcmd bootm 0xbf0a0000; saveenv;
       tftpboot 0c00000 <filename-of-initramfs-kernel>.bin;
       bootm 0c00000;
  6. Copy sysupgrade image to /tmp on MR12
  7. sysupgrade /tmp/<filename-of-sysupgrade>.bin

Notes:

  - kmod-owl-loader is still required to load the ART partition into the
    driver.

  - The manner of storing MAC addresses is updated from ar71xx; it is
    at 0x66 of the 'config' partition, where it was discovered that the
    OEM firmware stores it. This is set as read-only. If you are
    migrating from ar71xx and used the method mentioned above to
    upgrade, use kmod-mtd-rw or UCI to add the MAC back in. One more
    method for doing this is described below.

  - Migrating directly from ar71xx has not been thoroughly tested, but
    one method has been used a couple of times with good success,
    migrating 18.06.2 to a full image produced as of this commit. Please
    note that these instructions are only for experienced users, and/or
    those still able to open their device up to flash it via the serial
    headers should anything go wrong.

    1) Install kmod-mtd-rw and uboot-envtools
    2) Run `insmod mtd-rw.ko i_want_a_brick=1`
    3) Modify /etc/fw_env.config to point to the u-boot-env partition.
       The file /etc/fw_env.config should contain:

       # MTD device   env offset  env size    sector size
       /dev/mtd1      0x00000     0x10000     0x10000

       See https://openwrt.org/docs/techref/bootloader/uboot.config
       for more details.

    4) Run `fw_printenv` to verify everything is correct, as per the
       link above.
    5) Run `fw_setenv bootcmd bootm 0xbf0a0000` to set a new boot address.
    6) Manually modify /lib/upgrade/common.sh's get_image function:
       Change ...

       cat "$from" 2>/dev/null | $cmd

       ... into ...

       (
         dd if=/dev/zero bs=1 count=$((0x66)) ; # Pad the first 102 bytes
         echo -ne '\x00\x18\x0a\x12\x34\x56'  ; # Add in MAC address
         dd if=/dev/zero bs=1 count=$((0x20000-0x66-0x6)) ; # Pad the rest
         cat "$from" 2>/dev/null
       ) | $cmd

       ... which, during the upgrade process, will pad the image by
       128K of zeroes-plus-MAC-address, in order for the ar71xx's
       firmware partition -- which starts at 0xbf080000 -- to be
       instead aligned with the ath79 firmware partition, which
       starts 128K later at 0xbf0a0000.

    7) Copy the sysupgrade image into /tmp, as above
    8) Run `sysupgrade -F /tmp/<sysupgrade>.bin`, then wait

    Again, this may BRICK YOUR DEVICE, so make *sure* to have your
    serial cable handy.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>