### PR TITLE
ramips: add support for ELECOM WRC-1167FS

### DIFF
--- a/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
+++ b/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "elecom,wrc-1167fs", "mediatek,mt7628an-soc";
+	model = "ELECOM WRC-1167FS";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wps {
+			label = "red:wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		ap {
+			label = "ap";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x730000>;
+			};
+
+			partition@780000 {
+				label = "storage";
+				reg = <0x780000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,portdisable = <0x27>;
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wled_an", "p3led_an", "p4led_an", "wdt", "refclk", "i2c", "i2s";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -25,6 +25,10 @@ cudy,wr1000)
 	ucidef_set_led_switch "lan1" "lan1" "blue:lan1" "switch0" "0x08"
 	ucidef_set_led_switch "lan2" "lan2" "blue:lan2" "switch0" "0x04"
 	;;
+elecom,wrc-1167fs)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x8"
+	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x10"
+	;;
 glinet,gl-mt300n-v2)
 	ucidef_set_led_netdev "wifi_led" "wifi" "red:wlan" "wlan0"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x1"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	buffalo,wcr-1166ds|\
+	elecom,wrc-1167fs|\
 	wavlink,wl-wn577a2)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
@@ -180,6 +181,10 @@ ramips_setup_macs()
 	wrtnode,wrtnode2r|\
 	zyxel,keenetic-extra-ii)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
+		;;
+	elecom,wrc-1167fs)
+		wan_mac=$(mtd_get_mac_binary factory 0x22)
+		label_mac=$wan_mac
 		;;
 	hilink,hlk-7628n)
 		lan_mac=$(macaddr_setbit_la "$(cat /sys/class/net/eth0/address)")


### PR DESCRIPTION
ELECOM WRC-1167FS is a 2.4/5 GHz band 11ac (WiFi-5) router, based on
MT7628AN.

Specification:

- SoC		: MediaTek MT7628AN
- RAM		: DDR2 64 MiB (NT5TU32M16FG-AC)
- Flash		: SPI-NOR 16 MiB (W25Q128JVSIQ)
- WLAN		: 2.4/5 GHz 2T2R
  - 2.4 GHz	: MediaTek MT7628AN (SoC)
  - 5 GHz	: MediaTek MT7612E
- Ethernet	: 10/100 Mbps x2
  - Switch	: MT7628AN (SoC)
- LEDs/Keys	: 6x, 3x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J1: 3.3V, GND, TX, RX from "J1" marking
  - 57600n8
- Power		: 12 VDC, 1 A

Flash instruction using factory image:

1. Boot WRC-1167FS normally
2. Access to "http://192.168.2.1/" and open firmware update page
   ("ファームウェア更新")
3. Select the OpenWrt factory image and click apply ("適用") button to
   perform firmware update
4. Wait ~120 seconds to complete flashing

Notes:

- Last 0x800000 (8 MiB) in SPI-NOR flash is not used on stock firmware

- Additional padding in factory image is required to avoid incomplete
  flashing on stock firmware

MAC addresses:

- LAN	: BC:5C:4C:xx:xx:68 (Config, ethaddr (text) / Factory, 0x28   (hex))
- WAN	: BC:5C:4C:xx:xx:69 (Config, wanaddr (text) / Factory, 0x22   (hex))
- 2.4GHz: BC:5C:4C:xx:xx:6A (Config, rmac    (text) / Factory, 0x4    (hex))
- 5GHz	: BC:5C:4C:xx:xx:6B (Config, rmac2   (text) / Factory, 0x8004 (hex))

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>