### PR TITLE
base-files: avoid unnecessary NTP traffic

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -290,10 +290,7 @@ generate_static_system() {
 		set system.ntp='timeserver'
 		set system.ntp.enabled='1'
 		set system.ntp.enable_server='0'
-		add_list system.ntp.server='0.openwrt.pool.ntp.org'
-		add_list system.ntp.server='1.openwrt.pool.ntp.org'
 		add_list system.ntp.server='2.openwrt.pool.ntp.org'
-		add_list system.ntp.server='3.openwrt.pool.ntp.org'
 	EOF
 
 	if json_is_a system object; then


### PR DESCRIPTION
The script `sysntpd` appends all listed NTP servers. Then, the tool `ntpd` resolves all hostnames via DNS and picks the first IP, for each name. Consequently, OpenWrt did NTP with four different servers. This created four times more NTP traffic than expected. Because the NTP Pool Project returns four IP addresses for each hostname, there is enough backup to go just for a single hostname. However, still in the year 2021, [only](https://community.ntppool.org/t/91/15) the prefix 2 is IPv6 enabled. Consequently, we go (just) for `2.openwrt.pool.ntp.org`.