### PR TITLE
Netgear EX6150: Mark the toggle switch as EV_SW

### DIFF
--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -86,6 +86,7 @@
 			label = "AP/Extender toggle";
 			gpios = <&gpio 48 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
 			/* Active when switch is set to "Access Point" */
 		};
 	};


### PR DESCRIPTION
Fixes: FS#3590

I would like to fix this in 19.07 too, should I create an additional pull request for that?

Tested on 19.07