### PR TITLE
ramips: add support for HiLink HLK-7621A

### DIFF
--- a/target/linux/ramips/dts/mt7621_hilink_hlk-7621a.dts
+++ b/target/linux/ramips/dts/mt7621_hilink_hlk-7621a.dts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+/ {
+	compatible = "hilink,hlk-7621a", "mediatek,mt7621-soc";
+	model = "HiLink HLK-7621A";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <44000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -531,9 +531,9 @@ TARGET_DEVICES += gnubee_gb-pc2
 
 define Device/hilink_hlk-7621a
   $(Device/dsa-migration)
-  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := HiLink
   DEVICE_MODEL := HLK-7621A
+  IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += hilink_hlk-7621a
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -529,6 +529,14 @@ define Device/gnubee_gb-pc2
 endef
 TARGET_DEVICES += gnubee_gb-pc2
 
+define Device/hilink_hlk-7621a
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := HiLink
+  DEVICE_MODEL := HLK-7621A
+endef
+TARGET_DEVICES += hilink_hlk-7621a
+
 define Device/hiwifi_hc5962
   $(Device/dsa-migration)
   BLOCKSIZE := 128k


### PR DESCRIPTION
Specifications:

- SoC: MediaTek MT7621AT
- RAM: 256 MB (DDR3)
- Flash: 32 MB SPI NOR 44MHz
- Switch: 1 WAN, 4 LAN (Gigabit)
- LEDs: 1 WAN, 4 LAN (controlled by PHY)

UART Serial:
UART1 as console : 57600 baud

Installation:

- Update firmware by internal GNUBEE uboot: [https://github.com/gnubee-git/GnuBee-MT7621-uboot](url)
- By HTTP: Initial uboot address is http://10.10.10.123, your address needs to be 10.10.10.x, and mask 255.255.255.0.
- By TFTP: Uboot is in client mode, the address of the firmware must be tftp://10.10.10.3/uboot.bin

Recovery:

- Manufacturer provides MTK OpenWrt 14.07 source code, compile then flash it by uboot.

HLK-7621A is a stamp hole package module for embedded development, users have to design IO boards to use it.  So only basic IOs are defined in the DTS file.

User Manual (Chinese & English):
[HLK-7621A用户手册V1.5.pdf](https://github.com/openwrt/openwrt/files/5884699/HLK-7621A.V1.5.pdf)

Signed-off-by: Chen Yijun cyjason@bupt.edu.cn