### PR TITLE
ar71xx: disable pdata->use_flow_control for AR7240

### DIFF
--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
@@ -931,7 +931,6 @@ void __init ath79_register_eth(unsigned int id)
 			pdata->speed = SPEED_1000;
 			pdata->duplex = DUPLEX_FULL;
 			pdata->switch_data = &ath79_switch_data;
-			pdata->use_flow_control = 1;
 
 			ath79_switch_data.phy_poll_mask |= BIT(4);
 		}


### PR DESCRIPTION
Flow Control is causing the AR7240 switch to hang.
Disabling Flow Control improves the situation considerably.

It's related to this bug report FS#3054. It only fixes one of the reasons that are causing the switch to hang.

Flow control has been disabled in the past for AR7240 (see https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=0ebc93831f6f1527533bcbc22dd78b888a8ccc10 ) also has been disabled for other SoCs (see for example https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=83997146e76d4097e30facf6ad89e5fa3bd7c65b  ).

It has been tested for more than 1 year with my TL-WR841ND v5 and without Flow Control stability of the switch has been improved considerably.