### PR TITLE
ath79: fix USB power on TL-WR810N v1

### DIFF
--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
@@ -13,6 +13,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-always-on;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
@@ -13,7 +13,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-always-on;
+		regulator-always-on; 
 	};
 };
 


### PR DESCRIPTION
Before: Kernel reported "usb_vbus: disabling" and the USB was not providing power
After: USB power is switched on, peripheral is powered from the device

Signed-off-by: Tom Stöveken <tom@naaa.de>