### PR TITLE
ramips: improve GPIO pin control for HC5x61 

### DIFF
--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
@@ -36,6 +36,17 @@
 			linux,default-trigger = "phy0tpt";
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &ehci {

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -104,3 +104,8 @@
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
+
+&wmac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -19,23 +19,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		};
-	};
-};
-
-&sysc {
-	ralink,gpiomux = "i2c", "jtag";
-	ralink,uartmux = "gpio";
-	ralink,wdtmux = <1>;
 };
 
 &gpio3 {
@@ -101,9 +84,6 @@
 };
 
 &ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
-
 	mtd-mac-address = <&factory 0x4>;
 
 	mediatek,portmap = "wllll";
@@ -115,8 +95,6 @@
 
 &wmac {
 	ralink,mtd-eeprom = <&factory 0x0>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&pa_pins>;
 };
 
 &state_default {


### PR DESCRIPTION
HC5661 does not have USB port, remove usb power control pin.
HC5x61 do not have LAN LEDs, remove ethernet LED control pin.
Only HC5861 has PA in 2.4G channel.