### PR TITLE
build/json: preserve profiles.json

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -18,19 +18,33 @@ work_dir = Path(getenv("WORK_DIR"))
 
 output = {}
 
+
+def get_initial_output(image_info):
+    # preserve existing profiles.json
+    if output_path.is_file():
+        profiles = json.loads(output_path.read_text())
+        if profiles["version_code"] == image_info["version_code"]:
+            return profiles
+    return image_info
+
+
 for json_file in work_dir.glob("*.json"):
     image_info = json.loads(json_file.read_text())
+
     if not output:
-        output.update(image_info)
+        output = get_initial_output(image_info)
+
+    # get first and only profile in json file
+    device_id, profile = next(iter(image_info["profiles"].items()))
+    if device_id not in output["profiles"]:
+        output["profiles"][device_id] = profile
     else:
-        # get first (and only) profile in json file
-        device_id = next(iter(image_info["profiles"].keys()))
-        if device_id not in output["profiles"]:
-            output["profiles"].update(image_info["profiles"])
-        else:
-            output["profiles"][device_id]["images"].append(
-                image_info["profiles"][device_id]["images"][0]
-            )
+        output["profiles"][device_id]["images"].extend(profile["images"])
+
+# make image lists unique by name, keep last/latest
+for device_id, profile in output["profiles"].items():
+    profile["images"] = list({e["name"]: e for e in profile["images"]}.values())
+
 
 if output:
     default_packages, output["arch_packages"] = run(


### PR DESCRIPTION
Keep other profiles.json content if the data belongs to the current build version.

This is needed when building with the image builder, where one make invokation only builds one model and throws all other entries out of the profiles.json file.