### PR TITLE
ath79: add support for GL.iNet GL-X300B

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-x300b.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-x300b.dts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "glinet,gl-x300b", "qca,qca9531";
+	model = "GL.iNet GL-X300B";
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lte {
+			label = "green:lte";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		minipcie {
+			gpio-export,name = "minipcie";
+			gpio-export,output = <0>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		rs485tx_en {
+			gpio-export,name = "rs485tx_en";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		ble_rst {
+			gpio-export,name = "ble_rst";
+			gpio-export,output = <0>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	watchdog {
+		compatible = "hw_wdt";
+		dog_en_gpio = <12>;
+		feed_dog_gpio = <2>;
+		feed_dog_interval = <100000000>;
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		nor_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xfa0000>;
+			};
+
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&art 0x0>;
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	mtd-mac-address = <&art 0x0>;
+	mtd-mac-address-increment = <1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -218,6 +218,7 @@ qxwlan,e750a-v4-16m)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x02"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;
+glinet,gl-x300b|\
 glinet,gl-x750)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -269,6 +269,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan"
 		;;
+	glinet,gl-x300b)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "4:lan"
+		;;
 	iodata,etg3-r|\
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1236,6 +1236,15 @@ define Device/glinet_gl-usb150
 endef
 TARGET_DEVICES += glinet_gl-usb150
 
+define Device/glinet_gl-x300b
+  SOC := qca9531
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-X300B
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += glinet_gl-x300b
+
 define Device/glinet_gl-x750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
The GL-X300B is a industrial 4G LTE router based on the Qualcomm QCA9531 SoC.

Specifications:
 - Qualcomm QCA9531 @ 650 MHz
 - 128 MB of RAM
 - 16 MB of SPI NOR FLASH
 - 2x 10/100 Mbps Ethernet
 - 2.4GHz 802.11b/g/n
 - 1x USB 2.0 (vbus driven by GPIO)
 - 4x LED, driven by GPIO
 - 1x button (reset)
 - 1x mini pci-e slot (vcc driven by GPIO)
 - RS-485 Serial Port (untested)

Flash instructions:

This firmware can be flashed using either sysupgrade from the GL.iNet
firmware or the recovery console as follows:

 - Press and hold the reset button
 - Connect power to the router, wait five seconds
 - Manually configure 192.168.1.2/24 on your computer, connect to 192.168.1.1
 - Upload the firmware image using the web interface

RS-485 serial port is untested and may depend on the following commit in
the GL.iNet repo:

https://github.com/gl-inet/openwrt/commit/202e83a32ae308fbb70502b6dbe3bb0bf8b1fba9

MAC addresses as verified by OEM firmware:

vendor   OpenWrt   address
WAN      eth0      label
LAN      eth1      label + 1
2g       phy0      label + 2

The label MAC address was found in the art partition at 0x0

Based on vendor commit:

https://github.com/gl-inet/openwrt/commit/16c5708b207eb76ff19a040dc973e560d3d8074b

Signed-off-by: John Marrett <johnf@zioncluster.ca>