### PR TITLE
tplink-safeloader.c: Add support for Archer A6 v2 EU

### DIFF
--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -952,6 +952,7 @@ static struct device_info boards[] = {
 		.support_list =
 			"SupportList:\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:45550000}\r\n"
+			"{product_name:Archer A6,product_ver:2.0.0,special_id:45550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:52550000}\r\n"
 			"{product_name:Archer C6,product_ver:2.0.0,special_id:4A500000}\r\n",
 		.part_trail = 0x00,


### PR DESCRIPTION
This change allows the a6 to install openwrt via tftp properly
Found this thanks to this thread:
https://forum.openwrt.org/t/tp-link-archer-a6-v2-eu-ru-support/60075/9

Signed-off-by: Iscru Cezar <cezar.iscru@cnmv.ro>