### PR TITLE
tools/squashfskit4: fix compilation under big endian

### DIFF
--- a/tools/squashfskit4/Makefile
+++ b/tools/squashfskit4/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=squashfskit4
 PKG_VERSION:=4.14
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_SOURCE:=squashfskit-v$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/squashfskit/squashfskit/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=5761aaa3aedc4f7112b708367d891c9abdc1ffea972e3fe47923ddba23984d95

--- a/tools/squashfskit4/patches/0002-fix-build-failure-against-gcc-10.patch
+++ b/tools/squashfskit4/patches/0002-fix-build-failure-against-gcc-10.patch
@@ -28,16 +28,14 @@ Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>
  squashfs-tools/mksquashfs.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/squashfs-tools/mksquashfs.h b/squashfs-tools/mksquashfs.h
-index 1beefef7..b6503063 100644
 --- a/squashfs-tools/mksquashfs.h
 +++ b/squashfs-tools/mksquashfs.h
-@@ -143,7 +143,7 @@ struct append_file {
- #endif
+@@ -133,7 +133,7 @@ struct append_file {
+ #define BLOCK_OFFSET 2
  
  extern struct cache *reader_buffer, *fragment_buffer, *reserve_cache;
 -struct cache *bwriter_buffer, *fwriter_buffer;
 +extern struct cache *bwriter_buffer, *fwriter_buffer;
  extern struct queue *to_reader, *to_deflate, *to_writer, *from_writer,
- 	*to_frag, *locked_fragment, *to_process_frag;
+ 	       *locked_fragment, *to_process_frag;
  extern struct append_file **file_mapping;

--- a/tools/squashfskit4/patches/0020-big-endian.patch
+++ b/tools/squashfskit4/patches/0020-big-endian.patch
@@ -1,0 +1,14 @@
+--- a/squashfs-tools/xz_wrapper.c
++++ b/squashfs-tools/xz_wrapper.c
+@@ -192,7 +192,10 @@ static void xz_display_options(void *buf
+ 	if(size != sizeof(struct comp_opts))
+ 		goto failed;
+ 
+-	SQUASHFS_INSWAP_LZMA_COMP_OPTS(comp_opts);
++#if __BYTE_ORDER == __BIG_ENDIAN
++	comp_opts->dictionary_size = inswap_le32(comp_opts->dictionary_size);
++	comp_opts->flags = inswap_le32(comp_opts->flags);
++#endif
+ 
+ 	dictionary_size = comp_opts->dictionary_size;
+ 	flags = comp_opts->flags;


### PR DESCRIPTION
The macro used is for the wrong struct. Just byte swap manually.

Tested on sparc64.

Signed-off-by: Rosen Penev <rosenp@gmail.com>