### PR TITLE
ramips: split Youku YK1 to YK-L1 and YK-L1c

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku.dtsi
@@ -4,9 +4,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "youku,yk1", "ralink,mt7620a-soc";
-	model = "YOUKU YK1";
-
 	aliases {
 		led-boot = &led_power;
 		led-failsafe = &led_power;
@@ -88,10 +85,10 @@
 				read-only;
 			};
 
-			partition@50000 {
+			firmware: partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0x1fb0000>;
+				/* reg property is set based on flash size in DTS files */
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_youku.dtsi"
+
+/ {
+	compatible = "youku,yk-l1", "ralink,mt7620a-soc";
+	model = "Youku YK-L1";
+};
+
+&firmware {
+	reg = <0x50000 0x1fb0000>;
+};

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1c.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1c.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_youku.dtsi"
+
+/ {
+	compatible = "youku,yk-l1c", "ralink,mt7620a-soc";
+	model = "Youku YK-L1c";
+};
+
+&firmware {
+	reg = <0x50000 0xfb0000>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1109,16 +1109,26 @@ define Device/xiaomi_miwifi-mini
 endef
 TARGET_DEVICES += xiaomi_miwifi-mini
 
-define Device/youku_yk1
+define Device/youku_yk-l1
   SOC := mt7620a
   IMAGE_SIZE := 32448k
-  DEVICE_VENDOR := YOUKU
-  DEVICE_MODEL := YK1
+  DEVICE_VENDOR := Youku
+  DEVICE_MODEL := YK-L1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \
 	kmod-usb-ledtrig-usbport
-  SUPPORTED_DEVICES += youku-yk1
+  SUPPORTED_DEVICES += youku-yk1 youku,yk1
 endef
-TARGET_DEVICES += youku_yk1
+TARGET_DEVICES += youku_yk-l1
+
+define Device/youku_yk-l1c
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Youku
+  DEVICE_MODEL := YK-L1c
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += youku_yk-l1c
 
 define Device/yukai_bocco
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -215,7 +215,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "4:wan" "6@eth0"
 		;;
-	youku,yk1)
+	youku,yk-l1|\
+	youku,yk-l1c)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "4:wan" "6@eth0"
 		;;
@@ -338,7 +339,8 @@ ramips_setup_macs()
 	lenovo,newifi-y1s|\
 	ohyeah,oy-0001|\
 	wavlink,wl-wn530hg4|\
-	youku,yk1)
+	youku,yk-l1|\
+	youku,yk-l1c)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	linksys,e1700)


### PR DESCRIPTION
Device specifications:
* Model: Youku YK-L1/L1c
* CPU: MT7620A
* RAM: 128 MiB
* Flash: 32 MiB (YK-L1)/ 16 MiB (YK-L1c)
* LAN: 2* 10M/100M Ports
* WAN: 1* 10M/100M Port
* USB: 1* USB2.0
* SD: 1* MicroSD socket
* UART: 1* TTL, Baudrate 57600

Descriptions:
  Previous supported device YOUKU yk1 is actually Youku YK-L1. Though they look
  really different, the only hardware difference between the two models is flash
  size, YK-L1 has 32 MiB flash but YK-L1c has 16MiB. It seems that YK-L1c can
  compatible with YK-L1's firmware but it's better to split it to different models.

  It is easy to identify the models by looking at the label on the bottom of the
  device. The label has the model number "YK-L1" or "YK-L1c". Due to different flash
  sizes, YK-L1c that using previous YK-L1's firmware needs to apply "force update"
  to install compatible firmware, so please backup config file before system upgrade.