### PR TITLE
iperf3: add uci server handling

### DIFF
--- a/package/network/utils/iperf3/files/etc/config/iperf3
+++ b/package/network/utils/iperf3/files/etc/config/iperf3
@@ -1,10 +1,16 @@
 
-#config server wan
-#	option enabled '1'
-#	option port '5202'
-#	option iface 'wan'
-#	option redirect '1'
-#
+config server wan
+	option enabled '1'
+	option port '5202'
+	option iface 'wan'
+	option redirect '1'
+	option interval '1'
+
 #config client internet
-#	option server '192.168.0.51'
+#	option server '<IP>'
 #	option port '5202'
+#	option duration '10'
+#	option proto 'ipv4'
+#	option reverse '0'
+#	option udp '1'
+#	option redirect '1'

--- a/package/network/utils/iperf3/files/etc/config/iperf3
+++ b/package/network/utils/iperf3/files/etc/config/iperf3
@@ -1,0 +1,10 @@
+
+#config server wan
+#	option enabled '1'
+#	option port '5202'
+#	option iface 'wan'
+#	option redirect '1'
+#
+#config client internet
+#	option server '192.168.0.51'
+#	option port '5202'

--- a/package/network/utils/iperf3/files/etc/init.d/iperf3
+++ b/package/network/utils/iperf3/files/etc/init.d/iperf3
@@ -1,0 +1,120 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+
+START=50
+PROG_DEFAULT="/usr/bin/iperf3"
+PROG_REDIRECT="/usr/libexec/iperf3-ubus-redirect"
+
+DIR="/var/run/iperf3"
+PIDFILE="${DIR}/pidfile"
+LOGFILE="${DIR}/logfile"
+
+. $IPKG_INSTROOT/lib/functions/network.sh
+
+start_server() {
+	local cfg="$1"
+
+	local enabled port iface interval proto ip redirect prog
+
+	config_get_bool enabled "$cfg" 'enabled' 1
+	[ $enabled -gt 0 ] || return
+
+	rm -f "${LOGFILE}-${cfg}.log"
+
+	config_get port "$cfg" port '5201'
+	config_get interval "$cfg" interval '1'
+	config_get iface "$cfg" iface
+
+	[ -n "$iface" ] && {
+		config_get proto "$cfg" proto 'ipv4'
+		[ "$proto" = "ipv4" ] && network_get_ipaddr ip "$iface"
+		[ "$proto" = "ipv6" ] && network_get_ipaddr6 ip "$iface"
+	}
+
+	config_get_bool redirect "$cfg" 'redirect' 0
+
+	if [ "$redirect" -eq 1 ]; then
+		prog="$PROG_REDIRECT"
+	else
+		prog="$PROG_DEFAULT"
+	fi
+
+	procd_open_instance "$cfg"
+	procd_set_param command "$prog" --server
+	[ -n "$ip" ] && procd_append_param command --bind "$ip"
+	procd_append_param command --port "$port"
+	procd_append_param command --interval "$interval"
+	[ "$redirect" -eq 0 ] && procd_append_param command --logfile "${LOGFILE}-${cfg}.log"
+	procd_append_param command --forceflush
+	procd_set_param pidfile "${PIDFILE}-${cfg}.pid"
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "iperf3"
+}
+
+start_service() {
+	mkdir -p "$DIR"
+	config_load iperf3
+	config_foreach start_server server
+}
+
+start_client() {
+	local cfg="$1"
+
+	local server port duration reverse proto udp
+	local version redirect prog
+
+	config_load iperf3
+	config_get server "$cfg" server
+	config_get port "$cfg" port '5201'
+	config_get duration "$cfg" duration '10'
+	config_get_bool reverse "$cfg" reverse
+	config_get_bool udp "$cfg" udp
+
+	config_get proto "$cfg" proto "ipv4"
+	if [ "$proto" = "ipv6" ]; then
+		version="--version6"
+	else
+		version="--version4"
+	fi
+
+	[ -n "$server" ] || {
+		echo "No server configured" >&2
+		exit 1
+	}
+
+	rm -f "${LOGFILE}-${cfg}.log"
+
+	config_get_bool redirect "$cfg" 'redirect' 0
+
+	if [ "$redirect" -eq 1 ]; then
+		prog="$PROG_REDIRECT"
+	else
+		prog="$PROG_DEFAULT"
+	fi
+
+	procd_open_instance "$cfg"
+	procd_set_param command "$prog"
+	procd_append_param command --client "$server"
+	procd_append_param command --port "$port"
+	procd_append_param command --time "$duration"
+	procd_append_param command "$version"
+	[ "$redirect" -eq 0 ] && procd_append_param command --logfile "${LOGFILE}-${cfg}.log"
+	[ -n "$reverse" ] && procd_append_param command --reverse
+	[ -n "$udp" ] && procd_append_param command --udp
+	procd_append_param command --forceflush
+	procd_close_instance
+}
+
+extra_command "client" "<cfg> Start a client"
+client() {
+	local cfg="$1"
+
+	mkdir -p "$DIR"
+	rc_procd start_client "$cfg"
+}

--- a/package/network/utils/iperf3/files/etc/init.d/iperf3
+++ b/package/network/utils/iperf3/files/etc/init.d/iperf3
@@ -73,8 +73,8 @@ start_client() {
 	config_get server "$cfg" server
 	config_get port "$cfg" port '5201'
 	config_get duration "$cfg" duration '10'
-	config_get_bool reverse "$cfg" reverse
-	config_get_bool udp "$cfg" udp
+	config_get_bool reverse "$cfg" reverse '0'
+	config_get_bool udp "$cfg" udp '1'
 
 	config_get proto "$cfg" proto "ipv4"
 	if [ "$proto" = "ipv6" ]; then
@@ -83,10 +83,10 @@ start_client() {
 		version="--version4"
 	fi
 
-	[ -n "$server" ] || {
+	if [ -n "$server" ]; then
 		echo "No server configured" >&2
 		exit 1
-	}
+	fi
 
 	rm -f "${LOGFILE}-${cfg}.log"
 
@@ -105,13 +105,14 @@ start_client() {
 	procd_append_param command --time "$duration"
 	procd_append_param command "$version"
 	[ "$redirect" -eq 0 ] && procd_append_param command --logfile "${LOGFILE}-${cfg}.log"
-	[ -n "$reverse" ] && procd_append_param command --reverse
-	[ -n "$udp" ] && procd_append_param command --udp
+	[ "$reverse" -eq 1 ] && procd_append_param command --reverse
+	[ "$udp" -eq 1 ] && procd_append_param command --udp
 	procd_append_param command --forceflush
 	procd_close_instance
 }
 
 extra_command "client" "<cfg> Start a client"
+
 client() {
 	local cfg="$1"
 

--- a/package/network/utils/iperf3/files/usr/libexec/iperf3-ubus-redirect
+++ b/package/network/utils/iperf3/files/usr/libexec/iperf3-ubus-redirect
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+trap_with_arg() {
+	func="$1" ; shift
+	pid="$1" ; shift
+	for sig ; do
+		# shellcheck disable=SC2064
+		trap "$func $sig $pid" "$sig"
+	done
+}
+
+func_trap() {
+	kill -${1} ${2} 2>/dev/null
+}
+
+main() {
+	local args="$@"
+	sh -c "echo \$\$; exec iperf3 $args" | {
+		read -r iperf3_pid
+		trap_with_arg func_trap "$iperf3_pid" SIGINT SIGTERM SIGKILL
+		while read -r line; do
+			ubus send luci.iperf3.notify.data '{ "line": "'"$line"'" }'
+		done
+	} &
+	child=$!
+	kill -SIGSTOP $child
+	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
+	kill -SIGCONT $child
+	wait $child
+}
+
+main $@

--- a/package/network/utils/iperf3/files/usr/libexec/iperf3-ubus-redirect
+++ b/package/network/utils/iperf3/files/usr/libexec/iperf3-ubus-redirect
@@ -1,27 +1,33 @@
 #!/bin/sh
 
 trap_with_arg() {
-	func="$1" ; shift
-	pid="$1" ; shift
-	for sig ; do
+	local func="$1"; shift
+	local pid="$1"; shift
+
+	for sig in $@; do
 		# shellcheck disable=SC2064
 		trap "$func $sig $pid" "$sig"
 	done
 }
 
 func_trap() {
-	kill -${1} ${2} 2>/dev/null
+	kill "-${1}" "$2" 2>/dev/null
 }
 
 main() {
 	local args="$@"
+	local child
+
 	sh -c "echo \$\$; exec iperf3 $args" | {
-		read -r iperf3_pid
-		trap_with_arg func_trap "$iperf3_pid" SIGINT SIGTERM SIGKILL
+		local ppid
+
+		read -r ppid
+		trap_with_arg func_trap "$ppid" SIGINT SIGTERM SIGKILL
 		while read -r line; do
 			ubus send luci.iperf3.notify.data '{ "line": "'"$line"'" }'
 		done
 	} &
+
 	child=$!
 	kill -SIGSTOP $child
 	trap_with_arg func_trap "$child" SIGINT SIGTERM SIGKILL
@@ -29,4 +35,4 @@ main() {
 	wait $child
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
@pprindeville
This P/R adds the possibility that iperf3 can be configured via the uci as server and also as client.
I also added a shell wrapper to send the output from Iperf3 to the ubus.
This is needed for the LuCI [feature](https://github.com/openwrt/luci/pull/4651).