### PR TITLE
ramips: add support for Netgear PR2000

### DIFF
--- a/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
+++ b/target/linux/ramips/dts/mt7620n_netgear_pr2000.dts
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "netgear,pr2000", "ralink,mt7620n-soc";
+	model = "Netgear PR2000";
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wireless {
+			label = "wireless";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		wired {
+			label = "wired";
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			/* sercomm header for kernel starts at 0x3ffba
+			 * can be safely ignored since not used by OpenWRT
+			 */
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xf20000>;
+			};
+
+			factory: partition@f60000 {
+				label = "factory";
+				reg = <0xf60000 0x10000>;
+				read-only;
+			};
+
+			board_data: partition@f70000 {
+				label = "board_data";
+				reg = <0xf70000 0x10000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "POT";
+				reg = <0xf80000 0x10000>;
+				read-only;
+			};
+
+			partition@f90000 {
+				label = "Traffic Meter";
+				reg = <0xf90000 0x10000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "Traffic Meter2";
+				reg = <0xfa0000 0x10000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "nvram";
+				reg = <0xfb0000 0x10000>;
+			};
+
+			partition@fc0000 {
+				label = "DPF";
+				reg = <0xfc0000 0x10000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "ralink_nvram";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "reserved1";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "reserved2";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&board_data 0xb0>;
+	mediatek,portmap = "wllll";
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+	mtd-mac-address = <&board_data 0xb0>;
+};
+
+&state_default {
+	default {
+		groups = "ephy", "wled", "pa", "i2c";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -740,6 +740,21 @@ define Device/netgear_jwnr2010-v5
 endef
 TARGET_DEVICES += netgear_jwnr2010-v5
 
+define Device/netgear_pr2000
+  $(Device/netgear_sercomm_nor)
+  SOC := mt7620n
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 15488k
+  DEVICE_MODEL := PR2000
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+  SERCOMM_HWNAME := PR2000
+  SERCOMM_HWID := AQ7
+  SERCOMM_HWVER := A001
+  SERCOMM_SWVER := 0x0000
+  SERCOMM_PAD := 640k
+endef
+TARGET_DEVICES += netgear_pr2000
+
 define Device/netgear_wn3000rp-v3
   SOC := mt7620a
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -164,6 +164,9 @@ netgear,jwnr2010-v5)
 	ucidef_set_led_switch "lan4" "lan4" "green:lan4" "switch0" "0x01"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
+netgear,pr2000)
+	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x01"
+	;;
 phicomm,psg1208)
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wlan2g" "wlan0"
 	;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -192,6 +192,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	netgear,pr2000|\
 	nexx,wt3020-4m|\
 	nexx,wt3020-8m)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
This patch adds support for Netgear PR2000, sold as "Travel Router and
Range Extender".

Specifications:
--------------

* SoC: Mediatek MT7620A
* RAM: 64MB DDR2
* Flash: 16MB SPI NOR flash (Macronix MX25L12805D)
* WiFi 2.4GHz: builtin
* Ethernet: builtin
* LED: Power, Internet, WiFi, USB
* Buttons: Reset (GPIO 1/2)
* UART: Serial console (57600 8n1)
* USB: 1 x USB2

Installation:
------------

There are two possible ways to install the firmware. Flashing via web
interface of original firmware is not tested due to a broken firmware.

1) Gain TTY control and use u-boot or built-in "dd" tool. Please notice
   you have to remove R54 otherwise you won't be able to input anything.
2) Use well-known Netgear debug switch. Access
   http://192.168.168.1/setup.cgi?todo=debug to start telnet service
   (username: root, password: <none>).

Remark:
------

As a "Range Extender", it has a switch to switch between Wired mode (GPIO
21 low) and Wireless mode (GPIO 20 low), which is not implemented in this
patch. However, there is a turn-off mode between the above mode, which
makes this switch much less useful.

MAC addresses:
-------------

There are three MACs stored in factory, as in MT7620A reference design:

source address   usage
   0x4 label     WLAN
  0x28 label     MAC 1
  0x2e label + 1 MAC 2

Signed-off-by: David Yang <mmyangfl@gmail.com>