### PR TITLE
tools/fakeroot: remove undefined symbol messages

### DIFF
--- a/tools/fakeroot/Makefile
+++ b/tools/fakeroot/Makefile
@@ -6,6 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=fakeroot
 PKG_VERSION:=1.24
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).orig.tar.gz
 PKG_SOURCE_URL:=http://deb.debian.org/debian/pool/main/f/fakeroot

--- a/tools/fakeroot/patches/200-hide-dlsym-error.patch
+++ b/tools/fakeroot/patches/200-hide-dlsym-error.patch
@@ -1,0 +1,32 @@
+Description: Hide error from dlsym()
+ dlsym(), starting in glibc 2.24 actually reports errors. In our case,
+ we try to get ACL functions which are not in the glibc. This causes
+ failures in test suites, so hide those messages for non-debugging
+ purposes for now. It also makes the build logs annoying to read.
+Author: Julian Andres Klode <juliank@ubuntu.com>
+Origin: vendor
+Bug-Debian: https://bugs.debian.org/830912
+Forwarded: no
+Last-Update: 2016-08-12
+
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -256,10 +256,16 @@ void load_library_symbols(void){
+  /* clear dlerror() just in case dlsym() legitimately returns NULL */
+     msg = dlerror();
+     *(next_wrap[i].doit)=dlsym(get_libc(), next_wrap[i].name);
++
+     if ( (msg = dlerror()) != NULL){
+-      fprintf (stderr, "dlsym(%s): %s\n", next_wrap[i].name, msg);
+-/*    abort ();*/
++#ifdef LIBFAKEROOT_DEBUGGING
++      if (fakeroot_debug) {
++        fprintf (stderr, "dlsym(%s): %s\n", next_wrap[i].name, msg);
++/*      abort ();*/
++      }
++#endif
+     }
++
+   }
+ }
+ 


### PR DESCRIPTION
glibc started to return errors from dlerror() for dlsym() lookup failures which
results in a lot of messages from fakeroot like

```
dlsym(acl_get_fd): staging_dir/host/lib/libfakeroot.so: undefined symbol: acl_get_fd
dlsym(acl_get_file): staging_dir/host/lib/libfakeroot.so: undefined symbol: acl_get_file
dlsym(acl_set_fd): staging_dir/host/lib/libfakeroot.so: undefined symbol: acl_set_fd
```

when building OpenWrt using a recent glibc. Use the patch from the upstream
Debian package to silence these messages.

Link: https://bugs.debian.org/830912
Fixes: FS#3393
Signed-off-by: Sven Wegener <sven.wegener@stealer.net>