### PR TITLE
cypress-firmware: update to v5.4.18-2021_0527

### DIFF
--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -10,13 +10,13 @@ include $(TOPDIR)/rules.mk
 UNPACK_CMD=unzip -q -p $(DL_DIR)/$(PKG_SOURCE) $(PKG_SOURCE_UNZIP) | gzip -dc | $(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 PKG_NAME:=cypress-firmware
-PKG_VERSION:=v5.4.18-2020_0402
-PKG_RELEASE:=3
+PKG_VERSION:=v5.4.18-2021_0527
+PKG_RELEASE:=1
 
 PKG_SOURCE_UNZIP:=cypress-firmware-$(PKG_VERSION).tar.gz
 PKG_SOURCE:=cypress-fmac-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://community.cypress.com/gfawx74859/attachments/gfawx74859/resourcelibrary/1016/1/
-PKG_HASH:=b12b0570f462c2f3c26dde98b10235a845a7109037def1e7e51af728bcc1a958
+PKG_SOURCE_URL:=https://community.cypress.com/gfawx74859/attachments/gfawx74859/WiFiBluetoothLinux/1911/2/
+PKG_HASH:=6dd1fe42791cb56fa4162d0a384cdca4052a428a259200afdc1eb2caa53543aa
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
@@ -41,10 +41,10 @@ endef
 define Package/cypress-firmware-43012-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.clm_blob
 endef
 
@@ -59,7 +59,7 @@ endef
 define Package/cypress-firmware-43340-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43340-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43340-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43340-sdio.bin
 endef
 
@@ -76,7 +76,7 @@ endef
 define Package/cypress-firmware-43362-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43362-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43362-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43362-sdio.bin
 endef
 
@@ -91,7 +91,7 @@ endef
 define Package/cypress-firmware-4339-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4339-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4339-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4339-sdio.bin
 endef
 
@@ -108,10 +108,10 @@ endef
 define Package/cypress-firmware-43430-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
 endef
 
@@ -128,10 +128,10 @@ endef
 define Package/cypress-firmware-43455-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
 endef
 
@@ -146,10 +146,10 @@ endef
 define Package/cypress-firmware-4354-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.clm_blob
 endef
 
@@ -164,10 +164,10 @@ endef
 define Package/cypress-firmware-4356-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.clm_blob
 endef
 
@@ -182,10 +182,10 @@ endef
 define Package/cypress-firmware-4356-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.clm_blob
 endef
 
@@ -200,50 +200,14 @@ endef
 define Package/cypress-firmware-43570-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.clm_blob
 endef
 
 $(eval $(call BuildPackage,cypress-firmware-43570-pcie))
-
-# Cypress 4359 PCIe Firmware
-define Package/cypress-firmware-4359-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-4359-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-pcie))
-
-# Cypress 4359 SDIO Firmware
-define Package/cypress-firmware-4359-sdio
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW4359 FullMac SDIO firmware
-endef
-
-define Package/cypress-firmware-4359-sdio/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.bin \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-4359-sdio))
 
 # Cypress 4373 SDIO Firmware
 define Package/cypress-firmware-4373-sdio
@@ -254,10 +218,10 @@ endef
 define Package/cypress-firmware-4373-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.clm_blob
 endef
 
@@ -272,10 +236,10 @@ endef
 define Package/cypress-firmware-4373-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-usb.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-usb.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-usb.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373.clm_blob
 endef
 
@@ -290,29 +254,11 @@ endef
 define Package/cypress-firmware-54591-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.clm_blob
 endef
 
 $(eval $(call BuildPackage,cypress-firmware-54591-pcie))
-
-# Cypress 89459 PCIe Firmware
-define Package/cypress-firmware-89459-pcie
-  $(Package/cypress-firmware-default)
-  TITLE:=CYW89459 FullMac PCIe firmware
-endef
-
-define Package/cypress-firmware-89459-pcie/install
-	$(INSTALL_DIR) $(1)/lib/firmware/brcm
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.bin \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.bin
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.clm_blob \
-		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.clm_blob
-endef
-
-$(eval $(call BuildPackage,cypress-firmware-89459-pcie))


### PR DESCRIPTION
- This firmware update include fixes for WFA Fragment and Forge 
  Vulnerability Detection test suite for chips:
   43012
   File: firmware/cyfmac43012-sdio.bin
   Version: 13.10.271.266
   43340
   File: firmware/cyfmac43340-sdio.bin
   Version: 6.10.190.91
   43430
   File: firmware/cyfmac43430-sdio.bin
   Version: 7.45.98.118
   43455
   File: firmware/cyfmac43455-sdio.bin
   Version: 7.45.234
   4354
   File: firmware/cyfmac4354-sdio.bin
   Version: 7.35.349.104
   4356
   File: firmware/cyfmac4356-sdio.bin
   Version: 7.35.349.104
   43570
   File: firmware/cyfmac43570-pcie.bin
   Version: 7.124.22
   4373
   File: firmware/cyfmac4373-sdio.bin
   Version: 13.10.246.253
   54591
   File: firmware/cyfmac54591-pcie.bin
   Version: 13.35.225

- Dropped firmwares that are no longer available:
   Cypress 4359 PCIe
   Cypress 4359 SDIO
   Cypress 89459 PCIe
  
- Fixes renamed firmware files.

