### PR TITLE
ath79: mikrotik: add support for early RB911 Lite5 NAND boards

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-911-5hn-nand128m.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-911-5hn-nand128m.dts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_mikrotik_routerboard-sxt-5n.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-911-5hn-nand128m", "qca,ar9344";
+	model = "MikroTik RouterBOARD 911-5Hn NAND 128MB (911 Lite5)";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			routerboot: partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x10000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5n.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5n.dtsi
@@ -76,60 +76,6 @@
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	beeper {
-		compatible = "gpio-beeper";
-		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <40000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "RouterBoot";
-				reg = <0x0 0x20000>;
-				read-only;
-				compatible = "mikrotik,routerboot-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "bootloader1";
-					reg = <0x0 0x0>;
-					read-only;
-				};
-
-				hard_config: hard_config {
-					read-only;
-				};
-
-				bios {
-					size = <0x1000>;
-					read-only;
-				};
-
-				soft_config {
-				};
-
-				partition@10000 {
-					label = "bootloader2";
-					reg = <0x10000 0x10000>;
-					read-only;
-				};
-			};
-		};
-	};
 };
 
 &nand {

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
@@ -5,4 +5,58 @@
 / {
 	compatible = "mikrotik,routerboard-sxt-5nd-r2", "qca,ar9344";
 	model = "MikroTik RouterBOARD SXT 5nD r2 (SXT Lite5)";
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config: hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				soft_config {
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x10000>;
+					read-only;
+				};
+			};
+		};
+	};
 };

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -9,6 +9,17 @@ define Device/mikrotik_routerboard-493g
 endef
 TARGET_DEVICES += mikrotik_routerboard-493g
 
+define Device/mikrotik_routerboard-911-5hn-nand128m
+  $(Device/mikrotik_nand)
+  SOC := ar9344
+  DEVICE_MODEL := RouterBOARD 911-5Hn NAND 128MB (911 Lite5)
+  DEVICE_ALT0_VENDOR := MikroTik
+  DEVICE_ALT0_MODEL := RouterBOARD 911-2Hn NAND 128MB (911 Lite2)
+  DEVICE_PACKAGES += rssileds
+  SUPPORTED_DEVICES += rb-911-5hn-nand
+endef
+TARGET_DEVICES += mikrotik_routerboard-911-5hn-nand128m
+
 define Device/mikrotik_routerboard-912uag-2hpnd
   $(Device/mikrotik_nand)
   SOC := ar9342

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -15,6 +15,7 @@ mikrotik,routerboard-wapr-2nd)
 	ucidef_set_led_rssi "rssimedium" "rssimedium" "green:rssimedium" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan0" "66" "100"
 	;;
+mikrotik,routerboard-911-5hn-nand128m|\
 mikrotik,routerboard-sxt-5nd-r2)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0@eth1" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"
 		;;
+	mikrotik,routerboard-911-5hn-nand128m|\
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-lhg-2nd|\
@@ -37,6 +38,7 @@ ath79_setup_macs()
 	local mac_base="$(cat /sys/firmware/mikrotik/hard_config/mac_base)"
 
 	case "$board" in
+	mikrotik,routerboard-911-5hn-nand128m|\
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-lhg-2nd|\

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -23,6 +23,7 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	mikrotik,routerboard-911-5hn-nand128m|\
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-lhg-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -32,6 +32,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	mikrotik,routerboard-493g|\
+	mikrotik,routerboard-911-5hn-nand128m|\
 	mikrotik,routerboard-912uag-2hpnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd|\


### PR DESCRIPTION
These two patches add support for the early version of the MikroTik RB911 Lite5 boards with NAND storage. They were very almost hardware-identical to the already supported SXT Lite5, even the bootloader passes the same board identifier "sxt5n". The only difference is found in the tiny SPI NOR storage for the bootloader, which is half the size (64 kB for RB911Lite5NAND, 128 kB for the SXTLite5).

The first patch adapts the "SXT 5N" .dtsi to handle both 64 kB and 128 kB (bootloader2 partition will be added on a per-device basis, when needed). The second patch adds actual support for the RB911Lite5NAND boards.

Later versions of the RB911Lite5, which used an SPI NOR chip as their main storage, are not supported by the "sxt5n" platform, but by the "911L" one. The whole discussion and findings can be found at https://bugs.openwrt.org/index.php?do=details&task_id=3471.