### PR TITLE
ramips: correct Phicomm K2x mac address

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -264,8 +264,6 @@ ramips_setup_macs()
 		;;
 	alfa-network,ac1200rm|\
 	dlink,dir-810l|\
-	phicomm,psg1218a|\
-	phicomm,psg1218b|\
 	trendnet,tew-810dr)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
@@ -328,14 +326,16 @@ ramips_setup_macs()
 	iptime,a104ns)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary u-boot 0x1fc20)" 2)
 		;;
-	lb-link,bl-w1200)
+	lb-link,bl-w1200|\
+	phicomm,k2g|\
+	phicomm,psg1218a|\
+	phicomm,psg1218b)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$wan_mac
 		;;
 	lenovo,newifi-y1|\
 	lenovo,newifi-y1s|\
 	ohyeah,oy-0001|\
-	phicomm,k2g|\
 	wavlink,wl-wn530hg4)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;


### PR DESCRIPTION
Description:
Phicomm K2G: add missing label_mac
Phicomm PSG1218A & PSG1218B: The previous wan mac set as
factory@0x28 +1, but the right wan mac is factory@0x28 -1,
be equal to directly called from factory@0x2e.

Signed-off-by: Shiji Yang <yangshiji66@qq.com>