### PR TITLE
rockchip: add RK3399 NanoPi R4S 

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -5,10 +5,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2020.07
-PKG_RELEASE:=3
+PKG_VERSION:=2020.10
+PKG_RELEASE:=1
 
-PKG_HASH:=c1f5bf9ee6bb6e648edbf19ce2ca9452f614b08a9f886f1a566aa42e8cf05f6a
+PKG_HASH:=0d481bbdc05c0ee74908ec2f56a6daa53166cc6a78a0e4fac2ac5d025770a622
 
 PKG_MAINTAINER:=Tobias Maedel <openwrt@tbspace.de>
 

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,16 @@ endef
 
 # RK3399 boards
 
+define U-Boot/nanopi-r4s-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rock-pi-4-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=Rock Pi 4
@@ -61,6 +71,7 @@ endef
 UBOOT_TARGETS := \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
+  nanopi-r4s-rk3399 \
   nanopi-r2s-rk3328
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -48,6 +48,16 @@ define U-Boot/nanopi-r4s-rk3399
   ATF:=rk3399_bl31.elf
 endef
 
+define U-Boot/nanopi-r4s-1g-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S-1G
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s-1g
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-1g-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rock-pi-4-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=Rock Pi 4
@@ -72,6 +82,7 @@ UBOOT_TARGETS := \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   nanopi-r4s-rk3399 \
+  nanopi-r4s-1g-rk3399 \
   nanopi-r2s-rk3328
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes

--- a/package/boot/uboot-rockchip/patches/200-uboot-rockchip-add-support-for-NanoPi-R4S.patch
+++ b/package/boot/uboot-rockchip/patches/200-uboot-rockchip-add-support-for-NanoPi-R4S.patch
@@ -107,6 +107,25 @@ Signed-off-by: Marty Jones <mj8263788@gmail.com>
 +	status = "disabled";
 +};
 +
++&leds {
++	lan_led: led-1 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:lan";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:wan";
++	};
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
 +&pcie0 {
 +	max-link-speed = <1>;
 +	num-lanes = <1>;

--- a/package/boot/uboot-rockchip/patches/200-uboot-rockchip-add-support-for-NanoPi-R4S.patch
+++ b/package/boot/uboot-rockchip/patches/200-uboot-rockchip-add-support-for-NanoPi-R4S.patch
@@ -1,0 +1,208 @@
+From 6b2ff6193a7f402e70a7def00857b3c12e0b7891 Mon Sep 17 00:00:00 2001
+From: Marty Jones <mj8263788@gmail.com>
+Date: Sat, 12 Dec 2020 02:08:13 -0500
+Subject: [PATCH] uboot-rockchip: add support for NanoPi R4S
+
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm/dts/Makefile                      |   1 +
+ arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi |   7 ++
+ arch/arm/dts/rk3399-nanopi-r4s.dts         | 103 +++++++++++++++++++++
+ configs/nanopi-r4s-rk3399_defconfig        |  62 +++++++++++++
+ 4 files changed, 173 insertions(+)
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s.dts
+ create mode 100644 configs/nanopi-r4s-rk3399_defconfig
+
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -130,6 +130,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
+ 	rk3399-nanopi-m4.dtb \
+ 	rk3399-nanopi-m4-2gb.dtb \
+ 	rk3399-nanopi-neo4.dtb \
++	rk3399-nanopi-r4s.dtb \
+ 	rk3399-orangepi.dtb \
+ 	rk3399-pinebook-pro.dtb \
+ 	rk3399-puma-haikou.dtb \
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2019 Jagan Teki <jagan@amarulasolutions.com>
++ */
++
++#include "rk3399-nanopi4-u-boot.dtsi"
++#include "rk3399-sdram-lpddr4-100.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s.dts
+@@ -0,0 +1,103 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * FriendlyElec NanoPC-T4 board device tree source
++ *
++ * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * Copyright (c) 2018 Collabora Ltd.
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S";
++	compatible = "friendlyarm,nanopi-r4s", "rockchip,rk3399";
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/* FIXME: adjust leveles for the connected fan */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};
+--- /dev/null
++++ b/configs/nanopi-r4s-rk3399_defconfig
+@@ -0,0 +1,62 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ROCKCHIP_RK3399=y
++CONFIG_TARGET_EVB_RK3399=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF1A0000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-nanopi-r4s.dtb"
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_TPL=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-nanopi-r4s"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM_RK3399_LPDDR4=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_ASIX=y
++CONFIG_USB_ETHER_ASIX88179=y
++CONFIG_USB_ETHER_MCS7830=y
++CONFIG_USB_ETHER_RTL8152=y
++CONFIG_USB_ETHER_SMSC95XX=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
+

--- a/package/boot/uboot-rockchip/patches/201-uboot-rockchip-add-NanoPi-R4S-1Gb-DDR3.patch
+++ b/package/boot/uboot-rockchip/patches/201-uboot-rockchip-add-NanoPi-R4S-1Gb-DDR3.patch
@@ -1,0 +1,105 @@
+From 2d51eeb1dd80b5fa030cd2b2962eeff7599af9a3 Mon Sep 17 00:00:00 2001
+From: Marty Jones <mj8263788@gmail.com>
+Date: Sat, 12 Dec 2020 03:23:32 -0500
+Subject: [PATCH] uboot-rockchip: add NanoPi R4S 1Gb DDR3
+
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm/dts/Makefile                         |  1 +
+ arch/arm/dts/rk3399-nanopi-r4s-1g-u-boot.dtsi |  7 +++
+ arch/arm/dts/rk3399-nanopi-r4s-1g.dts         |  2 +
+ configs/nanopi-r4s-1g-rk3399_defconfig        | 61 +++++++++++++++++++
+ 4 files changed, 71 insertions(+)
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-1g-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-1g.dts
+ create mode 100644 configs/nanopi-r4s-1g-rk3399_defconfig
+
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -131,6 +131,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
+ 	rk3399-nanopi-m4-2gb.dtb \
+ 	rk3399-nanopi-neo4.dtb \
+ 	rk3399-nanopi-r4s.dtb \
++	rk3399-nanopi-r4s-1g.dtb \
+ 	rk3399-orangepi.dtb \
+ 	rk3399-pinebook-pro.dtb \
+ 	rk3399-puma-haikou.dtb \
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-1g-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2019 Jagan Teki <jagan@amarulasolutions.com>
++ */
++
++#include "rk3399-nanopi4-u-boot.dtsi"
++#include "rk3399-sdram-ddr3-1600.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-1g.dts
+@@ -0,0 +1,2 @@
++// SPDX-License-Identifier: GPL-2.0
++#include "rk3399-nanopi-r4s.dts"
+--- /dev/null
++++ b/configs/nanopi-r4s-1g-rk3399_defconfig
+@@ -0,0 +1,61 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ROCKCHIP_RK3399=y
++CONFIG_TARGET_EVB_RK3399=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF1A0000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-nanopi-r4s-1g.dtb"
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_TPL=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-nanopi-r4s-1g"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_ASIX=y
++CONFIG_USB_ETHER_ASIX88179=y
++CONFIG_USB_ETHER_MCS7830=y
++CONFIG_USB_ETHER_RTL8152=y
++CONFIG_USB_ETHER_SMSC95XX=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -9,7 +9,8 @@ boardname="${board##*,}"
 board_config_update
 
 case $board in
-friendlyarm,nanopi-r2s)
+friendlyarm,nanopi-r2s|\
+friendlyarm,nanopi-r4s)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -10,7 +10,8 @@ board_config_update
 
 case $board in
 friendlyarm,nanopi-r2s|\
-friendlyarm,nanopi-r4s)
+friendlyarm,nanopi-r4s|\
+friendlyarm,nanopi-r4s-1g)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -11,6 +11,9 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r2s)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
+	friendlyarm,nanopi-r4s)
+		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
+		;;
 	*)
 		ucidef_set_interface_lan 'eth0'
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r4s)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
+	friendlyarm,nanopi-r4s-1g)
+		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
+		;;
 	*)
 		ucidef_set_interface_lan 'eth0'
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -8,12 +8,8 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
-	friendlyarm,nanopi-r2s)
-		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
-		;;
-	friendlyarm,nanopi-r4s)
-		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
-		;;
+	friendlyarm,nanopi-r2s|\
+	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-1g)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -26,5 +26,13 @@ friendlyarm,nanopi-r2s)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1" "xhci-hcd:usb3"
 	;;
+friendlyarm,nanopi-r4s)
+	set_interface_core 2 "eth0"
+	set_interface_core 4 "eth1"
+	;;
+friendlyarm,nanopi-r4s-1g)
+	set_interface_core 2 "eth0"
+	set_interface_core 4 "eth1"
+	;;
 esac
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -15,6 +15,16 @@ define Device/friendlyarm_nanopi-r2s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
+define Device/friendlyarm_nanopi-r4s
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R4S
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := nanopi-r4s-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s
+
 define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -20,7 +20,7 @@ define Device/friendlyarm_nanopi-r4s
   DEVICE_MODEL := NanoPi R4S
   SOC := rk3399
   UBOOT_DEVICE_NAME := nanopi-r4s-rk3399
-  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
   DEVICE_PACKAGES := kmod-r8169
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r4s

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -25,6 +25,16 @@ define Device/friendlyarm_nanopi-r4s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r4s
 
+define Device/friendlyarm_nanopi-r4s-1g
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R4S-1G
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := nanopi-r4s-1g-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s-1g
+
 define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64

--- a/target/linux/rockchip/image/nanopi-r4s.bootscript
+++ b/target/linux/rockchip/image/nanopi-r4s.bootscript
@@ -1,0 +1,8 @@
+part uuid mmc ${devnum}:2 uuid
+
+setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=${uuid} rw rootwait"
+
+load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
+load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
+
+booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/target/linux/rockchip/patches-5.4/110-rockchip-add-NanoPi-R4S-DTS.patch
+++ b/target/linux/rockchip/patches-5.4/110-rockchip-add-NanoPi-R4S-DTS.patch
@@ -1,0 +1,143 @@
+From ca74fb56aaa3fe565bfe08574dcb0fd094736e28 Mon Sep 17 00:00:00 2001
+From: Marty Jones <mj8263788@gmail.com>
+Date: Sat, 12 Dec 2020 02:48:47 -0500
+Subject: [PATCH] rockchip: add NanoPi R4S DTS
+
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dts   | 118 ++++++++++++++++++
+ 2 files changed, 119 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -24,6 +24,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-khadas-edge-v.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-leez-p710.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopc-t4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-m4.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+@@ -0,0 +1,118 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * FriendlyElec NanoPC-T4 board device tree source
++ *
++ * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * Copyright (c) 2018 Collabora Ltd.
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S";
++	compatible = "friendlyarm,nanopi-r4s", "rockchip,rk3399";
++
++	aliases {
++		ethernet1 = &r8169;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/* FIXME: adjust leveles for the connected fan */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++
++	pcie@0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		r8169: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++			local-mac-address = [ 00 00 00 00 00 00 ];
++		};
++	};
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};

--- a/target/linux/rockchip/patches-5.4/110-rockchip-add-NanoPi-R4S-DTS.patch
+++ b/target/linux/rockchip/patches-5.4/110-rockchip-add-NanoPi-R4S-DTS.patch
@@ -97,6 +97,25 @@ Signed-off-by: Marty Jones <mj8263788@gmail.com>
 +	status = "disabled";
 +};
 +
++&leds {
++	lan_led: led-1 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:lan";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:wan";
++	};
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
 +&pcie0 {
 +	max-link-speed = <1>;
 +	num-lanes = <1>;

--- a/target/linux/rockchip/patches-5.4/111-rockchip-add-NanoPi-R4S-1Gb-DDR3.patch
+++ b/target/linux/rockchip/patches-5.4/111-rockchip-add-NanoPi-R4S-1Gb-DDR3.patch
@@ -1,0 +1,27 @@
+From dbbcf8b2cb8e321310510179caa12afb30525c17 Mon Sep 17 00:00:00 2001
+From: Marty Jones <mj8263788@gmail.com>
+Date: Sat, 12 Dec 2020 03:54:03 -0500
+Subject: [PATCH] rockchip: add NanoPi R4S 1Gb DDR3
+
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile                 | 1 +
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-1g.dts | 2 ++
+ 2 files changed, 3 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-1g.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -25,6 +25,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-leez-p710.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopc-t4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-m4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s-1g.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s-1g.dts
+@@ -0,0 +1,2 @@
++// SPDX-License-Identifier: GPL-2.0
++#include "rk3399-nanopi-r4s.dts"


### PR DESCRIPTION
![Screen Shot 2020-12-03 at 2.26.12 PM|690x433](https://forum.openwrt.org/uploads/default/optimized/3X/4/9/4984b34522061250fb5dd6c847babb9e5ff60c6f_2_690x433.jpeg) 

* SoC – Rockchip RK3399 hexa-core processor with dual-Core Cortex-A72 up to 2.0GHz,  quad-core Cortex-A53 up to 1.5GHz, Mali-T864 GPU with OpenGL ES1.1/2.0/3.0/3.1, OpenCL, DX11, and AFBC support, 4K VP9 and 4K 10-bit H265/H264 60fps video decoder
* System Memory – 1GB DDR3 or 4GB LPDDR4
* Storage – MicroSD card slot
* Networking – 2x GbE(RTL8211E 1Gbps - RTL8111H 1Gbps), including one native Gigabit Ethernet, and one PCIe Gigabit Ethernet
* USB – 2x USB 3.0 Type-A ports, USB 2.0 via 4-pin header
* Expansion – 2×5-pin header with 1x SPI, 1x I2C
* Debugging – 3-pin debug UART header
* Misc- 1x power LED, and 3x user LEDs (SYS, LAN, WAN), user button, 2-pin RTC battery connector, 5V fan connector
* Power Supply
  * 5V/3A via USB-C connector or pin header
  * RK808-D PMIC and independent DC/DC enabling DVFS, software power-down, RTC wake-up, system sleep mode
* Dimensions – 66 x 66 mm (8-layer PCB)
* Temperature Range – -20°C to 70°C

The detailed information for [NanoPi R4S](https://wiki.friendlyarm.com/wiki/index.php/NanoPi_R4S)

![Screen Shot 2020-12-06 at 5.04.02 PM|690x85](https://forum.openwrt.org/uploads/default/original/3X/d/0/d01adeaf9a1c73aec7a49396ae4fe33c8b468c93.png)

Signed-off-by: Xiaobo Tian tianxiaobo@gelaxy.io