### PR TITLE
base-files: fix status display command

### DIFF
--- a/package/base-files/files/etc/shinit
+++ b/package/base-files/files/etc/shinit
@@ -22,7 +22,7 @@ service() {
 			printf "%-30s\t%10s\t%10s\n"  "$F" \
 			$( $($F enabled) && echo "enabled" || echo "disabled" ) \
 			$( [ "$(ubus call service list "{ 'verbose': true, 'name': '$(basename $F)' }" \
-			| jsonfilter -q -e "@.$(basename $F).instances[*].running")" = "true" ] \
+			| jsonfilter -q -e "@.$(basename $F).instances[*].running" | uniq)" = "true" ] \
 			&& echo "running" || echo "stopped" )
 		done;
 		return 1


### PR DESCRIPTION
If service() is called w/o parameter then the status display for services
with multiple instances is incorrect. E.g. samba4 or wpad have 2 instances.

```
root@OpenWrt:~# /etc/init.d/samba4 status
running
root@OpenWrt:~# /etc/init.d/wpad status
running
```

Before change:
```
/etc/init.d/samba4                 enabled         stopped
/etc/init.d/wpad                   enabled         stopped
```

After change:
```
/etc/init.d/samba4                 enabled         running
/etc/init.d/wpad                   enabled         running
```

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
