### PR TITLE
read udhcpc and odhcp6c user scripts from directory

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -27,6 +27,7 @@ endef
 
 define Package/netifd/conffiles
 /etc/udhcpc.user
+/etc/udhcpc.user.d/
 endef
 
 TARGET_CFLAGS += \
@@ -44,6 +45,7 @@ define Package/netifd/install
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/netifd $(1)/sbin/
 	$(CP) ./files/* $(1)/
+	$(INSTALL_DIR) $(1)/etc/udhcpc.user.d/
 	$(CP) $(PKG_BUILD_DIR)/scripts/* $(1)/lib/netifd/
 endef
 

--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -112,5 +112,8 @@ esac
 
 # user rules
 [ -f /etc/udhcpc.user ] && . /etc/udhcpc.user "$@"
+for f in /etc/udhcpc.user.d/*; do
+	[ -f "$f" ] && (. "$f" "$@")
+done
 
 exit 0

--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -44,6 +44,7 @@ endef
 
 define Package/odhcp6c/conffiles
 /etc/odhcp6c.user
+/etc/odhcp6c.user.d/
 endef
 
 define Package/odhcp6c/install
@@ -52,7 +53,7 @@ define Package/odhcp6c/install
 	$(INSTALL_DIR) $(1)/lib/netifd/proto
 	$(INSTALL_BIN) ./files/dhcpv6.sh $(1)/lib/netifd/proto/dhcpv6.sh
 	$(INSTALL_BIN) ./files/dhcpv6.script $(1)/lib/netifd/
-	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/odhcp6c.user.d/
 	$(INSTALL_CONF) ./files/odhcp6c.user $(1)/etc/
 endef
 

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -237,5 +237,8 @@ esac
 
 # user rules
 [ -f /etc/odhcp6c.user ] && . /etc/odhcp6c.user "$@"
+for f in /etc/odhcp6c.user.d/*; do
+  [ -f "$f" ] && (. "$f" "$@")
+done
 
 exit 0


### PR DESCRIPTION
Placeholder DHCP user scripts were added recently.
These files make package-based installations of such scripts more difficult.

Pull user callbacks from directories instead to allow packages and users to install co-existing scripts more easily.

References:
130118f7a netifd: add a udhcpc.user placeholder script
b4f3d93b5 odhcp6c: add a odhcp6c.user placeholder script