### PR TITLE
ramips: Add support for Dlink DIR-853-R1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include "mt7621_dlink_flash-16m-r1.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dir-853-r1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-853 R1";
+
+	aliases {
+		label-mac-device = &wan;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_net_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			label = "orange:power";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_net_orange: net_orange {
+			label = "orange:net";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		net_blue {
+			label = "blue:net";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_blue {
+			label = "blue:usb";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mtd-mac-address = <&factory 0x4>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x4>;
+	mtd-mac-address-increment = <(-1)>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		wan: port@4 {
+			status = "okay";
+			label = "wan";
+			mtd-mac-address = <&factory 0x4>;
+			mtd-mac-address-increment = <(-2)>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -342,6 +342,14 @@ define Device/dlink_dir-2660-a1
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 
+define Device/dlink_dir-853-r1
+$(Device/dlink_dir-8xx-r1)
+  DEVICE_MODEL := DIR-853
+  DEVICE_VARIANT := R1
+  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += dlink_dir-853-r1
+
 define Device/dlink_dir-860l-b1
   $(Device/dsa-migration)
   $(Device/seama)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -23,6 +23,9 @@ d-team,newifi-d2)
 	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "blue:wlan2g" "wlan0"
 	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "blue:wlan5g" "wlan1"
 	;;
+dlink,dir-853-r1)
+	ucidef_set_led_netdev "internet" "internet" "blue:net" "wan"
+	;;
 d-team,pbr-m1|\
 gehua,ghl-r-001|\
 jcg,y2|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,12 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	dlink,dir-853-r1)
+		[ "$PHYNBR" = "0" ] && \
+			base_mac=$(mtd_get_mac_binary factory 0x4)
+			base_mac=$(macaddr_setbit $base_mac 28)
+			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
+		;;
 	glinet,gl-mt1300)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
This PR adds suppotr for router Dlink DIR-853-R1

Specifications:

    SoC: MT7621AT
    RAM: 128MB
    Flash: 16MB SPI
    WiFi: MT7615DN (2.4GHz+5Ghz) with DBDC (This mode allows
    this single chip act as an 2x2 11n radio and an 2x2 11ac radio at the
    same time)
    LAN: 5x1000M
    LEDs Power Blue+Orange,Wan Blue+Orange,WPS Blue,"2.4G"Blue, "5G" Blue,
    USB Blue
    Buttons Reset,WPS, Wifi

MAC address:

|      Interface    |        MAC         |     Factory     |                Comment                        |
| ------------------ |:-------------------:|:-----------------:|----------------------------------------------:|
| WAN (stiker)  | C4:XX:XX:6E:XX:2A  |                 | (MACE -4)  Decrement Sticker                  |
| LAN               | C4:XX:XX:6E:XX:2B  |                 | (MACF -4)  Decrement                          |
| Wifi (5g)         | C4:XX:XX:6E:XX:2C  |  0x4            | (MACF -2) WIFI It is possible not to specify  |
| Wifi (2.4g)      | C6:XX:XX:7E:XX:2C  |                 | It is not yet clear how to calculate          |
|               |                    |                 |                                               |
|               | C4:XX:XX:6E:XX:2E  |  0x8004  0xe000 |  MACE                                         |
|               | C4:XX:XX:6E:XX:2F  |  0xe006         |  MACF                                         |


Flashing instruction:

The Dlink "Emergency Room"

Connect your client computer to LAN1 of the device
Set your client IP address manually to 192.168.0.101 / 255.255.255.0.
Then, power down the router, press and hold the reset button, then
re-plug it. Keep the reset button pressed until the internet LED stops
flashing
Call the recovery page or tftp for the device at http://192.168.0.1
Use the provided emergency web GUI to upload and flash a new firmware to
the device.

Signed-off-by: Stas Fiduchi fiduchi@protonmail.com