### PR TITLE
6in4: add new options to customize tunnel startup

### DIFF
--- a/package/network/ipv6/6in4/Makefile
+++ b/package/network/ipv6/6in4/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=6in4
-PKG_RELEASE:=26
+PKG_RELEASE:=27
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
The following options were added:

1. **peerdependency** - boolean, default: 1, controls whether to add a host
only route to the peer.
The initial purpose of such a route is to ensure that there is a route to
the tunnel endpoint regardless of the defaultroute state.
When there are multiple WAN connections managed by mwan3, a specific route
to the peer prevents the tunnel from automatic failover to the backup WAN
interface. With 'add_peer_route' option set to '0', the route to the
tunnel endpoint won't be automatically added allowing tunnel traffic to be
managed by mwan3.
The default value of the option preserves the current behavior.

2. **sendipaddr** - boolean, default: 1. Controls whether to send the local IP
address in the endpoint update request.
The current behavior is to explicitly send local public (non RFC 1918
private) IP address in the endpoint update request, e.g.
http(s)://ipv4.tunnelbroker.net/nic/
update?hostname=<tunnelid>&myip=<ipaddress>"
By default, the local IP address corresponds to the IP address of the WAN
interface with the lowest metric value.
With 'sendipaddr' is set to '0', the local IP is not sent to the tunnel
broker. In this case, the broker uses the request's source IP address.
This allows to correctly update the endpoint address during WAN interface
failover by mwan3.
The default value of the option preserves the current behavior.

3. **delay** - int, default: 0. Specifies the delay before endpoint address
update.
The possibility to delay the endpoint update allows preventing failed
update attempts during interface failover.
The default value of the option preserves the current behavior.

4. **timeout** - int, default: 5. Specifies the update request timeout.
The default value of the option preserves the current behavior.

5. **retryinterval** - int, default: 5. Specifies the interval between the
update attemps.
The default value of the option preserves the current behavior.

6. **maxretries** - int, default: 3. Specifies the max number of retry
attemps.
The default value of the option preserves the current behavior.

The update routine was changed to use native uclient timeout functionality
that allowed more accurate error and result handling. There was a flaw in
the previous approach, that the kill signal might terminate the update
routine when the HTTP request has been already completed, but the result
hasn't been yet processed further down the pipe. This resulted in the
false-negative "timeout" errors.

Signed-off-by: Andriy Sharandakov <ash.ashway@gmail.com>
