### PR TITLE
kernel: bump 5.10 to 5.10.28

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .109
-LINUX_VERSION-5.10 = .27
+LINUX_VERSION-5.10 = .28
 
 LINUX_KERNEL_HASH-5.4.109 = ac6af4562717d030266fcddb0a3c44598610ca8c9c3a654725f58b9cbd61b7ee
-LINUX_KERNEL_HASH-5.10.27 = d99dc9662951299c53a0a8d8c8d0a72a16ff861d20e927c0f9b14f63282d69d9
+LINUX_KERNEL_HASH-5.10.28 = 4dfc3aea719556e63e90b8692e9d4b779ad1cb2a9a4823bf721e30004e7ac354
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/backport-5.10/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
+++ b/target/linux/generic/backport-5.10/601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
@@ -76,7 +76,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  /**
   *	napi_synchronize - wait until NAPI is not running
-@@ -1835,6 +1825,8 @@ enum netdev_priv_flags {
+@@ -1842,6 +1832,8 @@ enum netdev_ml_priv_type {
   *
   *	@wol_enabled:	Wake-on-LAN is enabled
   *
@@ -85,7 +85,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
   *	@net_notifier_list:	List of per-net netdev notifier block
   *				that follow this device when it is moved
   *				to another network namespace.
-@@ -2152,6 +2144,7 @@ struct net_device {
+@@ -2161,6 +2153,7 @@ struct net_device {
  	struct lock_class_key	*qdisc_running_key;
  	bool			proto_down;
  	unsigned		wol_enabled:1;

--- a/target/linux/generic/pending-5.10/640-02-net-resolve-forwarding-path-from-virtual-netdevice-a.patch
+++ b/target/linux/generic/pending-5.10/640-02-net-resolve-forwarding-path-from-virtual-netdevice-a.patch
@@ -104,7 +104,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  };
  
  /**
-@@ -2795,6 +2820,8 @@ void dev_remove_offload(struct packet_of
+@@ -2827,6 +2852,8 @@ void dev_remove_offload(struct packet_of
  
  int dev_get_iflink(const struct net_device *dev);
  int dev_fill_metadata_dst(struct net_device *dev, struct sk_buff *skb);

--- a/target/linux/generic/pending-5.10/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
+++ b/target/linux/generic/pending-5.10/680-NET-skip-GRO-for-foreign-MAC-addresses.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/include/linux/netdevice.h
 +++ b/include/linux/netdevice.h
-@@ -2029,6 +2029,8 @@ struct net_device {
+@@ -2036,6 +2036,8 @@ struct net_device {
  	struct netdev_hw_addr_list	mc;
  	struct netdev_hw_addr_list	dev_addrs;
  


### PR DESCRIPTION
Automatically refreshed:
601-v5.12-net-implement-threaded-able-napi-poll-loop-support.patch
640-02-net-resolve-forwarding-path-from-virtual-netdevice-a.patch
680-NET-skip-GRO-for-foreign-MAC-addresses.patch

Run tested:
ramips/mt7621 (Redmi AC2100)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>