### PR TITLE
feeds: management: remove dead and out of project feed

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -4,6 +4,5 @@ src-git routing https://git.openwrt.org/feed/routing.git
 src-git telephony https://git.openwrt.org/feed/telephony.git
 #src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
-#src-git management https://github.com/openwrt-management/packages.git
 #src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed


### PR DESCRIPTION
The feed is being removed because:
a) it is an external project and the OpenWrt team does not have access to it.
b) there has been no activity for several years.

This is based on PR #3900, #3901