### PR TITLE
Makefile for ppp: libcap dependency moved to Default and multilink pa…

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -23,8 +23,6 @@ PKG_CPE_ID:=cpe:/a:samba:ppp
 PKG_RELEASE_VERSION:=2.4.9
 PKG_VERSION:=$(PKG_RELEASE_VERSION).git-$(PKG_SOURCE_DATE)
 
-PKG_BUILD_DEPENDS:=libpcap
-
 PKG_ASLR_PIE_REGULAR:=1
 PKG_BUILD_PARALLEL:=1
 PKG_INSTALL:=1
@@ -39,14 +37,14 @@ endef
 
 define Package/ppp
 $(call Package/ppp/Default)
-  DEPENDS:=+kmod-ppp
+  DEPENDS:=+kmod-ppp +libpcap
   TITLE:=PPP daemon
   VARIANT:=default
 endef
 
 define Package/ppp-multilink
 $(call Package/ppp/Default)
-  DEPENDS:=+kmod-ppp
+  DEPENDS:=+kmod-ppp +libpcap
   TITLE:=PPP daemon (with multilink support)
   VARIANT:=multilink
 endef


### PR DESCRIPTION
This patch fixes a compilation problem: When I download and compile the sources,  I get  the following error:

Package ppp is missing dependencies for the following libraries:
libpcap.so.1
make[3]: *** [Makefile:322: /usr/local/src/embedded/openwrt/snapshot.new/bin/packages/mips_24kc/base/ppp_2.4.9.git-2021-01-04-3_mips_24kc.ipk] Error 1
make[3]: Leaving directory '/usr/local/src/embedded/openwrt/snapshot.new/package/network/services/ppp'
time: package/network/services/ppp/default/compile#11.48#1.14#12.42
    ERROR: package/network/services/ppp failed to build (build variant: default).
make[2]: *** [package/Makefile:114: package/network/services/ppp/compile] Error 1

This patch fixes this problem by moving the dependency on libcap to all packages.
