### PR TITLE
kernel: add "model name" display in `/proc/cpuinfo` for aarch64 arch

### DIFF
--- a/target/linux/generic/hack-5.4/310-arm64-cpuinfo-Add-model-name-in-proc-cpuinfo-for-64bit-ta.patch
+++ b/target/linux/generic/hack-5.4/310-arm64-cpuinfo-Add-model-name-in-proc-cpuinfo-for-64bit-ta.patch
@@ -1,0 +1,38 @@
+From: Sumit Gupta <sumitg@nvidia.com>
+To: <catalin.marinas@arm.com>, <linux-arm-kernel@lists.infradead.org>,
+	<linux-kernel@vger.kernel.org>
+Cc: <will.deacon@arm.com>, <suzuki.poulose@arm.com>,
+	<james.morse@arm.com>, <mark.rutland@arm.com>,
+	<yang.shi@linaro.org>, <julien.grall@arm.com>,
+	<steve.capper@linaro.org>, <bbasu@nvidia.com>,
+	<linux-tegra@vger.kernel.org>, Sumit Gupta <sumitg@nvidia.com>
+Subject: [PATCH] arm64: cpuinfo: Add "model name" in /proc/cpuinfo for 64bit tasks also
+Date: Mon, 29 Aug 2016 14:32:25 +0530
+Message-ID: <1472461345-28219-1-git-send-email-sumitg@nvidia.com> (raw)
+
+Removed restriction of displaying model name for 32 bit tasks only.
+Because of this Processor details were not displayed in
+"System setting -> Details" in Ubuntu model name display is generic
+and can be printed for 64 bit also.
+
+model name : ARMv8 Processor rev X (v8l)
+
+Signed-off-by: Sumit Gupta <sumitg@nvidia.com>
+---
+ arch/arm64/kernel/cpuinfo.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+--- a/arch/arm64/kernel/cpuinfo.c
++++ b/arch/arm64/kernel/cpuinfo.c
+@@ -139,9 +139,8 @@ static int c_show(struct seq_file *m, vo
+ 		 * "processor".  Give glibc what it expects.
+ 		 */
+ 		seq_printf(m, "processor\t: %d\n", i);
+-		if (compat)
+-			seq_printf(m, "model name\t: ARMv8 Processor rev %d (%s)\n",
+-				   MIDR_REVISION(midr), COMPAT_ELF_PLATFORM);
++		seq_printf(m, "model name\t: ARMv8 Processor rev %d (%s)\n",
++			   MIDR_REVISION(midr), COMPAT_ELF_PLATFORM);
+ 
+ 		seq_printf(m, "BogoMIPS\t: %lu.%02lu\n",
+ 			   loops_per_jiffy / (500000UL/HZ),


### PR DESCRIPTION
Original patch here: https://lore.kernel.org/lkml/1472461345-28219-1-git-send-email-sumitg@nvidia.com/
I have no idea why this patch was not merged into upstream, maybe
they just don't want to display it[1] for aarch64 devices.

1. https://lore.kernel.org/lkml/20160830105218.GD1223@leverpostej/

Commit mesage:
```
The restriction of displaying model name, called "compat", is used for 32 bit
tasks only, as some old ARMv5/6 devices may do not have a vaild `midr` passing
to cpuinfo, and it's totally useless for ARMv7 and later.

So, it's fine to remove the restriction for ARMv8 devices, and then we can see
"ARMv8 Processor rev X (v8l)" displayed on our LuCI index instead of "?".

Runtime-tested on: bcm27xx, rockchip

Signed-off-by: Tianling Shen <cnsztl@gmail.com>
```