### PR TITLE
ramips: add Hooolink HL-MF908v3, also known as CHANEVE MF909

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hooolink_hl-mf908-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_hooolink_hl-mf908-v3.dts
@@ -1,0 +1,135 @@
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "hooolink,hl-mf908-v3", "mediatek,mt7628an-soc";
+	model = "HL-MF908v3";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+			label = "green:lan";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan {
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			label = "green:wlan";
+		};
+
+		4g {
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			label = "green:4g";
+		};
+
+		led_status: status {
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			label = "green:status";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		minipcie {
+			gpio-export,name = "minipcie";
+			gpio-export,output = <0>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&i2c {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&factory 0x2e>;
+};
+
+&esw {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0x04>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "gpio", "uart1", "refclk", "wdt", "pwm0";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -194,6 +194,17 @@ define Device/hiwifi_hc5861b
 endef
 TARGET_DEVICES += hiwifi_hc5861b
 
+define Device/hooolink_hl-mf908-v3
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Hooolink
+  DEVICE_MODEL := HL-MF908
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+	kmod-usb-serial-option kmod-usb-net-qmi-wwan uqmi
+  SUPPORTED_DEVICES += hl-mf908-v3
+endef
+TARGET_DEVICES += hooolink_hl-mf908-v3
+
 define Device/iptime_a3
   IMAGE_SIZE := 7936k
   UIMAGE_NAME := a3

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -33,6 +33,7 @@ glinet,gl-mt300n-v2)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x1"
 	;;
 hilink,hlk-7628n|\
+hooolink,hl-mf908-v3|\
 skylab,skw92a)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ramips_setup_interfaces()
 	glinet,microuter-n300|\
 	glinet,vixmini|\
 	hak5,wifi-pineapple-mk7|\
+	hooolink,hl-mf908-v3|\
 	mediatek,linkit-smart-7688|\
 	onion,omega2p|\
 	onion,omega2|\


### PR DESCRIPTION
Specifications:

    MediaTek MT7628AN ver:1 eco:2 (575 MHz)
    128 MB RAM
    16 MB Flash
    802.11bgn 2T2R
    2x internal, non-detachable antenna
    1x 10/100 Mbps Ethernet
    1x USB 2.0 (Type-A)
    1x LTE CAT4 up to 150 mb/s modem @ mini PCI (USB, QMI)
    4 leds
    1 button
    UART header on PCB (57600 8n1)
    Breed bootloader
    ~8000 mAh battery (~16 hours uptime without traffic)

Features:

    upgrade from stock fw via web gui
    all leds avaible
    all buttons work
    LTE modem power on by default

Installation:
Apply sysupgrade image via http web-gui


Recovery:
This board contains a Chinese, closed-source bootloader called Breed
(Boot and Recovery Environment for Embedded Devices). Breed supports web
recovery and to enter it, you keep the reset button pressed for around
5 seconds during boot. Your machine will be assigned an IP through DHCP
and the router will use IP address 192.168.1.1. The recovery website is
in Chinese, but is easy to use. Click on the second item in the list to
access the recovery page, then the second item on the next page is where
you select the firmware. In order to start the recovery, you click the
button at the bottom.

Signed-off-by: Rozhuk Ivan rozhuk.im@gmail.com