### PR TITLE
ramips: add support for Senao Engenius ESR600H

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -17,7 +17,8 @@ alfa-network,ac1200rm|\
 alfa-network,awusfree1|\
 alfa-network,quad-e4g|\
 alfa-network,r36m-e4g|\
-alfa-network,tube-e4g)
+alfa-network,tube-e4g|\
+engenius,esr600h)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"
 	;;
 allnet,all0256n-4m|\

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rt3883.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,esr600h", "ralink,rt3662-soc", "ralink,rt3883-soc";
+	model = "EnGenius ESR600H";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset-wps {
+			label = "reset-wps";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb {
+			gpio-export,name = "usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x1000>;
+			};
+
+			partition@32000 {
+				label = "config";
+				reg = <0x32000 0xe000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uartf";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	status = "okay";
+
+	port@0 {
+		phy-handle = <&phy0>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+
+			qca,ar8327-initvals = <
+				0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+				0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+				0x10 0x40000000 /* Power-on Strapping: 176-pin interface configuration */
+				0x50 0xc437c437 /* LED Control Register 0 */
+				0x54 0xc337c337 /* LED Control Register 1 */
+				0x58 0x00000000 /* LED Control Register 2 */
+				0x5c 0x03ffff00 /* LED Control Register 3 */
+				0x7c 0x0000007e /* PORT0_STATUS */
+				0x94 0x0000007e /* PORT6 STATUS */
+			>;
+		};
+	};
+};
+
+&pci {
+	status = "okay";
+};
+
+&pci1 {
+	status = "okay";
+
+	wifi@0,1,0 {
+		compatible = "pci1814,3091";
+		reg = <0x0 1 0 0 0>;
+		ralink,5ghz = <0>;
+		ralink,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	ralink,2ghz = <0>;
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -59,6 +59,20 @@ define Device/edimax_br-6475nd
 endef
 TARGET_DEVICES += edimax_br-6475nd
 
+define Device/engenius_esr600h
+  $(Device/uimage-lzma-loader)
+  SOC := rt3662
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7872k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size | \
+	senao-header -r 0x101 -p 0x44 -t 2
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := ESR600H
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 uboot-envtools
+endef
+TARGET_DEVICES += engenius_esr600h
+
 define Device/loewe_wmdr-143n
   SOC := rt3662
   BLOCKSIZE := 64k

--- a/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt3883/base-files/etc/board.d/02_network
@@ -25,6 +25,13 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "9@eth0"
 		;;
+	engenius,esr600h|\
+	sitecom,wlr-6000|\
+	trendnet,tew-691gr|\
+	trendnet,tew-692gr)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
+		;;
 	loewe,wmdr-143n|\
 	omnima,hpm)
 		ucidef_set_interface_lan "eth0"
@@ -32,12 +39,6 @@ ramips_setup_interfaces()
 	samsung,cy-swr1100)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "9@eth0"
-		;;
-	sitecom,wlr-6000|\
-	trendnet,tew-691gr|\
-	trendnet,tew-692gr)
-		ucidef_add_switch "switch0" \
-			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
 	esac
 }
@@ -65,6 +66,11 @@ ramips_setup_macs()
 		;;
 	edimax,br-6475nd)
 		wan_mac=$(mtd_get_mac_binary devdata 0x7)
+		;;
+	engenius,esr600h)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	samsung,cy-swr1100)
 		lan_mac=$(mtd_get_mac_ascii nvram lanmac)


### PR DESCRIPTION
FCC ID: A8J-ESR750H

Engenius ESR600H is an indoor wireless router with a gigabit switch,
2.4 GHz and 5 GHz wireless, internal and external antennas, and a USB port.

**Specification:**

  - RT3662F			MIPS SOC, 5 GHz WMAC (2x2)
  - RT5392L			PCI on-board, 2.4 GHz (2x2)
  - AR8327			RGMII, 7-port GbE, 25 MHz clock
  - 40 MHz reference clock
  - 8 MB FLASH			25L6406EM2I-12G
  - 64 MB RAM
  - UART at J12			(unpopulated)
  - 2 internal antennas		(5 GHz)
  - 2 external antennas		(2.4 GHz)
  - 9 LEDs, 1 button		(power, wps, wifi2g, wifi5g, 5 LAN/WAN)
  - USB 2 port			(GPIO controlled power)

**MAC addresses:**

  MAC Addresses are labeled as WAN and WLAN
  U-boot environment has the the vendor MAC address for ethernet
  MAC addresses in "factory" are part of wifi calibration data

  eth0.2	WAN	*:13:e7		u-boot-env wanaddr
  eth0.1	----	*:13:e8		u-boot-env wanaddr + 1
  phy0		WLAN	*:14:b8		factory 0x8004
  phy1		----	*:14:bc		factory 0x4

**Installation:**

  Method 1: Firmware upgrade page

  OEM webpage at 192.168.0.1
  username and password "admin"
  Navigate to Network Setting --> Tools --> Firmware
  Click Browse and select the factory.dlf image
  Click Continue to confirm and wait 6 minutes or more...

  Method 2: Serial console to load TFTP image:

  (see TFTP recovery)

**Return to OEM:**

  Unlike most Engenius boards, this does not have a 'failsafe' image
  the only way to return to OEM is serial access to uboot

  Unlike most Engenius boards, public images are not available...
  so the only way to return to OEM is to have a copy
  of the MTD partition "firmware" BEFORE flashing openwrt.

**TFTP recovery:**

  Unlike most Engenius boards, TFTP is reliable here
  however it requires serial console access
  (soldering pins to the UART pinouts)

  build your own image...
  with "ramdisk" selected under "Target Images"

  rename initramfs-kernel.bin to 'uImageESR-600H'
  make the file available on a TFTP server at 192.168.99.8
  interrupt boot by holding or pressing "4" in serial console
  as soon as board is powered on

  `tftpboot 0x81000000`
  `bootm 0x81000000`
  perform a sysupgrade

**Format of OEM firmware image:**

  This Engenius board uses the Senao proprietary header
  with a unique Product ID. The header for factory.bin is
  generated by the mksenaofw program included in openwrt.

  .dlf file extension is also required for OEM software to accept it

**Note on using OKLI:**

  the kernel is now too large for the bootloader to handle
  so OKLI is used via the `kernel-loader` image command
  recently in master several other ramips boards have the same problem

  "Kernel panic - not syncing: Failed to find ralink,rt3883-sysc node"

  see commit ad19751edc21ae713bd95df6b93be64bd1e0c612

Signed-off-by: Michael Pratt <mcpratt@pm.me>