### PR TITLE
ramips: add support for ELECOM WRC-1750GST2

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-gs-2pci.dtsi"
+
+/ {
+	compatible = "elecom,wrc-1750gst2", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-1750GST2";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1800000>;
+	};
+
+	partition@1850000 {
+		label = "tm_pattern";
+		reg = <0x1850000 0x400000>;
+		read-only;
+	};
+
+	partition@1c50000 {
+		label = "tm_key";
+		reg = <0x1c50000 0x100000>;
+		read-only;
+	};
+
+	partition@1d50000 {
+		label = "nvram";
+		reg = <0x1d50000 0xb0000>;
+		read-only;
+	};
+
+	partition@1e00000 {
+		label = "user_data";
+		reg = <0x1e00000 0x200000>;
+		read-only;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -460,6 +460,14 @@ define Device/elecom_wrc-1750gs
 endef
 TARGET_DEVICES += elecom_wrc-1750gs
 
+define Device/elecom_wrc-1750gst2
+  $(Device/elecom_wrc-gs)
+  IMAGE_SIZE := 24576k
+  DEVICE_MODEL := WRC-1750GST2
+  ELECOM_HWNAME := WRC-1750GST2
+endef
+TARGET_DEVICES += elecom_wrc-1750gst2
+
 define Device/elecom_wrc-1750gsv
   $(Device/elecom_wrc-gs)
   IMAGE_SIZE := 11264k


### PR DESCRIPTION
ELECOM WRC-1750GST2 is a 2.4/5 GHz band 11ac (Wi-Fi 5) router, based on
MT7621A.

Specification:

- SoC		: MediaTek MT7621A
- RAM		: DDR3 256 MiB (NT5CC128M16JR-EK)
- Flash		: SPI-NOR 32 MiB (MX25L25645GMI-08G)
- WLAN		: 2.4/5 GHz 3T3R (2x MediaTek MT7615)
- Ethernet	: 10/100/1000 Mbps x5
  - Switch	: MediaTek MT7530 (SoC)
- LEDs/Keys	: 4x/6x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J4: 3.3V, GND, TX, RX, from ethernet port side
  - 57600n8
- Power		: 12 VDC, 1.5 A

Flash instruction using factory image:

1. Boot WRC-1750GST2 normally with "Router" mode
2. Access to "http://192.168.2.1/" and open firmware update page
   ("ファームウェア更新")
3. Select the OpenWrt factory image and click apply ("適用") button
4. Wait ~120 seconds to complete flashing

MAC addresses:

LAN	: 04:AB:18:xx:xx:23 (Factory, 0xE000 (hex))
WAN	: 04:AB:18:xx:xx:24 (Factory, 0xE006 (hex))
2.4GHz	: 04:AB:18:xx:xx:25 (Factory, 0x4    (hex))
5GHz	: 04:AB:18:xx:xx:26 (Factory, 0x8004 (hex))

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>