### PR TITLE
bcm53xx: add support for Iptime A5004NS

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -49,6 +49,10 @@ bcm53xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "5@eth0"
 		;;
+	iptime,a5004ns)
+		ucidef_add_switch "switch0" \
+			"0:wan" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5@eth0"
+                ;;
 	*)
 		# NVRAM entries may contain unsorted ports, e.g. Netgear R6250 uses
 		# vlan1ports=3 2 1 0 5*

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -452,4 +452,14 @@ define Device/tplink_archer-c9-v1
 endef
 TARGET_DEVICES += tplink_archer-c9-v1
 
+define Device/iptime_a5004ns
+  DEFICE_VENDOR = ipTIME
+  DEVICE_MODEL := A5004NS
+  DEVICE_PACKAGES := $(B43) $(USB3_PACKAGES)
+  DEVICE_DTS := bcm4708-iptime-a5004ns
+  IMAGES := bin
+  IMAGE/bin := append-rootfs | trx-serial
+endef
+TARGET_DEVICES += iptime_a5004ns
+
 $(eval $(call BuildImage))

--- a/target/linux/bcm53xx/patches-5.4/340-ARM-BCM4708-Add-DT-for-Iptime-A5004NS.patch
+++ b/target/linux/bcm53xx/patches-5.4/340-ARM-BCM4708-Add-DT-for-Iptime-A5004NS.patch
@@ -1,0 +1,121 @@
+From 724c4f3bcb861e0a3896fc844da9aa5e87c2acdf Mon Sep 17 00:00:00 2001
+From: sodo <djdisodo@gmail.com>
+Date: Sun, 14 Mar 2021 17:11:32 +0900
+Subject: [PATCH] ARM: BCM4708: Add DT for Iptime A5004NS
+
+Signed-off-by: sodo <djdisodo@gmail.com>
+---
+ arch/arm/boot/dts/Makefile                   |  1 +
+ arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts | 88 ++++++++++++++++++++
+ 2 files changed, 89 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 8e5d4ab4e..650227653 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -95,6 +95,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4708-asus-rt-ac56u.dtb \
+ 	bcm4708-asus-rt-ac68u.dtb \
+ 	bcm4708-buffalo-wzr-1750dhp.dtb \
++	bcm4708-iptime-a5004ns.dtb \
+ 	bcm4708-linksys-ea6300-v1.dtb \
+ 	bcm4708-linksys-ea6500-v2.dtb \
+ 	bcm4708-luxul-xap-1510.dtb \
+diff --git a/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts b/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+new file mode 100644
+index 000000000..b3dcbf942
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+@@ -0,0 +1,88 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Broadcom BCM470X / BCM5301X ARM platform code.
++ * DTS for Iptime a5004ns
++ *
++ * Copyright (C) 2021 sodo <djdisodo@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm4708.dtsi"
++
++/ {
++	compatible = "iptime,a5004ns", "brcm,bcm4708";
++	model = "ipTIME A5004NS (BCM4708)";
++
++	chosen {
++                bootargs = "console=ttyS0,115200";
++        };
++
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x00000000 0x08000000
++		       0x88000000 0x08000000>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		power {
++			label = "bcm53xx:blue:power";
++			gpios = <&chipcommon 3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		cpu {
++                        label = "blue:cpu";
++                        gpios = <&chipcommon 6 GPIO_ACTIVE_HIGH>;
++                        linux,default-trigger = "timer";
++                };
++
++		usb {
++			label = "blue:usb";
++			gpios = <&chipcommon 4 GPIO_ACTIVE_HIGH>;
++			trigger-sources = <&ohci_port1>, <&ehci_port1>, <&xhci_port1>;
++			linux,default-trigger = "usbport";
++		};
++
++		
++		wlan5g {
++			label = "blue:wlan5g";
++			gpios = <&chipcommon 0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "phy1tpt";
++		};
++	};
++
++	keys: keys {
++		compatible = "gpio-keys";
++
++                wps {
++                        label = "WPS";
++                        linux,code = <KEY_WPS_BUTTON>;
++                        gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++                };
++
++                reset {
++                        label = "Reset";
++                        linux,code = <KEY_RESTART>;
++                        gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++                };
++	};
++};
++
++&spi_nor {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++
++	};
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 10 GPIO_ACTIVE_HIGH>;
++};
+-- 
+2.20.1
+


### PR DESCRIPTION
1 usb 3.0 port
1 wan port and 4 lan port

2.4GHz wifi (14e4:a8db) bcm43217 (b/g/~~n~~) (two antennas)
~~5GHz wifi (14e4:4360) bcm4360 (b/g/n/ac) (broken) (three antennas)~~

Cpu: Broadcom BCM4708 (800 MHz, 2 cores)
Serial flash: 32 MiB
Ram: 256 MiB

flashing:
i failed to break vendor's firmware check

but it has uart pin on board so you don't need to make it
it uses [CFE](https://openwrt.org/docs/techref/bootloader/cfe) bootloader



Signed-off-by: sodo <djdisodo@gmail.com>