### PR TITLE
comgt: filter modem output by supported manufacturer list

### DIFF
--- a/package/network/utils/comgt/Makefile
+++ b/package/network/utils/comgt/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=comgt
 PKG_VERSION:=0.32
-PKG_RELEASE:=33
+PKG_RELEASE:=34
 
 PKG_SOURCE:=$(PKG_NAME).$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=@SF/comgt


### PR DESCRIPTION
Some modems produce status messages starting with ^ character which
obscure manufacturer name in gcom's output. As list of supported manufacturers
is known beforehand, this patch uses it to filter only valid values from
modem output. Awk's exit code is made to mimic grep.

Note: there are other 2 PRs #3231, #4203 which more or less try to fix the same problem, that is invocation of gcom produces i.e. ^rssi:31 instead of say 'huawei' and consequently failure to get modem information being reported and connection dropped.

Signed-off-by: Lubos Lecko <sam_@centrum.sk>
