### PR TITLE
kernel: bump 5.4 to 5.4.81

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .80
+LINUX_VERSION-5.4 = .81
 
-LINUX_KERNEL_HASH-5.4.80 = 49da425c1f3c530fd3ff31d85a0461f6b6dc6e459f7faf3eee23e49a98ce64c7
+LINUX_KERNEL_HASH-5.4.81 = 9470bde475726996202d845a5fc3bc8bd3bb546bbc6816fb663fa73df25d8427
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/backport-5.4/746-v5.5-net-dsa-mv88e6xxx-Split-monitor-port-configuration.patch
+++ b/target/linux/generic/backport-5.4/746-v5.5-net-dsa-mv88e6xxx-Split-monitor-port-configuration.patch
@@ -19,7 +19,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2378,7 +2378,14 @@ static int mv88e6xxx_setup_upstream_port
+@@ -2380,7 +2380,14 @@ static int mv88e6xxx_setup_upstream_port
  
  		if (chip->info->ops->set_egress_port) {
  			err = chip->info->ops->set_egress_port(chip,
@@ -62,7 +62,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  #define MV88E6XXX_CASCADE_PORT_MULTIPLE		0xf
 --- a/drivers/net/dsa/mv88e6xxx/global1.c
 +++ b/drivers/net/dsa/mv88e6xxx/global1.c
-@@ -263,7 +263,9 @@ int mv88e6250_g1_ieee_pri_map(struct mv8
+@@ -294,7 +294,9 @@ int mv88e6250_g1_ieee_pri_map(struct mv8
  /* Offset 0x1a: Monitor Control */
  /* Offset 0x1a: Monitor & MGMT Control on some devices */
  
@@ -73,7 +73,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  {
  	u16 reg;
  	int err;
-@@ -272,11 +274,20 @@ int mv88e6095_g1_set_egress_port(struct
+@@ -303,11 +305,20 @@ int mv88e6095_g1_set_egress_port(struct
  	if (err)
  		return err;
  
@@ -99,7 +99,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	return mv88e6xxx_g1_write(chip, MV88E6185_G1_MONITOR_CTL, reg);
  }
-@@ -310,17 +321,24 @@ static int mv88e6390_g1_monitor_write(st
+@@ -341,17 +352,24 @@ static int mv88e6390_g1_monitor_write(st
  	return mv88e6xxx_g1_write(chip, MV88E6390_G1_MONITOR_MGMT_CTL, reg);
  }
  
@@ -132,7 +132,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		return err;
 --- a/drivers/net/dsa/mv88e6xxx/global1.h
 +++ b/drivers/net/dsa/mv88e6xxx/global1.h
-@@ -288,8 +288,12 @@ int mv88e6095_g1_stats_set_histogram(str
+@@ -289,8 +289,12 @@ int mv88e6095_g1_stats_set_histogram(str
  int mv88e6390_g1_stats_set_histogram(struct mv88e6xxx_chip *chip);
  void mv88e6xxx_g1_stats_read(struct mv88e6xxx_chip *chip, int stat, u32 *val);
  int mv88e6xxx_g1_stats_clear(struct mv88e6xxx_chip *chip);

--- a/target/linux/generic/backport-5.4/747-v5.5-net-dsa-mv88e6xxx-Add-support-for-port-mirroring.patch
+++ b/target/linux/generic/backport-5.4/747-v5.5-net-dsa-mv88e6xxx-Add-support-for-port-mirroring.patch
@@ -25,7 +25,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -4920,6 +4920,80 @@ static int mv88e6xxx_port_mdb_del(struct
+@@ -4922,6 +4922,80 @@ static int mv88e6xxx_port_mdb_del(struct
  	return err;
  }
  
@@ -106,7 +106,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static int mv88e6xxx_port_egress_floods(struct dsa_switch *ds, int port,
  					 bool unicast, bool multicast)
  {
-@@ -4974,6 +5048,8 @@ static const struct dsa_switch_ops mv88e
+@@ -4976,6 +5050,8 @@ static const struct dsa_switch_ops mv88e
  	.port_mdb_prepare       = mv88e6xxx_port_mdb_prepare,
  	.port_mdb_add           = mv88e6xxx_port_mdb_add,
  	.port_mdb_del           = mv88e6xxx_port_mdb_del,
@@ -139,7 +139,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
 --- a/drivers/net/dsa/mv88e6xxx/global1.c
 +++ b/drivers/net/dsa/mv88e6xxx/global1.c
-@@ -267,6 +267,7 @@ int mv88e6095_g1_set_egress_port(struct
+@@ -298,6 +298,7 @@ int mv88e6095_g1_set_egress_port(struct
  				 enum mv88e6xxx_egress_direction direction,
  				 int port)
  {
@@ -147,7 +147,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	u16 reg;
  	int err;
  
-@@ -276,11 +277,13 @@ int mv88e6095_g1_set_egress_port(struct
+@@ -307,11 +308,13 @@ int mv88e6095_g1_set_egress_port(struct
  
  	switch (direction) {
  	case MV88E6XXX_EGRESS_DIR_INGRESS:
@@ -161,7 +161,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		reg &= MV88E6185_G1_MONITOR_CTL_EGRESS_DEST_MASK;
  		reg |= port <<
  		       __bf_shf(MV88E6185_G1_MONITOR_CTL_EGRESS_DEST_MASK);
-@@ -289,7 +292,11 @@ int mv88e6095_g1_set_egress_port(struct
+@@ -320,7 +323,11 @@ int mv88e6095_g1_set_egress_port(struct
  		return -EINVAL;
  	}
  
@@ -174,7 +174,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  
  /* Older generations also call this the ARP destination. It has been
-@@ -325,14 +332,17 @@ int mv88e6390_g1_set_egress_port(struct
+@@ -356,14 +363,17 @@ int mv88e6390_g1_set_egress_port(struct
  				 enum mv88e6xxx_egress_direction direction,
  				 int port)
  {
@@ -192,7 +192,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		ptr = MV88E6390_G1_MONITOR_MGMT_CTL_PTR_EGRESS_DEST;
  		break;
  	default:
-@@ -340,10 +350,10 @@ int mv88e6390_g1_set_egress_port(struct
+@@ -371,10 +381,10 @@ int mv88e6390_g1_set_egress_port(struct
  	}
  
  	err = mv88e6390_g1_monitor_write(chip, ptr, port);

--- a/target/linux/generic/backport-5.4/748-v5.5-net-dsa-mv88e6xxx-fix-broken-if-statement-because-of.patch
+++ b/target/linux/generic/backport-5.4/748-v5.5-net-dsa-mv88e6xxx-fix-broken-if-statement-because-of.patch
@@ -19,7 +19,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -4987,7 +4987,7 @@ static void mv88e6xxx_port_mirror_del(st
+@@ -4989,7 +4989,7 @@ static void mv88e6xxx_port_mirror_del(st
  		if (chip->info->ops->set_egress_port(chip,
  						     direction,
  						     dsa_upstream_port(ds,

--- a/target/linux/generic/backport-5.4/749-v5.5-net-dsa-mv88e6xxx-Fix-masking-of-egress-port.patch
+++ b/target/linux/generic/backport-5.4/749-v5.5-net-dsa-mv88e6xxx-Fix-masking-of-egress-port.patch
@@ -16,7 +16,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/global1.c
 +++ b/drivers/net/dsa/mv88e6xxx/global1.c
-@@ -278,13 +278,13 @@ int mv88e6095_g1_set_egress_port(struct
+@@ -309,13 +309,13 @@ int mv88e6095_g1_set_egress_port(struct
  	switch (direction) {
  	case MV88E6XXX_EGRESS_DIR_INGRESS:
  		dest_port_chip = &chip->ingress_dest_port;

--- a/target/linux/generic/pending-5.4/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
+++ b/target/linux/generic/pending-5.4/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
@@ -17,7 +17,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2657,6 +2657,7 @@ static int mv88e6xxx_setup(struct dsa_sw
+@@ -2659,6 +2659,7 @@ static int mv88e6xxx_setup(struct dsa_sw
  
  	chip->ds = ds;
  	ds->slave_mii_bus = mv88e6xxx_default_mdio_bus(chip);

--- a/target/linux/layerscape/patches-5.4/301-arch-0002-arm64-add-support-to-remap-kernel-cacheable-memory-t.patch
+++ b/target/linux/layerscape/patches-5.4/301-arch-0002-arm64-add-support-to-remap-kernel-cacheable-memory-t.patch
@@ -13,7 +13,7 @@ Reviewed-by: Stuart Yoder <stuart.yoder@freescale.com>
 
 --- a/arch/arm64/include/asm/pgtable.h
 +++ b/arch/arm64/include/asm/pgtable.h
-@@ -414,6 +414,9 @@ static inline pmd_t pmd_mkdevmap(pmd_t p
+@@ -422,6 +422,9 @@ static inline pmd_t pmd_mkdevmap(pmd_t p
  	__pgprot_modify(prot, PTE_ATTRINDX_MASK, PTE_ATTRINDX(MT_DEVICE_nGnRnE) | PTE_PXN | PTE_UXN)
  #define pgprot_writecombine(prot) \
  	__pgprot_modify(prot, PTE_ATTRINDX_MASK, PTE_ATTRINDX(MT_NORMAL_NC) | PTE_PXN | PTE_UXN)

--- a/target/linux/layerscape/patches-5.4/301-arch-0003-arm64-pgtable-add-support-to-map-cacheable-and-non-s.patch
+++ b/target/linux/layerscape/patches-5.4/301-arch-0003-arm64-pgtable-add-support-to-map-cacheable-and-non-s.patch
@@ -11,7 +11,7 @@ Signed-off-by: Haiying Wang <Haiying.wang@freescale.com>
 
 --- a/arch/arm64/include/asm/pgtable.h
 +++ b/arch/arm64/include/asm/pgtable.h
-@@ -417,6 +417,8 @@ static inline pmd_t pmd_mkdevmap(pmd_t p
+@@ -425,6 +425,8 @@ static inline pmd_t pmd_mkdevmap(pmd_t p
  #define pgprot_cached(prot) \
  	__pgprot_modify(prot, PTE_ATTRINDX_MASK, PTE_ATTRINDX(MT_NORMAL) | \
  			PTE_PXN | PTE_UXN)


### PR DESCRIPTION
All modifications made by `update_kernel.sh`/no human intervention needed

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>