### PR TITLE
[19.07] rampis: add support for Sitecom WLR-4100

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -390,6 +390,10 @@ wrh-300cr)
 	set_wifi_led "$boardname:green:wlan"
 	ucidef_set_led_netdev "lan" "lan" "$boardname:green:ethernet" "eth0"
 	;;
+sitecom,wlr-4100v1002)
+	set_wifi_led "$boardname:blue:wifi2g"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:white:wps" "eth0"
+	;;
 xiaomi,mir3g)
 	ucidef_set_led_switch "wan-amber"  "WAN (amber)"  "$boardname:amber:wan"  "switch0" "0x02" "0x08"
 	ucidef_set_led_switch "lan1-amber" "LAN1 (amber)" "$boardname:amber:lan1" "switch0" "0x08" "0x08"

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -419,6 +419,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
 		;;
+	sitecom,wlr-4100v1002)
+		ucidef_add_switch "switch0" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "0t@eth0"
+		;;
 	tplink,tl-wr902ac-v3)
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"

--- a/target/linux/ramips/dts/WLR-4100v1002.dts
+++ b/target/linux/ramips/dts/WLR-4100v1002.dts
@@ -1,0 +1,181 @@
+/dts-v1/;
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "sitecom,wlr-4100v1002", "ralink,mt7620a-soc";
+	model = "Sitecom WLR-4100 v1 002";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {	
+		compatible = "gpio-leds";
+		
+		led_power: power {				
+			label = "wlr-4100v1002:amber:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+		
+		wifi2g {
+			label = "wlr-4100v1002:blue:wifi2g";					
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_wps: wps {
+			label = "wlr-4100v1002:white:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};		
+	};
+
+	gpio_export {			
+		compatible = "gpio-export";
+		#size-cells = <0>;
+		usb-power {
+			gpio-export,name = "usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			config: partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "backup";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "storage";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&gsw {
+	mediatek,port4 = "gmac";
+};
+
+&ethernet {
+	status = "okay";
+	mtd-mac-address = <&factory 0x4>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		phy-mode = "rgmii";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-handle = <&phy0>;
+	};
+
+	mdio-bus {
+		status = "okay";
+		mediatek,mdio-mode = <1>;
+		phy0: ethernet-phy@0 {
+				reg = <0>;
+				phy-mode = "rgmii";
+				qca,ar8327-initvals = <
+					0x04 0x06200000  // PORT0 PAD MODE CTRL 
+					0x08 0x01000000  //  PORT5 PAD MODE CTRL  RX delay EN all ports 0, 5, 6 
+					0x7C 0x0000004e  // 	PORT0_STATUS 
+					>;
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	ralink,mtd-eeprom = <&factory 0>;
+};
+
+&pinctrl {
+	state_default: pinctrl0 {
+		gpio {
+			ralink,group = "uartf", "i2c", "rgmii2", "wled", "spi refclk", "ephy",  "nd_sd";
+			ralink,function = "gpio";
+		};
+	};
+};

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7620.c
@@ -163,26 +163,26 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw, int mdio_mode)
 			val &= ~BIT(11);
 			_mt7620_mii_write(gsw, i, 0, val);
 		}
+
+		/* global page 0 */
+		_mt7620_mii_write(gsw, 1, 31, 0x8000);
+		_mt7620_mii_write(gsw, 0, 30, 0xa000);
+		_mt7620_mii_write(gsw, 1, 30, 0xa000);
+		_mt7620_mii_write(gsw, 2, 30, 0xa000);
+		_mt7620_mii_write(gsw, 3, 30, 0xa000);
+
+		_mt7620_mii_write(gsw, 0, 4, 0x05e1);
+		_mt7620_mii_write(gsw, 1, 4, 0x05e1);
+		_mt7620_mii_write(gsw, 2, 4, 0x05e1);
+		_mt7620_mii_write(gsw, 3, 4, 0x05e1);
+
+		/* global page 2 */
+		_mt7620_mii_write(gsw, 1, 31, 0xa000);
+		_mt7620_mii_write(gsw, 0, 16, 0x1111);
+		_mt7620_mii_write(gsw, 1, 16, 0x1010);
+		_mt7620_mii_write(gsw, 2, 16, 0x1515);
+		_mt7620_mii_write(gsw, 3, 16, 0x0f0f);
 	}
-
-	/* global page 0 */
-	_mt7620_mii_write(gsw, 1, 31, 0x8000);
-	_mt7620_mii_write(gsw, 0, 30, 0xa000);
-	_mt7620_mii_write(gsw, 1, 30, 0xa000);
-	_mt7620_mii_write(gsw, 2, 30, 0xa000);
-	_mt7620_mii_write(gsw, 3, 30, 0xa000);
-
-	_mt7620_mii_write(gsw, 0, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 1, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 2, 4, 0x05e1);
-	_mt7620_mii_write(gsw, 3, 4, 0x05e1);
-
-	/* global page 2 */
-	_mt7620_mii_write(gsw, 1, 31, 0xa000);
-	_mt7620_mii_write(gsw, 0, 16, 0x1111);
-	_mt7620_mii_write(gsw, 1, 16, 0x1010);
-	_mt7620_mii_write(gsw, 2, 16, 0x1515);
-	_mt7620_mii_write(gsw, 3, 16, 0x0f0f);
 
 	/* CPU Port6 Force Link 1G, FC ON */
 	mtk_switch_w32(gsw, 0x5e33b, GSW_REG_PORT_PMCR(6));

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -706,6 +706,19 @@ define Device/wn3000rpv3
 endef
 TARGET_DEVICES += wn3000rpv3
 
+define Device/wlr-4100v1002
+  DTS := WLR-4100v1002
+  $(Device/dsa-migration)
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7244k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size $$$$(IMAGE_SIZE) | \
+	senao-header -r 0x0222 -p 0x104A -t 2
+  DEVICE_TITLE := Sitecom WLR-4100 v1 002
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += wlr-4100v1002
+
 define Device/wrh-300cr
   DTS := WRH-300CR
   IMAGE_SIZE := $(ralink_default_fw_size_16M)


### PR DESCRIPTION
Sitecom WLR-4100 v1 002 (marked as X4 N300 ) is a wireless router

Specification
SoC: MT7620A
RAM: 64 MB DDR2
Flash: 8 MB SPI NOR
WIFI: 2.4 GHz integrated
Ethernet: 5x 10/100/1000 Mbps QCA8337
USB: 1x 2.0
LEDS: 2x GPIO controlled, 5x switch
Buttons: 1x GPIO controlled
UART: row of 4 unpopulated holes near USB port, starting count from
      white triangle on PCB
      1. VCC 3.3V, 2. GND, 3. TX, 4. RX
      baud: 115200, parity: none, flow control: none

Installation
1. Connect to one of LAN (yellow) ethernet ports,
2. Open router configuration interface,
3. Go to Toolbox > Firmware,
4. Browse for OpenWrt factory image with dlf extension and hit Apply,
5. Wait few minutes, after the Power LED will stop blinking, the router
   is ready for configuration.

Known issues
- Work only three Gigabit ports (3/5, 1 WAN and 2LAN).
- USB 1.1 mode only

Additional information
OEM firmware shell password is: SitecomSenao
useful for creating backup of original firmware.
There is also another revision of this device (v1 001), based on
RT3352 SoC

Signed-off-by: Andrea Poletti <polex73@yahoo.it>