### PR TITLE
WIP libpcap: install/adjust pcap-config in PATH

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -79,6 +79,15 @@ define Build/InstallDev
 	$(LN) ../../usr/bin/pcap-config $(2)/bin/pcap-config
 endef
 
+define Build/InstallDev
+	$(call Build/InstallDev/cmake,$(1))
+	$(SED) \
+		's,^\(prefix\)=.*,\1=$(STAGING_DIR)/usr,g' \
+		$(1)/usr/bin/pcap-config $(1)/usr/lib/pkgconfig/libpcap.pc
+	$(INSTALL_DIR) $(2)/bin
+	$(LN) ../../usr/bin/pcap-config $(2)/bin/
+endef
+
 define Package/libpcap/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcap.so.* $(1)/usr/lib/


### PR DESCRIPTION
pcap-config is currently installed in $(STAGING_DIR)/usr/bin which is not in
PATH.
As a result, it isn't detected correctly by e.g. tcpdump:
checking for pcap-config... /usr/bin/pcap-config

This isn't likely to be causing any problems as long as the host has libpcap
installed. But further, pcap-config yields -L/usr/lib and -I/usr/include
(based on CMAKE_INSTALL_PREFIX) which, in turn, causes cross builds
to fail with (from tcpdump's config.log):
/usr/lib/libpcap.so: file not recognized: file format not recognized

This patch installs a copy of pcap-config in host/bin with the prefix set to
$STAGING_DIR/usr.

I'm not sure there isn't a better solution to this.
But it works for me :grinning: :grimacing: 