### PR TITLE
arc770: set device vendor and model variables

### DIFF
--- a/target/linux/arc770/image/Makefile
+++ b/target/linux/arc770/image/Makefile
@@ -24,6 +24,8 @@ endef
 
 define Device/nsim
 	$(call Device/vmlinux)
+	DEVICE_VENDOR := Synopsys
+	DEVICE_MODEL := nSIM
 	DEVICE_PROFILE := nsim
 	DEVICE_DTS := nsim_700
 endef


### PR DESCRIPTION
This fixes the profiles.json output.

Signed-off-by: Moritz Warning <moritzwarning@web.de>
