### PR TITLE
[19.07] build/json: add filesystem information

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -534,6 +534,7 @@ define Device/Build/image
 	BIN_DIR="$(BIN_DIR)" \
 	IMAGE_NAME="$(IMAGE_NAME)" \
 	IMAGE_TYPE=$(word 1,$(subst ., ,$(2))) \
+	IMAGE_FILESYSTEM="$(1)" \
 	IMAGE_PREFIX="$(IMAGE_PREFIX)" \
 	DEVICE_TITLE="$(DEVICE_TITLE)" \
 	DEVICE_PACKAGES="$(DEVICE_PACKAGES)" \

--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -37,6 +37,7 @@ image_info = {
             "images": [
                 {
                     "type": getenv("IMAGE_TYPE"),
+                    "filesystem": getenv("IMAGE_FILESYSTEM"),
                     "name": getenv("IMAGE_NAME"),
                     "sha256": image_hash,
                 }


### PR DESCRIPTION
Some images are created using different filesystems, most popular
squashfs and ext4. To allow downstream projects to distinguesh between
those, add the `filesystem` information to created json files.

Signed-off-by: Paul Spooren <mail@aparcar.org>
(cherry picked from commit bc0ffff36a0bd8043e958913f574cb8d2a79e93d)