### PR TITLE
ramips: reduce spi-max-frequency for Xiaomi MI Router 4AG / 3G V2 models

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4a-3g-v2.dtsi
@@ -49,7 +49,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <80000000>;
+		spi-max-frequency = <50000000>;
 		m25p,fast-read;
 
 		partitions {


### PR DESCRIPTION
Reduce spi-max-frequency for Xiaomi MI Router 4AG model

Xiaomi MI Router 4AG MTD uses two flash chips (no specific on router versions when produced from factory) - GD25Q128C and W25Q128BV.

These flash chips are capable of high frequency, but due to poor board design or manufacture process.

We are seeing the following errors in the linux kernel bootup:

`spi-nor spi0.0: unrecognized JEDEC id bytes: cc 60 1c cc 60 1c
 spi-nor: probe of spi0.0 failed with error -2`

This causes the partitions not to be detected

`VFS: Cannot open root device "(null)" or unknown-block(0,0): error -6`

Then creates a bootloop and a bricked router.

The solution to limit this race condition is to reduce the frequency from 80 mhz to 50 mhz.

Signed-off-by: David Bentham <db260179@gmail.com>