### PR TITLE
kernel: qlcnic: fix typo in module description

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1204,7 +1204,7 @@ define KernelPackage/qlcnic
   AUTOLOAD:=$(call AutoProbe,qlcnic)
 endef
 
-define KernelPackage/macvlan/description
+define KernelPackage/qlcnic/description
   This driver supports QLogic QLE8240 and QLE8242 Converged Ethernet
   devices.
 endef


### PR DESCRIPTION
Fixes: f88c64d28ccf ("kernel: netdev: add qlcnic")

Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>