### PR TITLE
ramips: fix mac address of Youku YK1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -12,6 +12,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
 	};
 
 	leds {
@@ -106,7 +107,7 @@
 &ethernet {
 	pinctrl-names = "default";
 
-	mtd-mac-address = <&factory 0x4>;
+	mtd-mac-address = <&factory 0x28>;
 
 	mediatek,portmap = "llllw";
 };

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -254,7 +254,6 @@ ramips_setup_macs()
 	sanlinking,d240|\
 	vonets,var11n-300|\
 	wrtnode,wrtnode|\
-	youku,yk1|\
 	zbtlink,zbt-ape522ii|\
 	zbtlink,zbt-wa05|\
 	zbtlink,zbt-we2026|\
@@ -338,6 +337,7 @@ ramips_setup_macs()
 	lenovo,newifi-y1|\
 	lenovo,newifi-y1s|\
 	ohyeah,oy-0001|\
+	youku,yk1|\
 	wavlink,wl-wn530hg4)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;


### PR DESCRIPTION
correct mac address of Youku YK1.

Mac address read from official firmware:
        value       adress
Wlan    xx 71 de    factory@0x04
Lan     xx 71 dd    factory@0x28
Wan     xx 71 df    factory@0x2e
Label   xx 71 dd    factory@0x28