### PR TITLE
kernel: bump 5.4 to 5.4.83

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .82
+LINUX_VERSION-5.4 = .83
 
-LINUX_KERNEL_HASH-5.4.82 = fb4458e4ea38b6c5df4ee8cee0d9b0420b5aed07e273787b045c0db48709ddaf
+LINUX_KERNEL_HASH-5.4.83 = beec970bbb93de8ab839f27930f7ab00c7bd65af0ffa07a50e765affdc2561c6
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/pending-5.4/640-netfilter-nf_flow_table-add-hardware-offload-support.patch
+++ b/target/linux/generic/pending-5.4/640-netfilter-nf_flow_table-add-hardware-offload-support.patch
@@ -506,7 +506,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
 +MODULE_ALIAS("nf-flow-table-hw");
 --- a/net/netfilter/nf_tables_api.c
 +++ b/net/netfilter/nf_tables_api.c
-@@ -5742,6 +5742,13 @@ static int nf_tables_flowtable_parse_hoo
+@@ -5743,6 +5743,13 @@ static int nf_tables_flowtable_parse_hoo
  	if (err < 0)
  		return err;
  
@@ -520,7 +520,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  	ops = kcalloc(n, sizeof(struct nf_hook_ops), GFP_KERNEL);
  	if (!ops)
  		return -ENOMEM;
-@@ -5872,10 +5879,19 @@ static int nf_tables_newflowtable(struct
+@@ -5873,10 +5880,19 @@ static int nf_tables_newflowtable(struct
  	}
  
  	flowtable->data.type = type;
@@ -540,7 +540,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  	err = nf_tables_flowtable_parse_hook(&ctx, nla[NFTA_FLOWTABLE_HOOK],
  					     flowtable);
  	if (err < 0)
-@@ -6001,7 +6017,8 @@ static int nf_tables_fill_flowtable_info
+@@ -6002,7 +6018,8 @@ static int nf_tables_fill_flowtable_info
  	    nla_put_string(skb, NFTA_FLOWTABLE_NAME, flowtable->name) ||
  	    nla_put_be32(skb, NFTA_FLOWTABLE_USE, htonl(flowtable->use)) ||
  	    nla_put_be64(skb, NFTA_FLOWTABLE_HANDLE, cpu_to_be64(flowtable->handle),

--- a/target/linux/ipq40xx/patches-5.4/0019-v5.6-mtd-spi-nor-Add-support-for-mx25r3235f.patch
+++ b/target/linux/ipq40xx/patches-5.4/0019-v5.6-mtd-spi-nor-Add-support-for-mx25r3235f.patch
@@ -18,7 +18,7 @@ Signed-off-by: Tudor Ambarus <tudor.ambarus@microchip.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2344,6 +2344,8 @@ static const struct flash_info spi_nor_i
+@@ -2351,6 +2351,8 @@ static const struct flash_info spi_nor_i
  	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },
  	{ "mx25l12805d", INFO(0xc22018, 0, 64 * 1024, 256, 0) },
  	{ "mx25l12855e", INFO(0xc22618, 0, 64 * 1024, 256, 0) },

--- a/target/linux/layerscape/patches-5.4/808-i2c-0002-MLK-10893-i2c-imx-add-irqf_no_suspend.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0002-MLK-10893-i2c-imx-add-irqf_no_suspend.patch
@@ -17,7 +17,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -1131,7 +1131,8 @@ static int i2c_imx_probe(struct platform
+@@ -1159,7 +1159,8 @@ static int i2c_imx_probe(struct platform
  		goto rpm_disable;
  
  	/* Request IRQ */

--- a/target/linux/layerscape/patches-5.4/808-i2c-0003-MLK-11403-I2C-imx-restore-pin-setting-for-i2c.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0003-MLK-11403-I2C-imx-restore-pin-setting-for-i2c.patch
@@ -15,7 +15,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -1229,7 +1229,8 @@ static int __maybe_unused i2c_imx_runtim
+@@ -1257,7 +1257,8 @@ static int __maybe_unused i2c_imx_runtim
  {
  	struct imx_i2c_struct *i2c_imx = dev_get_drvdata(dev);
  
@@ -25,7 +25,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
  
  	return 0;
  }
-@@ -1239,14 +1240,28 @@ static int __maybe_unused i2c_imx_runtim
+@@ -1267,14 +1268,28 @@ static int __maybe_unused i2c_imx_runtim
  	struct imx_i2c_struct *i2c_imx = dev_get_drvdata(dev);
  	int ret;
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0004-MLK-16203-enable-runtime-pm-of-i2c-temporary-when-do.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0004-MLK-16203-enable-runtime-pm-of-i2c-temporary-when-do.patch
@@ -19,7 +19,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -896,10 +896,17 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -924,10 +924,17 @@ static int i2c_imx_xfer(struct i2c_adapt
  	unsigned int i, temp;
  	int result;
  	bool is_lastmsg = false;
@@ -37,7 +37,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
  	result = pm_runtime_get_sync(i2c_imx->adapter.dev.parent);
  	if (result < 0)
  		goto out;
-@@ -971,6 +978,9 @@ fail0:
+@@ -999,6 +1006,9 @@ fail0:
  	pm_runtime_put_autosuspend(i2c_imx->adapter.dev.parent);
  
  out:
@@ -47,7 +47,7 @@ Signed-off-by: Vipul Kumar <vipul_kumar@mentor.com>
  	dev_dbg(&i2c_imx->adapter.dev, "<%s> exit with: %s: %d\n", __func__,
  		(result < 0) ? "error" : "success msg",
  			(result < 0) ? result : num);
-@@ -1261,7 +1271,7 @@ static int i2c_imx_resume(struct device
+@@ -1289,7 +1299,7 @@ static int i2c_imx_resume(struct device
  }
  
  static const struct dev_pm_ops i2c_imx_pm_ops = {

--- a/target/linux/layerscape/patches-5.4/808-i2c-0005-MLK-20773-i2c-imx-add-a-limit-of-maximum-transfer-sp.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0005-MLK-20773-i2c-imx-add-a-limit-of-maximum-transfer-sp.patch
@@ -77,7 +77,7 @@ Signed-off-by: Clark Wang <xiaoning.wang@nxp.com>
  static inline void imx_i2c_write_reg(unsigned int val,
  		struct imx_i2c_struct *i2c_imx, unsigned int reg)
  {
-@@ -1159,6 +1177,14 @@ static int i2c_imx_probe(struct platform
+@@ -1187,6 +1205,14 @@ static int i2c_imx_probe(struct platform
  	clk_notifier_register(i2c_imx->clk, &i2c_imx->clk_change_nb);
  	i2c_imx_set_clk(i2c_imx, clk_get_rate(i2c_imx->clk));
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0006-MLK-20368-i2c-imx-Coverity-fix-divide-by-zero-warnin.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0006-MLK-20368-i2c-imx-Coverity-fix-divide-by-zero-warnin.patch
@@ -19,7 +19,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -492,16 +492,24 @@ static int i2c_imx_acked(struct imx_i2c_
+@@ -514,16 +514,24 @@ static int i2c_imx_acked(struct imx_i2c_
  	return 0;
  }
  
@@ -47,7 +47,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
  
  	i2c_imx->cur_clk = i2c_clk_rate;
  
-@@ -532,20 +540,23 @@ static void i2c_imx_set_clk(struct imx_i
+@@ -554,20 +562,23 @@ static void i2c_imx_set_clk(struct imx_i
  	dev_dbg(&i2c_imx->adapter.dev, "IFDR[IC]=0x%x, REAL DIV=%d\n",
  		i2c_clk_div[i].val, i2c_clk_div[i].div);
  #endif
@@ -73,7 +73,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
  }
  
  static int i2c_imx_start(struct imx_i2c_struct *i2c_imx)
-@@ -555,6 +566,10 @@ static int i2c_imx_start(struct imx_i2c_
+@@ -577,6 +588,10 @@ static int i2c_imx_start(struct imx_i2c_
  
  	dev_dbg(&i2c_imx->adapter.dev, "<%s>\n", __func__);
  
@@ -84,7 +84,7 @@ Signed-off-by: Shrikant Bobade <Shrikant_Bobade@mentor.com>
  	imx_i2c_write_reg(i2c_imx->ifdr, i2c_imx, IMX_I2C_IFDR);
  	/* Enable I2C controller */
  	imx_i2c_write_reg(i2c_imx->hwdata->i2sr_clr_opcode, i2c_imx, IMX_I2C_I2SR);
-@@ -1175,7 +1190,11 @@ static int i2c_imx_probe(struct platform
+@@ -1203,7 +1218,11 @@ static int i2c_imx_probe(struct platform
  		i2c_imx->bitrate = pdata->bitrate;
  	i2c_imx->clk_change_nb.notifier_call = i2c_imx_clk_notifier_call;
  	clk_notifier_register(i2c_imx->clk, &i2c_imx->clk_change_nb);

--- a/target/linux/layerscape/patches-5.4/808-i2c-0007-i2c-imx-add-workaround-for-erratum-ERR010027.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0007-i2c-imx-add-workaround-for-erratum-ERR010027.patch
@@ -17,7 +17,7 @@ Signed-off-by: Zhang Ying-22455 <ying.zhang22455@nxp.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -940,6 +940,14 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -968,6 +968,14 @@ static int i2c_imx_xfer(struct i2c_adapt
  		enable_runtime_pm = true;
  	}
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0008-i2c-imx-implement-bus-recovery-with-gpio-for-Layersc.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0008-i2c-imx-implement-bus-recovery-with-gpio-for-Layersc.patch
@@ -106,7 +106,7 @@ Signed-off-by: Zhang Ying-22455 <ying.zhang22455@nxp.com>
  };
  
  static const struct imx_i2c_hwdata imx1_i2c_hwdata = {
-@@ -923,6 +983,78 @@ static int i2c_imx_read(struct imx_i2c_s
+@@ -951,6 +1011,78 @@ static int i2c_imx_read(struct imx_i2c_s
  	return 0;
  }
  
@@ -185,7 +185,7 @@ Signed-off-by: Zhang Ying-22455 <ying.zhang22455@nxp.com>
  static int i2c_imx_xfer(struct i2c_adapter *adapter,
  						struct i2c_msg *msgs, int num)
  {
-@@ -945,8 +1077,13 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -973,8 +1105,13 @@ static int i2c_imx_xfer(struct i2c_adapt
  	 * before switching to master mode and attempting a Start cycle
  	 */
  	result =  i2c_imx_bus_busy(i2c_imx, 0);
@@ -201,7 +201,7 @@ Signed-off-by: Zhang Ying-22455 <ying.zhang22455@nxp.com>
  
  	result = pm_runtime_get_sync(i2c_imx->adapter.dev.parent);
  	if (result < 0)
-@@ -1093,6 +1230,50 @@ static int i2c_imx_init_recovery_info(st
+@@ -1121,6 +1258,50 @@ static int i2c_imx_init_recovery_info(st
  	return 0;
  }
  
@@ -252,7 +252,7 @@ Signed-off-by: Zhang Ying-22455 <ying.zhang22455@nxp.com>
  static u32 i2c_imx_func(struct i2c_adapter *adapter)
  {
  	return I2C_FUNC_I2C | I2C_FUNC_SMBUS_EMUL
-@@ -1217,8 +1398,13 @@ static int i2c_imx_probe(struct platform
+@@ -1245,8 +1426,13 @@ static int i2c_imx_probe(struct platform
  			i2c_imx, IMX_I2C_I2CR);
  	imx_i2c_write_reg(i2c_imx->hwdata->i2sr_clr_opcode, i2c_imx, IMX_I2C_I2SR);
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0009-i2c-imx-get-rid-of-CONFIG_ARCH_LAYERSCAPE.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0009-i2c-imx-get-rid-of-CONFIG_ARCH_LAYERSCAPE.patch
@@ -14,7 +14,7 @@ Signed-off-by: Dong Aisheng <aisheng.dong@nxp.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -1398,13 +1398,12 @@ static int i2c_imx_probe(struct platform
+@@ -1426,13 +1426,12 @@ static int i2c_imx_probe(struct platform
  			i2c_imx, IMX_I2C_I2CR);
  	imx_i2c_write_reg(i2c_imx->hwdata->i2sr_clr_opcode, i2c_imx, IMX_I2C_I2SR);
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0010-i2c-imx-fix-system-hang-due-to-access-i2c-registers-.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0010-i2c-imx-fix-system-hang-due-to-access-i2c-registers-.patch
@@ -22,7 +22,7 @@ Signed-off-by: Dong Aisheng <aisheng.dong@nxp.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -1066,12 +1066,15 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -1094,12 +1094,15 @@ static int i2c_imx_xfer(struct i2c_adapt
  
  	dev_dbg(&i2c_imx->adapter.dev, "<%s>\n", __func__);
  
@@ -39,7 +39,7 @@ Signed-off-by: Dong Aisheng <aisheng.dong@nxp.com>
  	/*
  	 * workround for ERR010027: ensure that the I2C BUS is idle
  	 * before switching to master mode and attempting a Start cycle
-@@ -1085,10 +1088,6 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -1113,10 +1116,6 @@ static int i2c_imx_xfer(struct i2c_adapt
  			goto out;
  	}
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0011-i2c-imx-support-slave-mode-for-imx-I2C-driver.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0011-i2c-imx-support-slave-mode-for-imx-I2C-driver.patch
@@ -38,7 +38,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  /* Functions for DMA support */
  static void i2c_imx_dma_request(struct imx_i2c_struct *i2c_imx,
  						dma_addr_t phy_addr)
-@@ -681,23 +692,33 @@ static void i2c_imx_stop(struct imx_i2c_
+@@ -705,21 +716,33 @@ static void i2c_imx_stop(struct imx_i2c_
  	imx_i2c_write_reg(temp, i2c_imx, IMX_I2C_I2CR);
  }
  
@@ -57,9 +57,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
 -	if (temp & I2SR_IIF) {
 -		/* save status register */
 -		i2c_imx->i2csr = temp;
--		temp &= ~I2SR_IIF;
--		temp |= (i2c_imx->hwdata->i2sr_clr_opcode & I2SR_IIF);
--		imx_i2c_write_reg(temp, i2c_imx, IMX_I2C_I2SR);
+-		i2c_imx_clear_irq(i2c_imx, I2SR_IIF);
 -		wake_up(&i2c_imx->queue);
 -		return IRQ_HANDLED;
 -	}
@@ -70,8 +68,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
 +	status |= (i2c_imx->hwdata->i2sr_clr_opcode & I2SR_IAL);
 +	imx_i2c_write_reg(status, i2c_imx, IMX_I2C_I2SR);
 +}
- 
--	return IRQ_NONE;
++
 +static irqreturn_t i2c_imx_master_isr(struct imx_i2c_struct *i2c_imx)
 +{
 +	unsigned int status;
@@ -81,12 +78,13 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
 +	i2c_imx->i2csr = status | I2SR_IIF;
 +
 +	wake_up(&i2c_imx->queue);
-+
+ 
+-	return IRQ_NONE;
 +	return IRQ_HANDLED;
  }
  
  static int i2c_imx_dma_write(struct imx_i2c_struct *i2c_imx,
-@@ -1066,6 +1087,13 @@ static int i2c_imx_xfer(struct i2c_adapt
+@@ -1094,6 +1117,13 @@ static int i2c_imx_xfer(struct i2c_adapt
  
  	dev_dbg(&i2c_imx->adapter.dev, "<%s>\n", __func__);
  
@@ -100,7 +98,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  	if (!pm_runtime_enabled(i2c_imx->adapter.dev.parent)) {
  		pm_runtime_enable(i2c_imx->adapter.dev.parent);
  		enable_runtime_pm = true;
-@@ -1279,11 +1307,169 @@ static u32 i2c_imx_func(struct i2c_adapt
+@@ -1307,11 +1337,169 @@ static u32 i2c_imx_func(struct i2c_adapt
  		| I2C_FUNC_SMBUS_READ_BLOCK_DATA;
  }
  
@@ -270,7 +268,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  static int i2c_imx_probe(struct platform_device *pdev)
  {
  	struct imx_i2c_struct *i2c_imx;
-@@ -1392,10 +1578,7 @@ static int i2c_imx_probe(struct platform
+@@ -1420,10 +1608,7 @@ static int i2c_imx_probe(struct platform
  	if (is_imx7d_i2c(i2c_imx) && i2c_imx->bitrate > IMX_I2C_MAX_E_BIT_RATE)
  		i2c_imx->bitrate = IMX_I2C_MAX_E_BIT_RATE;
  

--- a/target/linux/layerscape/patches-5.4/808-i2c-0012-i2c-imx-correct-code-of-errata-A-010650-for-layersca.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0012-i2c-imx-correct-code-of-errata-A-010650-for-layersca.patch
@@ -17,8 +17,8 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -503,6 +503,14 @@ static void i2c_imx_dma_free(struct imx_
- 	dma->chan_using = NULL;
+@@ -516,6 +516,14 @@ static void i2c_imx_clear_irq(struct imx
+ 	imx_i2c_write_reg(temp, i2c_imx, IMX_I2C_I2SR);
  }
  
 +/* Clear arbitration lost bit */
@@ -32,17 +32,16 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  static int i2c_imx_bus_busy(struct imx_i2c_struct *i2c_imx, int for_busy)
  {
  	unsigned long orig_jiffies = jiffies;
-@@ -515,8 +523,7 @@ static int i2c_imx_bus_busy(struct imx_i
+@@ -528,7 +536,7 @@ static int i2c_imx_bus_busy(struct imx_i
  
  		/* check for arbitration lost */
  		if (temp & I2SR_IAL) {
--			temp &= ~I2SR_IAL;
--			imx_i2c_write_reg(temp, i2c_imx, IMX_I2C_I2SR);
+-			i2c_imx_clear_irq(i2c_imx, I2SR_IAL);
 +			i2c_imx_clr_al_bit(temp, i2c_imx);
  			return -EAGAIN;
  		}
  
-@@ -700,14 +707,6 @@ static void i2c_imx_clr_if_bit(unsigned
+@@ -724,14 +732,6 @@ static void i2c_imx_clr_if_bit(unsigned
  	imx_i2c_write_reg(status, i2c_imx, IMX_I2C_I2SR);
  }
  
@@ -57,7 +56,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  static irqreturn_t i2c_imx_master_isr(struct imx_i2c_struct *i2c_imx)
  {
  	unsigned int status;
-@@ -1050,12 +1049,14 @@ static int i2c_imx_recovery_for_layersca
+@@ -1080,12 +1080,14 @@ static int i2c_imx_recovery_for_layersca
  	gpio_set_value(i2c_imx->gpio, 1);
  
  	/*
@@ -77,7 +76,7 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  
  	/* Restore the saved value of the register SCFG_RCWPMUXCR0 */
  	if (i2c_imx->need_set_pmuxcr == 1) {
-@@ -1069,10 +1070,9 @@ static int i2c_imx_recovery_for_layersca
+@@ -1099,10 +1101,9 @@ static int i2c_imx_recovery_for_layersca
  	 * I2C_IBSR[IBAL] = 1
  	 */
  	temp = imx_i2c_read_reg(i2c_imx, IMX_I2C_I2SR);

--- a/target/linux/layerscape/patches-5.4/808-i2c-0013-LF-98-i2c-imx-fix-the-judgement-of-slave-mode-in-isr.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0013-LF-98-i2c-imx-fix-the-judgement-of-slave-mode-in-isr.patch
@@ -15,7 +15,7 @@ Signed-off-by: Clark Wang <xiaoning.wang@nxp.com>
 
 --- a/drivers/i2c/busses/i2c-imx.c
 +++ b/drivers/i2c/busses/i2c-imx.c
-@@ -1451,23 +1451,20 @@ static const struct i2c_algorithm i2c_im
+@@ -1482,23 +1482,20 @@ static const struct i2c_algorithm i2c_im
  static irqreturn_t i2c_imx_isr(int irq, void *dev_id)
  {
  	struct imx_i2c_struct *i2c_imx = dev_id;

--- a/target/linux/layerscape/patches-5.4/808-i2c-0016-LF-162-i2c-imx-Defer-probing-if-EDMA-not-available.patch
+++ b/target/linux/layerscape/patches-5.4/808-i2c-0016-LF-162-i2c-imx-Defer-probing-if-EDMA-not-available.patch
@@ -52,7 +52,7 @@ Signed-off-by: Peng Ma <peng.ma@nxp.com>
  }
  
  static void i2c_imx_dma_callback(void *arg)
-@@ -1602,10 +1604,14 @@ static int i2c_imx_probe(struct platform
+@@ -1633,10 +1635,14 @@ static int i2c_imx_probe(struct platform
  	dev_info(&i2c_imx->adapter.dev, "IMX I2C adapter registered\n");
  
  	/* Init DMA config if supported */

--- a/target/linux/layerscape/patches-5.4/817-spi-0006-LF-20-2-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0006-LF-20-2-mtd-spi-nor-Use-1-bit-mode-of-spansion-s25fs.patch
@@ -11,7 +11,7 @@ Signed-off-by: Kuldeep Singh <kuldeep.singh@nxp.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2410,7 +2410,7 @@ static const struct flash_info spi_nor_i
+@@ -2417,7 +2417,7 @@ static const struct flash_info spi_nor_i
  	{ "s25fl512s",  INFO6(0x010220, 0x4d0080, 256 * 1024, 256,
  			SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
  			SPI_NOR_HAS_LOCK | USE_CLSR) },

--- a/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -10,7 +10,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -4930,6 +4930,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -4937,6 +4937,7 @@ int spi_nor_scan(struct spi_nor *nor, co
  	struct mtd_info *mtd = &nor->mtd;
  	struct device_node *np = spi_nor_get_flash_node(nor);
  	struct spi_nor_flash_parameter *params = &nor->params;
@@ -18,7 +18,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
  	int ret;
  	int i;
  
-@@ -4992,7 +4993,12 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -4999,7 +5000,12 @@ int spi_nor_scan(struct spi_nor *nor, co
  	/* Init flash parameters based on flash_info struct and SFDP */
  	spi_nor_init_params(nor);
  

--- a/target/linux/ramips/patches-5.4/302-spi-nor-add-gd25q512.patch
+++ b/target/linux/ramips/patches-5.4/302-spi-nor-add-gd25q512.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -2296,6 +2296,11 @@ static const struct flash_info spi_nor_i
+@@ -2303,6 +2303,11 @@ static const struct flash_info spi_nor_i
  			SPI_NOR_4B_OPCODES | SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
  			.fixups = &gd25q256_fixups,
  	},


### PR DESCRIPTION
Manually merged:
```
  layerscape/patches-5.4/808-i2c-0011-i2c-imx-support-slave-mode-for-imx-I2C-driver.patch
  layerscape/patches-5.4/808-i2c-0012-i2c-imx-correct-code-of-errata-A-010650-for-layersca.patch
```

* Requesting a review of the manually merged patches.

Remaining modifications made by `update_kernel.sh`

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>