### PR TITLE
ramips: unify elecom-*-factory for ELECOM WRC-GHBK2-S/GS/GST devices

### DIFF
--- a/scripts/mkhash.c
+++ b/scripts/mkhash.c
@@ -747,6 +747,7 @@ static int usage(const char *progname)
 	fprintf(stderr, "Usage: %s <hash type> [options] [<file>...]\n"
 		"Options:\n"
 		"	-n		Print filename(s)\n"
+		"	-N		Suppress trailing newline\n"
 		"\n"
 		"Supported hash types:", progname);
 
@@ -771,7 +772,8 @@ static struct hash_type *get_hash_type(const char *name)
 }
 
 
-static int hash_file(struct hash_type *t, const char *filename, bool add_filename)
+static int hash_file(struct hash_type *t, const char *filename, bool add_filename,
+	bool no_newline)
 {
 	const char *str;
 
@@ -801,9 +803,10 @@ static int hash_file(struct hash_type *t, const char *filename, bool add_filenam
 	}
 
 	if (add_filename)
-		printf("%s %s\n", str, filename ? filename : "-");
+		printf("%s %s%s", str, filename ? filename : "-",
+			no_newline ? "" : "\n");
 	else
-		printf("%s\n", str);
+		printf("%s%s", str, no_newline ? "" : "\n");
 	return 0;
 }
 
@@ -813,12 +816,15 @@ int main(int argc, char **argv)
 	struct hash_type *t;
 	const char *progname = argv[0];
 	int i, ch;
-	bool add_filename = false;
+	bool add_filename = false, no_newline = false;
 
-	while ((ch = getopt(argc, argv, "n")) != -1) {
+	while ((ch = getopt(argc, argv, "nN")) != -1) {
 		switch (ch) {
 		case 'n':
 			add_filename = true;
+			break;
+		case 'N':
+			no_newline = true;
 			break;
 		default:
 			return usage(progname);
@@ -836,10 +842,10 @@ int main(int argc, char **argv)
 		return usage(progname);
 
 	if (argc < 2)
-		return hash_file(t, NULL, add_filename);
+		return hash_file(t, NULL, add_filename, no_newline);
 
 	for (i = 0; i < argc - 1; i++) {
-		int ret = hash_file(t, argv[1 + i], add_filename);
+		int ret = hash_file(t, argv[1 + i], add_filename, no_newline);
 		if (ret)
 			return ret;
 	}

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -12,20 +12,8 @@ DEVICE_VARS += ELECOM_HWNAME LINKSYS_HWNAME
 define Build/elecom-wrc-gs-factory
 	$(eval product=$(word 1,$(1)))
 	$(eval version=$(word 2,$(1)))
-	( $(STAGING_DIR_HOST)/bin/mkhash md5 $@ | tr -d '\n' ) >> $@
-	( \
-		echo -n "ELECOM $(product) v$(version)" | \
-			dd bs=32 count=1 conv=sync; \
-		dd if=$@; \
-	) > $@.new
-	mv $@.new $@
-	echo -n "MT7621_ELECOM_$(product)" >> $@
-endef
-
-define Build/elecom-wrc-factory
-	$(eval product=$(word 1,$(1)))
-	$(eval version=$(word 2,$(1)))
-	$(STAGING_DIR_HOST)/bin/mkhash md5 $@ >> $@
+	$(eval hash_opt=$(word 3,$(1)))
+	$(STAGING_DIR_HOST)/bin/mkhash md5 $(hash_opt) $@ >> $@
 	( \
 		echo -n "ELECOM $(product) v$(version)" | \
 			dd bs=32 count=1 conv=sync; \
@@ -400,7 +388,7 @@ define Device/elecom_wrc-1167ghbk2-s
   DEVICE_MODEL := WRC-1167GHBK2-S
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
-	elecom-wrc-factory WRC-1167GHBK2-S 0.00
+	elecom-wrc-gs-factory WRC-1167GHBK2-S 0.00
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
@@ -411,7 +399,8 @@ define Device/elecom_wrc-gs
   DEVICE_VENDOR := ELECOM
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
-	elecom-wrc-gs-factory $$$$(ELECOM_HWNAME) 0.00
+	elecom-wrc-gs-factory $$$$(ELECOM_HWNAME) 0.00 -N | \
+	append-string MT7621_ELECOM_$$$$(ELECOM_HWNAME)
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
 endef
 


### PR DESCRIPTION
- add ```-N``` to mkhash
- unify ```Build/elecom-wrc-factory``` and ```Build/elecom-wrc-gs-factory``` in image/mt7621.mk in ramips

This firmware format is used only on WRC-1167GHBK2-S in "GHBK" series of ELECOM and all of GS/GSV/GST series uses it. And other "WRC" devices also use different format, so I used ```elecom-wrc-gs-factory``` as the new definition.