### PR TITLE
ramips: add missing "pinctrl-names" for Youku YK1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -103,6 +103,7 @@
 
 &ethernet {
 	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
 
 	mtd-mac-address = <&factory 0x28>;
 


### PR DESCRIPTION
Without this definition ethernet led can work as usual, but it's better to
re-add it. Relying on default values may cause uncontrollable factors.

Fixes: 882a611 ("ramips: improve pinctrl for Youku YK-L1")