### PR TITLE
[POC] Add APK package building capabilities to OpenWrt

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -59,6 +59,7 @@ $(curdir)/merge-index: $(curdir)/merge
 	(cd $(PACKAGE_DIR_ALL) && $(SCRIPT_DIR)/ipkg-make-index.sh . 2>&1 > Packages; )
 
 ifndef SDK
+  $(curdir)/compile: $(curdir)/utils/apk/host/compile
   $(curdir)/compile: $(curdir)/system/opkg/host/compile
 endif
 

--- a/package/Makefile
+++ b/package/Makefile
@@ -87,6 +87,7 @@ $(curdir)/index: FORCE
 	@for d in $(PACKAGE_SUBDIRS); do ( \
 		mkdir -p $$d; \
 		cd $$d || continue; \
+		$(SCRIPT_DIR)/apk-make-index.sh . 2>&1; \
 		$(SCRIPT_DIR)/ipkg-make-index.sh . 2>&1 > Packages.manifest; \
 		grep -vE '^(Maintainer|LicenseFiles|Source|SourceName|Require|SourceDateEpoch)' Packages.manifest > Packages; \
 		case "$$(((64 + $$(stat -L -c%s Packages)) % 128))" in 110|111) \

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -106,6 +106,10 @@ ifdef CONFIG_SIGNED_PACKAGES
 	[ -s $(BUILD_KEY).ucert ] || \
 		$(STAGING_DIR_HOST)/bin/ucert -I -c $(BUILD_KEY).ucert -p $(BUILD_KEY).pub -s $(BUILD_KEY)
 
+	[ -s $(BUILD_KEY_APK_SEC) -a -s $(BUILD_KEY_APK_PUB) ] || \
+		openssl ecparam -name prime256v1 -genkey -noout -out $(BUILD_KEY_APK_SEC); \
+		openssl ec -in $(BUILD_KEY_APK_SEC) -pubout > $(BUILD_KEY_APK_PUB)
+
   endef
 
 ifndef CONFIG_BUILDBOT

--- a/package/utils/apk/Makefile
+++ b/package/utils/apk/Makefile
@@ -1,0 +1,58 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=apk
+PKG_VERSION:=d02b1030e903ef372b962117a8ae93bf8bc43608
+PKG_RELEASE:=$(AUTORELEASE)
+
+PKG_SOURCE:=apk-tools-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://gitlab.alpinelinux.org/alpine/apk-tools/-/archive/$(PKG_VERSION)
+PKG_HASH:=530ec9f6cfde24b362c696199d002a693446e97ce536d3bb3b25788df17c730c
+PKG_BUILD_DIR:=$(BUILD_DIR)/apk-tools-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/apk-tools-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
+PKG_LICENSE:=GPL-2.0-only
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
+HOST_BUILD_DEPENDS:=libressl/host zlib/host
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+
+define Package/apk
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=apk package manager
+  DEPENDS:=+zlib +libopenssl +libpthread @!arc
+  URL:=$(PKG_SOURCE_URL)
+endef
+
+MAKE_FLAGS += LUA=no
+HOST_CFLAGS += -I$(STAGING_DIR_HOSTPKG)/lib/
+HOST_LDFLAGS += -pthread
+HOST_MAKE_FLAGS += \
+	DESTDIR=$(STAGING_DIR_HOSTPKG) \
+	LUA=no
+
+define Package/apk/install
+	$(INSTALL_DIR) $(1)/lib/apk/db
+
+	$(INSTALL_DIR) $(1)/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/sbin/apk $(1)/bin/apk
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/lib/* $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/apk.pc \
+		$(1)/usr/lib/pkgconfig/
+
+	$(INSTALL_DIR) $(1)/etc/apk/
+	echo $(ARCH) > $(1)/etc/apk/arch
+	touch $(1)/etc/apk/world
+endef
+
+$(eval $(call BuildPackage,apk))
+$(eval $(call HostBuild))

--- a/package/utils/apk/patches/0001-remove-doc-generation.patch
+++ b/package/utils/apk/patches/0001-remove-doc-generation.patch
@@ -1,0 +1,21 @@
+From b05a93c48fdbb50f0c464310dc2ce45777d32ea2 Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Fri, 2 Oct 2020 14:08:52 -1000
+Subject: [PATCH] remove doc generation
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -25,7 +25,7 @@ export DESTDIR SBINDIR LIBDIR CONFDIR MA
+ ##
+ # Top-level subdirs
+ 
+-subdirs		:= libfetch/ src/ doc/
++subdirs		:= libfetch/ src/
+ 
+ ##
+ # Include all rules and stuff

--- a/package/utils/apk/patches/fix-host-compilation.patch
+++ b/package/utils/apk/patches/fix-host-compilation.patch
@@ -1,0 +1,93 @@
+diff --git a/src/apk_pathbuilder.h b/src/apk_pathbuilder.h
+index 34181db..d70e400 100644
+--- a/src/apk_pathbuilder.h
++++ b/src/apk_pathbuilder.h
+@@ -10,6 +10,7 @@
+ #define APK_PATHBUILDER_H
+ 
+ #include "apk_blob.h"
++#include <limits.h>
+ 
+ struct apk_pathbuilder {
+ 	uint16_t namelen;
+diff --git a/src/app_mkpkg.c b/src/app_mkpkg.c
+index 3c3972b..26e3838 100644
+--- a/src/app_mkpkg.c
++++ b/src/app_mkpkg.c
+@@ -14,6 +14,7 @@
+ #include <assert.h>
+ #include <unistd.h>
+ #include <sys/stat.h>
++#include <limits.h>
+ 
+ #include "apk_defines.h"
+ #include "apk_adb.h"
+@@ -146,6 +147,8 @@ static int mkpkg_process_dirent(void *pctx, int dirfd, const char *entry)
+ 
+ 		adb_wa_append_obj(ctx->files, &fio);
+ 		break;
++	case S_IFLNK:
++		break;
+ 	default:
+ 		apk_pathbuilder_push(&ctx->pb, entry);
+ 		apk_err(out, "special file '%s' not supported",
+diff --git a/src/crypto_openssl.c b/src/crypto_openssl.c
+index 5512a49..4bb31c2 100644
+--- a/src/crypto_openssl.c
++++ b/src/crypto_openssl.c
+@@ -101,7 +101,7 @@ int apk_pkey_load(struct apk_pkey *pkey, int dirfd, const char *fn)
+ 
+ 	key = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL);
+ 	if (!key) {
+-		BIO_reset(bio);
++		(void ) BIO_reset(bio);
+ 		key = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+ 	}
+ 	ERR_clear_error();
+@@ -115,7 +115,7 @@ int apk_pkey_load(struct apk_pkey *pkey, int dirfd, const char *fn)
+ 
+ int apk_sign_start(struct apk_digest_ctx *dctx, struct apk_pkey *pkey)
+ {
+-	EVP_MD_CTX_set_pkey_ctx(dctx->mdctx, NULL);
++	//EVP_MD_CTX_set_pkey_ctx(dctx->mdctx, NULL);
+ 	if (EVP_DigestSignInit(dctx->mdctx, NULL, EVP_sha512(), NULL, pkey->key) != 1)
+ 		return -EIO;
+ 	return 0;
+@@ -130,7 +130,7 @@ int apk_sign(struct apk_digest_ctx *dctx, void *sig, size_t *len)
+ 
+ int apk_verify_start(struct apk_digest_ctx *dctx, struct apk_pkey *pkey)
+ {
+-	EVP_MD_CTX_set_pkey_ctx(dctx->mdctx, NULL);
++	//EVP_MD_CTX_set_pkey_ctx(dctx->mdctx, NULL);
+ 	if (EVP_DigestVerifyInit(dctx->mdctx, NULL, EVP_sha512(), NULL, pkey->key) != 1)
+ 		return -EIO;
+ 	return 0;
+diff --git a/src/database.c b/src/database.c
+index 0c5cd43..ac1ea19 100644
+--- a/src/database.c
++++ b/src/database.c
+@@ -1958,9 +1958,9 @@ static int update_permissions(apk_hash_item item, void *ctx)
+ 
+ 	r = fstatat(db->root_fd, dir->name, &st, AT_SYMLINK_NOFOLLOW);
+ 	if (r < 0 || (st.st_mode & 07777) != (dir->mode & 07777))
+-		fchmodat(db->root_fd, dir->name, dir->mode, 0);
++		return fchmodat(db->root_fd, dir->name, dir->mode, 0);
+ 	if (r < 0 || st.st_uid != dir->uid || st.st_gid != dir->gid)
+-		fchownat(db->root_fd, dir->name, dir->uid, dir->gid, 0);
++		return fchownat(db->root_fd, dir->name, dir->uid, dir->gid, 0);
+ 
+ 	return 0;
+ }
+diff --git a/src/print.c b/src/print.c
+index 26e31e2..ad60807 100644
+--- a/src/print.c
++++ b/src/print.c
+@@ -187,7 +187,7 @@ void apk_print_progress(struct apk_progress *p, size_t done, size_t total)
+ 	if (p->last_done == done && (!p->out || p->last_out_change == p->out->last_change)) return;
+ 	if (p->fd != 0) {
+ 		i = snprintf(buf, sizeof(buf), "%zu/%zu\n", done, total);
+-		write(p->fd, buf, i);
++		printf("%ld\n", write(p->fd, buf, i));
+ 	}
+ 	p->last_done = done;
+ 

--- a/rules.mk
+++ b/rules.mk
@@ -258,6 +258,8 @@ else
 endif
 
 BUILD_KEY=$(TOPDIR)/key-build
+BUILD_KEY_APK_SEC=$(TOPDIR)/private-key.pem
+BUILD_KEY_APK_PUB=$(TOPDIR)/public-key.pem
 
 FAKEROOT:=$(STAGING_DIR_HOST)/bin/fakeroot
 

--- a/scripts/apk-make-index.sh
+++ b/scripts/apk-make-index.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+pkg_dir=$1
+
+if [ -z "$pkg_dir" ] || [ ! -d "$pkg_dir" ]; then
+	echo "Usage: apk-make-index <package_directory>" >&2
+	exit 1
+fi
+
+(
+	cd "$pkg_dir" || exit 1
+	GLOBIGNORE="kernel*:libc*"
+	set -- *.apk
+	if [ "$1" = '*.apk' ]; then
+		echo "No APK packages found"
+	fi
+	apk index --output APKINDEX.tar.gz "$@"
+	unset GLOBIGNORE
+)


### PR DESCRIPTION
APK is the main package manager of Alpine Linux. This is just a proof of concept to double create package for OPKG and APK in parrallel.

(Personal) motivation is a long time replacement of OPKG with APK and join forces with Alpine Linux to create a great package manager for embedded devices rather than maintaining OPKG.

The scripts is heavily insprired by Alpines abuild script to create repositores.