### PR TITLE
feeds: switch git.openwrt.org URLs to github.com

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,7 +1,7 @@
-src-git packages https://git.openwrt.org/feed/packages.git
-src-git luci https://git.openwrt.org/project/luci.git
-src-git routing https://git.openwrt.org/feed/routing.git
-src-git telephony https://git.openwrt.org/feed/telephony.git
+src-git packages https://github.com/openwrt/packages.git
+src-git luci https://github.com/openwrt/luci.git
+src-git routing https://github.com/openwrt/routing.git
+src-git telephony https://github.com/openwrt/telephony.git
 #src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git


### PR DESCRIPTION
Switch from very slow `git.openwrt.org` urls to very fast `github.com` urls.

`git.openwrt.org` urls are very slow to clone(around 20kb/s, takes 10-20mins to clone), and the `github.com` urls clone at full speed(takes few seconds to clone).