### PR TITLE
ath79: small fixes for Engenius boards

### DIFF
--- a/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
+++ b/target/linux/ath79/dts/ar9341_engenius_eap300-v2.dts
@@ -7,8 +7,8 @@
 #include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
-	model = "Engenius EAP300 v2";
 	compatible = "engenius,eap300-v2", "qca,ar9341";
+	model = "EnGenius EAP300 v2";
 
 	aliases {
 		serial0 = &uart;
@@ -42,11 +42,6 @@
 			label = "blue:wlan";
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
-		};
-
-		lan {
-			label = "blue:lan";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -84,7 +79,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <40000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -145,21 +140,8 @@
 	};
 };
 
-&eth0 {
-	status = "okay";
-
-	mtd-mac-address = <&art 0x0>;
-
-	phy-handle = <&swphy0>;
-
-	gmac-config {
-		device = <&gmac>;
-		switch-phy-swap = <1>;
-	};
-};
-
 &eth1 {
-	compatible = "syscon", "simple-mfd";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &wmac {

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -156,7 +156,6 @@ telco,t1)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	;;
 comfast,cf-wr752ac-v1|\
-engenius,eap300-v2|\
 enterasys,ws-ap3705i|\
 openmesh,mr900-v1|\
 openmesh,mr900-v2|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -108,6 +108,8 @@ ath79_setup_interfaces()
 	alfa-network,n5q|\
 	devolo,dvl1200e|\
 	devolo,dvl1750e|\
+	engenius,enstationac-v1|\
+	engenius,ews511ap|\
 	ocedo,ursus|\
 	ubnt,unifi-ap-outdoor-plus)
 		ucidef_set_interface_lan "eth0 eth1"
@@ -236,12 +238,9 @@ ath79_setup_interfaces()
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
 		;;
 	engenius,ens202ext-v1)
-		ucidef_set_interface_wan "eth1"
+		ucidef_set_interface_lan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan"
-		;;
-	engenius,ews511ap)
-		ucidef_set_interface_lan "eth0 eth1" "dhcp"
 		;;
 	etactica,eg200)
 		ucidef_set_interface_lan "eth0" "dhcp"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -33,7 +33,6 @@ ath79_setup_interfaces()
 	dlink,dap-3320-a1|\
 	dlink,dir-505|\
 	engenius,eap1200h|\
-	engenius,eap300-v2|\
 	engenius,eap600|\
 	engenius,ecb1200|\
 	engenius,ecb1750|\
@@ -236,6 +235,10 @@ ath79_setup_interfaces()
 	embeddedwireless,dorin)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan:3" "3:lan:2"
+		;;
+	engenius,eap300-v2)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan"
 		;;
 	engenius,ens202ext-v1)
 		ucidef_set_interface_lan "eth1"

--- a/target/linux/ath79/image/common-engenius.mk
+++ b/target/linux/ath79/image/common-engenius.mk
@@ -4,8 +4,7 @@ DEVICE_VARS += ENGENIUS_IMGNAME
 # sysupgrade, as otherwise it will implant the old configuration from
 # OEM firmware when writing rootfs from factory.bin
 define Build/engenius-tar-gz
-	-[ -f "$@" ] && \
-	mkdir -p $@.tmp && \
+	if mkdir -p $@.tmp && \
 	touch $@.tmp/failsafe.bin && \
 	echo '#!/bin/sh' > $@.tmp/before-upgrade.sh && \
 	echo ': > /tmp/_sys/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
@@ -15,7 +14,12 @@ define Build/engenius-tar-gz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
 		-C $@.tmp . | gzip -9n > $@ && \
-	rm -rf $@.tmp
+	rm -rf $@.tmp; then \
+		echo 'engenius-tar-gz succeeded'; \
+	else \
+		echo 'engenius-tar-gz failed' && \
+		rm $@; \
+	fi
 endef
 
 define Device/engenius_loader_okli

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -54,7 +54,7 @@ ath79_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	engenius,enh202-v1)
-		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_lan "eth0"
 		ucidef_add_switch "switch0" \
 			"0@eth1" "4:lan:1"
 		;;


### PR DESCRIPTION
### ath79: move small flash Engenius boards to tiny
for:
 - EAP350 v1
 - ECB350 v1
 - ENH202 v1

Because of the unique situation for these boards:

 - 8 MB flash
 - an extra "failsafe" image for recovery
 - TFTP does not work
 - bootloader loads image from a longer flash offset
 - 1 eraseblock each needed for OKLI kernel loader and fake rootfs
 - using mtd-concat to make use of remaining space...

factory.bin builds are already failing on master branch
so move them to the tiny subtarget

this still may not be enough for LuCI in future releases...
maybe should be handled another way in the future...
(disable LuCI?)

the user has other options such as:

flashing without LuCI and installing LuCI afterward
or
removing the "failsafe" image from the DTS
with the risk that involves (extremely difficult recovery)

---

### ath79: make Engenius fakeroot partitions read-only

for:
 - ENH202 v1
 - ENS202EXT v1

these boards were committed before it was discovered
that for all Engenius boards with a "failsafe" image
forcing the failsafe image to load next boot
can be achieved by editing the u-boot environment like so

  `fw_setenv rootfs_checksum 0`

so its not necessary to delete a partition to trigger it

now all "fake" partitions are read-only for all boards
both the fake kernel: OKLI kernel loader
and the fake rootfs: empty squashfs

---

### ath79: make all eth ports LAN for Engenius APs

for:
 - ENH202 v1
 - ENS202EXT v1
 - EnstationAC v1

on second thought...these boards are sold as
Client Bridge or Point to Point or Access Point
so there is probably no benefit to have WAN by default
for one of the ports

---

### ath79: use internal switch for ENS202EXT

Have both ports on the built-in switch of AR9341
in order to take advantage of memory and CPU savings
and switch offloading features like STP and VLAN

Also, the use of GMAC1 with internal switch for the ports
fixes the issue of the ethernet LEDs not functioning.
The LEDs are triggered by the internal switch, not a GPIO.

---

### ath79: use internal switch and small fixes for EAP300 v2

other small corrections

 - model after compatible, capitalization
 - spi frequency to 40 MHz

Have the port use GMAC1 with internal switch
which fixes the issue of the ethernet LED not functioning
The LED is triggered by the internal switch, not a GPIO.

The GPIO for the ethernet LED was added in ath79
as it was defined in the ar71xx target
but it was not functioning in ath79 for a previously unknown reason.

It is unknown why that GPIO was defined as an LED in ar71xx.

---

### ath79: catch Engenius factory.bin build error

Add logic to common-engenius.mk
so that in the event where the recipe fails
there is not an incomplete or broken factory.bin

Instead, it is removed and the build of other images
is allowed to continue.

Suggested-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
Signed-off-by: Michael Pratt <mcpratt@pm.me>
