### PR TITLE
[21.02] ramips: add support for ZTE MF283+

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,7 +34,8 @@ xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,mi-router-4c|\
 xiaomi,miwifi-nano|\
-zbtlink,zbt-wg2626)
+zbtlink,zbt-wg2626|\
+zte,mf283plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
 hootoo,ht-tm05|\

--- a/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
+++ b/target/linux/ramips/dts/rt3352_zte_mf283plus.dts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rt3352.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zte,mf283plus", "ralink,rt3352-soc";
+	model = "ZTE MF283+";
+
+	aliases {
+		led-boot = &led_wwan_green;
+		led-failsafe = &led_wwan_red;
+		led-upgrade = &led_wwan_red;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wwan_blue: wwan_blue {
+			label = "blue:wwan";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wwan_green: wwan_green {
+			label = "green:wwan";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wwan_red: wwan_red {
+			label = "red:wwan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		signal {
+			label = "blue:signal";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x60000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "u-boot-env";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@70000 {
+				label = "factory";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x80000 0xf80000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "rgmii", "mdio", "uartf";
+		function = "gpio";
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1183,6 +1183,16 @@ define Device/zorlik_zl5900v2
 endef
 TARGET_DEVICES += zorlik_zl5900v2
 
+define Device/zte_mf283plus
+  SOC := rt3352
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := ZTE
+  DEVICE_MODEL := MF283+
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-net-qmi-wwan uqmi \
+	kmod-usb-serial kmod-usb-serial-option
+endef
+TARGET_DEVICES += zte_mf283plus
+
 define Device/zyxel_keenetic
   SOC := rt3052
   BLOCKSIZE := 64k

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -1184,6 +1184,7 @@ endef
 TARGET_DEVICES += zorlik_zl5900v2
 
 define Device/zte_mf283plus
+  $(Device/uimage-lzma-loader)
   SOC := rt3352
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := ZTE

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
@@ -94,6 +94,10 @@ vocore,vocore-16m)
 zorlik,zl5900v2)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+zte,mf283plus)
+	ucidef_set_led_wlan "wifi" "wifi" "rt2800soc-phy0::radio" "phy0tpt"
+	ucidef_set_led_netdev "wwan" "wwan" "blue:wwan" "wwan0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/02_network
@@ -164,6 +164,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:wan" "6@eth0"
 		;;
+	zte,mf283plus)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "3:lan" "6@eth0"
+		;;
 	zyxel,keenetic-lite-b|\
 	zyxel,keenetic-start)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
This is quite a popular device in my country (Poland) and I already got a few support requests from random people trying snapshot builds on my email. It'll benefit many people if this device is included in 21.02 release, and at least for now, setup will be easier on 21.02 snapshots.
 
Cherry-pick required commits from master. No changes were needed for support since master, aside from dropping patches for modem support which are already upstream as of kernel 5.4.102.

If you prefer so, I'd also be happy with backport done manually or with both commits squashed.