### PR TITLE
realtek: use kernel defined halt

### DIFF
--- a/target/linux/realtek/files-5.4/arch/mips/rtl838x/setup.c
+++ b/target/linux/realtek/files-5.4/arch/mips/rtl838x/setup.c
@@ -59,19 +59,12 @@ static void rtl838x_restart(char *command)
 	sw_w32(1, RTL838X_RST_GLB_CTRL_1);
 }
 
-static void rtl838x_halt(void)
-{
-	pr_info("System halted.\n");
-	while(1);
-}
-
 void __init plat_mem_setup(void)
 {
 	void *dtb;
 
 	set_io_port_base(KSEG1);
 	_machine_restart = rtl838x_restart;
-	_machine_halt = rtl838x_halt;
 
 	if (fw_passed_dtb) /* UHI interface */
 		dtb = (void *)fw_passed_dtb;


### PR DESCRIPTION
If _machine_hang is not defined on MIPS, the kernel will check if the CPU can enter a more power efficient sleep mode. Since the realtek platform supports mips32_r2, this should issue a WAIT instruction instead of a trivial infinite loop.

The relevant kernel code is in [arch/mips/kernel/reset.c](https://elixir.bootlin.com/linux/latest/source/arch/mips/kernel/reset.c)

