### PR TITLE
ath79: fix Sitecom WLR-8100 lan port leds

### DIFF
--- a/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
+++ b/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
@@ -153,10 +153,10 @@
 
 		qca,ar8327-initvals = <
 			0x04 0x87600000 /* PORT0 PAD MODE CTRL */
-			0x50 0xc437c437 /* LED Control Register 0 */
-			0x54 0xc337c337 /* LED Control Register 1 */
+			0x50 0xcf37cf37 /* LED Control Register 0 */
+			0x54 0x00000000 /* LED Control Register 1 */
 			0x58 0x00000000 /* LED Control Register 2 */
-			0x5c 0x03ffff00 /* LED Control Register 3 */
+			0x5c 0x0030c300 /* LED Control Register 3 */
 			0x7c 0x0000007e /* PORT0_STATUS */
 			>;
 	};


### PR DESCRIPTION
Incorrect values were used for the switch initialization causing the
lan port leds to not light up in case of 10Mb or 100Mb connections.

This commit fixes this problem and removes unused values.

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>