### PR TITLE
kernel-defaults: fix external kernel build when user_headers is missing

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -43,7 +43,9 @@ else
 		rmdir $(LINUX_DIR); \
 	fi
 	ln -s $(CONFIG_EXTERNAL_KERNEL_TREE) $(LINUX_DIR)
-	$(_SINGLE) [ -d $(LINUX_DIR)/user_headers ] && rm -rf $(LINUX_DIR)/user_headers
+	if [ -d $(LINUX_DIR)/user_headers ]; then \
+		rm -rf $(LINUX_DIR)/user_headers; \
+	fi
   endef
 endif
 


### PR DESCRIPTION
Use an 'if' so the absence of $(LINUX_DIR)/user_headers doesn't make the
line evaluate to false and cause the build to fail.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

this was encountered when building openwrt-21.02 with an out of tree kernel, it would be nice to cherry-pick this in, thanks.