### PR TITLE
ath79: Remove PPP from TL-WPA8630Pv2 images.

### DIFF
--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -592,7 +592,7 @@ define Device/tplink_tl-wpa8630p-v2
   SOC := qca9563
   DEVICE_MODEL := TL-WPA8630P
   IMAGE_SIZE := 6016k
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct -ppp -ppp-mod-pppoe -uboot-envtools
 endef
 
 define Device/tplink_tl-wpa8630p-v2-int


### PR DESCRIPTION
The available firmware space on these devices is only ~6M.
Removing PPP allows for an otherwise regular (+luci) build
of 21.02-rc1.

Signed-off-by: Joe Mullally <jwmullally@gmail.com>

For 21.02-rc1, no factory.bin were generated for these images. If possible, could this be backported to the `openwrt-21.02` branch?