### PR TITLE
ramips: fix image size for hc5962

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -559,7 +559,7 @@ define Device/hiwifi_hc5962
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
   UBINIZE_OPTS := -E 5
-  IMAGE_SIZE := 32768k
+  IMAGE_SIZE := 124672k
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \


### PR DESCRIPTION
This commit corrects an error in a previous commit on the master branch [1] where the author forgot to change IMAGE_SIZE accordingly after modifying the partition table and increasing the kernel size to 4096k in preparation for a kernel upgrade.

Referring to the partitions in dts, this parameter indicates the size of the concatenated virtual ubi partition.

[1] https://github.com/openwrt/openwrt/commit/d74fb0088c5bc89ba080816921699a980966d015

Signed-off-by: Stephen Sun js2597@cam.ac.uk

Partition sizes according to dts on the master branch in a human readable form:
u-boot: 524288
debug: 524288
factory: 262144
kernel: 4194304 (i.e. 4096k)
ubipart0: 29884416
ubipart1: 97779712

Signed-off-by: Stephen Sun js2597@cam.ac.uk