### PR TITLE
ramips: add support for Xiaomi Mi Router CR660x series

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -68,6 +68,11 @@ zyxel,nr7101)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x80000"
 	;;
+xiaomi,mi-router-cr6606|\
+xiaomi,mi-router-cr6608|\
+xiaomi,mi-router-cr6609)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
+	;;
 esac
 
 config_load ubootenv

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6606.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6606.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-cr6606", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router CR6606";
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6608.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6608.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-cr6608", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router CR6608";
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6609.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr6609.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_xiaomi_mi-router-cr660x.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-cr6609", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router CR6609";
+};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-cr660x.dtsi
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys_yellow;
+		led-failsafe = &led_sys_yellow;
+		led-running = &led_sys_blue;
+		led-upgrade = &led_sys_yellow;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys_yellow: sys_yellow {
+			label = "yellow:sys";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sys_blue: sys_blue {
+			label = "blue:sys";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		net_yellow {
+			label = "yellow:net";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		net_blue {
+			label = "blue:net";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Nvram";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "crash";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "crash_log";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		/* "kernel" and "ubi" partition is the result of
+		 * squashing next consecutive stock partitions:
+		 * 1. firmware  0x0200000 - 0x2000000 (Stock firmware 0)
+		 * 2. firmware1 0x2000000 - 0x3e00000 (Stock firmware 1)
+		 * 3. overlay   0x3e00000 - 0x7000000 (Stock fw Ubi overlay)
+		 * 4. obr       0x7000000 - 0x8000000 (Unallocated?)
+		 */
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x7980000>;
+		};
+
+		/*
+		 * Leave 512 KiB for the bad block table
+		 */
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_3fffa>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_3fff4: macaddr@3fff4 {
+		reg = <0x3fff4 0x6>;
+	};
+
+	macaddr_factory_3fffa: macaddr@3fffa {
+		reg = <0x3fffa 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1568,6 +1568,40 @@ define Device/xiaomi_mi-router-ac2100
 endef
 TARGET_DEVICES += xiaomi_mi-router-ac2100
 
+define Device/xiaomi_mi-router-cr660x
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Xiaomi
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  UBINIZE_OPTS := -E 5
+  IMAGE_SIZE := 128512k
+  IMAGES += firmware.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/firmware.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_PACKAGES += kmod-mt7915e uboot-envtools
+endef
+
+define Device/xiaomi_mi-router-cr6606
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router CR6606
+endef
+TARGET_DEVICES += xiaomi_mi-router-cr6606
+
+define Device/xiaomi_mi-router-cr6608
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router CR6608
+endef
+TARGET_DEVICES += xiaomi_mi-router-cr6608
+
+define Device/xiaomi_mi-router-cr6609
+  $(Device/xiaomi_mi-router-cr660x)
+  DEVICE_MODEL := Mi Router CR6609
+endef
+TARGET_DEVICES += xiaomi_mi-router-cr6609
+
 define Device/xiaomi_redmi-router-ac2100
   $(Device/xiaomi_nand_separate)
   DEVICE_MODEL := Redmi Router AC2100

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -116,6 +116,11 @@ tplink,re650-v1)
 xiaomi,mi-router-ac2100)
 	ucidef_set_led_netdev "wan-blue" "WAN (blue)" "blue:wan" "wan"
 	;;
+xiaomi,mi-router-cr6606|\
+xiaomi,mi-router-cr6608|\
+xiaomi,mi-router-cr6609)
+	ucidef_set_led_netdev "internet" "Internet" "blue:net" "wan"
+	;;
 xiaomi,redmi-router-ac2100)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -26,6 +26,9 @@ ramips_setup_interfaces()
 	hiwifi,hc5962|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
+	xiaomi,mi-router-cr6606|\
+	xiaomi,mi-router-cr6608|\
+	xiaomi,mi-router-cr6609|\
 	xiaomi,redmi-router-ac2100)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -79,6 +79,9 @@ platform_do_upgrade() {
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\
 	xiaomi,mi-router-ac2100|\
+	xiaomi,mi-router-cr6606|\
+	xiaomi,mi-router-cr6608|\
+	xiaomi,mi-router-cr6609|\
 	xiaomi,redmi-router-ac2100)
 		nand_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Xiaomi Mi Router CR6606 is a Wi-Fi6 AX1800 Router with four GbE Ports.
Alongside the general model, it has three carrier customized models:
CR6606 (China Unicom), CR6608 (China Mobile), CR6609 (China Telecom)

Specifications:
- SoC: MediaTek MT7621AT
- RAM: 256MB DDR3 (ESMT M15T2G16128A)
- Flash: 128MB NAND (ESMT F59L1G81MB)
- Ethernet: 1000Base-T x4 (MT7530 SoC)
- WLAN: 2x2 2.4GHz 574Mbps + 2x2 5GHz 1201Mbps (MT7905DAN + MT7975DN)
- LEDs: System (Blue, Yellow), Internet (Blue, Yellow)
- Buttons: Reset, WPS
- UART: through-hole on PCB (\[VCC 3.3v\]\(RX\)(GND)(TX) 115200, 8n1)
- Power: 12VDC, 1A

Jailbreak Notes:
1. Get shell access.
   (See the commit message for details)
2. There's no official binary firmware available, and if you lose the content of your flash, no one except Xiaomi can help you. Dump these partitions in case you need them: "Bootloader" "Nvram" "Bdata" "crash" "crash_log" "firmware" "firmware1" "overlay" "obr"
   (See the commit message for details)
3. Since UART access is locked ootb, you should get permanent UART access by editing uboot env. Otherwise, your router may become bricked.
   (See the commit message for details)

Migrate to OpenWrt:
1. Transfer squashfs-firmware.bin to the router. 
2. nvram set flag_try_sys1_failed=0
3. nvram set flag_try_sys2_failed=1
4. nvram commit
5. mtd -r write /path/to/image/squashfs-firmware.bin firmware

Additional Info:
1. CR660x series routers have a different nand layout compared to other Xiaomi nand devices.
2. This router has a relatively fresh uboot (2018.09) compared to other Xiaomi devices, and it is capable of booting fit image firmware. Unfortunately, no successful attempt of booting OpenWrt fit image were made so far. The cause is still yet to be known. For now, we use legacy image instead.

Signed-off-by: Raymond Wang <infiwang@pm.me>