### PR TITLE
build: display primary device name first

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -642,19 +642,19 @@ $(if $(strip $(DEVICE_ALT2_TITLE)),- $(DEVICE_ALT2_TITLE))
 endef
 
 define Device/Dump
+DEVICE_DISPLAY = x$$(DEVICE_TITLE)
 ifneq ($$(strip $$(DEVICE_ALT0_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT0_TITLE) ($$(DEVICE_TITLE))
+DEVICE_DISPLAY = $$(DEVICE_TITLE) ($$(DEVICE_ALT0_TITLE))
 $$(info $$(call Device/DumpInfo,$(1)))
 endif
 ifneq ($$(strip $$(DEVICE_ALT1_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT1_TITLE) ($$(DEVICE_TITLE))
+DEVICE_DISPLAY = $$(DEVICE_TITLE) ($$(DEVICE_ALT1_TITLE))
 $$(info $$(call Device/DumpInfo,$(1)))
 endif
 ifneq ($$(strip $$(DEVICE_ALT2_TITLE)),)
-DEVICE_DISPLAY = $$(DEVICE_ALT2_TITLE) ($$(DEVICE_TITLE))
+DEVICE_DISPLAY = $$(DEVICE_TITLE) ($$(DEVICE_ALT2_TITLE))
 $$(info $$(call Device/DumpInfo,$(1)))
 endif
-DEVICE_DISPLAY = $$(DEVICE_TITLE)
 $$(eval $$(if $$(DEVICE_TITLE),$$(info $$(call Device/DumpInfo,$(1)))))
 endef
 


### PR DESCRIPTION
Devices can have a name and alternative names
in the build system.

Change the displayed name in `make menuconfig`
to show the primary name first with alternatives
in parenthesis.

Example:
"Linksys Cobra (Linksys WRT1900AC v2)"
=> "Linksys WRT1900AC v2 (Linksys Cobra)"

Signed-off-by: Moritz Warning <moritzwarning@web.de>