### PR TITLE
scripts: improve dl_cleanup script

### DIFF
--- a/scripts/dl_cleanup.py
+++ b/scripts/dl_cleanup.py
@@ -185,6 +185,9 @@ def usage():
     print(" -d|--dry-run            Do a dry-run. Don't delete any files")
     print(" -B|--show-blacklist     Show the blacklist and exit")
     print(" -w|--whitelist ITEM     Remove ITEM from blacklist")
+    print(
+        " -D|--download-dir       Provide path to dl dir to clean also the build directory"
+    )
 
 
 def main(argv):
@@ -193,25 +196,20 @@ def main(argv):
     try:
         (opts, args) = getopt.getopt(
             argv[1:],
-            "hdBw:",
+            "hdBwD:",
             [
                 "help",
                 "dry-run",
                 "show-blacklist",
                 "whitelist=",
+                "download-dir=",
             ],
         )
-        if len(args) != 1:
-            usage()
-            return 1
     except getopt.GetoptError as e:
         usage()
         return 1
-    directory = args[0]
 
-    if not os.path.exists(directory):
-        print("Can't find dl path", directory)
-        return 1
+    directory = "dl/"
 
     for (o, v) in opts:
         if o in ("-h", "--help"):
@@ -235,6 +233,12 @@ def main(argv):
                     sep = "\t"
                 print("%s%s(%s)" % (name, sep, regex.pattern))
             return 0
+        if o in ("-D", "--download-dir"):
+            directory = v
+
+    if not os.path.exists(directory):
+        print("Can't find dl path", directory)
+        return 1
 
     # Create a directory listing and parse the file names.
     entries = []

--- a/scripts/dl_cleanup.py
+++ b/scripts/dl_cleanup.py
@@ -119,8 +119,10 @@ versionRegex = (
     (re.compile(r"(.+)[-_](\d\d\d\d)-?(\d\d)-?(\d\d)"), parseVer_ymd),  # xxx-YYYY-MM-DD
     (re.compile(r"(.+)[-_]([0-9a-fA-F]{40,40})"), parseVer_GIT),  # xxx-GIT_SHASUM
     (re.compile(r"(.+)[-_](\d+)\.(\d+)\.(\d+)(\w?)"), parseVer_123),  # xxx-1.2.3a
+    (re.compile(r"(.+)[-_]v(\d+)\.(\d+)\.(\d+)(\w?)"), parseVer_123),  # xxx-v1.2.3a
     (re.compile(r"(.+)[-_](\d+)_(\d+)_(\d+)"), parseVer_123),  # xxx-1_2_3
     (re.compile(r"(.+)[-_](\d+)\.(\d+)(\w?)"), parseVer_12),  # xxx-1.2a
+    (re.compile(r"(.+)[-_]v(\d+)\.(\d+)(\w?)"), parseVer_12),  # xxx-v1.2a
     (re.compile(r"(.+)[-_]r?(\d+)"), parseVer_r),  # xxx-r1111
 )
 


### PR DESCRIPTION
Improve dl_cleanup by adding an option to also clean the build directory related to the downloaded package.
Also add some check to the existence of the provided dl and build directory.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
