### PR TITLE
apm821xx: WNDR4700 additional user space on "ecos" partition

### DIFF
--- a/target/linux/apm821xx/dts/netgear-wndr4700.dts
+++ b/target/linux/apm821xx/dts/netgear-wndr4700.dts
@@ -24,6 +24,7 @@
 
 	chosen {
 		stdout-path = "/plb/opb/serial@ef600300:115200n8";
+		bootargs = "rootfstype=squashfs noinitrd ubi.mtd=ubi ubi.mtd=ecos";
 	};
 
 	thermal-zones {
@@ -240,7 +241,6 @@
 			partition0,9@1fa0000 {
 				label = "ecos";
 				reg = <0x01fa0000 0x06020000>;
-				read-only;
 			};
 
 			partition0,10@7fc0000 {


### PR DESCRIPTION
This change allows to use "ecos" partition as extroot (or even rootfs_data)
Detailed description in commit message.

Identical solution was provided by @chunkeey on the forum some time ago, as a script to modify DTS in the image.

I think it would be nice to have this feature as a standard for WNDR4700, without it there is almost no space to install any additional services.

Side effect of this change is that if "ecos" partition is not formatted with ubifs kernel will print an error message at boot time:
`UBI error: cannot attach mtd9`