### PR TITLE
busybox: preserve crontabs

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -47,7 +47,6 @@ define Package/base-files/conffiles
 /etc/config/
 /etc/config/network
 /etc/config/system
-/etc/crontabs/
 /etc/dropbear/
 /etc/ethers
 /etc/group

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -73,13 +73,24 @@ define Package/busybox/config
 	source "$(SOURCE)/Config.in"
 endef
 
-ifdef CONFIG_BUSYBOX_CONFIG_FEATURE_SYSLOG
-define Package/busybox/conffiles
+ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_FEATURE_SYSLOG)$(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_FEATURE_SYSLOGD_CFG),)
+define Package/busybox/conffiles/syslog
 /etc/syslog.conf
+endef
+endif
+
+ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_CROND),)
+define Package/busybox/conffiles/crond
+/etc/crontabs/
+endef
+endif
+
+define Package/busybox/conffiles
+$(Package/busybox/conffiles/syslog)
+$(Package/busybox/conffiles/crond)
 endef
 
 Package/busybox-selinux/conffiles = $(Package/busybox/conffiles)
-endif
 
 ifndef CONFIG_USE_MUSL
 LDLIBS:=m crypt
@@ -129,8 +140,12 @@ define Package/busybox/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(CP) $(PKG_INSTALL_DIR)/* $(1)/
+ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_FEATURE_SYSLOG)$(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_FEATURE_SYSLOGD_CFG),)
+	touch $(1)/etc/syslog.conf
+endif
 ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_CROND),)
 	$(INSTALL_BIN) ./files/cron $(1)/etc/init.d/cron
+	$(INSTALL_DIR) $(1)/etc/crontabs
 endif
 ifneq ($(CONFIG_BUSYBOX_$(BUSYBOX_SYM)_NTPD),)
 	$(INSTALL_BIN) ./files/sysntpd $(1)/etc/init.d/sysntpd


### PR DESCRIPTION
The directory `/etc/crontabs/` and the file `/etc/syslog.conf` are both used by utilities in `Busybox`.   By convention, the ownership should be associated with that package.

Description:

```
/etc/syslog.conf is used by sysklogd, and /etc/crontabs is used
by crond, both features of busybox.  Given this, ownership for
these files should be bound to busybox, especially if one day
there's a way to do an in-place opkg update of busybox.
```