### PR TITLE
bpftools: fix param order for install on macOS

### DIFF
--- a/package/network/utils/bpftools/patches/200-fix-install-param-order-on-macos.patch
+++ b/package/network/utils/bpftools/patches/200-fix-install-param-order-on-macos.patch
@@ -1,0 +1,13 @@
+Index: bpftools-5.11.2/tools/lib/bpf/Makefile
+===================================================================
+--- bpftools-5.11.2.orig/tools/lib/bpf/Makefile
++++ bpftools-5.11.2/tools/lib/bpf/Makefile
+@@ -236,7 +236,7 @@ define do_install
+ 	if [ ! -d '$(DESTDIR_SQ)$2' ]; then		\
+ 		$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$2';	\
+ 	fi;						\
+-	$(INSTALL) $1 $(if $3,-m $3,) '$(DESTDIR_SQ)$2'
++	$(INSTALL) $(if $3,-m $3,) $1 '$(DESTDIR_SQ)$2'
+ endef
+ 
+ install_lib: all_cmd


### PR DESCRIPTION
Fix: bpftools 5.11.2 does not compile on macOS, because the -m option was placed between src and dst. Corrected by moving -m before src:

```
-	$(INSTALL) $1 $(if $3,-m $3,) '$(DESTDIR_SQ)$2'
+	$(INSTALL) $(if $3,-m $3,) $1 '$(DESTDIR_SQ)$2'
```

@hauke @nbd168 @ynezz @dangowrt 