### PR TITLE
ath79: add support for MikroTik hAP ac

### DIFF
--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-962uigs-5hact2hnt.dts
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-962uigs-5hact2hnt.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_mikrotik_routerboard-96x.dtsi"
+
+/ {
+	compatible = "mikrotik,routerboard-962uigs-5hact2hnt", "qca,qca9558";
+	model = "MikroTik RouterBOARD 962UiGS-5HacT2HnT (hAP ac)";
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		port5_poe {
+			gpio-export,name = "port5-poe";
+			gpio-export,output = <1>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio {
+	input-poe-out-compat {
+		gpio-hog;
+		gpios = <2 GPIO_ACTIVE_HIGH>;
+		input;
+		line-name = "PoE out compat";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};
+
+&pcie1 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-upgrade = &led_user;
+		serial0 = &uart;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_user: user {
+			label = "green:user";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		buzzer {
+			/* Beeper requires PWM for frequency selection */
+			gpio-export,name = "buzzer";
+			gpio-export,output = <0>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_power {
+			gpio-export,name = "usb-power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	i2c: i2c {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&gpio 18 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 19 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <5>;
+		i2c-gpio,timeout-ms = <1>;
+	};
+
+	sfp1: sfp {
+		compatible = "sff,sfp";
+
+		i2c-bus = <&i2c>;
+		maximum-power-milliwatt = <1000>;
+		los-gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		// Toggling GPIO16 actually enables/disables the transmitter,
+		// but the SFP driver does not seem to be using it.
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "RouterBoot";
+				reg = <0x0 0x20000>;
+				read-only;
+				compatible = "mikrotik,routerboot-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "bootloader1";
+					reg = <0x0 0x0>;
+					read-only;
+				};
+
+				hard_config {
+					read-only;
+				};
+
+				bios {
+					size = <0x1000>;
+					read-only;
+				};
+
+				partition@10000 {
+					label = "bootloader2";
+					reg = <0x10000 0x0>;
+					read-only;
+				};
+
+				soft_config {
+				};
+			};
+
+			partition@20000 {
+				compatible = "mikrotik,minor";
+				label = "firmware";
+				reg = <0x020000 0xfe0000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			/* PAD0_MODE from vendor firmware
+			 * RGMII_EN, TX/RXCLK_DELAY_EN, TXCLK_DELAY_SEL=1
+			 */
+			0x04 0x07400000 /* PAD0_MODE */
+			0x50 0xc737c737 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x58 0x00000000 /* LED_CTRL2 */
+			0x5c 0x0030c300 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+	/* gigabit pll-data from vendor firmware
+	 * TX_INVERT, TX_DELAY=3, GIGE, OFFSET_PHASE
+	 */
+	pll-data = <0x8f000000 0x00000101 0x00001616>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&mdio1 {
+	status = "okay";
+
+	phy_sfp: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		sfp = <&sfp1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-handle = <&phy_sfp>;
+	pll-data = <0x03000000 0x00000101 0x00001616>;
+	qca955x-sgmii-fixup;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -38,6 +38,17 @@ define Device/mikrotik_routerboard-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
+define Device/mikrotik_routerboard-962uigs-5hact2hnt
+  $(Device/mikrotik_nor)
+  SOC := qca9558
+  DEVICE_MODEL := RouterBOARD 962UiGS-5HacT2HnT (hAP ac)
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2 \
+	kmod-i2c-gpio kmod-sfp
+  IMAGE_SIZE := 16256k
+  SUPPORTED_DEVICES += rb-962uigs-5hact2hnt
+endef
+TARGET_DEVICES += mikrotik_routerboard-962uigs-5hact2hnt
+
 define Device/mikrotik_routerboard-lhg-2nd
   $(Device/mikrotik_nor)
   SOC := qca9533

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -23,6 +23,10 @@ ath79_setup_interfaces()
 	mikrotik,routerboard-wapr-2nd)
 		ucidef_set_interface_lan "eth0"
 		;;
+	mikrotik,routerboard-962uigs-5hact2hnt)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "1:wan"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -34,6 +34,9 @@ case "$FIRMWARE" in
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 2)
 		;;
+	mikrotik,routerboard-962uigs-5hact2hnt)
+		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 7)
+		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 "ath10k/cal-pci-0000:00:00.0.bin")
 	case $board in
 	mikrotik,routerboard-921gs-5hpacd-15s|\
+	mikrotik,routerboard-962uigs-5hact2hnt|\
 	mikrotik,routerboard-wap-g-5hact2hnd)
 		caldata_sysfsload_from_file $wlan_data 0x5000 0x844
 		;;


### PR DESCRIPTION
This patch adds support for the MikroTik hAP ac (RouterBOARD 962UiGS-5HacT2HnT)

Working:
- 2.4GHz WLAN (SoC)
- 5GHz WLAN (QCA9880)
- Switch (QCA8337)
- SFP cage (tested with genuine & generic GLC-T)
- USB

Not working:
- Red WLAN LED

Note that config persistence on sysupgrade only worked after applying https://github.com/openwrt/openwrt/pull/3271