### PR TITLE
base-files: upgrade: use zcat command provided by busybox

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -95,7 +95,7 @@ get_image() { # <source> [ <command> ]
 	if [ -z "$cmd" ]; then
 		local magic="$(dd if="$from" bs=2 count=1 2>/dev/null | hexdump -n 2 -e '1/1 "%02x"')"
 		case "$magic" in
-			1f8b) cmd="zcat";;
+			1f8b) cmd="busybox zcat";;
 			425a) cmd="bzcat";;
 			*) cmd="cat";;
 		esac


### PR DESCRIPTION
If gzip is installed, the [`switch_to_ramfs()`](https://github.com/openwrt/openwrt/blob/3d12b47985fc1983849925d2dc23430f55210c80/package/base-files/files/lib/upgrade/stage2#L35) call will not copy the gzip executable to ramfs, however `/bin/zcat` will call it instead of the busybox-supplied zcat. This will cause sysupgrade to fail.

Signed-off-by: Chuck <fanck0605@qq.com>

fix openwrt/packages#14925

tested on FriendlyElec NanoPi R2S
