### PR TITLE
ath79: Add support for OpenMesh OM2P v1

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -103,6 +103,7 @@ netgear,wndr4300tn|\
 netgear,wndr4300sw)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
 	;;
+openmesh,om2p-v1|\
 openmesh,om2p-v2|\
 openmesh,om2p-v4|\
 openmesh,om2p-hs-v1|\

--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7240.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "openmesh,om2p-v1", "qca,ar7240";
+	model = "OpenMesh OM2P v1";
+
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_disable_pins>;
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi_green {
+			label = "green:wifi";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_yellow {
+			label = "yellow:wifi";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_blue {
+			label = "blue:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		linux,mtd-name = "ar7240-nor0";
+
+		/* partitions are passed via bootloader */
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x040000>;
+			};
+
+			partition@80000 {
+				label = "custom";
+				reg = <0x080000 0x140000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "inactive";
+				reg = <0x1c0000 0x700000>;
+			};
+
+			partition@8c0000 {
+				label = "inactive2";
+				reg = <0x8c0000 0x700000>;
+			};
+
+			art: partition@fc0000 {
+				label = "ART";
+				reg = <0xfc0000 0x040000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -7,26 +7,34 @@
 
 / {
 	compatible = "openmesh,om5p-ac-v2", "qca,qca9558";
-	model = "OpenMesh OM5P-AC V2";
+	model = "OpenMesh OM5P-AC v2";
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		power {
-			label = "blue:power";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		};
-
 		wifi_green {
 			label = "green:wifi";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
 		};
 
 		wifi_yellow {
@@ -50,6 +58,32 @@
 		};
 	};
 
+	i2c {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH /* sda */
+			 &gpio 18 GPIO_ACTIVE_HIGH /* scl */
+			>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-gpio,scl-open-drain;
+		i2c-gpio,sda-open-drain;
+
+		tmp423a@4e {
+			compatible = "ti,tmp423";
+			reg = <0x4e>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+
 	gpio-export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
@@ -69,20 +103,16 @@
 
 &pinmux {
 	pinmux_pa_dcdc_pins {
-		pinctrl-single,bits = <0x0 0xff00 0x0>;
+		pinctrl-single,bits = <0x0 0x0 0xff0000>;
 	};
 
 	pinmux_pa_high_pins {
-		pinctrl-single,bits = <0x10 0xff 0x0>;
+		pinctrl-single,bits = <0x10 0x0 0xff>;
 	};
 };
 
 &pcie0 {
 	status = "okay";
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {
@@ -93,6 +123,7 @@
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
+		/* partitions are passed via bootloader */
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -104,19 +135,29 @@
 				read-only;
 			};
 
-			partition@1 {
+			partition@40000 {
 				label = "u-boot-env";
 				reg = <0x040000 0x010000>;
 			};
 
-			partition@2 {
-				compatible = "denx,uimage";
-				label = "firmware";
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x060000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "inactive";
+				reg = <0x0b0000 0x7a0000>;
+			};
+
+			partition@850000 {
+				label = "inactive2";
 				reg = <0x850000 0x7a0000>;
 			};
 
-			partition@3 {
-				label = "art";
+			art: partition@ff0000 {
+				label = "ART";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};
@@ -127,18 +168,25 @@
 &mdio0 {
 	status = "okay";
 
+	phy-mask = <0x10>;
+
 	phy4: ethernet-phy@4 {
 		reg = <4>;
-		phy-mode = "rgmii-id";
+		eee-broken-100tx;
+		eee-broken-1000t;
 	};
 };
 
 &mdio1 {
 	status = "okay";
 
+	phy-mask = <0x2>;
+
 	phy1: ethernet-phy@1 {
 		reg = <1>;
-		phy-mode = "sgmii";
+		eee-broken-100tx;
+		eee-broken-1000t;
+		at803x-override-sgmii-link-check;
 	};
 };
 
@@ -147,7 +195,20 @@
 
 	pll-data = <0x82000101 0x80000101 0x80001313>;
 
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-id";
 	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+		txd-delay = <0>;
+		txen-delay = <0>;
+	};
 };
 
 &eth1 {
@@ -155,5 +216,33 @@
 
 	pll-data = <0x03000101 0x80000101 0x80001313>;
 
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+
+	qca955x-sgmii-fixup;
+
 	phy-handle = <&phy1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <2>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -271,6 +271,10 @@ openmesh,om2p-hs-v4)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"
 	;;
+openmesh,om2p-v1)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
+	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x10"
+	;;
 openmesh,om5p-ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -188,6 +188,7 @@ ath79_setup_interfaces()
 	compex,wpj531-16m|\
 	openmesh,a40|\
 	openmesh,a60|\
+	openmesh,om2p-v1|\
 	openmesh,om2p-v4|\
 	openmesh,om2p-hs-v4|\
 	plasmacloud,pa300|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -131,6 +131,9 @@ case "$FIRMWARE" in
 	openmesh,om5p-an)
 		caldata_extract "ART" 0x5000 0x440
 		;;
+	openmesh,om2p-v1)
+		caldata_extract "ART" 0x1000 0x440
+		;;
 	wd,mynet-n600|\
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -105,12 +105,9 @@ case "$FIRMWARE" in
 	openmesh,a40|\
 	openmesh,a60|\
 	openmesh,mr1750-v1|\
-	openmesh,mr1750-v2)
-		caldata_extract "ART" 0x5000 0x844
-		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) 16)
-		;;
+	openmesh,mr1750-v2|\
 	openmesh,om5p-ac-v2)
-		caldata_extract "art" 0x5000 0x844
+		caldata_extract "ART" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) 16)
 		;;
 	qihoo,c301)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -82,6 +82,7 @@ platform_do_upgrade() {
 	openmesh,om2p-lc|\
 	openmesh,om5p|\
 	openmesh,om5p-ac-v1|\
+	openmesh,om5p-ac-v2|\
 	openmesh,om5p-an)
 		PART_NAME="inactive"
 		platform_do_upgrade_openmesh "$1"

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -73,6 +73,7 @@ platform_do_upgrade() {
 	openmesh,mr900-v2|\
 	openmesh,mr1750-v1|\
 	openmesh,mr1750-v2|\
+	openmesh,om2p-v1|\
 	openmesh,om2p-v2|\
 	openmesh,om2p-v4|\
 	openmesh,om2p-hs-v1|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1835,6 +1835,16 @@ define Device/openmesh_mr1750-v2
 endef
 TARGET_DEVICES += openmesh_mr1750-v2
 
+define Device/openmesh_om2p-v1
+  $(Device/openmesh_common_256k)
+  SOC := ar7240
+  DEVICE_MODEL := OM2P
+  DEVICE_VARIANT := v1
+  OPENMESH_CE_TYPE := OM2P
+  SUPPORTED_DEVICES += om2p
+endef
+TARGET_DEVICES += openmesh_om2p-v1
+
 define Device/openmesh_om2p-v2
   $(Device/openmesh_common_256k)
   SOC := ar9330

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1925,12 +1925,12 @@ endef
 TARGET_DEVICES += openmesh_om5p-ac-v1
 
 define Device/openmesh_om5p-ac-v2
+  $(Device/openmesh_common_64k)
   SOC := qca9558
-  DEVICE_VENDOR := OpenMesh
   DEVICE_MODEL := OM5P-AC
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct om-watchdog
-  IMAGE_SIZE := 7808k
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  OPENMESH_CE_TYPE := OM5PAC
   SUPPORTED_DEVICES += om5p-acv2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2

--- a/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -1,0 +1,54 @@
+From f32bc2aa01edcba2f2ed5db151cf183eac9ef919 Mon Sep 17 00:00:00 2001
+From: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+Date: Sat, 25 Feb 2017 16:42:50 +0000
+Subject: mtd: nor: support mtd name from device tree
+
+Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -3183,6 +3183,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	struct device *dev = nor->dev;
+ 	struct mtd_info *mtd = &nor->mtd;
+ 	struct device_node *np = spi_nor_get_flash_node(nor);
++	const char __maybe_unused *of_mtd_name = NULL;
+ 	int ret;
+ 	int i;
+ 
+@@ -3237,7 +3238,12 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	if (ret)
+ 		return ret;
+ 
+-	if (!mtd->name)
++#ifdef CONFIG_MTD_OF_PARTS
++	of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++#endif
++	if (of_mtd_name)
++		mtd->name = of_mtd_name;
++	else if (!mtd->name)
+ 		mtd->name = dev_name(dev);
+ 	mtd->priv = nor;
+ 	mtd->type = MTD_NORFLASH;
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -778,6 +778,17 @@ out_error:
+  */
+ static void mtd_set_dev_defaults(struct mtd_info *mtd)
+ {
++#ifdef CONFIG_MTD_OF_PARTS
++	const char __maybe_unused *of_mtd_name = NULL;
++	struct device_node *np;
++
++	np = mtd_get_of_node(mtd);
++	if (np && !mtd->name) {
++		of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++		if (of_mtd_name)
++			mtd->name = of_mtd_name;
++	} else
++#endif
+ 	if (mtd->dev.parent) {
+ 		if (!mtd->owner && mtd->dev.parent->driver)
+ 			mtd->owner = mtd->dev.parent->driver->owner;


### PR DESCRIPTION
This PR is based on the PR https://github.com/openwrt/openwrt/pull/3720

OpenMesh OM2P v1
================

Device specifications:
----------------------

* Qualcomm/Atheros AR7240 rev 2
* 350/350/175 MHz (CPU/DDR/AHB)
* 32 MB of RAM
* 16 MB of SPI NOR flash
  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
* 2x 10/100 Mbps Ethernet
* 1T1R 2.4 GHz Wi-Fi
* 6x GPIO-LEDs (3x wifi, 2x ethernet, 1x power)
* 1x GPIO-button (reset)
* external h/w watchdog (enabled by default)
* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
* 2x fast ethernet
  - eth0
    + 18-24V passive POE (mode B)
    + used as WAN interface
  - eth1
    + builtin switch port 4
    + used as LAN interface
* 12-24V 1A DC
* external antenna

The device itself requires the mtdparts from the uboot arguments to properly boot the flashed image and to support dual-boot (primary + recovery image). Unfortunately, the name of the mtd device in mtdparts is still using the legacy name "ar7240-nor0" which must be supplied using the Linux-specfic DT parameter linux,mtd-name to overwrite the generic name "spi0.0".

Flashing instructions:
----------------------

Various methods can be used to install the actual image on the flash.
Two easy ones are:

### ap51-flash

The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be used to transfer the image to the u-boot when the device boots up.


### initramfs from TFTP

The serial console must be used to access the u-boot shell during bootup. It can then be used to first boot up the initramfs image from a TFTP server (here with the IP 192.168.1.21):

    setenv serverip 192.168.1.21
    setenv ipaddr 192.168.1.1
    tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr

The actual sysupgrade image can then be transferred (on the LAN port) to the device via

    scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/

On the device, the sysupgrade must then be started using

    sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
