### PR TITLE
uboot-envtools: fix build errors on macOS 11

### DIFF
--- a/package/boot/uboot-envtools/patches/300-macos-compatibility.patch
+++ b/package/boot/uboot-envtools/patches/300-macos-compatibility.patch
@@ -1,0 +1,24 @@
+--- a/Makefile
++++ b/Makefile
+@@ -327,7 +327,9 @@ KBUILD_HOSTLDFLAGS += $(call os_x_before
+ # since Lion (10.7) ASLR is on by default, but we use linker generated lists
+ # in some host tools which is a problem then ... so disable ASLR for these
+ # tools
+-KBUILD_HOSTLDFLAGS += $(call os_x_before, 10, 7, "", "-Xlinker -no_pie")
++# since Big Sur (11.0) -Xlinker -no_pie cause build errors ld: cannot find -lgcc_s
++MACOS10_7_HOSTLDFLAGS = $(call os_x_before, 10, 7, "", "-Xlinker -no_pie")
++KBUILD_HOSTLDFLAGS += $(call os_x_after, 11, 0, "", $(MACOS10_7_HOSTLDFLAGS))
+ 
+ # macOS Mojave (10.14.X) 
+ # Undefined symbols for architecture x86_64: "_PyArg_ParseTuple"
+--- a/scripts/Makefile.host
++++ b/scripts/Makefile.host
+@@ -67,7 +67,7 @@ host-shared	:= $(addprefix $(obj)/,$(hos
+ #####
+ # Handle options to gcc. Support building with separate output directory
+ 
+-_hostc_flags   = $(KBUILD_HOSTCFLAGS)   $(HOST_EXTRACFLAGS)   \
++_hostc_flags   = $(HOSTCFLAGS) $(KBUILD_HOSTCFLAGS) $(HOST_EXTRACFLAGS) \
+                  $(HOSTCFLAGS_$(basetarget).o)
+ _hostcxx_flags = $(KBUILD_HOSTCXXFLAGS) $(HOST_EXTRACXXFLAGS) \
+                  $(HOSTCXXFLAGS_$(basetarget).o)


### PR DESCRIPTION
Upstream changes in u-boot 2021.01 added prefix KBUILD_ to HOSTCFLAGS, HOSTLDFLAGS, etc.
These changes result in build warnings and errors on macOS 11:
HOSTCC  tools/env/crc32.o
cc1: note: someone does not honour COPTS correctly, passed 0 times
HOSTLD  tools/env/fw_printenv
.../arm-openwrt-linux-muslgnueabi/bin/ld: cannot find -lgcc_s

This patch preserves HOSTCFLAGS and removes the -Xlinker -no_pie flags when building on macOS 11.

Hosts tested: macOS 11, Ubuntu Linux 20.04.
Targets tested: WRT3200ACM, Orange PI zero.
Please review my changes and let me know if additional modifications are required!
It would be good to know why these variables are handled differently on macOS.

@hauke @aparcar @adschm @blocktrron @neheb 