### PR TITLE
ath79:fix switch0 lan port order sitecom wlr-7100

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -225,7 +225,8 @@ ath79_setup_interfaces()
 	engenius,epg5000|\
 	tplink,archer-c2-v3|\
 	tplink,tl-wr1043nd-v4|\
-	tplink,tl-wr1043n-v5)
+	tplink,tl-wr1043n-v5|\
+	sitecom,wlr-7100)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
 		;;
@@ -262,7 +263,6 @@ ath79_setup_interfaces()
 	iodata,wn-ac1600dgr2|\
 	iodata,wn-ag300dgr|\
 	pcs,cr5000|\
-	sitecom,wlr-7100|\
 	wd,mynet-n750)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"


### PR DESCRIPTION
Physical port order watched from the back of the device is:
4 / 3 / 2 / 1 / WAN which also matches corresponding leds.
This patch corrects LuCI switch webpage LAN port order.

Signed-off-by: Walter Sonius walterav1984@gmail.com