### PR TITLE
ipq806x: fix CPU_TYPE

### DIFF
--- a/target/linux/ipq806x/Makefile
+++ b/target/linux/ipq806x/Makefile
@@ -6,7 +6,7 @@ ARCH:=arm
 BOARD:=ipq806x
 BOARDNAME:=Qualcomm Atheros IPQ806X
 FEATURES:=squashfs nand fpu ramdisk
-CPU_TYPE:=cortex-a15
+CPU_TYPE:=generic-armv7-a
 CPU_SUBTYPE:=neon-vfpv4
 SUBTARGETS:=generic
 


### PR DESCRIPTION
The Qualcom IPQ806X-Series, aka Snapdragon, aka Krait is not identical with Cortex-A15
see: https://en.wikipedia.org/wiki/Comparison_of_ARMv7-A_cores
this leads to wrong code optimization und undefined behavior.

This may eventually also fix:
https://forum.openwrt.org/t/unexplained-hangs-freezes-and-reboots-with-archer-c2600/61999

Run-Tested: Archer C2600 (gcc 9)