### PR TITLE
ramips: add support for Xiaomi MiWifi 3C

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -36,6 +36,7 @@ samknows,whitebox-v8|\
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,mi-router-4c|\
+xiaomi,miwifi-3c|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626|\
 zte,mf283plus)

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
@@ -1,0 +1,119 @@
+//SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,miwifi-3c", "mediatek,mt7628an-soc";
+	model = "Xiaomi MiWiFi 3C";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -807,6 +807,14 @@ define Device/xiaomi_mi-router-4c
 endef
 TARGET_DEVICES += xiaomi_mi-router-4c
 
+define Device/xiaomi_miwifi-3c
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi 3C
+  DEVICE_PACKAGES := uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_miwifi-3c
+
 define Device/xiaomi_miwifi-nano
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -143,6 +143,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "1:wan" "6@eth0"
 		;;
+	xiaomi,miwifi-3c)
+		ucidef_add_switch "switch0" \
+			"0:wan" "2:lan:2" "4:lan:1" "6@eth0"
+		;;
 	xiaomi,miwifi-nano)
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "2:lan:1" "4:wan" "6@eth0"
@@ -247,6 +251,7 @@ ramips_setup_macs()
 	xiaomi,mi-router-4c)
 		wan_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
+	xiaomi,miwifi-3c|\
 	esac
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac

--- a/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
@@ -9,6 +9,9 @@ boot() {
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
 	xiaomi,mi-router-4c|\
+	xiaomi,miwifi-3c)
+		fw_setenv flag_boot_success 1
+		;;
 	xiaomi,miwifi-nano)
 		fw_setenv flag_boot_success 1
 		;;


### PR DESCRIPTION
This commit adds support for Xiaomi MiWiFi 3C device.

Xiaomi MiWifi 3C has almost the same system architecture as the Xiaomi Mi WiFi Nano, which is already officially supported by OpenWrt.

The differences are:
- Numbers of antennas (4 instead of 2). The antenna management is done via the µC. There is no configuration needed in the software code.
- LAN port assignments are different. LAN1 and WAN are interchanged.

OpenWrt Wiki: https://openwrt.org/toh/xiaomi/mir3c

OpenWrt developers forum page: https://forum.openwrt.org/t/support-for-xiaomi-mi-3c

Specifications:

- CPU: MediaTek MT7628AN (575MHz)
- Flash: 16MB
- RAM: 64MB DDR2
- 2.4 GHz: IEEE 802.11b/g/n with Integrated LNA and PA
- Antennas: 4x external single band antennas
- WAN: 1x 10/100M
- LAN: 2x 10/100M
- LED: 1x amber/blue/red. Programmable
- Button: Reset

The stock bootloader use "Dual ROM Partition System". OS1 is deep copy of OS2.
But this setting is not useful for openwrt.
With this configuration OS1 and OS2 is merged in a single partition. 
Breed Bootloader uses single partition.
https://openwrt.org/toh/xiaomi/mir3c#alternative_bootloader_breed

How to install:

1- Use OpenWRTInvasion to gain telnet and ftp access.
    https://github.com/acecilia/OpenWRTInvasion
2- Backup all partitions. Pull /dev/mtd0 to computer using FTP.
3- Backup factory ("EEPROM") partition. Pull /dev/mtd4 to computer using FTP.
4- Download BREED to computer:
https://breed.hackpascal.net/breed-mt7688-reset38.bin
5- Push BREED bootloader to /tmp/ using FTP.
6- Connect to router using TELNET. (IP: 192.168.31.1 -
Username: root - Password: root)
7- Use command "mtd -r write /tmp/breed-mt7688-reset38.bin Bootloader" to flash into the router BREED bootloader.
8- Restart the router to BREED bootloader by pressing the reset button then plug in the router and hold the reset button until the router LED flashes fastly. Then release the reset button.
9- Open the BREED GUI in web browser: 192.168.1.1
10- Select as FIRMWARE the OpenWrt binary (*.bin) and select as EEPROM the factory image you had saved on your PC.
11- Flash the FIRMWARE and EEPROM
12- It takes about 3 minutes until the router boots up
13- Then access the OpenWrt GUI in the web browser by: 192.168.1.1

Thanks for all community and especially for this device:
@minax007, @earth08

Signed-off-by: Eduardo Santos <edu.2000.kill@gmail.com>