### PR TITLE
rework ramips ralink ethernet drivers

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -439,8 +439,8 @@
 		compatible = "mediatek,mt7628-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23>;
-		reset-names = "esw";
+		resets = <&rstctrl 23 &rstctrl 24>;
+		reset-names = "esw", "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -429,8 +429,8 @@
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;
 
-		resets = <&rstctrl 21 &rstctrl 23>;
-		reset-names = "fe", "esw";
+		resets = <&rstctrl 21>;
+		reset-names = "fe";
 
 		mediatek,switch = <&esw>;
 	};

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -319,8 +319,8 @@
 		compatible = "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23>;
-		reset-names = "esw";
+		resets = <&rstctrl 23 &rstctrl 24>;
+		reset-names = "esw", "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -331,8 +331,8 @@
 		compatible = "ralink,rt3352-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23>;
-		reset-names = "esw";
+		resets = <&rstctrl 23 &rstctrl 24>;
+		reset-names = "esw", "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -343,8 +343,8 @@
 		compatible = "ralink,rt5350-eth";
 		reg = <0x10100000 0x10000>;
 
-		resets = <&rstctrl 21 &rstctrl 23>;
-		reset-names = "fe", "esw";
+		resets = <&rstctrl 21>;
+		reset-names = "fe";
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <5>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -356,8 +356,8 @@
 		compatible = "ralink,rt5350-esw", "ralink,rt3050-esw";
 		reg = <0x10110000 0x8000>;
 
-		resets = <&rstctrl 23>;
-		reset-names = "esw";
+		resets = <&rstctrl 23 &rstctrl 24>;
+		reset-names = "esw", "ephy";
 
 		interrupt-parent = <&intc>;
 		interrupts = <17>;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -24,6 +24,7 @@
 #include <linux/reset.h>
 
 #include "mtk_eth_soc.h"
+#include "esw_rt3050.h"
 
 /* HW limitations for this switch:
  * - No large frame support (PKT_MAX_LEN at most 1536)
@@ -216,6 +217,7 @@ struct rt305x_esw {
 	struct device		*dev;
 	void __iomem		*base;
 	int			irq;
+	struct fe_priv		*priv;
 
 	/* Protects against concurrent register r/w operations. */
 	spinlock_t		reg_rw_lock;
@@ -736,19 +738,44 @@ static void esw_hw_init(struct rt305x_esw *esw)
 	esw_w32(esw, ~RT305X_ESW_PORT_ST_CHG, RT305X_ESW_REG_IMR);
 }
 
+
+int rt3050_esw_has_carrier(struct fe_priv *priv)
+{
+	struct rt305x_esw *esw = priv->soc->swpriv;
+	u32 link;
+	int i;
+	bool cpuport;
+
+	link = esw_r32(esw, RT305X_ESW_REG_POA);
+	link >>= RT305X_ESW_POA_LINK_SHIFT;
+	cpuport = link & BIT(RT305X_ESW_PORT6);
+	link &= RT305X_ESW_POA_LINK_MASK;
+	for (i = 0; i <= RT305X_ESW_PORT5; i++) {
+		if (priv->link[i] != (link & BIT(i)))
+			dev_info(esw->dev, "port %d link %s\n", i, link & BIT(i) ? "up" : "down");
+		priv->link[i] = link & BIT(i);
+	}
+
+	return !!link && cpuport;
+}
+
 static irqreturn_t esw_interrupt(int irq, void *_esw)
 {
-	struct rt305x_esw *esw = (struct rt305x_esw *)_esw;
+	struct rt305x_esw *esw = (struct rt305x_esw *) _esw;
 	u32 status;
+	int i;
 
 	status = esw_r32(esw, RT305X_ESW_REG_ISR);
 	if (status & RT305X_ESW_PORT_ST_CHG) {
-		u32 link = esw_r32(esw, RT305X_ESW_REG_POA);
-
-		link >>= RT305X_ESW_POA_LINK_SHIFT;
-		link &= RT305X_ESW_POA_LINK_MASK;
-		dev_info(esw->dev, "link changed 0x%02X\n", link);
+		if (!esw->priv)
+			goto out;
+		if (rt3050_esw_has_carrier(esw->priv))
+			netif_carrier_on(esw->priv->netdev);
+		else
+			netif_carrier_off(esw->priv->netdev);
 	}
+
+out:
 	esw_w32(esw, status, RT305X_ESW_REG_ISR);
 
 	return IRQ_HANDLED;
@@ -1376,9 +1403,7 @@ static int esw_probe(struct platform_device *pdev)
 	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	struct device_node *np = pdev->dev.of_node;
 	const __be32 *port_map, *port_disable, *reg_init;
-	struct switch_dev *swdev;
 	struct rt305x_esw *esw;
-	int ret;
 
 	esw = devm_kzalloc(&pdev->dev, sizeof(*esw), GFP_KERNEL);
 	if (!esw)
@@ -1417,48 +1442,10 @@ static int esw_probe(struct platform_device *pdev)
 	if (IS_ERR(esw->rst_ephy))
 		esw->rst_ephy = NULL;
 
-	swdev = &esw->swdev;
-	swdev->of_node = pdev->dev.of_node;
-	swdev->name = "rt305x-esw";
-	swdev->alias = "rt305x";
-	swdev->cpu_port = RT305X_ESW_PORT6;
-	swdev->ports = RT305X_ESW_NUM_PORTS;
-	swdev->vlans = RT305X_ESW_NUM_VIDS;
-	swdev->ops = &esw_ops;
-
-	ret = register_switch(swdev, NULL);
-	if (ret < 0) {
-		dev_err(&pdev->dev, "register_switch failed\n");
-		return ret;
-	}
-
+	spin_lock_init(&esw->reg_rw_lock);
 	platform_set_drvdata(pdev, esw);
 
-	spin_lock_init(&esw->reg_rw_lock);
-
-	esw_hw_init(esw);
-
-	reg_init = of_get_property(np, "ralink,rgmii", NULL);
-	if (reg_init && be32_to_cpu(*reg_init) == 1) {
-		/* 
-		 * External switch connected to RGMII interface. 
-		 * Unregister the switch device after initialization. 
-		 */
-		dev_err(&pdev->dev, "RGMII mode, not exporting switch device.\n");
-		unregister_switch(&esw->swdev);
-		platform_set_drvdata(pdev, NULL);
-		return -ENODEV;
-	}
-
-	ret = devm_request_irq(&pdev->dev, esw->irq, esw_interrupt, 0, "esw",
-			       esw);
-
-	if (!ret) {
-		esw_w32(esw, RT305X_ESW_PORT_ST_CHG, RT305X_ESW_REG_ISR);
-		esw_w32(esw, ~RT305X_ESW_PORT_ST_CHG, RT305X_ESW_REG_IMR);
-	}
-
-	return ret;
+	return 0;
 }
 
 static int esw_remove(struct platform_device *pdev)
@@ -1478,6 +1465,71 @@ static const struct of_device_id ralink_esw_match[] = {
 	{},
 };
 MODULE_DEVICE_TABLE(of, ralink_esw_match);
+
+/* called by the ethernet driver to bound with the switch driver */
+int rt3050_esw_init(struct fe_priv *priv)
+{
+	struct device_node *np = priv->switch_np;
+	struct platform_device *pdev = of_find_device_by_node(np);
+	struct switch_dev *swdev;
+	struct rt305x_esw *esw;
+	const __be32 *rgmii;
+	int ret;
+
+	if (!pdev)
+		return -ENODEV;
+
+	if (!of_device_is_compatible(np, ralink_esw_match->compatible))
+		return -EINVAL;
+
+	esw = platform_get_drvdata(pdev);
+	if (!esw)
+		return -EPROBE_DEFER;
+
+	priv->soc->swpriv = esw;
+	esw->priv = priv;
+
+	esw_hw_init(esw);
+
+	rgmii = of_get_property(np, "ralink,rgmii", NULL);
+	if (rgmii && be32_to_cpu(*rgmii) == 1) {
+		/*
+		 * External switch connected to RGMII interface.
+		 * Unregister the switch device after initialization.
+		 */
+		dev_err(&pdev->dev, "RGMII mode, not exporting switch device.\n");
+		unregister_switch(&esw->swdev);
+		platform_set_drvdata(pdev, NULL);
+		return -ENODEV;
+	}
+
+	swdev = &esw->swdev;
+	swdev->of_node = pdev->dev.of_node;
+	swdev->name = "rt305x-esw";
+	swdev->alias = "rt305x";
+	swdev->cpu_port = RT305X_ESW_PORT6;
+	swdev->ports = RT305X_ESW_NUM_PORTS;
+	swdev->vlans = RT305X_ESW_NUM_VIDS;
+	swdev->ops = &esw_ops;
+
+	ret = register_switch(swdev, NULL);
+	if (ret < 0) {
+		dev_err(&pdev->dev, "register_switch failed\n");
+		return ret;
+	}
+
+	ret = devm_request_irq(&pdev->dev, esw->irq, esw_interrupt, 0, "esw",
+			esw);
+	if (!ret) {
+		esw_w32(esw, RT305X_ESW_PORT_ST_CHG, RT305X_ESW_REG_ISR);
+		esw_w32(esw, ~RT305X_ESW_PORT_ST_CHG, RT305X_ESW_REG_IMR);
+	}
+
+	dev_info(&pdev->dev, "mediatek esw at 0x%08lx, irq %d initialized\n",
+		   esw->base, esw->irq);
+
+	return 0;
+}
 
 static struct platform_driver esw_driver = {
 	.probe = esw_probe,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -462,6 +462,8 @@ static void esw_hw_init(struct rt305x_esw *esw)
 	u8 port_disable = 0;
 	u8 port_map = RT305X_ESW_PMAP_LLLLLL;
 
+	esw_reset(esw);
+
 	/* vodoo from original driver */
 	esw_w32(esw, 0xC8A07850, RT305X_ESW_REG_FCT0);
 	esw_w32(esw, 0x00000000, RT305X_ESW_REG_SGC2);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.h
@@ -26,4 +26,7 @@ static inline int __init mtk_switch_init(void) { return 0; }
 static inline void mtk_switch_exit(void) { }
 
 #endif
+
+int rt3050_esw_init(struct fe_priv *priv);
+int rt3050_esw_has_carrier(struct fe_priv *priv);
 #endif

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -141,6 +141,17 @@ void fe_reset(u32 reset_bits)
 	usleep_range(10, 20);
 }
 
+void fe_reset_fe(struct fe_priv *priv)
+{
+	if (!priv->rst_fe)
+		return;
+
+	reset_control_assert(priv->rst_fe);
+	usleep_range(60, 120);
+	reset_control_deassert(priv->rst_fe);
+	usleep_range(60, 120);
+}
+
 static inline void fe_int_disable(u32 mask)
 {
 	fe_reg_w32(fe_reg_r32(FE_REG_FE_INT_ENABLE) & ~mask,
@@ -1360,7 +1371,10 @@ static int __init fe_init(struct net_device *dev)
 	const char *mac_addr;
 	int err;
 
-	priv->soc->reset_fe(priv);
+	if (priv->soc->reset_fe)
+		priv->soc->reset_fe(priv);
+	else
+		fe_reset_fe(priv);
 
 	if (priv->soc->switch_init)
 		if (priv->soc->switch_init(priv)) {
@@ -1579,6 +1593,12 @@ static int fe_probe(struct platform_device *pdev)
 		goto err_free_dev;
 	}
 
+	priv = netdev_priv(netdev);
+	spin_lock_init(&priv->page_lock);
+	priv->rst_fe = devm_reset_control_get(&pdev->dev, "fe");
+	if (IS_ERR(priv->rst_fe))
+		priv->rst_fe = NULL;
+
 	if (soc->init_data)
 		soc->init_data(soc, netdev);
 	netdev->vlan_features = netdev->hw_features &
@@ -1593,8 +1613,6 @@ static int fe_probe(struct platform_device *pdev)
 	if (fe_reg_table[FE_REG_FE_DMA_VID_BASE])
 		netdev->features |= NETIF_F_HW_VLAN_CTAG_FILTER;
 
-	priv = netdev_priv(netdev);
-	spin_lock_init(&priv->page_lock);
 	if (fe_reg_table[FE_REG_FE_COUNTER_BASE]) {
 		priv->hw_stats = kzalloc(sizeof(*priv->hw_stats), GFP_KERNEL);
 		if (!priv->hw_stats) {

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1376,11 +1376,16 @@ static int __init fe_init(struct net_device *dev)
 	else
 		fe_reset_fe(priv);
 
-	if (priv->soc->switch_init)
-		if (priv->soc->switch_init(priv)) {
+	if (priv->soc->switch_init) {
+		err = priv->soc->switch_init(priv);
+		if (err) {
+			if (err == -EPROBE_DEFER)
+				return err;
+
 			netdev_err(dev, "failed to initialize switch core\n");
 			return -ENODEV;
 		}
+	}
 
 	fe_reset_phy(priv);
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1360,7 +1360,7 @@ static int __init fe_init(struct net_device *dev)
 	const char *mac_addr;
 	int err;
 
-	priv->soc->reset_fe();
+	priv->soc->reset_fe(priv);
 
 	if (priv->soc->switch_init)
 		if (priv->soc->switch_init(priv)) {

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -494,6 +494,7 @@ struct fe_priv {
 	DECLARE_BITMAP(pending_flags, FE_FLAG_MAX);
 
 	struct reset_control		*rst_ppe;
+	struct reset_control		*rst_fe;
 	struct mtk_foe_entry		*foe_table;
 	dma_addr_t			foe_table_phys;
 	struct flow_offload __rcu	**foe_flow_table;
@@ -513,6 +514,7 @@ void fe_reg_w32(u32 val, enum fe_reg reg);
 u32 fe_reg_r32(enum fe_reg reg);
 
 void fe_reset(u32 reset_bits);
+void fe_reset_fe(struct fe_priv *priv);
 
 static inline void *priv_netdev(struct fe_priv *priv)
 {

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -378,7 +378,7 @@ struct fe_soc_data {
 	const u16 *reg_table;
 
 	void (*init_data)(struct fe_soc_data *data, struct net_device *netdev);
-	void (*reset_fe)(void);
+	void (*reset_fe)(struct fe_priv *priv);
 	void (*set_mac)(struct fe_priv *priv, unsigned char *mac);
 	int (*fwd_config)(struct fe_priv *priv);
 	void (*tx_dma)(struct fe_tx_dma *txd);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_mt7620.c
@@ -281,7 +281,7 @@ static void mt7620_port_init(struct fe_priv *priv, struct device_node *np)
 	}
 }
 
-static void mt7620_fe_reset(void)
+static void mt7620_fe_reset(struct fe_priv *priv)
 {
 	fe_reset(MT7620A_RESET_FE | MT7620A_RESET_ESW);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt2880.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt2880.c
@@ -33,7 +33,7 @@ static void rt2880_init_data(struct fe_soc_data *data,
 	/* netdev->hw_features |= NETIF_F_IP_CSUM | NETIF_F_RXCSUM; */
 }
 
-void rt2880_fe_reset(void)
+void rt2880_fe_reset(struct fe_priv *priv)
 {
 	fe_reset(RT2880_RESET_FE);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt2880.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt2880.c
@@ -19,8 +19,6 @@
 #include "mtk_eth_soc.h"
 #include "mdio_rt2880.h"
 
-#define RT2880_RESET_FE			BIT(18)
-
 static void rt2880_init_data(struct fe_soc_data *data,
 			     struct net_device *netdev)
 {
@@ -31,11 +29,6 @@ static void rt2880_init_data(struct fe_soc_data *data,
 	netdev->hw_features = NETIF_F_SG | NETIF_F_HW_VLAN_CTAG_TX;
 	/* this should work according to the datasheet but actually does not*/
 	/* netdev->hw_features |= NETIF_F_IP_CSUM | NETIF_F_RXCSUM; */
-}
-
-void rt2880_fe_reset(struct fe_priv *priv)
-{
-	fe_reset(RT2880_RESET_FE);
 }
 
 static int rt2880_fwd_config(struct fe_priv *priv)
@@ -55,7 +48,6 @@ static int rt2880_fwd_config(struct fe_priv *priv)
 
 struct fe_soc_data rt2880_data = {
 	.init_data = rt2880_init_data,
-	.reset_fe = rt2880_fe_reset,
 	.fwd_config = rt2880_fwd_config,
 	.pdma_glo_cfg = FE_PDMA_SIZE_8DWORDS,
 	.checksum_bit = RX_DMA_L4VALID,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
@@ -17,6 +17,7 @@
 #include <asm/mach-ralink/ralink_regs.h>
 
 #include "mtk_eth_soc.h"
+#include "esw_rt3050.h"
 #include "mdio_rt2880.h"
 
 static const u16 rt5350_reg_table[FE_REG_COUNT] = {
@@ -115,6 +116,7 @@ static void rt5350_tx_dma(struct fe_tx_dma *txd)
 static struct fe_soc_data rt3050_data = {
 	.init_data = rt305x_init_data,
 	.fwd_config = rt3050_fwd_config,
+	.switch_init = rt3050_esw_init,
 	.pdma_glo_cfg = FE_PDMA_SIZE_8DWORDS,
 	.checksum_bit = RX_DMA_L4VALID,
 	.rx_int = FE_RX_DONE_INT,
@@ -127,6 +129,7 @@ static struct fe_soc_data rt5350_data = {
 	.reg_table = rt5350_reg_table,
 	.set_mac = rt5350_set_mac,
 	.fwd_config = rt5350_fwd_config,
+	.switch_init = rt3050_esw_init,
 	.tx_dma = rt5350_tx_dma,
 	.pdma_glo_cfg = FE_PDMA_SIZE_8DWORDS,
 	.checksum_bit = RX_DMA_L4VALID,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
@@ -69,7 +69,7 @@ static int rt3050_fwd_config(struct fe_priv *priv)
 	return 0;
 }
 
-static void rt305x_fe_reset(void)
+static void rt305x_fe_reset(struct fe_priv *priv)
 {
 	fe_reset(RT305X_RESET_FE);
 }
@@ -120,7 +120,7 @@ static void rt5350_tx_dma(struct fe_tx_dma *txd)
 	txd->txd4 = 0;
 }
 
-static void rt5350_fe_reset(void)
+static void rt5350_fe_reset(struct fe_priv *priv)
 {
 	fe_reset(RT305X_RESET_FE | RT305X_RESET_ESW);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
@@ -69,11 +69,6 @@ static int rt3050_fwd_config(struct fe_priv *priv)
 	return 0;
 }
 
-static void rt305x_fe_reset(struct fe_priv *priv)
-{
-	fe_reset(RT305X_RESET_FE);
-}
-
 static void rt5350_init_data(struct fe_soc_data *data,
 			     struct net_device *netdev)
 {
@@ -127,7 +122,6 @@ static void rt5350_fe_reset(struct fe_priv *priv)
 
 static struct fe_soc_data rt3050_data = {
 	.init_data = rt305x_init_data,
-	.reset_fe = rt305x_fe_reset,
 	.fwd_config = rt3050_fwd_config,
 	.pdma_glo_cfg = FE_PDMA_SIZE_8DWORDS,
 	.checksum_bit = RX_DMA_L4VALID,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3050.c
@@ -19,9 +19,6 @@
 #include "mtk_eth_soc.h"
 #include "mdio_rt2880.h"
 
-#define RT305X_RESET_FE         BIT(21)
-#define RT305X_RESET_ESW        BIT(23)
-
 static const u16 rt5350_reg_table[FE_REG_COUNT] = {
 	[FE_REG_PDMA_GLO_CFG] = RT5350_PDMA_GLO_CFG,
 	[FE_REG_PDMA_RST_CFG] = RT5350_PDMA_RST_CFG,
@@ -115,11 +112,6 @@ static void rt5350_tx_dma(struct fe_tx_dma *txd)
 	txd->txd4 = 0;
 }
 
-static void rt5350_fe_reset(struct fe_priv *priv)
-{
-	fe_reset(RT305X_RESET_FE | RT305X_RESET_ESW);
-}
-
 static struct fe_soc_data rt3050_data = {
 	.init_data = rt305x_init_data,
 	.fwd_config = rt3050_fwd_config,
@@ -133,7 +125,6 @@ static struct fe_soc_data rt3050_data = {
 static struct fe_soc_data rt5350_data = {
 	.init_data = rt5350_init_data,
 	.reg_table = rt5350_reg_table,
-	.reset_fe = rt5350_fe_reset,
 	.set_mac = rt5350_set_mac,
 	.fwd_config = rt5350_fwd_config,
 	.tx_dma = rt5350_tx_dma,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3883.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3883.c
@@ -21,7 +21,7 @@
 
 #define RT3883_RSTCTRL_FE		BIT(21)
 
-static void rt3883_fe_reset(void)
+static void rt3883_fe_reset(struct fe_priv *priv)
 {
 	fe_reset(RT3883_RSTCTRL_FE);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3883.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/soc_rt3883.c
@@ -19,13 +19,6 @@
 #include "mtk_eth_soc.h"
 #include "mdio_rt2880.h"
 
-#define RT3883_RSTCTRL_FE		BIT(21)
-
-static void rt3883_fe_reset(struct fe_priv *priv)
-{
-	fe_reset(RT3883_RSTCTRL_FE);
-}
-
 static int rt3883_fwd_config(struct fe_priv *priv)
 {
 	int ret;
@@ -54,7 +47,6 @@ static void rt3883_init_data(struct fe_soc_data *data,
 
 static struct fe_soc_data rt3883_data = {
 	.init_data = rt3883_init_data,
-	.reset_fe = rt3883_fe_reset,
 	.fwd_config = rt3883_fwd_config,
 	.pdma_glo_cfg = FE_PDMA_SIZE_8DWORDS,
 	.rx_int = FE_RX_DONE_INT,


### PR DESCRIPTION
* Introduce the reset of hardware unit via reset controller api
* rework rt3050 driver to allow link states of the master device

- [x] tested on mt76x8 tl 841v13
- [x] tested on mt7620 device (tp-link archer c20 v1)
- [x] tested on ra3883 device 

