### PR TITLE
apm821xx: MR24: Change default config of WLAN LED

### DIFF
--- a/target/linux/apm821xx/base-files/etc/board.d/01_leds
+++ b/target/linux/apm821xx/base-files/etc/board.d/01_leds
@@ -8,10 +8,10 @@ board=$(board_name)
 case "$board" in
 meraki,mr24)
 	ucidef_set_led_netdev "wan" "WAN" "mr24:green:wan" "eth0"
-	ucidef_set_led_wlan "wlan1" "WLAN1" "mr24:green:wifi1" "phy0assoc"
-	ucidef_set_led_wlan "wlan2" "WLAN2" "mr24:green:wifi2" "phy0assoc"
-	ucidef_set_led_wlan "wlan3" "WLAN3" "mr24:green:wifi3" "phy0assoc"
-	ucidef_set_led_wlan "wlan4" "WLAN4" "mr24:green:wifi4" "phy0tpt"
+	ucidef_set_led_wlan "wlan5g_1" "WIFI 5GHz-1" "mr24:green:wifi1" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g_0" "WIFI 5GHz-0" "mr24:green:wifi2" "phy1radio"
+	ucidef_set_led_wlan "wlan2g_1" "WIFI 2.4GHz-1" "mr24:green:wifi3" "phy0tpt"
+	ucidef_set_led_wlan "wlan2g_0" "WIFI 2.4GHz-0" "mr24:green:wifi4" "phy0radio"
 	;;
 
 meraki,mx60)


### PR DESCRIPTION
The previous config will only show 2.4G radio activity status

This change mr24:green:wifi4 and mr24:green:wifi2 to
show 2.4G and 5G radio on and off status

change mr24:green:wifi3 and mr24:green:wifi1 to
show 2.4G and 5G radio activity status

Signed-off-by: Tan Zien <nabsdh9@gmail.com>
