### PR TITLE
ipq806x: fix Ubiquiti UniFi AC HD partition map

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-unifi-ac-hd.dts
@@ -144,7 +144,7 @@
 
 				partition@90000 {
 					label = "SSD";
-					reg = <0x90000 0x100000>;
+					reg = <0x90000 0x10000>;
 					read-only;
 				};
 


### PR DESCRIPTION
This fixes a typo in the previously committed partition map that led to
the extension of the read-only mtd partition "SSD" into the following
partitions.

Fixes: 4e46beb31342 ("ipq806x: add support for Ubiquiti UniFi AC HD")