### PR TITLE
hostapd: stop advertising 11w feature

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=33
+PKG_RELEASE:=34
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/src/src/utils/build_features.h
+++ b/package/network/services/hostapd/src/src/utils/build_features.h
@@ -23,8 +23,6 @@ static inline int has_feature(const char *feat)
 	if (!strcmp(feat, "11r"))
 		return 1;
 #endif
-	if (!strcmp(feat, "11w"))
-		return 1;
 #ifdef CONFIG_ACS
 	if (!strcmp(feat, "acs"))
 		return 1;


### PR DESCRIPTION
This is a follow up of 1a9b896d ("treewide: nuke DRIVER_11W_SUPPORT").
LuCI commit ab010406 ("luci-mod-network: skip check for 802.11w feature")
skips check of the 11w feature [1]. Now advertising it in hostapd is
superfluous so stop doing it.

[1]: https://github.com/openwrt/luci/pull/4689

Signed-off-by: Dobroslaw Kijowski <dobo90@gmail.com>

Probably @ynezz would be the most interested person to review as this is a follow-up of https://github.com/openwrt/openwrt/pull/3347