### PR TITLE
elfutils: remove unneeded host build from target package

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -25,7 +25,6 @@ PKG_USE_MIPS16:=0
 PKG_BUILD_DEPENDS:=!USE_GLIBC:argp-standalone
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/nls.mk
 
 define Package/elfutils/Default
@@ -99,4 +98,3 @@ endef
 $(eval $(call BuildPackage,libelf))
 $(eval $(call BuildPackage,libdw))
 $(eval $(call BuildPackage,libasm))
-$(eval $(call HostBuild))


### PR DESCRIPTION
**Maintainer**: @luizluca 

**Description**:
Commit f4da28c301 ("elfutils: Add host build") supplied a libelf host library to fix a glib2 host build error, but this need was later removed by b6212c8769 ("glib2: don't use libelf during host build").

More importantly, there are already two sources for libelf host libraries: OpenWRT build prerequisites [1] and tools/libelf. A third is not needed.

Ref [1]: https://openwrt.org/docs/guide-developer/build-system/install-buildsystem#prerequisites

**Distribution**: @neheb added the original host lib support, and was included in prior discussion (https://github.com/openwrt/packages/issues/9927).

**Testing**: This has been regularly build and run-tested for a few months, as part of #3855, using QEMU on malta/mips32be, armvirt32, armvirt64, and x86/64 archs.

