### PR TITLE
feeds.conf.default: remove freifunk feed in 21.02

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,5 +2,4 @@ src-git packages https://git.openwrt.org/feed/packages.git;openwrt-21.02
 src-git luci https://git.openwrt.org/project/luci.git;openwrt-21.02
 src-git routing https://git.openwrt.org/feed/routing.git;openwrt-21.02
 src-git telephony https://git.openwrt.org/feed/telephony.git;openwrt-21.02
-src-git freifunk https://github.com/freifunk/openwrt-packages.git;openwrt-21.02
 #src-link custom /usr/src/openwrt/custom-feed


### PR DESCRIPTION
The feed is being removed for a few reasons which can be read at the
following links:

http://lists.openwrt.org/pipermail/openwrt-devel/2021-February/033807.html
https://github.com/freifunk/openwrt-packages/issues/37

Openwrt PR #3900 removes the feed in master

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
