### PR TITLE
ath79: add support for Joy-IT JT-OR750i

### DIFF
--- a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+++ b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "joyit,jt-or750i", "qca,qca9531";
+	model = "Joy-IT JT-OR750i";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pinmux {
+	pinmux_led_eth_pins: pinmux_led_eth_pins {
+		pinctrl-single,bits = \
+			/* GPIO 4: LED_LINK_5 (WAN) */     \
+			<0x04 0x0000002d 0x000000ff>,      \
+			/* GPIO 14: LED_LINK_2 (LAN 3) */  \
+			/* GPIO 15: LED_LINK_3 (LAN 2) */  \
+			<0x0c 0x2b2c0000 0xffff0000>,      \
+			/* GPIO 16: LED_LINK_4 (LAN 1) */  \
+			<0x10 0x0000002a 0x000000ff>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+				compatible = "denx,uimage";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -225,6 +225,9 @@ glinet,gl-x750)
 hak5,lan-turtle)
 	ucidef_set_led_netdev "wan" "WAN" "orange:system" "eth1"
 	;;
+joyit,jt-or750i)
+	ucidef_set_led_default "ath10k" "ath10k-disable" "ath10k-phy0" "0"
+	;;
 meraki,mr12|\
 tplink,cpe210-v2|\
 tplink,cpe210-v3)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -280,6 +280,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
+	joyit,jt-or750i)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	librerouter,librerouter-v1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "5:wan" "6@eth1" "4:lan"

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,6 +25,7 @@ case "$FIRMWARE" in
 	comfast,cf-wr650ac-v2|\
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi|\
+	joyit,jt-or750i|\
 	qxwlan,e1700ac-v2-8m|\
 	qxwlan,e1700ac-v2-16m|\
 	qxwlan,e600gac-v2-8m|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1362,6 +1362,15 @@ define Device/jjplus_ja76pf2
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
+define Device/joyit_jt-or750i
+  SOC := qca9531
+  DEVICE_VENDOR := Joy-IT
+  DEVICE_MODEL := JT-OR750i
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += joyit_jt-or750i
+
 define Device/librerouter_librerouter-v1
   SOC := qca9558
   DEVICE_VENDOR := Librerouter


### PR DESCRIPTION
Specifications:
 * QCA9531, 16 MiB flash, 128 MiB RAM, 802.11n 2T2R
 * QCA9887, 802.11ac 1T1R
 * 3x 10/100 LAN, 1x 10/100 WAN

Installation:
 * The device comes with a bootloader installed only
 * The bootloader offers DHCP and is reachable at http://10.123.123.1
 * Accept the agreement and flash sysupgrade.bin
 * Use Firefox if flashing does not work

TFTP recovery with static IP:
 * Rename sysupgrade.bin to jt-or750i_firmware.bin
 * Offer it via TFTP server at 192.168.0.66
 * Keep the reset button pressed for 4 seconds after connecting power

TFTP recovery with dynamic IP:
 * Rename sysupgrade.bin to jt-or750i_firmware.bin
 * Offer it via TFTP server with a DHCP server running at the same address
 * Keep the reset button pressed for 6 seconds after connecting power

Co-authored-by: Sebastian Schaper <openwrt@sebastianschaper.net>
Signed-off-by: Vincent Wiemann <vincent.wiemann@ironai.com>
