### PR TITLE
ath79: add Mikrotik mAP lite support

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-mapl-2nd.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9533_mikrotik_routerboard-16m.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-mapl-2nd", "qca,qca9533";
+	model = "MikroTik RouterBOARD mAPL-2nD (mAP lite)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		eth {
+			label = "green:eth";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		user {
+			label = "green:user";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio {
+	// gpios 4,11,14,17
+	mask = <0x00024810>;
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -35,6 +35,14 @@ define Device/mikrotik_routerboard-lhg-2nd
 endef
 TARGET_DEVICES += mikrotik_routerboard-lhg-2nd
 
+define Device/mikrotik_routerboard-mapl-2nd
+  $(Device/mikrotik_nor)
+  SOC := qca9533
+  DEVICE_MODEL := RouterBOARD mAPL-2nD (mAP lite)
+  IMAGE_SIZE := 16256k
+endef
+TARGET_DEVICES += mikrotik_routerboard-mapl-2nd
+
 define Device/mikrotik_routerboard-sxt-5nd-r2
   $(Device/mikrotik_nand)
   SOC := ar9344

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -10,6 +10,9 @@ case "$board" in
 mikrotik,routerboard-lhg-2nd)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+mikrotik,routerboard-mapl-2nd)
+	ucidef_set_led_netdev "lan" "lan" "green:eth" "eth0"
+	;;
 mikrotik,routerboard-wapr-2nd)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd|\
 	mikrotik,routerboard-lhg-2nd|\
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)
@@ -40,6 +41,7 @@ ath79_setup_macs()
 	case "$board" in
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-lhg-2nd|\
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-sxt-5nd-r2|\
 	mikrotik,routerboard-wap-g-5hact2hnd|\
 	mikrotik,routerboard-wapr-2nd)

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -28,6 +28,7 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-wapr-2nd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" +1)
 		;;
+	mikrotik,routerboard-mapl-2nd|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" +2)
 		;;

--- a/target/linux/ath79/patches-5.4/931-fix-ar71xx-registers.patch
+++ b/target/linux/ath79/patches-5.4/931-fix-ar71xx-registers.patch
@@ -1,0 +1,16 @@
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+@@ -923,11 +923,11 @@
+ #define AR71XX_GPIO_REG_OUT		0x08
+ #define AR71XX_GPIO_REG_SET		0x0c
+ #define AR71XX_GPIO_REG_CLEAR		0x10
+-#define AR71XX_GPIO_REG_INT_MODE	0x14
++#define AR71XX_GPIO_REG_INT_ENABLE	0x14
+ #define AR71XX_GPIO_REG_INT_TYPE	0x18
+ #define AR71XX_GPIO_REG_INT_POLARITY	0x1c
+ #define AR71XX_GPIO_REG_INT_PENDING	0x20
+-#define AR71XX_GPIO_REG_INT_ENABLE	0x24
++#define AR71XX_GPIO_REG_INT_MASK	0x24
+ #define AR71XX_GPIO_REG_FUNC		0x28
+ 
+ #define AR934X_GPIO_REG_OUT_FUNC0	0x2c

--- a/target/linux/ath79/patches-5.4/932-add-qca953x-gpio-mask.patch
+++ b/target/linux/ath79/patches-5.4/932-add-qca953x-gpio-mask.patch
@@ -1,0 +1,55 @@
+--- a/drivers/gpio/gpio-ath79.c
++++ b/drivers/gpio/gpio-ath79.c
+@@ -14,17 +14,7 @@
+ #include <linux/interrupt.h>
+ #include <linux/module.h>
+ #include <linux/irq.h>
+-
+-#define AR71XX_GPIO_REG_OE		0x00
+-#define AR71XX_GPIO_REG_IN		0x04
+-#define AR71XX_GPIO_REG_SET		0x0c
+-#define AR71XX_GPIO_REG_CLEAR		0x10
+-
+-#define AR71XX_GPIO_REG_INT_ENABLE	0x14
+-#define AR71XX_GPIO_REG_INT_TYPE	0x18
+-#define AR71XX_GPIO_REG_INT_POLARITY	0x1c
+-#define AR71XX_GPIO_REG_INT_PENDING	0x20
+-#define AR71XX_GPIO_REG_INT_MASK	0x24
++#include <asm/mach-ath79/ar71xx_regs.h>
+ 
+ struct ath79_gpio_ctrl {
+ 	struct gpio_chip gc;
+@@ -230,6 +220,8 @@
+ 	u32 ath79_gpio_count;
+ 	bool oe_inverted;
+ 	int err;
++	u32 gpio_mask;
++	u32 gpio;
+ 
+ 	ctrl = devm_kzalloc(dev, sizeof(*ctrl), GFP_KERNEL);
+ 	if (!ctrl)
+@@ -263,6 +255,24 @@
+ 	if (!ctrl->base)
+ 		return -ENOMEM;
+ 
++	of_property_read_u32(np, "mask", &gpio_mask);
++	if (gpio_mask != 0) {
++		for (gpio = 0; gpio < 32; gpio++) {
++			if (1 << gpio & gpio_mask) {
++				unsigned int reg = AR934X_GPIO_REG_OUT_FUNC0 + 4 * (gpio / 4);
++				u32 t, s = 8 * (gpio % 4);
++
++				t = readl(ctrl->base + reg);
++				t &= ~(0xff << s);
++				t |= AR934X_GPIO_OUT_GPIO << s;
++				writel(t, ctrl->base + reg);
++
++				/* flush write */
++				(void) readl(ctrl->base + reg);
++			}
++		}
++	}
++
+ 	raw_spin_lock_init(&ctrl->lock);
+ 	err = bgpio_init(&ctrl->gc, dev, 4,
+ 			ctrl->base + AR71XX_GPIO_REG_IN,


### PR DESCRIPTION
... and fix some minor errors in kernel ar71xx_regs.h include file.

As boot loader leaves some of the gpio pins that control leds in a not-controllable-by-gpio-output state, a DT gpio mask property is introduced that can be used to properly configure the gpio output pins (more or less copy pasted from the cod e from ar71xx target)
