### PR TITLE
ath79: add support for Compex WPJ558

### DIFF
--- a/target/linux/ath79/dts/qca9558_compex_wpj558-16m.dts
+++ b/target/linux/ath79/dts/qca9558_compex_wpj558-16m.dts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "compex,wpj558-16m", "qca,qca9558";
+	model = "Compex WPJ558 (16MB flash)";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_sig4;
+		led-failsafe = &led_sig4;
+		led-running = &led_sig4;
+		led-upgrade = &led_sig4;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		sig1 {
+			label = "red:sig1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "yellow:sig2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		sig3 {
+			label = "green:sig3";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sig4: sig4 {
+			label = "green:sig4";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			firmware@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0xfc0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x56000000 0x00000101 0x00001616>;
+	mtd-mac-address = <&uboot 0x2e010>;
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -211,6 +211,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "3:lan" "2:wan"
 		;;
+	compex,wpj558-16m)
+		ucidef_add_switch "switch0" \
+			"1:wan" "5:lan" "6@eth0"
+		;;
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi)
 		ucidef_add_switch "switch0" \
@@ -507,6 +511,10 @@ ath79_setup_macs()
 		;;
 	compex,wpj344-16m|\
 	compex,wpj563)
+		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
+		;;
+	compex,wpj558-16m)
+		lan_mac=$(mtd_get_mac_binary u-boot 0x2e010)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x2e018)
 		;;
 	devolo,dlan-pro-1200plus-ac|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -652,6 +652,20 @@ define Device/compex_wpj531-16m
 endef
 TARGET_DEVICES += compex_wpj531-16m
 
+define Device/compex_wpj558-16m
+  SOC := qca9558
+  IMAGE_SIZE := 16128k
+  DEVICE_VENDOR := Compex
+  DEVICE_MODEL := WPJ558
+  DEVICE_VARIANT := 16M
+  SUPPORTED_DEVICES += wpj558
+  IMAGES += cpximg-6a07.bin
+  IMAGE/cpximg-6a07.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | mkmylofw_16m 0x691 3
+  DEVICE_PACKAGES := kmod-gpio-beeper
+endef
+TARGET_DEVICES += compex_wpj558-16m
+
 define Device/compex_wpj563
   SOC := qca9563
   DEVICE_PACKAGES := kmod-usb2 kmod-usb3


### PR DESCRIPTION
Specifications:
- SoC: QCA9558
- DRAM: 128MB DDR2
- Flash: 16MB SPI-NOR
- Wireless: on-board abgn 2×2 2.4GHz radio
- Ethernet: 2x 10/100/1000 Mbps (1x 802.11af PoE)
- miniPCIe slot

Flash instruction:
- From u-boot

tftpboot 0x80500000 openwrt-ath79-generic-compex_wpj558-16m-squashfs-sysupgrade.bin
erase 0x9f030000 +$filesize
cp.b $fileaddr 0x9f030000 $filesize
boot

- From cpximg loader

The cpximg loader can be started either by holding the reset button
during power up. Once it's running, a TFTP-server under 192.168.1.1 will accept
the image appropriate for the board revision that is etched on the board.

For example, if the board is labelled '6A07':

tftp -v -m binary 192.168.1.1 -c put openwrt-ath79-generic-compex_wpj558-16m-squashfs-cpximg-6a07.bin

Signed-off-by: Romain Mahoux <romain@mahoux.fr>