### PR TITLE
build: remove grep filter obsolete by c7aec47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell command -pv pkg-config | grep -E '\/usr' | head -n 1)
+DISTRO_PKG_CONFIG:=$(shell command -pv pkg-config | head -n 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)


### PR DESCRIPTION
Originally `which -a` was used to find all paths to `pkg-config`,
and a grep filter was used to return only the path under `/usr`.
Since commit c7aec47 _build: replace which with Bash command built-in_,
`command -pv` is used, which returns only the first occurrence of
`pkg-config` in PATH. Hence the grep filter is no longer needed.

Tested on Ubuntu Linux 20.04, and macOS 11.

This should also fix errors if `pkg-config` is not under `/usr`:
https://github.com/openwrt/openwrt/pull/3820

@ynezz @dangowrt @aparcar @nbd168 @jow- 