### PR TITLE
[21.02] ramips: rt305x: use lzma-loader for ZyXEL Keenetic Lite rev.B

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1196,6 +1196,7 @@ endef
 TARGET_DEVICES += zyxel_keenetic
 
 define Device/zyxel_keenetic-lite-b
+  $(Device/uimage-lzma-loader)
   SOC := rt5350
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := ZyXEL


### PR DESCRIPTION
This is the backport (`git cherry-pick -x`) of commit dd3c1ad8ee9ee361285cb9142bdcb35bc3a30ac7 (as the PR #3834 landed by @ynezz) onto branch `openwrt-21.02`.


This is currently draft: let me compile test it, and ask @KOLANICH to verify the compiled binaries.