### PR TITLE
fakeroot: hacky fix for build errors

### DIFF
--- a/tools/fakeroot/patches/300-no_STAT_VER.patch
+++ b/tools/fakeroot/patches/300-no_STAT_VER.patch
@@ -1,0 +1,15 @@
+diff --git a/libfakeroot.c b/libfakeroot.c
+index 3e80e38..14e56bc 100644
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -90,6 +90,10 @@
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+ #endif
+ 
++#ifndef _STAT_VER
++#define _STAT_VER 0
++#endif
++
+ /*
+    These INT_* (which stands for internal) macros should always be used when
+    the fakeroot library owns the storage of the stat variable.


### PR DESCRIPTION
When running the latest toolchain on x86_64 host systems, fakeroot
fails to build which also affects OW's build system when it tries.
This is a workaround fix for the yet unknown breakage.

Credit for the idea and the patch to loqs[[1](https://bugs.archlinux.org/task/69572#comment196447)].

Signed-off-by: John Audia <graysky@archlinux.us>