### PR TITLE
kernel: robustify dependencies in kmod-sound-hda-core

### DIFF
--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -304,10 +304,7 @@ $(eval $(call KernelPackage,sound-dummy))
 define KernelPackage/sound-hda-core
   SUBMENU:=$(SOUND_MENU)
   TITLE:=HD Audio Sound Core Support
-  DEPENDS:= \
-	+LINUX_5_10&&PACKAGE_kmod-sound-hda-codec-realtek:kmod-ledtrig-audio \
-	+LINUX_5_10&&PACKAGE_kmod-sound-hda-codec-conexant:kmod-ledtrig-audio \
-	+LINUX_5_10&&PACKAGE_kmod-sound-hda-codec-idt:kmod-ledtrig-audio
+  DEPENDS:=+kmod-ledtrig-audio
   KCONFIG:= \
 	CONFIG_SND_HDA_CORE \
 	CONFIG_SND_HDA_HWDEP=y \


### PR DESCRIPTION
Dependency tracking for `kmod-sound-hda-core` is fragile. Enabling some sound codecs (Realtek, Conexant, Sigmatel) implicitly adds a `kmod-ledtrig-audio` dependency, while an enabled `kmod-ledtrig-audio` can be picked up through enabling others (e.g. `kmod-sound-hda-intel`), and the behaviour can change across kernel versions.

As `kmod-ledtrig-audio` is under 2KB, make it an unconditional dependency.

Fixes: a374b8f19051 ("kernel: 5.10: update sound modules")
Signed-off-by: Tony Ambardar <itugrok@yahoo.com>
