### PR TITLE
ath79: add support for booting QCN5502 SoC

### DIFF
--- a/target/linux/ath79/patches-5.4/940-ath79-add-qcn550x.patch
+++ b/target/linux/ath79/patches-5.4/940-ath79-add-qcn550x.patch
@@ -1,0 +1,35 @@
+--- a/arch/mips/ath79/early_printk.c
++++ b/arch/mips/ath79/early_printk.c
+@@ -121,6 +121,7 @@ static void prom_putchar_init(void)
+ 	case REV_ID_MAJOR_QCA9558:
+ 	case REV_ID_MAJOR_TP9343:
+ 	case REV_ID_MAJOR_QCA956X:
++	case REV_ID_MAJOR_QCN550X:
+ 		_prom_putchar = prom_putchar_ar71xx;
+ 		break;
+ 
+--- a/arch/mips/ath79/setup.c
++++ b/arch/mips/ath79/setup.c
+@@ -179,6 +179,12 @@ static void __init ath79_detect_sys_type
+ 		rev = id & QCA956X_REV_ID_REVISION_MASK;
+ 		break;
+ 
++	case REV_ID_MAJOR_QCN550X:
++		ath79_soc = ATH79_SOC_QCA956X;
++		chip = "550X";
++		rev = id & QCA956X_REV_ID_REVISION_MASK;
++		break;
++
+ 	case REV_ID_MAJOR_TP9343:
+ 		ath79_soc = ATH79_SOC_TP9343;
+ 		chip = "9343";
+--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+@@ -867,6 +867,7 @@
+ #define REV_ID_MAJOR_QCA9558		0x1130
+ #define REV_ID_MAJOR_TP9343		0x0150
+ #define REV_ID_MAJOR_QCA956X		0x1150
++#define REV_ID_MAJOR_QCN550X		0x2170
+ 
+ #define AR71XX_REV_ID_MINOR_MASK	0x3
+ #define AR71XX_REV_ID_MINOR_AR7130	0x0


### PR DESCRIPTION
Split from https://github.com/openwrt/openwrt/pull/4271

Based on wikidevi, [QCN5502](https://wikidevi.wi-cat.ru/Qualcomm#bgn) is a "Dragonfly" like [QCA9561 and QCA9563](https://wikidevi.wi-cat.ru/Qualcomm_Atheros#.28a.29bgn_2).
Treating it as QCA956x seems to work.