### PR TITLE
archs38: set device vendor and model variables

### DIFF
--- a/target/linux/archs38/image/Makefile
+++ b/target/linux/archs38/image/Makefile
@@ -24,6 +24,8 @@ endef
 
 define Device/nsim_hs
 	$(call Device/vmlinux)
+	DEVICE_VENDOR := Synopsys
+	DEVICE_MODEL := nSIM HS
 	DEVICE_PROFILE := nsim_hs
 	DEVICE_DTS := nsim_hs_idu
 endef


### PR DESCRIPTION
This fixes the profiles.json output.

Signed-off-by: Moritz Warning <moritzwarning@web.de>