### PR TITLE
libunwind: Add MIPS64 dep check

### DIFF
--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -32,7 +32,7 @@ define Package/libunwind
   CATEGORY:=Libraries
   TITLE:=The libunwind project
   URL:=http://www.nongnu.org/libunwind/
-  DEPENDS:=@((mips||mipsel||x86_64||arm||aarch64)||(USE_GLIBC&&(powerpc||i386))) +zlib
+  DEPENDS:=@((mips||mipsel||mips64||x86_64||arm||aarch64)||(USE_GLIBC&&(powerpc||i386))) +zlib
   ABI_VERSION:=8
 endef
 


### PR DESCRIPTION
libunwind dependency check does not allow for MIPS64 arch.  Add MIPS64 awareness.

libunwind seems to support MIPS64 without issues, it was limited by the dep arch
check in the Makefile.

Used to compile Suricata6/Rust locally without issue.

Signed-off-by: Donald Hoskins <grommish@gmail.com>

Ping @yousong as Maintainer for additional comments/testing.