### PR TITLE
ramips: add support for HiLink HLK-7621A evaluation board

### DIFF
--- a/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
+++ b/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hilink,hlk-7621a-evb", "mediatek,mt7621-soc";
+	model = "HiLink HLK-7621A evaluation board";
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <44000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_8004>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie2 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_8004: macaddr@8004 {
+		reg = <0x8004 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -623,6 +623,16 @@ define Device/gnubee_gb-pc2
 endef
 TARGET_DEVICES += gnubee_gb-pc2
 
+define Device/hilink_hlk-7621a-evb
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := HiLink
+  DEVICE_MODEL := HLK-7621A evaluation board
+  DEVICE_PACKAGES += kmod-mt76x2 kmod-usb3
+  IMAGE_SIZE := 32448k
+endef
+TARGET_DEVICES += hilink_hlk-7621a-evb
+
 define Device/hiwifi_hc5962
   $(Device/dsa-migration)
   BLOCKSIZE := 128k


### PR DESCRIPTION
 Specifications:
   - SoC: MediaTek MT7621AT
   - RAM: 256 MB (DDR3)
   - Flash: 32 MB SPI NOR 44MHz
   - Switch: 1 WAN, 4 LAN (Gigabit)
   - LEDs: 1 WAN, 4 LAN (controlled by PHY)
   - USB Ports: 1 x USB2, 1 x USB3
   - WLAN: 1 x 2.4, 5 GHz 866Mbps (MT7612E)
   - Button: 1 button (reset)
   - UART Serial: UART1 as console : 57600 baud
   - Power: 12V, 1A

Installation:

- Update openWRT firmware by internal GNUBEE uboot: https://github.com/gnubee-git/GnuBee-MT7621-uboot
- By HTTP: Initial uboot address is http://10.10.10.123, your address needs to be 10.10.10.x, and mask 255.255.255.0.
- By TFTP: Uboot is in client mode, the address of the firmware must be tftp://10.10.10.3/uboot.bin

Recovery:
- Manufacturer provides MTK OpenWrt 14.07 source code, compile then flash it by uboot.

HLK-7621A is a stamp hole package module for embedded development, users have to design IO boards to use it.

 Mac addresses:
- Ethernet mac address is only located in uboot-env partition and can be retrieved as follows:
       # mtd_get_mac_ascii u-boot-env ethaddr
       03:17:73:ab:cd:ef
      Since this address is obviously a placeholder should not be used.
      We will set factory partition 0x8004 offset as mac start value to have a fixed address
  instead of random one since we cannot do anything better if vendor is not setting up
  properly this. Hence ethernet mac will be: 8c:88:2b:00:00:1b.
- Wifi mac address is located at '/sys/class/ieee80211/phy0/macaddress':
       # cat /sys/class/ieee80211/phy0/macaddress
       f8:62:aa:50:11:a8
      This is already properly assigned so nothing is necessary to be done.

User Manual (Chinese & English):
[HLK-7621A用户手册V1.5.pdf](https://github.com/openwrt/openwrt/files/5884699/HLK-7621A.V1.5.pdf)

Signed-off-by: Chen Yijun <cyjason[at]bupt[dot]edu[dot]cn>
[add keys and pcie nodes to properly support evaluation board]
Signed-off-by: Sergio Paracuellos <sergio.paracuellos[at]gmail[dot]com>

NOTE: This superseds the following PR: https://github.com/openwrt/openwrt/pull/3817
