### PR TITLE
busybox: show reproducible timestamp

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -84,10 +84,6 @@ endef
 Package/busybox-selinux/conffiles = $(Package/busybox/conffiles)
 endif
 
-# don't create a version string containing the actual timestamp
-export KCONFIG_NOTIMESTAMP=1
-
-
 ifndef CONFIG_USE_MUSL
 LDLIBS:=m crypt
 endif

--- a/package/utils/busybox/patches/530-use-SOURCE_DATE_EPOCH-for-timestamp-if-available.patch
+++ b/package/utils/busybox/patches/530-use-SOURCE_DATE_EPOCH-for-timestamp-if-available.patch
@@ -1,0 +1,80 @@
+From 59f773ee81a8945321f4aa20abc5e9577e6483e4 Mon Sep 17 00:00:00 2001
+From: Paul Spooren <mail@aparcar.org>
+Date: Thu, 13 May 2021 11:25:34 +0200
+Subject: [PATCH] use SOURCE_DATE_EPOCH for timestamp if available
+
+The SOURCE_DATE_EPOCH is an effort of the Reproducible Builds
+organization to make timestamps/build dates in compiled tools
+deterministic over several repetitive builds.
+
+Busybox shows by default the build date timestamp which changes whenever
+compiled. To have a reasonable accurate build date while staying
+reproducible, it's possible to use the *date of last source
+modification* rather than the current time and date.
+
+Further information on SOURCE_DATE_EPOCH are available online [1].
+
+This patch modifies `confdata.c` so that the content of the
+SOURCE_DATE_EPOCH env variable is used as timestamp.
+
+To be independent of different timezones between builds, whenever
+SOURCE_DATE_EPOCH is defined the GMT time is used.
+
+[1]: https://reproducible-builds.org/docs/source-date-epoch/
+
+Signed-off-by: Paul Spooren <mail@aparcar.org>
+---
+ scripts/kconfig/confdata.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/kconfig/confdata.c b/scripts/kconfig/confdata.c
+index b05b96e45..73c25e3a8 100644
+--- a/scripts/kconfig/confdata.c
++++ b/scripts/kconfig/confdata.c
+@@ -342,6 +342,8 @@ int conf_write(const char *name)
+ 	time_t now;
+ 	int use_timestamp = 1;
+ 	char *env;
++	char *source_date_epoch;
++	struct tm *build_time;
+ 
+ 	dirname[0] = 0;
+ 	if (name && name[0]) {
+@@ -378,7 +380,16 @@ int conf_write(const char *name)
+ 	}
+ 	sym = sym_lookup("KERNELVERSION", 0);
+ 	sym_calc_value(sym);
+-	time(&now);
++
++	source_date_epoch = getenv("SOURCE_DATE_EPOCH");
++	if (source_date_epoch && *source_date_epoch) {
++		now = strtoull(source_date_epoch, NULL, 10);
++		build_time = gmtime(&now);
++	} else {
++		time(&now);
++		build_time = localtime(&now);
++	}
++
+ 	env = getenv("KCONFIG_NOTIMESTAMP");
+ 	if (env && *env)
+ 		use_timestamp = 0;
+@@ -398,14 +409,14 @@ int conf_write(const char *name)
+ 		if (use_timestamp) {
+ 			size_t ret = \
+ 				strftime(buf, sizeof(buf), "#define AUTOCONF_TIMESTAMP "
+-					"\"%Y-%m-%d %H:%M:%S %Z\"\n", localtime(&now));
++					"\"%Y-%m-%d %H:%M:%S %Z\"\n", build_time);
+ 			/* if user has Factory timezone or some other odd install, the
+ 			 * %Z above will overflow the string leaving us with undefined
+ 			 * results ... so let's try again without the timezone.
+ 			 */
+ 			if (ret == 0)
+ 				strftime(buf, sizeof(buf), "#define AUTOCONF_TIMESTAMP "
+-					"\"%Y-%m-%d %H:%M:%S\"\n", localtime(&now));
++					"\"%Y-%m-%d %H:%M:%S\"\n", build_time);
+ 		} else { /* bbox */
+ 			strcpy(buf, "#define AUTOCONF_TIMESTAMP \"\"\n");
+ 		}
+-- 
+2.30.2
+


### PR DESCRIPTION
On login busybox shows a timestamp per default contianing the build
date. Since the build date isn't reproducible per default this behaviour
was disabled by default via 34df4d40 "busybox: disable timestamp in
version".

This commit modifies busybox so that the printed timestamp reproducible
using SOURCE_DATE_EPOCH and therefore shouldn't be disabled anymore.

Before:

    BusyBox v1.33.1 () built-in shell (ash)

After:

    BusyBox v1.33.1 (2021-05-13 09:34:34 UTC) built-in shell (ash)

Signed-off-by: Paul Spooren <mail@aparcar.org>