### PR TITLE
base-files: fix enabled for services with only STOP

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -55,7 +55,12 @@ enable() {
 
 enabled() {
 	name="$(basename "${initscript}")"
-	[ -x "$IPKG_INSTROOT/etc/rc.d/S${START}${name##S[0-9][0-9]}" ]
+	name="${name##[SK][0-9][0-9]}"
+	{
+		[ -z "${START:-}" ] || [ -L "$IPKG_INSTROOT/etc/rc.d/S${START}$name" ]
+	} && {
+		[ -z "${STOP:-}" ] || [ -L "$IPKG_INSTROOT/etc/rc.d/K${STOP}$name" ]
+	}
 }
 
 depends() {


### PR DESCRIPTION
There are services that have only STOP value set. They are executed only
on shutdown and it is common to use them for system cleanup. There is
one such service shipped directly with base-files, it is 'umount'. Those
work the same way as those with START but enabled does not report them
as enabled although it should have as they can be enabled and disabled
as any other service.

Signed-off-by: Karel Kočí <karel.koci@nic.cz>