### PR TITLE
ath79: add support for Ruckus R500

### DIFF
--- a/target/linux/ath79/dts/qca9557_ruckus_r500.dts
+++ b/target/linux/ath79/dts/qca9557_ruckus_r500.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ruckus,r500", "qca,qca9557";
+	model = "Ruckus R500";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "red:power";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		// DIR (Zone Director) LED - Indicates Zone director connection status
+		dir {
+			label = "green:dir";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		// AIR (Signal/Air Quality) LED - Indicates uplink status and the quality of the wireless signal to the uplink AP
+		air {
+			label = "green:air";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g_orange {
+			label = "orange:wlan5g";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+	};
+
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x40000>;
+			};
+
+			art: partition@140000 {
+				label = "art";
+				reg = <0x0140000 0x80000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "config-data";
+				reg = <0x01c0000 0x640000>;
+				read-only;
+			};
+
+			partition@800000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				openwrt,offset = <0xA0>;
+				openwrt,partition-magic = <0x52434B53>;
+				reg = <0x0800000 0x1800000>;
+			};
+			
+			partition@2000000 {
+				label = "firmware-backup";
+				reg = <0x2000000 0x1800000>;
+			};
+			
+			partition@3800000 {
+				label = "backup-config-data";
+				reg = <0x3800000 0x300000>;
+				read-only;
+			};
+			
+			partition@3B00000 {
+				label = "reserved-space";
+				reg = <0x3B00000 0x500000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+		    0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+		    0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+		    0x7c 0x0000007e /* PORT0_STATUS */
+		    0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x66>;
+	pll-data = <0x96000000 0x00000101 0x00001616>;
+
+	phy-handle = <&phy0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x6c>;
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+	
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -473,6 +473,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth1" "4:lan:1" "3:lan:2" "2:lan:3" "1:lan:4"
 		;;
+	ruckus,r500)
+		ucidef_add_switch "switch0" \
+			"0@eth1" "3:lan" "6@eth0" "5:wan"
+		;;
 	teltonika,rut955|\
 	teltonika,rut955-h7v3c0)
 		ucidef_set_interface_wan "eth1"
@@ -777,6 +781,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
+	ruckus,r500|\
 	ruckus,zf7025|\
 	ruckus,zf7321|\
 	ruckus,zf7341|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -78,6 +78,7 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
 		ath9k_patch_mac $(macaddr_add $base_mac 1)
+		;;
 	ruckus,r500)
 		caldata_extract "art" 0x41000 0x440
 		ath9k_patch_mac $(mtd_get_mac_binary "art" 0x60)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -78,6 +78,9 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
 		ath9k_patch_mac $(macaddr_add $base_mac 1)
+	ruckus,r500)
+		caldata_extract "art" 0x41000 0x440
+		ath9k_patch_mac $(mtd_get_mac_binary "art" 0x60)
 		;;
 	*)
 		caldata_die "board $board is not supported yet"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -114,6 +114,10 @@ case "$FIRMWARE" in
 		caldata_extract "radiocfg" 0x5000 0x844
 		ath10k_patch_mac $(mtd_get_mac_ascii devdata wlan5mac)
 		;;
+	ruckus,r500)
+		caldata_extract "art" 0x45000 0x844
+		ath10k_patch_mac $(mtd_get_mac_binary "art" 0x76)
+		;;
 	tplink,archer-a7-v5|\
 	tplink,archer-c2-v3|\
 	tplink,archer-c7-v4|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -121,6 +121,11 @@ define Build/pisen_wmb001n-factory
   rm -rf "$@.tmp"
 endef
 
+define Build/ruckus_fw_header
+	$(STAGING_DIR_HOST)/bin/ruckus_fw_header -i $@ -o $@.out
+	mv -f $@.out $@
+endef
+
 define Build/teltonika-fw-fake-checksum
 	# Teltonika U-Boot web based firmware upgrade/recovery routine compares
 	# 16 bytes from md5sum1[16] field in TP-Link v1 header (offset: 76 bytes
@@ -2740,6 +2745,18 @@ define Device/ruckus_zf7372
   DEVICE_MODEL := ZoneFlex 7352/7372[-E/-U]
 endef
 TARGET_DEVICES += ruckus_zf7372
+
+define Device/ruckus_r500
+  SOC := qca9557
+  DEVICE_VENDOR := Ruckus
+  DEVICE_MODEL := R500
+  IMAGE_SIZE := 24576k
+  BLOCKSIZE := 256k
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  KERNEL := kernel-bin | append-dtb | lzma-no-dict | uImage lzma | ruckus_fw_header
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+endef
+TARGET_DEVICES += ruckus_r500
 
 define Device/samsung_wam250
   SOC := ar9344

--- a/tools/firmware-utils/patches/002-add-ruckus-fw
+++ b/tools/firmware-utils/patches/002-add-ruckus-fw
@@ -1,0 +1,288 @@
+This image builder builds a tftp updatable binary for Ruckus hardware
+
+Signed-off-by: Damien Mascord <tus...@tusker.org>
+---
+ CMakeLists.txt         |   1 +
+ src/ruckus_fw_header.c | 258 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 259 insertions(+)
+ create mode 100644 src/ruckus_fw_header.c
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f406520..c6fbf5c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -88,6 +88,7 @@ FW_UTIL(oseama src/md5.c "" "")
+ FW_UTIL(otrx "" "" "")
+ FW_UTIL(pc1crypt "" "" "")
+ FW_UTIL(ptgen src/cyg_crc32.c "" "")
++FW_UTIL(ruckus_fw_header src/md5.c "" "")
+ FW_UTIL(seama src/md5.c "" "")
+ FW_UTIL(sign_dlink_ru src/md5.c "" "")
+ FW_UTIL(spw303v "" "" "")
+diff --git a/src/ruckus_fw_header.c b/src/ruckus_fw_header.c
+new file mode 100644
+index 0000000..aad3a81
+--- /dev/null
++++ b/src/ruckus_fw_header.c
+@@ -0,0 +1,258 @@
++/*
++ * rucks_fw_header.c - partially based on OpenWrt's xorimage.c
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License as published by
++ * the Free Software Foundation; either version 2 of the License, or
++ * (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++ * General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
++ */
++
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <stdint.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include "md5.h"
++
++#define BUF_SIZE                0x200
++static int data_size;
++
++static int get_file_size(char *name)
++{
++       struct stat st;
++       int res;
++
++       res = stat(name, &st);
++       if (res){
++               fprintf(stderr,"stat failed on %s", name);
++               return -1;
++       }
++
++       return st.st_size;
++}
++
++static int md5_file(const char *filename, uint8_t *dst)
++{
++        FILE *fp_src;
++        MD5_CTX ctx;
++        char buf[BUF_SIZE];
++        size_t bytes_read;
++
++        MD5_Init(&ctx);
++
++        fp_src = fopen(filename, "r+b");
++        if (!fp_src) {
++                return -1;
++        }
++        while (!feof(fp_src)) {
++                bytes_read = fread(&buf, 1, BUF_SIZE, fp_src);
++                MD5_Update(&ctx, &buf, bytes_read);
++        }
++        fclose(fp_src);
++
++        MD5_Final(dst, &ctx);
++
++        return 0;
++}
++
++int write_header(FILE *out, char* md5sum){
++       // lzma kernel offset is ruckus header + uimage header = 160 + 64 = 224 = 0xE0
++       char header1[12] = {
++               0x52, 0x43, 0x4b, 0x53, 0x00, 0x13, 0x00, 0x00, 0x00, 0xe0, 0x6c, 0x37 };
++       char load_address[4] = {        
++               0x80, 0x06, 0x00, 0x00 };       
++       char fakesize[4] = {
++               0x01, 0x76, 0xd7, 0x5c };
++       char header_postsize[4] = {
++               0x60, 0x9a, 0x43, 0xd2 };
++       char fakemd5[16] = {
++               0x39, 0x17, 0x73, 0x56, 0xed, 0x87, 0x33, 0x9a, 0xe3, 0xe4, 0xff, 0xc9,
++               0xee, 0xcd, 0xd2, 0x9c };
++       char header2[4] = {
++               0x00, 0x04, 0x66, 0x69 };
++       //200.7.10.202.9 - OPENWRT12345678
++       char fake_version[16] = {
++               0x4f, 0x50, 0x45, 0x4e, 0x57, 0x52, 0x54, 0x31, 0x32, 0x33, 0x34, 0x35, 
++               0x36, 0x37, 0x38, 0x39 };
++       char header3[48] = {
++               0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++               0x7a, 0x66, 0x37, 0x37, 0x35, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
++       //200.7.10.202.9 - OPENWRT12345678
++       char header4[4] = {     
++               0x00, 0x00, 0x00, 0x03 };
++       char entry_point[4] = { 
++               0x80, 0x06, 0x00, 0x00 };
++       char header_postentry[28] = {
++           0x00, 0x00, 0x00, 0x01, 0x01, 0x76, 0xcf, 0x60, 0x00, 0x00, 0x00, 0x00, 
++           0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
++           0x00, 0x00, 0x00, 0x00 };
++
++       if (!fwrite(header1, sizeof(header1), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(load_address, sizeof(load_address), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       u_int32_t ds = htonl(data_size);
++       fprintf(stdout, "data_size: %d\n", ds);
++       if (!fwrite(&ds, sizeof(ds), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(header_postsize, sizeof(header_postsize), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++
++       if (!fwrite(md5sum, 0x10, 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++
++       if (!fwrite(header2, sizeof(header2), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(fake_version, sizeof(fake_version), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(header3, sizeof(header3), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(fake_version, sizeof(fake_version), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(header4, sizeof(header4), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(entry_point, sizeof(entry_point), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       if (!fwrite(header_postentry, sizeof(header_postentry), 1, out)) {
++               fprintf(stderr, "fwrite error\n");
++               return EXIT_FAILURE;
++       }
++       
++       return 0;
++}
++
++void usage(void) __attribute__ (( __noreturn__ ));
++
++void usage(void)
++{
++       fprintf(stderr, "Usage: ruckus_fw_header [-i infile] [-o outfile] [-d]\n");
++       exit(EXIT_FAILURE);
++}
++
++int main(int argc, char **argv)
++{
++       char buf[1];    /* keep this at 1k or adjust garbage calc below */
++       FILE *in = stdin;
++       FILE *out = stdout;
++       char *ifn = NULL;
++       char *ofn = NULL;
++       int c;
++       int v0, v1, v2;
++       size_t n;
++       int p_len, p_off = 0;
++    uint8_t  md5sum[0x10];
++
++       while ((c = getopt(argc, argv, "i:o:h")) != -1) {
++               switch (c) {
++                       case 'i':
++                               ifn = optarg;
++                               break;
++                       case 'o':
++                               ofn = optarg;
++                               break;
++                       case 'h':
++                       default:
++                               usage();
++               }
++       }
++       
++       data_size = get_file_size(ifn);
++
++       if (optind != argc || optind == 1) {
++               fprintf(stderr, "illegal arg \"%s\"\n", argv[optind]);
++               usage();
++       }
++
++       if (ifn && md5_file(ifn, md5sum)) {
++               fprintf(stderr, "can not get md5sum for \"%s\"\n", ifn);
++               usage();
++       }
++
++       if (ifn && !(in = fopen(ifn, "r"))) {
++               fprintf(stderr, "can not open \"%s\" for reading\n", ifn);
++               usage();
++       }
++
++       if (ofn && !(out = fopen(ofn, "w"))) {
++               fprintf(stderr, "can not open \"%s\" for writing\n", ofn);
++               usage();
++       }
++
++       if (ofn && (write_header(out, md5sum))) {
++               fprintf(stderr, "can not write header to \"%s\"\n", ofn);
++               usage();
++       }
++
++       while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
++               if (n < sizeof(buf)) {
++                       if (ferror(in)) {
++                       FREAD_ERROR:
++                               fprintf(stderr, "fread error\n");
++                               return EXIT_FAILURE;
++                       }
++               }
++
++               if (!fwrite(buf, n, 1, out)) {
++               FWRITE_ERROR:
++                       fprintf(stderr, "fwrite error\n");
++                       return EXIT_FAILURE;
++               }
++       }
++
++       if (ferror(in)) {
++               goto FREAD_ERROR;
++       }
++
++       if (fflush(out)) {
++               goto FWRITE_ERROR;
++       }
++
++       fclose(in);
++       fclose(out);
++
++       return EXIT_SUCCESS;
++}
+-- 
+2.30.2
+


### PR DESCRIPTION
Ruckus R500 datasheet: https://webresources.ruckuswireless.com/datasheets/r500/ds-ruckus-r500.html

Specifications:

SoC: 720Mhz QCA9558
RAM: 256MB
Storage: 64MB of FLASH (SPI NOR - S25FL512S)
1x AR8327 GB switch
Ethernet: 1x1000M (802.11), port #3 on AR8327,
          1x1000M (802.11at POE), port #5 on AR8327
Wireless: QCA988X HW2.0 802.11ac
AR9550 2.4GHz 802.11b/g/n
5x GPIO LED
1x GPIO Reset Button
1x DC Jack 12v
1x UART, 3.3v, 115200

MAC addresses:
 1. art 0x807E | Factory bridged | f0:3e:90:XX:XX:80 | - on label - not in use in OpenWRT
 2. art 0x66     | eth0                   | f0:3e:90:XX:XX:83 | (port 5, cpu port 6) - PoE port
 3. art 0x6c     | eth1                    | f0:3e:90:XX:XX:84 | (port 3, cpu port 0) - non PoE port

Installation:

Serial Port/TFTP

 1. Setup tftp server on the local network
 2. Connect to UART with TTL
 3. Interupt uboot process with Ctrl-C
 4. Setup appropriate ipaddr and serverip in setenv:
	a) setenv ipaddr 192.168.1.1
	b) setenv serverip 192.168.1.2
 5. On TFTP Server - copy openwrt-ath79-generic-ruckus_r500-initramfs-kernel.bin to /srv/tftp/1600000A.img
 6. On R500 boot into initrd image
	a) tftpboot
	b) bootm
 7. On TFTP server - scp openwrt-ath79-generic-ruckus_r500-squashfs-sysupgrade.bin root@192.168.1.1:/tmp
 8. On R500 - sysupgrade /tmp/openwrt-ath79-generic-ruckus_r500-squashfs-sysupgrade.bin

This patch adapted from https://github.com/victhor393/openwrt-ruckus-r500/tree/ruckus-r500-master

Signed-off-by: Damien Mascord <tusker@tusker.org>