### PR TITLE
ipq806x: disable SPC of IPQ8064 on NEC WG2600HP to fix boot issue

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-wg2600hp.dts
@@ -119,6 +119,10 @@
 	};
 };
 
+&CPU_SPC {
+	status = "disabled";
+};
+
 &adm_dma {
 	status = "okay";
 };


### PR DESCRIPTION
The SPC (Standalone Power Collapse) of IPQ8064 on NEC Aterm WG2600HP
need to be disabled to fix the boot stucking issue on WG2600HP with
kernel 5.4.

log:

[    3.036965] cpuidle: enable-method property 'qcom,kpss-acc-v1' found operations
[    3.038007] cpuidle: enable-method property 'qcom,kpss-acc-v1' found operations
[    3.045849] sdhci: Secure Digital Host Controller Interface driver
[    3.052385] sdhci: Copyright(c) Pierre Ossman
[    3.058712] sdhci-pltfm: SDHCI platform and OF driver helper
[    3.065469] NET: Registered protocol family 10
[    3.070184] Segment Routing with IPv6
[    3.073141] NET: Registered protocol family 17
[    3.078157] 8021q: 802.1Q VLAN Support v1.8
[    3.081149] Registering SWP/SWPB emulation handler
[    3.107125] qcom_rpm 108000.rpm: RPM firmware 3.0.16777371
[    3.120475] s1a: Bringing 0uV into 1050000-1050000uV
[    3.120747] s1a: supplied by regulator-dummy
[    3.124775] s1b: Bringing 0uV into 1050000-1050000uV
[    3.128969] s1b: supplied by regulator-dummy
[    3.133905] s2a: Bringing 0uV into 800000-800000uV
[    3.138190] s2a: supplied by regulator-dummy
[    3.142693] s2b: Bringing 0uV into 800000-800000uV
[    3.147266] s2b: supplied by regulator-dummy
[
(stuck)

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>