### PR TITLE
ramips: fix booting of ZTE MF283+using lzma-loader

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1184,6 +1184,7 @@ endef
 TARGET_DEVICES += zorlik_zl5900v2
 
 define Device/zte_mf283plus
+  $(Device/uimage-lzma-loader)
   SOC := rt3352
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := ZTE


### PR DESCRIPTION
Due to changes on master between opening initial support PR and merging it, first snapshots (and my recent local images too) were unbootable due to LZMA decompression error. Fix that by using lzma-loader.

Compile and run-tested on ZTE MF283+ (built from scratch using default configuration).
Signed-off-by: Lech Perczak <lech.perczak@gmail.com>