### PR TITLE
ramips: mt7620: add kernel size for Jboot devices

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -62,6 +62,7 @@ TARGET_DEVICES += alfa-network_tube-e4g
 define Device/amit_jboot
   DLINK_IMAGE_OFFSET := 0x10000
   KERNEL := $(KERNEL_DTB)
+  KERNEL_SIZE := 2048k
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
   IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -67,6 +67,7 @@ define Device/amit_jboot
   IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
   IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
   DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-ohci
+  DEFAULT := n
 endef
 
 define Device/asus_rp-n53


### PR DESCRIPTION
Since few months multiple users reported problems with various JBoot
devices. [0][1][2][3] All of them was bricked.

On my Lava LR-25G001 it freezes with current snapshot:

```
CDW57CAM_003 Jboot B695
Giga Switch AR8327 init
AR8327/AR8337 id   ==> 0x1302
JRecovery Version R1.2 2014/04/01 18:25
SPI FLASH: MX25l12805d 16M
.
.
(freeze)
```

The kernel size is >2048k.

I built current master with minimal config and it boots well:

```
CDW57CAM_003 Jboot B695
Giga Switch AR8327 init
AR8327/AR8337 id   ==> 0x1302
JRecovery Version R1.2 2014/04/01 18:25
SPI FLASH: MX25l12805d 16M
.
...........................
Starting kernel @80000000...
[    0.000000] Linux version 5.4.124
```

Kernel size is <2048k.

Jboot bootloader isn't open source, so it's impossible to find
solution in code. It looks, that some buffer for kernel have 2MB size.

To avoid bricked devices, this commit introduces 2048k limit kernel
size for all jboot routers.

Fixes: FS#3539

[0] https://bugs.openwrt.org/index.php?do=details&task_id=3539
[1] https://eko.one.pl/forum/viewtopic.php?pid=254344
[2] https://eko.one.pl/forum/viewtopic.php?id=20930
[3] https://eko.one.pl/forum/viewtopic.php?pid=241376#p241376

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
