### PR TITLE
bcm27xx: add config option for /boot/config.txt

### DIFF
--- a/target/linux/bcm27xx/image/Config.in
+++ b/target/linux/bcm27xx/image/Config.in
@@ -1,0 +1,6 @@
+config BCM27XX_CONFIG_EXTRA
+	string "Extra contents for /boot/config.txt"
+	depends on TARGET_bcm27xx
+	help
+	  Added to the end of /boot/config.txt. C-style \X escapes are interpreted,
+	  so lines should be seperated by \n.

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -20,7 +20,8 @@ define Build/boot-common
 	mcopy -i $@.boot $(KDIR)/COPYING.linux ::
 	mcopy -i $@.boot $(KDIR)/LICENCE.broadcom ::
 	mcopy -i $@.boot cmdline.txt ::
-	mcopy -i $@.boot config.txt ::
+	(cat config.txt; printf "%b\n" "$(CONFIG_BCM27XX_CONFIG_EXTRA)") > $@.config.txt
+	mcopy -i $@.boot $@.config.txt ::/config.txt
 	mcopy -i $@.boot distroconfig.txt ::
 	mcopy -i $@.boot $(IMAGE_KERNEL) ::$(KERNEL_IMG)
 	$(foreach dts,$(shell echo $(DEVICE_DTS)),mcopy -i $@.boot $(DTS_DIR)/$(dts).dtb ::;)


### PR DESCRIPTION
This is useful for building raspberry pi images, where there are many configuration options which can only be set by modifying this file.

An alternative to this would be to copy this file from the overlay `files` directory, if one exists, however:

- A `/boot` directory would end up on the rootfs, which could be confusing (and cause mount issues?).
- No other targets do anything like this.
- It might be nice to add more fine-grained kconfig options for options in this file, which would then be ignored.