### PR TITLE
build: kernel2minor: work around path length limit

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -272,8 +272,11 @@ define Build/jffs2
 endef
 
 define Build/kernel2minor
-	kernel2minor -k $@ -r $@.new $(1)
-	mv $@.new $@
+	$(eval temp_file := $(shell mktemp))
+	cp $@ $(temp_file)
+	kernel2minor -k $(temp_file) -r $(temp_file).new $(1)
+	mv $(temp_file).new $@
+	rm -f $(temp_file)
 endef
 
 define Build/kernel-bin


### PR DESCRIPTION
When building for MikroTik devices the kernel2minor tool will sometimes
fail with:

  Can't get lstat from kernel file!: No such file or directory.

This is because kernel2minor expects paths no longer than 250 chars.
To work around this the include/image-commands.mk has been modified
to copy the kernel to a temporary file (/tmp/tmp.XXXXXXXXXX) before
calling kernel2minor.

Note that this is an alternative to #4152.