### PR TITLE
treewide: refresh all patches with quilt

### DIFF
--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -116,7 +116,7 @@ define Quilt/RefreshDir
 endef
 
 define Quilt/Refresh/Host
-	$(call Quilt/RefreshDir,$(HOST_BUILD_DIR),$(PATCH_DIR))
+	$(call Quilt/RefreshDir,$(HOST_BUILD_DIR),$(HOST_PATCH_DIR))
 endef
 
 define Quilt/Refresh/Package

--- a/package/boot/tfa-layerscape/patches/003-plat-nxp-tools-fix-create_pbl-and-byte_swap-host-bui.patch
+++ b/package/boot/tfa-layerscape/patches/003-plat-nxp-tools-fix-create_pbl-and-byte_swap-host-bui.patch
@@ -11,8 +11,6 @@ Signed-off-by: Biwen Li <biwen.li@nxp.com>
  plat/nxp/tools/pbl_ch3.mk | 5 -----
  2 files changed, 8 deletions(-)
 
-diff --git a/plat/nxp/tools/pbl_ch2.mk b/plat/nxp/tools/pbl_ch2.mk
-index afa43520..ff624dd9 100644
 --- a/plat/nxp/tools/pbl_ch2.mk
 +++ b/plat/nxp/tools/pbl_ch2.mk
 @@ -20,8 +20,6 @@ ifeq ($(RCW),"")
@@ -32,8 +30,6 @@ index afa43520..ff624dd9 100644
  	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE} \
  	-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl ;
  # Swapping of RCW is required for QSPi Chassis 2 devices
-diff --git a/plat/nxp/tools/pbl_ch3.mk b/plat/nxp/tools/pbl_ch3.mk
-index 944ae3bb..9aa8f635 100644
 --- a/plat/nxp/tools/pbl_ch3.mk
 +++ b/plat/nxp/tools/pbl_ch3.mk
 @@ -27,9 +27,6 @@ else
@@ -55,6 +51,3 @@ index 944ae3bb..9aa8f635 100644
  	# Add Block Copy command and populate boot loc ptrfor bl2.bin to RCW
  	${CREATE_PBL} -r ${RCW} -i ${BUILD_PLAT}/bl2.bin -b ${BOOT_MODE} -c ${SOC_NUM} -d ${BL2_BASE} -e ${BL2_BASE} \
  	-o ${BUILD_PLAT}/bl2_${BOOT_MODE}.pbl -f ${BL2_SRC_OFFSET};
--- 
-2.17.1
-

--- a/package/boot/uboot-at91/patches/001-fix-Wformat-security.patch
+++ b/package/boot/uboot-at91/patches/001-fix-Wformat-security.patch
@@ -1,8 +1,6 @@
-diff --git a/cmd/version.c b/cmd/version.c
-index b2fffe99..bcbbeb18 100644
 --- a/cmd/version.c
 +++ b/cmd/version.c
-@@ -18,7 +18,7 @@ static int do_version(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
+@@ -18,7 +18,7 @@ static int do_version(cmd_tbl_t *cmdtp,
  {
  	char buf[DISPLAY_OPTIONS_BANNER_LENGTH];
  
@@ -11,11 +9,9 @@ index b2fffe99..bcbbeb18 100644
  #ifdef CC_VERSION_STRING
  	puts(CC_VERSION_STRING "\n");
  #endif
-diff --git a/drivers/pinctrl/pinctrl-uclass.c b/drivers/pinctrl/pinctrl-uclass.c
-index 3425ed11..8c2e1d5c 100644
 --- a/drivers/pinctrl/pinctrl-uclass.c
 +++ b/drivers/pinctrl/pinctrl-uclass.c
-@@ -368,7 +368,7 @@ int pinctrl_get_pin_name(struct udevice *dev, int selector, char *buf,
+@@ -368,7 +368,7 @@ int pinctrl_get_pin_name(struct udevice
  	if (!ops->get_pin_name)
  		return -ENOSYS;
  
@@ -24,11 +20,9 @@ index 3425ed11..8c2e1d5c 100644
  
  	return 0;
  }
-diff --git a/lib/efi_loader/efi_variable.c b/lib/efi_loader/efi_variable.c
-index c316bdfe..5fe8129c 100644
 --- a/lib/efi_loader/efi_variable.c
 +++ b/lib/efi_loader/efi_variable.c
-@@ -522,7 +522,7 @@ efi_status_t EFIAPI efi_set_variable(u16 *variable_name,
+@@ -522,7 +522,7 @@ efi_status_t EFIAPI efi_set_variable(u16
  
  	if (old_size)
  		/* APPEND_WRITE */

--- a/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/007-nsa310-uboot-generic.patch
@@ -28,13 +28,13 @@ NOTE: this patch is ready for upstream, LEDE-specific parts are in
 @@ -53,6 +53,9 @@ config TARGET_GOFLEXHOME
  config TARGET_NAS220
  	bool "BlackArmor NAS220"
-
+ 
 +config TARGET_NSA310
 +	bool "Zyxel NSA310 Board"
 +
  config TARGET_NSA310S
  	bool "Zyxel NSA310S"
-
+ 
 @@ -86,6 +89,7 @@ source "board/raidsonic/ib62x0/Kconfig"
  source "board/Seagate/dockstar/Kconfig"
  source "board/Seagate/goflexhome/Kconfig"

--- a/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
+++ b/package/boot/uboot-kirkwood/patches/010-pogoplug_v4.patch
@@ -3,13 +3,13 @@
 @@ -25,6 +25,9 @@ config TARGET_LSXL
  config TARGET_POGO_E02
  	bool "pogo_e02 Board"
-
+ 
 +config TARGET_POGOPLUGV4
 +    bool "Pogoplug V4 Board"
 +
  config TARGET_DNS325
  	bool "dns325 Board"
-
+ 
 @@ -83,6 +86,7 @@ source "board/Marvell/guruplug/Kconfig"
  source "board/Marvell/sheevaplug/Kconfig"
  source "board/buffalo/lsxl/Kconfig"
@@ -22,11 +22,11 @@
 +++ b/arch/arm/mach-kirkwood/include/mach/kw88f6192.h
 @@ -15,6 +15,6 @@
  #define KW_REGS_PHY_BASE		KW88F6192_REGS_PHYS_BASE
-
+ 
  /* TCLK Core Clock defination */
 -#define CONFIG_SYS_TCLK	  166000000 /* 166MHz */
 +#define CONFIG_SYS_TCLK	  166666667 /* 166MHz */
-
+ 
  #endif /* _CONFIG_KW88F6192_H */
 --- a/arch/arm/mach-kirkwood/include/mach/mpp.h
 +++ b/arch/arm/mach-kirkwood/include/mach/mpp.h
@@ -35,12 +35,12 @@
  #define MPP33_TDM_DTX		MPP( 33, 0x2, 0, 1, 0,   0,   1,   1    )
  #define MPP33_GE1_13		MPP( 33, 0x3, 0, 0, 0,   1,   1,   1    )
 +#define MPP33_SATA1_ACTn        MPP( 33, 0x5, 0, 1, 0,   1,   1,   1    )
-
+ 
  #define MPP34_GPIO		MPP( 34, 0x0, 1, 1, 0,   1,   1,   1    )
  #define MPP34_TDM_SPI_CS1	MPP( 34, 0x2, 0, 1, 0,   0,   1,   1    )
  #define MPP34_GE1_14		MPP( 34, 0x3, 0, 0, 0,   1,   1,   1    )
 +#define MPP34_SATA1_ACTn       MPP( 34, 0x5, 0, 1, 0,   1,   1,   1    )
-
+ 
  #define MPP35_GPIO		MPP( 35, 0x0, 1, 1, 1,   1,   1,   1    )
  #define MPP35_TDM_CH0_TX_QL	MPP( 35, 0x2, 0, 1, 0,   0,   1,   1    )
 --- /dev/null
@@ -630,7 +630,7 @@
  obj-$(CONFIG_MMC_SDHCI_XENON)		+= xenon_sdhci.o
  obj-$(CONFIG_MMC_SDHCI_ZYNQ)		+= zynq_sdhci.o
 +obj-$(CONFIG_KIRKWOOD_MMC)		+= kirkwood_mmc.o
-
+ 
  obj-$(CONFIG_MMC_SUNXI)			+= sunxi_mmc.o
  obj-$(CONFIG_MMC_UNIPHIER)		+= tmio-common.o uniphier-sd.o
 --- /dev/null
@@ -1123,7 +1123,7 @@
 @@ -75,4 +75,10 @@
  #define CONFIG_SYS_MAX_NAND_DEVICE     1
  #endif
-
+ 
 +/*
 + * Kirkwood MMC
 + */

--- a/package/boot/uboot-kirkwood/patches/110-dockstar.patch
+++ b/package/boot/uboot-kirkwood/patches/110-dockstar.patch
@@ -5,7 +5,7 @@
  #define CONFIG_KW88F6281	1	/* SOC Name */
  #define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
 +#define CONFIG_SYS_MVFS
-
+ 
  /*
   * mv-common.h should be defined after CMD configs since it used them
 @@ -37,19 +38,15 @@
@@ -20,7 +20,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
 +	"bootm 0x800000"
-
+ 
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -	"console=console=ttyS0,115200\0" \
 -	"mtdids=nand0=orion_nand\0" \
@@ -32,7 +32,7 @@
 +	"mtdids=nand0=orion_nand\0"		\
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
-
+ 
  /*
   * Ethernet Driver configuration
 --- a/configs/dockstar_defconfig

--- a/package/boot/uboot-kirkwood/patches/120-iconnect.patch
+++ b/package/boot/uboot-kirkwood/patches/120-iconnect.patch
@@ -10,7 +10,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
  	"bootm 0x800000"
-
+ 
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"	\
  	"mtdids=nand0=orion_nand\0"		\
@@ -19,7 +19,7 @@
 -	"bootargs_root=noinitrd ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs\0"
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
-
+ 
  /*
   * Ethernet driver configuration
 --- a/configs/iconnect_defconfig

--- a/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
+++ b/package/boot/uboot-kirkwood/patches/130-ib62x0.patch
@@ -14,7 +14,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
 +	"bootm 0x800000"
-
+ 
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0"				\
  	"mtdids=nand0=orion_nand\0"					\
@@ -24,7 +24,7 @@
 -	"bootargs_root=ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs rw\0"
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"			\
 +	"bootargs_root=\0"
-
+ 
  /*
   * Ethernet driver configuration
 --- a/configs/ib62x0_defconfig

--- a/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
+++ b/package/boot/uboot-kirkwood/patches/140-pogoplug_e02.patch
@@ -12,7 +12,7 @@
 +	"ubifsmount ubi:rootfs; "					\
 +	"ubi read 0x800000 kernel; "					\
 +	"bootm 0x800000"
-
+ 
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -	"mtdparts=mtdparts=orion_nand:1M(u-boot),4M(uImage)," \
 -	"32M(rootfs),-(data)\0"\
@@ -24,7 +24,7 @@
 +	"mtdids=nand0=orion_nand\0"		\
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"	\
 +	"bootargs_root=\0"
-
+ 
  /*
   * Ethernet Driver configuration
 --- a/configs/pogo_e02_defconfig

--- a/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
+++ b/package/boot/uboot-kirkwood/patches/150-goflexhome.patch
@@ -10,7 +10,7 @@
 +	"ubi part ubi; " \
 +	"ubi read 0x800000 kernel; " \
  	"bootm 0x800000"
-
+ 
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	"console=console=ttyS0,115200\0" \
  	"mtdids=nand0=orion_nand\0" \
@@ -19,7 +19,7 @@
 -	"bootargs_root=ubi.mtd=root root=ubi0:root rootfstype=ubifs ro\0"
 +	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0" \
 +	"bootargs_root=\0"
-
+ 
  /*
   * Ethernet Driver configuration
 --- a/configs/goflexhome_defconfig

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -3,7 +3,7 @@
 @@ -107,4 +107,7 @@ source "board/alliedtelesis/SBx81LIFXCAT
  source "board/Marvell/db-88f6281-bp/Kconfig"
  source "board/checkpoint/l-50/Kconfig"
-
+ 
 +config SECOND_STAGE
 +	bool "OpenWrt second stage hack"
 +
@@ -13,7 +13,7 @@
 @@ -60,4 +60,6 @@
   * File system
   */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_DOCKSTAR_H */
@@ -22,7 +22,7 @@
 @@ -77,4 +77,6 @@
  #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_IB62x0_H */
@@ -31,7 +31,7 @@
 @@ -67,4 +67,6 @@
   * File system
   */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_ICONNECT_H */
@@ -40,7 +40,7 @@
 @@ -12,6 +12,8 @@
  #ifndef _CONFIG_L50_H
  #define _CONFIG_L50_H
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  /*
@@ -85,7 +85,7 @@
 @@ -66,4 +66,6 @@
   * File system
   */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_POGO_E02_H */
@@ -94,7 +94,7 @@
 @@ -85,4 +85,6 @@
  #define CONFIG_SYS_ATA_IDE0_OFFSET      MV_SATA_PORT0_OFFSET
  #endif /*CONFIG_MVSATA_IDE*/
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_GOFLEXHOME_H */
@@ -103,7 +103,7 @@
 @@ -100,4 +100,6 @@
  #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_NSA310_H */
@@ -200,7 +200,7 @@
 @@ -63,4 +63,6 @@
  #define CONFIG_RTC_MV
  #endif /* CONFIG_CMD_DATE */
-
+ 
 +#include "openwrt-kirkwood-common.h"
 +
  #endif /* _CONFIG_NSA310S_H */

--- a/package/boot/uboot-kirkwood/patches/701-phy-mv88e61xx-add-support-for-RGMII-TX-RX-delay.patch
+++ b/package/boot/uboot-kirkwood/patches/701-phy-mv88e61xx-add-support-for-RGMII-TX-RX-delay.patch
@@ -17,8 +17,6 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  drivers/net/phy/mv88e61xx.c | 11 ++++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
 
-diff --git a/drivers/net/phy/mv88e61xx.c b/drivers/net/phy/mv88e61xx.c
-index 5aff7ed397..889327639d 100644
 --- a/drivers/net/phy/mv88e61xx.c
 +++ b/drivers/net/phy/mv88e61xx.c
 @@ -94,6 +94,8 @@
@@ -30,7 +28,7 @@ index 5aff7ed397..889327639d 100644
  #define PORT_REG_PHYS_CTRL_PCS_AN_EN	BIT(10)
  #define PORT_REG_PHYS_CTRL_PCS_AN_RST	BIT(9)
  #define PORT_REG_PHYS_CTRL_FC_VALUE	BIT(7)
-@@ -747,9 +749,16 @@ static int mv88e61xx_fixed_port_setup(struct phy_device *phydev, u8 port)
+@@ -747,9 +749,16 @@ static int mv88e61xx_fixed_port_setup(st
  		       PORT_REG_PHYS_CTRL_SPD1000;
  	}
  
@@ -48,6 +46,3 @@ index 5aff7ed397..889327639d 100644
  
  	return mv88e61xx_port_write(phydev, port, PORT_REG_PHYS_CTRL,
  				   val);
--- 
-2.20.1
-

--- a/package/boot/uboot-kirkwood/patches/702-phy-mv88e61xx-add-support-for-MV88E6171.patch
+++ b/package/boot/uboot-kirkwood/patches/702-phy-mv88e61xx-add-support-for-MV88E6171.patch
@@ -16,8 +16,6 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  drivers/net/phy/mv88e61xx.c | 14 ++++++++++++++
  1 file changed, 14 insertions(+)
 
-diff --git a/drivers/net/phy/mv88e61xx.c b/drivers/net/phy/mv88e61xx.c
-index 889327639d..e0b648a54e 100644
 --- a/drivers/net/phy/mv88e61xx.c
 +++ b/drivers/net/phy/mv88e61xx.c
 @@ -180,6 +180,7 @@
@@ -28,7 +26,7 @@ index 889327639d..e0b648a54e 100644
  #define PORT_SWITCH_ID_6172		0x1720
  #define PORT_SWITCH_ID_6176		0x1760
  #define PORT_SWITCH_ID_6220		0x2200
-@@ -997,6 +998,7 @@ static int mv88e61xx_probe(struct phy_device *phydev)
+@@ -997,6 +998,7 @@ static int mv88e61xx_probe(struct phy_de
  	switch (priv->id) {
  	case PORT_SWITCH_ID_6096:
  	case PORT_SWITCH_ID_6097:
@@ -36,7 +34,7 @@ index 889327639d..e0b648a54e 100644
  	case PORT_SWITCH_ID_6172:
  	case PORT_SWITCH_ID_6176:
  	case PORT_SWITCH_ID_6240:
-@@ -1152,6 +1154,17 @@ static struct phy_driver mv88e61xx_driver = {
+@@ -1152,6 +1154,17 @@ static struct phy_driver mv88e61xx_drive
  	.shutdown = &genphy_shutdown,
  };
  
@@ -54,7 +52,7 @@ index 889327639d..e0b648a54e 100644
  static struct phy_driver mv88e609x_driver = {
  	.name = "Marvell MV88E609x",
  	.uid = 0x1410c89,
-@@ -1177,6 +1190,7 @@ static struct phy_driver mv88e6071_driver = {
+@@ -1177,6 +1190,7 @@ static struct phy_driver mv88e6071_drive
  int phy_mv88e61xx_init(void)
  {
  	phy_register(&mv88e61xx_driver);
@@ -62,6 +60,3 @@ index 889327639d..e0b648a54e 100644
  	phy_register(&mv88e609x_driver);
  	phy_register(&mv88e6071_driver);
  
--- 
-2.20.1
-

--- a/package/boot/uboot-lantiq/patches/0021-MIPS-vrx200-add-NAND-SPL-support.patch
+++ b/package/boot/uboot-lantiq/patches/0021-MIPS-vrx200-add-NAND-SPL-support.patch
@@ -19,7 +19,7 @@ Signed-off-by: Daniel Schwierzeck <daniel.schwierzeck@gmail.com>
  endif
 --- a/arch/mips/include/asm/arch-vrx200/config.h
 +++ b/arch/mips/include/asm/arch-vrx200/config.h
-@@ -167,7 +167,7 @@
+@@ -168,7 +168,7 @@
  #define CONFIG_SYS_TEXT_BASE		0xB0000000
  #endif
  

--- a/package/boot/uboot-lantiq/patches/0028-gcc-compat.patch
+++ b/package/boot/uboot-lantiq/patches/0028-gcc-compat.patch
@@ -22,8 +22,6 @@ Signed-off-by: Tom Rini <trini@konsulko.com>
  delete mode 100644 include/linux/compiler-gcc4.h
  create mode 100644 include/linux/compiler-intel.h
 
-diff --git a/include/linux/compiler-gcc.h b/include/linux/compiler-gcc.h
-index 9896e54..22ab246 100644
 --- a/include/linux/compiler-gcc.h
 +++ b/include/linux/compiler-gcc.h
 @@ -5,11 +5,28 @@
@@ -147,20 +145,6 @@ index 9896e54..22ab246 100644
   */
 -#ifndef __pure
 -# define __pure				__attribute__((pure))
--#endif
--#ifndef __aligned
--# define __aligned(x)			__attribute__((aligned(x)))
--#endif
--#define __printf(a,b)			__attribute__((format(printf,a,b)))
--#define  noinline			__attribute__((noinline))
--#define __attribute_const__		__attribute__((__const__))
--#define __maybe_unused			__attribute__((unused))
--#define __always_unused			__attribute__((unused))
--
--#define __gcc_header(x) #x
--#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
--#define gcc_header(x) _gcc_header(x)
--#include gcc_header(__GNUC__)
 +#define __pure			__attribute__((pure))
 +#define __aligned(x)		__attribute__((aligned(x)))
 +#define __printf(a, b)		__attribute__((format(printf, a, b)))
@@ -189,7 +173,9 @@ index 9896e54..22ab246 100644
 +
 +#if GCC_VERSION >= 30400
 +#define __must_check		__attribute__((warn_unused_result))
-+#endif
+ #endif
+-#ifndef __aligned
+-# define __aligned(x)			__attribute__((aligned(x)))
 +
 +#if GCC_VERSION >= 40000
 +
@@ -206,7 +192,17 @@ index 9896e54..22ab246 100644
 +
 +#if GCC_VERSION >= 40100 && GCC_VERSION < 40600
 +# define __compiletime_object_size(obj) __builtin_object_size(obj, 0)
-+#endif
+ #endif
+-#define __printf(a,b)			__attribute__((format(printf,a,b)))
+-#define  noinline			__attribute__((noinline))
+-#define __attribute_const__		__attribute__((__const__))
+-#define __maybe_unused			__attribute__((unused))
+-#define __always_unused			__attribute__((unused))
+-
+-#define __gcc_header(x) #x
+-#define _gcc_header(x) __gcc_header(linux/compiler-gcc##x.h)
+-#define gcc_header(x) _gcc_header(x)
+-#include gcc_header(__GNUC__)
 +
 +#if GCC_VERSION >= 40300
 +/* Mark functions as cold. gcc will assume any path leading to a call
@@ -328,9 +324,6 @@ index 9896e54..22ab246 100644
 + * code
 + */
 +#define uninitialized_var(x) x = x
-diff --git a/include/linux/compiler-gcc3.h b/include/linux/compiler-gcc3.h
-deleted file mode 100644
-index 2befe65..0000000
 --- a/include/linux/compiler-gcc3.h
 +++ /dev/null
 @@ -1,21 +0,0 @@
@@ -355,9 +348,6 @@ index 2befe65..0000000
 -#define uninitialized_var(x) x = x
 -
 -#define __always_inline		inline __attribute__((always_inline))
-diff --git a/include/linux/compiler-gcc4.h b/include/linux/compiler-gcc4.h
-deleted file mode 100644
-index 27d11ca..0000000
 --- a/include/linux/compiler-gcc4.h
 +++ /dev/null
 @@ -1,63 +0,0 @@
@@ -424,9 +414,6 @@ index 27d11ca..0000000
 -#define __compiletime_warning(message) __attribute__((warning(message)))
 -#define __compiletime_error(message) __attribute__((error(message)))
 -#endif
-diff --git a/include/linux/compiler-intel.h b/include/linux/compiler-intel.h
-new file mode 100644
-index 0000000..d4c7113
 --- /dev/null
 +++ b/include/linux/compiler-intel.h
 @@ -0,0 +1,45 @@
@@ -475,8 +462,6 @@ index 0000000..d4c7113
 +#define __builtin_bswap16 _bswap16
 +#endif
 +
-diff --git a/include/linux/compiler.h b/include/linux/compiler.h
-index 5be3dab..020ad16 100644
 --- a/include/linux/compiler.h
 +++ b/include/linux/compiler.h
 @@ -5,16 +5,24 @@
@@ -505,7 +490,7 @@ index 5be3dab..020ad16 100644
  extern void __chk_user_ptr(const volatile void __user *);
  extern void __chk_io_ptr(const volatile void __iomem *);
  #else
-@@ -27,20 +35,32 @@ extern void __chk_io_ptr(const volatile void __iomem *);
+@@ -27,20 +35,32 @@ extern void __chk_io_ptr(const volatile
  # define __chk_user_ptr(x) (void)0
  # define __chk_io_ptr(x) (void)0
  # define __builtin_warning(x, y...) (1)
@@ -538,7 +523,7 @@ index 5be3dab..020ad16 100644
  
  /* Intel compiler defines __GNUC__. So we will overwrite implementations
   * coming from above header files here
-@@ -49,6 +69,13 @@ extern void __chk_io_ptr(const volatile void __iomem *);
+@@ -49,6 +69,13 @@ extern void __chk_io_ptr(const volatile
  # include <linux/compiler-intel.h>
  #endif
  
@@ -552,7 +537,7 @@ index 5be3dab..020ad16 100644
  /*
   * Generic compiler-dependent macros required for kernel
   * build go below this comment. Actual compiler/compiler version
-@@ -117,7 +144,7 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -117,7 +144,7 @@ void ftrace_likely_update(struct ftrace_
   */
  #define if(cond, ...) __trace_if( (cond , ## __VA_ARGS__) )
  #define __trace_if(cond) \
@@ -561,7 +546,7 @@ index 5be3dab..020ad16 100644
  	({								\
  		int ______r;						\
  		static struct ftrace_branch_data			\
-@@ -144,6 +171,10 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -144,6 +171,10 @@ void ftrace_likely_update(struct ftrace_
  # define barrier() __memory_barrier()
  #endif
  
@@ -572,7 +557,7 @@ index 5be3dab..020ad16 100644
  /* Unreachable code */
  #ifndef unreachable
  # define unreachable() do { } while (1)
-@@ -156,6 +187,135 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -156,6 +187,135 @@ void ftrace_likely_update(struct ftrace_
      (typeof(ptr)) (__ptr + (off)); })
  #endif
  
@@ -708,7 +693,7 @@ index 5be3dab..020ad16 100644
  #endif /* __KERNEL__ */
  
  #endif /* __ASSEMBLY__ */
-@@ -228,7 +388,7 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -228,7 +388,7 @@ void ftrace_likely_update(struct ftrace_
  
  /*
   * Rather then using noinline to prevent stack consumption, use
@@ -717,7 +702,7 @@ index 5be3dab..020ad16 100644
   */
  #define noinline_for_stack noinline
  
-@@ -270,11 +430,28 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -270,11 +430,28 @@ void ftrace_likely_update(struct ftrace_
  # define __section(S) __attribute__ ((__section__(#S)))
  #endif
  
@@ -746,7 +731,7 @@ index 5be3dab..020ad16 100644
  /* Compile time object size, -1 for unknown */
  #ifndef __compiletime_object_size
  # define __compiletime_object_size(obj) -1
-@@ -284,7 +461,48 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+@@ -284,8 +461,49 @@ void ftrace_likely_update(struct ftrace_
  #endif
  #ifndef __compiletime_error
  # define __compiletime_error(message)
@@ -760,11 +745,11 @@ index 5be3dab..020ad16 100644
 +#  define __compiletime_error_fallback(condition) \
 +	do { ((void)sizeof(char[1 - 2 * condition])); } while (0)
 +# endif
- #endif
++#endif
 +#ifndef __compiletime_error_fallback
 +# define __compiletime_error_fallback(condition) do { } while (0)
-+#endif
-+
+ #endif
+ 
 +#define __compiletime_assert(condition, msg, prefix, suffix)		\
 +	do {								\
 +		bool __cond = !(condition);				\
@@ -792,10 +777,11 @@ index 5be3dab..020ad16 100644
 +#define compiletime_assert_atomic_type(t)				\
 +	compiletime_assert(__native_word(t),				\
 +		"Need native word sized stores/loads for atomicity.")
- 
++
  /*
   * Prevent the compiler from merging or refetching accesses.  The compiler
-@@ -293,11 +511,45 @@ void ftrace_likely_update(struct ftrace_branch_data *f, int val, int expect);
+  * is also forbidden from reordering successive instances of ACCESS_ONCE(),
+@@ -293,11 +511,45 @@ void ftrace_likely_update(struct ftrace_
   * to make the compiler aware of ordering is to put the two invocations of
   * ACCESS_ONCE() in different C statements.
   *
@@ -847,6 +833,3 @@ index 5be3dab..020ad16 100644
 +# define nokprobe_inline	inline
 +#endif
  #endif /* __LINUX_COMPILER_H */
--- 
-2.7.4
-

--- a/package/boot/uboot-mxs/patches/001-add-i2se-duckbill.patch
+++ b/package/boot/uboot-mxs/patches/001-add-i2se-duckbill.patch
@@ -43,8 +43,6 @@ Signed-off-by: Stefan Wahren <stefan.wahren@i2se.com>
  create mode 100644 configs/duckbill_defconfig
  create mode 100644 include/configs/duckbill.h
 
-diff --git a/arch/arm/mach-imx/mxs/Kconfig b/arch/arm/mach-imx/mxs/Kconfig
-index b90d7b6e41..e7d8bc6792 100644
 --- a/arch/arm/mach-imx/mxs/Kconfig
 +++ b/arch/arm/mach-imx/mxs/Kconfig
 @@ -50,6 +50,10 @@ config TARGET_APX4DEVKIT
@@ -66,9 +64,6 @@ index b90d7b6e41..e7d8bc6792 100644
  source "board/liebherr/xea/Kconfig"
  source "board/ppcag/bg0900/Kconfig"
  source "board/schulercontrol/sc_sps_1/Kconfig"
-diff --git a/board/i2se/duckbill/Kconfig b/board/i2se/duckbill/Kconfig
-new file mode 100644
-index 0000000000..98c1e4689f
 --- /dev/null
 +++ b/board/i2se/duckbill/Kconfig
 @@ -0,0 +1,15 @@
@@ -87,9 +82,6 @@ index 0000000000..98c1e4689f
 +	default "duckbill"
 +
 +endif
-diff --git a/board/i2se/duckbill/MAINTAINERS b/board/i2se/duckbill/MAINTAINERS
-new file mode 100644
-index 0000000000..5496baa330
 --- /dev/null
 +++ b/board/i2se/duckbill/MAINTAINERS
 @@ -0,0 +1,6 @@
@@ -99,9 +91,6 @@ index 0000000000..5496baa330
 +F:	board/i2se/duckbill/
 +F:	include/configs/duckbill.h
 +F:	configs/duckbill_defconfig
-diff --git a/board/i2se/duckbill/Makefile b/board/i2se/duckbill/Makefile
-new file mode 100644
-index 0000000000..11bac98e4c
 --- /dev/null
 +++ b/board/i2se/duckbill/Makefile
 @@ -0,0 +1,10 @@
@@ -115,9 +104,6 @@ index 0000000000..11bac98e4c
 +else
 +obj-y	:= iomux.o
 +endif
-diff --git a/board/i2se/duckbill/duckbill.c b/board/i2se/duckbill/duckbill.c
-new file mode 100644
-index 0000000000..93defc6c28
 --- /dev/null
 +++ b/board/i2se/duckbill/duckbill.c
 @@ -0,0 +1,189 @@
@@ -310,9 +296,6 @@ index 0000000000..93defc6c28
 +
 +	return 0;
 +}
-diff --git a/board/i2se/duckbill/iomux.c b/board/i2se/duckbill/iomux.c
-new file mode 100644
-index 0000000000..c6cc211181
 --- /dev/null
 +++ b/board/i2se/duckbill/iomux.c
 @@ -0,0 +1,157 @@
@@ -473,9 +456,6 @@ index 0000000000..c6cc211181
 +	else
 +		mxs_iomux_setup_multiple_pads(iomux_setup_v1, ARRAY_SIZE(iomux_setup_v1));
 +}
-diff --git a/configs/duckbill_defconfig b/configs/duckbill_defconfig
-new file mode 100644
-index 0000000000..b2d7fbcf77
 --- /dev/null
 +++ b/configs/duckbill_defconfig
 @@ -0,0 +1,43 @@
@@ -522,9 +502,6 @@ index 0000000000..b2d7fbcf77
 +CONFIG_MII=y
 +CONFIG_CONS_INDEX=0
 +CONFIG_OF_LIBFDT=y
-diff --git a/include/configs/duckbill.h b/include/configs/duckbill.h
-new file mode 100644
-index 0000000000..565d8c58b7
 --- /dev/null
 +++ b/include/configs/duckbill.h
 @@ -0,0 +1,172 @@
@@ -700,6 +677,3 @@ index 0000000000..565d8c58b7
 +#include <configs/mxs.h>
 +
 +#endif /* __CONFIGS_DUCKBILL_H__ */
--- 
-2.17.1
-

--- a/package/boot/uboot-mxs/patches/210-link-libcrypto-static.patch
+++ b/package/boot/uboot-mxs/patches/210-link-libcrypto-static.patch
@@ -3,9 +3,9 @@ needed dependencies are added too.
 
 --- a/tools/Makefile
 +++ b/tools/Makefile
-@@ -147,7 +147,7 @@ endif
- # MXSImage needs LibSSL
- ifneq ($(CONFIG_MX23)$(CONFIG_MX28)$(CONFIG_ARMADA_38X)$(CONFIG_ARMADA_39X)$(CONFIG_FIT_SIGNATURE),)
+@@ -162,7 +162,7 @@ ifneq ($(CONFIG_MX23)$(CONFIG_MX28)$(CON
+ HOSTCFLAGS_kwbimage.o += \
+ 	$(shell pkg-config --cflags libssl libcrypto 2> /dev/null || echo "")
  HOSTLOADLIBES_mkimage += \
 -	$(shell pkg-config --libs libssl libcrypto 2> /dev/null || echo "-lssl -lcrypto")
 +	$(shell pkg-config --libs --static libssl libcrypto 2> /dev/null || echo "-lssl -lpthread -lcrypto")

--- a/package/boot/uboot-ramips/patches/0001-add-support-for-RAVPower-RP-WD009.patch
+++ b/package/boot/uboot-ramips/patches/0001-add-support-for-RAVPower-RP-WD009.patch
@@ -20,8 +20,6 @@ Subject: [PATCH] add support for RAVPower RP-WD009
  create mode 100644 configs/ravpower-rp-wd009-ram_defconfig
  create mode 100644 include/configs/ravpower-rp-wd009.h
 
-diff --git a/arch/mips/dts/Makefile b/arch/mips/dts/Makefile
-index c9d75596f2..23868ae1d2 100644
 --- a/arch/mips/dts/Makefile
 +++ b/arch/mips/dts/Makefile
 @@ -2,7 +2,8 @@
@@ -34,9 +32,6 @@ index c9d75596f2..23868ae1d2 100644
  dtb-$(CONFIG_TARGET_AP121) += ap121.dtb
  dtb-$(CONFIG_TARGET_AP143) += ap143.dtb
  dtb-$(CONFIG_TARGET_AP152) += ap152.dtb
-diff --git a/arch/mips/dts/ravpower-rp-wd009.dts b/arch/mips/dts/ravpower-rp-wd009.dts
-new file mode 100644
-index 0000000000..b271d5bfbc
 --- /dev/null
 +++ b/arch/mips/dts/ravpower-rp-wd009.dts
 @@ -0,0 +1,50 @@
@@ -90,11 +85,9 @@ index 0000000000..b271d5bfbc
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&ephy_router_mode>;
 +};
-diff --git a/arch/mips/mach-mtmips/Kconfig b/arch/mips/mach-mtmips/Kconfig
-index c8dcf19c0d..85ac8878ab 100644
 --- a/arch/mips/mach-mtmips/Kconfig
 +++ b/arch/mips/mach-mtmips/Kconfig
-@@ -32,6 +32,14 @@ config BOARD_GARDENA_SMART_GATEWAY_MT7688
+@@ -32,6 +32,14 @@ config BOARD_GARDENA_SMART_GATEWAY_MT768
  	  GARDENA smart Gateway boards have a MT7688 SoC with 128 MiB of RAM
  	  and 8 MiB of flash (SPI NOR) and additional SPI NAND storage.
  
@@ -117,9 +110,6 @@ index c8dcf19c0d..85ac8878ab 100644
  source "board/seeed/linkit-smart-7688/Kconfig"
  
  endmenu
-diff --git a/board/ravpower/rp-wd009/Kconfig b/board/ravpower/rp-wd009/Kconfig
-new file mode 100644
-index 0000000000..111f8e4478
 --- /dev/null
 +++ b/board/ravpower/rp-wd009/Kconfig
 @@ -0,0 +1,12 @@
@@ -135,18 +125,12 @@ index 0000000000..111f8e4478
 +	default "ravpower-rp-wd009"
 +
 +endif
-diff --git a/board/ravpower/rp-wd009/Makefile b/board/ravpower/rp-wd009/Makefile
-new file mode 100644
-index 0000000000..70cd7a8e56
 --- /dev/null
 +++ b/board/ravpower/rp-wd009/Makefile
 @@ -0,0 +1,3 @@
 +# SPDX-License-Identifier: GPL-2.0+
 +
 +obj-y += board.o
-diff --git a/board/ravpower/rp-wd009/board.c b/board/ravpower/rp-wd009/board.c
-new file mode 100644
-index 0000000000..eabcf85735
 --- /dev/null
 +++ b/board/ravpower/rp-wd009/board.c
 @@ -0,0 +1,16 @@
@@ -166,9 +150,6 @@ index 0000000000..eabcf85735
 +{
 +	return 0;
 +}
-diff --git a/configs/ravpower-rp-wd009-ram_defconfig b/configs/ravpower-rp-wd009-ram_defconfig
-new file mode 100644
-index 0000000000..08cbf40638
 --- /dev/null
 +++ b/configs/ravpower-rp-wd009-ram_defconfig
 @@ -0,0 +1,59 @@
@@ -231,9 +212,6 @@ index 0000000000..08cbf40638
 +CONFIG_WDT_MT7621=y
 +CONFIG_LZMA=y
 +CONFIG_BAUDRATE=57600
-diff --git a/include/configs/ravpower-rp-wd009.h b/include/configs/ravpower-rp-wd009.h
-new file mode 100644
-index 0000000000..bb4145197c
 --- /dev/null
 +++ b/include/configs/ravpower-rp-wd009.h
 @@ -0,0 +1,48 @@
@@ -285,6 +263,3 @@ index 0000000000..bb4145197c
 +#define CONFIG_BOARD_SIZE_LIMIT		CONFIG_ENV_OFFSET
 +
 +#endif /* __CONFIG_RAVPOWER_RP_WD009_H */
--- 
-2.27.0
-

--- a/package/boot/uboot-zynq/patches/010-fix_dtc_compilation_on_host_gcc10.patch
+++ b/package/boot/uboot-zynq/patches/010-fix_dtc_compilation_on_host_gcc10.patch
@@ -34,8 +34,6 @@ Signed-off-by: Rob Herring <robh@kernel.org>
  scripts/dtc/dtc-lexer.l | 1 -
  1 file changed, 1 deletion(-)
 
-diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
-index 5c6c3fd557d7f..b3b7270300de5 100644
 --- a/scripts/dtc/dtc-lexer.l
 +++ b/scripts/dtc/dtc-lexer.l
 @@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n

--- a/package/firmware/layerscape/ls-rcw/patches/0001-Remove-tclsh-checking.patch
+++ b/package/firmware/layerscape/ls-rcw/patches/0001-Remove-tclsh-checking.patch
@@ -10,8 +10,6 @@ Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>
  Makefile | 6 ------
  1 file changed, 6 deletions(-)
 
-diff --git a/Makefile b/Makefile
-index 9183e19..2832ab2 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -12,15 +12,9 @@ BOARDS = b4420qds b4860qds \
@@ -30,6 +28,3 @@ index 9183e19..2832ab2 100644
  	@for board in $(BOARDS); do \
  		$(MAKE) -C $$board $@ DESTDIR=$(DESTDIR)/$$board; \
  	done
--- 
-2.7.4
-

--- a/package/kernel/acx-mac80211/patches/100-compat.patch
+++ b/package/kernel/acx-mac80211/patches/100-compat.patch
@@ -1,8 +1,6 @@
-diff --git a/pci.c b/pci.c
-index ae07f5a..72d542f 100644
 --- a/pci.c
 +++ b/pci.c
-@@ -1495,7 +1495,11 @@ static struct acxpci_device_info acxpci_info_tbl[] __devinitdata = {
+@@ -1495,7 +1495,11 @@ static struct acxpci_device_info acxpci_
  #endif
  
  #ifdef CONFIG_PCI

--- a/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
+++ b/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
@@ -17,8 +17,6 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  backends/ppc_initreg.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/backends/ppc_initreg.c b/backends/ppc_initreg.c
-index 0e0d359..e5cca7e 100644
 --- a/backends/ppc_initreg.c
 +++ b/backends/ppc_initreg.c
 @@ -33,6 +33,7 @@
@@ -29,6 +27,3 @@ index 0e0d359..e5cca7e 100644
  # include <sys/user.h>
  #endif
  
--- 
-2.23.0
-

--- a/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
+++ b/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
@@ -22,8 +22,6 @@ Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
  backends/arm_initreg.c     | 2 +-
  2 files changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/backends/aarch64_initreg.c b/backends/aarch64_initreg.c
-index daf6f37..6445276 100644
 --- a/backends/aarch64_initreg.c
 +++ b/backends/aarch64_initreg.c
 @@ -33,7 +33,7 @@
@@ -35,7 +33,7 @@ index daf6f37..6445276 100644
  # include <sys/user.h>
  # include <sys/ptrace.h>
  /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */
-@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t tid __attribute__ ((unused)),
+@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t
  
    Dwarf_Word dwarf_fregs[32];
    for (int r = 0; r < 32; r++)
@@ -44,8 +42,6 @@ index daf6f37..6445276 100644
  
    if (! setfunc (64, 32, dwarf_fregs, arg))
      return false;
-diff --git a/backends/arm_initreg.c b/backends/arm_initreg.c
-index efcabaf..062bb9e 100644
 --- a/backends/arm_initreg.c
 +++ b/backends/arm_initreg.c
 @@ -38,7 +38,7 @@

--- a/package/libs/libaudit/patches/0001-Add-substitue-functions-for-strndupa-rawmemchr.patch
+++ b/package/libs/libaudit/patches/0001-Add-substitue-functions-for-strndupa-rawmemchr.patch
@@ -12,8 +12,6 @@ Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
  src/ausearch-lol.c  | 12 +++++++++++-
  4 files changed, 43 insertions(+), 4 deletions(-)
 
-diff --git a/auparse/auparse.c b/auparse/auparse.c
-index 650db02..2e1c737 100644
 --- a/auparse/auparse.c
 +++ b/auparse/auparse.c
 @@ -1,5 +1,5 @@
@@ -23,7 +21,7 @@ index 650db02..2e1c737 100644
   * All Rights Reserved.
   *
   * This library is free software; you can redistribute it and/or
-@@ -1118,6 +1118,16 @@ static int str2event(char *s, au_event_t *e)
+@@ -1118,6 +1118,16 @@ static int str2event(char *s, au_event_t
  	return 0;
  }
  
@@ -40,8 +38,6 @@ index 650db02..2e1c737 100644
  /* Returns 0 on success and 1 on error */
  static int extract_timestamp(const char *b, au_event_t *e)
  {
-diff --git a/auparse/interpret.c b/auparse/interpret.c
-index 51c4a5e..67b7b77 100644
 --- a/auparse/interpret.c
 +++ b/auparse/interpret.c
 @@ -853,6 +853,13 @@ err_out:
@@ -58,7 +54,7 @@ index 51c4a5e..67b7b77 100644
  static const char *print_proctitle(const char *val)
  {
  	char *out = (char *)print_escaped(val);
-@@ -863,7 +870,7 @@ static const char *print_proctitle(const char *val)
+@@ -863,7 +870,7 @@ static const char *print_proctitle(const
  		// Proctitle has arguments separated by NUL bytes
  		// We need to write over the NUL bytes with a space
  		// so that we can see the arguments
@@ -67,8 +63,6 @@ index 51c4a5e..67b7b77 100644
  			if (ptr >= end)
  				break;
  			*ptr = ' ';
-diff --git a/configure.ac b/configure.ac
-index 6e345f1..6f3007e 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -1,7 +1,7 @@
@@ -80,7 +74,7 @@ index 6e345f1..6f3007e 100644
  ###
  ### Permission is hereby granted, free of charge, to any person obtaining a
  ### copy of this software and associated documentation files (the "Software"),
-@@ -72,6 +72,18 @@ dnl; posix_fallocate is used in audisp-remote
+@@ -72,6 +72,18 @@ dnl; posix_fallocate is used in audisp-r
  AC_CHECK_FUNCS([posix_fallocate])
  dnl; signalfd is needed for libev
  AC_CHECK_FUNC([signalfd], [], [ AC_MSG_ERROR([The signalfd system call is necessary for auditd]) ])
@@ -99,8 +93,6 @@ index 6e345f1..6f3007e 100644
  
  ALLWARNS=""
  ALLDEBUG="-g"
-diff --git a/src/ausearch-lol.c b/src/ausearch-lol.c
-index 5d17a72..758c33e 100644
 --- a/src/ausearch-lol.c
 +++ b/src/ausearch-lol.c
 @@ -1,6 +1,6 @@
@@ -111,7 +103,7 @@ index 5d17a72..758c33e 100644
  * All Rights Reserved. 
  *
  * This software may be freely redistributed and/or modified under the
-@@ -152,6 +152,16 @@ static int compare_event_time(event *e1, event *e2)
+@@ -152,6 +152,16 @@ static int compare_event_time(event *e1,
  	return 0;
  }
  
@@ -128,6 +120,3 @@ index 5d17a72..758c33e 100644
  /*
   * This function will look at the line and pick out pieces of it.
   */
--- 
-2.21.0
-

--- a/package/libs/libaudit/patches/0002-fix-gcc-10.patch
+++ b/package/libs/libaudit/patches/0002-fix-gcc-10.patch
@@ -8,8 +8,6 @@ Subject: [PATCH 01/30] Header definitions need to be external when building
  src/ausearch-common.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/src/ausearch-common.h b/src/ausearch-common.h
-index 6669203..3040547 100644
 --- a/src/ausearch-common.h
 +++ b/src/ausearch-common.h
 @@ -50,7 +50,7 @@ extern pid_t event_pid;
@@ -21,6 +19,3 @@ index 6669203..3040547 100644
  extern const char *event_comm;
  extern const char *event_filename;
  extern const char *event_hostname;
--- 
-2.26.2
-

--- a/package/libs/nettle/patches/100-portability.patch
+++ b/package/libs/nettle/patches/100-portability.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -4635,6 +4635,7 @@ $as_echo_n "checking build system compil
+@@ -4637,6 +4637,7 @@ $as_echo_n "checking build system compil
  # remove anything that might look like compiler output to our "||" expression
  rm -f conftest* a.out b.out a.exe a_out.exe
  cat >conftest.c <<EOF
@@ -8,7 +8,7 @@
  int
  main ()
  {
-@@ -4667,6 +4668,7 @@ $as_echo_n "checking build system compil
+@@ -4669,6 +4670,7 @@ $as_echo_n "checking build system compil
  # remove anything that might look like compiler output to our "||" expression
  rm -f conftest* a.out b.out a.exe a_out.exe
  cat >conftest.c <<EOF
@@ -16,7 +16,7 @@
  int
  main ()
  {
-@@ -4703,6 +4705,7 @@ $as_echo_n "checking build system compil
+@@ -4705,6 +4707,7 @@ $as_echo_n "checking build system compil
  # remove anything that might look like compiler output to our "||" expression
  rm -f conftest* a.out b.out a.exe a_out.exe
  cat >conftest.c <<EOF
@@ -24,7 +24,7 @@
  int
  main ()
  {
-@@ -4753,6 +4756,7 @@ else
+@@ -4755,6 +4758,7 @@ else
    gmp_cv_prog_exeext_for_build="$EXEEXT"
  else
    cat >conftest.c <<EOF

--- a/package/libs/openssl/patches/100-Configure-afalg-support.patch
+++ b/package/libs/openssl/patches/100-Configure-afalg-support.patch
@@ -8,11 +8,9 @@ version to disable building the AFALG engine on openwrt targets.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/Configure b/Configure
-index 5a699836f3..74d057c219 100755
 --- a/Configure
 +++ b/Configure
-@@ -1545,7 +1545,9 @@ unless ($disabled{"crypto-mdebug-backtrace"})
+@@ -1545,7 +1545,9 @@ unless ($disabled{"crypto-mdebug-backtra
  
  unless ($disabled{afalgeng}) {
      $config{afalgeng}="";

--- a/package/libs/openssl/patches/110-openwrt_targets.patch
+++ b/package/libs/openssl/patches/110-openwrt_targets.patch
@@ -7,9 +7,6 @@ Targets are named: linux-$(CONFIG_ARCH)-openwrt
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/Configurations/25-openwrt.conf b/Configurations/25-openwrt.conf
-new file mode 100644
-index 0000000000..86a86d31e4
 --- /dev/null
 +++ b/Configurations/25-openwrt.conf
 @@ -0,0 +1,48 @@

--- a/package/libs/openssl/patches/120-strip-cflags-from-binary.patch
+++ b/package/libs/openssl/patches/120-strip-cflags-from-binary.patch
@@ -8,11 +8,9 @@ OpenSSL_version(OPENSSL_CFLAGS), or running openssl version -a
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/crypto/build.info b/crypto/build.info
-index 2c619c62e8..893128345a 100644
 --- a/crypto/build.info
 +++ b/crypto/build.info
-@@ -10,7 +10,7 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink.c ../ms/applink.c \
+@@ -10,7 +10,7 @@ EXTRA=  ../ms/uplink-x86.pl ../ms/uplink
          ppccpuid.pl pariscid.pl alphacpuid.pl arm64cpuid.pl armv4cpuid.pl
  
  DEPEND[cversion.o]=buildinf.h

--- a/package/libs/openssl/patches/130-dont-build-tests-fuzz.patch
+++ b/package/libs/openssl/patches/130-dont-build-tests-fuzz.patch
@@ -7,11 +7,9 @@ This shortens build time.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/Configure b/Configure
-index 74d057c219..5813e9f8fe 100755
 --- a/Configure
 +++ b/Configure
-@@ -318,7 +318,7 @@ my $auto_threads=1;    # enable threads automatically? true by default
+@@ -318,7 +318,7 @@ my $auto_threads=1;    # enable threads
  my $default_ranlib;
  
  # Top level directories to build

--- a/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
+++ b/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
@@ -14,8 +14,6 @@ when the client has it on top of its ciphersuite preference.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/include/openssl/ssl.h b/include/openssl/ssl.h
-index 6724ccf2d2..96d959427e 100644
 --- a/include/openssl/ssl.h
 +++ b/include/openssl/ssl.h
 @@ -173,9 +173,15 @@ extern "C" {
@@ -37,11 +35,9 @@ index 6724ccf2d2..96d959427e 100644
  # else
  #  define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
                                     "TLS_AES_128_GCM_SHA256"
-diff --git a/ssl/ssl_ciph.c b/ssl/ssl_ciph.c
-index 27a1b2ec68..7039811323 100644
 --- a/ssl/ssl_ciph.c
 +++ b/ssl/ssl_ciph.c
-@@ -1467,11 +1467,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method,
+@@ -1467,11 +1467,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      ssl_cipher_apply_rule(0, SSL_kECDHE, 0, 0, 0, 0, 0, CIPHER_DEL, -1, &head,
                            &tail);
  
@@ -71,7 +67,7 @@ index 27a1b2ec68..7039811323 100644
  
      /*
       * ...and generally, our preferred cipher is AES.
-@@ -1527,7 +1545,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method,
+@@ -1527,7 +1545,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * Within each group, ciphers remain sorted by strength and previous
       * preference, i.e.,
       * 1) ECDHE > DHE

--- a/package/libs/openssl/patches/400-eng_devcrypto-save-ioctl-if-EVP_MD_.FLAG_ONESHOT.patch
+++ b/package/libs/openssl/patches/400-eng_devcrypto-save-ioctl-if-EVP_MD_.FLAG_ONESHOT.patch
@@ -14,8 +14,6 @@ Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
 Reviewed-by: Richard Levitte <levitte@openssl.org>
 (Merged from https://github.com/openssl/openssl/pull/7585)
 
-diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
-index a727c6f646..a2c9a966f7 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/crypto/engine/eng_devcrypto.c
 @@ -461,6 +461,7 @@ struct digest_ctx {
@@ -26,7 +24,7 @@ index a727c6f646..a2c9a966f7 100644
  };
  
  static const struct digest_data_st {
-@@ -564,12 +565,15 @@ static int digest_update(EVP_MD_CTX *ctx, const void *data, size_t count)
+@@ -564,12 +565,15 @@ static int digest_update(EVP_MD_CTX *ctx
      if (digest_ctx == NULL)
          return 0;
  
@@ -46,7 +44,7 @@ index a727c6f646..a2c9a966f7 100644
  }
  
  static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
-@@ -579,7 +583,10 @@ static int digest_final(EVP_MD_CTX *ctx, unsigned char *md)
+@@ -579,7 +583,10 @@ static int digest_final(EVP_MD_CTX *ctx,
  
      if (md == NULL || digest_ctx == NULL)
          return 0;

--- a/package/libs/openssl/patches/410-eng_devcrypto-add-configuration-options.patch
+++ b/package/libs/openssl/patches/410-eng_devcrypto-add-configuration-options.patch
@@ -13,8 +13,6 @@ Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
 Reviewed-by: Richard Levitte <levitte@openssl.org>
 (Merged from https://github.com/openssl/openssl/pull/7585)
 
-diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
-index a2c9a966f7..5ec38ca8f3 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/crypto/engine/eng_devcrypto.c
 @@ -16,6 +16,7 @@
@@ -80,7 +78,7 @@ index a2c9a966f7..5ec38ca8f3 100644
  
      /*
       * Code further down must make sure that only NIDs in the table above
-@@ -333,19 +367,40 @@ static int cipher_cleanup(EVP_CIPHER_CTX *ctx)
+@@ -333,19 +367,40 @@ static int cipher_cleanup(EVP_CIPHER_CTX
  }
  
  /*
@@ -186,7 +184,7 @@ index a2c9a966f7..5ec38ca8f3 100644
  static const EVP_CIPHER *get_cipher_method(int nid)
  {
      size_t i = get_cipher_data_index(nid);
-@@ -438,6 +520,36 @@ static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
+@@ -438,6 +520,36 @@ static int devcrypto_ciphers(ENGINE *e,
      return *cipher != NULL;
  }
  
@@ -247,7 +245,7 @@ index a2c9a966f7..5ec38ca8f3 100644
  
      /*
       * Code further down must make sure that only NIDs in the table above
-@@ -516,8 +637,8 @@ static const struct digest_data_st *get_digest_data(int nid)
+@@ -516,8 +637,8 @@ static const struct digest_data_st *get_
  }
  
  /*
@@ -258,7 +256,7 @@ index a2c9a966f7..5ec38ca8f3 100644
   */
  
  static int digest_init(EVP_MD_CTX *ctx)
-@@ -630,52 +751,94 @@ static int digest_cleanup(EVP_MD_CTX *ctx)
+@@ -630,52 +751,94 @@ static int digest_cleanup(EVP_MD_CTX *ct
      return clean_devcrypto_session(&digest_ctx->sess);
  }
  
@@ -403,7 +401,7 @@ index a2c9a966f7..5ec38ca8f3 100644
      }
  }
  
-@@ -739,8 +909,154 @@ static int devcrypto_digests(ENGINE *e, const EVP_MD **digest,
+@@ -739,7 +909,153 @@ static int devcrypto_digests(ENGINE *e,
      return *digest != NULL;
  }
  
@@ -479,8 +477,8 @@ index a2c9a966f7..5ec38ca8f3 100644
 +    "DIGESTS",
 +    "either ALL, NONE, or a comma-separated list of digests to enable [default=ALL]",
 +    ENGINE_CMD_FLAG_STRING},
- #endif
- 
++#endif
++
 +   {0, NULL, NULL, 0}
 +};
 +
@@ -504,7 +502,7 @@ index a2c9a966f7..5ec38ca8f3 100644
 +        use_softdrivers = i;
 +#ifdef IMPLEMENT_DIGEST
 +        rebuild_known_digest_nids(e);
-+#endif
+ #endif
 +        rebuild_known_cipher_nids(e);
 +        return 1;
 +#endif /* CIOCGSESSINFO */
@@ -554,11 +552,10 @@ index a2c9a966f7..5ec38ca8f3 100644
 +    }
 +    return 0;
 +}
-+
+ 
  /******************************************************************************
   *
-  * LOAD / UNLOAD
-@@ -793,6 +1109,8 @@ void engine_load_devcrypto_int()
+@@ -806,6 +1122,8 @@ void engine_load_devcrypto_int()
  
      if (!ENGINE_set_id(e, "devcrypto")
          || !ENGINE_set_name(e, "/dev/crypto engine")

--- a/package/libs/openssl/patches/420-eng_devcrypto-add-command-to-dump-driver-info.patch
+++ b/package/libs/openssl/patches/420-eng_devcrypto-add-command-to-dump-driver-info.patch
@@ -11,11 +11,9 @@ Reviewed-by: Matthias St. Pierre <Matthias.St.Pierre@ncp-e.com>
 Reviewed-by: Richard Levitte <levitte@openssl.org>
 (Merged from https://github.com/openssl/openssl/pull/7585)
 
-diff --git a/crypto/engine/eng_devcrypto.c b/crypto/engine/eng_devcrypto.c
-index 5ec38ca8f3..64dc6b891d 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/crypto/engine/eng_devcrypto.c
-@@ -50,16 +50,20 @@ static int use_softdrivers = DEVCRYPTO_DEFAULT_USE_SOFDTRIVERS;
+@@ -50,16 +50,20 @@ static int use_softdrivers = DEVCRYPTO_D
   */
  struct driver_info_st {
      enum devcrypto_status_t {
@@ -82,7 +80,7 @@ index 5ec38ca8f3..64dc6b891d 100644
  #endif /* CIOCGSESSINFO */
          }
          ioctl(cfd, CIOCFSESSION, &sess.ses);
-@@ -505,8 +514,11 @@ static void destroy_all_cipher_methods(void)
+@@ -505,8 +514,11 @@ static void destroy_all_cipher_methods(v
  {
      size_t i;
  
@@ -95,7 +93,7 @@ index 5ec38ca8f3..64dc6b891d 100644
  }
  
  static int devcrypto_ciphers(ENGINE *e, const EVP_CIPHER **cipher,
-@@ -550,6 +562,40 @@ static int cryptodev_select_cipher_cb(const char *str, int len, void *usr)
+@@ -550,6 +562,40 @@ static int cryptodev_select_cipher_cb(co
      return 1;
  }
  
@@ -190,7 +188,7 @@ index 5ec38ca8f3..64dc6b891d 100644
              EVP_MD_meth_free(known_digest_methods[i]);
              known_digest_methods[i] = NULL;
              goto finish;
-@@ -894,8 +945,11 @@ static void destroy_all_digest_methods(void)
+@@ -894,8 +945,11 @@ static void destroy_all_digest_methods(v
  {
      size_t i;
  
@@ -203,7 +201,7 @@ index 5ec38ca8f3..64dc6b891d 100644
  }
  
  static int devcrypto_digests(ENGINE *e, const EVP_MD **digest,
-@@ -939,6 +993,43 @@ static int cryptodev_select_digest_cb(const char *str, int len, void *usr)
+@@ -939,6 +993,43 @@ static int cryptodev_select_digest_cb(co
      return 1;
  }
  
@@ -247,7 +245,7 @@ index 5ec38ca8f3..64dc6b891d 100644
  #endif
  
  /******************************************************************************
-@@ -983,6 +1074,11 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+@@ -983,6 +1074,11 @@ static const ENGINE_CMD_DEFN devcrypto_c
      ENGINE_CMD_FLAG_STRING},
  #endif
  
@@ -259,7 +257,7 @@ index 5ec38ca8f3..64dc6b891d 100644
     {0, NULL, NULL, 0}
  };
  
-@@ -1051,6 +1147,13 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+@@ -1051,6 +1147,13 @@ static int devcrypto_ctrl(ENGINE *e, int
          return 1;
  #endif /* IMPLEMENT_DIGEST */
  

--- a/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
+++ b/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
@@ -8,8 +8,6 @@ engines/e_devcrypto.c.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/crypto/engine/build.info b/crypto/engine/build.info
-index e00802a3fd..47fe948966 100644
 --- a/crypto/engine/build.info
 +++ b/crypto/engine/build.info
 @@ -6,6 +6,3 @@ SOURCE[../../libcrypto]=\
@@ -19,11 +17,9 @@ index e00802a3fd..47fe948966 100644
 -IF[{- !$disabled{devcryptoeng} -}]
 -  SOURCE[../../libcrypto]=eng_devcrypto.c
 -ENDIF
-diff --git a/crypto/init.c b/crypto/init.c
-index 1b0d523bea..ee3e2eb075 100644
 --- a/crypto/init.c
 +++ b/crypto/init.c
-@@ -329,18 +329,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
+@@ -329,18 +329,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_
      engine_load_openssl_int();
      return 1;
  }
@@ -42,7 +38,7 @@ index 1b0d523bea..ee3e2eb075 100644
  
  # ifndef OPENSSL_NO_RDRAND
  static CRYPTO_ONCE engine_rdrand = CRYPTO_ONCE_STATIC_INIT;
-@@ -365,6 +353,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_dynamic)
+@@ -365,6 +353,18 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_
      return 1;
  }
  # ifndef OPENSSL_NO_STATIC_ENGINE
@@ -61,7 +57,7 @@ index 1b0d523bea..ee3e2eb075 100644
  #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
  static CRYPTO_ONCE engine_padlock = CRYPTO_ONCE_STATIC_INIT;
  DEFINE_RUN_ONCE_STATIC(ossl_init_engine_padlock)
-@@ -713,11 +713,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
+@@ -713,11 +713,6 @@ int OPENSSL_init_crypto(uint64_t opts, c
      if ((opts & OPENSSL_INIT_ENGINE_OPENSSL)
              && !RUN_ONCE(&engine_openssl, ossl_init_engine_openssl))
          return 0;
@@ -73,7 +69,7 @@ index 1b0d523bea..ee3e2eb075 100644
  # ifndef OPENSSL_NO_RDRAND
      if ((opts & OPENSSL_INIT_ENGINE_RDRAND)
              && !RUN_ONCE(&engine_rdrand, ossl_init_engine_rdrand))
-@@ -727,6 +722,11 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
+@@ -727,6 +722,11 @@ int OPENSSL_init_crypto(uint64_t opts, c
              && !RUN_ONCE(&engine_dynamic, ossl_init_engine_dynamic))
          return 0;
  # ifndef OPENSSL_NO_STATIC_ENGINE
@@ -85,8 +81,6 @@ index 1b0d523bea..ee3e2eb075 100644
  #  if !defined(OPENSSL_NO_HW) && !defined(OPENSSL_NO_HW_PADLOCK)
      if ((opts & OPENSSL_INIT_ENGINE_PADLOCK)
              && !RUN_ONCE(&engine_padlock, ossl_init_engine_padlock))
-diff --git a/engines/build.info b/engines/build.info
-index 1db771971c..33a25d7004 100644
 --- a/engines/build.info
 +++ b/engines/build.info
 @@ -11,6 +11,9 @@ IF[{- !$disabled{"engine"} -}]
@@ -116,7 +110,6 @@ diff --git a/crypto/engine/eng_devcrypto.c b/engines/e_devcrypto.c
 similarity index 95%
 rename from crypto/engine/eng_devcrypto.c
 rename to engines/e_devcrypto.c
-index 2c1b52d572..eff1ed3a7d 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/engines/e_devcrypto.c
 @@ -7,7 +7,7 @@
@@ -152,7 +145,7 @@ index 2c1b52d572..eff1ed3a7d 100644
  
  /*
   * cipher/digest status & acceleration definitions
-@@ -1058,7 +1060,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+@@ -1058,7 +1060,7 @@ static const ENGINE_CMD_DEFN devcrypto_c
          OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
          OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
          "=use if acceleration can't be determined) [default="
@@ -161,7 +154,7 @@ index 2c1b52d572..eff1ed3a7d 100644
      ENGINE_CMD_FLAG_NUMERIC},
  #endif
  
-@@ -1166,32 +1168,22 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+@@ -1166,32 +1168,22 @@ static int devcrypto_ctrl(ENGINE *e, int
   *
   *****/
  

--- a/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
+++ b/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
@@ -19,8 +19,6 @@ turn them on if it is safe and fast enough.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
-index 3fcd81de7a..d25230d366 100644
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
 @@ -852,7 +852,7 @@ static void prepare_digest_methods(void)
@@ -32,7 +30,7 @@ index 3fcd81de7a..d25230d366 100644
  
          /*
           * Check that the digest is usable
-@@ -1072,7 +1072,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+@@ -1072,7 +1072,7 @@ static const ENGINE_CMD_DEFN devcrypto_c
  #ifdef IMPLEMENT_DIGEST
     {DEVCRYPTO_CMD_DIGESTS,
      "DIGESTS",

--- a/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
+++ b/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
@@ -8,11 +8,9 @@ session.  It may have been closed by another process after a fork.
 
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
-diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
-index d25230d366..f4570f1666 100644
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
-@@ -195,9 +195,8 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+@@ -195,9 +195,8 @@ static int cipher_init(EVP_CIPHER_CTX *c
          get_cipher_data(EVP_CIPHER_CTX_nid(ctx));
  
      /* cleanup a previous session */

--- a/package/libs/zlib/patches/001-neon-implementation-of-adler32.patch
+++ b/package/libs/zlib/patches/001-neon-implementation-of-adler32.patch
@@ -21,8 +21,6 @@ https://bugs.chromium.org/p/chromium/issues/detail?id=688601
  4 files changed, 166 insertions(+), 8 deletions(-)
  create mode 100644 contrib/arm/neon_adler32.c
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0fe939df..8e75f664 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -7,6 +7,7 @@ set(VERSION "1.2.11")
@@ -77,8 +75,6 @@ index 0fe939df..8e75f664 100644
  set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
  set_target_properties(zlib PROPERTIES SOVERSION 1)
  
-diff --git a/adler32.c b/adler32.c
-index d0be4380..45ebaa4b 100644
 --- a/adler32.c
 +++ b/adler32.c
 @@ -136,7 +136,12 @@ uLong ZEXPORT adler32(adler, buf, len)
@@ -94,11 +90,9 @@ index d0be4380..45ebaa4b 100644
  }
  
  /* ========================================================================= */
-diff --git a/contrib/README.contrib b/contrib/README.contrib
-index a411d5c3..3fd1d202 100644
 --- a/contrib/README.contrib
 +++ b/contrib/README.contrib
-@@ -12,6 +12,9 @@ amd64/      by Mikhail Teterin <mi@ALDAN.algebra.com>
+@@ -12,6 +12,9 @@ amd64/      by Mikhail Teterin <mi@ALDAN
          asm code for AMD64
          See patch at http://www.freebsd.org/cgi/query-pr.cgi?pr=bin/96393
  
@@ -108,9 +102,6 @@ index a411d5c3..3fd1d202 100644
  asm686/     by Brian Raiter <breadbox@muppetlabs.com>
          asm code for Pentium and PPro/PII, using the AT&T (GNU as) syntax
          See http://www.muppetlabs.com/~breadbox/software/assembly.html
-diff --git a/contrib/arm/neon_adler32.c b/contrib/arm/neon_adler32.c
-new file mode 100644
-index 00000000..f173a74f
 --- /dev/null
 +++ b/contrib/arm/neon_adler32.c
 @@ -0,0 +1,137 @@

--- a/package/libs/zlib/patches/002-arm-specific-optimisations-for-inflate.patch
+++ b/package/libs/zlib/patches/002-arm-specific-optimisations-for-inflate.patch
@@ -11,9 +11,6 @@ Change-Id: Id4cda552b39bfb39ab35ec499dbe122b43b6d1a1
  create mode 100644 contrib/arm/inffast.c
  create mode 100644 contrib/arm/inflate.c
 
-diff --git a/contrib/arm/inffast.c b/contrib/arm/inffast.c
-new file mode 100644
-index 00000000..0dbd1dbc
 --- /dev/null
 +++ b/contrib/arm/inffast.c
 @@ -0,0 +1,323 @@
@@ -340,9 +337,6 @@ index 00000000..0dbd1dbc
 + */
 +
 +#endif /* !ASMINF */
-diff --git a/contrib/arm/inflate.c b/contrib/arm/inflate.c
-new file mode 100644
-index 00000000..ac333e8c
 --- /dev/null
 +++ b/contrib/arm/inflate.c
 @@ -0,0 +1,1561 @@

--- a/package/libs/zlib/patches/003-arm-specific-optimisations-for-inflate.patch
+++ b/package/libs/zlib/patches/003-arm-specific-optimisations-for-inflate.patch
@@ -16,9 +16,6 @@ Change-Id: I59854eb25d2b1e43561c8a2afaf9175bf10cf674
  3 files changed, 335 insertions(+), 62 deletions(-)
  create mode 100644 contrib/arm/chunkcopy.h
 
-diff --git a/contrib/arm/chunkcopy.h b/contrib/arm/chunkcopy.h
-new file mode 100644
-index 00000000..2d6fd6f9
 --- /dev/null
 +++ b/contrib/arm/chunkcopy.h
 @@ -0,0 +1,279 @@
@@ -301,8 +298,6 @@ index 00000000..2d6fd6f9
 +#undef Z_RESTRICT
 +
 +#endif /* CHUNKCOPY_H */
-diff --git a/contrib/arm/inffast.c b/contrib/arm/inffast.c
-index 0dbd1dbc..f7f50071 100644
 --- a/contrib/arm/inffast.c
 +++ b/contrib/arm/inffast.c
 @@ -7,6 +7,7 @@
@@ -313,7 +308,7 @@ index 0dbd1dbc..f7f50071 100644
  
  #ifdef ASMINF
  #  pragma message("Assembler code may have bugs -- use at your own risk")
-@@ -57,6 +58,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
+@@ -57,6 +58,7 @@ unsigned start;         /* inflate()'s s
      unsigned char FAR *out;     /* local strm->next_out */
      unsigned char FAR *beg;     /* inflate()'s initial strm->next_out */
      unsigned char FAR *end;     /* while out < end, enough space available */
@@ -321,7 +316,7 @@ index 0dbd1dbc..f7f50071 100644
  #ifdef INFLATE_STRICT
      unsigned dmax;              /* maximum distance from zlib header */
  #endif
-@@ -84,12 +86,13 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
+@@ -84,12 +86,13 @@ unsigned start;         /* inflate()'s s
      out = strm->next_out;
      beg = out - (start - strm->avail_out);
      end = out + (strm->avail_out - 257);
@@ -336,7 +331,7 @@ index 0dbd1dbc..f7f50071 100644
      window = state->window;
      hold = state->hold;
      bits = state->bits;
-@@ -197,70 +200,51 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
+@@ -197,70 +200,51 @@ unsigned start;         /* inflate()'s s
  #endif
                      }
                      from = window;
@@ -371,14 +366,8 @@ index 0dbd1dbc..f7f50071 100644
 -                                } while (--op);
 -                                from = out - dist;      /* rest from output */
 -                            }
-+                            out = chunkcopy_safe(out, from, op, limit);
-+                            from = window;      /* more from start of window */
-+                            op = wnext;
-+                            /* This (rare) case can create a situation where
-+                               the first chunkcopy below must be checked.
-+                             */
-                         }
-                     }
+-                        }
+-                    }
 -                    else {                      /* contiguous in window */
 -                        from += wnext - op;
 -                        if (op < len) {         /* some from window */
@@ -399,6 +388,14 @@ index 0dbd1dbc..f7f50071 100644
 -                        *out++ = *from++;
 -                        if (len > 1)
 -                            *out++ = *from++;
++                            out = chunkcopy_safe(out, from, op, limit);
++                            from = window;      /* more from start of window */
++                            op = wnext;
++                            /* This (rare) case can create a situation where
++                               the first chunkcopy below must be checked.
++                             */
++                        }
++                    }
 +                    if (op < len) {             /* still need some from output */
 +                        out = chunkcopy_safe(out, from, op, limit);
 +                        len -= op;
@@ -443,8 +440,6 @@ index 0dbd1dbc..f7f50071 100644
                  }
              }
              else if ((op & 64) == 0) {          /* 2nd level distance code */
-diff --git a/contrib/arm/inflate.c b/contrib/arm/inflate.c
-index ac333e8c..e40322c3 100644
 --- a/contrib/arm/inflate.c
 +++ b/contrib/arm/inflate.c
 @@ -84,6 +84,7 @@

--- a/package/libs/zlib/patches/004-attach-sourcefiles-in-patch-002-to-buildsystem.patch
+++ b/package/libs/zlib/patches/004-attach-sourcefiles-in-patch-002-to-buildsystem.patch
@@ -1,5 +1,3 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8e75f66..24d7329 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -95,34 +95,67 @@ set(ZLIB_PUBLIC_HDRS

--- a/package/network/config/ltq-adsl-app/patches/001-stupid_breakage_fix.patch
+++ b/package/network/config/ltq-adsl-app/patches/001-stupid_breakage_fix.patch
@@ -1,6 +1,6 @@
---- a/src/dsl_cpe_cli_access.c	2016-05-27 12:34:43.612485449 -0700
-+++ b/src/dsl_cpe_cli_access.c	2016-05-27 12:45:37.491727862 -0700
-@@ -1142,7 +1142,7 @@
+--- a/src/dsl_cpe_cli_access.c
++++ b/src/dsl_cpe_cli_access.c
+@@ -1142,7 +1142,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_Auto
  
        if ((ret < 0) && (autobootCtrl.accessCtl.nReturn < DSL_SUCCESS))
        {
@@ -9,7 +9,7 @@
        }
        else
        {
-@@ -1213,7 +1213,7 @@
+@@ -1213,7 +1213,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_Auto
  
     if ((ret < 0) && (pData.accessCtl.nReturn < DSL_SUCCESS))
     {
@@ -18,7 +18,7 @@
     }
     else
     {
-@@ -1290,7 +1290,7 @@
+@@ -1290,7 +1290,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_Line
  
     if ((ret < 0) && (pData.accessCtl.nReturn < DSL_SUCCESS))
     {
@@ -27,7 +27,7 @@
     }
     else
     {
-@@ -1355,7 +1355,7 @@
+@@ -1355,7 +1355,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_Reso
                    pCtx, &resourceUsageStatisticsData);
           if (ret < 0)
           {
@@ -36,7 +36,7 @@
           }
           else
           {
-@@ -3084,7 +3084,7 @@
+@@ -3084,7 +3084,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_G997
  
     if ((ret < 0) && (pData->accessCtl.nReturn < DSL_SUCCESS))
     {
@@ -45,7 +45,7 @@
     }
     else
     {
-@@ -4654,7 +4654,7 @@
+@@ -4654,7 +4654,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_G997
  
     if ((ret < 0) && (pData.accessCtl.nReturn < DSL_SUCCESS))
     {
@@ -54,7 +54,7 @@
     }
     else
     {
-@@ -5714,7 +5714,7 @@
+@@ -5714,7 +5714,7 @@ DSL_CLI_LOCAL DSL_int_t DSL_CPE_CLI_G997
  
     if ((ret < 0) && (pData.accessCtl.nReturn < DSL_SUCCESS))
     {

--- a/package/network/ipv6/thc-ipv6/patches/000-cflags_override.patch
+++ b/package/network/ipv6/thc-ipv6/patches/000-cflags_override.patch
@@ -1,7 +1,6 @@
-diff -urN thc-ipv6-2.7/Makefile thc-ipv6-2.7.new/Makefile
---- thc-ipv6-2.7/Makefile	2014-12-27 05:05:30.000000000 -0800
-+++ thc-ipv6-2.7.new/Makefile	2017-02-04 20:55:51.679898101 -0800
-@@ -3,7 +3,7 @@
+--- a/Makefile
++++ b/Makefile
+@@ -3,7 +3,7 @@ HAVE_SSL=yes
  
  CC=gcc
  #CFLAGS=-g

--- a/package/network/services/dnsmasq/patches/0001-Tweak-sort-order-of-tags-in-get-version.patch
+++ b/package/network/services/dnsmasq/patches/0001-Tweak-sort-order-of-tags-in-get-version.patch
@@ -15,8 +15,6 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  bld/get-version | 7 +++++--
  1 file changed, 5 insertions(+), 2 deletions(-)
 
-diff --git a/bld/get-version b/bld/get-version
-index e472aab..1d7e7f0 100755
 --- a/bld/get-version
 +++ b/bld/get-version
 @@ -9,7 +9,10 @@
@@ -40,6 +38,3 @@ index e472aab..1d7e7f0 100755
       else
           cat $1/VERSION
       fi
--- 
-2.24.3 (Apple Git-128)
-

--- a/package/network/services/dnsmasq/patches/0002-Tweak-f1204a875e0f16fd645df965db346fc56d2ab1dd.patch
+++ b/package/network/services/dnsmasq/patches/0002-Tweak-f1204a875e0f16fd645df965db346fc56d2ab1dd.patch
@@ -10,8 +10,6 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  bld/get-version | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/bld/get-version b/bld/get-version
-index 1d7e7f0..1f51768 100755
 --- a/bld/get-version
 +++ b/bld/get-version
 @@ -31,7 +31,7 @@ else
@@ -23,6 +21,3 @@ index 1d7e7f0..1f51768 100755
       else
           cat $1/VERSION
       fi
--- 
-2.24.3 (Apple Git-128)
-

--- a/package/network/services/dnsmasq/patches/100-remove-old-runtime-kernel-support.patch
+++ b/package/network/services/dnsmasq/patches/100-remove-old-runtime-kernel-support.patch
@@ -27,7 +27,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  
 --- a/src/dnsmasq.h
 +++ b/src/dnsmasq.h
-@@ -1125,7 +1125,7 @@ extern struct daemon {
+@@ -1130,7 +1130,7 @@ extern struct daemon {
    int inotifyfd;
  #endif
  #if defined(HAVE_LINUX_NETWORK)
@@ -36,7 +36,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  #elif defined(HAVE_BSD_NETWORK)
    int dhcp_raw_fd, dhcp_icmp_fd, routefd;
  #endif
-@@ -1306,9 +1306,6 @@ int read_write(int fd, unsigned char *pa
+@@ -1312,9 +1312,6 @@ int read_write(int fd, unsigned char *pa
  void close_fds(long max_fd, int spare1, int spare2, int spare3);
  int wildcard_match(const char* wildcard, const char* match);
  int wildcard_matchn(const char* wildcard, const char* match, int num);

--- a/package/network/services/hostapd/patches/020-ignore-4addr-mode-enabling-error.patch
+++ b/package/network/services/hostapd/patches/020-ignore-4addr-mode-enabling-error.patch
@@ -18,8 +18,6 @@ Signed-off-by: Jouni Malinen <j@w1.fi>
  src/drivers/driver_nl80211.c | 23 +++++++++++++++++++++++
  1 file changed, 23 insertions(+)
 
-diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
-index 72189da24..011a15e68 100644
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
 @@ -617,6 +617,7 @@ struct wiphy_idx_data {
@@ -30,7 +28,7 @@ index 72189da24..011a15e68 100644
  };
  
  
-@@ -639,6 +640,9 @@ static int netdev_info_handler(struct nl_msg *msg, void *arg)
+@@ -639,6 +640,9 @@ static int netdev_info_handler(struct nl
  		os_memcpy(info->macaddr, nla_data(tb[NL80211_ATTR_MAC]),
  			  ETH_ALEN);
  
@@ -40,7 +38,7 @@ index 72189da24..011a15e68 100644
  	return NL_SKIP;
  }
  
-@@ -691,6 +695,20 @@ static int nl80211_get_macaddr(struct i802_bss *bss)
+@@ -691,6 +695,20 @@ static int nl80211_get_macaddr(struct i8
  }
  
  
@@ -61,7 +59,7 @@ index 72189da24..011a15e68 100644
  static int nl80211_register_beacons(struct wpa_driver_nl80211_data *drv,
  				    struct nl80211_wiphy_data *w)
  {
-@@ -11482,6 +11500,11 @@ static int nl80211_set_4addr_mode(void *priv, const char *bridge_ifname,
+@@ -11508,6 +11526,11 @@ static int nl80211_set_4addr_mode(void *
  
  	ret = send_and_recv_msgs(drv, msg, NULL, NULL);
  	msg = NULL;
@@ -73,6 +71,3 @@ index 72189da24..011a15e68 100644
  	if (!ret) {
  		if (bridge_ifname[0] && val &&
  		    i802_check_bridge(drv, bss, bridge_ifname, bss->ifname) < 0)
--- 
-2.29.2
-

--- a/package/network/services/hostapd/patches/050-mesh-make-forwarding-configurable.patch
+++ b/package/network/services/hostapd/patches/050-mesh-make-forwarding-configurable.patch
@@ -59,7 +59,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -10023,6 +10023,9 @@ static int nl80211_put_mesh_config(struc
+@@ -10041,6 +10041,9 @@ static int nl80211_put_mesh_config(struc
  	if (((params->flags & WPA_DRIVER_MESH_CONF_FLAG_AUTO_PLINKS) &&
  	     nla_put_u8(msg, NL80211_MESHCONF_AUTO_OPEN_PLINKS,
  			params->auto_plinks)) ||

--- a/package/network/services/hostapd/patches/200-multicall.patch
+++ b/package/network/services/hostapd/patches/200-multicall.patch
@@ -231,7 +231,7 @@
  	os_memset(&global, 0, sizeof(global));
 --- a/wpa_supplicant/events.c
 +++ b/wpa_supplicant/events.c
-@@ -4581,8 +4581,8 @@ static void wpas_event_unprot_beacon(str
+@@ -4579,8 +4579,8 @@ static void wpas_event_unprot_beacon(str
  }
  
  
@@ -242,7 +242,7 @@
  {
  	struct wpa_supplicant *wpa_s = ctx;
  	int resched;
-@@ -5400,7 +5400,7 @@ void wpa_supplicant_event(void *ctx, enu
+@@ -5398,7 +5398,7 @@ void wpa_supplicant_event(void *ctx, enu
  }
  
  

--- a/package/network/services/hostapd/patches/330-nl80211_fix_set_freq.patch
+++ b/package/network/services/hostapd/patches/330-nl80211_fix_set_freq.patch
@@ -1,6 +1,6 @@
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -4646,7 +4646,7 @@ static int nl80211_set_channel(struct i8
+@@ -4664,7 +4664,7 @@ static int nl80211_set_channel(struct i8
  		   freq->freq, freq->ht_enabled, freq->vht_enabled, freq->he_enabled,
  		   freq->bandwidth, freq->center_freq1, freq->center_freq2);
  

--- a/package/network/services/hostapd/patches/350-nl80211_del_beacon_bss.patch
+++ b/package/network/services/hostapd/patches/350-nl80211_del_beacon_bss.patch
@@ -1,6 +1,6 @@
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -2788,10 +2788,15 @@ static int wpa_driver_nl80211_del_beacon
+@@ -2806,10 +2806,15 @@ static int wpa_driver_nl80211_del_beacon
  	struct nl_msg *msg;
  	struct wpa_driver_nl80211_data *drv = bss->drv;
  
@@ -18,7 +18,7 @@
  	return send_and_recv_msgs(drv, msg, NULL, NULL);
  }
  
-@@ -5261,7 +5266,7 @@ static void nl80211_teardown_ap(struct i
+@@ -5279,7 +5284,7 @@ static void nl80211_teardown_ap(struct i
  		nl80211_mgmt_unsubscribe(bss, "AP teardown");
  
  	nl80211_put_wiphy_data_ap(bss);
@@ -27,7 +27,7 @@
  }
  
  
-@@ -7679,8 +7684,6 @@ static int wpa_driver_nl80211_if_remove(
+@@ -7697,8 +7702,6 @@ static int wpa_driver_nl80211_if_remove(
  	} else {
  		wpa_printf(MSG_DEBUG, "nl80211: First BSS - reassign context");
  		nl80211_teardown_ap(bss);
@@ -36,7 +36,7 @@
  		nl80211_destroy_bss(bss);
  		if (!bss->added_if)
  			i802_set_iface_flags(bss, 0);
-@@ -8074,7 +8077,6 @@ static int wpa_driver_nl80211_deinit_ap(
+@@ -8092,7 +8095,6 @@ static int wpa_driver_nl80211_deinit_ap(
  	if (!is_ap_interface(drv->nlmode))
  		return -1;
  	wpa_driver_nl80211_del_beacon(bss);
@@ -44,7 +44,7 @@
  
  	/*
  	 * If the P2P GO interface was dynamically added, then it is
-@@ -8094,7 +8096,6 @@ static int wpa_driver_nl80211_stop_ap(vo
+@@ -8112,7 +8114,6 @@ static int wpa_driver_nl80211_stop_ap(vo
  	if (!is_ap_interface(drv->nlmode))
  		return -1;
  	wpa_driver_nl80211_del_beacon(bss);

--- a/package/network/services/hostapd/patches/370-ap_sta_support.patch
+++ b/package/network/services/hostapd/patches/370-ap_sta_support.patch
@@ -274,7 +274,7 @@
  	if (ieee802_11_build_ap_params(hapd, &params) < 0)
 --- a/wpa_supplicant/events.c
 +++ b/wpa_supplicant/events.c
-@@ -4581,6 +4581,60 @@ static void wpas_event_unprot_beacon(str
+@@ -4579,6 +4579,60 @@ static void wpas_event_unprot_beacon(str
  }
  
  
@@ -335,7 +335,7 @@
  void supplicant_event(void *ctx, enum wpa_event_type event,
  		      union wpa_event_data *data)
  {
-@@ -4883,8 +4937,10 @@ void supplicant_event(void *ctx, enum wp
+@@ -4881,8 +4935,10 @@ void supplicant_event(void *ctx, enum wp
  			channel_width_to_string(data->ch_switch.ch_width),
  			data->ch_switch.cf1,
  			data->ch_switch.cf2);

--- a/package/network/services/hostapd/patches/461-driver_nl80211-use-new-parameters-during-ibss-join.patch
+++ b/package/network/services/hostapd/patches/461-driver_nl80211-use-new-parameters-during-ibss-join.patch
@@ -10,7 +10,7 @@ Signed-hostap: Antonio Quartulli <ordex@autistici.org>
 
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -5584,7 +5584,7 @@ static int wpa_driver_nl80211_ibss(struc
+@@ -5602,7 +5602,7 @@ static int wpa_driver_nl80211_ibss(struc
  				   struct wpa_driver_associate_params *params)
  {
  	struct nl_msg *msg;
@@ -19,7 +19,7 @@ Signed-hostap: Antonio Quartulli <ordex@autistici.org>
  	int count = 0;
  
  	wpa_printf(MSG_DEBUG, "nl80211: Join IBSS (ifindex=%d)", drv->ifindex);
-@@ -5611,6 +5611,37 @@ retry:
+@@ -5629,6 +5629,37 @@ retry:
  	    nl80211_put_beacon_int(msg, params->beacon_int))
  		goto fail;
  

--- a/package/network/services/hostapd/patches/463-add-mcast_rate-to-11s.patch
+++ b/package/network/services/hostapd/patches/463-add-mcast_rate-to-11s.patch
@@ -29,7 +29,7 @@ Tested-by: Simon Wunderlich <simon.wunderlich@openmesh.com>
  struct wpa_driver_set_key_params {
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -10043,6 +10043,18 @@ static int nl80211_put_mesh_id(struct nl
+@@ -10061,6 +10061,18 @@ static int nl80211_put_mesh_id(struct nl
  }
  
  
@@ -48,7 +48,7 @@ Tested-by: Simon Wunderlich <simon.wunderlich@openmesh.com>
  static int nl80211_put_mesh_config(struct nl_msg *msg,
  				   struct wpa_driver_mesh_bss_params *params)
  {
-@@ -10104,6 +10116,7 @@ static int nl80211_join_mesh(struct i802
+@@ -10122,6 +10134,7 @@ static int nl80211_join_mesh(struct i802
  	    nl80211_put_basic_rates(msg, params->basic_rates) ||
  	    nl80211_put_mesh_id(msg, params->meshid, params->meshid_len) ||
  	    nl80211_put_beacon_int(msg, params->beacon_int) ||

--- a/package/network/services/hostapd/patches/700-wifi-reload.patch
+++ b/package/network/services/hostapd/patches/700-wifi-reload.patch
@@ -174,7 +174,7 @@
  hostapd_alloc_bss_data(struct hostapd_iface *hapd_iface,
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -4493,6 +4493,9 @@ static int wpa_driver_nl80211_set_ap(voi
+@@ -4511,6 +4511,9 @@ static int wpa_driver_nl80211_set_ap(voi
  	if (ret) {
  		wpa_printf(MSG_DEBUG, "nl80211: Beacon set failed: %d (%s)",
  			   ret, strerror(-ret));

--- a/package/network/utils/layerscape/restool/patches/0001-restool-fix-get_device_file-function.patch
+++ b/package/network/utils/layerscape/restool/patches/0001-restool-fix-get_device_file-function.patch
@@ -16,11 +16,9 @@ Signed-off-by: Ioana Ciornei <ioana.ciornei@nxp.com>
  restool.c | 44 ++++++++++++++++++++++++++++----------------
  1 file changed, 28 insertions(+), 16 deletions(-)
 
-diff --git a/restool.c b/restool.c
-index 7553659..78fd1bf 100644
 --- a/restool.c
 +++ b/restool.c
-@@ -1185,8 +1185,13 @@ out:
+@@ -1193,8 +1193,13 @@ out:
  
  static int get_device_file(void)
  {
@@ -34,7 +32,7 @@ index 7553659..78fd1bf 100644
  
  	memset(restool.device_file, '\0', DEV_FILE_SIZE);
  
-@@ -1214,10 +1219,6 @@ static int get_device_file(void)
+@@ -1222,10 +1227,6 @@ static int get_device_file(void)
  			goto out;
  		}
  	} else {
@@ -45,7 +43,7 @@ index 7553659..78fd1bf 100644
  
  		d = opendir("/dev");
  		if (!d) {
-@@ -1227,26 +1228,34 @@ static int get_device_file(void)
+@@ -1235,26 +1236,34 @@ static int get_device_file(void)
  		}
  		while ((dir = readdir(d)) != NULL) {
  			if (strncmp(dir->d_name, "dprc.", 5) == 0) {
@@ -92,7 +90,7 @@ index 7553659..78fd1bf 100644
  		} else {
  			error = -1;
  			if (num_dev_files == 0)
-@@ -1255,6 +1264,9 @@ static int get_device_file(void)
+@@ -1263,6 +1272,9 @@ static int get_device_file(void)
  				ERROR_PRINTF("error: multiple root containers\n");
  		}
  	}
@@ -102,6 +100,3 @@ index 7553659..78fd1bf 100644
  out:
  	return error;
  }
--- 
-2.17.1
-

--- a/package/network/utils/linux-atm/patches/800-include_sockios.patch
+++ b/package/network/utils/linux-atm/patches/800-include_sockios.patch
@@ -1,21 +1,20 @@
---- a/src/maint/saaldump.c	2020-03-29 22:58:01.089711789 +0200
-+++ b/src/maint/saaldump.c	2020-03-29 22:59:17.564639387 +0200
+--- a/src/maint/saaldump.c
++++ b/src/maint/saaldump.c
 @@ -6,6 +6,7 @@
  #include <config.h>
  #endif
-
+ 
 +#include <linux/sockios.h>
  #include <stdlib.h>
  #include <stdarg.h>
  #include <stdio.h>
---- a/src/maint/atmdump.c	2020-03-29 22:58:18.573694469 +0200
-+++ b/src/maint/atmdump.c	2020-03-29 22:58:49.956729365 +0200
+--- a/src/maint/atmdump.c
++++ b/src/maint/atmdump.c
 @@ -6,6 +6,7 @@
  #include <config.h>
  #endif
-
+ 
 +#include <linux/sockios.h>
  #include <stdlib.h>
  #include <stdio.h>
  #include <unistd.h>
-

--- a/package/system/refpolicy/patches/100-no-docs.patch
+++ b/package/system/refpolicy/patches/100-no-docs.patch
@@ -1,7 +1,5 @@
-Index: refpolicy-2.20200229/Makefile
-===================================================================
---- refpolicy-2.20200229.orig/Makefile
-+++ refpolicy-2.20200229/Makefile
+--- a/Makefile
++++ b/Makefile
 @@ -648,6 +648,6 @@ ifneq ($(generated_fc),)
  endif
  endif

--- a/package/utils/bsdiff/patches/001-musl.patch
+++ b/package/utils/bsdiff/patches/001-musl.patch
@@ -1,6 +1,6 @@
---- a/bsdiff.c	2005-08-17 00:13:52.000000000 +0200
-+++ b/bsdiff.c	2016-02-21 01:39:31.157915765 +0100
-@@ -101,7 +101,7 @@
+--- a/bsdiff.c
++++ b/bsdiff.c
+@@ -101,7 +101,7 @@ static void split(off_t *I,off_t *V,off_
  	if(start+len>kk) split(I,V,kk,start+len-kk,h);
  }
  
@@ -9,7 +9,7 @@
  {
  	off_t buckets[256];
  	off_t i,h,len;
-@@ -139,7 +139,7 @@
+@@ -139,7 +139,7 @@ static void qsufsort(off_t *I,off_t *V,u
  	for(i=0;i<oldsize+1;i++) I[V[i]]=i;
  }
  
@@ -18,7 +18,7 @@
  {
  	off_t i;
  
-@@ -149,8 +149,8 @@
+@@ -149,8 +149,8 @@ static off_t matchlen(u_char *old,off_t
  	return i;
  }
  
@@ -29,7 +29,7 @@
  {
  	off_t x,y;
  
-@@ -175,7 +175,7 @@
+@@ -175,7 +175,7 @@ static off_t search(off_t *I,u_char *old
  	};
  }
  
@@ -38,7 +38,7 @@
  {
  	off_t y;
  
-@@ -196,7 +196,7 @@
+@@ -196,7 +196,7 @@ static void offtout(off_t x,u_char *buf)
  int main(int argc,char *argv[])
  {
  	int fd;
@@ -47,7 +47,7 @@
  	off_t oldsize,newsize;
  	off_t *I,*V;
  	off_t scan,pos,len;
-@@ -206,9 +206,9 @@
+@@ -206,9 +206,9 @@ int main(int argc,char *argv[])
  	off_t overlap,Ss,lens;
  	off_t i;
  	off_t dblen,eblen;
@@ -60,9 +60,9 @@
  	FILE * pf;
  	BZFILE * pfbz2;
  	int bz2err;
---- a/bspatch.c	2005-08-17 00:14:00.000000000 +0200
-+++ b/bspatch.c	2016-02-21 01:39:29.753859970 +0100
-@@ -36,7 +36,7 @@
+--- a/bspatch.c
++++ b/bspatch.c
+@@ -36,7 +36,7 @@ __FBSDID("$FreeBSD: src/usr.bin/bsdiff/b
  #include <unistd.h>
  #include <fcntl.h>
  
@@ -71,7 +71,7 @@
  {
  	off_t y;
  
-@@ -62,8 +62,8 @@
+@@ -62,8 +62,8 @@ int main(int argc,char * argv[])
  	int fd;
  	ssize_t oldsize,newsize;
  	ssize_t bzctrllen,bzdatalen;

--- a/package/utils/busybox/patches/001-backport1330fix-ash-make-strdup-copy.patch
+++ b/package/utils/busybox/patches/001-backport1330fix-ash-make-strdup-copy.patch
@@ -13,11 +13,9 @@ Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
  shell/ash.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/shell/ash.c b/shell/ash.c
-index f16d7fb6a..ecbfbf091 100644
 --- a/shell/ash.c
 +++ b/shell/ash.c
-@@ -14499,7 +14499,7 @@ int ash_main(int argc UNUSED_PARAM, char **argv)
+@@ -14499,7 +14499,7 @@ int ash_main(int argc UNUSED_PARAM, char
  
  	if (sflag || minusc == NULL) {
  #if MAX_HISTORY > 0 && ENABLE_FEATURE_EDITING_SAVEHISTORY
@@ -26,7 +24,7 @@ index f16d7fb6a..ecbfbf091 100644
  			const char *hp = lookupvar("HISTFILE");
  			if (!hp) {
  				hp = lookupvar("HOME");
-@@ -14513,7 +14513,7 @@ int ash_main(int argc UNUSED_PARAM, char **argv)
+@@ -14513,7 +14513,7 @@ int ash_main(int argc UNUSED_PARAM, char
  				}
  			}
  			if (hp)
@@ -35,6 +33,3 @@ index f16d7fb6a..ecbfbf091 100644
  # if ENABLE_FEATURE_SH_HISTFILESIZE
  			hp = lookupvar("HISTFILESIZE");
  			line_input_state->max_history = size_from_HISTFILESIZE(hp);
--- 
-cgit v1.2.1
-

--- a/package/utils/busybox/patches/002-backport1330fix-traceroute.patch
+++ b/package/utils/busybox/patches/002-backport1330fix-traceroute.patch
@@ -8,8 +8,6 @@ Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
  networking/traceroute.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/networking/traceroute.c b/networking/traceroute.c
-index 3f1a9ab46..29f5e480b 100644
 --- a/networking/traceroute.c
 +++ b/networking/traceroute.c
 @@ -896,7 +896,7 @@ traceroute_init(int op, char **argv)
@@ -21,6 +19,3 @@ index 3f1a9ab46..29f5e480b 100644
  		, &tos_str, &device, &max_ttl_str, &port_str, &nprobes_str
  		, &source, &waittime_str, &pausemsecs_str, &first_ttl_str
  	);
--- 
-cgit v1.2.1
-

--- a/package/utils/busybox/patches/205-udhcpc_allow_zero_length_options.patch
+++ b/package/utils/busybox/patches/205-udhcpc_allow_zero_length_options.patch
@@ -24,11 +24,9 @@ Signed-off-by: Russell Senior <russell@personaltelco.net>
  networking/udhcp/common.c | 9 +++++++--
  1 file changed, 7 insertions(+), 2 deletions(-)
 
-diff --git a/networking/udhcp/common.c b/networking/udhcp/common.c
-index 4bc719001..a16fd85d0 100644
 --- a/networking/udhcp/common.c
 +++ b/networking/udhcp/common.c
-@@ -277,8 +277,13 @@ uint8_t* FAST_FUNC udhcp_scan_options(struct dhcp_packet *packet, struct dhcp_sc
+@@ -277,8 +277,13 @@ uint8_t* FAST_FUNC udhcp_scan_options(st
  			goto complain; /* complain and return NULL */
  		len = 2 + scan_state->optionptr[OPT_LEN];
  		scan_state->rem -= len;
@@ -44,6 +42,3 @@ index 4bc719001..a16fd85d0 100644
  			goto complain; /* complain and return NULL */
  
  		if (scan_state->optionptr[OPT_CODE] == DHCP_OPTION_OVERLOAD) {
--- 
-2.30.1
-

--- a/package/utils/lua/patches-host/001-include-version-number.patch
+++ b/package/utils/lua/patches-host/001-include-version-number.patch
@@ -8,7 +8,6 @@ Including it allows multiple lua versions to coexist.
 Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 ---
 
-diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -41,10 +41,10 @@ RANLIB= ranlib
@@ -39,10 +38,9 @@ rename to doc/lua5.1.1
 diff --git a/doc/luac.1 b/doc/luac5.1.1
 rename from doc/luac.1
 rename to doc/luac5.1.1
-diff --git a/src/Makefile b/src/Makefile
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -29,10 +29,10 @@ CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
+@@ -29,10 +29,10 @@ CORE_O=	lapi.o lcode.o ldebug.o ldo.o ld
  LIB_O=	lauxlib.o lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o \
  	lstrlib.o loadlib.o linit.o
  

--- a/package/utils/lua/patches-host/013-lnum-strtoul-parsing-fixes.patch
+++ b/package/utils/lua/patches-host/013-lnum-strtoul-parsing-fixes.patch
@@ -1,8 +1,6 @@
-diff --git a/src/lnum.c b/src/lnum.c
-index 1456b6a2ed23..b0632b04c2b7 100644
 --- a/src/lnum.c
 +++ b/src/lnum.c
-@@ -127,6 +127,8 @@ static int luaO_str2i (const char *s, lua_Integer *res, char **endptr_ref) {
+@@ -127,6 +127,8 @@ static int luaO_str2i (const char *s, lu
  #else
        return 0;  /* Reject the number */
  #endif
@@ -11,7 +9,7 @@ index 1456b6a2ed23..b0632b04c2b7 100644
      }
    } else if ((v > LUA_INTEGER_MAX) || (*endptr && (!isspace(*endptr)))) {
      return TK_NUMBER;	/* not in signed range, or has '.', 'e' etc. trailing */
-@@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Integer ib ) {
+@@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Inte
    return 0;
  }
  
@@ -25,8 +23,6 @@ index 1456b6a2ed23..b0632b04c2b7 100644
 +  return (unsigned LUA_INTEGER)v;
 +}
 +#endif
-diff --git a/src/lnum_config.h b/src/lnum_config.h
-index 19d7a4231a49..1092eead6629 100644
 --- a/src/lnum_config.h
 +++ b/src/lnum_config.h
 @@ -141,7 +141,12 @@
@@ -43,6 +39,3 @@ index 19d7a4231a49..1092eead6629 100644
  #endif
  #ifndef LUA_INTEGER_MIN
  # define LUA_INTEGER_MIN (-LUA_INTEGER_MAX -1)  /* -2^16|32 */
--- 
-1.9.1
-

--- a/package/utils/lua/patches-host/100-no_readline.patch
+++ b/package/utils/lua/patches-host/100-no_readline.patch
@@ -10,7 +10,7 @@
  #if defined(LUA_USE_MACOSX)
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -17,6 +17,7 @@
+@@ -17,6 +17,7 @@ LIBS= -lm $(MYLIBS)
  MYCFLAGS=
  MYLDFLAGS=
  MYLIBS=
@@ -18,7 +18,7 @@
  
  # == END OF USER SETTINGS. NO NEED TO CHANGE ANYTHING BELOW THIS LINE =========
  
-@@ -75,7 +76,7 @@
+@@ -75,7 +76,7 @@ echo:
  	@echo "MYLIBS = $(MYLIBS)"
  
  # convenience targets for popular platforms
@@ -27,7 +27,7 @@
  none:
  	@echo "Please choose a platform:"
  	@echo "   $(PLATS)"
-@@ -90,16 +91,16 @@
+@@ -90,16 +91,16 @@ bsd:
  	$(MAKE) all MYCFLAGS="-DLUA_USE_POSIX -DLUA_USE_DLOPEN" MYLIBS="-Wl,-E"
  
  freebsd:

--- a/package/utils/lua/patches/001-include-version-number.patch
+++ b/package/utils/lua/patches/001-include-version-number.patch
@@ -8,7 +8,6 @@ Including it allows multiple lua versions to coexist.
 Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 ---
 
-diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -41,10 +41,10 @@ RANLIB= ranlib
@@ -39,10 +38,9 @@ rename to doc/lua5.1.1
 diff --git a/doc/luac.1 b/doc/luac5.1.1
 rename from doc/luac.1
 rename to doc/luac5.1.1
-diff --git a/src/Makefile b/src/Makefile
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -29,10 +29,10 @@ CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
+@@ -29,10 +29,10 @@ CORE_O=	lapi.o lcode.o ldebug.o ldo.o ld
  LIB_O=	lauxlib.o lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o \
  	lstrlib.o loadlib.o linit.o
  

--- a/package/utils/lua/patches/013-lnum-strtoul-parsing-fixes.patch
+++ b/package/utils/lua/patches/013-lnum-strtoul-parsing-fixes.patch
@@ -1,8 +1,6 @@
-diff --git a/src/lnum.c b/src/lnum.c
-index 1456b6a2ed23..b0632b04c2b7 100644
 --- a/src/lnum.c
 +++ b/src/lnum.c
-@@ -127,6 +127,8 @@ static int luaO_str2i (const char *s, lua_Integer *res, char **endptr_ref) {
+@@ -127,6 +127,8 @@ static int luaO_str2i (const char *s, lu
  #else
        return 0;  /* Reject the number */
  #endif
@@ -11,7 +9,7 @@ index 1456b6a2ed23..b0632b04c2b7 100644
      }
    } else if ((v > LUA_INTEGER_MAX) || (*endptr && (!isspace(*endptr)))) {
      return TK_NUMBER;	/* not in signed range, or has '.', 'e' etc. trailing */
-@@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Integer ib ) {
+@@ -310,3 +312,13 @@ int try_unmint( lua_Integer *r, lua_Inte
    return 0;
  }
  
@@ -25,8 +23,6 @@ index 1456b6a2ed23..b0632b04c2b7 100644
 +  return (unsigned LUA_INTEGER)v;
 +}
 +#endif
-diff --git a/src/lnum_config.h b/src/lnum_config.h
-index 19d7a4231a49..1092eead6629 100644
 --- a/src/lnum_config.h
 +++ b/src/lnum_config.h
 @@ -141,7 +141,12 @@
@@ -43,6 +39,3 @@ index 19d7a4231a49..1092eead6629 100644
  #endif
  #ifndef LUA_INTEGER_MIN
  # define LUA_INTEGER_MIN (-LUA_INTEGER_MAX -1)  /* -2^16|32 */
--- 
-1.9.1
-

--- a/package/utils/lua5.3/patches-host/001-include-version-number.patch
+++ b/package/utils/lua5.3/patches-host/001-include-version-number.patch
@@ -8,7 +8,6 @@ Including it allows multiple lua versions to coexist.
 Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 ---
 
-diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -12,7 +12,7 @@ PLAT= none
@@ -49,7 +48,6 @@ rename to doc/lua5.3.1
 diff --git a/doc/luac.1 b/doc/luac5.3.1
 rename from doc/luac.1
 rename to doc/luac5.3.1
-diff --git a/src/Makefile b/src/Makefile
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -28,7 +28,7 @@ MYOBJS=

--- a/package/utils/lua5.3/patches/001-include-version-number.patch
+++ b/package/utils/lua5.3/patches/001-include-version-number.patch
@@ -8,7 +8,6 @@ Including it allows multiple lua versions to coexist.
 Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 ---
 
-diff --git a/Makefile b/Makefile
 --- a/Makefile
 +++ b/Makefile
 @@ -12,7 +12,7 @@ PLAT= none
@@ -49,7 +48,6 @@ rename to doc/lua5.3.1
 diff --git a/doc/luac.1 b/doc/luac5.3.1
 rename from doc/luac.1
 rename to doc/luac5.3.1
-diff --git a/src/Makefile b/src/Makefile
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -28,7 +28,7 @@ MYOBJS=

--- a/package/utils/lua5.3/patches/020-shared_liblua.patch
+++ b/package/utils/lua5.3/patches/020-shared_liblua.patch
@@ -1,5 +1,5 @@
---- a/Makefile	2019-07-02 09:24:57.554332875 -0600
-+++ b/Makefile	2019-07-02 09:25:42.626694604 -0600
+--- a/Makefile
++++ b/Makefile
 @@ -41,7 +41,7 @@ PLATS= aix bsd c89 freebsd generic linux
  # What to install.
  TO_BIN= lua$V luac$V
@@ -19,8 +19,8 @@
  	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
  
  uninstall:
---- a/src/ldo.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/ldo.h	2019-07-02 09:25:42.626694604 -0600
+--- a/src/ldo.h
++++ b/src/ldo.h
 @@ -47,8 +47,8 @@ LUAI_FUNC int luaD_pcall (lua_State *L,
  LUAI_FUNC int luaD_poscall (lua_State *L, CallInfo *ci, StkId firstResult,
                                            int nres);
@@ -32,8 +32,8 @@
  LUAI_FUNC void luaD_inctop (lua_State *L);
  
  LUAI_FUNC l_noret luaD_throw (lua_State *L, int errcode);
---- a/src/lfunc.h	2017-04-19 11:39:34.000000000 -0600
-+++ b/src/lfunc.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lfunc.h
++++ b/src/lfunc.h
 @@ -47,14 +47,14 @@ struct UpVal {
  #define upisopen(up)	((up)->v != &(up)->u.value)
  
@@ -55,8 +55,8 @@
                                           int pc);
  
  
---- a/src/lgc.h	2017-04-19 11:39:34.000000000 -0600
-+++ b/src/lgc.h	2019-07-02 09:25:42.634694666 -0600
+--- a/src/lgc.h
++++ b/src/lgc.h
 @@ -133,11 +133,11 @@
  
  LUAI_FUNC void luaC_fix (lua_State *L, GCObject *o);
@@ -71,8 +71,8 @@
  LUAI_FUNC void luaC_barrierback_ (lua_State *L, Table *o);
  LUAI_FUNC void luaC_upvalbarrier_ (lua_State *L, UpVal *uv);
  LUAI_FUNC void luaC_checkfinalizer (lua_State *L, GCObject *o, Table *mt);
---- a/src/llex.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/llex.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/llex.h
++++ b/src/llex.h
 @@ -73,13 +73,13 @@ typedef struct LexState {
  
  
@@ -92,8 +92,8 @@
  
  
  #endif
---- a/src/lmem.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/lmem.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lmem.h
++++ b/src/lmem.h
 @@ -56,12 +56,12 @@
  #define luaM_reallocvector(L, v,oldn,n,t) \
     ((v)=cast(t *, luaM_reallocv(L, v, oldn, n, sizeof(t))))
@@ -110,8 +110,8 @@
                                 size_t size_elem, int limit,
                                 const char *what);
  
---- a/src/lobject.h	2017-04-19 11:39:34.000000000 -0600
-+++ b/src/lobject.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lobject.h
++++ b/src/lobject.h
 @@ -525,7 +525,7 @@ typedef struct Table {
  #define luaO_nilobject		(&luaO_nilobject_)
  
@@ -141,8 +141,8 @@
  
  
  #endif
---- a/src/lopcodes.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/lopcodes.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lopcodes.h
++++ b/src/lopcodes.h
 @@ -278,7 +278,7 @@ enum OpArgMask {
    OpArgK   /* argument is a constant or register/constant */
  };
@@ -161,8 +161,8 @@
  
  
  /* number of list items to accumulate before a SETLIST instruction */
---- a/src/lstate.h	2017-04-19 11:39:34.000000000 -0600
-+++ b/src/lstate.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lstate.h
++++ b/src/lstate.h
 @@ -244,9 +244,9 @@ union GCUnion {
  
  LUAI_FUNC void luaE_setdebt (global_State *g, l_mem debt);
@@ -176,8 +176,8 @@
  
  
  #endif
---- a/src/lstring.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/lstring.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/lstring.h
++++ b/src/lstring.h
 @@ -35,15 +35,15 @@
  
  LUAI_FUNC unsigned int luaS_hash (const char *str, size_t l, unsigned int seed);
@@ -198,8 +198,8 @@
  
  
  #endif
---- a/src/ltable.h	2018-05-24 13:39:05.000000000 -0600
-+++ b/src/ltable.h	2019-07-02 09:25:42.630694635 -0600
+--- a/src/ltable.h
++++ b/src/ltable.h
 @@ -41,14 +41,14 @@
  
  
@@ -218,8 +218,8 @@
  LUAI_FUNC void luaH_resize (lua_State *L, Table *t, unsigned int nasize,
                                                      unsigned int nhsize);
  LUAI_FUNC void luaH_resizearray (lua_State *L, Table *t, unsigned int nasize);
---- a/src/ltm.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/ltm.h	2019-07-02 09:25:42.634694666 -0600
+--- a/src/ltm.h
++++ b/src/ltm.h
 @@ -55,10 +55,10 @@ typedef enum {
  LUAI_DDEC const char *const luaT_typenames_[LUA_TOTALTAGS];
  
@@ -245,8 +245,8 @@
                                  const TValue *p2, TMS event);
  
  
---- a/src/lundump.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/lundump.h	2019-07-02 09:25:42.634694666 -0600
+--- a/src/lundump.h
++++ b/src/lundump.h
 @@ -23,10 +23,10 @@
  #define LUAC_FORMAT	0	/* this is the official format */
  
@@ -260,8 +260,8 @@
                           void* data, int strip);
  
  #endif
---- a/src/lzio.h	2017-04-19 11:20:42.000000000 -0600
-+++ b/src/lzio.h	2019-07-02 09:25:42.634694666 -0600
+--- a/src/lzio.h
++++ b/src/lzio.h
 @@ -61,6 +61,6 @@ struct Zio {
  };
  
@@ -270,8 +270,8 @@
 +LUA_API int luaZ_fill (ZIO *z);
  
  #endif
---- a/src/Makefile	2019-07-02 09:24:57.554332875 -0600
-+++ b/src/Makefile	2019-07-02 09:25:42.630694635 -0600
+--- a/src/Makefile
++++ b/src/Makefile
 @@ -29,6 +29,7 @@ MYOBJS=
  PLATS= aix bsd c89 freebsd generic linux macosx mingw posix solaris
  


### PR DESCRIPTION
Cleans up patch fuzz and whatnot.

Ran with
find ./package -type d -name patches | rev | cut -d '/' -f 2 | rev > p
while read PKG;make package/$PKG/refresh;end < p

Signed-off-by: Rosen Penev <rosenp@gmail.com>

First patch is to fix refreshing lua host patches as they live in a different directory.
The non treewide patches are to fix quilt not being able to deal with file renames properly.