### PR TITLE
ltq-dsl-base: fix line uptime

### DIFF
--- a/package/network/utils/ltq-dsl-base/Makefile
+++ b/package/network/utils/ltq-dsl-base/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ltq-dsl-base
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/network/utils/ltq-dsl-base/files/lib/functions/lantiq_dsl.sh
+++ b/package/network/utils/ltq-dsl-base/files/lib/functions/lantiq_dsl.sh
@@ -537,6 +537,7 @@ line_uptime() {
 
 	ccsg=$(dsl_cmd pmccsg 0 0 0)
 	et=$(dsl_val "$ccsg" nElapsedTime)
+	let et=et*1024/1000
 
 	[ -z "$et" ] && et=0
 


### PR DESCRIPTION
The Lantiq firmware under reports the uptime due to incorrect ticks per second bug - 1000 used in firmware calculation versus 1024 in modem hardware timer. Apply workaround. Both modem clock and system clock will still drift independently but now at the usual few seconds per day.

Original discussion at https://forum.openwrt.org/t/lantiq-dsl-modem-line-uptime-drift-lagging/ and seems unlikely firmware bug will ever be fixed.

Since there is another ltq-dsl-base pull request https://github.com/openwrt/openwrt/pull/3660 and other [patches](https://lists.infradead.org/pipermail/openwrt-devel/2020-December/032523.html) on the openwrt-devel mailing list, would be nice to get this added at the same time.