### PR TITLE
kernel: bump 5.10 to 5.10.33

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .113
-LINUX_VERSION-5.10 = .32
+LINUX_VERSION-5.10 = .33
 
 LINUX_KERNEL_HASH-5.4.113 = 30cde92463c474b75f9eb197654570dd6dbb32ec20695544c5469f292662da47
-LINUX_KERNEL_HASH-5.10.32 = 644f8e326e4cb8eac65f0874774c09ccf91cbe0b55eb8438c1e8711d3d07d7ba
+LINUX_KERNEL_HASH-5.10.33 = 933fdbc36371c0f830b7a6a957a559fca2dad1cc0eaa852ef42fb168185b4315
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))


### PR DESCRIPTION
No patches required refreshing.

Run-tested:
ath79/generic (Archer C6 v2)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>