### PR TITLE
ramips: Add support for Beeline SmartBox TURBO+

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -39,6 +39,7 @@ ampedwireless,ally-r1900k)
 	;;
 beeline,smartbox-giga|\
 beeline,smartbox-turbo|\
+beeline,smartbox-turbo-plus|\
 etisalat,s3|\
 rostelecom,rt-sf-1)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"

--- a/scripts/sercomm-kernel-header.py
+++ b/scripts/sercomm-kernel-header.py
@@ -48,11 +48,11 @@ def get_kernel_header(args):
 	struct.pack_into('<L', header, 0x2c, rootfs_size)
 	struct.pack_into('<L', header, 0x30, crc)
 
-	rootfs_end_offset = args.rootfs_offset + rootfs_size
-	struct.pack_into('<L', header, 0x4, rootfs_end_offset)
-
 	kernel_size = os.path.getsize(args.kernel_file)
 	struct.pack_into('<L', header, 0x14, kernel_size)
+
+	kernel_end_offset = args.kernel_offset + kernel_size
+	struct.pack_into('<L', header, 0x4, kernel_end_offset)
 
 	buf = open(args.kernel_file,'rb').read()
 	crc = binascii.crc32(buf) & 0xffffffff

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo-plus.dts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "beeline,smartbox-turbo-plus", "mediatek,mt7621-soc";
+	model = "Beeline SmartBox TURBO+";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "blue:wan";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-2 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x4f80000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "sercomm,sc-partitions", "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			sercomm,scpart-id = <0>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "dynamic partition map";
+			reg = <0x100000 0x100000>;
+			sercomm,scpart-id = <1>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			sercomm,scpart-id = <2>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_21000: macaddr@21000 {
+				reg = <0x21000 0x6>;
+			};
+		};
+
+		partition@300000 {
+			label = "Boot Flag";
+			reg = <0x300000 0x100000>;
+			sercomm,scpart-id = <3>;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x400000 0x600000>;
+			sercomm,scpart-id = <4>;
+		};
+
+		partition@a00000 {
+			label = "Kernel 2";
+			reg = <0xa00000 0x600000>;
+			sercomm,scpart-id = <5>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1000000 {
+			label = "File System 1";
+			reg = <0x1000000 0x2000000>;
+			sercomm,scpart-id = <6>;
+		};
+
+		partition@3000000 {
+			label = "File System 2";
+			reg = <0x3000000 0x2000000>;
+			sercomm,scpart-id = <7>;
+			read-only;
+		};
+
+		ubiconcat1: partition@5000000 {
+			label = "Configuration/log";
+			reg = <0x5000000 0x1400000>;
+			sercomm,scpart-id = <8>;
+		};
+
+		ubiconcat2: partition@6400000 {
+			label = "application tmp buffer (Ftool)";
+			reg = <0x6400000 0x1b80000>;
+			sercomm,scpart-id = <9>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(5)>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&macaddr_factory_21000>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(4)>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_21000>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(1)>;
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&uartlite3 {
+	status = "okay";
+	current-speed = <57600>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -1,4 +1,5 @@
 DEVICE_VARS += SERCOMM_KERNEL_OFFSET SERCOMM_ROOTFS_OFFSET
+DEVICE_VARS += SERCOMM_KERNEL2_OFFSET SERCOMM_ROOTFS2_OFFSET
 
 define Build/sercomm-crypto
 	$(TOPDIR)/scripts/sercomm-crypto.py \
@@ -16,6 +17,23 @@ define Build/sercomm-crypto
 	rm -f $@.enc $@.key
 endef
 
+define Build/sercomm-factory-cqr
+	$(TOPDIR)/scripts/sercomm-pid.py \
+		--hw-version $(SERCOMM_HWVER) \
+		--hw-id $(SERCOMM_HWID) \
+		--sw-version $(SERCOMM_SWVER) \
+		--pid-file $@.fhdr
+	printf $$(stat -c%s $(IMAGE_KERNEL)) | \
+		dd seek=$$((0x70)) of=$@.fhdr bs=1 conv=notrunc 2>/dev/null
+	printf $$(($$(stat -c%s $@)-$$(stat -c%s $(IMAGE_KERNEL))-$$((0x200)))) | \
+		dd seek=$$((0x80)) of=$@.fhdr bs=1 conv=notrunc 2>/dev/null
+	dd bs=$$((0x200)) skip=1 if=$@ conv=notrunc 2>/dev/null | \
+		$(MKHASH) md5 | awk '{print $$1}' | tr -d '\n' | \
+		dd seek=$$((0x1e0)) of=$@.fhdr bs=1 conv=notrunc 2>/dev/null
+	dd if=$@ >> $@.fhdr 2>/dev/null
+	mv $@.fhdr $@
+endef
+
 define Build/sercomm-kernel
 	$(TOPDIR)/scripts/sercomm-kernel-header.py \
 		--kernel-image $@ \
@@ -24,6 +42,22 @@ define Build/sercomm-kernel
 		--output-header $@.hdr
 	dd if=$@ >> $@.hdr 2>/dev/null
 	mv $@.hdr $@
+endef
+
+define Build/sercomm-kernel-factory
+	$(TOPDIR)/scripts/sercomm-kernel-header.py \
+		--kernel-image $@ \
+		--kernel-offset $(SERCOMM_KERNEL_OFFSET) \
+		--rootfs-offset $(SERCOMM_ROOTFS_OFFSET) \
+		--output-header $@.khdr1
+	$(TOPDIR)/scripts/sercomm-kernel-header.py \
+		--kernel-image $@ \
+		--kernel-offset $(SERCOMM_KERNEL2_OFFSET) \
+		--rootfs-offset $(SERCOMM_ROOTFS2_OFFSET) \
+		--output-header $@.khdr2
+	cat $@.khdr1 $@.khdr2 > $@.khdr
+	dd if=$@ >> $@.khdr 2>/dev/null
+	mv $@.khdr $@
 endef
 
 define Build/sercomm-part-tag
@@ -64,24 +98,37 @@ define Build/sercomm-prepend-tagged-kernel
 	mv $(IMAGE_KERNEL).tagged $@
 endef
 
-define Device/sercomm_dxx
-  $(Device/dsa-migration)
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  UBINIZE_OPTS := -E 5
+define Device/sercomm
+  $(Device/nand)
   LOADER_TYPE := bin
+  KERNEL_SIZE := 6144k
   KERNEL_LOADADDR := 0x81001000
   LZMA_TEXT_START := 0x82800000
+  SERCOMM_KERNEL_OFFSET := 0x400100
+  SERCOMM_ROOTFS_OFFSET := 0x1000000
+  IMAGES += factory.img
+endef
+
+define Device/sercomm_cxx
+  $(Device/sercomm)
+  SERCOMM_KERNEL2_OFFSET := 0xa00100
+  SERCOMM_ROOTFS2_OFFSET := 0x3000000
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | lzma -a0 | \
+	uImage lzma
+  IMAGE/sysupgrade.bin := append-kernel | sercomm-kernel | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+  IMAGE/factory.img := append-kernel | sercomm-kernel-factory | \
+	append-ubi | sercomm-factory-cqr
+endef
+
+define Device/sercomm_dxx
+  $(Device/sercomm)
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | lzma -a0 | \
 	uImage lzma | sercomm-kernel
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	lzma -a0 | uImage lzma
-  IMAGES += factory.img
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.img := append-ubi | check-size | \
 	sercomm-part-tag rootfs | sercomm-prepend-tagged-kernel kernel | \
 	gzip | sercomm-payload | sercomm-crypto
-  SERCOMM_KERNEL_OFFSET := 0x400100
-  SERCOMM_ROOTFS_OFFSET := 0x1000000
 endef

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -408,6 +408,18 @@ define Device/beeline_smartbox-turbo
 endef
 TARGET_DEVICES += beeline_smartbox-turbo
 
+define Device/beeline_smartbox-turbo-plus
+  $(Device/sercomm_cxx)
+  IMAGE_SIZE := 32768k
+  SERCOMM_HWID := CQR
+  SERCOMM_HWVER := 10000
+  SERCOMM_SWVER := 2010
+  DEVICE_VENDOR := Beeline
+  DEVICE_MODEL := SmartBox TURBO+
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
+endef
+TARGET_DEVICES += beeline_smartbox-turbo-plus
+
 define Device/belkin_rt1800
   $(Device/nand)
   IMAGE_SIZE := 49152k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -35,6 +35,7 @@ asus,rt-n56u-b1)
 beeline,smartbox-flash|\
 beeline,smartbox-giga|\
 beeline,smartbox-turbo|\
+beeline,smartbox-turbo-plus|\
 etisalat,s3|\
 rostelecom,rt-sf-1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -9,6 +9,7 @@ boot() {
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
 	beeline,smartbox-turbo|\
+	beeline,smartbox-turbo-plus|\
 	rostelecom,rt-sf-1)
 		[[ $(hexdump -n 1 -e '/1 "%1d"' -s $((0x20001)) /dev/mtd3) == \
 			$((0xff)) ]] || printf '\xff' | dd of=/dev/mtdblock3 \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -60,6 +60,7 @@ platform_do_upgrade() {
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
 	beeline,smartbox-turbo|\
+	beeline,smartbox-turbo-plus|\
 	belkin,rt1800|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1960-a1|\


### PR DESCRIPTION
# [Beeline Smart Box TURBO+](https://openwrt.org/inbox/toh/beeline/smartbox_turbo_plus)
This PR adds support for router Beeline Smart Box TURBO+.
## Specifications
- SoC Type: MediaTek MT7621AT (880 MHz, 2 cores)
- RAM (Nanya NT5CC64M16GP): 128 MiB
- Flash (Macronix MX30LF1G18AC): 128 MiB
- Wireless 2.4 GHz (MT7603EN): b/g/n, 2x2
- Wireless 5 GHz (MT7615N): a/n/ac, 4x4
- Ethernet: 5 ports - 5×GbE (WAN, LAN1-4)
- USB ports: 1xUSB3.0
- Buttons: 2 button (reset, wps)
- LEDs: Red, Green, Blue
- Zigbee (EFR32MG1B232GG): 3.0
- Stock bootloader: U-Boot 1.1.3
- Power: 12 VDC, 1.5 A
### Installation
* Web UI Update
  1. Rename the firmware so that there are no dots in the name, except
  	for the dot in the ".img" file type. Example "openwrt-factory.img".
  2. Upload and update the firmware via the original web interface.

Remark: You might need make the 2rd step twice if your running firmware
is booted from the Slot 1 (Sercomm0 bootflag). The stock firmware
reverses the bootflag (Sercomm0 / Sercomm1) on each firmware update.
#### Discussion forum topic: 
- [Add support for Beeline SmartBox Turbo+](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-turbo/99635?u=maxs0nix).
##### Related devices (SerComm OEM/ODM):
* Sercomm S1500 - #4770 
  * [Beeline SmartBox PRO](https://wikidevi.wi-cat.ru/Beeline_SmartBox_Pro)
  * [WiFire S1500.NBN](https://wikidevi.wi-cat.ru/WiFire_S1500.NBN)
* Sercomm S2
  * [Beeline SmartBox GIGA](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-giga-on-stock-u-boot/99390) - :heavy_check_mark: #4195
* Sercomm S3
  * [Beeline SmartBox TURBO+](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-turbo/99635) - #4108
  * [Beeline SmartBox TURBO](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-turbo/99635/37) - :heavy_check_mark: #10118
  * [Etisalat Sercomm S3](https://forum.openwrt.org/t/add-support-for-sercomm-s3-on-stock-uboot/95970) - #11352
  * Rostelecom RT-SF-1 - :heavy_check_mark: #11137
  * Rostelecom RT-FE-1
###### Previous
PR #3435 (by author Andrew Freeman labz56@gmail.com)