### PR TITLE
[19.07] ramips: partition layout patch for hc5962

### DIFF
--- a/target/linux/ramips/dts/HC5962.dts
+++ b/target/linux/ramips/dts/HC5962.dts
@@ -85,45 +85,7 @@
 
 		partition@340000 {
 			label = "ubi";
-			reg = <0x340000 0x1E00000>;
-		};
-
-		partition@2140000 {
-			label = "hw_panic";
-			reg = <0x2140000 0x80000>;
-			read-only;
-		};
-
-		partition@21c0000 {
-			label = "bdinfo";
-			reg = <0x21c0000 0x80000>;
-			read-only;
-		};
-
-		partition@2240000 {
-			label = "backup";
-			reg = <0x2240000 0x80000>;
-			read-only;
-		};
-
-		partition@22c0000 {
-			label = "overly";
-			reg = <0x22c0000 0x1000000>;
-		};
-
-		partition@32c0000 {
-			label = "firmware_backup";
-			reg = <0x32c0000 0x2000000>;
-		};
-
-		partition@52c0000 {
-			label = "oem";
-			reg = <0x52c0000 0x200000>;
-		};
-
-		partition@54c0000 {
-			label = "opt";
-			reg = <0x54c0000 0x2ac0000>;
+			reg = <0x340000 0x7C40000>;
 		};
 	};
 };


### PR DESCRIPTION
Device: https://openwrt.org/toh/hwdata/hiwifi_gee/hiwifi_gee_hc5962

This patch attempts to reclaim space from _non device-specific_ partitions (see below) at the end of the partition table and has been sufficiently tested to work with the current build system.

Further details of the issue were discussed [here](https://forum.openwrt.org/t/hiwifi-gee-hc5962-flash-layout-patch/63256) and more primarily on some Chinese forums.

Signed-off-by: Stephen Sun js2597@cam.ac.uk