### PR TITLE
ipq806x: fix error with cache handling

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -77,6 +77,17 @@
 	qcom,mpll = <5>;
 };
 
+&opp_table_l2 {
+	/delete-node/opp-1200000000;
+
+	opp-1400000000 {
+		opp-hz = /bits/ 64 <1400000000>;
+		opp-microvolt = <1150000>;
+		clock-latency-ns = <100000>;
+		opp-level = <2>;
+	};
+};
+
 &opp_table0 {
 	/* 
 	 * On ipq8065 1.2 ghz freq is not present

--- a/target/linux/ipq806x/patches-5.10/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
+++ b/target/linux/ipq806x/patches-5.10/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
@@ -75,7 +75,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  ##################################################################################
 --- /dev/null
 +++ b/drivers/cpufreq/qcom-cpufreq-krait.c
-@@ -0,0 +1,601 @@
+@@ -0,0 +1,603 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -115,9 +115,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +	int cpu, ret;
 +
 +	if (l2_pdev) {
++		int policy_cpu = policy->cpu;
++
 +		/* find the max freq across all core */
 +		for_each_present_cpu(cpu)
-+			if (cpu != index)
++			if (cpu != policy_cpu)
 +				target_freq = max(
 +					target_freq,
 +					(unsigned long)cpufreq_quick_get(cpu));
@@ -132,6 +134,18 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		level = dev_pm_opp_get_level(opp);
 +		dev_pm_opp_put(opp);
 +
++		/*
++		 * Hardware constraint:
++		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
++		 * Assume index 0 with the idle freq and level > 0 as 
++		 * any L2 freq > 384MHz.
++		 * Skip CPU freq change in this corner case.
++		 */
++		if (unlikely(index == 0 && level != 0)) {
++			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
++			return -EINVAL;
++		}
++
 +		opp = dev_pm_opp_find_level_exact(&l2_pdev->dev, level);
 +		if (IS_ERR(opp)) {
 +			dev_err(&l2_pdev->dev,
@@ -144,18 +158,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		ret = dev_pm_opp_set_rate(&l2_pdev->dev, target_freq);
 +		if (ret)
 +			return ret;
-+
-+		/*
-+		 * Hardware constraint:
-+		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
-+		 * Assume index 0 with the idle freq and level > 0 as 
-+		 * any L2 freq > 384MHz.
-+		 * Skip CPU freq change in this corner case.
-+		 */
-+		if (unlikely(index == 0 && level != 0)) {
-+			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
-+			return -EINVAL;
-+		}
 +	}
 +
 +	ret = dev_pm_opp_set_rate(priv->cpu_dev, freq * 1000);

--- a/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
@@ -42,19 +42,9 @@
 +			cpu-idle-states = <&CPU_SPC>;
  		};
  
- 		L2: l2-cache {
- 			compatible = "cache";
- 			cache-level = <2>;
-+			qcom,saw = <&saw_l2>;
-+		};
-+
-+		qcom,l2 {
-+			qcom,l2-rates = <384000000 1000000000 1200000000>;
-+			qcom,l2-cpufreq = <384000000 600000000 1200000000>;
-+			qcom,l2-volt = <1100000 1100000 1150000>;
-+			qcom,l2-supply = <&smb208_s1a>;
-+		};
-+
+-		L2: l2-cache {
+-			compatible = "cache";
+-			cache-level = <2>;
 +		idle-states {
 +			CPU_SPC: spc {
 +				compatible = "qcom,idle-state-spc", "arm,idle-state";
@@ -66,6 +56,31 @@
 +		};
 +	};
 +
++	opp_table_l2: opp_table_l2 {
++		compatible = "operating-points-v2";
++
++		opp-384000000 {
++			opp-hz = /bits/ 64 <384000000>;
++			opp-microvolt = <1100000>;
++			clock-latency-ns = <100000>;
++			opp-level = <0>;
++		};
++
++		opp-1000000000 {
++			opp-hz = /bits/ 64 <1000000000>;
++			opp-microvolt = <1100000>;
++			clock-latency-ns = <100000>;
++			opp-level = <1>;
++		};
++
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1150000>;
++			clock-latency-ns = <100000>;
++			opp-level = <2>;
++ 		};
++ 	};
++ 
 +	opp_table0: opp_table0 {
 +		compatible = "operating-points-v2-kryo-cpu";
 +		nvmem-cells = <&speedbin_efuse>;
@@ -78,6 +93,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <800000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <0>;
 +		};
 +
 +		opp-600000000 {
@@ -88,6 +104,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <850000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-800000000 {
@@ -98,6 +115,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <900000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1000000000 {
@@ -108,6 +126,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <950000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1200000000 {
@@ -118,6 +137,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <1000000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <1>;
 +		};
 +
 +		opp-1400000000 {
@@ -128,6 +148,7 @@
 +			opp-microvolt-speed0-pvs3-v0 = <1050000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
++			opp-level = <2>;
 +		};
 +	};
 +
@@ -501,10 +522,21 @@
  	firmware {
  		scm {
  			compatible = "qcom,scm-ipq806x", "qcom,scm";
-@@ -120,6 +588,84 @@
+@@ -120,6 +588,95 @@
  			reg-names = "lpass-lpaif";
  		};
  
++		L2: l2-cache {
++			compatible = "qcom,krait-cache", "cache";
++			cache-level = <2>;
++			qcom,saw = <&saw_l2>;
++
++			clocks = <&kraitcc 4>;
++			clock-names = "l2";
++			l2-supply = <&smb208_s1a>;
++			operating-points-v2 = <&opp_table_l2>;
++		};
++
 +		qfprom: qfprom@700000 {
 +			compatible = "qcom,qfprom", "syscon";
 +			reg = <0x700000 0x1000>;

--- a/target/linux/ipq806x/patches-5.4/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
+++ b/target/linux/ipq806x/patches-5.4/098-1-cpufreq-add-Krait-dedicated-scaling-driver.patch
@@ -75,7 +75,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  ##################################################################################
 --- /dev/null
 +++ b/drivers/cpufreq/qcom-cpufreq-krait.c
-@@ -0,0 +1,601 @@
+@@ -0,0 +1,603 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
@@ -115,9 +115,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +	int cpu, ret;
 +
 +	if (l2_pdev) {
++		int policy_cpu = policy->cpu;
++
 +		/* find the max freq across all core */
 +		for_each_present_cpu(cpu)
-+			if (cpu != index)
++			if (cpu != policy_cpu)
 +				target_freq = max(
 +					target_freq,
 +					(unsigned long)cpufreq_quick_get(cpu));
@@ -132,6 +134,18 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		level = dev_pm_opp_get_level(opp);
 +		dev_pm_opp_put(opp);
 +
++		/*
++		 * Hardware constraint:
++		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
++		 * Assume index 0 with the idle freq and level > 0 as 
++		 * any L2 freq > 384MHz.
++		 * Skip CPU freq change in this corner case.
++		 */
++		if (unlikely(index == 0 && level != 0)) {
++			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
++			return -EINVAL;
++		}
++
 +		opp = dev_pm_opp_find_level_exact(&l2_pdev->dev, level);
 +		if (IS_ERR(opp)) {
 +			dev_err(&l2_pdev->dev,
@@ -144,18 +158,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		ret = dev_pm_opp_set_rate(&l2_pdev->dev, target_freq);
 +		if (ret)
 +			return ret;
-+
-+		/*
-+		 * Hardware constraint:
-+		 * Krait CPU cannot operate at 384MHz with L2 at 1Ghz.
-+		 * Assume index 0 with the idle freq and level > 0 as 
-+		 * any L2 freq > 384MHz.
-+		 * Skip CPU freq change in this corner case.
-+		 */
-+		if (unlikely(index == 0 && level != 0)) {
-+			dev_err(priv->cpu_dev, "Krait CPU can't operate at idle freq with L2 at 1GHz");
-+			return -EINVAL;
-+		}
 +	}
 +
 +	ret = dev_pm_opp_set_rate(priv->cpu_dev, freq * 1000);


### PR DESCRIPTION
These 2 patch improve cache handling for this target.
In the 5.10 merge, ipq8065 never reimplemented the 1.4ghz for the cache and currently is working with 1.2ghz.
Fix a wrong implementation in the logic used in the dedicated cpufreq driver.
