### PR TITLE
lantiq: set maximum kernel size for ARV7519RW22

### DIFF
--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -17,9 +17,11 @@ define Device/arcadyan_arv7519rw22
   DEVICE_ALT0_VARIANT := 2.1
   DEVICE_ALT1_VENDOR := Astoria Networks
   DEVICE_ALT1_MODEL := ARV7519RW22
+  KERNEL_SIZE := 2048k
   IMAGE_SIZE := 31232k
   DEVICE_PACKAGES := kmod-usb-dwc2
   SUPPORTED_DEVICES += ARV7519RW22
+  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv7519rw22
 


### PR DESCRIPTION
Some users report that current snapshot producies non-bootable images.
Stock uboot can boot images if the kernel is smaller than 2MB.

Set maximum kernel size and disable image building for this board.

Ref: https://forum.openwrt.org/t/astoria-arv7519rw22-bootloops-after-upgrade/89843
Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>