### PR TITLE
bpftools: fix libbpf pkgconfig file

### DIFF
--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -145,6 +145,10 @@ define Build/InstallDev/libbpf
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib$(LIB_SUFFIX)/pkgconfig/libbpf.pc \
 		$(1)/usr/lib/pkgconfig/
+	$(SED) 's,/usr/include,$$$${prefix}/include,g' \
+		$(1)/usr/lib/pkgconfig/libbpf.pc
+	$(SED) 's,/usr/lib,$$$${exec_prefix}/lib,g' \
+		$(1)/usr/lib/pkgconfig/libbpf.pc
 endef
 
 ifeq ($(BUILD_VARIANT),lib)


### PR DESCRIPTION
The pkgconfig file hardcodes a host library directory which cannot be
overridden by OpenWrt during builds. Use SED to fix this and potential
include directory problems, as is done with several other packages.

This fixes a strange issue intermittently seen building iproute2 on the
oxnas target:

iptables modules directory: /usr/lib/iptables
libc has setns: yes
SELinux support: no
libbpf support: no
	libbpf version 0.3.0 is too low, please update it to at least 0.1.0
	LIBBPF_FORCE=on set, but couldn't find a usable libbpf

Fixes: 2f0d672088c3 ("bpftools: add utility and library packages
supporting eBPF usage")
Reported-by: Russell Senior <russell@personaltelco.net>
Signed-off-by: Tony Ambardar <itugrok@yahoo.com>


@RussellSenior  Hi Russel, can you confirm this fixes the problem we saw with your `oxnas` build yesterday? I've verified the correct library paths are used and done functional testing on malta/mips/be32, but as before I'm unable to reproduce the issue with my own `oxnas` build.
