### PR TITLE
dnsmasq: Allow specifying dbus/ubus interface names in configuration

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -202,6 +202,24 @@ append_interface_name() {
 	xappend "--interface-name=$1,$2"
 }
 
+append_bus() {
+	local section="$1"
+	local option="$2"
+	local bus_option="$3"
+	local default="$4"
+	local value
+
+	[ -z "$default" ] && default="0"
+
+	config_get value "$section" "$option" "$default"
+
+	case "$(get_bool "$value")" in
+		0) ;;
+		1) xappend "$bus_option" ;;
+		*) xappend "$bus_option=$value" ;;
+	esac
+}
+
 filter_dnsmasq() {
 	local cfg="$1" func="$2" match_cfg="$3" found_cfg
 
@@ -878,8 +896,8 @@ dnsmasq_start()
 	append_bool "$cfg" noresolv "--no-resolv"
 	append_bool "$cfg" localise_queries "--localise-queries"
 	append_bool "$cfg" readethers "--read-ethers"
-	append_bool "$cfg" dbus "--enable-dbus"
-	append_bool "$cfg" ubus "--enable-ubus"	1
+	append_bus "$cfg" dbus "--enable-dbus"
+	append_bus "$cfg" ubus "--enable-ubus" 1
 	append_bool "$cfg" expandhosts "--expand-hosts"
 	config_get tftp_root "$cfg" "tftp_root"
 	[ -n "$tftp_root" ] && mkdir -p "$tftp_root" && append_bool "$cfg" enable_tftp "--enable-tftp"


### PR DESCRIPTION
Currently it is not possible to specify different dbus/ubus interface names, so when multiple dnsmasq instances are running, there is a bus path/name conflict (dbus path and ubus name). This leads to errors in log:

```
  daemon.err dnsmasq[]: Cannot add object to UBus: Invalid argument
```

Allow specifying non-default ubus/dbus names (default dbus path is "uk.org.thekelleys.dnsmasq", default ubus name is "dnsmasq").

The dbus path and ubus name can be changed by using the following configuration:

```
config dnsmasq 'main_dhcp'
        ...
	option ubus 'dnsmasq.main'
	option dbus 'uk.org.thekelleys.dnsmasq.main'
```

Or enable for example only dbus with defaults:

```
config dnsmasq 'main_dhcp'
        ...
	option ubus 'disabled'
	option dbus 'enabled'
```
