### PR TITLE
ramips: drop duplicate statement in K2G device tree

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
@@ -12,7 +12,6 @@
 		led-failsafe = &led_blue;
 		led-running = &led_blue;
 		led-upgrade = &led_blue;
-		serial0 = &uartlite;
 	};
 
 	leds {


### PR DESCRIPTION
Description: This has been defined in "mt7620.dtsi."