### PR TITLE
Update mt7621 to support xiaomi,mir-3g board name

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1207,7 +1207,7 @@ define Device/xiaomi_mi-router-3g
   DEVICE_MODEL := Mi Router 3G
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport uboot-envtools
-  SUPPORTED_DEVICES += R3G mir3g xiaomi,mir3g
+  SUPPORTED_DEVICES += R3G mir3g xiaomi,mir3g xiaomi,mir-3g
 endef
 TARGET_DEVICES += xiaomi_mi-router-3g
 


### PR DESCRIPTION
Some board name has `xiaomi,mir-3g` for xiaomi router 3G