### PR TITLE
elfutils: enable building with MIPS16

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.180
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
@@ -21,7 +21,7 @@ PKG_CPE_ID:=cpe:/a:elfutils_project:elfutils
 
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
-PKG_USE_MIPS16:=0
+PKG_USE_MIPS16:=1
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Building with MIPS16 was disabled in 2013 due to an issue with GCC TLS: https://dev.archive.openwrt.org/ticket/13572. But after the problematic GCC version was retired, this change wasn't revisited.

Re-enable MIPS16 builds to reduce average elfutils library sizes ~10%. This was compile-tested on malta/mips32be and malta/mips32le, and linked with iproute2 for run-testing. Package sizes (mips32be) follow:
```
Library  MIPS16:=0  MIPS16:=1
-------  ---------  ---------
libelf1    43217      37492
libasm1    12481      11658
libdw1    229723     205793
```
Pinging package maintainer @luizluca , past updater @neheb , and @nbd168 who first disabled MIPS16 way back when.
