### PR TITLE
mvebu: add support for Turris Omnia 2019/2020 to openwrt 19.07 branch

### DIFF
--- a/target/linux/mvebu/base-files/lib/upgrade/sdcard.sh
+++ b/target/linux/mvebu/base-files/lib/upgrade/sdcard.sh
@@ -88,15 +88,6 @@ platform_do_upgrade_sdcard() {
 		get_image "$@" | dd of="/dev/$diskdev" bs=1 skip=440 count=4 seek=440 conv=fsync
 	fi
 
-	case "$board" in
-	cznic,turris-omnia)
-		fw_setenv openwrt_bootargs 'earlyprintk console=ttyS0,115200 root=/dev/mmcblk0p2 rootfstype=auto rootwait'
-		fw_setenv openwrt_mmcload 'setenv bootargs "$openwrt_bootargs cfg80211.freg=$regdomain"; fatload mmc 0 0x01000000 zImage; fatload mmc 0 0x02000000 armada-385-turris-omnia.dtb'
-		fw_setenv factory_mmcload 'setenv bootargs "$bootargs cfg80211.freg=$regdomain"; btrload mmc 0 0x01000000 boot/zImage @; btrload mmc 0 0x02000000 boot/dtb @'
-		fw_setenv mmcboot 'run openwrt_mmcload || run factory_mmcload; bootz 0x01000000 - 0x02000000'
-		;;
-	esac
-
 	sleep 1
 }
 

--- a/target/linux/mvebu/image/cortex-a9.mk
+++ b/target/linux/mvebu/image/cortex-a9.mk
@@ -175,11 +175,12 @@ define Device/cznic_turris-omnia
     wpad-basic kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct \
     partx-utils kmod-i2c-core kmod-i2c-mux kmod-i2c-mux-pca954x
   IMAGES := $$(IMAGE_PREFIX)-sysupgrade.img.gz omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz
-  IMAGE/$$(IMAGE_PREFIX)-sysupgrade.img.gz := boot-img | sdcard-img | gzip | append-metadata
+  IMAGE/$$(IMAGE_PREFIX)-sysupgrade.img.gz := boot-scr | boot-img | sdcard-img | gzip | append-metadata
   IMAGE/omnia-medkit-$$(IMAGE_PREFIX)-initramfs.tar.gz := omnia-medkit-initramfs | gzip
   IMAGE_NAME = $$(2)
   DEVICE_DTS := armada-385-turris-omnia
   SUPPORTED_DEVICES += armada-385-turris-omnia
+  BOOT_SCRIPT := turris-omnia
 endef
 TARGET_DEVICES += cznic_turris-omnia
 

--- a/target/linux/mvebu/image/turris-omnia.bootscript
+++ b/target/linux/mvebu/image/turris-omnia.bootscript
@@ -1,0 +1,17 @@
+# Determine root device
+setexpr rootpart ${distro_bootpart} + 1
+if test ${devtype} = mmc -a ${devnum} = 0; then
+	setenv rootdev /dev/mmcblk0p${rootpart}
+elif test ${devtype} = scsi -a ${devnum} = 0; then
+	setenv rootdev /dev/sda${rootpart}
+else
+	# New U-Boot only
+	part uuid ${devtype} ${devnum}:${rootpart} uuid
+	setenv rootdev PARTUUID=${uuid}
+fi
+setenv bootargs earlyprintk console=ttyS0,115200 root=${rootdev} rootfstype=auto rootwait
+
+# Load and boot
+load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} @DTB@.dtb
+load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} zImage
+bootz ${kernel_addr_r} - ${fdt_addr_r}


### PR DESCRIPTION
Cherry picked from PR: https://github.com/openwrt/openwrt/pull/2693
Tested on my Turris Omnia 2020:
- Gunzip openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade.img.gz, to the root of a USB flash drive
- Enter a rescue shell via 7-LED reset and the serial console.
- Insert the USB drive and mount it:
  mkdir /mnt; mount /dev/sda1 /mnt
- Flash the OpenWrt image to eMMC:
  dd if=/mnt/openwrt-mvebu-cortexa9-cznic_turris-omnia-sysupgrade.img of=/dev/mmcblk0 bs=4096 conv=fsync
- Reboot.