### PR TITLE
kernel: limit hardware crypto accelerator modules to proper targets

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -375,7 +375,7 @@ $(eval $(call KernelPackage,crypto-hw-hifn-795x))
 
 define KernelPackage/crypto-hw-padlock
   TITLE:=VIA PadLock ACE with AES/SHA hw crypto module
-  DEPENDS:=+kmod-crypto-manager
+  DEPENDS:=@TARGET_x86 +kmod-crypto-manager
   KCONFIG:= \
 	CONFIG_CRYPTO_HW=y \
 	CONFIG_CRYPTO_DEV_PADLOCK \


### PR DESCRIPTION
CONFIG_CRYPTO_DEV_PADLOCK depends on X86. This driver only makes sense on X86.
CONFIG_CRYPTO_DEV_GEODE depends on X86_32. This driver only makes sense on X86\geode.
CONFIG_CRYPTO_DEV_TALITOS depends on FSL_SOC. This driver only makes sense on Freescale(NXP) SoCs.

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>