### PR TITLE
bcm47xx: use device vendor/model variable

### DIFF
--- a/target/linux/bcm47xx/image/Makefile
+++ b/target/linux/bcm47xx/image/Makefile
@@ -146,17 +146,20 @@ define Device/Default
 endef
 
 define Device/standard
-  DEVICE_TITLE := Image with LZMA loader and LZMA compressed kernel
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := Image with LZMA loader and LZMA compressed kernel
 endef
 
 define Device/standard-noloader-gz
-  DEVICE_TITLE := Image with gzipped kernel
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := Image with gzipped kernel
   KERNEL_NAME = vmlinux.gz
   IMAGE/trx := append-rootfs | trx-without-loader
 endef
 
 define Device/standard-noloader-nodictionarylzma
-  DEVICE_TITLE := Image with LZMA compressed kernel matching CFE decompressor
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := Image with LZMA compressed kernel matching CFE decompressor
   KERNEL_NAME = vmlinux-nodictionary.lzma
   IMAGE/trx := append-rootfs | trx-without-loader
 endef

--- a/target/linux/bcm47xx/image/generic.mk
+++ b/target/linux/bcm47xx/image/generic.mk
@@ -66,7 +66,8 @@ TARGET_DEVICES += linksys_e3000-v1
 
 # generic has Ethernet drivers as modules so overwrite standard image
 define Device/standard
-  DEVICE_TITLE := Image with LZMA loader and LZMA compressed kernel
+  DEVICE_VENDOR := Generic
+  DEVICE_MODEL := Image with LZMA loader and LZMA compressed kernel
   DEVICE_PACKAGES := kmod-b44 kmod-bgmac kmod-tg3
 endef
 TARGET_DEVICES += standard


### PR DESCRIPTION
Remove use of DEVICE_TITLE in favor of the
DEVICE_VENDOR and DEVICE_MODEL as used by
all other targets.