### PR TITLE
ipq806x: case-insensitive checks for qcom-smem partitions, required for kernel >=5.10

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -28,8 +28,14 @@ tplink,vr2600v)
 	;;
 edgecore,ecw5410)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
-	ucidef_set_interface_macaddr "lan" "$(mtd_get_mac_binary "0:ART" 0x6)"
-	ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary "0:ART" 0x0)"
+	if [ -b "$(find_mtd_part 0:art)" ]; then
+		ucidef_set_interface_macaddr "lan" "$(mtd_get_mac_binary "0:art" 0x6)"
+		ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary "0:art" 0x0)"
+	else
+		# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+		ucidef_set_interface_macaddr "lan" "$(mtd_get_mac_binary "0:ART" 0x6)"
+		ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary "0:ART" 0x0)"
+	fi
 	;;
 linksys,ea7500-v1)
 	hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -69,7 +69,10 @@ ubnt,unifi-ac-hd)
 	ucidef_set_interface_lan "eth0 eth1"
 	;;
 zyxel,nbg6817)
-	hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
+	hw_mac_addr=$(mtd_get_mac_ascii 0:appsblenv ethaddr)
+	# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+	[ -n "$hw_mac_addr" ] || \
+		hw_mac_addr=$(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
 	ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 2)"

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -45,8 +45,14 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary default-mac 0x0) -1)
 		;;
 	zyxel,nbg6817)
-		caldata_extract "0:ART" 0x1000 0x2f20
-		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) +1)
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x1000 0x2f20
+			ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii 0:appsblenv ethaddr) +1)
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x1000 0x2f20
+			ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii 0:APPSBLENV ethaddr) +1)
+		fi
 		;;
 	esac
 	;;
@@ -85,8 +91,14 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(mtd_get_mac_binary default-mac 0x0)
 		;;
 	zyxel,nbg6817)
-		caldata_extract "0:ART" 0x5000 0x2f20
-		ath10k_patch_mac $(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x5000 0x2f20
+			ath10k_patch_mac $(mtd_get_mac_ascii 0:appsblenv ethaddr)
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x5000 0x2f20
+			ath10k_patch_mac $(mtd_get_mac_ascii 0:APPSBLENV ethaddr)
+		fi
 		;;
 	esac
 	;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -22,7 +22,12 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(mtd_get_mac_binary ART 0x1e)
 		;;
 	edgecore,ecw5410)
-		caldata_extract "0:ART" 0x1000 0x2f20
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x1000 0x2f20
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x1000 0x2f20
+		fi
 		;;
 	linksys,ea7500-v1 |\
 	linksys,ea8500)
@@ -115,7 +120,12 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0002:01:00.0.bin")
 	case $board in
 	edgecore,ecw5410)
-		caldata_extract "0:ART" 0x5000 0x2f20
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x5000 0x2f20
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x5000 0x2f20
+		fi
 		;;
 	esac
 	;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -10,7 +10,12 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
 	asrock,g10)
-		caldata_extract "0:ART" 0x1000 0x2f20
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x1000 0x2f20
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x1000 0x2f20
+		fi
 		;;
 	buffalo,wxr-2533dhp)
 		caldata_extract "ART" 0x1000 0x2f20
@@ -59,7 +64,12 @@ case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
 	asrock,g10)
-		caldata_extract "0:ART" 0x5000 0x2f20
+		if [ -b "$(find_mtd_part 0:art)" ]; then
+			caldata_extract "0:art" 0x5000 0x2f20
+		else
+			# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+			caldata_extract "0:ART" 0x5000 0x2f20
+		fi
 		;;
 	buffalo,wxr-2533dhp)
 		caldata_extract "ART" 0x5000 0x2f20

--- a/target/linux/ipq806x/base-files/lib/upgrade/asrock.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/asrock.sh
@@ -1,7 +1,9 @@
 . /lib/functions.sh
 
 asrock_bootconfig_mangle() {
-	local mtdnum="$( find_mtd_index 0:BOOTCONFIG )"
+	local mtdnum="$(find_mtd_index 0:bootconfig)"
+	# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+	[ -n "$mtdnum" ] || mtdnum="$(find_mtd_index 0:BOOTCONFIG)"
 
 	if [ -z "$mtdnum" ]; then
 		echo "cannot find bootconfig mtd partition"

--- a/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/zyxel.sh
@@ -90,7 +90,10 @@ zyxel_do_upgrade() {
 	[ -b "${rootfs}" ] || return 1
 	case "$board" in
 	zyxel,nbg6817)
-		local dualflagmtd="$(find_mtd_part 0:DUAL_FLAG)"
+		local dualflagmtd="$(find_mtd_part 0:dual_flag)"
+		# XXX: drop upper case after kernel v5.4 is gone (qcom-smem)
+		[ -b $dualflagmtd ] || \
+			dualflagmtd="$(find_mtd_part 0:DUAL_FLAG)"
 		[ -b $dualflagmtd ] || return 1
 
 		case "$rootfs" in


### PR DESCRIPTION
qcom-smem traditionally displayed mtd partition names in upper case,
starting with kernel v5.10 it switches to normalizing the partition
names to lower case.

Adapt the sysupgrade support for the nbg6817 to check for both variants.

Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>

**This patch is needed to go in before adding support for kernel v5.10 in https://github.com/openwrt/openwrt/pull/3954**, otherwise subsequent sysupgrades of the nbg6817 will fail, as the (then-) existing sysupgrade support code can't find the `DUAL_FLAG` partition.