### PR TITLE
uboot-sunxi: add missing type __u64

### DIFF
--- a/package/boot/uboot-sunxi/patches/260-add-missing-type-u64.patch
+++ b/package/boot/uboot-sunxi/patches/260-add-missing-type-u64.patch
@@ -1,0 +1,10 @@
+--- a/include/linux/types.h
++++ b/include/linux/types.h
+@@ -1,6 +1,7 @@
+ #ifndef _LINUX_TYPES_H
+ #define _LINUX_TYPES_H
+ 
++typedef unsigned long long __u64;
+ #include <linux/posix_types.h>
+ #include <asm/types.h>
+ #include <stdbool.h>


### PR DESCRIPTION
Non Linux systems e.g. macOS lack the __u64 type and produce build errors:
In file included from tools/aisimage.c:9:
In file included from include/image.h:19:
In file included from ./arch/arm/include/asm/byteorder.h:29:
In file included from include/linux/byteorder/little_endian.h:13:
include/linux/types.h:146:9: error: unknown type name '__u64'; did you mean '__s64'?
typedef __u64 __bitwise __le64;

Resolved by declaring __u64 in include/linux/types.h
Build tested on macOS and Ubuntu.
Target System (Allwinner A1x/A20/A3x/H3/H5/R40)
Subtarget (Allwinner A20/A3x/H3/R40)
Target Profile (Xunlong Orange Pi Zero)

@wigyori @nbd168 @neheb 