### PR TITLE
[RFC] kernel: add VirtIO-blk and VirtIO-net

### DIFF
--- a/package/kernel/linux/modules/block.mk
+++ b/package/kernel/linux/modules/block.mk
@@ -587,3 +587,20 @@ define KernelPackage/iosched-bfq
 endef
 
 $(eval $(call KernelPackage,iosched-bfq))
+
+
+define KernelPackage/virtio-blk
+  SUBMENU:=$(BLOCK_MENU)
+  TITLE:=VirtIO block device
+  DEPENDS:=@TARGET_x86
+  KCONFIG:=CONFIG_VIRTIO_BLK
+  FILES:=$(LINUX_DIR)/drivers/block/virtio_blk.ko
+  AUTOLOAD:=$(call AutoProbe,virtio-blk,1)
+endef
+
+define KernelPackage/virtio-blk/description
+  This is the virtual block driver for virtio.  It can be used with
+  QEMU based VMMs (like KVM or Xen).
+endef
+
+$(eval $(call KernelPackage,virtio-blk))

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1249,3 +1249,20 @@ define KernelPackage/sfc-falcon/description
 endef
 
 $(eval $(call KernelPackage,sfc-falcon))
+
+
+define KernelPackage/virtio-net
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=VirtIO network device
+  DEPENDS:=@TARGET_x86
+  KCONFIG:=CONFIG_VIRTIO_NET
+  FILES:=$(LINUX_DIR)/drivers/net/virtio_net.ko
+  AUTOLOAD:=$(call AutoProbe,virtio-net,1)
+endef
+
+define KernelPackage/virtio-net/description
+  This is the virtual network driver for virtio.  It can be used with
+  QEMU based VMMs (like KVM or Xen).
+endef
+
+$(eval $(call KernelPackage,virtio-net))


### PR DESCRIPTION
Add VirtIO-blk and VirtIO-net for less emulation in virtual machines.

Signed-off-by: Vieno Hakkerinen <vieno@hakkerinen.eu>
