### PR TITLE
ath79: add support for D-Link COVR-C1200 A1

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -175,6 +175,11 @@ define Build/check-size
 	}
 endef
 
+define Build/dlink-sge-image
+	$(STAGING_DIR_HOST)/bin/dlink-sge-image $@ $@.enc
+	mv $@.enc $@
+endef
+
 define Build/elecom-product-header
 	$(eval product=$(word 1,$(1)))
 	$(eval fw=$(if $(word 2,$(1)),$(word 2,$(1)),$@))

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -23,6 +23,10 @@ define Build/append-dtb-elf
 		.appended_dtb=$(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb $@
 endef
 
+define Build/append-file
+	dd if=$(1) >> $@
+endef
+
 define Build/append-kernel
 	dd if=$(IMAGE_KERNEL) >> $@
 endef

--- a/scripts/dlink-sge-signature.py
+++ b/scripts/dlink-sge-signature.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#
+# Copyright (C) 2021 Sebastian Schaper <openwrt@sebastianschaper.net>
+#
+# append model string and gzip-based signature used by
+# certain D-Link devices manufactured by SGE / T&W.
+#
+# e.g. COVR-P2500 requires this to be appended to the
+# encrypted factory image, while for COVR-C1200 the
+# signature needs to be appended to the unencrypted payload
+#
+
+import gzip, hashlib, sys
+
+if len(sys.argv) != 3:
+    exit(f"usage: {sys.argv[0]} input.bin model_name")
+
+input_file = sys.argv[1]
+model_name = sys.argv[2]
+
+with open(input_file, "rb+") as fd:
+    input_bytes = fd.read()
+
+    gzipped = gzip.compress(input_bytes)[-8:-4]
+    m = hashlib.md5()
+    m.update(input_bytes)
+
+    fd.write(m.hexdigest().encode())
+    fd.write(f"\n{model_name}\n".encode())
+    fd.write(gzipped[::-1].hex().encode()) # change byte order
+
+    exit()
+
+exit(1)

--- a/target/linux/ath79/dts/qca9563_dlink_covr-c1200-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_covr-c1200-a1.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_dlink_covr.dtsi"
+
+/ {
+	model = "D-Link COVR-C1200 A1";
+	compatible = "dlink,covr-c1200-a1", "qca,qca9563";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_white: power_white {
+			label = "white:power";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};

--- a/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x68737173>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x50000 0xe30000>;
+			};
+
+			partition@e80000 {
+				label = "loader";
+				reg = <0xe80000 0x10000>;
+				read-only;
+			};
+
+			fwconcat1: partition@e90000 {
+				label = "fwconcat1";
+				reg = <0xe90000 0x160000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,mib-poll-interval = <500>;
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x50 0xcc35cc35 /* LED_CTRL0 */
+			0x54 0xcb37cb37 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x00f3cf00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x03000101 0x00000101 0x00001919>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -233,6 +233,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:wan" "3:lan" "4:lan"
 		;;
+	dlink,covr-c1200-a1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:wan" "2:lan"
+		;;
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan" "6@eth1"
@@ -542,6 +546,11 @@ ath79_setup_macs()
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi)
 		label_mac=$(macaddr_add "$(mtd_get_mac_binary art 0x1002)" 3)
+		;;
+	dlink,covr-c1200-a1)
+		lan_mac=$(mtd_get_mac_ascii art "protest_lan_mac")
+		wan_mac=$(mtd_get_mac_ascii art "protest_wan_mac")
+		label_mac=$lan_mac
 		;;
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -189,6 +189,12 @@ case "$FIRMWARE" in
 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
 		rm /lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
 		;;
+	dlink,covr-c1200-a1)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_ascii art "protest_ath1_mac")
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9880/hw2.0/board.bin
+		;;
 	dlink,dap-2680-a1)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii bdcfg wlanmac_a)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,6 +17,10 @@ case "$board" in
 	adtran,bsap1840)
 		macaddr_add "$(mtd_get_mac_binary 'Board data' 2)" $(($PHYNBR * 8 + 1)) > /sys${DEVPATH}/macaddress
 		;;
+	dlink,covr-c1200-a1)
+		[ "$PHYNBR" -eq 1 ] && \
+			mtd_get_mac_ascii art "protest_ath0_mac" > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dap-1330-a1|\
 	dlink,dap-1365-a1|\
 	dlink,dch-g020-a1)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -48,6 +48,10 @@ define Build/cybertan-trx
 	-rm $@-empty.bin
 endef
 
+define Build/dlink-sge-signature
+	$(TOPDIR)/scripts/dlink-sge-signature.py $@ $(1)
+endef
+
 define Build/edimax-headers
 	$(eval edimax_magic=$(word 1,$(1)))
 	$(eval edimax_model=$(word 2,$(1)))
@@ -771,6 +775,29 @@ define Device/devolo_magic-2-wifi
   IMAGE_SIZE := 15872k
 endef
 TARGET_DEVICES += devolo_magic-2-wifi
+
+define Device/dlink_covr
+  $(Device/loader-okli-uimage)
+  SOC := qca9563
+  LOADER_FLASH_OFFS := 0x050000
+  LOADER_KERNEL_MAGIC := 0x68737173
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x68737173
+  IMAGE_SIZE := 14528k
+endef
+
+define Device/dlink_covr-c1200-a1
+  $(Device/dlink_covr)
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := COVR-C1200
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | pad-to 14528k | \
+	append-file $(KDIR)/loader-$(1).uImage | pad-to 15616k | \
+	dlink-sge-signature COVR-C1200 | dlink-sge-image
+endef
+TARGET_DEVICES += dlink_covr-c1200-a1
 
 define Device/dlink_dap-13xx
   SOC := qca9533

--- a/tools/firmware-utils/Makefile
+++ b/tools/firmware-utils/Makefile
@@ -34,6 +34,7 @@ define Host/Compile
 	$(call cc,buffalo-tftp buffalo-lib,-Wall)
 	$(call cc,dgfirmware,-Wall)
 	$(call cc,dgn3500sum,-Wall)
+	$(call cc,dlink-sge-image,-lcrypto -pthread -Wall)
 	$(call cc,dns313-header,-Wall)
 	$(call cc,edimax_fw_header,-Wall)
 	$(call cc,encode_crc,-Wall)

--- a/tools/firmware-utils/src/dlink-sge-image.c
+++ b/tools/firmware-utils/src/dlink-sge-image.c
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (C) 2021 Sebastian Schaper <openwrt@sebastianschaper.net>
+ *
+ * This tool encrypts factory images for certain D-Link Devices
+ * manufactured by SGE / T&W, e.g. COVR-C1200, COVR-P2500, DIR-882, ...
+ *
+ * Build instructions:
+ *   gcc -lcrypto dlink-sge-image.c -o dlink-sge-image
+ *
+ * Usage:
+ *   ./dlink-sge-image infile outfile [-d: decrypt]
+ *
+ */
+
+#include "dlink-sge-image.h"
+
+#include <openssl/aes.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/sha.h>
+
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BUFSIZE		4096
+
+#define HEAD_MAGIC		"SHRS"
+#define HEAD_MAGIC_LEN	4
+#define SHA512_DIGEST_LENGTH	64
+#define RSA_KEY_LENGTH_BYTES	512
+#define AES_BLOCK_SIZE	16
+#define HEADER_LEN		1756
+
+unsigned char aes_iv[AES_BLOCK_SIZE];
+
+unsigned char readbuf[BUFSIZE];
+unsigned char encbuf[BUFSIZE];
+
+unsigned int read_bytes;
+unsigned long read_total;
+unsigned int i;
+
+unsigned char vendor_key[AES_BLOCK_SIZE];
+AES_KEY enc_key;
+
+FILE *input_file;
+FILE *output_file;
+
+void image_encrypt(void)
+{
+	char buf[HEADER_LEN];
+	SHA512_CTX digest;
+	SHA512_CTX digest_post;
+	SHA512_CTX digest_vendor;
+	uint32_t payload_length_before, pad_len, sizebuf;
+	unsigned char md_before[SHA512_DIGEST_LENGTH];
+	unsigned char md_post[SHA512_DIGEST_LENGTH];
+	unsigned char md_vendor[SHA512_DIGEST_LENGTH];
+	unsigned char sigret[RSA_KEY_LENGTH_BYTES];
+	unsigned int siglen = RSA_KEY_LENGTH_BYTES;
+	char footer[] = {0x00, 0x00, 0x00, 0x00, 0x30};
+
+	// seek to position 1756 (begin of AES-encrypted data),
+	// write image headers later
+	memset(buf, 0, HEADER_LEN);
+	fwrite(&buf, 1, HEADER_LEN, output_file);
+
+	RSA *rsa = RSA_new();
+	BIO *rsa_private_bio = BIO_new_mem_buf(key2_pem, -1);
+
+	PEM_read_bio_RSAPrivateKey(rsa_private_bio, &rsa, NULL, NULL);
+
+	SHA512_Init(&digest);
+	SHA512_Init(&digest_post);
+
+	memcpy(&aes_iv, &salt, AES_BLOCK_SIZE);
+	AES_set_encrypt_key(&vendor_key[0], 128, &enc_key);
+
+	while ((read_bytes = fread(&readbuf, 1, BUFSIZE, input_file)) == BUFSIZE) {
+		SHA512_Update(&digest, &readbuf[0], read_bytes);
+		read_total += read_bytes;
+
+		AES_cbc_encrypt(&readbuf[0], encbuf, BUFSIZE, &enc_key, aes_iv, AES_ENCRYPT);
+		fwrite(&encbuf, 1, BUFSIZE, output_file);
+
+		SHA512_Update(&digest_post, &encbuf[0], BUFSIZE);
+	}
+
+	// handle last block of data (read_bytes < BUFSIZE)
+	SHA512_Update(&digest, &readbuf[0], read_bytes);
+	read_total += read_bytes;
+
+	pad_len = AES_BLOCK_SIZE - (read_total % AES_BLOCK_SIZE);
+	if (pad_len == 0)
+		pad_len = 16;
+	memset(&readbuf[read_bytes], 0, pad_len);
+
+	AES_cbc_encrypt(&readbuf[0], encbuf, read_bytes + pad_len, &enc_key, aes_iv, AES_ENCRYPT);
+	fwrite(&encbuf, 1, read_bytes + pad_len, output_file);
+
+	SHA512_Update(&digest_post, &encbuf[0], read_bytes + pad_len);
+
+	fclose(input_file);
+	payload_length_before = read_total;
+	printf("\npayload_length_before: %li\n", read_total);
+
+	// copy digest state, since we need another one with vendor key appended,
+	// without having to re-hash the whole file (SHA512_Final is destructive)
+	memcpy(&digest_vendor, &digest, sizeof(SHA512_CTX));
+
+	SHA512_Final(&md_before[0], &digest);
+
+	printf("\ndigest_before: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_before[i]);
+
+	SHA512_Update(&digest_vendor, &vendor_key[0], AES_BLOCK_SIZE);
+	SHA512_Final(&md_vendor[0], &digest_vendor);
+
+	printf("\ndigest_vendor: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_vendor[i]);
+
+	SHA512_Final(&md_post[0], &digest_post);
+
+	printf("\ndigest_post: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_post[i]);
+
+	fwrite(&footer, 1, 5, output_file);
+
+	// go back to file header and write all the digests and signatures
+	fseek(output_file, 0, SEEK_SET);
+
+	fwrite(HEAD_MAGIC, 1, HEAD_MAGIC_LEN, output_file);
+
+	// write payload length before
+	sizebuf = htonl(payload_length_before);
+	fwrite((char *) &sizebuf, 1, 4, output_file);
+
+	// write payload length post
+	payload_length_before += pad_len;
+	sizebuf = htonl(payload_length_before);
+	fwrite((char *) &sizebuf, 1, 4, output_file);
+
+	// write salt and digests
+	fwrite(salt, 1, AES_BLOCK_SIZE, output_file);
+	fwrite(&md_vendor[0], 1, SHA512_DIGEST_LENGTH, output_file);
+	fwrite(&md_before[0], 1, SHA512_DIGEST_LENGTH, output_file);
+	fwrite(&md_post[0],   1, SHA512_DIGEST_LENGTH, output_file);
+
+	// zero-fill rsa_pub field, unused in header
+	memset(sigret, 0, RSA_KEY_LENGTH_BYTES);
+	fwrite(&sigret[0], 1, RSA_KEY_LENGTH_BYTES, output_file);
+
+	// sign md_before
+	RSA_sign(NID_sha512, &md_before[0], SHA512_DIGEST_LENGTH, &sigret[0], &siglen, rsa);
+	printf("\nsigned before:\n");
+	for (i = 0; i < RSA_KEY_LENGTH_BYTES; i++)
+		printf("%02x", sigret[i]);
+	fwrite(&sigret[0], 1, RSA_KEY_LENGTH_BYTES, output_file);
+
+	// sign md_post
+	RSA_sign(NID_sha512, &md_post[0], SHA512_DIGEST_LENGTH, &sigret[0], &siglen, rsa);
+	printf("\nsigned post:\n");
+	for (i = 0; i < RSA_KEY_LENGTH_BYTES; i++)
+		printf("%02x", sigret[i]);
+	fwrite(&sigret[0], 1, RSA_KEY_LENGTH_BYTES, output_file);
+
+	fclose(output_file);
+}
+
+void image_decrypt(void)
+{
+	RSA *rsa = RSA_new();
+	BIO *rsa_public_bio = BIO_new_mem_buf(public_pem, -1);
+	char magic[4];
+	uint32_t payload_length_before, payload_length_post, pad_len;
+	char salt[AES_BLOCK_SIZE];
+	char md_vendor[SHA512_DIGEST_LENGTH];
+	char md_before[SHA512_DIGEST_LENGTH];
+	char md_post[SHA512_DIGEST_LENGTH];
+	unsigned char rsa_sign_before[RSA_KEY_LENGTH_BYTES];
+	unsigned char rsa_sign_post[RSA_KEY_LENGTH_BYTES];
+	unsigned char md_post_actual[SHA512_DIGEST_LENGTH];
+	unsigned char md_before_actual[SHA512_DIGEST_LENGTH];
+	unsigned char md_vendor_actual[SHA512_DIGEST_LENGTH];
+	SHA512_CTX digest_post;
+	SHA512_CTX digest_before;
+	SHA512_CTX digest_vendor;
+
+	printf("\ndecrypt mode\n");
+
+	RSA_print(rsa_public_bio, rsa, 0);
+	PEM_read_bio_RSAPublicKey(rsa_public_bio, &rsa, NULL, NULL);
+
+	fread(&magic, 1, HEAD_MAGIC_LEN, input_file);
+	if (strncmp(magic, HEAD_MAGIC, HEAD_MAGIC_LEN) != 0)	{
+		fprintf(stderr, "Input File header magic does not match '%s'.\n"
+			"Maybe this file is not encrypted?\n", HEAD_MAGIC);
+		exit(1);
+	}
+
+	fread((char *) &payload_length_before, 1, 4, input_file);
+	fread((char *) &payload_length_post, 1, 4, input_file);
+	payload_length_before = ntohl(payload_length_before);
+	payload_length_post   = ntohl(payload_length_post);
+
+	fread(salt, 1, AES_BLOCK_SIZE, input_file);
+	fread(md_vendor, 1, SHA512_DIGEST_LENGTH, input_file);
+	fread(md_before, 1, SHA512_DIGEST_LENGTH, input_file);
+	fread(md_post, 1, SHA512_DIGEST_LENGTH, input_file);
+
+	// skip rsa_pub
+	fread(readbuf, 1, RSA_KEY_LENGTH_BYTES, input_file);
+
+	fread(rsa_sign_before, 1, RSA_KEY_LENGTH_BYTES, input_file);
+	fread(rsa_sign_post, 1, RSA_KEY_LENGTH_BYTES, input_file);
+
+	// file should be at position HEADER_LEN now, start AES decryption
+	SHA512_Init(&digest_post);
+	SHA512_Init(&digest_before);
+
+	memcpy(&aes_iv, &salt, AES_BLOCK_SIZE);
+	AES_set_decrypt_key(&vendor_key[0], 128, &enc_key);
+	pad_len = payload_length_post - payload_length_before;
+
+	while (read_total < payload_length_post) {
+		if (read_total + BUFSIZE <= payload_length_post)
+			read_bytes = fread(&readbuf, 1, BUFSIZE, input_file);
+		else
+			read_bytes = fread(&readbuf, 1, payload_length_post - read_total, \
+				input_file);
+
+		read_total += read_bytes;
+
+		SHA512_Update(&digest_post, &readbuf[0], read_bytes);
+
+		AES_cbc_encrypt(&readbuf[0], &encbuf[0], read_bytes, &enc_key, aes_iv, AES_DECRYPT);
+
+		// only update digest_before until payload_length_before,
+		// do not hash decrypted padding
+		if (read_total > payload_length_before) {
+			// only calc hash for data before padding
+			SHA512_Update(&digest_before, &encbuf[0], read_bytes - pad_len);
+			fwrite(&encbuf[0], 1, read_bytes - pad_len, output_file);
+
+			// copy state of digest, since SHA512_Final is desctructive
+			memcpy(&digest_vendor, &digest_before, sizeof(SHA512_CTX));
+
+			// append vendor_key
+			SHA512_Update(&digest_vendor, &vendor_key[0], AES_BLOCK_SIZE);
+		} else {
+			// calc hash for all of read_bytes
+			SHA512_Update(&digest_before, &encbuf[0], read_bytes);
+			fwrite(&encbuf[0], 1, read_bytes, output_file);
+		}
+	}
+
+	fclose(output_file);
+
+	SHA512_Final(&md_post_actual[0], &digest_post);
+
+	printf("\ndigest_post: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_post_actual[i]);
+
+	if (strncmp(md_post, (char *) md_post_actual, SHA512_DIGEST_LENGTH) != 0) {
+		fprintf(stderr, "SHA512 post does not match file contents.\n");
+		exit(1);
+	}
+
+	SHA512_Final(&md_before_actual[0], &digest_before);
+
+	printf("\ndigest_before: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_before_actual[i]);
+
+	if (strncmp(md_before, (char *) md_before_actual, SHA512_DIGEST_LENGTH) != 0) {
+		fprintf(stderr, "SHA512 before does not match decrypted payload.\n");
+		exit(1);
+	}
+
+	SHA512_Final(&md_vendor_actual[0], &digest_vendor);
+
+	printf("\ndigest_vendor: ");
+	for (i = 0; i < SHA512_DIGEST_LENGTH; i++)
+		printf("%02x", md_vendor_actual[i]);
+
+	if (strncmp(md_vendor, (char *) md_vendor_actual, SHA512_DIGEST_LENGTH) != 0) {
+		fprintf(stderr, "SHA512 vendor does not match decrypted payload padded" \
+			" with vendor key.\n");
+		exit(1);
+	}
+
+	if (RSA_verify(NID_sha512, &md_before_actual[0], SHA512_DIGEST_LENGTH, \
+		&rsa_sign_before[0], RSA_KEY_LENGTH_BYTES, rsa)) {
+		printf("\nsignature before verification success");
+	} else {
+		fprintf(stderr, "Signature before verification failed.\nThe decrypted" \
+			" image file may however be flashable via bootloader recovery.\n");
+	}
+
+	if (RSA_verify(NID_sha512, &md_post_actual[0], SHA512_DIGEST_LENGTH, \
+		&rsa_sign_post[0], RSA_KEY_LENGTH_BYTES, rsa)) {
+		printf("\nsignature post verification success");
+	} else {
+		fprintf(stderr, "Signature post verification failed.\nThe decrypted" \
+			" image file may however be flashable via bootloader recovery.\n");
+	}
+
+	printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+	if (argc < 2 || argc > 4) {
+		fprintf(stderr, "Usage:\n"
+			"\tdlink-sge-image infile outfile [-d: decrypt]\n\n");
+		exit(1);
+	}
+
+	input_file = fopen(argv[1], "rb");
+	if (input_file == NULL) {
+		fprintf(stderr, "Input File %s could not be opened.\n", argv[1]);
+		exit(1);
+	}
+
+	output_file = fopen(argv[2], "wb");
+	if (input_file == NULL) {
+		fprintf(stderr, "Output File %s could not be opened.\n", argv[2]);
+		exit(1);
+	}
+
+	memcpy(&aes_iv, &iv, AES_BLOCK_SIZE);
+	AES_set_decrypt_key(&key1[0], 128, &enc_key);
+	AES_cbc_encrypt(&key2[0], &vendor_key[0], AES_BLOCK_SIZE, &enc_key, \
+		aes_iv, AES_DECRYPT);
+
+	printf("\nvendor_key: ");
+	for (i = 0; i < AES_BLOCK_SIZE; i++)
+		printf("%02x", vendor_key[i]);
+
+	if (argc == 4 && strncmp(argv[3], "-d", 2) == 0)
+		image_decrypt();
+	else
+		image_encrypt();
+}

--- a/tools/firmware-utils/src/dlink-sge-image.h
+++ b/tools/firmware-utils/src/dlink-sge-image.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+const unsigned char key1[] =
+	"\x35\x87\x90\x03\x45\x19\xf8\xc8\x23\x5d\xb6\x49\x28\x39\xa7\x3f";
+
+const unsigned char key2[] =
+	"\xc8\xd3\x2f\x40\x9c\xac\xb3\x47\xc8\xd2\x6f\xdc\xb9\x09\x0b\x3c";
+
+const unsigned char iv[] =
+	"\x98\xc9\xd8\xf0\x13\x3d\x06\x95\xe2\xa7\x09\xc8\xb6\x96\x82\xd4";
+
+const unsigned char salt[] =
+	"\x67\xc6\x69\x73\x51\xff\x4a\xec\x29\xcd\xba\xab\xf2\xfb\xe3\x46";
+
+// public.pem as found in GPL tarball
+const unsigned char public_pem[] = R"(
+-----BEGIN RSA PUBLIC KEY-----
+MIICCgKCAgEApZLuH2XFDWuazEMpx4v6QY0ePRJm344JgkLKfeofovxvbjfX6RHU
+7yUz6b2wJnW4lomEzjrJEQFnPGNFV/oWO/NaTb3k0rPUewDzlzy/pn7ZMehqnMK1
+tHVnyQ6RZ+9qkdYEu08f79UgZcGQzSy2TLNMquAB9ffGbTHAjRfoK7cDjQX+RKWh
+OOs5tbnzhR0B4Jdd6UL9Sqoq5UisTdlnFhy67RdsItz3OOrHIiDYmfkEOqAZySKZ
+MhY7h7kkC8t1IzZOncBx3LYU4PMo9ulycAx7xDUric8xswnKoYAJbbKtp9xnGKRJ
+HPuZOZyXFdWNlTVhzG3sGdDzcpHxrFOJZ5RK/n19DArbq6w9MEInTmU3bcwDYFvX
+JCQ5Al05lgqP8vk7U4xx3AcwZUQHNVzduBuibB26jhpPXSk1Cl6NpFdXlKvcynfV
+H8XaCHy8LXhZBMiuR62Ft6YkcIpBdsQ2uBGL5GOmVFA/cOEtPZjWxzN/miXaZ7In
+iRhXEHFus6zYIPOTa9DNyAA87UCqxkem7Xgu59fgq49YwGPk+Q7HJXKgts9QTn9y
+26OtlUAq1i23EJK6GJvTmszslXbAWEi5Mlb/o7QdpEQt/gyz9udnVmfXOy4UmNXN
+ZxuVyXNomTBFRObZ5Zmn6n+xat5eBDpvct+OO1IUMC154div9i2szF0CAwEAAQ==
+-----END RSA PUBLIC KEY-----
+)";
+
+// key2.pem as found in GPL tarball, decrypted via openssl using
+// PEM passphrase 12345678 to reduce code and runtime complexity
+const unsigned char key2_pem[] = R"(
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKAIBAAKCAgEApZLuH2XFDWuazEMpx4v6QY0ePRJm344JgkLKfeofovxvbjfX
+6RHU7yUz6b2wJnW4lomEzjrJEQFnPGNFV/oWO/NaTb3k0rPUewDzlzy/pn7ZMehq
+nMK1tHVnyQ6RZ+9qkdYEu08f79UgZcGQzSy2TLNMquAB9ffGbTHAjRfoK7cDjQX+
+RKWhOOs5tbnzhR0B4Jdd6UL9Sqoq5UisTdlnFhy67RdsItz3OOrHIiDYmfkEOqAZ
+ySKZMhY7h7kkC8t1IzZOncBx3LYU4PMo9ulycAx7xDUric8xswnKoYAJbbKtp9xn
+GKRJHPuZOZyXFdWNlTVhzG3sGdDzcpHxrFOJZ5RK/n19DArbq6w9MEInTmU3bcwD
+YFvXJCQ5Al05lgqP8vk7U4xx3AcwZUQHNVzduBuibB26jhpPXSk1Cl6NpFdXlKvc
+ynfVH8XaCHy8LXhZBMiuR62Ft6YkcIpBdsQ2uBGL5GOmVFA/cOEtPZjWxzN/miXa
+Z7IniRhXEHFus6zYIPOTa9DNyAA87UCqxkem7Xgu59fgq49YwGPk+Q7HJXKgts9Q
+Tn9y26OtlUAq1i23EJK6GJvTmszslXbAWEi5Mlb/o7QdpEQt/gyz9udnVmfXOy4U
+mNXNZxuVyXNomTBFRObZ5Zmn6n+xat5eBDpvct+OO1IUMC154div9i2szF0CAwEA
+AQKCAgBmWvh9zGoOq9CcKYDwbOYeE+D3nCKgXKwgLK4FPPClzywLlNYSrQVXeUYo
+Xy0/+VJNLWI+IzUdICLzv+KkSmPoV74hhRyp7KWUDLiJa/KGOLCIG8ecdPnjPxkT
+v7+/4s+crBNsv7NcjgJjJVAgpl1j+QuSLrzHk47E/hasonTSYWb+jQ/s2/9YsoGQ
+iA204oPAlZJmmxT+TUgLSevKjHUfxE8CNpKQ0sy6ENldjbSZKsmkfEi0gID356qR
+crCH4hTd2bqr5sX8zUsG7QsL6LDn96+jUcNChCWTKqBrSj2J5QVZWfUZ1KWmFxtX
+9CeqRcQq0z9MIz/rjbKRxwsBnvq3YK9XoieKtCsoz63/vGT5cnmc5Jrx5C5VRlVr
+zitlW5WuRA+SYwFoPr0ZiLYMfBVljsZ/poFPxkv5nEnJSvHe8S7pHGpE650NW477
+WNlh88K1dILGpTiW4PqHpCuYB+Cqw8pFC9s8P80ZnELPI/KdEfFMHXhbFdVbjEWZ
+KJFdklYcD4cSvINczw5YPs9O1eJ1S8L61bgpipOS6juy4BgQNSxi5EaGBkZfe8pj
+8IRfkzdwDXywSbN56aslDuPgoXJW1DQeNhEJUa6w9f9cgH5uI1Lh0XPFDPFiNomw
+mBAYHuTeodgp5b2b9jtXSECfmmgCl2jcY90Fwyt1RUFZsmp1eQKCAQEA170ibn8P
+hq8M33t0+7nlxU7g3Q6IShj1vCdyjipSTlKDFdXwVaE0gORj9ooLNfbGc80Rol1U
+HWB2CEuVGmPH3dwEgcCRoJzlLKgNsEzj28L2kGZoCWLyevsCxsiLBAf+xd48kzSs
+grfQlL5HH2oGshjHoQwybTntXJ3Y+N/Yhl+CfRS2ReJM2YNwpluWM6wpESb329Na
+hQSt5SxnuQS3B909YAueUreTRUg41NATOh2zlzjBxWZJwAMNuwKNEEOr7gMiqwdI
+zHcwpNFvrPplNavHuHQQ8ErvnL5KvhSuNeB9QDGnKYxs7hhPk07glIufNTgrsNBT
+P44Vtv1R3SncwwKCAQEAxHkutjFgzCvugzaiEr9qRWDnBooKXCBdxJ89t69i1IxV
+p3tv9jm9pvGoOK1rjP1NWl1RmpxjM6SbYIiRdMXmAl/IqKrKg9/y9vBYzFQ5sZXv
+IuJCiwecgOYq4YRLIUxRKKpnAf6Gtgcn7e1BEb9YTg1/1rT0YvcG+nZEKHUjPLCq
+DckEQJW2wp1illgMi9OSDYechXrNArapU3ightaJLPl8sOLvNMECUUQp6esOoM3A
+Los5Jj9k2+Wboyr/mFWgQCXz6QFVCw5NFEW+MKnWvABs5gDWwCznIveMpi8AlQin
+nDNsagTosuCWhmsnkmFC6vsifkm0NbUmS+QPv46gXwKCAQAVjvPi4NWXWuTJbFfb
+U89PMTutO2eJKAdeXv7GkBobc4lf5DoZBHvvqWMH3vGR2fAo4EQz2mmuadZBq/Ph
+aDkvxW253Zlv2F3aYYzEolpeupPTCDi7P2UFvxGe9alWpMnj0fpxp2DZyy6Pvpfy
+3rB+mZVRVZuwaIp8p9VnwU6s1tx+TVSNlTiiv8zBAwP2c+zCpwc7s1onUrlh3lcb
+GQqFQamBcIfIskmIMdhkA8r4EsHAic5rQHZ8NpHnrzCTgH+s0Cllt9uhewOkZL1p
+Jrh4bYsOtqJ+sK5TFnz3k694+M7rXErdDwhPnqRNDyPIFE+7jLpo99hp0HQBDj1h
+AW7rAoIBABnXhplYLU8tiBWiHfcxTh0J/dkSVwJ/D1ZJS6jZXLpwKuP4jGVqetN2
+fZXW2YqV1pLIK2+WmkW0pOsxi1A8p2AwkQf+TtzBnAd23XcirOP6wJVqBS6cNa2O
+mJ1I9UjP7OzYXOwaOkW+8zWMOz7GWCsMA4COFIbfzv8qhxR7M8NLyVI+2lxUVNGM
+OedkdWH+1fsJl0DHQifVNrhP6W1S0oAj4I6zipr5uABQYuLtk+L6rQhyL3YkaHOz
+46C2ix/SQ12soERJdJIbs2+zLKzh6eiYdbpa6eQlA9HJlapWDFGN7d3RtbTMKH8+
+ow3TEkVinZaiqYrKzvUxenQI7zlW3SkCggEBAIwoBqSmdeNLwhnNuG8TdIgkUWLm
+grYCted3HpCIeScdH/pnDbzrZRG7Xxwel8MAumEyJLI6dVZJ4oLhbGp/utjgHfl8
+ayQ2VglPxRGIu/eUBbB0vQhVHu38vHK+NwxadLpijK61K7+0H2yb8DaZ/uw9wQow
+dlEellimg3odVqg5KAdcH6mSgXpL0SUcZWbuUBXvRLY9+m2ea1kvZs+IAjIy9guK
+rx07QpaJC5BszIbymn1wmeJ0P5r76kbVyhrV7j7HNogNXBdL0k7U8X3HharXIDOC
+1yWONun2aWDGeWBDZ81ur35cKsDnH1DNVJIuFxBpe7TpvuLa/dPf+hAaac8=
+-----END RSA PRIVATE KEY-----
+)";


### PR DESCRIPTION
The COVR-C1200 devices are sold as "Whole Home Mesh Wi-Fi"
sets in packs of two (COVR-C1202) and three (COVR-C1203).

Specifications:
 * QCA9563, 16 MiB flash, 128 MiB RAM, 2x3:2 802.11n
 * QCA9886 2x2:2 801.11ac Wave 2
 * AR8337, 2 Gigabit ports (1: WAN; 2: LAN)
 * USB Type-C power connector (5V, 3A)

Installation COVR Point A:
 * In factory reset state: OEM Web UI is at 192.168.0.50
   no DHCP, skip wizard by directly accessing:
     http://192.168.0.50/UpdateFirmware_Simple.html
 * After completing setup wizard: Web UI is at 192.168.0.1
     DHCP enabled, login with empty password
 * Flash factory.bin

Installation COVR Points B:
 * OEM Web UI is at 192.168.0.50, no DHCP, empty password
 * Flash factory.bin

Recovery:
 * Keep reset button pressed during power on
 * Recovery Web UI is at 192.168.0.50, no DHCP
 * Flash factory.bin
   seems to work best with Chromium-based browsers or curl:
     curl -F firmware=@factory.bin \
       http://192.168.0.50/upgrade.cgi

Since the device is based on OpenWrt Attitude Adjustment (ar71xx),
uci configuration is broken after flashing via the OEM Web Updater
(sysupgrade will append old uci settings to jffs2 after flashing).

To enforce OpenWrt default settings after flashing, a script in
`uci-defaults/10_discard_oem_config` will call `firstboot` if a
magic uci configuration string from the OEM firmware is present.

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>