### PR TITLE
[21.02]exfat: update to 5.12.3

### DIFF
--- a/package/kernel/exfat/Makefile
+++ b/package/kernel/exfat/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=exfat
-PKG_VERSION:=5.10.1
-PKG_RELEASE:=1
+PKG_VERSION:=5.12.3
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/namjaejeon/linux-exfat-oot/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=0ff77dd7d39eb231d00c3c4909b9fad31ebeeb618bd6fa18fce142becc9c1f98
+PKG_HASH:=43889c73af76c466bbc904aff80354a62ecaa24c7b20e354ff735f5949907982
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/linux-exfat-oot-$(PKG_VERSION)
 
 PKG_MAINTAINER:=


### PR DESCRIPTION
Major changes are:
    Avoid page allocation failure from upcase table allocation.
    Add support for FITRIM.
    Improve write perofmrance on dirsync mount.
    Improve lookup perofmrance.
    Fix a bug on discard mount.

Switch to AUTORELEASE to avoid having to bump it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>