### PR TITLE
bcm53xx: fix pinctrl node name for BCM5301X

### DIFF
--- a/target/linux/bcm53xx/patches-5.10/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
+++ b/target/linux/bcm53xx/patches-5.10/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
@@ -21,7 +21,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 -			#size-cells = <1>;
  
 -			pinctrl: pin-controller@1c0 {
-+			pinctrl: pinctrl {
++			pinctrl: pin-controller {
  				compatible = "brcm,bcm4708-pinmux";
 -				reg = <0x1c0 0x24>;
 -				reg-names = "cru_gpio_control";

--- a/target/linux/bcm53xx/patches-5.4/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
+++ b/target/linux/bcm53xx/patches-5.4/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
@@ -21,7 +21,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 -			#size-cells = <1>;
  
 -			pinctrl: pin-controller@1c0 {
-+			pinctrl: pinctrl {
++			pinctrl: pin-controller {
  				compatible = "brcm,bcm4708-pinmux";
 -				reg = <0x1c0 0x24>;
 -				reg-names = "cru_gpio_control";


### PR DESCRIPTION
The current build for Linksys EA9500 router - based on bcm47094 SoC is broken.
This is because the current pinctrl label name is same as the  node name, this causes pinctrl to fail.

This change fixes pinctrl node name to pin-controller. This is how it is in mainline. 

Tested on EA9500

Signed-off-by: Vivek Unune <npcomplete13@gmail.com>
