### PR TITLE
ramips: add support for Qihoo 360 P2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_qihoo_p2.dts
+++ b/target/linux/ramips/dts/mt7628an_qihoo_p2.dts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "qihoo,p2", "mediatek,mt7628an-soc";
+	model = "Qihoo P2";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "blue:system";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "refclk", "wdt", "wled_an", "uart1";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_ffe8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_ffe8: macaddr@ffe8 {
+		reg = <0xffe8 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -335,6 +335,15 @@ define Device/onion_omega2p
 endef
 TARGET_DEVICES += onion_omega2p
 
+define Device/qihoo_p2
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := P2
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ohci kmod-usb2 \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += qihoo_p2
+
 define Device/rakwireless_rak633
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Rakwireless

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -71,6 +71,7 @@ ramips_setup_interfaces()
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
 	hiwifi,hc5861b|\
+	qihoo,p2|\
 	skylab,skw92a|\
 	tplink,archer-c20-v4|\
 	tplink,archer-c20-v5|\
@@ -215,6 +216,10 @@ ramips_setup_macs()
 		;;
 	mercury,mac1200r-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory_info 0xd)" 1)
+		;;
+	qihoo,p2)
+		wan_mac=$(mtd_get_mac_binary factory 0xffee)
+		label_mac=$wan_mac
 		;;
 	rakwireless,rak633|\
 	unielec,u7628-01-16m|\


### PR DESCRIPTION
Specifications:
 * SOC: MT7628AN + MT7612EN
 * RAM: 128 MiB
 * Flash: Winbond W25Q128 (16MiB)
 * WLAN: 2*2 MIMO 2.4G (300M) + 2*2 MIMO 5G (867M)
 * LAN: four 10M/100M LAN ports
 * WAN: one 10M/100M WAN port
 * USB: 1* USB 2.0
 * Buttons: 2, Reset + Release USB (use as WPS in OpenWrt)
 * LEDs: 11
 * TTL: 1, Baudrate 57600
 * TFTP Server IP: 192.168.1.192

Installation:
1. Downgrade firmware to Ver 1.0.xx
2. Upgrade firmware to a special version Ver 1.0.42.42668, which can use
telnet. (search "360POP-P2-DEBUG-V1.0.42.42668.bin" to get it)
3. Use putty to open telnet (account: admin), upload a 3rd party bootloader
to /tmp by wget command and "hfs". (Due to factory bootloader would verify
firmware, and the firmware verify bootloader too, so a 3rd party bootloader
is needed. By the way, Qihoo 360 is a very famous computer security company,
I think it's ambitious to try to crack official bootloader. Recommended to
use "BREED" by HackPascal, search OpenWrt wiki. The bootloader compatible
with HIWIFI HC5661A)
/====================================================================
Notice! Before step 4!
a. If you want to backup official firmware, just use cat command to get mtd0
to /tmp, then use tftp command to transfer it to your computer
        cat /dev/mtd0 > /tmp/all.bin
        tftp -p -l /tmp/all.bin -r all.bin 192.168.x.x
b. Make sure everything is done otherwise your device may broken. It's
necessary to read back mtd1 to check if bootloader are write Correctly.
c. Do not try to use "dd" or "mtd write"!
/=====================================================================
4. Erase and write bootloader (Due to factory bootloader would verify firmware,
and the system verify bootloader too, so a 3rd party bootloader is
. By the way, Qihoo 360 is a very famous computer security company, it's
ambitious to try to crack official bootloader)
	mtd_write erase /dev/mtd1
	cat yourbootloader.bin > /dev/mtd1
5. Unplug the power, push reset button and plug in, hold for several seconds
to enter into bootloader's web recovery. if you do not flash 3rd party firmware,
the factory firmware will replace your bootloader to factory version when next
power on.
6. Flash openwrt*.bin, then it will boot.
