### PR TITLE
ramips: add support for the Wavlink WL-WN579X3

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,wl-wn579x3", "ralink,mt7620a-soc";
+	model = "Wavlink WL-WN579X3";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		switch_aps {
+			label = "mode_aps";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		switch_repeater {
+			label = "mode_repeater";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "blue:wps";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		/* These three form the signal wifi strength segments */
+		wifi_high {
+			label = "blue:wifi_high";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_medium {
+			label = "blue:wifi_medium";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_low {
+			label = "blue:wifi_low";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "board_data";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	mtd-mac-address = <&factory 0x28>;
+
+	mediatek,portmap = "llllw";
+
+	port@4 {
+		status = "okay";
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+	};
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,port4 = "gmac";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	gpio {
+		groups = "ephy", "i2c", "wled", "uartf";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1089,6 +1089,15 @@ define Device/wavlink_wl-wn530hg4
 endef
 TARGET_DEVICES += wavlink_wl-wn530hg4
 
+define Device/wavlink_wl-wn579x3
+  SOC := mt7620a
+  IMAGE_SIZE := 7744k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN579X3
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
+endef
+TARGET_DEVICES += wavlink_wl-wn579x3
+
 define Device/wrtnode_wrtnode
   SOC := mt7620n
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -194,6 +194,10 @@ tplink,archer-mr200)
 tplink,re200-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+wavlink,wl-wn579x3)
+	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x20"
+	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
+	;;
 zbtlink,zbt-ape522ii)
 	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "green:wlan2g4" "wlan1"
 	ucidef_set_led_netdev "sys1" "wlan1" "green:sys1" "wlan1" "tx rx"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -215,6 +215,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "4:wan" "6@eth0"
 		;;
+	wavlink,wl-wn579x3)
+		ucidef_add_switch "switch0" \
+			"5:lan" "4:wan" "6@eth0"
+		;;
 	youku,yk1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "4:wan" "6@eth0"


### PR DESCRIPTION
About the device
----------------

SoC: MediaTek MT7620a @ 580MHz
RAM: 64M
FLASH: 8MB
WiFi: SoC-integrated: MediaTek MT7620a bgn
WiFi: MediaTek MT7612EN nac
GbE: 2x (RTL8211F)
BTN: - WPS
- Reset
- Router/Repeater/AP (3-way slide-switch)
LED: - WPS (blue)
- 3-segment Wifi signal representation (blue)
- WiFi (blue)
- WAN (blue)
- LAN (blue)
- Power (blue)
UART: UART is present as Pads with through-holes on the PCB. They are
located next to the reset button and are labelled Vcc/TX/RX/GND as
appropriate. Use 3.3V, 57600-8N1.

Installation
------------

Using the webcmd interface
--------------------------

Warning: Do not update to the latest Wavlink firmware (version
20201201) as this removes the webcmd console and you will need to
use the serial port instead.

You will need to have built uboot/sqauashfs image for this device,
and you will need to provide an HTTP service where the image can
be downloaded from that is accessible by the device.
You cannot use the device manufacturers firmware upgrade interface
as it rejects the OpenWrt image.

1. Log into the device's admin portal. This is necessary to
   authenticate you as a user in order to be able to access the
   webcmd interface.
2. Navigate to http://<device-ip>/webcmd.shtml - you can access
   the console directly through this page, or you may wish to
   launch the installed `telnetd` and use telnet instead.
   * Using telnet is recommended since it provides a more
     convenient shell interface that the web form.
   * Launch telnetd from the form with the command `telnetd`.
   * Check the port that telnetd is running on using
     `netstat -antp|grep telnetd`, it is likely to be 2323.
   * Connect to the target using `telnet`. The username should
     be `admin2860`, and the password is your admin password.
3. On the target use `curl` to download the image.
   e.g.  `curl -L -O http://<some-other-lan-ip>/openwrt-ramips-mt7620-\
          wavlink_wl-wn579x3-squashfs-sysupgrade.bin`.
   Check the hash using `md5sum`.
4. Use the mtd_write command to flash the image.
   * The flash partition should be mtd4, but check
     /sys/class/mtd/mtd4/name first. The partition should be
     called 'Kernel'.
   * To flash use the following command:
     `mtd_write -r -e /dev/mtd<n> write <image-file> /dev/mtd<n>`
     Where mtd<n> is the Kernel partition, and <image-file> is
     the OpenWrt image previously downloaded.
   * The command above will erase, flash and then reboot the
     device. Once it reboots it will be running OpenWrt.

Connect via ssh to the device at 192.168.1.1 on the LAN port.
The WAN port will be configured via DHCP.

Using the serial port
---------------------

The device uses uboot like many other MT7260a based boards. To
use this interface, you will need to connect to the serial
interface, and provide a TFTP server. At boot follow the
bootloader menu and select option 2 to erase/flash the image.
Provide the address and filename details for the tftp server.
The bootloader will do the rest.

Once the image is flashed, the board will boot into OpenWrt. The
console is available over the serial port.

Signed-off-by: Ben Gainey <ba.gainey@googlemail.com>