### PR TITLE
ramips: add support for RAISECOM MSG1500 X.00

### DIFF
--- a/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
+++ b/target/linux/ramips/dts/mt7621_raisecom_msg1500-x-00.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "raisecom,msg1500-x-00", "mediatek,mt7621-soc";
+	model = "RAISECOM MSG1500 X.00";
+
+	aliases {
+		led-boot = &led_usb;
+		led-failsafe = &led_usb;
+		led-upgrade = &led_usb;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led_usb: usb {
+			label = "blue:usb";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "kernel";
+			reg = <0x140000 0x400000>;
+		};
+
+		partition@540000 {
+			label = "ubi";
+			reg = <0x540000 0x7a40000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		/* 5 GHz (phy1) does not take the address from calibration data,
+		   but setting it manually here works */
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1267,6 +1267,23 @@ define Device/planex_vr500
 endef
 TARGET_DEVICES += planex_vr500
 
+define Device/raisecom_msg1500-x-00
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 129280k
+  UBINIZE_OPTS := -E 5
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := RAISECOM
+  DEVICE_MODEL := MSG1500
+  DEVICE_VARIANT := X.00
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3 \
+	kmod-usb-ledtrig-usbport uboot-envtools
+endef
+TARGET_DEVICES += raisecom_msg1500-x-00
+
 define Device/samknows_whitebox-v8
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -161,6 +161,11 @@ ramips_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
 		;;
+	raisecom,msg1500-x-00)
+		lan_mac=$(mtd_get_mac_ascii Config protest_lan_mac)
+		wan_mac=$(mtd_get_mac_ascii Config protest_wan_mac)
+		label_mac=$lan_mac
+		;;
 	esac
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -39,6 +39,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	raisecom,msg1500-x-00)
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \
+				> /sys${DEVPATH}/macaddress
+		;;
 	tenbay,t-mb5eu-v01)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr "1" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -78,6 +78,7 @@ platform_do_upgrade() {
 	netgear,wac104|\
 	netgear,wac124|\
 	netis,wf2881|\
+	raisecom,msg1500-x-00|\
 	sercomm,na502|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\


### PR DESCRIPTION
RAISECOM MSG1500 X.00 is a 2.4/5 GHz band 11ac (Wi-Fi 5) router.
Apart from the general model, there are two ISP customized models:
China Mobile and China Telecom.

Specifications:

- SoC: Mediatek MT7621AT
- RAM: 256MiB DDR3
- Flash: 128MiB NAND
- Ethernet: 5 * 10/100/1000Mbps: 4 * LAN + 1 * WAN
  - Switch: MediaTek MT7530 (SoC)
- WLAN: 1 * MT7615DN Dual-Band 2.4GHz 2T2R (400Mbps) 5GHz 2T2R (867Mbps)
- USB: 1 * USB 2.0 port
- Button: 1 * RESET button, 1 * WPS button, 1 * WIFI button
- LED: blue color: POWER, WAN, WPS, 2.4G, 5G, LAN1, LAN2, LAN3, LAN4, USB
- UART: 1 * serial port header (4-pin)
- Power: DC 12V, 1A
  - Switch: 1 * POWER switch

MAC addresses as verified by vendor firmware:

use   address             source
LAN   C8:XX:XX:3A:XX:E7   Config   "protest_lan_mac"  ascii  (label)
WAN   C8:XX:XX:3A:XX:EA   Config   "protest_wan_mac"  ascii
5G    C8:XX:XX:3A:XX:E8   Factory  "0x4"              hex
2.4G  CA:XX:XX:4A:XX:E8   [not on flash]

The increment of the 4th byte for the 2.4g address appears to vary.
Reported cases:

       5g                 2.4g         increment
 C8:XX:XX:90:XX:C3  CA:XX:XX:C0:XX:C3  0x30
 C8:XX:XX:3A:XX:08  CA:XX:XX:4A:XX:08  0x10
 C8:XX:XX:3A:XX:E8  CA:XX:XX:4A:XX:E8  0x10

Since increment is inconsistent and there is no obvious pattern
in swapping bytes, and the 2.4g address has local bit set anyway,
it seems safer to use the LAN address with flipped byte here in
order to prevent collisions between OpenWrt devices and OEM devices
for this interface. This way we at least use an address as base
that is definitely owned by the device at hand.

Notes:

1. The vendor firmware allows you to connect to the router by telnet.
   (known version 1.0.0 can open telnet.)
   There is no official binary firmware available.
   Backup the important partitions data:
   "Bootloader", "Config", "Factory", and "firmware".
   Note that with the vendor firmware the memory is detected only 128MiB
   and the last 512KiB in NAND flash is not used.

2. The POWER LED is default on after press POWER switch.
   The WAN and LAN1 - 4 LEDs are wired to ethernet switch.
   The WPS LED is controlled by MT7615DN's GPIO.
   Currently there is no proper way to configure it.

3. At the time of adding support the wireless config needs to be set up 
   by editing the wireless config file:

 * Setting the country code is mandatory, otherwise the router loses
   connectivity at the next reboot. This is mandatory and can be done
   from luci. After setting the country code the router boots correctly.
   A reset with the reset button will fix the issue and the user has to
   reconfigure.

 * This is minor since the 5g interface does not come up online although
   it is not set as disabled. 2 options here:

   1- Either run the "wifi" command. Can be added from LuCI in system -
      startup - local startup and just add wifi above "exit 0".

   2- Or add the serialize option in the wireless config file as shown
      below. This one would work and bring both interfaces automatically
      at every boot:

      config wifi-device 'radio0'
          option serialize '1'

      config wifi-device 'radio1'
          option serialize '1'

Flash instructions using initramfs image:

1. Press POWER switch to power down if the router is running.

2. Connect PC to one of LAN ports, and set
   static IP address to "10.10.10.2", netmask to "255.255.255.0",
   and gateway to "10.10.10.1" manually on the PC.

3. Push and hold the WIFI button, and then power up the router.
   After about 10s (or you can call the recovery page, see "4" below)
   you can release the WIFI button.
   There is no clear indication when the router
   is entering or has entered into "RAISECOM Router Recovery Mode".

4. Call the recovery page for the router at "http://10.10.10.1".
   Keep an eye on the "WARNING!! tip" of the recovery page.
   Click "Choose File" to select initramfs image, then click "Upload".

5. If image is uploaded successfully, you will see the page display
   "Device is upgrading the firmware... %".
   Keep an eye on the "WARNING!! tip" of the recovery page.
   When the page display "Upgrade Successfully",
   you can set IP address as "automatically obtain".

6. After the rebooting (PC should automatically obtain an IP address),
   open the SSH connection, then download the sysupgrade image
   to the router and perform sysupgrade with it.

Flash back to vendor firmware:

 See "Flash instructions 1 - 5" above.
 The only difference is that in step 4
 you should select the vendor firmware which you backup.

Signed-off-by: Liangkuan Yang <ylk951207@gmail.com>
