### PR TITLE
bcm63xx: remove USB status red and green LEDs in 01_leds

### DIFF
--- a/target/linux/bcm63xx/base-files/etc/board.d/01_leds
+++ b/target/linux/bcm63xx/base-files/etc/board.d/01_leds
@@ -27,10 +27,9 @@ adb,a4001n1)
 	ucidef_set_led_usbdev "usb" "USB" "green:3g" "1-1"
 	;;
 adb,pdg-a4001n-a-000-1a1-ax|\
+technicolor,tg582n|\
 technicolor,tg582n-telecom-italia)
 	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
-	ucidef_set_led_usbdev "usb1" "USB1" "green:service" "1-1"
-	ucidef_set_led_usbdev "usb2" "USB2" "red:service" "2-1"
 	;;
 adb,av4202n)
 	ucidef_set_led_netdev "wlan0" "WLAN" "blue:wifi" "wlan0"
@@ -91,10 +90,6 @@ sercomm,ad1018-nor)
 sercomm,h500-s-lowi|\
 sercomm,h500-s-vfes)
 	ucidef_set_led_netdev "wan" "WAN" "green:internet" "eth0.2"
-	;;
-technicolor,tg582n)
-	ucidef_set_led_netdev "wlan0" "WIFI" "green:wifi" "wlan0"
-	ucidef_set_led_usbdev "usb" "USB" "red:power" "1-1"
 	;;
 telsey,cpva502plus)
 	ucidef_set_led_netdev "lan" "LAN" "amber:link" "eth0"


### PR DESCRIPTION
Remove the USB status red and green LEDs for
- ADB P.DG A4001N A-000-1A1-AX
- Technicolor TG582N
- Technicolor TG582N Telecom Italia

After having mounted an SMD socket for the flash memory for
JTAG reverse engineering, and so be able to easly swap between
OpenWrt and the stock FW, it turned out that the stock FW does
not light up the red and green USB LEDs exactly as I remembered.

Signed-off-by: Daniele Castro <danielecastro@hotmail.it>