### PR TITLE
libevent2: trigger rebuild on libevent2-pthreads

### DIFF
--- a/package/libs/libevent2/Makefile
+++ b/package/libs/libevent2/Makefile
@@ -23,6 +23,7 @@ PKG_CPE_ID:=cpe:/a:libevent_project:libevent
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_libevent2-openssl \
+	CONFIG_PACKAGE_libevent2-pthreads \
 	CONFIG_PACKAGE_libevent2-mbedtls
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
The symbol determines if the libevent2-pthreads libraries get built or not.
If we want to select libevent2-pthreads, and these haven't been built, an
error will occur mentioning that there are no 'libevent_pthreads-2.1.so'
files.

Adding CONFIG_PACKAGE_libevent2-pthreads to PKG_CONFIG_DEPEND will make
sure that the libraries get re-built in case libevent2-pthreads is
selected.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>