### PR TITLE
feeds.conf.default: remove freifunk feed

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,7 +2,6 @@ src-git packages https://git.openwrt.org/feed/packages.git
 src-git luci https://git.openwrt.org/project/luci.git
 src-git routing https://git.openwrt.org/feed/routing.git
 src-git telephony https://git.openwrt.org/feed/telephony.git
-src-git freifunk https://github.com/freifunk/openwrt-packages.git
 #src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git management https://github.com/openwrt-management/packages.git


### PR DESCRIPTION
The feed is being removed because:
a) it is an external project and the OpenWrt team does not have access to it.
b) upon original addition of the feed, there was only a very weak tendency for the addition.
c) there is a general lack of interest in the freifunk repo to review and/or merge pull requests.
d) as far as can be found, all projects which use the freifunk feed have their own make system and self-maintained feeds list.  They do not use the feeds.conf.default from the openwrt repo.
    
more information can be read at the following links:

http://lists.openwrt.org/pipermail/openwrt-devel/2021-February/033807.html
https://github.com/freifunk/openwrt-packages/issues/37

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>
