### PR TITLE
build: fix profile duplication for imagebuilder

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -642,18 +642,6 @@ $(if $(strip $(DEVICE_ALT2_TITLE)),- $(DEVICE_ALT2_TITLE))
 endef
 
 define Device/Dump
-ifneq ($$(strip $$(DEVICE_ALT0_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT0_TITLE) ($$(DEVICE_TITLE))
-$$(info $$(call Device/DumpInfo,$(1)))
-endif
-ifneq ($$(strip $$(DEVICE_ALT1_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT1_TITLE) ($$(DEVICE_TITLE))
-$$(info $$(call Device/DumpInfo,$(1)))
-endif
-ifneq ($$(strip $$(DEVICE_ALT2_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT2_TITLE) ($$(DEVICE_TITLE))
-$$(info $$(call Device/DumpInfo,$(1)))
-endif
 DEVICE_DISPLAY = $$(DEVICE_TITLE)
 $$(eval $$(if $$(DEVICE_TITLE),$$(info $$(call Device/DumpInfo,$(1)))))
 endef


### PR DESCRIPTION
Dumping device info more than once for alternative device title leads to
duplication in `.targetinfo` and `.profiles.mk`, which causes problem in
imagebuilder.

When this happens,

1. `make info` outputs duplicate/redundent information
2. `make image` does not install DEVICE_PACKAGES as it should
3. manifest filename becomes quirky

Remove duplicates to fix above bugs.

In `make menuconfig`, users can still press <?> to see alternative
device titles during target profile selection.

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>

Cc: @aparcar

Two examples to reproduce the problem:

## Imagination Technologies Creator Ci40

1. Get imagebuilder https://downloads.openwrt.org/snapshots/targets/pistachio/generic/openwrt-imagebuilder-pistachio.Linux-x86_64.tar.xz
2. Run `make info`, profile appeared twice, with exact same info
3. Run `make image PROFILE="img_creator-ci40"` and observe the build message, `kmod-tpm-i2c-infineon` is not installed
4. Instead of `openwrt-pistachio-img_creator-ci40.manifest`, manifest filename is now `openwrt-pistachio-img_creator-ci40-img_creator-ci40.manifest`

## Raspberry Pi 2B/2B 1.2 (32bit)

1. Get imagebuilder https://downloads.openwrt.org/snapshots/targets/bcm27xx/bcm2709/openwrt-imagebuilder-bcm27xx-bcm2709.Linux-x86_64.tar.xz
2. Run `make info`, profile appeared 3 times, with exact same info
3. Run `make image PROFILE="rpi-2"` and observe the build message, `kmod-brcmfmac` is not installed
4. Instead of `openwrt-bcm27xx-bcm2709-rpi-2.manifest`, manifest filename is now `openwrt-bcm27xx-bcm2709-rpi-2-rpi-2-rpi-2.manifest`