### PR TITLE
ramips: correct Phicomm PSG1218A switch config

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -18,7 +18,6 @@ ramips_setup_interfaces()
 	dovado,tiny-ac|\
 	ohyeah,oy-0001|\
 	phicomm,psg1208|\
-	phicomm,psg1218a|\
 	planex,db-wrt01|\
 	planex,mzk-750dhp|\
 	ralink,mt7620a-evb|\
@@ -110,6 +109,7 @@ ramips_setup_interfaces()
 		;;
 	dlink,dir-810l|\
 	netgear,jwnr2010-v5|\
+	phicomm,psg1218a|\
 	trendnet,tew-810dr|\
 	zbtlink,zbt-we2026)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Description:
The lan ports sequence is reversed of the device label number.

Signed-off-by: Shiji Yang <yangshiji66@qq.com>
