### PR TITLE
base-files: upgrade: use procd to kill managed daemons

### DIFF
--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -123,15 +123,31 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 
 indicate_upgrade
 
+while read -r a b c; do
+	case "$a" in
+		MemT*) mem="$b" ;; esac
+done < /proc/meminfo
+
+[ "$mem" -gt 32768 ] && \
+	skip_services="dnsmasq log network"
+for service in /etc/init.d/*; do
+	service=${service##*/}
+
+	case " $skip_services " in
+		*" $service "*) continue ;; esac
+
+	ubus call service delete '{ "name": "'"$service"'" }' 2>/dev/null
+done
+
 killall -9 telnetd
 killall -9 dropbear
 killall -9 ash
 
 kill_remaining TERM
-sleep 3
+sleep 4
 kill_remaining KILL 1
 
-sleep 1
+sleep 6
 
 echo 3 > /proc/sys/vm/drop_caches
 


### PR DESCRIPTION
These processes are managed by procd and set to start again when killed
via the procd instance parameter "respawn" being set during init.

Example:
procd_set_param respawn 3600 1 0

When they are killed manually during sysupgrade,
they are started again in 5 seconds or less, depending on
how the "respawn" parameter is set.

Use procd through init.d to disable the instances that respawn them.

Properly closing all processes saves about 6 MB in memory,
which should help some low memory devices upgrade without crashing.

Signed-off-by: Michael Pratt <mcpratt@pm.me>
