### PR TITLE
ramips: mt7620: use OKLI loader with Jboot devices

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dir-510l", "ralink,mt7620a-soc";
@@ -85,7 +86,9 @@
 			};
 
 			partition@210000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x210000 0xde0000>;
 			};

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-118-a1", "ralink,mt7620a-soc";
@@ -106,7 +107,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-118-a2", "ralink,mt7620a-soc";
@@ -103,7 +104,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-960", "ralink,mt7620a-soc";
@@ -143,7 +144,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "lava,lr-25g001", "ralink,mt7620a-soc";
@@ -83,7 +84,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-116-a1", "ralink,mt7620n-soc";
@@ -69,7 +70,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0x7e0000>;
 			};

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
@@ -2,6 +2,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-921-c1", "ralink,mt7620n-soc";
@@ -111,7 +112,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
@@ -4,6 +4,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "dlink,dwr-922-e2", "ralink,mt7620n-soc";
@@ -114,7 +115,9 @@
 			};
 
 			partition@10000 {
-				compatible = "amit,jimage";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+				openwrt,offset = <0x10000>;
 				label = "firmware";
 				reg = <0x10000 0xfe0000>;
 			};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -89,6 +89,16 @@ define Build/mkdlinkfw-factory
 	mv $@.new $@
 endef
 
+define Build/mkdlinkfw-loader
+	-$(STAGING_DIR_HOST)/bin/mkdlinkfw \
+		-k $(KDIR)/loader-$(DEVICE_NAME).bin \
+		-r $@ \
+		-o $@.new \
+		$(if $(DLINK_IMAGE_OFFSET), -O $(DLINK_IMAGE_OFFSET)) \
+		-s $(DLINK_FIRMWARE_SIZE)
+	mv $@.new $@
+endef
+
 define Build/netis-tail
 	echo -n $(1) >> $@
 	echo -n $(UIMAGE_NAME)-yun | $(MKHASH) md5 | \

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -61,13 +61,18 @@ TARGET_DEVICES += alfa-network_tube-e4g
 
 define Device/amit_jboot
   DLINK_IMAGE_OFFSET := 0x10000
-  KERNEL := $(KERNEL_DTB)
-  KERNEL_SIZE := 2048k
+  KERNEL := $(KERNEL_DTB) | uImage lzma -M 0x4f4b4c49
+  LOADER_FLASH_OFFS := 0x20000
+  LOADER_TYPE := bin
+  COMPILE := loader-$(1).bin
+  COMPILE/loader-$(1).bin := loader-okli-compile | pad-to 64k | lzma | \
+	pad-to 65480
   IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := mkdlinkfw | pad-rootfs | append-metadata
-  IMAGE/factory.bin := mkdlinkfw | pad-rootfs | mkdlinkfw-factory
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | mkdlinkfw-loader | \
+	pad-rootfs | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | mkdlinkfw-loader | \
+	pad-rootfs | mkdlinkfw-factory
   DEVICE_PACKAGES := jboot-tools kmod-usb2 kmod-usb-ohci
-  DEFAULT := n
 endef
 
 define Device/asus_rp-n53
@@ -194,6 +199,7 @@ define Device/dlink_dir-510l
   $(Device/amit_jboot)
   SOC := mt7620a
   IMAGE_SIZE := 14208k
+  LOADER_FLASH_OFFS := 0x220000
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-510L
   DEVICE_PACKAGES += kmod-mt76x0e


### PR DESCRIPTION
Jboot devices have problem with >2MB kernelsize. The only way to avoid
this problem is use small loader.

This patch switch all mt7620 Jboot devices to lzma OKLI loader.

Suggested-by: Szabolcs Hubai <szab.hu@gmail.com> @xabolcs 
Co-authored-by: Michael Pratt <mcpratt@pm.me> @mpratt14 
Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
