### PR TITLE
ramips: add support for Senao Engenius EPG600

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -17,6 +17,7 @@ alfa-network,awusfree1|\
 alfa-network,quad-e4g|\
 alfa-network,r36m-e4g|\
 alfa-network,tube-e4g|\
+engenius,epg600|\
 engenius,esr600h|\
 sitecom,wlr-4100-v1-002)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"

--- a/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_epg600.dts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "engenius,epg600", "ralink,mt7620a-soc";
+	model = "EnGenius EPG600";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reg {
+			linux,code = <BTN_0>;
+			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps2g {
+			label = "blue:wps2g";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps5g {
+			label = "amber:wps5g";
+			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+		};
+
+		line {
+			label = "blue:line";
+			gpios = <&gpio2 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <30000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			rf: partition@50000 {
+				label = "rf";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "firmware";
+				reg = <0x60000 0xf40000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@fa0000 {
+				label = "backup";
+				reg = <0xfa0000 0x10000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "storage";
+				reg = <0xfb0000 0x50000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins &rgmii1_pins &rgmii2_pins>;
+
+	nvmem-cells = <&macaddr_rf_4>;
+	nvmem-cell-names = "mac-address";
+
+	port@5 {
+		status = "okay";
+
+		phy-mode = "rgmii-txid";
+
+		mediatek,fixed-link = <1000 1 1 1>;
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+
+			qca,ar8327-initvals = <
+				0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+				0x08 0x01000000 /* PORT5 PAD MODE CTRL */
+				0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+				0x10 0x40000000 /* POWER-ON STRAPPING  */
+				0x7c 0x0000007e /* PORT0_STATUS */
+				0x94 0x0000007e /* PORT6_STATUS */
+			>;
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-disable;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,1,0 {
+		compatible = "pci1814,3091";
+		reg = <0x0 1 0 0 0>;
+		ralink,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&rf 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&state_default {
+	default {
+		groups = "ephy", "wled", "spi refclk", "i2c", "uartf", "nd_sd";
+		function = "gpio";
+	};
+};
+
+&rf {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_rf_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -61,19 +61,11 @@ static irqreturn_t gsw_interrupt_mt7620(int irq, void *_priv)
 	return IRQ_HANDLED;
 }
 
-static void mt7620_hw_init(struct mt7620_gsw *gsw)
+static void mt7620_ephy_init(struct mt7620_gsw *gsw)
 {
 	u32 i;
 	u32 val;
 	u32 is_BGA = (rt_sysc_r32(SYSC_REG_CHIP_REV_ID) >> 16) & 1;
-
-	/* Internal ethernet requires PCIe RC mode */
-	rt_sysc_w32(rt_sysc_r32(SYSC_REG_CFG1) | PCIE_RC_MODE, SYSC_REG_CFG1);
-
-	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_CKGCR) & ~(0x3 << 4), GSW_REG_CKGCR);
-
-	/* Enable MIB stats */
-	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_MIB_CNT_EN) | (1 << 1), GSW_REG_MIB_CNT_EN);
 
 	if (gsw->ephy_disable) {
 		mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_GPC1) |
@@ -81,6 +73,8 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw)
 			GSW_REG_GPC1);
 
 		pr_info("gsw: internal ephy disabled\n");
+
+		return;
 	} else if (gsw->ephy_base) {
 		mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_GPC1) |
 			(gsw->ephy_base << 16),
@@ -158,12 +152,6 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw)
 	_mt7620_mii_write(gsw, gsw->ephy_base + 2, 16, 0x1515);
 	_mt7620_mii_write(gsw, gsw->ephy_base + 3, 16, 0x0f0f);
 
-	/* CPU Port6 Force Link 1G, FC ON */
-	mtk_switch_w32(gsw, 0x5e33b, GSW_REG_PORT_PMCR(6));
-
-	/* Set Port 6 as CPU Port */
-	mtk_switch_w32(gsw, 0x7f7f7fe0, 0x0010);
-
 	/* setup port 4 */
 	if (gsw->port4_ephy) {
 		val = rt_sysc_r32(SYSC_REG_CFG1);
@@ -175,6 +163,24 @@ static void mt7620_hw_init(struct mt7620_gsw *gsw)
 		_mt7620_mii_write(gsw, gsw->ephy_base + 4, 16, 0x1313);
 		pr_info("gsw: setting port4 to ephy mode\n");
 	}
+}
+
+static void mt7620_mac_init(struct mt7620_gsw *gsw)
+{
+	/* Internal ethernet requires PCIe RC mode */
+	rt_sysc_w32(rt_sysc_r32(SYSC_REG_CFG1) | PCIE_RC_MODE, SYSC_REG_CFG1);
+
+	/* Keep Global Clocks on Idle traffic */
+	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_CKGCR) & ~(0x3 << 4), GSW_REG_CKGCR);
+
+	/* Set Port 6 to Force Link 1G, Flow Control ON */
+	mtk_switch_w32(gsw, 0x5e33b, GSW_REG_PORT_PMCR(6));
+
+	/* Set Port 6 as CPU Port */
+	mtk_switch_w32(gsw, 0x7f7f7fe0, 0x0010);
+
+	/* Enable MIB stats */
+	mtk_switch_w32(gsw, mtk_switch_r32(gsw, GSW_REG_MIB_CNT_EN) | (1 << 1), GSW_REG_MIB_CNT_EN);
 }
 
 static const struct of_device_id mediatek_gsw_match[] = {
@@ -222,7 +228,9 @@ int mtk_gsw_init(struct fe_priv *priv)
 	else
 		gsw->ephy_base = 0;
 
-	mt7620_hw_init(gsw);
+	mt7620_mac_init(gsw);
+
+	mt7620_ephy_init(gsw);
 
 	if (gsw->irq) {
 		request_irq(gsw->irq, gsw_interrupt_mt7620, 0,

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -433,6 +433,21 @@ define Device/elecom_wrh-300cr
 endef
 TARGET_DEVICES += elecom_wrh-300cr
 
+define Device/engenius_epg600
+  $(Device/uimage-lzma-loader)
+  SOC := mt7620a
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 15616k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size | \
+	senao-header -r 0x101 -p 0x6a -t 2
+  DEVICE_VENDOR := EnGenius
+  DEVICE_MODEL := EPG600
+  DEVICE_PACKAGES += kmod-rt2800-pci kmod-usb-storage \
+	kmod-usb-ohci kmod-usb2 uboot-envtools
+endef
+TARGET_DEVICES += engenius_epg600
+
 define Device/engenius_esr600
   SOC := mt7620a
   BLOCKSIZE := 64k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -147,6 +147,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
+	engenius,epg600|\
 	engenius,esr600|\
 	lava,lr-25g001|\
 	sitecom,wlr-4100-v1-002)
@@ -326,6 +327,7 @@ ramips_setup_macs()
 	edimax,br-6478ac-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 2)
 		;;
+	engenius,epg600|\
 	engenius,esr600)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -331,6 +331,7 @@ ramips_setup_macs()
 	engenius,esr600)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
+		label_mac=$wan_mac
 		;;
 	glinet,gl-mt300a|\
 	glinet,gl-mt300n|\


### PR DESCRIPTION
original issues:

- ~~depends on #4111~~
- 5 GHz wireless not working yet #8780
- ~~in linux 5.10, the flash chip will have 4k blocksize [1], for now uboot-env is read-only~~

Not supported:

- there are 2 phone ports for VoIP with Si3050 + Si3019 chipset [2]

[1] https://github.com/torvalds/linux/commit/02892d405358288e0057cbdfe6476d13ea62fd2f
[2] https://www.silabs.com/documents/public/data-sheets/Si3050-11-18-19.pdf