### PR TITLE
ipq806x: improve system latency

### DIFF
--- a/target/linux/ipq806x/base-files/etc/init.d/cpufreq
+++ b/target/linux/ipq806x/base-files/etc/init.d/cpufreq
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=15
+
+boot() {
+  local governor
+
+  governor=$(cat /sys/devices/system/cpu/cpufreq/policy0/scaling_governor)
+
+  if [ "$governor" = "ondemand" ]; then
+    # Effective only with ondemand
+    echo 600000 > /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq
+    echo 600000 > /sys/devices/system/cpu/cpufreq/policy1/scaling_min_freq
+    echo 10 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
+    echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+  fi
+}


### PR DESCRIPTION
Various report and data show that the freq 384000 is too low and cause some extra latency to the entire system. OEM qsdk code also set the min frequency for this target to 800 mhz.
Also some user notice some instability with this idle frequency, solved by setting the min frequency to 600mhz. Fix all these kind of problem by introducing a boot init.d script that set the min frequency to 600mhz and set the ondemand governor to be more aggressive. The script set these value only if the ondemand governor is detected. 384 mhz freq is still available and user can decide to restore the old behavior by disabling this script.

@hnyman 

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
