### PR TITLE
wolfssl: WOLFSSL_HAS_WPAS requires WOLFSSL_HAS_DH

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -43,6 +43,7 @@ config WOLFSSL_HAS_OCSP
 config WOLFSSL_HAS_WPAS
 	bool "Include wpa_supplicant support"
 	select WOLFSSL_HAS_ARC4
+	select WOLFSSL_HAS_DH
 	select WOLFSSL_HAS_OCSP
 	select WOLFSSL_HAS_SESSION_TICKET
 	default y


### PR DESCRIPTION
Without this, WOLFSSL_HAS_DH can be disabled even if WOLFSSL_HAS_WPAS is
enabled, resulting in an "Anonymous suite requires DH" error when trying
to compile wolfssl.

Signed-off-by: Pascal Ernster <git@hardfalcon.net>