### PR TITLE
ath79: add support for ZyXEL NWA1100-NH / NWA1121-NI / NWA1123-NI / NWA1123-AC

### DIFF
--- a/target/linux/ath79/dts/ar9342_zyxel_nwa1100-nh.dts
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa1100-nh.dts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_zyxel_nwa11xx.dtsi"
+
+/ {
+	compatible = "zyxel,nwa1100-nh", "qca,ar9342";
+	model = "Zyxel NWA1100-NH";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan_green: wlan_green {
+			label = "green:wlan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_lan_green: lan_green {
+			label = "green:lan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan_amber: lan_amber {
+			label = "amber:lan";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa1121-ni.dts
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa1121-ni.dts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_zyxel_nwa11xx.dtsi"
+
+/ {
+	compatible = "zyxel,nwa1121-ni", "qca,ar9342";
+	model = "Zyxel NWA1121-NI";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa1123-ac.dts
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa1123-ac.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_zyxel_nwa11xx.dtsi"
+
+/ {
+	compatible = "zyxel,nwa1123-ac", "qca,ar9342";
+	model = "Zyxel NWA1123-AC";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa1123-ni.dts
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa1123-ni.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9342_zyxel_nwa11xx.dtsi"
+
+/ {
+	compatible = "zyxel,nwa1123-ni", "qca,ar9342";
+	model = "Zyxel NWA1123-NI";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_amber;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x050000 0x800000>;
+			};
+
+			partition@850000 {
+				label = "loader";
+				reg = <0x850000 0x010000>;
+				read-only;
+			};
+
+			fwconcat1: partition@860000 {
+				label = "fwconcat1";
+				reg = <0x860000 0x740000>;
+			};
+
+			partition@fa0000 {
+				label = "config";
+				reg = <0xfa0000 0x040000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "mib0";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_mib0_4b: macaddr@4b {
+					reg = <0x4b 0x11>;
+				};
+
+				macaddr_mib0_66: macaddr@66 {
+					reg = <0x66 0x11>;
+				};
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				calibration_ath9k: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <3>;
+		txd-delay = <3>;
+		rgmii-gmac0 = <1>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	ieee80211-freq-limit = <2402000 2482000>;
+
+	nvmem-cells = <&macaddr_mib0_4b>, <&calibration_ath9k>;
+	nvmem-cell-names = "mac-address-ascii", "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -484,6 +484,9 @@ zbtlink,zbt-wd323)
 	ucidef_set_led_switch "lan1" "LAN1" "orange:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "orange:lan2" "switch0" "0x08"
 	;;
+zyxel,nwa1100-nh)
+	ucidef_set_led_netdev "lan_data" "LAN_DATA" "amber:lan" "eth0" "tx rx"
+	ucidef_set_led_netdev "lan_link" "LAN_LINK" "green:lan" "eth0" "link"
 esac
 
 board_config_flush

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -108,7 +108,8 @@ ath79_setup_interfaces()
 	ubnt,unifiac-mesh|\
 	ubnt,unifi|\
 	wd,mynet-wifi-rangeextender|\
-	winchannel,wb2000)
+	winchannel,wb2000|\
+	zyxel,nwa1121-ni)
 		ucidef_set_interface_lan "eth0"
 		;;
 	airtight,c-75)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -110,6 +110,7 @@ ath79_setup_interfaces()
 	wd,mynet-wifi-rangeextender|\
 	winchannel,wb2000|\
 	zyxel,nwa1121-ni|\
+	zyxel,nwa1123-ac|\
 	zyxel,nwa1123-ni)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -109,7 +109,8 @@ ath79_setup_interfaces()
 	ubnt,unifi|\
 	wd,mynet-wifi-rangeextender|\
 	winchannel,wb2000|\
-	zyxel,nwa1121-ni)
+	zyxel,nwa1121-ni|\
+	zyxel,nwa1123-ni)
 		ucidef_set_interface_lan "eth0"
 		;;
 	airtight,c-75)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -109,6 +109,7 @@ ath79_setup_interfaces()
 	ubnt,unifi|\
 	wd,mynet-wifi-rangeextender|\
 	winchannel,wb2000|\
+	zyxel,nwa1100-nh|\
 	zyxel,nwa1121-ni|\
 	zyxel,nwa1123-ac|\
 	zyxel,nwa1123-ni)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -68,6 +68,10 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii u-boot-env ethaddr > /sys${DEVPATH}/macaddress
 		;;
+	zyxel,nwa1123-ac)
+		[ "$PHYNBR" -eq 0 ] && \
+			mtd_get_mac_text mib0 0x66 > /sys${DEVPATH}/macaddress
+		;;
 	zyxel,nwa1123-ni)
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_text mib0 0x66 > /sys${DEVPATH}/macaddress

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -68,4 +68,8 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii u-boot-env ethaddr > /sys${DEVPATH}/macaddress
 		;;
+	zyxel,nwa1123-ni)
+		[ "$PHYNBR" -eq 1 ] && \
+			mtd_get_mac_text mib0 0x66 > /sys${DEVPATH}/macaddress
+		;;
 esac

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2699,6 +2699,14 @@ define Device/zyxel_nwa11xx
 	vmlinux_mi124_f1e mi124_f1e-jffs2 | append-md5sum-bin
 endef
 
+define Device/zyxel_nwa1100-nh
+  $(Device/zyxel_nwa11xx)
+  DEVICE_MODEL := NWA1100
+  DEVICE_VARIANT := NH
+  ZYXEL_MODEL_STRING := AASI
+endef
+TARGET_DEVICES += zyxel_nwa1100-nh
+
 define Device/zyxel_nwa1121-ni
   $(Device/zyxel_nwa11xx)
   DEVICE_MODEL := NWA1121

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2707,6 +2707,16 @@ define Device/zyxel_nwa1121-ni
 endef
 TARGET_DEVICES += zyxel_nwa1121-ni
 
+define Device/zyxel_nwa1123-ac
+  $(Device/zyxel_nwa11xx)
+  DEVICE_MODEL := NWA1123
+  DEVICE_VARIANT := AC
+  ZYXEL_MODEL_STRING := AAOX
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers \
+	ath10k-firmware-qca988x-ct
+endef
+TARGET_DEVICES += zyxel_nwa1123-ac
+
 define Device/zyxel_nwa1123-ni
   $(Device/zyxel_nwa11xx)
   DEVICE_MODEL := NWA1123

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2707,6 +2707,14 @@ define Device/zyxel_nwa1121-ni
 endef
 TARGET_DEVICES += zyxel_nwa1121-ni
 
+define Device/zyxel_nwa1123-ni
+  $(Device/zyxel_nwa11xx)
+  DEVICE_MODEL := NWA1123
+  DEVICE_VARIANT := NI
+  ZYXEL_MODEL_STRING := AAEO
+endef
+TARGET_DEVICES += zyxel_nwa1123-ni
+
 define Device/zyxel_nbg6616
   SOC := qca9557
   DEVICE_VENDOR := ZyXEL

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -9,7 +9,7 @@ DEVICE_VARS += ADDPATTERN_ID ADDPATTERN_VERSION
 DEVICE_VARS += SEAMA_SIGNATURE SEAMA_MTDBLOCK
 DEVICE_VARS += KERNEL_INITRAMFS_PREFIX DAP_SIGNATURE
 DEVICE_VARS += EDIMAX_HEADER_MAGIC EDIMAX_HEADER_MODEL
-DEVICE_VARS += OPENMESH_CE_TYPE
+DEVICE_VARS += OPENMESH_CE_TYPE ZYXEL_MODEL_STRING
 
 define Build/add-elecom-factory-initramfs
   $(eval edimax_model=$(word 1,$(1)))
@@ -161,6 +161,13 @@ define Build/wrgg-pad-rootfs
 	$(STAGING_DIR_HOST)/bin/padjffs2 $(IMAGE_ROOTFS) -c 64 >>$@
 endef
 
+define Build/zyxel-tar-bz2
+	mkdir -p $@.tmp
+	mv $@ $@.tmp/$(word 2,$(1))
+	cp $(KDIR)/loader-$(DEVICE_NAME).uImage $@.tmp/$(word 1,$(1)).lzma.uImage
+	$(TAR) -cjf $@ -C $@.tmp .
+	rm -rf $@.tmp
+endef
 
 define Device/seama
   KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
@@ -2677,6 +2684,28 @@ define Device/zbtlink_zbt-wd323
 	kmod-usb-serial-cp210x uqmi
 endef
 TARGET_DEVICES += zbtlink_zbt-wd323
+
+define Device/zyxel_nwa11xx
+  $(Device/loader-okli-uimage)
+  SOC := ar9342
+  DEVICE_VENDOR := ZyXEL
+  LOADER_FLASH_OFFS := 0x050000
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  IMAGE_SIZE := 8192k
+  IMAGES += factory-$$$$(ZYXEL_MODEL_STRING).bin
+  IMAGE/factory-$$$$(ZYXEL_MODEL_STRING).bin := \
+	append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | \
+	pad-rootfs | pad-to 8192k | check-size | zyxel-tar-bz2 \
+	vmlinux_mi124_f1e mi124_f1e-jffs2 | append-md5sum-bin
+endef
+
+define Device/zyxel_nwa1121-ni
+  $(Device/zyxel_nwa11xx)
+  DEVICE_MODEL := NWA1121
+  DEVICE_VARIANT := NI
+  ZYXEL_MODEL_STRING := AABJ
+endef
+TARGET_DEVICES += zyxel_nwa1121-ni
 
 define Device/zyxel_nbg6616
   SOC := qca9557


### PR DESCRIPTION
The NWA112x series are wall/ceiling-mounted PoE Business Access Points
in a compact, "smoke detector" style case.

Specifications:
 * AR9342, 16 MiB Flash, 64 MiB RAM, 802.11n 2T2R, 2.4 GHz
 * 1x Gigabit Ethernet, 802.3af PoE
 * NWA1123-NI has an additional AR9382 PCIe card, 802.11n 2T2R, 5 GHz
 * NWA1123-AC has an additional QCA9882 PCIe card, 802.11ac 2T2R, 5 GHz

Newer devices from the series (e.g. `NWA1123-AC v2` / `HD` / `Pro` etc.) use a different mtd layout and
bootloader (just as NWA512x, which even use the same hardware as NWA112x) and are not supported.

Installation:
* OEM Web UI is at 192.168.1.2
  login as `admin` with password `1234`
* Flash factory-XXX.bin

A model string `XXXX` needs to be present within the file name of the uploaded
image to be accepted by the OEM Web-based updater, the factory image is
named accordingly to save the user from the hassle of manual renaming.

TFTP Recovery:
* Open the case, connect to TTL UART port (this is the official method
  described by Zyxel, the reset button is useless during power-on)
* Extract factory image (.tar.bz2), serve `vmlinux_mi124_f1e.lzma.uImage`
  and `mi124_f1e-jffs2` via tftp at 192.168.1.10
* Interrupt uboot countdown, execute commands
  `run lk`
  `run lf`
  to flash the kernel / filesystem accordingly

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>