### PR TITLE
kernel: bump 5.4 to 5.4.97

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .96
+LINUX_VERSION-5.4 = .97
 
-LINUX_KERNEL_HASH-5.4.96 = f728de695ec5eb17efa15acaecc48fcd7a6c4a912b51704ed137cccf93f9f5e0
+LINUX_KERNEL_HASH-5.4.97 = 71a866100a630fbc66d24770f932feb121dd764c0bb95a88c0a00e3cb629483f
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
+++ b/target/linux/apm821xx/patches-5.4/802-usb-xhci-force-msi-renesas-xhci.patch
@@ -43,7 +43,7 @@ produce a noisy warning.
  		hcd->msi_enabled = 1;
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1881,6 +1881,7 @@ struct xhci_hcd {
+@@ -1882,6 +1882,7 @@ struct xhci_hcd {
  	struct xhci_hub		usb2_rhub;
  	struct xhci_hub		usb3_rhub;
  	/* support xHCI 1.0 spec USB2 hardware LPM */

--- a/target/linux/bcm27xx/patches-5.4/950-0267-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0267-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
@@ -85,6 +85,6 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  #define XHCI_RESET_PLL_ON_DISCONNECT	BIT_ULL(34)
  #define XHCI_SNPS_BROKEN_SUSPEND    BIT_ULL(35)
 +#define XHCI_EP_CTX_BROKEN_DCS	BIT_ULL(36)
+ #define XHCI_SKIP_PHY_INIT	BIT_ULL(37)
  #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
  
- 	unsigned int		num_active_eps;

--- a/target/linux/bcm27xx/patches-5.4/950-0316-kbuild-Allow-.dtbo-overlays-to-be-built-piecemeal.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0316-kbuild-Allow-.dtbo-overlays-to-be-built-piecemeal.patch
@@ -24,7 +24,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 
 --- a/Makefile
 +++ b/Makefile
-@@ -1267,6 +1267,9 @@ ifneq ($(dtstree),)
+@@ -1261,6 +1261,9 @@ ifneq ($(dtstree),)
  %.dtb: include/config/kernel.release scripts_dtc
  	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
  

--- a/target/linux/bcm27xx/patches-5.4/950-0460-Kbuild-Allow-.dtbo-overlays-to-be-built-adjust.patch
+++ b/target/linux/bcm27xx/patches-5.4/950-0460-Kbuild-Allow-.dtbo-overlays-to-be-built-adjust.patch
@@ -15,7 +15,7 @@ Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>
 
 --- a/Makefile
 +++ b/Makefile
-@@ -1267,7 +1267,7 @@ ifneq ($(dtstree),)
+@@ -1261,7 +1261,7 @@ ifneq ($(dtstree),)
  %.dtb: include/config/kernel.release scripts_dtc
  	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
  

--- a/target/linux/bcm53xx/patches-5.4/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
+++ b/target/linux/bcm53xx/patches-5.4/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
@@ -19,7 +19,7 @@ it on BCM4708 family.
 
 --- a/drivers/usb/host/xhci-plat.c
 +++ b/drivers/usb/host/xhci-plat.c
-@@ -67,6 +67,8 @@ static int xhci_priv_resume_quirk(struct
+@@ -77,6 +77,8 @@ static int xhci_priv_resume_quirk(struct
  static void xhci_plat_quirks(struct device *dev, struct xhci_hcd *xhci)
  {
  	struct xhci_plat_priv *priv = xhci_to_priv(xhci);
@@ -28,7 +28,7 @@ it on BCM4708 family.
  
  	/*
  	 * As of now platform drivers don't provide MSI support so we ensure
-@@ -74,6 +76,9 @@ static void xhci_plat_quirks(struct devi
+@@ -84,6 +86,9 @@ static void xhci_plat_quirks(struct devi
  	 * dev struct in order to setup MSI
  	 */
  	xhci->quirks |= XHCI_PLAT | priv->quirks;
@@ -132,6 +132,6 @@ it on BCM4708 family.
  #define XHCI_RESET_PLL_ON_DISCONNECT	BIT_ULL(34)
  #define XHCI_SNPS_BROKEN_SUSPEND    BIT_ULL(35)
 +#define XHCI_FAKE_DOORBELL	BIT_ULL(36)
+ #define XHCI_SKIP_PHY_INIT	BIT_ULL(37)
  #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
  
- 	unsigned int		num_active_eps;

--- a/target/linux/generic/backport-5.4/746-v5.5-net-dsa-mv88e6xxx-Split-monitor-port-configuration.patch
+++ b/target/linux/generic/backport-5.4/746-v5.5-net-dsa-mv88e6xxx-Split-monitor-port-configuration.patch
@@ -19,7 +19,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2380,7 +2380,14 @@ static int mv88e6xxx_setup_upstream_port
+@@ -2384,7 +2384,14 @@ static int mv88e6xxx_setup_upstream_port
  
  		if (chip->info->ops->set_egress_port) {
  			err = chip->info->ops->set_egress_port(chip,

--- a/target/linux/generic/backport-5.4/747-v5.5-net-dsa-mv88e6xxx-Add-support-for-port-mirroring.patch
+++ b/target/linux/generic/backport-5.4/747-v5.5-net-dsa-mv88e6xxx-Add-support-for-port-mirroring.patch
@@ -25,7 +25,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -4922,6 +4922,80 @@ static int mv88e6xxx_port_mdb_del(struct
+@@ -4926,6 +4926,80 @@ static int mv88e6xxx_port_mdb_del(struct
  	return err;
  }
  
@@ -106,7 +106,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static int mv88e6xxx_port_egress_floods(struct dsa_switch *ds, int port,
  					 bool unicast, bool multicast)
  {
-@@ -4976,6 +5050,8 @@ static const struct dsa_switch_ops mv88e
+@@ -4980,6 +5054,8 @@ static const struct dsa_switch_ops mv88e
  	.port_mdb_prepare       = mv88e6xxx_port_mdb_prepare,
  	.port_mdb_add           = mv88e6xxx_port_mdb_add,
  	.port_mdb_del           = mv88e6xxx_port_mdb_del,

--- a/target/linux/generic/backport-5.4/748-v5.5-net-dsa-mv88e6xxx-fix-broken-if-statement-because-of.patch
+++ b/target/linux/generic/backport-5.4/748-v5.5-net-dsa-mv88e6xxx-fix-broken-if-statement-because-of.patch
@@ -19,7 +19,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -4989,7 +4989,7 @@ static void mv88e6xxx_port_mirror_del(st
+@@ -4993,7 +4993,7 @@ static void mv88e6xxx_port_mirror_del(st
  		if (chip->info->ops->set_egress_port(chip,
  						     direction,
  						     dsa_upstream_port(ds,

--- a/target/linux/generic/pending-5.4/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
+++ b/target/linux/generic/pending-5.4/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
@@ -17,7 +17,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2659,6 +2659,7 @@ static int mv88e6xxx_setup(struct dsa_sw
+@@ -2663,6 +2663,7 @@ static int mv88e6xxx_setup(struct dsa_sw
  
  	chip->ds = ds;
  	ds->slave_mii_bus = mv88e6xxx_default_mdio_bus(chip);

--- a/target/linux/layerscape/patches-5.4/302-dts-0008-arm64-dts-ls1046a-accumulated-change-to-ls1046a-boar.patch
+++ b/target/linux/layerscape/patches-5.4/302-dts-0008-arm64-dts-ls1046a-accumulated-change-to-ls1046a-boar.patch
@@ -277,15 +277,6 @@ Date:   Fri May 5 17:53:27 2017 +0800
  		compatible = "spansion,m25p80";
 --- a/arch/arm64/boot/dts/freescale/fsl-ls1046a.dtsi
 +++ b/arch/arm64/boot/dts/freescale/fsl-ls1046a.dtsi
-@@ -304,7 +304,7 @@
- 
- 		dcfg: dcfg@1ee0000 {
- 			compatible = "fsl,ls1046a-dcfg", "syscon";
--			reg = <0x0 0x1ee0000 0x0 0x10000>;
-+			reg = <0x0 0x1ee0000 0x0 0x1000>;
- 			big-endian;
- 		};
- 
 @@ -376,7 +376,7 @@
  		};
  

--- a/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0015-MLK-17380-4-usb-host-xhci-add-EH-SINGLE_STEP_SET_FEA.patch
@@ -42,7 +42,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  			retval = xhci_enter_test_mode(xhci, test_mode, wIndex,
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -3582,6 +3582,129 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
+@@ -3591,6 +3591,129 @@ int xhci_queue_ctrl_tx(struct xhci_hcd *
  	return 0;
  }
  
@@ -184,7 +184,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  void xhci_init_driver(struct hc_driver *drv,
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -2144,6 +2144,16 @@ int xhci_find_raw_port_number(struct usb
+@@ -2149,6 +2149,16 @@ int xhci_find_raw_port_number(struct usb
  struct xhci_hub *xhci_get_rhub(struct usb_hcd *hcd);
  
  void xhci_hc_died(struct xhci_hcd *xhci);

--- a/target/linux/layerscape/patches-5.4/820-usb-0016-MLK-16735-usb-host-add-XHCI_CDNS_HOST-flag.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0016-MLK-16735-usb-host-add-XHCI_CDNS_HOST-flag.patch
@@ -36,7 +36,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  #define XHCI_DEFAULT_PM_RUNTIME_ALLOW	BIT_ULL(33)
  #define XHCI_RESET_PLL_ON_DISCONNECT	BIT_ULL(34)
  #define XHCI_SNPS_BROKEN_SUSPEND    BIT_ULL(35)
-+#define XHCI_CDNS_HOST		BIT_ULL(36)
++#define XHCI_CDNS_HOST	BIT_ULL(36)
+ #define XHCI_SKIP_PHY_INIT	BIT_ULL(37)
  #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
  
- 	unsigned int		num_active_eps;

--- a/target/linux/layerscape/patches-5.4/820-usb-0017-MLK-19153-2-usb-host-xhci-do-not-return-error-status.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0017-MLK-19153-2-usb-host-xhci-do-not-return-error-status.patch
@@ -22,7 +22,7 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -2053,12 +2053,9 @@ static int process_ctrl_td(struct xhci_h
+@@ -2058,12 +2058,9 @@ static int process_ctrl_td(struct xhci_h
  
  	switch (trb_comp_code) {
  	case COMP_SUCCESS:

--- a/target/linux/layerscape/patches-5.4/820-usb-0018-MLK-18794-1-usb-host-xhci-add-.bus_suspend-override.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0018-MLK-18794-1-usb-host-xhci-add-.bus_suspend-override.patch
@@ -29,17 +29,17 @@ Signed-off-by: Peter Chen <peter.chen@nxp.com>
  		if (over->start)
  			drv->start = over->start;
 +		if (over->bus_suspend)
-+			drv->bus_suspend = over->bus_suspend;
- 	}
- }
- EXPORT_SYMBOL_GPL(xhci_init_driver);
++			drv->->bus_suspend = over->bus_suspend;
+ 		if (over->check_bandwidth)
+ 			drv->check_bandwidth = over->check_bandwidth;
+ 		if (over->reset_bandwidth)
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1912,6 +1912,7 @@ struct xhci_driver_overrides {
+@@ -1913,6 +1913,7 @@ struct xhci_driver_overrides {
  	size_t extra_priv_size;
  	int (*reset)(struct usb_hcd *hcd);
  	int (*start)(struct usb_hcd *hcd);
 +	int (*bus_suspend)(struct usb_hcd *hcd);
+ 	int (*check_bandwidth)(struct usb_hcd *, struct usb_device *);
+ 	void (*reset_bandwidth)(struct usb_hcd *, struct usb_device *);
  };
- 
- #define	XHCI_CFC_DELAY		10

--- a/target/linux/layerscape/patches-5.4/820-usb-0020-MLK-16604-1-usb-host-xhci-plat-add-XHCI_MISSING_CAS-.patch
+++ b/target/linux/layerscape/patches-5.4/820-usb-0020-MLK-16604-1-usb-host-xhci-plat-add-XHCI_MISSING_CAS-.patch
@@ -16,7 +16,7 @@ Acked-by: Peter Chen <peter.chen@nxp.com>
 
 --- a/drivers/usb/host/xhci-plat.c
 +++ b/drivers/usb/host/xhci-plat.c
-@@ -291,6 +291,10 @@ static int xhci_plat_probe(struct platfo
+@@ -303,6 +303,10 @@ static int xhci_plat_probe(struct platfo
  
  		device_property_read_u32(tmpdev, "imod-interval-ns",
  					 &xhci->imod_interval);


### PR DESCRIPTION
Ran `update_kernel.sh` in a fresh clone without any existing toolchains.

Manually rebased:
```
 bcm27xx
  950-0267-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
 bcm53xx
  180-usb-xhci-add-support-for-performing-fake-doorbell.patch
 layerscape
  302-dts-0008-arm64-dts-ls1046a-accumulated-change-to-ls1046a-boar.patch*
  820-usb-0016-MLK-16735-usb-host-add-XHCI_CDNS_HOST-flag.patch
  820-usb-0018-MLK-18794-1-usb-host-xhci-add-.bus_suspend-override.patch
```
*Quilt threw errors but patch seemed to apply cleanly
```
Build system: x86_64
Build-tested: bcm27xx/bcm2711, ipq806x/R7800
Run-tested: ipq806x/R7800
```
No dmesg regressions/everything functional.

Signed-off-by: John Audia <graysky@archlinux.us>