### PR TITLE
ramips: mt7621: use lzma-loader for WeVO W2914NS

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1221,6 +1221,7 @@ TARGET_DEVICES += wevo_11acnas
 
 define Device/wevo_w2914ns-v2
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   UIMAGE_NAME := W2914NS-V2(0.0.0)
   DEVICE_VENDOR := WeVO


### PR DESCRIPTION
"This device has trouble extracting big kernel from flash,
and supports LZMA compressed kernels only.

Using OpenWrt kernel loader saves us 64 KB compared to the dictionary
size limiting workaround.

See the thread at [0] for more details!"

[0] https://github.com/openwrt/openwrt/commit/ce1957100411b0a751d6431d36def9c28048b4dc

