### PR TITLE
ltq-dsl-base: use ActualNetDataRate for DSL bitrate statistics

### DIFF
--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -532,7 +532,12 @@ static void g997_channel_status(int fd, DSL_AccessDir_t direction) {
 	IOCTL_DIR(DSL_G997_ChannelStatus_t, DSL_FIO_G997_CHANNEL_STATUS_GET, direction);
 
 	m_u32("interleave_delay", out.data.ActualInterleaveDelay * 10);
+#ifndef INCLUDE_DSL_CPE_API_DANUBE
+	// prefer ACTNDR, see comments in drv_dsl_cpe_api_g997.h
+	m_u32("data_rate", out.data.ActualNetDataRate);
+#else
 	m_u32("data_rate", out.data.ActualDataRate);
+#endif
 }
 
 static void g997_line_status(int fd, DSL_AccessDir_t direction) {


### PR DESCRIPTION
Both my ISP and Fr!tzbox 7490 consistently report slightly different speeds then OpenWrt. Before this patch, my ISP reports the same speed as the 7490 reports, which was always different from what OpenWrt reported.

This patch fixes this discrepancy. 

Signed-off-by: Jeroen Peelaerts <jeroen.peelaerts@gmail.com>
