### PR TITLE
ath79: add support for Senao Engenius EAP1200H

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -23,6 +23,7 @@ allnet,all-wap02860ac|\
 arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\
+engenius,eap1200h|\
 engenius,eap300-v2|\
 engenius,eap350-v1|\
 engenius,eap600|\

--- a/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
+++ b/target/linux/ath79/dts/qca9557_engenius_eap1200h.dts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "engenius,eap1200h", "qca,qca9557";
+	model = "EnGenius EAP1200H";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x050000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "loader";
+				reg = <0x0a0000 0x010000>;
+				read-only;
+			};
+
+			fwconcat1: partition@b0000 {
+				label = "fwconcat1";
+				reg = <0x0b0000 0x170000>;
+			};
+
+			partition@220000 {
+				label = "fakeroot";
+				reg = <0x220000 0x010000>;
+				read-only;
+			};
+
+			fwconcat0: partition@230000 {
+				label = "fwconcat0";
+				reg = <0x230000 0xb40000>;
+			};
+
+			partition@d70000 {
+				label = "failsafe";
+				reg = <0xd70000 0x280000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -32,6 +32,7 @@ ath79_setup_interfaces()
 	dlink,dap-2680-a1|\
 	dlink,dap-3320-a1|\
 	dlink,dir-505|\
+	engenius,eap1200h|\
 	engenius,eap300-v2|\
 	engenius,eap600|\
 	engenius,ecb1200|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,6 +11,7 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
 	allnet,all-wap02860ac|\
+	engenius,eap1200h|\
 	engenius,enstationac-v1|\
 	glinet,gl-x750)
 		caldata_extract "art" 0x5000 0x844

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -957,6 +957,17 @@ define Device/embeddedwireless_dorin
 endef
 TARGET_DEVICES += embeddedwireless_dorin
 
+define Device/engenius_eap1200h
+  $(Device/engenius_loader_okli)
+  SOC := qca9557
+  DEVICE_MODEL := EAP1200H
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 11520k
+  LOADER_FLASH_OFFS := 0x230000
+  ENGENIUS_IMGNAME := ar71xx-generic-eap1200h
+endef
+TARGET_DEVICES += engenius_eap1200h
+
 define Device/engenius_eap300-v2
   $(Device/engenius_loader_okli)
   SOC := ar9341


### PR DESCRIPTION
FCC ID: A8J-EAP1200H

Engenius EAP1200H is an indoor wireless access point with
1 Gb ethernet port, dual-band wireless,
internal antenna plates, and 802.3at PoE+

**Specification:**

  - QCA9557 SOC
  - QCA9882 WLAN	PCI card, 5 GHz, 2x2, 26dBm
  - AR8035-A PHY	RGMII GbE with PoE+ IN
  - 40 MHz clock
  - 16 MB FLASH		MX25L12845EMI-10G
  - 2x 64 MB RAM	NT5TU32M16FG
  - UART at J10		populated
  - 4 internal antenna plates (5 dbi, omni-directional)
  - 5 LEDs, 1 button (power, eth0, 2G, 5G, WPS) (reset)

**MAC addresses:**

  MAC addresses are labeled as ETH, 2.4G, and 5GHz
  Only one Vendor MAC address in flash

  eth0 ETH  *:a2 art 0x0
  phy1 2.4G *:a3 ---
  phy0 5GHz *:a4 ---

**Serial Access:**

  the RX line on the board for UART is shorted to ground by resistor R176
  therefore it must be removed to use the console
  but it is not necessary to remove to view boot log

  optionally, R175 can be replaced with a solder bridge short

  the resistors R175 and R176 are next to the UART RX pin at J10

**Installation:**

  2 ways to flash factory.bin from OEM:

  Method 1: Firmware upgrade page:

    OEM webpage at 192.168.1.1
    username and password "admin"
    Navigate to "Firmware Upgrade" page from left pane
    Click Browse and select the factory.bin image
    Upload and verify checksum
    Click Continue to confirm and wait 3 minutes

  Method 2: Serial to load Failsafe webpage:

    After connecting to serial console and rebooting...
    Interrupt uboot with any key pressed rapidly
    execute `run failsafe_boot` OR `bootm 0x9fd70000`
    wait a minute
    connect to ethernet and navigate to
    "192.168.1.1/index.htm"
    Select the factory.bin image and upload
    wait about 3 minutes

**Return to OEM:**

  If you have a serial cable, see Serial Failsafe instructions
  otherwise, uboot-env can be used to make uboot load the failsafe image

  *DISCLAIMER*
  The Failsafe image is unique to Engenius boards.
  If the failsafe image is missing or damaged this will brick the device
  DO NOT downgrade to ar71xx this way, it can cause kernel loop or halt

  ssh into openwrt and run
  `fw_setenv rootfs_checksum 0`
  reboot, wait 3 minutes
  connect to ethernet and navigate to 192.168.1.1/index.htm
  select OEM firmware image from Engenius and click upgrade

**TFTP recovery:**

  Requires serial console, reset button does nothing

  rename initramfs to 'vmlinux-art-ramdisk'
  make available on TFTP server at 192.168.1.101
  power board, interrupt boot
  execute tftpboot and bootm 0x81000000

  NOTE: TFTP is not reliable due to bugged bootloader
  set MTU to 600 and try many times

**Format of OEM firmware image:**

  The OEM software of EAP1200H is a heavily modified version
  of Openwrt Kamikaze. One of the many modifications
  is to the sysupgrade program. Image verification is performed
  simply by the successful ungzip and untar of the supplied file
  and name check and header verification of the resulting contents.
  To form a factory.bin that is accepted by OEM Openwrt build,
  the kernel and rootfs must have specific names...

    openwrt-ar71xx-generic-eap1200h-uImage-lzma.bin
    openwrt-ar71xx-generic-eap1200h-root.squashfs

  and begin with the respective headers (uImage, squashfs).
  Then the files must be tarballed and gzipped.
  The resulting binary is actually a tar.gz file in disguise.
  This can be verified by using binwalk on the OEM firmware images,
  ungzipping then untaring.

  Newer EnGenius software requires more checks but their script
  includes a way to skip them, otherwise the tar must include
  a text file with the version and md5sums in a deprecated format.

  The OEM upgrade script is at /etc/fwupgrade.sh.

  OKLI kernel loader is required because the OEM software
  expects the kernel to be no greater than 1536k
  and the factory.bin upgrade procedure would otherwise
  overwrite part of the kernel when writing rootfs.

Note on PLL-data cells:

  The default PLL register values will not work
  because of the external AR8035 switch between
  the SOC and the ethernet port.

  For QCA955x series, the PLL registers for eth0 and eth1
  can be see in the DTSI as 0x28 and 0x48 respectively.
  Therefore the PLL registers can be read from uboot
  for each link speed after attempting tftpboot
  or another network action using that link speed
  with `md 0x18050028 1` and `md 0x18050048 1`.

  The clock delay required for RGMII can be applied
  at the PHY side, using the at803x driver `phy-mode`.
  Therefore the PLL registers for GMAC0
  do not need the bits for delay on the MAC side.
  This is possible due to fixes in at803x driver
  since Linux 5.1 and 5.3

Signed-off-by: Michael Pratt <mcpratt@pm.me>