### PR TITLE
ramips: add support for TP-Link Archer A6 v3

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_archer-a6-v3.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-a6-v3.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,archer-a6-v3", "mediatek,mt7621-soc";
+	model = "TP-Link Archer A6 v3";
+	
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+	
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};	
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan_green {
+			label = "green:wan";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+			
+			partition@40000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x40000 0xf60000>;
+			};
+			
+			config: partition@fa0000 {
+				label = "config";
+				reg = <0xfa0000 0x50000>;
+				read-only;
+			};
+			
+			radio: partition@ff0000 {
+				label = "radio";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups =  "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+        pinctrl-names = "default";
+        pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x0>;
+		mtd-mac-address = <&config 0x8>;
+		mtd-mac-address-increment = <1>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		mtd-mac-address = <&config 0x8>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&config 0x8>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+		
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+		
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+		
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+		
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1114,6 +1114,20 @@ define Device/totolink_x5000r
 endef
 TARGET_DEVICES += totolink_x5000r
 
+define Device/tplink_archer-a6-v3
+  $(Device/dsa-migration)
+  $(Device/tplink-safeloader)
+  IMAGES += factory.bin
+  DEVICE_MODEL := Archer A6
+  DEVICE_VARIANT := V3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e \
+	kmod-mt7663-firmware-ap kmod-mt7663-firmware-sta
+  TPLINK_BOARD_ID := ARCHER-A6-V3
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 15744k
+endef
+TARGET_DEVICES += tplink_archer-a6-v3
+
 define Device/tplink_eap235-wall-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -78,6 +78,10 @@ netgear,r6800)
 	ucidef_set_led_netdev "lan3" "LAN3" "white:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "white:lan4" "lan4"
 	;;
+tplink,archer-a6-v3)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	;;
 tplink,re350-v1)
 	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "blue:wifi2G" "wlan0"
 	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "blue:wifi5G" "wlan1"

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1059,7 +1059,44 @@ static struct device_info boards[] = {
 		.first_sysupgrade_partition = "os-image",
 		.last_sysupgrade_partition = "file-system",
 	},
+	/** Firmware layout for the Archer A6 v3  */
+	{
+		.id     = "ARCHER-A6-V3",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:Archer A6,product_ver:3.0.0,special_id:55530000}\n"
+			"{product_name:Archer A6,product_ver:3.0.0,special_id:54570000}\n",
+		.part_trail = 0x00,
+		.soft_ver = "soft_ver:1.0.5\n",
 
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x40000},
+			{"firmware", 0x40000, 0xf60000},
+			{"default-mac", 0xfa0000, 0x00200},
+			{"pin", 0xfa0200, 0x00100},
+			{"device-id", 0xfa0300, 0x00100},
+			{"product-info", 0xfa0400, 0x0fc00},
+			{"default-config", 0xfb0000, 0x08000},
+			{"ap-def-config", 0xfb8000, 0x08000},
+			{"user-config", 0xfc0000, 0x0a000},
+			{"ag-config", 0xfca000, 0x04000},
+			{"certificate", 0xfce000, 0x02000},
+			{"ap-config", 0xfd0000, 0x06000},
+			{"router-config", 0xfd6000, 0x06000},
+			{"favicon", 0xfdc000, 0x02000},
+			{"logo", 0xfde000, 0x02000},
+			{"partition-table", 0xfe0000, 0x00800},
+			{"soft-version", 0xfe0800, 0x00100},
+			{"support-list", 0xfe0900, 0x00200},
+			{"profile", 0xfe0b00, 0x03000},
+			{"extra-para", 0xfe3b00, 0x00100},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
 	/** Firmware layout for the C60v1 */
 	{
 		.id     = "ARCHER-C60-V1",
@@ -2824,7 +2861,8 @@ static void build_image(const char *output,
 	parts[4] = read_file("file-system", rootfs_image, add_jffs2_eof, file_system_partition);
 
 	/* Some devices need the extra-para partition to accept the firmware */
-	if (strcasecmp(info->id, "ARCHER-A7-V5") == 0 ||
+	if (strcasecmp(info->id, "ARCHER-A6-V3") == 0 ||
+	    strcasecmp(info->id, "ARCHER-A7-V5") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C2-V3") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C7-V4") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C7-V5") == 0 ||


### PR DESCRIPTION
Patch to add support for the TP-Link Archer A6 v3.

The device is sold in US and India (FCC ID TE7A6V3) with following specifications.


### **Specification**
- MediaTek MT7621 SOC -  880MHz 
- RAM:               128MB DDR3
- SPI Flash:        W25Q128 (16MB)
- Ethernet:          MT7530  5x 1000Base-T
- WiFi 5GHz:      Mediatek MT7613BE 
- WiFi 2.4GHz:   Mediatek MT7603E
- UART/ Serial:  115200 8n1

### How to Use
**Flashing from TP-Link Web Interface**
- Go to "Advanced/System Tools/Firmware Update".
- Click "Browse" and upload the OpenWrt factory image: openwrt-ramips-mt7621-tplink_archer-a6-v3-squashfs-factory.bin.
- Click the "Upgrade" button, and select "Yes" when prompted.


**TFTP Booting**
- Setup TFTP server with address 192.168.0.5
- While starting U-boot press '4' key to stop autoboot. 
- Copy the openwrt-ramips-mt7621-tplink_archera6-v3-initramfs-kernel.bin to TFTP server folder and rename it as test.bin
- From u-boot command prompt run _tftpboot_ followed by _bootm_

### Recovery 
Archer A6 V3 has recovery page activated if SPI booting from flash fails. Recovery page can also be activated from serial console, by pressing 'x' while u-boot is starting. But TFTP boot can be activated only from u-boot serial console.
Recovery address: 192.168.0.1

The OEM Firmware can be downloaded from: https://www.tp-link.com/us/support/download/archer-a6/

Signed-off-by: Vinay P post2vinay@gmail.com