### PR TITLE
ath79: add support for GL.iNet GL-XE300

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9531_glinet_gl-xe300.dtsi"
+
+/ {
+	compatible = "glinet,gl-xe300", "qca,qca9531";
+	model = "GL.iNet GL-XE300";
+};
+
+&nor_partitions {
+	partition@60000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x060000 0xfa0000>;
+	};
+};

--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dtsi
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+
+/ {
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		button0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lte {
+			label = "green:lte";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_minipcie {
+			gpio-export,name = "minipcie";
+			gpio-export,output = <1>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_sd_detect {
+			gpio-export,name = "sd_detect";
+			gpio-export,output = <0>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	i2c: i2c {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&gpio 14 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 16 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rtc@32 {
+                        compatible = "rtc-sd2068";
+                        reg = <0x32>;
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&uart {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		nor_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+		};
+	};
+
+	flash_nand: flash@1 {
+		compatible = "spinand,glinet";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		NAND_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			nand_ubi: partition@0 {
+				label = "nand_ubi";
+				reg = <0x000000 0x8000000>;
+			};
+		};
+	};
+
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&swphy4>;
+	ifname = "eth1";
+};
+
+&eth1 {
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+	ifname = "eth0";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x1002>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -221,6 +221,10 @@ qxwlan,e750a-v4-16m)
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;
+glinet,gl-xe300|\
+        ucidef_set_led_netdev "wan"   "WAN" "green:wan" "eth1"
+        ucidef_set_led_netdev "3gnet" "LTE" "green:lte" "wwan0"
+        ;;
 hak5,lan-turtle)
 	ucidef_set_led_netdev "wan" "WAN" "orange:system" "eth1"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1245,6 +1245,15 @@ define Device/glinet_gl-x750
 endef
 TARGET_DEVICES += glinet_gl-x750
 
+define Device/glinet_gl-xe300
+  SOC := qca9531
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-XE300
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-serial-ch341
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += glinet_gl-xe300
+
 define Device/hak5_lan-turtle
   $(Device/tplink-16mlzma)
   SOC := ar9331


### PR DESCRIPTION
The GL-XE300 is a 4G LTE router based on the Qualcomm QCA9531 SoC.

Specifications:
 - Qualcomm QCA9531 @ 650 MHz
 - 128 MB of RAM
 - 16 MB of SPI NOR FLASH
 - 128 MB NAND FLASH (Not supported in this commit)
 - 2x 10/100 Mbps Ethernet
 - 2.4GHz 802.11b/g/n
 - 1x USB 2.0 (vbus driven by GPIO)
 - 5x LED, driven by GPIO
 - 1x button (reset)
 - 1x mini pci-e slot (vcc driven by GPIO)

Flash instructions:

You will need to use the uboot recovery console to install OpenWrt.

 - Press and hold the reset button
 - Connect power to the router, wait five seconds
 - Manually configure 192.168.1.2/24 on your computer, connect to 192.168.1.1
 - Upload the firmware image using the web interface

Based on vendor commit:

https://github.com/gl-inet/openwrt/commit/60553d7269df7442c8b6f18e4d10f3a58ed4b7ac

Signed-off-by: John Marrett <johnf@zioncluster.ca>
