### PR TITLE
ipq806x: improve support for Askey RT4230W REV6

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -17,9 +17,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
-	askey,rt4230w-rev6)
-		caldata_extract "0:ART" 0x1000 0x2f20
-		;;
 	asrock,g10)
 		caldata_extract "0:art" 0x1000 0x2f20
 		;;
@@ -40,9 +37,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
-	askey,rt4230w-rev6)
-		caldata_extract "0:ART" 0x5000 0x2f20
-		;;
 	asrock,g10)
 		caldata_extract "0:art" 0x5000 0x2f20
 		;;

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
@@ -151,100 +151,139 @@
 				reg = <0x0000000 0x0040000>;
 				read-only;
 			};
+
 			partition@40000 {
 				label = "0:MIBIB";
 				reg = <0x0040000 0x0140000>;
 				read-only;
 			};
+
 			partition@180000 {
 				label = "0:SBL2";
 				reg = <0x0180000 0x0140000>;
 				read-only;
 			};
+
 			partition@2c0000 {
 				label = "0:SBL3";
 				reg = <0x02c0000 0x0280000>;
 				read-only;
 			};
+
 			partition@540000 {
 				label = "0:DDRCONFIG";
 				reg = <0x0540000 0x0120000>;
 				read-only;
 			};
+
 			partition@660000 {
 				label = "0:SSD";
 				reg = <0x0660000 0x0120000>;
 				read-only;
 			};
+
 			partition@780000 {
 				label = "0:TZ";
 				reg = <0x0780000 0x0280000>;
 				read-only;
 			};
+
 			partition@a00000 {
 				label = "0:RPM";
 				reg = <0x0a00000 0x0280000>;
 				read-only;
 			};
+
 			partition@c80000 {
 				label = "0:APPSBL";
 				reg = <0x0c80000 0x0500000>;
 				read-only;
 			};
+
 			partition@1180000 {
 				label = "0:APPSBLENV";
 				reg = <0x1180000 0x0080000>;
 			};
-			ART: partition@1200000 {
+
+			partition@1200000 {
 				label = "0:ART";
 				reg = <0x1200000 0x0140000>;
 				read-only;
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_ART_0: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_ART_6: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				precal_ART_1000: precal@1000 {
+					reg = <0x1000 0x2f20>;
+				};
+
+				precal_ART_5000: precal@5000 {
+					reg = <0x5000 0x2f20>;
+				};
 			};
+
 			partition@1340000 {
 				label = "0:BOOTCONFIG";
 				reg = <0x1340000 0x0060000>;
 				read-only;
 			};
+
 			partition@13a0000 {
 				label = "0:SBL2_1";
 				reg = <0x13a0000 0x0140000>;
 				read-only;
 			};
+
 			partition@14e0000 {
 				label = "0:SBL3_1";
 				reg = <0x14e0000 0x0280000>;
 				read-only;
 			};
+
 			partition@1760000 {
 				label = "0:DDRCONFIG_1";
 				reg = <0x1760000 0x0120000>;
 				read-only;
 			};
+
 			partition@1880000 {
 				label = "0:SSD_1";
 				reg = <0x1880000 0x0120000>;
 				read-only;
 			};
+
 			partition@19a0000 {
 				label = "0:TZ_1";
 				reg = <0x19a0000 0x0280000>;
 				read-only;
 			};
+
 			partition@1c20000 {
 				label = "0:RPM_1";
 				reg = <0x1c20000 0x0280000>;
 				read-only;
 			};
+
 			partition@1ea0000 {
 				label = "0:BOOTCONFIG1";
 				reg = <0x1ea0000 0x0060000>;
 				read-only;
 			};
+
 			partition@1f00000 {
 				label = "0:APPSBL_1";
 				reg = <0x1f00000 0x0500000>;
 				read-only;
 			};
+
 			partition@2400000 {
 				label = "ubi";
 				reg = <0x2400000 0x1a000000>;
@@ -325,6 +364,21 @@
 	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
 	pinctrl-0 = <&pcie0_pins>;
 	pinctrl-names = "default";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi0: wifi@1,0 {
+			compatible = "pci168c,0046";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&precal_ART_1000>;
+			nvmem-cell-names = "pre-calibration";
+		};
+	};
 };
 
 &pcie1 {
@@ -333,18 +387,19 @@
 	pinctrl-0 = <&pcie1_pins>;
 	pinctrl-names = "default";
 	max-link-speed = <1>;
-};
 
-&ART {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
 
-	macaddr_ART_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
+		wifi1: wifi@1,0 {
+			compatible = "pci168c,0046";
+			reg = <0x00010000 0 0 0 0>;
 
-	macaddr_ART_6: macaddr@6 {
-		reg = <0x6 0x6>;
+			nvmem-cells = <&precal_ART_5000>;
+			nvmem-cell-names = "pre-calibration";
+		};
 	};
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev6.dts
@@ -96,6 +96,35 @@
 			input-disable;
 		};
 	};
+
+	spi_pins: spi_pins {
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "everspin,mr25h256";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <40000000>;
+			reg = <0>;
+		};
+	};
 };
 
 &nand_controller {


### PR DESCRIPTION
- Fix caldata script
The partition name in the device dts is '0:ART'.
Be independent to prevent this part from becoming
incorrect once the kernel v5.4 gone.
Fixes: da8428d ("ipq806x: add support for Askey RT4230W REV6")
- Use usual writing for pcie part
The problem has been fixed in f47cb40 ("ipq806x: fix pci broken on bootm
command"), now the pcie part can be written in the usual way.
- Enable onboard spi flash
There is a mr25h256 spi flash on this machine. From the mtd backup
of the original firmware, this spi flash is empty.