### PR TITLE
Add support for Linksys E5600

### DIFF
--- a/scripts/gemtekImageBuilder.sh
+++ b/scripts/gemtekImageBuilder.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+IMAGE=$1
+OUTPUT=$2
+MAGIC=".GEMTEK."
+CHKSUM=$(cksum $IMAGE | awk '{print $1}')
+# 16 bytes
+HDR=$(printf "%8s%08X" $MAGIC $CHKSUM)
+
+(cat $IMAGE ; echo -n $HDR) > $OUTPUT
+(md5sum $OUTPUT | cut -d' ' -f 1) > ${OUTPUT}.md5

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -100,19 +100,22 @@
 		};
 
 		partition@180000 {
-			label = "firmware";
-			compatible = "denx,uimage";
-			reg = <0x180000 0x1e00000>;
+			label = "kernel";
+			reg = <0x180000 0x400000>;
 		};
+
+		partition@580000 {
+			label = "ubi";
+			reg = <0x580000 0x1a00000>;
+		};
+
 		partition@1f80000 {
 			label = "alt_firmware";
-			compatible = "denx,uimage";
 			reg = <0x1f80000 0x1e00000>;
-			read-only;
 		};
+
 		partition@3d80000 {
 			label = "gdata";
-			compatible = "denx,uimage";
 			reg = <0x3d80000 0x4200000>;
 		};
 	};

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "linksys,e5600", "mediatek,mt7621-soc";
+	model = "Linksys E5600";
+		aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+
+		wan_a {
+			label = "amber:wan";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_b {
+			label = "blue:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps { 
+			label = "amber:wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u_env";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@c0000 {
+			label = "factory";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "s_env";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "devinfo";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "firmware";
+			compatible = "denx,uimage";
+			reg = <0x180000 0x1e00000>;
+		};
+		partition@1f80000 {
+			label = "alt_firmware";
+			compatible = "denx,uimage";
+			reg = <0x1f80000 0x1e00000>;
+			read-only;
+		};
+		partition@3d80000 {
+			label = "gdata";
+			compatible = "denx,uimage";
+			reg = <0x3d80000 0x4200000>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -22,6 +22,11 @@ define Build/elecom-wrc-gs-factory
 	mv $@.new $@
 endef
 
+define Build/gemtek-trailer
+  $(TOPDIR)/scripts/gemtekImageBuilder.sh $@ $@.new
+  mv $@.new $@
+endef
+
 define Build/iodata-factory
 	$(eval fw_size=$(word 1,$(1)))
 	$(eval fw_type=$(word 2,$(1)))
@@ -779,15 +784,13 @@ define Device/linksys_e5600
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 26624k
   DEVICE_MODEL := E5600
-  LINKSYS_HWNAME := E5600
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware \
-  uboot-envtools
+  SUPPORTED_DEVICES += e5600
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware uboot-envtools
   UBINIZE_OPTS := -E 5
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
-  append-ubi | check-size | linksys-image type=$$$$(LINKSYS_HWNAME)
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | check-size | gemtek-trailer
 endef
 TARGET_DEVICES += linksys_e5600
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -771,6 +771,26 @@ define Device/linksys_re6500
 endef
 TARGET_DEVICES += linksys_re6500
 
+define Device/linksys_e5600
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 26624k
+  DEVICE_MODEL := E5600
+  LINKSYS_HWNAME := E5600
+  DEVICE_VENDOR := Linksys
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware \
+  uboot-envtools
+  UBINIZE_OPTS := -E 5
+  IMAGES := sysupgrade.bin factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+  append-ubi | check-size | linksys-image type=$$$$(LINKSYS_HWNAME)
+endef
+TARGET_DEVICES += linksys_e5600
+
 define Device/mediatek_ap-mt7621a-v60
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -43,11 +43,10 @@ gnubee,gb-pc2)
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2)
+	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
+	;;
+linksys,e5600)
 	ucidef_set_led_netdev "lan1" "lan1 link" "green:lan1" "lan1" "link"
-	ucidef_set_led_netdev "lan2" "lan2 link" "green:lan2" "lan2" "link"
-	ucidef_set_led_netdev "lan3" "lan3 link" "green:lan3" "lan3" "link"
-	ucidef_set_led_netdev "lan4" "lan4 link" "green:lan4" "lan4" "link"
-	ucidef_set_led_netdev "wan" "wan link" "green:wan" "wan" "link"
 	;;
 mikrotik,routerboard-760igs)
 	ucidef_set_led_netdev "sfp" "SFP" "blue:sfp" "sfp"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -43,10 +43,14 @@ gnubee,gb-pc2)
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2)
-	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
+	ucidef_set_led_netdev "lan1" "lan1 link" "green:lan1" "lan1" "link"
+	ucidef_set_led_netdev "lan2" "lan2 link" "green:lan2" "lan2" "link"
+	ucidef_set_led_netdev "lan3" "lan3 link" "green:lan3" "lan3" "link"
+	ucidef_set_led_netdev "lan4" "lan4 link" "green:lan4" "lan4" "link"
+	ucidef_set_led_netdev "wan" "wan link" "green:wan" "wan" "link"
 	;;
 linksys,e5600)
-	ucidef_set_led_netdev "lan1" "lan1 link" "green:lan1" "lan1" "link"
+	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
 	;;
 mikrotik,routerboard-760igs)
 	ucidef_set_led_netdev "sfp" "SFP" "blue:sfp" "sfp"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -123,7 +123,8 @@ ramips_setup_macs()
 		;;
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
-	linksys,ea7500-v2)
+	linksys,ea7500-v2|\
+	linksys,e5600)
 		lan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		wan_mac=$lan_mac
 		label_mac=$lan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -16,7 +16,8 @@ case "$board" in
 		;;
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
-	linksys,ea7500-v2)
+	linksys,ea7500-v2|\
+	linksys,e5600)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -10,7 +10,8 @@ boot() {
 		;;
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
-	linksys,ea7500-v2)
+	linksys,ea7500-v2|\
+	linksys,e5600)
 		mtd resetbc s_env || true
 		;;
 	samknows,whitebox-v8)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -52,6 +52,7 @@ platform_do_upgrade() {
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
+	linksys,e5600|\
 	netgear,r6220|\
 	netgear,r6260|\
 	netgear,r6350|\


### PR DESCRIPTION
ramips: add support for Linksys E5600

This submission relied heavily on the work of
Santiago Rodriguez-Papa and DavideFioravanti for their work on Linksys EA7300 v1 and v2.

Specifications:

*  SoC:            MediaTek  MT7621A            (880  MHz  2c/4t)
*  RAM:            Unknown         (128M  DDR3-1600)
*  Flash:          Winbond W29N01HVSIN          (128M  NAND)
*  Eth:            MediaTek  MT7621A            (10/100/1000  Mbps  x5)
*  Radio:          MT7603E/MT7613E              (2.4  GHz  &  5  GHz)
                     4  antennae:  2 on PCB internal  and  2 PCB type mounted on casing
*  USB:            None
*  LEDs:
          Blue/ Amber    (x1  Power/ WPS)
          Blue/ Amber    (x1  Internet/ WPS)
          Blue   (x4,  Ethernet Link)
*  Buttons:
          Reset    (x1)
          WPS      (x1)

Installation:

Flash factory image through GUI.

This might fail due to the A/B nature of this device. When flashing, OEM
firmware writes over the non-booted partition. If booted from 'A',
flashing over 'B' won't work. To get around this, you should flash the
OEM image over itself. This will then boot the router from 'B' and
allow you to flash OpenWRT without problems.

Reverting to factory firmware:

Hard-reset the router three times to force it to boot from 'B.' This is
where the stock firmware resides. To remove any traces of OpenWRT from
your router simply flash the OEM image at this point.

