### PR TITLE
Disable BusyBox bz2

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -96,7 +96,6 @@ get_image() { # <source> [ <command> ]
 		local magic="$(dd if="$from" bs=2 count=1 2>/dev/null | hexdump -n 2 -e '1/1 "%02x"')"
 		case "$magic" in
 			1f8b) cmd="zcat";;
-			425a) cmd="bzcat";;
 			*) cmd="cat";;
 		esac
 	fi

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -39,7 +39,7 @@ switch_to_ramfs() {
 	for binary in \
 		/bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount	\
 		pivot_root mount_root reboot sync kill sleep		\
-		md5sum hexdump cat zcat bzcat dd tar			\
+		md5sum hexdump cat zcat dd tar			\
 		ls basename find cp mv rm mkdir rmdir mknod touch chmod \
 		'[' printf wc grep awk sed cut				\
 		mtd partx losetup mkfs.ext4 nandwrite flash_erase	\

--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -351,10 +351,10 @@ config BUSYBOX_DEFAULT_FEATURE_GUNZIP_LONG_OPTIONS
 	default n
 config BUSYBOX_DEFAULT_BUNZIP2
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_BZCAT
 	bool
-	default y
+	default n
 config BUSYBOX_DEFAULT_UNLZMA
 	bool
 	default n


### PR DESCRIPTION
BB is built with enabled bzip2 which in fact not used by OpenWrt itself

See related forum thread https://forum.openwrt.org/t/is-bz2-compression-used/72120
