### PR TITLE
base-files: flush kernel memory cache during sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -297,6 +297,7 @@ indicate_upgrade() {
 # $(2): (optional) pipe command to extract firmware, e.g. dd bs=n skip=m
 default_do_upgrade() {
 	sync
+	echo 3 > /proc/sys/vm/drop_caches
 	if [ -n "$UPGRADE_BACKUP" ]; then
 		get_image "$1" "$2" | mtd $MTD_ARGS $MTD_CONFIG_ARGS -j "$UPGRADE_BACKUP" write - "${PART_NAME:-image}"
 	else

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -123,6 +123,7 @@ kill_remaining KILL 1
 
 sleep 1
 
+echo 3 > /proc/sys/vm/drop_caches
 
 if [ -n "$IMAGE" ] && type 'platform_pre_upgrade' >/dev/null 2>/dev/null; then
 	platform_pre_upgrade "$IMAGE"


### PR DESCRIPTION
Flush kernel memory caches during sysupgrade in order to mitigate the impact from memory consumption spikes in low-RAM devices.

This may help to prevent sysupgrade causing a reboot before the actual flashing starts.

---

I have noticed this to help with 64 MB RAM WNDR3700v2, where (OpenWrt master) sysupgrade typically has lately failed when the router has been running some time, but succeeded when sysupgrade is done right after a reboot.

The cache flushing is non-destructive and as the router is going to sysupgrade, there aren't any "long-term" performance issues.

Reference to mailing list discussion in 
http://lists.openwrt.org/pipermail/openwrt-devel/2020-November/032266.html

Kernel documentation:
https://www.kernel.org/doc/Documentation/sysctl/vm.txt

----
I originally submitted this via mailing list, but thought to submit it also as a PR.
http://lists.openwrt.org/pipermail/openwrt-devel/2020-November/032273.html
https://patchwork.ozlabs.org/project/openwrt/list/?series=216321
