### PR TITLE
scripts/feeds: generate index after all feeds are updated

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -756,12 +756,11 @@ sub uninstall {
 	return 0;
 }
 
-sub update_feed($$$$$)
+sub update_feed($$$$)
 {
 	my $type=shift;
 	my $name=shift;
 	my $src=shift;
-	my $perform_update=shift;
 	my $force_update=shift;
 	my $force_relocate=update_location( $name, "@$src" );
 	my $rv=0;
@@ -773,28 +772,22 @@ sub update_feed($$$$$)
 		warn "Unknown type '$type' in feed $name\n";
 		return 1;
 	};
-	$perform_update and do {
-		my $failed = 1;
-		foreach my $feedsrc (@$src) {
-			warn "Updating feed '$name' from '$feedsrc' ...\n";
-			if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update) != 0) {
-				if ($force_update) {
-					$rv=1;
-					$failed=0;
-					warn "failed, ignore.\n";
-					next;
-				}
-				last;
+
+	my $failed = 1;
+	foreach my $feedsrc (@$src) {
+		warn "Updating feed '$name' from '$feedsrc' ...\n";
+		if (update_feed_via($type, $name, $feedsrc, $force_relocate, $force_update) != 0) {
+			if ($force_update) {
+				$rv=1;
+				$failed=0;
+				warn "failed, ignore.\n";
+				next;
 			}
-			$failed = 0;
+			last;
 		}
-		$failed and do {
-			warn "failed.\n";
-			return 1;
-		};
-	};
-	warn "Create index file './feeds/$name.index' \n";
-	update_index($name) == 0 or do {
+		$failed = 0;
+	}
+	$failed and do {
 		warn "failed.\n";
 		return 1;
 	};
@@ -803,45 +796,39 @@ sub update_feed($$$$$)
 
 sub update {
 	my %opts;
-	my $feed_name;
-	my $perform_update=1;
+	my %argv_feeds;
 	my $failed=0;
 
 	$ENV{SCAN_COOKIE} = $$;
 	$ENV{OPENWRT_VERBOSE} = 's';
 
 	getopts('ahif', \%opts);
+	%argv_feeds = map { $_ => 1 } @ARGV;
 
 	if ($opts{h}) {
 		usage();
 		return 0;
 	}
 
-	if ($opts{i}) {
-		# don't update from (remote) repository
-		# only re-create index information
-		$perform_update=0;
-	}
-
 	-d "feeds" or do {
 			mkdir "feeds" or die "Unable to create the feeds directory";
 		};
 
-	if ( ($#ARGV == -1) or $opts{a}) {
-		foreach my $feed (@feeds) {
-			my ($type, $name, $src) = @$feed;
-			update_feed($type, $name, $src, $perform_update, $opts{f}) == 0 or $failed=1;
+	my @index_feeds;
+	foreach my $feed (@feeds) {
+		my ($type, $name, $src) = @$feed;
+		next unless $#ARGV == -1 or $opts{a} or $argv_feeds{$name};
+		if (not $opts{i}) {
+			update_feed($type, $name, $src, $opts{f}) == 0 or $failed=1;
 		}
-	} else {
-		while ($feed_name = shift @ARGV) {
-			foreach my $feed (@feeds) {
-				my ($type, $name, $src) = @$feed;
-				if($feed_name ne $name) {
-					next;
-				}
-				update_feed($type, $name, $src, $perform_update, $opts{f}) == 0 or $failed=1;
-			}
-		}
+		push @index_feeds, $name;
+	}
+	foreach my $name (@index_feeds) {
+		warn "Create index file './feeds/$name.index' \n";
+		update_index($name) == 0 or do {
+			warn "failed.\n";
+			$failed=1;
+		};
 	}
 
 	refresh_config();


### PR DESCRIPTION
This separates index update from feed update. The result is that all
requested feeds are first updated and only then indexed.

The reason for this change is to prevent errors being reported and
potentially invalid index being generated thanks to cross feeds
dependency.
The feeds script pulls in default all feeds as they come and on install
prefers packages from first feeds (unless special feed is requested).
Thus order of feeds in some way specifies preferences. This is handy for
downstream distributions as they can simply override any package from
upstream feeds by placing their feed before them. This removes need to
patch or fork upstream feeds.
The problem is that such feed most likely depends in some way also on
subsequent feeds. The most likely feeds are 'packages' or 'luci'. The
example would be Python package that needs 'python.mk' from 'packages'
feed. Ordering custom feed after dependent feeds is sometimes just not
possible because of preference requirement described before.
The solution is to just first pull all feeds and generate indexes only
after that. In the end this ensures that index is generated correctly at
first try without any error.

In terms of code this removes 'perform_update' argument from
'update_feed' as with index update removal the update is the only action
performed in that subroutine. Thus this moves condition to 'update'
subroutine.