### PR TITLE
ath79: add support for Archer A6 v2 EU/RU

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-a6-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-a6-v2.dts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_tplink_archer-x6-v2.dtsi"
+
+/ {
+	compatible = "tplink,archer-a6-v2", "qca,qca9563";
+	model = "TP-Link Archer A6 v2 (EU/RU)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "amber:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			info: partition@20000 {
+				label = "info";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0x7a0000>;
+			};
+
+			partition@7d0000 {
+				label = "tplink";
+				reg = <0x7d0000 0x020000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -1,5 +1,17 @@
 include ./common-tp-link.mk
 
+define Device/tplink_archer-a6-v2
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := Archer A6
+  DEVICE_VARIANT := v2 (EU/RU)
+  TPLINK_BOARD_ID := ARCHER-A6-V2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_archer-a6-v2
+
+
 define Device/tplink_archer-a7-v5
   $(Device/tplink-safeloader-uimage)
   SOC := qca9563

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -760,6 +760,39 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the Archer A6 v2 (EU/RU) */
+	{
+		.id	 = "ARCHER-A6-V2",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:Archer A6,product_ver:2.0.0,special_id:45550000}\r\n",
+		.part_trail = 0x00,
+		.soft_ver = "soft_ver:1.9.1\n",
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00200},
+			{"pin", 0x20200, 0x00100},
+			{"product-info", 0x20300, 0x00200},
+			{"device-id", 0x20500, 0x0fb00},
+			{"firmware", 0x30000, 0x7a9400},
+			{"soft-version", 0x7d9400, 0x00100},
+			{"extra-para", 0x7d9500, 0x00100},
+			{"support-list", 0x7d9600, 0x00200},
+			{"profile", 0x7d9800, 0x03000},
+			{"default-config", 0x7dc800, 0x03000},
+			{"partition-table", 0x7df800, 0x00800},
+			{"user-config", 0x7e0000, 0x0c000},
+			{"certificate", 0x7ec000, 0x04000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the A7-V5 */
 	{
 		.id     = "ARCHER-A7-V5",


### PR DESCRIPTION
This patch adds support for TP-Link Archer A6 v2 (EU/RU)

Hardware specification:
- SOC: Qualcomm QCA9563 @ 775MHz
- Flash: GigaDevice GD25Q64CSIG (8MiB)
- RAM: Zentel A3R1GE40JBF (128 MiB DDR2)
- Ethernet: Qualcomm QCA8337N: 4x 1Gbps LAN + 1x 1Gbps WAN
- Wireless:
  - 2.4GHz (bgn) QCA9563 integrated (3x3)
  - 5GHz (ac) Qualcomm QCA9886 (2x2)
- Button: 1x power, 1x reset, 1x wps
- LED: 6x LEDs: power, wlan2g, wlan5g, lan, wan, wps
- UART: There's no UART header on the board

Flash instructions:

Upload
openwrt-ath79-generic-tplink_archer-a6-v2-squashfs-factory.bin
via the router Web interface.

Flash instruction using tftp recovery:

1. Connect the computer to one of the LAN ports of the router
2. Set the computer IP to 192.168.0.66
3. Start a tftp server with the OpenWrt factory image in the
   tftp root directory renamed to ArcherA6v2_tp_recovery.bin.
4. Connect power cable to router, press and hold the reset
   button and turn the router on
5. Keep the reset button pressed until the WPS LED lights up
6. Wait ~150 seconds to complete flashing

According to the GPL source the non-EU variant has different
GPIOs assigned to some of the LEDs and buttons. The flash
layout might be different as well.

Signed-off-by: Andrey Chalkin <L2jLiga@gmail.com>

Replaces #3704 

According to https://github.com/openwrt/openwrt/pull/3704#issuecomment-748691641 created separated device for TP-Link Archer A6 v2 EU/RU