### PR TITLE
build: add NPROC_OVERRIDE option, to manually limit parallel CPU-usage

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -105,7 +105,7 @@ endif
 	$(CP) $(TOPDIR)/staging_dir/host/lib/libfakeroot* $(PKG_BUILD_DIR)/staging_dir/host/lib
 	STRIP=$(STAGING_DIR_HOST)/bin/sstrip $(SCRIPT_DIR)/rstrip.sh $(PKG_BUILD_DIR)/staging_dir/host/bin/
 	(cd $(BUILD_DIR); \
-		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' -cf $@ $(IB_NAME) \
+		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(NPROC_OVERRIDE),$(NPROC_OVERRIDE),$(if $(filter 1,$(NPROC)),2,0))' -cf $@ $(IB_NAME) \
 		--mtime="$(shell date --date=@$(SOURCE_DATE_EPOCH))"; \
 	)
 

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -164,7 +164,7 @@ $(BIN_DIR)/$(SDK_NAME).tar.xz: clean
 	find $(SDK_BUILD_DIR) -name CVS | $(XARGS) rm -rf
 	-make -C $(SDK_BUILD_DIR)/scripts/config clean
 	(cd $(BUILD_DIR); \
-		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' -cf $@ $(SDK_NAME) \
+		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(NPROC_OVERRIDE),$(NPROC_OVERRIDE),$(if $(filter 1,$(NPROC)),2,0))' -cf $@ $(SDK_NAME) \
 		--mtime="$(shell date --date=@$(SOURCE_DATE_EPOCH))"; \
 	)
 


### PR DESCRIPTION
The NPROC variable is used by some tools to control the parallel usage of the CPUs. By default all available CPUs are used. The new option can be used to keep some CPUs free and the system more responsitive. 

Currently the NPROC variable is useed for compressing the imagebuilder and sdk.


This value can also prevent out of memory errors on low RAM and high CPU systems. Mine has 8 CPUs but only 8GB RAM. Having some browser windows open usually tar get killed with OoM during build. Running with ```make -j6 NPROC_OVERRIDE=4``` always succeeds.
