### PR TITLE
ath79: add support for COMFAST CF-E355AC v2

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-e355ac-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e355ac-v2.dts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "comfast,cf-e355ac-v2", "qca,qca9531";
+	model = "COMFAST CF-E355AC V2";
+
+	aliases {
+		serial0 = &uart;
+		label-mac-device = &eth1;
+		led-boot = &led_lan;
+		led-failsafe = &led_lan;
+		led-upgrade = &led_lan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_lan: lan {
+			label = "green:lan";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "red:wlan5g";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&eth1 {
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+			};
+
+			partition@ff0000 {
+				label = "art-backup";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&wdt {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <3>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -13,6 +13,7 @@ case "$board" in
 alfa-network,ap121f|\
 alfa-network,ap121fe|\
 avm,fritz450e|\
+comfast,cf-e355ac-v2|\
 glinet,6408|\
 glinet,6416|\
 glinet,gl-ar300m-lite|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -177,6 +177,7 @@ case "$FIRMWARE" in
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 		;;
+	comfast,cf-e355ac-v2|\
 	comfast,cf-e375ac|\
 	comfast,cf-e560ac|\
 	comfast,cf-ew72|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -553,6 +553,17 @@ define Device/comfast_cf-e314n-v2
 endef
 TARGET_DEVICES += comfast_cf-e314n-v2
 
+define Device/comfast_cf-e355ac-v2
+  SOC := qca9531
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E355AC
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct \
+	-swconfig -uboot-envtools
+  IMAGE_SIZE := 16192k
+endef
+TARGET_DEVICES += comfast_cf-e355ac-v2
+
 define Device/comfast_cf-e375ac
   SOC := qca9563
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
# Hardware

COMFAST CF-E355AC v2 is a ceiling mount AP with PoE support,
based on Qualcomm/Atheros QCA9531 + QCA9886.

## Short specification:

- 1x 10/100 Mbps Ethernet, with PoE support (wan/eth1)
- 1x 10/100/1000 Mbps Ethernet, with PoE support (lan/eth0)
- 128MB of RAM (DDR2)
- 16 MB of FLASH
- 2T2R 2.4 GHz, 802.11b/g/n (wlan2g)
- 2T2R 5 GHz, 802.11ac/n/a, WAVE 2 (wlan5g)
- built-in 4x 3 dBi antennas
- output power (max): 500 mW (27 dBm)
- 1x RGB LED, 1x button
- separate watchdog chip (bottom of PCB?)

## Markings on PCB:

* R121QH_VER2.1 (silkscreen, bottom)
* CF-WA800 (sticker, top)

# Initial flashing instructions:

Original firmware is based on OpenWrt.

a) Use sysupgrade image directly in vendor GUI.

b) Or via tftp:

    ipaddr=192.168.1.1
    serverip=192.168.1.10
    bootfile="firmware.bin"

c) Or possibly via u-boot's `httpd` command.

## MAC addresses

MAC-address mapping follows differs somewhat from original firmware:

* eth1 (wan) is the lowest mac address (art @ 0x0)
* eth0 (lan) uses eth1 + 1 (art @ 0x1002)
* wlan2g uses eth1 + 2 (art @ 0x06)
* wlan5g uses eth1 + 3 (art @ 0x5006) **\*\*\*** **(original firmware is using eth1 + 10)**, no clue where it comes from.

Art dump (`hexdump /dev/mtd1 |grep ZZZZ`):

    0000000 ZZZZ XXXX XXX0 ZZZZ XXXX XXX2 ffff ffff
    0001000 0202 ZZZZ XXXX XXX1 0000 0000 0000 0000
    0005000 202f bd21 0101 ZZZZ XXXX XXX3 0000 2000
