### PR TITLE
kernel: bump 5.4 to 5.4.87

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .86
+LINUX_VERSION-5.4 = .87
 
-LINUX_KERNEL_HASH-5.4.86 = eb36b5fc6ef7b953acba0a3e62d872e0330c4d34b38d58f5714493a4fe3b0e8b
+LINUX_KERNEL_HASH-5.4.87 = 6a34e93e2e84bb645155124962307ad9d3646124f43838d087209ed4ea595c31
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.4/950-0084-hci_h5-Don-t-send-conf_req-when-ACTIVE.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0084-hci_h5-Don-t-send-conf_req-when-ACTIVE.patch
@@ -11,7 +11,7 @@ other with conf_req and conf_rsp messages, in a demented game of tag.
 
 --- a/drivers/bluetooth/hci_h5.c
 +++ b/drivers/bluetooth/hci_h5.c
-@@ -342,7 +342,8 @@ static void h5_handle_internal_rx(struct
+@@ -346,7 +346,8 @@ static void h5_handle_internal_rx(struct
  		h5_link_control(hu, conf_req, 3);
  	} else if (memcmp(data, conf_req, 2) == 0) {
  		h5_link_control(hu, conf_rsp, 2);

--- a/target/linux/generic/hack-5.4/204-module_strip.patch
+++ b/target/linux/generic/hack-5.4/204-module_strip.patch
@@ -112,7 +112,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config MODULES_TREE_LOOKUP
 --- a/kernel/module.c
 +++ b/kernel/module.c
-@@ -3127,9 +3127,11 @@ static int setup_load_info(struct load_i
+@@ -3125,9 +3125,11 @@ static int setup_load_info(struct load_i
  
  static int check_modinfo(struct module *mod, struct load_info *info, int flags)
  {
@@ -125,7 +125,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (flags & MODULE_INIT_IGNORE_VERMAGIC)
  		modmagic = NULL;
  
-@@ -3150,6 +3152,7 @@ static int check_modinfo(struct module *
+@@ -3148,6 +3150,7 @@ static int check_modinfo(struct module *
  				mod->name);
  		add_taint_module(mod, TAINT_OOT_MODULE, LOCKDEP_STILL_OK);
  	}

--- a/target/linux/generic/pending-5.4/530-jffs2_make_lzma_available.patch
+++ b/target/linux/generic/pending-5.4/530-jffs2_make_lzma_available.patch
@@ -244,7 +244,7 @@ Signed-off-by: Alexandros C. Couloumbis <alex@ozo.com>
 +}
 --- a/fs/jffs2/super.c
 +++ b/fs/jffs2/super.c
-@@ -377,14 +377,41 @@ static int __init init_jffs2_fs(void)
+@@ -380,14 +380,41 @@ static int __init init_jffs2_fs(void)
  	BUILD_BUG_ON(sizeof(struct jffs2_raw_inode) != 68);
  	BUILD_BUG_ON(sizeof(struct jffs2_raw_summary) != 32);
  

--- a/target/linux/ramips/patches-5.4/0003-MIPS-Fix-memory-reservation-in-bootmem_init-for-cert.patch
+++ b/target/linux/ramips/patches-5.4/0003-MIPS-Fix-memory-reservation-in-bootmem_init-for-cert.patch
@@ -16,7 +16,7 @@ Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>
 
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
-@@ -285,6 +285,8 @@ static unsigned long __init init_initrd(
+@@ -287,6 +287,8 @@ static unsigned long __init init_initrd(
   * Initialize the bootmem allocator. It also setup initrd related data
   * if needed.
   */
@@ -25,7 +25,7 @@ Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>
  #if defined(CONFIG_SGI_IP27) || (defined(CONFIG_CPU_LOONGSON3) && defined(CONFIG_NUMA))
  
  static void __init bootmem_init(void)
-@@ -323,7 +325,7 @@ static void __init bootmem_init(void)
+@@ -325,7 +327,7 @@ static void __init bootmem_init(void)
  	/*
  	 * Reserve any memory between the start of RAM and PHYS_OFFSET
  	 */
@@ -34,7 +34,7 @@ Signed-off-by: Tobias Wolf <dev-NTEO@vplace.de>
  		memblock_reserve(PHYS_OFFSET, ramstart - PHYS_OFFSET);
  
  	if (PFN_UP(ramstart) > ARCH_PFN_OFFSET) {
-@@ -384,8 +386,6 @@ static void __init bootmem_init(void)
+@@ -386,8 +388,6 @@ static void __init bootmem_init(void)
  
  #endif	/* CONFIG_SGI_IP27 */
  

--- a/target/linux/ramips/patches-5.4/0013-owrt-hack-fix-mt7688-cache-issue.patch
+++ b/target/linux/ramips/patches-5.4/0013-owrt-hack-fix-mt7688-cache-issue.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 
 --- a/arch/mips/kernel/setup.c
 +++ b/arch/mips/kernel/setup.c
-@@ -652,8 +652,6 @@ static void __init arch_mem_init(char **
+@@ -723,8 +723,6 @@ static void __init arch_mem_init(char **
  		memblock_reserve(crashk_res.start,
  				 crashk_res.end - crashk_res.start + 1);
  #endif
@@ -19,7 +19,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	/*
  	 * In order to reduce the possibility of kernel panic when failed to
  	 * get IO TLB memory under CONFIG_SWIOTLB, it is better to allocate
-@@ -770,6 +768,7 @@ void __init setup_arch(char **cmdline_p)
+@@ -841,6 +839,7 @@ void __init setup_arch(char **cmdline_p)
  
  	cpu_cache_init();
  	paging_init();

--- a/target/linux/realtek/patches-5.4/705-add-rtl-phy.patch
+++ b/target/linux/realtek/patches-5.4/705-add-rtl-phy.patch
@@ -1,9 +1,9 @@
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -454,6 +454,12 @@
+@@ -540,6 +540,12 @@ config REALTEK_PHY
  	---help---
  	  Supports the Realtek 821x PHY.
-
+ 
 +config REALTEK_SOC_PHY
 +	tristate "Realtek SoC PHYs"
 +	depends on RTL838X
@@ -15,7 +15,7 @@
  	---help---
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
-@@ -87,6 +87,7 @@
+@@ -102,6 +102,7 @@ obj-$(CONFIG_NATIONAL_PHY)	+= national.o
  obj-$(CONFIG_NXP_TJA11XX_PHY)	+= nxp-tja11xx.o
  obj-$(CONFIG_QSEMI_PHY)		+= qsemi.o
  obj-$(CONFIG_REALTEK_PHY)	+= realtek.o


### PR DESCRIPTION
All modification by `update_kernel.sh.`

Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>