### PR TITLE
ramips: Fix booting on MTC WR1201

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -848,6 +848,7 @@ TARGET_DEVICES += mqmaker_witi
 
 define Device/mtc_wr1201
   $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := MTC
   DEVICE_MODEL := Wireless Router WR1201


### PR DESCRIPTION
This fixes the dreaded "lzma error 1" also reported on similar devices
Ref: https://bugs.openwrt.org/index.php?do=details&task_id=3057

Signed-off-by: René van Dorst <opensource@vdorst.com>

Same as #4004
