### PR TITLE
ath79: add support for Xiaomi AIoT Router AC2350

### DIFF
--- a/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
+++ b/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Xiaomi AIoT AC2350";
+	compatible = "xiaomi,aiot-ac2350", "qca,qca9563";
+
+	aliases {
+		label-mac-device = &eth0;
+
+		led-boot = &led_system_orange;
+		led-failsafe = &led_system_orange;
+		led-running = &led_system_blue;
+		led-upgrade = &led_system_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_blue: system_blue {
+			label = "blue:system";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system_orange: system_orange {
+			label = "orange:system";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		wps {
+			gpio-export,name = "wps";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb-reset {
+			gpio-export,name = "usb-reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Nvram";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "Bdata";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "crash";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "cfg_bak";
+				reg = <0x70000 0x20000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "overlay";
+				reg = <0x90000 0x170000>;
+				read-only;
+			};
+
+			partition@200000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x200000 0xe00000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x08 0x01000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x10 0x602613a0 /* POWER_ON_STRAP */
+			0x50 0xcf35cf35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x000000fe /* PORT0_STATUS */
+			0x94 0x000010c2 /* PORT6_STATUS */
+			0xe0 0xc74164de /* SGMII_CTRL */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -403,6 +403,9 @@ wd,mynet-wifi-rangeextender)
 	ucidef_set_led_rssi "rssimedium" "RSSIMED" "blue:rssi-med" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIMAX" "blue:rssi-max" "wlan0" "66" "100"
 	;;
+xiaomi,aiot-ac2350)
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
+	;;
 yuncore,a770)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -303,7 +303,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan"
 		;;
-	nec,wg800hp)
+	nec,wg800hp|\
+	xiaomi,aiot-ac2350)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "1:wan"
 		;;
@@ -655,6 +656,9 @@ ath79_setup_macs()
 		;;
 	wd,mynet-wifi-rangeextender)
 		lan_mac=$(nvram get et0macaddr)
+		;;
+	xiaomi,aiot-ac2350)
+		lan_mac=$(mtd_get_mac_binary art 0x1002)
 		;;
 	zyxel,nbg6616)
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -242,6 +242,11 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
+	xiaomi,aiot-ac2350)
+		caldata_extract "art" 0x5000 0x2f20
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9984/hw1.0/board.bin
+		;;
 	yuncore,a782|\
 	yuncore,xd4200)
 		caldata_extract "art" 0x5000 0x2f20

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2181,6 +2181,15 @@ define Device/winchannel_wb2000
 endef
 TARGET_DEVICES += winchannel_wb2000
 
+define Device/xiaomi_aiot-ac2350
+  SOC := qca9563
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := AIoT AC2350
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9984-ct
+  IMAGE_SIZE := 14336k
+endef
+TARGET_DEVICES += xiaomi_aiot-ac2350
+
 define Device/xiaomi_mi-router-4q
   SOC := qca9561
   DEVICE_VENDOR := Xiaomi


### PR DESCRIPTION
## Device specifications
- SoC: QCA9563 @ 775MHz (MIPS 74Kc)
- RAM: 128MiB DDR2
- Flash: 16MiB SPI-NOR (EN25QH128)
- Wireless 2.4GHz (SoC): b/g/n, 3x3
- Wireless 5Ghz (QCA9988): a/n/ac, 4x4 MU-MIMO
- IoT Wireless 2.4GHz (QCA6006): currently unusable
- Ethernet (AR8327): 3 LAN × 1GbE, 1 WAN × 1GbE
- LEDs: Internet (blue/orange), System (blue/orange)
- Buttons: Reset
- UART: through-hole on PCB (\[VCC 3.3v\](RX)(GND)(TX) 115200, 8n1)
- Power: 12VDC, 1,5A

## MAC addresses map (like in OEM firmware)
Source | Address | Use
-|-|-
art@0x0 | 88:C3:97:*:57 | wan/label
art@0x1002 | 88:C3:97:*:2D | lan/wlan2g
art@0x5006 | 88:C3:97:*:2C | wlan5g

## Obtain SSH Access
1. Flash the firmware version 1.3.8 (China)
2. Login to the router web interface and get the value of `stok=` from the URL
3. Open a new tab and go to the following URL (replace <STOK> with the stok value gained above):
```
http://192.168.31.1/cgi-bin/luci/;stok=<STOK>/api/misystem/set_config_iotdev?bssid=any&user_id=any&ssid=-h%0Anvram%20set%20ssh_en%3D1%0Anvram%20commit%0Ased%20-i%20%27s%2Fchannel%3D.%2A%2Fchannel%3D%5C%5C%22debug%5C%5C%22%2Fg%27%20%2Fetc%2Finit.d%2Fdropbear%0A%2Fetc%2Finit.d%2Fdropbear%20start%0A
```
4. Wait 30-60 seconds (this is the time required to generate keys for the SSH server on the router)

## Create Full Backup
1. Obtain SSH Access
2. Create backup of all flash (on router):
```
dd if=/dev/mtd0 of=/tmp/ALL.backup
```
3. Copy backup to PC (on PC):
```
scp root@192.168.31.1:/tmp/ALL.backup ./
```
Tip: backup of the original firmware, taken three times, increases the chances of recovery :)

## Calculate The Password
- Locally using shell (replace "12345/E0QM98765" with your router's serial number):
 
On Linux
```
printf "%s6d2df50a-250f-4a30-a5e6-d44fb0960aa0" "12345/E0QM98765" | md5sum - | head -c8 && echo
```
On macOS
```
printf "%s6d2df50a-250f-4a30-a5e6-d44fb0960aa0" "12345/E0QM98765" | md5 | head -c8
```
- Locally using python [script](https://github.com/eisaev/ax3600-files/blob/master/scripts/calc_passwd.py) (replace "12345/E0QM98765" with your router's serial number):
```
python3.7 -c 'from calc_passwd import calc_passwd; print(calc_passwd("12345/E0QM98765"))'
```
- [Online](https://www.oxygen7.cn/miwifi/)

## Debricking (lite)
If you have a healthy bootloader, you can use recovery via TFTP using programs like TinyPXE on Windows or dnsmasq on Linux. To switch the router to TFTP recovery mode, hold down the reset button, connect the power supply, and release the button after about 10 seconds. The router must be connected directly to the PC via the LAN port.

## Debricking
You will need a full dump of your flash, a CH341 programmer, and a clip for in-circuit programming.

## Install OpenWRT
1. Obtain SSH Access.
2. Create script (on router):
```
echo '#!/bin/sh' > /tmp/flash_fw.sh
echo >> /tmp/flash_fw.sh
echo '. /bin/boardupgrade.sh' >> /tmp/flash_fw.sh
echo >> /tmp/flash_fw.sh
echo 'board_prepare_upgrade' >> /tmp/flash_fw.sh
echo 'mtd erase rootfs_data' >> /tmp/flash_fw.sh
echo 'mtd write /tmp/openwrt.bin firmware' >> /tmp/flash_fw.sh
echo 'sleep 3' >> /tmp/flash_fw.sh
echo 'reboot' >> /tmp/flash_fw.sh
echo >> /tmp/flash_fw.sh
chmod +x /tmp/flash_fw.sh
```
3. Copy `openwrt-ath79-generic-xiaomi_aiot-ac2350-squashfs-sysupgrade.bin`
to the router (on PC):
```
scp openwrt-ath79-generic-xiaomi_aiot-ac2350-squashfs-sysupgrade.bin root@192.168.31.1:/tmp/openwrt.bin
```
4. Flash OpenWRT (on router):
```
/bin/ash /tmp/flash_fw.sh &
```
5. SSH connection will be interrupted - this is normal.
6. Wait for the indicator to turn blue.

Signed-off-by: Evgeniy Isaev \<isaev.evgeniy@gmail.com\>