### PR TITLE
ath79: add support for TP-Link Archer C900 V1.1

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c900-v1.1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c900-v1.1.dts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,archer-c900-v1.1", "qca,qca9563";
+	model = "TP-Link Archer C900 v1.1";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_wps {
+			label = "green:wps";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "orange:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "factory-uboot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "uboot";
+				reg = <0x020000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "firmware";
+				reg = <0x030000 0x7A0000>;
+				compatible = "denx,uimage";
+			};
+
+			info: partition@7e0000 {
+				label = "info";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&info 0x8>;
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c900-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c900-v1.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "tplink,archer-c900-v1.1", "qca,qca9563";
-	model = "TP-Link Archer C900 v1.1";
+	compatible = "tplink,archer-c900-v1", "qca,qca9563";
+	model = "TP-Link Archer C900 v1";
 
 	aliases {
 		led-boot = &led_system;

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -256,7 +256,7 @@ tplink,archer-c7-v5)
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x20"
 	;;
 tplink,archer-c2-v3|\
-tplink,archer-c900-v1.1|\
+tplink,archer-c900-v1|\
 tplink,tl-wr1043nd-v4|\
 tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x20"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -256,6 +256,7 @@ tplink,archer-c7-v5)
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x20"
 	;;
 tplink,archer-c2-v3|\
+tplink,archer-c900-v1.1|\
 tplink,tl-wr1043nd-v4|\
 tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x20"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -211,7 +211,7 @@ ath79_setup_interfaces()
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
-	tplink,archer-c900-v1.1|\
+	tplink,archer-c900-v1|\
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -211,6 +211,7 @@ ath79_setup_interfaces()
 	dlink,dir-859-a1|\
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
+	tplink,archer-c900-v1.1|\
 	tplink,tl-wr1043nd-v4|\
 	tplink,tl-wr1043n-v5)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -106,6 +106,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c2-v3|\
+	tplink,archer-c900-v1.1|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -106,7 +106,7 @@ case "$FIRMWARE" in
 		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c2-v3|\
-	tplink,archer-c900-v1.1|\
+	tplink,archer-c900-v1|\
 	tplink,archer-c7-v4|\
 	tplink,archer-c7-v5|\
 	tplink,archer-c25-v1|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -200,16 +200,16 @@ define Device/tplink_archer-c7-v5
 endef
 TARGET_DEVICES += tplink_archer-c7-v5
 
-define Device/tplink_archer-c900-v1.1
+define Device/tplink_archer-c900-v1
   $(Device/tplink-safeloader-uimage)
   SOC := qca9563
   IMAGE_SIZE := 7808k
   DEVICE_MODEL := Archer C900
-  DEVICE_VARIANT := v1.1
+  DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct
-  TPLINK_BOARD_ID := ARCHER-C900-V1.1
+  TPLINK_BOARD_ID := ARCHER-C900-V1
 endef
-TARGET_DEVICES += tplink_archer-c900-v1.1
+TARGET_DEVICES += tplink_archer-c900-v1
 
 define Device/tplink_archer-d50-v1
   $(Device/tplink-v2)

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -200,6 +200,17 @@ define Device/tplink_archer-c7-v5
 endef
 TARGET_DEVICES += tplink_archer-c7-v5
 
+define Device/tplink_archer-c900-v1.1
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := Archer C900
+  DEVICE_VARIANT := v1.1
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct
+  TPLINK_BOARD_ID := ARCHER-C900-V1.1
+endef
+TARGET_DEVICES += tplink_archer-c900-v1.1
+
 define Device/tplink_archer-d50-v1
   $(Device/tplink-v2)
   SOC := qca9531

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1328,6 +1328,44 @@ static struct device_info boards[] = {
 		.first_sysupgrade_partition = "os-image",
 		.last_sysupgrade_partition = "file-system"
 	},
+	
+	/** Firmware layout for the C900 V1.1 */
+	{
+		.id     = "ARCHER-C900-V1.1",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:ArcherC900,product_ver:1.0.0,special_id:00000000}\n"
+			"{product_name:ArcherC900,product_ver:1.0.0,special_id:55530000}\n"
+			"{product_name:ArcherC900,product_ver:1.0.0,special_id:45550000}\n",
+		.part_trail = 0x00,
+		.soft_ver = "soft_ver:1.0.0 Build 20161130 Rel. 67783\n",
+
+		/** We're using a dynamic kernel/rootfs split here */
+
+		.partitions = {
+			{"factory-boot", 0x00000, 0x20000},
+			{"fs-uboot", 0x20000, 0x10000},
+			{"firmware", 0x30000, 0x7a0000},
+			{"user-config", 0x7d0000, 0x04000},
+			{"default-mac", 0x7e0000, 0x00100},
+			{"device-id", 0x7e0100, 0x00100},
+			{"extra-para", 0x7e0200, 0x00100},
+			{"pin", 0x7e0300, 0x00100},
+			{"support-list", 0x7e0400, 0x00400},
+			{"soft-version", 0x7e0800, 0x00400},
+			{"product-info", 0x7e0c00, 0x01400},
+			{"partition-table", 0x7e2000, 0x01000},
+			{"profile", 0x7e3000, 0x01000},
+			{"default-config", 0x7e4000, 0x04000},
+			{"merge-config", 0x7ec000, 0x02000},
+			{"qos-db", 0x7ee000, 0x02000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
 
 	/** Firmware layout for the EAP120 */
 	{
@@ -2802,6 +2840,7 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "ARCHER-C59-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V3") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C900-V1.1") == 0 ||
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const uint8_t extra_para[2] = {0x01, 0x00};
 		parts[5] = make_extra_para(info, extra_para,

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1329,9 +1329,9 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 	
-	/** Firmware layout for the C900 V1.1 */
+	/** Firmware layout for the C900 V1 */
 	{
-		.id     = "ARCHER-C900-V1.1",
+		.id     = "ARCHER-C900-V1",
 		.support_list =
 			"SupportList:\n"
 			"{product_name:ArcherC900,product_ver:1.0.0,special_id:00000000}\n"
@@ -2840,7 +2840,7 @@ static void build_image(const char *output,
 	    strcasecmp(info->id, "ARCHER-C59-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V2") == 0 ||
 	    strcasecmp(info->id, "ARCHER-C60-V3") == 0 ||
-	    strcasecmp(info->id, "ARCHER-C900-V1.1") == 0 ||
+	    strcasecmp(info->id, "ARCHER-C900-V1") == 0 ||
 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
 		const uint8_t extra_para[2] = {0x01, 0x00};
 		parts[5] = make_extra_para(info, extra_para,


### PR DESCRIPTION
This commit adds support for the TP-link Archer C900 V1.1

Specifications:

 - CPU: QCA9563 750Mhz
 - Ram: 64MB (DDR2)
 - Flash: 8MB (SPI NOR)
 - Ethernet: 5x 10/100/1000
 - Wifi: QCA9563 bgn + QCA9887 an+ac
 - 9x Leds, 2x buttons

Flash instructions:

Upload openwrt-ath79-generic-tplink_archer-c900-v1.1-squashfs-factory.bin
via the router Web interface and flash as normal firmware update.

Signed-off-by: Tim Thorpe <tim@tfthorpe.net>