### PR TITLE
ramips: add support for ZTE MF283+

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,7 +34,8 @@ xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,mi-router-4c|\
 xiaomi,miwifi-nano|\
-zbtlink,zbt-wg2626)
+zbtlink,zbt-wg2626|\
+zte,mf283plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 hootoo,ht-tm05|\

--- a/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
+++ b/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "rt3352.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zte,mf283plus", "ralink,rt3352-soc";
+	model = "ZTE MF283+";
+
+	aliases {
+		led-boot = &led_wwan_green;
+		led-failsafe = &led_wwan_red;
+		led-upgrade = &led_wwan_red;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wwan_blue: wwan_blue {
+			label = "blue:wwan";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wwan_green: wwan_green {
+			label = "green:wwan";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wwan_red: wwan_red {
+			label = "red:wwan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		signal {
+			label = "blue:signal";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x60000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "u-boot-env";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@70000 {
+				label = "factory";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x80000 0xf80000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "rgmii", "mdio", "uartf";
+		function = "gpio";
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1183,6 +1183,16 @@ define Device/zorlik_zl5900v2
 endef
 TARGET_DEVICES += zorlik_zl5900v2
 
+define Device/zte_mf283plus
+  SOC := rt3352
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := ZTE
+  DEVICE_MODEL := MF283+
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport \
+	kmod-usb-serial kmod-usb-serial-option kmod-usb-net-qmi-wwan uqmi
+endef
+TARGET_DEVICES += zte_mf283plus
+
 define Device/zyxel_keenetic
   SOC := rt3052
   BLOCKSIZE := 64k

--- a/target/linux/ramips/patches-5.4/113-net-usb-qmi_wwan-support-ZTE-P685M-modem.patch
+++ b/target/linux/ramips/patches-5.4/113-net-usb-qmi_wwan-support-ZTE-P685M-modem.patch
@@ -1,0 +1,55 @@
+From c8df2dc3bb033eed953a3d7b7a6839779bec9415 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Thu, 4 Feb 2021 22:10:10 +0100
+Subject: [PATCH 1/2] net: usb: qmi_wwan: support ZTE P685M modem
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The modem is used inside ZTE MF283+ router and carriers identify it as
+such.
+Interface mapping is:
+0: QCDM, 1: AT (PCUI), 2: AT (Modem), 3: QMI, 4: ADB
+
+T:  Bus=02 Lev=02 Prnt=02 Port=05 Cnt=01 Dev#=  3 Spd=480  MxCh= 0
+D:  Ver= 2.01 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
+P:  Vendor=19d2 ProdID=1275 Rev=f0.00
+S:  Manufacturer=ZTE,Incorporated
+S:  Product=ZTE Technologies MSM
+S:  SerialNumber=P685M510ZTED0000CP&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&0
+C:* #Ifs= 5 Cfg#= 1 Atr=a0 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
+E:  Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+E:  Ad=83(I) Atr=03(Int.) MxPS=  10 Ivl=32ms
+E:  Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+E:  Ad=85(I) Atr=03(Int.) MxPS=  10 Ivl=32ms
+E:  Ad=84(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E:  Ad=87(I) Atr=03(Int.) MxPS=   8 Ivl=32ms
+E:  Ad=86(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E:  Ad=88(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+
+Cc: Bjørn Mork <bjorn@mork.no>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+---
+ drivers/net/usb/qmi_wwan.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/usb/qmi_wwan.c
++++ b/drivers/net/usb/qmi_wwan.c
+@@ -1280,6 +1280,7 @@ static const struct usb_device_id produc
+ 	{QMI_FIXED_INTF(0x19d2, 0x1255, 4)},
+ 	{QMI_FIXED_INTF(0x19d2, 0x1256, 4)},
+ 	{QMI_FIXED_INTF(0x19d2, 0x1270, 5)},	/* ZTE MF667 */
++	{QMI_FIXED_INTF(0x19d2, 0x1275, 3)},	/* ZTE P685M */
+ 	{QMI_FIXED_INTF(0x19d2, 0x1401, 2)},
+ 	{QMI_FIXED_INTF(0x19d2, 0x1402, 2)},	/* ZTE MF60 */
+ 	{QMI_FIXED_INTF(0x19d2, 0x1424, 2)},

--- a/target/linux/ramips/patches-5.4/114-usb-serial-option-add-full-support-for-ZTE-P685M.patch
+++ b/target/linux/ramips/patches-5.4/114-usb-serial-option-add-full-support-for-ZTE-P685M.patch
@@ -1,0 +1,66 @@
+From 350c4b8de468814303c292517eb1801d6cf04029 Mon Sep 17 00:00:00 2001
+From: Lech Perczak <lech.perczak@gmail.com>
+Date: Thu, 4 Feb 2021 22:11:00 +0100
+Subject: [PATCH 2/2] usb: serial: option: add full support for ZTE P685M
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Only 1st (DIAG) port was supported, support ports 1 (PCUI) and 2 (Modem)
+on ff/00/00 too. Ports expose AT command interface. Blacklist ports 3
+now used by qmi_wwan and port 4 for ADB, and finally simplify device ID
+to match only ports 0-2.
+
+The modem is used inside ZTE MF283+ router and carriers identify it as
+such.
+Interface mapping is:
+0: QCDM, 1: AT (PCUI), 2: AT (Modem), 3: QMI, 4: ADB
+
+T:  Bus=02 Lev=02 Prnt=02 Port=05 Cnt=01 Dev#=  3 Spd=480  MxCh= 0
+D:  Ver= 2.01 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
+P:  Vendor=19d2 ProdID=1275 Rev=f0.00
+S:  Manufacturer=ZTE,Incorporated
+S:  Product=ZTE Technologies MSM
+S:  SerialNumber=P685M510ZTED0000CP&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&0
+C:* #Ifs= 5 Cfg#= 1 Atr=a0 MxPwr=500mA
+I:* If#= 0 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=ff Prot=ff Driver=option
+E:  Ad=81(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=01(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 1 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+E:  Ad=83(I) Atr=03(Int.) MxPS=  10 Ivl=32ms
+E:  Ad=82(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=02(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 2 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=00 Prot=00 Driver=option
+E:  Ad=85(I) Atr=03(Int.) MxPS=  10 Ivl=32ms
+E:  Ad=84(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=03(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 3 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=ff Prot=ff Driver=qmi_wwan
+E:  Ad=87(I) Atr=03(Int.) MxPS=   8 Ivl=32ms
+E:  Ad=86(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=04(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+I:* If#= 4 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=42 Prot=01 Driver=(none)
+E:  Ad=88(I) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+E:  Ad=05(O) Atr=02(Bulk) MxPS= 512 Ivl=0ms
+
+Cc: Johan Hovold <johan@kernel.org>
+Cc: Bjørn Mork <bjorn@mork.no>
+Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
+
+---
+v2: Blacklist ports 3-4 and simplify device ID,
+as suggested by Lars Melin.
+
+ drivers/usb/serial/option.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -1567,7 +1567,7 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1272, 0xff, 0xff, 0xff) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1273, 0xff, 0xff, 0xff) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1274, 0xff, 0xff, 0xff) },
+-	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1275, 0xff, 0xff, 0xff) },
++	{ USB_DEVICE(ZTE_VENDOR_ID, 0x1275), .driver_info = RSVD(3) | RSVD(4) }, /* ZTE P685M */
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1276, 0xff, 0xff, 0xff) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1277, 0xff, 0xff, 0xff) },
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(ZTE_VENDOR_ID, 0x1278, 0xff, 0xff, 0xff) },

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
@@ -94,6 +94,10 @@ vocore,vocore-16m)
 zorlik,zl5900v2)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+zte,mf283plus)
+	ucidef_set_led_wlan "wifi" "wifi" "rt2800soc-phy0::radio" "phy0tpt"
+	ucidef_set_led_netdev "wwan" "wwan" "blue:wwan" "wwan0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -164,6 +164,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:wan" "6@eth0"
 		;;
+	zte,mf283plus)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "6@eth0"
+		;;
 	zyxel,keenetic-lite-b|\
 	zyxel,keenetic-start)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
ZTE MF283+ is a dual-antenna LTE category 4 router, based on Ralink
RT3352 SoC, and built-in ZTE P685M PCIe MiniCard LTE modem.

Hardware highlighs:
- CPU: MIPS24KEc at 400MHz,
- RAM: 64MB DDR2,
- Flash: 16MB SPI,
- Ethernet: 4 10/100M port switch with VLAN support,
- Wireless: Dual-stream 802.11n (RT2860), with two internal antennas,
- WWAN: Built-in ZTE P685M modem, with two internal antennas and two
  switching SMA connectors for external antennas,
- FXS: Single ATA, with two connectors marked PHONE1 and PHONE2,
  internally wired in parallel by 0-Ohm resistors, handled entirely by
  internal WWAN modem.
- USB: internal miniPCIe slot for modem,
  unpopulated USB A connector on PCB.
- SIM slot for the WWAN modem.
- UART connector for the console (unpopulated) at 3.3V,
  pinout: 1: VCC, 2: TXD, 3: RXD, 4: GND,
  settings: 57600-8-N-1.
- LEDs: Power (fixed), WLAN, WWAN (RGB),
  phone (bicolor, controlled by modem), Signal,
  4 link/act LEDs for LAN1-4.
- Buttons: WPS, reset.

Installation:
As the modem is, for most of the time, provided by carriers, there is no
possibility to flash through web interface, only built-in FOTA update
and TFTP recovery are supported.

There are two installation methods:
(1) Using serial console and initramfs-kernel - recommended, as it
allows you to back up original firmware, or
(2) Using TFTP recovery - does not require disassembly.

(1) Using serial console:
To install OpenWrt, one needs to disassemble the
router and flash it via TFTP by using serial console:
- Locate unpopulated 4-pin header on the top of the board, near buttons.
- Connect UART adapter to the connector. Use 3.3V voltage level only,
  omit VCC connection. Pin 1 (VCC) is marked by square pad.
- Put your initramfs-kernel image in TFTP server directory.
- Power-up the device.
- Press "1" to load initramfs image to RAM.
- Enter IP address chosen for the device (defaults to 192.168.0.1).
- Enter TFTP server IP address (defaults to 192.168.0.22).
- Enter image filename as put inside TFTP server - something short,
  like firmware.bin is recommended.
- Hit enter to load the image. U-boot will store above values in
  persistent environment for next installation.
- If you ever might want to return to vendor firmware,
  BACK UP CONTENTS OF YOUR FLASH NOW.
  For this router, commonly used by mobile networks,
  plain vendor images are not officially available.
  To do so, copy contents of each /dev/mtd[0-3], "firmware" - mtd3 being the
  most important, and copy them over network to your PC. But in case
  anything goes wrong, PLEASE do back up ALL OF THEM.
- From under OpenWrt just booted, load the sysupgrade image to tmpfs,
  and execute sysupgrade.

(2) Using TFTP recovery
- Set your host IP to 192.168.0.22 - for example using:
sudo ip addr add 192.168.0.22/24 dev <interface>
- Set up a TFTP server on your machine
- Put the sysupgrade image in TFTP server root named as 'root_uImage'
  (no quotes), for example using tftpd:
  cp openwrt-ramips-rt305x-zte_mf283plus-squashfs-sysupgrade.bin /srv/tftp/root_uImage
- Power on the router holding BOTH Reset and WPS buttons held for around
  5 seconds, until after WWAN and Signal LEDs blink.
- Wait for OpenWrt to start booting up, this should take around a
  minute.

Return to original firmware:
Here, again there are two possibilities are possible, just like for
installation:
(1) Using initramfs-kernel image and serial console
(2) Using TFTP recovery

(1) Using initramfs-kernel image and serial console
- Boot OpenWrt initramfs-kernel image via TFTP the same as for
  installation.
- Copy over the backed up "firmware.bin" image of "mtd3" to /tmp/
- Use "mtd write /tmp/firmware.bin /dev/mtd3", where firmware.bin is
  your backup taken before OpenWrt installation, and /dev/mtd3 is the
  "firmware" partition.

(2) Using TFTP recovery
- Follow the same steps as for installation, but replacing 'root_uImage'
  with firmware backup you took during installation, or by vendor
  firmware obtained elsewhere.

A few quirks of the device, noted from my instance:
- Wired and wireless MAC addresses written in flash are the same,
  despite being in separate locations.
- Power LED is hardwired to 3.3V, so there is no status LED per se, and
  WLAN LED is controlled by WLAN driver, so I had to hijack 3G/4G LED
  for status - original firmware also does this in bootup.
- FXS subsystem and its LED is controlled by the
  modem, so it work independently of OpenWrt.
  Tested to work even before OpenWrt booted.
  I managed to open up modem's shell via ADB,
  and found from its kernel logs, that FXS and its LED is indeed controlled
  by modem.
- While finding LEDs, I had no GPL source drop from ZTE, so I had to probe for
  each and every one of them manually, so this might not be complete -
  it looks like bicolor LED is used for FXS, possibly to support
  dual-ported variant in other device sharing the PCB.
- Flash performance is very low, despite enabling 50MHz clock and fast
  read command, due to using 4k sectors throughout the target. I decided
  to keep it at the moment, to avoid breaking existing devices - I
  identified one potentially affected, should this be limited to under
  4MB of Flash. The difference between sysupgrade durations is whopping
  3min vs 8min, so this is worth pursuing.

In vendor firmware, WWAN LED behaviour is as follows, citing the manual:
- red - no registration,
- green - 3G,
- blue - 4G.
Blinking indicates activity, so netdev trigger mapped from wwan0 to blue:wwan
looks reasonable at the moment, for full replacement, a script similar to
"rssileds" would need to be developed.

Behaviour of "Signal LED" in vendor firmware is as follows:
- Off - no signal,
- Blinking - poor coverage
- Solid - good coverage.

A few more details on the built-in LTE modem:
Modem is not fully supported upstream in Linux - only two CDC ports
(DIAG and one for QMI) probe. I sent patches upstream to add required device
IDs for full support.
The mapping of USB functions is as follows:
- CDC (QCDM) - dedicated to comunicating with proprietary Qualcomm tools.
- CDC (PCUI) - not supported by upstream 'option' driver yet. Patch
  submitted upstream.
- CDC (Modem) - Exactly the same as above
- QMI - A patch is sent upstream to add device ID, with that in place,
  uqmi did connect successfully, once I selected correct PDP context
  type for my SIM (IPv4-only, not default IPv4v6).
- ADB - self-explanatory, one can access the ADB shell with a device ID
  added to 51-android.rules like so:

SUBSYSTEM!="usb", GOTO="android_usb_rules_end"
LABEL="android_usb_rules_begin"
SUBSYSTEM=="usb", ATTR{idVendor}=="19d2", ATTR{idProduct}=="1275", ENV{adb_user}="yes"
ENV{adb_user}=="yes", MODE="0660", GROUP="plugdev", TAG+="uaccess"
LABEL="android_usb_rules_end"

While not really needed in OpenWrt, it might come useful if one decides to
move the modem to their PC to hack it further, insides seem to be pretty
interesting. ADB also works well from within OpenWrt without that. O
course it isn't needed for normal operation, so I left it out of
DEVICE_PACKAGES.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>
