### PR TITLE
tools/ccache: keep ccache configuration when running cacheclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ dirclean: clean
 
 cacheclean:
 ifneq ($(CONFIG_CCACHE),)
-	rm -rf $(CCACHE_DIR)
+	$(STAGING_DIR_HOST)/bin/ccache -C
 endif
 
 ifndef DUMP_TARGET_DB

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -261,8 +261,8 @@ package/symlinks-clean:
 help:
 	cat README.md
 
-distclean: cacheclean
-	rm -rf bin build_dir .config* dl feeds key-build* logs package/feeds package/openwrt-packages staging_dir tmp
+distclean:
+	rm -rf bin build_dir .ccache .config* dl feeds key-build* logs package/feeds package/openwrt-packages staging_dir tmp
 	@$(_SINGLE)$(SUBMAKE) -C scripts/config clean
 
 ifeq ($(findstring v,$(DEBUG)),)


### PR DESCRIPTION
This keeps the configuration, like the size of the cache, and the
statistics alive. Move the removal of the cache directory to the
dirclean target, but only delete the directory if we're managing it
inside of our build tree.