### PR TITLE
ramips: Fix booting on MQmaker WiTi board

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -837,6 +837,7 @@ TARGET_DEVICES += mikrotik_routerboard-m33g
 
 define Device/mqmaker_witi
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := MQmaker
   DEVICE_MODEL := WiTi


### PR DESCRIPTION
This fixes the dreaded "lzma error 1" also reported on similar devices
Ref: https://bugs.openwrt.org/index.php?do=details&task_id=3057

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>