### PR TITLE
ramips: add support for Phicomm K2 new flash layout

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2-v22.4.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2-v22.4.dts
@@ -1,8 +1,8 @@
 #include "mt7620a_phicomm_k2x.dtsi"
 
 / {
-	compatible = "phicomm,psg1218a", "phicomm,psg1218", "ralink,mt7620a-soc";
-	model = "Phicomm PSG1218 rev.A";
+	compatible = "phicomm,k2-v22.4", "ralink,mt7620a-soc";
+	model = "Phicomm K2";
 };
 
 &partitions {

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2-v22.5.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2-v22.5.dts
@@ -1,0 +1,42 @@
+#include "mt7620a_phicomm_k2x.dtsi"
+
+/ {
+	compatible = "phicomm,k2-v22.5", "ralink,mt7620a-soc";
+	model = "Phicomm K2";
+};
+
+&partitions {
+	partition@50000 {
+		label = "permanent_config";
+		reg = <0x50000 0x50000>;
+		read-only;
+	};
+
+	partition@a0000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0xa0000 0x760000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -807,6 +807,27 @@ define Device/ohyeah_oy-0001
 endef
 TARGET_DEVICES += ohyeah_oy-0001
 
+define Device/phicomm_k2-v22.4
+  SOC := mt7620a
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Phicomm
+  DEVICE_MODEL := K2
+  DEVICE_VARIANT:= Version 22.4 or older
+  DEVICE_PACKAGES := kmod-mt76x2
+  SUPPORTED_DEVICES += psg1218 psg1218a phicomm,psg1218a
+endef
+TARGET_DEVICES += phicomm_k2-v22.4
+
+define Device/phicomm_k2-v22.5
+  SOC := mt7620a
+  IMAGE_SIZE := 7552k
+  DEVICE_VENDOR := Phicomm
+  DEVICE_MODEL := K2
+  DEVICE_VARIANT:= Version 22.5 or newer
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += phicomm_k2-v22.5
+
 define Device/phicomm_k2g
   SOC := mt7620a
   IMAGE_SIZE := 7552k
@@ -825,17 +846,6 @@ define Device/phicomm_psg1208
   SUPPORTED_DEVICES += psg1208
 endef
 TARGET_DEVICES += phicomm_psg1208
-
-define Device/phicomm_psg1218a
-  SOC := mt7620a
-  IMAGE_SIZE := 7872k
-  DEVICE_VENDOR := Phicomm
-  DEVICE_MODEL := PSG1218
-  DEVICE_VARIANT:= Ax
-  DEVICE_PACKAGES := kmod-mt76x2
-  SUPPORTED_DEVICES += psg1218 psg1218a
-endef
-TARGET_DEVICES += phicomm_psg1218a
 
 define Device/phicomm_psg1218b
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -107,7 +107,8 @@ ramips_setup_interfaces()
 		;;
 	dlink,dir-810l|\
 	netgear,jwnr2010-v5|\
-	phicomm,psg1218a|\
+	phicomm,k2-v22.4|\
+	phicomm,k2-v22.5|\
 	trendnet,tew-810dr|\
 	zbtlink,zbt-we2026)
 		ucidef_add_switch "switch0" \
@@ -339,8 +340,9 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary u-boot 0x1fc20)" 2)
 		;;
 	lb-link,bl-w1200|\
+	phicomm,k2-v22.4|\
+	phicomm,k2-v22.5|\
 	phicomm,k2g|\
-	phicomm,psg1218a|\
 	phicomm,psg1218b)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$wan_mac


### PR DESCRIPTION
Descriptions：
Phicomm K2 (PSG1218) got a new "permanent_config" partition after update
firmware to v22.5. This partition located in front of the firmware partition,
same as The Phicomm K2P and K2G. Due to this change the new bootloader can't
load previous firmware any more. This commit is aimed at add support for
Phicomm K2 which official firmware version is 22.5.x or newer. For which runs
old firmware version, just update OpenWrt that has a prefix of "k2-v22.4".
For uniform naming, this commit also changed the model name PSG1218 to a more
recognizable name K2, refer to Phicomm K2G, K2P K2T.

OpenWrt selection table:
official firmware version           OpenWrt
v21.4.x.x or older              phicomm_k2-v22.4
v22.5.x.x or newer              phicomm_k2-v22.5

Installation:
Same as Phicomm K2G, K2P, PSG1208.
a. TFTP + U-Boot
b. Open telnet by some web page vulnerability (Search Baidu by key words "K2 telnet"),
and then we can upload firmware image to /tmp and write it to firmware partition with
mtd instruction.