### PR TITLE
mamba/venom: increase kernel partition size

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,7 +1,8 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
-	linksys,wrt1900ac-v1)
+	linksys,wrt1900ac-v1|\
+        linksys,wrt32x)
 		uci set system.@system[0].compat_version="2.0"
 		uci commit system
 		;;

--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,0 +1,10 @@
+. /lib/functions.sh
+
+case "$(board_name)" in
+	linksys,wrt1900ac-v1)
+		uci set system.@system[0].compat_version="2.0"
+		uci commit system
+		;;
+esac
+
+exit 0

--- a/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-venom.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/armada-385-linksys-venom.dts
@@ -157,9 +157,9 @@
 			reg = <0x900000 0x7b00000>;	/* 123MB */
 		};
 
-		partition@c00000 {
+		partition@f00000 {
 			label = "rootfs1";
-			reg = <0xc00000 0x7800000>;	/* 120MB */
+			reg = <0xf00000 0x7500000>;	/* 117MB */
 		};
 
 		/* kernel2 overlaps with rootfs2 by design */
@@ -168,9 +168,9 @@
 			reg = <0x8400000 0x7b00000>;	/* 123MB */
 		};
 
-		partition@8700000 {
+		partition@8a00000 {
 			label = "rootfs2";
-			reg = <0x8700000 0x7800000>;	/* 120MB */
+			reg = <0x8a00000 0x7500000>;	/* 117MB */
 		};
 
 		/* last MB is for the BBT, not writable */

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -123,7 +123,6 @@ define Device/linksys_wrt1900ac-v1
   DEVICE_PACKAGES += mwlwifi-firmware-88w8864
   KERNEL_SIZE := 4096k
   SUPPORTED_DEVICES += armada-xp-linksys-mamba linksys,mamba
-  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt1900ac-v1
 
@@ -163,7 +162,6 @@ define Device/linksys_wrt32x
   KERNEL_SIZE := 6144k
   KERNEL := kernel-bin | append-dtb
   SUPPORTED_DEVICES += armada-385-linksys-venom linksys,venom
-  DEFAULT := n
 endef
 TARGET_DEVICES += linksys_wrt32x
 

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -154,13 +154,13 @@ TARGET_DEVICES += linksys_wrt3200acm
 
 define Device/linksys_wrt32x
   $(call Device/linksys)
-  $(Device/dsa-migration)
+  $(Device/kernel-size-migration)
   DEVICE_MODEL := WRT32X
   DEVICE_ALT0_VENDOR := Linksys
   DEVICE_ALT0_MODEL := Venom
   DEVICE_DTS := armada-385-linksys-venom
   DEVICE_PACKAGES += kmod-btmrvl kmod-mwifiex-sdio mwlwifi-firmware-88w8964
-  KERNEL_SIZE := 3072k
+  KERNEL_SIZE := 6144k
   KERNEL := kernel-bin | append-dtb
   SUPPORTED_DEVICES += armada-385-linksys-venom linksys,venom
   DEFAULT := n

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -8,6 +8,12 @@ define Device/dsa-migration
   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
 endef
 
+define Device/kernel-size-migration
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition design has changed compared to older versions (up to 19.07) due to kernel size restrictions. \
+	Upgrade via sysupgrade mechanism is not possible, so new installation via factory style image is required.
+endef
+
 define Device/buffalo_ls421de
   $(Device/NAND-128K)
   DEVICE_VENDOR := Buffalo
@@ -108,14 +114,14 @@ TARGET_DEVICES += linksys_wrt1900acs
 
 define Device/linksys_wrt1900ac-v1
   $(call Device/linksys)
-  $(Device/dsa-migration)
+  $(Device/kernel-size-migration)
   DEVICE_MODEL := WRT1900AC
   DEVICE_VARIANT := v1
   DEVICE_ALT0_VENDOR := Linksys
   DEVICE_ALT0_MODEL := Mamba
   DEVICE_DTS := armada-xp-linksys-mamba
   DEVICE_PACKAGES += mwlwifi-firmware-88w8864
-  KERNEL_SIZE := 3072k
+  KERNEL_SIZE := 4096k
   SUPPORTED_DEVICES += armada-xp-linksys-mamba linksys,mamba
   DEFAULT := n
 endef

--- a/target/linux/mvebu/patches-5.10/316-armada-xp-linksys-mamba-resize-kernel.patch
+++ b/target/linux/mvebu/patches-5.10/316-armada-xp-linksys-mamba-resize-kernel.patch
@@ -1,0 +1,37 @@
+From 258233f00bcd013050efee00c5d9128ef8cd62dd Mon Sep 17 00:00:00 2001
+From: Tad <tad@spotco.us>
+Date: Fri, 5 Feb 2021 22:32:11 -0500
+Subject: [PATCH] ARM: dts: armada-xp-linksys-mamba: Increase kernel
+ partition to 4MB
+
+Signed-off-by: Tad Davanzo <tad@spotco.us>
+---
+ arch/arm/boot/dts/armada-xp-linksys-mamba.dts | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/arch/arm/boot/dts/armada-xp-linksys-mamba.dts
++++ b/arch/arm/boot/dts/armada-xp-linksys-mamba.dts
+@@ -456,9 +456,9 @@
+ 				reg = <0xa00000 0x2800000>;  /* 40MB */
+ 			};
+ 
+-			partition@d00000 {
++			partition@e00000 {
+ 				label = "rootfs1";
+-				reg = <0xd00000 0x2500000>;  /* 37MB */
++				reg = <0xe00000 0x2400000>;  /* 36MB */
+ 			};
+ 
+ 			/* kernel2 overlaps with rootfs2 by design */
+@@ -467,9 +467,9 @@
+ 				reg = <0x3200000 0x2800000>; /* 40MB */
+ 			};
+ 
+-			partition@3500000 {
++			partition@3600000 {
+ 				label = "rootfs2";
+-				reg = <0x3500000 0x2500000>; /* 37MB */
++				reg = <0x3600000 0x2400000>; /* 36MB */
+ 			};
+ 
+ 			/*

--- a/target/linux/mvebu/patches-5.4/318-armada-xp-linksys-mamba-resize-kernel.patch
+++ b/target/linux/mvebu/patches-5.4/318-armada-xp-linksys-mamba-resize-kernel.patch
@@ -1,0 +1,37 @@
+From 258233f00bcd013050efee00c5d9128ef8cd62dd Mon Sep 17 00:00:00 2001
+From: Tad <tad@spotco.us>
+Date: Fri, 5 Feb 2021 22:32:11 -0500
+Subject: [PATCH] ARM: dts: armada-xp-linksys-mamba: Increase kernel
+ partition to 4MB
+
+Signed-off-by: Tad Davanzo <tad@spotco.us>
+---
+ arch/arm/boot/dts/armada-xp-linksys-mamba.dts | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/arch/arm/boot/dts/armada-xp-linksys-mamba.dts
++++ b/arch/arm/boot/dts/armada-xp-linksys-mamba.dts
+@@ -456,9 +456,9 @@
+ 				reg = <0xa00000 0x2800000>;  /* 40MB */
+ 			};
+ 
+-			partition@d00000 {
++			partition@e00000 {
+ 				label = "rootfs1";
+-				reg = <0xd00000 0x2500000>;  /* 37MB */
++				reg = <0xe00000 0x2400000>;  /* 36MB */
+ 			};
+ 
+ 			/* kernel2 overlaps with rootfs2 by design */
+@@ -467,9 +467,9 @@
+ 				reg = <0x3200000 0x2800000>; /* 40MB */
+ 			};
+ 
+-			partition@3500000 {
++			partition@3600000 {
+ 				label = "rootfs2";
+-				reg = <0x3500000 0x2500000>; /* 37MB */
++				reg = <0x3600000 0x2400000>; /* 36MB */
+ 			};
+ 
+ 			/*


### PR DESCRIPTION
This merge request contains four commits:
1. Increases mamba kernel partition from 3MB to 4MB
2. Increases venom kernel partition from 3MB to 6MB.
This is accomplished by shrinking their root partitions by 1MB and 3MB respectively.
3. Re-enables these devices for buildbots
4. Adds a compatibility version check and message

3MB is not enough for building with many kernel modules included and is not enough for Linux 5.10.
Both of their uboots from factory load up to those respective values.

I have tested mamba working with a 3.2MB 5.4 kernel.
I have tested mamba working with a 3.1MB 5.10 kernel.
@anomeome has tested mamba with a 3.2MB 5.10 kernel.
@solidus1983 has tested venom with a <3MB 5.4 kernel.

Compatibility can be checked like so:
mamba: `fw_printenv | grep "pri_kern_size";` *must* equal 0x400000
venom: `fw_printenv | grep "priKernSize";` *must* equal 0x0600000

Flashing process:
A factory style image is necessary when flashing to or away from a resized build
- backup
- flash a factory style image via sysupgrade, with `force` set and `keep settings` unset
- restore backup
- afterwards, you can flash normally.

Flashing from normal OpenWrt to resized has been tested to work.
Flashing from resized OpenWrt to normal has been tested to work.
Flashing from OEM firmware to resized has been tested to work (via user report).
Flashing from resized to OEM firmware has been tested to work (via user report).

There is more information in the forum thread post:
https://forum.openwrt.org/t/increasing-mamba-and-venom-kernel-partition-to-6mb/87807