### PR TITLE
tools/elfutils: use modern libelf on linux hosts

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,7 +28,7 @@ tools-y += mklibs mm-macros mtd-utils mtools padjffs2 patch-image
 tools-y += patchelf pkgconf quilt squashfskit4 sstrip zip zlib zstd
 tools-$(BUILD_B43_TOOLS) += b43-tools
 tools-$(BUILD_ISL) += isl
-tools-$(BUILD_TOOLCHAIN) += expat gmp libelf mpc mpfr
+tools-$(BUILD_TOOLCHAIN) += expat gmp mpc mpfr
 tools-$(CONFIG_TARGET_apm821xx)$(CONFIG_TARGET_gemini) += genext2fs
 tools-$(CONFIG_TARGET_ath79) += lzma-old squashfs
 tools-$(CONFIG_TARGET_mxs) += elftosb sdimage
@@ -77,6 +77,16 @@ $(curdir)/zstd/compile := $(curdir)/cmake/compile
 ifneq ($(HOST_OS),Linux)
   $(curdir)/squashfskit4/compile += $(curdir)/coreutils/compile
   tools-y += coreutils
+endif
+
+ifneq ($(HOST_OS),Linux)
+  $(curdir)/libelf/compile := $(curdir)/libtool/compile
+  tools-$(BUILD_TOOLCHAIN) += libelf
+else
+  $(curdir)/elfutils/compile := $(curdir)/m4/compile
+  $(curdir)/elfutils/compile := $(curdir)/zlib/compile
+  $(curdir)/elfutils/compile := $(curdir)/lzma/compile
+  tools-$(BUILD_TOOLCHAIN) += elfutils
 endif
 
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)

--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -1,0 +1,42 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=elfutils
+PKG_VERSION:=0.180
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
+PKG_HASH:=b827b6e35c59d188ba97d7cf148fa8dc6f5c68eb6c5981888dfdbb758c0b569d
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING COPYING-GPLV2 COPYING-LGPLV3
+PKG_CPE_ID:=cpe:/a:elfutils_project:elfutils
+
+HOST_BUILD_PARALLEL:=1
+HOST_FIXUP:=autoreconf
+
+include $(INCLUDE_DIR)/host-build.mk
+
+HOST_CONFIGURE_ARGS += \
+	--program-prefix=eu- \
+	--disable-debuginfod \
+	--without-bzlib
+
+#define Host/Uninstall
+#	-$(MAKE) -C $(HOST_BUILD_DIR) uninstall
+#endef
+
+define Host/Clean
+	rm -f $(STAGING_DIR_HOST)/lib/pkgconfig/lib{elf,dw}.pc
+	rm -rf $(STAGING_DIR_HOST)/include/elfutils
+	rm -f $(STAGING_DIR_HOST)/include/{libelf,gelf,nlist,dwarf}.h
+	rm -f $(STAGING_DIR_HOST)/lib/lib{elf,dw,asm}{,-*}.{so,so.*,a}
+	$(call Host/Clean/Default)
+endef
+
+$(eval $(call HostBuild))

--- a/tools/elfutils/patches/005-build_only_libs.patch
+++ b/tools/elfutils/patches/005-build_only_libs.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -27,7 +27,7 @@ AM_MAKEFLAGS = --no-print-directory
+ pkginclude_HEADERS = version.h
+
+ SUBDIRS = config m4 lib libelf libcpu backends libebl libdwelf libdwfl libdw \
+-	  libasm src po doc tests
++	  libasm
+
+ if DEBUGINFOD
+ SUBDIRS += debuginfod


### PR DESCRIPTION
This is based on prior work @ https://github.com/openwrt/openwrt/pull/3855

This change is required to build linux kernels 5.8+ as the existing, quite old, libelf does not support gelf_getsymshndx. See https://github.com/torvalds/linux/blob/4e909124f8ed54b13e07e42273c3452b7deb5a0b/tools/objtool/elf.c#L378

```Signed-off-by: Curtis Deptuck <curtdept@me.com>```
