### PR TITLE
ath79: add support for Devolo dLAN pro 1200+ WiFi ac

### DIFF
--- a/target/linux/ath79/dts/ar9344_devolo_dlan-pro-1200-ac.dts
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan-pro-1200-ac.dts
@@ -3,6 +3,6 @@
 #include "ar9344_devolo_dlan_wifi.dtsi"
 
 / {
-	model = "Devolo Magic 2 Wifi";
-	compatible = "devolo,magic-2-wifi", "qca,ar9344";
+	model = "Devolo dLAN pro 1200+ WiFi ac";
+	compatible = "devolo,dlan-pro-1200-ac", "qca,ar9344";
 };

--- a/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_dlan_red;
+		led-failsafe = &led_dlan_red;
+		led-running = &led_dlan_white;
+		led-upgrade = &led_dlan_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "white:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_dlan_white: dlan_white {
+			label = "white:dlan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_dlan_red: dlan_red {
+			label = "red:dlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			label = "WIFI button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		dlan {
+			label = "DLAN button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&gpio {
+	wlan_power {
+		gpio-hog;
+		line-name = "WLAN power";
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Config1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "Config2";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x70000 0xf80000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x02000000 0x00000101 0x00001616>;
+
+	mtd-mac-address = <&art 0x1002>;
+	mtd-mac-address-increment = <2>;
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			/* PORT0: RGMII, MAC0/6 exchange, tx_delay 01, No rx_delay */
+			0x04 0x06400000
+			0x08 0x00000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -178,6 +178,7 @@ compex,wpj531-16m)
 	ucidef_set_led_rssi "sig3" "SIG3" "green:sig3" "wlan0" "65" "100"
 	ucidef_set_led_rssi "sig4" "SIG4" "green:sig4" "wlan0" "50" "100"
 	;;
+devolo,dlan-pro-1200-ac|\
 devolo,magic-2-wifi)
 	ucidef_set_led_netdev "plcw" "dLAN" "white:dlan" "eth0.1" "rx"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -206,6 +206,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan" "2:wan"
 		;;
+	devolo,dlan-pro-1200-ac|\
 	devolo,magic-2-wifi)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:wan" "3:lan" "4:lan"
@@ -498,6 +499,7 @@ ath79_setup_macs()
 	compex,wpj563)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
 		;;
+	devolo,dlan-pro-1200-ac|\
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
 		;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -31,6 +31,9 @@ telco,t1)
 	ucidef_add_gpio_switch "lte_poweroff" "LTE Poweroff" "1" "1"
 	ucidef_add_gpio_switch "lte_reset" "LTE Reset" "12" "1"
 	;;
+devolo,dlan-pro-1200-ac)
+	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "0"
+	;;
 devolo,magic-2-wifi)
 	ucidef_add_gpio_switch "plc_pairing" "PLC pairing" "11" "1"
 	ucidef_add_gpio_switch "plc_enable" "PLC enable" "13" "1"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -23,6 +23,7 @@ case "$FIRMWARE" in
 		;;
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
+	devolo,dlan-pro-1200-ac|\
 	devolo,magic-2-wifi|\
 	qxwlan,e1700ac-v2-8m|\
 	qxwlan,e1700ac-v2-16m|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -664,6 +664,15 @@ define Device/compex_wpj563
 endef
 TARGET_DEVICES += compex_wpj563
 
+define Device/devolo_dlan-pro-1200-ac
+  SOC := ar9344
+  DEVICE_VENDOR := Devolo
+  DEVICE_MODEL := dLAN pro 1200+ WiFi ac
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15872k
+endef
+TARGET_DEVICES += devolo_dlan-pro-1200-ac
+
 define Device/devolo_dvl1200e
   SOC := qca9558
   DEVICE_VENDOR := devolo


### PR DESCRIPTION
This patch adds support for the Devolo dLAN pro 1200+ WiFi ac.
This device is a plc wifi AC2400 router/extender with 2 Ethernet ports,
has a QCA7500 PLC and uses the HomePlug AV2 standard.

Other than the PLC the hardware is identical to the Devolo Magic 2 WIFI.
Therefore it uses the same dts, which was moved to a dtsi to be included
by both boards.

This is a board that was previously included in the ar71xx tree.

Hardware:
   SoC:         AR9344
   CPU:         560 MHz
   Flash:       16 MiB (W25Q128JVSIQ)
   RAM:         128 MiB DDR2
   Ethernet:    2xLAN 10/100/1000
   PLC:         QCA75000 (Qualcomm HPAV2)
   PLC Uplink:  1Gbps MIMO
   PLC Link:    RGMII 1Gbps (WAN)
   WiFi:        Atheros AR9340 2.4GHz 802.11bgn
                Atheros AR9882-BR4A 5GHz 802.11ac
   Switch:      QCA8337, Port0:CPU, Port2:PLC, Port3:LAN1, Port4:LAN2
   Button:      3x Buttons (Reset, wifi and plc)
   LED:         3x Leds (wifi, plc white, plc red)
   GPIO Switch: 11-PLC Pairing (Active Low)
                13-PLC Enable
                21-WLAN power

MACs Details verified with the stock firmware:
   Radio1: 2.4 GHz &wmac     *:4c Art location: 0x1002
   Radio0: 5.0 GHz &pcie     *:4d Art location: 0x5006
   Ethernet        &ethernet *:4e = 2.4 GHz + 2
   PLC uplink      ---       *:4f = 2.4 GHz + 3
Label MAC address is from PLC uplink

The Powerline (PLC) interface of the dLAN pro 1200+ WiFi ac requires 3rd
party firmware which is not available from standard OpenWrt package
feeds. There is a package feed on github which you must add to
OpenWrt buildroot so you can build a firmware image which supports the
plc interface.

See: https://github.com/0xFelix/dlan-openwrt (forked from Devolo and
added compatibility for OpenWrt 21.02)

Flash instruction (TFTP):
 1. Set PC to fixed ip address 192.168.0.100
 2. Download the sysupgrade image and rename it to uploadfile
 3. Start a tftp server with the image file in its root directory
 4. Turn off the router
 5. Press and hold Reset button
 6. Turn on router with the reset button pressed and wait ~15 seconds
 7. Release the reset button and after a short time
    the firmware should be transferred from the tftp server
 8. Allow 1-2 minutes for the first boot.