### PR TITLE
kirkwood: add support for Netgear Stora (MS2110) NAS

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -65,6 +65,11 @@ define U-Boot/nas220
   BUILD_DEVICES:=seagate_blackarmor-nas220
 endef
 
+define U-Boot/netgear_ms2110
+  NAME:=Netgear Stora (MS2000/2110)
+  BUILD_DEVICES:=netgear_stora
+endef
+
 define U-Boot/nsa310
   NAME:=Zyxel NSA310
   BUILD_DEVICES:=zyxel_nsa310b
@@ -107,6 +112,7 @@ UBOOT_TARGETS := \
 	iconnect iconnect_second_stage \
 	l-50 \
 	nas220 \
+	netgear_ms2110 \
 	nsa310 \
 	nsa310s \
 	nsa325 \

--- a/package/boot/uboot-kirkwood/patches/180-netgear-stora.patch
+++ b/package/boot/uboot-kirkwood/patches/180-netgear-stora.patch
@@ -1,0 +1,648 @@
+diff -ruN u-boot-2020.04.old/arch/arm/mach-kirkwood/Kconfig u-boot-2020.04/arch/arm/mach-kirkwood/Kconfig
+--- u-boot-2020.04.old/arch/arm/mach-kirkwood/Kconfig	2020-07-09 00:46:15.000000000 +0200
++++ u-boot-2020.04/arch/arm/mach-kirkwood/Kconfig	2020-07-09 01:07:00.309219477 +0200
+@@ -44,6 +44,9 @@
+ config TARGET_NETSPACE_V2
+ 	bool "LaCie netspace_v2 Board"
+ 
++config TARGET_NETGEAR_MS2110
++	bool "Netgear MS2110 Board"
++
+ config TARGET_IB62X0
+ 	bool "ib62x0 Board"
+ 
+@@ -92,6 +95,7 @@
+ source "board/keymile/Kconfig"
+ source "board/LaCie/net2big_v2/Kconfig"
+ source "board/LaCie/netspace_v2/Kconfig"
++source "board/Marvell/netgear_ms2110/Kconfig"
+ source "board/raidsonic/ib62x0/Kconfig"
+ source "board/Seagate/dockstar/Kconfig"
+ source "board/Seagate/goflexhome/Kconfig"
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/Kconfig u-boot-2020.04/board/Marvell/netgear_ms2110/Kconfig
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/Kconfig	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/Kconfig	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,12 @@
++if TARGET_NETGEAR_MS2110
++
++config SYS_BOARD
++	default "netgear_ms2110"
++
++config SYS_VENDOR
++	default "Marvell"
++
++config SYS_CONFIG_NAME
++	default "netgear_ms2110"
++
++endif
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/kwbimage.cfg u-boot-2020.04/board/Marvell/netgear_ms2110/kwbimage.cfg
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/kwbimage.cfg	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/kwbimage.cfg	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,167 @@
++#
++# (C) Copyright 2009
++# Marvell Semiconductor <www.marvell.com>
++# Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++#
++# See file CREDITS for list of people who contributed to this
++# project.
++#
++# This program is free software; you can redistribute it and/or
++# modify it under the terms of the GNU General Public License as
++# published by the Free Software Foundation; either version 2 of
++# the License, or (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software
++# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++# MA 02110-1301 USA
++#
++# Refer docs/README.kwimage for more details about how-to configure
++# and create kirkwood boot image
++#
++
++# Boot Media configurations
++BOOT_FROM	nand
++NAND_ECC_MODE	default
++NAND_PAGE_SIZE	0x0800
++
++# SOC registers configuration using bootrom header extension
++# Maximum KWBIMAGE_MAX_CONFIG configurations allowed
++
++# Configure RGMII-0 interface pad voltage to 1.8V
++DATA 0xFFD100e0 0x1b1b1b9b
++
++#Dram initalization for SINGLE x16 CL=5 @ 400MHz
++DATA 0xFFD01400 0x43000c30	# DDR Configuration register
++# bit13-0:  0xc30 (3120 DDR2 clks refresh rate)
++# bit23-14: zero
++# bit24: 1= enable exit self refresh mode on DDR access
++# bit25: 1 required
++# bit29-26: zero
++# bit31-30: 01
++
++DATA 0xFFD01404 0x37543000	# DDR Controller Control Low
++# bit 4:    0=addr/cmd in smame cycle
++# bit 5:    0=clk is driven during self refresh, we don't care for APX
++# bit 6:    0=use recommended falling edge of clk for addr/cmd
++# bit14:    0=input buffer always powered up
++# bit18:    1=cpu lock transaction enabled
++# bit23-20: 5=recommended value for CL=5 and STARTBURST_DEL disabled bit31=0
++# bit27-24: 7= CL+2, STARTBURST sample stages, for freqs 400MHz, unbuffered DIMM
++# bit30-28: 3 required
++# bit31:    0=no additional STARTBURST delay
++
++DATA 0xFFD01408 0x22125451	# DDR Timing (Low) (active cycles value +1)
++# bit3-0:   TRAS lsbs
++# bit7-4:   TRCD
++# bit11- 8: TRP
++# bit15-12: TWR
++# bit19-16: TWTR
++# bit20:    TRAS msb
++# bit23-21: 0x0
++# bit27-24: TRRD
++# bit31-28: TRTP
++
++DATA 0xFFD0140C 0x00000833	#  DDR Timing (High)
++# bit6-0:   TRFC
++# bit8-7:   TR2R
++# bit10-9:  TR2W
++# bit12-11: TW2W
++# bit31-13: zero required
++
++DATA 0xFFD01410 0x00000099	#  DDR Address Control
++# bit1-0:   00, Cs0width=x8
++# bit3-2:   11, Cs0size=1Gb
++# bit5-4:   00, Cs1width=x8
++# bit7-6:   11, Cs1size=1Gb
++# bit9-8:   00, Cs2width=nonexistent
++# bit11-10: 00, Cs2size =nonexistent
++# bit13-12: 00, Cs3width=nonexistent
++# bit15-14: 00, Cs3size =nonexistent
++# bit16:    0,  Cs0AddrSel
++# bit17:    0,  Cs1AddrSel
++# bit18:    0,  Cs2AddrSel
++# bit19:    0,  Cs3AddrSel
++# bit31-20: 0 required
++
++DATA 0xFFD01414 0x00000000	#  DDR Open Pages Control
++# bit0:    0,  OpenPage enabled
++# bit31-1: 0 required
++
++DATA 0xFFD01418 0x00000000	#  DDR Operation
++# bit3-0:   0x0, DDR cmd
++# bit31-4:  0 required
++
++DATA 0xFFD0141C 0x00000C52	#  DDR Mode
++# bit2-0:   2, BurstLen=2 required
++# bit3:     0, BurstType=0 required
++# bit6-4:   4, CL=5
++# bit7:     0, TestMode=0 normal
++# bit8:     0, DLL reset=0 normal
++# bit11-9:  6, auto-precharge write recovery ????????????
++# bit12:    0, PD must be zero
++# bit31-13: 0 required
++
++DATA 0xFFD01420 0x00000004	#  DDR Extended Mode
++# bit0:    0,  DDR DLL enabled
++# bit1:    0,  DDR drive strenght normal
++# bit2:    1,  DDR ODT control lsd (disabled)
++# bit5-3:  000, required
++# bit6:    0,  DDR ODT control msb, (disabled)
++# bit9-7:  000, required
++# bit10:   0,  differential DQS enabled
++# bit11:   0, required
++# bit12:   0, DDR output buffer enabled
++# bit31-13: 0 required
++
++DATA 0xFFD01424 0x0000F17F	#  DDR Controller Control High
++# bit2-0:  111, required
++# bit3  :  1  , MBUS Burst Chop disabled
++# bit6-4:  111, required
++# bit7  :  0
++# bit8  :  1  , add writepath sample stage, must be 1 for DDR freq >= 300MHz
++# bit9  :  0  , no half clock cycle addition to dataout
++# bit10 :  0  , 1/4 clock cycle skew enabled for addr/ctl signals
++# bit11 :  0  , 1/4 clock cycle skew disabled for write mesh
++# bit15-12: 1111 required
++# bit31-16: 0    required
++
++DATA 0xFFD01428 0x00085520	# DDR2 ODT Read Timing (default values)
++DATA 0xFFD0147C 0x00008552	# DDR2 ODT Write Timing (default values)
++
++DATA 0xFFD01500 0x00000000	# CS[0]n Base address to 0x0
++DATA 0xFFD01504 0x03FFFFF1	# CS[0]n Size
++# bit0:    1,  Window enabled
++# bit1:    0,  Write Protect disabled
++# bit3-2:  00, CS0 hit selected
++# bit23-4: ones, required
++# bit31-24: 0x0F, Size (i.e. 256MB)
++
++DATA 0xFFD01508 0x04000000	# CS[1]n Base address to 256Mb
++DATA 0xFFD0150C 0x03FFFFF5	# CS[1]n Size 256Mb Window enabled for CS1
++
++DATA 0xFFD01514 0x00000000	# CS[2]n Size, window disabled
++DATA 0xFFD0151C 0x00000000	# CS[3]n Size, window disabled
++
++DATA 0xFFD01494 0x00120012	#  DDR ODT Control (Low)
++# bit3-0:  2, ODT0Rd, MODT[0] asserted during read from DRAM CS1
++# bit7-4:  1, ODT0Rd, MODT[0] asserted during read from DRAM CS0
++# bit19-16:2, ODT0Wr, MODT[0] asserted during write to DRAM CS1
++# bit23-20:1, ODT0Wr, MODT[0] asserted during write to DRAM CS0
++
++DATA 0xFFD01498 0x00000000	#  DDR ODT Control (High)
++# bit1-0:  00, ODT0 controlled by ODT Control (low) register above
++# bit3-2:  01, ODT1 active NEVER!
++# bit31-4: zero, required
++
++DATA 0xFFD0149C 0x0000E40F	# CPU ODT Control
++DATA 0xFFD01480 0x00000001	# DDR Initialization Control
++#bit0=1, enable DDR init upon this register write
++
++# End of Header extension
++DATA 0x0 0x0
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/MAINTAINERS u-boot-2020.04/board/Marvell/netgear_ms2110/MAINTAINERS
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/MAINTAINERS	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/MAINTAINERS	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,6 @@
++NETGEAR_MS2110 BOARD
++M:	bodhi <mibodhi@gmail.com>
++S:	Maintained
++F:	board/Marvell/netgear_ms2110
++F:	include/configs/netgear_ms2110.h
++F:	configs/netgear_ms2110_defconfig
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/Makefile u-boot-2020.04/board/Marvell/netgear_ms2110/Makefile
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/Makefile	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/Makefile	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,13 @@
++#
++# (C) Copyright 2014 bodhi <mibodhi@gmail.com>
++#
++# Based on
++# (C) Copyright 2009
++# Marvell Semiconductor <www.marvell.com>
++# Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++obj-y	:= netgear_ms2110.o
++
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/netgear_ms2110.c u-boot-2020.04/board/Marvell/netgear_ms2110/netgear_ms2110.c
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/netgear_ms2110.c	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/netgear_ms2110.c	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,151 @@
++/*
++ * Copyright (C) 2014-2017 bodhi <mibodhi@gmail.com>
++ *
++ * Based on Kirkwood support:
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ * Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#include <common.h>
++#include <miiphy.h>
++#include <netdev.h>
++#include <asm/arch/soc.h>
++#include <asm/arch/mpp.h>
++#include "netgear_ms2110.h"
++#include <asm/mach-types.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++int board_early_init_f(void)
++{
++	/*
++	 * default gpio configuration
++	 * There are maximum 64 gpios controlled through 2 sets of registers
++	 * the  below configuration configures mainly initial LED status
++	 */
++	mvebu_config_gpio(NETGEAR_MS2110_OE_VAL_LOW,
++			NETGEAR_MS2110_OE_VAL_HIGH,
++			NETGEAR_MS2110_OE_LOW, NETGEAR_MS2110_OE_HIGH);
++
++	/* Multi-Purpose Pins Functionality configuration */
++	u32 kwmpp_config[] = {
++		MPP0_NF_IO2,
++		MPP1_NF_IO3,
++		MPP2_NF_IO4,
++		MPP3_NF_IO5,
++		MPP4_NF_IO6,
++		MPP5_NF_IO7,
++		MPP6_SYSRST_OUTn,
++		MPP7_SPI_SCn,
++		MPP8_TW_SDA,
++		MPP9_TW_SCK,
++		MPP10_UART0_TXD,
++		MPP11_UART0_RXD,
++		MPP12_SD_CLK,
++		MPP13_SD_CMD,
++		MPP14_SD_D0,
++		MPP15_SD_D1,
++		MPP16_SD_D2,
++		MPP17_SD_D3,
++		MPP18_NF_IO0,
++		MPP19_NF_IO1,
++		MPP20_SATA1_ACTn,
++		MPP21_SATA0_ACTn,
++		MPP22_GPIO,
++		MPP23_GPIO,
++		MPP24_GE1_4,
++		MPP25_GE1_5,
++		MPP26_GE1_6,
++		MPP27_GE1_7,
++		MPP28_GPIO,
++		MPP29_GPIO,
++		MPP30_GPIO,
++		MPP31_GPIO,
++		MPP32_GPIO,
++		MPP33_GE1_13,
++		MPP34_SATA1_ACTn,
++		MPP35_GPIO,
++		MPP36_GPIO,
++		MPP37_GPIO,
++		MPP38_GPIO,
++		MPP39_GPIO,
++		MPP40_GPIO,
++		MPP41_GPIO,
++		MPP42_GPIO,
++		MPP43_GPIO,
++		MPP44_GPIO,
++		MPP45_TDM_PCLK,
++		MPP46_TDM_FS,
++		MPP47_TDM_DRX,
++		MPP48_TDM_DTX,
++		MPP49_GPIO,
++		0
++	};
++	kirkwood_mpp_conf(kwmpp_config, NULL);
++	return 0;
++}
++
++int board_init(void)
++{	/*
++	 * arch number of board
++	 */
++	gd->bd->bi_arch_number = MACH_TYPE_NETGEAR_MS2110;
++
++	/* adress of boot parameters */
++	gd->bd->bi_boot_params = mvebu_sdram_bar(0) + 0x100;
++
++	return 0;
++}
++#ifdef CONFIG_RESET_PHY_R
++/* Configure and enable MV88E1116 PHY */
++void reset_phy(void)
++{
++	u16 reg;
++	u16 devadr;
++	char *name = "egiga0";
++
++	if (miiphy_set_current_dev(name))
++		return;
++
++	/* command to read PHY dev address */
++	if (miiphy_read(name, 0xEE, 0xEE, (u16 *) &devadr)) {
++		printf("Err..%s could not read PHY dev address\n",
++			__FUNCTION__);
++		return;
++	}
++
++	/*
++	 * Enable RGMII delay on Tx and Rx for CPU port
++	 * Ref: sec 4.7.2 of chip datasheet
++	 */
++	miiphy_write(name, devadr, MV88E1116_PGADR_REG, 2);
++	miiphy_read(name, devadr, MV88E1116_MAC_CTRL_REG, &reg);
++	reg |= (MV88E1116_RGMII_RXTM_CTRL | MV88E1116_RGMII_TXTM_CTRL);
++	miiphy_write(name, devadr, MV88E1116_MAC_CTRL_REG, reg);
++	miiphy_write(name, devadr, MV88E1116_PGADR_REG, 0);
++
++	/* reset the phy */
++	miiphy_reset(name, devadr);
++
++	printf("88E1116 Initialized on %s\n", name);
++}
++#endif /* CONFIG_RESET_PHY_R */
++
+diff -ruN u-boot-2020.04.old/board/Marvell/netgear_ms2110/netgear_ms2110.h u-boot-2020.04/board/Marvell/netgear_ms2110/netgear_ms2110.h
+--- u-boot-2020.04.old/board/Marvell/netgear_ms2110/netgear_ms2110.h	1970-01-01 01:00:00.000000000 +0100
++++ u-boot-2020.04/board/Marvell/netgear_ms2110/netgear_ms2110.h	2020-07-09 00:59:29.000000000 +0200
+@@ -0,0 +1,41 @@
++/*
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ * Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#ifndef __NETGEAR_MS2110_H
++#define __NETGEAR_MS2110_H
++
++#define NETGEAR_MS2110_OE_LOW			(~(1 << 7))
++#define NETGEAR_MS2110_OE_HIGH			(~(1 << 2 | 1 << 12))
++#define NETGEAR_MS2110_OE_VAL_LOW		(0)
++#define NETGEAR_MS2110_OE_VAL_HIGH		(1 << 12)
++
++/* PHY related */
++#define MV88E1116_LED_FCTRL_REG		10
++#define MV88E1116_CPRSP_CR3_REG		21
++#define MV88E1116_MAC_CTRL_REG		21
++#define MV88E1116_PGADR_REG		22
++#define MV88E1116_RGMII_TXTM_CTRL	(1 << 4)
++#define MV88E1116_RGMII_RXTM_CTRL	(1 << 5)
++
++#endif /* __NETGEAR_MS2110_H */
+diff -ruN a/configs/netgear_ms2110_defconfig b/configs/netgear_ms2110_defconfig
+--- a/configs/netgear_ms2110_defconfig	1970-01-01 01:00:00.000000000 +0100
++++ b/configs/netgear_ms2110_defconfig	2020-07-14 17:59:18.000000000 +0200
+@@ -0,0 +1,50 @@
++CONFIG_ARM=y
++CONFIG_KIRKWOOD=y
++CONFIG_SYS_DCACHE_OFF=y
++CONFIG_ARCH_CPU_INIT=y
++CONFIG_TARGET_NETGEAR_MS2110=y
++CONFIG_IDENT_STRING="\nNetgear Stora MS2110"
++CONFIG_SYS_PROMPT="Stora> "
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_TEXT_BASE=0x600000
++# CONFIG_DISPLAY_BOARDINFO is not set
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++CONFIG_CMD_IDE=y
++CONFIG_MVGBE=y
++CONFIG_MII=y
++CONFIG_SYS_NS16550=y
++CONFIG_OF_LIBFDT=y
++CONFIG_CMD_FDT=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_DATE=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_MII=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_JFFS2=y
++CONFIG_CMD_USB=y
++CONFIG_ISO_PARTITION=y
++CONFIG_EFI_PARTITION=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_MTD_RAW_NAND=y
++CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:0xe0000@0x0(uboot),0x20000@0xe0000(uboot_env),-@0x100000(ubi)"
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_NAND=y
++CONFIG_ENV_IS_IN_NAND=y
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_ADDR=0xe0000
++CONFIG_ENV_OFFSET=0xe0000
++CONFIG_ENV_SECT_SIZE=0x20000
++CONFIG_CMD_UBI=y
++CONFIG_USB=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_STORAGE=y
++CONFIG_BLK=y
++CONFIG_MVSATA_IDE=y
++CONFIG_DM_RTC=y
++CONFIG_RTC_MV=y
+diff -ruN a/include/configs/netgear_ms2110.h b/include/configs/netgear_ms2110.h
+--- a/include/configs/netgear_ms2110.h	1970-01-01 01:00:00.000000000 +0100
++++ b/include/configs/netgear_ms2110.h	2020-07-14 17:49:15.000000000 +0200
+@@ -0,0 +1,155 @@
++/*
++ * (C) Copyright 2014-2017 bodhi <mibodhi@gmail.com>
++ * (C) Copyright 2020 Zoltan HERPAI <wigyori@uid0.hu>
++ *
++ * Based on Kirkwood support: 
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ * Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#ifndef _CONFIG_NGMS2110_H
++#define _CONFIG_NGMS2110_H
++
++/*
++ * High Level Configuration Options (easy to change)
++ */
++#define CONFIG_MARVELL		1
++#define CONFIG_ARM926EJS	1	/* Basic Architecture */
++#define CONFIG_FEROCEON_88FR131	1	/* CPU Core subversion */
++#define CONFIG_KIRKWOOD		1	/* SOC Family Name */
++#define CONFIG_KW88F6281	1	/* SOC Name */
++#define CONFIG_MACH_NETGEAR_MS2110	/* Machine type */
++#define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
++
++/*
++ * Commands configuration
++ */
++#define CONFIG_SYS_NO_FLASH             /* Declare no flash (NOR/SPI) */
++#define CONFIG_SYS_MVFS                 /* Picks up Filesystem from mv-common.h */
++#define CONFIG_CMD_ENV
++#define CONFIG_PREBOOT
++#define CONFIG_SYS_HUSH_PARSER
++#define CONFIG_SYS_PROMPT_HUSH_PS2 "> "
++
++/* #define CONFIG_CMD_AUTOSCRIPT */
++
++/*
++ * mv-common.h should be defined after CMD configs since it used them
++ * to enable certain macros
++ */
++#include "mv-common.h"
++
++/* Remove or override few declarations from mv-common.h */
++//#undef CONFIG_SYS_PROMPT        /* previously defined in mv-common.h */
++//#define CONFIG_SYS_PROMPT       "Netgear Stora> "
++
++/*
++ * NAND configuration
++ */
++#ifdef CONFIG_CMD_NAND
++#define CONFIG_NAND_KIRKWOOD
++#define CONFIG_SYS_MAX_NAND_DEVICE	1
++#define NAND_MAX_CHIPS			1
++#define CONFIG_SYS_NAND_BASE		0xD8000000	/* KW_DEFADR_NANDF */
++#define NAND_ALLOW_ERASE_ALL		1
++#endif
++
++/*
++ * Default environment variables
++*/
++#define CONFIG_BOOTCOMMAND \
++        "setenv bootargs ${console} ${mtdparts} ${bootargs_root}; "     \
++        "ubi part ubi; "                                                \
++        "ubifsmount ubi:rootfs; "                                       \
++        "ubi read 0x800000 kernel; "                                    \
++        "bootm 0x800000"
++
++#define CONFIG_EXTRA_ENV_SETTINGS \
++	"arcNumber=2743\0" \
++	"console=console=ttyS0,115200\0"        \
++	"ethact=egiga0\0" \
++	"ethaddr=52:3b:20:9c:11:51\0" \
++	"ipaddr=192.168.0.231\0" \
++	"mtdids=nand0=orion_nand\0"             \
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0" \
++	"serverip=192.168.0.220\0" \
++	"bootargs_root=\0"
++
++/* size in bytes reserved for initial data */
++#define CONFIG_SYS_GBL_DATA_SIZE	128
++
++/*
++ * Other required minimal configurations
++ */
++#define CONFIG_STACKSIZE	0x00100000	/* regular stack- 1M */
++
++/*
++ * Ethernet Driver configuration
++ */
++#ifdef CONFIG_CMD_NET
++#define CONFIG_NETCONSOLE      /* include NetConsole support */
++#define CONFIG_NET_MULTI       /* specify more that one ports available */
++#define CONFIG_KIRKWOOD_EGIGA_PORTS    {1,0}   /* enable first port */
++#define CONFIG_MV88E61XX_MULTICHIP_ADRMODE
++#define CONFIG_DIS_AUTO_NEG_SPEED_GMII /*Disable Auto speed negociation */
++#define CONFIG_PHY_SPEED       _1000BASET      /*Force PHYspeed to 1GBPs */
++#define CONFIG_MVGBE_PORTS	{1, 0}	/* enable port 0 only */
++#define CONFIG_PHY_BASE_ADR	0x0A
++#define CONFIG_RESET_PHY_R	/* use reset_phy() to init PHY */
++#endif /* CONFIG_CMD_NET */
++
++/*
++ * USB/EHCI
++ */
++#ifdef CONFIG_CMD_USB
++#define CONFIG_USB_EHCI			/* Enable EHCI USB support */
++#define CONFIG_USB_EHCI_KIRKWOOD	/* on Kirkwood platform	*/
++#define CONFIG_EHCI_IS_TDI
++#define CONFIG_SUPPORT_VFAT
++#endif /* CONFIG_CMD_USB */
++
++/*
++ * File system
++ */
++#define CONFIG_JFFS2_NAND
++#define CONFIG_JFFS2_LZO
++#define CONFIG_MTD_DEVICE               /* needed for mtdparts commands */
++
++/*
++ * SATA 
++ */
++
++#ifdef CONFIG_MVSATA_IDE
++#define CONFIG_SYS_ATA_IDE0_OFFSET      MV_SATA_PORT0_OFFSET
++#define CONFIG_SYS_ATA_IDE1_OFFSET      MV_SATA_PORT1_OFFSET
++#endif
++
++/*
++ *  Date Time
++ *   */
++#ifdef CONFIG_CMD_DATE
++#define CONFIG_RTC_MV
++#define CONFIG_CMD_SNTP
++#define CONFIG_CMD_DNS
++#endif /* CONFIG_CMD_DATE */
++
++#endif /* _CONFIG_NGMS2110_H */

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -572,6 +572,21 @@ endef
 $(eval $(call KernelPackage,hwmon-sht3x))
 
 
+define KernelPackage/hwmon-tc654
+  TITLE:=TC654 monitoring support
+  KCONFIG:=CONFIG_SENSORS_TC654
+  FILES:=$(LINUX_DIR)/drivers/hwmon/tc654.ko
+  AUTOLOAD:=$(call AutoLoad,60,tc654)
+  $(call AddDepends/hwmon,+kmod-i2c-core)
+endef
+
+define KernelPackage/hwmon-tc654/description
+ Kernel module for Microchip TC654/TC655 and compatibles
+endef
+
+$(eval $(call KernelPackage,hwmon-tc654))
+
+
 define KernelPackage/hwmon-tmp102
   TITLE:=Texas Instruments TMP102 monitoring support
   KCONFIG:=CONFIG_SENSORS_TMP102

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -24,6 +24,7 @@ kirkwood_setup_interfaces()
 	iom,ix2-200|\
 	iptime,nas1|\
 	netgear,readynas-duo-v2|\
+	netgear,stora|\
 	raidsonic,ib-nas62x0|\
 	seagate,blackarmor-nas220|\
 	seagate,dockstar|\

--- a/target/linux/kirkwood/base-files/etc/uci-defaults/04_storafan
+++ b/target/linux/kirkwood/base-files/etc/uci-defaults/04_storafan
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+netgear,stora)
+	# Set fan script execution in crontab
+	grep -s -q fan_ctrl.sh /etc/crontabs/root && exit 0
+
+	echo "# stora fan script runs every 5 minutes" >> /etc/crontabs/root
+	echo "*/5 * * * * /sbin/fan_ctrl.sh" >> /etc/crontabs/root
+
+	# Execute one time after initial flash (instead of waiting 5 min for cron)
+	/sbin/fan_ctrl.sh
+	;;
+esac
+
+exit 0

--- a/target/linux/kirkwood/base-files/sbin/fan_ctrl.sh
+++ b/target/linux/kirkwood/base-files/sbin/fan_ctrl.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+CPU_TEMP=$(cut -c1-2 /sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-0048/hwmon/hwmon?/temp1_input)
+
+CPU_LOW=45
+CPU_MID=50
+CPU_HIGH=55
+
+if [ ! -e /sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-001b/hwmon/hwmon?/pwm1 ]; then
+	exit 0
+else
+	FAN_CTRL=$(ls /sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-001b/hwmon/hwmon?/pwm1)
+fi
+
+if [ "$CPU_TEMP" -ge "$CPU_HIGH" ]; then
+	echo "255" > $FAN_CTRL
+elif [ "$CPU_TEMP" -ge "$CPU_MID" ]; then
+	echo "100" > $FAN_CTRL
+elif [ "$CPU_TEMP" -ge "$CPU_LOW" ]; then
+	echo "50" > $FAN_CTRL
+else
+	echo "0" > $FAN_CTRL
+fi

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-stora.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-stora.dts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Device Tree file for NETGEAR Stora (MS2000/2110)
+ *
+ * Copyright (C) 2013, Arnaud EBALARD <arno@natisbad.org>
+ * Copyright (C) 2021, Zoltan HERPAI <wigyori@uid0.hu>
+ */
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6281.dtsi"
+
+/ {
+	model = "NETGEAR Stora (MS2000/2110)";
+	compatible = "netgear,stora", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+
+	memory { /* 128 MB */
+		device_type = "memory";
+		reg = <0x00000000 0x8000000>;
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8 earlyprintk";
+		stdout-path = &uart0;
+	};
+
+	ocp@f1000000 {
+		pinctrl: pin-controller@10000 {
+			pmx_button_power: pmx-button-power {
+				marvell,pins = "mpp36";
+				marvell,function = "gpio";
+			};
+
+			pmx_button_reset: pmx-button-reset {
+				marvell,pins = "mpp38";
+				marvell,function = "gpio";
+			};
+
+			pmx_led_blue_power: pmx-led-blue-power {
+				marvell,pins = "mpp31";
+				marvell,function = "gpio";
+			};
+
+			pmx_led_green_disk1: pmx-led-green-disk1 {
+				marvell,pins = "mpp21";
+				marvell,function = "gpio";
+			};
+
+			pmx_led_green_disk2: pmx-led-green-disk2 {
+				marvell,pins = "mpp20";
+				marvell,function = "gpio";
+			};
+
+			pmx_led_red_disk1: pmx-led-red-disk1 {
+				marvell,pins = "mpp23";
+				marvell,function = "gpio";
+			};
+
+			pmx_led_red_disk2: pmx-led-red-disk2 {
+				marvell,pins = "mpp22";
+				marvell,function = "gpio";
+			};
+
+			pmx_poweroff: pmx-poweroff {
+				marvell,pins = "mpp40";
+				marvell,function = "gpio";
+			};
+
+			pmx_fan_tacho: pmx-fan-tacho {
+				marvell,pins = "mpp41";
+				marvell,function = "gpio";
+			};
+		};
+
+		clocks {
+			pcf8563_clk: pcf8563-oscillator {
+				 compatible = "fixed-clock";
+				 #clock-cells = <0>;
+				 clock-frequency = <2048>;
+			};
+		};
+
+		i2c@11000 {
+			status = "okay";
+
+			tc654@1b {
+				compatible = "microchip,tc654";
+				reg = <0x1b>;
+			};
+
+			lm75@48 {
+				compatible = "national,lm75";
+				reg = <0x48>;
+			};
+
+			pcf8563@51 {
+				compatible = "nxp,pcf8563";
+				reg = <0x51>;
+			};
+		};
+
+		serial@12000 {
+			status = "okay";
+		};
+
+		sata@80000 {
+			status = "okay";
+			phy-names = "port0", "port1";
+			nr-ports = <2>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = < &pmx_led_blue_power
+			      &pmx_led_green_disk1 &pmx_led_green_disk2
+			      &pmx_led_red_disk1 &pmx_led_red_disk2 >;
+		pinctrl-names = "default";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+
+		disk1 {
+			label = "green:disk1";
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata1";
+		};
+
+		disk2 {
+			label = "green:disk2";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata2";
+		};
+
+		disk1_fail {
+			label = "red:disk1_fail";
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		disk2_fail {
+			label = "red:disk2_fail";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&pmx_button_power &pmx_button_reset >;
+		pinctrl-names = "default";
+
+		power {
+			label = "Power Button";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "Reset Button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-poweroff {
+		compatible = "gpio-poweroff";
+		pinctrl-0 = <&pmx_poweroff>;
+		pinctrl-names = "default";
+		gpios = <&gpio0 40 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&nand {
+	status = "okay";
+	chip-delay = <40>;
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0000000 0x0e0000>;
+		read-only;
+	};
+
+	partition@e0000 {
+		label = "u-boot-env";
+		reg = <0x0e00000 0x020000>;
+	};
+
+	partition@100000 {
+		label = "ubi";
+		reg = <0x0100000 0xff00000>;
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	ethphy0: ethernet-phy@0 { /* Marvell 88E1318 */
+		compatible = "marvell,88e1116";
+		reg = <8>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	ethernet0-port@0 {
+		phy-handle = <&ethphy0>;
+	};
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -271,6 +271,16 @@ define Device/netgear_readynas-duo-v2
 endef
 TARGET_DEVICES += netgear_readynas-duo-v2
 
+define Device/netgear_stora
+  DEVICE_VENDOR := Netgear
+  DEVICE_MODEL := Stora (MS2000/2110)
+  DEVICE_DTS := kirkwood-stora
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+        kmod-rtc-pcf8563 kmod-hwmon-lm75 kmod-hwmon-tc654 \
+        kmod-gpio-button-hotplug
+endef
+TARGET_DEVICES += netgear_stora
+
 define Device/raidsonic_ib-nas62x0
   DEVICE_VENDOR := RaidSonic
   DEVICE_MODEL := ICY BOX IB-NAS62x0

--- a/target/linux/kirkwood/patches-5.15/117-netgear_stora.patch
+++ b/target/linux/kirkwood/patches-5.15/117-netgear_stora.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -315,6 +315,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
+ 	kirkwood-net5big.dtb \
+ 	kirkwood-netgear_readynas_duo_v2.dtb \
+ 	kirkwood-netgear_readynas_nv+_v2.dtb \
++	kirkwood-stora.dtb \
+ 	kirkwood-ns2.dtb \
+ 	kirkwood-ns2lite.dtb \
+ 	kirkwood-ns2max.dtb \

--- a/target/linux/kirkwood/patches-6.1/117-netgear_stora.patch
+++ b/target/linux/kirkwood/patches-6.1/117-netgear_stora.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -351,6 +351,7 @@ dtb-$(CONFIG_MACH_KIRKWOOD) += \
+ 	kirkwood-net5big.dtb \
+ 	kirkwood-netgear_readynas_duo_v2.dtb \
+ 	kirkwood-netgear_readynas_nv+_v2.dtb \
++	kirkwood-stora.dtb \
+ 	kirkwood-ns2.dtb \
+ 	kirkwood-ns2lite.dtb \
+ 	kirkwood-ns2max.dtb \


### PR DESCRIPTION
Dual-slot NAS based on Marvell Kirkwood.

Specifications:
 - Marvell 88F6281 @1GHz
 - 128Mb RAM
 - 256Mb NAND
 - 1x GbE LAN (Marvell 88E1116)
 - 1x USB 2.0
 - 2x SATA
 - PCF8563 RTC
 - LM75 sensor
 - TC654 PWM fan controller
 - Serial on J2 (115200,8n1)
 - Newer bootROM so kwboot-ing via serial is possible

Installation:

1. Serial console
 - Connect your levelshifter to the serial console
   on J2 (refer to the wiki page for pinout)
2. Update u-boot
 - Download the u-boot.kwb image for the device
 - Powercycle the NAS
 - Run "kwboot -b ./u-boot.kwb /dev/ttyUSB0 -p"
 - Connect to the serial console with minicom
 - tftp 0x0800000 netgear_stora-u-boot.kwb
 - nand erase 0x0 100000
 - nand write 0x0800000 0x0 0x100000
 - reset
3. Install OpenWrt
 - Boot up the initramfs image
 - tftpboot 0x800000 openwrt-kirkwood-netgear_stora-initramfs-uImage; bootm 0x800000
 - Download the sysupgrade image and perform sysupgrade

The fan is controlled in 3 stages by a script running every minute
from cron, measuring the CPU temperature.

Snippets taken from bodhi <mibodhi@gmail.com>

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>