### PR TITLE
bcm53xx: add support for Iptime A5004NS

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -31,6 +31,7 @@ bcm53xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "5t@eth0"
 		;;
+	iptime,a5004ns|\
 	luxul,abr-4500-v1|\
 	luxul,xbr-4500-v1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -242,6 +242,16 @@ define Device/dlink_dir-885l
 endef
 TARGET_DEVICES += dlink_dir-885l
 
+define Device/iptime_a5004ns
+  $(Device/Default)
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A5004NS
+  DEVICE_PACKAGES := $(B43) $(USB3_PACKAGES)
+  IMAGES := bin
+  IMAGE/bin := append-rootfs | trx-serial
+endef
+TARGET_DEVICES += iptime_a5004ns
+
 # Linksys devices are disabled due to problem with 2 TRX partitions
 define Device/linksys_ea6300-v1
   DEVICE_VENDOR := Linksys

--- a/target/linux/bcm53xx/patches-5.4/340-ARM-BCM4708-Add-DT-for-Iptime-A5004NS.patch
+++ b/target/linux/bcm53xx/patches-5.4/340-ARM-BCM4708-Add-DT-for-Iptime-A5004NS.patch
@@ -1,0 +1,118 @@
+From 2cd008901274924620bd974e985679dcc2514986 Mon Sep 17 00:00:00 2001
+From: Lee Jisoo <djdisodo@gmail.com>
+Date: Sat, 3 Apr 2021 18:30:33 +0900
+Subject: [PATCH] ARM: BCM4708: Add DT for Iptime A5004NS
+
+Signed-off-by: Lee Jisoo <djdisodo@gmail.com>
+---
+ arch/arm/boot/dts/Makefile                   |  1 +
+ arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts | 85 ++++++++++++++++++++
+ 2 files changed, 86 insertions(+)
+ create mode 100644 arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 8e5d4ab4e..650227653 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -95,6 +95,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4708-asus-rt-ac56u.dtb \
+ 	bcm4708-asus-rt-ac68u.dtb \
+ 	bcm4708-buffalo-wzr-1750dhp.dtb \
++	bcm4708-iptime-a5004ns.dtb \
+ 	bcm4708-linksys-ea6300-v1.dtb \
+ 	bcm4708-linksys-ea6500-v2.dtb \
+ 	bcm4708-luxul-xap-1510.dtb \
+diff --git a/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts b/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+new file mode 100644
+index 000000000..f3b42c70b
+--- /dev/null
++++ b/arch/arm/boot/dts/bcm4708-iptime-a5004ns.dts
+@@ -0,0 +1,85 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Broadcom BCM470X / BCM5301X ARM platform code.
++ * DTS for Iptime a5004ns
++ *
++ * Copyright (C) 2021 Lee Jisoo <djdisodo@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm4708.dtsi"
++
++/ {
++	compatible = "iptime,a5004ns", "brcm,bcm4708";
++	model = "ipTIME A5004NS";
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x00000000 0x08000000
++		       0x88000000 0x08000000>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		// though it is cpu led, set to power for diag.sh
++		power {	
++			label = "blue:power";
++			gpios = <&chipcommon 6 GPIO_ACTIVE_HIGH>;
++		};
++
++		usb {
++			label = "blue:usb";
++			gpios = <&chipcommon 4 GPIO_ACTIVE_HIGH>;
++			trigger-sources = <&ohci_port1>, <&ehci_port1>, <&xhci_port1>;
++			linux,default-trigger = "usbport";
++		};
++
++		wlan2g {
++			label = "blue:wlan2g";
++			gpios = <&chipcommon 3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "phyltpt";
++		};
++
++		wlan5g {
++			label = "blue:wlan5g";
++			gpios = <&chipcommon 0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "phy1tpt";
++		};
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++		};
++
++		reset {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&spi_nor {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++	};
++};
++
++&usb3 {
++	vcc-gpio = <&chipcommon 10 GPIO_ACTIVE_HIGH>;
++};
+-- 
+2.20.1
+


### PR DESCRIPTION
1 usb 3.0 port
1 wan port and 4 lan port

2.4GHz wifi (14e4:a8db) bcm43217 (b/g/~~n~~) (two antennas)
~~5GHz wifi (14e4:4360) bcm4360 (b/g/n/ac) (broken) (three antennas) (not supported chip)~~

Cpu: Broadcom BCM4708 (800 MHz, 2 cores)
Serial flash: 32 MiB
Ram: 256 MiB

flashing:
i failed to break vendor's firmware check

but it has uart pin on board so you don't need to make it
it uses CFE bootloader
(it lacks some commands like tftpd)
1. connect with router with cable
2. set pc's ip manually 192.168.0.2
3. run command `flash -noheader : flash0.trx` on CFE console
4. push firmware to 192.168.0.1 with tftp