### PR TITLE
octeon: move usb3 usb-dwc3 and usb-storage-uas kmods to DEFAULT_PACKAGES

### DIFF
--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -21,6 +21,11 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += mkf2fs e2fsprogs
+DEFAULT_PACKAGES += \
+	e2fsprogs \
+	kmod-usb3 \
+	kmod-usb-dwc3 \
+	kmod-usb-storage-uas \
+	mkf2fs
 
 $(eval $(call BuildTarget))

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -58,7 +58,7 @@ define Device/ubnt_edgerouter-4
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := EdgeRouter 4
   DEVICE_DTS := cn7130_ubnt_edgerouter-4
-  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-sfp kmod-usb3 kmod-usb-dwc3 kmod-usb-storage-uas
+  DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio kmod-of-mdio kmod-sfp
   KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
   KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
   CMDLINE := root=/dev/mmcblk0p2 rootfstype=squashfs,ext4 rootwait


### PR DESCRIPTION
as reported on forums and irc - automated initramfs builds
  does not include packages from DEVICE_PACKAGES list
  hence the fresh installs from usb flash drive are not possible.

DEVICE_PACKAGES are ignored on initramfs images when:
 - CONFIG_TARGET_MULTI_PROFILE
 - CONFIG_TARGET_PER_DEVICE_ROOTFS
 - CONFIG_TARGET_ALL_PROFILES
are set.

here we move DEVICE_PACKAGES that implement usb support to
  DEFAULT_PACKAGES so fresh installs from initramfs would be possible again.

Signed-off-by: Roman Kuzmitskii <damex.pp@icloud.com>
