### PR TITLE
[19.07] ppp/pppoe-discovery: fix -W option

### DIFF
--- a/package/network/services/ppp/patches/520-fix_-W_option_for_pppoe-discovery_utility.patch
+++ b/package/network/services/ppp/patches/520-fix_-W_option_for_pppoe-discovery_utility.patch
@@ -1,0 +1,62 @@
+From 22d9c14ae3930fe10f26bafc3eab45e3a17eb3fa Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sun, 19 Jul 2020 11:55:43 +0200
+Subject: [PATCH] Fix -W option for pppoe-discovery utility
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+pppoe-discovery's -W option is totally broken. pppoe-discovery currently
+expects that Host-Unique attribute equals to its own process pid if set.
+
+This patch fixes parsing received PPPoE PADO packets when -W option is set.
+Same implementation is in pppd pppoe plugin.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+---
+ pppd/plugins/rp-pppoe/pppoe-discovery.c | 18 +++++++-----------
+ 1 file changed, 7 insertions(+), 11 deletions(-)
+
+diff --git a/pppd/plugins/rp-pppoe/pppoe-discovery.c b/pppd/plugins/rp-pppoe/pppoe-discovery.c
+index f19c6d8b..1a243fe4 100644
+--- a/pppd/plugins/rp-pppoe/pppoe-discovery.c
++++ b/pppd/plugins/rp-pppoe/pppoe-discovery.c
+@@ -328,14 +328,10 @@ void
+ parseForHostUniq(UINT16_t type, UINT16_t len, unsigned char *data,
+ 		 void *extra)
+ {
+-    int *val = (int *) extra;
+-    if (type == TAG_HOST_UNIQ && len == sizeof(pid_t)) {
+-	pid_t tmp;
+-	memcpy(&tmp, data, len);
+-	if (tmp == getpid()) {
+-	    *val = 1;
+-	}
+-    }
++    PPPoETag *tag = extra;
++
++    if (type == TAG_HOST_UNIQ && len == ntohs(tag->length))
++	tag->length = memcmp(data, tag->payload, len);
+ }
+ 
+ /**********************************************************************
+@@ -352,7 +348,7 @@ parseForHostUniq(UINT16_t type, UINT16_t len, unsigned char *data,
+ int
+ packetIsForMe(PPPoEConnection *conn, PPPoEPacket *packet)
+ {
+-    int forMe = 0;
++    PPPoETag hostUniq = conn->hostUniq;
+ 
+     /* If packet is not directed to our MAC address, forget it */
+     if (memcmp(packet->ethHdr.h_dest, conn->myEth, ETH_ALEN)) return 0;
+@@ -360,8 +356,8 @@ packetIsForMe(PPPoEConnection *conn, PPPoEPacket *packet)
+     /* If we're not using the Host-Unique tag, then accept the packet */
+     if (!conn->hostUniq.length) return 1;
+ 
+-    parsePacket(packet, parseForHostUniq, &forMe);
+-    return forMe;
++    parsePacket(packet, parseForHostUniq, &hostUniq);
++    return !hostUniq.length;
+ }
+ 
+ /**********************************************************************


### PR DESCRIPTION
This patch is already included in ppp-2.4.9 which is used in openwrt
master.

Backport this patch to openwrt-19.07.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
