### PR TITLE
kernel-defaults: fix external kernel build

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -43,7 +43,7 @@ else
 		rmdir $(LINUX_DIR); \
 	fi
 	ln -s $(CONFIG_EXTERNAL_KERNEL_TREE) $(LINUX_DIR)
-	$(_SINGLE) [ -d $(LINUX_DIR)/user_headers ] && rm -rf $(LINUX_DIR)/user_headers
+	$(_SINGLE) rm -rf $(LINUX_DIR)/user_headers
   endef
 endif
 


### PR DESCRIPTION
`make` treats it as a error if `$(LINUX_DIR)/user_headers` does not exist

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>