### PR TITLE
lantiq: xrx200: remove unused lan/wan labels from dts

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
@@ -70,7 +70,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -94,7 +94,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -112,7 +112,7 @@
 		    <&gphy1_led0_pins>, <&gphy1_led1_pins>;
 	pinctrl-names = "default";
 
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -130,7 +130,7 @@
 	pinctrl-0 = <&mdio_pins>, <&gphy0_led1_pins>, <&gphy1_led0_pins>;
 	pinctrl-names = "default";
 
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2.dtsi
@@ -115,7 +115,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -81,7 +81,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -115,7 +115,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_buffalo_wbmr-300hpd.dts
@@ -153,7 +153,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -96,7 +96,7 @@
 };
 
 &eth0 {
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -129,7 +129,7 @@
 		};
 	};
 
-	wan: interface@1 {
+	interface@1 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
@@ -86,7 +86,7 @@
 &eth0 {
 	lantiq,phys = <&gphy1>;
 
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -111,7 +111,7 @@
 	pinctrl-0 = <&mdio_pins>, <&gphy0_led1_pins>, <&gphy1_led1_pins>;
 	pinctrl-names = "default";
 
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -116,7 +116,7 @@
 		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
 	pinctrl-names = "default";
 
-	lan: interface@0 {
+	interface@0 {
 		compatible = "lantiq,xrx200-pdi";
 		#address-cells = <1>;
 		#size-cells = <0>;


### PR DESCRIPTION
These labels are not used anywhere and can be removed.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
