### PR TITLE
xfrm: support 'multicast' attribute on interfaces

### DIFF
--- a/package/network/config/xfrm/Makefile
+++ b/package/network/config/xfrm/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfrm
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/xfrm/files/xfrm.sh
+++ b/package/network/config/xfrm/files/xfrm.sh
@@ -11,8 +11,8 @@ proto_xfrm_setup() {
 	local cfg="$1"
 	local mode="xfrm"
 
-	local tunlink ifid mtu zone
-	json_get_vars tunlink ifid mtu zone
+	local tunlink ifid mtu zone multicast
+	json_get_vars tunlink ifid mtu zone multicast
 
 	[ -z "$tunlink" ] && {
 		proto_notify_error "$cfg" NO_TUNLINK
@@ -35,6 +35,8 @@ proto_xfrm_setup() {
 	json_add_int mtu "${mtu:-1280}"
 
 	json_add_string link "$tunlink"
+
+	json_add_boolean multicast "${multicast:-1}"
 
 	json_add_object 'data'
 	[ -n "$ifid" ] && json_add_int ifid "$ifid"
@@ -61,6 +63,7 @@ proto_xfrm_init_config() {
 	proto_config_add_string "tunlink"
 	proto_config_add_string "zone"
 	proto_config_add_int "ifid"
+	proto_config_add_boolean "multicast"
 }
 
 


### PR DESCRIPTION
The support for `xfrm` interfaces included an `mtu` attribute but not `multicast`.  Add it.