### PR TITLE
treewide: remove redundant KERNEL_PREFIX def

### DIFF
--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -4,8 +4,6 @@ include $(INCLUDE_DIR)/image.mk
 define Device/Default
 	PROFILES := Default
 	KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
-	KERNEL_INITRAMFS_PREFIX := $$(IMG_PREFIX)-$(1)-initramfs
-	KERNEL_PREFIX := $$(IMAGE_PREFIX)
 	KERNEL_LOADADDR := 0x80208000
 	DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
 	IMAGES := sysupgrade.bin

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -26,8 +26,6 @@ endef
 define Device/Default
 	PROFILES := Default
 	KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
-	KERNEL_INITRAMFS_PREFIX := $$(IMG_PREFIX)-$(1)-initramfs
-	KERNEL_PREFIX := $$(IMAGE_PREFIX)
 	KERNEL_LOADADDR = 0x42208000
 	DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
 	IMAGES := sysupgrade.bin

--- a/target/linux/zynq/image/Makefile
+++ b/target/linux/zynq/image/Makefile
@@ -31,8 +31,6 @@ define Device/Default
 	PROFILES := Default
 	DEVICE_DTS := $(lastword $(subst _, ,$(1)))
 	KERNEL_DEPENDS = $$(wildcard $(DTS_DIR)/$$(DEVICE_DTS).dts)
-	KERNEL_INITRAMFS_PREFIX := $$(IMG_PREFIX)-$(1)-initramfs
-	KERNEL_PREFIX := $$(IMAGE_PREFIX)
 	KERNEL_LOADADDR := 0x8000
 	IMAGES := sdcard.img.gz
 	IMAGE/sdcard.img.gz := zynq-sdcard | gzip


### PR DESCRIPTION
The variables KERNEL_INITRAMFS_PREFIX and KERNEL_PREFIX are already
defined in include/image.mk and don't have to be redefined in the
target Makefiles.

Signed-off-by: Paul Spooren <mail@aparcar.org>