### PR TITLE
kernel: bump 5.4 to 5.4.96

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .95
+LINUX_VERSION-5.4 = .96
 
-LINUX_KERNEL_HASH-5.4.95 = 030ae544f346bfa2ce619dd9e17e93d10ec393632d3b6d6cf5d1fc84b914d449
+LINUX_KERNEL_HASH-5.4.96 = f728de695ec5eb17efa15acaecc48fcd7a6c4a912b51704ed137cccf93f9f5e0
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-5.4/910-unaligned_access_hacks.patch
@@ -706,7 +706,7 @@
  EXPORT_SYMBOL(xfrm_parse_spi);
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
-@@ -3975,14 +3975,16 @@ static bool tcp_parse_aligned_timestamp(
+@@ -3976,14 +3976,16 @@ static bool tcp_parse_aligned_timestamp(
  {
  	const __be32 *ptr = (const __be32 *)(th + 1);
  

--- a/target/linux/bcm4908/patches-5.4/071-v5.12-0029-net-dsa-bcm_sf2-support-BCM4908-s-integrated-switch.patch
+++ b/target/linux/bcm4908/patches-5.4/071-v5.12-0029-net-dsa-bcm_sf2-support-BCM4908-s-integrated-switch.patch
@@ -68,7 +68,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  			offset = CORE_STS_OVERRIDE_IMP;
  		else
  			offset = CORE_STS_OVERRIDE_IMP2;
-@@ -542,7 +543,8 @@ static void bcm_sf2_sw_mac_config(struct
+@@ -546,7 +547,8 @@ static void bcm_sf2_sw_mac_config(struct
  	if (port == core_readl(priv, CORE_IMP0_PRT_ID))
  		return;
  
@@ -78,7 +78,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		offset = CORE_STS_OVERRIDE_GMIIP_PORT(port);
  	else
  		offset = CORE_STS_OVERRIDE_GMIIP2_PORT(port);
-@@ -984,6 +986,30 @@ struct bcm_sf2_of_data {
+@@ -988,6 +990,30 @@ struct bcm_sf2_of_data {
  	unsigned int num_cfp_rules;
  };
  
@@ -109,7 +109,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  /* Register offsets for the SWITCH_REG_* block */
  static const u16 bcm_sf2_7445_reg_offsets[] = {
  	[REG_SWITCH_CNTRL]	= 0x00,
-@@ -1032,6 +1058,9 @@ static const struct bcm_sf2_of_data bcm_
+@@ -1036,6 +1062,9 @@ static const struct bcm_sf2_of_data bcm_
  };
  
  static const struct of_device_id bcm_sf2_of_match[] = {

--- a/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
+++ b/target/linux/mediatek/patches-5.4/0601-net-dsa-propagate-resolved-link-config-via-mac_link_.patch
@@ -38,7 +38,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		     const struct switchdev_obj_port_vlan *vlan);
 --- a/drivers/net/dsa/bcm_sf2.c
 +++ b/drivers/net/dsa/bcm_sf2.c
-@@ -635,7 +635,9 @@ static void bcm_sf2_sw_mac_link_down(str
+@@ -639,7 +639,9 @@ static void bcm_sf2_sw_mac_link_down(str
  static void bcm_sf2_sw_mac_link_up(struct dsa_switch *ds, int port,
  				   unsigned int mode,
  				   phy_interface_t interface,


### PR DESCRIPTION
Ran `update_kernel.sh` in a fresh clone without any existing toolchains.

```
Build system: x86_64
Build-tested: ipq806x/R7800, bcm27xx/bcm2711
Run-tested: ipq806x/R7800
```

Signed-off-by: John Audia <graysky@archlinux.us>