### PR TITLE
kernel: drop io_uring's kernel version dependency

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -380,7 +380,6 @@ config KERNEL_AIO
 config KERNEL_IO_URING
 	bool "Compile the kernel with io_uring support"
 	default y if !SMALL_FLASH
-	depends on LINUX_5_4
 
 config KERNEL_FHANDLE
 	bool "Compile the kernel with support for fhandle syscalls"


### PR DESCRIPTION
Drop io_uring's kernel version dependency, snapshots has only 5.4+ kernels now and io_uring works fine on those and newer kernels.
I mainly tested with 5.4 + samba-4.13.x and had no issues.
