### PR TITLE
Revert "build: replace which with Bash command built-in"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell command -pv pkg-config | grep -E '\/usr' | head -n 1)
+DISTRO_PKG_CONFIG:=$(shell which -a pkg-config | grep -E '\/usr' | head -n 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)

--- a/include/cmake.mk
+++ b/include/cmake.mk
@@ -15,7 +15,7 @@ MAKE_PATH = $(firstword $(CMAKE_BINARY_SUBDIR) .)
 ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
   cmake_tool=$(TOOLCHAIN_DIR)/bin/$(1)
 else
-  cmake_tool=$(shell command -v $(1))
+  cmake_tool=$(shell which $(1))
 endif
 
 ifeq ($(CONFIG_CCACHE),)

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -52,7 +52,7 @@ endef
 
 define RequireCommand
   define Require/$(1)
-    command -pv $(1)
+    which $(1)
   endef
 
   $$(eval $$(call Require,$(1),$(2)))
@@ -106,7 +106,7 @@ define SetupHostCommand
 	           $(call QuoteHostCommand,$(11)) $(call QuoteHostCommand,$(12)); do \
 		if [ -n "$$$$$$$$cmd" ]; then \
 			bin="$$$$$$$$(PATH="$(subst $(space),:,$(filter-out $(STAGING_DIR_HOST)/%,$(subst :,$(space),$(PATH))))" \
-				command -pv "$$$$$$$${cmd%% *}")"; \
+				which "$$$$$$$${cmd%% *}")"; \
 			if [ -x "$$$$$$$$bin" ] && eval "$$$$$$$$cmd" >/dev/null 2>/dev/null; then \
 				mkdir -p "$(STAGING_DIR_HOST)/bin"; \
 				ln -sf "$$$$$$$$bin" "$(STAGING_DIR_HOST)/bin/$(strip $(1))"; \


### PR DESCRIPTION
This reverts commit c7aec47e5e3a3ff7b5fdaa11cd1e62cae6746acb.

The original commit replaces 'which' with 'command'. Sadly most of
them are not equivalent and for 'which -a', there is no easy
replacements that would not reimplement PATH parsing logic. Hence
revert. Keeping a dependency on which is absolutely fine.
