### PR TITLE
kernel: fix warning sched Kconfig

### DIFF
--- a/target/linux/generic/hack-5.10/661-use_fq_codel_by_default.patch
+++ b/target/linux/generic/hack-5.10/661-use_fq_codel_by_default.patch
@@ -31,12 +31,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  struct Qdisc_class_common {
 --- a/net/sched/Kconfig
 +++ b/net/sched/Kconfig
-@@ -4,8 +4,9 @@
- #
+@@ -5,7 +5,9 @@
  
  menuconfig NET_SCHED
--	bool "QoS and/or fair queueing"
-+	def_bool y
+ 	bool "QoS and/or fair queueing"
++	default y
  	select NET_SCH_FIFO
 +	select NET_SCH_FQ_CODEL
  	help

--- a/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
+++ b/target/linux/generic/hack-5.4/661-use_fq_codel_by_default.patch
@@ -31,12 +31,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  struct Qdisc_class_common {
 --- a/net/sched/Kconfig
 +++ b/net/sched/Kconfig
-@@ -4,8 +4,9 @@
- #
+@@ -5,7 +5,9 @@
  
  menuconfig NET_SCHED
--	bool "QoS and/or fair queueing"
-+	def_bool y
+ 	bool "QoS and/or fair queueing"
++	default y
  	select NET_SCH_FIFO
 +	select NET_SCH_FQ_CODEL
  	---help---


### PR DESCRIPTION
Use default y instead of def_bool.
Fix compilation warning about missing config description.

@adschm 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
