### PR TITLE
kernel: usb: add kmod-usb-gadget-ncm

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -179,6 +179,23 @@ endef
 
 $(eval $(call KernelPackage,usb-gadget-eth))
 
+define KernelPackage/usb-gadget-ncm
+  TITLE:=USB Network Control Model (NCM) Gadget support
+  KCONFIG:=CONFIG_USB_G_NCM
+  DEPENDS:=+kmod-usb-gadget +kmod-usb-lib-composite \
+	+kmod-usb-gadget-eth
+  FILES:= \
+	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_ncm.ko \
+	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_ncm.ko
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_ncm)
+  $(call AddDepends/usb)
+endef
+
+define KernelPackage/usb-gadget-ncm/description
+  Kernel support for USB Network Control Model (NCM) Gadget
+endef
+
+$(eval $(call KernelPackage,usb-gadget-ncm))
 
 define KernelPackage/usb-gadget-serial
   TITLE:=USB Serial Gadget support


### PR DESCRIPTION
Add kernel module package for USB Network Control Model (NCM) Gadget support.

Network Control Model (NCM) is substantially more efficient than Ethernet Control Model (ECM) and it's supported by Linux, macOS and Windows.

Microsoft even recommends that hardware vendors build USB NCM compatible devices instead of RNDIS. (https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/supported-usb-classes)

Runtime-tested on bcm27xx/bcm2711.

Signed-off-by: Kuan-Yi Li <kyli@abysm.org>