### PR TITLE
wireguard-tools: depend on kmod-wireguard

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -36,7 +36,10 @@ define Package/wireguard-tools
   URL:=https://www.wireguard.com
   MAINTAINER:=Jason A. Donenfeld <Jason@zx2c4.com>
   TITLE:=WireGuard userspace control program (wg)
-  DEPENDS:=+@BUSYBOX_CONFIG_IP +@BUSYBOX_CONFIG_FEATURE_IP_LINK
+  DEPENDS:= \
+	  +@BUSYBOX_CONFIG_IP \
+	  +@BUSYBOX_CONFIG_FEATURE_IP_LINK \
+	  +kmod-wireguard
 endef
 
 define Package/wireguard-tools/description


### PR DESCRIPTION
To the vast majority of the users, wireguard-tools are not useful
without the underlying kernel module. The cornercase of only generating
keys and not using the secure tunnel is something that won't be done on
an embedded OpenWrt system often. On the other hand, maintaining a
separate meta-package only for this use case introduces extra
complexity. WireGuard changes for Linux 5.10 remove the meta-package.
So let's make wireguard-tools depend on kmod-wireguard
to make WireGuard easier to use without having to install multiple
packages.

Fixes: ea980fb9 ("wireguard: bump to 20191226")
Signed-off-by: Ilya Lipnitskiy <ilya.lipnitskiy@gmail.com>

cc: @zx2c4 @rsalvaterra @karlp 