### PR TITLE
kernel: bump 5.10 to 5.10.31

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .110
-LINUX_VERSION-5.10 = .30
+LINUX_VERSION-5.10 = .31
 
 LINUX_KERNEL_HASH-5.4.110 = d0f6978440e8a4b266cb1847405a764bca83667541b9e4cdbbc161fb0dd9b228
-LINUX_KERNEL_HASH-5.10.30 = d40269b5ac5c8424ec808f4484c7f80947f8f2d549b1ef1a5149aec5b6a20640
+LINUX_KERNEL_HASH-5.10.31 = 54eef1a4d29a2582281375e028ac73c2c5d90dfa21500fa8c3b00e529a2b510d
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/ramips/patches-5.10/710-at803x.patch
+++ b/target/linux/ramips/patches-5.10/710-at803x.patch
@@ -139,11 +139,11 @@ Signed-off-by: René van Dorst <opensource@vdorst.com>
  	ret = at803x_config_mdix(phydev, phydev->mdix_ctrl);
  	if (ret < 0)
  		return ret;
-@@ -1120,6 +1203,7 @@ static struct phy_driver at803x_driver[]
+@@ -1083,6 +1166,7 @@ static struct phy_driver at803x_driver[]
  	.suspend		= at803x_suspend,
  	.resume			= at803x_resume,
  	/* PHY_GBIT_FEATURES */
 +	.config_aneg		= at803x_config_aneg,
  	.read_status		= at803x_read_status,
- 	.aneg_done		= at803x_aneg_done,
- 	.ack_interrupt		= &at803x_ack_interrupt,
+ 	.ack_interrupt		= at803x_ack_interrupt,
+ 	.config_intr		= at803x_config_intr,


### PR DESCRIPTION
Automatically refreshed:
ramips/patches-5.10/710-at803x.patch

Run-tested:
ramips/mt7621 (Redmi AC2100)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>