### PR TITLE
ath79: Add support for OpenMesh OM5P-AN

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -57,6 +57,7 @@ openmesh,mr900-v2|\
 openmesh,mr1750-v1|\
 openmesh,mr1750-v2|\
 openmesh,om5p|\
+openmesh,om5p-an|\
 openmesh,om5p-ac-v2|\
 samsung,wam250|\
 ubnt,nanostation-m|\

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "openmesh,om5p-an", "qca,ar9344";
+	model = "OpenMesh OM5P-AN";
+
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_lan_wan_blue_pin>;
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_blue {
+			label = "blue:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_green {
+			label = "green:wifi";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_yellow {
+			label = "yellow:wifi";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH /* sda */
+			 &gpio 20 GPIO_ACTIVE_HIGH /* scl */
+			>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-gpio,scl-open-drain;
+		i2c-gpio,sda-open-drain;
+
+		tmp423a@4c {
+			compatible = "ti,tmp423";
+			reg = <0x4c>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&pinmux {
+	led_lan_wan_blue_pin: pinmux_lan_wan_blue_pin {
+		pinctrl-single,bits = <0xc 0x0 0xffff0000>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		/* partitions are passed via bootloader */
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x060000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "inactive";
+				reg = <0x0b0000 0x7a0000>;
+			};
+
+			partition@850000 {
+				label = "inactive2";
+				reg = <0x850000 0x7a0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x80>;
+
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy7>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <2>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <16>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -261,6 +261,10 @@ openmesh,om2p-hs-v4)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"
 	;;
+openmesh,om5p-an)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
+	;;
 pcs,cr3000)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -124,7 +124,8 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x1000
 		;;
 	openmesh,mr600-v1|\
-	openmesh,mr600-v2)
+	openmesh,mr600-v2|\
+	openmesh,om5p-an)
 		caldata_extract "ART" 0x5000 0x440
 		;;
 	wd,mynet-n600|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -80,7 +80,8 @@ platform_do_upgrade() {
 	openmesh,om2p-hs-v3|\
 	openmesh,om2p-hs-v4|\
 	openmesh,om2p-lc|\
-	openmesh,om5p)
+	openmesh,om5p|\
+	openmesh,om5p-an)
 		PART_NAME="inactive"
 		platform_do_upgrade_openmesh "$1"
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1912,6 +1912,15 @@ define Device/openmesh_om5p-ac-v2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
 
+define Device/openmesh_om5p-an
+  $(Device/openmesh_common_64k)
+  SOC := ar9344
+  DEVICE_MODEL := OM5P-AN
+  OPENMESH_CE_TYPE := OM5P
+  SUPPORTED_DEVICES += om5p-an
+endef
+TARGET_DEVICES += openmesh_om5p-an
+
 define Device/pcs_cap324
   SOC := ar9344
   DEVICE_VENDOR := PowerCloud Systems


### PR DESCRIPTION
OpenMesh OM5P-AN
================

Device specifications:
----------------------

* Qualcomm/Atheros AR9344 rev 2
* 560/450/225 MHz (CPU/DDR/AHB)
* 64 MB of RAM
* 16 MB of SPI NOR flash
  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
* 1T1R 2.4 GHz Wi-Fi
* 2T2R 5 GHz Wi-Fi
* 6x GPIO-LEDs (3x wifi, 2x ethernet, 1x power)
* 1x GPIO-button (reset)
* external h/w watchdog (enabled by default)
* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
* TI tmp423 (package kmod-hwmon-tmp421) for temperature monitoring
* 2x ethernet
  - eth0
    + 10/100/1000 Mbps Ethernet
    + 802.3af POE
    + used as LAN interface
  - eth1
    + 10/100 Mbps Ethernet
    + builtin switch port 1
    + 18-24V passive POE (mode B)
    + used as WAN interface
* 12-24V 1A DC
* internal antennas

Flashing instructions:
----------------------

Various methods can be used to install the actual image on the flash.
Two easy ones are:

### ap51-flash

The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be used to transfer the image to the u-boot when the device boots up.


### initramfs from TFTP

The serial console must be used to access the u-boot shell during bootup. It can then be used to first boot up the initramfs image from a TFTP server (here with the IP 192.168.1.21):

    setenv serverip 192.168.1.21
    setenv ipaddr 192.168.1.1
    tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr

The actual sysupgrade image can then be transferred (on the LAN port) to the device via

    scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/

On the device, the sysupgrade must then be started using

    sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin