### PR TITLE
[19.07] ramips: add support for Wavlink WL-WN577A2

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -382,6 +382,10 @@ wavlink,wl-wn575a3)
 	ucidef_set_led_rssi "wifi-med" "wifi-med" "$boardname:green:wifi-med" "wlan1" "50" "84"
 	ucidef_set_led_rssi "wifi-high" "wifi-high" "$boardname:green:wifi-high" "wlan1" "85" "100"
 	;;
+wavlink,wl-wn577a2)
+        ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x8"
+        ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
+        ;;
 we1026-5g-16m)
 	ucidef_set_led_netdev "lan" "LAN" "we1026-5g:green:lan" "eth0"
 	set_wifi_led "we1026-5g:green:wifi"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -178,7 +178,8 @@ ramips_setup_interfaces()
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
 	alfa-network,r36m-e4g|\
-	wcr-1166ds)
+	wcr-1166ds|\
+	wavlink,wl-wn577a2)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
 		;;
@@ -659,6 +660,10 @@ ramips_setup_macs()
 	w306r-v20)
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 5)
+		;;
+	wavlink,wl-wn577a2)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	wcr-1166ds|\
 	wsr-1166)

--- a/target/linux/ramips/dts/WL-WN577A2.dts
+++ b/target/linux/ramips/dts/WL-WN577A2.dts
@@ -1,0 +1,138 @@
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7628an.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn577a2", "maginon,wlr-755", "mediatek,mt7628an-soc";
+	model = "Wavlink WL-WN577A2";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			label = "wl-wn577a2:green:lan";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "wl-wn577a2:green:wan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps: wps {
+			label = "wl-wn577a2:green:wps";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "wdt", "p0led_an", "p3led_an", "p4led_an";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -419,6 +419,15 @@ define Device/wcr-1166ds
 endef
 TARGET_DEVICES += wcr-1166ds
 
+define Device/wavlink_wl-wn577a2
+  DTS := WL-WN577A2
+  IMAGE_SIZE := 7872k
+  DEVICE_TITLE := Wavlink WL-WN577A2
+  DEVICE_PACKAGES := kmod-mt76x0e
+  SUPPORTED_DEVICES += wl-wn577a2
+endef
+TARGET_DEVICES += wavlink_wl-wn577a2
+
 define Device/widora_neo-16m
   DTS := WIDORA-NEO-16M
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
This commit adds support for the Wavlink WL-WN577A2 (black case) dual-band
wall-plug wireless router. In Germany this device is sold under the brand
name Maginon WL-755 (white case). Modified from @lrswss:

Device specifications:

- CPU: MediaTek MT7628AN (580MHz)
- Flash: 8MB
- RAM: 64MB
- Bootloader: U-Boot
- Ethernet: 2x 10/100 Mbps (Ralink RT3050)
- 2.4 GHz: 802.11b/g/n SoC
- 5 GHz: 802.11a/n/ac MT7610E
- Antennas: internal
- 4 green LEDs: 1 programmable (WPS) + LAN, WAN, POWER
- Buttons: Reset, WPS
- Small sliding power switch

Flashing instructions (U-boot):

- Configure a TFTP server on your PC/Laptop and set its IP
  to 192.168.10.100

- Rename the OpenWrt image to firmware.bin and place it in the
  root folder of the TFTP server

- Power off (using the small sliding power switch on the left
  side) the device and connect an ethernet cable from its LAN
  or WAN port to your PC/Laptop

- Press the WPS button (and keep it pressed)

- Power on the device (using the small power switch)

- After a few seconds, when the WAN/LAN LED stops blinking
  very fast, release the WPS button

- Flashing OpenWrt takes less than a minute, system will
  reboot automatically

- After reboot the WPS LED will indicate the current OpenWrt
  running status

Signed-off by: Trey Sis <treysis@gmx.net>