### PR TITLE
gre & vti: use alternate way to check if kernel support is enabled

### DIFF
--- a/package/network/config/gre/Makefile
+++ b/package/network/config/gre/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gre
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/gre/files/gre.sh
+++ b/package/network/config/gre/files/gre.sh
@@ -291,8 +291,6 @@ proto_grev6tap_init_config() {
 }
 
 [ -n "$INCLUDE_ONLY" ] || {
-	[ -f /lib/modules/$(uname -r)/gre.ko ] && add_protocol gre
-	[ -f /lib/modules/$(uname -r)/gre.ko ] && add_protocol gretap
-	[ -f /lib/modules/$(uname -r)/ip6_gre.ko ] && add_protocol grev6
-	[ -f /lib/modules/$(uname -r)/ip6_gre.ko ] && add_protocol grev6tap
+	[ -d /sys/module/ip_gre ] && { add_protocol gre; add_protocol gretap; }
+	[ -d /sys/module/ip6_gre ] && { add_protocol grev6; add_protocol grev6tap; }
 }

--- a/package/network/config/vti/Makefile
+++ b/package/network/config/vti/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=vti
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/vti/files/vti.sh
+++ b/package/network/config/vti/files/vti.sh
@@ -149,6 +149,6 @@ proto_vti6_init_config() {
 }
 
 [ -n "$INCLUDE_ONLY" ] || {
-	[ -f /lib/modules/$(uname -r)/ip_vti.ko ] && add_protocol vti
-	[ -f /lib/modules/$(uname -r)/ip6_vti.ko ] && add_protocol vti6
+	[ -d /sys/module/ip_vti ] && add_protocol vti
+	[ -d /sys/module/ip6_vti ] && add_protocol vti6
 }

--- a/package/network/config/xfrm/Makefile
+++ b/package/network/config/xfrm/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xfrm
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/xfrm/files/xfrm.sh
+++ b/package/network/config/xfrm/files/xfrm.sh
@@ -68,5 +68,5 @@ proto_xfrm_init_config() {
 
 
 [ -n "$INCLUDE_ONLY" ] || {
-	[ -f /lib/modules/$(uname -r)/xfrm_interface.ko -o -d /sys/module/xfrm_interface ] && add_protocol xfrm
+	[ -d /sys/module/xfrm_interface ] && add_protocol xfrm
 }


### PR DESCRIPTION
When necessary support is built in kernel, gre and vti protocol
support is not enabled in netifd.

Signed-off-by: Alin Nastac <alin.nastac@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
