### PR TITLE
kernel: bump 5.4 to 5.4.91

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .90
+LINUX_VERSION-5.4 = .91
 
-LINUX_KERNEL_HASH-5.4.90 = 646736bc063f181c22648934f0dc3d97d49aec6edfd7358d2fe3df29fb66fa1a
+LINUX_KERNEL_HASH-5.4.91 = 0e0161bb034b9ba59e58a20985e49ecfb38104586602f53f37b382f508fc5c17
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/pending-5.4/613-netfilter_optional_tcp_window_check.patch
+++ b/target/linux/generic/pending-5.4/613-netfilter_optional_tcp_window_check.patch
@@ -49,7 +49,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static bool enable_hooks __read_mostly;
  MODULE_PARM_DESC(enable_hooks, "Always enable conntrack hooks");
  module_param(enable_hooks, bool, 0000);
-@@ -646,6 +649,7 @@ enum nf_ct_sysctl_index {
+@@ -649,6 +652,7 @@ enum nf_ct_sysctl_index {
  	NF_SYSCTL_CT_PROTO_TIMEOUT_GRE_STREAM,
  #endif
  
@@ -57,7 +57,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	__NF_SYSCTL_CT_LAST_SYSCTL,
  };
  
-@@ -972,6 +976,13 @@ static struct ctl_table nf_ct_sysctl_tab
+@@ -975,6 +979,13 @@ static struct ctl_table nf_ct_sysctl_tab
  		.proc_handler   = proc_dointvec_jiffies,
  	},
  #endif


### PR DESCRIPTION
All modification made by `update_kernel.sh` in a fresh clone without
existing toolchains.
```
Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800
```
No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>
