### PR TITLE
ramips: mikrotik: enable additional UART on MikroTik RouterBOARD M33G

### DIFF
--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-m33g.dts
@@ -127,3 +127,7 @@
 &pcie {
 	status = "okay";
 };
+
+&uartlite3 {
+	status = "okay";
+};


### PR DESCRIPTION
The RouterBOARD M33G has an additional UART that should be enabled by
default.

Signed-off-by: Philipp Borgers <borgers@mi.fu-berlin.de>
