### PR TITLE
ramips: fix amber LAN LED assignment for Xiaomi Router 3 Pro

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -48,7 +48,7 @@
 		lan3_amber {
 			label = "amber:lan3";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "dsa-0.0:01:1Gbps";
+			linux,default-trigger = "dsa-0.0:03:1Gbps";
 		};
 
 		lan2_amber {
@@ -60,7 +60,7 @@
 		lan1_amber {
 			label = "amber:lan1";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "dsa-0.0:03:1Gbps";
+			linux,default-trigger = "dsa-0.0:01:1Gbps";
 		};
 	};
 


### PR DESCRIPTION
The default trigger for the amber lights on lan1 and lan3 were mistakenly swapped after the device's migration to DSA. This caused activity on one port to trigger the amber light on the other port. Swapping their default trigger in the DTS file fixes that.

Signed-off-by: Adam Elyas <adamelyas@outlook.com>
