### PR TITLE
package/base-files: caldata: use dd iflag fullblock

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=239
+PKG_RELEASE:=240
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -3,6 +3,16 @@
 . /lib/functions.sh
 . /lib/functions/system.sh
 
+caldata_dd() {
+	local source=$1
+	local target=$2
+	local count=$(($3))
+	local offset=$(($4))
+
+	dd if=$source of=$target iflag=skip_bytes,fullblock bs=$count skip=$offset count=1 2>/dev/null
+	return $?
+}
+
 caldata_die() {
 	echo "caldata: " "$*"
 	exit 1
@@ -17,7 +27,7 @@ caldata_extract() {
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || caldata_die "no mtd device found for partition $part"
 
-	dd if=$mtd of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+	caldata_dd $mtd /lib/firmware/$FIRMWARE $count $offset || \
 		caldata_die "failed to extract calibration data from $mtd"
 }
 
@@ -34,7 +44,7 @@ caldata_extract_ubi() {
 	ubi=$(nand_find_volume $ubidev $part)
 	[ -n "$ubi" ] || caldata_die "no UBI volume found for $part"
 
-	dd if=/dev/$ubi of=/lib/firmware/$FIRMWARE iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+	caldata_dd /dev/$ubi /lib/firmware/$FIRMWARE $count $offset || \
 		caldata_die "failed to extract calibration data from $ubi"
 }
 
@@ -64,8 +74,7 @@ caldata_from_file() {
 
 	[ -n "$target" ] || target=/lib/firmware/$FIRMWARE
 
-	# dd doesn't handle partial reads from special files: use cat
-	cat $source | dd of=$target iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+	caldata_dd $source $target $count $offset || \
 		caldata_die "failed to extract calibration data from $source"
 }
 
@@ -73,16 +82,20 @@ caldata_sysfsload_from_file() {
 	local source=$1
 	local offset=$(($2))
 	local count=$(($3))
+	local target_dir="/sys/$DEVPATH"
+	local target="$target_dir/data"
 
-	# dd doesn't handle partial reads from special files: use cat
-	# test extract to /dev/null first
-	cat $source | dd of=/dev/null iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null || \
+	[ -d "$target_dir" ] || \
+		caldata_die "no sysfs dir to write: $target"
+
+	echo 1 > "$target_dir/loading"
+	caldata_dd $source $target $count $offset
+	if [ $? != 0 ]; then
+		echo 1 > "$target_dir/loading"
 		caldata_die "failed to extract calibration data from $source"
-
-	# can't fail now
-	echo 1 > /sys/$DEVPATH/loading
-	cat $source | dd of=/sys/$DEVPATH/data iflag=skip_bytes bs=$count skip=$offset count=1 2>/dev/null
-	echo 0 > /sys/$DEVPATH/loading
+	else
+		echo 0 > "$target_dir/loading"
+	fi
 }
 
 caldata_valid() {


### PR DESCRIPTION
This dd flag ensures that the requested size
is retrieved from pipes or special filesystems (if available).

Without this flag, on multi-core systems,
Piped or special filesystem data can be truncated
when a size greater than PIPE_BUF is requested.

Fixes: FS#3494
Fixes: 7557e7f ("package/base-files: caldata: work around dd's
limitation")
Cc: Thibaut VARÈNE <hacks@slashdirt.org>

Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>

___



[Bug report: FS#3494](https://bugs.openwrt.org/index.php?do=details&task_id=3494)

http://lists.busybox.net/pipermail/busybox/2020-November/088326.html
> iflag=fullblock is the right solution. I added that feature a couple of
years ago. I thought it should be busybox's default behavior, but that goes
against the POSIX spec.
>
> POSIX dd specifies that one block == one read() call, unless modified by an
iflag. Read() calls can return partial data pretty often, especially when
reading from pipes. A filesystem read() will _usually_ give you as much
data as you request, but it's not guaranteed at all.
>
>So if you want to make _sure_ you're getting all of the data you want, the
only guaranteed safe approach is to use iflag=fullblock. It's good practice
to always use it with dd.

In the sysfs load:
I added the second `echo 1 > /sys/$DEVPATH/loading` to indicate to the driver there is a problem with the supplied firmware

https://www.kernel.org/doc/html/v5.4/driver-api/firmware/fallback-mechanisms.html#firmware-sysfs-loading-facility
> Using `echo 1 > /sys/$DEVPATH/loading`
> Will clean any previous partial load at once and make the firmware API return an error.

Tested on mikrotik hap ac2 & wap-g
I do not have an mtd or ubi caldata based device to test the other functions

@f00b4r0 Could you please take a look at this PR?



Somewhat related:

- We should be able to save a few cpu cycles by only running firmware hotplug caldata when $ACTION=add [not for remove as well](https://bugs.openwrt.org/index.php?do=details&task_id=3493)