### PR TITLE
ramips: add support for TP-Link RE305 v3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v3.dts
@@ -3,8 +3,8 @@
 #include "mt7628an_tplink_re305.dtsi"
 
 / {
-	compatible = "tplink,re305-v1", "mediatek,mt7628an-soc";
-	model = "TP-Link RE305 v1";
+	compatible = "tplink,re305-v3", "mediatek,mt7628an-soc";
+	model = "TP-Link RE305 v3";
 };
 
 &spi0 {
@@ -29,19 +29,14 @@
 			partition@20000 {
 				compatible = "tplink,firmware";
 				label = "firmware";
-				reg = <0x20000 0x5e0000>;
+				reg = <0x20000 0x7a0000>;
 			};
 
-			config: partition@600000 {
+			config: partition@7c0000 {
 				label = "config";
-				reg = <0x600000 0x50000>;
+				reg = <0x7c0000 0x30000>;
 				read-only;
 			};
-
-			/*
-				The flash space between 0x650000 and 0x7f0000 is blank in the
-				stock firmware so it is left out as well.
-			*/
 
 			radio: partition@7f0000 {
 				label = "radio";
@@ -55,21 +50,21 @@
 &wlan5g {
 	mediatek,mtd-eeprom = <&radio 0x8000>;
 
-	nvmem-cells = <&macaddr_config_10008>;
+	nvmem-cells = <&macaddr_config_2008>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
+	mac-address-increment = <(-2)>;
 };
 
 &wmac {
 	mediatek,mtd-eeprom = <&radio 0x0>;
 
-	nvmem-cells = <&macaddr_config_10008>;
+	nvmem-cells = <&macaddr_config_2008>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
+	mac-address-increment = <(-1)>;
 };
 
 &ethernet {
-	nvmem-cells = <&macaddr_config_10008>;
+	nvmem-cells = <&macaddr_config_2008>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -78,7 +73,7 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	macaddr_config_10008: macaddr@10008 {
-		reg = <0x10008 0x6>;
+	macaddr_config_2008: macaddr@2008 {
+		reg = <0x2008 0x6>;
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		rssi1 {
+			label = "red:rssi";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi2 {
+			label = "blue:rssi";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "refclk", "wdt", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wlan5g: mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -512,6 +512,16 @@ define Device/tplink_re305-v1
 endef
 TARGET_DEVICES += tplink_re305-v1
 
+define Device/tplink_re305-v3
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE305
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-mt76x2
+  TPLINK_BOARD_ID := RE305-V3
+endef
+TARGET_DEVICES += tplink_re305-v3
+
 define Device/tplink_tl-mr3020-v3
   $(Device/tplink-v2)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ ramips_setup_interfaces()
 	tplink,re200-v4|\
 	tplink,re220-v2|\
 	tplink,re305-v1|\
+	tplink,re305-v3|\
 	tplink,tl-mr3020-v3|\
 	tplink,tl-wr802n-v4|\
 	tplink,tl-wa801nd-v5|\


### PR DESCRIPTION
Specs (same as in v1):
- MT7628AN (575 MHz)
- 64MB RAM
- 8MB of flash (SPI NOR)
- 1x 10/100Mbps Ethernet (MT7628AN built-in switch with vlan)
- 1x 2.4GHz wifi (MT7628AN)
- 1x 5Ghz wifi (MT7612E)
- 4x LEDs (5 GPIO-controlled)
- 1x reset button
- 1x WPS button

The only and important difference between v1 & v3 is in flash memory layout, so pls don't interchange these 2 builds!

So far verified way to load the build:
1. connect trough serial (1n8, baudrate=57600)
2. setup the TFTP server and connect it via ethernet (ipaddr=192.168.0.254 of device, serverip=192.168.0.184 - your pc)
3. boot from a initramfs image first (choose 1 in the bootloader options)
4. test it a bit with that, then proceed to run sysupgrade build

Signed-off-by: servitkar <servitkar[at]gmail[dot]com>