### PR TITLE
Remove dangling symlinks from toolchain

### DIFF
--- a/include/toolchain-build.mk
+++ b/include/toolchain-build.mk
@@ -21,6 +21,6 @@ define FixupLibdir
 		mkdir -p $(1)/lib; \
 		mv $(1)/lib64/* $(1)/lib/; \
 		rm -rf $(1)/lib64; \
+		ln -sf lib $(1)/lib64; \
 	fi
-	ln -sf lib $(1)/lib64
 endef

--- a/toolchain/gcc/final/Makefile
+++ b/toolchain/gcc/final/Makefile
@@ -74,7 +74,7 @@ define Host/Install
 	# Set up the symlinks to enable lying about target name.
 	set -e; \
 	(cd $(TOOLCHAIN_DIR); \
-		ln -sf $(REAL_GNU_TARGET_NAME) $(GNU_TARGET_NAME); \
+		ln -nsf $(REAL_GNU_TARGET_NAME) $(GNU_TARGET_NAME); \
 		cd bin; \
 		for app in $(REAL_GNU_TARGET_NAME)-* ; do \
 			ln -sf $$$${app} \


### PR DESCRIPTION
When re-installing the toolchain there are two dangling self symlinks, because of the `ln` command missing the `-n` option:

```
./staging_dir/toolchain-mips_24kc_gcc-9.3.0_musl/lib/lib -> lib
./staging_dir/toolchain-mips_24kc_gcc-9.3.0_musl/mips-openwrt-linux-musl/mips-openwrt-linux-musl -> mips-openwrt-linux-musl
```