### PR TITLE
wireguard-tools: add ippeer option

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=wireguard-tools
 
 PKG_VERSION:=1.0.20210223
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=wireguard-tools-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://git.zx2c4.com/wireguard-tools/snapshot/

--- a/package/network/utils/wireguard-tools/files/wireguard.sh
+++ b/package/network/utils/wireguard-tools/files/wireguard.sh
@@ -108,6 +108,7 @@ proto_wireguard_setup() {
 	config_get private_key "${config}" "private_key"
 	config_get listen_port "${config}" "listen_port"
 	config_get addresses "${config}" "addresses"
+	config_get ippeer "${config}" "ippeer"
 	config_get mtu "${config}" "mtu"
 	config_get fwmark "${config}" "fwmark"
 	config_get ip6prefix "${config}" "ip6prefix"
@@ -153,13 +154,13 @@ proto_wireguard_setup() {
 				proto_add_ipv6_address "${address%%/*}" "${address##*/}"
 				;;
 			*.*/*)
-				proto_add_ipv4_address "${address%%/*}" "${address##*/}"
+				proto_add_ipv4_address "${address%%/*}" "${address##*/}" "" "${ippeer}"
 				;;
 			*:*)
 				proto_add_ipv6_address "${address%%/*}" "128"
 				;;
 			*.*)
-				proto_add_ipv4_address "${address%%/*}" "32"
+				proto_add_ipv4_address "${address%%/*}" "32" "" "${ippeer}"
 				;;
 		esac
 	done


### PR DESCRIPTION
This allow to set IPv4 peer address for point to point tunnel
This simplify a lot bird ospf usage / configuration
```
~# cat /etc/config/network
config interface 'test'
	option proto 'wireguard'
	option private_key '<key>'
	list addresses '1.2.3.4'
	option ippeer '5.6.7.8'
	option nohostroute '1'

~# ip a show test
9: test: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN qlen 1000
    link/[65534]
    inet 1.2.3.4 peer 5.6.7.8/32 brd 255.255.255.255 scope global test
       valid_lft forever preferred_lft forever
```
------------------------------------------------

`ippeer` is not really a good fit with `addresses` but I don't have a better idea for now.