### PR TITLE
bpftools: update to latest stable 5.11.2

### DIFF
--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bpftools
-PKG_VERSION:=5.10.10
+PKG_VERSION:=5.11.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=linux-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/v5.x
-PKG_HASH:=60ed866fa951522a5255ea37ec3ac2006d3f3427d4783a13ef478464f37cdb19
+PKG_HASH:=904a5b3cbaf5264ef8da6c7a5445fa7ea19168ad77fb83a7cc1b8ba95d52d0a0
 
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
 


### PR DESCRIPTION
Compile and run-tested on malta/mip32be, using bpftool directly and also libbpf (linked with tc) to inspect and load simple eBPF programs.

Signed-off-by: Tony Ambardar <itugrok@yahoo.com>

Pinging @dangowrt and @ynezz since you've both previously reviewed/merged updates for this package. Please let me know of any questions/concerns and thanks for looking. Together with https://github.com/openwrt/openwrt/pull/3904, I'd like to get these pushed to 21.02 as well if possible.