### PR TITLE
ipq806x: fix warning about tsens debugfs already registered

### DIFF
--- a/target/linux/ipq806x/patches-5.10/107-1-thermal-qcom-tsens-init-debugfs-only-with-successful.patch
+++ b/target/linux/ipq806x/patches-5.10/107-1-thermal-qcom-tsens-init-debugfs-only-with-successful.patch
@@ -1,0 +1,46 @@
+From 8f32d48a309246a80bdca505968085a484d54408 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 19 Apr 2021 03:01:53 +0200
+Subject: [thermal-next PATCH v2 1/2] thermal: qcom: tsens: init debugfs only with
+ successful probe
+
+calibrate and tsens_register can fail or PROBE_DEFER. This will cause a
+double or a wrong init of the debugfs information. Init debugfs only
+with successful probe fixing warning about directory already present.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Acked-by: Thara Gopinath <thara.gopinath@linaro.org>
+---
+ drivers/thermal/qcom/tsens.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/thermal/qcom/tsens.c b/drivers/thermal/qcom/tsens.c
+index 4c7ebd1d3..f9d50a67e 100644
+--- a/drivers/thermal/qcom/tsens.c
++++ b/drivers/thermal/qcom/tsens.c
+@@ -918,8 +918,6 @@ int __init init_common(struct tsens_priv *priv)
+ 	if (tsens_version(priv) >= VER_0_1)
+ 		tsens_enable_irq(priv);
+ 
+-	tsens_debug_init(op);
+-
+ err_put_device:
+ 	put_device(&op->dev);
+ 	return ret;
+@@ -1158,7 +1156,12 @@ static int tsens_probe(struct platform_device *pdev)
+ 		}
+ 	}
+ 
+-	return tsens_register(priv);
++	ret = tsens_register(priv);
++
++	if (!ret)
++		tsens_debug_init(pdev);
++
++	return ret;
+ }
+ 
+ static int tsens_remove(struct platform_device *pdev)
+-- 
+2.30.2
+

--- a/target/linux/ipq806x/patches-5.10/107-2-thermal-qcom-tsens-simplify-debugfs-init-function.patch
+++ b/target/linux/ipq806x/patches-5.10/107-2-thermal-qcom-tsens-simplify-debugfs-init-function.patch
@@ -1,0 +1,59 @@
+From 4204f22060f7a5d42c6ccb4d4c25a6a875571099 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 19 Apr 2021 03:08:37 +0200
+Subject: [thermal-next PATCH v2 2/2] thermal: qcom: tsens: simplify debugfs init
+ function
+
+Simplify debugfs init function.
+- Add check for existing dev directory.
+- Fix wrong version in dbg_version_show (with version 0.0.0, 0.1.0 was
+  incorrectly reported)
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Thara Gopinath <thara.gopinath@linaro.org>
+---
+ drivers/thermal/qcom/tsens.c | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/thermal/qcom/tsens.c b/drivers/thermal/qcom/tsens.c
+index f9d50a67e..b086d1496 100644
+--- a/drivers/thermal/qcom/tsens.c
++++ b/drivers/thermal/qcom/tsens.c
+@@ -692,7 +692,7 @@ static int dbg_version_show(struct seq_file *s, void *data)
+ 			return ret;
+ 		seq_printf(s, "%d.%d.%d\n", maj_ver, min_ver, step_ver);
+ 	} else {
+-		seq_puts(s, "0.1.0\n");
++		seq_printf(s, "0.%d.0\n", priv->feat->ver_major);
+ 	}
+ 
+ 	return 0;
+@@ -704,21 +704,17 @@ DEFINE_SHOW_ATTRIBUTE(dbg_sensors);
+ static void tsens_debug_init(struct platform_device *pdev)
+ {
+ 	struct tsens_priv *priv = platform_get_drvdata(pdev);
+-	struct dentry *root, *file;
+ 
+-	root = debugfs_lookup("tsens", NULL);
+-	if (!root)
++	priv->debug_root = debugfs_lookup("tsens", NULL);
++	if (!priv->debug_root)
+ 		priv->debug_root = debugfs_create_dir("tsens", NULL);
+-	else
+-		priv->debug_root = root;
+ 
+-	file = debugfs_lookup("version", priv->debug_root);
+-	if (!file)
++	if (!debugfs_lookup("version", priv->debug_root))
+ 		debugfs_create_file("version", 0444, priv->debug_root,
+ 				    pdev, &dbg_version_fops);
+ 
+ 	/* A directory for each instance of the TSENS IP */
+-	priv->debug = debugfs_create_dir(dev_name(&pdev->dev), priv->debug_root);
++	priv->debug = debugfs_lookup(dev_name(&pdev->dev), priv->debug_root);
+ 	debugfs_create_file("sensors", 0444, priv->debug, pdev, &dbg_sensors_fops);
+ }
+ #else
+-- 
+2.30.2
+


### PR DESCRIPTION
Backport a pending patch already reviewed that fix some warning about tsens debugs already registered.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

@ynezz and also this
