### PR TITLE
ramips: improve gpio control for Phicomm PSG1218

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
@@ -84,6 +84,13 @@
 	};
 };
 
+&state_default {
+	gpio {
+		groups = "i2c", "uartf";
+		function = "gpio";
+	};
+};
+
 &pcie {
 	status = "okay";
 };

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218a.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218a.dts
@@ -5,17 +5,7 @@
 	model = "Phicomm PSG1218 rev.A";
 };
 
-&state_default {
-	gpio {
-		groups = "i2c", "uartf", "rgmii1", "rgmii2", "wled", "nd_sd";
-		function = "gpio";
-	};
-};
-
 &ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
-
 	mtd-mac-address = <&factory 0x28>;
 
 	mediatek,portmap = "llllw";

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218b.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218b.dts
@@ -5,16 +5,6 @@
 	model = "Phicomm PSG1218 rev.B";
 };
 
-&state_default {
-	gpio {
-		groups = "i2c", "uartf", "rgmii1", "rgmii2", "wled", "nd_sd", "pa";
-		function = "gpio";
-	};
-};
-
 &ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
-
 	mtd-mac-address = <&factory 0x28>;
 };


### PR DESCRIPTION
Description:
1. From key and led config setting, we can find only "uartf" and "i2c" are used
as gpio by check mt7620 datasheet. It's time to remove unused pin group.

2. PSG1218 only have three led, so we can remove ethernet led pinctrl. refer to
Phicomm K2G.