### PR TITLE
ramips: add support for Netcore NW5212

### DIFF
--- a/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
+++ b/target/linux/ramips/dts/mt7620a_netcore_nw5212.dts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netcore,nw5212", "ralink,mt7620a-soc";
+	model = "Netcore NW5212";
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <70000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "wled", "ephy";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+	mediatek,portmap = "llllw";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -667,6 +667,16 @@ define Device/microduino_microwrt
 endef
 TARGET_DEVICES += microduino_microwrt
 
+define Device/netcore_nw5212
+  SOC := mt7620a
+  IMAGE_SIZE := 16064k
+  BLOCKSIZE := 4k
+  DEVICE_VENDOR := Netcore
+  DEVICE_MODEL := NW5212
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+endef
+TARGET_DEVICES += netcore_nw5212
+
 define Device/netgear_ex2700
   SOC := mt7620a
   NETGEAR_HW_ID := 29764623+4+0+32+2x2+0

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -148,6 +148,14 @@ lenovo,newifi-y1s)
 	ucidef_set_led_netdev "wifi5g" "WIFI5G" "blue:wifi" "wlan0"
 	ucidef_set_led_netdev "wan" "WAN" "blue:internet" "eth0.2" "tx rx"
 	;;
+netcore,nw5212|\
+netgear,jwnr2010-v5)
+	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x08"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"
+	ucidef_set_led_switch "lan3" "lan3" "green:lan3" "switch0" "0x02"
+	ucidef_set_led_switch "lan4" "lan4" "green:lan4" "switch0" "0x01"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 netgear,ex2700|\
 netgear,wn3000rp-v3)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:router" "wlan0"
@@ -156,13 +164,6 @@ netgear,ex3700|\
 netgear,ex6130)
 	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "green:router" "wlan0"
 	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "green:device" "wlan1"
-	;;
-netgear,jwnr2010-v5)
-	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x08"
-	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"
-	ucidef_set_led_switch "lan3" "lan3" "green:lan3" "switch0" "0x02"
-	ucidef_set_led_switch "lan4" "lan4" "green:lan4" "switch0" "0x01"
-	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
 phicomm,psg1208)
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wlan2g" "wlan0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -106,6 +106,7 @@ ramips_setup_interfaces()
 			"0:lan" "6@eth0"
 		;;
 	dlink,dir-810l|\
+	netcore,nw5212|\
 	netgear,jwnr2010-v5|\
 	phicomm,psg1218a|\
 	trendnet,tew-810dr|\


### PR DESCRIPTION
This patch adds support for Netcore NW5212, provided by some carrier in China.

Specifications:
--------------

* SoC: Mediatek MT7620A
* RAM: 128MB DDR3
* Flash: 16MB SPI NOR flash (Winbond 25Q128)
* WiFi 2.4GHz: builtin
* Ethernet: builtin
* LED: Power, WAN, LAN 1-4, WiFi
* Buttons: Reset (GPIO 13)
* UART: Serial console (57600 8n1)
* USB: 1 x USB2

Installation:
------------

The router comes with (a very old) OpenWrt built with MTK SDK. However, as the
modem is provided by carriers, so the web interface is highly minimized and only
contains a static page with no interaction options.

There are two possible ways to install the firmware.

1) Gain TTY control and use u-boot or OpenWrt "mtd" tool. Please notice you have
   to remove R54 otherwise you won't be able to input anything.
2) Use built-in backdoor. Access http://192.168.1.1/cgi-bin/_/testxst to start
   dropbear service at port 9122. Be warned the software is super old and only
   diffie-hellman-group1-sha1, diffie-hellman-group14-sha1,
   kexguess2@matt.ucc.asn.au is support, you may not be able to connect it with
   an up-to-date ssh client.

Signed-off-by: David Yang <mmyangfl@gmail.com>