### PR TITLE
ramips: add support for TP-Link Archer C6U v1 (EU)

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,archer-c6u-v1", "mediatek,mt7621-soc";
+	model = "TP-Link Archer C6U v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		wan-orange {
+			label = "orange:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan-green {
+			label = "green:wan";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xf60000>;
+			};
+
+			config: partition@fa0000 {
+				label = "config";
+				reg = <0xfa0000 0x010000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "tplink";
+				reg = <0xfb0000 0x040000>;
+				read-only;
+			};
+
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		mtd-mac-address = <&config 0x8>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&config 0x8>;
+		mtd-mac-address-increment = <(-1)>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+};
+
+&gmac0 {
+	mtd-mac-address = <&config 0x8>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&config 0x8>;
+			mtd-mac-address-increment = <1>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt", "sdhci";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1114,6 +1114,20 @@ define Device/totolink_x5000r
 endef
 TARGET_DEVICES += totolink_x5000r
 
+define Device/tplink_archer-c6u-v1
+  $(Device/dsa-migration)
+  $(Device/tplink-safeloader)
+  DEVICE_MODEL := Archer C6U
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7603 \
+	kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-usb3 kmod-usb-ledtrig-usbport
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  TPLINK_BOARD_ID := ARCHER-C6U-V1
+  IMAGE_SIZE := 15744k
+endef
+TARGET_DEVICES += tplink_archer-c6u-v1
+
 define Device/tplink_eap235-wall-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -79,6 +79,10 @@ netgear,r6800)
 	ucidef_set_led_netdev "lan3" "LAN3" "white:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "white:lan4" "lan4"
 	;;
+tplink,archer-c6u-v1)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
+	;;
 tplink,re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "blue:wifi5G" "wlan1"

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1060,6 +1060,41 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+	/** Firmware layout for the Archer C6U v1 */
+	{
+		.id     = "ARCHER-C6U-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:Archer C6U,product_ver:1.0.0,special_id:45550000}\n",
+		.part_trail = 0x00,
+		.soft_ver = "soft_ver:1.0.2\n",
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x40000},
+			{"firmware", 0x40000, 0xf60000},
+			{"default-mac", 0xfa0000, 0x00200},
+			{"pin", 0xfa0200, 0x00100},
+			{"device-id", 0xfa0300, 0x00100},
+			{"product-info", 0xfa0400, 0x0fc00},
+			{"default-config", 0xfb0000, 0x08000},
+			{"ap-def-config", 0xfb8000, 0x08000},
+			{"user-config", 0xfc0000, 0x0c000},
+			{"certificate", 0xfcc000, 0x04000},
+			{"ap-config", 0xfd0000, 0x08000},
+			{"router-config", 0xfd8000, 0x08000},
+			{"partition-table", 0xfe0000, 0x00800},
+			{"soft-version", 0xfe0800, 0x00100},
+			{"support-list", 0xfe0900, 0x00200},
+			{"profile", 0xfe0b00, 0x03000},
+			{"extra-para", 0xfe3b00, 0x00100},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the C60v1 */
 	{
 		.id     = "ARCHER-C60-V1",
@@ -2832,6 +2867,7 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "ARCHER-C59-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V3") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C6U-V1") == 0 ||
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const uint8_t extra_para[2] = {0x01, 0x00};
 		parts[5] = make_extra_para(info, extra_para,


### PR DESCRIPTION
This patch adds support for TP-Link Archer C6U v1 (EU).
The device is also known in some market as Archer C6 v3.
This patch supports only Archer C6U v1 (EU).

Specifications:
--------------

* SoC: Mediatek MT7621AT 2C2T, 880MHz
* RAM: 128MB DDR3
* Flash: 16MB SPI NOR flash (Winbond 25Q128)
* WiFi 5GHz: Mediatek MT7613BEN (2x2:2)
* WiFi 2.4GHz: Mediatek MT7603EN (2x2:2)
* Ethernet: MT7630, 5x 1000Base-T.
* LED: Power, WAN, LAN, WiFi 2GHz and 5GHz, USB
* Buttons: Reset, WPS.
* UART: Serial console (115200 8n1), J1(GND:3)
* USB: One USB2 port.

Installation:
------------
Install the OpenWrt factory image for C6U is from the
TP-Link web interface.

1) Go to "Advanced/System Tools/Firmware Update".
2) Click "Browse" and upload the OpenWrt factory image:
openwrt-ramips-mt7621-tplink_archer-c6u-v1-squashfs-factory.bin.
3) Click the "Upgrade" button, and select "Yes" when prompted.

Recovery to stock firmware:
--------------------------
The C6U bootloader has a failsafe mode that provides a web
interface (running at 192.168.0.1) for reverting back to the
stock TP-Link firmware. The failsafe interface is triggered
from the serial console or on failed kernel boot. Unfortunately,
there's no key combination that enables the failsafe mode. This
gives us two options for recovery:

1) Recover using the serial console (J1 header).
The recovery interface can be selected by hitting 'x' when
prompted on boot.

2) Trigger the bootloader failsafe mode.
A more dangerous option is force the bootloader into
recovery mode by erasing the OpenWrt partition from the
OpenWrt's shell - e.g "mtd erase firmware". Please be
careful, since erasing the wrong partition can brick
your device.
    
MAC addresses:
-------------
OEM firmware configuration:
D8:07:B6:xx:xx:83 : 5G
D8:07:B6:xx:xx:84 : LAN (label)
D8:07:B6:xx:xx:84 : 2.4G
D8:07:B6:xx:xx:85 : WAN

Signed-off-by: Georgi Vlaev <georgi.vlaev@konsulko.com>
