### PR TITLE
ramips: fix partition layout of hiwifi hc5x61

### DIFF
--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -62,7 +62,7 @@
 			};
 
 			partition@30000 {
-				label = "u-boot-env";
+				label = "hw_panic";
 				reg = <0x30000 0x10000>;
 				read-only;
 			};
@@ -76,12 +76,12 @@
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0xf80000>;
+				reg = <0x50000 0xf70000>;
 			};
 
-			partition@fd0000 {
-				label = "hwf_config";
-				reg = <0xfd0000 0x10000>;
+			partition@fc0000 {
+				label = "oem";
+				reg = <0xfc0000 0x20000>;
 				read-only;
 			};
 


### PR DESCRIPTION
Changes:
 * Increase "oem" partition size from 0x10000 to 0x20000
 * Correct partition lables, synchronize with official firmware

Evidence:
It should be the same as hiwifi hc5x61a and the fact indeed the
case. Here is part of dmesg boot log read from official firmware:
[    1.470000] Creating 7 MTD partitions on "raspi":
[    1.470000] 0x000000000000-0x000000030000 : "u-boot"
[    1.480000] 0x000000030000-0x000000040000 : "hw_panic"
[    1.490000] 0x000000040000-0x000000050000 : "Factory"
[    1.490000] 0x000000fc0000-0x000000fe0000 : "oem"
[    1.500000] 0x000000fe0000-0x000000ff0000 : "bdinfo"
[    1.510000] 0x000000ff0000-0x000001000000 : "backup"
[    1.510000] 0x000000050000-0x000000fc0000 : "firmware"

Signed-off-by: Shiji Yang <yangshiji66@qq.com>