### PR TITLE
ipq40xx: mikrotik: add MikroTik wAP ac support

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ipq40xx_setup_interfaces()
 	engenius,emr3500|\
 	engenius,ens620ext|\
 	luma,wrtq-329acn|\
+	mikrotik,routerboard-wap-g-5hacd2hnd|\
 	netgear,wac510|\
 	plasmacloud,pa1200|\
 	plasmacloud,pa2200)
@@ -207,7 +208,8 @@ ipq40xx_setup_macs()
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2|\
-	mikrotik,hap-ac3)
+	mikrotik,hap-ac3|\
+	mikrotik,routerboard-wap-g-5hacd2hnd)
 		wan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		lan_mac=$(macaddr_add $wan_mac 1)
 		label_mac="$wan_mac"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -115,7 +115,8 @@ case "$FIRMWARE" in
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3)
+	mikrotik,hap-ac3 |\
+	mikrotik,routerboard-wap-g-5hacd2hnd)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x0 0x2f20 ) || \
 		( [ -d "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data/data_0" 0x0 0x2f20 )
@@ -196,6 +197,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
+	mikrotik,routerboard-wap-g-5hacd2hnd |\
 	mikrotik,sxtsq-5-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x8000 0x2f20 ) || \

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -171,6 +171,7 @@ platform_do_upgrade() {
 	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
 	mikrotik,lhgg-60ad|\
+	mikrotik,routerboard-wap-g-5hacd2hnd |\
 	mikrotik,sxtsq-5-ac)
 		[ "$(rootfs_type)" = "tmpfs" ] && mtd erase firmware
 		default_do_upgrade "$1"

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-routerboard-wap-g-5hacd2hnd.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-routerboard-wap-g-5hacd2hnd.dts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2020, Robert Marko <robimarko@gmail.com> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "MikroTik RouterBOARD wAP G-5HacD2HnD";
+	compatible = "mikrotik,routerboard-wap-g-5hacd2hnd";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x08000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		usb3@8af8800 {
+			status = "okay";
+
+			dwc3@8a00000 {
+				phys = <&usb3_hs_phy>;
+				phy-names = "usb2-phy";
+			};
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		mode {
+			label = "mode";
+			gpios = <&tlmm 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power {
+			label = "blue:power";
+			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+			panic-indicator;
+		};
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <2>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	enable-usb-power {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "enable USB power";
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Qualcomm";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				label = "RouterBoot";
+				reg = <0x80000 0x80000>;
+				read-only;
+
+				hard_config {
+					read-only;
+				};
+
+				dtb_config {
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+
+			partition@100000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x100000 0xf00000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "MikroTik-RB-wap-g-5hacd2hnd";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "MikroTik-RB-wap-g-5hacd2hnd";
+};

--- a/target/linux/ipq40xx/image/mikrotik.mk
+++ b/target/linux/ipq40xx/image/mikrotik.mk
@@ -55,6 +55,14 @@ define Device/mikrotik_lhgg-60ad
 endef
 TARGET_DEVICES += mikrotik_lhgg-60ad
 
+define Device/mikrotik_routerboard-wap-g-5hacd2hnd
+	$(call Device/mikrotik_nor)
+	DEVICE_MODEL := RouterBOARD wAP G-5HacD2HnD (wAP AC)
+	SOC := qcom-ipq4018
+	DEVICE_PACKAGES := -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
+endef
+TARGET_DEVICES += mikrotik_routerboard-wap-g-5hacd2hnd
+
 define Device/mikrotik_sxtsq-5-ac
 	$(call Device/mikrotik_nor)
 	DEVICE_MODEL := SXTsq 5 ac (RBSXTsqG-5acD)


### PR DESCRIPTION
This adds support for the MikroTik RouterBOARD RBwAPG-5HacD2HnD
(wAP ac), a outdoor dual band, dual-radio 802.11ac
wireless AP with integrated omnidirectional antennae and two
10/100/1000 Mbps Ethernet ports.

See https://mikrotik.com/product/wap_ac for more info.

Specifications:
 - SoC: Qualcomm Atheros IPQ4018
 - RAM: 128 MB
 - Storage: 16 MB NOR
 - Wireless:
   · Built-in IPQ4018 (SoC) 802.11b/g/n 2x2:2, 2.5 dBi antennae
   · Built-in IPQ4018 (SoC) 802.11a/n/ac 2x2:2, 2.5 dBi antennae
 - Ethernet: Built-in IPQ4018 (SoC, QCA8075) , 2x 1000/100/10 port,
             802.3af/at PoE in

(Text edited 4/5/2021)