### PR TITLE
ramips: add support for I-O DATA WN-DX1200GR

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iodata,wn-dx1200gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-DX1200GR";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &wan;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		repeater {
+			label = "repeater";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot-env";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "factory";
+			reg = <0x200000 0x200000>;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x400000 0x400000>;
+		};
+
+		partition@800000 {
+			label = "ubi";
+			reg = <0x800000 0x2e00000>;
+		};
+
+		partition@3600000 {
+			label = "Config";
+			reg = <0x3600000 0x100000>;
+			read-only;
+		};
+
+		partition@3700000 {
+			label = "firmware_2";
+			reg = <0x3700000 0x3200000>;
+		};
+
+		partition@6900000 {
+			label = "Config_2";
+			reg = <0x6900000 0x100000>;
+			read-only;
+		};
+
+		partition@6a00000 {
+			label = "persist";
+			reg = <0x6a00000 0x100000>;
+		};
+
+		partition@6b00000 {
+			label = "idmkey";
+			reg = <0x6b00000 0x100000>;
+			read-only;
+		};
+
+		partition@6c00000 {
+			label = "Backup";
+			reg = <0x6c00000 0x1380000>;
+			read-only;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x1e000>;
+};
+
+&switch0 {
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0x1e006>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -618,6 +618,15 @@ define Device/iodata_wn-dx1167r
 endef
 TARGET_DEVICES += iodata_wn-dx1167r
 
+define Device/iodata_wn-dx1200gr
+  $(Device/iodata_nand)
+  DEVICE_MODEL := WN-DX1200GR
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	uImage lzma -M 0x434f4d43 -n '3.10(XIQ.0)b20' | iodata-mstc-header
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += iodata_wn-dx1200gr
+
 define Device/iodata_wn-gx300gr
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
@@ -16,9 +16,13 @@ iodata_mstc_prepare_fail() {
 #     use 1st image in OpenWrt
 # - debugflag: enable/disable debug
 #     users can interrupt Z-Loader for recovering the device if enabled
+#
+# parameters:
+# - $1: the offset of "debugflag"
 iodata_mstc_upgrade_prepare() {
 	local persist_mtd="$(find_mtd_part persist)"
 	local factory_mtd="$(find_mtd_part factory)"
+	local dflag_offset="${1}"
 
 	if [ -z "$persist_mtd" -o -z "$factory_mtd" ]; then
 		echo 'cannot find mtd partition(s), "factory" or "persist"'
@@ -26,14 +30,14 @@ iodata_mstc_upgrade_prepare() {
 	fi
 
 	local bootnum=$(hexdump -s 4 -n 1 -e '"%x"' ${persist_mtd})
-	local debugflag=$(hexdump -s 65141 -n 1 -e '"%x"' ${factory_mtd})
+	local debugflag=$(hexdump -s $((dflag_offset)) -n 1 -e '"%x"' ${factory_mtd})
 
 	if [ "$bootnum" != "1" -a "$bootnum" != "2" ]; then
 		echo "failed to get bootnum, please check the value at 0x4 in ${persist_mtd}"
 		iodata_mstc_prepare_fail
 	fi
 	if [ "$debugflag" != "0" -a "$debugflag" != "1" ]; then
-		echo "failed to get debugflag, please check the value at 0xFE75 in ${factory_mtd}"
+		echo "failed to get debugflag, please check the value at ${dflag_offset} in ${factory_mtd}"
 		iodata_mstc_prepare_fail
 	fi
 	echo "current: bootnum => ${bootnum}, debugflag => ${debugflag}"
@@ -46,7 +50,7 @@ iodata_mstc_upgrade_prepare() {
 		echo "### switch to 1st os-image on next boot ###"
 	fi
 	if [ "$debugflag" = "0" ]; then
-		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=65141 conv=notrunc of=${factory_mtd} 2>/dev/null); then
+		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=$((dflag_offset)) conv=notrunc of=${factory_mtd} 2>/dev/null); then
 			echo "failed to set debugflag"
 			iodata_mstc_prepare_fail
 		fi

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -71,7 +71,11 @@ platform_do_upgrade() {
 	iodata,wn-ax1167gr2|\
 	iodata,wn-ax2033gr|\
 	iodata,wn-dx1167r)
-		iodata_mstc_upgrade_prepare
+		iodata_mstc_upgrade_prepare "0xfe75"
+		nand_do_upgrade "$1"
+		;;
+	iodata,wn-dx1200gr)
+		iodata_mstc_upgrade_prepare "0x1fe75"
 		nand_do_upgrade "$1"
 		;;
 	ubnt,edgerouter-x|\


### PR DESCRIPTION
I-O DATA WN-DX1200GR is a 2.4/5 GHz band 11ac (WiFi-5) router, based on
MT7621A.

Specification:

- SoC		: MediaTek MT7621A
- RAM		: DDR3 128 MiB
- Flash		: raw NAND 128 MiB
- WLAN		: 2.4/5 GHz 2T2R
  - 2.4 GHz	: MediaTek MT7603E
  - 5 GHz	: MediaTek MT7613BE
- Ethernet	: 10/100/1000 Mbps x5
  - Switch	: MediaTek MT7530 (SoC)
- LEDs/keys	: 2x/3x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J5: 3.3V, TX, RX, NC, GND from triangle-mark
  - 57600n8
- Power		: 12 VDC, 1 A

Flash instruction using initramfs image:

1. Boot WN-DX1200GR normally
2. Access to "http://192.168.0.1/" and open firmware update page
   ("ファームウェア")
3. Select the OpenWrt initramfs image and click update ("更新") button
   to perform firmware update
4. On the initramfs image, perform sysupgrade with the
   squashfs-sysupgrade image
5. Wait ~120 seconds to complete flashing

Notes:

- currently, mt7615e driver in mt76 doesn't fully support MT7613
  (MT7663) wifi chip
  - the eeprom data in flash is not used by mt7615e driver and the
    driver reports the tx-power up to 3dBm
  - the correct MAC address for MT7613BE in eeprom data cannot be
    assigned to the phy

- last 0x80000 (512 KiB) in NAND flash is not used on stock firmware

- stock firmware requires "customized uImage header" (called as "combo
  image") by MSTC (MitraStar Technology Corp.), but U-Boot doesn't

  - uImage magic ( 0x0 - 0x3 ) : 0x434F4D43 ("COMC")
  - header crc32 ( 0x4 - 0x7 ) : with "data length" and "data crc32"
  - image name   (0x20 - 0x37) : model ID and firmware versions
  - data length  (0x38 - 0x3b) : kernel + rootfs
  - data crc32   (0x3c - 0x3f) : kernel + rootfs

MAC addresses:

LAN:	50:41:B9:xx:xx:08 (Ubootenv, ethaddr (text) / Factory, 0x1E000 (hex))
WAN:	50:41:B9:xx:xx:0A (Factory,  0x1E006 (hex))
2.4GHz:	50:41:B9:xx:xx:08 (Factory,  0x4     (hex))
5GHz:	50:41:B9:xx:xx:09 (Factory,  0x8004  (hex))

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>