### PR TITLE
rockchip: add support for NanoPi  M4

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,26 @@ endef
 
 # RK3399 boards
 
+define U-Boot/nanopi-m4-2gb-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi M4 2GB
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-m4-2gb
+  DEPENDS:=+PACKAGE_u-boot-nanopi-m4-2gb-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
+define U-Boot/nanopi-m4-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi M4
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-m4
+  DEPENDS:=+PACKAGE_u-boot-nanopi-m4-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/nanopi-r4s-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=NanoPi R4S
@@ -69,6 +89,8 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopi-m4-2gb-rk3399 \
+  nanopi-m4-rk3399 \
   nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \

--- a/package/firmware/linux-firmware/broadcom.mk
+++ b/package/firmware/linux-firmware/broadcom.mk
@@ -79,6 +79,35 @@ define Package/brcmfmac-firmware-43455-sdio-rpi-4b/install
 endef
 $(eval $(call BuildPackage,brcmfmac-firmware-43455-sdio-rpi-4b))
 
+Package/brcmfmac-firmware-4356-sdio = $(call Package/firmware-default,Broadcom BCM4356 FullMac SDIO firmware)
+define Package/brcmfmac-firmware-4356-sdio/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/cypress/cyfmac4356-sdio.bin \
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.bin
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/cypress/cyfmac4356-sdio.clm_blob \
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.clm_blob
+endef
+$(eval $(call BuildPackage,brcmfmac-firmware-4356-sdio))
+
+Package/brcmfmac-firmware-4356-sdio-nanopi-m4 = $(call Package/firmware-default,Broadcom BCM4356 NVRAM for NanoPi M4)
+define Package/brcmfmac-firmware-4356-sdio-nanopi-m4/install
+	$(INSTALL_DIR) $(1)/lib/firmware/brcm
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcm/brcmfmac4356-pcie.gpd-win-pocket.txt \
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
+	$(SED) 's/boardrev=.*/boardrev=0x1102/g'\
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
+	$(SED) 's/ccode=.*/ccode=0x5854/g'\
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
+	$(SED) 's/regrev=.*/regrev=205/g'\
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
+	$(SED) 's/devid=.*/devid=0x43ec/g'\
+		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
+endef
+$(eval $(call BuildPackage,brcmfmac-firmware-4356-sdio-nanopi-m4))
+
 Package/brcmfmac-firmware-usb = $(call Package/firmware-default,Broadcom BCM43xx fullmac USB firmware)
 define Package/brcmfmac-firmware-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm

--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -450,6 +450,7 @@ define KernelPackage/brcmfmac/config
 	config BRCMFMAC_SDIO
 		bool "Enable SDIO bus interface support"
 		default y if TARGET_bcm27xx
+		default y if TARGET_rockchip
 		default y if TARGET_sunxi
 		default n
 		help

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -2,6 +2,36 @@
 #
 # Copyright (C) 2020 Tobias Maedel
 
+define Device/friendlyarm_nanopi-m4-2gb
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi M4 2GB
+  DEVICE_VARIANT := DDR3
+  DEVICE_DTS := rockchip/rk3399-nanopi-m4
+  SOC := rk3399
+  SUPPORTED_DEVICES :=friendlyarm,nanopi-m4
+  UBOOT_DEVICE_NAME := nanopi-m4-2gb-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := \
+	brcmfmac-firmware-4356-sdio \
+	brcmfmac-firmware-4356-sdio-nanopi-m4 \
+	kmod-bluetooth kmod-brcmfmac wpad-basic-wolfssl
+endef
+TARGET_DEVICES += friendlyarm_nanopi-m4-2gb
+
+define Device/friendlyarm_nanopi-m4
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi M4
+  DEVICE_VARIANT := 4GB LPDDR3
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := nanopi-m4-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := \
+	brcmfmac-firmware-4356-sdio \
+	brcmfmac-firmware-4356-sdio-nanopi-m4 \
+	kmod-bluetooth kmod-brcmfmac wpad-basic-wolfssl
+endef
+TARGET_DEVICES += friendlyarm_nanopi-m4
+
 define Device/friendlyarm_nanopi-r2s
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2S


### PR DESCRIPTION
Specification:

 - SoC: Rockchip RK3399
 - CPU: Dual-Core Cortex-A72(up to 2.0GHz) + Quad-Core Cortex-A53(up to 1.5GHz)
 - GPU: Mali-T864 GPU
 - RAM: Dual-Channel 4GB LPDDR3-1866, or Dual-Channel 2GB DDR3-1866
 - Ethernet: Native Gigabit Ethernet
 - Wi-Fi/BT: 802.11a/b/g/n/ac, Bluetooth 4.1
 - HDMI: HDMI 2.0a
 - USB 3.0: four USB 3.0 Type-A ports
 - USB Type-C: Supports USB2.0 OTG and Power input
 - microSD Slot x 1
 - 40Pin GPIO Extension ports:
 - 3 X 3V/1.8V I2C, up to 1 x 3V UART, 1 X 3V SPI, 1 x SPDIF_TX, up to 8 x 3V GPIOs
 - 1 x 1.8V 8 channels I2S
 - 24Pin Extension ports:
 - 2 independent native USB 2.0 Host
 - PCIe x2
 - PWM x1, PowerKeyps
 - LED: 1 x power LED and 1 x GPIO Controlled LED
 - RTC Battery: 2 Pin 1.27/1.25mm RTC battery input connector
 - Power supply: DC 5V/3A

Installation:

 - gunzip sysupgrade image , write to SD Card with dd
 
OpenWrt Kernel log:
```
U-Boot TPL 2021.04 (May 25 2021 - 05:27:04)

Channel 0: DDR3, 933MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS=1 Die BW=16 Size=1024MB
Channel 1: DDR3, 933MHz
BW=32 Col=10 Bk=8 CS0 Row=15 CS=1 Die BW=16 Size=1024MB
256B stride
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2021.04 (May 25 2021 - 05:27:04 +0000)
Trying to boot from MMC2


U-Boot 2021.04 (May 25 2021 - 05:27:04 +0000) OpenWrt

SoC: Rockchip rk3399
Reset cause: RST
Model: FriendlyElec NanoPi M4
DRAM:  2 GiB
PMIC:  RK808 
MMC:   mmc@fe310000: 2, mmc@fe320000: 1, sdhci@fe330000: 0
Loading Environment from MMC... *** Warning - bad CRC, using default environment

In:    serial
Out:   serial
Err:   serial
Model: FriendlyElec NanoPi M4
Net:   
Error: ethernet@fe300000 address not set.
No ethernet found.

Hit any key to stop autoboot:  0 
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
365 bytes read in 8 ms (43.9 KiB/s)
## Executing script at 00500000
55821 bytes read in 17 ms (3.1 MiB/s)
15136776 bytes read in 1443 ms (10 MiB/s)
Moving Image from 0x2080000 to 0x2200000, end=3130000
## Flattened Device Tree blob at 01f00000
   Booting using the fdt blob at 0x1f00000
   Loading Device Tree to 0000000079f24000, end 0000000079f34a0c ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.10.42 (builder@buildhost) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 8.4.0 r16925+3-b721579842) 8.4.0, GNU ld (GNU Binutils) 2.34) #0 SMP PREEMPT Thu Jun 10 13:11:02 2021
[    0.000000] Machine model: FriendlyElec NanoPi M4
[    0.000000] earlycon: uart8250 at MMIO32 0x00000000ff1a0000 (options '')
[    0.000000] printk: bootconsole [uart8250] enabled
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000] cma: Reserved 8 MiB at 0x000000007f000000
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 21 pages/cpu s46040 r8192 d31784 u86016
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 515592
[    0.000000] Kernel command line: console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=5452574f-02 rw rootwait
[    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
[    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 2030528K/2095104K available (8254K kernel code, 2366K rwdata, 2368K rodata, 1728K init, 729K bss, 56384K reserved, 8192K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=6, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu:     RCU event tracing is enabled.
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=6.
[    0.000000]  Trampoline variant of Tasks RCU enabled.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=6
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 256 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x00000000fef00000
[    0.000000] ITS [mem 0xfee20000-0xfee3ffff]
[    0.000000] ITS@0x00000000fee20000: allocated 65536 Devices @480000 (flat, esz 8, psz 64K, shr 0)
[    0.000000] ITS: using cache flushing for cmd queue
[    0.000000] GICv3: using LPI property table @0x0000000000440000
[    0.000000] GIC: using cache flushing for LPI property table
[    0.000000] GICv3: CPU0: using allocated LPI pending table @0x0000000000450000
[    0.000000] GICv3: GIC: PPI partition interrupt-partition-0[0] { /cpus/cpu@0[0] /cpus/cpu@1[1] /cpus/cpu@2[2] /cpus/cpu@3[3] }
[    0.000000] GICv3: GIC: PPI partition interrupt-partition-1[1] { /cpus/cpu@100[4] /cpus/cpu@101[5] }
[    0.000000] random: get_random_bytes called from start_kernel+0x294/0x3d0 with crng_init=0
[    0.000000] arch_timer: cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000007] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.001777] Console: colour dummy device 80x25
[    0.002211] printk: console [tty1] enabled
[    0.002619] printk: bootconsole [uart8250] disabled
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.10.42 (builder@buildhost) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 8.4.0 r16925+3-b721579842) 8.4.0, GNU ld (GNU Binutils) 2.34) #0 SMP PREEMPT Thu Jun 10 13:11:02 2021
[    0.000000] Machine model: FriendlyElec NanoPi M4
[    0.000000] earlycon: uart8250 at MMIO32 0x00000000ff1a0000 (options '')
[    0.000000] printk: bootconsole [uart8250] enabled
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000200000-0x000000007fffffff]
[    0.000000] cma: Reserved 8 MiB at 0x000000007f000000
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 21 pages/cpu s46040 r8192 d31784 u86016
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 515592
[    0.000000] Kernel command line: console=ttyS2,1500000 console=tty1 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=5452574f-02 rw rootwait
[    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
[    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 2030528K/2095104K available (8254K kernel code, 2366K rwdata, 2368K rodata, 1728K init, 729K bss, 56384K reserved, 8192K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=6, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu:     RCU event tracing is enabled.
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=6.
[    0.000000]  Trampoline variant of Tasks RCU enabled.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=6
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 256 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x00000000fef00000
[    0.000000] ITS [mem 0xfee20000-0xfee3ffff]
[    0.000000] ITS@0x00000000fee20000: allocated 65536 Devices @480000 (flat, esz 8, psz 64K, shr 0)
[    0.000000] ITS: using cache flushing for cmd queue
[    0.000000] GICv3: using LPI property table @0x0000000000440000
[    0.000000] GIC: using cache flushing for LPI property table
[    0.000000] GICv3: CPU0: using allocated LPI pending table @0x0000000000450000
[    0.000000] GICv3: GIC: PPI partition interrupt-partition-0[0] { /cpus/cpu@0[0] /cpus/cpu@1[1] /cpus/cpu@2[2] /cpus/cpu@3[3] }
[    0.000000] GICv3: GIC: PPI partition interrupt-partition-1[1] { /cpus/cpu@100[4] /cpus/cpu@101[5] }
[    0.000000] random: get_random_bytes called from start_kernel+0x294/0x3d0 with crng_init=0
[    0.000000] arch_timer: cp15 timer(s) running at 24.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000007] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.001777] Console: colour dummy device 80x25
[    0.002211] printk: console [tty1] enabled
[    0.002619] printk: bootconsole [uart8250] disabled
[    0.003142] Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=240000)
[    0.003190] pid_max: default: 32768 minimum: 301
[    0.003425] Mount-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.003466] Mountpoint-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.005735] rcu: Hierarchical SRCU implementation.
[    0.005954] dyndbg: Ignore empty _ddebug table in a CONFIG_DYNAMIC_DEBUG_CORE build
[    0.006103] Platform MSI: interrupt-controller@fee20000 domain created
[    0.006481] PCI/MSI: /interrupt-controller@fee00000/interrupt-controller@fee20000 domain created
[    0.007062] smp: Bringing up secondary CPUs ...
[    0.007725] Detected VIPT I-cache on CPU1
[    0.007767] GICv3: CPU1: found redistributor 1 region 0:0x00000000fef20000
[    0.007784] GICv3: CPU1: using allocated LPI pending table @0x0000000000460000
[    0.007845] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.008525] Detected VIPT I-cache on CPU2
[    0.008558] GICv3: CPU2: found redistributor 2 region 0:0x00000000fef40000
[    0.008573] GICv3: CPU2: using allocated LPI pending table @0x0000000000470000
[    0.008614] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[    0.009242] Detected VIPT I-cache on CPU3
[    0.009274] GICv3: CPU3: found redistributor 3 region 0:0x00000000fef60000
[    0.009288] GICv3: CPU3: using allocated LPI pending table @0x0000000000500000
[    0.009328] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[    0.009962] CPU features: detected: EL2 vector hardening
[    0.009976] CPU features: detected: Spectre-v2
[    0.009989] Detected PIPT I-cache on CPU4
[    0.010025] GICv3: CPU4: found redistributor 100 region 0:0x00000000fef80000
[    0.010040] GICv3: CPU4: using allocated LPI pending table @0x0000000000510000
[    0.010083] CPU4: Booted secondary processor 0x0000000100 [0x410fd082]
[    0.010744] Detected PIPT I-cache on CPU5
[    0.010774] GICv3: CPU5: found redistributor 101 region 0:0x00000000fefa0000
[    0.010787] GICv3: CPU5: using allocated LPI pending table @0x0000000000520000
[    0.010821] CPU5: Booted secondary processor 0x0000000101 [0x410fd082]
[    0.010939] smp: Brought up 1 node, 6 CPUs
[    0.011403] SMP: Total of 6 processors activated.
[    0.011429] CPU features: detected: 32-bit EL0 Support
[    0.011454] CPU features: detected: CRC32 instructions
[    0.012008] CPU: All CPU(s) started at EL2
[    0.012071] alternatives: patching kernel code
[    0.025745] KASLR disabled due to lack of seed
[    0.025892] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.025925] futex hash table entries: 2048 (order: 5, 131072 bytes, linear)
[    0.026262] pinctrl core: initialized pinctrl subsystem
[    0.027207] NET: Registered protocol family 16
[    0.029735] DMA: preallocated 256 KiB GFP_KERNEL pool for atomic allocations
[    0.029912] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.030166] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.031109] thermal_sys: Registered thermal governor 'step_wise'
[    0.031116] thermal_sys: Registered thermal governor 'power_allocator'
[    0.031492] cpuidle: using governor menu
[    0.031627] ASID allocator initialised with 65536 entries
[    0.031727] Serial: AMBA PL011 UART driver
[    0.076200] HugeTLB registered 1.00 GiB page size, pre-allocated 0 pages
[    0.076230] HugeTLB registered 32.0 MiB page size, pre-allocated 0 pages
[    0.076248] HugeTLB registered 2.00 MiB page size, pre-allocated 0 pages
[    0.076265] HugeTLB registered 64.0 KiB page size, pre-allocated 0 pages
[    0.081410] vcc5v0_sys: supplied by vdd_5v
[    0.081521] vbus_typec: supplied by vdd_5v
[    0.081592] vcc5v0_core: supplied by vdd_5v
[    0.081886] vcc3v3_sys: supplied by vcc5v0_core
[    0.081953] vcc3v0_sd: supplied by vcc3v3_sys
[    0.082036] vcc5v0_usb1: supplied by vcc5v0_sys
[    0.082379] vcc5v0_usb2: supplied by vcc5v0_sys
[    0.082730] iommu: Default domain type: Translated 
[    0.084923] SCSI subsystem initialized
[    0.085105] usbcore: registered new interface driver usbfs
[    0.085153] usbcore: registered new interface driver hub
[    0.085202] usbcore: registered new device driver usb
[    0.086481] clocksource: Switched to clocksource arch_sys_counter
[    0.086680] VFS: Disk quotas dquot_6.6.0
[    0.086751] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    0.090097] NET: Registered protocol family 2
[    0.090330] IP idents hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.093334] tcp_listen_portaddr_hash hash table entries: 1024 (order: 2, 16384 bytes, linear)
[    0.093443] TCP established hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.093643] TCP bind hash table entries: 16384 (order: 6, 262144 bytes, linear)
[    0.093991] TCP: Hash tables configured (established 16384 bind 16384)
[    0.094126] UDP hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.094210] UDP-Lite hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.094666] NET: Registered protocol family 1
[    0.094706] PCI: CLS 0 bytes, default 64
[    0.096067] workingset: timestamp_bits=46 max_order=19 bucket_order=0
[    0.101963] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.101985] jffs2: version 2.2 (NAND) (SUMMARY) (ZLIB) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.103236] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 252)
[    0.103401] io scheduler mq-deadline registered
[    0.111434] rockchip-pcie f8000000.pcie: host bridge /pcie@f8000000 ranges:
[    0.111488] rockchip-pcie f8000000.pcie:      MEM 0x00fa000000..0x00fbdfffff -> 0x00fa000000
[    0.111518] rockchip-pcie f8000000.pcie:       IO 0x00fbe00000..0x00fbefffff -> 0x00fbe00000
[    0.112152] rockchip-pcie f8000000.pcie: no vpcie12v regulator found
[    0.112186] rockchip-pcie f8000000.pcie: no vpcie3v3 regulator found
[    0.114455] dma-pl330 ff6d0000.dma-controller: Loaded driver for PL330 DMAC-241330
[    0.114482] dma-pl330 ff6d0000.dma-controller:       DBUFF-32x8bytes Num_Chans-6 Num_Peri-12 Num_Events-12
[    0.115563] dma-pl330 ff6e0000.dma-controller: Loaded driver for PL330 DMAC-241330
[    0.115588] dma-pl330 ff6e0000.dma-controller:       DBUFF-128x8bytes Num_Chans-8 Num_Peri-20 Num_Events-16
[    0.117933] Serial: 8250/16550 driver, 16 ports, IRQ sharing enabled
[    0.120648] ff180000.serial: ttyS0 at MMIO 0xff180000 (irq = 47, base_baud = 1500000) is a 16550A
[    0.120795] serial serial0: tty port ttyS0 registered
[    0.121393] ff1a0000.serial: ttyS2 at MMIO 0xff1a0000 (irq = 48, base_baud = 1500000) is a 16550A
[    0.206267] printk: console [ttyS2] enabled
[    0.208320] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.213214] loop: module loaded
[    0.213511] mtip32xx Version 1.3.1
[    0.213922] Loading iSCSI transport class v2.0-870.
[    0.216577] libphy: Fixed MDIO Bus: probed
[    0.218302] rk_gmac-dwmac fe300000.ethernet: IRQ eth_wake_irq not found
[    0.218900] rk_gmac-dwmac fe300000.ethernet: IRQ eth_lpi not found
[    0.219555] rk_gmac-dwmac fe300000.ethernet: PTP uses main clock
[    0.220126] rk_gmac-dwmac fe300000.ethernet: phy regulator is not available yet, deferred probing
[    0.223869] dwc3 fe800000.usb: Configuration mismatch. dr_mode forced to host
[    0.239464] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[    0.240054] ehci-pci: EHCI PCI platform driver
[    0.240492] ehci-platform: EHCI generic platform driver
[    0.243234] ehci-platform fe380000.usb: EHCI Host Controller
[    0.243761] ehci-platform fe380000.usb: new USB bus registered, assigned bus number 1
[    0.244555] ehci-platform fe380000.usb: irq 39, io mem 0xfe380000
[    0.266482] ehci-platform fe380000.usb: USB 2.0 started, EHCI 1.00
[    0.267459] hub 1-0:1.0: USB hub found
[    0.267829] hub 1-0:1.0: 1 port detected
[    0.270784] ehci-platform fe3c0000.usb: EHCI Host Controller
[    0.271307] ehci-platform fe3c0000.usb: new USB bus registered, assigned bus number 2
[    0.272099] ehci-platform fe3c0000.usb: irq 41, io mem 0xfe3c0000
[    0.296484] ehci-platform fe3c0000.usb: USB 2.0 started, EHCI 1.00
[    0.297428] hub 2-0:1.0: USB hub found
[    0.297797] hub 2-0:1.0: 1 port detected
[    0.298725] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[    0.299295] ohci-platform: OHCI generic platform driver
[    0.299983] ohci-platform fe3a0000.usb: Generic Platform OHCI controller
[    0.300595] ohci-platform fe3a0000.usb: new USB bus registered, assigned bus number 3
[    0.301375] ohci-platform fe3a0000.usb: irq 40, io mem 0xfe3a0000
[    0.370879] hub 3-0:1.0: USB hub found
[    0.371248] hub 3-0:1.0: 1 port detected
[    0.372140] ohci-platform fe3e0000.usb: Generic Platform OHCI controller
[    0.372753] ohci-platform fe3e0000.usb: new USB bus registered, assigned bus number 4
[    0.373539] ohci-platform fe3e0000.usb: irq 42, io mem 0xfe3e0000
[    0.440884] hub 4-0:1.0: USB hub found
[    0.441254] hub 4-0:1.0: 1 port detected
[    0.442720] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
[    0.443233] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 5
[    0.444043] xhci-hcd xhci-hcd.0.auto: hcc params 0x0220fe64 hci version 0x110 quirks 0x0000000002010010
[    0.444925] xhci-hcd xhci-hcd.0.auto: irq 76, io mem 0xfe800000
[    0.446013] hub 5-0:1.0: USB hub found
[    0.446382] hub 5-0:1.0: 1 port detected
[    0.447043] xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
[    0.447546] xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 6
[    0.448234] xhci-hcd xhci-hcd.0.auto: Host supports USB 3.0 SuperSpeed
[    0.448869] usb usb6: We don't know the algorithms for LPM for this host, disabling LPM.
[    0.449957] hub 6-0:1.0: USB hub found
[    0.450330] hub 6-0:1.0: 1 port detected
[    0.451079] xhci-hcd xhci-hcd.1.auto: xHCI Host Controller
[    0.451585] xhci-hcd xhci-hcd.1.auto: new USB bus registered, assigned bus number 7
[    0.452392] xhci-hcd xhci-hcd.1.auto: hcc params 0x0220fe64 hci version 0x110 quirks 0x0000000002010010
[    0.453264] xhci-hcd xhci-hcd.1.auto: irq 77, io mem 0xfe900000
[    0.454337] hub 7-0:1.0: USB hub found
[    0.454705] hub 7-0:1.0: 1 port detected
[    0.455305] xhci-hcd xhci-hcd.1.auto: xHCI Host Controller
[    0.455807] xhci-hcd xhci-hcd.1.auto: new USB bus registered, assigned bus number 8
[    0.456527] xhci-hcd xhci-hcd.1.auto: Host supports USB 3.0 SuperSpeed
[    0.457166] usb usb8: We don't know the algorithms for LPM for this host, disabling LPM.
[    0.458255] hub 8-0:1.0: USB hub found
[    0.458621] hub 8-0:1.0: 1 port detected
[    0.459401] usbcore: registered new interface driver usb-storage
[    0.460099] i2c /dev entries driver
[    0.463971] fan53555-regulator 0-0040: FAN53555 Option[8] Rev[1] Detected!
[    0.465480] vdd_cpu_b: supplied by vcc3v3_sys
[    0.467632] fan53555-regulator 0-0041: FAN53555 Option[8] Rev[1] Detected!
[    0.469132] vdd_gpu: supplied by vcc3v3_sys
[    0.471926] rk808 0-001b: chip id: 0x0
[    0.475702] rk808-regulator rk808-regulator: there is no dvs0 gpio
[    0.476278] rk808-regulator rk808-regulator: there is no dvs1 gpio
[    0.477650] vdd_center: supplied by vcc3v3_sys
[    0.478567] vdd_cpu_l: supplied by vcc3v3_sys
[    0.479207] vcc_ddr: supplied by vcc3v3_sys
[    0.480119] vcc_1v8: supplied by vcc3v3_sys
[    0.481678] vcc1v8_cam: supplied by vcc3v3_sys
[    0.483003] vcc3v0_touch: supplied by vcc3v3_sys
[    0.484462] vcc1v8_pmupll: supplied by vcc3v3_sys
[    0.485939] vcc_sdio: supplied by vcc3v3_sys
[    0.487252] vcca3v0_codec: supplied by vcc3v3_sys
[    0.488726] vcc_1v5: supplied by vcc3v3_sys
[    0.490021] vcca1v8_codec: supplied by vcc3v3_sys
[    0.491514] vcc_3v0: supplied by vcc3v3_sys
[    0.492135] vcc3v3_s3: supplied by vcc3v3_sys
[    0.492770] vcc3v3_s0: supplied by vcc3v3_sys
[    0.496073] rk808-rtc rk808-rtc: registered as rtc0
[    0.497072] rk808-rtc rk808-rtc: setting system clock to 2021-06-10T14:33:40 UTC (1623335620)
[    0.499707] OF: graph: no port node found in /i2c@ff3d0000/typec-portc@22
[    0.501941] random: fast init done
[    0.508174] cpu cpu0: EM: created perf domain
[    0.509965] cpu cpu4: EM: created perf domain
[    0.513337] sdhci: Secure Digital Host Controller Interface driver
[    0.513924] sdhci: Copyright(c) Pierre Ossman
[    0.514342] Synopsys Designware Multimedia Card Interface Driver
[    0.515368] sdhci-pltfm: SDHCI platform and OF driver helper
[    0.515859] dwmmc_rockchip fe310000.mmc: IDMAC supports 32-bit address mode.
[    0.515966] dwmmc_rockchip fe320000.mmc: IDMAC supports 32-bit address mode.
[    0.516589] dwmmc_rockchip fe310000.mmc: Using internal DMA controller.
[    0.517198] dwmmc_rockchip fe320000.mmc: Using internal DMA controller.
[    0.517288] mmc2: CQHCI version 5.10
[    0.517764] dwmmc_rockchip fe310000.mmc: Version ID is 270a
[    0.518345] dwmmc_rockchip fe320000.mmc: Version ID is 270a
[    0.518717] dwmmc_rockchip fe310000.mmc: DW MMC controller at irq 36,32 bit host data width,256 deep fifo
[    0.519196] dwmmc_rockchip fe320000.mmc: DW MMC controller at irq 37,32 bit host data width,256 deep fifo
[    0.519881] dwmmc_rockchip fe310000.mmc: allocated mmc-pwrseq
[    0.520887] dwmmc_rockchip fe320000.mmc: Got CD GPIO
[    0.521369] mmc_host mmc0: card is non-removable.
[    0.523043] ledtrig-cpu: registered to indicate activity on CPUs
[    0.524011] hid: raw HID events driver (C) Jiri Kosina
[    0.524551] usbcore: registered new interface driver usbhid
[    0.525045] usbhid: USB HID core driver
[    0.526425] NET: Registered protocol family 10
[    0.527339] Segment Routing with IPv6
[    0.527690] NET: Registered protocol family 17
[    0.528093] bridge: filtering via arp/ip/ip6tables is no longer available by default. Update your scripts to load br_netfilter if you need this.
[    0.529221] 8021q: 802.1Q VLAN Support v1.8
[    0.534788] mmc_host mmc1: Bus speed (slot 0) = 400000Hz (slot req 400000Hz, actual 400000HZ div = 0)
[    0.536193] mmc_host mmc0: Bus speed (slot 0) = 400000Hz (slot req 400000Hz, actual 400000HZ div = 0)
[    0.542301] rockchip-pcie f8000000.pcie: host bridge /pcie@f8000000 ranges:
[    0.542928] rockchip-pcie f8000000.pcie:      MEM 0x00fa000000..0x00fbdfffff -> 0x00fa000000
[    0.543423] mmc2: SDHCI controller on fe330000.sdhci [fe330000.sdhci] using ADMA
[    0.543669] rockchip-pcie f8000000.pcie:       IO 0x00fbe00000..0x00fbefffff -> 0x00fbe00000
[    0.545712] rockchip-pcie f8000000.pcie: no vpcie12v regulator found
[    0.546318] rockchip-pcie f8000000.pcie: no vpcie3v3 regulator found
[    0.546965] vcc1v8_s3: supplied by vcc_1v8
[    0.547939] vcca1v8_s3: supplied by vcc1v8_s3
[    0.548443] vcca0v9_s3: supplied by vcc1v8_s3
[    0.583157] mmc0: queuing unknown CIS tuple 0x80 (2 bytes)
[    0.585169] mmc0: queuing unknown CIS tuple 0x80 (3 bytes)
[    0.587379] mmc0: queuing unknown CIS tuple 0x80 (3 bytes)
[    0.591163] mmc0: queuing unknown CIS tuple 0x80 (7 bytes)
[    0.614691] mmc2: Command Queue Engine enabled
[    0.615115] mmc2: new HS200 MMC card at address 0001
[    0.616283] mmcblk2: mmc2:0001 8GTF4R 7.28 GiB 
[    0.616900] mmcblk2boot0: mmc2:0001 8GTF4R partition 1 4.00 MiB
[    0.617587] mmcblk2boot1: mmc2:0001 8GTF4R partition 2 4.00 MiB
[    0.618190] mmcblk2rpmb: mmc2:0001 8GTF4R partition 3 512 KiB, chardev (250:0)
[    0.619635]  mmcblk2: p1 p2
[    0.650717] mmc_host mmc0: Bus speed (slot 0) = 148500000Hz (slot req 150000000Hz, actual 148500000HZ div = 0)
[    0.746653] usb 7-1: new high-speed USB device number 2 using xhci-hcd
[    0.797463] dwmmc_rockchip fe310000.mmc: Successfully tuned phase to 191
[    0.800883] mmc0: new ultra high speed SDR104 SDIO card at address 0001
[    0.969681] hub 7-1:1.0: USB hub found
[    0.970182] hub 7-1:1.0: 4 ports detected
[    1.086597] rockchip-pcie f8000000.pcie: PCIe link training gen1 timeout!
[    1.087970] rockchip-pcie: probe of f8000000.pcie failed with error -110
[    1.091100] rk_gmac-dwmac fe300000.ethernet: IRQ eth_wake_irq not found
[    1.091710] rk_gmac-dwmac fe300000.ethernet: IRQ eth_lpi not found
[    1.092405] rk_gmac-dwmac fe300000.ethernet: PTP uses main clock
[    1.093145] rk_gmac-dwmac fe300000.ethernet: clock input or output? (input).
[    1.093791] rk_gmac-dwmac fe300000.ethernet: TX delay(0x28).
[    1.094311] rk_gmac-dwmac fe300000.ethernet: RX delay(0x11).
[    1.094833] rk_gmac-dwmac fe300000.ethernet: integrated PHY? (no).
[    1.095461] rk_gmac-dwmac fe300000.ethernet: cannot get clock clk_mac_speed
[    1.095571] usb 8-1: new SuperSpeed Gen 1 USB device number 2 using xhci-hcd
[    1.096101] rk_gmac-dwmac fe300000.ethernet: clock input from PHY
[    1.102388] rk_gmac-dwmac fe300000.ethernet: init for RGMII
[    1.103506] rk_gmac-dwmac fe300000.ethernet: User ID: 0x10, Synopsys ID: 0x35
[    1.104159] rk_gmac-dwmac fe300000.ethernet:         DWMAC1000
[    1.104637] rk_gmac-dwmac fe300000.ethernet: DMA HW capability register supported
[    1.105313] rk_gmac-dwmac fe300000.ethernet: RX Checksum Offload Engine supported
[    1.105990] rk_gmac-dwmac fe300000.ethernet: COE Type 2
[    1.106500] rk_gmac-dwmac fe300000.ethernet: TX Checksum insertion supported
[    1.107138] rk_gmac-dwmac fe300000.ethernet: Wake-Up On Lan supported
[    1.107721] rk_gmac-dwmac fe300000.ethernet: Normal descriptors
[    1.108256] rk_gmac-dwmac fe300000.ethernet: Ring mode enabled
[    1.108785] rk_gmac-dwmac fe300000.ethernet: Enable RX Mitigation via HW Watchdog Timer
[    1.109513] rk_gmac-dwmac fe300000.ethernet: device MAC address 12:56:66:86:13:f9
[    1.110875] libphy: stmmac: probed
[    1.194032] hub 8-1:1.0: USB hub found
[    1.194726] hub 8-1:1.0: 4 ports detected
[    1.235890] VFS: Mounted root (squashfs filesystem) readonly on device 179:2.
[    1.237231] Freeing unused kernel memory: 1728K
[    1.306985] Run /sbin/init as init process
[    1.478815] init: Console is alive
[    1.640793] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    1.648034] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    1.652600] init: - preinit -
[    1.776886] usb 8-1.3: new SuperSpeed Gen 1 USB device number 3 using xhci-hcd
[    1.819595] random: procd: uninitialized urandom read (4 bytes read)
[    1.947065] random: jshn: uninitialized urandom read (4 bytes read)
[    2.001353] random: jshn: uninitialized urandom read (4 bytes read)
[    5.223987] EXT4-fs (loop0): recovery complete
[    5.225812] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[    5.226580] ext4 filesystem being mounted at /tmp/overlay supports timestamps until 2038 (0x7fffffff)
[    5.227863] mount_root: switching to ext4 overlay
[    5.280010] EXT4-fs (mmcblk2p1): mounted filesystem without journal. Opts: (null)
[    5.286332] urandom-seed: Seeding with /etc/urandom.seed
[    5.335756] procd: - early -
[    5.902729] procd: - ubus -
[    5.954059] urandom_read: 3 callbacks suppressed
[    5.954063] random: ubusd: uninitialized urandom read (4 bytes read)
[    5.955567] random: ubusd: uninitialized urandom read (4 bytes read)
[    5.956419] random: ubusd: uninitialized urandom read (4 bytes read)
[    5.962152] procd: - init -
[    5.965069] dw-apb-uart ff1a0000.serial: forbid DMA for kernel console
Please press Enter to activate this console.
[    6.184233] kmodloader: loading kernel modules from /etc/modules.d/*
[    6.186786] urngd: v1.0.2 started.
[    6.204225] random: crng init done
[    6.204529] random: 1 urandom warning(s) missed due to ratelimiting
[    6.206092] Bluetooth: Core ver 2.22
[    6.206542] NET: Registered protocol family 31
[    6.206956] Bluetooth: HCI device and connection manager initialized
[    6.207537] Bluetooth: HCI socket layer initialized
[    6.207986] Bluetooth: L2CAP socket layer initialized
[    6.208454] Bluetooth: SCO socket layer initialized
[    6.210017] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[    6.210494] Bluetooth: BNEP filters: protocol multicast
[    6.210963] Bluetooth: BNEP socket layer initialized
[    6.213399] usbcore: registered new interface driver btusb
[    6.214169] Loading modules backported from Linux version v5.10.42-0-g65859eca4dff
[    6.214841] Backport generated by backports.git v5.10.42-1-0-gbee5c545
[    6.216368] Bluetooth: HCI UART driver ver 2.3
[    6.216813] Bluetooth: HCI UART protocol H4 registered
[    6.217283] Bluetooth: HCI UART protocol BCSP registered
[    6.217760] Bluetooth: HCI UART protocol ATH3K registered
[    6.219199] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
[    6.219740] Bluetooth: HIDP socket layer initialized
[    6.224384] Bluetooth: RFCOMM TTY layer initialized
[    6.224822] Bluetooth: RFCOMM socket layer initialized
[    6.225281] Bluetooth: RFCOMM ver 1.11
[    6.227829] xt_time: kernel timezone is -0000
[    6.250637] PPP generic driver version 2.4.2
[    6.251370] NET: Registered protocol family 24
[    6.261064] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac4356-sdio for chip BCM4356/2
[    6.409760] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac4356-sdio for chip BCM4356/2
[    6.413969] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4356/2 wl0: Jun 10 2020 01:01:28 version 7.35.349.91 (r726048 CY) FWID 01-997abfc7
[    6.435689] usbcore: registered new interface driver brcmfmac
[    6.438557] kmodloader: done loading kernel modules from /etc/modules.d/*
[    8.417793] rk_gmac-dwmac fe300000.ethernet eth0: PHY [stmmac-0:01] driver [RTL8211E Gigabit Ethernet] (irq=90)
[    8.421787] rk_gmac-dwmac fe300000.ethernet eth0: No Safety Features support found
[    8.422508] rk_gmac-dwmac fe300000.ethernet eth0: PTP not supported by HW
[    8.423809] rk_gmac-dwmac fe300000.ethernet eth0: configuring for phy/rgmii link mode
[    8.426199] br-lan: port 1(eth0) entered blocking state
[    8.427173] br-lan: port 1(eth0) entered disabled state
[    8.428035] device eth0 entered promiscuous mode
[    8.429928] br-lan: port 1(eth0) entered blocking state
[    8.430415] br-lan: port 1(eth0) entered forwarding state
[    9.446900] br-lan: port 1(eth0) entered disabled state
[   11.873775] br-lan: port 1(eth0) entered blocking state
[   11.874269] br-lan: port 1(eth0) entered forwarding state
[   11.874943] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
[   11.875870] rk_gmac-dwmac fe300000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[   11.923192] IPv6: ADDRCONF(NETDEV_CHANGE): wlan0: link becomes ready
