### PR TITLE
kernel: add rtl881au-mw package

### DIFF
--- a/package/kernel/rtl8812au-mw/Makefile
+++ b/package/kernel/rtl8812au-mw/Makefile
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl8812au-mw
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE_URL:=https://github.com/morrownr/8812au
+PKG_MIRROR_HASH:=fa3a0eb4f97565efb2a12f83711cb0c25343c7bc83fc4dbc0247fc47d8d6c79b
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-05-31
+PKG_SOURCE_VERSION:=2ad8892541d0321f1b859f52c438a74822b01bfa
+
+PKG_MAINTAINER:=Dirk Neukirchen <plntyk.lede@plntyk.name>
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/rtl8812au-mw
+  SUBMENU:=Wireless Drivers
+  TITLE:=Realtek 8812AU driver based on 5.9.3.2 mod by morrownr
+  DEPENDS:=+kmod-cfg80211 +kmod-usb-core +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT
+  FILES:=\
+	$(PKG_BUILD_DIR)/rtl8812au.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8812au)
+  PROVIDES:=kmod-rtl8812au
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h
+
+ifdef CONFIG_PACKAGE_kmod-rtl8812au-mw
+   PKG_MAKE_FLAGS += CONFIG_RTL8812AU=m
+endif
+
+NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
+
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		$(PKG_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,rtl8812au-mw))

--- a/package/kernel/rtl8812au-mw/patches/0001-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
+++ b/package/kernel/rtl8812au-mw/patches/0001-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
@@ -1,0 +1,25 @@
+From dce84c6518090efae57f8357e67642f4f21b6c36 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:34:01 +0200
+Subject: [PATCH 01/12] OpenWrt patch 001-use-kernel-byteorder.patch
+
+---
+ include/drv_types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/drv_types.h b/include/drv_types.h
+index 86c569f0..086b6bf9 100644
+--- a/include/drv_types.h
++++ b/include/drv_types.h
+@@ -25,7 +25,7 @@
+ #include <drv_conf.h>
+ #include <basic_types.h>
+ #include <osdep_service.h>
+-#include <rtw_byteorder.h>
++#include <asm/byteorder.h>
+ #include <wlan_bssdef.h>
+ #include <wifi.h>
+ #include <ieee80211.h>
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0002-OpenWrt-patch-002-vendor_command_policy.patch.patch
+++ b/package/kernel/rtl8812au-mw/patches/0002-OpenWrt-patch-002-vendor_command_policy.patch.patch
@@ -1,0 +1,346 @@
+From 188e6890961f5a922b2cfbf742d9452d8f6b4be3 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:34:55 +0200
+Subject: [PATCH 02/12] OpenWrt patch 002-vendor_command_policy.patch
+
+---
+ os_dep/linux/rtw_cfgvendor.c | 99 ++++++++++++++++++++++++------------
+ 1 file changed, 66 insertions(+), 33 deletions(-)
+
+diff --git a/os_dep/linux/rtw_cfgvendor.c b/os_dep/linux/rtw_cfgvendor.c
+index 8781d231..977006a6 100644
+--- a/os_dep/linux/rtw_cfgvendor.c
++++ b/os_dep/linux/rtw_cfgvendor.c
+@@ -1791,7 +1791,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_GET_CAPABILITIES
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_gscan_get_capabilities
++		.doit = rtw_cfgvendor_gscan_get_capabilities,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1799,7 +1800,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_SET_CONFIG
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_scan_cfg
++		.doit = rtw_cfgvendor_set_scan_cfg,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1807,7 +1809,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_SET_SCAN_CONFIG
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_batch_scan_cfg
++		.doit = rtw_cfgvendor_set_batch_scan_cfg,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1815,7 +1818,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_ENABLE_GSCAN
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_initiate_gscan
++		.doit = rtw_cfgvendor_initiate_gscan,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1823,7 +1827,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_ENABLE_FULL_SCAN_RESULTS
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_enable_full_scan_result
++		.doit = rtw_cfgvendor_enable_full_scan_result,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1831,7 +1836,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_SET_HOTLIST
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_hotlist_cfg
++		.doit = rtw_cfgvendor_hotlist_cfg,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1839,7 +1845,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_SET_SIGNIFICANT_CHANGE_CONFIG
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_significant_change_cfg
++		.doit = rtw_cfgvendor_significant_change_cfg,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1847,7 +1854,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_GET_SCAN_RESULTS
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_gscan_get_batch_results
++		.doit = rtw_cfgvendor_gscan_get_batch_results,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1855,7 +1863,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = GSCAN_SUBCMD_GET_CHANNEL_LIST
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_gscan_get_channel_list
++		.doit = rtw_cfgvendor_gscan_get_channel_list,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif /* GSCAN_SUPPORT */
+ #if defined(RTT_SUPPORT) && 0
+@@ -1865,7 +1874,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = RTT_SUBCMD_SET_CONFIG
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_rtt_set_config
++		.doit = rtw_cfgvendor_rtt_set_config,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1873,7 +1883,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = RTT_SUBCMD_CANCEL_CONFIG
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_rtt_cancel_config
++		.doit = rtw_cfgvendor_rtt_cancel_config,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1881,7 +1892,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = RTT_SUBCMD_GETCAPABILITY
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_rtt_get_capability
++		.doit = rtw_cfgvendor_rtt_get_capability,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif /* RTT_SUPPORT */
+ #ifdef CONFIG_RTW_CFGVENDOR_LLSTATS
+@@ -1891,7 +1903,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LSTATS_SUBCMD_GET_INFO
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_lstats_get_info
++		.doit = rtw_cfgvendor_lstats_get_info,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1899,7 +1912,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LSTATS_SUBCMD_SET_INFO
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_lstats_set_info
++		.doit = rtw_cfgvendor_lstats_set_info,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1907,7 +1921,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LSTATS_SUBCMD_CLEAR_INFO
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_lstats_clear_info
++		.doit = rtw_cfgvendor_lstats_clear_info,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif /* CONFIG_RTW_CFGVENDOR_LLSTATS */
+ #ifdef CONFIG_RTW_CFGVENDOR_RSSIMONITOR
+@@ -1917,7 +1932,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+                         .subcmd = WIFI_SUBCMD_SET_RSSI_MONITOR
+                 },
+                 .flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-                .doit = rtw_cfgvendor_set_rssi_monitor
++                .doit = rtw_cfgvendor_set_rssi_monitor,
++		.policy = VENDOR_CMD_RAW_DATA,
+         },
+ #endif /* CONFIG_RTW_CFGVENDOR_RSSIMONITOR */
+ #ifdef CONFIG_RTW_CFGVENDOR_WIFI_LOGGER
+@@ -1927,7 +1943,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_START_LOGGING
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_start_logging
++		.doit = rtw_cfgvendor_logger_start_logging,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1935,7 +1952,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_FEATURE
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_feature
++		.doit = rtw_cfgvendor_logger_get_feature,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1943,7 +1961,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_VER
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_version
++		.doit = rtw_cfgvendor_logger_get_version,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1951,7 +1970,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_RING_STATUS
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_ring_status
++		.doit = rtw_cfgvendor_logger_get_ring_status,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1959,7 +1979,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_RING_DATA
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_ring_data
++		.doit = rtw_cfgvendor_logger_get_ring_data,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1967,7 +1988,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_TRIGGER_MEM_DUMP
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_firmware_memory_dump
++		.doit = rtw_cfgvendor_logger_get_firmware_memory_dump,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1975,7 +1997,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_START_PKT_FATE_MONITORING
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_start_pkt_fate_monitoring
++		.doit = rtw_cfgvendor_logger_start_pkt_fate_monitoring,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1983,7 +2006,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_TX_PKT_FATES
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_tx_pkt_fates
++		.doit = rtw_cfgvendor_logger_get_tx_pkt_fates,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -1991,7 +2015,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = LOGGER_GET_RX_PKT_FATES
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_logger_get_rx_pkt_fates
++		.doit = rtw_cfgvendor_logger_get_rx_pkt_fates,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},	
+ #endif /* CONFIG_RTW_CFGVENDOR_WIFI_LOGGER */
+ #ifdef CONFIG_RTW_WIFI_HAL
+@@ -2002,7 +2027,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_SET_PNO_RANDOM_MAC_OUI
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_rand_mac_oui
++		.doit = rtw_cfgvendor_set_rand_mac_oui,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif
+ #ifdef CONFIG_RTW_CFGVENDOR_WIFI_OFFLOAD
+@@ -2012,7 +2038,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_OFFLOAD_SUBCMD_START_MKEEP_ALIVE
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_start_mkeep_alive
++		.doit = rtw_cfgvendor_start_mkeep_alive,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -2020,7 +2047,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_OFFLOAD_SUBCMD_STOP_MKEEP_ALIVE
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_stop_mkeep_alive
++		.doit = rtw_cfgvendor_stop_mkeep_alive,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif
+ 	{
+@@ -2029,7 +2057,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_NODFS_SET
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_nodfs_flag
++		.doit = rtw_cfgvendor_set_nodfs_flag,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 
+ 	},
+ 	{
+@@ -2038,7 +2067,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_SET_COUNTRY_CODE
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_country
++		.doit = rtw_cfgvendor_set_country,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -2046,7 +2076,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_CONFIG_ND_OFFLOAD
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_set_nd_offload
++		.doit = rtw_cfgvendor_set_nd_offload,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ #endif /* CONFIG_RTW_WIFI_HAL */
+ 	{
+@@ -2055,7 +2086,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_GET_FEATURE_SET
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_get_feature_set
++		.doit = rtw_cfgvendor_get_feature_set,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	},
+ 	{
+ 		{
+@@ -2063,7 +2095,8 @@ static const struct wiphy_vendor_command rtw_vendor_cmds[] = {
+ 			.subcmd = WIFI_SUBCMD_GET_FEATURE_SET_MATRIX
+ 		},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_WDEV | WIPHY_VENDOR_CMD_NEED_NETDEV,
+-		.doit = rtw_cfgvendor_get_feature_set_matrix
++		.doit = rtw_cfgvendor_get_feature_set_matrix,
++		.policy = VENDOR_CMD_RAW_DATA,
+ 	}
+ };
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0003-OpenWrt-003-wireless-5.8.patch.patch
+++ b/package/kernel/rtl8812au-mw/patches/0003-OpenWrt-003-wireless-5.8.patch.patch
@@ -1,0 +1,44 @@
+From fc0e90868cea94c9334dfb53396f3130380f265d Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:37:35 +0200
+Subject: [PATCH 03/12] OpenWrt 003-wireless-5.8.patch
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 7719b728..ed6bb53a 100644
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -8024,6 +8024,15 @@ exit:
+ }
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)) || defined(BUILD_OPENWRT)
++static void cfg80211_rtw_update_mgmt_frame_registrations(struct wiphy *wiphy,
++						   struct wireless_dev *wdev,
++						   struct mgmt_frame_regs *upd)
++{
++
++}
++#endif
++
+ #if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
+ static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
+ 	struct net_device *ndev,
+@@ -10419,7 +10428,10 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
+ 	.update_ft_ies = cfg80211_rtw_update_ft_ies,
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || defined(BUILD_OPENWRT)
++	.mgmt_tx = cfg80211_rtw_mgmt_tx,
++	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_registrations,
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+ 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
+ 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0004-fix-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-mw/patches/0004-fix-misleading-indentation.patch
@@ -1,0 +1,25 @@
+From e899fe276469c90b2702d472eac4142ae48afbc3 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:46:17 +0200
+Subject: [PATCH 04/12] fix misleading indentation
+
+---
+ core/rtw_mlme.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/rtw_mlme.c b/core/rtw_mlme.c
+index 0629a4e0..ce1046d2 100644
+--- a/core/rtw_mlme.c
++++ b/core/rtw_mlme.c
+@@ -3157,7 +3157,7 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
+ 		else
+ 		#endif
+ 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+-			goto exit;
++		goto exit;
+ 	}
+ 	else if (ssc_chk != SS_ALLOW)
+ 		goto exit;
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0005-fix-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-mw/patches/0005-fix-misleading-indentation.patch
@@ -1,0 +1,31 @@
+From 15dc86a1ec1d8c80d0f0574f849d52b9b0937173 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:58:04 +0200
+Subject: [PATCH 05/12] fix misleading indentation
+
+---
+ core/efuse/rtw_efuse.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/core/efuse/rtw_efuse.c b/core/efuse/rtw_efuse.c
+index b67637fe..ad981af9 100644
+--- a/core/efuse/rtw_efuse.c
++++ b/core/efuse/rtw_efuse.c
+@@ -909,10 +909,10 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++		, pEfuseHal->fakeEfuseInitMap[i]
++		, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
+ 		}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0006-fix-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-mw/patches/0006-fix-misleading-indentation.patch
@@ -1,0 +1,34 @@
+From bc3c4248562db1fbe6a622865f1ab5da2aeac9f4 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:59:28 +0200
+Subject: [PATCH 06/12] fix misleading indentation
+
+---
+ core/rtw_recv.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/core/rtw_recv.c b/core/rtw_recv.c
+index 6e903b94..dbc8a507 100644
+--- a/core/rtw_recv.c
++++ b/core/rtw_recv.c
+@@ -3598,11 +3598,12 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+ 			for (i = 0; i < precv_frame->u.hdr.len; i = i + 8)
+ 				RTW_INFO("%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:\n", *(ptr + i),
+ 					*(ptr + i + 1), *(ptr + i + 2) , *(ptr + i + 3) , *(ptr + i + 4), *(ptr + i + 5), *(ptr + i + 6), *(ptr + i + 7));
+-				RTW_INFO("#############################\n");
+-				_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
+-				_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
+-				pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
+-				pmppriv->mplink_brx =_TRUE;
++			
++			RTW_INFO("#############################\n");
++			_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
++			_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
++			pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
++			pmppriv->mplink_brx =_TRUE;
+ 		}
+ 	}
+ 	if (pmppriv->bloopback) {
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0007-port-allow-cross-compile-on-cmdline-from-Ben-Grear.patch
+++ b/package/kernel/rtl8812au-mw/patches/0007-port-allow-cross-compile-on-cmdline-from-Ben-Grear.patch
@@ -1,0 +1,39 @@
+From c09c95bce8f1be53982c42beeed4d8682a0f95d6 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 15:31:46 +0200
+Subject: [PATCH 07/12] port allow cross compile on cmdline from Ben Grear
+
+---
+ Makefile | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 3f41c79b..c3a8921a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1324,11 +1324,22 @@ EXTRA_CFLAGS += -DCONFIG_GTK_OL
+ endif
+ 
+ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
++
++ifdef EXT_EXTRA_CFLAGS
++EXTRA_CFLAGS += $(EXT_EXTRA_CFLAGS)
++else
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++endif
++
++ifndef ARCH
+ SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/armv.l/arm/ -e s/aarch64/arm64/)
+ ARCH ?= $(SUBARCH)
++endif
++
++ifndef CROSS_COMPILE
+ CROSS_COMPILE ?=
++endif
+ KVER  := $(shell uname -r)
+ KSRC := /lib/modules/$(KVER)/build
+ MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0008-makefile-Allow-defining-KSRC-outside-of-build.patch
+++ b/package/kernel/rtl8812au-mw/patches/0008-makefile-Allow-defining-KSRC-outside-of-build.patch
@@ -1,0 +1,36 @@
+From e8f92ac4a42e32b549661b3b386ed07d78e3ac67 Mon Sep 17 00:00:00 2001
+From: Ben Greear <greearb@candelatech.com>
+Date: Thu, 8 Nov 2018 13:05:41 -0800
+Subject: [PATCH 08/12] makefile: Allow defining KSRC outside of build.
+
+So, you can do this:
+
+KSRC=/tmp/my/kernel make
+
+And not have to edit the makefile to have this function as desired.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+---
+ Makefile | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index c3a8921a..29555236 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1341,8 +1341,12 @@ ifndef CROSS_COMPILE
+ CROSS_COMPILE ?=
+ endif
+ KVER  := $(shell uname -r)
++ifndef KSRC
+ KSRC := /lib/modules/$(KVER)/build
++endif
++ifndef MODDESTDIR
+ MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
++endif
+ INSTALL_PREFIX :=
+ STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
+ endif
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0009-Fix-build-against-openwrt-backports-tree.patch
+++ b/package/kernel/rtl8812au-mw/patches/0009-Fix-build-against-openwrt-backports-tree.patch
@@ -1,0 +1,45 @@
+From c76473b28ee700ffe68b20ab5f134525bf098ec4 Mon Sep 17 00:00:00 2001
+From: Ben Greear <greearb@candelatech.com>
+Date: Fri, 9 Nov 2018 16:21:43 -0800
+Subject: [PATCH 09/12] Fix build against openwrt backports tree.
+
+Like breaks builds elsewhere, can fix it up later.
+
+Signed-off-by: Ben Greear <greearb@candelatech.com>
+
+modified for rtl8812au-mw by
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ include/drv_conf.h                                      | 4 +++-
+ include/linux/{wireless.h => old_unused_rtl_wireless.h} | 0
+ include/{autoconf.h => rtl_autoconf.h}                  | 0
+ 3 files changed, 3 insertions(+), 1 deletion(-)
+ rename include/linux/{wireless.h => old_unused_rtl_wireless.h} (100%)
+ rename include/{autoconf.h => rtl_autoconf.h} (100%)
+
+diff --git a/include/drv_conf.h b/include/drv_conf.h
+index b0f856b8..7195df1a 100644
+--- a/include/drv_conf.h
++++ b/include/drv_conf.h
+@@ -14,7 +14,9 @@
+  *****************************************************************************/
+ #ifndef __DRV_CONF_H__
+ #define __DRV_CONF_H__
+-#include "autoconf.h"
++#include <generated/autoconf.h>
++#include "rtl_autoconf.h"
++
+ #include "hal_ic_cfg.h"
+ 
+ #define CONFIG_RSSI_PRIORITY
+diff --git a/include/linux/wireless.h b/include/linux/old_unused_rtl_wireless.h
+similarity index 100%
+rename from include/linux/wireless.h
+rename to include/linux/old_unused_rtl_wireless.h
+diff --git a/include/autoconf.h b/include/rtl_autoconf.h
+similarity index 100%
+rename from include/autoconf.h
+rename to include/rtl_autoconf.h
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0010-modified-from-ben-greear.patch
+++ b/package/kernel/rtl8812au-mw/patches/0010-modified-from-ben-greear.patch
@@ -1,0 +1,42 @@
+From 2aec5769852b0edb7b5b2d6f25c50ad6fc64e9cf Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 16:10:00 +0200
+Subject: [PATCH 10/12] modified from ben greear
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ Makefile | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 29555236..20ee249c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -202,6 +202,7 @@ CONFIG_PLATFORM_NV_TK1_UBUNTU = n
+ CONFIG_PLATFORM_RTL8197D = n
+ CONFIG_PLATFORM_AML_S905 = n
+ CONFIG_PLATFORM_ZTE_ZX296716 = n
++CONFIG_PLATFORM_OPENWRT_TREE = n
+ ########### CUSTOMER ################################
+ CONFIG_CUSTOMER_HUAWEI_GENERAL = n
+ 
+@@ -1597,6 +1598,16 @@ CROSS_COMPILE := mips-openwrt-linux-
+ KSRC := /home/alex/test_openwrt/tmp/linux-2.6.30.9
+ endif
+ 
++# modified from Ben Greear
++ifeq ($(CONFIG_PLATFORM_OPENWRT_TREE), y)
++EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
++ARCH := x86_64
++CROSS_COMPILE := x86_64-openwrt-linux-
++#export PATH=$PATH:/home/tenchi/programming/upstream/plntyk/openwrt/staging_dir/toolchain-x86_64_gcc-8.4.0_musl/bin/
++#export STAGING_DIR=/home/tenchi/programming/upstream/plntyk/openwrt/staging_dir/
++KSRC := /home/tenchi/programming/upstream/plntyk/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-5.10.41/
++endif
++
+ ifeq ($(CONFIG_PLATFORM_DMP_PHILIPS), y)
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DRTK_DMP_PLATFORM
+ ARCH := mips
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0011-cosmetic-Kconfig-change.patch
+++ b/package/kernel/rtl8812au-mw/patches/0011-cosmetic-Kconfig-change.patch
@@ -1,0 +1,24 @@
+From 5ffeee5bdfc0a69dd9fd0cbf9e532e9d36d169ed Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 17:30:11 +0200
+Subject: [PATCH 11/12] cosmetic Kconfig change
+
+---
+ Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Kconfig b/Kconfig
+index 846a4f62..f87653d5 100644
+--- a/Kconfig
++++ b/Kconfig
+@@ -1,6 +1,6 @@
+ config RTL8812AU
+ 	tristate "Realtek 8812A USB WiFi"
+ 	depends on USB
+-	help
++	---help---
+ 	  Help message of RTL8812AU
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl8812au-mw/patches/0012-module-name-like-ct-Makefile.patch
+++ b/package/kernel/rtl8812au-mw/patches/0012-module-name-like-ct-Makefile.patch
@@ -1,0 +1,25 @@
+From 3e31f051a23799ae2ffec1b834366bab18b26a96 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 17:48:07 +0200
+Subject: [PATCH 12/12] module name like -ct Makefile
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 20ee249c..b513b6c9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2320,7 +2320,7 @@ endif
+ 
+ endif
+ 
+-USER_MODULE_NAME ?=
++USER_MODULE_NAME ?= rtl$(MODULE_NAME)
+ ifneq ($(USER_MODULE_NAME),)
+ MODULE_NAME := $(USER_MODULE_NAME)
+ endif
+-- 
+2.31.1
+


### PR DESCRIPTION
another Realtek rtl8812au driver modified by morrownr
used in Arch Linux AUR

scanning works with qemu x86_64 + TP-Link T4U stock

- joining open networks fails
- joining encrypted networks fails

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>
