### PR TITLE
kernel: new package rtl8812au-ac

### DIFF
--- a/package/kernel/rtl8812au-ac/Makefile
+++ b/package/kernel/rtl8812au-ac/Makefile
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rtl8812au-ac
+PKG_RELEASE=1
+
+PKG_LICENSE:=GPLv2
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_SOURCE_URL:=https://github.com/aircrack-ng/rtl8812au
+PKG_MIRROR_HASH:=4538b37eacd2a6f634cfa00dfe6373f2f8f2cb0f570b76e63c8c865a102e9290
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-05-21
+PKG_SOURCE_VERSION:=0b87ed921a8682856aed5a3e68344b0087f3c93c
+
+PKG_MAINTAINER:=Dirk Neukirchen <plntyk.lede@plntyk.name>
+PKG_BUILD_PARALLEL:=1
+
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
+include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/rtl8812au-ac
+  SUBMENU:=Wireless Drivers
+  TITLE:=Realtek 8812AU driver based on 5.6.4.2 mod by aircrack-ng
+  DEPENDS:=+kmod-cfg80211 +kmod-usb-core +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT
+  FILES:=\
+	$(PKG_BUILD_DIR)/rtl8812au.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8812au)
+  PROVIDES:=kmod-rtl8812au
+endef
+
+NOSTDINC_FLAGS := \
+	$(KERNEL_NOSTDINC_FLAGS) \
+	-I$(PKG_BUILD_DIR) \
+	-I$(PKG_BUILD_DIR)/include \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-include backport/backport.h
+
+ifdef CONFIG_PACKAGE_kmod-rtl8812au-ac
+   PKG_MAKE_FLAGS += CONFIG_RTL8812AU=m
+endif
+
+NOSTDINC_FLAGS+=-DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT -DBUILD_OPENWRT
+
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		$(PKG_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,rtl8812au-ac))

--- a/package/kernel/rtl8812au-ac/patches/0000-Makefile_fix_build.patch
+++ b/package/kernel/rtl8812au-ac/patches/0000-Makefile_fix_build.patch
@@ -1,0 +1,1146 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+-EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS) -fno-pie
+-EXTRA_CFLAGS += -O3
++EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS)
++EXTRA_CFLAGS += -O2
+ EXTRA_CFLAGS += -Wno-unused-variable
+ #EXTRA_CFLAGS += -Wno-unused-value
+ EXTRA_CFLAGS += -Wno-unused-label
+@@ -18,7 +18,10 @@ EXTRA_CFLAGS += -Wno-vla -g
+ #endif
+ 
+ EXTRA_CFLAGS += -I$(src)/include
+-EXTRA_LDFLAGS += --strip-all -O3
++
++EXTRA_LDFLAGS += --strip-debug
++
++CONFIG_AUTOCFG_CP = n
+ 
+ ########################## WIFI IC ############################
+ CONFIG_RTL8812A = y
+@@ -93,73 +96,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+ CONFIG_PLATFORM_I386_PC = y
+-CONFIG_PLATFORM_ANDROID_ARM64 = n
+ CONFIG_PLATFORM_ARM_RPI = n
+-CONFIG_PLATFORM_ARM64_RPI = n
+-CONFIG_PLATFORM_ARM_NV_NANO = n
+-CONFIG_PLATFORM_ANDROID_X86 = n
+-CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+-CONFIG_PLATFORM_JB_X86 = n
+-CONFIG_PLATFORM_OPENWRT_NEO2 = n
+-CONFIG_PLATFORM_ARM_S3C2K4 = n
+-CONFIG_PLATFORM_ARM_PXA2XX = n
+-CONFIG_PLATFORM_ARM_S3C6K4 = n
+-CONFIG_PLATFORM_MIPS_RMI = n
+-CONFIG_PLATFORM_RTD2880B = n
+-CONFIG_PLATFORM_MIPS_AR9132 = n
+-CONFIG_PLATFORM_RTK_DMP = n
+-CONFIG_PLATFORM_MIPS_PLM = n
+-CONFIG_PLATFORM_MSTAR389 = n
+-CONFIG_PLATFORM_MT53XX = n
+-CONFIG_PLATFORM_ARM_MX51_241H = n
+-CONFIG_PLATFORM_FS_MX61 = n
+-CONFIG_PLATFORM_ACTIONS_ATJ227X = n
+-CONFIG_PLATFORM_TEGRA3_CARDHU = n
+-CONFIG_PLATFORM_TEGRA4_DALMORE = n
+-CONFIG_PLATFORM_ARM_TCC8900 = n
+-CONFIG_PLATFORM_ARM_TCC8920 = n
+-CONFIG_PLATFORM_ARM_TCC8920_JB42 = n
+-CONFIG_PLATFORM_ARM_TCC8930_JB42 = n
+-CONFIG_PLATFORM_ARM_RK2818 = n
+-CONFIG_PLATFORM_ARM_RK3066 = n
+-CONFIG_PLATFORM_ARM_RK3188 = n
+-CONFIG_PLATFORM_ARM_URBETTER = n
+-CONFIG_PLATFORM_ARM_TI_PANDA = n
+-CONFIG_PLATFORM_MIPS_JZ4760 = n
+-CONFIG_PLATFORM_DMP_PHILIPS = n
+-CONFIG_PLATFORM_MSTAR_TITANIA12 = n
+-CONFIG_PLATFORM_MSTAR = n
+-CONFIG_PLATFORM_SZEBOOK = n
+-CONFIG_PLATFORM_ARM_SUNxI = n
+-CONFIG_PLATFORM_ARM_SUN6I = n
+-CONFIG_PLATFORM_ARM_SUN7I = n
+-CONFIG_PLATFORM_ARM_SUN8I_W3P1 = n
+-CONFIG_PLATFORM_ARM_SUN8I_W5P1 = n
+-CONFIG_PLATFORM_ACTIONS_ATM702X = n
+-CONFIG_PLATFORM_ACTIONS_ATV5201 = n
+-CONFIG_PLATFORM_ACTIONS_ATM705X = n
+-CONFIG_PLATFORM_ARM_SUN50IW1P1 = n
+-CONFIG_PLATFORM_ARM_RTD299X = n
+-CONFIG_PLATFORM_ARM_LGE = n
+-CONFIG_PLATFORM_ARM_SPREADTRUM_6820 = n
+-CONFIG_PLATFORM_ARM_SPREADTRUM_8810 = n
+-CONFIG_PLATFORM_ARM_WMT = n
+-CONFIG_PLATFORM_TI_DM365 = n
+-CONFIG_PLATFORM_MOZART = n
+-CONFIG_PLATFORM_RTK119X = n
+-CONFIG_PLATFORM_RTK119X_AM = n
+-CONFIG_PLATFORM_RTK129X = n
+-CONFIG_PLATFORM_RTK390X = n
+-CONFIG_PLATFORM_NOVATEK_NT72668 = n
+-CONFIG_PLATFORM_HISILICON = n
+-CONFIG_PLATFORM_HISILICON_HI3798 = n
+-CONFIG_PLATFORM_NV_TK1 = n
+-CONFIG_PLATFORM_NV_TK1_UBUNTU = n
+-CONFIG_PLATFORM_RTL8197D = n
+-CONFIG_PLATFORM_AML_S905 = n
+-CONFIG_PLATFORM_ZTE_ZX296716 = n
+-CONFIG_PLATFORM_ARM_ODROIDC2 = n
+-CONFIG_PLATFORM_PPC = n
++
+ ########### CUSTOMER ################################
+ CONFIG_CUSTOMER_HUAWEI_GENERAL = n
+ 
+@@ -180,13 +118,11 @@ endif
+ 
+ ifeq ($(CONFIG_RTL8812A)_$(CONFIG_RTL8821A)_$(CONFIG_RTL8814A), y_y_n)
+ 
+-EXTRA_CFLAGS += -DDRV_NAME=\"rtl88XXau\"
+ ifeq ($(CONFIG_USB_HCI), y)
+-USER_MODULE_NAME = 88XXau
+-endif
+-else
++USER_MODULE_NAME = rtl8812au
+ EXTRA_CFLAGS += -DDRV_NAME=\"rtl8812au\"
+ endif
++endif
+ 
+ _OS_INTFS_FILES :=	os_dep/osdep_service.o \
+ 			os_dep/linux/os_intfs.o \
+@@ -1134,7 +1070,7 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x
+ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
++SUBARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/ppc/powerpc/ -e s/armv.l/arm/ -e s/aarch64/arm64/)
+ ARCH ?= $(SUBARCH)
+ CROSS_COMPILE ?=
+ KVER  := $(shell uname -r)
+@@ -1155,983 +1091,6 @@ MODDESTDIR := /lib/modules/$(KVER)/kerne
+ INSTALL_PREFIX :=
+ endif
+ 
+-ifeq ($(CONFIG_PLATFORM_ARM64_RPI), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH ?= arm64
+-CROSS_COMPILE ?=
+-KVER ?= $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_NV_NANO), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm64
+-KVER := $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_ODROIDC2), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH ?= arm64
+-CROSS_COMPILE ?=
+-KVER ?= $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_PPC), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
+-SUBARCH := $(shell uname -m | sed -e s/ppc/powerpc/)
+-ARCH ?= $(SUBARCH)
+-CROSS_COMPILE ?=
+-KVER ?= $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_NV_TK1), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_NV_TK1
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_P2P_IPS -DCONFIG_PLATFORM_ANDROID
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-EXTRA_CFLAGS += -DRTW_VENDOR_EXT_SUPPORT
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-ARCH ?= arm
+-
+-CROSS_COMPILE := /mnt/newdisk/android_sdk/nvidia_tk1/android_L/prebuilts/gcc/linux-x86/arm/arm-eabi-4.8/bin/arm-eabi-
+-KSRC :=/mnt/newdisk/android_sdk/nvidia_tk1/android_L/out/target/product/shieldtablet/obj/KERNEL/
+-MODULE_NAME = wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_NV_TK1_UBUNTU), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_NV_TK1
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-ARCH ?= arm
+-
+-CROSS_COMPILE ?=
+-KVER := $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ACTIONS_ATM702X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFORM_ACTIONS_ATM702X
+-#ARCH := arm
+-ARCH := $(R_ARCH)
+-#CROSS_COMPILE := arm-none-linux-gnueabi-
+-CROSS_COMPILE := $(R_CROSS_COMPILE)
+-KVER:= 3.4.0
+-#KSRC := ../../../../build/out/kernel
+-KSRC := $(KERNEL_BUILD_PATH)
+-MODULE_NAME :=wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ACTIONS_ATM705X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-#EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-# default setting for Android 4.1, 4.2, 4.3, 4.4
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ACTIONS_ATM705X
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-_PLATFORM_FILES += platform/platform_arm_act_sdio.o
+-endif
+-
+-ARCH := arm
+-CROSS_COMPILE := /opt/arm-2011.09/bin/arm-none-linux-gnueabi-
+-KSRC := /home/android_sdk/Action-semi/705a_android_L/android/kernel
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUN50IW1P1), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN50IW1P1
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_RESUME_IN_WORKQUEUE
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_SUN50IW1P1_sdio.o
+-endif
+-
+-ARCH := arm64
+-# ===Cross compile setting for Android 5.1(64) SDK ===
+-CROSS_COMPILE := /home/android_sdk/Allwinner/a64/android-51/lichee/out/sun50iw1p1/android/common/buildroot/external-toolchain/bin/aarch64-linux-gnu-
+-KSRC :=/home/android_sdk/Allwinner/a64/android-51/lichee/linux-3.10/
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_TI_AM3517), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFORM_SHUTTLE
+-CROSS_COMPILE := arm-eabi-
+-KSRC := $(shell pwd)/../../../Android/kernel
+-ARCH := arm
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MSTAR_TITANIA12), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR -DCONFIG_PLATFORM_MSTAR_TITANIA12
+-ARCH:=mips
+-CROSS_COMPILE:= /usr/src/Mstar_kernel/mips-4.3/bin/mips-linux-gnu-
+-KVER:= 2.6.28.9
+-KSRC:= /usr/src/Mstar_kernel/2.6.28.9/
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MSTAR), y)
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_MSTAR
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_MSTAR_HIGH
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX -DCONFIG_FIX_NR_BULKIN_BUFFER
+-endif
+-ARCH:=arm
+-CROSS_COMPILE:= /usr/src/bin/arm-none-linux-gnueabi-
+-KVER:= 3.1.10
+-KSRC:= /usr/src/Mstar_kernel/3.1.10/
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ANDROID_ARM64), y)
+-# For this to work, change the "modules:" section is also needed, in order to build with CLANG.
+-# "$(MAKE) ARCH=$(ARCH) SUBARCH=$(ARCH) REAL_CC=${CC_DIR}/clang CLANG_TRIPLE=aarch64-linux-gnu- CROSS_COMPILE=$(CROSS_COMPILE) -C $(KSRC) M=$(shell pwd) O="$(KBUILD_OUTPUT)" modules"
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -fno-pic
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC -DCONFIG_RADIO_WORK
+-#Enable this to have two interfaces:
+-#EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_P2P_IPS
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ANDROID_X86), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+-ARCH := $(SUBARCH)
+-CROSS_COMPILE := /media/DATA-2/android-x86/ics-x86_20120130/prebuilt/linux-x86/toolchain/i686-unknown-linux-gnu-4.2.1/bin/i686-unknown-linux-gnu-
+-KSRC := /media/DATA-2/android-x86/ics-x86_20120130/out/target/product/generic_x86/obj/kernel
+-MODULE_NAME :=wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ANDROID_INTEL_X86), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ANDROID_INTEL_X86
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_INTEL_BYT
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_SKIP_SIGNAL_SCALE_MAPPING
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_RESUME_IN_WORKQUEUE
+-endif
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_JB_X86), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+-ARCH := $(SUBARCH)
+-CROSS_COMPILE := /home/android_sdk/android-x86_JB/prebuilts/gcc/linux-x86/x86/i686-linux-android-4.7/bin/i686-linux-android-
+-KSRC := /home/android_sdk/android-x86_JB/out/target/product/x86/obj/kernel/
+-MODULE_NAME :=wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_PXA2XX), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm
+-CROSS_COMPILE := arm-none-linux-gnueabi-
+-KVER  := 2.6.34.1
+-KSRC ?= /usr/src/linux-2.6.34.1
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_S3C2K4), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm
+-CROSS_COMPILE := arm-linux-
+-KVER  := 2.6.24.7_$(ARCH)
+-KSRC := /usr/src/kernels/linux-$(KVER)
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_S3C6K4), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm
+-CROSS_COMPILE := arm-none-linux-gnueabi-
+-KVER  := 2.6.34.1
+-KSRC ?= /usr/src/linux-2.6.34.1
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTD2880B), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN -DCONFIG_PLATFORM_RTD2880B
+-ARCH:=
+-CROSS_COMPILE:=
+-KVER:=
+-KSRC:=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MIPS_RMI), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH:=mips
+-CROSS_COMPILE:=mipsisa32r2-uclibc-
+-KVER:=
+-KSRC:= /root/work/kernel_realtek
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MIPS_PLM), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
+-ARCH:=mips
+-CROSS_COMPILE:=mipsisa32r2-uclibc-
+-KVER:=
+-KSRC:= /root/work/kernel_realtek
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MSTAR389), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MSTAR389
+-ARCH:=mips
+-CROSS_COMPILE:= mips-linux-gnu-
+-KVER:= 2.6.28.10
+-KSRC:= /home/mstar/mstar_linux/2.6.28.9/
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MIPS_AR9132), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
+-ARCH := mips
+-CROSS_COMPILE := mips-openwrt-linux-
+-KSRC := /home/alex/test_openwrt/tmp/linux-2.6.30.9
+-endif
+-
+-# This is how I built for openwrt Neo2 platform. --Ben
+-ifeq ($(CONFIG_PLATFORM_OPENWRT_NEO2), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm64
+-CROSS_COMPILE := aarch64-openwrt-linux-
+-#export PATH=$PATH:/home/greearb/git/openwrt-neo2-dev/staging_dir/toolchain-aarch64_cortex-a53_gcc-7.3.0_musl/bin/
+-#export STAGING_DIR=/home/greearb/git/openwrt-neo2-dev/staging_dir
+-KSRC := /home/greearb/git/openwrt-neo2-dev/build_dir/target-aarch64_cortex-a53_musl/linux-sunxi_cortexa53/linux-4.14.78
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_DMP_PHILIPS), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DRTK_DMP_PLATFORM
+-ARCH := mips
+-#CROSS_COMPILE:=/usr/local/msdk-4.3.6-mips-EL-2.6.12.6-0.9.30.3/bin/mipsel-linux-
+-CROSS_COMPILE:=/usr/local/toolchain_mipsel/bin/mipsel-linux-
+-KSRC ?=/usr/local/Jupiter/linux-2.6.12
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTK_DMP), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DRTK_DMP_PLATFORM  -DCONFIG_WIRELESS_EXT
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-_PLATFORM_FILES += platform/platform_RTK_DMP_usb.o
+-endif
+-ARCH:=mips
+-CROSS_COMPILE:=mipsel-linux-
+-KVER:=
+-KSRC ?= /usr/src/DMP_Kernel/jupiter/linux-2.6.12
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MT53XX), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MT53XX
+-ARCH:= arm
+-CROSS_COMPILE:= arm11_mtk_le-
+-KVER:= 2.6.27
+-KSRC?= /proj/mtk00802/BD_Compare/BDP/Dev/BDP_V301/BDP_Linux/linux-2.6.27
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_MX51_241H), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_WISTRON_PLATFORM
+-ARCH := arm
+-CROSS_COMPILE := /opt/freescale/usr/local/gcc-4.1.2-glibc-2.5-nptl-3/arm-none-linux-gnueabi/bin/arm-none-linux-gnueabi-
+-KVER  := 2.6.31
+-KSRC ?= /lib/modules/2.6.31-770-g0e46b52/source
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_FS_MX61), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-CROSS_COMPILE ?=
+-KVER ?= $(shell uname -r)
+-KSRC := /lib/modules/$(KVER)/build
+-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ACTIONS_ATJ227X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATJ227X
+-ARCH := mips
+-CROSS_COMPILE := /home/cnsd4/project/actions/tools-2.6.27/bin/mipsel-linux-gnu-
+-KVER  := 2.6.27
+-KSRC := /home/cnsd4/project/actions/linux-2.6.27.28
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_TI_DM365), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_TI_DM365
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_RX
+-EXTRA_CFLAGS += -DCONFIG_SINGLE_XMIT_BUF -DCONFIG_SINGLE_RECV_BUF
+-ARCH := arm
+-#CROSS_COMPILE := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/arm/v5t_le/bin/arm_v5t_le-
+-#KSRC := /home/cnsd4/Appro/mv_pro_5.0/montavista/pro/devkit/lsp/ti-davinci/linux-dm365
+-CROSS_COMPILE := /opt/montavista/pro5.0/devkit/arm/v5t_le/bin/arm-linux-
+-KSRC:= /home/vivotek/lsp/DM365/kernel_platform/kernel/linux-2.6.18
+-KERNELOUTPUT := ${PRODUCTDIR}/tmp
+-KVER  := 2.6.18
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MOZART), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_MOZART
+-ARCH := arm
+-CROSS_COMPILE := /home/vivotek/lsp/mozart3v2/Mozart3e_Toolchain/build_arm_nofpu/usr/bin/arm-linux-
+-KVER  := $(shell uname -r)
+-KSRC:= /opt/Vivotek/lsp/mozart3v2/kernel_platform/kernel/mozart_kernel-1.17
+-KERNELOUTPUT := /home/pink/sample/ODM/IP8136W-VINT/tmp/kernel
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_TEGRA3_CARDHU), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/nvidia/tegra-16r3-partner-android-4.1_20120723/prebuilt/linux-x86/toolchain/arm-eabi-4.4.3/bin/arm-eabi-
+-KSRC := /home/android_sdk/nvidia/tegra-16r3-partner-android-4.1_20120723/out/target/product/cardhu/obj/KERNEL
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_TEGRA4_DALMORE), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/nvidia/tegra-17r9-partner-android-4.2-dalmore_20130131/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6/bin/arm-eabi-
+-KSRC := /home/android_sdk/nvidia/tegra-17r9-partner-android-4.2-dalmore_20130131/out/target/product/dalmore/obj/KERNEL
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_TCC8900), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Telechips/SDK_2304_20110613/prebuilt/linux-x86/toolchain/arm-eabi-4.4.3/bin/arm-eabi-
+-KSRC := /home/android_sdk/Telechips/SDK_2304_20110613/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_TCC8920), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Telechips/v12.06_r1-tcc-android-4.0.4/prebuilt/linux-x86/toolchain/arm-eabi-4.4.3/bin/arm-eabi-
+-KSRC := /home/android_sdk/Telechips/v12.06_r1-tcc-android-4.0.4/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_TCC8920_JB42), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Telechips/v13.03_r1-tcc-android-4.2.2_ds_patched/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6/bin/arm-eabi-
+-KSRC := /home/android_sdk/Telechips/v13.03_r1-tcc-android-4.2.2_ds_patched/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_RK2818), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFORM_ROCKCHIPS
+-ARCH := arm
+-CROSS_COMPILE := /usr/src/release_fae_version/toolchain/arm-eabi-4.4.0/bin/arm-eabi-
+-KSRC := /usr/src/release_fae_version/kernel25_A7_281x
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_RK3188), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ANDROID -DCONFIG_PLATFORM_ROCKCHIPS
+-# default setting for Android 4.1, 4.2, 4.3, 4.4
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-# default setting for Power control
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-EXTRA_CFLAGS += -DRTW_SUPPORT_PLATFORM_SHUTDOWN
+-# default setting for Special function
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Rockchip/Rk3188/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6/bin/arm-eabi-
+-KSRC := /home/android_sdk/Rockchip/Rk3188/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_RK3066), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_RK3066
+-EXTRA_CFLAGS += -DRTW_ENABLE_WIFI_CONTROL_FUNC
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DRTW_SUPPORT_PLATFORM_SHUTDOWN
+-endif
+-EXTRA_CFLAGS += -fno-pic
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Rockchip/rk3066_20130607/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.6/bin/arm-linux-androideabi-
+-#CROSS_COMPILE := /home/android_sdk/Rockchip/Rk3066sdk/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.6/bin/arm-linux-androideabi-
+-KSRC := /home/android_sdk/Rockchip/Rk3066sdk/kernel
+-MODULE_NAME :=wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_URBETTER), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN #-DCONFIG_MINIMAL_MEMORY_USAGE
+-ARCH := arm
+-CROSS_COMPILE := /media/DATA-1/urbetter/arm-2009q3/bin/arm-none-linux-gnueabi-
+-KSRC := /media/DATA-1/urbetter/ics-urbetter/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_TI_PANDA), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN #-DCONFIG_MINIMAL_MEMORY_USAGE
+-ARCH := arm
+-#CROSS_COMPILE := /media/DATA-1/aosp/ics-aosp_20111227/prebuilt/linux-x86/toolchain/arm-eabi-4.4.3/bin/arm-eabi-
+-#KSRC := /media/DATA-1/aosp/android-omap-panda-3.0_20120104
+-CROSS_COMPILE := /media/DATA-1/android-4.0/prebuilt/linux-x86/toolchain/arm-eabi-4.4.3/bin/arm-eabi-
+-KSRC := /media/DATA-1/android-4.0/panda_kernel/omap
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_MIPS_JZ4760), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_MINIMAL_MEMORY_USAGE
+-ARCH ?= mips
+-CROSS_COMPILE ?= /mnt/sdb5/Ingenic/Umido/mips-4.3/bin/mips-linux-gnu-
+-KSRC ?= /mnt/sdb5/Ingenic/Umido/kernel
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_SZEBOOK), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
+-ARCH:=arm
+-CROSS_COMPILE:=/opt/crosstool2/bin/armeb-unknown-linux-gnueabi-
+-KVER:= 2.6.31.6
+-KSRC:= ../code/linux-2.6.31.6-2020/
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUNxI), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUNxI
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-# default setting for A10-EVB mmc0
+-#EXTRA_CFLAGS += -DCONFIG_WITS_EVB_V13
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_sdio.o
+-endif
+-
+-ARCH := arm
+-#CROSS_COMPILE := arm-none-linux-gnueabi-
+-CROSS_COMPILE=/home/android_sdk/Allwinner/a10/android-jb42/lichee-jb42/buildroot/output/external-toolchain/bin/arm-none-linux-gnueabi-
+-KVER  := 3.0.8
+-#KSRC:= ../lichee/linux-3.0/
+-KSRC=/home/android_sdk/Allwinner/a10/android-jb42/lichee-jb42/linux-3.0
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUN6I), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN6I
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2, 4.3, 4.4
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS +=  -DCONFIG_QOS_OPTIMIZATION
+-
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-# default setting for A31-EVB mmc0
+-EXTRA_CFLAGS += -DCONFIG_A31_EVB
+-_PLATFORM_FILES += platform/platform_ARM_SUNnI_sdio.o
+-endif
+-
+-ARCH := arm
+-#Android-JB42
+-#CROSS_COMPILE := /home/android_sdk/Allwinner/a31/android-jb42/lichee/buildroot/output/external-toolchain/bin/arm-linux-gnueabi-
+-#KSRC :=/home/android_sdk/Allwinner/a31/android-jb42/lichee/linux-3.3
+-#ifeq ($(CONFIG_USB_HCI), y)
+-#MODULE_NAME := 8188eu_sw
+-#endif
+-# ==== Cross compile setting for kitkat-a3x_v4.5 =====
+-CROSS_COMPILE := /home/android_sdk/Allwinner/a31/kitkat-a3x_v4.5/lichee/buildroot/output/external-toolchain/bin/arm-linux-gnueabi-
+-KSRC :=/home/android_sdk/Allwinner/a31/kitkat-a3x_v4.5/lichee/linux-3.3
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUN7I), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN7I
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2, 4.3, 4.4
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS +=  -DCONFIG_QOS_OPTIMIZATION
+-
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_SUNnI_sdio.o
+-endif
+-
+-ARCH := arm
+-# ===Cross compile setting for Android 4.2 SDK ===
+-#CROSS_COMPILE := /home/android_sdk/Allwinner/a20_evb/lichee/out/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-#KSRC := /home/android_sdk/Allwinner/a20_evb/lichee/linux-3.3
+-# ==== Cross compile setting for Android 4.3 SDK =====
+-#CROSS_COMPILE := /home/android_sdk/Allwinner/a20/android-jb43/lichee/out/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-#KSRC := /home/android_sdk/Allwinner/a20/android-jb43/lichee/linux-3.4
+-# ==== Cross compile setting for kitkat-a20_v4.4 =====
+-CROSS_COMPILE := /home/android_sdk/Allwinner/a20/kitkat-a20_v4.4/lichee/out/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-KSRC := /home/android_sdk/Allwinner/a20/kitkat-a20_v4.4/lichee/linux-3.4
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUN8I_W3P1), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN8I
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN8I_W3P1
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_SUNnI_sdio.o
+-endif
+-
+-ARCH := arm
+-# ===Cross compile setting for Android 4.2 SDK ===
+-#CROSS_COMPILE := /home/android_sdk/Allwinner/a23/android-jb42/lichee/out/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-#KSRC :=/home/android_sdk/Allwinner/a23/android-jb42/lichee/linux-3.4
+-# ===Cross compile setting for Android 4.4 SDK ===
+-CROSS_COMPILE := /home/android_sdk/Allwinner/a23/android-kk44/lichee/out/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-KSRC :=/home/android_sdk/Allwinner/a23/android-kk44/lichee/linux-3.4
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SUN8I_W5P1), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN8I
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN8I_W5P1
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_SUNnI_sdio.o
+-endif
+-
+-ARCH := arm
+-# ===Cross compile setting for Android L SDK ===
+-CROSS_COMPILE := /home/android_sdk/Allwinner/a33/android-L/lichee/out/sun8iw5p1/android/common/buildroot/external-toolchain/bin/arm-linux-gnueabi-
+-KSRC :=/home/android_sdk/Allwinner/a33/android-L/lichee/linux-3.4
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ACTIONS_ATV5201), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATV5201
+-EXTRA_CFLAGS += -DCONFIG_SDIO_DISABLE_RXFIFO_POLLING_LOOP
+-ARCH := mips
+-CROSS_COMPILE := mipsel-linux-gnu-
+-KVER  := $(KERNEL_VER)
+-KSRC:= $(CFGDIR)/../../kernel/linux-$(KERNEL_VER)
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_RTD299X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ifeq ($(CONFIG_ANDROID), y)
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-endif
+-#ARCH, CROSS_COMPILE, KSRC,and  MODDESTDIR are provided by external makefile
+-INSTALL_PREFIX :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_RTD299X_LG), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DRTW_P2P_GROUP_INTERFACE=1
+-EXTRA_CFLAGS += -DCONFIG_IFACE_NUMBER=3
+-#EXTRA_CFLAGS += -DCONFIG_FIX_HWPORT
+-EXTRA_CFLAGS += -DLGE_PRIVATE
+-EXTRA_CFLAGS += -DPURE_SUPPLICANT
+-EXTRA_CFLAGS += -DCONFIG_CUSTOMIZED_COUNTRY_CHPLAN_MAP -DCONFIG_RTW_IOCTL_SET_COUNTRY
+-EXTRA_CFLAGS += -DDBG_RX_DFRAME_RAW_DATA
+-EXTRA_CFLAGS += -DRTW_REDUCE_SCAN_SWITCH_CH_TIME
+-ARCH ?= arm
+-KVER ?=
+-
+-ifneq ($(PLATFORM), WEBOS)
+-$(info PLATFORM is empty)
+-CROSS_COMPILE ?= /mnt/newdisk/LGE/arm-lg115x-linux-gnueabi-4.8-2016.03-x86_64/bin/arm-lg115x-linux-gnueabi-
+-KSRC ?= /mnt/newdisk/LGE/linux-rockhopper_k3lp_drd4tv_423
+-endif
+-
+-CROSS_COMPILE ?=
+-KSRC ?= $(LINUX_SRC)
+-INSTALL_PREFIX ?=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_HISILICON), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_HISILICON
+-ifeq ($(SUPPORT_CONCURRENT),y)
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-endif
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-ifeq ($(CROSS_COMPILE),)
+-       CROSS_COMPILE = arm-hisiv200-linux-
+-endif
+-MODULE_NAME := rtl8192eu
+-ifeq ($(KSRC),)
+-       KSRC := ../../../../../../kernel/linux-3.4.y
+-endif
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_HISILICON_HI3798), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_HISILICON
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_HISILICON_HI3798
+-#EXTRA_CFLAGS += -DCONFIG_PLATFORM_HISILICON_HI3798_MV200_HDMI_DONGLE
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+-EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT
+-# default setting for Android 5.x and later
+-#EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-# If system could power on and recognize Wi-Fi SDIO automatically,
+-# platfrom operations are not necessary.
+-#ifeq ($(CONFIG_SDIO_HCI), y)
+-#EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-#_PLATFORM_FILES += platform/platform_hisilicon_hi3798_sdio.o
+-#EXTRA_CFLAGS += -DCONFIG_HISI_SDIO_ID=1
+-#endif
+-
+-ARCH ?= arm
+-CROSS_COMPILE ?= /HiSTBAndroidV600R003C00SPC021_git_0512/device/hisilicon/bigfish/sdk/tools/linux/toolchains/arm-histbv310-linux/bin/arm-histbv310-linux-
+-ifndef KSRC
+-KSRC := /HiSTBAndroidV600R003C00SPC021_git_0512/device/hisilicon/bigfish/sdk/source/kernel/linux-3.18.y
+-KSRC += O=/HiSTBAndroidV600R003C00SPC021_git_0512/out/target/product/Hi3798MV200/obj/KERNEL_OBJ
+-endif
+-
+-ifeq ($(CONFIG_RTL8822B), y)
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-CONFIG_RTL8822BS ?= m
+-USER_MODULE_NAME := rtl8822bs
+-endif
+-endif
+-
+-endif
+-
+-# Platform setting
+-ifeq ($(CONFIG_PLATFORM_ARM_SPREADTRUM_6820), y)
+-ifeq ($(CONFIG_ANDROID_2X), y)
+-EXTRA_CFLAGS += -DANDROID_2X
+-endif
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_SPRD
+-EXTRA_CFLAGS += -DPLATFORM_SPREADTRUM_6820
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ifeq ($(RTL871X), rtl8188e)
+-EXTRA_CFLAGS += -DSOFTAP_PS_DURATION=50
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-_PLATFORM_FILES += platform/platform_sprd_sdio.o
+-endif
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_SPREADTRUM_8810), y)
+-ifeq ($(CONFIG_ANDROID_2X), y)
+-EXTRA_CFLAGS += -DANDROID_2X
+-endif
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_SPRD
+-EXTRA_CFLAGS += -DPLATFORM_SPREADTRUM_8810
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-ifeq ($(RTL871X), rtl8188e)
+-EXTRA_CFLAGS += -DSOFTAP_PS_DURATION=50
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-_PLATFORM_FILES += platform/platform_sprd_sdio.o
+-endif
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_WMT), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_WMT_sdio.o
+-endif
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/WonderMedia/wm8880-android4.4/toolchain/arm_201103_gcc4.5.2/mybin/arm_1103_le-
+-KSRC := /home/android_sdk/WonderMedia/wm8880-android4.4/kernel4.4/
+-MODULE_NAME :=8189es_kk
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTK119X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-#EXTRA_CFLAGS += -DCONFIG_PLATFORM_ARM_SUN7I
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-#EXTRA_CFLAGS +=  -DCONFIG_QOS_OPTIMIZATION
+-EXTRA_CFLAGS += -DCONFIG_QOS_OPTIMIZATION
+-
+-#EXTRA_CFLAGS += -DCONFIG_#PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-#_PLATFORM_FILES += platform/platform_ARM_SUNxI_usb.o
+-endif
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-_PLATFORM_FILES += platform/platform_ARM_SUNnI_sdio.o
+-endif
+-
+-ARCH := arm
+-
+-# ==== Cross compile setting for Android 4.4 SDK =====
+-#CROSS_COMPILE := arm-linux-gnueabihf-
+-KVER  := 3.10.24
+-#KSRC :=/home/android_sdk/Allwinner/a20/android-kitkat44/lichee/linux-3.4
+-CROSS_COMPILE := /home/realtek/software_phoenix/phoenix/toolchain/usr/local/arm-2013.11/bin/arm-linux-gnueabihf-
+-KSRC := /home/realtek/software_phoenix/linux-kernel
+-MODULE_NAME := 8192eu
+-
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTK119X_AM), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_RTK119X_AM
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE -DCONFIG_FULL_CH_IN_P2P_HANDSHAKE
+-EXTRA_CFLAGS += -DCONFIG_IFACE_NUMBER=3
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-endif
+-
+-ARCH := arm
+-
+-#CROSS_COMPILE := arm-linux-gnueabihf-
+-KVER  := 3.10.24
+-#KSRC :=
+-CROSS_COMPILE :=
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTK129X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DRTK_129X_PLATFORM
+-EXTRA_CFLAGS += -DCONFIG_TRAFFIC_PROTECT
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-#EXTRA_CFLAGS += -DCONFIG_P2P_IPS -DCONFIG_QOS_OPTIMIZATION
+-EXTRA_CFLAGS += -DCONFIG_QOS_OPTIMIZATION
+-# Enable this for Android 5.0
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-ifeq ($(CONFIG_RTL8821C)$(CONFIG_SDIO_HCI),yy)
+-EXTRA_CFLAGS += -DCONFIG_WAKEUP_GPIO_INPUT_MODE
+-EXTRA_CFLAGS += -DCONFIG_BT_WAKE_HST_OPEN_DRAIN
+-endif
+-EXTRA_CFLAGS += -Wno-error=date-time
+-# default setting for Android 7.0
+-ifeq ($(RTK_ANDROID_VERSION), nougat)
+-EXTRA_CFLAGS += -DRTW_P2P_GROUP_INTERFACE=1
+-endif
+-#EXTRA_CFLAGS += -DCONFIG_#PLATFORM_OPS
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-endif
+-
+-ARCH := arm64
+-
+-# ==== Cross compile setting for Android 4.4 SDK =====
+-#CROSS_COMPILE := arm-linux-gnueabihf-
+-#KVER  := 4.1.10
+-#CROSS_COMPILE := $(CROSS)
+-#KSRC := $(LINUX_KERNEL_PATH)
+-CROSS_COMPILE := /home/android_sdk/DHC/trunk-6.0.0_r1-QA160627/phoenix/toolchain/asdk64-4.9.4-a53-EL-3.10-g2.19-a64nt-160307/bin/asdk64-linux-
+-KSRC := /home/android_sdk/DHC/trunk-6.0.0_r1-QA160627/linux-kernel
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTK390X), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_RTK390X
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_RTW_NETIF_SG
+-ifeq ($(CONFIG_USB_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-endif
+-
+-ARCH:=rlx
+-
+-CROSS_COMPILE:=mips-linux-
+-KSRC:= /home/realtek/share/Develop/IPCAM_SDK/RealSil/rts3901_sdk_v1.2_vanilla/linux-3.10
+-
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_NOVATEK_NT72668), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_NOVATEK_NT72668
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_RX
+-EXTRA_CFLAGS += -DCONFIG_USE_USB_BUFFER_ALLOC_TX
+-ARCH ?= arm
+-CROSS_COMPILE := arm-linux-gnueabihf-
+-KVER := 3.8.0
+-KSRC := /Custom/Novatek/TCL/linux-3.8_header
+-#KSRC := $(KERNELDIR)
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ARM_TCC8930_JB42), y)
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android 4.1, 4.2
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-ARCH := arm
+-CROSS_COMPILE := /home/android_sdk/Telechips/v13.05_r1-tcc-android-4.2.2_tcc893x-evm_build/prebuilts/gcc/linux-x86/arm/arm-eabi-4.6/bin/arm-eabi-
+-KSRC := /home/android_sdk/Telechips/v13.05_r1-tcc-android-4.2.2_tcc893x-evm_build/kernel
+-MODULE_NAME := wlan
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_RTL8197D), y)
+-EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN -DCONFIG_PLATFORM_RTL8197D
+-export DIR_LINUX=$(shell pwd)/../SDK/rlxlinux-sdk321-v50/linux-2.6.30
+-ARCH ?= rlx
+-CROSS_COMPILE:= $(DIR_LINUX)/../toolchain/rsdk-1.5.5-5281-EB-2.6.30-0.9.30.3-110714/bin/rsdk-linux-
+-KSRC := $(DIR_LINUX)
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_AML_S905), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_AML_S905
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -fno-pic
+-# default setting for Android
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+-EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT
+-# default setting for Android 5.x and later
+-EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-_PLATFORM_FILES += platform/platform_aml_s905_sdio.o
+-endif
+-
+-ARCH ?= arm64
+-CROSS_COMPILE ?= /4.4_S905L_8822bs_compile/gcc-linaro-aarch64-linux-gnu-4.9-2014.09_linux/bin/aarch64-linux-gnu-
+-ifndef KSRC
+-KSRC := /4.4_S905L_8822bs_compile/common
+-# To locate output files in a separate directory.
+-KSRC += O=/4.4_S905L_8822bs_compile/KERNEL_OBJ
+-endif
+-
+-ifeq ($(CONFIG_RTL8822B), y)
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-CONFIG_RTL8822BS ?= m
+-USER_MODULE_NAME := 8822bs
+-endif
+-endif
+-
+-endif
+-
+-ifeq ($(CONFIG_PLATFORM_ZTE_ZX296716), y)
+-EXTRA_CFLAGS += -Wno-error=date-time
+-EXTRA_CFLAGS += -DCONFIG_PLATFORM_ZTE_ZX296716
+-EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+-# default setting for Android
+-EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+-EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+-EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT
+-# default setting for Android 5.x and later
+-#EXTRA_CFLAGS += -DCONFIG_RADIO_WORK
+-
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-# mark this temporarily
+-#EXTRA_CFLAGS += -DCONFIG_PLATFORM_OPS
+-#_PLATFORM_FILES += platform/platform_zte_zx296716_sdio.o
+-endif
+-
+-ARCH ?= arm64
+-CROSS_COMPILE ?=
+-KSRC ?=
+-
+-ifeq ($(CONFIG_RTL8822B), y)
+-ifeq ($(CONFIG_SDIO_HCI), y)
+-CONFIG_RTL8822BS ?= m
+-USER_MODULE_NAME := 8822bs
+-endif
+-endif
+-
+-endif
+-
+-ifeq ($(ARCH), i386)
+-EXTRA_CFLAGS += -mhard-float
+-EXTRA_CFLAGS += -DMARK_KERNEL_PFU
+-else ifeq ($(ARCH), x86_64)
+-EXTRA_CFLAGS += -mhard-float
+-EXTRA_CFLAGS += -DMARK_KERNEL_PFU
+-endif
+-
+ ########### CUSTOMER ################################
+ ifeq ($(CONFIG_CUSTOMER_HUAWEI_GENERAL), y)
+ CONFIG_CUSTOMER_HUAWEI = y
+@@ -2157,7 +1116,7 @@ endif
+ 
+ endif
+ 
+-USER_MODULE_NAME ?=
++USER_MODULE_NAME ?= rtl$(MODULE_NAME)
+ ifneq ($(USER_MODULE_NAME),)
+ MODULE_NAME := $(USER_MODULE_NAME)
+ endif
+@@ -2167,16 +1126,6 @@ ifneq ($(KERNELRELEASE),)
+ ########### this part for *.mk ############################
+ include $(src)/hal/phydm/phydm.mk
+ 
+-########### HAL_RTL8822B #################################
+-ifeq ($(CONFIG_RTL8822B), y)
+-include $(src)/rtl8822b.mk
+-endif
+-
+-########### HAL_RTL8821C #################################
+-ifeq ($(CONFIG_RTL8821C), y)
+-include $(src)/rtl8821c.mk
+-endif
+-
+ rtk_core :=	core/rtw_cmd.o \
+ 		core/rtw_security.o \
+ 		core/rtw_debug.o \
+@@ -2232,11 +1181,11 @@ $(MODULE_NAME)-y += $(_PLATFORM_FILES)
+ 
+ $(MODULE_NAME)-$(CONFIG_MP_INCLUDED) += core/rtw_mp.o
+ 
+-obj-$(CONFIG_88XXAU) := $(MODULE_NAME).o
++obj-$(CONFIG_RTL8812AU) := $(MODULE_NAME).o
+ 
+ else
+ 
+-export CONFIG_88XXAU = m
++export CONFIG_RTL8812AU = m
+ 
+ all: modules
+ 

--- a/package/kernel/rtl8812au-ac/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
+++ b/package/kernel/rtl8812au-ac/patches/0001-core-rtw_mlme.c-fix-warning-misleading-indentation.patch
@@ -1,0 +1,21 @@
+From b3fa4d9b0b8eae46c7523d03e18fbb12876d7155 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:46:17 +0200
+Subject: [PATCH 1/6] core/rtw_mlme.c: fix warning:  misleading indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/rtw_mlme.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/core/rtw_mlme.c
++++ b/core/rtw_mlme.c
+@@ -3196,7 +3196,7 @@ void rtw_drv_scan_by_self(_adapter *pada
+ 		else
+ 		#endif
+ 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+-			goto exit;
++		goto exit;
+ 	}
+ 	else if (ssc_chk != SS_ALLOW)
+ 		goto exit;

--- a/package/kernel/rtl8812au-ac/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
+++ b/package/kernel/rtl8812au-ac/patches/0002-core-efuse-rtw_efuse.c-fix-warning-misleading-indent.patch
@@ -1,0 +1,28 @@
+From 159b26937a0b61d03fc687a284b13b87a27b6cef Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:58:04 +0200
+Subject: [PATCH 2/6] core/efuse/rtw_efuse.c: fix warning: misleading
+ indentation
+
+Signed-off-by: Dirk Neukirchen <gh2020@plntyk.name>
+---
+ core/efuse/rtw_efuse.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/core/efuse/rtw_efuse.c
++++ b/core/efuse/rtw_efuse.c
+@@ -780,10 +780,10 @@ void rtw_efuse_analyze(PADAPTER	padapter
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++		, pEfuseHal->fakeEfuseInitMap[i]
++		, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
+ 		}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 

--- a/package/kernel/rtl8812au-ac/patches/0006-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
+++ b/package/kernel/rtl8812au-ac/patches/0006-OpenWrt-patch-001-use-kernel-byteorder.patch.patch
@@ -1,0 +1,20 @@
+From 07d685c67cf678435a644c5b26742d68ffd9ec79 Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:34:01 +0200
+Subject: [PATCH 6/6] OpenWrt patch 001-use-kernel-byteorder.patch
+
+---
+ include/drv_types.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/include/drv_types.h
++++ b/include/drv_types.h
+@@ -24,7 +24,7 @@
+ #include <drv_conf.h>
+ #include <basic_types.h>
+ #include <osdep_service.h>
+-#include <rtw_byteorder.h>
++#include <asm/byteorder.h>
+ #include <wlan_bssdef.h>
+ #include <wifi.h>
+ #include <ieee80211.h>

--- a/package/kernel/rtl8812au-ac/patches/0006-OpenWrt-patch-003-wireless-5.8.patch.patch
+++ b/package/kernel/rtl8812au-ac/patches/0006-OpenWrt-patch-003-wireless-5.8.patch.patch
@@ -1,0 +1,39 @@
+From fc0e90868cea94c9334dfb53396f3130380f265d Mon Sep 17 00:00:00 2001
+From: Dirk Neukirchen <gh2020@plntyk.name>
+Date: Tue, 1 Jun 2021 14:37:35 +0200
+Subject: [PATCH 03/12] OpenWrt 003-wireless-5.8.patch
+
+---
+ os_dep/linux/ioctl_cfg80211.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+--- a/os_dep/linux/ioctl_cfg80211.c
++++ b/os_dep/linux/ioctl_cfg80211.c
+@@ -7768,6 +7768,15 @@ exit:
+ 	return;
+ }
+ 
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)) || defined(BUILD_OPENWRT)
++static void cfg80211_rtw_update_mgmt_frame_registrations(struct wiphy *wiphy,
++						   struct wireless_dev *wdev,
++						   struct mgmt_frame_regs *upd)
++{
++
++}
++#endif
++
+ #if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
+ static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
+ 	struct net_device *ndev,
+@@ -10183,7 +10192,10 @@ static struct cfg80211_ops rtw_cfg80211_
+ 	.update_ft_ies = cfg80211_rtw_update_ft_ies,
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)) || defined(BUILD_OPENWRT)
++	.mgmt_tx = cfg80211_rtw_mgmt_tx,
++	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_registrations,
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)
+ 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0))
+ 	.update_mgmt_frame_registrations = cfg80211_rtw_update_mgmt_frame_register,


### PR DESCRIPTION
another Realtek rtl8812au driver modified by aircrack-ng

rtl8812au-ct is based on 4.3.14
- it might support RTL8821A (CONFIG_RTL8821A = y)

this driver is based on 5.6.4.2
- this might support RTL8821A (CONFIG_RTL8821A = y) (untested)

changes:
- unknown

compile tested: x86-64
run tested: x86-64 with issues

issues:
- luci scan does not work compared with other drivers ("regression" to rtl8812au-gb / -mw)
- commandline scan does work
- terminal hangs on "wifi up" / wifi configuring with during:
iw phy dev wlan0 , ip a s, ip l commands
- deletion hangs: iw dev wlan0 del hangs
- cmdline: client mode works
- cmdline: simple ap mode shows in scan (no connect test)
- enabling some debug kernel options like lock checking results
in dumps with all(?) realtek variants in various stages

- 8812au-ct dumps during boot
- 8812au-gb + others dump when doing ip l dev wlan0 up

Signed-off-by: Dirk Neukirchen <plntyk.lede@plntyk.name>

