### PR TITLE
kernel: bump 5.4 to 5.4.93

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .92
+LINUX_VERSION-5.4 = .93
 
-LINUX_KERNEL_HASH-5.4.92 = c0937ff98824c4b14cfea68a04340e0beb3c00f1cc02984daf2f3bdf542394fd
+LINUX_KERNEL_HASH-5.4.93 = d37449403664cc3b1bac96d0d9a199dbe619885cd899c0ae3108843f42e3d522
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
@@ -706,7 +706,7 @@
  EXPORT_SYMBOL(xfrm_parse_spi);
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
-@@ -3972,14 +3972,16 @@ static bool tcp_parse_aligned_timestamp(
+@@ -3973,14 +3973,16 @@ static bool tcp_parse_aligned_timestamp(
  {
  	const __be32 *ptr = (const __be32 *)(th + 1);
  

--- a/target/linux/bcm27xx/patches-5.4/950-0283-hid-usb-Add-device-quirks-for-Freeway-Airmouse-T3-an.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0283-hid-usb-Add-device-quirks-for-Freeway-Airmouse-T3-an.patch
@@ -33,7 +33,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  #define USB_VENDOR_ID_BELKIN		0x050d
  #define USB_DEVICE_ID_FLIP_KVM		0x3201
  
-@@ -1253,6 +1256,9 @@
+@@ -1254,6 +1257,9 @@
  #define USB_VENDOR_ID_XAT	0x2505
  #define USB_DEVICE_ID_XAT_CSR	0x0220
  

--- a/target/linux/bcm63xx/patches-5.4/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
+++ b/target/linux/bcm63xx/patches-5.4/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -666,6 +666,10 @@ int ehci_setup(struct usb_hcd *hcd)
+@@ -678,6 +678,10 @@ int ehci_setup(struct usb_hcd *hcd)
  
  	/* cache this readonly data; minimize chip reads */
  	ehci->hcs_params = ehci_readl(ehci, &ehci->caps->hcs_params);

--- a/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
+++ b/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
@@ -44,7 +44,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	  device, it has to decide which ones to send first, which ones to
 --- a/net/sched/sch_api.c
 +++ b/net/sched/sch_api.c
-@@ -2271,7 +2271,7 @@ static int __init pktsched_init(void)
+@@ -2272,7 +2272,7 @@ static int __init pktsched_init(void)
  		return err;
  	}
  

--- a/target/linux/generic/hack-5.4/721-phy_packets.patch
+++ b/target/linux/generic/hack-5.4/721-phy_packets.patch
@@ -136,7 +136,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #include <net/protocol.h>
  #include <net/dst.h>
-@@ -545,6 +546,22 @@ skb_fail:
+@@ -549,6 +550,22 @@ skb_fail:
  }
  EXPORT_SYMBOL(__napi_alloc_skb);
  

--- a/target/linux/generic/pending-5.4/110-ehci_hcd_ignore_oc.patch
+++ b/target/linux/generic/pending-5.4/110-ehci_hcd_ignore_oc.patch
@@ -17,7 +17,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -639,7 +639,7 @@ static int ehci_run (struct usb_hcd *hcd
+@@ -651,7 +651,7 @@ static int ehci_run (struct usb_hcd *hcd
  		"USB %x.%x started, EHCI %x.%02x%s\n",
  		((ehci->sbrn & 0xf0)>>4), (ehci->sbrn & 0x0f),
  		temp >> 8, temp & 0xff,
@@ -28,7 +28,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
  		    &ehci->regs->intr_enable); /* Turn On Interrupts */
 --- a/drivers/usb/host/ehci-hub.c
 +++ b/drivers/usb/host/ehci-hub.c
-@@ -640,7 +640,7 @@ ehci_hub_status_data (struct usb_hcd *hc
+@@ -643,7 +643,7 @@ ehci_hub_status_data (struct usb_hcd *hc
  	 * always set, seem to clear PORT_OCC and PORT_CSC when writing to
  	 * PORT_POWER; that's surprising, but maybe within-spec.
  	 */
@@ -37,7 +37,7 @@ Signed-off-by: Florian Fainelli <florian@openwrt.org>
  		mask = PORT_CSC | PORT_PEC | PORT_OCC;
  	else
  		mask = PORT_CSC | PORT_PEC;
-@@ -1010,7 +1010,7 @@ int ehci_hub_control(
+@@ -1013,7 +1013,7 @@ int ehci_hub_control(
  		if (temp & PORT_PEC)
  			status |= USB_PORT_STAT_C_ENABLE << 16;
  

--- a/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
+++ b/target/linux/generic/pending-5.4/690-net-add-support-for-threaded-NAPI-polling.patch
@@ -267,7 +267,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	/* Some drivers may have called napi_schedule
  	 * prior to exhausting their budget.
-@@ -10265,6 +10324,10 @@ static int __init net_dev_init(void)
+@@ -10270,6 +10329,10 @@ static int __init net_dev_init(void)
  		sd->backlog.weight = weight_p;
  	}
  

--- a/target/linux/layerscape/patches-5.4/303-core-0001-net-readd-skb_recycle.patch
+++ b/target/linux/layerscape/patches-5.4/303-core-0001-net-readd-skb_recycle.patch
@@ -24,7 +24,7 @@ Signed-off-by: Madalin Bucur <madalin.bucur@freescale.com>
  
 --- a/net/core/skbuff.c
 +++ b/net/core/skbuff.c
-@@ -941,6 +941,32 @@ void napi_consume_skb(struct sk_buff *sk
+@@ -945,6 +945,32 @@ void napi_consume_skb(struct sk_buff *sk
  }
  EXPORT_SYMBOL(napi_consume_skb);
  

--- a/target/linux/layerscape/patches-5.4/303-core-0002-drivers-base-add-sysfs-entries-for-suppliers-and-con.patch
+++ b/target/linux/layerscape/patches-5.4/303-core-0002-drivers-base-add-sysfs-entries-for-suppliers-and-con.patch
@@ -32,7 +32,7 @@ Signed-off-by: Ioana Ciornei <ioana.ciornei@nxp.com>
 +		a specific device.
 --- a/drivers/base/core.c
 +++ b/drivers/base/core.c
-@@ -1318,6 +1318,34 @@ static ssize_t online_store(struct devic
+@@ -1333,6 +1333,34 @@ static ssize_t online_store(struct devic
  }
  static DEVICE_ATTR_RW(online);
  
@@ -67,7 +67,7 @@ Signed-off-by: Ioana Ciornei <ioana.ciornei@nxp.com>
  int device_add_groups(struct device *dev, const struct attribute_group **groups)
  {
  	return sysfs_create_groups(&dev->kobj, groups);
-@@ -1489,8 +1517,20 @@ static int device_add_attrs(struct devic
+@@ -1504,8 +1532,20 @@ static int device_add_attrs(struct devic
  			goto err_remove_dev_groups;
  	}
  
@@ -88,7 +88,7 @@ Signed-off-by: Ioana Ciornei <ioana.ciornei@nxp.com>
   err_remove_dev_groups:
  	device_remove_groups(dev, dev->groups);
   err_remove_type_groups:
-@@ -1508,6 +1548,8 @@ static void device_remove_attrs(struct d
+@@ -1523,6 +1563,8 @@ static void device_remove_attrs(struct d
  	struct class *class = dev->class;
  	const struct device_type *type = dev->type;
  

--- a/target/linux/layerscape/patches-5.4/701-net-0238-net-mscc-ocelot-break-apart-ocelot_vlan_port_apply.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0238-net-mscc-ocelot-break-apart-ocelot_vlan_port_apply.patch
@@ -287,7 +287,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		}
  		if (netif_is_lag_master(info->upper_dev)) {
  			if (info->linking)
-@@ -2011,6 +2034,7 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2009,6 +2032,7 @@ int ocelot_probe_port(struct ocelot *oce
  {
  	struct ocelot_port *ocelot_port;
  	struct net_device *dev;
@@ -295,7 +295,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	int err;
  
  	dev = alloc_etherdev(sizeof(struct ocelot_port));
-@@ -2046,7 +2070,15 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2044,7 +2068,15 @@ int ocelot_probe_port(struct ocelot *oce
  	}
  
  	/* Basic L2 initialization */

--- a/target/linux/layerscape/patches-5.4/701-net-0243-net-mscc-ocelot-refactor-struct-ocelot_port-out-of-f.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0243-net-mscc-ocelot-refactor-struct-ocelot_port-out-of-f.patch
@@ -231,7 +231,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  						      info->upper_dev);
  		}
  		break;
-@@ -2140,7 +2133,7 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2138,7 +2131,7 @@ int ocelot_probe_port(struct ocelot *oce
  		       REW_PORT_VLAN_CFG, port);
  
  	/* Enable vcap lookups */

--- a/target/linux/layerscape/patches-5.4/701-net-0244-net-mscc-ocelot-separate-net_device-related-items-ou.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0244-net-mscc-ocelot-separate-net_device-related-items-ou.patch
@@ -707,7 +707,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		}
  		if (netif_is_lag_master(info->upper_dev)) {
  			if (info->linking)
-@@ -2084,21 +2110,23 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2082,21 +2108,23 @@ int ocelot_probe_port(struct ocelot *oce
  		      void __iomem *regs,
  		      struct phy_device *phy)
  {

--- a/target/linux/layerscape/patches-5.4/701-net-0247-net-mscc-ocelot-move-port-initialization-into-separa.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0247-net-mscc-ocelot-move-port-initialization-into-separa.patch
@@ -15,7 +15,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2137,6 +2137,28 @@ static int ocelot_init_timestamp(struct
+@@ -2135,6 +2135,28 @@ static int ocelot_init_timestamp(struct
  	return 0;
  }
  
@@ -44,7 +44,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  int ocelot_probe_port(struct ocelot *ocelot, u8 port,
  		      void __iomem *regs,
  		      struct phy_device *phy)
-@@ -2144,7 +2166,6 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2142,7 +2164,6 @@ int ocelot_probe_port(struct ocelot *oce
  	struct ocelot_port_private *priv;
  	struct ocelot_port *ocelot_port;
  	struct net_device *dev;
@@ -52,7 +52,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	int err;
  
  	dev = alloc_etherdev(sizeof(struct ocelot_port_private));
-@@ -2172,32 +2193,14 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2170,32 +2191,14 @@ int ocelot_probe_port(struct ocelot *oce
  	ocelot_mact_learn(ocelot, PGID_CPU, dev->dev_addr, ocelot_port->pvid,
  			  ENTRYTYPE_LOCKED);
  

--- a/target/linux/layerscape/patches-5.4/701-net-0249-net-mscc-ocelot-initialize-list-of-multicast-address.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0249-net-mscc-ocelot-initialize-list-of-multicast-address.patch
@@ -17,7 +17,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2247,6 +2247,7 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2245,6 +2245,7 @@ int ocelot_init(struct ocelot *ocelot)
  	if (!ocelot->stats_queue)
  		return -ENOMEM;
  

--- a/target/linux/layerscape/patches-5.4/701-net-0251-net-mscc-ocelot-split-assignment-of-the-cpu-port-int.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0251-net-mscc-ocelot-split-assignment-of-the-cpu-port-int.patch
@@ -32,7 +32,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	/* Set vlan ingress filter mask to all ports but the CPU port by
  	 * default.
  	 */
-@@ -2228,11 +2222,52 @@ int ocelot_probe_port(struct ocelot *oce
+@@ -2226,11 +2220,52 @@ int ocelot_probe_port(struct ocelot *oce
  }
  EXPORT_SYMBOL(ocelot_probe_port);
  
@@ -87,7 +87,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	ocelot->lags = devm_kcalloc(ocelot->dev, ocelot->num_phys_ports,
  				    sizeof(u32), GFP_KERNEL);
-@@ -2312,13 +2347,6 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2310,13 +2345,6 @@ int ocelot_init(struct ocelot *ocelot)
  		ocelot_write_rix(ocelot, 0, ANA_PGID_PGID, PGID_SRC + port);
  	}
  
@@ -101,7 +101,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	/* Allow broadcast MAC frames. */
  	for (i = ocelot->num_phys_ports + 1; i < PGID_CPU; i++) {
  		u32 val = ANA_PGID_PGID_PGID(GENMASK(ocelot->num_phys_ports - 1, 0));
-@@ -2331,13 +2359,6 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2329,13 +2357,6 @@ int ocelot_init(struct ocelot *ocelot)
  	ocelot_write_rix(ocelot, 0, ANA_PGID_PGID, PGID_MCIPV4);
  	ocelot_write_rix(ocelot, 0, ANA_PGID_PGID, PGID_MCIPV6);
  

--- a/target/linux/layerscape/patches-5.4/701-net-0255-net-mscc-ocelot-move-invariant-configs-out-of-adjust.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0255-net-mscc-ocelot-move-invariant-configs-out-of-adjust.patch
@@ -98,7 +98,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  }
  
  static void ocelot_port_adjust_link(struct net_device *dev)
-@@ -2145,11 +2104,53 @@ static int ocelot_init_timestamp(struct
+@@ -2143,11 +2102,53 @@ static int ocelot_init_timestamp(struct
  static void ocelot_init_port(struct ocelot *ocelot, int port)
  {
  	struct ocelot_port *ocelot_port = ocelot->ports[port];

--- a/target/linux/layerscape/patches-5.4/701-net-0256-net-mscc-ocelot-create-a-helper-for-changing-the-por.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0256-net-mscc-ocelot-create-a-helper-for-changing-the-por.patch
@@ -20,7 +20,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2101,11 +2101,32 @@ static int ocelot_init_timestamp(struct
+@@ -2099,11 +2099,32 @@ static int ocelot_init_timestamp(struct
  	return 0;
  }
  
@@ -54,7 +54,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	INIT_LIST_HEAD(&ocelot_port->skbs);
  
  	/* Basic L2 initialization */
-@@ -2126,8 +2147,7 @@ static void ocelot_init_port(struct ocel
+@@ -2124,8 +2145,7 @@ static void ocelot_init_port(struct ocel
  			   DEV_MAC_HDX_CFG);
  
  	/* Set Max Length and maximum tags allowed */
@@ -64,7 +64,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	ocelot_port_writel(ocelot_port, DEV_MAC_TAGS_CFG_TAG_ID(ETH_P_8021AD) |
  			   DEV_MAC_TAGS_CFG_VLAN_AWR_ENA |
  			   DEV_MAC_TAGS_CFG_VLAN_LEN_AWR_ENA,
-@@ -2137,20 +2157,6 @@ static void ocelot_init_port(struct ocel
+@@ -2135,20 +2155,6 @@ static void ocelot_init_port(struct ocel
  	ocelot_port_writel(ocelot_port, 0, DEV_MAC_FC_MAC_HIGH_CFG);
  	ocelot_port_writel(ocelot_port, 0, DEV_MAC_FC_MAC_LOW_CFG);
  

--- a/target/linux/layerscape/patches-5.4/701-net-0258-net-mscc-ocelot-adjust-MTU-on-the-CPU-port-in-NPI-mo.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0258-net-mscc-ocelot-adjust-MTU-on-the-CPU-port-in-NPI-mo.patch
@@ -22,7 +22,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2234,9 +2234,18 @@ void ocelot_set_cpu_port(struct ocelot *
+@@ -2232,9 +2232,18 @@ void ocelot_set_cpu_port(struct ocelot *
  	 * Only one port can be an NPI at the same time.
  	 */
  	if (cpu < ocelot->num_phys_ports) {

--- a/target/linux/layerscape/patches-5.4/701-net-0259-net-mscc-ocelot-separate-the-implementation-of-switc.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0259-net-mscc-ocelot-separate-the-implementation-of-switc.patch
@@ -20,7 +20,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2273,6 +2273,14 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2271,6 +2271,14 @@ int ocelot_init(struct ocelot *ocelot)
  	int i, ret;
  	u32 port;
  

--- a/target/linux/layerscape/patches-5.4/701-net-0260-net-mscc-ocelot-publish-structure-definitions-to-inc.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0260-net-mscc-ocelot-publish-structure-definitions-to-inc.patch
@@ -329,7 +329,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  static void ocelot_set_aggr_pgids(struct ocelot *ocelot)
  {
-@@ -2123,7 +2136,7 @@ static void ocelot_port_set_mtu(struct o
+@@ -2121,7 +2134,7 @@ static void ocelot_port_set_mtu(struct o
  	ocelot_write(ocelot, ocelot_wm_enc(atop_wm), SYS_ATOP_TOT_CFG);
  }
  
@@ -338,7 +338,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  {
  	struct ocelot_port *ocelot_port = ocelot->ports[port];
  
-@@ -2170,6 +2183,7 @@ static void ocelot_init_port(struct ocel
+@@ -2168,6 +2181,7 @@ static void ocelot_init_port(struct ocel
  	/* Enable vcap lookups */
  	ocelot_vcap_enable(ocelot, port);
  }

--- a/target/linux/layerscape/patches-5.4/701-net-0271-net-mscc-ocelot-use-skb-queue-instead-of-skbs-list.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0271-net-mscc-ocelot-use-skb-queue-instead-of-skbs-list.patch
@@ -96,7 +96,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
  }
  EXPORT_SYMBOL(ocelot_get_txtstamp);
-@@ -2210,7 +2201,7 @@ void ocelot_init_port(struct ocelot *oce
+@@ -2208,7 +2199,7 @@ void ocelot_init_port(struct ocelot *oce
  {
  	struct ocelot_port *ocelot_port = ocelot->ports[port];
  
@@ -105,7 +105,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	/* Basic L2 initialization */
  
-@@ -2495,9 +2486,7 @@ EXPORT_SYMBOL(ocelot_init);
+@@ -2493,9 +2484,7 @@ EXPORT_SYMBOL(ocelot_init);
  
  void ocelot_deinit(struct ocelot *ocelot)
  {
@@ -115,7 +115,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	int i;
  
  	cancel_delayed_work(&ocelot->stats_work);
-@@ -2509,14 +2498,7 @@ void ocelot_deinit(struct ocelot *ocelot
+@@ -2507,14 +2496,7 @@ void ocelot_deinit(struct ocelot *ocelot
  
  	for (i = 0; i < ocelot->num_phys_ports; i++) {
  		port = ocelot->ports[i];

--- a/target/linux/layerscape/patches-5.4/701-net-0272-net-mscc-ocelot-tsn-configuration-support.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0272-net-mscc-ocelot-tsn-configuration-support.patch
@@ -41,7 +41,7 @@ Signed-off-by: Xiaoliang Yang <xiaoliang.yang_1@nxp.com>
  		ocelot_write_rix(ocelot, val, ANA_PGID_PGID, i);
  
  	__dev_mc_sync(dev, ocelot_mc_sync, ocelot_mc_unsync);
-@@ -2412,10 +2412,11 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2410,10 +2410,11 @@ int ocelot_init(struct ocelot *ocelot)
  		     SYS_FRM_AGING_MAX_AGE(307692), SYS_FRM_AGING);
  
  	/* Setup flooding PGIDs */

--- a/target/linux/layerscape/patches-5.4/701-net-0341-LF-368-net-mscc-ocelot-add-VCAP-IS2-rule-to-trap-PTP.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0341-LF-368-net-mscc-ocelot-add-VCAP-IS2-rule-to-trap-PTP.patch
@@ -14,7 +14,7 @@ Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2342,6 +2342,20 @@ void ocelot_set_cpu_port(struct ocelot *
+@@ -2340,6 +2340,20 @@ void ocelot_set_cpu_port(struct ocelot *
  }
  EXPORT_SYMBOL(ocelot_set_cpu_port);
  
@@ -35,7 +35,7 @@ Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
  int ocelot_init(struct ocelot *ocelot)
  {
  	char queue_name[32];
-@@ -2479,6 +2493,13 @@ int ocelot_init(struct ocelot *ocelot)
+@@ -2477,6 +2491,13 @@ int ocelot_init(struct ocelot *ocelot)
  				"Timestamp initialization failed\n");
  			return ret;
  		}
@@ -49,7 +49,7 @@ Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
  	}
  
  	return 0;
-@@ -2493,6 +2514,8 @@ void ocelot_deinit(struct ocelot *ocelot
+@@ -2491,6 +2512,8 @@ void ocelot_deinit(struct ocelot *ocelot
  	cancel_delayed_work(&ocelot->stats_work);
  	destroy_workqueue(ocelot->stats_queue);
  	mutex_destroy(&ocelot->stats_lock);

--- a/target/linux/layerscape/patches-5.4/701-net-0367-net-mscc-ocelot-Workaround-to-allow-traffic-to-CPU-i.patch
+++ b/target/linux/layerscape/patches-5.4/701-net-0367-net-mscc-ocelot-Workaround-to-allow-traffic-to-CPU-i.patch
@@ -128,7 +128,7 @@ Signed-off-by: Vladimir Oltean <vladimir.oltean@nxp.com>
 
 --- a/drivers/net/ethernet/mscc/ocelot.c
 +++ b/drivers/net/ethernet/mscc/ocelot.c
-@@ -2296,6 +2296,18 @@ void ocelot_set_cpu_port(struct ocelot *
+@@ -2294,6 +2294,18 @@ void ocelot_set_cpu_port(struct ocelot *
  			 enum ocelot_tag_prefix injection,
  			 enum ocelot_tag_prefix extraction)
  {

--- a/target/linux/layerscape/patches-5.4/820-usb-0014-MLK-17380-3-usb-move-EH-SINGLE_STEP_SET_FEATURE-impl.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0014-MLK-17380-3-usb-move-EH-SINGLE_STEP_SET_FEATURE-impl.patch
@@ -163,7 +163,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -1233,6 +1233,10 @@ static const struct hc_driver ehci_hc_dr
+@@ -1245,6 +1245,10 @@ static const struct hc_driver ehci_hc_dr
  	 * device support
  	 */
  	.free_dev =		ehci_remove_device,
@@ -176,7 +176,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  void ehci_init_driver(struct hc_driver *drv,
 --- a/drivers/usb/host/ehci-hub.c
 +++ b/drivers/usb/host/ehci-hub.c
-@@ -724,145 +724,6 @@ ehci_hub_descriptor (
+@@ -727,145 +727,6 @@ ehci_hub_descriptor (
  }
  
  /*-------------------------------------------------------------------------*/

--- a/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
@@ -42,7 +42,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  			retval = xhci_enter_test_mode(xhci, test_mode, wIndex,
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -3580,6 +3580,129 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
+@@ -3582,6 +3582,129 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
  	return 0;
  }
  

--- a/target/linux/realtek/patches-5.4/302-clocksource-add-rtl9300-driver.patch
+++ b/target/linux/realtek/patches-5.4/302-clocksource-add-rtl9300-driver.patch
@@ -1,6 +1,6 @@
 --- a/drivers/clocksource/Kconfig
 +++ b/drivers/clocksource/Kconfig
-@@ -126,6 +126,15 @@
+@@ -126,6 +126,15 @@ config RDA_TIMER
  	help
  	  Enables the support for the RDA Micro timer driver.
  
@@ -16,7 +16,7 @@
  config SUN4I_TIMER
  	bool "Sun4i timer driver" if COMPILE_TEST
  	depends on HAS_IOMEM
-@@ -695,5 +704,4 @@
+@@ -695,5 +704,4 @@ config INGENIC_TIMER
  	select IRQ_DOMAIN
  	help
  	  Support for the timer/counter unit of the Ingenic JZ SoCs.
@@ -24,7 +24,7 @@
  endmenu
 --- a/drivers/clocksource/Makefile
 +++ b/drivers/clocksource/Makefile
-@@ -61,6 +61,7 @@
+@@ -61,6 +61,7 @@ obj-$(CONFIG_MILBEAUT_TIMER)	+= timer-mi
  obj-$(CONFIG_SPRD_TIMER)	+= timer-sprd.o
  obj-$(CONFIG_NPCM7XX_TIMER)	+= timer-npcm7xx.o
  obj-$(CONFIG_RDA_TIMER)		+= timer-rda.o

--- a/target/linux/realtek/patches-5.4/701-net-dsa-add-rtl838x-support-for-tag-trailer.patch
+++ b/target/linux/realtek/patches-5.4/701-net-dsa-add-rtl838x-support-for-tag-trailer.patch
@@ -13,7 +13,7 @@
  	trailer[2] = 0x10;
  	trailer[3] = 0x00;
  
-@@ -61,12 +69,23 @@ static struct sk_buff *trailer_rcv(struc
+@@ -61,12 +66,23 @@ static struct sk_buff *trailer_rcv(struc
  		return NULL;
  
  	trailer = skb_tail_pointer(skb) - 4;


### PR DESCRIPTION
All modification made by `update_kernel.sh` in a fresh clone without
existing toolchains.
```
Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800
```
No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>