### PR TITLE
linux: port CZ.NIC multi-CPU DSA patches

### DIFF
--- a/target/linux/generic/hack-5.4/721-phy_packets.patch
+++ b/target/linux/generic/hack-5.4/721-phy_packets.patch
@@ -15,7 +15,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/linux/netdevice.h
 +++ b/include/linux/netdevice.h
-@@ -1549,6 +1549,7 @@ enum netdev_priv_flags {
+@@ -1553,6 +1553,7 @@ enum netdev_priv_flags {
  	IFF_FAILOVER_SLAVE		= 1<<28,
  	IFF_L3MDEV_RX_HANDLER		= 1<<29,
  	IFF_LIVE_RENAME_OK		= 1<<30,
@@ -23,7 +23,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  #define IFF_802_1Q_VLAN			IFF_802_1Q_VLAN
-@@ -1581,6 +1582,7 @@ enum netdev_priv_flags {
+@@ -1585,6 +1586,7 @@ enum netdev_priv_flags {
  #define IFF_FAILOVER_SLAVE		IFF_FAILOVER_SLAVE
  #define IFF_L3MDEV_RX_HANDLER		IFF_L3MDEV_RX_HANDLER
  #define IFF_LIVE_RENAME_OK		IFF_LIVE_RENAME_OK
@@ -31,7 +31,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  /**
   *	struct net_device - The DEVICE structure.
-@@ -1882,6 +1884,11 @@ struct net_device {
+@@ -1886,6 +1888,11 @@ struct net_device {
  	const struct tlsdev_ops *tlsdev_ops;
  #endif
  
@@ -43,7 +43,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	const struct header_ops *header_ops;
  
  	unsigned int		flags;
-@@ -1964,6 +1971,10 @@ struct net_device {
+@@ -1968,6 +1975,10 @@ struct net_device {
  	struct mpls_dev __rcu	*mpls_ptr;
  #endif
  
@@ -101,7 +101,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	help
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -3192,10 +3192,20 @@ static int xmit_one(struct sk_buff *skb,
+@@ -3208,10 +3208,20 @@ static int xmit_one(struct sk_buff *skb,
  	if (dev_nit_active(dev))
  		dev_queue_xmit_nit(skb, dev);
  

--- a/target/linux/generic/pending-5.4/780-net-dsa-allow-for-multiple-CPU-ports.patch
+++ b/target/linux/generic/pending-5.4/780-net-dsa-allow-for-multiple-CPU-ports.patch
@@ -1,0 +1,212 @@
+From 3cbd1b83e555e33448f78cbdae3a0b691c8419cf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Tue, 5 May 2020 19:22:58 +0200
+Subject: [PATCH] net: dsa: allow for multiple CPU ports
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Allow for multiple CPU ports in a DSA switch tree. By default assign the
+CPU ports to user ports in a round robin way, ie. if there are two CPU
+ports connected to eth0 and eth1, and five user ports (lan1..lan5),
+assign them as:
+  lan1 <-> eth0
+  lan2 <-> eth1
+  lan3 <-> eth0
+  lan4 <-> eth1
+  lan5 <-> eth0
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ include/net/dsa.h |  5 +--
+ net/dsa/dsa2.c    | 82 ++++++++++++++++++++++++++++++-----------------
+ 2 files changed, 56 insertions(+), 31 deletions(-)
+
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -125,9 +125,10 @@ struct dsa_switch_tree {
+ 	struct dsa_platform_data	*pd;
+ 
+ 	/*
+-	 * The switch port to which the CPU is attached.
++	 * The switch ports to which the CPU is attached.
+ 	 */
+-	struct dsa_port		*cpu_dp;
++	size_t			num_cpu_dps;
++	struct dsa_port		*cpu_dps[DSA_MAX_PORTS];
+ 
+ 	/*
+ 	 * Data for the individual switch chips.
+--- a/net/dsa/dsa2.c
++++ b/net/dsa/dsa2.c
+@@ -194,11 +194,12 @@ static bool dsa_tree_setup_routing_table
+ 	return complete;
+ }
+ 
+-static struct dsa_port *dsa_tree_find_first_cpu(struct dsa_switch_tree *dst)
++static void dsa_tree_fill_cpu_ports(struct dsa_switch_tree *dst)
+ {
+ 	struct dsa_switch *ds;
+ 	struct dsa_port *dp;
+ 	int device, port;
++	int count = 0;
+ 
+ 	for (device = 0; device < DSA_MAX_SWITCHES; device++) {
+ 		ds = dst->ds[device];
+@@ -208,28 +209,37 @@ static struct dsa_port *dsa_tree_find_fi
+ 		for (port = 0; port < ds->num_ports; port++) {
+ 			dp = &ds->ports[port];
+ 
+-			if (dsa_port_is_cpu(dp))
+-				return dp;
++			if (dsa_port_is_cpu(dp)) {
++				if (count == ARRAY_SIZE(dst->cpu_dps)) {
++					pr_warn("Tree has too many CPU ports\n");
++					dst->num_cpu_dps = count;
++					return;
++				}
++
++				dst->cpu_dps[count++] = dp;
++			}
+ 		}
+ 	}
+ 
+-	return NULL;
++	dst->num_cpu_dps = count;
+ }
+ 
+-static int dsa_tree_setup_default_cpu(struct dsa_switch_tree *dst)
++static int dsa_tree_setup_default_cpus(struct dsa_switch_tree *dst)
+ {
+ 	struct dsa_switch *ds;
+ 	struct dsa_port *dp;
+-	int device, port;
++	int device, port, i;
+ 
+-	/* DSA currently only supports a single CPU port */
+-	dst->cpu_dp = dsa_tree_find_first_cpu(dst);
+-	if (!dst->cpu_dp) {
++	dsa_tree_fill_cpu_ports(dst);
++	if (!dst->num_cpu_dps) {
+ 		pr_warn("Tree has no master device\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	/* Assign the default CPU port to all ports of the fabric */
++	/* Assign the default CPU port to all ports of the fabric in a round
++	 * robin way. This should work nicely for all sane switch tree designs.
++	 */
++	i = 0;
+ 	for (device = 0; device < DSA_MAX_SWITCHES; device++) {
+ 		ds = dst->ds[device];
+ 		if (!ds)
+@@ -238,18 +248,20 @@ static int dsa_tree_setup_default_cpu(st
+ 		for (port = 0; port < ds->num_ports; port++) {
+ 			dp = &ds->ports[port];
+ 
+-			if (dsa_port_is_user(dp) || dsa_port_is_dsa(dp))
+-				dp->cpu_dp = dst->cpu_dp;
++			if (dsa_port_is_user(dp) || dsa_port_is_dsa(dp)) {
++				dp->cpu_dp = dst->cpu_dps[i++];
++				if (i == dst->num_cpu_dps)
++					i = 0;
++			}
+ 		}
+ 	}
+ 
+ 	return 0;
+ }
+ 
+-static void dsa_tree_teardown_default_cpu(struct dsa_switch_tree *dst)
++static void dsa_tree_teardown_default_cpus(struct dsa_switch_tree *dst)
+ {
+-	/* DSA currently only supports a single CPU port */
+-	dst->cpu_dp = NULL;
++	dst->num_cpu_dps = 0;
+ }
+ 
+ static int dsa_port_setup(struct dsa_port *dp)
+@@ -506,21 +518,33 @@ static void dsa_tree_teardown_switches(s
+ 	}
+ }
+ 
+-static int dsa_tree_setup_master(struct dsa_switch_tree *dst)
++static int dsa_tree_setup_masters(struct dsa_switch_tree *dst)
+ {
+-	struct dsa_port *cpu_dp = dst->cpu_dp;
+-	struct net_device *master = cpu_dp->master;
++	int i, err;
++
++	for (i = 0; i < dst->num_cpu_dps; ++i) {
++		struct dsa_port *cpu_dp = dst->cpu_dps[i];
++		struct net_device *master = cpu_dp->master;
+ 
+-	/* DSA currently supports a single pair of CPU port and master device */
+-	return dsa_master_setup(master, cpu_dp);
++		err = dsa_master_setup(master, cpu_dp);
++		if (err)
++			goto teardown;
++	}
++
++	return 0;
++teardown:
++	for (--i; i >= 0; --i)
++		dsa_master_teardown(dst->cpu_dps[i]->master);
++
++	return err;
+ }
+ 
+-static void dsa_tree_teardown_master(struct dsa_switch_tree *dst)
++static void dsa_tree_teardown_masters(struct dsa_switch_tree *dst)
+ {
+-	struct dsa_port *cpu_dp = dst->cpu_dp;
+-	struct net_device *master = cpu_dp->master;
++	int i;
+ 
+-	return dsa_master_teardown(master);
++	for (i = 0; i < dst->num_cpu_dps; ++i)
++		dsa_master_teardown(dst->cpu_dps[i]->master);
+ }
+ 
+ static int dsa_tree_setup(struct dsa_switch_tree *dst)
+@@ -538,7 +562,7 @@ static int dsa_tree_setup(struct dsa_swi
+ 	if (!complete)
+ 		return 0;
+ 
+-	err = dsa_tree_setup_default_cpu(dst);
++	err = dsa_tree_setup_default_cpus(dst);
+ 	if (err)
+ 		return err;
+ 
+@@ -546,7 +570,7 @@ static int dsa_tree_setup(struct dsa_swi
+ 	if (err)
+ 		goto teardown_default_cpu;
+ 
+-	err = dsa_tree_setup_master(dst);
++	err = dsa_tree_setup_masters(dst);
+ 	if (err)
+ 		goto teardown_switches;
+ 
+@@ -559,7 +583,7 @@ static int dsa_tree_setup(struct dsa_swi
+ teardown_switches:
+ 	dsa_tree_teardown_switches(dst);
+ teardown_default_cpu:
+-	dsa_tree_teardown_default_cpu(dst);
++	dsa_tree_teardown_default_cpus(dst);
+ 
+ 	return err;
+ }
+@@ -569,11 +593,11 @@ static void dsa_tree_teardown(struct dsa
+ 	if (!dst->setup)
+ 		return;
+ 
+-	dsa_tree_teardown_master(dst);
++	dsa_tree_teardown_masters(dst);
+ 
+ 	dsa_tree_teardown_switches(dst);
+ 
+-	dsa_tree_teardown_default_cpu(dst);
++	dsa_tree_teardown_default_cpus(dst);
+ 
+ 	pr_info("DSA: tree %d torn down\n", dst->index);
+ 

--- a/target/linux/generic/pending-5.4/781-net-add-ndo-for-setting-the-iflink-property.patch
+++ b/target/linux/generic/pending-5.4/781-net-add-ndo-for-setting-the-iflink-property.patch
@@ -1,0 +1,92 @@
+From 846d8a31f9cc9048f58358770d20d3153918c93d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Tue, 5 May 2020 19:28:53 +0200
+Subject: [PATCH] net: add ndo for setting the iflink property
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In DSA the iflink value is used to report to which CPU port a given
+switch port is connected to. Since we want to support multi-CPU DSA, we
+want the user to be able to change this value.
+
+Add ndo_set_iflink method into the ndo strucutre to be a pair to
+ndo_get_iflink. Also create dev_set_iflink and call this from the
+netlink code, so that userspace can change the iflink value.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ include/linux/netdevice.h |  5 +++++
+ net/core/dev.c            | 16 ++++++++++++++++
+ net/core/rtnetlink.c      |  7 +++++++
+ 3 files changed, 28 insertions(+)
+
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
+@@ -1231,6 +1231,8 @@ enum flow_offload_type {
+  *	TX queue.
+  * int (*ndo_get_iflink)(const struct net_device *dev);
+  *	Called to get the iflink value of this device.
++ * int (*ndo_set_iflink)(struct net_device *dev, int iflink);
++ *	Called to set the iflink value of this device.
+  * void (*ndo_change_proto_down)(struct net_device *dev,
+  *				 bool proto_down);
+  *	This function is used to pass protocol port error state information
+@@ -1455,6 +1457,8 @@ struct net_device_ops {
+ 						      int queue_index,
+ 						      u32 maxrate);
+ 	int			(*ndo_get_iflink)(const struct net_device *dev);
++	int			(*ndo_set_iflink)(struct net_device *dev,
++						  int iflink);
+ 	int			(*ndo_change_proto_down)(struct net_device *dev,
+ 							 bool proto_down);
+ 	int			(*ndo_fill_metadata_dst)(struct net_device *dev,
+@@ -2666,6 +2670,7 @@ void dev_add_offload(struct packet_offlo
+ void dev_remove_offload(struct packet_offload *po);
+ 
+ int dev_get_iflink(const struct net_device *dev);
++int dev_set_iflink(struct net_device *dev, int iflink);
+ int dev_fill_metadata_dst(struct net_device *dev, struct sk_buff *skb);
+ struct net_device *__dev_get_by_flags(struct net *net, unsigned short flags,
+ 				      unsigned short mask);
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -614,6 +614,22 @@ int dev_get_iflink(const struct net_devi
+ EXPORT_SYMBOL(dev_get_iflink);
+ 
+ /**
++ *	dev_set_iflink - set 'iflink' value of an interface
++ *	@dev: target interface
++ *	@iflink: new value
++ *
++ *	Change the interface to which this interface is linked to.
++ */
++int dev_set_iflink(struct net_device *dev, int iflink)
++{
++	if (dev->netdev_ops && dev->netdev_ops->ndo_set_iflink)
++		return dev->netdev_ops->ndo_set_iflink(dev, iflink);
++
++	return -EOPNOTSUPP;
++}
++EXPORT_SYMBOL(dev_set_iflink);
++
++/**
+  *	dev_fill_metadata_dst - Retrieve tunnel egress information.
+  *	@dev: targeted interface
+  *	@skb: The packet.
+--- a/net/core/rtnetlink.c
++++ b/net/core/rtnetlink.c
+@@ -2529,6 +2529,13 @@ static int do_setlink(const struct sk_bu
+ 		status |= DO_SETLINK_MODIFIED;
+ 	}
+ 
++	if (tb[IFLA_LINK]) {
++		err = dev_set_iflink(dev, nla_get_u32(tb[IFLA_LINK]));
++		if (err)
++			goto errout;
++		status |= DO_SETLINK_MODIFIED;
++	}
++
+ 	if (tb[IFLA_CARRIER]) {
+ 		err = dev_change_carrier(dev, nla_get_u8(tb[IFLA_CARRIER]));
+ 		if (err)

--- a/target/linux/generic/pending-5.4/782-net-dsa-implement-ndo_set_netlink-for-chaning-port-s.patch
+++ b/target/linux/generic/pending-5.4/782-net-dsa-implement-ndo_set_netlink-for-chaning-port-s.patch
@@ -1,0 +1,90 @@
+From 801d3c1a412e187242bca86daba77c4a6d7a4d21 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Tue, 5 May 2020 19:33:39 +0200
+Subject: [PATCH] net: dsa: implement ndo_set_netlink for chaning port's
+ CPU port
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Implement ndo_set_iflink for DSA slave device. In multi-CPU port setup
+this should be used to change to which CPU destination port a given port
+should be connected.
+
+This adds a new operation into the DSA switch operations structure,
+port_change_cpu_port. A driver implementing this function has the
+ability to change CPU destination port of a given port.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ include/net/dsa.h |  6 ++++++
+ net/dsa/slave.c   | 36 ++++++++++++++++++++++++++++++++++++
+ 2 files changed, 42 insertions(+)
+
+--- a/include/net/dsa.h
++++ b/include/net/dsa.h
+@@ -553,6 +553,12 @@ struct dsa_switch_ops {
+ 	 */
+ 	netdev_tx_t (*port_deferred_xmit)(struct dsa_switch *ds, int port,
+ 					  struct sk_buff *skb);
++
++	/*
++	 * Multi-CPU port support
++	 */
++	int	(*port_change_cpu_port)(struct dsa_switch *ds, int port,
++					struct dsa_port *new_cpu_dp);
+ };
+ 
+ struct dsa_switch_driver {
+--- a/net/dsa/slave.c
++++ b/net/dsa/slave.c
+@@ -68,6 +68,41 @@ static int dsa_slave_get_iflink(const st
+ 	return dsa_slave_to_master(dev)->ifindex;
+ }
+ 
++static int dsa_slave_set_iflink(struct net_device *dev, int iflink)
++{
++	struct dsa_port *dp = dsa_slave_to_port(dev);
++	struct dsa_slave_priv *p = netdev_priv(dev);
++	struct net_device *new_cpu_dev;
++	struct dsa_port *new_cpu_dp;
++	int err;
++
++	if (!dp->ds->ops->port_change_cpu_port)
++		return -EOPNOTSUPP;
++
++	new_cpu_dev = dev_get_by_index(dev_net(dev), iflink);
++	if (!new_cpu_dev)
++		return -ENODEV;
++
++	new_cpu_dp = new_cpu_dev->dsa_ptr;
++	if (!new_cpu_dp)
++		return -EINVAL;
++
++	/* new CPU port has to be on the same switch tree */
++	if (new_cpu_dp->dst != dp->dst)
++		return -EINVAL;
++
++	/* should this be done atomically? should this return to previous cpu_dp
++	 * in case of error? */
++	dp->cpu_dp = new_cpu_dp;
++	p->xmit = new_cpu_dp->tag_ops->xmit;
++
++	err = dp->ds->ops->port_change_cpu_port(dp->ds, dp->index, new_cpu_dp);
++	if (err)
++		return err;
++
++	return 0;
++}
++
+ static int dsa_slave_open(struct net_device *dev)
+ {
+ 	struct net_device *master = dsa_slave_to_master(dev);
+@@ -1258,6 +1293,7 @@ static const struct net_device_ops dsa_s
+ 	.ndo_fdb_dump		= dsa_slave_fdb_dump,
+ 	.ndo_do_ioctl		= dsa_slave_ioctl,
+ 	.ndo_get_iflink		= dsa_slave_get_iflink,
++	.ndo_set_iflink		= dsa_slave_set_iflink,
+ #ifdef CONFIG_NET_POLL_CONTROLLER
+ 	.ndo_netpoll_setup	= dsa_slave_netpoll_setup,
+ 	.ndo_netpoll_cleanup	= dsa_slave_netpoll_cleanup,

--- a/target/linux/generic/pending-5.4/783-net-dsa-mv88e6xxx-support-multi-CPU-DSA.patch
+++ b/target/linux/generic/pending-5.4/783-net-dsa-mv88e6xxx-support-multi-CPU-DSA.patch
@@ -1,0 +1,111 @@
+From a78ac68ff49c14c9ee74782978517e8afc55d942 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Tue, 5 May 2020 20:08:08 +0200
+Subject: [PATCH] net: dsa: mv88e6xxx: support multi-CPU DSA
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for multi-CPU DSA for mv88e6xxx.
+Currently only works with multiple CPUs when there is only one switch in
+the switch tree.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ drivers/net/dsa/mv88e6xxx/chip.c | 48 ++++++++++++++++++++++++++++++--
+ 1 file changed, 46 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/mv88e6xxx/chip.c
++++ b/drivers/net/dsa/mv88e6xxx/chip.c
+@@ -1061,6 +1061,7 @@ static u16 mv88e6xxx_port_vlan(struct mv
+ {
+ 	struct dsa_switch *ds = NULL;
+ 	struct net_device *br;
++	u8 upstream;
+ 	u16 pvlan;
+ 	int i;
+ 
+@@ -1072,17 +1073,36 @@ static u16 mv88e6xxx_port_vlan(struct mv
+ 		return 0;
+ 
+ 	/* Frames from DSA links and CPU ports can egress any local port */
+-	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++	if (dsa_is_dsa_port(ds, port))
+ 		return mv88e6xxx_port_mask(chip);
+ 
++	if (dsa_is_cpu_port(ds, port)) {
++		u16 pmask = mv88e6xxx_port_mask(chip);
++		pvlan = 0;
++
++		for (i = 0; i < mv88e6xxx_num_ports(chip); ++i) {
++			if (dsa_is_cpu_port(ds, i)) {
++				if (i == port)
++					pvlan |= BIT(i);
++				continue;
++			}
++			if ((pmask & BIT(i)) &&
++			    dsa_upstream_port(chip->ds, i) == port)
++				pvlan |= BIT(i);
++		}
++
++		return pvlan;
++	}
++
+ 	br = ds->ports[port].bridge_dev;
+ 	pvlan = 0;
+ 
+ 	/* Frames from user ports can egress any local DSA links and CPU ports,
+ 	 * as well as any local member of their bridge group.
+ 	 */
++	upstream = dsa_upstream_port(chip->ds, port);
+ 	for (i = 0; i < mv88e6xxx_num_ports(chip); ++i)
+-		if (dsa_is_cpu_port(chip->ds, i) ||
++		if ((dsa_is_cpu_port(chip->ds, i) && i == upstream) ||
+ 		    dsa_is_dsa_port(chip->ds, i) ||
+ 		    (br && dsa_to_port(chip->ds, i)->bridge_dev == br))
+ 			pvlan |= BIT(i);
+@@ -2371,6 +2391,7 @@ static int mv88e6xxx_setup_upstream_port
+ 	}
+ 
+ 	if (port == upstream_port) {
++		dev_info(chip->dev, "Setting CPU port as port %i\n", port);
+ 		if (chip->info->ops->set_cpu_port) {
+ 			err = chip->info->ops->set_cpu_port(chip,
+ 							    upstream_port);
+@@ -2396,6 +2417,28 @@ static int mv88e6xxx_setup_upstream_port
+ 	return 0;
+ }
+ 
++static int mv88e6xxx_port_change_cpu_port(struct dsa_switch *ds, int port,
++					  struct dsa_port *new_cpu_dp)
++{
++	struct mv88e6xxx_chip *chip = ds->priv;
++	int err;
++
++	mv88e6xxx_reg_lock(chip);
++
++	err = mv88e6xxx_setup_upstream_port(chip, port);
++	if (err)
++		goto unlock;
++
++	err = mv88e6xxx_port_vlan_map(chip, port);
++	if (err)
++		goto unlock;
++
++unlock:
++	mv88e6xxx_reg_unlock(chip);
++
++	return err;
++}
++
+ static int mv88e6xxx_setup_port(struct mv88e6xxx_chip *chip, int port)
+ {
+ 	struct dsa_switch *ds = chip->ds;
+@@ -5059,6 +5102,7 @@ static const struct dsa_switch_ops mv88e
+ 	.port_hwtstamp_get	= mv88e6xxx_port_hwtstamp_get,
+ 	.port_txtstamp		= mv88e6xxx_port_txtstamp,
+ 	.port_rxtstamp		= mv88e6xxx_port_rxtstamp,
++	.port_change_cpu_port	= mv88e6xxx_port_change_cpu_port,
+ 	.get_ts_info		= mv88e6xxx_get_ts_info,
+ };
+ 


### PR DESCRIPTION
Several platforms were converted to use DSA. One problem is that DSA
does not support multiple CPU ports unlike swconfig.

Ported here as this was submitted multiple times to kernel.org and has
the biggest chance of landing upstream. I don't expect the final
patchset to be much different.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @dengqf6 I believe you tested this patchset before?