### PR TITLE
6in4: add new options to customize tunnel startup

### DIFF
--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -23,19 +23,6 @@ test_6in4_rfc1918()
 	return 0
 }
 
-proto_6in4_update() {
-	sh -c '
-		timeout=5
-
-		(while [ $((timeout--)) -gt 0 ]; do
-			sleep 1
-			kill -0 $$ || exit 0
-		done; kill -9 $$) 2>/dev/null &
-
-		exec "$@"
-	' "$1" "$@"
-}
-
 proto_6in4_add_prefix() {
 	append "$3" "$1"
 }
@@ -45,8 +32,10 @@ proto_6in4_setup() {
 	local iface="$2"
 	local link="6in4-$cfg"
 
-	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink tunnelid username password updatekey
-	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink tunnelid username password updatekey
+	local mtu ttl tos ipaddr peeraddr ip6addr ip6prefix ip6prefixes tunlink add_peer_route \
+		tunnelid username password updatekey send_ip delay timeout retry_interval max_retries
+	json_get_vars mtu ttl tos ipaddr peeraddr ip6addr tunlink add_peer_route \
+		tunnelid username password updatekey send_ip delay timeout retry_interval max_retries
 	json_for_each_item proto_6in4_add_prefix ip6prefix ip6prefixes
 
 	[ -z "$peeraddr" ] && {
@@ -55,7 +44,9 @@ proto_6in4_setup() {
 		return
 	}
 
-	( proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink" )
+	[ ${add_peer_route:=1} -eq 1 ] && {
+		proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink"
+	}
 
 	[ -z "$ipaddr" ] && {
 		local wanif="$tunlink"
@@ -102,7 +93,7 @@ proto_6in4_setup() {
 
 		local http="http"
 		local urlget="uclient-fetch"
-		local urlget_opts="-qO-"
+		local urlget_opts="-qO- -T ${timeout:-5}"
 		local ca_path="${SSL_CERT_DIR:-/etc/ssl/certs}"
 
 		[ -f /lib/libustream-ssl.so ] && http=https
@@ -111,28 +102,46 @@ proto_6in4_setup() {
 		}
 
 		local url="$http://ipv4.tunnelbroker.net/nic/update?hostname=$tunnelid"
-		
-		test_6in4_rfc1918 "$ipaddr" && {
-			local url="${url}&myip=${ipaddr}"
+
+		test_6in4_rfc1918 "$ipaddr" && [ ${send_ip:=1} -eq 1 ] && {
+			url="${url}&myip=${ipaddr}"
 		}
 
-		local try=0
-		local max=3
+		[ ${delay:=0} -gt 0 ] && sleep $delay
 
 		(
-			set -o pipefail
-			while [ $((++try)) -le $max ]; do
-				if proto_6in4_update $urlget $urlget_opts --user="$username" --password="$password" "$url" 2>&1 | \
-					sed -e 's,^Killed$,timeout,' -e "s,^,update $try/$max: ," | \
-					logger -t "$link";
-				then
-					logger -t "$link" "updated"
+			local try=0
+			while [ $((++try)) -le ${max_retries:=3} ]; do
+				local response rc error
+				response=$($urlget $urlget_opts --user="$username" --password="$password" "$url" 2>&1)
+				rc=$?
+				case $rc in
+					4) error="timeout";;
+					5) error="SSL error";;
+					*) error="unknown error";;
+				esac
+
+				logger -t "$link" "update $try/$max_retries: ${response:-$error}"
+
+				local msg
+				if [ $rc -eq 0 ]; then
+					case "$response" in
+						good*) msg="updated";;
+						nochg*) msg="not changed";;
+						*) msg="unexpected response received";;
+					esac
+					logger -t "$link" "$msg"
 					return 0
 				fi
-				sleep 5
+				[ $try -lt $max_retries ] && sleep ${retry_interval:=5}
 			done
-			logger -t "$link" "update failed"
+			logger -t "$link" "max update retries exceeded"
 		)
+	}
+
+	[ -f "/etc/6in4.user" ] && {
+		env -i INTERFACE="$cfg" LINK="$link" \
+			/bin/sh /etc/6in4.user
 	}
 }
 
@@ -149,10 +158,16 @@ proto_6in4_init_config() {
 	proto_config_add_array "ip6prefix"
 	proto_config_add_string "peeraddr"
 	proto_config_add_string "tunlink"
+	proto_config_add_boolean "add_peer_route"
 	proto_config_add_string "tunnelid"
 	proto_config_add_string "username"
 	proto_config_add_string "password"
 	proto_config_add_string "updatekey"
+	proto_config_add_boolean "send_ip"
+	proto_config_add_int "delay"
+	proto_config_add_int "timeout"
+	proto_config_add_int "retry_interval"
+	proto_config_add_int "max_retries"
 	proto_config_add_int "mtu"
 	proto_config_add_int "ttl"
 	proto_config_add_string "tos"

--- a/package/network/ipv6/6in4/files/6in4.user
+++ b/package/network/ipv6/6in4/files/6in4.user
@@ -1,0 +1,8 @@
+# This file is interpreted as shell script.
+# Put your custom 6in4 actions here, they will
+# be executed with each 6in4 interface (re-)start.
+#
+# There are two main environment variables that are passed to this script:
+#
+# $INTERFACE    Name of the 6in4 interface (e.g. "wan6")
+# $LINK         Name of the 6in4 link (e.g. "6in4-wan6")


### PR DESCRIPTION
The following options were added:

1. add_peer_route - boolean, default: 1, controls whether to add a host
only route to the peer.
The initial purpose of such a route is to ensure that there is a route to
the tunnel endpoint regardless of the defaultroute state.
When there are multiple WAN connections managed by mwan3, a specific route
to the peer prevents the tunnel from automatic failover to the backup WAN
interface. With 'add_peer_route' option set to '0', the route to the
tunnel endpoint won't be automatically added allowing tunnel traffic to be
managed by mwan3.
The default value of the option preserves the current behavior.

2. send_ip - boolean, default: 1. Controls whether to send the local IP
address in the endpoint update request.
The current behavior is to explicitly send local public (non RFC 1918
private) IP address in the endpoint update request, e.g.
http(s)://ipv4.tunnelbroker.net/nic/
update?hostname=<tunnelid>&myip=<ipaddress>"
By default, the local IP address corresponds to the IP address of the WAN
interface with the lowest metric value.
With 'send_ip' is set to '0', the local IP is not sent to the tunnel
broker. In this case, the broker uses the request's source IP address.
This allows to correctly update the endpoint address during WAN interface
failover by mwan3.
The default value of the option preserves the current behavior.

3. delay - int, default: 0. Specifies the delay before endpoint address
update.
The possibility to delay the endpoint update allows preventing failed
update attempts during interface failover.
The default value of the option preserves the current behavior.

4. timeout - int, default: 5. Specifies the update request timeout.
The default value of the option preserves the current behavior.

5. retry_interval - int, default: 5. Specifies the interval between the
update attemps.
The default value of the option preserves the current behavior.

6. max_retries - int, default: 3. Specifies the max number of retry
attemps.
The default value of the option preserves the current behavior.

Besides the new options, the call of the user script /etc/6in4.user was
added, which allows users to implement a completely custom update routine,
as well as trigger custom events.
There are two main environment variables that are passed to this script:
$INTERFACE and $LINK with interface and link names respectively.

The update routine was changed to use native uclient timeout functionality
that allowed more accurate error and result handling. There was a flaw in
the previous approach, that the kill signal might terminate the update
routine when the HTTP request has been already completed, but the result
hasn't been yet processed further down the pipe. This resulted in the
false-negative "timeout" errors.

Signed-off-by: Andriy Sharandakov <ash.ashway@gmail.com>
