### PR TITLE
Update iptables to 1.8.6

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
-PKG_VERSION:=1.8.4
+PKG_VERSION:=1.8.6
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_HASH:=993a3a5490a544c2cbf2ef15cf7e7ed21af1845baf228318d5c36ef8827e157c
+PKG_HASH:=a0f4fe0c3eb8faa5bd9c8376d132f340b9558e750c91deb2d5028aa3d0047767
 
 PKG_FIXUP:=autoreconf
 PKG_FLAGS:=nonshared

--- a/package/network/utils/iptables/patches/101-remove-check-already.patch
+++ b/package/network/utils/iptables/patches/101-remove-check-already.patch
@@ -1,9 +1,9 @@
 --- a/libxtables/xtables.c
 +++ b/libxtables/xtables.c
-@@ -903,12 +903,6 @@ static void xtables_check_options(const
+@@ -968,12 +968,6 @@ void xtables_register_match(struct xtabl
+ 	struct xtables_match **pos;
+ 	bool seen_myself = false;
  
- void xtables_register_match(struct xtables_match *me)
- {
 -	if (me->next) {
 -		fprintf(stderr, "%s: match \"%s\" already registered\n",
 -			xt_params->program_name, me->name);
@@ -13,10 +13,10 @@
  	if (me->version == NULL) {
  		fprintf(stderr, "%s: match %s<%u> is missing a version\n",
  		        xt_params->program_name, me->name, me->revision);
-@@ -1096,12 +1090,6 @@ void xtables_register_matches(struct xta
+@@ -1152,12 +1146,6 @@ void xtables_register_target(struct xtab
+ 	struct xtables_target **pos;
+ 	bool seen_myself = false;
  
- void xtables_register_target(struct xtables_target *me)
- {
 -	if (me->next) {
 -		fprintf(stderr, "%s: target \"%s\" already registered\n",
 -			xt_params->program_name, me->name);


### PR DESCRIPTION
Update iptables to 1.8.6

ChangeLog:
https://netfilter.org/projects/iptables/files/changes-iptables-1.8.6.txt

Refresh patch:
101-remove-check-already.patch

Build and run tested on x86_64

Signed-off-by: Curtis Deptuck <curtdept@me.com>