### PR TITLE
package/utils: add script package to verify sysupgrade config

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -61,6 +61,7 @@ metadata_json = \
 			[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma) \
 			"supported_devices": ["$(call json_quote,$(legacy_supported_message))"]$(comma)) \
 		$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma)) \
+		$(if $(1),"$(call json_quote,$(1))": "$(if $(2),$(call json_quote,$(2)),1)"$(comma)) \
 		"version": { \
 			"dist": "$(call json_quote,$(VERSION_DIST))", \
 			"version": "$(call json_quote,$(VERSION_NUMBER))", \
@@ -71,7 +72,7 @@ metadata_json = \
 	}'
 
 define Build/append-metadata
-	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json) | fwtool -I - $@)
+	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_json,$(word 1,$(1)),$(word 2,$(1))) | fwtool -I - $@)
 	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
 		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
 		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\

--- a/package/base-files/files/etc/init.d/done
+++ b/package/base-files/files/etc/init.d/done
@@ -3,8 +3,10 @@
 
 START=95
 boot() {
+	. /lib/upgrade/common.sh
+
 	mount_root done
-	rm -f /sysupgrade.tgz && sync
+	rm -f /$BACKUP_FILE && sync
 
 	# process user commands
 	[ -f /etc/rc.local ] && {

--- a/package/base-files/files/etc/preinit
+++ b/package/base-files/files/etc/preinit
@@ -9,6 +9,7 @@ export PATH="%PATH%"
 . /lib/functions.sh
 . /lib/functions/preinit.sh
 . /lib/functions/system.sh
+. /lib/upgrade/common.sh
 
 boot_hook_init preinit_essential
 boot_hook_init preinit_main

--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -17,12 +17,12 @@ missing_lines() {
 do_mount_root() {
 	mount_root
 	boot_run_hook preinit_mount_root
-	[ -f /sysupgrade.tgz -o -f /tmp/sysupgrade.tar ] && {
+	[ -f /$BACKUP_FILE -o -f $BACKUP_FILE_TAR ] && {
 		echo "- config restore -"
 		cp /etc/passwd /etc/group /etc/shadow /tmp
 		cd /
-		[ -f /sysupgrade.tgz ] && tar xzf /sysupgrade.tgz
-		[ -f /tmp/sysupgrade.tar ] && tar xf /tmp/sysupgrade.tar
+		[ -f /$BACKUP_FILE ] && tar xzf /$BACKUP_FILE
+		[ -f $BACKUP_FILE_TAR ] && tar xf $BACKUP_FILE_TAR
 		missing_lines /tmp/passwd /etc/passwd >> /etc/passwd
 		missing_lines /tmp/group /etc/group >> /etc/group
 		missing_lines /tmp/shadow /etc/shadow >> /etc/shadow

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -1,6 +1,16 @@
-RAM_ROOT=/tmp/root
-
-export BACKUP_FILE=sysupgrade.tgz	# file extracted by preinit
+export BACKUP_FILE=sysupgrade.tgz		# file extracted by preinit
+export BACKUP_FILE_TAR=/tmp/sysupgrade.tar	# file extracted by preinit
+export CONF_TAR=/tmp/$BACKUP_FILE		# equal to $UPGRADE_BACKUP set by procd
+export ETCBACKUP_DIR=/etc/backup
+export IMAGE_FILE=/tmp/sysupgrade.img
+export INSTALLED_PACKAGES=${ETCBACKUP_DIR}/installed_packages.txt
+export KEEP_DIR=/lib/upgrade/keep.d
+export CONFFILES=/tmp/sysupgrade.conffiles
+export OVERLAY_DIR=/overlay/upper
+export UPGRADE_META=/tmp/sysupgrade.meta
+export UPGRADE_CERT=/tmp/sysupgrade.ucert
+export UPGRADE_CONF=/etc/sysupgrade.conf
+export RAM_ROOT=/tmp/root
 
 [ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
 libs() { ldd $* 2>/dev/null | sed -E 's/(.* => )?(.*) .*/\2/'; }

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -1,3 +1,5 @@
+. /lib/upgrade/common.sh
+
 fwtool_check_signature() {
 	[ $# -gt 1 ] && return 1
 
@@ -9,7 +11,7 @@ fwtool_check_signature() {
 		fi
 	}
 
-	if ! fwtool -q -s /tmp/sysupgrade.ucert "$1"; then
+	if ! fwtool -q -s $UPGRADE_CERT "$1"; then
 		v "Image signature not present"
 		[ "$REQUIRE_IMAGE_SIGNATURE" = 1 -a "$FORCE" != 1 ] && {
 			v "Use sysupgrade -F to override this check when downgrading or flashing to vendor firmware"
@@ -19,7 +21,7 @@ fwtool_check_signature() {
 	fi
 
 	fwtool -q -T -s /dev/null "$1" | \
-		ucert -V -m - -c "/tmp/sysupgrade.ucert" -P /etc/opkg/keys
+		ucert -V -m - -c "$UPGRADE_CERT" -P /etc/opkg/keys
 
 	return $?
 }
@@ -29,7 +31,7 @@ fwtool_check_image() {
 
 	. /usr/share/libubox/jshn.sh
 
-	if ! fwtool -q -i /tmp/sysupgrade.meta "$1"; then
+	if ! fwtool -q -i $UPGRADE_META "$1"; then
 		v "Image metadata not present"
 		[ "$REQUIRE_IMAGE_METADATA" = 1 -a "$FORCE" != 1 ] && {
 			v "Use sysupgrade -F to override this check when downgrading or flashing to vendor firmware"
@@ -38,7 +40,7 @@ fwtool_check_image() {
 		return 0
 	fi
 
-	json_load "$(cat /tmp/sysupgrade.meta)" || {
+	json_load "$(cat $UPGRADE_META)" || {
 		v "Invalid image metadata"
 		return 1
 	}

--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -2,6 +2,7 @@
 #
 
 . /lib/functions.sh
+. /lib/upgrade/common.sh
 
 # 'kernel' partition or UBI volume on NAND contains the kernel
 CI_KERNPART="${CI_KERNPART:-kernel}"
@@ -212,10 +213,8 @@ nand_upgrade_prepare_ubi() {
 }
 
 nand_do_upgrade_success() {
-	local conf_tar="/tmp/sysupgrade.tgz"
-
 	sync
-	[ -f "$conf_tar" ] && nand_restore_config "$conf_tar"
+	[ -f "$CONF_TAR" ] && nand_restore_config "$CONF_TAR"
 	echo "sysupgrade successful"
 	umount -a
 	reboot -f

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -2,13 +2,13 @@
 
 . /lib/functions.sh
 . /lib/functions/system.sh
+. /lib/upgrade/common.sh
 
 export IMAGE="$1"
 COMMAND="$2"
 
 export INTERACTIVE=0
 export VERBOSE=1
-export CONFFILES=/tmp/sysupgrade.conffiles
 
 RAMFS_COPY_BIN=		# extra programs for temporary ramfs root
 RAMFS_COPY_DATA=	# extra data files

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -2,6 +2,7 @@
 
 . /lib/functions.sh
 . /lib/functions/system.sh
+. /lib/upgrade/common.sh
 . /usr/share/libubox/jshn.sh
 
 # initialize defaults
@@ -53,11 +54,6 @@ while [ -n "$1" ]; do
 	shift;
 done
 
-export CONFFILES=/tmp/sysupgrade.conffiles
-export CONF_TAR=/tmp/sysupgrade.tgz
-export ETCBACKUP_DIR=/etc/backup
-export INSTALLED_PACKAGES=${ETCBACKUP_DIR}/installed_packages.txt
-
 IMAGE="$1"
 
 [ -z "$IMAGE" -a -z "$NEED_IMAGE" -a $CONF_BACKUP_LIST -eq 0 -o $HELP -gt 0 ] && {
@@ -86,7 +82,7 @@ upgrade-option:
 
 backup-command:
 	-b | --create-backup <file>
-	             create .tar.gz of files specified in sysupgrade.conf
+	             create .tar.gz of files specified in $UPGRADE_CONF
 	             then exit. Does not flash an image. If file is '-',
 	             i.e. stdout, verbosity is set to 0 (i.e. quiet).
 	-r | --restore-backup <file>
@@ -135,7 +131,7 @@ list_static_conffiles() {
 	local filter=$1
 
 	find $(sed -ne '/^[[:space:]]*$/d; /^#/d; p' \
-		/etc/sysupgrade.conf /lib/upgrade/keep.d/* 2>/dev/null) \
+		$UPGRADE_CONF ${KEEP_DIR}/* 2>/dev/null) \
 		\( -type f -o -type l \) $filter 2>/dev/null
 }
 
@@ -159,8 +155,7 @@ add_overlayfiles() {
 
 		list_conffiles | cut -f2 -d ' ' | sort -u > "$conffiles"
 
-		# backup files from /etc/sysupgrade.conf and /lib/upgrade/keep.d, but
-		# ignore those aready controlled by opkg conffiles
+		# ignore files already controlled by opkg conffiles
 		list_static_conffiles | sort -u |
 			grep -h -v -x -F -f $conffiles > "$keepfiles"
 
@@ -183,7 +178,7 @@ add_overlayfiles() {
 	# busybox grep bug when file is empty
 	[ -s "$packagesfiles" ] || echo > $packagesfiles
 
-	( cd /overlay/upper/; find .$SAVE_OVERLAY_PATH \( -type f -o -type l \) $find_filter | sed \
+	( cd ${OVERLAY_DIR}/; find .$SAVE_OVERLAY_PATH \( -type f -o -type l \) $find_filter | sed \
 		-e 's,^\.,,' \
 		-e '\,^/etc/board.json$,d' \
 		-e '\,/[^/]*-opkg$,d' \
@@ -198,8 +193,8 @@ add_overlayfiles() {
 }
 
 if [ $SAVE_OVERLAY = 1 ]; then
-	[ ! -d /overlay/upper/etc ] && {
-		echo "Cannot find '/overlay/upper/etc', required for '-c'" >&2
+	[ ! -d ${OVERLAY_DIR}/etc ] && {
+		echo "Cannot find '${OVERLAY_DIR}/etc', required for '-c'" >&2
 		exit 1
 	}
 	sysupgrade_init_conffiles="add_overlayfiles"
@@ -246,7 +241,7 @@ do_save_conffiles() {
 		# rom is used for pkgs in /rom, even if updated later
 		find /usr/lib/opkg/info -name "*.control" \( \
 			\( -exec test -f /rom/{} \; -exec echo {} rom \; \) -o \
-			\( -exec test -f /overlay/upper/{} \; -exec echo {} overlay \; \) -o \
+			\( -exec test -f ${OVERLAY_DIR}/{} \; -exec echo {} overlay \; \) -o \
 			\( -exec echo {} unknown \; \) \
 			\) | sed -e 's,.*/,,;s/\.control /\t/' > ${INSTALLED_PACKAGES}
 	fi
@@ -300,8 +295,8 @@ type platform_check_image >/dev/null 2>/dev/null || {
 case "$IMAGE" in
 	http://*|\
 	https://*)
-		wget -O/tmp/sysupgrade.img "$IMAGE" || exit 1
-		IMAGE=/tmp/sysupgrade.img
+		wget -O $IMAGE_FILE "$IMAGE" || exit 1
+		IMAGE=$IMAGE_FILE
 		;;
 esac
 
@@ -315,8 +310,8 @@ case "$IMAGE" in
 	/tmp/*)	;;
 	*)
 		v "Image not in /tmp, copying..."
-		cp -f "$IMAGE" /tmp/sysupgrade.img
-		IMAGE=/tmp/sysupgrade.img
+		cp -f "$IMAGE" $IMAGE_FILE
+		IMAGE=$IMAGE_FILE
 		;;
 esac
 

--- a/package/system/fstools/files/snapshot
+++ b/package/system/fstools/files/snapshot
@@ -65,7 +65,7 @@ do_convert() {
 	. /lib/functions.sh
 	. /lib/upgrade/common.sh
 
-	cd /overlay/upper
+	cd ${OVERLAY_DIR}
 	tar czf /tmp/snapshot.tar.gz *
 
 	install_bin /sbin/upgraded

--- a/package/utils/sysupgrade-config-verify/Makefile
+++ b/package/utils/sysupgrade-config-verify/Makefile
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=sysupgrade-config-verify
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/sysupgrade-config-verify
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Extra base-files to assist in factory OEM flash
+endef
+
+define Package/sysupgrade-config-verify/description
+	A set of extra base-files
+	that prevents config restore during factory.bin flash
+	by verifying each sysupgrade.bin flash.
+	This relies on the revision string and "sysupgrade" string
+	being in the image metadata
+	and for the image metadata to be saved
+	into the config tarball during sysupgrade via keep.d
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile/Default
+
+endef
+Build/Compile = $(Build/Compile/Default)
+
+define Package/sysupgrade-config-verify/install
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_DATA) ./files/75_config_restore_verify $(1)/lib/preinit
+endef
+
+$(eval $(call BuildPackage,sysupgrade-config-verify))

--- a/package/utils/sysupgrade-config-verify/files/75_config_restore_verify
+++ b/package/utils/sysupgrade-config-verify/files/75_config_restore_verify
@@ -1,0 +1,18 @@
+. /etc/os-release
+
+config_restore_verify() {
+	cd /
+
+	echo $UPGRADE_META > ${KEEP_DIR}/sysupgrade-config-verify
+
+	[ -f /$BACKUP_FILE ] && \
+		tar xzf /$BACKUP_FILE ${UPGRADE_META:1} &>/dev/null
+
+	[ -f $BACKUP_FILE_TAR ] && \
+		tar xf $BACKUP_FILE_TAR ${UPGRADE_META:1} &>/dev/null
+
+	(grep -qs "sysupgrade" $UPGRADE_META && grep -qs $BUILD_ID $UPGRADE_META) || \
+		mv -f /$BACKUP_FILE $BACKUP_FILE_TAR /etc &>/dev/null
+}
+
+boot_hook_add preinit_mount_root config_restore_verify


### PR DESCRIPTION
A friendlier per-device alternative to #4182 

in order to make this fix available on a per-device basis, have it supplied as a package
accompanied by some variable organization in base-files to prevent the need for code maintenance
in case anything used in the per-device script changes over time
the variable organization may also help other per-target or per-device fixes like this

There are some devices where OEM firmware is based on Openwrt,
and implants a sysupgrade.tgz into JFFS space during a factory.bin flash.
This behavior ends up completely breaking config of an affected device
after flashing with a factory.bin

The package allows for the config restore tarball to be verified
by inserting a set of extra base-files.
This prevents config restore during preinit after a factory.bin flash
by verifying the image metadata after a sysupgrade.bin flash.

It relies on the revision string and "sysupgrade" string
being in the image metadata
and for the image metadata to be saved
into the config tarball during sysupgrade via keep.d

Upon failing the checks,
the tarball is moved somewhere else and therefore never unpacked.
Instead of deleting, it remains stored in flash
in case the user still wants it for some reason.

For now, affected devices only need this one preinit file,
but in the future this package may have to be expanded or changed
based on changes in openwrt base-files or vendor SDKs.

Environment variables and symlinks are utilized as much as possible
to reduce possible code maintenance.

Moving this file or something similar to base-files
can considered in the future.

Usage example:
(assume IMAGE/sysupgrade.bin ends with append-metadata)

define Device/vendor_model-variant
  ...
  DEVICE_PACKAGES := sysupgrade-config-verify
  IMAGE/sysupgrade.bin += sysupgrade
  ...
endef

Signed-off-by: Michael Pratt <mcpratt@pm.me>

