### PR TITLE
ramips: improve support for MT7620 Phicomm K2x devices

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
@@ -1,99 +1,21 @@
-#include "mt7620a.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "mt7620a_phicomm_k2x.dtsi"
 
 / {
 	compatible = "phicomm,k2g", "ralink,mt7620a-soc";
 	model = "Phicomm K2G";
-
-	aliases {
-		led-boot = &led_blue;
-		led-failsafe = &led_blue;
-		led-running = &led_blue;
-		led-upgrade = &led_blue;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_blue: blue {
-			label = "blue:status";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-		};
-
-		yellow {
-			label = "yellow:status";
-			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
-		};
-
-		red {
-			label = "red:status";
-			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
 };
 
-&spi0 {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <24000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				reg = <0x0 0x30000>;
-				label = "u-boot";
-				read-only;
-			};
-
-			partition@30000 {
-				reg = <0x30000 0x10000>;
-				label = "u-boot-env";
-				read-only;
-			};
-
-			factory: partition@40000 {
-				reg = <0x40000 0x10000>;
-				label = "factory";
-				read-only;
-			};
-
-			partition@50000 {
-				reg = <0x50000 0x50000>;
-				label = "permanent_config";
-				read-only;
-			};
-
-			partition@a0000 {
-				compatible = "denx,uimage";
-				reg = <0xa0000 0x760000>;
-				label = "firmware";
-			};
-		};
+&partitions {
+	partition@50000 {
+		reg = <0x50000 0x50000>;
+		label = "permanent_config";
+		read-only;
 	};
-};
 
-&state_default {
-	gpio {
-		groups = "i2c", "uartf";
-		function = "gpio";
+	partition@a0000 {
+		compatible = "denx,uimage";
+		reg = <0xa0000 0x760000>;
+		label = "firmware";
 	};
 };
 
@@ -121,20 +43,7 @@
 	};
 };
 
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	mt76@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
 &wmac {
-	ralink,mtd-eeprom = <&factory 0x0>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pa_pins>;
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -4,8 +4,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "phicomm,psg1218", "ralink,mt7620a-soc";
-
 	aliases {
 		led-boot = &led_blue;
 		led-failsafe = &led_blue;
@@ -52,7 +50,7 @@
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -63,22 +61,16 @@
 				read-only;
 			};
 
-			partition@20000 {
+			partition@30000 {
 				label = "u-boot-env";
 				reg = <0x30000 0x10000>;
 				read-only;
 			};
 
-			factory: partition@30000 {
+			factory: partition@40000 {
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
-			};
-
-			partition@40000 {
-				compatible = "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x7b0000>;
 			};
 		};
 	};

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218a.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218a.dts
@@ -1,8 +1,16 @@
-#include "mt7620a_phicomm_psg1218.dtsi"
+#include "mt7620a_phicomm_k2x.dtsi"
 
 / {
 	compatible = "phicomm,psg1218a", "phicomm,psg1218", "ralink,mt7620a-soc";
 	model = "Phicomm PSG1218 rev.A";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x7b0000>;
+	};
 };
 
 &ethernet {

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218b.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218b.dts
@@ -1,8 +1,16 @@
-#include "mt7620a_phicomm_psg1218.dtsi"
+#include "mt7620a_phicomm_k2x.dtsi"
 
 / {
 	compatible = "phicomm,psg1218b", "phicomm,psg1218", "ralink,mt7620a-soc";
 	model = "Phicomm PSG1218 rev.B";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x7b0000>;
+	};
 };
 
 &ethernet {


### PR DESCRIPTION
Description:
 * Improve compatibility of the device tree include file. Now a new .dtsi
   file will support both PSG1218A, PSG1218B and K2G.