### PR TITLE
qos-scripts: add ifbN device before setting the link up

### DIFF
--- a/package/network/config/qos-scripts/Makefile
+++ b/package/network/config/qos-scripts/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=qos-scripts
 PKG_VERSION:=1.3.1
-PKG_RELEASE:=2
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
+++ b/package/network/config/qos-scripts/files/usr/lib/qos/generate.sh
@@ -326,7 +326,8 @@ start_interface() {
 			append cstr "$classnr:$prio:$avgrate:$pktsize:$pktdelay:$maxrate:$qdisc:$filter" "$N"
 		done
 		append ${prefix}q "$(tcrules)" "$N"
-		export dev_${dir}="ip link set $dev up >&- 2>&-
+		export dev_${dir}="ip link add ${dev} type ifb >&- 2>&-
+ip link set $dev up >&- 2>&-
 tc qdisc del dev $dev root >&- 2>&-
 tc qdisc add dev $dev root handle 1: hfsc default ${class_default}0
 tc class add dev $dev parent 1: classid 1:1 hfsc sc rate ${rate}kbit ul rate ${rate}kbit"


### PR DESCRIPTION
commit 50413e1 replaced ifconfig with ip.  In order to set a link state to up, 
the interface needs to be added first.

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>
