### PR TITLE
owipcalc: use v6 in cidr_parse6 function

### DIFF
--- a/package/network/utils/owipcalc/Makefile
+++ b/package/network/utils/owipcalc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owipcalc
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=Apache-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/utils/owipcalc/src/owipcalc.c
+++ b/package/network/utils/owipcalc/src/owipcalc.c
@@ -361,11 +361,11 @@ static struct cidr * cidr_parse6(const char *s)
 	if (!addr || (strlen(s) >= sizeof(addr->buf.v6)))
 		goto err;
 
-	snprintf(addr->buf.v4, sizeof(addr->buf.v6), "%s", s);
+	snprintf(addr->buf.v6, sizeof(addr->buf.v6), "%s", s);
 
 	addr->family = AF_INET6;
 
-	if ((p = strchr(addr->buf.v4, '/')) != NULL)
+	if ((p = strchr(addr->buf.v6, '/')) != NULL)
 	{
 		*p++ = 0;
 
@@ -379,9 +379,9 @@ static struct cidr * cidr_parse6(const char *s)
 		addr->prefix = 128;
 	}
 
-	if (p == addr->buf.v4+1)
+	if (p == addr->buf.v6+1)
 		memset(&addr->addr.v6, 0, sizeof(addr->addr.v6));
-	else if (inet_pton(AF_INET6, addr->buf.v4, &addr->addr.v6) != 1)
+	else if (inet_pton(AF_INET6, addr->buf.v6, &addr->addr.v6) != 1)
 		goto err;
 
 	return addr;


### PR DESCRIPTION
The cidr_parse6 function parses a string to an ipv6-address. The cidr struct contains a union called buf for the ipv4 and ipv6 address. Since it is a char pointer and the struct is initialized with the maximum size (so ipv6 string) it does not make any difference. However, we should access the buffer using the v6 name, since it could be confusing otherwise.