### PR TITLE
build: Change ERROR_MESSAGE macro output

### DIFF
--- a/include/verbose.mk
+++ b/include/verbose.mk
@@ -31,11 +31,11 @@ endif
 
 ifeq ($(findstring s,$(OPENWRT_VERBOSE)),)
   define MESSAGE
-	printf "$(_Y)%s$(_N)\n" "$(1)" >&8
+	printf "$(_Y)%s$(_N)\n" "$(1)"
   endef
 
   define ERROR_MESSAGE
-	printf "$(_R)%s$(_N)\n" "$(1)" >&8
+	printf "$(_R)%s$(_N)\n" "$(1)" >&2
   endef
 
   ifeq ($(QUIET),1)
@@ -51,7 +51,7 @@ ifeq ($(findstring s,$(OPENWRT_VERBOSE)),)
   else
     SILENT:=>/dev/null $(if $(findstring w,$(OPENWRT_VERBOSE)),,2>&1)
     export QUIET:=1
-    SUBMAKE=cmd() { $(SILENT) $(MAKE) -s "$$@" < /dev/null || { echo "make $$*: build failed. Please re-run make with -j1 V=s or V=sc for a higher verbosity level to see what's going on"; false; } } 8>&1 9>&2; cmd
+    SUBMAKE=cmd() { $(SILENT) $(MAKE) -s "$$@" < /dev/null || { echo "make $$*: build failed. Please re-run make with -j1 V=s or V=sc for a higher verbosity level to see what's going on"; false; } }; cmd
   endif
 
   .SILENT: $(MAKECMDGOALS)


### PR DESCRIPTION
When compiling, I noticed the following message:
```bash
Generating index for package ./sqm-scripts_1.5.0-2_all.ipk
Generating index for package ./sstp-client_1.0.13-1_aarch64_generic.ipk
bash: line 6: 8: Bad file descriptor
Signing package index...
```
After I found the problem appeared in  openwrt/package/Makefile Line: 90
```bash
$(call ERROR_MESSAGE,WARNING: Applying padding in $$d/Packages to workaround usign SHA-512 bug!); \
```
ERROR_MESSAGE is defined in openwrt/include/verbose.mk
```
  define ERROR_MESSAGE
	printf "$(_R)%s$(_N)\n" "$(1)" >&8
  endef
```

Apparently this outputs a message to file descriptor 8, but in reality file descriptor 8 is not available, so it ends up with an error.
So I made a change here.

Tested on : ubuntu 20.04