### PR TITLE
ramips: fix partition layout of hiwifi hc5x61

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -448,7 +448,7 @@ TARGET_DEVICES += head-weblink_hdrm200
 
 define Device/hiwifi_hc5661
   SOC := mt7620a
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5661
   DEVICE_PACKAGES := kmod-sdhci-mt7620
@@ -458,7 +458,7 @@ TARGET_DEVICES += hiwifi_hc5661
 
 define Device/hiwifi_hc5761
   SOC := mt7620a
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5761
   DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \
@@ -469,7 +469,7 @@ TARGET_DEVICES += hiwifi_hc5761
 
 define Device/hiwifi_hc5861
   SOC := mt7620a
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15808k
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5861
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-sdhci-mt7620 \


### PR DESCRIPTION
Changes:

Increase "oem" partition size from 0x10000 to 0x20000
Correct partition lables, synchronize with official firmware
Evidence:
It should be the same as hiwifi hc5x61a and the fact indeed the
case. Here is part of dmesg boot log read from official firmware:
[ 1.470000] Creating 7 MTD partitions on "raspi":
[ 1.470000] 0x000000000000-0x000000030000 : "u-boot"
[ 1.480000] 0x000000030000-0x000000040000 : "hw_panic"
[ 1.490000] 0x000000040000-0x000000050000 : "Factory"
[ 1.490000] 0x000000fc0000-0x000000fe0000 : "oem"
[ 1.500000] 0x000000fe0000-0x000000ff0000 : "bdinfo"
[ 1.510000] 0x000000ff0000-0x000001000000 : "backup"
[ 1.510000] 0x000000050000-0x000000fc0000 : "firmware"

"firmware" partition size defined in the device tree file is 0xf70000,
so the right IMAGE_SIZE is 15808k

Signed-off-by: Shiji Yang <yangshiji66@outlook.com>