### PR TITLE
tools/ccache: update to 4.3

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,13 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.2.1
+PKG_VERSION:=4.3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=9d6ba1cdefdc690401f404b747d81a9a1802b17af4235815866b7620d980477e
-
-HOST_BUILD_PARALLEL:=1
+PKG_HASH:=504a0f2184465c306826f035b4bc00bae7500308d6af4abbfb50e33a694989b4
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Remove BUILD_PARALLEL as it's default now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
