### PR TITLE
ath79: unset IMAGE/* definitions for every device

### DIFF
--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -67,6 +67,7 @@ define Device/Default
   COMPILE :=
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
   IMAGES := sysupgrade.bin
+  $$(foreach var,$$(filter IMAGE/%,$$(.VARIABLES)),$$(eval undefine $$(var)))
   IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | append-metadata | check-size
 endef


### PR DESCRIPTION
Commit 5fc28ef479 added the IMAGE/sysupgrade.bin/squashfs definition,
which leaks into other devices, resulting in sysupgrade.bin images that
are actually tarballs and do not boot when directly written to flash.

Signed-off-by: Sven Wegener <sven.wegener@stealer.net>