### PR TITLE
kernel: bump 5.10 to 5.10.26

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .106
-LINUX_VERSION-5.10 = .25
+LINUX_VERSION-5.10 = .26
 
 LINUX_KERNEL_HASH-5.4.106 = cc873b2c39c1823d4bc4f6cde527943c8cfd28ae94cb517804b0f9679359c8db
-LINUX_KERNEL_HASH-5.10.25 = 930ae76b9a3b64b98802849aca332d17a706f20595de21e1ae729b55ee461add
+LINUX_KERNEL_HASH-5.10.26 = fc532833f1ac167f363f1b9de85db39d2d635ab516f66dc381bdd70804601482
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ath79/patches-5.10/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
+++ b/target/linux/ath79/patches-5.10/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
@@ -36,11 +36,9 @@ Signed-off-by: Mauri Sandberg <sandberg@mailfence.com>
  drivers/mtd/chips/cfi_cmdset_0002.c | 4 ++++
  1 file changed, 4 insertions(+)
 
-diff --git a/drivers/mtd/chips/cfi_cmdset_0002.c b/drivers/mtd/chips/cfi_cmdset_0002.c
-index a1f3e1031c3d..28b6f3583f8a 100644
 --- a/drivers/mtd/chips/cfi_cmdset_0002.c
 +++ b/drivers/mtd/chips/cfi_cmdset_0002.c
-@@ -272,6 +272,10 @@ static void fixup_use_write_buffers(struct mtd_info *mtd)
+@@ -272,6 +272,10 @@ static void fixup_use_write_buffers(stru
  {
  	struct map_info *map = mtd->priv;
  	struct cfi_private *cfi = map->fldrv_priv;
@@ -51,8 +49,3 @@ index a1f3e1031c3d..28b6f3583f8a 100644
  	if (cfi->cfiq->BufWriteTimeoutTyp) {
  		pr_debug("Using buffer write method\n");
  		mtd->_write = cfi_amdstd_write_buffers;
-
-base-commit: 5de15b610f785f0e188fefb707f0b19de156968a
--- 
-2.25.1
-

--- a/target/linux/bcm63xx/patches-5.10/143-gpio-fix-device-tree-gpio-hogs-on-dual-role-gpio-pin.patch
+++ b/target/linux/bcm63xx/patches-5.10/143-gpio-fix-device-tree-gpio-hogs-on-dual-role-gpio-pin.patch
@@ -116,7 +116,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@gmail.com>
  }
 --- a/drivers/gpio/gpiolib.c
 +++ b/drivers/gpio/gpiolib.c
-@@ -1890,7 +1890,8 @@ int gpiochip_add_pingroup_range(struct g
+@@ -1897,7 +1897,8 @@ int gpiochip_add_pingroup_range(struct g
  
  	list_add_tail(&pin_range->node, &gdev->pin_ranges);
  
@@ -126,7 +126,7 @@ Signed-off-by: Jonas Gorski <jonas.gorski@gmail.com>
  }
  EXPORT_SYMBOL_GPL(gpiochip_add_pingroup_range);
  
-@@ -1947,7 +1948,7 @@ int gpiochip_add_pin_range(struct gpio_c
+@@ -1954,7 +1955,7 @@ int gpiochip_add_pin_range(struct gpio_c
  
  	list_add_tail(&pin_range->node, &gdev->pin_ranges);
  

--- a/target/linux/generic/hack-5.10/204-module_strip.patch
+++ b/target/linux/generic/hack-5.10/204-module_strip.patch
@@ -104,7 +104,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config MODULES_TREE_LOOKUP
 --- a/kernel/module.c
 +++ b/kernel/module.c
-@@ -3161,9 +3161,11 @@ static int setup_load_info(struct load_i
+@@ -3243,9 +3243,11 @@ static int setup_load_info(struct load_i
  
  static int check_modinfo(struct module *mod, struct load_info *info, int flags)
  {
@@ -117,7 +117,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (flags & MODULE_INIT_IGNORE_VERMAGIC)
  		modmagic = NULL;
  
-@@ -3184,6 +3186,7 @@ static int check_modinfo(struct module *
+@@ -3266,6 +3268,7 @@ static int check_modinfo(struct module *
  				mod->name);
  		add_taint_module(mod, TAINT_OOT_MODULE, LOCKDEP_STILL_OK);
  	}


### PR DESCRIPTION
Automatically refreshed:
ath79/patches-5.10/471-mtd-cfi_cmdset_0002-AMD-chip-0x2201-write-words.patch
bcm63xx/patches-5.10/143-gpio-fix-device-tree-gpio-hogs-on-dual-role-gpio-pin.patch
generic/hack-5.10/204-module_strip.patch

Run-tested:
ath79 (TL-WDR3600)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>