### PR TITLE
kirkwood: Add support for Sheevaplug

### DIFF
--- a/package/boot/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-envtools/files/kirkwood
@@ -16,6 +16,7 @@ case "$board" in
 checkpoint,l-50|\
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
+globalscale,sheevaplug|\
 iom,ix2-200|\
 linksys,e4200-v2|\
 linksys,ea4500|\

--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -94,6 +94,11 @@ define U-Boot/pogoplugv4
   BUILD_DEVICES:=cloudengines_pogoplugv4
 endef
 
+define U-Boot/sheevaplug
+  NAME:=SheevaPlug
+  BUILD_DEVICES:=globalscale_sheevaplug
+endef
+
 UBOOT_TARGETS := \
 	dockstar dockstar_second_stage \
 	goflexhome \
@@ -105,7 +110,8 @@ UBOOT_TARGETS := \
 	nsa310s \
 	nsa325 \
 	pogo_e02 pogo_e02_second_stage \
-	pogoplugv4
+	pogoplugv4 \
+	sheevaplug
 
 define Build/Configure
 	$(if $(findstring _second_stage,$(BUILD_VARIANT)),

--- a/package/boot/uboot-kirkwood/patches/160-sheevaplug.patch
+++ b/package/boot/uboot-kirkwood/patches/160-sheevaplug.patch
@@ -1,0 +1,39 @@
+--- a/include/configs/sheevaplug.h
++++ b/include/configs/sheevaplug.h
+@@ -47,15 +47,17 @@
+ /*
+  * Default environment variables
+  */
+-#define CONFIG_BOOTCOMMAND		"${x_bootcmd_kernel}; "	\
+-	"setenv bootargs ${x_bootargs} ${x_bootargs_root}; "	\
+-	"bootm 0x6400000;"
++#define CONFIG_BOOTCOMMAND					\
++ "setenv bootargs ${console} ${mtdparts} ${bootargs_root}; "	\
++	"ubi part ubi; " 						\
++	"ubi read 0x800000 kernel; " 			\
++	"bootm 0x800000"
+ 
+-#define CONFIG_EXTRA_ENV_SETTINGS	"x_bootargs=console"	\
+-	"=ttyS0,115200 mtdparts="CONFIG_MTDPARTS_DEFAULT	\
+-	"x_bootcmd_kernel=nand read 0x6400000 0x100000 0x400000\0" \
+-	"x_bootcmd_usb=usb start\0" \
+-	"x_bootargs_root=root=/dev/mtdblock3 rw rootfstype=jffs2\0"
++#define CONFIG_EXTRA_ENV_SETTINGS			\
++	"console=console=ttyS0,115200\0"		\
++	"mtdids="CONFIG_MTDIDS_DEFAULT "\0"		\
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
++	"bootargs_root=\0"
+ 
+ /*
+  * Ethernet Driver configuration
+--- a/configs/sheevaplug_defconfig
++++ b/configs/sheevaplug_defconfig
+@@ -22,7 +22,7 @@
+ CONFIG_CMD_FAT=y
+ CONFIG_CMD_JFFS2=y
+ CONFIG_MTDIDS_DEFAULT="nand0=orion_nand"
+-CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:512K(uboot),512K(env),4M(kernel),-(rootfs)"
++CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:1M(uboot),-(ubi)"
+ CONFIG_CMD_UBI=y
+ CONFIG_ISO_PARTITION=y
+ CONFIG_ENV_IS_IN_NAND=y

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -204,3 +204,13 @@
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_NSA310S_H */
+--- a/configs/sheevaplug_defconfig
++++ b/configs/sheevaplug_defconfig
+@@ -49,4 +49,7 @@
+ CONFIG_DM_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
+ CONFIG_LZMA=y
++CONFIG_LZO=y

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -19,6 +19,7 @@ case "$board" in
 	;;
 "cloudengines,pogoe02"|\
 "cloudengines,pogoplugv4"|\
+"globalscale,sheevaplug"|\
 "iom,iconnect-1.1"|\
 "iom,ix2-200"|\
 "raidsonic,ib-nas62x0"|\

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -71,6 +71,13 @@ define Device/cloudengines_pogoplugv4
 endef
 TARGET_DEVICES += cloudengines_pogoplugv4
 
+define Device/globalscale_sheevaplug
+  DEVICE_VENDOR := Globalscale
+  DEVICE_MODEL := Sheevaplug
+  DEVICE_PACKAGES := kmod-mvsdio
+endef
+TARGET_DEVICES += globalscale_sheevaplug
+
 define Device/iom_iconnect-1.1
   DEVICE_VENDOR := Iomega
   DEVICE_MODEL := Iconnect

--- a/target/linux/kirkwood/patches-5.4/112-sheevaplug-common.patch
+++ b/target/linux/kirkwood/patches-5.4/112-sheevaplug-common.patch
@@ -1,0 +1,17 @@
+--- a/arch/arm/boot/dts/kirkwood-sheevaplug-common.dtsi
++++ b/arch/arm/boot/dts/kirkwood-sheevaplug-common.dtsi
+@@ -79,13 +79,8 @@
+ 	};
+ 
+ 	partition@100000 {
+-		label = "uImage";
+-		reg = <0x0100000 0x400000>;
+-	};
+-
+-	partition@500000 {
+-		label = "root";
+-		reg = <0x0500000 0x1fb00000>;
++		label = "ubi";
++		reg = <0x0100000 0x1ff00000>;
+ 	};
+ };

--- a/target/linux/kirkwood/patches-5.4/113-sheevaplug.patch
+++ b/target/linux/kirkwood/patches-5.4/113-sheevaplug.patch
@@ -1,0 +1,29 @@
+--- a/arch/arm/boot/dts/kirkwood-sheevaplug.dts
++++ b/arch/arm/boot/dts/kirkwood-sheevaplug.dts
+@@ -13,6 +13,13 @@
+ 	model = "Globalscale Technologies SheevaPlug";
+ 	compatible = "globalscale,sheevaplug", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+ 
++	aliases {
++		led-boot = &led_health;
++		led-failsafe = &led_health;
++		led-running = &led_health;
++		led-upgrade = &led_health;
++	};
++
+ 	ocp@f1000000 {
+ 		mvsdio@90000 {
+ 			pinctrl-0 = <&pmx_sdio>;
+@@ -28,10 +35,10 @@
+ 		pinctrl-0 = <&pmx_led_blue &pmx_led_red>;
+ 		pinctrl-names = "default";
+ 
+-		health {
++		led_health: health {
+ 			label = "sheevaplug:blue:health";
+ 			gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+-			default-state = "keep";
++			default-state = "on";
+ 		};
+ 
+ 		misc {


### PR DESCRIPTION
Globalscale SheevaPlug:
* Marvell Kirkwood 88F6281
* 512 MB SDRAM
* 512 MB Flash
* Gigabit Network
* USB 2.0
* SD slot
* Serial console

The device is supported in mainline uboot/linux the commit adds only some openwrt config for building an image.

Installation:
1 - Update uboot:
setenv ipaddr '192.168.0.111'
setenv serverip '192.168.0.1'
tftpboot u-boot.kwb
nand erase 0x0 0x100000
nand write 0x800000 0x0 0x100000
reset
2 - Install OpenWRT:
setenv ethaddr 00:50:43:01:xx:xx
saveenv
setenv ipaddr '192.168.0.111'
setenv serverip '192.168.0.1'
tftpboot openwrt-kirkwood-globalscale_sheevaplug-squashfs-factory.bin
nand erase.part ubi
nand write 0x800000 ubi 0x600000
reset

Signed-off-by: BERENYI Balazs <balazs@wee.hu>
