### PR TITLE
ramips: speed up spi frequency for Youku YK-L1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -69,7 +69,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <80000000>;
 		m25p,fast-read;
 
 		partitions {


### PR DESCRIPTION
Youku YK-L1 has a huge storage space up to 32 MB. It is better to use a higher
spi clock to read or write serial nor flash chips. Youku YK-L1 has Winbond
w25q256fvfg on board that can support 104 MHz spi clock so 48 MHz is safe enough.
The real frequency can only be sysclk(580MHz ) /3 /(2^n) so 80 MHz defined in dts
file will set only 48 MHz in spi bus.