### PR TITLE
tplink-safeloader: add support for TPLink Archer A7 v5 (RU)

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -725,7 +725,8 @@ static struct device_info boards[] = {
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:55530000}\n"
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:43410000}\n"
 			"{product_name:Archer A7,product_ver:5.0.0,special_id:4A500000}\n"
-			"{product_name:Archer A7,product_ver:5.0.0,special_id:54570000}\n",
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:54570000}\n"
+			"{product_name:Archer A7,product_ver:5.0.0,special_id:52550000}\n",
 		.part_trail = 0x00,
 		.soft_ver = "soft_ver:1.0.0\n",
 


### PR DESCRIPTION
Signed-off-by: Alexey Kunitskiy <alexey.kv@gmail.com>

I have Archer A7 v5 hardware that I can't flash using official openwrt build. I've noticed this guide https://forum.openwrt.org/t/support-for-tp-link-archer-c7-v5-ru/28402 and that worked for me - I successfully flashed my variant (RU) of router. So I contributing my fix. It would be great to have it soon in stable revisions of latest 19.07*
