### PR TITLE
ath79: add partial support for QCN5502 SoC / Netgear EX7300v2

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -39,6 +39,7 @@ glinet,gl-ar750s-nor-nand|\
 librerouter,librerouter-v1|\
 netgear,ex6400|\
 netgear,ex7300|\
+netgear,ex7300-v2|\
 netgear,wndr4300-v2|\
 netgear,wndr4500-v3|\
 netgear,wnr1000-v2|\

--- a/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
+++ b/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Netgear EX7300 v2";
+	compatible = "netgear,ex7300-v2", "qca,qcn5500", "qca,qca9560";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <500000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_green {
+			label = "green:wps";
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		router_red {
+			label = "red:router";
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		router_green {
+			label = "green:router";
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		client_red {
+			label = "red:client";
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		client_green {
+			label = "green:client";
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		left_blue {
+			label = "blue:left";
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		right_blue {
+			label = "blue:right";
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		extender_apmode {
+			label = "EXTENDER/APMODE switch";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pll {
+	clocks = <&extosc>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "config";
+				reg = <0x050000 0x010000>;
+			};
+
+			partition@60000 {
+				label = "pot";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "firmware";
+				reg = <0x70000 0xe30000>;
+				compatible = "denx,uimage";
+			};
+
+			partition@ea0000 {
+				label = "rae";
+				reg = <0xea0000 0x100000>;
+				read-only;
+			};
+
+			partition@fa0000 {
+				label = "oopsdump";
+				reg = <0xfa0000 0x40000>;
+				read-only;
+			};
+
+			artmtd: partition@fe0000 {
+				label = "artmtd";
+				reg = <0xfe0000 0x10000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+/*
+Does not work due to lack of QCN5502 support in ath9k.
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&artmtd 0x6>;
+};
+*/
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		phy-mode = "sgmii";
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	mtd-mac-address = <&artmtd 0x0>;
+
+	phy-handle = <&phy5>;
+	phy-mode = "sgmii";
+
+	pll-data = <0x03000000 0x00000101 0x00001313>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -44,6 +44,7 @@ ath79_setup_interfaces()
 	meraki,mr16|\
 	netgear,ex6400|\
 	netgear,ex7300|\
+	netgear,ex7300-v2|\
 	ocedo,koala|\
 	ocedo,raccoon|\
 	onion,omega|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -218,6 +218,10 @@ case "$FIRMWARE" in
 		caldata_extract "caldata" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_binary caldata 0xc)
 		;;
+	netgear,ex7300-v2)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_binary artmtd 0xc)
+		;;
 	phicomm,k2t)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(k2t_get_mac "5g_mac")

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1580,6 +1580,23 @@ define Device/netgear_ex7300
 endef
 TARGET_DEVICES += netgear_ex7300
 
+define Device/netgear_ex7300-v2
+  $(Device/netgear_generic)
+  SOC := qcn5502
+  DEVICE_MODEL := EX7300
+  DEVICE_VARIANT := v2
+  UIMAGE_MAGIC := 0x27051956
+  NETGEAR_BOARD_ID := EX7300v2series
+  NETGEAR_HW_ID := 29765907+16+0+128
+  IMAGE_SIZE := 14528k
+  IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+	netgear-rootfs | pad-rootfs
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | check-size | append-metadata
+  IMAGE/factory.img := $$(IMAGE/default) | check-size | netgear-dni
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9984-ct
+endef
+TARGET_DEVICES += netgear_ex7300-v2
+
 define Device/netgear_wndr3x00
   $(Device/netgear_generic)
   SOC := ar7161

--- a/target/linux/ath79/patches-5.10/940-ath79-add-support-for-booting-QCN550x.patch
+++ b/target/linux/ath79/patches-5.10/940-ath79-add-support-for-booting-QCN550x.patch
@@ -1,0 +1,48 @@
+From: Wenli Looi <wlooi@ucalgary.ca>
+Date: Sun, 20 Jun 2021 23:32:28 -0700
+Subject: [PATCH] ath79: add support for booting QCN550x
+
+Based on wikidevi, QCN550x is a "Dragonfly" like QCA9561 and QCA9563.
+Treating it as QCA956x seems to work.
+Tested on Netgear EX7300v2 which boots successfully with
+the same CPU clock as the stock firmware.
+
+Link: https://wikidevi.wi-cat.ru/Qualcomm#bgn
+Link: https://wikidevi.wi-cat.ru/Qualcomm_Atheros#.28a.29bgn_2
+Signed-off-by: Wenli Looi <wlooi@ucalgary.ca>
+
+--- a/arch/mips/ath79/early_printk.c
++++ b/arch/mips/ath79/early_printk.c
+@@ -121,6 +121,7 @@ static void prom_putchar_init(void)
+ 	case REV_ID_MAJOR_QCA9558:
+ 	case REV_ID_MAJOR_TP9343:
+ 	case REV_ID_MAJOR_QCA956X:
++	case REV_ID_MAJOR_QCN550X:
+ 		_prom_putchar = prom_putchar_ar71xx;
+ 		break;
+ 
+--- a/arch/mips/ath79/setup.c
++++ b/arch/mips/ath79/setup.c
+@@ -179,6 +179,12 @@ static void __init ath79_detect_sys_type
+ 		rev = id & QCA956X_REV_ID_REVISION_MASK;
+ 		break;
+ 
++	case REV_ID_MAJOR_QCN550X:
++		ath79_soc = ATH79_SOC_QCA956X;
++		chip = "550X";
++		rev = id & QCA956X_REV_ID_REVISION_MASK;
++		break;
++
+ 	case REV_ID_MAJOR_TP9343:
+ 		ath79_soc = ATH79_SOC_TP9343;
+ 		chip = "9343";
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+@@ -867,6 +867,7 @@
+ #define REV_ID_MAJOR_QCA9558		0x1130
+ #define REV_ID_MAJOR_TP9343		0x0150
+ #define REV_ID_MAJOR_QCA956X		0x1150
++#define REV_ID_MAJOR_QCN550X		0x2170
+ 
+ #define AR71XX_REV_ID_MINOR_MASK	0x3
+ #define AR71XX_REV_ID_MINOR_AR7130	0x0


### PR DESCRIPTION
Hardware
--------
SoC: QCN5502
Flash: 16 MiB
RAM: 128 MiB
Ethernet: 1 gigabit port
Wireless No1: QCN5502 on-chip 2.4GHz 4x4
Wireless No2: QCA9984 pcie 5GHz 4x4
USB: none

Installation
------------
Flash the factory image using the stock web interface or TFTP the factory image to the bootloader.

What works
----------
- LEDs
- Ethernet port
- 5GHz wifi (QCA9984 pcie)

What doesn't work
-----------------
- 2.4GHz wifi (QCN5502 on-chip)
  (I was not able to make this work, probably because ath9k requires some changes to support QCN5502.)

Notes
-----
Based on wikidevi, [QCN5502](https://wikidevi.wi-cat.ru/Qualcomm#bgn) is a "Dragonfly" like [QCA9561 and QCA9563](https://wikidevi.wi-cat.ru/Qualcomm_Atheros#.28a.29bgn_2).
Treating it as QCA956x seems to work.

<details><summary>Stock boot log</summary>

```
[    0.000000] Linux version 3.3.8 (yaoheng.zhang@dnixm-compiler4) (gcc version 4.6.3 20120201 (prerelease) (Linaro GCC 4.6-2012.02) ) #1 Tue Jun 18 17:26:38 CST 2019
[    0.000000] MyLoader: sysp=b1a15d6d, boardp=b4ae97e1, parts=9098a427
[    0.000000] bootconsole [early0] enabled
[    0.000000] CPU revision is: 00019750 (MIPS 74Kc)
[    0.000000] SoC: Qualcomm Atheros QCA5502 rev 0
[    0.000000] Clocks: CPU:800.000MHz, DDR:675.000MHz, AHB:266.666MHz, Ref:25.000MHz
[    0.000000] Determined physical RAM map:
[    0.000000]  memory: 08000000 @ 00000000 (usable)
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Zone PFN ranges:
[    0.000000]   Normal   0x00000000 -> 0x00008000
[    0.000000] Movable zone start PFN for each node
[    0.000000] Early memory PFN ranges
[    0.000000]     0: 0x00000000 -> 0x00008000
[    0.000000] On node 0 totalpages: 32768
[    0.000000] free_area_init_node: node 0, pgdat 80347610, node_mem_map 81000000
[    0.000000]   Normal zone: 256 pages used for memmap
[    0.000000]   Normal zone: 0 pages reserved
[    0.000000]   Normal zone: 32512 pages, LIFO batch:7
[    0.000000] pcpu-alloc: s0 r0 d32768 u32768 alloc=1*32768
[    0.000000] pcpu-alloc: [0] 0 
[    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 32512
[    0.000000] Kernel command line:  board=APJET01_AR8033 console=ttyS0,115200 mtdparts=spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(config),64k(pot),1472k(kernel),13056k(rootfs),1024k(rae),256k(oopsdump),64k(artmtd),64k(art),14528k@0x70000(firmware) rootfstype=squashfs,jffs2 noinitrd crashkernel=10M@20M oops=panic
[    0.000000] PID hash table entries: 512 (order: -1, 2048 bytes)
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes)
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] Memory: 126092k/131072k available (2335k kernel code, 4980k reserved, 639k data, 224k init, 0k highmem)
[    0.000000] SLUB: Genslabs=9, HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS:83
[    0.000000] Calibrating delay loop... 398.13 BogoMIPS (lpj=1990656)
[    0.060000] pid_max: default: 32768 minimum: 301
[    0.060000] Mount-cache hash table entries: 512
[    0.070000] NET: Registered protocol family 16
[    0.070000] i2c-core: driver [dummy] registered
[    0.070000] gpiochip_add: registered GPIOs 0 to 20 on device: ath79
[    0.080000] MIPS: machine is Qualcomm Atheros APJET01 reference board
[    0.080000] 
[    0.080000] WLAN firmware dump buffer allocation of 2097152 bytes @ address 0x87a00000- SUCCESS !!!
[    0.090000] registering PCI controller with io_map_base unset
[    0.300000] bio: create slab <bio-0> at 0
[    0.300000] i2c-core: driver [pcf857x] registered
[    0.300000] i2c i2c-0: adapter [i2c-gpio0] registered
[    0.300000] i2c-gpio i2c-gpio.0: using pins 16 (SDA) and 17 (SCL)
[    0.310000] PCI host bridge to bus 0000:00
[    0.310000] pci_bus 0000:00: root bus resource [mem 0x12000000-0x13ffffff]
[    0.320000] pci_bus 0000:00: root bus resource [io  0x0001]
[    0.320000] pci 0000:00:00.0: [168c:0046] type 0 class 0x000280
[    0.320000] pci 0000:00:00.0: reg 10: [mem 0x00000000-0x001fffff 64bit]
[    0.320000] pci 0000:00:00.0: PME# supported from D0 D3hot D3cold
[    0.320000] pci 0000:00:00.0: BAR 0: assigned [mem 0x12000000-0x121fffff 64bit]
[    0.330000] pci 0000:00:00.0: using irq 40 for pin 1
[    0.330000] Switching to clocksource MIPS
[    0.340000] NET: Registered protocol family 2
[    0.340000] IP route cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.340000] TCP established hash table entries: 4096 (order: 3, 32768 bytes)
[    0.350000] TCP bind hash table entries: 4096 (order: 2, 16384 bytes)
[    0.350000] TCP: Hash tables configured (established 4096 bind 4096)
[    0.360000] TCP reno registered
[    0.360000] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    0.370000] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    0.370000] NET: Registered protocol family 1
[    0.380000] PCI: CLS 0 bytes, default 32
[    0.390000] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.390000] JFFS2 version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.400000] msgmni has been set to 246
[    0.410000] io scheduler noop registered
[    0.410000] io scheduler deadline registered (default)
[    0.420000] Serial: 8250/16550 driver, 1 ports, IRQ sharing disabled
[    0.440000] serial8250.0: ttyS0 at MMIO 0x18020000 (irq = 11) is a 16550A
[    0.450000] console [ttyS0] enabled, bootconsole disabled
[    0.460000] m25p80 spi0.0: found w25q128, expected m25p80
[    0.470000] m25p80 spi0.0: w25q128 (16384 Kbytes)
[    0.470000] 11 cmdlinepart partitions found on MTD device spi0.0
[    0.480000] Creating 11 MTD partitions on "spi0.0":
[    0.490000] 0x000000000000-0x000000040000 : "u-boot"
[    0.490000] 0x000000040000-0x000000050000 : "u-boot-env"
[    0.500000] 0x000000050000-0x000000060000 : "config"
[    0.510000] 0x000000060000-0x000000070000 : "pot"
[    0.510000] 0x000000070000-0x0000001e0000 : "kernel"
[    0.520000] 0x0000001e0000-0x000000ea0000 : "rootfs"
[    0.520000] mtd: partition "rootfs" set to be root filesystem
[    0.530000] mtd: partition "rootfs_data" created automatically, ofs=D20000, len=180000 
[    0.540000] 0x000000d20000-0x000000ea0000 : "rootfs_data"
[    0.540000] 0x000000ea0000-0x000000fa0000 : "rae"
[    0.550000] 0x000000fa0000-0x000000fe0000 : "oopsdump"
[    0.560000] 0x000000fe0000-0x000000ff0000 : "artmtd"
[    0.560000] 0x000000ff0000-0x000001000000 : "art"
[    0.570000] 0x000000070000-0x000000ea0000 : "firmware"
[    0.590000] ag71xx_mdio: probed
[    0.590000] eth0: Atheros AG71xx at 0xb9000000, irq 4
[    1.140000] ag71xx ag71xx.0: eth0: connected to PHY at ag71xx-mdio.0:05 [uid=004dd074, driver=Qualcomm Atheros AR8033 PHY]
[    1.160000] i2c-core: driver [smbus_alert] registered
[    1.160000] i2c /dev entries driver
[    1.160000] i2c-dev: adapter [i2c-gpio0] registered as minor 0
[    1.160000] TCP cubic registered
[    1.160000] NET: Registered protocol family 17
[    1.170000] Bridge firewalling registered
[    1.170000] 8021q: 802.1Q VLAN Support v1.8
[    1.180000] ### of_selftest(): No testcase data in device tree; not running tests
[    1.190000] VFS: Mounted root (squashfs filesystem) readonly on device 31:5.
[    1.200000] Freeing unused kernel memory: 224k freed
[    7.940000] NET: Registered protocol family 10
[    8.300000] SCSI subsystem initialized
[    8.330000] usbcore: registered new interface driver usbfs
[    8.330000] usbcore: registered new interface driver hub
[    8.340000] usbcore: registered new device driver usb
[    8.410000] Button Hotplug driver version 0.4.1
[    8.720000] PPP generic driver version 2.4.2
[    8.740000] bonding: Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)
[    8.890000] ip_tables: (C) 2000-2006 Netfilter Core Team
[    9.100000] nf_conntrack version 0.5.0 (1973 buckets, 7892 max)
[    9.690000] nf_conntrack_rtsp v0.6.21 loading
[    9.700000] nf_nat_rtsp v0.6.21 loading
[    9.750000] XHTTP netlink: create netlink OK.
[    9.810000] Ebtables v2.0 registered
[   10.100000] ip6_tables: (C) 2000-2006 Netfilter Core Team
[   10.810000] ssdk_alloc_priv[3822]:INFO:ess-switch dts node number: 1
[   10.820000] ssdk_plat_init start
[   10.820000] chip_version:0xff
[   10.830000] cannot get mii bus
[   10.830000] regi_init[3965]:INFO:qca-ssdk module init, no device found!
[   10.900000] AR71XX_RESET_REG_WDOG_CTRL: 0x0
[   10.900000]  
[   10.960000] fuse init (API version 7.18)
[   16.740000] power amber led on when booting ...
[   16.880000] ADDRCONF(NETDEV_UP): eth0: link is not ready
[   19.030000] ADDRCONF(NETDEV_UP): eth0: link is not ready
[   19.040000] device eth0 entered promiscuous mode
[   19.040000] ADDRCONF(NETDEV_UP): br-lan: link is not ready
[   21.560000] br-lan: port 1(eth0) entered disabled state
[   21.610000] ADDRCONF(NETDEV_UP): eth0: link is not ready
[   21.620000] ADDRCONF(NETDEV_UP): br-lan: link is not ready
[   23.600000] fast-classifier: starting up
[   23.610000] fast-classifier: registered
[   27.480000] Ebtables v2.0 unregistered
[   29.310000] mem_manager: module license 'unspecified' taints kernel.
[   29.310000] Disabling lock debugging due to kernel taint
[   29.540000] ath_dfs: Version 2.0.0
[   29.540000] Copyright (c) 2005-2006 Atheros Communications, Inc. All Rights Reserved
[   29.560000] ath_spectral: Version 2.0.0
[   29.560000] Copyright (c) 2005-2009 Atheros Communications, Inc. All Rights Reserved
[   30.920000] ath_hal: 0.9.17.1 (AR5416, AR9380, REGOPS_FUNC, PRIVATE_DIAG, WRITE_EEPROM, 11D)
[   30.940000] ath_rate_atheros: Copyright (c) 2001-2005 Atheros Communications, Inc, All Rights Reserved
[   31.000000] ath_tx99: Version 2.0
[   31.000000] Copyright (c) 2010 Atheros Communications, Inc, All Rights Reserved
[   31.190000] ath_dev: Copyright (c) 2001-2007 Atheros Communications, Inc, All Rights Reserved
[   31.340000]  JET_PRINT: init_ath_wmac[240]: Checking devid: 40
[   31.340000] __ath_attach: Set global_scn[0]
[   31.350000] *** All the minfree values should be <= ATH_TXBUF-32, otherwise default value will be used instead ***
[   31.360000] ACBKMinfree = 48
[   31.360000] ACBEMinfree = 32
[   31.360000] ACVIMinfree = 16
[   31.370000] ACVOMinfree = 0
[   31.370000] CABMinfree = 48
[   31.370000] UAPSDMinfree = 0
[   31.380000] ATH_TXBUF=2700
[   31.380000]  JET_PRINT: ath_hal_attach[389]: Jet support is enabled. devid: 40
[   31.390000] Enterprise mode: 0x03bda000
[   31.400000] Restoring Cal data from FS
[   31.400000] qdf_fs_read[66], Open File /tmp/wifi0.caldata SUCCESS!!file system magic:16914836super blocksize:4096inode 205file size:12064qdf_fs_read[86]: caldata data size mismatch, fsize=12064, cal_size=1344
[   31.420000] ART Version : -48.0.0
[   31.420000] SW Image Version : -48.0.0.0.0
[   31.430000] Board Revision :  
[   31.430000] ar9300_attach: nf_2_nom -110 nf_2_max -60 nf_2_min -125 
[   31.440000]  HAL_CAP_TXDESCLEN : 128 
[   31.440000] HAL_CAP_TXSTATUSLEN : 36 
[   31.450000] HAL_CAP_RXSTATUSLEN : 56 
[   31.450000] SPECTRAL : get_capability not registered
[   31.460000] HAL_CAP_PHYDIAG : Capable
[   31.460000] SPECTRAL : Need to fix the capablity check for RADAR (spectral_attach : 242)
[   31.470000] SPECTRAL : get_capability not registered
[   31.480000] HAL_CAP_RADAR   : Capable
[   31.480000] SPECTRAL : Need to fix the capablity check for SPECTRAL
[   31.480000]  (spectral_attach : 247)
[   31.490000] SPECTRAL : get_capability not registered
[   31.490000] HAL_CAP_SPECTRAL_SCAN : Capable
[   31.500000] SPECTRAL : get_tsf64 not registered
[   31.500000] spectral_init_netlink 85 NULL SKB
[   31.510000] SPECTRAL : No ADVANCED SPECTRAL SUPPORT
[   31.510000] SPECTRAL :----- module attached
[   31.520000] Green-AP : Green-AP : Attached
[   31.520000] 
[   31.530000] Starting random number generator thread
[   31.540000] ath_get_caps[6217] rx chainmask mismatch actual 15 sc_chainmak 0
[   31.540000] ath_get_caps[6180] tx chainmask mismatch actual 15 sc_chainmak 0
[   31.560000] ieee80211_cbs_init CBS Inited
[   31.560000] band steering initialized for direct attach hardware 
[   31.570000] ieee80211_bsteering_attach: Band steering initialized
[   31.570000] acfg_attach: 2979: Netlink socket created:86dcc600
[   31.580000] ath_attach_dfs[12727] dfsdomain 1
[   31.590000] dfs_attach: event log enabled by default
[   31.600000] SPECTRAL : module already attached
[   31.600000] ath_attach: Set global_ic[1]..gloabl_ic ptr:8517c150
[   31.610000] osif_wrap_attach:444 osif wrap attached
[   31.610000] osif_wrap_devt_init:405 osif wrap dev table init done
[   31.620000]  Wrap Attached: Wrap_com =86dcce00 ic->ic_wrap_com=86dcce00 &wrap_com->wc_devt=86dcce00 
[   31.640000] ath_tx_paprd_init sc 866f8000 PAPRD Enabled
[   31.640000] ath_thermal_mitigation_attach: --
[   31.650000] wifi0: Qualcomm Atheros 5500: mem_start: =0xb8100000, mem_end: =0xb8120000, irq=47
[   31.660000] ath_da_pci:  (Atheros/multi-bss)
[   32.260000] ath_ol_pci:  (Atheros/multi-bss)
[   32.270000] hif_pci_enable_bus: con_mode = 0x0, device_id = 0x46
[   32.280000] ath_ol_pci 0000:00:00.0: BAR 0: assigned [mem 0x12000000-0x121fffff 64bit]
[   32.280000] PCI: Enabling device 0000:00:00.0 (0000 -> 0002)
[   32.290000] hif_pci_enable_bus: hif_enable_pci done *********** QCA9984 *************hif_pci_enable_bus: hif_type = 0xc, target_type = 0xahif_pci_enable_bus: hif_pci_probe_tgt_wakeup donehif_target_sync: Loop checking FW signalhif_target_sync: Got FW signal, retries = 0hif_config_ce: ce_init donehif_config_ce: X, ret = 0hif_set_hia: Ehif_set_hia_extnd: E
[   32.330000] chip_id 0xa chip_revision 0x0
[   32.340000] 
[   32.340000]  CLOCK PLL skipped
[   32.340000] hif_set_hia_extnd: setting the target pll frac ffffffff intval ffffffff
[   32.350000] hif_set_hia_extnd: no frac provided, skipping pre-configuring PLL
[   32.360000] hif_set_hia_extnd: targ_clk is not provided, skipping pre-configuring PLL
[   32.370000] hif_pci_bus_configure: hif_set_hia donehif_configure_irq: Ehif_pci_configure_legacy_irq: Ehif_pci_configure_legacy_irq: X, ret = 0hif_enable: X OKhif_napi_create: NAPI structures initializedhif_napi_create: NAPI id 6 created for pipe 5qca_napi_create: napi instance 32 created on pipe 4
[   32.390000] hif_napi_event: received evnt: CONF cmd; v = 1 (state=0x1)hif_napi_event: setting configuration to ON
[   32.410000] __ol_ath_attach() Allocated scn 84f00380
[   32.410000] __ol_ath_attach: dev name wifi1
[   32.420000] ol_ath_attach interface_id 1
[   32.420000] ol_target_init() BMI inited.
[   32.430000] ol_target_init() BMI Get Target Info.
[   32.430000] Chip id: 0xa, chip version: 0x1000000
[   32.440000] 
[   32.440000]  CE WAR Disabled
[   32.440000] NUM_DEV=1 FWMODE=0x2 FWSUBMODE=0x0 FWBR_BUF 0
[   32.450000] ol_target_init() configure Target .
[   32.450000] 
[   32.450000]  Target Version is 1000000
[   32.460000] 
[   32.460000]  Flash Download Address  c0000 
[   32.460000] ol_transfer_bin_file: flash data file defined
[   32.470000] ol_transfer_bin_file[3965] Get Caldata for wifi1.
[   32.480000] qdf_fs_read[66], Open File /tmp/wifi1.caldata SUCCESS!!file system magic:16914836super blocksize:4096inode 206file size:12064qc98xx_verify_checksum: flash checksum passed: 0xaa7a
[   32.490000] ol_transfer_bin_file 4041: Download Flash data len 12064
[   32.500000] Board extended Data download address: 0x0
[   32.520000] 
[   32.520000]  Board data initialized
[   32.530000] ol_ath_download_firmware: Download OTP, flash download ADDRESS 0xc0000
[   32.540000] 
[   32.540000]  Selecting  OTP binary for CHIP Version 0
[   32.620000] ol_transfer_bin_file 3847: downloading file 0, Download data len 9256
[   32.650000] 
[   32.650000]  First OTP send param 8000
[   34.870000] ol_ath_download_firmware :First OTP download and Execute is good address:0x400 return param 4660
[   34.880000] ol_ath_download_firmware:##Board Id 1 , CHIP Id 0
[   34.890000] ol_ath_download_firmware: BOARDDATA DOWNLOAD TO address 0xc0000
[   34.940000] ol_transfer_bin_file: Board Data File download to address=0xc0000 file name=QCA9984/hw.1/boardData_QCA9984_CUS239_5G_v1_001.bin
[   34.960000] ol_transfer_bin_file 3847: downloading file 3, Download data len 12064
[   34.970000] Board extended Data download address: 0x0
[   34.990000] ol_ath_download_firmware: Using 0x1234 for the remainder of init
[   35.000000] 
[   35.000000]  Selecting  OTP binary for CHIP Version 0
[   35.020000] ol_transfer_bin_file 3847: downloading file 0, Download data len 9256
[   35.050000] 
[   35.050000]  [Flash] : Ignore Module param
[   35.060000] 
[   35.060000]  Second otp download Param 10000 
[   37.290000] ol_ath_download_firmware : Second OTP download and Execute is good, param=0x0 
[   37.290000] 
[   37.290000]  Mission mode: Firmware CHIP Version 0
[   37.470000] ol_swap_seg_alloc: Successfully allocated memory for SWAP size=262144 
[   37.590000] ol_swap_wlan_memory_expansion: length:258604 size_left:258624 dma_size_left:262144 fw_temp:c0bfc004 fw_entry_size:258628
[   37.600000] ol_swap_wlan_memory_expansion: dma_virt_addr :a4e40000 fw_temp: c0bfc008 length: 258604
[   37.620000] Swap: bytes_left to copy: fw:16; dma_page:3540
[   37.620000] ol_swap_wlan_memory_expansion: length:0 size_left:12 dma_size_left:3540 fw_temp:c0c3b238 fw_entry_size:258628
[   37.630000] Swap: wrong length read:0
[   37.640000] ol_swap_wlan_memory_expansion: Swap total_bytes copied: 258604 Target address 422800 
[   37.650000] scn=84f00380  target_write_addr=422800 seg_info=84f60510 
[   37.650000] ol_transfer_swap_struct:Code swap structure successfully downloaded for bin type =2 
[   37.660000] bin_filename=QCA9984/hw.1/athwlan.bin swap_filename=/lib/firmware/QCA9984/hw.1/athwlan.codeswap.bin 
[   37.670000] ol_transfer_bin_file: Downloading firmware file: QCA9984/hw.1/athwlan.bin
[   38.100000] ol_transfer_bin_file 3847: downloading file 1, Download data len 392776
[   39.360000] ol_target_init() Download FW done. 
[   39.360000] ol_ath_attach() WMI attached. wmi_handle 84fe8000 
[   39.370000] wmi_unified_register_event_handler: Event id 62 is unavailable
[   39.380000] +htc_create ..  HIF :867e4000-htc_create: (0x86698000)
[   39.380000] htc_wmi_init() HT Create . 86698000
[   39.390000] htc_wmi_init 8274 host_enable 0 nss_nwifi_offload 0
[   39.390000] ol_ath_set_default_tgt_config : AC Minfree buffer allocation through module param (umac.ko)
[   39.400000]  OL_ACBKMinfree : 0
[   39.410000]  OL_ACBEMinfree : 0
[   39.410000]  OL_ACVIMinfree : 0
[   39.410000]  OL_ACVOMinfree : 0
[   39.420000] hif_enable_fastpath, Enabling fastpath mode
[   39.420000] +HWT
[   39.420000] hif_completion_thread_startup: pipe_num:0 pipe_info:0x867e706chif_completion_thread_startup: pipe_num:3 pipe_info:0x867e712chif_completion_thread_startup: pipe_num:4 pipe_info:0x867e716c
[   39.450000] -HWT
[   39.450000] Startup Mode-0 set
[   39.450000] 
[   39.450000] <=== cfg max peer id 1056 ====>
[   39.460000] htt_peer_map_timer_init Enter pdev 84198000 hrtimer 8419c970
[   39.470000] 
[   39.470000]  htt_alloc_peer_map_mem : Alloc Success : host q vaddr 841a2000 paddr 41a2000
[   39.480000] 
[   39.480000]  htt_alloc_peer_map_mem : Flush Interval Configured to 256 pkts
[   39.490000] ol_txrx_pdev_attach: 2500 tx desc's allocated ; range starts from 83e20000
[   39.500000] Firmware_Build_Number:140 
[   39.500000] FW wireless modes: 0x7f9001
[   39.510000] num_rf_chain:0x00000004  ht_cap_info:0x0000185b  vht_cap_info:0x339b79fa  vht_supp_mcs:0x0000ffaa
[   39.520000] wmi_service_coex_gpio 0, wmi_service_4_wire_coex_support 0, coex_version 0
[   39.530000] 
[   39.530000] Sending Ext resource cfg: HOST PLATFORM as 1
[   39.530000] fw_feature_bitmap as 50 to TGT
[   39.540000] ol_ath_service_ready_event: tt_support: 1
[   39.540000] ol_ath_service_ready_event: periodic_chan_stats: 1
[   39.550000] ol_ath_service_ready_event: sw_cal_support_check_flag: 1
[   39.550000] Peer Caching Enabled ; num_peers = 530, num_active_peers = 52 num_tids = 104, num_vdevs = 17
[   39.560000] EXT NSS Supported
[   39.570000] idx 1 req 2  num_units 1 num_unit_info 12 unit size 256 actual units 53 
[   39.580000] ol_ath_alloc_host_mem_chunk req_id 2 idx 0 num_units 53 unit_len 256,
[   39.580000] idx 2 req 3  num_units 1 num_unit_info 12 unit size 1024 actual units 53 
[   39.590000] ol_ath_alloc_host_mem_chunk req_id 3 idx 1 num_units 53 unit_len 1024,
[   39.600000] idx 3 req 4  num_units 1 num_unit_info 12 unit size 4096 actual units 53 
[   39.610000] ol_ath_alloc_host_mem_chunk req_id 4 idx 2 num_units 53 unit_len 4096,
[   39.620000] idx 0 req 1  num_units 0 num_unit_info 2 unit size 2192 actual units 531 
[   39.630000] ol_ath_alloc_host_mem_chunk req_id 1 idx 3 num_units 531 unit_len 2192,
[   39.640000] idx 4 req 6  num_units 35 num_unit_info 0 unit size 3072 actual units 35 
[   39.650000] ol_ath_alloc_host_mem_chunk req_id 6 idx 4 num_units 35 unit_len 3072,
[   39.650000] idx 5 req 7  num_units 1 num_unit_info 0 unit size 12288 actual units 1 
[   39.660000] ol_ath_alloc_host_mem_chunk req_id 7 idx 5 num_units 1 unit_len 12288,
[   39.670000] idx 6 req 5  num_units 0 num_unit_info 2 unit size 2100 actual units 531 
[   39.680000] ol_ath_alloc_host_mem_chunk req_id 5 idx 6 num_units 531 unit_len 2100,
[   39.690000] Support not added yet for Service 91
[   39.700000] Support not added yet for Service 92
[   39.700000] No EXT_MSG send INIT now
[   39.700000] chunk 0 len 13568 requested , ptr  0x3e18000
[   39.710000] chunk 1 len 54272 requested , ptr  0x3e80000
[   39.720000] chunk 2 len 217088 requested , ptr  0x3ec0000
[   39.720000] chunk 3 len 1163952 requested , ptr  0x3800000
[   39.730000] chunk 4 len 107520 requested , ptr  0x3ea0000
[   39.730000] chunk 5 len 12288 requested , ptr  0x3e1c000
[   39.740000] chunk 6 len 1115100 requested , ptr  0x3a00000
[   39.740000] chunk 7 len 0 requested , ptr  0xffffffff
[   39.750000] ol_ath_service_ready_event[4273] WAPI MBSSID 2 
[   39.760000] smart_log_init: Smart logging Enabled buf=pK-error (size=65536)
[   39.830000] Version = 16777216 3  status = 0
[   39.830000] ol_ath_connect_htc() WMI is ready
[   39.830000] htt_h2t_frag_desc_bank_cfg_msg - HTT_H2T_MSG_TYPE_FRAG_DESC_BANK_CFG sent to FW for radio ID = 1
[   39.840000] target uses HTT version 2.2; host uses 2.2
[   39.850000] ol_ath_attach() connect HTC. 
[   39.860000] bypasswmi : 0
[   39.860000] ol_regdmn_start: reg-domain param: regdmn=0, countryName=, wModeSelect=FFFFFFFF, netBand=FFFFFFFF, extendedChanMode=0.
[   39.870000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x2) flags 0x2150
[   39.880000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   39.890000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   39.890000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   39.900000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   39.900000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   39.910000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   39.910000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   39.920000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   39.920000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   39.930000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   39.930000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   39.940000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   39.940000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   39.950000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   39.950000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   39.960000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   39.960000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   39.970000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   39.970000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   39.980000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   39.980000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   39.990000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   39.990000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.000000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   40.000000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x4) flags 0xa0
[   40.010000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x8) flags 0xc0
[   40.020000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x20) flags 0xd0
[   40.020000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x40) flags 0x150
[   40.030000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x800) flags 0x10080
[   40.040000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x2000) flags 0x20080
[   40.050000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x4000) flags 0x40080
[   40.050000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.060000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.060000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.070000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.070000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.080000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.080000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.090000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.090000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.100000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.100000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.110000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.110000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.120000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.120000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.130000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.130000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   40.140000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   40.140000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   40.150000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.150000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.160000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   40.160000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.170000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   40.170000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.180000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.180000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.190000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.190000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.200000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.200000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.210000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.220000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   40.220000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.230000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   40.230000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.240000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.240000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.250000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.250000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.260000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.260000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.270000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.270000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   40.280000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.280000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.290000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.290000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.300000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.300000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.310000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.310000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.320000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.320000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.330000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.330000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.340000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.340000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.350000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.350000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.360000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.360000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.370000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   40.370000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   40.380000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   40.380000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.390000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.390000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   40.400000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.400000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   40.410000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.410000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.420000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.420000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.430000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.430000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.440000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.440000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.450000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   40.450000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.460000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   40.460000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.470000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.470000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.480000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.480000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.490000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.490000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.500000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.500000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   40.510000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.510000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.520000] Add VHT80 channel: 5210
[   40.520000] Add VHT80 channel: 5290
[   40.520000] Add VHT80 channel: 5530
[   40.530000] Add VHT80 channel: 5610
[   40.530000] Add VHT80 channel: 5690
[   40.540000] Add VHT80 channel: 5775
[   40.540000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.540000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.550000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.550000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.560000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.560000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.570000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.570000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.580000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.580000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.590000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.590000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.600000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.600000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.610000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.610000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.620000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.620000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.630000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   40.630000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   40.640000] Skipping VHT80 channel 5825
[   40.640000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5290
[   40.640000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5210
[   40.640000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5610
[   40.640000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5610,5530
[   40.640000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.650000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.650000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.660000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.660000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.670000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.670000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.680000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.680000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.690000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.690000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.700000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.700000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.710000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.710000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.720000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5530
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5210
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5610
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5610,5210
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5690
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5210
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5775
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5210
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5530
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5290
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5610
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5610,5290
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5690
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5290
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5775
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5290
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5690
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5530
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5775
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5530
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5610,5775
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5610
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5775
[   40.720000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5690
[   40.720000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.730000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.730000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   40.740000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.750000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.750000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   40.760000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.760000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.770000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   40.770000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.780000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.780000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   40.790000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.790000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.800000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   40.800000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.810000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.810000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   40.820000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.820000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.830000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   40.830000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.840000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.840000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   40.850000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.850000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.860000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   40.860000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.870000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.870000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   40.880000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.880000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.890000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   40.890000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.900000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.900000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   40.910000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.910000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.920000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   40.920000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.930000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.930000] DNI: Freq:5600  POWERLIMIT DISABLE === 
[   40.940000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.940000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.950000] DNI: Freq:5620  POWERLIMIT DISABLE === 
[   40.950000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.960000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.960000] DNI: Freq:5640  POWERLIMIT DISABLE === 
[   40.970000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.970000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.980000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.980000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   40.990000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   40.990000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   41.000000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   41.000000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   41.010000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   41.010000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   41.020000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   41.020000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   41.030000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   41.030000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   41.040000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   41.040000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   41.050000] ol_ath_phyerr_attach: called
[   41.050000] freq=58 
[   41.050000] freq=106 
[   41.050000] freq=122 
[   41.060000] OL Resmgr Init-ed
[   41.060000] ieee80211_cbs_init CBS Inited
[   41.060000] ieee80211_bsteering_attach: Band steering initialized
[   41.070000] acfg_attach: using existing sock 86dcc600
[   41.080000] ol_if_spectral_setup
[   41.080000] SPECTRAL : get_capability not registered
[   41.080000] HAL_CAP_PHYDIAG : Capable
[   41.090000] SPECTRAL : Need to fix the capablity check for RADAR (spectral_attach : 242)
[   41.090000] SPECTRAL : get_capability not registered
[   41.100000] HAL_CAP_RADAR   : Capable
[   41.100000] SPECTRAL : Need to fix the capablity check for SPECTRAL
[   41.100000]  (spectral_attach : 247)
[   41.110000] SPECTRAL : get_capability not registered
[   41.120000] HAL_CAP_SPECTRAL_SCAN : Capable
[   41.120000] SPECTRAL : get_tsf64 not registered
[   41.130000] spectral_init_netlink 85 NULL SKB
[   41.130000] Green-AP : Green-AP : Attached
[   41.130000] 
[   41.140000] Green-AP : Attached
[   41.140000] rate power table override is only supported for AR98XX
[   41.150000] ol_if_dfs_setup: called 
[   41.150000] ol_if_dfs_attach: called; ptr=83f1197c, radar_info=87155b38
[   41.150000] dfs_attach: event log enabled by default
[   41.160000] ol_ath_rtt_meas_report_attach: called
[   41.160000] ol_ath_lowi_wmi_event_attach: called
[   41.160000] >>>> CB Set 00000000
[   41.160000] ol_ath_attach() UMAC attach . 
[   41.170000] 
[   41.170000]  BURSTING enabled by default
[   41.170000] ol_ath_attach: Set global_ic[2] ..ptr:8517c150
[   41.180000] ath_lowi_if_netlink_init LOWI Netlink successfully created
[   41.190000] osif_wrap_attach:444 osif wrap attached
[   41.190000] osif_wrap_devt_init:405 osif wrap dev table init done
[   41.200000]  Wrap Attached: Wrap_com =8655e600 ic->ic_wrap_com=8655e600 &wrap_com->wc_devt=8655e600 
[   41.210000] __ol_ath_attach: needed_headroom reservation 60
[   41.210000] ol_ath_thermal_mitigation_attach: --
[   41.220000] ol_ath_pci_probe num_radios=0, wifi_radios[0].sc = 84f00380 wifi_radio_type = 2
[   41.230000] ath_sysfs_diag_init: diag_fsattr 
[   41.230000] Suspending Target  scn=84f00380
[   41.240000] waiting for target paused event from target 
[   41.240000] [wifi1] FWLOG: [56742] WAL_DBGID_RST_STATS ( 0x1, 0x1, 0x1464, 0x0 )
[   41.250000] [wifi1] FWLOG: [56817] WAL_DBGID_TX_AC_BUFFER_SET ( 0x3, 0x1e, 0x94c, 0x94c, 0x0 )
[   41.260000] [wifi1] FWLOG: [56817] WAL_DBGID_TX_AC_BUFFER_SET ( 0x12, 0x1e, 0x94c, 0x94c, 0x0 )
[   41.270000] [wifi1] FWLOG: [56817] WAL_DBGID_TX_AC_BUFFER_SET ( 0x45, 0x1e, 0x94c, 0x94c, 0x0 )
[   41.280000] [wifi1] FWLOG: [56817] WAL_DBGID_TX_AC_BUFFER_SET ( 0x67, 0x1e, 0x94c, 0x94c, 0x0 )
[   41.290000] ol_ath_thermal_mitigation_detach: ++
[   41.290000] ol_ath_thermal_mitigation_detach: --
[   41.300000] ol_if_dfs_clist_update: called, cmd=1, nollist=00000000, nentries=0
[   41.310000] ce_h2t_tx_ce_cleanup 1039 Fastpath mode ON, Cleaning up HTT Tx CEsmart_log_deinit: Smart logging Disabled
[   41.320000] ol_tx_me_exit: Already Disabled !!!
[   41.330000] hif_pci_device_reset: Reset Devicehif_pci_disable_bus: Xhif_disable: Xhif_napi_destroy: NAPI 6 destroyed
[   41.340000] hif_napi_destroy: no NAPI instances. Zapped.ath_sysfs_diag_fini: diag_fsattr 
[   41.440000]  pktlog_init: Initializing Pktlog for AR900B, pktlog_hdr_size = 16
[   41.450000] Invalid sc in hif_pktlog_subscribe
[   41.450000] Unable to subscribe to the HIF pktlog_init
[   41.530000] __sa_init_module 
[   41.560000] ath_net80211_dfs_clist_update: called, cmd=1, nollist=00000000, nentries=0
[   41.570000] ath_attach_dfs[12727] dfsdomain 1
[   41.580000] dfs_attach: event log enabled by default
[   41.620000] 	DCS for CW interference mitigation:   0
[   41.620000] 	DCS for WLAN interference mitigation: 0
[   41.690000]  Disconnect_timeout value entered:10 
[   41.700000]  reconfiguration_timeout value entered:60 
[   41.790000] wlan_vap_create : enter. devhandle=0x86630380, opmode=IEEE80211_M_HOSTAP, flags=0x1
[   41.800000] ieee80211_mbo_vattach:MBO Initialized 
[   41.800000] ieee80211_oce_vattach: OCE Initialized 
[   41.810000] wlan_vap_create : exit. devhandle=0x86630380, vap=0x841d0000, opmode=IEEE80211_M_HOSTAP, flags=0x1.
[   41.820000] __ieee80211_smart_ant_init: Smart Antenna is not supported 
[   41.830000] VAP device ath0 created osifp: (86698380) os_if: (841d0000)
[   41.860000] siwfreq
[   41.860000] Set freq vap 0 stop send + 841d0000
[   41.870000] Set freq vap 0 stop send -841d0000
[   41.900000] Set wait done --841d0000
[   42.010000] WARNING: Fragmentation with HT mode NOT ALLOWED!!
[   42.080000] [DEBUG] vap-0(ath0):set SIOC80211NWID, 11 characters
[   42.080000]  
[   42.080000]  DES SSID SET=NETGEAR_EXT 
[   42.120000] device ath0 entered promiscuous mode
[   42.820000]  ieee80211_ioctl_siwmode: imr.ifm_active=131712, new mode=3, valid=1 
[   42.830000]  DEVICE IS DOWN ifname=ath0
[   42.840000]  DEVICE IS DOWN ifname=ath0
[   43.030000] br-lan: port 2(ath0) entered forwarding state
[   43.030000] br-lan: port 2(ath0) entered forwarding state
[   43.180000] 8021q: adding VLAN 0 to HW filter on device ath0
[   43.190000] ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
[   45.030000] br-lan: port 2(ath0) entered forwarding state
[   46.610000] ieee80211_derive_chan : Overriding HT40 channel with HT20 channel
[   46.800000] __ieee80211_smart_ant_init: Smart Antenna is not supported 
[   46.810000] __ieee80211_smart_ant_init: Smart Antenna is not supported 
[   46.820000] Not supported in this vap 
[   55.840000] Thermal Throttling flag set to : 1. 
[   55.850000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   55.860000] Thermal Throttling flag set to : 1. 
[   55.860000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   55.900000] Thermal Throttling flag set to : 1. 
[   55.900000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   55.940000] hif_pci_enable_bus: con_mode = 0x0, device_id = 0x46
[   55.950000] ath_ol_pci 0000:00:00.0: BAR 0: assigned [mem 0x12000000-0x121fffff 64bit]
[   55.950000] hif_pci_enable_bus: hif_enable_pci done *********** QCA9984 *************hif_pci_enable_bus: hif_type = 0xc, target_type = 0xahif_pci_enable_bus: hif_pci_probe_tgt_wakeup donehif_target_sync: Loop checking FW signalhif_target_sync: Got FW signal, retries = 0hif_config_ce: ce_init donehif_config_ce: X, ret = 0hif_set_hia: Ehif_set_hia_extnd: E
[   56.000000] chip_id 0xa chip_revision 0x0
[   56.000000] 
[   56.000000]  CLOCK PLL skipped
[   56.010000] hif_set_hia_extnd: setting the target pll frac ffffffff intval ffffffff
[   56.010000] hif_set_hia_extnd: no frac provided, skipping pre-configuring PLL
[   56.020000] hif_set_hia_extnd: targ_clk is not provided, skipping pre-configuring PLL
[   56.030000] hif_pci_bus_configure: hif_set_hia donehif_configure_irq: Ehif_pci_configure_legacy_irq: Ehif_pci_configure_legacy_irq: X, ret = 0hif_enable: X OKhif_napi_create: NAPI structures initializedhif_napi_create: NAPI id 6 created for pipe 5qca_napi_create: napi instance 32 created on pipe 4
[   56.060000] hif_napi_event: received evnt: CONF cmd; v = 1 (state=0x1)hif_napi_event: setting configuration to ON
[   56.070000] ol_target_init() BMI inited.
[   56.080000] ol_target_init() BMI Get Target Info.
[   56.080000] Chip id: 0xa, chip version: 0x1000000
[   56.090000] 
[   56.090000]  CE WAR Disabled
[   56.090000] NUM_DEV=1 FWMODE=0x2 FWSUBMODE=0x0 FWBR_BUF 0
[   56.100000] ol_target_init() configure Target .
[   56.100000] 
[   56.100000]  Target Version is 1000000
[   56.110000] 
[   56.110000]  Flash Download Address  c0000 
[   56.110000] ol_transfer_bin_file: flash data file defined
[   56.120000] ol_transfer_bin_file[3965] Get Caldata for wifi1.
[   56.130000] qdf_fs_read[66], Open File /tmp/wifi1.caldata SUCCESS!!file system magic:16914836super blocksize:4096inode 206file size:12064qc98xx_verify_checksum: flash checksum passed: 0xaa7a
[   56.140000] ol_transfer_bin_file 4041: Download Flash data len 12064
[   56.150000] Board extended Data download address: 0x0
[   56.180000] 
[   56.180000]  Board data initialized
[   56.180000] ol_ath_download_firmware: Download OTP, flash download ADDRESS 0xc0000
[   56.190000] 
[   56.190000]  Selecting  OTP binary for CHIP Version 0
[   56.210000] ol_transfer_bin_file 3847: downloading file 0, Download data len 9256
[   56.260000] 
[   56.260000]  First OTP send param 8000
[   58.480000] ol_ath_download_firmware :First OTP download and Execute is good address:0x400 return param 4660
[   58.490000] ol_ath_download_firmware:##Board Id 1 , CHIP Id 0
[   58.490000] ol_ath_download_firmware: BOARDDATA DOWNLOAD TO address 0xc0000
[   58.500000] ol_transfer_bin_file: Board Data File download to address=0xc0000 file name=QCA9984/hw.1/boardData_QCA9984_CUS239_5G_v1_001.bin
[   58.520000] ol_transfer_bin_file 3847: downloading file 3, Download data len 12064
[   58.530000] Board extended Data download address: 0x0
[   58.560000] ol_ath_download_firmware: Using 0x1234 for the remainder of init
[   58.560000] 
[   58.560000]  Selecting  OTP binary for CHIP Version 0
[   58.580000] ol_transfer_bin_file 3847: downloading file 0, Download data len 9256
[   58.620000] 
[   58.620000]  [Flash] : Ignore Module param
[   58.630000] 
[   58.630000]  Second otp download Param 10000 
[   60.850000] ol_ath_download_firmware : Second OTP download and Execute is good, param=0x0 
[   60.860000] 
[   60.860000]  Mission mode: Firmware CHIP Version 0
[   60.880000] ol_swap_wlan_memory_expansion: length:258604 size_left:258624 dma_size_left:262144 fw_temp:c0d37004 fw_entry_size:258628
[   60.890000] ol_swap_wlan_memory_expansion: dma_virt_addr :a4e40000 fw_temp: c0d37008 length: 258604
[   60.900000] Swap: bytes_left to copy: fw:16; dma_page:3540
[   60.910000] ol_swap_wlan_memory_expansion: length:0 size_left:12 dma_size_left:3540 fw_temp:c0d76238 fw_entry_size:258628
[   60.920000] Swap: wrong length read:0
[   60.920000] ol_swap_wlan_memory_expansion: Swap total_bytes copied: 258604 Target address 422800 
[   60.930000] scn=84f00380  target_write_addr=422800 seg_info=84f60510 
[   60.940000] ol_transfer_swap_struct:Code swap structure successfully downloaded for bin type =2 
[   60.950000] bin_filename=QCA9984/hw.1/athwlan.bin swap_filename=/lib/firmware/QCA9984/hw.1/athwlan.codeswap.bin 
[   60.960000] ol_transfer_bin_file: Downloading firmware file: QCA9984/hw.1/athwlan.bin
[   61.080000] ol_transfer_bin_file 3847: downloading file 1, Download data len 392776
[   62.340000] ol_target_init() Download FW done. 
[   62.350000] +htc_create ..  HIF :84ff0000-htc_create: (0x86606000)
[   62.350000] htc_wmi_init() HT Create . 86606000
[   62.360000] htc_wmi_init 8274 host_enable 0 nss_nwifi_offload 0
[   62.370000] ol_ath_set_default_tgt_config : AC Minfree buffer allocation through module param (umac.ko)
[   62.380000]  OL_ACBKMinfree : 0
[   62.380000]  OL_ACBEMinfree : 0
[   62.380000]  OL_ACVIMinfree : 0
[   62.380000]  OL_ACVOMinfree : 0
[   62.390000] hif_enable_fastpath, Enabling fastpath mode
[   62.390000] +HWT
[   62.400000] hif_completion_thread_startup: pipe_num:0 pipe_info:0x84ff306chif_completion_thread_startup: pipe_num:3 pipe_info:0x84ff312chif_completion_thread_startup: pipe_num:4 pipe_info:0x84ff316c
[   62.420000] -HWT
[   62.420000] wmi_unified_register_event_handler : event handler already registered 0x8002
[   62.430000] Startup Mode-0 set
[   62.430000] 
[   62.430000] <=== cfg max peer id 1056 ====>
[   62.450000] htt_peer_map_timer_init Enter pdev 83df0000 hrtimer 83df4970
[   62.450000] 
[   62.450000]  htt_alloc_peer_map_mem : Alloc Success : host q vaddr 84d8a000 paddr 4d8a000
[   62.460000] 
[   62.460000]  htt_alloc_peer_map_mem : Flush Interval Configured to 256 pkts
[   62.480000] ol_txrx_pdev_attach: 2500 tx desc's allocated ; range starts from 83020000
[   62.500000] Firmware_Build_Number:140 
[   62.500000] FW wireless modes: 0x7f9001
[   62.510000] num_rf_chain:0x00000004  ht_cap_info:0x0000185b  vht_cap_info:0x339b79fa  vht_supp_mcs:0x0000ffaa
[   62.520000] wmi_service_coex_gpio 0, wmi_service_4_wire_coex_support 0, coex_version 0
[   62.520000] 
[   62.520000] Sending Ext resource cfg: HOST PLATFORM as 1
[   62.520000] fw_feature_bitmap as 50 to TGT
[   62.540000] ol_ath_service_ready_event: tt_support: 1
[   62.540000] ol_ath_service_ready_event: periodic_chan_stats: 1
[   62.550000] ol_ath_service_ready_event: sw_cal_support_check_flag: 1
[   62.550000] Peer Caching Enabled ; num_peers = 530, num_active_peers = 52 num_tids = 104, num_vdevs = 17
[   62.560000] EXT NSS Supported
[   62.570000] idx 1 req 2  num_units 1 num_unit_info 12 unit size 256 actual units 53 
[   62.570000] ol_ath_alloc_host_mem_chunk req_id 2 idx 0 num_units 53 unit_len 256,
[   62.580000] idx 2 req 3  num_units 1 num_unit_info 12 unit size 1024 actual units 53 
[   62.590000] ol_ath_alloc_host_mem_chunk req_id 3 idx 1 num_units 53 unit_len 1024,
[   62.600000] idx 3 req 4  num_units 1 num_unit_info 12 unit size 4096 actual units 53 
[   62.610000] ol_ath_alloc_host_mem_chunk req_id 4 idx 2 num_units 53 unit_len 4096,
[   62.610000] idx 0 req 1  num_units 0 num_unit_info 2 unit size 2192 actual units 531 
[   62.620000] ol_ath_alloc_host_mem_chunk req_id 1 idx 3 num_units 531 unit_len 2192,
[   62.630000] idx 4 req 6  num_units 35 num_unit_info 0 unit size 3072 actual units 35 
[   62.640000] ol_ath_alloc_host_mem_chunk req_id 6 idx 4 num_units 35 unit_len 3072,
[   62.650000] idx 5 req 7  num_units 1 num_unit_info 0 unit size 12288 actual units 1 
[   62.650000] ol_ath_alloc_host_mem_chunk req_id 7 idx 5 num_units 1 unit_len 12288,
[   62.660000] idx 6 req 5  num_units 0 num_unit_info 2 unit size 2100 actual units 531 
[   62.670000] ol_ath_alloc_host_mem_chunk req_id 5 idx 6 num_units 531 unit_len 2100,
[   62.680000] Support not added yet for Service 91
[   62.680000] Support not added yet for Service 92
[   62.690000] No EXT_MSG send INIT now
[   62.690000] chunk 0 len 13568 requested , ptr  0x3e18000
[   62.700000] chunk 1 len 54272 requested , ptr  0x3e80000
[   62.700000] chunk 2 len 217088 requested , ptr  0x3ec0000
[   62.710000] chunk 3 len 1163952 requested , ptr  0x3800000
[   62.710000] chunk 4 len 107520 requested , ptr  0x3ea0000
[   62.720000] chunk 5 len 12288 requested , ptr  0x3e1c000
[   62.720000] chunk 6 len 1115100 requested , ptr  0x3a00000
[   62.730000] chunk 7 len 0 requested , ptr  0xffffffff
[   62.740000] ol_ath_service_ready_event[4273] WAPI MBSSID 2 
[   62.740000] smart_log_init: Smart logging Enabled buf=pK-error (size=65536)
[   62.810000] Version = 16777216 3  status = 0
[   62.820000] ol_ath_connect_htc() WMI is ready
[   62.820000] htt_h2t_frag_desc_bank_cfg_msg - HTT_H2T_MSG_TYPE_FRAG_DESC_BANK_CFG sent to FW for radio ID = 1
[   62.830000] target uses HTT version 2.2; host uses 2.2
[   62.840000] wmi_unified_register_event_handler : event handler already registered 0x900b
[   62.850000] wmi_unified_register_event_handler : event handler already registered 0x9042
[   62.860000] >>>> CB Set 00000000
[   62.860000] ol_ath_thermal_mitigation_attach: --
[   62.870000] ol_if_dfs_setup: called 
[   62.870000] ath_sysfs_diag_init: diag_fsattr 
[   62.870000] +hif_update_pipe_callback pipeid 8
[   62.880000] -hif_update_pipe_callback
[   63.370000] [wifi1] FWLOG: [21919] WAL_DBGID_RST_STATS ( 0x1, 0x1, 0x1464, 0x0 )
[   63.380000] [wifi1] FWLOG: [21994] WAL_DBGID_TX_AC_BUFFER_SET ( 0x3, 0x1e, 0x94c, 0x94c, 0x0 )
[   63.390000] [wifi1] FWLOG: [21994] WAL_DBGID_TX_AC_BUFFER_SET ( 0x12, 0x1e, 0x94c, 0x94c, 0x0 )
[   63.390000] [wifi1] FWLOG: [21994] WAL_DBGID_TX_AC_BUFFER_SET ( 0x45, 0x1e, 0x94c, 0x94c, 0x0 )
[   63.400000] [wifi1] FWLOG: [21994] WAL_DBGID_TX_AC_BUFFER_SET ( 0x67, 0x1e, 0x94c, 0x94c, 0x0 )
[   63.520000] wmi_dbg_cfg_send: mod[0]00000000 dbgcfg50000000 cfgvalid[0] 00000000 cfgvalid[1] 00000000, cfgvalid[2] 70000000
[   63.570000] isCountryCodeValid: EEPROM regdomain 0x0
[   63.580000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x2) flags 0x2150
[   63.580000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   63.590000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   63.600000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   63.600000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   63.610000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   63.610000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   63.620000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   63.620000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   63.630000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   63.630000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   63.640000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   63.640000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   63.650000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   63.650000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   63.660000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   63.660000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   63.670000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   63.670000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   63.680000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   63.680000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   63.690000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   63.690000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x4) flags 0xa0
[   63.700000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x8) flags 0xc0
[   63.710000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x20) flags 0xd0
[   63.710000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x40) flags 0x150
[   63.720000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x800) flags 0x10080
[   63.730000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x2000) flags 0x20080
[   63.730000] ol_regdmn_init_channels: !avail mode 0x7f9001 (0x4000) flags 0x40080
[   63.740000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   63.750000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   63.750000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   63.760000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   63.760000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   63.770000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   63.770000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   63.780000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   63.780000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   63.790000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   63.790000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   63.800000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   63.800000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   63.810000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   63.810000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   63.820000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   63.820000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   63.830000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   63.830000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   63.840000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   63.840000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   63.850000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   63.850000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   63.860000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   63.860000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   63.870000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   63.870000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   63.880000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   63.880000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   63.890000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   63.890000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   63.900000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   63.900000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   63.910000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   63.910000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   63.920000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   63.920000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   63.930000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   63.930000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   63.940000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   63.940000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   63.950000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   63.950000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   63.960000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   63.960000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   63.970000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   63.970000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   63.980000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   63.980000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   63.990000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   63.990000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.000000] DNI: Freq:5580  POWERLIMIT DISABLE === 
[   64.000000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   64.010000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   64.020000] DNI: Freq:5700  POWERLIMIT DISABLE === 
[   64.020000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.030000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.030000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.040000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.040000] DNI: Freq:5825  POWERLIMIT DISABLE === 
[   64.050000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   64.050000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   64.060000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   64.060000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   64.070000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   64.070000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   64.080000] DNI: Freq:5660  POWERLIMIT DISABLE === 
[   64.080000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.090000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.090000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   64.100000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   64.100000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   64.110000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   64.110000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   64.120000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.120000] DNI: Freq:5680  POWERLIMIT DISABLE === 
[   64.130000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.130000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.140000] Add VHT80 channel: 5210
[   64.140000] Add VHT80 channel: 5290
[   64.140000] Add VHT80 channel: 5530
[   64.150000] Add VHT80 channel: 5690
[   64.150000] Add VHT80 channel: 5775
[   64.150000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   64.160000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   64.160000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   64.170000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   64.170000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   64.180000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   64.180000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   64.190000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   64.190000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   64.200000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   64.200000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   64.210000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.210000] Skipping VHT80 channel 5580
[   64.220000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.220000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.230000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.230000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.240000] Skipping VHT80 channel 5825
[   64.240000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5290
[   64.240000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5210
[   64.240000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   64.250000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   64.250000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   64.260000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   64.260000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   64.270000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   64.270000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   64.280000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5530
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5210
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5690
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5210
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5210,5775
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5210
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5530
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5290
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5690
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5290
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5290,5775
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5290
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5690
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5530
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5530,5775
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5530
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5690,5775
[   64.280000] Add VHT160/VHT80_80 pri80 and sec80 centers: 5775,5690
[   64.280000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   64.290000] DNI: Freq:5180  POWERLIMIT DISABLE === 
[   64.290000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   64.300000] DNI: Freq:5200  POWERLIMIT DISABLE === 
[   64.300000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   64.310000] DNI: Freq:5220  POWERLIMIT DISABLE === 
[   64.310000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   64.320000] DNI: Freq:5240  POWERLIMIT DISABLE === 
[   64.320000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   64.330000] DNI: Freq:5260  POWERLIMIT DISABLE === 
[   64.330000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   64.340000] DNI: Freq:5280  POWERLIMIT DISABLE === 
[   64.340000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   64.350000] DNI: Freq:5300  POWERLIMIT DISABLE === 
[   64.350000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   64.360000] DNI: Freq:5320  POWERLIMIT DISABLE === 
[   64.360000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   64.370000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   64.370000] DNI: Freq:5500  POWERLIMIT DISABLE === 
[   64.380000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   64.380000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   64.390000] DNI: Freq:5520  POWERLIMIT DISABLE === 
[   64.390000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   64.400000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   64.400000] DNI: Freq:5540  POWERLIMIT DISABLE === 
[   64.410000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.410000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.420000] DNI: Freq:5560  POWERLIMIT DISABLE === 
[   64.430000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.430000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.440000] DNI: Freq:5745  POWERLIMIT DISABLE === 
[   64.440000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.450000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.450000] DNI: Freq:5765  POWERLIMIT DISABLE === 
[   64.460000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.460000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.470000] DNI: Freq:5785  POWERLIMIT DISABLE === 
[   64.470000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.480000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.480000] DNI: Freq:5805  POWERLIMIT DISABLE === 
[   64.490000] freq=58 
[   64.490000] freq=106 
[   64.530000] Resetting spectral chainmask to Rx chainmask
[   64.670000] set TXBF_SND_PERIOD: value 100 wmi_status 0
[   64.730000]  Disconnect_timeout value entered:10 
[   64.750000]  reconfiguration_timeout value entered:60 
[   64.810000] wlan_vap_create : enter. devhandle=0x84f00380, opmode=IEEE80211_M_HOSTAP, flags=0x1
[   64.810000] send_vdev_create_cmd_non_tlv: ID = 0 Type = 1, Subtype = 0 VAP Addr = (removed):
[   64.820000] su bfee 0 mu bfee 0 su bfer 0 mu bfer 0 impl bf 1 sounding dim 0
[   64.830000] ieee80211_mbo_vattach:MBO Initialized 
[   64.840000] ieee80211_oce_vattach: OCE Initialized 
[   64.840000] wlan_vap_create : exit. devhandle=0x84f00380, vap=0x83080000, opmode=IEEE80211_M_HOSTAP, flags=0x1.
[   64.850000] __ieee80211_smart_ant_init: Smart Antenna is not supported 
[   64.860000] Enabling TX checksum bit for the vap ath1 features 4000 
[   64.870000] Enabling SG bit for the vap ath1 features 4000 
[   64.870000] Enabling SG bit for the vap ath1 features 4000 
[   64.880000] Enabling TSO bit for the vap ath1 features 4000 
[   64.880000] Enabling LRO bit for the vap ath1 features 4000 
[   64.890000] VAP device ath1 created osifp: (86605b80) os_if: (83080000)
[   64.920000] siwfreq
[   64.930000] Set freq vap 0 stop send + 83080000
[   64.930000] Set freq vap 0 stop send -83080000
[   64.970000] Set wait done --83080000
[   65.060000] WARNING: Fragmentation with HT mode NOT ALLOWED!!
[   65.130000] [DEBUG] vap-0(ath1):set SIOC80211NWID, 14 characters
[   65.140000]  
[   65.140000]  DES SSID SET=NETGEAR-5G_EXT 
[   65.180000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.190000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.200000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.210000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.220000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.230000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.250000] device ath1 entered promiscuous mode
[   65.390000]  ieee80211_ioctl_siwmode: imr.ifm_active=66176, new mode=3, valid=1 
[   65.400000]  DEVICE IS DOWN ifname=ath1
[   65.410000]  DEVICE IS DOWN ifname=ath1
[   65.440000] OL vap_start +
[   65.440000] VDEV START
[   65.440000] OL vap_start -
[   65.700000] ol_vdev_start_resp_ev for vap 0 (pK-error)
[   65.710000] send_wmm_update_cmd_non_tlv:
[   65.710000] su bfee 1 mu bfee 0 su bfer 1 mu bfer 1 impl bf 1 sounding dim 3
[   65.720000] send_vdev_up_cmd_non_tlv for vap 0
[   65.730000] Beacon mode set to staggered. Cannot enable FD
[   65.730000] __ieee80211_smart_ant_init: Smart Antenna is not supported 
[   65.740000] ol_ath_vap_set_param: Now supported MGMT RATE is 6000(kbps) and rate code: 0x3
[   65.750000] br-lan: port 3(ath1) entered forwarding state
[   65.750000] br-lan: port 3(ath1) entered forwarding state
[   65.760000] 8021q: adding VLAN 0 to HW filter on device ath1
[   65.810000] Switching to Tx Mode-0
[   67.750000] br-lan: port 3(ath1) entered forwarding state
[   75.640000] wmi_dbg_cfg_send: mod[0]00000000 dbgcfg50000000 cfgvalid[0] 00000000 cfgvalid[1] 00000000, cfgvalid[2] 70000000
[   77.140000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f8f004c
[   77.140000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[   77.140000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f8effec
[   77.140000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=2
[   77.210000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fbc953c
[   77.210000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[   77.210000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fbc94dc
[   77.210000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=3
[   77.420000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fa0580c
[   77.420000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[   77.420000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fa057ac
[   77.420000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=2
[   77.620000] Thermal Throttling flag set to : 1. 
[   77.630000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   77.660000] Thermal Throttling flag set to : 1. 
[   77.670000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   77.700000] Thermal Throttling flag set to : 1. 
[   77.710000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   77.730000] Thermal Throttling flag set to : 1. 
[   77.740000] ath_config_thermal_mitigation_param:Active VAP found; starting the Thermal timer.
[   77.800000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fdc52d0
[   77.800000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[   77.800000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fdc52c0
[   77.800000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[   77.800000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  138.030000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fd61d30
[  138.030000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  138.030000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fd61d20
[  138.030000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  138.030000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  198.180000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fab29a0
[  198.180000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  198.180000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fab2990
[  198.180000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  198.180000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  258.360000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f905280
[  258.360000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  258.360000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f905270
[  258.360000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  258.360000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  318.520000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fd92b50
[  318.520000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  318.520000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fd92b40
[  318.520000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  318.520000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  378.670000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f978a50
[  378.670000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  378.670000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f978a40
[  378.670000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  378.670000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  438.820000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f81a3d0
[  438.820000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  438.820000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f81a3c0
[  438.820000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  438.820000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  498.980000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fe23630
[  498.980000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  498.980000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fe23620
[  498.980000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  498.980000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  559.140000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f9c8b60
[  559.140000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  559.140000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f9c8b50
[  559.140000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  559.140000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  619.290000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fc14750
[  619.290000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  619.290000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fc14740
[  619.290000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  619.290000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  679.440000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7faf13a0
[  679.440000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  679.440000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7faf1390
[  679.440000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  679.440000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  739.600000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fdcfcb0
[  739.600000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  739.600000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fdcfca0
[  739.600000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  739.600000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  799.780000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f9ded60
[  799.780000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  799.780000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f9ded50
[  799.780000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  799.780000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  859.990000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f8a8fb0
[  859.990000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  859.990000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f8a8fa0
[  859.990000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  859.990000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  920.140000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fc18f30
[  920.140000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  920.140000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fc18f20
[  920.140000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  920.140000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[  980.300000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fddbef0
[  980.300000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[  980.300000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fddbee0
[  980.300000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[  980.300000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[ 1040.450000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7fa092c0
[ 1040.450000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[ 1040.450000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7fa092b0
[ 1040.450000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[ 1040.450000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[ 1100.600000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7faad5b0
[ 1100.600000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[ 1100.600000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7faad5a0
[ 1100.600000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[ 1100.600000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
[ 1160.760000] i2c i2c-0: ioctl, cmd=0x705, arg=0x7f8ce220
[ 1160.760000] i2c i2c-0: ioctl, cmd=0x706, arg=0x4a
[ 1160.760000] i2c i2c-0: ioctl, cmd=0x720, arg=0x7f8ce210
[ 1160.760000] i2c i2c-0: master_xfer[0] W, addr=0x4a, len=1
[ 1160.760000] i2c i2c-0: master_xfer[1] R, addr=0x4a, len=2
```
</details>

<details><summary>OpenWrt boot log</summary>

```
[    0.000000] Linux version 5.4.124 (looi@looi) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16925-b721579842)) #0 Thu Jun 10 08:34:44 2021
[    0.000000] printk: bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019750 (MIPS 74Kc)
[    0.000000] MIPS: machine is Netgear EX7300v2
[    0.000000] SoC: Qualcomm Atheros QCA550X ver 1 rev 0
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 32480
[    0.000000] Kernel command line: console=ttyS0,115200n8 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 122124K/131072K available (4921K kernel code, 189K rwdata, 1128K rodata, 1176K init, 196K bss, 8948K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 51
[    0.000000] random: get_random_bytes called from start_kernel+0x358/0x54c with crng_init=0
[    0.000000] CPU clock: 800.000 MHz
[    0.000000] clocksource: MIPS: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 4778151116 ns
[    0.000006] sched_clock: 32 bits at 400MHz, resolution 2ns, wraps every 5368709118ns
[    0.008215] Calibrating delay loop... 398.13 BogoMIPS (lpj=1990656)
[    0.074807] pid_max: default: 32768 minimum: 301
[    0.079795] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.087492] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.099492] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.109891] futex hash table entries: 256 (order: -1, 3072 bytes, linear)
[    0.117149] pinctrl core: initialized pinctrl subsystem
[    0.123539] NET: Registered protocol family 16
[    0.153120] workqueue: max_active 576 requested for napi_workq is out of range, clamping between 1 and 512
[    0.166362] clocksource: Switched to clocksource MIPS
[    0.172675] NET: Registered protocol family 2
[    0.177472] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.185565] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.194444] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.202538] TCP bind hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.209982] TCP: Hash tables configured (established 1024 bind 1024)
[    0.216794] UDP hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.223692] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.231329] NET: Registered protocol family 1
[    0.235947] PCI: CLS 0 bytes, default 32
[    0.243342] workingset: timestamp_bits=14 max_order=15 bucket_order=1
[    0.256005] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.262205] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.285903] pinctrl-single 1804002c.pinmux: 544 pins, size 68
[    0.292897] Serial: 8250/16550 driver, 1 ports, IRQ sharing disabled
[    0.300246] printk: console [ttyS0] disabled
[    0.304781] 18020000.uart: ttyS0 at MMIO 0x18020000 (irq = 9, base_baud = 1562500) is a 16550A
[    0.313919] printk: console [ttyS0] enabled
[    0.313919] printk: console [ttyS0] enabled
[    0.322980] printk: bootconsole [early0] disabled
[    0.322980] printk: bootconsole [early0] disabled
[    0.349821] spi-nor spi0.0: w25q128 (16384 Kbytes)
[    0.354830] 9 fixed-partitions partitions found on MTD device spi0.0
[    0.361410] Creating 9 MTD partitions on "spi0.0":
[    0.366380] 0x000000000000-0x000000040000 : "u-boot"
[    0.372325] 0x000000040000-0x000000050000 : "u-boot-env"
[    0.378618] 0x000000050000-0x000000060000 : "config"
[    0.384501] 0x000000060000-0x000000070000 : "pot"
[    0.390168] 0x000000070000-0x000000ea0000 : "firmware"
[    0.399865] 2 uimage-fw partitions found on MTD device firmware
[    0.405982] Creating 2 MTD partitions on "firmware":
[    0.411157] 0x000000000000-0x000000200000 : "kernel"
[    0.417070] 0x000000200000-0x000000e30000 : "rootfs"
[    0.422906] mtd: device 6 (rootfs) set to be root filesystem
[    0.430345] 1 squashfs-split partitions found on MTD device rootfs
[    0.436789] 0x000000540000-0x000000e30000 : "rootfs_data"
[    0.443163] 0x000000ea0000-0x000000fa0000 : "rae"
[    0.448878] 0x000000fa0000-0x000000fe0000 : "oopsdump"
[    0.454941] 0x000000fe0000-0x000000ff0000 : "artmtd"
[    0.460900] 0x000000ff0000-0x000001000000 : "art"
[    0.468302] libphy: Fixed MDIO Bus: probed
[    1.166718] libphy: ag71xx_mdio: probed
[    1.172021] ag71xx 19000000.eth: connected to PHY at mdio.0:05 [uid=004dd074, driver=Atheros 8031 ethernet]
[    1.182652] eth0: Atheros AG71xx at 0xb9000000, irq 4, mode: sgmii
[    1.189249] i2c /dev entries driver
[    1.198333] NET: Registered protocol family 10
[    1.205921] Segment Routing with IPv6
[    1.209855] NET: Registered protocol family 17
[    1.214513] 8021q: 802.1Q VLAN Support v1.8
[    1.219624] PCI host bridge /ahb/pcie-controller@18250000 ranges:
[    1.225941]  MEM 0x0000000012000000..0x0000000013ffffff
[    1.231383]   IO 0x0000000000000000..0x0000000000000000
[    1.236922] PCI host bridge to bus 0000:00
[    1.241163] pci_bus 0000:00: root bus resource [mem 0x12000000-0x13ffffff]
[    1.248287] pci_bus 0000:00: root bus resource [io  0x0000]
[    1.254039] pci_bus 0000:00: root bus resource [??? 0x00000000 flags 0x0]
[    1.261056] pci_bus 0000:00: No busn resource found for root bus, will use [bus 00-ff]
[    1.269270] pci 0000:00:00.0: [168c:0046] type 00 class 0x028000
[    1.275522] pci 0000:00:00.0: reg 0x10: [mem 0x00000000-0x001fffff 64bit]
[    1.282672] pci 0000:00:00.0: PME# supported from D0 D3hot D3cold
[    1.289006] pci 0000:00:00.0: 2.000 Gb/s available PCIe bandwidth, limited by 2.5 GT/s x1 link at 0000:00:00.0 (capable of 4.000 Gb/s with 5 GT/s x1 link)
[    1.304237] pci_bus 0000:00: busn_res: [bus 00-ff] end is updated to 00
[    1.311115] pci 0000:00:00.0: BAR 0: assigned [mem 0x12000000-0x121fffff 64bit]
[    1.324059] VFS: Mounted root (squashfs filesystem) readonly on device 31:6.
[    1.337324] Freeing unused kernel memory: 1176K
[    1.342005] This architecture does not have kernel memory protection.
[    1.348672] Run /sbin/init as init process
[    1.951662] init: Console is alive
[    1.955381] init: - watchdog -
[    2.406381] random: fast init done
[    3.063529] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.216234] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.234257] init: - preinit -
[    4.041336] random: jshn: uninitialized urandom read (4 bytes read)
[    4.149208] random: jshn: uninitialized urandom read (4 bytes read)
[    4.180413] random: jshn: uninitialized urandom read (4 bytes read)
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    7.562501] jffs2: notice: (530) jffs2_build_xattr_subsystem: complete building xattr subsystem, 9 of xdatum (0 unchecked, 1 orphan) and 12 of xref (1 dead, 0 orphan) found.
[    7.580307] mount_root: switching to jffs2 overlay
[    7.588316] overlayfs: upper fs does not support tmpfile.
[    7.598947] urandom-seed: Seeding with /etc/urandom.seed
[    7.690540] procd: - early -
[    7.693612] procd: - watchdog -
[    8.303970] procd: - watchdog -
[    8.387927] procd: - ubus -
[    8.414473] urandom_read: 5 callbacks suppressed
[    8.414479] random: ubusd: uninitialized urandom read (4 bytes read)
[    8.441483] random: ubusd: uninitialized urandom read (4 bytes read)
[    8.451682] procd: - init -
Please press Enter to activate this console.
[    9.204870] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.257128] Loading modules backported from Linux version v5.10.42-0-g65859eca4dff
[    9.264948] Backport generated by backports.git v5.10.42-1-0-gbee5c545
[    9.315573] xt_time: kernel timezone is -0000
[    9.464427] PPP generic driver version 2.4.2
[    9.477398] NET: Registered protocol family 24
[    9.544266] urngd: v1.0.2 started.
[    9.560042] ath10k 5.10 driver, optimized for CT firmware, probing pci device: 0x46.
[    9.587241] ath10k_pci 0000:00:00.0: enabling device (0000 -> 0002)
[    9.593987] ath10k_pci 0000:00:00.0: pci irq legacy oper_irq_mode 1 irq_mode 0 reset_mode 0
[    9.694466] random: crng init done
[   12.155896] ath10k_pci 0000:00:00.0: qca9984/qca9994 hw1.0 target 0x01000000 chip_id 0x00000000 sub 168c:cafe
[   12.166172] ath10k_pci 0000:00:00.0: kconfig debug 1 debugfs 1 tracing 0 dfs 1 testmode 0
[   12.185571] ath10k_pci 0000:00:00.0: firmware ver 10.4b-ct-9984-fW-13-5ae337bb1 api 5 features mfp,peer-flow-ctrl,txstatus-noack,wmi-10.x-CT,ratemask-CT,regdump-CT,txrate-CT,flush-all-CT,pingpong-CT,ch-regs-CT,nop-CT,set-special-CT,tx-rc-CT,cust-stats-CT,txrate2-CT,beacon-cb-CT,wmi-block-ack-CT,wmi-bcn-rc-CT crc32 7ea63dc5
[   14.539901] ath10k_pci 0000:00:00.0: board_file api 2 bmi_id 0:1 crc32 85498734
[   18.081795] ath10k_pci 0000:00:00.0: 10.4 wmi init: vdevs: 16  peers: 48  tid: 96
[   18.089575] ath10k_pci 0000:00:00.0: msdu-desc: 2500  skid: 32
[   18.171265] ath10k_pci 0000:00:00.0: wmi print 'P 48/48 V 16 K 144 PH 176 T 186  msdu-desc: 2500  sw-crypt: 0 ct-sta: 0'
[   18.182569] ath10k_pci 0000:00:00.0: wmi print 'free: 84920 iram: 13156 sram: 11224'
[   18.468808] ath10k_pci 0000:00:00.0: htt-ver 2.2 wmi-op 6 htt-op 4 cal pre-cal-file max-sta 32 raw 0 hwcrypto 1
[   18.638246] kmodloader: done loading kernel modules from /etc/modules.d/*
[   27.659633] br-lan: port 1(eth0) entered blocking state
[   27.665037] br-lan: port 1(eth0) entered disabled state
[   27.670749] device eth0 entered promiscuous mode
[   30.817803] eth0: link up (1000Mbps/Full duplex)
[   30.822606] br-lan: port 1(eth0) entered blocking state
[   30.828038] br-lan: port 1(eth0) entered forwarding state
[   30.835409] IPv6: ADDRCONF(NETDEV_CHANGE): br-lan: link becomes ready
```

</details>