### PR TITLE
[19.07]ath10k-ct: update to latest version

### DIFF
--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE_FILES:=
 
 PKG_SOURCE_URL:=https://github.com/greearb/ath10k-ct.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2019-09-09
-PKG_SOURCE_VERSION:=5e8cd86f90dac966d12df6ece84ac41458d0e95f
-PKG_MIRROR_HASH:=dc1097f3a7b4b7e346918f206746d00a0b7df07ae3be9b89be55dfaef3cbbe45
+PKG_SOURCE_DATE:=2020-10-08
+PKG_SOURCE_VERSION:=1d28d176e5b6e63a6583f497adf68e1d9c1dc962
+PKG_MIRROR_HASH:=f611762647822742f7c8f9da242e33d9bf6da0a14976b87408af28f280802ae0
 
 # Build the 4.19 ath10k-ct driver version.  Other options are "-4.16", or
 # leave un-defined for 4.7 kernel.  Probably this should match as closely as


### PR DESCRIPTION
ath10k-ct: update to version 2020-10-08

1d28d17 ath10k-ct: Fix RSSI reporting for wave-1 firmware.
0c2949e ath10k-ct: fwcfg allows configuring dma-burst setting.