### PR TITLE
kernel: bump 5.4 to 5.4.85

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .83
+LINUX_VERSION-5.4 = .85
 
-LINUX_KERNEL_HASH-5.4.83 = beec970bbb93de8ab839f27930f7ab00c7bd65af0ffa07a50e765affdc2561c6
+LINUX_KERNEL_HASH-5.4.85 = 1de3586d8e7a9a814726610745d80907a267590d2770ec1079ef2875c4984008
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/apm821xx/patches-5.4/801-usb-xhci-add-firmware-loader-for-uPD720201-and-uPD72.patch
+++ b/target/linux/apm821xx/patches-5.4/801-usb-xhci-add-firmware-loader-for-uPD720201-and-uPD72.patch
@@ -48,7 +48,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  
  #include "xhci.h"
  #include "xhci-trace.h"
-@@ -62,6 +64,44 @@
+@@ -63,6 +65,44 @@
  #define PCI_DEVICE_ID_ASMEDIA_1142_XHCI			0x1242
  #define PCI_DEVICE_ID_ASMEDIA_2142_XHCI			0x2142
  
@@ -93,7 +93,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  static const char hcd_name[] = "xhci_hcd";
  
  static struct hc_driver __read_mostly xhci_pci_hc_driver;
-@@ -296,6 +336,873 @@ static void xhci_pme_acpi_rtd3_enable(st
+@@ -298,6 +338,873 @@ static void xhci_pme_acpi_rtd3_enable(st
  static void xhci_pme_acpi_rtd3_enable(struct pci_dev *dev) { }
  #endif /* CONFIG_ACPI */
  
@@ -967,7 +967,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  /* called during probe() after chip reset completes */
  static int xhci_pci_setup(struct usb_hcd *hcd)
  {
-@@ -337,6 +1244,27 @@ static int xhci_pci_probe(struct pci_dev
+@@ -339,6 +1246,27 @@ static int xhci_pci_probe(struct pci_dev
  	struct hc_driver *driver;
  	struct usb_hcd *hcd;
  
@@ -995,7 +995,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  	driver = (struct hc_driver *)id->driver_data;
  
  	/* Prevent runtime suspending between USB-2 and USB-3 initialization */
-@@ -398,6 +1326,16 @@ static void xhci_pci_remove(struct pci_d
+@@ -400,6 +1328,16 @@ static void xhci_pci_remove(struct pci_d
  {
  	struct xhci_hcd *xhci;
  
@@ -1012,7 +1012,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  	xhci = hcd_to_xhci(pci_get_drvdata(dev));
  	xhci->xhc_state |= XHCI_STATE_REMOVING;
  
-@@ -537,6 +1475,11 @@ static int xhci_pci_resume(struct usb_hc
+@@ -539,6 +1477,11 @@ static int xhci_pci_resume(struct usb_hc
  	if (pdev->vendor == PCI_VENDOR_ID_INTEL)
  		usb_enable_intel_xhci_ports(pdev);
  

--- a/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
+++ b/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
@@ -13,7 +13,7 @@ produce a noisy warning.
 
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -283,6 +283,7 @@ static void xhci_pci_quirks(struct devic
+@@ -285,6 +285,7 @@ static void xhci_pci_quirks(struct devic
  	    pdev->device == 0x0015) {
  		xhci->quirks |= XHCI_RESET_ON_RESUME;
  		xhci->quirks |= XHCI_ZERO_64B_REGS;

--- a/target/linux/ath79/patches-5.4/450-fix-block-protection-clearing.patch
+++ b/target/linux/ath79/patches-5.4/450-fix-block-protection-clearing.patch
@@ -17,12 +17,12 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
 
 --- a/drivers/mtd/spi-nor/spi-nor.c
 +++ b/drivers/mtd/spi-nor/spi-nor.c
-@@ -1981,7 +1981,7 @@ static int sr2_bit7_quad_enable(struct s
+@@ -1985,7 +1985,7 @@ static int sr2_bit7_quad_enable(struct s
  static int spi_nor_clear_sr_bp(struct spi_nor *nor)
  {
  	int ret;
 -	u8 mask = SR_BP2 | SR_BP1 | SR_BP0;
 +	u8 mask = SR_TB | SR_BP2 | SR_BP1 | SR_BP0;
  
- 	ret = read_sr(nor);
- 	if (ret < 0) {
+ 	if (nor->flags & SNOR_F_HAS_4BIT_BP)
+ 		mask |= SR_BP3;

--- a/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
@@ -706,7 +706,7 @@
  EXPORT_SYMBOL(xfrm_parse_spi);
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
-@@ -3971,14 +3971,16 @@ static bool tcp_parse_aligned_timestamp(
+@@ -3972,14 +3972,16 @@ static bool tcp_parse_aligned_timestamp(
  {
  	const __be32 *ptr = (const __be32 *)(th + 1);
  

--- a/target/linux/bcm27xx/patches-5.4/950-0214-usb-xhci-Show-that-the-VIA-VL805-supports-LPM.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0214-usb-xhci-Show-that-the-VIA-VL805-supports-LPM.patch
@@ -10,7 +10,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -252,6 +252,10 @@ static void xhci_pci_quirks(struct devic
+@@ -254,6 +254,10 @@ static void xhci_pci_quirks(struct devic
  			pdev->device == 0x3432)
  		xhci->quirks |= XHCI_BROKEN_STREAMS;
  

--- a/target/linux/bcm27xx/patches-5.4/950-0267-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0267-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
@@ -23,7 +23,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
 
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -253,8 +253,10 @@ static void xhci_pci_quirks(struct devic
+@@ -255,8 +255,10 @@ static void xhci_pci_quirks(struct devic
  		xhci->quirks |= XHCI_BROKEN_STREAMS;
  
  	if (pdev->vendor == PCI_VENDOR_ID_VIA &&

--- a/target/linux/bcm27xx/patches-5.4/950-0316-kbuild-Allow-.dtbo-overlays-to-be-built-piecemeal.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0316-kbuild-Allow-.dtbo-overlays-to-be-built-piecemeal.patch
@@ -24,7 +24,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 
 --- a/Makefile
 +++ b/Makefile
-@@ -1264,6 +1264,9 @@ ifneq ($(dtstree),)
+@@ -1267,6 +1267,9 @@ ifneq ($(dtstree),)
  %.dtb: include/config/kernel.release scripts_dtc
  	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
  

--- a/target/linux/bcm27xx/patches-5.4/950-0460-Kbuild-Allow-.dtbo-overlays-to-be-built-adjust.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0460-Kbuild-Allow-.dtbo-overlays-to-be-built-adjust.patch
@@ -15,7 +15,7 @@ Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>
 
 --- a/Makefile
 +++ b/Makefile
-@@ -1264,7 +1264,7 @@ ifneq ($(dtstree),)
+@@ -1267,7 +1267,7 @@ ifneq ($(dtstree),)
  %.dtb: include/config/kernel.release scripts_dtc
  	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
  

--- a/target/linux/generic/pending-5.4/643-net-bridge-support-hardware-flow-table-offload.patch
+++ b/target/linux/generic/pending-5.4/643-net-bridge-support-hardware-flow-table-offload.patch
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #include <linux/uaccess.h>
  #include "br_private.h"
-@@ -376,6 +380,28 @@ static const struct ethtool_ops br_ethto
+@@ -382,6 +386,28 @@ static const struct ethtool_ops br_ethto
  	.get_link	= ethtool_op_get_link,
  };
  
@@ -49,7 +49,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static const struct net_device_ops br_netdev_ops = {
  	.ndo_open		 = br_dev_open,
  	.ndo_stop		 = br_dev_stop,
-@@ -404,6 +430,9 @@ static const struct net_device_ops br_ne
+@@ -410,6 +436,9 @@ static const struct net_device_ops br_ne
  	.ndo_bridge_setlink	 = br_setlink,
  	.ndo_bridge_dellink	 = br_dellink,
  	.ndo_features_check	 = passthru_features_check,

--- a/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0149-soc-fsl-dpio-change-CENA-regs-to-be-cacheable.patch
@@ -32,7 +32,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  struct dpio_priv {
  	struct dpaa2_io *io;
  };
-@@ -200,13 +205,11 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -197,13 +202,11 @@ static int dpaa2_dpio_probe(struct fsl_m
  	if (dpio_dev->obj_desc.region_count < 3) {
  		/* No support for DDR backed portals, use classic mapping */
  		/*
@@ -50,7 +50,7 @@ Signed-off-by: Haiying Wang <Haiying.Wang@nxp.com>
  	} else {
  		desc.regs_cena = devm_memremap(dev, dpio_dev->regions[2].start,
  					resource_size(&dpio_dev->regions[2]),
-@@ -214,7 +217,7 @@ static int dpaa2_dpio_probe(struct fsl_m
+@@ -211,7 +214,7 @@ static int dpaa2_dpio_probe(struct fsl_m
  	}
  
  	if (IS_ERR(desc.regs_cena)) {

--- a/target/linux/layerscape/patches-5.4/701-net-0225-enetc-Configure-the-Time-Aware-Scheduler-via-tc-tapr.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0225-enetc-Configure-the-Time-Aware-Scheduler-via-tc-tapr.patch
@@ -141,7 +141,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  #define ENETC_SIPCAPR0_RSS	BIT(8)
  #define ENETC_SIPCAPR1	0x24
  #define ENETC_SITGTGR	0x30
-@@ -440,22 +441,6 @@ union enetc_rx_bd {
+@@ -444,22 +445,6 @@ union enetc_rx_bd {
  #define EMETC_MAC_ADDR_FILT_RES	3 /* # of reserved entries at the beginning */
  #define ENETC_MAX_NUM_VFS	2
  
@@ -164,7 +164,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  #define ENETC_CBD_FLAGS_SF	BIT(7) /* short format */
  #define ENETC_CBD_STATUS_MASK	0xf
  
-@@ -554,3 +539,70 @@ static inline void enetc_set_bdr_prio(st
+@@ -558,3 +543,70 @@ static inline void enetc_set_bdr_prio(st
  	val |= ENETC_TBMR_SET_PRIO(prio);
  	enetc_txbdr_wr(hw, bdr_idx, ENETC_TBMR, val);
  }

--- a/target/linux/layerscape/patches-5.4/701-net-0234-enetc-WA-for-MDIO-register-access-issue.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0234-enetc-WA-for-MDIO-register-access-issue.patch
@@ -254,7 +254,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  		rx_frm_cnt++;
 --- a/drivers/net/ethernet/freescale/enetc/enetc_hw.h
 +++ b/drivers/net/ethernet/freescale/enetc/enetc_hw.h
-@@ -321,8 +321,15 @@ struct enetc_hw {
+@@ -325,8 +325,15 @@ struct enetc_hw {
  };
  
  /* general register accessors */
@@ -272,7 +272,7 @@ Signed-off-by: Alex Marginean <alexandru.marginean@nxp.com>
  #ifdef ioread64
  #define enetc_rd_reg64(reg)	ioread64((reg))
  #else
-@@ -341,12 +348,102 @@ static inline u64 enetc_rd_reg64(void __
+@@ -345,12 +352,102 @@ static inline u64 enetc_rd_reg64(void __
  }
  #endif
  

--- a/target/linux/layerscape/patches-5.4/701-net-0235-enetc-Clean-up-of-ehtool-stats-len.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0235-enetc-Clean-up-of-ehtool-stats-len.patch
@@ -13,7 +13,7 @@ Signed-off-by: Claudiu Manoil <claudiu.manoil@nxp.com>
 
 --- a/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
 +++ b/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
-@@ -195,15 +195,21 @@ static const char tx_ring_stats[][ETH_GS
+@@ -199,15 +199,21 @@ static const char tx_ring_stats[][ETH_GS
  static int enetc_get_sset_count(struct net_device *ndev, int sset)
  {
  	struct enetc_ndev_priv *priv = netdev_priv(ndev);

--- a/target/linux/layerscape/patches-5.4/701-net-0236-enetc-Replace-enetc_gregs-with-a-readers-writer-lock.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0236-enetc-Replace-enetc_gregs-with-a-readers-writer-lock.patch
@@ -259,7 +259,7 @@ Signed-off-by: Claudiu Manoil <claudiu.manoil@nxp.com>
  
 --- a/drivers/net/ethernet/freescale/enetc/enetc_hw.h
 +++ b/drivers/net/ethernet/freescale/enetc/enetc_hw.h
-@@ -325,7 +325,7 @@ struct enetc_hw {
+@@ -329,7 +329,7 @@ struct enetc_hw {
  #define enetc_wr_reg(reg, val)	enetc_wr_reg_wa((reg), (val))
  
  /* accessors for data-path, due to MDIO issue on LS1028 these should be called
@@ -268,7 +268,7 @@ Signed-off-by: Claudiu Manoil <claudiu.manoil@nxp.com>
   */
  #define enetc_rd_reg_hot(reg)	ioread32((reg))
  #define enetc_wr_reg_hot(reg, val)	iowrite32((val), (reg))
-@@ -348,90 +348,45 @@ static inline u64 enetc_rd_reg64(void __
+@@ -352,90 +352,45 @@ static inline u64 enetc_rd_reg64(void __
  }
  #endif
  

--- a/target/linux/layerscape/patches-5.4/701-net-0336-enetc-add-support-Credit-Based-Shaper-CBS-for-hardwa.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0336-enetc-add-support-Credit-Based-Shaper-CBS-for-hardwa.patch
@@ -79,7 +79,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  #define ENETC_PTCCBSR1(n)	(0x1114 + (n) * 8) /* n = 0 to 7*/
  #define ENETC_RSSHASH_KEY_SIZE	40
  #define ENETC_PRSSK(n)		(0x1410 + (n) * 4) /* n = [0..9] */
-@@ -673,6 +675,8 @@ struct enetc_cbd {
+@@ -677,6 +679,8 @@ struct enetc_cbd {
  	u8 status_flags;
  };
  

--- a/target/linux/layerscape/patches-5.4/701-net-0337-enetc-add-support-tsn-capabilities-qbv-qci-qbu-cbs.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0337-enetc-add-support-tsn-capabilities-qbv-qci-qbu-cbs.patch
@@ -192,7 +192,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
 +#endif
 --- a/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
 +++ b/drivers/net/ethernet/freescale/enetc/enetc_ethtool.c
-@@ -183,6 +183,21 @@ static const struct {
+@@ -187,6 +187,21 @@ static const struct {
  	{ ENETC_PICDR(3),   "ICM DR3 discarded frames" },
  };
  
@@ -214,7 +214,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  static const char rx_ring_stats[][ETH_GSTRING_LEN] = {
  	"Rx ring %2d frames",
  	"Rx ring %2d alloc errors",
-@@ -192,6 +207,10 @@ static const char tx_ring_stats[][ETH_GS
+@@ -196,6 +211,10 @@ static const char tx_ring_stats[][ETH_GS
  	"Tx ring %2d frames",
  };
  
@@ -225,7 +225,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  static int enetc_get_sset_count(struct net_device *ndev, int sset)
  {
  	struct enetc_ndev_priv *priv = netdev_priv(ndev);
-@@ -209,6 +228,12 @@ static int enetc_get_sset_count(struct n
+@@ -213,6 +232,12 @@ static int enetc_get_sset_count(struct n
  
  	len += ARRAY_SIZE(enetc_port_counters);
  
@@ -238,7 +238,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  	return len;
  }
  
-@@ -247,6 +272,28 @@ static void enetc_get_strings(struct net
+@@ -251,6 +276,28 @@ static void enetc_get_strings(struct net
  				ETH_GSTRING_LEN);
  			p += ETH_GSTRING_LEN;
  		}
@@ -267,7 +267,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  		break;
  	}
  }
-@@ -274,6 +321,18 @@ static void enetc_get_ethtool_stats(stru
+@@ -278,6 +325,18 @@ static void enetc_get_ethtool_stats(stru
  
  	for (i = 0; i < ARRAY_SIZE(enetc_port_counters); i++)
  		data[o++] = enetc_port_rd(hw, enetc_port_counters[i].reg);
@@ -317,7 +317,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  
  /* MAC counters */
  #define ENETC_PM0_REOCT		0x8100
-@@ -294,6 +305,15 @@ enum enetc_bdr_type {TX, RX};
+@@ -298,6 +309,15 @@ enum enetc_bdr_type {TX, RX};
  #define ENETC_PM0_TSCOL		0x82E0
  #define ENETC_PM0_TLCOL		0x82E8
  #define ENETC_PM0_TECOL		0x82F0
@@ -333,7 +333,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  
  /* Port counters */
  #define ENETC_PICDR(n)		(0x0700 + (n) * 8) /* n = [0..3] */
-@@ -452,6 +472,7 @@ union enetc_tx_bd {
+@@ -456,6 +476,7 @@ union enetc_tx_bd {
  #define ENETC_TXBD_FLAGS_CSUM	BIT(3)
  #define ENETC_TXBD_FLAGS_EX	BIT(6)
  #define ENETC_TXBD_FLAGS_F	BIT(7)
@@ -341,7 +341,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  
  static inline void enetc_clear_tx_bd(union enetc_tx_bd *txbd)
  {
-@@ -479,6 +500,8 @@ static inline __le16 enetc_txbd_l3_csoff
+@@ -483,6 +504,8 @@ static inline __le16 enetc_txbd_l3_csoff
  #define ENETC_TXBD_L4_UDP	BIT(5)
  #define ENETC_TXBD_L4_TCP	BIT(6)
  
@@ -350,7 +350,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  union enetc_rx_bd {
  	struct {
  		__le64 addr;
-@@ -625,21 +648,307 @@ enum bdcr_cmd_class {
+@@ -629,21 +652,307 @@ enum bdcr_cmd_class {
  	BDCR_CMD_RFS,
  	BDCR_CMD_PORT_GCL,
  	BDCR_CMD_RECV_CLASSIFIER,
@@ -662,7 +662,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  /* gate control list entry */
  struct gce {
  	__le32	period;
-@@ -656,13 +965,55 @@ struct tgs_gcl_data {
+@@ -660,13 +969,55 @@ struct tgs_gcl_data {
  	struct gce	entry[0];
  };
  
@@ -719,7 +719,7 @@ Signed-off-by: Po Liu <Po.Liu@nxp.com>
  			};
  		};	/* Long format */
  		__le32 data[6];
-@@ -677,11 +1028,88 @@ struct enetc_cbd {
+@@ -681,11 +1032,88 @@ struct enetc_cbd {
  
  #define ENETC_CLK  400000000ULL
  

--- a/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0003-MLK-21960-1-spi-fspi-enable-fspi-on-imx8qxp-and-imx8.patch
@@ -35,7 +35,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  struct nxp_fspi {
  	void __iomem *iobase;
  	void __iomem *ahb_addr;
-@@ -1076,6 +1092,8 @@ static int nxp_fspi_resume(struct device
+@@ -1083,6 +1099,8 @@ static int nxp_fspi_resume(struct device
  
  static const struct of_device_id nxp_fspi_dt_ids[] = {
  	{ .compatible = "nxp,lx2160a-fspi", .data = (void *)&lx2160a_data, },

--- a/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
+++ b/target/linux/layerscape/patches-5.4/817-spi-0004-MLK-21960-2-spi-fspi-dynamically-alloc-AHB-memory.patch
@@ -76,7 +76,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  	} else {
  		if (op->data.nbytes && op->data.dir == SPI_MEM_DATA_OUT)
  			nxp_fspi_fill_txfifo(f, op);
-@@ -992,9 +1018,8 @@ static int nxp_fspi_probe(struct platfor
+@@ -999,9 +1025,8 @@ static int nxp_fspi_probe(struct platfor
  
  	/* find the resources - controller memory mapped space */
  	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, "fspi_mmap");
@@ -88,7 +88,7 @@ Signed-off-by: Han Xu <han.xu@nxp.com>
  		goto err_put_ctrl;
  	}
  
-@@ -1073,6 +1098,9 @@ static int nxp_fspi_remove(struct platfo
+@@ -1080,6 +1105,9 @@ static int nxp_fspi_remove(struct platfo
  
  	mutex_destroy(&f->lock);
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0021-MLK-22099-usb-host-xhci-do-warm-reset-for-link-state.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0021-MLK-22099-usb-host-xhci-do-warm-reset-for-link-state.patch
@@ -16,7 +16,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
 
 --- a/drivers/usb/host/xhci-hub.c
 +++ b/drivers/usb/host/xhci-hub.c
-@@ -1733,7 +1733,8 @@ static bool xhci_port_missing_cas_quirk(
+@@ -1737,7 +1737,8 @@ static bool xhci_port_missing_cas_quirk(
  		return false;
  
  	if (((portsc & PORT_PLS_MASK) != XDEV_POLLING) &&

--- a/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
+++ b/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
@@ -111,7 +111,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	struct mvpp2_port *port = netdev_priv(dev);
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -448,9 +448,10 @@ static void mtk_mac_link_down(struct phy
+@@ -449,9 +449,10 @@ static void mtk_mac_link_down(struct phy
  	mtk_w32(mac->hw, mcr, MTK_MAC_MCR(mac->id));
  }
  

--- a/target/linux/ramips/patches-5.4/401-net-ethernet-mediatek-support-net-labels.patch
+++ b/target/linux/ramips/patches-5.4/401-net-ethernet-mediatek-support-net-labels.patch
@@ -14,7 +14,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -2919,6 +2919,7 @@ static const struct net_device_ops mtk_n
+@@ -2922,6 +2922,7 @@ static const struct net_device_ops mtk_n
  
  static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
  {
@@ -22,7 +22,7 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
  	const __be32 *_id = of_get_property(np, "reg", NULL);
  	struct phylink *phylink;
  	int phy_mode, id, err;
-@@ -3011,6 +3012,9 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -3014,6 +3015,9 @@ static int mtk_add_mac(struct mtk_eth *e
  
  	eth->netdev[id]->max_mtu = MTK_MAX_RX_LENGTH - MTK_RX_ETH_HLEN;
  

--- a/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
+++ b/target/linux/rockchip/patches-5.4/004-arm64-dts-rockchip-Add-txpbl-node-for-RK3399-RK3328.patch
@@ -44,7 +44,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		mdio {
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -288,6 +288,7 @@
+@@ -291,6 +291,7 @@
  		resets = <&cru SRST_A_GMAC>;
  		reset-names = "stmmaceth";
  		rockchip,grf = <&grf>;


### PR DESCRIPTION
All modifications made by `update_kernel.sh` run in a fresh clone
without any existing toolchains.

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>