### PR TITLE
Revert "mac80211: create channel list for fixed channel operation"

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -139,9 +139,6 @@ mac80211_hostapd_setup_base() {
 	json_get_values ht_capab_list ht_capab tx_burst
 	json_get_values channel_list channels
 
-	[ "$auto_channel" = 0 ] && [ -z "$channel_list" ] && \
-		channel_list="$channel"
-
 	set_default noscan 0
 
 	[ "$noscan" -gt 0 ] && hostapd_noscan=1


### PR DESCRIPTION
_Edit:_ I rebased the pull request after the first three patches were merged. Only the last commit 9adbe61 is left to discuss and possibly merge. I'm leaving the full description of the original PR for reference.

I recently stumbled upon a few shortcomings of the hostapd configuration handling when I was trying to (more or less) sync the configurations of an OpenWrt access point with a non-OpenWrt device. In order to alleviate this, I came up with a few patches. The reasoning behind each patch is described in its respective commit message, but here's a gist of all:

- [X] Patch 1/4 exposes a hostapd option that allows the indication of indoor and outdoor use within the country code string.
- [X] Patch 2/4 makes an AP-side workaround against specific KRACK vulnerabilities affecting WNM Sleep Mode configurable
- [X] Patch 3/4 fixes an issue that makes the options bss_load_update_period and chan_util_avg_period unusable
- [ ] Patch 4/4 reverts a commit that introduces an issue with channel selection due to DFS events

Since these patches are simple, address issues or may even enhance security in some circumstances, I would also like to see these applied to the 21.02 branch once they are accepted. Please let me know if I should submit a separate pull request for the backports or if you cherry-pick them directly. Thanks.

Signed-off-by: Timo Sigurdsson <public_timo.s@silentcreek.de>