### PR TITLE
ramips: add support for Linksys E5600

### DIFF
--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "linksys,e5600", "mediatek,mt7621-soc";
+	model = "Linksys E5600";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps { 
+			label = "amber:wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+			default-state = "on";			
+		};
+
+		wan_amber {
+			label = "amber:wan";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u_env";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@c0000 {
+			label = "factory";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "s_env";
+			reg = <0x100000 0x40000>;
+		};
+
+		partition@140000 {
+			label = "devinfo";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		partition@580000 {
+			label = "ubi";
+			reg = <0x580000 0x1a00000>;
+		};
+
+		partition@1f80000 {
+			label = "alt_firmware";
+			reg = <0x1f80000 0x1e00000>;
+		};
+
+		partition@3d80000 {
+			label = "gdata";
+			reg = <0x3d80000 0x4200000>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "jtag";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -22,6 +22,10 @@ define Build/elecom-wrc-gs-factory
 	mv $@.new $@
 endef
 
+define Build/gemtek-trailer
+	printf "%s%08X" ".GEMTEK." "$$(cksum $@ | cut -d ' ' -f1)" >> $@
+endef
+
 define Build/iodata-factory
 	$(eval fw_size=$(word 1,$(1)))
 	$(eval fw_type=$(word 2,$(1)))
@@ -761,6 +765,25 @@ define Device/lenovo_newifi-d1
   SUPPORTED_DEVICES += newifi-d1
 endef
 TARGET_DEVICES += lenovo_newifi-d1
+
+define Device/linksys_e5600
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 26624k
+  DEVICE_VENDOR := Linksys
+  DEVICE_MODEL := E5600
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-mt7663-firmware-sta uboot-envtools
+  UBINIZE_OPTS := -E 5
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-ubi | check-size | gemtek-trailer
+endef
+TARGET_DEVICES += linksys_e5600
 
 define Device/linksys_ea7xxx
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -46,6 +46,9 @@ gnubee,gb-pc2)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2"
 	;;
+linksys,e5600)
+	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
+	;;
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -127,6 +127,7 @@ ramips_setup_macs()
 	zbtlink,zbt-wg3526-32m)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
+	linksys,e5600|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -18,6 +18,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	linksys,e5600|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2)

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -8,6 +8,7 @@ boot() {
 		[ -n "$(fw_printenv bootcount bootchanged 2>/dev/null)" ] &&\
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
+	linksys,e5600|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -50,6 +50,7 @@ platform_do_upgrade() {
 	dlink,dir-2660-a1|\
 	hiwifi,hc5962|\
 	jcg,q20|\
+	linksys,e5600|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\


### PR DESCRIPTION
This submission relied heavily on the work of Linksys EA7300 v1/ v2.

Specifications:

* SoC: MediaTek MT7621A (880 MHz 2c/4t)
* RAM: 128M DDR3-1600
* Flash: 128M NAND
* Eth: MediaTek MT7621A (10/100/1000 Mbps x5)
* Radio: MT7603E/MT7613BE (2.4 GHz & 5 GHz)
* Antennae: 2 internal fixed in the casing and 2 on the PCB
* LEDs: Blue (x4 Ethernet)
  Blue+Orange (x2 Power + WPS and Internet)
* Buttons: Reset (x1)
  WPS (x1)

Installation:

Flash factory image through GUI.

This device has 2 partitions for the firmware called firmware and
alt_firmware. To successfully flash and boot the device, the device
should have been running from alt_firmware partition. To get the device
booted through alt_firmware partition, download the OEM firmware from
Linksys website and upgrade the firmware from web GUI. Once this is done,
flash the OpenWrt Factory firmware from web GUI.

Reverting to factory firmware:

1. Boot to 'alt_firmware'(where stock firmware resides) by doing one of
   the following:
   Press the "wps" button as soon as power LED turns on when booting.
   (OR) Hard-reset the router consecutively three times to force it to
   boot from 'alt_firmware'.
2. To remove any traces of OpenWRT from your router simply flash the OEM
   image at this point.

Signed-off-by: Aashish Kulkarni <aashishkul@gmail.com>

[fix hanging indents and wrap to 74 characters per line,
 add kmod-mt7663-firmware-sta package for 5GHz STA mode to work,
 remove sysupgrade.bin and concatenate IMAGES instead in mt7621.mk,
 set default-state "on" for power LED]
Signed-off-by: Sannihith Kinnera <digislayer@protonmail.com>