### PR TITLE
ramips：Fixed the problem of MAC address and restart failure of hilink hlk-7628n.

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -47,6 +47,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -80,6 +80,10 @@
 	};
 };
 
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
 &wmac {
 	status = "okay";
 };

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -168,6 +168,7 @@ ramips_setup_macs()
 		lan_mac=$wan_mac
 		;;
 	cudy,wr1000|\
+	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
 	wavlink,wl-wn577a2|\
 	wavlink,wl-wn578a2)


### PR DESCRIPTION
1 ramips:Fix Ethernet random MAC address for HILINK HLK-7628N
2 ramips: Fixes the problem of software reboot failure in HILINK HLK-7628N


