### PR TITLE
kernel: video: add i915 & vboxvideo DRM kernel packages

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -294,6 +294,20 @@ endef
 
 $(eval $(call KernelPackage,drm-amdgpu))
 
+define KernelPackage/drm-vboxvideo
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Virtual Box DRM support
+  DEPENDS:=@TARGET_x86 @DISPLAY_SUPPORT +kmod-drm-kms-helper
+  KCONFIG:=CONFIG_DRM_VBOXVIDEO=m
+  FILES:=$(LINUX_DIR)/drivers/gpu/drm/vboxvideo/vboxvideo.ko
+  AUTOLOAD:=$(call AutoProbe,vboxvideo)
+endef
+
+define KernelPackage/drm-vboxvideo/description
+  Direct Rendering Manager (DRM) support for Virtual Box Graphics Card
+endef
+
+$(eval $(call KernelPackage,drm-vboxvideo))
 
 define KernelPackage/drm-imx
   SUBMENU:=$(VIDEO_MENU)
@@ -369,6 +383,27 @@ define KernelPackage/drm-imx-ldb/description
 endef
 
 $(eval $(call KernelPackage,drm-imx-ldb))
+
+define KernelPackage/drm-nouveau
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=nouveau DRM support
+  DEPENDS:=@TARGET_x86 @DISPLAY_SUPPORT +kmod-drm-kms-helper
+  KCONFIG:=CONFIG_DRM_NOUVEAU \
+	NOUVEAU_DEBUG=5 \
+	NOUVEAU_DEBUG_DEFAULT=3 \
+	NOUVEAU_DEBUG_MMU=n \
+	DRM_NOUVEAU_BACKLIGHT=y
+  FILES:=\
+	$(LINUX_DIR)/drivers/gpu/drm/nouveau/nouveau.ko \
+	$(LINUX_DIR)/drivers/platform/x86/wmi.ko
+  AUTOLOAD:=$(call AutoProbe,nouveau)
+endef
+
+define KernelPackage/drm-nouveau/description
+  Direct Rendering Manager (DRM) support for NVIDIA Cards
+endef
+
+$(eval $(call KernelPackage,drm-nouveau))
 
 define KernelPackage/drm-radeon
   SUBMENU:=$(VIDEO_MENU)


### PR DESCRIPTION
This commit adds support for nouveau & vboxvideo DRM kernel modules.

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
