### PR TITLE
lantiq: fix build of squashfs images

### DIFF
--- a/target/linux/lantiq/ase/target.mk
+++ b/target/linux/lantiq/ase/target.mk
@@ -7,7 +7,7 @@
 ARCH:=mips
 SUBTARGET:=ase
 BOARDNAME:=Amazon-SE
-FEATURES:=atm mips16 small_flash
+FEATURES+=atm mips16 small_flash
 CPU_TYPE:=mips32
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug \

--- a/target/linux/lantiq/falcon/target.mk
+++ b/target/linux/lantiq/falcon/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=falcon
 BOARDNAME:=Falcon
-FEATURES:=nand
+FEATURES+=nand
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+= kmod-leds-gpio \

--- a/target/linux/lantiq/xrx200/target.mk
+++ b/target/linux/lantiq/xrx200/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xrx200
 BOARDNAME:=XRX200
-FEATURES:=atm nand ramdisk
+FEATURES+=atm nand ramdisk
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio \

--- a/target/linux/lantiq/xway/target.mk
+++ b/target/linux/lantiq/xway/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xway
 BOARDNAME:=XWAY
-FEATURES:=atm nand ramdisk
+FEATURES+=atm nand ramdisk
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug swconfig

--- a/target/linux/lantiq/xway_legacy/target.mk
+++ b/target/linux/lantiq/xway_legacy/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xway_legacy
 BOARDNAME:=XWAY Legacy
-FEATURES:=atm ramdisk small_flash
+FEATURES+=atm ramdisk small_flash
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug swconfig


### PR DESCRIPTION
This patch fixes build of squashfs image on lantiq. Currently the FEATURE
variable is overwritten by the subtarget.

Fixes: FS#3480, f1c652337628eace40da3ded804d8c1b8ec4d63c

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>