### PR TITLE
ramips: add support for Xiaomi MiWifi 3C

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -37,6 +37,7 @@ samknows,whitebox-v8|\
 xiaomi,mi-router-3g-v2|\
 xiaomi,mi-router-4a-gigabit|\
 xiaomi,mi-router-4c|\
+xiaomi,miwifi-3c|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626|\
 zte,mf283plus)

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3c.dts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "xiaomi,miwifi-3c", "mediatek,mt7628an-soc";
+	model = "Xiaomi MiWiFi 3C";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: status_amber {
+			label = "amber:status";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&wmac {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+			
+			partition@40000 {
+				label = "Bdata";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+			
+			partition@60000 {
+				label = "crash";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+			
+			partition@70000 {
+				label = "cfg_bak";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+			
+			partition@80000 {
+				label = "overlay";
+				reg = <0x80000 0xc0000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x140000 0xec0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -831,6 +831,14 @@ define Device/xiaomi_mi-router-4c
 endef
 TARGET_DEVICES += xiaomi_mi-router-4c
 
+define Device/xiaomi_miwifi-3c
+  IMAGE_SIZE := 15104k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi 3C
+  DEVICE_PACKAGES := uboot-envtools
+endef
+TARGET_DEVICES += xiaomi_miwifi-3c
+
 define Device/xiaomi_miwifi-nano
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -149,6 +149,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "1:wan" "6@eth0"
 		;;
+	xiaomi,miwifi-3c)
+		ucidef_add_switch "switch0" \
+			"0:wan" "2:lan:2" "4:lan:1" "6@eth0"
+		;;
 	xiaomi,miwifi-nano)
 		ucidef_add_switch "switch0" \
 			"0:lan:2" "2:lan:1" "4:wan" "6@eth0"


### PR DESCRIPTION
This commit adds support for Xiaomi MiWiFi 3C device.

Xiaomi MiWifi 3C has almost the same system architecture as the Xiaomi Mi WiFi Nano, which is already officially supported by OpenWrt.

The differences are:

 - Numbers of antennas (4 instead of 2). The antenna management is done via the µC. There is no configuration needed in the software code.
 - LAN port assignments are different. LAN1 and WAN are interchanged.

OpenWrt Wiki: https://openwrt.org/toh/xiaomi/mir3c

OpenWrt developers forum page: https://forum.openwrt.org/t/support-for-xiaomi-mi-3c

Specifications:

 - CPU: MediaTek MT7628AN (575MHz)
 - Flash: 16MB
 - RAM: 64MB DDR2
 - 2.4 GHz: IEEE 802.11b/g/n with Integrated LNA and PA
 - Antennas: 4x external single band antennas
 - WAN: 1x 10/100M
 - LAN: 2x 10/100M
 - LED: 1x amber/blue/red. Programmable
 - Button: Reset

MAC addresses as verified by OEM firmware:

use address source
LAN *:92 factory 0x28
WAN *:92 factory 0x28
2g *:93 factory 0x4

OEM firmware uses VLAN's to create the network interface for WAN and LAN.

Bootloader info:
The stock bootloader uses a "Dual ROM Partition System". OS1 is a deep copy of OS2.
The bootloader start OS2 by default.
To force start OS1 it is needed to set "flag_try_sys2_failed=1".

How to install:
1- Use OpenWRTInvasion to gain telnet, ssh and ftp access.
https://github.com/acecilia/OpenWRTInvasion
(IP: 192.168.31.1 - Username: root - Password: root)
2- Connect to router using telnet or ssh.
3- Backup all partitions. Use command  "dd if=/dev/mtd0 of=/tmp/mtd0". Copy /tmp/mtd0 to computer using ftp.
4- Copy openwrt-ramips-mt76x8-xiaomi_miwifi-3c-squashfs-sysupgrade.bin to /tmp in router using ftp.
5- Enable UART access and change start image for OS1.
```
nvram set uart_en=1
nvram set flag_last_success=1
nvram set boot_wait=on
nvram set flag_try_sys2_failed=1
nvram commit
```
6- Installing Openwrt on OS1 and free OS2.
```
mtd erase OS1
mtd erase OS2
mtd -r write /tmp/openwrt-ramips-mt76x8-xiaomi_miwifi-3c-squashfs-sysupgrade.bin OS1
```

Limitations: For the first install the image size needs to be less than 7733248 bits.

Thanks for all community and especially for this device:
minax007, earth08, S.Farid

Signed-off-by: Eduardo Santos <edu.2000.kill@gmail.com>