### PR TITLE
bcm63xx: rename upstreamed patch in master

### DIFF
--- a/target/linux/bcm63xx/patches-5.4/047-v5.12-bcm63xx_enet-fix-kernel-panic.patch
+++ b/target/linux/bcm63xx/patches-5.4/047-v5.12-bcm63xx_enet-fix-kernel-panic.patch
@@ -1,7 +1,7 @@
-From ca6be00ca1d3a2f5b8794894e2dae175e63768f5 Mon Sep 17 00:00:00 2001
+From 90eda07518ea7e8d1b3e6445eb3633eef9f65218 Mon Sep 17 00:00:00 2001
 From: Sieng Piaw Liew <liew.s.piaw@gmail.com>
-Date: Tue, 16 Feb 2021 16:23:08 +0800
-Subject: [PATCH] bcm63xx_enet: Fix sporadic kernel panic
+Date: Mon, 22 Feb 2021 09:15:12 +0800
+Subject: [PATCH net] bcm63xx_enet: fix sporadic kernel panic
 
 In ndo_stop functions, netdev_completed_queue() is called during forced
 tx reclaim, after netdev_reset_queue(). This may trigger kernel panic if
@@ -11,6 +11,9 @@ This patch moves netdev_reset_queue() to after tx reclaim, so BQL can
 complete successfully then reset.
 
 Signed-off-by: Sieng Piaw Liew <liew.s.piaw@gmail.com>
+Acked-by: Florian Fainelli <f.fainelli@gmail.com>
+Fixes: 4c59b0f5543d ("bcm63xx_enet: add BQL support")
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 ---
  drivers/net/ethernet/broadcom/bcm63xx_enet.c | 8 ++++++--
  1 file changed, 6 insertions(+), 2 deletions(-)


### PR DESCRIPTION
Patch to fix kernel panic was recently accepted upstream so rename patch
and add acked lines to reflect that. @Noltari 

https://lore.kernel.org/netdev/20210222013530.1356-1-liew.s.piaw@gmail.com/