### PR TITLE
base-files: add syslog output for sysupgrade

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -71,6 +71,7 @@ _vn() {
 
 v() {
 	_v "$(date) upgrade: $@"
+	logger -p info -t upgrade "$@"
 }
 
 vn() {

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -65,17 +65,9 @@ _v() {
 	[ -n "$VERBOSE" ] && [ "$VERBOSE" -ge 1 ] && echo "$*" >&2
 }
 
-_vn() {
-	[ -n "$VERBOSE" ] && [ "$VERBOSE" -ge 1 ] && echo -n "$*" >&2
-}
-
 v() {
 	_v "$(date) upgrade: $@"
 	logger -p info -t upgrade "$@"
-}
-
-vn() {
-	_vn "$(date) upgrade: $@"
 }
 
 json_string() {

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -81,12 +81,12 @@ fwtool_check_image() {
 	done
 
 	v "Device $device not supported by this image"
-	vn "Supported devices:"
+	local devices
 	for k in $dev_keys; do
 		json_get_var dev "$k"
-		_vn " $dev"
+		devices="$devices $dev"
 	done
-	_v
+	v "Supported devices: $devices"
 
 	return 1
 }

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -75,7 +75,7 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 	local stat
 	local proc_ppid=$(cut -d' ' -f4  /proc/$$/stat)
 
-	vn "Sending $sig to remaining processes ..."
+	v "Sending $sig to remaining processes ..."
 
 	while $run; do
 		run=false
@@ -95,7 +95,7 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 			# Skip kernel threads
 			[ -n "$cmdline" ] || continue
 
-			_vn " $name"
+			v "Sending signal $sig to $name ($pid)"
 			kill -$sig $pid 2>/dev/null
 
 			[ $loop -eq 1 ] && run=true
@@ -103,12 +103,10 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 
 		let loop_limit--
 		[ $loop_limit -eq 0 ] && {
-			_v
 			v "Failed to kill all processes."
 			exit 1
 		}
 	done
-	_v
 }
 
 indicate_upgrade

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -111,9 +111,9 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 
 indicate_upgrade
 
-killall -9 telnetd
-killall -9 dropbear
-killall -9 ash
+killall -9 telnetd 2>/dev/null
+killall -9 dropbear 2>/dev/null
+killall -9 ash 2>/dev/null
 
 kill_remaining TERM
 sleep 3

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -42,7 +42,7 @@ switch_to_ramfs() {
 		mtd partx losetup mkfs.ext4 nandwrite flash_erase	\
 		ubiupdatevol ubiattach ubiblock ubiformat		\
 		ubidetach ubirsvol ubirmvol ubimkvol			\
-		snapshot snapshot_tool date				\
+		snapshot snapshot_tool date logger			\
 		$RAMFS_COPY_BIN
 	do
 		local file="$(command -v "$binary" 2>/dev/null)"

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -287,6 +287,7 @@ if [ -n "$CONF_RESTORE" ]; then
 	fi
 
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
+	v "Restoring config files..."
 	tar -C / -x${TAR_V}zf "$CONF_RESTORE"
 	exit $?
 fi


### PR DESCRIPTION
This P/R adds two changes.

1. On importing a configuration, a logging should also be added as with the an export.
2. The output of a sysupgrade should not only be in the shell session that is currently being executed, but also in the syslog. To better understand when an upgarde has taken place. For this purpose, the v function is extended by a logger call.

Shellsession output:
```
Mon Feb  1 11:23:05 CET 2021 upgrade: Image metadata not present
Mon Feb  1 11:23:05 CET 2021 upgrade: Reading partition table from bootdisk...
Mon Feb  1 11:23:05 CET 2021 upgrade: Extract boot sector from the image
Mon Feb  1 11:23:05 CET 2021 upgrade: Reading partition table from image...
Mon Feb  1 11:23:05 CET 2021 upgrade: Saving config files...
Mon Feb  1 11:23:05 CET 2021 upgrade: Commencing upgrade. Closing all shell sessions.
Connection to 192.168.0.51 closed by remote host.
Connection to 192.168.0.51 closed.
```

Syslog output:
```
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Image metadata not present
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Reading partition table from bootdisk...
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Extract boot sector from the image
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Reading partition table from image...
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Saving config files...
Mon Feb  1 11:23:05 2021 user.info sysupgrade: Commencing upgrade. Closing all shell sessions.
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Image metadata not present
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Reading partition table from bootdisk...
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Extract boot sector from the image
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Reading partition table from image..
```

In this context I noticed that the following lines are send twice after `Commencing upgrade. Closing all shell sessions.` I haven't had a closer look yet. But is it correct?
```
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Image metadata not present
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Reading partition table from bootdisk...
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Extract boot sector from the image
Mon Feb  1 11:23:06 2021 user.info sysupgrade: Reading partition table from image..
```