### PR TITLE
ath79: mikrotik: swap RB922UAGS-5HPaCD eth0/1 MACs

### DIFF
--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -44,6 +44,11 @@ ath79_setup_macs()
 		label_mac="$mac_base"
 		lan_mac="$mac_base"
 		;;
+	mikrotik,routerboard-922uags-5hpacd)
+		label_mac="$mac_base"
+		lan_mac="$mac_base"
+		wan_mac=$(macaddr_add $mac_base 1)
+		;;
 	*)
 		label_mac="$mac_base"
 		wan_mac="$mac_base"


### PR DESCRIPTION
Since support for SFP on the MikroTik RouterBOARD 922UAGS-5HPacD was
added by 4387fe00cb, the MAC addresses for eth0 (Ethernet) and eth1
(SFP) were swapped. This patch fixes the 02_network script to assign MAC
addresses correctly, so they match the label and the vendor's OS.

Tested on a RouterBOARD 922UAGS-5HPacD board.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>