### PR TITLE
Fix mt1300 wireless unavailability problem

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -521,7 +521,7 @@ define Device/glinet_gl-mt1300
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT1300
-  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3 kmod-mt7615d kmod-mt7615d_dbdc
 endef
 TARGET_DEVICES += glinet_gl-mt1300
 


### PR DESCRIPTION
Fix mt1300 wireless unavailability problem
add：kmod-mt7615d kmod-mt7615d_dbdc
mt1300 needs to add these two kmods to use wifi normally
