### PR TITLE
ramips: add support for Motorola MWR03

### DIFF
--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Motorola MWR03";
+	compatible = "motorola,mwr03", "mediatek,mt7628an-soc";
+
+	aliases {
+		led-boot = &led_orange;
+		led-failsafe = &led_orange;
+		led-running = &led_white;
+		led-upgrade = &led_orange;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_orange: orange {
+			label = "orange:status";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_white: white {
+			label = "white:status";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "i2s";
+		function = "gpio";
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x30>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -278,6 +278,14 @@ define Device/minew_g1-c
 endef
 TARGET_DEVICES += minew_g1-c
 
+define Device/motorola_mwr03
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Motorola
+  DEVICE_MODEL := MWR03
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += motorola_mwr03
+
 define Device/netgear_r6020
   $(Device/netgear_sercomm_nor)
   IMAGE_SIZE := 7104k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -109,6 +109,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "6@eth0"
 		;;
+	motorola,mwr03)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "0:wan" "6@eth0"
+		;;
 	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120)
@@ -215,6 +219,9 @@ ramips_setup_macs()
 		;;
 	mercury,mac1200r-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory_info 0xd)" 1)
+		;;
+	motorola,mwr03)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 2)
 		;;
 	onion,omega2|\
 	onion,omega2p|\


### PR DESCRIPTION
Specifications:
* SOC: MT7628AN + MT7612E
* ROM: 8 MiB Flash
* RAM: 64 MiB DDR2
* WAN: 10/100M *1
* LAN: 10/100M *3
* Button: Reset *1
* LEDs: orange *1, white *1
* Antennas: 2.4 GHz *2 + 5 GHz *2
* TTL Baudrate: 57600
* TFTP Upgrade: IP: 192.168.51.1, Server: 192.168.51.100

Installation (TFTP + U-Boot):
 * Connect device with a TTL cable and open a serial session by PuTTY.
 * Press "2" when booting to select "Load system code then write Flash via TFTP".
 * Configure the IP of local host server.
 * Upload firmware by tftpd64, it will boot when write instruction is executed.
