### PR TITLE
ramips: mt7621: add support for Xiaomi Mi Router 4

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -47,6 +47,7 @@ linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 xiaomi,mi-router-3g|\
 xiaomi,mi-router-3-pro|\
+xiaomi,mi-router-4|\
 xiaomi,mi-router-ac2100|\
 xiaomi,redmi-router-ac2100)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,mi-router-4", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router 4";
+
+	aliases {
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_yellow;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_yellow: status_yellow {
+			label = "yellow:status";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		minet {
+			label = "minet";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x40000>;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "crash";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "crash_syslog";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "reserved0";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* uboot expects to find kernels at 0x200000 & 0x600000
+		 * referred to as system 1 & system 2 respectively.
+		 * a kernel is considered suitable for handing control over
+		 * if its linux magic number exists & uImage CRC are correct.
+		 * If either of those conditions fail, a matching sys'n'_fail flag
+		 * is set in uboot env & a restart performed in the hope that the
+		 * alternate kernel is okay.
+		 * if neither kernel checksums ok and both are marked failed, system 2
+		 * is booted anyway.
+		 *
+		 * Note uboot's tftp flash install writes the transferred
+		 * image to both kernel partitions.
+		 */
+
+		partition@200000 {
+			label = "kernel_stock";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x600000 0x400000>;
+		};
+
+		/* ubi partition is the result of squashing
+		 * next consecutive stock partitions:
+		 * - rootfs0 (rootfs partition for stock kernel0),
+		 * - rootfs1 (rootfs partition for stock failsafe kernel1),
+		 * - overlay (used as ubi overlay in stock fw)
+		 * resulting 117,5MiB space for packages.
+		 */
+
+		partition@a00000 {
+			label = "ubi";
+			reg = <0xa00000 0x7580000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0xe006>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1243,6 +1243,22 @@ define Device/xiaomi_mi-router-3-pro
 endef
 TARGET_DEVICES += xiaomi_mi-router-3-pro
 
+define Device/xiaomi_mi-router-4
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 124416k
+  UBINIZE_OPTS := -E 5
+  IMAGES += kernel1.bin rootfs0.bin
+  IMAGE/kernel1.bin := append-kernel
+  IMAGE/rootfs0.bin := append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router 4
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_mi-router-4
+
 define Device/xiaomi_mi-router-4a-gigabit
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ ramips_setup_interfaces()
 	mikrotik,routerboard-m33g|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3g-v2|\
+	xiaomi,mi-router-4|\
 	xiaomi,mi-router-4a-gigabit)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -63,6 +63,7 @@ platform_do_upgrade() {
 	netis,wf2881|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
+	xiaomi,mi-router-4|\
 	xiaomi,mi-router-ac2100|\
 	xiaomi,redmi-router-ac2100)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
Xiaomi Mi Router 4 is the same as Xiaomi Mi Router 3G, except for the RAM(256Mib→128Mib) LED and gpio(MiNet button).

### Specification
Power: 12 VDC, 1 A
Connector type: barrel
CPU1: MediaTek MT7621A (880 MHz, 4 cores)
FLA1: 128 MiB (ESMT F59L1G81MA)
RAM1: 128 MiB (ESMT M15T1G1664A)
WI1 chip1: MediaTek MT7603EN
WI1 802dot11 protocols: bgn
WI1 MIMO config: 2x2:2
WI1 antenna connector: U.FL
WI2 chip1: MediaTek MT7612EN
WI2 802dot11 protocols: an+ac
WI2 MIMO config: 2x2:2
WI2 antenna connector: U.FL
ETH chip1: MediaTek MT7621A
Switch: MediaTek MT7621A

UART Serial
[o] TX
[o] GND
[o] RX
[ ] VCC - Do not connect it

MAC addresses as verified by OEM firmware:
```
use   address   source
LAN   *:c2      factory 0xe000 (label)
WAN   *:c3      factory 0xe006
2g    *:c4      factory 0x0000
5g    *:c5      factory 0x8000
```

### Flash instruction
1.Create a simple http server (nginx etc)
2.set uart enable
To enable writing to the console, you must reset to factory settings
Then you see uboot boot, press the keyboard 4 button (enter uboot command line)
If it is not successful, repeat the above operation of restoring the factory settings.
After entering the uboot command line, type:

```
setenv uart_en 1
saveenv
boot
```

3.use shell in uart
```
cd /tmp
wget http://"your_computer_ip:80"/openwrt-ramips-mt7621-xiaomi_mir4-squashfs-kernel1.bin
wget http://"your_computer_ip:80"/openwrt-ramips-mt7621-xiaomi_mir4-squashfs-rootfs0.bin
mtd write openwrt-ramips-mt7621-xiaomi_mir4-squashfs-kernel1.bin kernel1
mtd write openwrt-ramips-mt7621-xiaomi_mir4-squashfs-rootfs0.bin rootfs0
nvram set flag_try_sys1_failed=1
nvram commit
reboot
```
4.login to the router http://192.168.1.1/

Installation via Software exploit
Find the instructions in the https://github.com/acecilia/OpenWRTInvasion

Signed-off-by: Dmytro Oz <sequentiality@gmail.com>