### PR TITLE
hostapd: P2P: Fix a corner case in peer addition based on PD Request

### DIFF
--- a/package/network/services/hostapd/patches/060-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
+++ b/package/network/services/hostapd/patches/060-P2P-Fix-a-corner-case-in-peer-addition-based-on-PD-R.patch
@@ -1,0 +1,45 @@
+From 8460e3230988ef2ec13ce6b69b687e941f6cdb32 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni@codeaurora.org>
+Date: Tue, 8 Dec 2020 23:52:50 +0200
+Subject: [PATCH] P2P: Fix a corner case in peer addition based on PD Request
+
+p2p_add_device() may remove the oldest entry if there is no room in the
+peer table for a new peer. This would result in any pointer to that
+removed entry becoming stale. A corner case with an invalid PD Request
+frame could result in such a case ending up using (read+write) freed
+memory. This could only by triggered when the peer table has reached its
+maximum size and the PD Request frame is received from the P2P Device
+Address of the oldest remaining entry and the frame has incorrect P2P
+Device Address in the payload.
+
+Fix this by fetching the dev pointer again after having called
+p2p_add_device() so that the stale pointer cannot be used.
+
+Fixes: 17bef1e97a50 ("P2P: Add peer entry based on Provision Discovery Request")
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+---
+ src/p2p/p2p_pd.c | 12 +++++-------
+ 1 file changed, 5 insertions(+), 7 deletions(-)
+
+--- a/src/p2p/p2p_pd.c
++++ b/src/p2p/p2p_pd.c
+@@ -595,14 +595,12 @@ void p2p_process_prov_disc_req(struct p2
+ 			goto out;
+ 		}
+ 
++		dev = p2p_get_device(p2p, sa);
+ 		if (!dev) {
+-			dev = p2p_get_device(p2p, sa);
+-			if (!dev) {
+-				p2p_dbg(p2p,
+-					"Provision Discovery device not found "
+-					MACSTR, MAC2STR(sa));
+-				goto out;
+-			}
++			p2p_dbg(p2p,
++				"Provision Discovery device not found "
++				MACSTR, MAC2STR(sa));
++			goto out;
+ 		}
+ 	} else if (msg.wfd_subelems) {
+ 		wpabuf_free(dev->info.wfd_subelems);


### PR DESCRIPTION
This adds the security fix from https://w1.fi/security/2021-1/ to openwrt/master.

p2p_add_device() may remove the oldest entry if there is no room in the
peer table for a new peer. This would result in any pointer to that
removed entry becoming stale. A corner case with an invalid PD Request
frame could result in such a case ending up using (read+write) freed
memory. This could only by triggered when the peer table has reached its
maximum size and the PD Request frame is received from the P2P Device
Address of the oldest remaining entry and the frame has incorrect P2P
Device Address in the payload.

Fix this by fetching the dev pointer again after having called
p2p_add_device() so that the stale pointer cannot be used.

This fixes the following security vulnerabilities/bugs:
 
 - CVE-2021-27803 - A vulnerability was discovered in how p2p/p2p_pd.c in wpa_supplicant before 2.10 processes P2P (Wi-Fi Direct) provision discovery requests. It could result in denial of service or other impact (potentially execution of arbitrary code), for an attacker within radio range.

Fixes: 17bef1e97a50 ("P2P: Add peer entry based on Provision Discovery Request")
Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>