### PR TITLE
RFC: kirkwood: Add support for Sheevaplug

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -15,6 +15,7 @@ board=$(board_name)
 case "$board" in
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
+globalscale,sheevaplug|\
 iom,ix2-200|\
 linksys,viper|\
 raidsonic,ib-nas62x0|\

--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -79,6 +79,11 @@ define U-Boot/pogoplugv4
   BUILD_DEVICES:=cloudengines_pogoplugv4
 endef
 
+define U-Boot/sheevaplug
+  NAME:=SheevaPlug
+  BUILD_DEVICES:=globalscale_sheevaplug
+endef
+
 UBOOT_TARGETS := \
 	dockstar dockstar_second_stage \
 	goflexhome \
@@ -87,7 +92,8 @@ UBOOT_TARGETS := \
 	nsa310 \
 	nsa325 \
 	pogo_e02 pogo_e02_second_stage \
-	pogoplugv4
+	pogoplugv4 \
+	sheevaplug
 
 define Build/Configure
 	$(if $(findstring _second_stage,$(BUILD_VARIANT)),

--- a/package/boot/uboot-kirkwood/patches/160-sheevaplug.patch
+++ b/package/boot/uboot-kirkwood/patches/160-sheevaplug.patch
@@ -1,0 +1,39 @@
+--- a/include/configs/sheevaplug.h
++++ b/include/configs/sheevaplug.h
+@@ -47,15 +47,17 @@
+ /*
+  * Default environment variables
+  */
+-#define CONFIG_BOOTCOMMAND		"${x_bootcmd_kernel}; "	\
+-	"setenv bootargs ${x_bootargs} ${x_bootargs_root}; "	\
+-	"bootm 0x6400000;"
++#define CONFIG_BOOTCOMMAND					\
++ "setenv bootargs ${console} ${mtdparts} ${bootargs_root}; "	\
++	"ubi part ubi; " 						\
++	"ubi read 0x800000 kernel; " 			\
++	"bootm 0x800000"
+ 
+-#define CONFIG_EXTRA_ENV_SETTINGS	"x_bootargs=console"	\
+-	"=ttyS0,115200 mtdparts="CONFIG_MTDPARTS_DEFAULT	\
+-	"x_bootcmd_kernel=nand read 0x6400000 0x100000 0x400000\0" \
+-	"x_bootcmd_usb=usb start\0" \
+-	"x_bootargs_root=root=/dev/mtdblock3 rw rootfstype=jffs2\0"
++#define CONFIG_EXTRA_ENV_SETTINGS			\
++	"console=console=ttyS0,115200\0"		\
++	"mtdids="CONFIG_MTDIDS_DEFAULT "\0"		\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
++	"bootargs_root=\0"
+ 
+ /*
+  * Ethernet Driver configuration
+--- a/configs/sheevaplug_defconfig
++++ b/configs/sheevaplug_defconfig
+@@ -22,7 +22,7 @@
+ CONFIG_CMD_FAT=y
+ CONFIG_CMD_JFFS2=y
+ CONFIG_MTDIDS_DEFAULT="nand0=orion_nand"
+-CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:512K(uboot),512K(env),4M(kernel),-(rootfs)"
++CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:1M(uboot),-(ubi)"
+ CONFIG_CMD_UBI=y
+ CONFIG_ISO_PARTITION=y
+ CONFIG_ENV_IS_IN_NAND=y

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -164,3 +164,13 @@
 +CONFIG_FIT_VERBOSE=y
 +CONFIG_LZMA=y
 +CONFIG_LZO=y
+--- a/configs/sheevaplug_defconfig
++++ b/configs/sheevaplug_defconfig
+@@ -41,4 +41,7 @@
+ CONFIG_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+ CONFIG_LZMA=y
++CONFIG_LZO=y

--- a/target/linux/kirkwood/base-files/etc/board.d/01_leds
+++ b/target/linux/kirkwood/base-files/etc/board.d/01_leds
@@ -49,6 +49,9 @@ case "$board" in
 	ucidef_set_led_ataport "hdd1" "HDD1" "nsa325:green:hdd1" "1"
 	ucidef_set_led_ataport "hdd2" "HDD2" "nsa325:green:hdd2" "2"
 	;;
+"globalscale,sheevaplug")
+    ucidef_set_led_timer "health" "health" "sheevaplug:blue:health" "200" "800"
+    ;;
 esac
 
 board_config_flush

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ case "$board" in
 	;;
 "cloudengines,pogoe02"|\
 "cloudengines,pogoplugv4"|\
+"globalscale,sheevaplug"|\
 "iom,iconnect-1.1"|\
 "iom,ix2-200"|\
 "raidsonic,ib-nas62x0"|\

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -27,6 +27,13 @@ define Device/Default
   SUPPORTED_DEVICES := $(subst _,$(comma),$(1))
 endef
 
+define Device/globalscale_sheevaplug
+  DEVICE_TITLE := Globalscale Sheevaplug
+  DEVICE_DTS := kirkwood-sheevaplug
+  BOARD_NAME := sheevaplug
+endef
+TARGET_DEVICES += globalscale_sheevaplug
+
 define Device/cisco_on100
   DEVICE_TITLE := Cisco Systems ON100
   DEVICE_DTS := kirkwood-on100

--- a/target/linux/kirkwood/patches-4.14/110-sheevaplug.patch
+++ b/target/linux/kirkwood/patches-4.14/110-sheevaplug.patch
@@ -1,0 +1,18 @@
+--- a/arch/arm/boot/dts/kirkwood-sheevaplug-common.dtsi
++++ b/arch/arm/boot/dts/kirkwood-sheevaplug-common.dtsi
+@@ -79,13 +79,8 @@
+ 	};
+ 
+ 	partition@100000 {
+-		label = "uImage";
+-		reg = <0x0100000 0x400000>;
+-	};
+-
+-	partition@500000 {
+-		label = "root";
+-		reg = <0x0500000 0x1fb00000>;
++		label = "ubi";
++		reg = <0x0100000 0x1ff00000>;
+ 	};
+ };
+ 


### PR DESCRIPTION
Globalscale SheevaPlug:
* Marvell Kirkwood 88F6281
* 512 MB SDRAM
* 512 MB Flash
* Gigabit Network
* USB 2.0
* SD slot

The device is supported in mainline uboot/linux the commit  adds only some openwrt config for building an image.

Still under testing.
Installation guide to be made.

Signed-off-by: BERENYI Balazs <balazs@wee.hu>
