### PR TITLE
ath79: enable LNA (Low Noise Amplifier) for TPLink CPE210/220/510/520

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
@@ -114,3 +114,19 @@
 &eth1 {
 	status = "okay";
 };
+
+&gpio {
+	gpio_ext_lna0 {
+		gpio-hog;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:ext:lna0";
+	};
+
+	gpio_ext_lna1 {
+		gpio-hog;
+		gpios = <19 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:ext:lna1";
+	};
+};

--- a/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe_2port.dtsi
@@ -44,22 +44,6 @@
 	};
 };
 
-&gpio {
-	gpio_ext_lna0 {
-		gpio-hog;
-		gpios = <18 0>;
-		output-high;
-		line-name = "tp-link:ext:lna0";
-	};
-
-	gpio_ext_lna1 {
-		gpio-hog;
-		gpios = <19 0>;
-		output-high;
-		line-name = "tp-link:ext:lna1";
-	};
-};
-
 &eth1 {
 	mtd-mac-address = <&info 0x8>;
 


### PR DESCRIPTION
The hardware has a build-in LNA. This patch activates those in the receiving
chain and improves the rx sensitivity by about 20dB.

Tested on CPE210v1, CPE510 v1, v2 & v3.

Signed-off-by: Thomas Huehn <thomas.huehn@hs-nordhausen.de>