### PR TITLE
kirkwood: increase kernel size of Linksyses

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/05_compat-version
+++ b/target/linux/kirkwood/base-files/etc/board.d/05_compat-version
@@ -11,7 +11,7 @@ case "$(board_name)" in
 	linksys,e4200-v2|\
 	linksys,ea3500|\
 	linksys,ea4500)
-		ucidef_set_compat_version "1.1"
+		ucidef_set_compat_version "2.0"
 		;;
 esac
 

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-ea3500.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-ea3500.dts
@@ -165,22 +165,22 @@
 
 		partition@200000 {
 			label = "kernel1";
-			reg = <0x200000 0x290000>;
+			reg = <0x200000 0x1400000>;
 		};
 
-		partition@490000 {
+		partition@500000 {
 			label = "rootfs1";
-			reg = <0x490000 0x1170000>;
+			reg = <0x500000 0x1100000>;
 		};
 
 		partition@1600000 {
 			label = "kernel2";
-			reg = <0x1600000 0x290000>;
+			reg = <0x1600000 0x1400000>;
 		};
 
-		partition@1890000 {
+		partition@1900000 {
 			label = "rootfs2";
-			reg = <0x1890000 0x1170000>;
+			reg = <0x1900000 0x1100000>;
 		};
 
 		partition@2a00000 {

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -7,9 +7,12 @@ include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR:=0x8000
 
-define Device/dsa-migration
-  DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
+define Device/kernel-size-migration
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition design has changed compared to \
+	older versions (up to 21.02) due to kernel size restrictions. \
+	Upgrade via sysupgrade mechanism is not possible, so new \
+	installation via factory style image is required.
 endef
 
 define Device/Default
@@ -110,31 +113,31 @@ endef
 
 define Device/linksys_e4200-v2
   $(Device/linksys)
-  $(Device/dsa-migration)
+  $(Device/kernel-size-migration)
   DEVICE_MODEL := E4200
   DEVICE_VARIANT := v2
-  KERNEL_SIZE := 2688k
+  KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += linksys,viper linksys-viper
 endef
 TARGET_DEVICES += linksys_e4200-v2
 
 define Device/linksys_ea3500
   $(Device/linksys)
-  $(Device/dsa-migration)
+  $(Device/kernel-size-migration)
   DEVICE_MODEL := EA3500
   PAGESIZE := 512
   SUBPAGESIZE := 256
   BLOCKSIZE := 16k
-  KERNEL_SIZE := 2624k
+  KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += linksys,audi linksys-audi
 endef
 TARGET_DEVICES += linksys_ea3500
 
 define Device/linksys_ea4500
   $(Device/linksys)
-  $(Device/dsa-migration)
+  $(Device/kernel-size-migration)
   DEVICE_MODEL := EA4500
-  KERNEL_SIZE := 2688k
+  KERNEL_SIZE := 3072k
   SUPPORTED_DEVICES += linksys,viper linksys-viper
 endef
 TARGET_DEVICES += linksys_ea4500

--- a/target/linux/kirkwood/patches-5.10/105-linksys-viper-dts.patch
+++ b/target/linux/kirkwood/patches-5.10/105-linksys-viper-dts.patch
@@ -23,30 +23,37 @@
  		};
  
  		white-pulse {
-@@ -114,22 +119,22 @@
+@@ -114,23 +119,23 @@
  		};
  
  		partition@200000 {
 -			label = "kernel";
+-			reg = <0x200000 0x2A0000>;
 +			label = "kernel1";
- 			reg = <0x200000 0x2A0000>;
++			reg = <0x200000 0x1A00000>;
  		};
  
- 		partition@4a0000 {
+-		partition@4a0000 {
 -			label = "rootfs";
+-			reg = <0x4A0000 0x1760000>;
++		partition@500000 {
 +			label = "rootfs1";
- 			reg = <0x4A0000 0x1760000>;
++			reg = <0x500000 0x1700000>;
  		};
  
  		partition@1c00000 {
 -			label = "alt_kernel";
+-			reg = <0x1C00000 0x2A0000>;
 +			label = "kernel2";
- 			reg = <0x1C00000 0x2A0000>;
++			reg = <0x1C00000 0x1A00000>;
  		};
  
- 		partition@1ea0000 {
+-		partition@1ea0000 {
 -			label = "alt_rootfs";
+-			reg = <0x1EA0000 0x1760000>;
++		partition@1f00000 {
 +			label = "rootfs2";
- 			reg = <0x1EA0000 0x1760000>;
++			reg = <0x1F00000 0x1700000>;
  		};
  
+ 		partition@3600000 {

--- a/target/linux/kirkwood/patches-5.4/105-linksys-viper-dts.patch
+++ b/target/linux/kirkwood/patches-5.4/105-linksys-viper-dts.patch
@@ -23,30 +23,37 @@
  		};
  
  		white-pulse {
-@@ -114,22 +119,22 @@
+@@ -114,23 +119,23 @@
  		};
  
  		partition@200000 {
 -			label = "kernel";
+-			reg = <0x200000 0x2A0000>;
 +			label = "kernel1";
- 			reg = <0x200000 0x2A0000>;
++			reg = <0x200000 0x1A00000>;
  		};
  
- 		partition@4a0000 {
+-		partition@4a0000 {
 -			label = "rootfs";
+-			reg = <0x4A0000 0x1760000>;
++		partition@500000 {
 +			label = "rootfs1";
- 			reg = <0x4A0000 0x1760000>;
++			reg = <0x500000 0x1700000>;
  		};
  
  		partition@1c00000 {
 -			label = "alt_kernel";
+-			reg = <0x1C00000 0x2A0000>;
 +			label = "kernel2";
- 			reg = <0x1C00000 0x2A0000>;
++			reg = <0x1C00000 0x1A00000>;
  		};
  
- 		partition@1ea0000 {
+-		partition@1ea0000 {
 -			label = "alt_rootfs";
+-			reg = <0x1EA0000 0x1760000>;
++		partition@1f00000 {
 +			label = "rootfs2";
- 			reg = <0x1EA0000 0x1760000>;
++			reg = <0x1F00000 0x1700000>;
  		};
  
+ 		partition@3600000 {


### PR DESCRIPTION
Linksyses Audi EA3500 and Viper E4200/E4500 have too small kernel
partition size when kernel 5.10 is used. This patch change kernel
partition to maximum size allowed by u-boot.

Kernel size is overlaping rootfs now, like mvebu Linksyses and stock
partition table. It fix  back to stock via sysupgrade, which was broken
since 18.06.

Fixes: 9808b9a ("kirkwood: switch to kernel 4.9")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>