### PR TITLE
ramips: add support for ZBT WG1327

### DIFF
--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327-16m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327-16m.dts
@@ -1,0 +1,10 @@
+#include "mt7621_zbtlink_zbt-wg1327.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1327-16m", "zbtlink,zbt-wg1327", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1327 (16M)";
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327-32m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327-32m.dts
@@ -1,0 +1,10 @@
+#include "mt7621_zbtlink_zbt-wg1327.dtsi"
+
+/ {
+	compatible = "zbtlink,zbt-wg1327-32m", "zbtlink,zbt-wg1327", "mediatek,mt7621-soc";
+	model = "Zbtlink ZBT-WG1327 (32M)";
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327.dtsi
@@ -128,12 +128,6 @@
 			mtd-mac-address = <&factory 0xe006>;
 		};
 
-		port@3 {
-			status = "okay";
-			label = "lan4";
-			mtd-mac-address = <&factory 0xe006>;
-		};
-
 		port@4 {
 			status = "okay";
 			label = "wan";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1327.dtsi
@@ -1,0 +1,150 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zbtlink,zbt-wg1327", "mediatek,mt7621-soc";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&i2c {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-active-low;
+			led-sources = <2>;
+		};
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		
+		led {
+			led-active-low;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe000>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "rgmii2";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1350,6 +1350,32 @@ define Device/zbtlink_zbt-wg3526-32m
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-32m
 
+define Device/zbtlink_zbt-wg1327-16m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1327
+  DEVICE_VARIANT := 16M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 \
+	kmod-usb3 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += zbt-wg1327 zbt-wg1327-16M
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1327-16m
+
+define Device/zbtlink_zbt-wg1327-32m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-WG1327
+  DEVICE_VARIANT := 32M
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt7603 kmod-mt76x2 \
+	kmod-usb3 kmod-usb-ledtrig-usbport
+  SUPPORTED_DEVICES += zbt-wg1327-32M
+endef
+TARGET_DEVICES += zbtlink_zbt-wg1327-32m
+
 define Device/zio_freezio
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k


### PR DESCRIPTION
Specifications:
* SoC: MT7621A
* CPU: 800 MHz
* RAM: 512 MB DDR3
* Flash: 16/32MB NOR SPI flash
* WiFi: MT7612E (5GHz) and builtin MT7603E (2.4GHz)
* WAN: 1x1000M
* LAN: 3x1000M

The device is based on ZBT WG259

Installation:
The -factory images can be flashed from the
device's web interface or via mtd -r write <image.bin> firmware

Signed-off-by: Mikael Brostrom <mikael.brostrom+github@sweroam.se>