### PR TITLE
base-files: upgrade: kill remaining processes only once

### DIFF
--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -76,40 +76,56 @@ switch_to_ramfs() {
 	}
 }
 
+get_remaining() {
+	local stat
+
+	local proc_pid proc_name proc_state proc_ppid proc_rest
+	read proc_pid proc_name proc_state proc_ppid proc_rest < /proc/$$/stat
+
+	for stat in /proc/[0-9]*/stat; do
+		[ -f "$stat" ] || continue
+
+		local pid name state ppid rest
+		read pid name state ppid rest < $stat
+		name="${name#(}"; name="${name%)}"
+
+		# Skip PID1, our parent, ourself and our children
+		[ $pid -ne 1 -a $pid -ne $proc_ppid -a $pid -ne $$ -a $ppid -ne $$ ] || continue
+
+		local cmdline
+		read cmdline < /proc/$pid/cmdline
+
+		# Skip kernel threads
+		[ -n "$cmdline" ] || continue
+
+		procs="${procs}${pid} ${name}\n"
+	done
+	procs="${procs%??}"
+}
+
 kill_remaining() { # [ <signal> [ <loop> ] ]
+	local remaining pid name
+
 	local loop_limit=10
 
 	local sig="${1:-TERM}"
 	local loop="${2:-0}"
 	local run=true
-	local stat
-	local proc_ppid=$(cut -d' ' -f4  /proc/$$/stat)
 
 	vn "Sending $sig to remaining processes ..."
 
 	while $run; do
 		run=false
-		for stat in /proc/[0-9]*/stat; do
-			[ -f "$stat" ] || continue
-
-			local pid name state ppid rest
-			read pid name state ppid rest < $stat
-			name="${name#(}"; name="${name%)}"
-
-			# Skip PID1, our parent, ourself and our children
-			[ $pid -ne 1 -a $pid -ne $proc_ppid -a $pid -ne $$ -a $ppid -ne $$ ] || continue
-
-			local cmdline
-			read cmdline < /proc/$pid/cmdline
-
-			# Skip kernel threads
-			[ -n "$cmdline" ] || continue
+		echo -e $procs | while read pid name; do
+			[ -d "/proc/$pid" ] || continue
+			remaining="${remaining}${pid} ${name}\n"
 
 			_vn " $name"
 			kill -$sig $pid 2>/dev/null
 
 			[ $loop -eq 1 ] && run=true
 		done
+		procs="${remaining%??}"; remaining=""
 
 		let loop_limit--
 		[ $loop_limit -eq 0 ] && {
@@ -142,6 +158,10 @@ done
 killall -9 telnetd
 killall -9 dropbear
 killall -9 ash
+
+sleep 4
+
+get_remaining
 
 kill_remaining TERM
 sleep 4

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -85,9 +85,12 @@ get_remaining() {
 	for stat in /proc/[0-9]*/stat; do
 		[ -f "$stat" ] || continue
 
-		local pid name state ppid rest
-		read pid name state ppid rest < $stat
-		name="${name#(}"; name="${name%)}"
+		local pid name state ppid
+		read stat < $stat
+		pid="${stat%%[[:blank:]]*}"; stat="${stat#*[[:blank:]]}"
+		name="${stat%)*}"; name="${name#(}"; name="${name//[[:blank:]]/_}"; stat="${stat#*)[[:blank:]]}"
+		state="${stat%%[[:blank:]]*}"; stat="${stat#*[[:blank:]]}"
+		ppid="${stat%%[[:blank:]]*}"; stat="${stat#*[[:blank:]]}"
 
 		# Skip PID1, our parent, ourself and our children
 		[ $pid -ne 1 -a $pid -ne $proc_ppid -a $pid -ne $$ -a $ppid -ne $$ ] || continue


### PR DESCRIPTION
Some processes are managed by procd and set to restart when killed
via the procd instance parameter "respawn" being set during init.

Example:
procd_set_param respawn 3600 1 0

The function kill_remaining() is called twice,
and generates a new list of processes each time.
This causes some of the same procd managed daemons
to be killed and restarted twice instead of once.

Therefore, let the list of processes be generated in a separate function
and let kill_remaining() use that same list each time it is called.
This way, the list of processes to be killed is static and PID-specific,
so when a managed daemon restarts, it will not be killed again
due to having a different PID.

Also, sleep for a few seconds before the list is generated
so that processes already terminated are not included
in the list to be killed again.

Signed-off-by: Michael Pratt <mcpratt@pm.me>