### PR TITLE
ramips: mt7628: fix memory controller reset bit

### DIFF
--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -76,7 +76,7 @@
 			compatible = "ralink,mt7620a-memc", "ralink,rt3050-memc";
 			reg = <0x300 0x100>;
 
-			resets = <&rstctrl 20>;
+			resets = <&rstctrl 10>;
 			reset-names = "mc";
 
 			interrupt-parent = <&intc>;


### PR DESCRIPTION
According to MediaTek MT7688 Datasheet v1.4, as well as the MT7628
counterpart, the memory controller reset bit (MC_RST) is 10, not 20.
Reset bit 20 is used for for UART 2 (UART2_RST).

Please note: Due to the lack of hardware, I was not able to test this
change.