### PR TITLE
x86: support booting from grub2-xen (pvgrub2)

### DIFF
--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -44,6 +44,7 @@ define Build/combined
 	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/boot/vmlinuz
 	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
+	$(LN) grub $@.boot/boot/grub2
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \
 		$@.boot/boot/grub/core.img
 	$(if $(filter $(1),efi),


### PR DESCRIPTION
grub2 can be compiled as a paravirtualized kernel for booting systems
using the distribution standard configuration. It has a builtin script
that looks for the system grub.cfg. At least for SLES binary, it looks
for /boot/grub2/grub.cfg or /boot/grub/menu.lst, but not
/boot/grub/grub.cfg used by OpenWrt. This patch creates a symlink
/boot/grub2 -> grub.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>