### PR TITLE
ubox: fix log_ip validation in log init.d script

### DIFF
--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -15,7 +15,7 @@ validate_log_section()
 		'log_file:string' \
 		'log_size:uinteger' \
 		'log_hostname:string' \
-		'log_ip:ipaddr' \
+		'log_ip:string' \
 		'log_remote:bool:1' \
 		'log_port:port:514' \
 		'log_proto:or("tcp", "udp"):udp' \


### PR DESCRIPTION
The log_ip option can be not only an IP address but also a DNS name.

This is also already supported in the Luci.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
