### PR TITLE
ltq-vdsl-app: extent dsl metrics with line length

### DIFF
--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -563,6 +563,20 @@ static void band_plan_status(int fd, profile_t *profile) {
 #endif
 }
 
+static void line_loop_length(int fd) {
+	DSL_LoopLengthStatus_t in_out;
+	DSL_uint32_t avg;
+
+	memset(&in_out, 0, sizeof(DSL_LoopLengthStatus_t));
+	in_out.nUnit = DSL_UNIT_METER;
+	if (ioctl(fd, DSL_FIO_LOOP_LENGTH_STATUS_GET, &in_out))
+		return;
+
+	avg = (in_out.data.nLength_Awg24 + in_out.data.nLength_Awg26) / 2;
+	m_u32("loop_length", avg);
+	m_u32("loop_length_err", avg - in_out.data.nLength_Awg26);
+}
+
 static void line_feature_config(int fd, DSL_AccessDir_t direction) {
 	IOCTL_DIR(DSL_LineFeature_t, DSL_FIO_LINE_FEATURE_STATUS_GET, direction)
 
@@ -753,6 +767,8 @@ static int metrics(struct ubus_context *ctx, struct ubus_object *obj,
 	}
 
 	describe_mode(standard, profile, vector);
+
+	line_loop_length(fd);
 
 	c = blobmsg_open_table(&b, "upstream");
 	switch (vector) {


### PR DESCRIPTION
The lantiq driver supports different units and cable models.
In order to keep the ubus interface generic:
* SI units are used (metre).
* The available cable prediction types are averaged.
* The span of them is used for an error estimate.

The following JSON output values are added:
* "loop_length"
* "loop_length_err"

Side note:
Currently, the kernel module refuses to report these values for VDSL. 
Factory firmware however does show the loop length in the user interface.
It may thus be possible to patch the kernel module (depending on whether a proprietary modem fw blob is required).