### PR TITLE
fakeroot: Alpine linux libc.musl build error fix

### DIFF
--- a/tools/fakeroot/patches/400-alpine-libc.musl-fix.patch
+++ b/tools/fakeroot/patches/400-alpine-libc.musl-fix.patch
@@ -1,0 +1,17 @@
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -83,2 +83,3 @@
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a,b)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b,c)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b,c)
+@@ -89,2 +90,3 @@
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+@@ -127,4 +129,5 @@
+    id_t is used everywhere, just happens to be int on some OSes */
+-#ifndef _ID_T
++#if !defined(_ID_T) && !defined(__DEFINED_id_t)
+ #define _ID_T
++#define __DEFINED_id_t
+ typedef int id_t;


### PR DESCRIPTION
Prevent build error on Alpine Linux host:
libfakeroot.c error: conflicting types for 'id_t'
Error relocating openwrt/staging_dir/host/lib/libfakeroot.so: SEND_GET_XATTR: symbol not found

Signed-off-by: Ruslan Isaev <legale.legale@gmail.com>
