### PR TITLE
ipq40xx: fix 5Ghz transmit/receive power on the map-ac2200 

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-map-ac2200.dts
@@ -176,6 +176,22 @@
 			bias-pull-down;
 		};
 	};
+	enable_ext_pa_high {
+		gpio-hog;
+		gpios = <44 GPIO_ACTIVE_HIGH>,
+			<46 GPIO_ACTIVE_HIGH>;
+		output-high;
+		bias-pull-down;
+		line-name = "enable external PA output-high";
+	};
+	enable_ext_pa_low {
+		gpio-hog;
+		gpios = <45 GPIO_ACTIVE_HIGH>,
+			<47 GPIO_ACTIVE_HIGH>;
+		output-low;
+		bias-pull-down;
+		line-name = "enable external PA output-low";
+	};
 };
 
 &cryptobam {


### PR DESCRIPTION
The ASUS MAP-AC2200 has currently a low transmit/receive signal
power, this fixes it.

GPIO 44 and 46 have to be set to output high
GPIO 45 and 47 have to be set to output low

In the stock firmware those are set by
the "release/src/router/rc/init.c" routine.

Found in GPL_MAP-AC2200_3.0.0.4.384.46249-g97d05bb.tar.


the relevant place in init.c:

```
		/* set DPDT */
		gpio_dir(44, GPIO_DIR_OUT);
		set_gpio(44, 1);
		gpio_dir(45, GPIO_DIR_OUT);
		set_gpio(45, 0);
		gpio_dir(46, GPIO_DIR_OUT);
		set_gpio(46, 1);
		gpio_dir(47, GPIO_DIR_OUT);
		set_gpio(47, 0);
```
Here are some results, after activating the relevant gpios through cmdline:

https://forum.openwrt.org/t/asus-map-ac2200-low-transmit-receive-signal-5ghz/69005/12

THX @ slh

Signed-off-by: Yushi Nishida kyro2man@gmx.net
