### PR TITLE
ath79: Move Meraki MR12 caldata_extract to occur under correct chip

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -56,9 +56,6 @@ case "$FIRMWARE" in
 		caldata_extract "calibrate" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR1)
 		;;
-	meraki,mr12)
-		caldata_extract "art" 0x11000 0xeb8
-		;;
 	nec,wg800hp)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_text board_data 0x680)
@@ -107,6 +104,9 @@ case "$FIRMWARE" in
 	enterasys,ws-ap3705i)
 		caldata_extract "calibrate" 0x5000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR0)
+		;;
+	meraki,mr12)
+		caldata_extract "art" 0x11000 0xeb8
 		;;
 	netgear,wnr2200-8m|\
 	netgear,wnr2200-16m|\


### PR DESCRIPTION
The original commit 55d2db0e8 fails to trigger ART calibration data
extraction for the AR9287. Instead, it would only have extracted
calibration data for an internal WMAC chip which is not present on
this board.

Signed-off-by: Martin Kennedy <hurricos@gmail.com>