### PR TITLE
kernel: new package rtl8812au-gb

### DIFF
--- a/package/kernel/rtl8812au-gb/Makefile
+++ b/package/kernel/rtl8812au-gb/Makefile
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl8812au-gb
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=
+
+PKG_SOURCE_URL:=https://github.com/gordboy/rtl8812au-5.9.3.2/
+PKG_MIRROR_HASH:=9af90c32c2aeebf3705db219a47550e3e504886ebeb1cab618c293b5484eefb8
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-04-27
+PKG_SOURCE_VERSION:=6ef5d8fcdb0b94b7490a9a38353877708fca2cd4
+
+PKG_MAINTAINER:=Dirk Neukirchen <plntyk.lede@plntyk.name>
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/rtl8812au-gb
+  SUBMENU:=Wireless Drivers
+  TITLE:=Realtek 8812AU driver based on 5.9.3.2 mod by gordboy
+  DEPENDS:=+kmod-cfg80211 +kmod-usb-core +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT
+  FILES:=\
+	$(PKG_BUILD_DIR)/rtl8812au.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8812au)
+  PROVIDES:=kmod-rtl8812au
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h
+
+ifdef CONFIG_PACKAGE_kmod-rtl8812au-gb
+   PKG_MAKE_FLAGS += CONFIG_RTL8812AU=m
+endif
+
+NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
+
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		$(PKG_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,rtl8812au-gb))

--- a/package/kernel/rtl8812au-gb/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-gb/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
@@ -1,0 +1,26 @@
+From b3fa4d9b0b8eae46c7523d03e18fbb12876d7155 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:46:17 +0200
+Subject: [PATCH 1/6] core/rtw_mlme.c: fix warning:  misleading indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/rtw_mlme.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/rtw_mlme.c b/core/rtw_mlme.c
+index e6f61c8b..935e14cc 100644
+--- a/core/rtw_mlme.c
++++ b/core/rtw_mlme.c
+@@ -3157,7 +3157,7 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
+ 		else
+ 		#endif
+ 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+-			goto exit;
++		goto exit;
+ 	}
+ 	else if (ssc_chk != SS_ALLOW)
+ 		goto exit;
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
+++ b/package/kernel/rtl8812au-gb/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
@@ -1,0 +1,33 @@
+From 159b26937a0b61d03fc687a284b13b87a27b6cef Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:58:04 +0200
+Subject: [PATCH 2/6] core/efuse/rtw_efuse.c: fix warning: misleading
+ indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/efuse/rtw_efuse.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/core/efuse/rtw_efuse.c b/core/efuse/rtw_efuse.c
+index b67637fe..ad981af9 100644
+--- a/core/efuse/rtw_efuse.c
++++ b/core/efuse/rtw_efuse.c
+@@ -909,10 +909,10 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++		, pEfuseHal->fakeEfuseInitMap[i]
++		, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
+ 		}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0003-core-rtw_recv.c-fix-warning-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-gb/patches/0003-core-rtw_recv.c-fix-warning-misleading-indentation.patch
@@ -1,0 +1,35 @@
+From d7aa7bbfcd4275e51029eb397ed4cba7023126ae Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:59:28 +0200
+Subject: [PATCH 3/6] core/rtw_recv.c: fix warning: misleading indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/rtw_recv.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/core/rtw_recv.c b/core/rtw_recv.c
+index df9f1b42..4eed1042 100644
+--- a/core/rtw_recv.c
++++ b/core/rtw_recv.c
+@@ -3598,11 +3598,12 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+ 			for (i = 0; i < precv_frame->u.hdr.len; i = i + 8)
+ 				RTW_INFO("%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:\n", *(ptr + i),
+ 					*(ptr + i + 1), *(ptr + i + 2) , *(ptr + i + 3) , *(ptr + i + 4), *(ptr + i + 5), *(ptr + i + 6), *(ptr + i + 7));
+-				RTW_INFO("#############################\n");
+-				_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
+-				_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
+-				pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
+-				pmppriv->mplink_brx =_TRUE;
++
++			RTW_INFO("#############################\n");
++			_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
++			_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
++			pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
++			pmppriv->mplink_brx =_TRUE;
+ 		}
+ 	}
+ 	if (pmppriv->bloopback) {
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0004-module-name-like-ct-Makefile.patch
+++ b/package/kernel/rtl8812au-gb/patches/0004-module-name-like-ct-Makefile.patch
@@ -1,0 +1,25 @@
+From e0931ac32bbb179e0419e6d4b843b10baefa2b1f Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 17:48:07 +0200
+Subject: [PATCH 4/6] module name like -ct Makefile
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index f57825dd..97a5e87f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2244,7 +2244,7 @@ endif
+ 
+ endif
+ 
+-USER_MODULE_NAME ?=
++USER_MODULE_NAME ?= rtl$(MODULE_NAME)
+ ifneq ($(USER_MODULE_NAME),)
+ MODULE_NAME := $(USER_MODULE_NAME)
+ endif
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0005-Fix-build-against-openwrt-backports-tree.patch
+++ b/package/kernel/rtl8812au-gb/patches/0005-Fix-build-against-openwrt-backports-tree.patch
@@ -1,0 +1,45 @@
+From 1687092d260d749131756779a3274cced5deab29 Mon Sep 17 00:00:00 2001
+From: Ben Greear <greearb@candelatech.com>
+Date: Fri, 9 Nov 2018 16:21:43 -0800
+Subject: [PATCH 5/6] Fix build against openwrt backports tree.
+
+Like breaks builds elsewhere, can fix it up later.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+
+modified for rtl8812au-mw by
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ include/drv_conf.h                                      | 4 +++-
+ include/linux/{wireless.h => old_unused_rtl_wireless.h} | 0
+ include/{autoconf.h => rtl_autoconf.h}                  | 0
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+ rename include/linux/{wireless.h => old_unused_rtl_wireless.h} (100%)
+ rename include/{autoconf.h => rtl_autoconf.h} (100%)
+
+diff --git a/include/drv_conf.h b/include/drv_conf.h
+index 8395b768..6b74cb0c 100644
+--- a/include/drv_conf.h
++++ b/include/drv_conf.h
+@@ -14,7 +14,9 @@
+  *****************************************************************************/
+ #ifndef __DRV_CONF_H__
+ #define __DRV_CONF_H__
+-#include "autoconf.h"
++#include <generated/autoconf.h>
++#include "rtl_autoconf.h"
++
+ #include "hal_ic_cfg.h"
+ 
+ #define CONFIG_RSSI_PRIORITY
+diff --git a/include/linux/wireless.h b/include/linux/old_unused_rtl_wireless.h
+similarity index 100%
+rename from include/linux/wireless.h
+rename to include/linux/old_unused_rtl_wireless.h
+diff --git a/include/autoconf.h b/include/rtl_autoconf.h
+similarity index 100%
+rename from include/autoconf.h
+rename to include/rtl_autoconf.h
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0006-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
+++ b/package/kernel/rtl8812au-gb/patches/0006-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
@@ -1,0 +1,25 @@
+From 07d685c67cf678435a644c5b26742d68ffd9ec79 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:34:01 +0200
+Subject: [PATCH 6/6] OpenWrt patch 001-use-kernel-byteorder.patch
+
+---
+ include/drv_types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/drv_types.h b/include/drv_types.h
+index 963e7091..e38aa7c1 100644
+--- a/include/drv_types.h
++++ b/include/drv_types.h
+@@ -25,7 +25,7 @@
+ #include <drv_conf.h>
+ #include <basic_types.h>
+ #include <osdep_service.h>
+-#include <rtw_byteorder.h>
++#include <asm/byteorder.h>
+ #include <wlan_bssdef.h>
+ #include <wifi.h>
+ #include <ieee80211.h>
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-gb/patches/0006-OpenWrt-patch-003-wireless-5.8.patch.patch
+++ b/package/kernel/rtl8812au-gb/patches/0006-OpenWrt-patch-003-wireless-5.8.patch.patch
@@ -1,0 +1,44 @@
+From fc0e90868cea94c9334dfb53396f3130380f265d Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:37:35 +0200
+Subject: [PATCH 03/12] OpenWrt 003-wireless-5.8.patch
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 7719b728..ed6bb53a 100644
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -8024,6 +8024,15 @@ exit:
+ }
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)) || defined(BUILD_OPENWRT)
++static void cfg80211_rtw_update_mgmt_frame_registrations(struct wiphy *wiphy,
++						   struct wireless_dev *wdev,
++						   struct mgmt_frame_regs *upd)
++{
++
++}
++#endif
++
+ #if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
+ static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
+ 	struct net_device *ndev,
+@@ -10419,7 +10428,10 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
+ 	.update_ft_ies = cfg80211_rtw_update_ft_ies,
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || defined(BUILD_OPENWRT)
++	.mgmt_tx = cfg80211_rtw_mgmt_tx,
++	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_registrations,
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+ 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
+ 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
+-- 
+2.31.1
+


### PR DESCRIPTION
another Realtek rtl8812au driver modified by gordboy
used in Arch Linux AUR

scanning works with qemu x86_64 + TP-Link T4U stock

- joining open networks fails
- joining encrypted networks fails

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>
