### PR TITLE
kernel: bump 5.4 to 5.4.90

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .89
+LINUX_VERSION-5.4 = .90
 
-LINUX_KERNEL_HASH-5.4.89 = 268dd5177b6df1867d4ed2452ffb11a016d955c43aba5e07940886f347ab0aaf
+LINUX_KERNEL_HASH-5.4.90 = 646736bc063f181c22648934f0dc3d97d49aec6edfd7358d2fe3df29fb66fa1a
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/hack-5.4/221-module_exports.patch
+++ b/target/linux/generic/hack-5.4/221-module_exports.patch
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}								\
  									\
  	/* __*init sections */						\
-@@ -885,6 +895,8 @@
+@@ -888,6 +898,8 @@
  	EXIT_TEXT							\
  	EXIT_DATA							\
  	EXIT_CALL							\

--- a/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
+++ b/target/linux/mediatek/patches-5.4/0600-net-phylink-propagate-resolved-link-config-via-mac_l.patch
@@ -95,7 +95,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  
  	netif_tx_start_all_queues(port->dev);
-@@ -5127,8 +5131,11 @@ static void mvpp2_mac_config(struct phyl
+@@ -5139,8 +5143,11 @@ static void mvpp2_mac_config(struct phyl
  	mvpp2_port_enable(port);
  }
  

--- a/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
+++ b/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
@@ -51,7 +51,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	struct ethtool_eee *p = &priv->dev->ports[port].eee;
 --- a/drivers/net/dsa/lantiq_gswip.c
 +++ b/drivers/net/dsa/lantiq_gswip.c
-@@ -1507,7 +1507,9 @@ static void gswip_phylink_mac_link_down(
+@@ -1508,7 +1508,9 @@ static void gswip_phylink_mac_link_down(
  static void gswip_phylink_mac_link_up(struct dsa_switch *ds, int port,
  				      unsigned int mode,
  				      phy_interface_t interface,


### PR DESCRIPTION
All modification made by `update_kernel.sh` in a fresh clone without
existing toolchains.
```
Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800
```
No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>