### PR TITLE
comgt: ncm.sh manufacturer bug remove

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -73,7 +73,7 @@ proto_ncm_setup() {
 
 	[ -n "$delay" ] && sleep "$delay"
 
-	manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
+	manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /^\^|AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
 	[ $? -ne 0 -o -z "$manufacturer" ] && {
 		echo "Failed to get modem information"
 		proto_notify_error "$interface" GETINFO_FAILED


### PR DESCRIPTION
Signed-off-by: Alexander Stramoslab sicorski@madus.org

Maintainer: Felix Fietkau / <nbd@nbd.name>
Compile tested: GenuineIntel i-5 9400F, master
Run tested: YK-L1c, modem huawei E3276, OpenWrt 19.07.5 r11257-5090152ae3

Description:
[FIX] Fixed the appearance of annoying messages instead of the manufacturer's name.
