### PR TITLE
x86: add upgrade support to diag.sh

### DIFF
--- a/target/linux/x86/base-files/etc/diag.sh
+++ b/target/linux/x86/base-files/etc/diag.sh
@@ -73,6 +73,10 @@ set_state() {
 		status_led_blink_preinit_regular
 		;;
 
+	upgrade)
+		status_led_blink_preinit_regular
+		;;
+
 	done)
 		status_led_on
 		;;


### PR DESCRIPTION
Similar to how this is done in the diag.sh found in the base-files package, we should blink our status LED (if we have one) during the upgrade process. This follows the same blink pattern as seen at https://github.com/openwrt/openwrt/blob/master/package/base-files/files/etc/diag.sh#L36

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>