### PR TITLE
ipq806x: add support for Ubiquiti UniFi AC HD

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -45,6 +45,7 @@ qcom,ipq8064-ap148 |\
 qcom,ipq8064-db149)
 	ubootenv_add_uci_config $(ubootenv_mtdinfo)
 	;;
+ubnt,unifi-ac-hd |\
 zyxel,nbg6817)
 	ubootenv_add_uci_config "/dev/mtdblock9" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -65,6 +65,9 @@ qcom,ipq8064-db149)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6u@eth1" "5:wan" "0u@eth0"
 	;;
+ubnt,unifi-ac-hd)
+	ucidef_set_interface_lan "eth0 eth1"
+	;;
 zyxel,nbg6817)
 	hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 	ucidef_add_switch "switch0" \

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -9,6 +9,14 @@ PHYNBR=${DEVPATH##*/phy}
 . /lib/functions.sh
 . /lib/functions/system.sh
 
+board=$(board_name)
+
+case "$board" in
+	ubnt,unifi-ac-hd)
+		macaddr_add $(mtd_get_mac_binary EEPROM 0x6) $(($PHYNBR + 1)) > /sys${DEVPATH}/macaddress
+		;;
+esac
+
 OPATH=${DEVPATH##/devices/platform/}
 OPATH=${OPATH%%/ieee*}
 

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-unifi-ac-hd.dts
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq8064-v2.0.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Ubiquiti UniFi AC HD";
+	compatible = "ubnt,unifi-ac-hd", "qcom,ipq8064";
+
+	aliases {
+		label-mac-device = &gmac2;
+		led-boot = &led_dome_white;
+		led-failsafe = &led_dome_white;
+		led-running = &led_dome_blue;
+		led-upgrade = &led_dome_blue;
+		mdio-gpio0 = &mdio0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_dome_blue: dome_blue {
+			label = "blue:dome";
+			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_dome_white: dome_white {
+			label = "white:dome";
+			gpios = <&qcom_pinmux 53 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio68";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio9", "gpio53";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-low;
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			drive-strength = <10>;
+			bias-none;
+		};
+
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&CPU_SPC {
+	status = "disabled";
+};
+
+&gsbi5 {
+	status = "okay";
+
+	qcom,mode = <GSBI_PROT_SPI>;
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+		cs-gpios = <&qcom_pinmux 20 0>;
+
+		flash@0 {
+			compatible = "mx25u25635f", "jedec,spi-nor";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+			m25p,fast-read;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "SBL1";
+					reg = <0x0 0x20000>;
+					read-only;
+				};
+
+				partition@20000 {
+					label = "MIBIB";
+					reg = <0x20000 0x10000>;
+					read-only;
+				};
+
+				partition@30000 {
+					label = "SBL2";
+					reg = <0x30000 0x20000>;
+					read-only;
+				};
+
+				partition@50000 {
+					label = "SBL3";
+					reg = <0x50000 0x30000>;
+					read-only;
+				};
+
+				partition@80000 {
+					label = "DDRCONFIG";
+					reg = <0x80000 0x10000>;
+					read-only;
+				};
+
+				partition@90000 {
+					label = "SSD";
+					reg = <0x90000 0x100000>;
+					read-only;
+				};
+
+				partition@a0000 {
+					label = "TZ";
+					reg = <0xa0000 0x30000>;
+					read-only;
+				};
+
+				partition@d0000 {
+					label = "RPM";
+					reg = <0xd0000 0x20000>;
+					read-only;
+				};
+
+				partition@f0000 {
+					label = "APPSBL";
+					reg = <0xf0000 0xc0000>;
+					read-only;
+				};
+
+				partition@1b0000 {
+					label = "APPSBLENV";
+					reg = <0x1b0000 0x10000>;
+					read-only;
+				};
+
+				eeprom: partition@1c0000 {
+					label = "EEPROM";
+					reg = <0x1c0000 0x10000>;
+					read-only;
+				};
+
+				partition@1d0000 {
+					label = "bootselect";
+					reg = <0x1d0000 0x10000>;
+				};
+
+				partition@1e0000 {
+					compatible = "denx,fit";
+					label = "firmware";
+					reg = <0x1e0000 0xe70000>;
+				};
+
+				partition@1050000 {
+					label = "kernel1";
+					reg = <0x1050000 0xe70000>;
+					read-only;
+				};
+
+				partition@1ec0000 {
+					label = "debug";
+					reg = <0x1ec0000 0x100000>;
+					read-only;
+				};
+
+				partition@1fc0000 {
+					label = "cfg";
+					reg = <0x1fc0000 0x40000>;
+					read-only;
+				};
+			};
+		};
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	nand-ecc-strength = <4>;
+	nand-bus-width = <8>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+};
+
+&gmac2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+	qcom,emulation = <0>;
+	mdiobus = <&mdio0>;
+
+	mtd-mac-address = <&eeprom 0x0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	qcom,id = <1>;
+	qcom,emulation = <0>;
+	mdiobus = <&mdio0>;
+
+	mtd-mac-address = <&eeprom 0x6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&tcsr {
+	status = "okay";
+};
+
+&hs_phy_0 {
+	status = "okay";
+};
+
+&ss_phy_0 {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+};
+
+&hs_phy_1 {
+	status = "okay";
+};
+
+&ss_phy_1 {
+	status = "okay";
+};
+
+&usb3_1 {
+	status = "okay";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -366,6 +366,18 @@ define Device/tplink_vr2600v
 endef
 TARGET_DEVICES += tplink_vr2600v
 
+define Device/ubnt_unifi-ac-hd
+	$(call Device/FitImageLzma)
+	DEVICE_VENDOR := Ubiquiti
+	DEVICE_MODEL := UniFi AC HD
+	SOC := qcom-ipq8064
+	BLOCKSIZE := 64k
+	IMAGE_SIZE := 14784k
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | append-metadata | check-size
+endef
+TARGET_DEVICES += ubnt_unifi-ac-hd
+
 define Device/zyxel_nbg6817
 	DEVICE_VENDOR := ZyXEL
 	DEVICE_MODEL := NBG6817

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,23 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,24 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -25,6 +25,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-g10.dtb \
 +	qcom-ipq8064-r7500.dtb \
 +	qcom-ipq8064-r7500v2.dtb \
++	qcom-ipq8064-unifi-ac-hd.dtb \
 +	qcom-ipq8064-wg2600hp.dtb \
 +	qcom-ipq8064-wpq864.dtb \
 +	qcom-ipq8064-wxr-2533dhp.dtb \


### PR DESCRIPTION
Hardware
--------

SoC:   Qualcomm IPQ8064
RAM:   512MB DDR3
Flash: 256MB NAND (Micron MT29F2G08ABBEAH4)
       32MB SPI-NOR (Macronix MX25U25635F)
WLAN:  Qualcomm Atheros QCA9994 4T4R b/g/n
       Qualcomm Atheros QCA9994 4T4R a/n/ac
ETH:   eth0 - SECONDARY (Atheros AR8033)
       eth1 - MAIN (Atheros AR8033)
USB:   USB-C
LED:   Dome (white / blue)
BTN:   Reset

Installation
------------

Copy the OpenWrt sysupgrade image to the /tmp directory of the device
using scp. Default IP address is 192.168.1.20 and default username and
password are "ubnt".

SSH to the device and write the bootselect flag to ensure it is booting
from the mtd partition the OpenWrt image will be written to. Verify the
output device below matches mtd partition "bootselect" using /proc/mtd.

> dd if=/dev/zero bs=1 count=1 seek=7 conv=notrunc of=/dev/mtd11

Write the OpenWrt sysupgrade image to the mtd partition labeled
"kernel0". Also verify the used partition device using /proc/mtd.

> dd if=/tmp/sysupgrade.bin of=/dev/mtdblock12

Reboot the device.

Back to stock
-------------

Use the TFTP recovery procedure with the Ubiquiti firmware image to
restore the vendor firmware.