### PR TITLE
umdns: add check for seccomp list

### DIFF
--- a/package/network/services/umdns/Makefile
+++ b/package/network/services/umdns/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=umdns
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/mdnsd.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/umdns/files/umdns.init
+++ b/package/network/services/umdns/files/umdns.init
@@ -33,7 +33,7 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	procd_set_param seccomp /etc/seccomp/umdns.json
+	[ -f /etc/seccomp/umdns.json ] && procd_set_param seccomp /etc/seccomp/umdns.json
 	procd_set_param respawn
 	procd_open_trigger
 	procd_add_config_trigger "config.change" "umdns" /etc/init.d/umdns reload


### PR DESCRIPTION
This PR adds check for file /etc/seccomp/umdns.json in init script

This should fix  an issue when user have a router with enabled seccomp and 
tries to run umdns package which was build with SDK with disabled seccomp support.

This is similar to https://github.com/openwrt/packages/pull/12321

I think that it would be useful to cherry pick this fix to **OpenWrt 19.07**

Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>

