### PR TITLE
lantiq: xway: ar9: kernel 5.4: add icu1 (2nd core for SMP)

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -44,8 +44,8 @@
 			#interrupt-cells = <1>;
 			interrupt-controller;
 			compatible = "lantiq,icu";
-			/* TODO: AR9 should have ICU1 (like VR9) too */
-			reg = <0x80200 0xc8>;
+			reg = <0x80200 0xc8	/* icu0 */
+			       0x80300 0xc8>;	/* icu1 */
 		};
 
 		watchdog@803f0 {


### PR DESCRIPTION
see: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=6bf179b27004eb76df3e466bd080fc5a83ccf0dd

Mathias Kresin <dev@kresin.me>:

lantiq: add Linux 5.4 support as testing kernel version

The Lantiq IRQ SMP support added upstream required changes to the SoC
dtsi as well.

/target/linux/lantiq/files-5.4/arch/mips/boot/dts/lantiq/ar9.dtsi

/* TODO: AR9 should have ICU1 (like VR9) too */

Everloop2: Added ICU1 (like in vr9.dtsi) to ar9.dtsi and run tested FritzBox 7320 single core and SMP kernel.

Signed-off-by: everloop2 25203855+everloop2@users.noreply.github.com