### PR TITLE
ath79: add support for Dongwon T&I DW02-412H

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -77,9 +77,8 @@ buffalo,wzr-hp-g300nh-s)
 domywifi,dw33d)
 	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
 	;;
-glinet,gl-ar150)
-	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
-	;;
+dongwon,dw02-412h-64m|\
+dongwon,dw02-412h-128m|\
 glinet,gl-ar300m-lite|\
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor|\
@@ -87,6 +86,9 @@ glinet,gl-ar300m16)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	;;
+glinet,gl-ar150)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
 	;;
 netgear,wndr3700|\
 netgear,wndr3700-v2|\

--- a/target/linux/ath79/dts/qca9557_dongwon_dw02-412h-128m.dts
+++ b/target/linux/ath79/dts/qca9557_dongwon_dw02-412h-128m.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9557_dongwon_dw02-412h.dtsi"
+
+/ {
+	model = "Dongwon T&I DW02-412H (128M)";
+	compatible = "dongwon,dw02-412h-128m", "qca,qca9557";
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "current";
+			reg = <0x0 0x1000000>;
+			read-only;
+		};
+
+		partition@1000000 {
+			label = "kernel";
+			reg = <0x1000000 0x800000>;
+		};
+
+		partition@1800000 {
+			label = "ubi";
+			reg = <0x1800000 0x6800000>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9557_dongwon_dw02-412h-64m.dts
+++ b/target/linux/ath79/dts/qca9557_dongwon_dw02-412h-64m.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9557_dongwon_dw02-412h.dtsi"
+
+/ {
+	model = "Dongwon T&I DW02-412H (64M)";
+	compatible = "dongwon,dw02-412h-64m", "qca,qca9557";
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "current";
+			reg = <0x0 0x1000000>;
+			read-only;
+		};
+
+		partition@1000000 {
+			label = "kernel";
+			reg = <0x1000000 0x800000>;
+		};
+
+		partition@1800000 {
+			label = "ubi";
+			reg = <0x1800000 0x2800000>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9557_dongwon_dw02-412h.dtsi
+++ b/target/linux/ath79/dts/qca9557_dongwon_dw02-412h.dtsi
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_wan;
+		led-failsafe = &led_wan;
+		led-upgrade = &led_wan;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "WPS button";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+		
+		reset {
+			label = "Reset button";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wan: wan {
+			label = "green:wan";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "log";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "recoverk";
+				reg = <0x060000 0x0e0000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "recoverr";
+				reg = <0x140000 0x090000>;
+				read-only;
+			};
+
+			partition@1d0000 {
+				label = "nvram";
+				reg = <0x1d0000 0x010000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "nvbackup";
+				reg = <0x1e0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@1f0000 {
+				label = "art";
+				reg = <0x1f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <3>;
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x50 0xcf37cf37 /* LED Control Register 0 */
+			0x54 0x00000000 /* LED Control Register 1 */
+			0x58 0x00000000 /* LED Control Register 2 */
+			0x5c 0x0030c300 /* LED Control Register 3 */
+			0x7c 0x0000007e	/* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+	phy-handle = <&phy0>;
+	pll-data = <0xa6000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -1,3 +1,16 @@
+define Build/dw-headers
+	head -c 4 $@ >> $@.tmp && \
+	head -c 8 /dev/zero >> $@.tmp && \
+	tail -c +9 $@ >> $@.tmp && \
+	( \
+		header_crc="$$(head -c 68 $@.tmp | gzip -c | \
+			tail -c 8 | od -An -N4 -tx4 --endian little | tr -d ' \n')"; \
+		printf "$$(echo $$header_crc | sed 's/../\\x&/g')" | \
+			dd of=$@.tmp bs=4 count=1 seek=1 conv=notrunc \
+	)
+	mv $@.tmp $@
+endef
+
 # attention: only zlib compression is allowed for the boot fs
 define Build/zyxel-buildkerneljffs
 	rm -rf  $(KDIR_TMP)/zyxelnbg6716
@@ -76,6 +89,41 @@ define Device/domywifi_dw33d
 	check-size
 endef
 TARGET_DEVICES += domywifi_dw33d
+
+define Device/dongwon_dw02-412h
+  SOC := qca9557
+  DEVICE_VENDOR := Dongwon T&I
+  DEVICE_MODEL := DW02-412H
+  DEVICE_ALT0_VENDOR := KT
+  DEVICE_ALT0_MODEL := GiGA WiFi home
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  KERNEL_SIZE := 8192k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | dw-headers
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma | dw-headers
+  UBINIZE_OPTS := -E 5
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+
+define Device/dongwon_dw02-412h-64m
+  $(Device/dongwon_dw02-412h)
+  DEVICE_VARIANT := (64M)
+  DEVICE_ALT0_VARIANT := (64M)
+  IMAGE_SIZE := 49152k
+endef
+TARGET_DEVICES += dongwon_dw02-412h-64m
+
+define Device/dongwon_dw02-412h-128m
+  $(Device/dongwon_dw02-412h)
+  DEVICE_VARIANT := (128M)
+  DEVICE_ALT0_VARIANT := (128M)
+  IMAGE_SIZE := 114688k
+endef
+TARGET_DEVICES += dongwon_dw02-412h-128m
 
 define Device/glinet_gl-ar300m-common-nand
   SOC := qca9531

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -6,6 +6,10 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+dongwon,dw02-412h-64m|\
+dongwon,dw02-412h-128m)
+	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"
+	;;
 glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -15,6 +15,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth1"
 		;;
+	dongwon,dw02-412h-64m|\
+	dongwon,dw02-412h-128m)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
+		;;
 	glinet,gl-ar750s-nor|\
 	glinet,gl-ar750s-nor-nand)
 		ucidef_add_switch "switch0" \
@@ -47,6 +52,11 @@ ath79_setup_macs()
 	local board="$1"
 
 	case "$board" in
+	dongwon,dw02-412h-64m|\
+	dongwon,dw02-412h-128m)
+		wan_mac=$(mtd_get_mac_binary art 0x0)
+		label_mac=$wan_mac
+		;;
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -13,6 +13,11 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_binary art 0x12)
 		;;
+	dongwon,dw02-412h-64m|\
+	dongwon,dw02-412h-128m)
+		caldata_extract "art" 0x5000 0x844
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 4)
+		;;
 	glinet,gl-ar750s-nor|\
 	glinet,gl-ar750s-nor-nand)
 		caldata_extract "art" 0x5000 0x844

--- a/target/linux/generic/pending-5.10/484-mtd-spi-nor-add-esmt-f25l16pa.patch
+++ b/target/linux/generic/pending-5.10/484-mtd-spi-nor-add-esmt-f25l16pa.patch
@@ -1,0 +1,11 @@
+--- a/drivers/mtd/spi-nor/esmt.c
++++ b/drivers/mtd/spi-nor/esmt.c
+@@ -10,6 +10,8 @@
+ 
+ static const struct flash_info esmt_parts[] = {
+ 	/* ESMT */
++	{ "f25l16pa-2s", INFO(0x8c2115, 0, 64 * 1024, 32,
++			   SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l32pa", INFO(0x8c2016, 0, 64 * 1024, 64,
+ 			   SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l32qa", INFO(0x8c4116, 0, 64 * 1024, 64,

--- a/target/linux/generic/pending-5.4/484-mtd-spi-nor-add-esmt-f25l16pa.patch
+++ b/target/linux/generic/pending-5.4/484-mtd-spi-nor-add-esmt-f25l16pa.patch
@@ -1,0 +1,10 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -2243,6 +2243,7 @@ static const struct flash_info spi_nor_i
+ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },
+ 
+ 	/* ESMT */
++	{ "f25l16pa-2s", INFO(0x8c2115, 0, 64 * 1024, 32, SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l32pa", INFO(0x8c2016, 0, 64 * 1024, 64, SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l32qa", INFO(0x8c4116, 0, 64 * 1024, 64, SECT_4K | SPI_NOR_HAS_LOCK) },
+ 	{ "f25l64qa", INFO(0x8c4117, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_HAS_LOCK) },


### PR DESCRIPTION
Dongwon T&I DW02-412H is a 2.4/5GHz band 11ac (WiFi-5) router, based on Qualcomm Atheros QCA9557.

Specifications
--------------

- SoC: Qualcomm Atheros QCA9557-AT4A
- RAM: DDR2 128MB
- Flash: SPI NOR 2MB (Winbond W25Q16DVSSIG / ESMT F25L16PA) + NAND 64/128MB
- WiFi:
  - 2.4GHz: QCA9557 WMAC
  - 5GHz: QCA9882-BR4A
- Ethernet: 5x 10/100/1000Mbps
  - Switch: QCA8337N-AL3C
- USB: 1x USB 2.0
- UART:
  - JP2: 3.3V, TX, RX, GND (3.3V is the square pad) / 115200 8N1

Installation
--------------

1.  Connect a serial interface to UART header and interrupt the autostart of kernel.
2.  Transfer the factory image via TFTP and write it to the NAND flash.
3.  Update U-Boot environment variable.
```
> tftpboot 0x81000000 <your image>-factory.img
> nand erase 0x1000000
> nand write 0x81000000 0x1000000 ${filesize}
> setenv bootpart 2
> saveenv
```

Revert to stock firmware
--------------

1.  Revert to stock U-Boot environment variable.
```
> setenv bootpart 1
> saveenv
```

MAC addresses as verified by OEM firmware
--------------

```
   WAN: *:XX (label)
   LAN: *:XX + 1
  2.4G: *:XX + 3
    5G: *:XX + 4
```

The label MAC address was found in art 0x0.

Credits
--------------

Credit goes to the @manatails who first developed how to port OpenWRT to this device and had a significant impact on this patch.

And thanks to @adschm and @mans0n for guiding me to revise the code in many ways.

Signed-off-by: Jihoon Han rapid_renard@renard.ga