### PR TITLE
base-files: fix configuration generation of network if "bridge" exists

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -109,7 +109,7 @@ generate_network() {
 		ports="$ifname"
 	}
 
-	[ -n "$ports" ] && {
+	[ -n "$ports" ] && [ -z "$bridge" ] && {
 		uci -q batch <<-EOF
 			add network device
 			set network.@device[-1].name='br-$1'
@@ -121,6 +121,7 @@ generate_network() {
 	}
 
 	[ -n "$bridge" ] && {
+		[ -n "$ports" ] && ifname="$ports"
 		if [ -z "$vlan" ]; then
 			bridge_vlan_id=$((bridge_vlan_id + 1))
 			vlan=$bridge_vlan_id


### PR DESCRIPTION
After the commit 43fc720657c6e3b30c6ed89d7227ee6e646c158b, the wrong
network configuration is generated for the devices that already have the
bridge device section for VLAN, such as the devices in realtek target.

As a result, the bridge device by additional "device" section is
specified to the "ports" option in the "bridge-vlan" section and netifd
shuts down the switch and the ethernet when the network service started.

--- generated config ---
```
config device 'switch'
        option name 'switch'
        option type 'bridge'
        option macaddr '34:76:c5:xx:xx:a8'

config device
        option name 'br-wan'
        option type 'bridge'
        list ports 'lan1'
	... (truncated)
        list ports 'lan9'

config bridge-vlan 'wan_vlan'
        option device 'switch'
        option vlan '1'
        option ports 'br-wan'
```
--- config end ---

--- log ---
```
root@OpenWrt:/# /etc/init.d/network start
root@OpenWrt:/# [  159.752015] Using MAC 00003476c5d9f0a8
[  159.756993] RESETTING 8380, CPU_PORT 28
[  159.961309] rtl838x-eth bb00a300.ethernet eth0: configuring for fixed/internal link mode
[  159.970338] In rtl838x_mac_config, mode 1
[  159.975095] device eth0 left promiscuous mode
[  159.980356] In rtl838x_mac_config, mode 1
[  159.984896] rtl838x-eth bb00a300.ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[  160.005785] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  160.283111] device eth0 entered promiscuous mode
[  160.288322] rtl83xx-switch switch@bb000000 lan1: configuring for phy/qsgmii link mode
[  160.308034] 8021q: adding VLAN 0 to HW filter on device lan1
[  160.340250] br-wan: port 1(lan1) entered blocking state
[  160.346104] br-wan: port 1(lan1) entered disabled state
[  160.352724] device lan1 entered promiscuous mode
... (truncated)
[  162.123430] rtl83xx-switch switch@bb000000 lan9: configuring for phy/internal link mode
[  162.143153] 8021q: adding VLAN 0 to HW filter on device lan9
[  162.175597] br-wan: port 24(lan9) entered blocking state
[  162.181669] br-wan: port 24(lan9) entered disabled state
[  162.188327] device lan9 entered promiscuous mode
[  162.209932] device lan1 left promiscuous mode
[  162.215216] br-wan: port 1(lan1) entered disabled state
... (truncated)
[  162.827566] device lan9 left promiscuous mode
[  162.832938] br-wan: port 24(lan9) entered disabled state
[  162.844314] in rtl838x_eth_stop
[  162.847955] rtl838x-eth bb00a300.ethernet eth0: Link is Down
[  163.754337] Using MAC 00003476c5d9f0a8
[  163.779357] RESETTING 8380, CPU_PORT 28
[  163.983666] rtl838x-eth bb00a300.ethernet eth0: configuring for fixed/internal link mode
[  163.992695] In rtl838x_mac_config, mode 1
[  163.997434] device eth0 left promiscuous mode
[  164.002670] In rtl838x_mac_config, mode 1
[  164.007209] rtl838x-eth bb00a300.ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[  164.044261] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[  164.534390] device eth0 entered promiscuous mode
[  164.539704] rtl83xx-switch switch@bb000000 lan1: configuring for phy/qsgmii link mode
[  164.559826] 8021q: adding VLAN 0 to HW filter on device lan1
[  164.592421] br-wan: port 1(lan1) entered blocking state
[  164.598270] br-wan: port 1(lan1) entered disabled state
[  164.604910] device lan1 entered promiscuous mode
... (truncated)
[  166.601998] rtl83xx-switch switch@bb000000 lan9: configuring for phy/internal link mode
[  166.622328] 8021q: adding VLAN 0 to HW filter on device lan9
[  166.653459] br-wan: port 24(lan9) entered blocking state
[  166.659530] br-wan: port 24(lan9) entered disabled state
[  166.666195] device lan9 entered promiscuous mode
[  166.688759] device lan1 left promiscuous mode
[  166.694131] br-wan: port 1(lan1) entered disabled state
... (truncated)
[  167.310359] device lan9 left promiscuous mode
[  167.315636] br-wan: port 24(lan9) entered disabled state
[  167.326988] in rtl838x_eth_stop
[  167.331006] rtl838x-eth bb00a300.ethernet eth0: Link is Down
```
--- log end ---

```
root@OpenWrt:/# ifconfig
lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:448 errors:0 dropped:0 overruns:0 frame:0
          TX packets:448 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:34944 (34.1 KiB)  TX bytes:34944 (34.1 KiB)

root@OpenWrt:/#
```
This patch fixes this issue.

Fixes: 43fc720657 ("base-files: generate "device" UCI type section for
bridge")

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>