### PR TITLE
rockchip: use USB host by default on rk3399-rock-pi-4

### DIFF
--- a/target/linux/rockchip/patches-5.4/104-rockchip-use-USB-host-by-default-on-rk3399-rock-pi-4.patch
+++ b/target/linux/rockchip/patches-5.4/104-rockchip-use-USB-host-by-default-on-rk3399-rock-pi-4.patch
@@ -1,0 +1,32 @@
+From e12f67fe83446432ef16704c22ec23bd1dbcd094 Mon Sep 17 00:00:00 2001
+From: Vicente Bergas <vicencb@gmail.com>
+Date: Tue, 1 Dec 2020 16:41:32 +0100
+Subject: arm64: dts: rockchip: use USB host by default on rk3399-rock-pi-4
+
+Based on the board schematics at
+https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi_4c_v12_sch_20200620.pdf
+on page 19 there is an USB Type-A receptacle being used as an USB-OTG port.
+
+But the Type-A connector is not valid for OTG operation, for this reason
+there is a switch to select host or device role.
+This is non-compliant and error prone because switching is manual.
+So, use host mode as it corresponds for a Type-A receptacle.
+
+Signed-off-by: Vicente Bergas <vicencb@gmail.com>
+Link: https://lore.kernel.org/r/20201201154132.1286-4-vicencb@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+@@ -684,7 +684,7 @@
+ 
+ &usbdrd_dwc3_0 {
+ 	status = "okay";
+-	dr_mode = "otg";
++	dr_mode = "host";
+ };
+ 
+ &usbdrd3_1 {


### PR DESCRIPTION
 This backport  fix connections errors
on the upper USB3 port of the Radxa ROCK Pi 4.

Link: https://lore.kernel.org/r/20201201154132.1286-4-vicencb@gmail.com
