### PR TITLE
ath79: add support for TP-Link TL-WR710N v2.0

### DIFF
--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-4m.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-4m.dtsi
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9331_tplink_tl-wr710n.dtsi"
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				reg = <0x0 0x20000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				reg = <0x20000 0x3d0000>;
+				label = "firmware";
+			};
+
+			art: partition@3f0000 {
+				reg = <0x3f0000 0x10000>;
+				label = "art";
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v2.0.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-v2.0.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9331_tplink_tl-wr710n-4m.dtsi"
+
+/ {
+	model = "TP-Link TL-WR710N v2.0";
+	compatible = "tplink,tl-wr710n-v2.0", "qca,ar9331";
+};

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -233,6 +233,18 @@ define Device/tplink_tl-wr703n
 endef
 TARGET_DEVICES += tplink_tl-wr703n
 
+define Device/tplink_tl-wr710n-v2.0
+  $(Device/tplink-4mlzma)
+  SOC := ar9331
+  DEVICE_MODEL := TL-WR710N
+  DEVICE_VARIANT := v2.0
+  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-ledtrig-usbport
+  TPLINK_HWID := 0x07100002
+  TPLINK_HWREV := 0x1
+  SUPPORTED_DEVICES += tl-wr710n
+endef
+TARGET_DEVICES += tplink_tl-wr710n-v2.0
+
 define Device/tplink_tl-wr740n-v1
   $(Device/tplink-4m)
   SOC := ar7240


### PR DESCRIPTION
This re-adds support for the TP-Link TL-WR710N v2.0. This device was
supported in the old ar71xx target, but that support was not ported to the
new ath79 target which eventually replaced the now dropped ar71xx target.

Specifications:

SoC:       Atheros AR9331
CPU:       400 MHz
Flash:     4 MiB
RAM:       32 MiB
WiFi:      2.4 GHz b/g/n
Ethernet:  2x 100M ports
USB:       1x 2.0

Signed-off-by: Pascal Ernster <git@hardfalcon.net>