### PR TITLE
kernel/modules: make sure igb loads at boot

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -657,7 +657,7 @@ define KernelPackage/igb
     CONFIG_IGB_HWMON=y \
     CONFIG_IGB_DCA=n
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/igb/igb.ko
-  AUTOLOAD:=$(call AutoLoad,35,igb)
+  AUTOLOAD:=$(call AutoLoad,35,igb,1)
 endef
 
 define KernelPackage/igb/description


### PR DESCRIPTION
This is to make sure that AutoLoad adds igb to modules-boot.d
so it's accessible via initramfs during boot. This is to ensure that
networking works when in recovery mode, and are loaded before
etc/board.d/02_network is called. Note that other network drivers
already have this set, such as tg3.

Signed-off-by: Chris Blake <chrisrblake93@gmail.com>