### PR TITLE
lantiq: xrx200: remove redundant stp parameters

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -263,9 +263,6 @@
 	status = "okay";
 	lantiq,shadow = <0xffff>;
 	lantiq,groups = <0x3>;
-	lantiq,dsl = <0x0>;
-	lantiq,phy1 = <0x0>;
-	lantiq,phy2 = <0x0>;
 	/* lantiq,rising; */
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -262,7 +262,6 @@
 	status = "okay";
 
 	lantiq,shadow = <0xffff>;
-	lantiq,groups = <0x7>;
 	lantiq,dsl = <0x3>;
 	lantiq,phy1 = <0x7>;
 	lantiq,phy2 = <0x7>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -232,12 +232,6 @@
 
 &stp {
 	status = "okay";
-
-	lantiq,shadow = <0xffffff>;
-	lantiq,groups = <0x7>;
-	lantiq,dsl = <0x0>;
-	lantiq,phy1 = <0x0>;
-	lantiq,phy2 = <0x0>;
 };
 
 &usb_phy0 {


### PR DESCRIPTION
These parameters are the same as in vr9.dtsi. This patch removes
redundant parameters.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
