### PR TITLE
uboot-envtools: add support for Buffalo WZR-HP-G300NH

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -67,6 +67,10 @@ zyxel,nbg6616)
 buffalo,wzr-hp-ag300h)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
 	;;
+buffalo,wzr-hp-g300nh-rb|\
+buffalo,wzr-hp-g300nh-s)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
 domywifi,dw33d)
 	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
 	;;


### PR DESCRIPTION
This adds an entries for wzr-hp-g300nh-r and wzr-hp-g300nh-s.

Tested on a device with the S variant. U-boot environment prints nicely.