### PR TITLE
ath79: add support for Atheros DB120 reference board

### DIFF
--- a/target/linux/ath79/dts/ar9344_atheros_db120.dts
+++ b/target/linux/ath79/dts/ar9344_atheros_db120.dts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	model = "Atheros DB120 reference board";
+	compatible = "atheros,db120", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	leds-ath9k {
+		compatible = "gpio-leds";
+
+		wlan5g-ath {
+			label = "green:wlan5g-ath";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			label = "WPS button";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwpart1 &fwpart2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			fwpart1: partition@50000 {
+				label = "fwpart1";
+				reg = <0x050000 0x630000>;
+			};
+
+			partition@680000 {
+				label = "loader";
+				reg = <0x680000 0x10000>;
+			};
+
+			fwpart2: partition@690000 {
+				label = "fwpart2";
+				reg = <0x690000 0x150000>;
+			};
+
+			nvram: partition@7e0000 {
+				label = "nvram";
+				reg = <0x7e0000 0x010000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x10 0xc1000000 /* POWER_ON_STRAP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6_STATUS */
+			>;
+	};
+};
+
+&pinmux {
+	pmx_led_wan_lan: pinmux_led_wan_lan {
+		pinctrl-single,bits = <0x10 0x2c2d0000 0xffff0000>,
+			 <0x14 0x292a2b 0xffffff>;
+	};
+};
+
+&builtin_switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_led_wan_lan>;
+
+	/delete-property/qca,phy4-mii-enable;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		qca,disable-2ghz;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&usb {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port1: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -113,6 +113,12 @@ ath79_setup_interfaces()
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
+	atheros,db120)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
+		ucidef_add_switch "switch1" \
+			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:lan"
+		;;
 	avm,fritz4020|\
 	pcs,cr3000|\
 	tplink,archer-c58-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -88,6 +88,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_mac $(macaddr_add $(mtd_get_mac_text "mac" 0x18) 1)
 		;;
+	atheros,db120|\
 	engenius,eap600|\
 	engenius,ecb600|\
 	mercury,mw4530r-v1|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -321,6 +321,25 @@ define Device/aruba_ap-105
 endef
 TARGET_DEVICES += aruba_ap-105
 
+define Device/atheros_db120
+  SOC := ar9344
+  DEVICE_VENDOR := Atheros
+  DEVICE_MODEL := DB120
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 7808k
+  SUPPORTED_DEVICES += db120
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x50000
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  COMPILE := loader-$(1).bin loader-$(1).uImage
+  COMPILE/loader-$(1).bin := loader-okli-compile
+  COMPILE/loader-$(1).uImage := append-loader-okli $(1) | pad-to 64k | lzma | \
+	uImage lzma
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 6336k | append-loader-okli-uimage $(1) | pad-to 64k
+endef
+TARGET_DEVICES += atheros_db120
+
 define Device/avm
   DEVICE_VENDOR := AVM
   KERNEL := kernel-bin | append-dtb | lzma | eva-image


### PR DESCRIPTION
Atheros DB120 reference board.

Specifications:

SoC:    QCA9344
DRAM:   128Mb DDR2
Flash:  8Mb SPI-NOR, 128Mb NAND flash
Switch: 5x 10/100Mbps via AR8229 switch (integrated into SoC),
        5x 10/100/1000Mbps via QCA8237 via RGMII
WLAN:   AR9300 (SoC, 2.4G+5G) + AR9340 (PCIe, 5G-only)
USB:    1x 2.0
UART:   standard QCA UART header
JTAG:   yes
Button: 1x reset
LEDs:   a lot
Slots:  2x mPCIe + 1x mini-PCI, using them requires
        additional undocumented changes.
Misc:   The board allows to boot off NAND, and there is
        I2S audio support as well - also requiring
        additional undocumented changes.

Installation:
 - Replace the original bootloader with pepe2k's u-boot mod.
 - Install the image with "run fw_upg", or hold the reset button
   at power-up, and install the image via the u-boot_mod GUI.

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>