### PR TITLE
kexec-tools: add patch to fix issue with appended DTB and zImage on ARM

### DIFF
--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kexec-tools
 PKG_VERSION:=2.0.21
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kexec

--- a/package/boot/kexec-tools/patches/001-arm-do-not-copy-magic-4-bytes-of-appended-DTB-in-zIm.patch
+++ b/package/boot/kexec-tools/patches/001-arm-do-not-copy-magic-4-bytes-of-appended-DTB-in-zIm.patch
@@ -1,0 +1,57 @@
+From 9817ec81968a5eec7863902833fb77680544eae4 Mon Sep 17 00:00:00 2001
+From: Alexander Egorenkov <egorenar-dev@posteo.net>
+Date: Mon, 12 Apr 2021 13:18:05 +0200
+Subject: [PATCH 1/1] arm: do not copy magic 4 bytes of appended DTB in zImage
+
+If the passed zImage happens to have a DTB appended, then the magic 4 bytes
+of the DTB are copied together with the kernel image. This leads to
+failed kexec boots because the decompressor finds the aforementioned
+DTB magic and falsely tries to replace the DTB passed in the register r2
+with the non-existent appended one.
+
+Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
+Signed-off-by: Simon Horman <horms@verge.net.au>
+---
+ kexec/arch/arm/kexec-zImage-arm.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/kexec/arch/arm/kexec-zImage-arm.c b/kexec/arch/arm/kexec-zImage-arm.c
+index 925a9be..f4c23bf 100644
+--- a/kexec/arch/arm/kexec-zImage-arm.c
++++ b/kexec/arch/arm/kexec-zImage-arm.c
+@@ -382,6 +382,7 @@ int zImage_arm_load(int argc, char **argv, const char *buf, off_t len,
+ 	unsigned int atag_offset = 0x1000; /* 4k offset from memory start */
+ 	unsigned int extra_size = 0x8000; /* TEXT_OFFSET */
+ 	const struct zimage_tag *tag;
++	size_t kernel_buf_size;
+ 	size_t kernel_mem_size;
+ 	const char *command_line;
+ 	char *modified_cmdline = NULL;
+@@ -537,6 +538,15 @@ int zImage_arm_load(int argc, char **argv, const char *buf, off_t len,
+ 		}
+ 	}
+ 
++	/*
++	 * Save the length of the compressed kernel image w/o the appended DTB.
++	 * This will be required later on when the kernel image contained
++	 * in the zImage will be loaded into a kernel memory segment.
++	 * And we want to load ONLY the compressed kernel image from the zImage
++	 * and discard the appended DTB.
++	 */
++	kernel_buf_size = len;
++
+ 	/*
+ 	 * Always extend the zImage by four bytes to ensure that an appended
+ 	 * DTB image always sees an initialised value after _edata.
+@@ -759,7 +769,7 @@ int zImage_arm_load(int argc, char **argv, const char *buf, off_t len,
+ 		add_segment(info, dtb_buf, dtb_length, dtb_offset, dtb_length);
+ 	}
+ 
+-	add_segment(info, buf, len, kernel_base, kernel_mem_size);
++	add_segment(info, buf, kernel_buf_size, kernel_base, kernel_mem_size);
+ 
+ 	info->entry = (void*)kernel_base;
+ 
+-- 
+2.31.1
+


### PR DESCRIPTION
This patch fixes a recently found problem when a zImage passed to
kexec-tools contains an appended DTB. In that case kexec boot fails because
the decompressor wrongly tries to use the non-existing appended DTB instead
of the one passed in the register r2.

- http://lists.infradead.org/pipermail/kexec/2021-April/022353.html

This patch has already landed upstream. W/o this patch on ARM, zImage with appended DTB cannot be
kexeced successfully.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>
