### PR TITLE
base-files: allow reusing of boolean value extraction logic

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=243
+PKG_RELEASE:=244
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -118,15 +118,22 @@ config_get() {
 	esac
 }
 
+# get_bool <value> [<default>]
+get_bool() {
+	local _tmp="$1"
+	case "$_tmp" in
+		1|on|true|yes|enabled) _tmp=1;;
+		0|off|false|no|disabled) _tmp=0;;
+		*) _tmp="$2";;
+	esac
+	echo -n "$_tmp"
+}
+
 # config_get_bool <variable> <section> <option> [<default>]
 config_get_bool() {
 	local _tmp
 	config_get _tmp "$2" "$3" "$4"
-	case "$_tmp" in
-		1|on|true|yes|enabled) _tmp=1;;
-		0|off|false|no|disabled) _tmp=0;;
-		*) _tmp="$4";;
-	esac
+	_tmp="$(get_bool "$_tmp" "$4")"
 	export ${NO_EXPORT:+-n} "$1=$_tmp"
 }
 


### PR DESCRIPTION
The `functions.sh` script has `config_get_bool()` function, which is usable when using UCI config direct access API, but there is no equivalent for the callback API. Introduce `get_bool()` function to allow reusing it from init scripts.

Example:

```sh
option_cb() {
    local option="$1"
    local value="$(get_bool "$2")"
    ...
}
```