### PR TITLE
kernel: add kmod-input-leds

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -159,3 +159,20 @@ define KernelPackage/leds-uleds/description
 endef
 
 $(eval $(call KernelPackage,leds-uleds))
+
+
+define KernelPackage/input-leds
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=Input device LED support
+  DEPENDS:=+kmod-input-core
+  KCONFIG:=CONFIG_INPUT_LEDS
+  FILES:=$(LINUX_DIR)/drivers/input/input-leds.ko
+  AUTOLOAD:=$(call AutoLoad,50,input-leds,1)
+endef
+
+define KernelPackage/input-leds/description
+ Provides support for LEDs on input devices- for example,
+ keyboard num/caps/scroll lock.
+endef
+
+$(eval $(call KernelPackage,input-leds))


### PR DESCRIPTION
Add support for LEDs on input devices. Useful for example on x86 laptops-
allows re-purposing num/caps/scroll lock LEDs.

Signed-off-by: Anderson McKinley <coyoso@tuta.io>