### PR TITLE
ath79: add support for Araknis AN-300 / AN-500 / AN-700

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -20,6 +20,7 @@ alfa-network,pi-wifi4|\
 alfa-network,r36a|\
 alfa-network,tube-2hq|\
 allnet,all-wap02860ac|\
+araknis,an-300-ap-i-n|\
 arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -21,6 +21,7 @@ alfa-network,r36a|\
 alfa-network,tube-2hq|\
 allnet,all-wap02860ac|\
 araknis,an-300-ap-i-n|\
+araknis,an-500-ap-i-ac|\
 arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\

--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -22,6 +22,7 @@ alfa-network,tube-2hq|\
 allnet,all-wap02860ac|\
 araknis,an-300-ap-i-n|\
 araknis,an-500-ap-i-ac|\
+araknis,an-700-ap-i-ac|\
 arduino,yun|\
 buffalo,bhr-4grv2|\
 devolo,magic-2-wifi|\

--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+#include "ar934x_senao_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "araknis,an-300-ap-i-n", "qca,ar9344";
+	model = "Araknis AN-300-AP-I-N";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wifi5g {
+			label = "blue:wifi5g";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	ath9k-leds {
+		compatible = "gpio-leds";
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy0>;
+	phy-mode = "rgmii-txid";
+
+	pll-data = <0x02000000 0x00000101 0x00001313>;
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0,0 {
+		compatible = "pci168c,0030";
+		reg = <0x0 0 0 0 0>;
+		nvmem-cells = <&macaddr_art_0>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <1>;
+		qca,disable-5ghz;
+		qca,no-eeprom;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,disable-2ghz;
+
+	mtd-cal-data = <&art 0x1000>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <2>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/qca9557_araknis_an-500-ap-i-ac.dts
+++ b/target/linux/ath79/dts/qca9557_araknis_an-500-ap-i-ac.dts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "araknis,an-500-ap-i-ac", "qca,qca9557";
+	model = "Araknis AN-500-AP-I-AC";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "blue:wifi5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&partitions {
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_araknis_an-700-ap-i-ac.dts
+++ b/target/linux/ath79/dts/qca9558_araknis_an-700-ap-i-ac.dts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_senao_loader.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "araknis,an-700-ap-i-ac", "qca,qca9558";
+	model = "Araknis AN-700-AP-I-AC";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		wifi2g {
+			label = "blue:wifi2g";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "blue:wifi5g";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&partitions {
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ath79_setup_interfaces()
 	alfa-network,pi-wifi4|\
 	alfa-network,tube-2hq|\
 	araknis,an-300-ap-i-n|\
+	araknis,an-500-ap-i-ac|\
 	arduino,yun|\
 	aruba,ap-105|\
 	asus,rp-ac66|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -16,6 +16,7 @@ ath79_setup_interfaces()
 	alfa-network,tube-2hq|\
 	araknis,an-300-ap-i-n|\
 	araknis,an-500-ap-i-ac|\
+	araknis,an-700-ap-i-ac|\
 	arduino,yun|\
 	aruba,ap-105|\
 	asus,rp-ac66|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -14,6 +14,7 @@ ath79_setup_interfaces()
 	alfa-network,ap121f|\
 	alfa-network,pi-wifi4|\
 	alfa-network,tube-2hq|\
+	araknis,an-300-ap-i-n|\
 	arduino,yun|\
 	aruba,ap-105|\
 	asus,rp-ac66|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -72,6 +72,7 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
+	araknis,an-300-ap-i-n|\
 	atheros,db120|\
 	engenius,eap600|\
 	engenius,ecb600|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -11,6 +11,7 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
 	allnet,all-wap02860ac|\
+	araknis,an-500-ap-i-ac|\
 	engenius,eap1200h|\
 	engenius,enstationac-v1|\
 	glinet,gl-x750)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 	case $board in
 	allnet,all-wap02860ac|\
 	araknis,an-500-ap-i-ac|\
+	araknis,an-700-ap-i-ac|\
 	engenius,eap1200h|\
 	engenius,enstationac-v1|\
 	glinet,gl-x750)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -48,6 +48,7 @@ platform_do_upgrade() {
 		redboot_fis_do_upgrade "$1" vmlinux_2
 		;;
 	allnet,all-wap02860ac|\
+	araknis,an-300-ap-i-n|\
 	engenius,eap1200h|\
 	engenius,eap300-v2|\
 	engenius,eap600|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -49,6 +49,7 @@ platform_do_upgrade() {
 		;;
 	allnet,all-wap02860ac|\
 	araknis,an-300-ap-i-n|\
+	araknis,an-500-ap-i-ac|\
 	engenius,eap1200h|\
 	engenius,eap300-v2|\
 	engenius,eap600|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -50,6 +50,7 @@ platform_do_upgrade() {
 	allnet,all-wap02860ac|\
 	araknis,an-300-ap-i-n|\
 	araknis,an-500-ap-i-ac|\
+	araknis,an-700-ap-i-ac|\
 	engenius,eap1200h|\
 	engenius,eap300-v2|\
 	engenius,eap600|\

--- a/target/linux/ath79/image/common-senao.mk
+++ b/target/linux/ath79/image/common-senao.mk
@@ -1,6 +1,6 @@
 DEVICE_VARS += SENAO_IMGNAME
 
-# This needs to make /tmp/_sys/sysupgrade.tgz an empty file prior to
+# This needs to make OEM config archive 'sysupgrade.tgz' an empty file prior to OEM
 # sysupgrade, as otherwise it will implant the old configuration from
 # OEM firmware when writing rootfs from factory.bin
 # rootfs size and checksum is taken from a squashfs header
@@ -9,7 +9,9 @@ define Build/senao-tar-gz
 	-[ -f "$@" ] && \
 	mkdir -p $@.tmp && \
 	touch $@.tmp/failsafe.bin && \
+	touch $@.tmp/FWINFO-$(word 1,$(1))-$(REVISION) && \
 	echo '#!/bin/sh' > $@.tmp/before-upgrade.sh && \
+	echo ': > /tmp/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
 	echo ': > /tmp/_sys/sysupgrade.tgz' >> $@.tmp/before-upgrade.sh && \
 	echo -n $$(( $$(cat $@ | wc -c) / 4096 * 4096 )) > $@.len && \
 	dd if=$@ bs=$$(cat $@.len) count=1 | md5sum - | cut -d ' ' -f 1 > $@.md5 && \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -331,6 +331,18 @@ define Device/araknis_an-300-ap-i-n
 endef
 TARGET_DEVICES += araknis_an-300-ap-i-n
 
+define Device/araknis_an-500-ap-i-ac
+  $(Device/senao_loader_okli)
+  SOC := qca9557
+  DEVICE_VENDOR := Araknis
+  DEVICE_MODEL := AN-500-AP-I-AC
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 11584k
+  LOADER_FLASH_OFFS := 0x220000
+  SENAO_IMGNAME := senao-generic-v1-an500
+endef
+TARGET_DEVICES += araknis_an-500-ap-i-ac
+
 define Device/arduino_yun
   SOC := ar9331
   DEVICE_VENDOR := Arduino

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -320,6 +320,17 @@ define Device/allnet_all-wap02860ac
 endef
 TARGET_DEVICES += allnet_all-wap02860ac
 
+define Device/araknis_an-300-ap-i-n
+  $(Device/senao_loader_okli)
+  SOC := ar9344
+  DEVICE_VENDOR := Araknis
+  DEVICE_MODEL := AN-300-AP-I-N
+  IMAGE_SIZE := 12096k
+  LOADER_FLASH_OFFS := 0x220000
+  SENAO_IMGNAME := senao-an300
+endef
+TARGET_DEVICES += araknis_an-300-ap-i-n
+
 define Device/arduino_yun
   SOC := ar9331
   DEVICE_VENDOR := Arduino

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -343,6 +343,18 @@ define Device/araknis_an-500-ap-i-ac
 endef
 TARGET_DEVICES += araknis_an-500-ap-i-ac
 
+define Device/araknis_an-700-ap-i-ac
+  $(Device/senao_loader_okli)
+  SOC := qca9558
+  DEVICE_VENDOR := Araknis
+  DEVICE_MODEL := AN-700-AP-I-AC
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 11584k
+  LOADER_FLASH_OFFS := 0x220000
+  SENAO_IMGNAME := senao-generic-v1-an700
+endef
+TARGET_DEVICES += araknis_an-700-ap-i-ac
+
 define Device/arduino_yun
   SOC := ar9331
   DEVICE_VENDOR := Arduino


### PR DESCRIPTION
these access points are Senao devices:

the hardware is equivalent to EnGenius EAP1200 / EAP600

the software is modified Senao SDK which is based on openwrt and uboot
including image checksum verification at boot time,
and a failsafe image that boots if checksum fails
