### PR TITLE
packages: NLS fixes for binutils, bpftools, iproute2

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
 PKG_VERSION:=2.35.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -34,7 +34,7 @@ define Package/libbfd
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=libbfd
-  DEPENDS:=+zlib $(ICONV_DEPENDS) $(INTL_DEPENDS)
+  DEPENDS:=+zlib $(INTL_DEPENDS)
 endef
 
 define Package/libctf
@@ -78,6 +78,8 @@ define Package/binutils/description
 endef
 
 TARGET_CFLAGS += $(FPIC) -Wno-unused-value
+
+TARGET_LDFLAGS += $(if $(INTL_FULL),-lintl)
 
 CONFIGURE_ARGS += \
 	--host=$(REAL_GNU_TARGET_NAME) \

--- a/package/network/utils/bpftools/Makefile
+++ b/package/network/utils/bpftools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bpftools
 PKG_VERSION:=5.11.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=linux-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/v5.x
@@ -91,10 +91,6 @@ endef
 ifneq ($(BUILD_VARIANT),lib)
   TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
   TARGET_LDFLAGS += -Wl,--gc-sections
-endif
-
-ifneq ($(INTL_FULL),)
-  TARGET_LDFLAGS += -Wl,-lintl
 endif
 
 MAKE_FLAGS += \

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iproute2
 PKG_VERSION:=5.11.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/net/iproute2

--- a/package/network/utils/iproute2/patches/190-fix-nls-rpath-link.patch
+++ b/package/network/utils/iproute2/patches/190-fix-nls-rpath-link.patch
@@ -1,0 +1,20 @@
+--- a/configure
++++ b/configure
+@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
+ }
+ EOF
+ 
+-    $CC -o $TMPDIR/libbpf_test $TMPDIR/libbpf_test.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS >/dev/null 2>&1
++    $CC -o $TMPDIR/libbpf_test $TMPDIR/libbpf_test.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS $LDFLAGS >/dev/null 2>&1
+     local ret=$?
+ 
+     rm -f $TMPDIR/libbpf_test.c $TMPDIR/libbpf_test
+@@ -277,7 +277,7 @@ int main(int argc, char **argv) {
+ }
+ EOF
+ 
+-    $CC -o $TMPDIR/libbpf_sec_test $TMPDIR/libbpf_sec_test.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS >/dev/null 2>&1
++    $CC -o $TMPDIR/libbpf_sec_test $TMPDIR/libbpf_sec_test.c $LIBBPF_CFLAGS $LIBBPF_LDLIBS $LDFLAGS >/dev/null 2>&1
+     local ret=$?
+ 
+     rm -f $TMPDIR/libbpf_sec_test.c $TMPDIR/libbpf_sec_test


### PR DESCRIPTION
### Description:
Investigating an NLS problem [reported on the ML](https://lists.openwrt.org/pipermail/openwrt-devel/2021-March/034487.html) led to finding other NLS-related issues, spanning **iproute2**, **bpftools** and **binutils**.

The relevant NLS fixes are candidates for backporting to 21.02 and also impact #4025:

1. bpftools: don't overlink with `-lintl` since there's no direct dependency.

2. binutils: link `libbfd` with `-lintl` to avoid other run-time link failures, and drop unneeded `iconv` dependency.

3. iproute2: fix LDFLAGS not being passed to CC call in upstream `configure`.

### Testing:
Tested with QEMU on malta/be32, building all packages from `binutils`, `bpftools` (which links `libbfd`) and `iproute2` (which links `libbpf`), and using both libc options: **musl** and **glibc**.
### Distribution:
@RussellSenior is maintainer for iproute2, with the related issue reported by Ian Cooper (@dl12345 ).

@nbd168 maintains binutils and authored 08e817569630b79a2a2e552cd551c29309f5aacd which this PR updates. Felix, does it make sense to remove $(ICONV_DEPENDS)? What were the link errors from your previous fix? Does binutils require further testing than that above?

@hauke Reviewed and merged other recent PRs for these packages.