### PR TITLE
uboot-envtools: add support for Aruba AP-303 and AP-365

### DIFF
--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -43,6 +43,12 @@ plasmacloud,pa1200 |\
 plasmacloud,pa2200)
 	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x10000" "0x10000"
 	;;
+aruba,ap-303)
+	ubootenv_add_uci_config "/dev/mtd13" "0x0" "0x10000" "0x10000"
+	;;
+aruba,ap-365)
+	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x10000" "0x10000"
+	;;
 buffalo,wtr-m2133hp)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x40000" "0x20000"
 	;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-303.dts
@@ -145,10 +145,8 @@
 			};
 
 			partition@380000 {
-				/* This is empty */
 				label = "appsblenv";
 				reg = <0x380000 0x10000>;
-				read-only;
 			};
 
 			partition@390000 {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-365.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-ap-365.dts
@@ -138,7 +138,6 @@
 			partition@e0000 {
 				label = "u-boot-env";
 				reg = <0xe0000 0x10000>;
-				read-only;
 			};
 
 			partition@f0000 {

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -156,6 +156,7 @@ endef
 define Device/aruba_ap-303
 	$(call Device/aruba_glenmorangie)
 	DEVICE_MODEL := AP-303
+	DEVICE_PACKAGES += uboot-envtools
 endef
 TARGET_DEVICES += aruba_ap-303
 
@@ -168,7 +169,7 @@ TARGET_DEVICES += aruba_ap-303h
 define Device/aruba_ap-365
 	$(call Device/aruba_glenmorangie)
 	DEVICE_MODEL := AP-365
-	DEVICE_PACKAGES += kmod-hwmon-ad7418
+	DEVICE_PACKAGES += kmod-hwmon-ad7418 uboot-envtools
 endef
 TARGET_DEVICES += aruba_ap-365
 


### PR DESCRIPTION
Both devices use u-boot env variables to boot OpenWrt from its flash
partition. Using u-boot envtools, it is possible to change the bootcmd
back to the stock firmware partition directly from OpenWrt without
attaching a serial cable or even physically accessing the device.