### PR TITLE
ath79: mikrotik: update nand-rb4xx driver

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
@@ -188,10 +188,15 @@ static int rb4xx_nand_probe(struct platform_device *pdev)
 	if (mtd->writesize == 512)
 		mtd_set_ooblayout(mtd, &rb4xx_nand_ecclayout_ops);
 
-	nand->chip.ecc.mode	= NAND_ECC_SOFT;
-	nand->chip.ecc.algo	= NAND_ECC_HAMMING;
-	nand->chip.options	= NAND_NO_SUBPAGE_WRITE;
-	nand->chip.priv		= nand;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	nand->chip.ecc.engine_type	= NAND_ECC_ENGINE_TYPE_SOFT;
+	nand->chip.ecc.algo		= NAND_ECC_ALGO_HAMMING;
+#else
+	nand->chip.ecc.mode		= NAND_ECC_SOFT;
+	nand->chip.ecc.algo		= NAND_ECC_HAMMING;
+#endif
+	nand->chip.options		= NAND_NO_SUBPAGE_WRITE;
+	nand->chip.priv			= nand;
 
 	nand->chip.legacy.read_byte	= rb4xx_nand_read_byte;
 	nand->chip.legacy.write_buf	= rb4xx_nand_write_buf;
@@ -206,7 +211,12 @@ static int rb4xx_nand_probe(struct platform_device *pdev)
 
 	ret = mtd_device_register(mtd, NULL, 0);
 	if (ret) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+		mtd_device_unregister(nand_to_mtd(&nand->chip));
+		nand_cleanup(&nand->chip);
+#else
 		nand_release(&nand->chip);
+#endif
 		return ret;
 	}
 
@@ -217,7 +227,12 @@ static int rb4xx_nand_remove(struct platform_device *pdev)
 {
 	struct rb4xx_nand *nand = platform_get_drvdata(pdev);
 
-	nand_release(&nand->chip);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+		mtd_device_unregister(nand_to_mtd(&nand->chip));
+		nand_cleanup(&nand->chip);
+#else
+		nand_release(&nand->chip);
+#endif
 
 	return 0;
 }

--- a/target/linux/ath79/patches-5.10/920-mikrotik-rb4xx.patch
+++ b/target/linux/ath79/patches-5.10/920-mikrotik-rb4xx.patch
@@ -1,0 +1,76 @@
+--- a/drivers/mfd/Kconfig
++++ b/drivers/mfd/Kconfig
+@@ -2141,6 +2141,14 @@ config RAVE_SP_CORE
+ 	  Select this to get support for the Supervisory Processor
+ 	  device found on several devices in RAVE line of hardware.
+ 
++config MFD_RB4XX_CPLD
++	tristate "CPLD driver for Mikrotik RB4xx series boards
++	select MFD_CORE
++	depends on ATH79 || COMPILE_TEST
++	help
++	  Enables support for the CPLD chip (NAND & GPIO) on Mikrotik
++	  Routerboard RB4xx series.
++
+ config SGI_MFD_IOC3
+ 	tristate "SGI IOC3 core driver"
+ 	depends on PCI && MIPS && 64BIT
+--- a/drivers/mfd/Makefile
++++ b/drivers/mfd/Makefile
+@@ -264,6 +264,7 @@ obj-$(CONFIG_MFD_ROHM_BD718XX)	+= rohm-bd718x7.o
+ obj-$(CONFIG_MFD_STMFX) 	+= stmfx.o
+ obj-$(CONFIG_MFD_KHADAS_MCU) 	+= khadas-mcu.o
+ 
++obj-$(CONFIG_MFD_RB4XX_CPLD)	+= rb4xx-cpld.o
+ obj-$(CONFIG_SGI_MFD_IOC3)	+= ioc3.o
+ obj-$(CONFIG_MFD_SIMPLE_MFD_I2C)	+= simple-mfd-i2c.o
+ obj-$(CONFIG_MFD_INTEL_M10_BMC)   += intel-m10-bmc.o
+--- a/drivers/gpio/Kconfig
++++ b/drivers/gpio/Kconfig
+@@ -1518,6 +1518,12 @@ config GPIO_SODAVILLE
+ 	help
+ 	  Say Y here to support Intel Sodaville GPIO.
+ 
++config GPIO_RB4XX
++	tristate "GPIO expander for Mikrotik RB4xx series boards"
++	depends on MFD_RB4XX_CPLD
++	help
++	  GPIO driver for Mikrotik Routerboard RB4xx series.
++
+ endmenu
+ 
+ menu "SPI GPIO expanders"
+--- a/drivers/gpio/Makefile
++++ b/drivers/gpio/Makefile
+@@ -120,6 +120,7 @@ obj-$(CONFIG_GPIO_PL061)		+= gpio-pl061.o
+ obj-$(CONFIG_GPIO_PMIC_EIC_SPRD)	+= gpio-pmic-eic-sprd.o
+ obj-$(CONFIG_GPIO_PXA)			+= gpio-pxa.o
+ obj-$(CONFIG_GPIO_RASPBERRYPI_EXP)	+= gpio-raspberrypi-exp.o
++obj-$(CONFIG_GPIO_RB4XX)		+= gpio-rb4xx.o
+ obj-$(CONFIG_GPIO_RC5T583)		+= gpio-rc5t583.o
+ obj-$(CONFIG_GPIO_RCAR)			+= gpio-rcar.o
+ obj-$(CONFIG_GPIO_RDA)			+= gpio-rda.o
+--- a/drivers/mtd/nand/raw/Kconfig
++++ b/drivers/mtd/nand/raw/Kconfig
+@@ -564,4 +564,11 @@ config MTD_NAND_AR934X
+ 	  Enables support for NAND controller on Qualcomm Atheros SoCs.
+ 	  This controller is found on AR934x and QCA955x SoCs.
+ 
++config MTD_NAND_RB4XX
++	tristate "Support for NAND driver for Mikrotik RB4xx series boards"
++	depends on MFD_RB4XX_CPLD
++	help
++	  Enables support for the NAND flash chip on Mikrotik Routerboard
++	  RB4xx series.
++
+ endif # MTD_RAW_NAND
+--- a/drivers/mtd/nand/raw/Makefile
++++ b/drivers/mtd/nand/raw/Makefile
+@@ -59,6 +59,7 @@ obj-$(CONFIG_MTD_NAND_MESON)		+= meson_nand.o
+ obj-$(CONFIG_MTD_NAND_CADENCE)		+= cadence-nand-controller.o
+ obj-$(CONFIG_MTD_NAND_ARASAN)		+= arasan-nand-controller.o
+ obj-$(CONFIG_MTD_NAND_AR934X)		+= ar934x_nand.o
++obj-$(CONFIG_MTD_NAND_RB4XX)		+= nand_rb4xx.o
+ 
+ nand-objs := nand_base.o nand_legacy.o nand_bbt.o nand_timings.o nand_ids.o
+ nand-objs += nand_onfi.o


### PR DESCRIPTION
This updates the NAND driver for MikroTik RB4XX series to work with
kernel 5.10, similarly to the ar934x-nand driver (fb64e2c).

Support for kernel 5.10 was added to all ath79 subtargets except for the
mikrotik one by commit d6b785d, since patch 920-mikrotik-rb4xx.patch
needed to be reworked. Later, commit f851266 enabled kernel 5.10 for
the mikrotik subtarget with the nand-rb4xx driver still pending, which
is updated and added back by this patch.

Compile-tested only.