### PR TITLE
[RFC] gpio-cdev: add nu801 userspace driver

### DIFF
--- a/package/system/gpio-cdev/nu801/Makefile
+++ b/package/system/gpio-cdev/nu801/Makefile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nu801
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/chunkeey/nu801.git
+PKG_SOURCE_VERSION:=39661bfcd0ee9a8e7e9a3e920abe1064c589aaa3
+
+PKG_MAINTAINER:=Christian Lamparter <chunkeey@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/nu801
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Userspace GPIO Drivers
+  DEPENDS:=@LINUX_5_10 +kmod-leds-uleds
+  KCONFIG:= \
+    CONFIG_GPIO_CDEV=y
+  TITLE:=NU801 LED Driver
+endef
+
+define Package/nu801/description
+This package contains a userspace driver to power the NUMEN Tech. NU801 LED Driver.
+endef
+
+define Package/nu801/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nu801 $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nu801.init $(1)/etc/init.d/nu801
+
+endef
+
+$(eval $(call BuildPackage,nu801))

--- a/package/system/gpio-cdev/nu801/files/nu801.init
+++ b/package/system/gpio-cdev/nu801/files/nu801.init
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+START=15
+STOP=94
+USE_PROCD=1
+BOARD_MODEL=$(ubus call system board | jsonfilter -e '@["model"]')
+
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/sbin/nu801 "${BOARD_MODEL}"
+	procd_set_param respawn 5 1 5
+	procd_close_instance
+}


### PR DESCRIPTION
This adds a userspace interpretation of the nu801 driver used by Meraki
hardware. Previously this was a driver that was added per target, but as
multiple targets now have this driver, we should move to something that
can be shared by all targets since no driver exists upstream.

Co-developed-by: Christian Lamparter <chunkeey@gmail.com>
Signed-off-by: Chris Blake <chrisrblake93@gmail.com>

So for additional details, the NU801 used to be used by the MR18 and Z1
boards under the old ath79 target using the Meraki GPL driver. This code can
be found at https://github.com/openwrt/openwrt/blob/v19.07.7/target/linux/ar71xx/files/drivers/leds/leds-nu801.

Since this driver was never upstreamed, and since multiple targets use this hardware,
we should probably move to using a cdev based driver that runs in userspace. This
allows it to be packaged per target, instead of throwing the nu801s kernel driver
in generic.

Note that there are some questions still since cdev based LED drivers are not yet
"supported" in OpenWRT. For example, is this a good way to start the service? How
can we get sysupgrade to support this? Is this a preferred implementation over nu801
being thrown in as a kernel patch under generic? Should cdev support be enabled in
generic?

The only downside to this method is it will require the 5.10 kernel since 
CONFIG_GPIO_CDEV was added in kernel 5.10.

Tested and working on a Meraki MX100 (slowly working on upstreaming into OpenWRT)

I am open to feedback/input/PRs to my source branch. Thanks for the consideration.