### PR TITLE
ramips: use lzma-loader for Wevo devices

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1241,6 +1241,7 @@ TARGET_DEVICES += wavlink_wl-wn531a6
 
 define Device/wevo_11acnas
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   UIMAGE_NAME := 11AC-NAS-Router(0.0.0)
   DEVICE_VENDOR := WeVO
@@ -1253,6 +1254,7 @@ TARGET_DEVICES += wevo_11acnas
 
 define Device/wevo_w2914ns-v2
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   UIMAGE_NAME := W2914NS-V2(0.0.0)
   DEVICE_VENDOR := WeVO


### PR DESCRIPTION
As kernel size increased it start to fail to load squishfs image, using lzma-loader fixed it
wevo_11acnas is almost same device as w2914ns-v2 except ram size, so I expect same thing would've happen in that device too.

Signed-off-by: Seo Suchan <abnoeh@mail.com>