### PR TITLE
kernel: add hid-cp2112 driver support

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1486,6 +1486,23 @@ endef
 $(eval $(call KernelPackage,usb-hid))
 
 
+define KernelPackage/usb-hid-cp2112
+  SUBMENU:=$(USB_MENU)
+  TITLE:=Silicon Labs CP2112 HID USB to SMBus Master Bridge
+  KCONFIG:=CONFIG_GPIOLIB=y CONFIG_HID_CP2112
+  DEPENDS:=+kmod-usb-hid +kmod-i2c-core
+  FILES:=$(LINUX_DIR)/drivers/hid/hid-cp2112.ko
+  AUTOLOAD:=$(call AutoProbe,hid-cp2112)
+endef
+
+define KernelPackage/usb-hid-cp2112/description
+ HID device driver which registers as an i2c adapter and gpiochip to expose
+ these functions of the CP2112.
+endef
+
+$(eval $(call KernelPackage,usb-hid-cp2112))
+
+
 define KernelPackage/usb-yealink
   TITLE:=USB Yealink VOIP phone
   DEPENDS:=+kmod-input-evdev


### PR DESCRIPTION
This patch adds kernel module for Silicon Labs CP2112 HID USB to SMBus Master
Bridge. This is a HID device driver which registers as an i2c adapter and
gpiochip to expose these functions of the CP2112.

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>

Some extra info:

```
Mon Jan  4 07:01:19 2021 kern.info kernel: [    7.706244] cp2112 0003:10C4:EA90.0001: hidraw0: USB HID v1.01 Device [Silicon Laboratories CP2112 HID USB-to-SMBus Bridge] on usb-xhci-hcd.1.auto-1/input0
Mon Jan  4 07:01:19 2021 kern.info kernel: [    7.819834] cp2112 0003:10C4:EA90.0001: Part Number: 0x0C Device Version: 0x02
```

```
T:  Bus=01 Lev=01 Prnt=01 Port=00 Cnt=01 Dev#=  2 Spd=12   MxCh= 0
D:  Ver= 1.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
P:  Vendor=10c4 ProdID=ea90 Rev= 0.00
S:  Manufacturer=Silicon Laboratories
S:  Product=CP2112 HID USB-to-SMBus Bridge
S:  SerialNumber=00417D26
C:* #Ifs= 1 Cfg#= 1 Atr=80 MxPwr=100mA
I:* If#= 0 Alt= 0 #EPs= 2 Cls=03(HID  ) Sub=00 Prot=00 Driver=usbhid
E:  Ad=81(I) Atr=03(Int.) MxPS=  64 Ivl=1ms
E:  Ad=01(O) Atr=03(Int.) MxPS=  64 Ivl=1ms
```

```
gpiochip2: GPIOs 440-447, parent: hid/0003:10C4:EA90.0001, cp2112_gpio, can sleep:
```

```
root@OpenWrt:/# cat sys/class/i2c-adapter/i2c-1/name
CP2112 SMBus Bridge on hidraw0
```