### PR TITLE
ramips: use fast-read instruction for Phicomm series devices 

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2g.dts
@@ -50,7 +50,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <24000000>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -53,7 +53,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1218.dtsi
@@ -50,7 +50,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -50,7 +50,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
From many teardown image in the internet, I find Phicomm K1/k2 series use
Winbond W25Q64/W25Q128 or GigaDevice GD25Q64/GD25Q128 Flash chips. both of
them support 100+ MHz clock spi operate and fast-read instruction. PSG1218
with W25x or GD25x has been tested and it can run well in OpenWrt v19.07.