### PR TITLE
ramips: rt305x: use lzma-loader for ZyXEL Keenetic Lite rev.B

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1207,6 +1207,7 @@ endef
 TARGET_DEVICES += zyxel_keenetic
 
 define Device/zyxel_keenetic-lite-b
+  $(Device/uimage-lzma-loader)
   SOC := rt5350
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL


### PR DESCRIPTION
Fixes boot loader LZMA decompression issue.

[Reported by](https://github.com/openwrt/openwrt/commit/fea232ae8feb6af780fd4fa78ebe9231778bf75a#commitcomment-45016560) @KOLANICH.


This device was introduced by PR #3057 and kernel 5.4 was successfully tested on 2020-06-10 with commit afea16b8f752b3ccd3f66f9ac3890586d44cde69.

The reported LZMA ERROR has date of 2020-07-20, soon after the device support landed as commit 4dc9ad4af8c921494d20b303b6772fc6b5af3a69.
```
Ralink UBoot Version: 3.5.2.4_ZyXEL

....

3: System Boot system code via Flash.

## Booting image at bc050000 ...

   Image Name:   MIPS OpenWrt Linux-4.14.187

   Created:      2020-07-20   3:39:11 UTC

   Image Type:   MIPS Linux Kernel Image (lzma compressed)

   Data Size:    1472250 Bytes =  1.4 MB

   Load Address: 80000000

   Entry Point:  80000000

   Verifying Checksum ... OK

   Uncompressing Kernel Image ... LZMA ERROR 1 - must RESET board to recover
```


Interesting. :thinking: 