### PR TITLE
ramips: fixes the problem of software reboot failure (using 32 Mbyte and above spi nor flash)

### DIFF
--- a/target/linux/ramips/patches-5.4/992-spi-nor.patch
+++ b/target/linux/ramips/patches-5.4/992-spi-nor.patch
@@ -1,0 +1,12 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c	2021-06-09 15:36:32.996926358 +0800
++++ b/drivers/mtd/spi-nor/spi-nor.c	2021-06-09 15:39:26.853063029 +0800
+@@ -4840,8 +4840,7 @@
+ void spi_nor_restore(struct spi_nor *nor)
+ {
+ 	/* restore the addressing mode */
+-	if (nor->addr_width == 4 && !(nor->flags & SNOR_F_4B_OPCODES) &&
+-	    nor->flags & SNOR_F_BROKEN_RESET)
++	if (nor->addr_width == 4 && !(nor->flags & SNOR_F_4B_OPCODES))
+ 		nor->params.set_4byte(nor, false);
+ }
+ EXPORT_SYMBOL_GPL(spi_nor_restore);


### PR DESCRIPTION
This patch fixes the problem of software reboot failure (using 32 Mbyte and above spi nor flash)

Signed-off-by: Liu Yu <f78fk@live.com>

I use hilink mt7628n to test, 32 Mbyte SPI flash, on Linux version 5.4.123 reboot command execution failed, patched, can be successfully restarted.
Here is the kernel log：
root@OpenWrt:/# dmesg 
```
[    0.000000] Linux version 5.4.123 (liuyu@ubuntu-HARD) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16859-2cd1a10829)) #0 Thu Jun 3 03:38:59 2021
[    0.000000] Board has DDR2
[    0.000000] Analog PMU set to hw control
[    0.000000] Digital PMU set to hw control
[    0.000000] SoC Type: MediaTek MT7628AN ver:1 eco:2
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019655 (MIPS 24KEc)
[    0.000000] MIPS: machine is HILINK HLK-7628N
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] On node 0 totalpages: 32768
[    0.000000]   Normal zone: 288 pages used for memmap
[    0.000000]   Normal zone: 0 pages reserved
[    0.000000]   Normal zone: 32768 pages, LIFO batch:7
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 32480
[    0.000000] Kernel command line: console=ttyS0,57600 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.000000] Writing ErrCtl register=0000ff66
[    0.000000] Readback ErrCtl register=0000ff66
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 122304K/131072K available (4745K kernel code, 201K rwdata, 1048K rodata, 1228K init, 197K bss, 8768K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 256
[    0.000000] intc: using register map from devicetree
[    0.000000] random: get_random_bytes called from start_kernel+0x358/0x54c with crng_init=0
[    0.000000] CPU Clock: 580MHz
[    0.000000] timer_probe: no matching timers found
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 6590553264 ns
[    0.000010] sched_clock: 32 bits at 290MHz, resolution 3ns, wraps every 7405115902ns
[    0.015390] Calibrating delay loop... 385.84 BogoMIPS (lpj=1929216)
[    0.087590] pid_max: default: 32768 minimum: 301
[    0.096914] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.111248] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.132732] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.152120] futex hash table entries: 256 (order: -1, 3072 bytes, linear)
[    0.165623] pinctrl core: initialized pinctrl subsystem
[    0.177033] NET: Registered protocol family 16
[    0.219525] workqueue: max_active 576 requested for napi_workq is out of range, clamping between 1 and 512
[    0.242366] clocksource: Switched to clocksource MIPS
[    0.253716] NET: Registered protocol family 2
[    0.262464] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.277371] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.293854] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.308928] TCP bind hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.322855] TCP: Hash tables configured (established 1024 bind 1024)
[    0.335556] UDP hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.348409] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.362515] NET: Registered protocol family 1
[    0.371013] PCI: CLS 0 bytes, default 32
[    0.383679] workingset: timestamp_bits=14 max_order=15 bucket_order=1
[    0.405042] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.416498] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.454102] mt7621_gpio 10000600.gpio: registering 32 gpios
[    0.465371] mt7621_gpio 10000600.gpio: registering 32 gpios
[    0.476626] mt7621_gpio 10000600.gpio: registering 32 gpios
[    0.487871] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.501571] printk: console [ttyS0] disabled
[    0.510010] 10000c00.uartlite: ttyS0 at MMIO 0x10000c00 (irq = 28, base_baud = 2500000) is a 16550A
[    0.527817] printk: console [ttyS0] enabled
[    0.544305] printk: bootconsole [early0] disabled
[    0.563571] 10000d00.uart1: ttyS1 at MMIO 0x10000d00 (irq = 29, base_baud = 2500000) is a 16550A
[    0.582519] spi-mt7621 10000b00.spi: sys_freq: 193333333
[    0.609818] spi-nor spi0.0: w25q256 (32768 Kbytes)
[    0.619419] 4 fixed-partitions partitions found on MTD device spi0.0
[    0.632015] Creating 4 MTD partitions on "spi0.0":
[    0.641523] 0x000000000000-0x000000030000 : "u-boot"
[    0.652531] 0x000000030000-0x000000040000 : "u-boot-env"
[    0.664076] 0x000000040000-0x000000050000 : "factory"
[    0.675230] 0x000000050000-0x000002000000 : "firmware"
[    0.689832] 2 uimage-fw partitions found on MTD device firmware
[    0.701628] Creating 2 MTD partitions on "firmware":
[    0.711494] 0x000000000000-0x0000001e8063 : "kernel"
[    0.722480] 0x0000001e8063-0x000001fb0000 : "rootfs"
[    0.733306] mtd: device 5 (rootfs) set to be root filesystem
[    0.746378] 1 squashfs-split partitions found on MTD device rootfs
[    0.758701] 0x0000004e0000-0x000001fb0000 : "rootfs_data"
[    0.771287] libphy: Fixed MDIO Bus: probed
[    0.790847] rt3050-esw 10110000.esw: link changed 0x00
[    0.803107] mtk_soc_eth 10100000.ethernet eth0: mediatek frame engine at 0xb0100000, irq 5
[    0.821494] NET: Registered protocol family 10
[    0.834756] Segment Routing with IPv6
[    0.842151] NET: Registered protocol family 17
[    0.851091] 8021q: 802.1Q VLAN Support v1.8
[    0.869676] VFS: Mounted root (squashfs filesystem) readonly on device 31:5.
[    0.890707] Freeing unused kernel memory: 1228K
[    0.899716] This architecture does not have kernel memory protection.
[    0.912474] Run /sbin/init as init process
[    2.022689] init: Console is alive
[    2.029697] init: - watchdog -
[    2.482468] random: fast init done
[    3.186668] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.372190] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.397097] init: - preinit -
[    4.981624] random: jshn: uninitialized urandom read (4 bytes read)
[    5.081585] random: jshn: uninitialized urandom read (4 bytes read)
[    5.369948] random: jshn: uninitialized urandom read (4 bytes read)
[    8.794966] mount_root: jffs2 not ready yet, using temporary tmpfs overlay
[    8.813377] urandom-seed: Seed file not found (/etc/urandom.seed)
[    8.927323] procd: - early -
[    8.933247] procd: - watchdog -
[    9.583552] procd: - watchdog -
[    9.590438] procd: - ubus -
[    9.746565] urandom_read: 2 callbacks suppressed
[    9.746575] random: ubusd: uninitialized urandom read (4 bytes read)
[    9.775835] random: ubusd: uninitialized urandom read (4 bytes read)
[    9.789071] random: ubusd: uninitialized urandom read (4 bytes read)
[    9.805400] procd: - init -
[   10.829200] kmodloader: loading kernel modules from /etc/modules.d/*
[   11.047078] Loading modules backported from Linux version v5.10.34-0-g0aa66717f684
[   11.062154] Backport generated by backports.git v5.10.34-1-0-g7b5533e1
[   11.150171] xt_time: kernel timezone is -0000
[   11.286734] mt76_wmac 10300000.wmac: ASIC revision: 76280001
[   11.398455] urngd: v1.0.2 started.
[   11.602731] random: crng init done
[   11.609464] random: 2 urandom warning(s) missed due to ratelimiting
[   12.334558] mt76_wmac 10300000.wmac: Firmware Version: 20151201
[   12.346367] mt76_wmac 10300000.wmac: Build Time: 20151201183641
[   12.402382] mt76_wmac 10300000.wmac: firmware init done
[   12.584840] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
[   12.705632] PPP generic driver version 2.4.2
[   12.733411] NET: Registered protocol family 24
[   12.779065] kmodloader: done loading kernel modules from /etc/modules.d/*
[   42.393868] rt3050-esw 10110000.esw: link changed 0x00
[   46.159031] rt3050-esw 10110000.esw: link changed 0x01
[   48.333189] jffs2_scan_eraseblock(): End of filesystem marker found at 0x0
[   48.372595] jffs2_build_filesystem(): unlocking the mtd device... 
[   48.372665] done.
[   48.388736] jffs2_build_filesystem(): erasing all blocks after the end marker... 
[   49.952883] br-lan: port 1(eth0.1) entered blocking state
[   49.978656] br-lan: port 1(eth0.1) entered disabled state
[   49.989789] device eth0.1 entered promiscuous mode
[   49.999343] device eth0 entered promiscuous mode
[   50.174775] br-lan: port 1(eth0.1) entered blocking state
[   50.185514] br-lan: port 1(eth0.1) entered forwarding state
[   50.952902] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready

root@OpenWrt:/# 
root@OpenWrt:/# 
root@OpenWrt:/# reboot
[  140.725420] done.
[  140.729269] jffs2: notice: (1823) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
root@OpenWrt:/# 
root@OpenWrt:/# [  140.955218] overlayfs: upper fs does not support tmpfile.
[  142.230920] br-lan: port 1(eth0.1) entered disabled state
[  142.263462] device eth0.1 left promiscuous mode
[  142.272514] device eth0 left promiscuous mode
[  142.281301] br-lan: port 1(eth0.1) entered disabled state
[  146.825886] reboot: Restarting system
******************************
Software System Reset Occurred
******************************
flash manufacture id: ef, device id 40 19
info id : ef info->jedec_id :40160000 buf[1]:40 buf[2]:19
info id : ef info->jedec_id :40170000 buf[1]:40 buf[2]:19
info id : ef info->jedec_id :40180000 buf[1]:40 buf[2]:19
info id : ef info->jedec_id :40190000 buf[1]:40 buf[2]:19
find flash: W25Q256FV
============================================ 
Ralink UBoot Version: 1.0
-------------------------------------------- 
ASIC 7628_MP (Port5<->None)
DRAM component: 1024 Mbits DDR, width 16
DRAM bus: 16 bit
Total memory: 128 MBytes
Flash component: SPI Flash
Date:May 23 2020  Time:14:42:28
============================================ 
icache: sets:512, ways:4, linesz:32 ,total:65536
dcache: sets:256, ways:4, linesz:32 ,total:32768 
RESET MT7628 PHY!!!!!!


  _    _   _        _  __  ______     __    ___     ___    _   _   
 | |  | | | |      | |/ / |____  |   / /   |__ \   / _ \  | \ | |  
 | |__| | | |      | ' /      / /   / /_      ) | | (_) | |  \| |  
 |  __  | | |      |  <      / /   | '_ \    / /   > _ <  | . ` |  
 | |  | | | |____  | . \    / /    | (_) |  / /_  | (_) | | |\  |  
 |_|  |_| |______| |_|\_\  /_/      \___/  |____|  \___/  |_| \_|  
-------------------------------------------------------------------------
             https://github.com/gnubee-git
-------------7628N build May 23 2020 14:42:28--------------------
-------------------------------------------------------------------------

Please choose the operation: 
   1: Load system code to SDRAM via TFTP. 
   2: Load system code then write to Flash via TFTP. 
   3: Boot system code via Flash (default).
   4: Entr boot command line interface.
   5: Load system code then write to Flash via Httpd.
   7: Load Boot Loader code then write to Flash via Serial. 
   9: Load Boot Loader code then write to Flash via TFTP. 

You chose 2

 0 
```

