### PR TITLE
base-files: fix alias more to properly detect /usr/bin/more

### DIFF
--- a/package/base-files/files/etc/shinit
+++ b/package/base-files/files/etc/shinit
@@ -1,4 +1,4 @@
-[ -x /bin/more ] || alias more=less
+[ -x /bin/more ] || [ -x /usr/bin/more ] || alias more=less
 [ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
 
 alias ll='ls -alF --color=auto'


### PR DESCRIPTION
Package more is installed to `/usr/bin` rather than `/bin`.

https://github.com/openwrt/openwrt/blob/9762cf107bdbd709717b8adbba6f987c9935c74f/package/utils/util-linux/Makefile#L690