### PR TITLE
kernel: add kmod-leds-uleds

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -145,3 +145,17 @@ define KernelPackage/leds-pwm/description
 endef
 
 $(eval $(call KernelPackage,leds-pwm))
+
+define KernelPackage/leds-uleds
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=Userspace LEDs
+  KCONFIG:=CONFIG_LEDS_USER
+  FILES:=$(LINUX_DIR)/drivers/leds/uleds.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-uleds,1)
+endef
+
+define KernelPackage/leds-uleds/description
+ The options enables support for userspace LEDs.
+endef
+
+$(eval $(call KernelPackage,leds-uleds))

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -155,7 +155,7 @@ define KernelPackage/leds-uleds
 endef
 
 define KernelPackage/leds-uleds/description
- The options enables support for userspace LEDs.
+ The option enables support for userspace LEDs.
 endef
 
 $(eval $(call KernelPackage,leds-uleds))


### PR DESCRIPTION
The allows userspace LEDs to be created and controlled. This can be useful
for testing triggers and can also be used to implement virtual LEDs.

Signed-off-by: Keith T. Garner <kgarner@kgarner.com>
