### PR TITLE
owipcalc: fix owipcalc

### DIFF
--- a/package/network/utils/owipcalc/Makefile
+++ b/package/network/utils/owipcalc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=owipcalc
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 PKG_LICENSE:=Apache-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/utils/owipcalc/src/owipcalc.c
+++ b/package/network/utils/owipcalc/src/owipcalc.c
@@ -227,7 +227,7 @@ static bool cidr_contains4(struct cidr *a, struct cidr *b)
 	if (printed)
 		qprintf(" ");
 
-	if ((b->prefix >= a->prefix) && (net1 == net2))
+	if (a->prefix == 0 || ((b->prefix >= a->prefix) && (net1 == net2)))
 	{
 		qprintf("1");
 		return true;
@@ -537,8 +537,8 @@ static bool cidr_contains6(struct cidr *a, struct cidr *b)
 	if (printed)
 		qprintf(" ");
 
-	if ((b->prefix >= a->prefix) && (net1 == net2) &&
-	    ((i == 15) || !memcmp(&x->s6_addr, &y->s6_addr, 15-i)))
+	if (a->prefix == 0 || ((b->prefix >= a->prefix) && (net1 == net2) &&
+	    ((i == 15) || !memcmp(&x->s6_addr, &y->s6_addr, 15-i))))
 	{
 		qprintf("1");
 		return true;


### PR DESCRIPTION
First commit:

    owipcalc: remove clone in cidr_contains6

    The "cidr_contains6" functions clones the given cidr. The contains4 does not clone the cidr. Both functions do not behave the same.

    I see no reason to push the cidr. I think that we get only a negligible performance gain, but it makes ipv4 and ipv6 equal again.

Second commit:


   owipcalc: fix contains not respect default route
    
    In IPv4 the default route can be written as
     0.0.0.0/0
    
    In IPv6 the default route can be written as
     ::/0
    
    If u try
      owipcalc 0.0.0.0/0 contains 1.1.1.1
    or
      owipcalc ::/0 contains ::1
    owipcalc will respond with 0 meaning that the "default prefixes" do not
    contain the routes.
    
    That is why we check now for 0 prefix.