### PR TITLE
kernel: bump 5.10 to 5.10.40

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .121
-LINUX_VERSION-5.10 = .39
+LINUX_VERSION-5.10 = .40
 
 LINUX_KERNEL_HASH-5.4.121 = 9d9327fca397e114bcc59d69fa5ae1ac8bac76b170ed811d1b1645df7456375f
-LINUX_KERNEL_HASH-5.10.39 = 5738a515ca97853481767360c568eae46c8d777d98a69e018a3299baa6b3f614
+LINUX_KERNEL_HASH-5.10.40 = 7480803acd7152b1e8248954e219ca9d8d95afa73ec2d8973170939ac44b2f24
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/hack-5.10/902-debloat_proc.patch
+++ b/target/linux/generic/hack-5.10/902-debloat_proc.patch
@@ -135,7 +135,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	do {								\
 --- a/ipc/msg.c
 +++ b/ipc/msg.c
-@@ -1348,6 +1348,9 @@ void __init msg_init(void)
+@@ -1350,6 +1350,9 @@ void __init msg_init(void)
  {
  	msg_init_ns(&init_ipc_ns);
  

--- a/target/linux/generic/pending-5.10/110-perf-jevents-fix-getting-maximum-number-of-fds.patch
+++ b/target/linux/generic/pending-5.10/110-perf-jevents-fix-getting-maximum-number-of-fds.patch
@@ -13,7 +13,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/tools/perf/pmu-events/jevents.c
 +++ b/tools/perf/pmu-events/jevents.c
-@@ -897,7 +897,7 @@ static int get_maxfds(void)
+@@ -894,7 +894,7 @@ static int get_maxfds(void)
  	struct rlimit rlim;
  
  	if (getrlimit(RLIMIT_NOFILE, &rlim) == 0)


### PR DESCRIPTION
Automatically refreshed:
generic/hack-5.10/902-debloat_proc.patch
generic/pending-5.10/110-perf-jevents-fix-getting-maximum-number-of-fds.patch

Run-tested:
ramips/mt7621 (Redmi AC2100)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>