### PR TITLE
[21.02] x86/base-files: add support for Sophos SG/XG-105

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -12,6 +12,9 @@ case "$(board_name)" in
 pc-engines-apu|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;
+sophos-sg-105|sophos-xg-105)
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
+	;;
 traverse-technologies-geos)
 	ucidef_set_interface_lan "eth0 eth1"
 	ucidef_add_atm_bridge "0" "35" "llc" "bridged"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -18,6 +18,14 @@ do_sysinfo_x86() {
 	for file in product_name board_name; do
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
+		"Sophos:SG"|"Sophos:XG")
+			case "$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)" in
+			105*)
+				product="${product}-105"
+				break
+				;;
+			esac
+			;;
 		"Supermicro:Super Server")
 			continue
 			;;


### PR DESCRIPTION
This adds detection of the Sophos SG-105 and Sophos XG-105 models
and assignment of ethernet ports these models have to LAN/WAN.

This has already been merged to master, I wonder if this can also be picked for 21.02: https://github.com/openwrt/openwrt/pull/4024

Signed-off-by: Stan Grishin <stangri@melmac.net>
