### PR TITLE
ath79: add support for TP-Link TL-WA1201 v2

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wa1201-v2", "qca,qca9563";
+	model = "TP-Link TL-WA1201 v2";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		mdio-gpio0 = &mdio2;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	mdio2: mdio {
+		compatible = "virtual,mdio-gpio";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>, /* MDC */
+			<&gpio 4 GPIO_ACTIVE_HIGH>; /* MDIO */
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+
+			eee-broken-100tx;
+			eee-broken-1000t;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy4>;
+
+	mtd-mac-address = <&info 0x8>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			info: partition@20000 {
+				label = "info";
+				reg = <0x020000 0x010000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x030000 0xce0000>;
+			};
+
+			partition@d10000 {
+				label = "tplink";
+				reg = <0xd10000 0x2e0000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -19,7 +19,8 @@ glinet,gl-ar300m-lite|\
 glinet,gl-ar300m16|\
 pcs,cap324|\
 tplink,cpe610-v1|\
-tplink,cpe610-v2)
+tplink,cpe610-v2|\
+tplink,tl-wa1201-v2)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	;;
 alfa-network,n2q)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ ath79_setup_interfaces()
 	tplink,re450-v2|\
 	tplink,re450-v3|\
 	tplink,re455-v1|\
+	tplink,tl-wa1201-v2|\
 	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-ac|\
 	ubnt,bullet-m-ar7240|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -229,7 +229,8 @@ case "$FIRMWARE" in
 	tplink,archer-c60-v2|\
 	tplink,archer-c60-v3|\
 	tplink,archer-c6-v2|\
-	tplink,archer-c6-v2-us)
+	tplink,archer-c6-v2-us|\
+	tplink,tl-wa1201-v2)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) -1)
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -510,6 +510,17 @@ define Device/tplink_tl-mr6400-v1
 endef
 TARGET_DEVICES += tplink_tl-mr6400-v1
 
+define Device/tplink_tl-wa1201-v2
+  $(Device/tplink-safeloader-uimage)
+  SOC := qca9563
+  IMAGE_SIZE := 13184k
+  DEVICE_MODEL := TL-WA1201
+  DEVICE_VARIANT := v2
+  TPLINK_BOARD_ID := TL-WA1201-V2
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += tplink_tl-wa1201-v2
+
 define Device/tplink_tl-wdr3500-v1
   $(Device/tplink-8mlzma)
   SOC := ar9344

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1619,6 +1619,48 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the TL-WA1201 v2 */
+	{
+		.id     = "TL-WA1201-V2",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WA1201,product_ver:2.0.0,special_id:45550000}\n"
+			"{product_name:TL-WA1201,product_ver:2.0.0,special_id:55530000}\n",
+		.part_trail = 0x00,
+		.soft_ver = "soft_ver:1.0.1 Build 20200709 rel.66244\n",
+
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00200},
+			{"pin", 0x20200, 0x00100},
+			{"product-info", 0x20300, 0x00200},
+			{"device-id", 0x20500, 0x0fb00},
+			{"firmware", 0x30000, 0xce0000},
+			{"portal-logo", 0xd10000, 0x20000},
+			{"portal-back", 0xd30000, 0x200000},
+			{"soft-version", 0xf30000, 0x00200},
+			{"extra-para", 0xf30200, 0x00200},
+			{"support-list", 0xf30400, 0x00200},
+			{"profile", 0xf30600, 0x0fa00},
+			{"apdef-config", 0xf40000, 0x10000},
+			{"ap-config", 0xf50000, 0x10000},
+			{"redef-config", 0xf60000, 0x10000},
+			{"re-config", 0xf70000, 0x10000},
+			{"multidef-config", 0xf80000, 0x10000},
+			{"multi-config", 0xf90000, 0x10000},
+			{"clientdef-config", 0xfa0000, 0x10000},
+			{"client-config", 0xfb0000, 0x10000},
+			{"partition-table", 0xfc0000, 0x10000},
+			{"user-config", 0xfd0000, 0x10000},
+			{"certificate", 0xfe0000, 0x10000},
+			{"radio", 0xff0000, 0x10000},
+			{NULL, 0, 0}
+		},
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the TL-WA850RE v2 */
 	{
 		.id     = "TLWA850REV2",
@@ -2995,7 +3037,8 @@ static void build_image(const char *output,
 		const uint8_t extra_para[2] = {0x01, 0x00};
 		parts[5] = make_extra_para(info, extra_para,
 			sizeof(extra_para));
-	} else if (strcasecmp(info->id, "ARCHER-C6-V2") == 0) {
+	} else if (strcasecmp(info->id, "ARCHER-C6-V2") == 0 ||
+		   strcasecmp(info->id, "TL-WA1201-V2") == 0) {
 		const uint8_t extra_para[2] = {0x00, 0x01};
 		parts[5] = make_extra_para(info, extra_para,
 			sizeof(extra_para));


### PR DESCRIPTION
This device is a wireless access point working on the 2.4 GHz and 5 GHz
band, based on Qualcomm/Atheros QCA9563 + QCA9886.

Specification:
- 385 MHz CPU
- 128 MB of RAM (DDR2)
- 8 MB of FLASH (SPI NOR)
- QCA9563: 2.4 GHz 3x3
- QCA9886: 5 GHz
- AR8031: 1x 1 Gbs Ethernet
- 4x LED, WPS factory reset and power button
- bare UART on PCB (accessible through testpoints)

Methods for Flashing:
- Apply factory image in OEM firmware web-gui. Wait a minute after the
  progress bar completes and restart the device.
- Sysupgrade on top of existing OpenWRT image
- Solder wires onto UART testpoints and attach a terminal.
  Boot the device and press enter to enter U-Boot's menu. Then issue the
  following commands
  1. setenv serverip your-server-ip
     setenv ipaddr your-device-ip
  2. tftp 0x80060000 openwrt-squashfs.bin (Rembember output of size in
    hex, henceforth "sizeinhex")
  3. erase 0x9f030000 +"sizeinhex"
  4. cp.b 0x80060000 0x9f030000 0x"sizeinhex"
  5. reboot

Recovery:
- U-Boot serial console

Signed-off-by: Robert Balas <balasr@iis.ee.ethz.ch>

