### PR TITLE
ath79: add support for Qualcomm AP143 reference board

### DIFF
--- a/target/linux/ath79/dts/qca9533_qca_ap143-16m.dts
+++ b/target/linux/ath79/dts/qca9533_qca_ap143-16m.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_qca_ap143.dtsi"
+
+/ {
+	model = "Qualcomm Atheros AP143 (16M) reference board";
+	compatible = "qca,ap143-16m", "qca,qca9533";
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwpart1 &fwpart2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+};
+
+&partitions {
+	fwpart1: partition@50000 {
+		label = "fwpart1";
+		reg = <0x050000 0xe30000>;
+	};
+
+	partition@e80000 {
+		label = "loader";
+		reg = <0xe80000 0x10000>;
+	};
+
+	fwpart2: partition@e90000 {
+		label = "fwpart2";
+		reg = <0xe90000 0x160000>;
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};
+

--- a/target/linux/ath79/dts/qca9533_qca_ap143-8m.dts
+++ b/target/linux/ath79/dts/qca9533_qca_ap143-8m.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_qca_ap143.dtsi"
+
+/ {
+	model = "Qualcomm Atheros AP143 (8M) reference board";
+	compatible = "qca,ap143-8m", "qca,qca9533";
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwpart1 &fwpart2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+};
+
+&partitions {
+	fwpart1: partition@50000 {
+		label = "fwpart1";
+		reg = <0x050000 0x630000>;
+	};
+
+	partition@680000 {
+		label = "loader";
+		reg = <0x680000 0x10000>;
+	};
+
+	fwpart2: partition@690000 {
+		label = "fwpart2";
+		reg = <0x690000 0x160000>;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/dts/qca9533_qca_ap143.dtsi
+++ b/target/linux/ath79/dts/qca9533_qca_ap143.dtsi
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps: wps {
+			label = "green:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	mtd-mac-address = <&art 0x6>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -253,6 +253,14 @@ pcs,cr3000)
 	ucidef_set_led_switch "lan3" "LAN3" "blue:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "blue:lan4" "switch0" "0x02"
 	;;
+qca,ap143-8m|\
+qca,ap143-16m)
+	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x10"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	;;
 qihoo,c301)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -180,7 +180,9 @@ ath79_setup_interfaces()
 	ubnt,routerstation)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
-	comfast,cf-e560ac)
+	comfast,cf-e560ac|\
+	qca,ap143-8m|\
+	qca,ap143-16m)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -44,6 +44,10 @@ define Build/append-loader-okli
 	cat "$(KDIR)/loader-$(word 1,$(1)).$(LOADER_TYPE)" >> "$@"
 endef
 
+define Build/append-loader-okli-uimage
+	cat "$(KDIR)/loader-$(word 1,$(1)).uImage" >> "$@"
+endef
+
 define Build/relocate-kernel
 	rm -rf $@.relocate
 	$(CP) ../../generic/image/relocate $@.relocate

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1838,6 +1838,39 @@ define Device/plasmacloud_pa300e
 endef
 TARGET_DEVICES += plasmacloud_pa300e
 
+define Device/qca_ap143
+  SOC := qca9533
+  DEVICE_VENDOR := Qualcomm Atheros
+  DEVICE_MODEL := AP143
+  DEVICE_PACKAGES := kmod-usb2
+  SUPPORTED_DEVICES += ap143
+  LOADER_TYPE := bin
+  LOADER_FLASH_OFFS := 0x50000
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  COMPILE := loader-$(1).bin loader-$(1).uImage
+  COMPILE/loader-$(1).bin := loader-okli-compile
+  COMPILE/loader-$(1).uImage := append-loader-okli $(1) | pad-to 64k | lzma | \
+	uImage lzma
+endef
+
+define Device/qca_ap143-8m
+  $(Device/qca_ap143)
+  DEVICE_VARIANT := (8M)
+  IMAGE_SIZE := 7808k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 6336k | append-loader-okli-uimage $(1) | pad-to 64k
+endef
+TARGET_DEVICES += qca_ap143-8m
+
+define Device/qca_ap143-16m
+  $(Device/qca_ap143)
+  DEVICE_VARIANT := (16M)
+  IMAGE_SIZE := 16000k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | pad-to 14528k | append-loader-okli-uimage $(1) | pad-to 64k
+endef
+TARGET_DEVICES += qca_ap143-16m
+
 define Device/qihoo_c301
   $(Device/seama)
   SOC := ar9344


### PR DESCRIPTION
Specifications:

SoC:    QCA9533
DRAM:   32Mb DDR1
Flash:  8Mb SPI-NOR (a 16Mb version also exists)
LAN:    4x 10/100Mbps via AR8229 switch (integrated into SoC)
        on GMII
WAN:    1x 10/100Mbps via MII
WLAN:   QCA9530
USB:    1x 2.0
UART:   standard QCA UART header
JTAG:   yes
Button: 1x WPS, 1x reset
LEDs:   8x LEDs

A version with 4Mb flash is also available, but due to lack of
enough space it's not supported.

Installation:
 - Replace the original bootloader with pepe2k's u-boot mod.
 - Install the image with "run fw_upg", or hold the reset button
   at power-up, and install the image via the u-boot_mod GUI.

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>