### PR TITLE
ipq40xx: add netgear wac510 support

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -318,6 +318,16 @@ define Build/netgear-dni
 	mv $@.new $@
 endef
 
+define Build/netgear-tar
+	mkdir $@.tmp
+	mv $@ $@.tmp/wac5xx-ubifs-root.img
+	md5sum $@.tmp/wac5xx-ubifs-root.img > $@.tmp/wac5xx-ubifs-root.md5sum
+	echo "WAC505 WAC510" > $@.tmp/metadata.txt
+	echo "WAC505_V9.9.9.9" > $@.tmp/version
+	tar -C $@.tmp/ -cf $@ .
+	rm -rf $@.tmp
+endef
+
 define Build/openmesh-image
 	$(TOPDIR)/scripts/om-fwupgradecfg-gen.sh \
 		"$(call param_get_default,ce_type,$(1),$(DEVICE_NAME))" \

--- a/package/boot/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-envtools/files/ipq40xx
@@ -36,6 +36,7 @@ edgecore,ecw5211|\
 glinet,gl-ap1300|\
 glinet,gl-b1300|\
 luma,wrtq-329acn|\
+netgear,wac510|\
 openmesh,a42|\
 openmesh,a62|\
 plasmacloud,pa1200|\

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -47,6 +47,7 @@ ALLWIFIBOARDS:= \
 	mikrotik_sxtsq-5-ac \
 	mobipromo_cm520-79f \
 	nec_wg2600hp3 \
+	netgear_wac510 \
 	plasmacloud_pa1200 \
 	plasmacloud_pa2200 \
 	qxwlan_e2600ac
@@ -132,6 +133,7 @@ $(eval $(call generate-ipq-wifi-package,mikrotik_hap-ac2,Mikrotik hAP ac2))
 $(eval $(call generate-ipq-wifi-package,mikrotik_sxtsq-5-ac,MikroTik SXTsq 5 ac))
 $(eval $(call generate-ipq-wifi-package,mobipromo_cm520-79f,MobiPromo CM520-79F))
 $(eval $(call generate-ipq-wifi-package,nec_wg2600hp3,NEC Platforms WG2600HP3))
+$(eval $(call generate-ipq-wifi-package,netgear_wac510,Netgear WAC510))
 $(eval $(call generate-ipq-wifi-package,plasmacloud_pa1200,Plasma Cloud PA1200))
 $(eval $(call generate-ipq-wifi-package,plasmacloud_pa2200,Plasma Cloud PA2200))
 $(eval $(call generate-ipq-wifi-package,qxwlan_e2600ac,Qxwlan E2600AC))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ipq40xx_setup_interfaces()
 	engenius,emr3500|\
 	engenius,ens620ext|\
 	luma,wrtq-329acn|\
+	netgear,wac510|\
 	plasmacloud,pa1200|\
 	plasmacloud,pa2200)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -150,6 +150,10 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_binary dnidata 0x0)
 		;;
+	netgear,wac510)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_binary "0:MANUDATA" 0x6)
+		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)
 		caldata_extract "ART" 0x1000 0x2f20
@@ -259,6 +263,10 @@ case "$FIRMWARE" in
 	netgear,ex6150v2)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_binary dnidata 0xc)
+		;;
+	netgear,wac510)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary "0:MANUDATA" 0x6) +16)
 		;;
 	zyxel,nbg6617 |\
 	zyxel,wre6606)

--- a/target/linux/ipq40xx/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq40xx/base-files/etc/init.d/bootcount
@@ -13,5 +13,8 @@ boot() {
 	linksys,mr8300)
 		mtd resetbc s_env || true
 		;;
+	netgear,wac510)
+		fw_setenv boot_cnt=0
+		;;
 	esac
 }

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -72,6 +72,7 @@ platform_do_upgrade() {
 	glinet,gl-ap1300 |\
 	luma,wrtq-329acn |\
 	mobipromo,cm520-79f |\
+	netgear,wac510 |\
 	qxwlan,e2600ac-c2)
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-wac510.dts
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2020, Robert Marko <robimarko@gmail.com> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "Netgear WAC510";
+	compatible = "netgear,wac510";
+
+	aliases {
+		led-boot = &led_power_amber;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	soc {
+		rng@22000 {
+			status = "okay";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			status = "okay";
+
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		usb2: usb2@60f8800 {
+			status = "okay";
+		};
+
+		usb3: usb3@8af8800 {
+			status = "okay";
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&tlmm 4 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		ssr: ssr@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <1000000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&ssr 6 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&ssr 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_blue {
+			label = "blue:wlan2g";
+			gpios = <&ssr 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g_green {
+			label = "green:wlan2g";
+			gpios = <&ssr 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g_blue {
+			label = "blue:wlan5g";
+			gpios = <&ssr 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&ssr 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		act_green {
+			label = "green:act";
+			gpios = <&ssr 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pinmux {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		pinmux_cs {
+			function = "gpio";
+			pins = "gpio54", "gpio59";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
+			   <&tlmm 59 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "0:CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "0:APPSBLENV";
+				reg = <0x000e0000 0x00010000>;
+			};
+
+			partition@f0000 {
+				label = "0:APPSBL";
+				reg = <0x000f0000 0x000f0000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "0:MANUDATA";
+				reg = <0x001e0000 0x00010000>;
+				read-only;
+			};
+
+			partition@1f0000 {
+				label = "0:ART";
+				reg = <0x001f0000 0x00010000>;
+				read-only;
+			};
+		};
+	};
+
+	nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <48000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs";
+				reg = <0x00000000 0x03800000>;
+			};
+
+			partition@3800000 {
+				label = "rootfs_1";
+				reg = <0x03800000 0x03800000>;
+			};
+
+			partition@7000000 {
+				label = "var_config";
+				reg = <0x07000000 0x00f00000>;
+				read-only;
+			};
+
+			partition@7f00000 {
+				label = "Oops_log";
+				reg = <0x07f00000 0x000c0000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
+};
+
+&gmac0 {
+	qcom,forced_duplex = <1>;
+	qcom,forced_speed = <1000>;
+	qcom,phy_mdio_addr = <3>;
+	qcom,poll_required = <1>;
+	vlan_tag = <1 0x10>;
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-WAC510";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-WAC510";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -636,6 +636,21 @@ define Device/netgear_ex6150v2
 endef
 TARGET_DEVICES += netgear_ex6150v2
 
+define Device/netgear_wac510
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Netgear
+	DEVICE_MODEL := WAC510
+	SOC := qcom-ipq4018
+	DEVICE_DTS_CONFIG := config@5
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGES += nand-factory.tar
+	IMAGE/nand-factory.tar := append-ubi | netgear-tar
+	DEVICE_PACKAGES := uboot-envtools
+endef
+TARGET_DEVICES += netgear_wac510
+
 define Device/openmesh_a42
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := OpenMesh

--- a/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-5.4/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -837,11 +837,60 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -837,11 +837,61 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -37,6 +37,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4019-oap100.dtb \
 +	qcom-ipq4018-pa1200.dtb \
 +	qcom-ipq4018-rt-ac58u.dtb \
++	qcom-ipq4018-wac510.dtb \
 +	qcom-ipq4018-wre6606.dtb \
 +	qcom-ipq4018-wrtq-329acn.dtb \
  	qcom-ipq4019-ap.dk01.1-c1.dtb \


### PR DESCRIPTION
This adds support for the Netgear WAC510 Insight Managed Smart Cloud
Wireless Access Point, an indoor dual-band, dual-radio 802.11ac
business-class wireless AP with integrated omnidirectional antennae and
two 10/100/1000 Mbps Ethernet ports.

See https://www.netgear.com/business/wifi/access-points/wac510 for more
info.

Specifications:
SoC:        Qualcomm IPQ4018 (DAKOTA) ARM Quad-Core
RAM:        256 MiB
Flash1:     2 MiB Winbond W25Q16JV SPI-NOR
Flash2:     128 MiB Winbond W25N01GVZEIG SPI-NAND
Ethernet:   Built-in IPQ4018 (SoC, QCA8072 PHY), 2x 1000/100/10 port,
            WAN port active IEEE 802.3af/at PoE in
Wireless1:  Built-in IPQ4018 (SoC) 802.11b/g/n 2x2:2, 3 dBi antennae
Wireless2:  Built-in IPQ4018 (SoC) 802.11a/n/ac 2x2:2, 4 dBi antennae
Input:      (Optional) Barrel 12 V 2.5 A Power, Reset button SW1
LEDs:       Power, Insight, WAN PoE, LAN, 2.4G WLAN, 5G WLAN
Serial:     Header J2
1 - 3.3 Volt (Do NOT connect!)
2 - TX
3 - RX
4 - Ground
WARNING: The serial port needs a TTL/RS-232 3.3 volt level converter!
         The Serial settings are 115200-8-N-1.

Installation via Stock Web Interface:
BTW: The default factory console/web interface login user/password are
admin/password.
In the web interface navigating to Management - Maintenance - Upgrade -
'Firmware Upgrade' will show you what is currently installed e.g.:
Manage Firmware
Current Firmware Version: V5.0.10.2
Backup Firmware Version: V1.2.5.11
Under 'Upgrade Options' choose Local (alternatively SFTP would be
available) then click/select 'Browse File' on the right side, choose
openwrt-ipq40xx-generic-netgear_wac510-squashfs-nand-factory.tar and hit
the Upgrade button below. After a minute or two your browser should
indicate completion printing 'Firmware update complete.' and
'Rebooting AP...'.
Note that OpenWrt will use the WAN PoE port as actual WAN port
defaulting to DHCP client but NOT allowing LuCI access, use LAN port
defaulting to 192.168.1.1/24 to access LuCI.

Installation via TFTP Requiring Serial U-Boot Access:
Connect to the device's serial port and hit any key to stop autoboot.
Upload and boot the initramfs based OpenWrt image as follows:
(IPQ40xx) # setenv serverip 192.168.1.1
(IPQ40xx) # setenv ipaddr 192.168.1.2
(IPQ40xx) # tftpboot openwrt-ipq40xx-generic-netgear_wac510-initramfs-fit-uImage.itb
(IPQ40xx) # bootm
Note this only runs OpenWrt from RAM and has not installed anything to
flash as of yet. One may permanently install OpenWrt as follows:
Check the MTD device number of the active partition:
root@OpenWrt:/# dmesg | grep 'set to be root filesystem'
[    1.010084] mtd: device 9 (rootfs) set to be root filesystem
Upload the factory image ending with .ubi to /tmp (e.g. using scp or
tftp). Then flash the image as follows (substituting the 9 in mtd9
below with whatever number reported above):
root@OpenWrt:/# ubiformat /dev/mtd9 -f /tmp/openwrt-ipq40xx-generic-netgear_wac510-squashfs-nand-factory.ubi
And reboot.

Dual Image Configuration:
The default U-Boot boot command bootipq uses the U-Boot environment
variables primary/secondary to decide which image to boot. E.g.
primary=0, secondary=3800000 uses rootfs while primary=3800000,
secondary=0 uses rootfs_1.
Switching their values changes the active partition. E.g. from within
U-Boot:
(IPQ40xx) # setenv primary 0
(IPQ40xx) # setenv secondary 3800000
(IPQ40xx) # saveenv
Or from a OpenWrt userspace serial/SSH console:
fw_setenv primary 0
fw_setenv secondary 3800000
Note that if you install two copies of OpenWrt then each will have its
independent configuration not like when switching partitions on the
stock firmware.
BTW: The kernel log shows which boot partition is active:
[    2.439050] ubi0: attached mtd9 (name "rootfs", size 56 MiB)
vs.
[    2.978785] ubi0: attached mtd10 (name "rootfs_1", size 56 MiB)
Note: After 3 failed boot attempts it automatically switches partition.

Signed-off-by: Robert Marko <robimarko@gmail.com>
Signed-off-by: Marcel Ziswiler <marcel@ziswiler.com>