### PR TITLE
mvebu: Fix sysupgrade for GL.iNet GL-MV1000

### DIFF
--- a/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa53/base-files/lib/upgrade/platform.sh
@@ -9,6 +9,7 @@ REQUIRE_IMAGE_METADATA=1
 
 platform_check_image() {
 	case "$(board_name)" in
+	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
 	globalscale,espressobin-ultra|\
@@ -24,6 +25,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
 	globalscale,espressobin-ultra|\
@@ -41,6 +43,7 @@ platform_do_upgrade() {
 }
 platform_copy_config() {
 	case "$(board_name)" in
+	glinet,gl-mv1000|\
 	globalscale,espressobin|\
 	globalscale,espressobin-emmc|\
 	globalscale,espressobin-ultra|\


### PR DESCRIPTION
The GL.iNet GL-MV1000 is booting from eMMC and the images for it are in theory sysupgrade compatible. But the platform upgrade scripts were not adjusted to select the mmcblock device as upgrade target. This resulted in a failed sysupgrade because the mtd device (NOR flash) was instead tried to  be modified by the sysupgrade script.

@gl-inet