### PR TITLE
realtek: add support for ZyXEL GS1900-8

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -11,6 +11,7 @@ case "$board" in
 d-link,dgs-1210-16|\
 d-link,dgs-1210-28|\
 d-link,dgs-1210-10p|\
+zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\
 zyxel,gs1900-10hp)

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-8", "realtek,rtl838x-soc";
+	model = "ZyXEL GS1900-8 Switch";
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -94,6 +94,16 @@ define Device/zyxel_gs1900-10hp
 endef
 TARGET_DEVICES += zyxel_gs1900-10hp
 
+define Device/zyxel_gs1900-8
+  SOC := rtl8380
+  IMAGE_SIZE := 6976k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := GS1900-8
+  UIMAGE_MAGIC := 0x83800000
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | gzip | zyxel-vers AAHH | uImage gzip
+endef
+TARGET_DEVICES += zyxel_gs1900-8
+
 define Device/zyxel_gs1900-8hp-v1
   SOC := rtl8380
   IMAGE_SIZE := 6976k


### PR DESCRIPTION
The ZyXEL GS1900-8 is an 8 port smart-managed (L2) gigabit switch, which
appears to share its PCB with the ALLNET ALL-SG8208M (down to the markings on
the PCB, with the only notable difference of the reset GPIO, which follows the
example of its ZyXEL GS1900 siblings), albeit using a rather different OEM
firmware and flash partitioning. Like the other RTL8380M based members of the
GS1900 switch family, the device has a dual firmware layout; for the time
being, booting OpenWrt is only supported from the first partition (mtd5).

Specifications
--------------
* Device:    ZyXEL GS1900-8 v1.2
* SoC:       Realtek RTL8380M 500 MHz MIPS 4KEc
* Flash:     Macronix MX25L12835F 16 MiB
* RAM:       Nanya NT5TU128M8GE-AC 128 MiB DDR2 SDRAM
* Ethernet:  8x 10/100/1000 Mbit
* LEDs:      1 PWR LED (green, not configurable)
             1 SYS LED (green, configurable)
             8 ethernet port status LEDs (green, SoC controlled)
* Buttons:   1 on-off glide switch at the back (not configurable)
             1 reset button at the right side, behind the air-vent
               (not configurable)
             1 reset button on front panel (configurable)
* Power      12V 1A barrel connector
* UART:      1 serial header (JP2) with populated standard pin connector on
             the left side of the PCB, towards the back. Pins are labelled:
             + VCC (3.3V)
             + TX (really RX)
             + RX (really TX)
             + GND
             the labelling is done from the usb2serial connector's point of
             view, so RX/ TX are mixed up.

Serial connection parameters for both devices: 115200 8N1.

Installation
------------

* Configure your client with a static 192.168.1.x IP (e.g. 192.168.1.10).
* Set up a TFTP server on your client and make it serve the initramfs image.
* Connect serial, power up the switch, interrupt U-boot by hitting the
  space bar, and enable the network:
   > rtk network on
* Since the GS1900-8 is a dual-partition device, you want to keep the OEM
  firmware on the backup partition for the time being. OpenWrt can only boot
  from the first partition anyway (hardcoded in the DTS). To make sure we are
  manipulating the first partition, issue the following commands:
  > setsys bootpartition 0
  > savesys
* Download the image onto the device and boot from it:
   > tftpboot 0x84f00000 192.168.1.10:openwrt-realtek-generic-zyxel_gs1900-8-initramfs-kernel.bin
   > bootm
* Once OpenWrt has booted, scp the sysupgrade image to /tmp and flash it:
   > sysupgrade -n /tmp/openwrt-realtek-generic-zyxel_gs1900-8-squashfs-sysupgrade.bin
   it may be necessary to restart the network (/etc/init.d/network restart) on
   the running initramfs image.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>