### PR TITLE
realtek: add support for INABA Abaniact AML2-17GP

### DIFF
--- a/target/linux/realtek/dts/rtl8382_inaba_aml2-17gp.dts
+++ b/target/linux/realtek/dts/rtl8382_inaba_aml2-17gp.dts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "inaba,aml2-17gp", "realtek,rtl838x-soc";
+	model = "INABA Abaniact AML2-17GP";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio0 {
+	indirect-access-bus-id = <0>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "u-boot-env2";
+				reg = <0x90000 0x10000>;
+			};
+
+			partition@a0000 {
+				label = "jffs2_cfg";
+				reg = <0xa0000 0x400000>;
+				read-only;
+			};
+
+			partition@4a0000 {
+				label = "jffs2_log";
+				reg = <0x4a0000 0x100000>;
+				read-only;
+			};
+
+			partition@5a0000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x5a0000 0xd30000>;
+				openwrt,ih-magic = <0x83800000>;
+			};
+
+			partition@12d0000 {
+				label = "runtime2";
+				reg = <0x12d0000 0xd30000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+
+		EXTERNAL_PHY(24)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(8, 1, internal)
+		SWITCH_PORT(9, 2, internal)
+		SWITCH_PORT(10, 3, internal)
+		SWITCH_PORT(11, 4, internal)
+		SWITCH_PORT(12, 5, internal)
+		SWITCH_PORT(13, 6, internal)
+		SWITCH_PORT(14, 7, internal)
+		SWITCH_PORT(15, 8, internal)
+
+		SWITCH_PORT(16, 9, qsgmii)
+		SWITCH_PORT(17, 10, qsgmii)
+		SWITCH_PORT(18, 11, qsgmii)
+		SWITCH_PORT(19, 12, qsgmii)
+		SWITCH_PORT(20, 13, qsgmii)
+		SWITCH_PORT(21, 14, qsgmii)
+		SWITCH_PORT(22, 15, qsgmii)
+		SWITCH_PORT(23, 16, qsgmii)
+
+		port@24 {
+			reg = <24>;
+			label = "wan";
+			phy-handle = <&phy24>;
+			phy-mode = "qsgmii";
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -72,6 +72,15 @@ define Device/d-link_dgs-1210-28
 endef
 TARGET_DEVICES += d-link_dgs-1210-28
 
+define Device/inaba_aml2-17gp
+  SOC := rtl8382
+  IMAGE_SIZE := 13504k
+  DEVICE_VENDOR := INABA
+  DEVICE_MODEL := Abaniact AML2-17GP
+  UIMAGE_MAGIC := 0x83800000
+endef
+TARGET_DEVICES += inaba_aml2-17gp
+
 define Device/netgear_gs108t-v3
   $(Device/netgear_nge)
   DEVICE_MODEL := GS108T


### PR DESCRIPTION
INABA Abaniact AML2-17GP is a 17 port gigabit switch, based on RTL8382.

Specification:

- SoC		: Realtek RTL8382
- RAM		: DDR3 128 MiB (SK hynix H5TQ1G63EFR)
- Flash		: SPI-NOR 32 MiB (Macronix MX25L25635FZ2I-10G)
- Ethernet	: 10/100/1000 Mbps x17
  - port 1-8	: RTL8218B (SoC)
  - port 8-16	: RTL8218D
  - port wan	: RTL8214FC
- LEDs/Keys	: 1x, 1x
- UART		: pin header on PCB (Molex 530470410 compatible)
  - J14: 3.3V, GND, RX, TX from rear side
  - 115200n8
- Power		: 100-240 VAC, 50/60 Hz, 0.21 A
  - Plug	: IEC 60320-C13

Flash instruction using initramfs image:

1.  Boot AML2-17GP normally
2.  Set the IP address of computer to the range of 192.168.1.0/24, other
    than 192.168.1.248 and connect computer to "WAN/CONSOLE" port of
    AML2-17GP
3.  Access to "http://192.168.1.248" and open firmware setting page

    -- UI Language: 日本語 --
    "メンテナンス" -> "デュアルイメージ"

    -- UI Language: ENGLISH --
    "Maintenance" -> "Dual Image"

4.  Check "イメージ情報 (en: "Images Information")" and set the first
    image to active by choosing "アクティブイメージ" (en: "Active
    Image") in the partition "0"
5.  open firmware upgrade page

    -- UI Language: 日本語 --
    "メンテナンス" -> "アップグレードマネージャー"

    -- UI Language: ENGLISH --
    "Maintenance" -> "Upgrade Manager"

6.  Set the properties as follows

    -- UI Language: 日本語 --
    "アップグレード方式"	: "HTTP"
    "アップグレードタイプ"	: "イメージ"
    "イメージ"			: "アクティブ"
    "ブラウズファイル"		: (select the OpenWrt initramfs image)

    -- UI Language: ENGLISH --
    "Upgrade Method"		: "HTTP"
    "Upgrade Type"		: "Image"
    "Image"			: "(Active)"
    "Browse file"		: (select the OpenWrt initramfs image)

7.  Press "アップグレード" (en: "Upgrade") button and perform upgrade
8.  Wait ~150 seconds to complete flashing
9.  After the flashing, the following message is showed and press "OK"
    button to reboot

    -- UI Language: 日本語 --
    "成功!! 今すぐリブートしますか?"

    -- UI Language: ENGLISH --
    "Success!! Do you want to reboot now?"

10. After the rebooting, reconnect the cable to other port (1-16) and
    open the SSH connection, download the sysupgrade image to the device
    and perform sysupgrade with it
11. Wait ~120 seconds to complete sysupgrade

Note:

- The uploaded image via WebUI will only be written with the length
  embedded in the uImage header. If the sysupgrade image is specified,
  only the kernel is flashed and lacks the rootfs, this causes a kernel
  panic while booting and bootloops.
  To avoid this issue, initramfs image is required for flashing on WebUI
  of stock firmware.

- This device has 1x LED named as "POWER", but it's not connected to the
  GPIO of SoC and cannot be controlled.

- port 17 is named as "WAN/CONSOLE". This port is for the upstream
  connection and console access (telnet/WebUI) on stock firmware.

Back to stock firmware:

1. Set "bootpartition" variable in u-boot-env2 partition to "1" by
   fw_setsys

   fw_setsys bootpartition 1

2. Reboot AML2-17GP

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>