### PR TITLE
Lantiq: xrx200: Add support for AVM Fritzbox 3390

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -223,6 +223,7 @@
 			compatible = "lantiq,xrx200-pinctrl";
 			#gpio-cells = <2>;
 			gpio-controller;
+			gpio-ranges = <&gpio 0 0 50>;
 			reg = <0xe100b10 0xa0>;
 
 			gphy0_led0_pins: gphy0-led0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	compatible = "avm,fritz3390", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3390";
+
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+
+		led-dsl = &led_dsl;
+		led-internet = &led_info;
+		led-wifi = &led_wifi;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		power {
+			label = "power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_POWER>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: wifi {
+			label = "green:wifi";
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		led_dsl: dsl {
+			label = "green:dsl";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan {
+			label = "green:lan";
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info: info {
+			label = "green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	usb0_vbus: regulator-usb0-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB0_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	usb1_vbus: regulator-usb1-vbus {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB1_VBUS";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&eth0 {
+	interface@0 {
+		compatible = "lantiq,xrx200-pdi";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+		lantiq,switch;
+
+		ethernet@0 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <0>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy0>;
+			gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@1 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <1>;
+			phy-mode = "rgmii";
+			phy-handle = <&phy1>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		ethernet@2 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <2>;
+			phy-mode = "gmii";
+			phy-handle = <&phy11>;
+		};
+
+		ethernet@4 {
+			compatible = "lantiq,xrx200-pdi-port";
+			reg = <4>;
+			phy-mode = "gmii";
+			phy-handle = <&phy13>;
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "lantiq,xrx200-mdio";
+
+		phy0: ethernet-phy@0 {
+			reg = <0x0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <0x1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy11: ethernet-phy@11 {
+			reg = <0x11>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+
+		phy13: ethernet-phy@13 {
+			reg = <0x13>;
+			compatible = "lantiq,phy11g", "ethernet-phy-ieee802.3-c22";
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	pcie-rst-dev {
+		gpio-hog;
+		line-name = "pcie-rst-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x20000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@20000 {
+				reg = <0x20000 0x10000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@30000 {
+				reg = <0x30000 0x10000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	flash@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <1>;
+		reg = <1 0x0 0x2000000>;
+
+		pinctrl-0 = <&nand_pins>;
+		pinctrl-names = "default";
+
+		nand-ecc-mode = "on-die";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7c00000>;
+			};
+		};
+	};
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	vbus-supply = <&usb0_vbus>;
+};
+
+&usb1 {
+	status = "okay";
+	vbus-supply = <&usb1_vbus>;
+};
+
+&pcie0 {
+	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		reg = <0 0 0 0 0>;
+		#interrupt-cells = <1>;
+		#size-cells = <1>;
+		#address-cells = <2>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			compatible = "pci168c,0033";
+			reg = <0 0 0 0 0>;
+			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+		};
+	};
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -118,6 +118,17 @@ define Device/avm_fritz3370-rev2-micron
 endef
 TARGET_DEVICES += avm_fritz3370-rev2-micron
 
+define Device/avm_fritz3390
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3390
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-wolfssl \
+	kmod-usb-dwc2 fritz-tffs
+endef
+TARGET_DEVICES += avm_fritz3390
+
 define Device/avm_fritz7360sl
   $(Device/AVM)
   DEVICE_MODEL := FRITZ!Box 7360 SL

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -45,7 +45,8 @@ arcadyan,vgv7519-brn)
 	ucidef_set_led_wlan "wifi" "wifi" "green:wireless" "phy0radio"
 	;;
 avm,fritz3370-rev2-hynix|\
-avm,fritz3370-rev2-micron)
+avm,fritz3370-rev2-micron|\
+avm,fritz3390)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"
 	;;
 bt,homehub-v5a)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ lantiq_setup_interfaces()
 		;;
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7360sl|\
 	avm,fritz7360-v2|\
 	avm,fritz7362sl)
@@ -87,6 +88,7 @@ lantiq_setup_dsl()
 	arcadyan,vgv7510kw22-nor|\
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
@@ -136,6 +138,7 @@ lantiq_setup_macs()
 	avm,fritz7360sl)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
+	avm,fritz3390|\
 	avm,fritz7362sl)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))

--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -16,6 +16,9 @@ case "$FIRMWARE" in
 			avm,fritz7362sl)
 				caldata_extract_reverse "urlader" 0x1541 0x440
 				;;
+			avm,fritz3390)
+				caldata_extract_reverse "urlader" 0x2546 0x440
+				;;
 			avm,fritz7360sl|\
 			avm,fritz7360-v2)
 				caldata_extract "urlader" 0x985 0x1000

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -11,6 +11,7 @@ platform_do_upgrade() {
 	case "$board" in
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
+	avm,fritz3390|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	avm,fritz7430|\


### PR DESCRIPTION
All the work has been done some time ago by Andreas Böhler alias @andyboeh  and was already documented in this closed Pull-Request: https://github.com/openwrt/openwrt/pull/2662

I have rebased that changes to Kernel 5.x, tested it and are now filing this pull request, because andyboeh did not want to continue this PR. I added some HW-details here:
https://openwrt.org/inbox/toh/avm/avm_fritzbox_3390

Status:
avm_fritz3390 is working with 5 GHz WIFI and tested for a couple of weeks as DSL-Router

2.4GHz not supported
(2.4 Ghz is implemented by a second SOC via "WASP-Interface". andyboeh did basic work on it, but to me it seemed to complicated and I am not interested in 2.4 Ghz WIFI of this box.) For details see https://www.aboehler.at/doku/doku.php/projects:fritz3390
