### PR TITLE
kernel: crypto: drop kmod-crypto-wq and kmod-crypto-pcompress

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -986,16 +986,6 @@ endef
 $(eval $(call KernelPackage,crypto-user))
 
 
-define KernelPackage/crypto-wq
-  TITLE:=CryptoAPI work queue handling
-  KCONFIG:=CONFIG_CRYPTO_WORKQUEUE
-  FILES:=$(LINUX_DIR)/crypto/crypto_wq.ko
-  AUTOLOAD:=$(call AutoLoad,09,crypto_wq)
-  $(call AddDepends/crypto)
-endef
-$(eval $(call KernelPackage,crypto-wq))
-
-
 define KernelPackage/crypto-xts
   TITLE:=XTS cipher CryptoAPI module
   DEPENDS:=+kmod-crypto-gf128 +kmod-crypto-manager

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -600,7 +600,7 @@ $(eval $(call KernelPackage,crypto-lib-poly1305))
 
 define KernelPackage/crypto-manager
   TITLE:=CryptoAPI algorithm manager
-  DEPENDS:=+kmod-crypto-aead +kmod-crypto-hash +kmod-crypto-pcompress
+  DEPENDS:=+kmod-crypto-aead +kmod-crypto-hash
   KCONFIG:= \
 	CONFIG_CRYPTO_MANAGER \
 	CONFIG_CRYPTO_MANAGER2
@@ -768,19 +768,6 @@ define KernelPackage/crypto-pcbc
 endef
 
 $(eval $(call KernelPackage,crypto-pcbc))
-
-
-define KernelPackage/crypto-pcompress
-  TITLE:=CryptoAPI Partial (de)compression operations
-  KCONFIG:= \
-	CONFIG_CRYPTO_PCOMP=y \
-	CONFIG_CRYPTO_PCOMP2
-  FILES:=$(LINUX_DIR)/crypto/pcompress.ko
-  AUTOLOAD:=$(call AutoLoad,09,pcompress)
-  $(call AddDepends/crypto)
-endef
-
-$(eval $(call KernelPackage,crypto-pcompress))
 
 
 define KernelPackage/crypto-rsa


### PR DESCRIPTION
CONFIG_CRYPTO_WORKQUEUE was removed in upstream commit[1]. This symbol doesn't
exist since kernel 5.3 and this package is empty.
CONFIG_CRYPTO_PCOMP and CONFIG_CRYPTO_PCOMP2 have been removed in upstream commit[2].
This symbol doesn't exist since kernel 4.6 and this package is empty.

1. [ crypto: compress - remove unused pcomp interface ]
(torvalds/linux@1104921)
2. [ crypto: cryptd - move kcrypto_wq into cryptd ]
(torvalds/linux@3e56e16)

Signed-off-by: Aleksander Jan Bajkowski <A.Bajkowski@stud.elka.pw.edu.pl>
