### PR TITLE
ath79: Upate image command for Plasma Cloud PA300

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1623,7 +1623,7 @@ define Device/plasmacloud_pa300-common
   IMAGES += factory.bin
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-to $$(BLOCKSIZE)
   IMAGE/factory.bin := append-rootfs | pad-rootfs | openmesh-image ce_type=PA300
-  IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
+  IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
 define Device/plasmacloud_pa300


### PR DESCRIPTION
Commit 5fc28ef479 added the IMAGE/sysupgrade.bin/squashfs definition,
which leaks into other devices, resulting in sysupgrade.bin images that
are actually tarballs and do not boot when directly written to flash. We
can use the normal sysupgrade.bin command variable for this device.

Signed-off-by: Sven Wegener <sven.wegener@stealer.net>