### PR TITLE
ramips: add support for Haier HW-L1W

### DIFF
--- a/target/linux/ramips/dts/mt7620a_haier_hw-l1w.dts
+++ b/target/linux/ramips/dts/mt7620a_haier_hw-l1w.dts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Haier HW-L1W";
+	compatible = "haier,hw-l1w", "ralink,mt7620a-soc";
+
+	aliases {
+		led-boot = &led_usb;
+		led-failsafe = &led_usb;
+		led-upgrade = &led_usb;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_usb: usb {
+			label = "white:usb";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+		};
+
+		wlan {
+			label = "white:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "wled";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+
+	mediatek,portmap = "wllll";
+
+	nvmem-cells = <&macaddr_factory_ffe8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_ffe8: macaddr@ffe8 {
+		reg = <0xffe8 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -468,6 +468,16 @@ define Device/glinet_gl-mt750
 endef
 TARGET_DEVICES += glinet_gl-mt750
 
+define Device/haier_hw-l1w
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Haier
+  DEVICE_MODEL := HW-L1W
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-sdhci-mt7620 \
+	kmod-usb-ohci kmod-usb2 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += haier_hw-l1w
+
 define Device/head-weblink_hdrm200
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -149,6 +149,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "4:wan" "6@eth0"
 		;;
+	haier,hw-l1w)
+		ucidef_add_switch "switch0" \
+			"1:lan:2" "2:lan:1" "0:wan" "6@eth0"
+		;;
 	head-weblink,hdrm200)
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:lan" "0:wan" "6@eth0"
@@ -327,6 +331,10 @@ ramips_setup_macs()
 	glinet,gl-mt750)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4000)" 1)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
+	haier,hw-l1w)
+		wan_mac=$(mtd_get_mac_binary factory 0xffee)
+		label_mac=$wan_mac
 		;;
 	hiwifi,hc5661|\
 	hiwifi,hc5761|\


### PR DESCRIPTION
Specifications:
* SOC: MT7620A + MT7610E
* ROM: 16 MiB spi flash (Winbond W25Q128)
* RAM: 128MiB DDR2
* WAN: 10/100M *1
* LAN: 10/100M *2
* USB: Type-A USB2.0 *1
* SD: MicroSD *1
* Button: Reset *1
* LEDs: Ethernet *3 + Wlan *1 + USB *1
* Antennas: 2.4 GHz *2 (inside) + 5 GHz *1
* TTL Baudrate: 57600
* Power: DC 5V 2A

Partitions:
mtd0    0x000000000000-0x000001000000 : "ALL"
mtd1    0x000000000000-0x000000030000 : "Bootloader"
mtd2    0x000000030000-0x000000040000 : "Parameter2"
mtd3    0x000000040000-0x000000050000 : "Factory"
mtd4    0x000000050000-0x0000001ed6bb : "Kernel"
mtd5    0x0000001ed6bb-0x000000b50000 : "RootFS"
mtd6    0x000000050000-0x000000b50000 : "Kernel_RootFS"
mtd7    0x000000b50000-0x000000bb0000 : "Kernel_mini"
mtd8    0x000000bb0000-0x000000c00000 : "Parameter1"
mtd9    0x000000c00000-0x000001000000 : "Application"
(Useful data is stored in "Factory" and "Bootloader" so other partitions can be
formated)

TFTP Recovery Info:
* IP: 192.168.1.6, Server: 192.168.1.33, bootfile: ra288.bin
* Push reset button and plug in to upload official firmware ra288.bin.

Installation:
* Reset the router and use putty to open telnet (IP: 192.168.1.1, Port: 20023,
  account: admin, password: admin).
* Backup full flash storage to computer (optional but recommended)
  / $ dd if=/dev/mtd0 of=/tmp/full.bin
  / $ tftp -p -l /tmp/full.bin -r full.bin 192.168.1.x (your IP)
* Use wget command to download openwrt image from local http server to /tmp:
  / $ wget -P /tmp http://192.168.1.x/openwrt-xxxx.bin
* Use mtd_write and dd commands to write it to firmware partitions:
  / $ mtd_write erase mtd6
  / $ dd if=/tmp/openwrt-xxxx.bin of=dev/mtd6

Signed-off-by: Shiji Yang <yangshiji66@qq.com>