### PR TITLE
x86: use device vendor/model variable

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -1,5 +1,6 @@
 define Device/generic
-  DEVICE_TITLE := Generic x86/64
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := x86/64
   DEVICE_PACKAGES += kmod-amazon-ena kmod-bnx2 kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-igb kmod-ixgbe kmod-amd-xgbe kmod-r8169
   GRUB2_VARIANT := generic

--- a/target/linux/x86/image/generic.mk
+++ b/target/linux/x86/image/generic.mk
@@ -1,5 +1,6 @@
 define Device/generic
-  DEVICE_TITLE := Generic x86
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := x86
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-natsemi \
 	kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 \
 	kmod-via-rhine kmod-via-velocity kmod-forcedeth

--- a/target/linux/x86/image/geode.mk
+++ b/target/linux/x86/image/geode.mk
@@ -1,5 +1,6 @@
 define Device/generic
-  DEVICE_TITLE := Generic x86/Geode
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := x86/Geode
   DEVICE_PACKAGES += kmod-crypto-cbc kmod-crypto-hw-geode kmod-ledtrig-gpio
   GRUB2_VARIANT := legacy
 endef
@@ -7,7 +8,8 @@ TARGET_DEVICES += generic
 
 define Device/geos
   $(call Device/generic)
-  DEVICE_TITLE := Traverse Technologies Geos
+  DEVICE_VENDOR := Traverse Technologies
+  DEVICE_MODEL := Geos
   DEVICE_PACKAGES += br2684ctl flashrom kmod-hwmon-lm90 kmod-mppe kmod-pppoa \
 	kmod-usb-ohci-pci linux-atm ppp-mod-pppoa pppdump pppstats soloscli tc
 endef

--- a/target/linux/x86/image/legacy.mk
+++ b/target/linux/x86/image/legacy.mk
@@ -1,5 +1,6 @@
 define Device/generic
-  DEVICE_TITLE := Generic x86/legacy
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := x86/legacy
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 \
 	kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 \
 	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth


### PR DESCRIPTION
Remove use of DEVICE_TITLE in favor of the
DEVICE_VENDOR and DEVICE_MODEL as used by
all other targets.

Signed-off-by: Moritz Warning <moritzwarning@web.de>