### PR TITLE
kernel: ltq-tapi add customer pulse digit time

### DIFF
--- a/package/kernel/lantiq/ltq-tapi/Makefile
+++ b/package/kernel/lantiq/ltq-tapi/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=drv_tapi
 PKG_VERSION:=3.13.0
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=drv_tapi-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=@OPENWRT

--- a/package/kernel/lantiq/ltq-tapi/patches/410-custom_pulsedigit_time.patch
+++ b/package/kernel/lantiq/ltq-tapi/patches/410-custom_pulsedigit_time.patch
@@ -1,0 +1,54 @@
+diff -aurN a/src/drv_tapi.h b/src/drv_tapi.h
+--- a/src/drv_tapi.h	2010-06-17 11:39:57.000000000 +0200
++++ b/src/drv_tapi.h	2021-05-27 18:18:37.511725834 +0200
+@@ -25,6 +25,7 @@
+ #include <lib_bufferpool.h>
+ #include "drv_tapi_io.h"
+ #include "drv_tapi_event.h"
++#include <linux/module.h>
+ 
+ 
+ /* ============================= */
+diff -aurN a/src/drv_tapi_dial.c b/src/drv_tapi_dial.c
+--- a/src/drv_tapi_dial.c	2010-06-21 17:27:59.000000000 +0200
++++ b/src/drv_tapi_dial.c	2021-05-27 18:24:47.705084613 +0200
+@@ -20,6 +20,19 @@
+ #include "drv_tapi.h"
+ #include "drv_tapi_errno.h"
+ 
++
++
++static unsigned int min_digit_low = TAPI_MIN_DIGIT_LOW;
++static unsigned int max_digit_low = TAPI_MAX_DIGIT_LOW;
++static unsigned int min_digit_high = TAPI_MIN_DIGIT_HIGH;
++static unsigned int max_digit_high = TAPI_MAX_DIGIT_HIGH;
++static unsigned int min_interdigit = TAPI_MIN_INTERDIGIT;
++module_param(min_digit_low, uint, 0);
++module_param(max_digit_low, uint, 0);
++module_param(min_digit_high, uint, 0);
++module_param(max_digit_high, uint, 0);
++module_param(min_interdigit, uint, 0);
++
+ /*lint -save -esym(749, TAPI_HOOK_STATE_PULSE_H_FLASH_VAL) */
+ /* ============================= */
+ /* Local macros and definitions  */
+@@ -408,14 +421,14 @@
+       }
+    }
+    /* set default values for the validation timers */
+-   pTapiDialData->TapiDigitLowTime.nMinTime      = TAPI_MIN_DIGIT_LOW;
+-   pTapiDialData->TapiDigitLowTime.nMaxTime      = TAPI_MAX_DIGIT_LOW;
+-   pTapiDialData->TapiDigitHighTime.nMinTime     = TAPI_MIN_DIGIT_HIGH;
+-   pTapiDialData->TapiDigitHighTime.nMaxTime     = TAPI_MAX_DIGIT_HIGH;
++   pTapiDialData->TapiDigitLowTime.nMinTime      = min_digit_low;
++   pTapiDialData->TapiDigitLowTime.nMaxTime      = max_digit_low;
++   pTapiDialData->TapiDigitHighTime.nMinTime     = min_digit_high;
++   pTapiDialData->TapiDigitHighTime.nMaxTime     = max_digit_high;
+    pTapiDialData->TapiHookFlashTime.nMinTime     = TAPI_MIN_FLASH;
+    pTapiDialData->TapiHookFlashTime.nMaxTime     = TAPI_MAX_FLASH;
+    pTapiDialData->TapiHookFlashMakeTime.nMinTime = TAPI_MIN_FLASH_MAKE;
+-   pTapiDialData->TapiInterDigitTime.nMinTime    = TAPI_MIN_INTERDIGIT;
++   pTapiDialData->TapiInterDigitTime.nMinTime    = min_interdigit;
+    pTapiDialData->TapiHookOffTime.nMinTime       = TAPI_MIN_OFF_HOOK;
+    pTapiDialData->TapiHookOnTime.nMinTime        = TAPI_MIN_ON_HOOK;
+    /* start hook state FSM in onhook state */


### PR DESCRIPTION
With this patch you can change the pulse digit time by loading the Lantiq
FXS driver kernel module called ltq-tapi. This is relevant for old
rotaryphones that uses pulsedialing.

The default values are:
30-80ms for the low pulse
30-80ms for the high pulse
300ms for minimum Interdigit time

this is OK but on some Phones it can be usefull to customize the values
If you want to change the values to high and low pulse to 40-90ms and
minimum interdigit time to 400ms

than change /etc/modules.d/20-ltq-tapi to (without linebrakes):
drv_tapi min_digit_low=40  min_digit_high=90 max_digit_low=40 max_digit_high=90 min_interdigit=400

Signed-off-by: Jonas Albrecht <plonkbong100@protonmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
