### PR TITLE
Add Data Plane Development Kit (DPDK) Support

### DIFF
--- a/package/network/utils/dpdk/Makefile
+++ b/package/network/utils/dpdk/Makefile
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME := dpdk
+PKG_VERSION := 21.05
+
+PKG_SOURCE := dpdk-$(PKG_VERSION).tar.xz
+PKG_SOURCE_URL := http://static.dpdk.org/rel
+PKG_MD5SUM := a78bba290b11d9717d1272cc6bfaf7c3
+
+PKG_BUILD_DEPENDS:= meson/host ninja/host
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
+include ../../../feeds/packages/meson/meson.mk
+include ../../../feeds/packages/ninja/ninja.mk
+
+TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral
+
+define Package/dpdk
+  SECTION    := net
+  CATEGORY   := Network
+  TITLE      := Data Plane Development Kit (DPDK)
+  DEPENDS    := @(x86_64||arm||aarch64) +librt +libpthread +libbpf +libpcap +libopenssl
+endef
+
+define Package/dpdk/description
+  DPDK consists of libraries to accelerate packet processing
+  workloads running on a wide variety of CPU architectures.
+endef
+
+define Package/dpdk/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dpdk-testpmd $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dpdk-proc-info $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/dpdk-test-flow-perf $(1)/usr/bin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,dpdk))

--- a/package/network/utils/dpdk/patches/0001-Handling-backtrace-and-execinfo-header-file.patch
+++ b/package/network/utils/dpdk/patches/0001-Handling-backtrace-and-execinfo-header-file.patch
@@ -1,0 +1,40 @@
+From afe64bae6d398fc9a194bce2763d6b2ab080f38f Mon Sep 17 00:00:00 2001
+From: Chandrakant Sharpa <s.chandrakant@globaledgesoft.com>
+Date: Mon, 14 Jun 2021 17:53:16 +0530
+Subject: [PATCH] Handling backtrace and execinfo header file
+
+Signed-off-by: Chandrakant Sharpa <s.chandrakant@globaledgesoft.com>
+---
+ lib/eal/linux/eal_debug.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/eal/linux/eal_debug.c b/lib/eal/linux/eal_debug.c
+index 64dab4e0d..24b8b23dd 100644
+--- a/lib/eal/linux/eal_debug.c
++++ b/lib/eal/linux/eal_debug.c
+@@ -2,9 +2,11 @@
+  * Copyright(c) 2010-2014 Intel Corporation
+  */
+ 
++#ifdef __GLIBC__
+ #ifdef RTE_BACKTRACE
+ #include <execinfo.h>
+ #endif
++#endif
+ #include <stdarg.h>
+ #include <signal.h>
+ #include <stdlib.h>
+@@ -26,8 +28,10 @@ void rte_dump_stack(void)
+ 	char **symb = NULL;
+ 	int size;
+ 
++#ifdef __GLIBC__
+ 	size = backtrace(func, BACKTRACE_SIZE);
+ 	symb = backtrace_symbols(func, size);
++#endif
+ 
+ 	if (symb == NULL)
+ 		return;
+-- 
+2.17.1
+


### PR DESCRIPTION
DPDK consists of libraries to accelerate packet processing
workloads running on a wide variety of CPU architectures.
Add DPDK 21.05 support for Armv7 based platforms.

Signed-off-by: Chandrakant Sharpa <s.chandrakant@globaledgesoft.com>
