### PR TITLE
ramips: fix software reboot failure on HILINK HLK-7628N

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -47,6 +47,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
In the new kernel version 5.X,reboot will fail.

When SOC is reset, flash has not exited the 4-byte address mode,
which causes the operation mode mismatch of flash during boot.Add
broken-flash-reset to make flash exit 4-byte address mode before
SOC reset

Signed-off-by: Liu Yu <f78fk@live.com>


