### PR TITLE
hostapd: Disable 802.11b data rates by default

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=17
+PKG_RELEASE:=18
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -123,7 +123,7 @@ hostapd_prepare_device_config() {
 	set_default country_ie 1
 	set_default spectrum_mgmt_required 0
 	set_default doth 1
-	set_default legacy_rates 1
+	set_default legacy_rates 0
 	set_default airtime_mode 0
 	set_default cell_density 0
 


### PR DESCRIPTION
Set legacy_rates to 0 by default to disable 802.11b data rates by default.

The time has long come where 802.11b DSSS/CCK data rates should be disabled
by default in OpenWRT. Users in need of 802.11b client support can reasonably
enable these where they are needed.

The balance of equities has significantly, and for a long time, tipped
such that dropping backwards compatibility by default with 802.11b
devices is appropriate, proportionate and justified. By doing so,
management and control traffic is moved by default to a 20
MHz wide 6 Mb/s OFDM data rate instead of a 22 MHz wide 1 Mb/s DSSS data
rate. This is significantly more airtime efficient.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>