### PR TITLE
ramips: add support for DomyWifi DM202/DM203/DW22D

### DIFF
--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_system_amber;
+		led-failsafe = &led_system_amber;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_amber;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_green: system_green {
+			label = "green:system";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system_amber: system_amber {
+			label = "amber:system";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_green {
+			label = "green:internet";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_amber {
+			label = "amber:internet";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "amber:lan1";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "amber:lan2";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "amber:lan3";
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "amber:lan4";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "amber:wan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "rgmii1", "wled";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+
+	mediatek,portmap = "wllll";
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7620a_domywifi_dm202.dts
+++ b/target/linux/ramips/dts/mt7620a_domywifi_dm202.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_domywifi.dtsi"
+
+/ {
+	compatible = "domywifi,dm202", "ralink,mt7620a-soc";
+	model = "DomyWifi DM202";
+};

--- a/target/linux/ramips/dts/mt7620a_domywifi_dm203.dts
+++ b/target/linux/ramips/dts/mt7620a_domywifi_dm203.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_domywifi.dtsi"
+
+/ {
+	compatible = "domywifi,dm203", "ralink,mt7620a-soc";
+	model = "DomyWifi DM203";
+};

--- a/target/linux/ramips/dts/mt7620a_domywifi_dw22d.dts
+++ b/target/linux/ramips/dts/mt7620a_domywifi_dw22d.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a_domywifi.dtsi"
+
+/ {
+	compatible = "domywifi,dw22d", "ralink,mt7620a-soc";
+	model = "DomyWifi DW22D";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -308,6 +308,33 @@ define Device/dlink_dwr-960
 endef
 TARGET_DEVICES += dlink_dwr-960
 
+define Device/domywifi_dm202
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := DomyWifi
+  DEVICE_MODEL := DM202
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-sdhci-mt7620 kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += domywifi_dm202
+
+define Device/domywifi_dm203
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := DomyWifi
+  DEVICE_MODEL := DM203
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-sdhci-mt7620 kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += domywifi_dm203
+
+define Device/domywifi_dw22d
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := DomyWifi
+  DEVICE_MODEL := DW22D
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-sdhci-mt7620 kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += domywifi_dw22d
+
 define Device/dovado_tiny-ac
   SOC := mt7620a
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -81,6 +81,15 @@ dlink,dwr-960)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x2e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
+domywifi,dm202|\
+domywifi,dm203|\
+domywifi,dw22d)
+	ucidef_set_led_switch "lan1" "lan1" "amber:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "lan2" "amber:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "lan3" "amber:lan3" "switch0" "0x08"
+	ucidef_set_led_switch "lan4" "lan4" "amber:lan4" "switch0" "0x10"
+	ucidef_set_led_switch "wan" "wan" "amber:wan" "switch0" "0x01"
+		;;
 dovado,tiny-ac)
 	ucidef_set_led_netdev "wifi_led" "wifi" "orange:wifi" "wlan0"
 	;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -76,6 +76,9 @@ ramips_setup_interfaces()
 	asus,rt-ac54u|\
 	asus,rt-n14u|\
 	bdcom,wap2100-sk|\
+	domywifi,dm202|\
+	domywifi,dm203|\
+	domywifi,dw22d|\
 	edimax,ew-7478apc|\
 	glinet,gl-mt300a|\
 	glinet,gl-mt300n|\
@@ -280,6 +283,9 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
 	alfa-network,r36m-e4g|\
+	domywifi,dm202|\
+	domywifi,dm203|\
+	domywifi,dw22d|\
 	zbtlink,zbt-we1026-h-32m)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$(mtd_get_mac_binary factory 0x4)


### PR DESCRIPTION
Specifications:
* SOC: MT7620A + MT7610E
* ROM: 16 MiB spi flash (W25Q128FVSG)
* RAM: 128MiB DDR2 (W971GG6KB-25)
* WAN: 10/100M *1
* LAN: 10/100M *4
* USB: Type-A USB2.0 *1
* SD: MicroSD *1
* Button: Reset *1
* Antennas: 2.4 GHz *2 + 5 GHz *1
* TTL Baudrate: 57600
* U-Boot Recovery: IP: 10.10.10.123, Server: 10.10.10.3

Installation:
* Web UI Update
  1. Open http://192.168.10.1/upgrade.html in the browser.
  2. Rename firmware to a short name like firmware.bin and then upload it.
  3. Fill in the password column with the following content:
  password | mtd -x mIp2osnRG3qZGdIlQPh1 -r write /tmp/firmware.bin firmware
* TFTP + U-Boot
  1. Connect device with a TTL cable.
  2. Press "2" when booting to select "Load system code then write Flash via TFTP".
  3. Upload firmware by tftpd64, it will boot when write instruction is executed.