### PR TITLE
ath79: copy cfi patch from 5.4 over to 5.10

### DIFF
--- a/target/linux/ath79/patches-5.10/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
+++ b/target/linux/ath79/patches-5.10/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
@@ -1,0 +1,58 @@
+From f1f811410af297c848e9ec17eaa280d190fdce10 Mon Sep 17 00:00:00 2001
+From: Mauri Sandberg <sandberg@mailfence.com>
+Date: Tue, 23 Feb 2021 18:09:31 +0200
+Subject: [PATCH] mtd: cfi_cmdset_0002: AMD chip 0x2201 - write words
+
+Buffer writes do not work with AMD chip 0x2201. The chip in question
+is a AMD/Spansion/Cypress Semiconductor S29GL256N and datasheet [1]
+talks about writing buffers being possible. While waiting for a neater
+solution resort to writing word-sized chunks only.
+
+Without the patch kernel logs will be flooded with entries like below:
+
+jffs2_scan_eraseblock(): End of filesystem marker found at 0x0
+jffs2_build_filesystem(): unlocking the mtd device...
+done.
+jffs2_build_filesystem(): erasing all blocks after the end marker...
+MTD do_write_buffer_wait(): software timeout, address:0x01ec000a.
+jffs2: Write clean marker to block at 0x01920000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01e2000a.
+jffs2: Write clean marker to block at 0x01880000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01e0000a.
+jffs2: Write clean marker to block at 0x01860000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01dc000a.
+jffs2: Write clean marker to block at 0x01820000 failed: -5
+MTD do_write_buffer_wait(): software timeout, address:0x01da000a.
+jffs2: Write clean marker to block at 0x01800000 failed: -5
+...
+
+Tested on a Buffalo wzr-hp-g300nh running kernel 5.10.16.
+
+[1] https://www.cypress.com/file/219941/download
+or  https://datasheetspdf.com/pdf-file/565708/SPANSION/S29GL256N/1
+
+Signed-off-by: Mauri Sandberg <sandberg@mailfence.com>
+---
+ drivers/mtd/chips/cfi_cmdset_0002.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/mtd/chips/cfi_cmdset_0002.c b/drivers/mtd/chips/cfi_cmdset_0002.c
+index a1f3e1031c3d..28b6f3583f8a 100644
+--- a/drivers/mtd/chips/cfi_cmdset_0002.c
++++ b/drivers/mtd/chips/cfi_cmdset_0002.c
+@@ -272,6 +272,10 @@ static void fixup_use_write_buffers(struct mtd_info *mtd)
+ {
+ 	struct map_info *map = mtd->priv;
+ 	struct cfi_private *cfi = map->fldrv_priv;
++
++	if ((cfi->mfr == CFI_MFR_AMD) && (cfi->id == 0x2201))
++		return;
++
+ 	if (cfi->cfiq->BufWriteTimeoutTyp) {
+ 		pr_debug("Using buffer write method\n");
+ 		mtd->_write = cfi_amdstd_write_buffers;
+
+base-commit: 5de15b610f785f0e188fefb707f0b19de156968a
+-- 
+2.25.1
+


### PR DESCRIPTION
Related to adding support for Buffalo WZR-HP-G300NH, add the same patch to 5.10 too. The patch is in process of being upstreamed.

Signed-off-by: Mauri Sandberg <sandberg@mailfence.com>
