### PR TITLE
hostapd: add default_disabled option to the supplicant

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -333,6 +333,7 @@ hostapd_common_add_bss_config() {
 	config_add_boolean multicast_to_unicast per_sta_vif
 
 	config_add_array hostapd_bss_options
+	config_add_boolean default_disabled
 }
 
 hostapd_set_vlan_file() {
@@ -1099,7 +1100,8 @@ wpa_supplicant_add_network() {
 		ssid bssid key \
 		basic_rate mcast_rate \
 		ieee80211w ieee80211r \
-		multi_ap
+		multi_ap \
+		default_disabled
 
 	case "$auth_type" in
 		sae|owe|eap192|eap-eap192)
@@ -1112,6 +1114,7 @@ wpa_supplicant_add_network() {
 
 	set_default ieee80211r 0
 	set_default multi_ap 0
+	set_default default_disabled 0
 
 	local key_mgmt='NONE'
 	local network_data=
@@ -1143,7 +1146,10 @@ wpa_supplicant_add_network() {
 		scan_ssid=""
 	}
 
-	[ "$multi_ap" = 1 -a "$_w_mode" = "sta" ] && append network_data "multi_ap_backhaul_sta=1" "$N$T"
+	[ "$_w_mode" = "sta" ] && {
+		[ "$multi_ap" = 1 ] && append network_data "multi_ap_backhaul_sta=1" "$N$T"
+		[ "$default_disabled" = 1 ] && append network_data "disabled=1" "$N$T"
+	}
 
 	case "$auth_type" in
 		none) ;;


### PR DESCRIPTION
With the default configuration we generate, the supplicant starts
scanning and tries to connect to any open network when the interface
is enabled.

In some cases it can be desirable to prevent the supplicant from
scanning by itself. For example, if on the same radio an AP is
configured and an unconfigured STA is added (to be configured with
WPS), the AP might not be able to beacon until the STA stops
scanning.

In such a case, the STA configuration can still be required to set
specific settings (e.g. multi_ap_backhaul_sta) so it can't be set to
"disabled" in uci (because that would prevent the supplicant from
being run at all). The alternative is to add the "disabled" parameter
to the default network block in the supplicant configuration.

This patch adds a "default_disabled" setting in UCI which, when set,
adds the "disabled" parameter to the supplicant default network block.
