### PR TITLE
ramips: improve pinctrl for Youku YK-L1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -17,14 +17,10 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wan {
-			label = "blue:wan";
-			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
-		};
-
-		air {
-			label = "blue:air";
+		wlan {
+			label = "blue:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {
@@ -52,10 +48,6 @@
 };
 
 &gpio1 {
-	status = "okay";
-};
-
-&gpio2 {
 	status = "okay";
 };
 
@@ -106,7 +98,7 @@
 
 &state_default {
 	default {
-		groups = "i2c", "rgmii1", "ephy", "wled";
+		groups = "i2c", "rgmii1", "wled";
 		function = "gpio";
 	};
 };

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -194,10 +194,6 @@ tplink,archer-mr200)
 tplink,re200-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
-youku,yk1)
-	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:air" "wlan0"
-	;;
 zbtlink,zbt-ape522ii)
 	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "green:wlan2g4" "wlan1"
 	ucidef_set_led_netdev "sys1" "wlan1" "green:sys1" "wlan1" "tx rx"


### PR DESCRIPTION
1. rename led pin "air" to a more common name "wlan" and use "phy0tpt" to trigger it.
2. led "wan" can be triggered by ethernet pinctrl by default so just drop it.