### PR TITLE
ath79: Add support for OpenMesh A60 family

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -49,6 +49,7 @@ netgear,wnr2200-16m|\
 netgear,wnr612-v2|\
 ocedo,koala|\
 ocedo,raccoon|\
+openmesh,a40|\
 openmesh,a60|\
 openmesh,mr600-v1|\
 openmesh,mr600-v2|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -93,6 +93,7 @@ netgear,wndr4300tn|\
 netgear,wndr4300sw)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
 	;;
+openmesh,om2p-v1|\
 openmesh,om2p-v2|\
 openmesh,om2p-v4|\
 openmesh,om2p-hs-v1|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -56,6 +56,7 @@ openmesh,mr900-v2|\
 openmesh,mr1750-v1|\
 openmesh,mr1750-v2|\
 openmesh,om5p|\
+openmesh,om5p-an|\
 openmesh,om5p-ac-v2|\
 samsung,wam250|\
 ubnt,nanostation-m|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -49,6 +49,7 @@ netgear,wnr2200-16m|\
 netgear,wnr612-v2|\
 ocedo,koala|\
 ocedo,raccoon|\
+openmesh,a60|\
 openmesh,mr600-v1|\
 openmesh,mr600-v2|\
 openmesh,mr900-v1|\

--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7240.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "openmesh,om2p-v1", "qca,ar7240";
+	model = "OpenMesh OM2P v1";
+
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_disable_pins>;
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi_green {
+			label = "green:wifi";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_yellow {
+			label = "yellow:wifi";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_blue {
+			label = "blue:lan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		linux,mtd-name = "ar7240-nor0";
+
+		/* partitions are passed via bootloader */
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x040000>;
+			};
+
+			partition@80000 {
+				label = "custom";
+				reg = <0x080000 0x140000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "inactive";
+				reg = <0x1c0000 0x700000>;
+			};
+
+			partition@8c0000 {
+				label = "inactive2";
+				reg = <0x8c0000 0x700000>;
+			};
+
+			art: partition@fc0000 {
+				label = "ART";
+				reg = <0xfc0000 0x040000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "openmesh,om5p-an", "qca,ar9344";
+	model = "OpenMesh OM5P-AN";
+
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&led_lan_wan_blue_pin>;
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_blue {
+			label = "blue:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_green {
+			label = "green:wifi";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_yellow {
+			label = "yellow:wifi";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH /* sda */
+			 &gpio 20 GPIO_ACTIVE_HIGH /* scl */
+			>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-gpio,scl-open-drain;
+		i2c-gpio,sda-open-drain;
+
+		tmp423a@4c {
+			compatible = "ti,tmp423";
+			reg = <0x4c>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&pinmux {
+	led_lan_wan_blue_pin: pinmux_lan_wan_blue_pin {
+		pinctrl-single,bits = <0xc 0x0 0xffff0000>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		/* partitions are passed via bootloader */
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x060000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "inactive";
+				reg = <0x0b0000 0x7a0000>;
+			};
+
+			partition@850000 {
+				label = "inactive2";
+				reg = <0x850000 0x7a0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x80>;
+
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy7>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <2>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		mtd-mac-address = <&art 0x0>;
+		mtd-mac-address-increment = <16>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_openmesh_a40.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_a40.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_openmesh_a60.dtsi"
+
+/ {
+	compatible = "openmesh,a40", "qca,qca9558";
+	model = "OpenMesh A40";
+};

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_openmesh_a60.dtsi"
+
+/ {
+	compatible = "openmesh,a60", "qca,qca9558";
+	model = "OpenMesh A60";
+};

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_blue {
+			label = "blue:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_red {
+			label = "red:status";
+			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		/* partitions are passed via bootloader */
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x060000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "inactive";
+				reg = <0x0b0000 0x7a0000>;
+			};
+
+			partition@850000 {
+				label = "inactive2";
+				reg = <0x850000 0x7a0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "ART";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x6>;
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+		at803x-override-sgmii-link-check;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x82000101 0x80000101 0x80001313>;
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy1>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+		rxd-delay = <3>;
+		rxdv-delay = <3>;
+		txd-delay = <0>;
+		txen-delay = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x80000101 0x80001313>;
+
+	mtd-mac-address = <&art 0x6>;
+
+	qca955x-sgmii-fixup;
+
+	phy-handle = <&phy2>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <2>;
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -250,6 +250,10 @@ openmesh,om2p-v1)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x10"
 	;;
+openmesh,om5p-an)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
+	;;
 pcs,cr3000)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -246,6 +246,10 @@ openmesh,om2p-hs-v4)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"
 	;;
+openmesh,om2p-v1)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
+	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x10"
+	;;
 pcs,cr3000)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -164,6 +164,7 @@ ath79_setup_interfaces()
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\
 	compex,wpj531-16m|\
+	openmesh,a60|\
 	openmesh,om2p-v1|\
 	openmesh,om2p-v4|\
 	openmesh,om2p-hs-v4|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -164,6 +164,7 @@ ath79_setup_interfaces()
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\
 	compex,wpj531-16m|\
+	openmesh,a40|\
 	openmesh,a60|\
 	openmesh,om2p-v1|\
 	openmesh,om2p-v4|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -164,6 +164,7 @@ ath79_setup_interfaces()
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\
 	compex,wpj531-16m|\
+	openmesh,om2p-v1|\
 	openmesh,om2p-v4|\
 	openmesh,om2p-hs-v4|\
 	plasmacloud,pa300|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -125,7 +125,8 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x1000
 		;;
 	openmesh,mr600-v1|\
-	openmesh,mr600-v2)
+	openmesh,mr600-v2|\
+	openmesh,om5p-an)
 		caldata_extract "ART" 0x5000 0x440
 		;;
 	openmesh,om2p-v1)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -128,6 +128,9 @@ case "$FIRMWARE" in
 	openmesh,mr600-v2)
 		caldata_extract "ART" 0x5000 0x440
 		;;
+	openmesh,om2p-v1)
+		caldata_extract "ART" 0x1000 0x440
+		;;
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -98,6 +98,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
+	openmesh,a40|\
 	openmesh,a60|\
 	openmesh,mr1750-v1|\
 	openmesh,mr1750-v2)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -98,6 +98,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
+	openmesh,a60|\
 	openmesh,mr1750-v1|\
 	openmesh,mr1750-v2)
 		caldata_extract "ART" 0x5000 0x844

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -50,6 +50,7 @@ platform_do_upgrade() {
 	jjplus,ja76pf2)
 		redboot_fis_do_upgrade "$1" linux
 		;;
+	openmesh,a60|\
 	openmesh,mr600-v1|\
 	openmesh,mr600-v2|\
 	openmesh,mr900-v1|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -50,6 +50,7 @@ platform_do_upgrade() {
 	jjplus,ja76pf2)
 		redboot_fis_do_upgrade "$1" linux
 		;;
+	openmesh,a40|\
 	openmesh,a60|\
 	openmesh,mr600-v1|\
 	openmesh,mr600-v2|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -56,6 +56,7 @@ platform_do_upgrade() {
 	openmesh,mr900-v2|\
 	openmesh,mr1750-v1|\
 	openmesh,mr1750-v2|\
+	openmesh,om2p-v1|\
 	openmesh,om2p-v2|\
 	openmesh,om2p-v4|\
 	openmesh,om2p-hs-v1|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -64,7 +64,8 @@ platform_do_upgrade() {
 	openmesh,om2p-hs-v3|\
 	openmesh,om2p-hs-v4|\
 	openmesh,om2p-lc|\
-	openmesh,om5p)
+	openmesh,om5p|\
+	openmesh,om5p-an)
 		PART_NAME="inactive"
 		platform_do_upgrade_openmesh "$1"
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1654,6 +1654,16 @@ define Device/openmesh_mr1750-v2
 endef
 TARGET_DEVICES += openmesh_mr1750-v2
 
+define Device/openmesh_om2p-v1
+  $(Device/openmesh_common_256k)
+  SOC := ar7240
+  DEVICE_MODEL := OM2P
+  DEVICE_VARIANT := v1
+  OPENMESH_CE_TYPE := OM2P
+  SUPPORTED_DEVICES += om2p
+endef
+TARGET_DEVICES += openmesh_om2p-v1
+
 define Device/openmesh_om2p-v2
   $(Device/openmesh_common_256k)
   SOC := ar9330

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1753,6 +1753,15 @@ define Device/openmesh_om5p-ac-v2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2
 
+define Device/openmesh_om5p-an
+  $(Device/openmesh_common_64k)
+  SOC := ar9344
+  DEVICE_MODEL := OM5P-AN
+  OPENMESH_CE_TYPE := OM5P
+  SUPPORTED_DEVICES += om5p-an
+endef
+TARGET_DEVICES += openmesh_om5p-an
+
 define Device/pcs_cap324
   SOC := ar9344
   DEVICE_VENDOR := PowerCloud Systems

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1592,6 +1592,16 @@ define Device/openmesh_common_256k
 	openmesh-image ce_type=$$$$(OPENMESH_CE_TYPE) | append-metadata
 endef
 
+define Device/openmesh_a40
+  $(Device/openmesh_common_64k)
+  SOC := qca9558
+  DEVICE_MODEL := A40
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
+  OPENMESH_CE_TYPE := A60
+  SUPPORTED_DEVICES += a40
+endef
+TARGET_DEVICES += openmesh_a40
+
 define Device/openmesh_a60
   $(Device/openmesh_common_64k)
   SOC := qca9558

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1592,6 +1592,16 @@ define Device/openmesh_common_256k
 	openmesh-image ce_type=$$$$(OPENMESH_CE_TYPE) | append-metadata
 endef
 
+define Device/openmesh_a60
+  $(Device/openmesh_common_64k)
+  SOC := qca9558
+  DEVICE_MODEL := A60
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
+  OPENMESH_CE_TYPE := A60
+  SUPPORTED_DEVICES += a60
+endef
+TARGET_DEVICES += openmesh_a60
+
 define Device/openmesh_mr600-v1
   $(Device/openmesh_common_64k)
   SOC := ar9344

--- a/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -1,0 +1,51 @@
+From f32bc2aa01edcba2f2ed5db151cf183eac9ef919 Mon Sep 17 00:00:00 2001
+From: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+Date: Sat, 25 Feb 2017 16:42:50 +0000
+Subject: mtd: nor: support mtd name from device tree
+
+Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -3088,6 +3088,7 @@ int spi_nor_scan(struct spi_nor *nor, const char *name,
+ 	struct device *dev = nor->dev;
+ 	struct mtd_info *mtd = &nor->mtd;
+ 	struct device_node *np = spi_nor_get_flash_node(nor);
++	const char __maybe_unused *of_mtd_name = NULL;
+ 	int ret;
+ 	int i;
+ 
+@@ -3142,7 +3143,12 @@ int spi_nor_scan(struct spi_nor *nor, const char *name,
+ 	if (ret)
+ 		return ret;
+ 
+-	if (!mtd->name)
++#ifdef CONFIG_MTD_OF_PARTS
++	of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++#endif
++	if (of_mtd_name)
++		mtd->name = of_mtd_name;
++	else if (!mtd->name)
+ 		mtd->name = dev_name(dev);
+ 	mtd->priv = nor;
+ 	mtd->type = MTD_NORFLASH;
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -762,6 +762,17 @@ int del_mtd_device(struct mtd_info *mtd)
+  */
+ static void mtd_set_dev_defaults(struct mtd_info *mtd)
+ {
++#ifdef CONFIG_MTD_OF_PARTS
++	const char __maybe_unused *of_mtd_name = NULL;
++	struct device_node *np;
++
++	np = mtd_get_of_node(mtd);
++	if (np && !mtd->name) {
++		of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++		if (of_mtd_name)
++			mtd->name = of_mtd_name;
++	} else
++#endif
+ 	if (mtd->dev.parent) {
+ 		if (!mtd->owner && mtd->dev.parent->driver)
+ 			mtd->owner = mtd->dev.parent->driver->owner;

--- a/target/linux/ath79/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/ath79/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -1,0 +1,54 @@
+From f32bc2aa01edcba2f2ed5db151cf183eac9ef919 Mon Sep 17 00:00:00 2001
+From: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+Date: Sat, 25 Feb 2017 16:42:50 +0000
+Subject: mtd: nor: support mtd name from device tree
+
+Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
+---
+ drivers/mtd/spi-nor/spi-nor.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -4937,6 +4937,7 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	struct mtd_info *mtd = &nor->mtd;
+ 	struct device_node *np = spi_nor_get_flash_node(nor);
+ 	struct spi_nor_flash_parameter *params = &nor->params;
++	const char __maybe_unused *of_mtd_name = NULL;
+ 	int ret;
+ 	int i;
+ 
+@@ -4999,7 +5000,12 @@ int spi_nor_scan(struct spi_nor *nor, co
+ 	/* Init flash parameters based on flash_info struct and SFDP */
+ 	spi_nor_init_params(nor);
+ 
+-	if (!mtd->name)
++#ifdef CONFIG_MTD_OF_PARTS
++	of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++#endif
++	if (of_mtd_name)
++		mtd->name = of_mtd_name;
++	else if (!mtd->name)
+ 		mtd->name = dev_name(dev);
+ 	mtd->priv = nor;
+ 	mtd->type = MTD_NORFLASH;
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -778,6 +778,17 @@ out_error:
+  */
+ static void mtd_set_dev_defaults(struct mtd_info *mtd)
+ {
++#ifdef CONFIG_MTD_OF_PARTS
++	const char __maybe_unused *of_mtd_name = NULL;
++	struct device_node *np;
++
++	np = mtd_get_of_node(mtd);
++	if (np && !mtd->name) {
++		of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
++		if (of_mtd_name)
++			mtd->name = of_mtd_name;
++	} else
++#endif
+ 	if (mtd->dev.parent) {
+ 		if (!mtd->owner && mtd->dev.parent->driver)
+ 			mtd->owner = mtd->dev.parent->driver->owner;


### PR DESCRIPTION
This PR is based on the PR #3710 + #3712

All these devices were part of the A60 image in the ar71xx target. These were now converted to ath79 and split into different images in this process


OpenMesh A40
============

Device specifications:
----------------------

* Qualcomm/Atheros QCA9558 ver 1 rev 0
* 720/600/240 MHz (CPU/DDR/AHB)
* 128 MB of RAM
* 16 MB of SPI NOR flash
  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
* 2T2R 2.4 GHz Wi-Fi (11n)
* 2T2R 5 GHz Wi-Fi (11ac)
* multi-color LED (controlled via red/green/blue GPIOs)
* 1x GPIO-button (reset)
* external h/w watchdog (enabled by default))
* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
* 2x ethernet
  - eth0
    + Label: Ethernet 1
    + 10/100/1000 Mbps Ethernet
    + 802.3af POE
    + used as WAN interface
  - eth1
    + Label: Ethernet 1
    + 10/100/1000 Mbps Ethernet
    + used as LAN interface
* 1x USB
* internal antennas

Flashing instructions:
----------------------

Various methods can be used to install the actual image on the flash.
Two easy ones are:

### ap51-flash

The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be used to transfer the image to the u-boot when the device boots up.


### initramfs from TFTP

The serial console must be used to access the u-boot shell during bootup. It can then be used to first boot up the initramfs image from a TFTP server (here with the IP 192.168.1.21):

    setenv serverip 192.168.1.21
    setenv ipaddr 192.168.1.1
    tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr

The actual sysupgrade image can then be transferred (on the LAN port) to the device via

    scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/

On the device, the sysupgrade must then be started using

    sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin



OpenMesh A60
============

Device specifications:
----------------------

* Qualcomm/Atheros QCA9558 ver 1 rev 0
* 720/600/240 MHz (CPU/DDR/AHB)
* 128 MB of RAM
* 16 MB of SPI NOR flash
  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
* 3T3R 2.4 GHz Wi-Fi (11n)
* 3T3R 5 GHz Wi-Fi (11ac)
* multi-color LED (controlled via red/green/blue GPIOs)
* 1x GPIO-button (reset)
* external h/w watchdog (enabled by default))
* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
* 2x ethernet
  - eth0
    + Label: Ethernet 1
    + 10/100/1000 Mbps Ethernet
    + 802.3af POE
    + used as WAN interface
  - eth1
    + Label: Ethernet 1
    + 10/100/1000 Mbps Ethernet
    + used as LAN interface
* 1x USB
* internal antennas

Flashing instructions:
----------------------

Various methods can be used to install the actual image on the flash.
Two easy ones are:

### ap51-flash

The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be used to transfer the image to the u-boot when the device boots up.


### initramfs from TFTP

The serial console must be used to access the u-boot shell during bootup. It can then be used to first boot up the initramfs image from a TFTP server (here with the IP 192.168.1.21):

    setenv serverip 192.168.1.21
    setenv ipaddr 192.168.1.1
    tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr

The actual sysupgrade image can then be transferred (on the LAN port) to the device via

    scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/

On the device, the sysupgrade must then be started using

    sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin