### PR TITLE
ramips: use spi fast-read for HIWIFI HC5x61 devices

### DIFF
--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5x61.dtsi
@@ -31,7 +31,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
HIWIFI HC5x61 devices support high speed spi clock up to 100+ MHz. So set spi
frequency to 80 MHz here (Due to frequency division the real clock is 48 MHz).
I have tested HC5661 and it can run well in OpenWrt v19.07.