### PR TITLE
ipq806x: Enlarge D7800 flash - use netgear partition

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-d7800.dts
@@ -293,13 +293,7 @@
 
 			ubi@1880000 {
 				label = "ubi";
-				reg = <0x1880000 0x1C00000>;
-			};
-
-			netgear@3480000 {
-				label = "netgear";
-				reg = <0x3480000 0x4480000>;
-				read-only;
+				reg = <0x1880000 0x6080000>;
 			};
 
 			reserve@7900000 {

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -242,6 +242,9 @@ define Device/netgear_d7800
 	BOARD_NAME := d7800
 	SUPPORTED_DEVICES += d7800
 	DEVICE_PACKAGES := ath10k-firmware-qca99x0-ct
+	DEVICE_COMPAT_VERSION := 2.0
+	DEVICE_COMPAT_MESSAGE := Sysupgrade does not work due to rootfs ubi partition size change. \
+		Use factory image with the TFTP recovery flash routine.
 endef
 TARGET_DEVICES += netgear_d7800
 


### PR DESCRIPTION
Increase the available flash memory size in Netgear R7800
by taking into the use the unused "netgear" partition
that is located after the firmware partition.

Available flash space for kernel+rootfs+overlay increases
by 68 MB from 32 MB to 100 MB.

In a typical build, overlay space increases from 15 to 85,
increasing the package installation possibilities greatly.

Reverting to the OEM firmware is still possible, as the OEM
firmware contains logic to initialise the "netgear" partition
if its contents do not match expectations. In OEM firmware,
"netgear" contains 6 UBI sub-partitions that are defined in
/etc/netgear.cfg and initialisation is done by /etc/preinit

This is based on https://github.com/openwrt/openwrt/commit/fb8a578aa70572b3e56b64d296e22c2931e77b69

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
