### PR TITLE
base-files: prevent config restore after factory.bin

### DIFF
--- a/package/base-files/files/bin/config_restore
+++ b/package/base-files/files/bin/config_restore
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+FILE="$1"
+TAR_OPT="${2:-xzf}"
+
+missing_lines() {
+        local file1 file2 line
+        file1="$1"
+        file2="$2"
+        oIFS="$IFS"
+        IFS=":"
+        while read line; do
+                set -- $line
+                grep -q "^$1:" "$file2" || echo "$*"
+        done < "$file1"
+        IFS="$oIFS"
+}
+
+do_config_restore() {
+	echo "- config restore -"
+
+	cd /
+
+	cp /etc/passwd /etc/group /etc/shadow /tmp
+
+	tar $TAR_OPT $FILE
+
+	missing_lines /tmp/passwd /etc/passwd >> /etc/passwd
+	missing_lines /tmp/group /etc/group >> /etc/group
+	missing_lines /tmp/shadow /etc/shadow >> /etc/shadow
+
+	rm /tmp/passwd /tmp/group /tmp/shadow
+}
+
+do_config_restore
+
+# Prevent configuration corruption from power loss
+sync

--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -1,12 +1,27 @@
 # Copyright (C) 2006 OpenWrt.org
 # Copyright (C) 2010 Vertical Communications
 
-do_mount_root() {
-	mount_root
-	boot_run_hook preinit_mount_root
+config_restore_verify() {
+	cd /
+
+	[ -f /sysupgrade.tgz ] && \
+		tar xzf /sysupgrade.tgz etc/sysupgrade_version && \
+		[ $(cat /etc/openwrt_version) = $(cat /etc/sysupgrade_version) ] && \
+			echo "- config restore verified -"
+
+	[ -f /tmp/sysupgrade.tar ] && \
+		tar xf /tmp/sysupgrade.tar etc/sysupgrade_version && \
+		[ $(cat /etc/openwrt_version) = $(cat /etc/sysupgrade_version) ] && \
+			echo "- config restore verified -"
 
 	[ -f /sysupgrade.tgz ] && config_restore /sysupgrade.tgz xzf
 	[ -f /tmp/sysupgrade.tar ] && config_restore /tmp/sysupgrade.tar xf
+}
+
+do_mount_root() {
+	mount_root
+	boot_run_hook preinit_mount_root
+	config_restore_verify
 }
 
 [ "$INITRAMFS" = "1" ] || boot_hook_add preinit_main do_mount_root

--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -1,35 +1,12 @@
 # Copyright (C) 2006 OpenWrt.org
 # Copyright (C) 2010 Vertical Communications
 
-missing_lines() {
-	local file1 file2 line
-	file1="$1"
-	file2="$2"
-	oIFS="$IFS"
-	IFS=":"
-	while read line; do
-		set -- $line
-		grep -q "^$1:" "$file2" || echo "$*"
-	done < "$file1"
-	IFS="$oIFS"
-}
-
 do_mount_root() {
 	mount_root
 	boot_run_hook preinit_mount_root
-	[ -f /sysupgrade.tgz -o -f /tmp/sysupgrade.tar ] && {
-		echo "- config restore -"
-		cp /etc/passwd /etc/group /etc/shadow /tmp
-		cd /
-		[ -f /sysupgrade.tgz ] && tar xzf /sysupgrade.tgz
-		[ -f /tmp/sysupgrade.tar ] && tar xf /tmp/sysupgrade.tar
-		missing_lines /tmp/passwd /etc/passwd >> /etc/passwd
-		missing_lines /tmp/group /etc/group >> /etc/group
-		missing_lines /tmp/shadow /etc/shadow >> /etc/shadow
-		rm /tmp/passwd /tmp/group /tmp/shadow
-		# Prevent configuration corruption on a power loss
-		sync
-	}
+
+	[ -f /sysupgrade.tgz ] && config_restore /sysupgrade.tgz xzf
+	[ -f /tmp/sysupgrade.tar ] && config_restore /tmp/sysupgrade.tar xf
 }
 
 [ "$INITRAMFS" = "1" ] || boot_hook_add preinit_main do_mount_root

--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -7,15 +7,12 @@ config_restore_verify() {
 	[ -f /sysupgrade.tgz ] && \
 		tar xzf /sysupgrade.tgz etc/sysupgrade_version && \
 		[ $(cat /etc/openwrt_version) = $(cat /etc/sysupgrade_version) ] && \
-			echo "- config restore verified -"
+			config_restore /sysupgrade.tgz xzf
 
 	[ -f /tmp/sysupgrade.tar ] && \
 		tar xf /tmp/sysupgrade.tar etc/sysupgrade_version && \
 		[ $(cat /etc/openwrt_version) = $(cat /etc/sysupgrade_version) ] && \
-			echo "- config restore verified -"
-
-	[ -f /sysupgrade.tgz ] && config_restore /sysupgrade.tgz xzf
-	[ -f /tmp/sysupgrade.tar ] && config_restore /tmp/sysupgrade.tar xf
+			config_restore /tmp/sysupgrade.tar xf
 }
 
 do_mount_root() {

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -43,6 +43,12 @@ fwtool_check_image() {
 		return 1
 	}
 
+	json_select version
+	json_get_var revision revision
+	json_select ..
+	[ -n "$revision" ] || revision="unknown"
+	echo $revision > /etc/sysupgrade_version
+
 	device="$(cat /tmp/sysinfo/board_name)"
 	devicecompat="$(uci -q get system.@system[0].compat_version)"
 	[ -n "$devicecompat" ] || devicecompat="1.0"

--- a/package/base-files/files/lib/upgrade/keep.d/base-files-essential
+++ b/package/base-files/files/lib/upgrade/keep.d/base-files-essential
@@ -8,4 +8,5 @@
 /etc/shells
 /etc/shinit
 /etc/sysctl.conf
+/etc/sysupgrade_version
 /etc/rc.local


### PR DESCRIPTION
There are several devices where the OEM firmware is based on Openwrt,
and a factory.bin flash causes a config restore file `sysupgrade.tgz` to be appended to JFFS space
in the same way that config is saved during a sysupgrade with today's modern Openwrt.

When the OEM config is restored after factory.bin flash, it breaks the config,
and a factory reset, or other workarounds are necessary.

This PR introduces a universal fix for this issue that is backwards compatible and forward compatible:
a simple method for verifying the config restore tarball after a sysupgrade.bin flash,
using the revision string of the new version stored in the tarball.

In order to make these changes forward compatible with past branches:
(in other words, allow saving configuration from previous branches to master)
the first 2 commits would be backported, but not the 3rd.
This way, only master and future branches would *require* this verification,
while the branches in the past fulfill the requirement for master and future branches.

alternative branch where lines stay in preinit:
https://github.com/openwrt/openwrt/compare/master...mpratt14:factory-firstboot