### PR TITLE
hostapd: enable CONFIG_NO_VLAN for all variants

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=32
+PKG_RELEASE:=33
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd-basic.config
+++ b/package/network/services/hostapd/files/hostapd-basic.config
@@ -195,7 +195,7 @@ CONFIG_NO_ACCOUNTING=y
 CONFIG_NO_RADIUS=y
 
 # Remove support for VLANs
-#CONFIG_NO_VLAN=y
+CONFIG_NO_VLAN=y
 
 # Enable support for fully dynamic VLANs. This enables hostapd to
 # automatically create bridge and VLAN interfaces if necessary.

--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -195,7 +195,7 @@ CONFIG_DEBUG_SYSLOG=y
 #CONFIG_NO_RADIUS=y
 
 # Remove support for VLANs
-#CONFIG_NO_VLAN=y
+CONFIG_NO_VLAN=y
 
 # Enable support for fully dynamic VLANs. This enables hostapd to
 # automatically create bridge and VLAN interfaces if necessary.

--- a/package/network/services/hostapd/files/hostapd-mini.config
+++ b/package/network/services/hostapd/files/hostapd-mini.config
@@ -195,7 +195,7 @@ CONFIG_NO_ACCOUNTING=y
 CONFIG_NO_RADIUS=y
 
 # Remove support for VLANs
-#CONFIG_NO_VLAN=y
+CONFIG_NO_VLAN=y
 
 # Enable support for fully dynamic VLANs. This enables hostapd to
 # automatically create bridge and VLAN interfaces if necessary.


### PR DESCRIPTION
This PR disables VLAN support for hostapd.

When hostapd is compiled without CONFIG_NO_VLAN option then
WPA-EAP/802.1x AP mode is not working with wifi card which does not
support NL80211_CMD_SET_STATION command and uses nl80211 hostapd
driver. hostapd is also trying to use VLANs even when they were not
enabled in the runtime config file.

This was reported to hostapd upstream but it looks that VLAN support will not be fixed soon.
For more details,  read  this thread https://www.spinics.net/lists/hostap/msg07823.html

If someone still needs VLAN support it is possible to use Macvlan subsystem see the commit message for more details
 https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=79cf79abce71

cc @pali 