### PR TITLE
ramips: Add support for SERCOMM NA502

### DIFF
--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "sercomm,na502", "mediatek,mt7621-soc";
+	model = "SERCOMM NA502";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		zwave {
+			label = "green:zwave";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		service {
+			label = "green:service";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		zigbee {
+			label = "green:zigbee";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		bluetooth {
+			label = "green:bluetooth";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		select {
+			label = "select";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		sync {
+			label = "sync";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		zwave_reset {
+			gpio-export,name = "zwave_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		zigbee_reset {
+			gpio-export,name = "zigbee_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "kernel1";
+			reg = <0x140000 0x1400000>;
+		};
+
+		partition@1540000 {
+			label = "kernel";
+			reg = <0x1540000 0x400000>;
+		};
+
+		partition@1940000 {
+			label = "ubi";
+			reg = <0x1940000 0x1000000>;
+		};
+
+		partition@2940000 {
+			label = "user_storage";
+			reg = <0x2940000 0x100000>;
+		};
+
+		partition@2a40000 {
+			label = "data";
+			reg = <0x2a40000 0x1000000>;
+		};
+
+		partition@3a40000 {
+			label = "storage";
+			reg = <0x3a40000 0x3200000>;
+		};
+
+		partition@6c40000 {
+			label = "backup";
+			reg = <0x6c40000 0x1340000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		mtd-mac-address = <&factory 0xe000>;
+		mtd-mac-address-increment = <1>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		mtd-mac-address = <&factory 0xe000>;
+		mtd-mac-address-increment = <2>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&uartlite2 {
+	status = "okay";
+};
+
+&uartlite3 {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1064,6 +1064,20 @@ define Device/samknows_whitebox-v8
 endef
 TARGET_DEVICES += samknows_whitebox-v8
 
+define Device/sercomm_na502
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 20971520
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  UBINIZE_OPTS := -E 5
+  KERNEL_SIZE := 4096k
+  DEVICE_VENDOR := SERCOMM
+  DEVICE_MODEL := NA502
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb3
+endef
+TARGET_DEVICES += sercomm_na502
+
 define Device/storylink_sap-g3200u3
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ramips_setup_interfaces()
 	edimax,re23s|\
 	mikrotik,routerboard-m11g|\
 	netgear,ex6150|\
+	sercomm,na502|\
 	thunder,timecloud|\
 	tplink,re350-v1|\
 	tplink,re500-v1|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -61,6 +61,7 @@ platform_do_upgrade() {
 	netgear,wac104|\
 	netgear,wac124|\
 	netis,wf2881|\
+	sercomm,na502|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
The SERCOMM NA502 is a smart home gateway manufactured by SERCOMM and sold
under different brands (among others, A1 Telekom Austria SmartHome
Gateway). It has multi-protocol radio support in addition to LAN and WiFi.

Note: BLE is currently unsupported.

Specifications
--------------

  - MT7621ST 880MHz, Single-Core, Dual-Thread
  - MT7603EN 2.4GHz WiFi
  - MT7662EN 5GHz WiFi + BLE
  - 128MiB NAND
  - 256MiB DDR3 RAM
  - SD3503 ZWave Controller
  - EM357 Zigbee Coordinator

MAC address assignment
----------------------

LAN MAC is read from the config partition, WiFi 2.4GHz is LAN+2 and matches
the OEM firmware. WiFi 5GHz with LAN+1 is an educated guess since the
OEM firmware does not enable 5GHz WiFi.

Installation
------------
Attach serial console, then boot the initramfs image via TFTP.
Once inside OpenWrt, run sysupgrade -n with the sysupgrade file.

Attention: The device has a dual-firmware design. We overwrite kernel2,
since kernel1 contains an automatic recovery image.

If you get NAND ECC errors and are stuck with bad eraseblocks, try to
erase the mtd partition first with

mtd unlock ubi
mtd erase ubi

This should only be needed once.

Signed-off-by: Andreas Böhler <dev@aboehler.at>

