### PR TITLE
ramips: add support for wavlink WN576A2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "wavlink,wl-wn576a2", "silvercrest,swv-733-b1", "mediatek,mt7628an-soc";
+	model = "WAVLINK WL-WN576A2";
+
+	aliases {
+		led-boot = &led_wps;
+		led-failsafe = &led_wps;
+		led-running = &led_wps;
+		led-upgrade = &led_wps;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		repeatermode {
+			label = "repeatermode";
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		accesspointmode {
+			label = "accesspointmode";
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi-high {
+			label = "blue:wifi-high";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-mediumhigh {
+			label = "blue:wifi-mediumhigh";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-medium {
+			label = "blue:wifi-medium";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-mediumlow {
+			label = "blue:wifi-mediumlow";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "blue:wifi-low";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps: wps {
+			label = "blue:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wdt", "p0led_an", "p3led_an", "p4led_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -724,6 +724,16 @@ define Device/wavlink_wl-wn575a3
 endef
 TARGET_DEVICES += wavlink_wl-wn575a3
 
+define Device/wavlink_wl-wn576a2
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN576A2
+  DEVICE_ALT0_VENDOR := Silvercrest
+  DEVICE_ALT0_MODEL := SWV 733 B1
+  DEVICE_PACKAGES := kmod-mt76x0e rssileds
+endef
+TARGET_DEVICES += wavlink_wl-wn576a2
+
 define Device/wavlink_wl-wn577a2
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -129,6 +129,16 @@ wavlink,wl-wn575a3)
 	ucidef_set_led_rssi "wifi-med" "wifi-med" "green:wifi-med" "wlan1" "50" "84"
 	ucidef_set_led_rssi "wifi-high" "wifi-high" "green:wifi-high" "wlan1" "85" "100"
 	;;
+wavlink,wl-wn576a2)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "wifi-low" "wifi-low" "blue:wifi-low" "wlan0" "1" "29"
+	ucidef_set_led_rssi "wifi-mediumlow" "wifi-mediumlow" "blue:wifi-mediumlow" "wlan0" "30" "49"
+	ucidef_set_led_rssi "wifi-medium" "wifi-medium" "blue:wifi-medium" "wlan0" 50" "69"
+	ucidef_set_led_rssi "wifi-mediumhigh" "wifi-mediumhigh" "blue:wifi-mediumhigh" "wlan0" "70" "84"
+	ucidef_set_led_rssi "wifi-high" "wifi-high" "blue:wifi-high" "wlan0" "85" "100"
+	ucidef_set_led_switch "wps" "wps" "blue:wps" "switch0" "0x8"
+	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
+	;;
 wavlink,wl-wn577a2|\
 wavlink,wl-wn578a2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x8"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -122,6 +122,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;
+	wavlink,wl-wn576a2|\
 	tplink,tl-wr902ac-v3)
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
@@ -170,6 +171,7 @@ ramips_setup_macs()
 	cudy,wr1000|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
+	wavlink,wl-wn576a2|\
 	wavlink,wl-wn577a2|\
 	wavlink,wl-wn578a2)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)


### PR DESCRIPTION
- Sticker: WN576A2-A SilverCrest (LIDL brand) 8G01/2787-1 [brand model: swv 733 b1]
- PCB: WS-WN578A2-A-V1.2
- CPU: Mediatek MT7628AN
- WiFi: Mediathek MT7610EN
- Flash: AH1731 25Q64CS163 (64M-bit)
- RAM: Zentel A3R12E40DBF-AH ( 512Mb DDRII SDRAM)
- LEDs: 5x WiFi strength, 1x Lan/WAN, 1x WPS
- Buttons: 1x WPS, 1x slider switch
- UART 57600, 8N1, only pcb contact pads

install instruction

    

1. Configure a TFTP server on your PC/Laptop and set its IP to 192.168.10.100
2. Rename the OpenWrt image to firmware.bin and place it in the root folder of the TFTP server
3. Power off the device and connect an ethernet cable from its LAN/WAN port to your PC/Laptop
4. Press the WPS button (and keep it pressed)
5. Power on the device
6. After a few seconds, when the WAN/LAN LED stops blinking very fast, release the WPS button
7. Flashing OpenWrt takes less than a minute, system will reboot automatically
8. After reboot the WPS LED will indicate the current OpenWrt running status
9. The first boot takes about 90 seconds

The device ist mostly identically to https://openwrt.org/toh/wavlink/wavlink_wl-wn577a2
Further information: https://forum.openwrt.org/t/wn578a2-repeater-support/88410