### PR TITLE
uboot-rockchip: fix RockPro64 boot from eMMC

### DIFF
--- a/package/boot/uboot-rockchip/patches/101-rock64pro-disable-CONFIG_USE_PREBOOT.patch
+++ b/package/boot/uboot-rockchip/patches/101-rock64pro-disable-CONFIG_USE_PREBOOT.patch
@@ -1,0 +1,24 @@
+From 2114d68b3c755ec8043ae9e43ac8e9753e0cec84 Mon Sep 17 00:00:00 2001
+From: Marty Jones <mj8263788@gmail.com>
+Date: Sun, 17 Jan 2021 15:26:09 -0500
+Subject: [PATCH] rockpro64: disable CONFIG_USE_PREBOOT
+
+On commit https://github.com/u-boot/u-boot/commit/f81f9f0ebac596bae7f27db095f4f0272b606cc3
+CONFIG_USE_PREBOOT was enabled on the the RockPro64, this is causing boot issues
+when a eMMC is used, as a workaround will temporarily disable this option.
+
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ configs/rockpro64-rk3399_defconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/configs/rockpro64-rk3399_defconfig
++++ b/configs/rockpro64-rk3399_defconfig
+@@ -12,7 +12,6 @@ CONFIG_SPL_SPI_FLASH_SUPPORT=y
+ CONFIG_SPL_SPI_SUPPORT=y
+ CONFIG_DEFAULT_DEVICE_TREE="rk3399-rockpro64"
+ CONFIG_DEBUG_UART=y
+-CONFIG_USE_PREBOOT=y
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-rockpro64.dtb"
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+ CONFIG_MISC_INIT_R=y


### PR DESCRIPTION
The RockPro64 has an issue with uboot v2021.01, it hangs on booting when an eMMC is used, SD is unaffected.
```
U-Boot TPL 2021.01 (Jan 17 2021 - 13:31:56)
Channel 0: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=16/15 CS=1 Die BW=16 Size=2048MB
Channel 1: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=16/15 CS=1 Die BW=16 Size=2048MB
256B stride
lpddr4_set_rate: change freq to 400000000 mhz 0, 1
lpddr4_set_rate: change freq to 800000000 mhz 1, 0
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2021.01 (Jan 17 2021 - 13:31:56 +0000)
Trying to boot from MMC2


U-Boot 2021.01 (Jan 17 2021 - 13:31:56 +0000) OpenWrt

SoC: Rockchip rk3399
Reset cause: POR
Model: Pine64 RockPro64 v2.1
DRAM:  3.9 GiB
PMIC:  RK808 
MMC:   mmc@fe310000: 2, mmc@fe320000: 1, sdhci@fe330000: 0
Loading Environment from SPIFlash... SF: Detected gd25q128 with page size 256 Bytes, erase size 4 KiB, total 16 MiB
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Model: Pine64 RockPro64 v2.1
Net:   eth0: ethernet@fe300000
starting USB...
Bus usb@fe380000: USB EHCI 1.00
Bus usb@fe3a0000: USB OHCI 1.0
Bus usb@fe3c0000: USB EHCI 1.00
Bus usb@fe3e0000: USB OHCI 1.0
Bus dwc3: usb maximum-speed not found
Register 2000140 NbrPorts 2
Starting the controller
USB XHCI 1.10
scanning bus usb@fe380000 for devices... 1 USB Device(s) found
scanning bus usb@fe3a0000 for devices... 1 USB Device(s) found
scanning bus usb@fe3c0000 for devices... 1 USB Device(s) found
scanning bus usb@fe3e0000 for devices... 1 USB Device(s) found
scanning bus dwc3 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
365 bytes read in 8 ms (43.9 KiB/s)
## Executing script at 00500000
54757 bytes read in 17 ms (3.1 MiB/s)
12638216 bytes read in 1212 ms (9.9 MiB/s)
## Flattened Device Tree blob at 01f00000
     Booting using the fdt blob at 0x1f00000
```
It seems that `CONFIG_USE_PREBOOT=y` is causing the boot problem with OpenWrt, disabling it restore the normal boot.

```
U-Boot TPL 2021.01 (Jan 17 2021 - 20:22:39)
Channel 0: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=16/15 CS=1 Die BW=16 Size=2048MB
Channel 1: LPDDR4, 50MHz
BW=32 Col=10 Bk=8 CS0 Row=16/15 CS=1 Die BW=16 Size=2048MB
256B stride
lpddr4_set_rate: change freq to 400000000 mhz 0, 1
lpddr4_set_rate: change freq to 800000000 mhz 1, 0
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2021.01 (Jan 17 2021 - 20:22:39 +0000)
Trying to boot from MMC2


U-Boot 2021.01 (Jan 17 2021 - 20:22:39 +0000) OpenWrt

SoC: Rockchip rk3399
Reset cause: POR
Model: Pine64 RockPro64 v2.1
DRAM:  3.9 GiB
PMIC:  RK808 
MMC:   mmc@fe310000: 2, mmc@fe320000: 1, sdhci@fe330000: 0
Loading Environment from SPIFlash... SF: Detected gd25q128 with page size 256 Bytes, erase size 4 KiB, total 16 MiB
*** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Model: Pine64 RockPro64 v2.1
Net:   eth0: ethernet@fe300000
Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
365 bytes read in 8 ms (43.9 KiB/s)
## Executing script at 00500000
54757 bytes read in 17 ms (3.1 MiB/s)
12638216 bytes read in 1211 ms (10 MiB/s)
## Flattened Device Tree blob at 01f00000
   Booting using the fdt blob at 0x1f00000
   Loading Device Tree to 00000000f1f16000, end 00000000f1f265e4 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.4.89 (builder@buildhost) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r15520-54bfebdca0)) #0 SMP PREEMPT Sun Jan 17 20:22:39 2021
[    0.000000] Machine model: Pine64 RockPro64
```



