### PR TITLE
ath79: add support for Extreme Networks AP3805i

### DIFF
--- a/target/linux/ath79/dts/qca9557_extreme_ap3805i.dts
+++ b/target/linux/ath79/dts/qca9557_extreme_ap3805i.dts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "extreme,ap3805i", "qca,qca9557";
+	model = "Extreme Networks AP3805i";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5 {
+			label = "green:wlan5";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};	
+
+		wlan2 {
+			label = "green:wlan2";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <20000>;
+		always-running;
+	};
+};
+
+&wdt {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot-bak";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot";
+				reg = <0x080000 0x80000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "cfg1";
+				reg = <0x100000 0x40000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "cfg2";
+				reg = <0x140000 0x40000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "nvram4";
+				reg = <0x180000 0x40000>;
+			};
+
+			partition@1c0000 {
+				label = "nvram3";
+				reg = <0x1c0000 0x40000>;
+			};
+
+			partition@200000 {
+				label = "nvram2";
+				reg = <0x200000 0x40000>;
+			};
+
+			partition@240000 {
+				label = "nvram1";
+				reg = <0x240000 0x40000>;
+			}; 
+
+			partition@280000 {
+				label = "PriImg";
+				reg = <0x280000 0x1000000>;
+			}; 
+
+			partition@1280000 {
+				label = "SecImg";
+				reg = <0x1280000 0x1000000>;
+			}; 
+
+			partition@2280000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x2280000 0x1cc0000>;
+			};	
+
+			partition@3f40000 {
+				label = "cert";
+				reg = <0x3f40000 0x80000>;
+			}; 
+
+			partition@3fc0000 {
+				label = "art";
+				reg = <0x3fc0000 0x40000>;
+				read-only;
+			};	
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ath79_setup_interfaces()
 	engenius,ecb1750|\
 	engenius,ecb600|\
 	enterasys,ws-ap3705i|\
+	extreme,ap3805i|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\
 	hak5,wifi-pineapple-nano|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -56,6 +56,10 @@ case "$FIRMWARE" in
 		caldata_extract "calibrate" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR1)
 		;;
+	extreme,ap3805i)
+		caldata_extract "art" 0x1000 0x440
+		ath9k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR1)
+		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_text board_data 0x680)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -82,6 +82,10 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
 		;;
+	extreme,ap3805i)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR0)
+		;;
 	glinet,gl-ar750)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) +1)

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -14,6 +14,7 @@ preinit_set_mac_address() {
 	enterasys,ws-ap3705i)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env0 ethaddr)
 		;;
+	extreme,ap3805i|\
 	siemens,ws-ap3610)
 		ip link set dev eth0 address $(mtd_get_mac_ascii cfg1 ethaddr)
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1079,6 +1079,15 @@ define Device/etactica_eg200
 endef
 TARGET_DEVICES += etactica_eg200
 
+define Device/extreme_ap3805i
+  SOC := qca9557
+  DEVICE_VENDOR := Extreme Networks
+  DEVICE_MODEL := AP3805i
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 29440k
+endef
+TARGET_DEVICES += extreme_ap3805i
+
 define Device/glinet_6408
   $(Device/tplink-8mlzma)
   SOC := ar9331


### PR DESCRIPTION
Based mostly on: [WS-AP3705i](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=ebddc5f984a240980303aed68524eb615484eef8) and: [AP3610](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=d2b8ccb1c04def81224da6f42f644c7d239b9986)

### Extreme Networks AP3805i, Indoor Access Point.

Hardware:
------------

- 	SoC:	Qualcomm Atheros QCA9557-AT4A
- 	RAM:	2x 128MB Nanya NT5TU64M16HG
- 	FLASH:	64MB - SPANSION FL512SAIFG1
- 	LAN:	Atheros AR8035-A (RGMII GbE with PoE+ IN)
- 	WLAN2:	Qualcomm Atheros QCA9557 2x2 2T2R
- 	WLAN5:	Qualcomm Atheros QCA9882-BR4A 2x2 2T2R
- 	SERIAL:	UART pins at J10 (115200 8n1)
- 	LEDs:	Power (Green/Amber)
 	WiFi 5 (Green)
 	WiFi 2 (Green)
- 	BTN:	Reset


Installation:
------------------------

1. Download the OpenWrt initramfs-image.
Place it into a TFTP server root directory and rename it to 1D01A8C0.img
Configure the TFTP server to listen at 192.168.1.66/24.

2. Connect the TFTP server to the access point.

3. Connect to the serial console of the access point.
Attach power and interrupt the boot procedure when prompted.

4. Configure U-Boot for booting OpenWrt from ram and flash:
 $ setenv boot_openwrt 'setenv bootargs; bootm 0xa1280000'
 $ setenv ramboot_openwrt 'setenv serverip 192.168.1.66; tftpboot; bootm'
 $ setenv bootcmd 'run boot_openwrt'
 $ saveenv

5. Load OpenWrt into memory:
 $ run ramboot_openwrt

6. Transfer the OpenWrt sysupgrade image to the device.
Write the image to flash using sysupgrade:
 $ sysupgrade -n /path/to/openwrt-sysupgrade.bin



**Notes:**
------------------------

WIP

New manufacturer, i took a wild guess to name it just "extreme,...", maybe it should be something else?

ath79-wdt Error at boot, related to the external GPIO-Watchdog?
```
ath79-wdt 18060008.wdt: unable to register misc device, err=-16
ath79-wdt: probe of 18060008.wdt failed with error -16
```