### PR TITLE
uhttpd: Improve handling of organization (O=) of the cert

### DIFF
--- a/package/network/services/uhttpd/Makefile
+++ b/package/network/services/uhttpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uhttpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uhttpd.git

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -35,13 +35,14 @@ generate_keys() {
 	local cfg="$1"
 	local key="$2"
 	local crt="$3"
-	local days bits country state location commonname
+	local days bits country state location organization commonname
 
 	config_get days       "$cfg" days
 	config_get bits       "$cfg" bits
 	config_get country    "$cfg" country
 	config_get state      "$cfg" state
 	config_get location   "$cfg" location
+	config_get organization "$cfg" organization
 	config_get commonname "$cfg" commonname
 	config_get key_type   "$cfg" key_type
 	config_get ec_curve   "$cfg" ec_curve
@@ -56,7 +57,7 @@ generate_keys() {
 	[ -n "$GENKEY_CMD" ] && {
 		$GENKEY_CMD \
 			-days ${days:-730} -newkey ${KEY_OPTS} -keyout "${UHTTPD_KEY}.new" -out "${UHTTPD_CERT}.new" \
-			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${commonname:-OpenWrt}$UNIQUEID"/CN="${commonname:-OpenWrt}"
+			-subj /C="${country:-ZZ}"/ST="${state:-Somewhere}"/L="${location:-Unknown}"/O="${organization:-OpenWrt$UNIQUEID}"/CN="${commonname:-OpenWrt}"
 		sync
 		mv "${UHTTPD_KEY}.new" "${UHTTPD_KEY}"
 		mv "${UHTTPD_CERT}.new" "${UHTTPD_CERT}"


### PR DESCRIPTION
@hnyman 
@adschm 

In this PR, I would like to finish the work started in #2989.

As already shown with https://github.com/openwrt/openwrt/pull/2989#issuecomment-858412195 the original problem of the Firefox browser and the need for UNIQUEID seems to be gone. (tested with a Debian 10 system with Firefox 78.11.0esr 64-bit)

Therefore I would now revert commit 9097dc5ad844c336020be11085e1c8c80390ac9c and introduce the possibility to configure the organization registered in the certificate.
