### PR TITLE
ath79: add support for TP-Link TL-WR841HP v3

### DIFF
--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,tl-wr841hp-v3", "qca,qca9533";
+	model = "TP-Link TL-WR841HP v3";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_pwr: pwr {
+			label = "green:pwr";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "amber:wan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		re {
+			label = "green:re";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			label = "WiFi button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		re {
+			label = "RE button";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_0>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	mtd-mac-address = <&uboot 0x1fc00>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	mtd-mac-address = <&uboot 0x1fc00>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&uboot 0x1fc00>;
+};

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -32,7 +32,7 @@
 			default-state = "on";
 		};
 
-		wan {
+		wan_green {
 			label = "green:wan";
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
@@ -84,7 +84,6 @@
 
 		re {
 			label = "RE button";
-			linux,input-type = <EV_SW>;
 			linux,code = <BTN_0>;
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -11,10 +11,10 @@
 
 	aliases {
 		label-mac-device = &wmac;
-		led-boot = &led_pwr;
-		led-failsafe = &led_pwr;
-		led-running = &led_pwr;
-		led-upgrade = &led_pwr;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 	};
 
 	leds {
@@ -26,8 +26,8 @@
 			linux,default-trigger = "phy0tpt";
 		};
 
-		led_pwr: pwr {
-			label = "green:pwr";
+		led_power: power {
+			label = "green:power";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -71,7 +71,8 @@ tplink,archer-c59-v1|\
 tplink,archer-c59-v2|\
 tplink,archer-c60-v1|\
 tplink,archer-c60-v2|\
-tplink,archer-c60-v3)
+tplink,archer-c60-v3|\
+tplink,tl-wr841hp-v3)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -190,7 +190,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:wan" "2:lan"
 		;;
-	comfast,cf-e560ac)
+	comfast,cf-e560ac|\
+	tplink,tl-wr841hp-v3)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -742,6 +742,15 @@ define Device/tplink_tl-wr810n-v2
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
+define Device/tplink_tl-wr841hp-v3
+  $(Device/tplink-8mlzma)
+  SOC := qca9533
+  DEVICE_MODEL := TL-WR841HP
+  DEVICE_VARIANT := v3
+  TPLINK_HWID := 0x08411003
+endef
+TARGET_DEVICES += tplink_tl-wr841hp-v3
+
 define Device/tplink_tl-wr842n-v1
   $(Device/tplink-8m)
   SOC := ar7241


### PR DESCRIPTION
Specifications:
- QCA9533 SoC, 8 MB nor flash, 64 MB DDR2 RAM
- 4x Ethernet LAN 10/100, 1x Ethernet WAN 10/100
- 1x WAN, LAN, Wifi, PWR, WPS, RE Leds
- Reset, Wifi on/off, WPS, RE buttons
- Serial UART at J4 onboard: 3.3v GND RX TX, 1152008N1

Label MAC addresses based on vendor firmware, example:
LAN    *:ea    label
WAN    *:eb   label +1
2.4 GHz  *:ea   label
The label MAC address found in u-boot at 0x1fc00

Installation:
Upload openwrt-ath79-generic-tplink_tl-wr841hp-v3-squashfs-factory.bin
from stock firmware webgui.
Maybe we need rename to shorten file name due to stock webgui error.

Revert back to stock firmware instructions:
- set your PC to static IP address 192.168.0.66 netmask 255.255.255.0
- download stock firmware from Tp-link website
- put it in the root directory of tftp server software
- rename it to wr841hpv3_tp_recovery.bin
- power on while pressing Reset button until any Led is lighting up
- wait for the router to reboot. done

Forum support topic:
https://forum.openwrt.org/t/support-for-tp-link-tl-wr841hp-v3-router

Signed-off-by: teqlee <congquynh284@yahoo.com>
