### PR TITLE
[RFC] set interface MAC addresses for mikrotik ramips targets

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -135,11 +135,27 @@ ramips_setup_macs()
 		label_mac=$lan_mac
 		;;
 	mikrotik,routerboard-750gr3|\
-	mikrotik,routerboard-760igs|\
 	mikrotik,routerboard-m33g)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
+		;;
+	mikrotik,routerboard-760igs)
+		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
+
+		ucidef_set_network_device_mac "wan" $label_mac
+
+		ucidef_set_network_device_mac "lan2" \
+			$(macaddr_add $label_mac 1)
+		ucidef_set_network_device_mac "lan3" \
+			$(macaddr_add $label_mac 2)
+		ucidef_set_network_device_mac "lan4" \
+			$(macaddr_add $label_mac 3)
+		ucidef_set_network_device_mac "lan5" \
+			$(macaddr_add $label_mac 4)
+
+		ucidef_set_network_device_mac "sfp" \
+			$(macaddr_add $label_mac 5)
 		;;
 	mikrotik,routerboard-m11g)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -136,11 +136,14 @@ ramips_setup_macs()
 		;;
 	mikrotik,routerboard-750gr3|\
 	mikrotik,routerboard-760igs|\
-	mikrotik,routerboard-m11g|\
 	mikrotik,routerboard-m33g)
 		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add $label_mac 1)
+		;;
+	mikrotik,routerboard-m11g)
+		label_mac=$(cat "/sys/firmware/mikrotik/hard_config/mac_base")
+		lan_mac=$label_mac
 		;;
 	esac
 


### PR DESCRIPTION
A low priority nice-to-have change: For Mikrotik ramips targets, use `ucidef_set_network_device_mac` (introduced by 9290539ca9c7b296891b1b386052c0fe308e9a62 "base-files: allow setting device and bridge macs") to apply a MAC address to each (DSA port) interface. This then matches OEM firmware MAC address assignment.

netifd automatically applies the `ucidef_set_network_device_mac board.json network-device` settings to a an OpenWrt configured device: https://git.openwrt.org/?p=project/netifd.git;a=commitdiff;h=42c48866f1c1fce068f41536baa8dd2e80fc08d7

Store the MAC addresses in style of 9aa449050297b58a41843bceaff6179458b64003 ("realtek: clean up board.json generation")

RFC as quick and dirty, and worth considering how interface macs should be set in `config_generate` while is it undergoing recent changes.