### PR TITLE
build/json: add initramfs images to profiles.json

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -18,6 +18,10 @@ assert getenv("WORK_DIR"), "$WORK_DIR required"
 def get_output(work_dir):
     output = None
 
+    # preserve existing profiles.json file data
+    if output_path.is_file():
+        output = json.loads(output_path.read_text())
+
     for json_file in work_dir.glob("*.json"):
         image_info = json.loads(json_file.read_text())
 


### PR DESCRIPTION
This patch add initramfs images to the generated profiles.json files.

For the image builder, die previous profiles.json also needs to be preserved.
