### PR TITLE
ppp: compile fix: unset FILTER variable in Makefile

### DIFF
--- a/package/network/services/ppp/patches/610-pppd_compile_fix.patch
+++ b/package/network/services/ppp/patches/610-pppd_compile_fix.patch
@@ -1,0 +1,12 @@
+--- a/pppd/Makefile.linux
++++ b/pppd/Makefile.linux
+@@ -49,7 +49,8 @@ MPPE=y
+ # Uncomment the next line to include support for PPP packet filtering.
+ # This requires that the libpcap library and headers be installed
+ # and that the kernel driver support PPP packet filtering.
+-#FILTER=y
++# libpcap statically linked in OpenWRT, hence disabled here.
++FILTER=
+ 
+ # Support for precompiled filters
+ PRECOMPILED_FILTER=y


### PR DESCRIPTION
This patch fixes a compilation problem within ppp. Compiling the sources produces

Package ppp is missing dependencies for the following libraries:
libpcap.so.1
make[3]: *** [Makefile:322: /usr/local/src/embedded/openwrt/openwrt_github/bin/packages/mips_24kc/base/ppp_2.4.9.git-2021-01-04-3_mips_24kc.ipk] Error 1
make[3]: Leaving directory '/usr/local/src/embedded/openwrt/openwrt_github/package/network/services/ppp'
time: package/network/services/ppp/default/compile#0.24#0.07#0.32
    ERROR: package/network/services/ppp failed to build (build variant: default).
make[2]: *** [package/Makefile:114: package/network/services/ppp/compile] Error 1

The fix consists of moving the dependency of ppp on libcap to the packages Default and multilink (and hence to all packages).

Signed-off-by: Eike Ritter <git@rittere.co.uk>


