### PR TITLE
kernel: bump 5.4 to 5.4.89

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .87
+LINUX_VERSION-5.4 = .89
 
-LINUX_KERNEL_HASH-5.4.87 = 6a34e93e2e84bb645155124962307ad9d3646124f43838d087209ed4ea595c31
+LINUX_KERNEL_HASH-5.4.89 = 268dd5177b6df1867d4ed2452ffb11a016d955c43aba5e07940886f347ab0aaf
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.4/950-0084-hci_h5-Don-t-send-conf_req-when-ACTIVE.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0084-hci_h5-Don-t-send-conf_req-when-ACTIVE.patch
@@ -11,7 +11,7 @@ other with conf_req and conf_rsp messages, in a demented game of tag.
 
 --- a/drivers/bluetooth/hci_h5.c
 +++ b/drivers/bluetooth/hci_h5.c
-@@ -346,7 +346,8 @@ static void h5_handle_internal_rx(struct
+@@ -342,7 +342,8 @@ static void h5_handle_internal_rx(struct
  		h5_link_control(hu, conf_req, 3);
  	} else if (memcmp(data, conf_req, 2) == 0) {
  		h5_link_control(hu, conf_rsp, 2);

--- a/target/linux/generic/hack-5.4/904-debloat_dma_buf.patch
+++ b/target/linux/generic/hack-5.4/904-debloat_dma_buf.patch
@@ -45,7 +45,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	selftest.o \
 --- a/drivers/dma-buf/dma-buf.c
 +++ b/drivers/dma-buf/dma-buf.c
-@@ -1300,4 +1300,5 @@ static void __exit dma_buf_deinit(void)
+@@ -1313,4 +1313,5 @@ static void __exit dma_buf_deinit(void)
  	dma_buf_uninit_debugfs();
  	kern_unmount(dma_buf_mnt);
  }

--- a/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0005-usb-dwc3-add-otg-properties-update.patch
@@ -36,7 +36,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  	dwc->sysdev_is_parent = device_property_read_bool(dev,
 --- a/drivers/usb/dwc3/core.h
 +++ b/drivers/usb/dwc3/core.h
-@@ -954,6 +954,7 @@ struct dwc3_scratchpad_array {
+@@ -955,6 +955,7 @@ struct dwc3_scratchpad_array {
   * @nr_scratch: number of scratch buffers
   * @u1u2: only used on revisions <1.83a for workaround
   * @maximum_speed: maximum speed requested (mainly for testing purposes)
@@ -44,7 +44,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
   * @revision: revision register contents
   * @version_type: VERSIONTYPE register contents, a sub release of a revision
   * @dr_mode: requested mode of operation
-@@ -1110,6 +1111,7 @@ struct dwc3 {
+@@ -1111,6 +1112,7 @@ struct dwc3 {
  	u32			nr_scratch;
  	u32			u1u2;
  	u32			maximum_speed;

--- a/target/linux/layerscape/patches-5.4/820-usb-0006-usb-dwc3-drd-add-usb-role-switch-class-support-for-d.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0006-usb-dwc3-drd-add-usb-role-switch-class-support-for-d.patch
@@ -23,7 +23,7 @@ Signed-off-by: Li Jun <jun.li@nxp.com>
  #include <linux/ulpi/interface.h>
  
  #include <linux/phy/phy.h>
-@@ -1095,6 +1096,7 @@ struct dwc3 {
+@@ -1096,6 +1097,7 @@ struct dwc3 {
  	void __iomem		*regs;
  	size_t			regs_size;
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0009-usb-dwc3-Add-workaround-for-host-mode-VBUS-glitch-wh.patch
@@ -44,7 +44,7 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
  
 --- a/drivers/usb/dwc3/core.h
 +++ b/drivers/usb/dwc3/core.h
-@@ -1047,6 +1047,8 @@ struct dwc3_scratchpad_array {
+@@ -1048,6 +1048,8 @@ struct dwc3_scratchpad_array {
   * 	3	- Reserved
   * @dis_metastability_quirk: set to disable metastability quirk.
   * @dis_split_quirk: set to disable split boundary.
@@ -53,7 +53,7 @@ Reviewed-by: Peter Chen <peter.chen@nxp.com>
   * @imod_interval: set the interrupt moderation interval in 250ns
   *                 increments or 0 to disable.
   */
-@@ -1242,6 +1244,8 @@ struct dwc3 {
+@@ -1243,6 +1245,8 @@ struct dwc3 {
  
  	unsigned		dis_split_quirk:1;
  

--- a/target/linux/mediatek/patches-5.4/0303-mtd-spinand-disable-on-die-ECC.patch
+++ b/target/linux/mediatek/patches-5.4/0303-mtd-spinand-disable-on-die-ECC.patch
@@ -11,7 +11,7 @@ Signed-off-by: Xiangsheng Hou <xiangsheng.hou@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -495,7 +495,7 @@ static int spinand_mtd_read(struct mtd_i
+@@ -491,7 +491,7 @@ static int spinand_mtd_read(struct mtd_i
  	int ret = 0;
  
  	if (ops->mode != MTD_OPS_RAW && spinand->eccinfo.ooblayout)
@@ -20,7 +20,7 @@ Signed-off-by: Xiangsheng Hou <xiangsheng.hou@mediatek.com>
  
  	mutex_lock(&spinand->lock);
  
-@@ -543,7 +543,7 @@ static int spinand_mtd_write(struct mtd_
+@@ -539,7 +539,7 @@ static int spinand_mtd_write(struct mtd_
  	int ret = 0;
  
  	if (ops->mode != MTD_OPS_RAW && mtd->ooblayout)

--- a/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
+++ b/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
@@ -83,7 +83,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  /* Queue modes */
  #define MVPP2_QDIST_SINGLE_MODE	0
-@@ -3467,8 +3470,9 @@ static void mvpp2_start_dev(struct mvpp2
+@@ -3468,8 +3471,9 @@ static void mvpp2_start_dev(struct mvpp2
  			.interface = port->phy_interface,
  		};
  		mvpp2_mac_config(&port->phylink_config, MLO_AN_INBAND, &state);
@@ -95,7 +95,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  
  	netif_tx_start_all_queues(port->dev);
-@@ -5126,8 +5130,11 @@ static void mvpp2_mac_config(struct phyl
+@@ -5127,8 +5131,11 @@ static void mvpp2_mac_config(struct phyl
  	mvpp2_port_enable(port);
  }
  

--- a/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
+++ b/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
@@ -51,7 +51,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	struct ethtool_eee *p = &priv->dev->ports[port].eee;
 --- a/drivers/net/dsa/lantiq_gswip.c
 +++ b/drivers/net/dsa/lantiq_gswip.c
-@@ -1518,7 +1518,9 @@ static void gswip_phylink_mac_link_down(
+@@ -1507,7 +1507,9 @@ static void gswip_phylink_mac_link_down(
  static void gswip_phylink_mac_link_up(struct dsa_switch *ds, int port,
  				      unsigned int mode,
  				      phy_interface_t interface,


### PR DESCRIPTION
All modification made by `update_kernel.sh` in a fresh clone without
existing toolchains.

Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>
