### PR TITLE
x86/base-files: add support for Sophos SG/XG-105

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -11,6 +11,9 @@ case "$(board_name)" in
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;
+sophos-sg-105|sophos-xg-105)
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
+	;;
 traverse-technologies-geos)
 	ucidef_set_interface_lan "eth0 eth1"
 	ucidef_add_atm_bridge "0" "35" "llc" "bridged"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -22,6 +22,14 @@ do_sysinfo_x86() {
 			product="apu1"
 			break
 			;;
+		"Sophos:SG"|"Sophos:XG")
+			case "$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)" in
+			105*)
+				product="${product}-105"
+				break
+				;;
+			esac
+			;;
 		"Supermicro:Super Server")
 			continue
 			;;


### PR DESCRIPTION
This patch adds detection of the Sophos SG-105 and Sophos XG-105 models and assignment of ethernet ports these models have to LAN/WAN. Please cherry-pick this for 21.02 or let me know if I should create a separate PR for openwrt-21.02 branch.

Thanks to @pkgadd and @jow for help!

Signed-off-by: Stan Grishin <stangri@melmac.net>
