### PR TITLE
build: prevent dupes in autotools.mk

### DIFF
--- a/include/autotools.mk
+++ b/include/autotools.mk
@@ -2,6 +2,9 @@
 #
 # Copyright (C) 2007-2020 OpenWrt.org
 
+ifneq ($(__autotools_inc),1)
+__autotools_inc=1
+
 autoconf_bool = $(patsubst %,$(if $($(1)),--enable,--disable)-%,$(2))
 
 # delete *.la-files from staging_dir - we can not yet remove respective lines within all package
@@ -152,12 +155,8 @@ define patch_libtool_host
     $(HOST_BUILD_DIR)))
 endef
 
-ifneq ($(filter patch-libtool,$(PKG_FIXUP)),)
-  Hooks/HostConfigure/Pre += patch_libtool_host
-endif
-
 ifneq ($(filter patch-libtool,$(HOST_FIXUP)),)
-  Hooks/HostConfigure/Pre += $(strip $(call patch_libtool,$(HOST_BUILD_DIR)))
+  Hooks/HostConfigure/Pre += patch_libtool_host
 endif
 
 ifneq ($(filter libtool,$(HOST_FIXUP)),)
@@ -177,3 +176,5 @@ ifneq ($(filter autoreconf,$(HOST_FIXUP)),)
     Hooks/HostConfigure/Pre += autoreconf_host
   endif
 endif
+
+endif #__autotools_inc

--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -24,6 +24,7 @@ PKG_CPE_ID:=cpe:/a:gnu:gettext
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host
+HOST_BUILD_DEPENDS:=libiconv-full/host
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
 
@@ -61,17 +62,15 @@ HOST_CONFIGURE_ARGS += \
 	--disable-shared \
 	--enable-static \
 	--disable-libasprintf \
-	--disable-rpath \
+	--enable-rpath \
 	--disable-java \
 	--disable-openmp \
+	--with-libiconv-prefix=$(STAGING_DIR_HOSTPKG) \
 	--without-emacs \
 	--without-libxml2-prefix
 
 HOST_CONFIGURE_VARS += \
-	EMACS="no" \
-	am_cv_lib_iconv=no \
-	am_cv_func_iconv=no \
-	ac_cv_header_iconv_h=no \
+	EMACS="no"
 
 HOST_CFLAGS += $(HOST_FPIC)
 

--- a/package/libs/libiconv-full/Makefile
+++ b/package/libs/libiconv-full/Makefile
@@ -15,15 +15,19 @@ PKG_SOURCE:=libiconv-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libiconv
 PKG_HASH:=e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 PKG_BUILD_DIR:=$(BUILD_DIR)/libiconv-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/libiconv-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=LGPL-2.1-or-later
 PKG_LICENSE_FILES:=COPYING.LIB
 
 PKG_FIXUP:=patch-libtool
+HOST_FIXUP:=
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
+HOST_BUILD_PARALLEL:=1
 
+include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/libiconv-full/Default
@@ -88,3 +92,4 @@ endef
 $(eval $(call BuildPackage,libcharset))
 $(eval $(call BuildPackage,libiconv-full))
 $(eval $(call BuildPackage,iconv))
+$(eval $(call HostBuild))


### PR DESCRIPTION
autotools.mk does not have any protection currently that would prevent
it from being sourced multiple times. This is not readily apparent,
because the builds do not fail.

Note that both package.mk and host-build.mk source autotools.mk. Take
for example a package that also has a host build. And say that PKG_FIXUP
is set to autoreconf and HOST_FIXUP is not set. Now autotools.mk is
sourced for the first time and will then set HOST_FIXUP to whatever is
in PKG_FIXUP. Then it will add autoreconf_target to both
Hooks/Configure/Pre as well as Hooks/HostConfigure/Pre.

And then autotools.mk is sourced a second time and it will add
autoreconf_target to both Hooks/Configure/Pre and
Hooks/HostConfigure/Pre again.

This doesn't fail the build. But imagine a package that has PKG_FIXUP
set to patch_libtool and has a host package (using libiconv-full and
adding a line that includes host-build.mk will reproduce this). The
patch_libtool define starts with an "@" to prevent echoing. The shell
will be invoked and asked to run patch_libtool once and then again with
the "@" in front, because make saw the first "@" and did what it was
supposed to do, but the second "@" it just took as a literal. Now the
build fails:

bash: -c: line 0: syntax error near unexpected token `cd'
bash: -c: line 0: `(cd /openwrt/build_dir/target-mips_24kc_musl/libiconv-1.16; for lt in $(/openwrt/staging_dir/host/bin/find . -name ltmain.sh); do lt_version="$(/openwrt/staging_dir/host/bin/sed -ne 's,^[[:space:]]*VERSION="\?\([0-9]\.[0-9]\+\).*,\1,p' $lt)"; case "$lt_version" in 1.5|2.2|2.4) echo "autotools.mk: Found libtool v$lt_version - applying patch to $lt"; (cd $(dirname $lt) && patch -N -s -p1 < /openwrt/tools/libtool/files/libtool-v$lt_version.patch || true) ;; *) echo "autotools.mk: error: Unsupported libtool version v$lt_version - cannot patch $lt"; exit 1 ;; esac; done; );   @(cd /openwrt/build_dir/target-mips_24kc_musl/libiconv-1.16; for lt in $(/openwrt/staging_dir/host/bin/find . -name ltmain.sh); do lt_version="$(/openwrt/staging_dir/host/bin/sed -ne 's,^[[:space:]]*VERSION="\?\([0-9]\.[0-9]\+\).*,\1,p' $lt)"; case "$lt_version" in 1.5|2.2|2.4) echo "autotools.mk: Found libtool v$lt_version - applying patch to $lt"; (cd $(dirname $lt) && patch -N -s -p1 < /openwrt/tools/libtool/files/libtool-v$lt_version.patch || true) ;; *) echo "autotools.mk: error: Unsupported libtool version v$lt_version - cannot patch $lt"; exit 1 ;; esac; done; );'
make[2]: *** [Makefile:94: /openwrt/build_dir/target-mips_24kc_musl/libiconv-1.16/.configured_68b329da9893e34099c7d8ad5cb9c940] Error 1

(notice the "@(cd ..." in the middle)

This is fixed by declaring a new variable, __autotools_inc, and only
continuing if this variable doesn't equal 1. The same is done by
rules.mk already.

Also, this commit does away with an ifneq that checks PKG_FIXUP (instead
of HOST_FIXUP) for patch-libtool before adding to the host pre-configure
hook. This does not make sense.

The second ifneq is amended. The current one manually does what the
define patch_libtool_host is already doing. It can just use the define.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>