### PR TITLE
kernel: add rtl88x2bu-cl package

### DIFF
--- a/package/kernel/rtl88x2bu-cl/Makefile
+++ b/package/kernel/rtl88x2bu-cl/Makefile
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl88x2bu-cl
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE_URL:=https://github.com/cilynx/rtl88x2bu
+PKG_MIRROR_HASH:=d9d06afb154256e4bee287d0ceee431994880e7d40cfbe9cf640fe4144425c02
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-04-15
+PKG_SOURCE_VERSION:=342c46353b523dee8c61282eb1cab5788c7d3386
+
+PKG_MAINTAINER:=Dirk Neukirchen <plntyk.lede@plntyk.name>
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/rtl88x2bu-cl
+  SUBMENU:=Wireless Drivers
+  TITLE:=Realtek 88x2BU driver based on 5.6.1 mod by cilynx
+  DEPENDS:=+kmod-cfg80211 +kmod-usb-core +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT
+  FILES:=\
+	$(PKG_BUILD_DIR)/rtl88x2bu.ko
+  AUTOLOAD:=$(call AutoProbe,rtl88x2bu)
+  PROVIDES:=kmod-rtl88x2bu
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h
+
+# from Makefile: obj-(CONFIG_RTL8822BU) = ...
+ifdef CONFIG_PACKAGE_kmod-rtl88x2bu-cl
+   PKG_MAKE_FLAGS += CONFIG_RTL8822BU=m
+endif
+
+NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
+
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		$(PKG_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,rtl88x2bu-cl))

--- a/package/kernel/rtl88x2bu-cl/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
@@ -1,0 +1,26 @@
+From f5e1e77b628d2d460451f91028a6109f38dec3cf Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:46:17 +0200
+Subject: [PATCH 1/6] core/rtw_mlme.c: fix warning: misleading indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/rtw_mlme.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/rtw_mlme.c b/core/rtw_mlme.c
+index b33c1a1..6ae9933 100644
+--- a/core/rtw_mlme.c
++++ b/core/rtw_mlme.c
+@@ -3196,7 +3196,7 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
+ 		else
+ 		#endif
+ 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+-			goto exit;
++		goto exit;
+ 	}
+ 	else if (ssc_chk != SS_ALLOW)
+ 		goto exit;
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
@@ -1,0 +1,33 @@
+From 0bfd7037f402e1b9cc58fdfb708bee8d78d50994 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:58:04 +0200
+Subject: [PATCH 2/6] core/efuse/rtw_efuse.c: fix warning: misleading
+ indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/efuse/rtw_efuse.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/core/efuse/rtw_efuse.c b/core/efuse/rtw_efuse.c
+index 59b3464..27788c1 100644
+--- a/core/efuse/rtw_efuse.c
++++ b/core/efuse/rtw_efuse.c
+@@ -780,10 +780,10 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++		, pEfuseHal->fakeEfuseInitMap[i]
++		, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
+ 		}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0003-core-rtw_wlan_util.c-fix-indent-warning.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0003-core-rtw_wlan_util.c-fix-indent-warning.patch
@@ -1,0 +1,27 @@
+From 470a9eaa5b5884288becd0bcccec44f9be615001 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <dirkneukirchen@web.de>
+Date: Mon, 7 Jun 2021 10:36:51 +0200
+Subject: [PATCH 3/6] core/rtw_wlan_util.c: fix indent warning
+
+Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>
+---
+ core/rtw_wlan_util.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/core/rtw_wlan_util.c b/core/rtw_wlan_util.c
+index 0e6193e..7f470ed 100644
+--- a/core/rtw_wlan_util.c
++++ b/core/rtw_wlan_util.c
+@@ -3226,7 +3226,8 @@ void rtw_parse_sta_vendor_ie_8812(_adapter *adapter, struct sta_info *sta, u8 *t
+ 		if(*(p+1) > 6 ) {
+ 			for(i=0; i<9;i++)
+ 				RTW_INFO("p[%d]=0x%x",i,*(p+i) );
+-				RTW_INFO("\n");
++			RTW_INFO("\n");
++
+ 			if(*(p+6) != 2)
+ 				goto exit;
+ 
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0004-os_dep-linux-recv_linux-fix-Kernel-5.12-deprecated-G.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0004-os_dep-linux-recv_linux-fix-Kernel-5.12-deprecated-G.patch
@@ -1,0 +1,33 @@
+From 10e1c67490a3f80b30b37e2a5ae73594ed858814 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <dirkneukirchen@web.de>
+Date: Mon, 7 Jun 2021 10:45:15 +0200
+Subject: [PATCH 4/6] os_dep/linux/recv_linux: fix Kernel 5.12 deprecated
+ GRO_DROP
+
+patch taken from 8812au-mw morrownr:
+commit-id fcb0343c52daa647150f027258958194824e2ace
+---
+ os_dep/linux/recv_linux.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/os_dep/linux/recv_linux.c b/os_dep/linux/recv_linux.c
+index 6bd2e09..95703c6 100644
+--- a/os_dep/linux/recv_linux.c
++++ b/os_dep/linux/recv_linux.c
+@@ -355,8 +355,13 @@ static int napi_recv(_adapter *padapter, int budget)
+ 
+ #ifdef CONFIG_RTW_GRO
+ 		if (pregistrypriv->en_gro) {
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0))
+ 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
+ 				rx_ok = _TRUE;
++#else
++			rtw_napi_gro_receive(&padapter->napi, pskb);
++			rx_ok = _TRUE;
++#endif
+ 			goto next;
+ 		}
+ #endif /* CONFIG_RTW_GRO */
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0005-module-name-like-ct-Makefile.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0005-module-name-like-ct-Makefile.patch
@@ -1,0 +1,25 @@
+From 1c554abe0f3521c8fbaf3160b4d01ee2535f150c Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 17:48:07 +0200
+Subject: [PATCH 5/6] module name like -ct Makefile
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 66c88b0..4805b8e 100755
+--- a/Makefile
++++ b/Makefile
+@@ -2193,7 +2193,7 @@ endif
+ 
+ endif
+ 
+-USER_MODULE_NAME ?=
++USER_MODULE_NAME ?= rtl$(MODULE_NAME)
+ ifneq ($(USER_MODULE_NAME),)
+ MODULE_NAME := $(USER_MODULE_NAME)
+ endif
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0006-include-drv_conf.h-fix-OpenWrt-build-against-backpor.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0006-include-drv_conf.h-fix-OpenWrt-build-against-backpor.patch
@@ -1,0 +1,39 @@
+From 09db068278522e5a3b457dc06b7b1e9e2e342fd5 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <dirkneukirchen@web.de>
+Date: Mon, 7 Jun 2021 10:57:51 +0200
+Subject: [PATCH 6/6] include/drv_conf.h: fix OpenWrt build against backports
+
+from Ben Greearb 8812au-ct: 9b2b0ec1bc2d31ddf93ed74d63fdfa6044e329a4
+---
+ include/drv_conf.h                                  | 3 ++-
+ include/linux/{wireless.h => old_unused_wireless.h} | 0
+ include/{autoconf.h => rtl_autoconf.h}              | 0
+ 3 files changed, 2 insertions(+), 1 deletion(-)
+ rename include/linux/{wireless.h => old_unused_wireless.h} (100%)
+ rename include/{autoconf.h => rtl_autoconf.h} (100%)
+
+diff --git a/include/drv_conf.h b/include/drv_conf.h
+index 8d6a040..52c9506 100755
+--- a/include/drv_conf.h
++++ b/include/drv_conf.h
+@@ -14,7 +14,8 @@
+  *****************************************************************************/
+ #ifndef __DRV_CONF_H__
+ #define __DRV_CONF_H__
+-#include "autoconf.h"
++#include <generated/autoconf.h>
++#include "rtl_autoconf.h"
+ #include "hal_ic_cfg.h"
+ #if defined(PLATFORM_LINUX) && defined (PLATFORM_WINDOWS)
+ 
+diff --git a/include/linux/wireless.h b/include/linux/old_unused_wireless.h
+similarity index 100%
+rename from include/linux/wireless.h
+rename to include/linux/old_unused_wireless.h
+diff --git a/include/autoconf.h b/include/rtl_autoconf.h
+similarity index 100%
+rename from include/autoconf.h
+rename to include/rtl_autoconf.h
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0007-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0007-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
@@ -1,0 +1,25 @@
+From 07d685c67cf678435a644c5b26742d68ffd9ec79 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:34:01 +0200
+Subject: [PATCH 6/6] OpenWrt patch 001-use-kernel-byteorder.patch
+
+---
+ include/drv_types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/drv_types.h b/include/drv_types.h
+index 963e7091..e38aa7c1 100644
+--- a/include/drv_types.h
++++ b/include/drv_types.h
+@@ -25,7 +25,7 @@
+ #include <drv_conf.h>
+ #include <basic_types.h>
+ #include <osdep_service.h>
+-#include <rtw_byteorder.h>
++#include <asm/byteorder.h>
+ #include <wlan_bssdef.h>
+ #include <wifi.h>
+ #include <ieee80211.h>
+-- 
+2.31.1
+

--- a/package/kernel/rtl88x2bu-cl/patches/0007-OpenWrt-patch-003-wireless-5.8.patch.patch
+++ b/package/kernel/rtl88x2bu-cl/patches/0007-OpenWrt-patch-003-wireless-5.8.patch.patch
@@ -1,0 +1,44 @@
+From fc0e90868cea94c9334dfb53396f3130380f265d Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:37:35 +0200
+Subject: [PATCH 03/12] OpenWrt 003-wireless-5.8.patch
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/os_dep/linux/ioctl_cfg80211.c b/os_dep/linux/ioctl_cfg80211.c
+index 7719b728..ed6bb53a 100644
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -8024,6 +8024,15 @@ exit:
+ }
+ #endif
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)) || defined(BUILD_OPENWRT)
++static void cfg80211_rtw_update_mgmt_frame_registrations(struct wiphy *wiphy,
++						   struct wireless_dev *wdev,
++						   struct mgmt_frame_regs *upd)
++{
++
++}
++#endif
++
+ #if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
+ static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
+ 	struct net_device *ndev,
+@@ -10419,7 +10428,10 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
+ 	.update_ft_ies = cfg80211_rtw_update_ft_ies,
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || defined(BUILD_OPENWRT)
++	.mgmt_tx = cfg80211_rtw_mgmt_tx,
++	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_registrations,
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+ 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0))
+ 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
+-- 
+2.31.1
+


### PR DESCRIPTION
support USB sticks from Realtek
seems 8822B is different from A units

list of USB IDs that should be supported
taken from os_dep/linux/usb_intf.c

no-name / realtek branding
	0BDA:0xB82C
	0BDA:0xB812

branded / customer stick branding
	13b1:0043 /* Alpha - Alpha*/
	2001:331c /* Dlink DWA-182*/
	2001:331e /* Dlink DWA-181-A1*/
	2001:331f /* Dlink DWA-183 */
	2357:012d /* TP-Link Archer T3U V1 */
	2357:0138 /* TP-Link Archer T3U Plus V1 */
	2357:0115 /* TP-Link Archer T4U V3 */
	7392:B822 /* Edimax EW-7822ULC */
	7392:C822 /* Edimax EW-7822UTC */
	0b05:1841 /* ASUS AC1300 USB-AC55 B1 */
	0b05:184c /* ASUS USB-AC53 Nano */
	0846:9055 /* Netgear A6150 - AC1200 Dual Band WiFi USB Mini Adapter */

based on Realtek 5.6.1 mod by cilynx

upstream changelog unknown

driver / hw names:
88 + Feature (1,2) BT-COEX (?) + Feature number?(2,4) + A,B (Version)
+ Bus (U USB, E PCIe, S SDIO)

Realtek packages the drivers with some tools that
seem to remove other chip architectures from their
common code base

compile tested: x86_64, ath79

runtime tested: x86_64 + Netis WF2190 @ USB2

results: "works"
iperf3: 94.2 Mbits/sec (USB2, old x86_64)

tested with
iw phy phy0 info
ip link set dev wlan0 up
iw dev wlan0 scan
wpa_supplicant -i wlan0 -c wpa.conf
udhcpc -i wlan0
<setup ip route for -B switch>
iperf3 -c <server ip>

issues:
- luci does not work similar to rtl8812au-* variants

- bug ping variance every other packet - might be BT-COEX:
64 bytes from 192.168.99.186: seq=81 ttl=64 time=465.202 ms
64 bytes from 192.168.99.186: seq=82 ttl=64 time=1.253 ms
64 bytes from 192.168.99.186: seq=83 ttl=64 time=512.594 ms
64 bytes from 192.168.99.186: seq=84 ttl=64 time=1.319 ms

