### PR TITLE
ramips: rename interfaces for Mikrotik 750gr3, 760igs

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -42,27 +42,27 @@
 	ports {
 		port@0 {
 			status = "okay";
-			label = "wan";
+			label = "eth1";
 		};
 
 		port@1 {
 			status = "okay";
-			label = "lan2";
+			label = "eth2";
 		};
 
 		port@2 {
 			status = "okay";
-			label = "lan3";
+			label = "eth3";
 		};
 
 		port@3 {
 			status = "okay";
-			label = "lan4";
+			label = "eth4";
 		};
 
 		port@4 {
 			status = "okay";
-			label = "lan5";
+			label = "eth5";
 		};
 	};
 };

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -50,10 +50,10 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	mikrotik,routerboard-750gr3)
-		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
+		ucidef_set_interfaces_lan_wan "eth2 eth3 eth4 eth5" "eth1"
 		;;
 	mikrotik,routerboard-760igs)
-		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan sfp"
+		ucidef_set_interfaces_lan_wan "eth2 eth3 eth4 eth5" "eth1 sfp"
 		;;
 	ubnt,edgerouter-x)
 		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"


### PR DESCRIPTION
Continued work of https://github.com/openwrt/openwrt/pull/3103, since in latest comments it was debated the port labels criteria.

Mikrotik RB760iGS is a device with 5 eth ports and a SFP port, actually the interfaces are named like this:

br-wan: sfp, wan
br-lan: lan2, lan3, lan4, lan5

Since "wan" interface is not a separate interface like most routers, it can be used for lan and wan bridges as well since it could be used to power the router via PoE (see PR 3103 latest comments and there will be also another scenarios where actual naming criteria becomes confusing).

Naming the interfaces like "eth1", "eth2", "eth3", "eth4", "eth5" and "sfp" will end confusions and keep being consistent with the ports usage, since they are all just eth ports and there is only one sfp port.

In this PR it is proposed to use the above criteria to subtitute the actual one.
