### PR TITLE
hostapd: Use EAPOLv1 (802.1X-2001) if WPA enabled

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=18
+PKG_RELEASE:=19
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -490,7 +490,7 @@ hostapd_set_bss_options() {
 	set_default uapsd 1
 	set_default wpa_disable_eapol_key_retries 0
 	set_default tdls_prohibit 0
-	set_default eapol_version 0
+	set_default eapol_version $((wpa & 1))
 	set_default acct_port 1813
 	set_default bss_load_update_period 60
 	set_default chan_util_avg_period 600


### PR DESCRIPTION
Currently, EAPOLv2 (802.1X-2004) is used by default for legacy clients that
are not WPA2 (RSN) capable. These legacy clients are often intolerant to this
EAPOL version and fail to connect.

hostapd.conf upstream documents for eapol_version the following and that this
is a known compatibility issue with version 2:

// IEEE 802.1X/EAPOL version
// hostapd is implemented based on IEEE Std 802.1X-2004 which defines EAPOL
// version 2. However, there are many client implementations that do not handle
// the new version number correctly (they seem to drop the frames completely).
// In order to make hostapd interoperate with these clients, the version number
// can be set to the older version (1) with this configuration value.
// Note: When using MACsec, eapol_version shall be set to 3, which is
// defined in IEEE Std 802.1X-2010.
//eapol_version=2

For the wpa parameter, hostapd.conf upstream documents that this is a bitfield,
configured as follows:

// Enable WPA. Setting this variable configures the AP to require WPA (either
// WPA-PSK or WPA-RADIUS/EAP based on other configuration). For WPA-PSK, either
// wpa_psk or wpa_passphrase must be set and wpa_key_mgmt must include WPA-PSK.
// Instead of wpa_psk / wpa_passphrase, wpa_psk_radius might suffice.
// For WPA-RADIUS/EAP, ieee8021x must be set (but without dynamic WEP keys),
// RADIUS authentication server must be configured, and WPA-EAP must be included
// in wpa_key_mgmt.
// This field is a bit field that can be used to enable WPA (IEEE 802.11i/D3.0)
// and/or WPA2 (full IEEE 802.11i/RSN):
// bit0 = WPA
// bit1 = IEEE 802.11i/RSN (WPA2) (dot11RSNAEnabled)
// Note that WPA3 is also configured with bit1 since it uses RSN just like WPA2.
// In other words, for WPA3, wpa=2 is used the configuration (and
// wpa_key_mgmt=SAE for WPA3-Personal instead of wpa_key_mgmt=WPA-PSK).
//wpa=2

For client compatibility therefore:

EAPOLv1 (802.1X-2001) should be used by default where WPA is enabled.
EAPOLv2 (802.1X-2004) should be used by default where WPA is disabled.

To fix this, we can therefore change in the script:

set_default eapol_version 0

To the following:

set_default eapol_version $((wpa & 1))

This therefore:
1) Sets eapol_version to 1 where WPA has been enabled via wpa bit0 being set.
2) Sets eapol_version to 0 where WPA has been disabled via wpa bit0 being unset.

For usual configurations that only have WPA2 enabled, EAPOLv2 is then used.

Signed-off-by: Nick Lowe <nick.lowe@gmail.com>