### PR TITLE
ath79: add support for D-Link DAP-2230 / 2680 / 3320 / 3662

### DIFF
--- a/target/linux/ath79/dts/qca9558_dlink_dap-3662-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dap-3662-a1.dts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_dlink_dap-2xxx.dtsi"
+
+/ {
+	compatible = "dlink,dap-3662-a1", "qca,qca9558";
+	model = "D-Link DAP-3662 A1";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+};
+
+&partitions {
+	partition@70000 {
+		label = "firmware";
+		reg = <0x70000 0xef0000>;
+		compatible = "wrg";
+	};
+
+	partition@f60000 {
+		label = "dlink";
+		reg = <0xf60000 0x90000>;
+		read-only;
+	};
+
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x10000>;
+		read-only;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0_PAD_CTRL */
+			0x0c 0x00080080 /* PORT6_PAD_CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -195,6 +195,10 @@ ath79_setup_interfaces()
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" "0@eth0" "2:lan" "3:wan" "6@eth1"
 		;;
+	dlink,dap-3662-a1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:2" "2:lan:1" "6@eth1"
+		;;
 	dlink,dch-g020-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:2" "2:lan:1"
@@ -492,7 +496,8 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii bdcfg "lanmac")
 		label_mac=$lan_mac
 		;;
-	dlink,dap-2695-a1)
+	dlink,dap-2695-a1|\
+	dlink,dap-3662-a1)
 		label_mac=$(mtd_get_mac_ascii bdcfg "wlanmac")
 		;;
 	dlink,dir-825-b1)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -54,7 +54,8 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) -1)
 		;;
 	dlink,dap-2660-a1|\
-	dlink,dap-2695-a1)
+	dlink,dap-2695-a1|\
+	dlink,dap-3662-a1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii bdcfg wlanmac_a)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -27,7 +27,8 @@ case "$board" in
 		mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
 	dlink,dap-2660-a1|\
-	dlink,dap-2680-a1)
+	dlink,dap-2680-a1|\
+	dlink,dap-3662-a1)
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/09_fix-checksum
@@ -17,7 +17,8 @@ dlink,dap-2230-a1|\
 dlink,dap-2660-a1|\
 dlink,dap-2680-a1|\
 dlink,dap-2695-a1|\
-dlink,dap-3320-a1)
+dlink,dap-3320-a1|\
+dlink,dap-3662-a1)
 	fixwrgg
 	;;
 qihoo,c301)

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -7,7 +7,8 @@ preinit_set_mac_address() {
 	avm,fritzdvbc)
 		ip link set dev eth0 address $(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
-	dlink,dap-2695-a1)
+	dlink,dap-2695-a1|\
+	dlink,dap-3662-a1)
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -815,6 +815,18 @@ define Device/dlink_dap-3320-a1
 endef
 TARGET_DEVICES += dlink_dap-3320-a1
 
+define Device/dlink_dap-3662-a1
+  $(Device/dlink_dap-2xxx)
+  SOC := qca9558
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-3662
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 15296k
+  DAP_SIGNATURE := wapac11_dkbs_dap3662
+endef
+TARGET_DEVICES += dlink_dap-3662-a1
+
 define Device/dlink_dch-g020-a1
   SOC := qca9531
   DEVICE_VENDOR := D-Link


### PR DESCRIPTION
Add support for multiple devices from the DAP-2xxx series,
based on .dtsi introduced in PR #3471 

* remove redundant `sysupgrade.bin` added to `IMAGES` in `Device/dlink_dap-2xxx`
* add support for DAP-2230 A1
* add support for DAP-2680 A1
* add support for DAP-3320 A1
* add support for DAP-3662 A1

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>