### PR TITLE
base-files: lint shell scripts

### DIFF
--- a/package/base-files/files/bin/board_detect
+++ b/package/base-files/files/bin/board_detect
@@ -6,7 +6,7 @@ CFG=$1
 
 [ -d "/etc/board.d/" -a ! -s "$CFG" ] && {
 	for a in $(ls /etc/board.d/*); do
-		[ -s $a ] || continue;
+		[ -s $a ] || continue
 		$(. $a)
 	done
 }

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -10,13 +10,13 @@ CFG=/etc/board.json
 generate_bridge() {
 	local name=$1
 	local macaddr=$2
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		set network.$name=device
 		set network.$name.name=$name
 		set network.$name.type=bridge
 	EOF
 	if [ -n "$macaddr" ]; then
-		uci -q batch <<-EOF
+		uci -q batch <<- EOF
 			set network.$name.macaddr=$macaddr
 		EOF
 	fi
@@ -28,7 +28,7 @@ generate_bridge_vlan() {
 	local device=$2
 	local ports="$3"
 	local vlan="$4"
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		set network.$name=bridge-vlan
 		set network.$name.device='$device'
 		set network.$name.vlan='$vlan'
@@ -37,7 +37,7 @@ generate_bridge_vlan() {
 }
 
 generate_static_network() {
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		delete network.loopback
 		set network.loopback='interface'
 		set network.loopback.device='lo'
@@ -45,46 +45,46 @@ generate_static_network() {
 		set network.loopback.ipaddr='127.0.0.1'
 		set network.loopback.netmask='255.0.0.0'
 	EOF
-		[ -e /proc/sys/net/ipv6 ] && {
-			uci -q batch <<-EOF
-				delete network.globals
-				set network.globals='globals'
-				set network.globals.ula_prefix='auto'
-			EOF
-		}
+	[ -e /proc/sys/net/ipv6 ] && {
+		uci -q batch <<- EOF
+			delete network.globals
+			set network.globals='globals'
+			set network.globals.ula_prefix='auto'
+		EOF
+	}
 
 	if json_is_a dsl object; then
 		json_select dsl
-			if json_is_a atmbridge object; then
-				json_select atmbridge
-					local vpi vci encaps payload nameprefix
-					json_get_vars vpi vci encaps payload nameprefix
-					uci -q batch <<-EOF
-						delete network.atm
-						set network.atm='atm-bridge'
-						set network.atm.vpi='$vpi'
-						set network.atm.vci='$vci'
-						set network.atm.encaps='$encaps'
-						set network.atm.payload='$payload'
-						set network.atm.nameprefix='$nameprefix'
-					EOF
-				json_select ..
-			fi
+		if json_is_a atmbridge object; then
+			json_select atmbridge
+			local vpi vci encaps payload nameprefix
+			json_get_vars vpi vci encaps payload nameprefix
+			uci -q batch <<- EOF
+				delete network.atm
+				set network.atm='atm-bridge'
+				set network.atm.vpi='$vpi'
+				set network.atm.vci='$vci'
+				set network.atm.encaps='$encaps'
+				set network.atm.payload='$payload'
+				set network.atm.nameprefix='$nameprefix'
+			EOF
+			json_select ..
+		fi
 
-			if json_is_a modem object; then
-				json_select modem
-					local type annex firmware tone xfer_mode
-					json_get_vars type annex firmware tone xfer_mode
-					uci -q batch <<-EOF
-						delete network.dsl
-						set network.dsl='dsl'
-						set network.dsl.annex='$annex'
-						set network.dsl.firmware='$firmware'
-						set network.dsl.tone='$tone'
-						set network.dsl.xfer_mode='$xfer_mode'
-					EOF
-				json_select ..
-			fi
+		if json_is_a modem object; then
+			json_select modem
+			local type annex firmware tone xfer_mode
+			json_get_vars type annex firmware tone xfer_mode
+			uci -q batch <<- EOF
+				delete network.dsl
+				set network.dsl='dsl'
+				set network.dsl.annex='$annex'
+				set network.dsl.firmware='$firmware'
+				set network.dsl.tone='$tone'
+				set network.dsl.xfer_mode='$xfer_mode'
+			EOF
+			json_select ..
+		fi
 		json_select ..
 	fi
 }
@@ -95,10 +95,10 @@ generate_network() {
 	local bridge=$2
 
 	json_select network
-		json_select "$1"
-			json_get_vars device macaddr protocol ipaddr netmask vlan
-			json_get_values ports ports
-		json_select ..
+	json_select "$1"
+	json_get_vars device macaddr protocol ipaddr netmask vlan
+	json_get_values ports ports
+	json_select ..
 	json_select ..
 
 	[ -n "$device" -o -n "$ports" ] || return
@@ -110,7 +110,7 @@ generate_network() {
 	}
 
 	[ -n "$ports" -a -z "$bridge" ] && {
-		uci -q batch <<-EOF
+		uci -q batch <<- EOF
 			add network device
 			set network.@device[-1].name='br-$1'
 			set network.@device[-1].type='bridge'
@@ -118,7 +118,7 @@ generate_network() {
 		for port in $ports; do uci add_list network.@device[-1].ports="$port"; done
 		[ -n "$macaddr" ] && {
 			for port in $ports; do
-				uci -q batch <<-EOF
+				uci -q batch <<- EOF
 					add network device
 					set network.@device[-1].name='$port'
 					set network.@device[-1].macaddr='$macaddr'
@@ -142,14 +142,14 @@ generate_network() {
 	}
 
 	if [ -n "$macaddr" ]; then
-		uci -q batch <<-EOF
+		uci -q batch <<- EOF
 			add network device
 			set network.@device[-1].name='$device'
 			set network.@device[-1].macaddr='$macaddr'
 		EOF
 	fi
 
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		delete network.$1
 		set network.$1='interface'
 		set network.$1.type='$type'
@@ -158,53 +158,53 @@ generate_network() {
 	EOF
 
 	case "$protocol" in
-		static)
-			local ipad
-			case "$1" in
-				lan) ipad=${ipaddr:-"192.168.1.1"} ;;
-				*) ipad=${ipaddr:-"192.168.$((addr_offset++)).1"} ;;
-			esac
+	static)
+		local ipad
+		case "$1" in
+		lan) ipad=${ipaddr:-"192.168.1.1"} ;;
+		*) ipad=${ipaddr:-"192.168.$((addr_offset++)).1"} ;;
+		esac
 
-			netm=${netmask:-"255.255.255.0"}
+		netm=${netmask:-"255.255.255.0"}
 
-			uci -q batch <<-EOF
-				set network.$1.proto='static'
-				set network.$1.ipaddr='$ipad'
-				set network.$1.netmask='$netm'
-			EOF
-			[ -e /proc/sys/net/ipv6 ] && uci set network.$1.ip6assign='60'
+		uci -q batch <<- EOF
+			set network.$1.proto='static'
+			set network.$1.ipaddr='$ipad'
+			set network.$1.netmask='$netm'
+		EOF
+		[ -e /proc/sys/net/ipv6 ] && uci set network.$1.ip6assign='60'
 		;;
 
-		dhcp)
-			# fixup IPv6 slave interface if parent is a bridge
-			[ "$type" = "bridge" ] && device="br-$1"
+	dhcp)
+		# fixup IPv6 slave interface if parent is a bridge
+		[ "$type" = "bridge" ] && device="br-$1"
 
-			uci set network.$1.proto='dhcp'
-			[ -e /proc/sys/net/ipv6 ] && {
-				uci -q batch <<-EOF
-					delete network.${1}6
-					set network.${1}6='interface'
-					set network.${1}6.device='$device'
-					set network.${1}6.proto='dhcpv6'
-				EOF
-			}
+		uci set network.$1.proto='dhcp'
+		[ -e /proc/sys/net/ipv6 ] && {
+			uci -q batch <<- EOF
+				delete network.${1}6
+				set network.${1}6='interface'
+				set network.${1}6.device='$device'
+				set network.${1}6.proto='dhcpv6'
+			EOF
+		}
 		;;
 
-		pppoe)
-			uci -q batch <<-EOF
-				set network.$1.proto='pppoe'
-				set network.$1.username='username'
-				set network.$1.password='password'
+	pppoe)
+		uci -q batch <<- EOF
+			set network.$1.proto='pppoe'
+			set network.$1.username='username'
+			set network.$1.password='password'
+		EOF
+		[ -e /proc/sys/net/ipv6 ] && {
+			uci -q batch <<- EOF
+				set network.$1.ipv6='1'
+				delete network.${1}6
+				set network.${1}6='interface'
+				set network.${1}6.device='@${1}'
+				set network.${1}6.proto='dhcpv6'
 			EOF
-			[ -e /proc/sys/net/ipv6 ] && {
-				uci -q batch <<-EOF
-					set network.$1.ipv6='1'
-					delete network.${1}6
-					set network.${1}6='interface'
-					set network.${1}6.device='@${1}'
-					set network.${1}6.proto='dhcpv6'
-				EOF
-			}
+		}
 		;;
 	esac
 }
@@ -223,10 +223,10 @@ generate_switch_vlans_ports() {
 
 		for role in $roles; do
 			json_select "$role"
-				json_get_vars ports
+			json_get_vars ports
 			json_select ..
 
-			uci -q batch <<-EOF
+			uci -q batch <<- EOF
 				add network switch_vlan
 				set network.@switch_vlan[-1].device='$switch'
 				set network.@switch_vlan[-1].vlan='$role'
@@ -236,7 +236,6 @@ generate_switch_vlans_ports() {
 
 		json_select ..
 	fi
-
 
 	#
 	# write port specific settings
@@ -248,23 +247,23 @@ generate_switch_vlans_ports() {
 
 		for port in $ports; do
 			json_select "$port"
-				json_get_vars num
+			json_get_vars num
 
-				if json_is_a attr object; then
-					json_get_keys attr attr
-					json_select attr
-						uci -q batch <<-EOF
-							add network switch_port
-							set network.@switch_port[-1].device='$switch'
-							set network.@switch_port[-1].port=$num
-						EOF
+			if json_is_a attr object; then
+				json_get_keys attr attr
+				json_select attr
+				uci -q batch <<- EOF
+					add network switch_port
+					set network.@switch_port[-1].device='$switch'
+					set network.@switch_port[-1].port=$num
+				EOF
 
-						for attr in $attr; do
-							json_get_var val "$attr"
-							uci -q set network.@switch_port[-1].$attr="$val"
-						done
-					json_select ..
-				fi
+				for attr in $attr; do
+					json_get_var val "$attr"
+					uci -q set network.@switch_port[-1].$attr="$val"
+				done
+				json_select ..
+			fi
 			json_select ..
 		done
 
@@ -281,7 +280,7 @@ generate_switch() {
 	json_get_vars enable reset blinkrate cpu_port \
 		ar8xxx_mib_type ar8xxx_mib_poll_interval
 
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		add network switch
 		set network.@switch[-1].name='$key'
 		set network.@switch[-1].reset='$reset'
@@ -298,7 +297,7 @@ generate_switch() {
 }
 
 generate_static_system() {
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		delete system.@system[0]
 		add system system
 		set system.@system[-1].hostname='OpenWrt'
@@ -319,32 +318,32 @@ generate_static_system() {
 
 	if json_is_a system object; then
 		json_select system
-			local hostname
-			if json_get_var hostname hostname; then
-				uci -q set "system.@system[-1].hostname=$hostname"
-			fi
+		local hostname
+		if json_get_var hostname hostname; then
+			uci -q set "system.@system[-1].hostname=$hostname"
+		fi
 
-			local compat_version
-			if json_get_var compat_version compat_version; then
-				uci -q set "system.@system[-1].compat_version=$compat_version"
-			else
-				uci -q set "system.@system[-1].compat_version=1.0"
-			fi
+		local compat_version
+		if json_get_var compat_version compat_version; then
+			uci -q set "system.@system[-1].compat_version=$compat_version"
+		else
+			uci -q set "system.@system[-1].compat_version=1.0"
+		fi
 
-			if json_is_a ntpserver array; then
-				local keys key
-				json_get_keys keys ntpserver
-				json_select ntpserver
-					uci -q delete "system.ntp.server"
+		if json_is_a ntpserver array; then
+			local keys key
+			json_get_keys keys ntpserver
+			json_select ntpserver
+			uci -q delete "system.ntp.server"
 
-					for key in $keys; do
-						local server
-						if json_get_var server "$key"; then
-							uci -q add_list "system.ntp.server=$server"
-						fi
-					done
-				json_select ..
-			fi
+			for key in $keys; do
+				local server
+				if json_get_var server "$key"; then
+					uci -q add_list "system.ntp.server=$server"
+				fi
+			done
+			json_select ..
+		fi
 		json_select ..
 	fi
 }
@@ -360,7 +359,7 @@ generate_rssimon() {
 	json_select ..
 	json_select ..
 
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		delete system.$cfg
 		set system.$cfg='rssid'
 		set system.$cfg.dev='$key'
@@ -377,7 +376,7 @@ generate_led() {
 	json_select "$key"
 	json_get_vars name sysfs type trigger default
 
-	uci -q batch <<-EOF
+	uci -q batch <<- EOF
 		delete system.$cfg
 		set system.$cfg='led'
 		set system.$cfg.name='$name'
@@ -387,84 +386,84 @@ generate_led() {
 	EOF
 
 	case "$type" in
-		gpio)
-			local gpio inverted
-			json_get_vars gpio inverted
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='gpio'
-				set system.$cfg.gpio='$gpio'
-				set system.$cfg.inverted='$inverted'
-			EOF
+	gpio)
+		local gpio inverted
+		json_get_vars gpio inverted
+		uci -q batch <<- EOF
+			set system.$cfg.trigger='gpio'
+			set system.$cfg.gpio='$gpio'
+			set system.$cfg.inverted='$inverted'
+		EOF
 		;;
 
-		netdev)
-			local device mode
-			json_get_vars device mode
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='netdev'
-				set system.$cfg.mode='$mode'
-				set system.$cfg.dev='$device'
-			EOF
+	netdev)
+		local device mode
+		json_get_vars device mode
+		uci -q batch <<- EOF
+			set system.$cfg.trigger='netdev'
+			set system.$cfg.mode='$mode'
+			set system.$cfg.dev='$device'
+		EOF
 		;;
 
-		usb)
-			local device
-			json_get_vars device
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='usbdev'
-				set system.$cfg.interval='50'
-				set system.$cfg.dev='$device'
-			EOF
+	usb)
+		local device
+		json_get_vars device
+		uci -q batch <<- EOF
+			set system.$cfg.trigger='usbdev'
+			set system.$cfg.interval='50'
+			set system.$cfg.dev='$device'
+		EOF
 		;;
 
-		usbport)
-			local ports port
-			json_get_values ports ports
-			uci set system.$cfg.trigger='usbport'
-			for port in $ports; do
-				uci add_list system.$cfg.port=$port
-			done
+	usbport)
+		local ports port
+		json_get_values ports ports
+		uci set system.$cfg.trigger='usbport'
+		for port in $ports; do
+			uci add_list system.$cfg.port=$port
+		done
 		;;
 
-		rssi)
-			local iface minq maxq offset factor
-			json_get_vars iface minq maxq offset factor
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='rssi'
-				set system.$cfg.iface='rssid_$iface'
-				set system.$cfg.minq='$minq'
-				set system.$cfg.maxq='$maxq'
-				set system.$cfg.offset='$offset'
-				set system.$cfg.factor='$factor'
-			EOF
+	rssi)
+		local iface minq maxq offset factor
+		json_get_vars iface minq maxq offset factor
+		uci -q batch <<- EOF
+			set system.$cfg.trigger='rssi'
+			set system.$cfg.iface='rssid_$iface'
+			set system.$cfg.minq='$minq'
+			set system.$cfg.maxq='$maxq'
+			set system.$cfg.offset='$offset'
+			set system.$cfg.factor='$factor'
+		EOF
 		;;
 
-		switch)
-			local port_mask speed_mask mode
-			json_get_vars port_mask speed_mask mode
-			uci -q batch <<-EOF
-				set system.$cfg.port_mask='$port_mask'
-				set system.$cfg.speed_mask='$speed_mask'
-				set system.$cfg.mode='$mode'
-			EOF
+	switch)
+		local port_mask speed_mask mode
+		json_get_vars port_mask speed_mask mode
+		uci -q batch <<- EOF
+			set system.$cfg.port_mask='$port_mask'
+			set system.$cfg.speed_mask='$speed_mask'
+			set system.$cfg.mode='$mode'
+		EOF
 		;;
 
-		portstate)
-			local port_state
-			json_get_vars port_state
-			uci -q batch <<-EOF
-				set system.$cfg.port_state='$port_state'
-			EOF
+	portstate)
+		local port_state
+		json_get_vars port_state
+		uci -q batch <<- EOF
+			set system.$cfg.port_state='$port_state'
+		EOF
 		;;
 
-		timer|oneshot)
-			local delayon delayoff
-			json_get_vars delayon delayoff
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='$type'
-				set system.$cfg.delayon='$delayon'
-				set system.$cfg.delayoff='$delayoff'
-			EOF
+	timer | oneshot)
+		local delayon delayoff
+		json_get_vars delayon delayoff
+		uci -q batch <<- EOF
+			set system.$cfg.trigger='$type'
+			set system.$cfg.delayon='$delayon'
+			set system.$cfg.delayoff='$delayoff'
+		EOF
 		;;
 	esac
 
@@ -476,17 +475,17 @@ generate_gpioswitch() {
 	local cfg="$1"
 
 	json_select gpioswitch
-		json_select "$cfg"
-			local name pin default
-			json_get_vars name pin default
-			uci -q batch <<-EOF
-				delete system.$cfg
-				set system.$cfg='gpio_switch'
-				set system.$cfg.name='$name'
-				set system.$cfg.gpio_pin='$pin'
-				set system.$cfg.value='$default'
-			EOF
-		json_select ..
+	json_select "$cfg"
+	local name pin default
+	json_get_vars name pin default
+	uci -q batch <<- EOF
+		delete system.$cfg
+		set system.$cfg='gpio_switch'
+		set system.$cfg.name='$name'
+		set system.$cfg.gpio_pin='$pin'
+		set system.$cfg.value='$default'
+	EOF
+	json_select ..
 	json_select ..
 }
 

--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-awk -f - $* <<EOF
+awk -f - $* << EOF
 function bitcount(c) {
 	c=and(rshift(c, 1),0x55555555)+and(c,0x55555555)
 	c=and(rshift(c, 2),0x33333333)+and(c,0x33333333)

--- a/package/base-files/files/etc/diag.sh
+++ b/package/base-files/files/etc/diag.sh
@@ -37,7 +37,7 @@ set_led_state() {
 		;;
 	done)
 		status_led_off
-		[ "$status_led" != "$running" ] && \
+		[ "$status_led" != "$running" ] &&
 			status_led_restore_trigger "boot"
 		[ -n "$running" ] && {
 			status_led="$running"

--- a/package/base-files/files/etc/hotplug.d/net/00-sysctl
+++ b/package/base-files/files/etc/hotplug.d/net/00-sysctl
@@ -2,8 +2,8 @@
 
 if [ "$ACTION" = add ]; then
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf; do
-		[ ! -f "$CONF" ] && continue;
-		sed -ne "/^[[:space:]]*net\..*\.$DEVICENAME\./p" "$CONF" | \
+		[ ! -f "$CONF" ] && continue
+		sed -ne "/^[[:space:]]*net\..*\.$DEVICENAME\./p" "$CONF" |
 			sysctl -e -p - | logger -t sysctl
 	done
 fi

--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -12,7 +12,7 @@ uci_apply_defaults() {
 	[ -z "$files" ] && return 0
 	mkdir -p /tmp/.uci
 	for file in $files; do
-		( . "./$(basename $file)" ) && rm -f "$file"
+		(. "./$(basename $file)") && rm -f "$file"
 	done
 	uci commit
 }
@@ -47,7 +47,7 @@ boot() {
 
 	/bin/config_generate
 	uci_apply_defaults
-	
+
 	# temporary hack until configd exists
 	/sbin/reload_config
 }

--- a/package/base-files/files/etc/init.d/gpio_switch
+++ b/package/base-files/files/etc/init.d/gpio_switch
@@ -5,9 +5,7 @@ START=94
 STOP=10
 USE_PROCD=1
 
-
-load_gpio_switch()
-{
+load_gpio_switch() {
 	local name
 	local gpio_pin
 	local value
@@ -27,7 +25,7 @@ load_gpio_switch()
 
 		# export GPIO pin for access
 		[ -d "$gpio_path" ] || {
-			echo "$gpio_pin" >/sys/class/gpio/export
+			echo "$gpio_pin" > /sys/class/gpio/export
 			# we need to wait a bit until the GPIO appears
 			[ -d "$gpio_path" ] || sleep 1
 		}
@@ -37,28 +35,26 @@ load_gpio_switch()
 		if [ -e "${gpio_path}/direction" ]; then
 			# set the pin to output with high or low pin value
 			{ [ "$value" = "0" ] && echo "low" || echo "high"; } \
-				>"$gpio_path/direction"
+				> "$gpio_path/direction"
 		else
 			{ [ "$value" = "0" ] && echo "0" || echo "1"; } \
-				>"$gpio_path/value"
+				> "$gpio_path/value"
 		fi
 	else
 		gpio_path="/sys/class/gpio/${gpio_pin}"
 
 		[ -d "$gpio_path" ] && {
 			{ [ "$value" = "0" ] && echo "0" || echo "1"; } \
-				>"$gpio_path/value"
+				> "$gpio_path/value"
 		}
 	fi
 }
 
-service_triggers()
-{
+service_triggers() {
 	procd_add_reload_trigger "system"
 }
 
-start_service()
-{
+start_service() {
 	[ -e /sys/class/gpio/ ] && {
 		config_load system
 		config_foreach load_gpio_switch gpio_switch

--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -53,10 +53,10 @@ load_led() {
 			"$sysfs" \
 			"$(sed -ne 's/^.*\[\(.*\)\].*$/\1/p' /sys/class/leds/${sysfs}/trigger)" \
 			"$(cat /sys/class/leds/${sysfs}/brightness)" \
-				>> /var/run/led.state
+			>> /var/run/led.state
 
 		[ "$default" = 0 ] &&
-			echo 0 >/sys/class/leds/${sysfs}/brightness
+			echo 0 > /sys/class/leds/${sysfs}/brightness
 
 		echo $trigger > /sys/class/leds/${sysfs}/trigger 2> /dev/null
 		ret="$?"
@@ -73,17 +73,17 @@ load_led() {
 			[ -n "$dev" ] && {
 				echo $dev > /sys/class/leds/${sysfs}/device_name
 				for m in $mode; do
-					[ -e "/sys/class/leds/${sysfs}/$m" ] && \
+					[ -e "/sys/class/leds/${sysfs}/$m" ] &&
 						echo 1 > /sys/class/leds/${sysfs}/$m
 				done
 				echo $interval > /sys/class/leds/${sysfs}/interval
 			}
 			;;
 
-		"timer"|"oneshot")
-			[ -n "$delayon" ] && \
+		"timer" | "oneshot")
+			[ -n "$delayon" ] &&
 				echo $delayon > /sys/class/leds/${sysfs}/delay_on
-			[ -n "$delayoff" ] && \
+			[ -n "$delayoff" ] &&
 				echo $delayoff > /sys/class/leds/${sysfs}/delay_off
 			;;
 
@@ -96,7 +96,7 @@ load_led() {
 			;;
 
 		"port_state")
-			[ -n "$port_state" ] && \
+			[ -n "$port_state" ] &&
 				echo $port_state > /sys/class/leds/${sysfs}/port_state
 			;;
 
@@ -109,12 +109,12 @@ load_led() {
 			local port_mask speed_mask
 
 			config_get port_mask $1 port_mask
-			[ -n "$port_mask" ] && \
+			[ -n "$port_mask" ] &&
 				echo $port_mask > /sys/class/leds/${sysfs}/port_mask
 			config_get speed_mask $1 speed_mask
-			[ -n "$speed_mask" ] && \
+			[ -n "$speed_mask" ] &&
 				echo $speed_mask > /sys/class/leds/${sysfs}/speed_mask
-			[ -n "$mode" ] && \
+			[ -n "$mode" ] &&
 				echo "$mode" > /sys/class/leds/${sysfs}/mode
 			;;
 		esac
@@ -126,10 +126,10 @@ start() {
 		[ -s /var/run/led.state ] && {
 			local led trigger brightness
 			while read led trigger brightness; do
-				[ -e "/sys/class/leds/$led/trigger" ] && \
+				[ -e "/sys/class/leds/$led/trigger" ] &&
 					echo "$trigger" > "/sys/class/leds/$led/trigger"
 
-				[ -e "/sys/class/leds/$led/brightness" ] && \
+				[ -e "/sys/class/leds/$led/brightness" ] &&
 					echo "$brightness" > "/sys/class/leds/$led/brightness"
 			done < /var/run/led.state
 			rm /var/run/led.state

--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -20,14 +20,14 @@ start() {
 }
 
 stop() {
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV && \
+	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV &&
 		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
 }
 
 maxtime() {
 	local file newest
 
-	for file in $( find /etc -type f ) ; do
+	for file in $(find /etc -type f); do
 		[ -z "$newest" -o "$newest" -ot "$file" ] && newest=$file
 	done
 	[ "$newest" ] && date -r "$newest" +%s

--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -22,9 +22,9 @@ system_config() {
 	echo "$hostname" > /proc/sys/kernel/hostname
 	[ -z "$conloglevel" -a -z "$buffersize" ] || dmesg ${conloglevel:+-n $conloglevel} ${buffersize:+-s $buffersize}
 	echo "$timezone" > /tmp/TZ
-	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ] \
-		&& ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime \
-		&& rm -f /tmp/TZ
+	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ] &&
+		ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime &&
+		rm -f /tmp/TZ
 
 	# apply timezone to kernel
 	hwclock -u --systz

--- a/package/base-files/files/etc/iproute2/ematch_map
+++ b/package/base-files/files/etc/iproute2/ematch_map
@@ -1,8 +1,8 @@
 # lookup table for ematch kinds
-1	cmp
-2	nbyte
-3	u32
-4	meta
-7	canid
-8	ipset
-9	ipt
+1 cmp
+2 nbyte
+3 u32
+4 meta
+7 canid
+8 ipset
+9 ipt

--- a/package/base-files/files/etc/iproute2/rt_protos
+++ b/package/base-files/files/etc/iproute2/rt_protos
@@ -1,18 +1,18 @@
 #
 # Reserved protocols.
 #
-0	unspec
-1	redirect
-2	kernel
-3	boot
-4	static
-8	gated
-9	ra
-10	mrt
-11	zebra
-12	bird
-13	dnrouted
-14	xorp
-15	ntk
-16	dhcp
-42	babel
+0 unspec
+1 redirect
+2 kernel
+3 boot
+4 static
+8 gated
+9 ra
+10 mrt
+11 zebra
+12 bird
+13 dnrouted
+14 xorp
+15 ntk
+16 dhcp
+42 babel

--- a/package/base-files/files/etc/iproute2/rt_tables
+++ b/package/base-files/files/etc/iproute2/rt_tables
@@ -1,11 +1,11 @@
 #
 # reserved values
 #
-128	prelocal
-255	local
-254	main
-253	default
-0	unspec
+128 prelocal
+255 local
+254 main
+253 default
+0 unspec
 #
 # local
 #

--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -15,7 +15,7 @@ export PS1='\u@\h:\w\$ '
 export ENV=/etc/shinit
 
 case "$TERM" in
-	xterm*|rxvt*)
+	xterm* | rxvt*)
 		export PS1='\[\e]0;\u@\h: \w\a\]'$PS1
 		;;
 esac
@@ -27,10 +27,9 @@ esac
 	unset FILE
 }
 
-if ( grep -qs '^root::' /etc/shadow && \
-     [ -z "$FAILSAFE" ] )
-then
-cat << EOF
+if (grep -qs '^root::' /etc/shadow \
+	&& [ -z "$FAILSAFE" ]); then
+	cat << EOF
 === WARNING! =====================================
 There is no root password defined on this device!
 Use the "passwd" command to set up a new password

--- a/package/base-files/files/etc/rc.button/reboot
+++ b/package/base-files/files/etc/rc.button/reboot
@@ -2,8 +2,7 @@
 
 [ "${ACTION}" = "released" ] || exit 0
 
-if [ "$SEEN" -ge 5 ]
-then
+if [ "$SEEN" -ge 5 ]; then
 	echo "REBOOT" > /dev/console
 	sync
 	reboot

--- a/package/base-files/files/etc/rc.button/reset
+++ b/package/base-files/files/etc/rc.button/reset
@@ -2,30 +2,28 @@
 
 . /lib/functions.sh
 
-OVERLAY="$( grep ' /overlay ' /proc/mounts )"
+OVERLAY="$(grep ' /overlay ' /proc/mounts)"
 
 case "$ACTION" in
 pressed)
 	[ -z "$OVERLAY" ] && return 0
 
 	return 5
-;;
+	;;
 timeout)
 	. /etc/diag.sh
 	set_state failsafe
-;;
+	;;
 released)
-	if [ "$SEEN" -lt 1 ]
-	then
+	if [ "$SEEN" -lt 1 ]; then
 		echo "REBOOT" > /dev/console
 		sync
 		reboot
-	elif [ "$SEEN" -ge 5 -a -n "$OVERLAY" ]
-	then
+	elif [ "$SEEN" -ge 5 -a -n "$OVERLAY" ]; then
 		echo "FACTORY RESET" > /dev/console
 		jffs2reset -y && reboot &
 	fi
-;;
+	;;
 esac
 
 return 0

--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -44,11 +44,11 @@ disable() {
 enable() {
 	err=1
 	name="$(basename "${initscript}")"
-	[ "$START" ] && \
-		ln -sf "../init.d/$name" "$IPKG_INSTROOT/etc/rc.d/S${START}${name##S[0-9][0-9]}" && \
+	[ "$START" ] &&
+		ln -sf "../init.d/$name" "$IPKG_INSTROOT/etc/rc.d/S${START}${name##S[0-9][0-9]}" &&
 		err=0
-	[ "$STOP" ] && \
-		ln -sf "../init.d/$name" "$IPKG_INSTROOT/etc/rc.d/K${STOP}${name##K[0-9][0-9]}" && \
+	[ "$STOP" ] &&
+		ln -sf "../init.d/$name" "$IPKG_INSTROOT/etc/rc.d/K${STOP}${name##K[0-9][0-9]}" &&
 		err=0
 	return $err
 }
@@ -79,7 +79,7 @@ extra_command() {
 }
 
 help() {
-	cat <<EOF
+	cat << EOF
 Syntax: $initscript [command]
 
 Available commands:
@@ -139,7 +139,7 @@ extra_command "enabled" "Check if service is started on boot"
 
 	start() {
 		rc_procd start_service "$@"
-		if eval "type service_started" 2>/dev/null >/dev/null; then
+		if eval "type service_started" 2> /dev/null > /dev/null; then
 			service_started
 		fi
 	}
@@ -153,13 +153,13 @@ extra_command "enabled" "Check if service is started on boot"
 		procd_lock
 		stop_service "$@"
 		procd_kill "$(basename ${basescript:-$initscript})" "$1"
-		if eval "type service_stopped" 2>/dev/null >/dev/null; then
+		if eval "type service_stopped" 2> /dev/null > /dev/null; then
 			service_stopped
 		fi
 	}
 
 	reload() {
-		if eval "type reload_service" 2>/dev/null >/dev/null; then
+		if eval "type reload_service" 2> /dev/null > /dev/null; then
 			procd_lock
 			reload_service "$@"
 		else
@@ -172,7 +172,7 @@ extra_command "enabled" "Check if service is started on boot"
 	}
 
 	status() {
-		if eval "type status_service" 2>/dev/null >/dev/null; then
+		if eval "type status_service" 2> /dev/null > /dev/null; then
 			status_service "$@"
 		else
 			_procd_status "$(basename ${basescript:-$initscript})" "$1"

--- a/package/base-files/files/etc/shinit
+++ b/package/base-files/files/etc/shinit
@@ -18,13 +18,13 @@ service() {
 		else
 			echo "The following services are available:"
 		fi
-		for F in /etc/init.d/* ; do
-			printf "%-30s\t%10s\t%10s\n"  "$F" \
-			$( $($F enabled) && echo "enabled" || echo "disabled" ) \
-			$( [ "$(ubus call service list "{ 'verbose': true, 'name': '$(basename $F)' }" \
-			| jsonfilter -q -e "@['$(basename $F)'].instances[*].running" | uniq)" = "true" ] \
-			&& echo "running" || echo "stopped" )
-		done;
+		for F in /etc/init.d/*; do
+			printf "%-30s\t%10s\t%10s\n" "$F" \
+				$($($F enabled) && echo "enabled" || echo "disabled") \
+				$([ "$(ubus call service list "{ 'verbose': true, 'name': '$(basename $F)' }" |
+					jsonfilter -q -e "@['$(basename $F)'].instances[*].running" | uniq)" = "true" ] &&
+					echo "running" || echo "stopped")
+		done
 		return 1
 	fi
 }

--- a/package/base-files/files/etc/uci-defaults/10_migrate-shadow
+++ b/package/base-files/files/etc/uci-defaults/10_migrate-shadow
@@ -3,7 +3,7 @@ spwd="$(sed -ne '/^root:/s/^root:\([^:]*\):.*$/\1/p' /etc/shadow)"
 
 if [ -n "${ppwd#[\!x]}" ] && [ -z "${spwd#[\!x]}" ]; then
 	logger -t migrate-shadow "Moving root password hash into shadow database"
-	sed -i -e "s:^root\:[^\:]*\::root\:x\::"     /etc/passwd
+	sed -i -e "s:^root\:[^\:]*\::root\:x\::" /etc/passwd
 	sed -i -e "s:^root\:[^\:]*\::root\:$ppwd\::" /etc/shadow
 fi
 

--- a/package/base-files/files/etc/uci-defaults/12_network-generate-ula
+++ b/package/base-files/files/etc/uci-defaults/12_network-generate-ula
@@ -1,13 +1,12 @@
 [ "$(uci -q get network.globals.ula_prefix)" != "auto" ] && exit 0
 
-r1=$(dd if=/dev/urandom bs=1 count=1 |hexdump -e '1/1 "%02x"')
-r2=$(dd if=/dev/urandom bs=2 count=1 |hexdump -e '2/1 "%02x"')
-r3=$(dd if=/dev/urandom bs=2 count=1 |hexdump -e '2/1 "%02x"')
+r1=$(dd if=/dev/urandom bs=1 count=1 | hexdump -e '1/1 "%02x"')
+r2=$(dd if=/dev/urandom bs=2 count=1 | hexdump -e '2/1 "%02x"')
+r3=$(dd if=/dev/urandom bs=2 count=1 | hexdump -e '2/1 "%02x"')
 
-uci -q batch <<-EOF >/dev/null
+uci -q batch <<- EOF > /dev/null
 	set network.globals.ula_prefix=fd$r1:$r2:$r3::/48
 	commit network
 EOF
 
 exit 0
-

--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -2,8 +2,7 @@
 # Copyright (C) 2006 Fokus Fraunhofer <carsten.tittel@fokus.fraunhofer.de>
 # Copyright (C) 2010 Vertical Communications
 
-
-debug () {
+debug() {
 	${DEBUG:-:} "$@"
 }
 
@@ -65,7 +64,7 @@ package() {
 	return 0
 }
 
-config () {
+config() {
 	local cfgtype="$1"
 	local name="$2"
 
@@ -77,8 +76,9 @@ config () {
 	[ -n "$NO_CALLBACK" ] || config_cb "$cfgtype" "$name"
 }
 
-option () {
-	local varname="$1"; shift
+option() {
+	local varname="$1"
+	shift
 	local value="$*"
 
 	config_set "$CONFIG_SECTION" "${varname}" "${value}"
@@ -86,7 +86,8 @@ option () {
 }
 
 list() {
-	local varname="$1"; shift
+	local varname="$1"
+	shift
 	local value="$*"
 	local len
 
@@ -107,12 +108,12 @@ config_unset() {
 # config_get <section> <option>
 config_get() {
 	case "$2${3:-$1}" in
-		*[!A-Za-z0-9_]*) : ;;
-		*)
-			case "$3" in
-				"") eval echo "\"\${CONFIG_${1}_${2}:-\${4}}\"";;
-				*)  eval export ${NO_EXPORT:+-n} -- "${1}=\${CONFIG_${2}_${3}:-\${4}}";;
-			esac
+	*[!A-Za-z0-9_]*) : ;;
+	*)
+		case "$3" in
+		"") eval echo "\"\${CONFIG_${1}_${2}:-\${4}}\"" ;;
+		*) eval export ${NO_EXPORT:+-n} -- "${1}=\${CONFIG_${2}_${3}:-\${4}}" ;;
+		esac
 		;;
 	esac
 }
@@ -121,9 +122,9 @@ config_get() {
 get_bool() {
 	local _tmp="$1"
 	case "$_tmp" in
-		1|on|true|yes|enabled) _tmp=1;;
-		0|off|false|no|disabled) _tmp=0;;
-		*) _tmp="$2";;
+	1 | on | true | yes | enabled) _tmp=1 ;;
+	0 | off | false | no | disabled) _tmp=0 ;;
+	*) _tmp="$2" ;;
 	esac
 	echo -n "$_tmp"
 }
@@ -161,9 +162,12 @@ config_foreach() {
 
 config_list_foreach() {
 	[ "$#" -ge 3 ] || return 0
-	local section="$1"; shift
-	local option="$1"; shift
-	local function="$1"; shift
+	local section="$1"
+	shift
+	local option="$1"
+	shift
+	local function="$1"
+	shift
 	local val
 	local len
 	local c=1
@@ -183,7 +187,7 @@ default_prerm() {
 	local ret=0
 
 	if [ -f "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" ]; then
-		( . "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" )
+		(. "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg")
 		ret=$?
 	fi
 
@@ -204,7 +208,7 @@ default_prerm() {
 
 add_group_and_user() {
 	local pkgname="$1"
-	local rusers="$(sed -ne 's/^Require-User: *//p' $root/usr/lib/opkg/info/${pkgname}.control 2>/dev/null)"
+	local rusers="$(sed -ne 's/^Require-User: *//p' $root/usr/lib/opkg/info/${pkgname}.control 2> /dev/null)"
 
 	if [ -n "$rusers" ]; then
 		local tuple oIFS="$IFS"
@@ -212,10 +216,16 @@ add_group_and_user() {
 			local uid gid uname gname
 
 			IFS=":"
-			set -- $tuple; uname="$1"; gname="$2"
+			set -- $tuple
+			uname="$1"
+			gname="$2"
 			IFS="="
-			set -- $uname; uname="$1"; uid="$2"
-			set -- $gname; gname="$1"; gid="$2"
+			set -- $uname
+			uname="$1"
+			uid="$2"
+			set -- $gname
+			gname="$1"
+			gid="$2"
 			IFS="$oIFS"
 
 			if [ -n "$gname" ] && [ -n "$gid" ]; then
@@ -246,7 +256,7 @@ default_postinst() {
 	add_group_and_user "${pkgname}"
 
 	if [ -f "$root/usr/lib/opkg/info/${pkgname}.postinst-pkg" ]; then
-		( . "$root/usr/lib/opkg/info/${pkgname}.postinst-pkg" )
+		(. "$root/usr/lib/opkg/info/${pkgname}.postinst-pkg")
 		ret=$?
 	fi
 
@@ -267,7 +277,7 @@ default_postinst() {
 		if grep -m1 -q -s "^/etc/uci-defaults/" "$filelist"; then
 			[ -d /tmp/.uci ] || mkdir -p /tmp/.uci
 			for i in $(grep -s "^/etc/uci-defaults/" "$filelist"); do
-				( [ -f "$i" ] && cd "$(dirname $i)" && . "$i" ) && rm -f "$i"
+				([ -f "$i" ] && cd "$(dirname $i)" && . "$i") && rm -f "$i"
 			done
 			uci commit
 		fi
@@ -293,7 +303,7 @@ default_postinst() {
 include() {
 	local file
 
-	for file in $(ls $1/*.sh 2>/dev/null); do
+	for file in $(ls $1/*.sh 2> /dev/null); do
 		. $file
 	done
 }

--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -9,7 +9,7 @@ caldata_dd() {
 	local count=$(($3))
 	local offset=$(($4))
 
-	dd if=$source of=$target iflag=skip_bytes,fullblock bs=$count skip=$offset count=1 2>/dev/null
+	dd if=$source of=$target iflag=skip_bytes,fullblock bs=$count skip=$offset count=1 2> /dev/null
 	return $?
 }
 
@@ -27,7 +27,7 @@ caldata_extract() {
 	mtd=$(find_mtd_chardev $part)
 	[ -n "$mtd" ] || caldata_die "no mtd device found for partition $part"
 
-	caldata_dd $mtd /lib/firmware/$FIRMWARE $count $offset || \
+	caldata_dd $mtd /lib/firmware/$FIRMWARE $count $offset ||
 		caldata_die "failed to extract calibration data from $mtd"
 }
 
@@ -44,7 +44,7 @@ caldata_extract_ubi() {
 	ubi=$(nand_find_volume $ubidev $part)
 	[ -n "$ubi" ] || caldata_die "no UBI volume found for $part"
 
-	caldata_dd /dev/$ubi /lib/firmware/$FIRMWARE $count $offset || \
+	caldata_dd /dev/$ubi /lib/firmware/$FIRMWARE $count $offset ||
 		caldata_die "failed to extract calibration data from $ubi"
 }
 
@@ -74,7 +74,7 @@ caldata_from_file() {
 
 	[ -n "$target" ] || target=/lib/firmware/$FIRMWARE
 
-	caldata_dd $source $target $count $offset || \
+	caldata_dd $source $target $count $offset ||
 		caldata_die "failed to extract calibration data from $source"
 }
 
@@ -85,7 +85,7 @@ caldata_sysfsload_from_file() {
 	local target_dir="/sys/$DEVPATH"
 	local target="$target_dir/data"
 
-	[ -d "$target_dir" ] || \
+	[ -d "$target_dir" ] ||
 		caldata_die "no sysfs dir to write: $target"
 
 	echo 1 > "$target_dir/loading"
@@ -127,7 +127,7 @@ caldata_patch_chksum() {
 	xor_fw_chksum=$(hexdump -v -n 2 -s $chksum_offset -e '/1 "%02x"' /lib/firmware/$FIRMWARE)
 	xor_fw_chksum=$(xor $xor_fw_chksum $xor_fw_mac $xor_mac)
 
-	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" | \
+	printf "%b" "\x${xor_fw_chksum:0:2}\x${xor_fw_chksum:2:2}" |
 		dd of=$target conv=notrunc bs=1 seek=$chksum_offset count=2
 }
 
@@ -143,7 +143,7 @@ caldata_patch_mac() {
 
 	[ -n "$chksum_offset" ] && caldata_patch_chksum "$mac" "$mac_offset" "$chksum_offset" "$target"
 
-	macaddr_2bin $mac | dd of=$target conv=notrunc oflag=seek_bytes bs=6 seek=$mac_offset count=1 || \
+	macaddr_2bin $mac | dd of=$target conv=notrunc oflag=seek_bytes bs=6 seek=$mac_offset count=1 ||
 		caldata_die "failed to write MAC address to eeprom file"
 }
 

--- a/package/base-files/files/lib/functions/leds.sh
+++ b/package/base-files/files/lib/functions/leds.sh
@@ -15,9 +15,9 @@ get_dt_led() {
 	local label
 	local ledpath=$(get_dt_led_path $1)
 
-	[ -n "$ledpath" ] && \
-		label=$(cat "$ledpath/label" 2>/dev/null) || \
-		label=$(cat "$ledpath/chan-name" 2>/dev/null) || \
+	[ -n "$ledpath" ] &&
+		label=$(cat "$ledpath/label" 2> /dev/null) ||
+		label=$(cat "$ledpath/chan-name" 2> /dev/null) ||
 		label=$(basename "$ledpath")
 
 	echo "$label"
@@ -47,10 +47,10 @@ status_led_restore_trigger() {
 	local trigger
 	local ledpath=$(get_dt_led_path $1)
 
-	[ -n "$ledpath" ] && \
-		trigger=$(cat "$ledpath/linux,default-trigger" 2>/dev/null)
+	[ -n "$ledpath" ] &&
+		trigger=$(cat "$ledpath/linux,default-trigger" 2> /dev/null)
 
-	[ -n "$trigger" ] && \
+	[ -n "$trigger" ] &&
 		led_set_attr "$(get_dt_led $1)" "trigger" "$trigger"
 }
 

--- a/package/base-files/files/lib/functions/migrations.sh
+++ b/package/base-files/files/lib/functions/migrations.sh
@@ -1,7 +1,8 @@
 . /lib/functions.sh
 
 migrate_led_sysfs() {
-	local cfg="$1"; shift
+	local cfg="$1"
+	shift
 	local tuples="$@"
 	local sysfs
 	local name
@@ -23,11 +24,12 @@ migrate_led_sysfs() {
 		uci set system.${cfg}.sysfs="${new_sysfs}"
 
 		logger -t led-migration "sysfs option of LED \"${name}\" updated to ${new_sysfs}"
-	done;
+	done
 }
 
 remove_devicename_led_sysfs() {
-	local cfg="$1"; shift
+	local cfg="$1"
+	shift
 	local exceptions="$@"
 	local sysfs
 	local name

--- a/package/base-files/files/lib/functions/preinit.sh
+++ b/package/base-files/files/lib/functions/preinit.sh
@@ -8,7 +8,8 @@ boot_hook_splice_start() {
 boot_hook_splice_finish() {
 	local hook
 	for hook in $PI_STACK_LIST; do
-		local v; eval "v=\${${hook}_splice:+\$${hook}_splice }$hook"
+		local v
+		eval "v=\${${hook}_splice:+\$${hook}_splice }$hook"
 		export -n "${hook}=${v% }"
 		export -n "${hook}_splice="
 	done
@@ -26,7 +27,8 @@ boot_hook_add() {
 	local func="${2}"
 
 	[ -n "$func" ] && {
-		local v; eval "v=\$$hook"
+		local v
+		eval "v=\$$hook"
 		export -n "$hook=${v:+$v }$func"
 	}
 }
@@ -35,12 +37,13 @@ boot_hook_shift() {
 	local hook="${1}_hook"
 	local rvar="${2}"
 
-	local v; eval "v=\$$hook"
+	local v
+	eval "v=\$$hook"
 	[ -n "$v" ] && {
 		local first="${v%% *}"
 
-		[ "$v" != "${v#* }" ] && \
-			export -n "$hook=${v#* }" || \
+		[ "$v" != "${v#* }" ] &&
+			export -n "$hook=${v#* }" ||
 			export -n "$hook="
 
 		export -n "$rvar=$first"
@@ -55,7 +58,8 @@ boot_run_hook() {
 	local func
 
 	while boot_hook_shift "$hook" func; do
-		local ran; eval "ran=\$PI_RAN_$func"
+		local ran
+		eval "ran=\$PI_RAN_$func"
 		[ -n "$ran" ] || {
 			export -n "PI_RAN_$func=1"
 			$func "$1" "$2"
@@ -64,8 +68,8 @@ boot_run_hook() {
 }
 
 pivot() { # <new_root> <old_root>
-	/bin/mount -o noatime,move /proc $1/proc && \
-	pivot_root $1 $1$2 && {
+	/bin/mount -o noatime,move /proc $1/proc &&
+		pivot_root $1 $1$2 && {
 		/bin/mount -o noatime,move $2/dev /dev
 		/bin/mount -o noatime,move $2/tmp /tmp
 		/bin/mount -o noatime,move $2/sys /sys 2>&-

--- a/package/base-files/files/lib/functions/service.sh
+++ b/package/base-files/files/lib/functions/service.sh
@@ -40,19 +40,20 @@ service() {
 	local start
 	ssd="${SERVICE_DEBUG:+echo }start-stop-daemon${SERVICE_QUIET:+ -q}"
 	case "$1" in
-	  -C)
+	-C)
 		ssd="$ssd -K -t"
 		;;
-	  -S)
+	-S)
 		ssd="$ssd -S${SERVICE_DAEMONIZE:+ -b}${SERVICE_WRITE_PID:+ -m}"
 		start=1
 		;;
-	  -K)
+	-K)
 		ssd="$ssd -K${SERVICE_SIG:+ -s $SERVICE_SIG}"
 		;;
-	  *)
+	*)
 		echo "service: unknown ACTION '$1'" 1>&2
 		return 1
+		;;
 	esac
 	shift
 	exec="$1"
@@ -65,8 +66,8 @@ service() {
 		return 1
 	}
 	name="${SERVICE_NAME:-${exec##*/}}"
-	[ -z "$SERVICE_USE_PID$SERVICE_WRITE_PID$SERVICE_PID_FILE" ] \
-		|| ssd="$ssd -p ${SERVICE_PID_FILE:-/var/run/$name.pid}"
+	[ -z "$SERVICE_USE_PID$SERVICE_WRITE_PID$SERVICE_PID_FILE" ] ||
+		ssd="$ssd -p ${SERVICE_PID_FILE:-/var/run/$name.pid}"
 	[ -z "$SERVICE_MATCH_NAME" ] || ssd="$ssd -n $name"
 	ssd="$ssd${SERVICE_UID:+ -c $SERVICE_UID${SERVICE_GID:+:$SERVICE_GID}}"
 	[ -z "$SERVICE_MATCH_EXEC$start" ] || ssd="$ssd -x $exec"

--- a/package/base-files/files/lib/preinit/02_sysinfo
+++ b/package/base-files/files/lib/preinit/02_sysinfo
@@ -1,10 +1,12 @@
 do_sysinfo_generic() {
 	[ -d /proc/device-tree ] || return
 	mkdir -p /tmp/sysinfo
-	[ -e /tmp/sysinfo/board_name ] || \
-		echo "$(strings /proc/device-tree/compatible | head -1)" > /tmp/sysinfo/board_name
-	[ ! -e /tmp/sysinfo/model -a -e /proc/device-tree/model ] && \
-		echo "$(cat /proc/device-tree/model)" > /tmp/sysinfo/model
+
+	[ -e /tmp/sysinfo/board_name ] ||
+		strings /proc/device-tree/compatible | head -1 > /tmp/sysinfo/board_name
+
+	[ ! -e /tmp/sysinfo/model ] && [ -e /proc/device-tree/model ] &&
+		cat /proc/device-tree/model > /tmp/sysinfo/model
 }
 
 boot_hook_add preinit_main do_sysinfo_generic

--- a/package/base-files/files/lib/preinit/10_indicate_failsafe
+++ b/package/base-files/files/lib/preinit/10_indicate_failsafe
@@ -3,7 +3,7 @@
 
 # commands for emitting messages to network in failsafe mode
 
-indicate_failsafe_led () {
+indicate_failsafe_led() {
 	set_state failsafe
 }
 

--- a/package/base-files/files/lib/preinit/10_indicate_preinit
+++ b/package/base-files/files/lib/preinit/10_indicate_preinit
@@ -47,20 +47,20 @@ preinit_config_switch() {
 		for role in $roles; do
 			json_select "$role"
 			json_get_vars ports device
-			json_select ..
+			json_select .. # roles
 
 			if [ "$device" = "$lan_if" ]; then
 				swconfig dev $name vlan $role set ports "$ports"
 			fi
 		done
 
-		json_select ..
+		json_select .. # $name
 	fi
 
 	swconfig dev $name set apply
 
-	json_select ..
-	json_select ..
+	json_select .. # switch
+	json_select .. # root
 }
 
 preinit_config_board() {
@@ -74,11 +74,10 @@ preinit_config_board() {
 	json_load "$(cat /tmp/board.json)"
 
 	json_select network
-		json_select "lan"
-			json_get_vars device
-			json_get_values ports ports
-		json_select ..
-	json_select ..
+	json_select "lan"
+	json_get_vars device
+	json_get_values ports ports
+	json_select .. # network
 
 	[ -n "$device" -o -n "$ports" ] || return
 

--- a/package/base-files/files/lib/preinit/30_failsafe_wait
+++ b/package/base-files/files/lib/preinit/30_failsafe_wait
@@ -1,7 +1,7 @@
 # Copyright (C) 2006-2010 OpenWrt.org
 # Copyright (C) 2010 Vertical Communications
 
-fs_wait_for_key () {
+fs_wait_for_key() {
 	local timeout=$3
 	local timer
 	local do_keypress
@@ -32,8 +32,8 @@ fs_wait_for_key () {
 		while [ $timer -gt 0 ]; do
 			pi_failsafe_net_message=true \
 				preinit_net_echo "Please press button now to enter failsafe"
-			echo "$timer" >$keypress_sec
-			timer=$(($timer - 1))
+			echo "$timer" > $keypress_sec
+			timer=$((timer - 1))
 			sleep 1
 		done
 		lock -u $keypress_wait
@@ -55,13 +55,13 @@ fs_wait_for_key () {
 				read -t "$timer" do_keypress
 				case "$do_keypress" in
 				$1)
-					echo "true" >$keypress_true
+					echo "true" > $keypress_true
 					;;
 				1 | 2 | 3 | 4)
-					echo "$do_keypress" >/tmp/debug_level
+					echo "$do_keypress" > /tmp/debug_level
 					;;
 				*)
-					continue;
+					continue
 					;;
 				esac
 				lock -u $keypress_wait

--- a/package/base-files/files/lib/preinit/40_run_failsafe_hook
+++ b/package/base-files/files/lib/preinit/40_run_failsafe_hook
@@ -2,15 +2,15 @@
 # Copyright (C) 2010 Vertical Communications
 
 run_failsafe_hook() {
-    [ "$pi_preinit_no_failsafe" = "y" ] && return
-    if [ "$FAILSAFE" = "true" ]; then
-	lock /tmp/.failsafe
-	boot_run_hook failsafe
-	while [ ! -e /tmp/sysupgrade ]; do
-	    lock -w /tmp/.failsafe
-	done
-	exit
-    fi
+	[ "$pi_preinit_no_failsafe" = "y" ] && return
+	if [ "$FAILSAFE" = "true" ]; then
+		lock /tmp/.failsafe
+		boot_run_hook failsafe
+		while [ ! -e /tmp/sysupgrade ]; do
+			lock -w /tmp/.failsafe
+		done
+		exit
+	fi
 }
 
 boot_hook_add preinit_main run_failsafe_hook

--- a/package/base-files/files/lib/preinit/99_10_failsafe_login
+++ b/package/base-files/files/lib/preinit/99_10_failsafe_login
@@ -6,7 +6,7 @@ failsafe_shell() {
 	[ -n "$console" ] || console=console
 	[ -c "/dev/$console" ] || return 0
 	while true; do
-		ash --login <"/dev/$console" >"/dev/$console" 2>"/dev/$console"
+		ash --login < "/dev/$console" > "/dev/$console" 2> "/dev/$console"
 		sleep 1
 	done &
 }

--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -1,9 +1,9 @@
 RAM_ROOT=/tmp/root
 
-export BACKUP_FILE=sysupgrade.tgz	# file extracted by preinit
+export BACKUP_FILE=sysupgrade.tgz # file extracted by preinit
 
 [ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
-libs() { ldd $* 2>/dev/null | sed -E 's/(.* => )?(.*) .*/\2/'; }
+libs() { ldd $* 2> /dev/null | sed -E 's/(.* => )?(.*) .*/\2/'; }
 
 install_file() { # <file> [ <file> ... ]
 	local target dest dir
@@ -36,26 +36,28 @@ install_bin() {
 }
 
 run_hooks() {
-	local arg="$1"; shift
+	local arg="$1"
+	shift
 	for func in "$@"; do
 		eval "$func $arg"
 	done
 }
 
 ask_bool() {
-	local default="$1"; shift;
+	local default="$1"
+	shift
 	local answer="$default"
 
 	[ "$INTERACTIVE" -eq 1 ] && {
 		case "$default" in
-			0) echo -n "$* (y/N): ";;
-			*) echo -n "$* (Y/n): ";;
+		0) echo -n "$* (y/N): " ;;
+		*) echo -n "$* (Y/n): " ;;
 		esac
 		read answer
 		case "$answer" in
-			y*) answer=1;;
-			n*) answer=0;;
-			*) answer="$default";;
+		y*) answer=1 ;;
+		n*) answer=0 ;;
+		*) answer="$default" ;;
 		esac
 	}
 	[ "$answer" -gt 0 ]
@@ -86,45 +88,52 @@ get_image() { # <source> [ <command> ]
 	local cmd="$2"
 
 	if [ -z "$cmd" ]; then
-		local magic="$(dd if="$from" bs=2 count=1 2>/dev/null | hexdump -n 2 -e '1/1 "%02x"')"
+		local magic="$(dd if="$from" bs=2 count=1 2> /dev/null | hexdump -n 2 -e '1/1 "%02x"')"
 		case "$magic" in
-			1f8b) cmd="busybox zcat";;
-			*) cmd="cat";;
+		1f8b) cmd="busybox zcat" ;;
+		*) cmd="cat" ;;
 		esac
 	fi
 
-	$cmd <"$from"
+	$cmd < "$from"
 }
 
 get_image_dd() {
-	local from="$1"; shift
+	local from="$1"
+	shift
 
 	(
 		exec 3>&2
-		( exec 3>&2; get_image "$from" 2>&1 1>&3 | grep -v -F ' Broken pipe'     ) 2>&1 1>&3 \
-			| ( exec 3>&2; dd "$@" 2>&1 1>&3 | grep -v -E ' records (in|out)') 2>&1 1>&3
+		(
+			exec 3>&2
+			get_image "$from" 2>&1 1>&3 | grep -v -F ' Broken pipe'
+		) 2>&1 1>&3 |
+			(
+				exec 3>&2
+				dd "$@" 2>&1 1>&3 | grep -v -E ' records (in|out)'
+			) 2>&1 1>&3
 		exec 3>&-
 	)
 }
 
 get_magic_word() {
-	(get_image "$@" | dd bs=2 count=1 | hexdump -v -n 2 -e '1/1 "%02x"') 2>/dev/null
+	(get_image "$@" | dd bs=2 count=1 | hexdump -v -n 2 -e '1/1 "%02x"') 2> /dev/null
 }
 
 get_magic_long() {
-	(get_image "$@" | dd bs=4 count=1 | hexdump -v -n 4 -e '1/1 "%02x"') 2>/dev/null
+	(get_image "$@" | dd bs=4 count=1 | hexdump -v -n 4 -e '1/1 "%02x"') 2> /dev/null
 }
 
 get_magic_gpt() {
-	(get_image "$@" | dd bs=8 count=1 skip=64) 2>/dev/null
+	(get_image "$@" | dd bs=8 count=1 skip=64) 2> /dev/null
 }
 
 get_magic_vfat() {
-	(get_image "$@" | dd bs=3 count=1 skip=18) 2>/dev/null
+	(get_image "$@" | dd bs=3 count=1 skip=18) 2> /dev/null
 }
 
 get_magic_fat32() {
-	(get_image "$@" | dd bs=1 count=5 skip=82) 2>/dev/null
+	(get_image "$@" | dd bs=1 count=5 skip=82) 2> /dev/null
 }
 
 part_magic_efi() {
@@ -144,42 +153,42 @@ export_bootdevice() {
 	local rootpart="$(cmdline_get_var root)"
 
 	case "$rootpart" in
-		PARTUUID=[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]-[a-f0-9][a-f0-9])
-			uuid="${rootpart#PARTUUID=}"
-			uuid="${uuid%-[a-f0-9][a-f0-9]}"
-			for blockdev in $(find /dev -type b); do
-				set -- $(dd if=$blockdev bs=1 skip=440 count=4 2>/dev/null | hexdump -v -e '4/1 "%02x "')
-				if [ "$4$3$2$1" = "$uuid" ]; then
-					uevent="/sys/class/block/${blockdev##*/}/uevent"
-					break
-				fi
-			done
+	PARTUUID=[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]-[a-f0-9][a-f0-9])
+		uuid="${rootpart#PARTUUID=}"
+		uuid="${uuid%-[a-f0-9][a-f0-9]}"
+		for blockdev in $(find /dev -type b); do
+			set -- $(dd if=$blockdev bs=1 skip=440 count=4 2> /dev/null | hexdump -v -e '4/1 "%02x "')
+			if [ "$4$3$2$1" = "$uuid" ]; then
+				uevent="/sys/class/block/${blockdev##*/}/uevent"
+				break
+			fi
+		done
 		;;
-		PARTUUID=????????-????-????-????-??????????02)
-			uuid="${rootpart#PARTUUID=}"
-			uuid="${uuid%02}00"
-			for disk in $(find /dev -type b); do
-				set -- $(dd if=$disk bs=1 skip=568 count=16 2>/dev/null | hexdump -v -e '8/1 "%02x "" "2/1 "%02x""-"6/1 "%02x"')
-				if [ "$4$3$2$1-$6$5-$8$7-$9" = "$uuid" ]; then
-					uevent="/sys/class/block/${disk##*/}/uevent"
-					break
-				fi
-			done
+	PARTUUID=????????-????-????-????-??????????02)
+		uuid="${rootpart#PARTUUID=}"
+		uuid="${uuid%02}00"
+		for disk in $(find /dev -type b); do
+			set -- $(dd if=$disk bs=1 skip=568 count=16 2> /dev/null | hexdump -v -e '8/1 "%02x "" "2/1 "%02x""-"6/1 "%02x"')
+			if [ "$4$3$2$1-$6$5-$8$7-$9" = "$uuid" ]; then
+				uevent="/sys/class/block/${disk##*/}/uevent"
+				break
+			fi
+		done
 		;;
-		/dev/*)
-			uevent="/sys/class/block/${rootpart##*/}/../uevent"
+	/dev/*)
+		uevent="/sys/class/block/${rootpart##*/}/../uevent"
 		;;
-		0x[a-f0-9][a-f0-9][a-f0-9] | 0x[a-f0-9][a-f0-9][a-f0-9][a-f0-9] | \
+	0x[a-f0-9][a-f0-9][a-f0-9] | 0x[a-f0-9][a-f0-9][a-f0-9][a-f0-9] | \
 		[a-f0-9][a-f0-9][a-f0-9] | [a-f0-9][a-f0-9][a-f0-9][a-f0-9])
-			rootpart=0x${rootpart#0x}
-			for class in /sys/class/block/*; do
-				while read line; do
-					export -n "$line"
-				done < "$class/uevent"
-				if [ $((rootpart/256)) = $MAJOR -a $((rootpart%256)) = $MINOR ]; then
-					uevent="$class/../uevent"
-				fi
-			done
+		rootpart=0x${rootpart#0x}
+		for class in /sys/class/block/*; do
+			while read line; do
+				export -n "$line"
+			done < "$class/uevent"
+			if [ $((rootpart / 256)) = $MAJOR -a $((rootpart % 256)) = $MINOR ]; then
+				uevent="$class/../uevent"
+			fi
+		done
 		;;
 	esac
 
@@ -203,7 +212,7 @@ export_partdevice() {
 		while read line; do
 			export -n "$line"
 		done < "$uevent"
-		if [ $BOOTDEV_MAJOR = $MAJOR -a $(($BOOTDEV_MINOR + $offset)) = $MINOR -a -b "/dev/$DEVNAME" ]; then
+		if [ $BOOTDEV_MAJOR = $MAJOR -a $((BOOTDEV_MINOR + offset)) = $MINOR -a -b "/dev/$DEVNAME" ]; then
 			export "$var=$DEVNAME"
 			return 0
 		fi
@@ -236,7 +245,7 @@ get_partitions() { # <device> <filename>
 	if [ -b "$disk" -o -f "$disk" ]; then
 		v "Reading partition table from $filename..."
 
-		local magic=$(dd if="$disk" bs=2 count=1 skip=255 2>/dev/null)
+		local magic=$(dd if="$disk" bs=2 count=1 skip=255 2> /dev/null)
 		if [ "$magic" != $'\x55\xAA' ]; then
 			v "Invalid partition table on $disk"
 			exit
@@ -249,12 +258,12 @@ get_partitions() { # <device> <filename>
 			#export_partdevice will fail when partition number is greater than 15, as
 			#the partition major device number is not equal to the disk major device number
 			for part in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-				set -- $(hexdump -v -n 48 -s "$((0x380 + $part * 0x80))" -e '4/4 "%08x"" "4/4 "%08x"" "4/4 "0x%08X "' "$disk")
+				set -- $(hexdump -v -n 48 -s "$((0x380 + part * 0x80))" -e '4/4 "%08x"" "4/4 "%08x"" "4/4 "0x%08X "' "$disk")
 
 				local type="$1"
-				local lba="$(( $(hex_le32_to_cpu $4) * 0x100000000 + $(hex_le32_to_cpu $3) ))"
-				local end="$(( $(hex_le32_to_cpu $6) * 0x100000000 + $(hex_le32_to_cpu $5) ))"
-				local num="$(( $end - $lba ))"
+				local lba="$(($(hex_le32_to_cpu $4) * 0x100000000 + $(hex_le32_to_cpu $3)))"
+				local end="$(($(hex_le32_to_cpu $6) * 0x100000000 + $(hex_le32_to_cpu $5)))"
+				local num="$((end - lba))"
 
 				[ "$type" = "00000000000000000000000000000000" ] && continue
 
@@ -262,11 +271,11 @@ get_partitions() { # <device> <filename>
 			done
 		} || {
 			for part in 1 2 3 4; do
-				set -- $(hexdump -v -n 12 -s "$((0x1B2 + $part * 16))" -e '3/4 "0x%08X "' "$disk")
+				set -- $(hexdump -v -n 12 -s "$((0x1B2 + part * 16))" -e '3/4 "0x%08X "' "$disk")
 
-				local type="$(( $(hex_le32_to_cpu $1) % 256))"
-				local lba="$(( $(hex_le32_to_cpu $2) ))"
-				local num="$(( $(hex_le32_to_cpu $3) ))"
+				local type="$(($(hex_le32_to_cpu $1) % 256))"
+				local lba="$(($(hex_le32_to_cpu $2)))"
+				local num="$(($(hex_le32_to_cpu $3)))"
 
 				[ $type -gt 0 ] || continue
 

--- a/package/base-files/files/lib/upgrade/do_stage2
+++ b/package/base-files/files/lib/upgrade/do_stage2
@@ -5,13 +5,13 @@
 include /lib/upgrade
 
 v "Performing system upgrade..."
-if type 'platform_do_upgrade' >/dev/null 2>/dev/null; then
+if type 'platform_do_upgrade' > /dev/null 2>&1; then
 	platform_do_upgrade "$IMAGE"
 else
 	default_do_upgrade "$IMAGE"
 fi
 
-if [ -n "$UPGRADE_BACKUP" ] && type 'platform_copy_config' >/dev/null 2>/dev/null; then
+if [ -n "$UPGRADE_BACKUP" ] && type 'platform_copy_config' > /dev/null 2>&1; then
 	platform_copy_config
 fi
 
@@ -22,4 +22,4 @@ v "Rebooting system..."
 umount -a
 reboot -f
 sleep 5
-echo b 2>/dev/null >/proc/sysrq-trigger
+echo b 2> /dev/null > /proc/sysrq-trigger

--- a/package/base-files/files/lib/upgrade/fwtool.sh
+++ b/package/base-files/files/lib/upgrade/fwtool.sh
@@ -18,7 +18,7 @@ fwtool_check_signature() {
 		return 0
 	fi
 
-	fwtool -q -T -s /dev/null "$1" | \
+	fwtool -q -T -s /dev/null "$1" |
 		ucert -V -m - -c "/tmp/sysupgrade.ucert" -P /etc/opkg/keys
 
 	return $?

--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -10,17 +10,16 @@ export INTERACTIVE=0
 export VERBOSE=1
 export CONFFILES=/tmp/sysupgrade.conffiles
 
-RAMFS_COPY_BIN=		# extra programs for temporary ramfs root
-RAMFS_COPY_DATA=	# extra data files
+RAMFS_COPY_BIN=  # extra programs for temporary ramfs root
+RAMFS_COPY_DATA= # extra data files
 
 include /lib/upgrade
 
-
 supivot() { # <new_root> <old_root>
 	/bin/mount | grep "on $1 type" 2>&- 1>&- || /bin/mount -o bind $1 $1
-	mkdir -p $1$2 $1/proc $1/sys $1/dev $1/tmp $1/overlay && \
-	/bin/mount -o noatime,move /proc $1/proc && \
-	pivot_root $1 $1$2 || {
+	mkdir -p $1$2 $1/proc $1/sys $1/dev $1/tmp $1/overlay &&
+		/bin/mount -o noatime,move /proc $1/proc &&
+		pivot_root $1 $1$2 || {
 		/bin/umount -l $1 $1
 		return 1
 	}
@@ -37,19 +36,18 @@ switch_to_ramfs() {
 	RAMFS_COPY_LVM="$(command -v lvm)"
 
 	for binary in \
-		/bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount	\
-		pivot_root mount_root reboot sync kill sleep		\
-		md5sum hexdump cat zcat dd tar				\
+		/bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount \
+		pivot_root mount_root reboot sync kill sleep \
+		md5sum hexdump cat zcat dd tar \
 		ls basename find cp mv rm mkdir rmdir mknod touch chmod \
-		'[' printf wc grep awk sed cut				\
-		mtd partx losetup mkfs.ext4 nandwrite flash_erase	\
-		ubiupdatevol ubiattach ubiblock ubiformat		\
-		ubidetach ubirsvol ubirmvol ubimkvol			\
-		snapshot snapshot_tool date logger			\
-		$RAMFS_COPY_LOSETUP $RAMFS_COPY_LVM			\
-		$RAMFS_COPY_BIN
-	do
-		local file="$(command -v "$binary" 2>/dev/null)"
+		'[' printf wc grep awk sed cut \
+		mtd partx losetup mkfs.ext4 nandwrite flash_erase \
+		ubiupdatevol ubiattach ubiblock ubiformat \
+		ubidetach ubirsvol ubirmvol ubimkvol \
+		snapshot snapshot_tool date logger \
+		$RAMFS_COPY_LOSETUP $RAMFS_COPY_LVM \
+		$RAMFS_COPY_BIN; do
+		local file="$(command -v "$binary" 2> /dev/null)"
 		[ -n "$file" ] && install_bin "$file"
 	done
 	install_file /etc/resolv.conf /lib/*.sh /lib/functions/*.sh /lib/upgrade/*.sh /lib/upgrade/do_stage2 /usr/share/libubox/jshn.sh $RAMFS_COPY_DATA
@@ -83,7 +81,7 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 	local loop="${2:-0}"
 	local run=true
 	local stat
-	local proc_ppid=$(cut -d' ' -f4  /proc/$$/stat)
+	local proc_ppid=$(cut -d' ' -f4 /proc/$$/stat)
 
 	v "Sending $sig to remaining processes ..."
 
@@ -94,7 +92,8 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 
 			local pid name state ppid rest
 			read pid name state ppid rest < $stat
-			name="${name#(}"; name="${name%)}"
+			name="${name#(}"
+			name="${name%)}"
 
 			# Skip PID1, our parent, ourself and our children
 			[ $pid -ne 1 -a $pid -ne $proc_ppid -a $pid -ne $$ -a $ppid -ne $$ ] || continue
@@ -106,7 +105,7 @@ kill_remaining() { # [ <signal> [ <loop> ] ]
 			[ -n "$cmdline" ] || continue
 
 			v "Sending signal $sig to $name ($pid)"
-			kill -$sig $pid 2>/dev/null
+			kill -$sig $pid 2> /dev/null
 
 			[ $loop -eq 1 ] && run=true
 		done
@@ -123,23 +122,22 @@ indicate_upgrade
 
 while read -r a b c; do
 	case "$a" in
-		MemT*) mem="$b" ;; esac
+	MemT*) mem="$b" ;; esac
 done < /proc/meminfo
 
-[ "$mem" -gt 32768 ] && \
-	skip_services="dnsmasq log network"
+[ "$mem" -gt 32768 ] && skip_services="dnsmasq log network"
 for service in /etc/init.d/*; do
 	service=${service##*/}
 
 	case " $skip_services " in
-		*" $service "*) continue ;; esac
+	*" $service "*) continue ;; esac
 
-	ubus call service delete '{ "name": "'"$service"'" }' 2>/dev/null
+	ubus call service delete '{ "name": "'"$service"'" }' 2> /dev/null
 done
 
-killall -9 telnetd 2>/dev/null
-killall -9 dropbear 2>/dev/null
-killall -9 ash 2>/dev/null
+killall -9 telnetd 2> /dev/null
+killall -9 dropbear 2> /dev/null
+killall -9 ash 2> /dev/null
 
 kill_remaining TERM
 sleep 4
@@ -149,7 +147,7 @@ sleep 6
 
 echo 3 > /proc/sys/vm/drop_caches
 
-if [ -n "$IMAGE" ] && type 'platform_pre_upgrade' >/dev/null 2>/dev/null; then
+if [ -n "$IMAGE" ] && type 'platform_pre_upgrade' > /dev/null 2>&1; then
 	platform_pre_upgrade "$IMAGE"
 fi
 

--- a/package/base-files/files/sbin/led.sh
+++ b/package/base-files/files/sbin/led.sh
@@ -11,15 +11,14 @@ do_led() {
 	config_get sysfs $1 sysfs
 	[ "$name" = "$NAME" -o "$sysfs" = "$NAME" -a -e "/sys/class/leds/${sysfs}" ] && {
 		[ "$ACTION" = "set" ] &&
-			echo 1 >/sys/class/leds/${sysfs}/brightness \
-			|| echo 0 >/sys/class/leds/${sysfs}/brightness
+			echo 1 > /sys/class/leds/${sysfs}/brightness ||
+			echo 0 > /sys/class/leds/${sysfs}/brightness
 		exit 0
 	}
 }
 
-[ "$1" = "clear" -o "$1" = "set" ] &&
-	[ -n "$2" ] &&{
-		config_load system
-		config_foreach do_led
-		exit 1
-	}
+[ "$1" = "clear" -o "$1" = "set" ] && [ -n "$2" ] && {
+	config_load system
+	config_foreach do_led
+	exit 1
+}

--- a/package/base-files/files/sbin/pkg_check
+++ b/package/base-files/files/sbin/pkg_check
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 ERRFATAL="no"
 QUIET="yes"
 MISSING=""
@@ -49,7 +48,10 @@ done
 
 # Check all packages by default
 if [ -z "$1" ]; then
-	set $(cd /usr/lib/opkg/info/; for i in *.files-sha256sum; do basename $i .files-sha256sum; done)
+	set $(
+		cd /usr/lib/opkg/info/
+		for i in *.files-sha256sum; do basename $i .files-sha256sum; done
+	)
 fi
 
 # Iterate over packages
@@ -78,8 +80,8 @@ while [ "$1" ]; do
 	if [ $? -ne 0 ] && [ "$(cat "/usr/lib/opkg/info/$1.files-sha256sum")" ]; then
 		NEWCHECK="$(echo "$CHECK" | grep '^.*: OK$')"
 		for i in $(echo "$CHECK" | sed -n 's|^\(.*\): FAILED$|\1|p'); do
-			if [ "$(grep "^$i\$" "/usr/lib/opkg/info/$1.conffiles" 2> /dev/null)" ] || \
-			   [ "$(echo "$i" | grep "^/etc/uci-defaults/")" ]; then
+			if [ "$(grep "^$i\$" "/usr/lib/opkg/info/$1.conffiles" 2> /dev/null)" ] ||
+				[ "$(echo "$i" | grep "^/etc/uci-defaults/")" ]; then
 				NEWCHECK="${NEWCHECK}${NL}${i}: CONFIGURED"
 			else
 				NEWCHECK="${NEWCHECK}${NL}${i}: FAILED"

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -28,29 +28,41 @@ export UMOUNT_ETCBACKUP_DIR=0
 # parse options
 while [ -n "$1" ]; do
 	case "$1" in
-		-i) export INTERACTIVE=1;;
-		-v) export VERBOSE="$(($VERBOSE + 1))";;
-		-q) export VERBOSE="$(($VERBOSE - 1))";;
-		-n) export SAVE_CONFIG=0;;
-		-c) export SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/etc;;
-		-o) export SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/;;
-		-p) export SAVE_PARTITIONS=0;;
-		-k) export SAVE_INSTALLED_PKGS=1;;
-		-u) export SKIP_UNCHANGED=1;;
-		-b|--create-backup) export CONF_BACKUP="$2" NEED_IMAGE=1; shift;;
-		-r|--restore-backup) export CONF_RESTORE="$2" NEED_IMAGE=1; shift;;
-		-l|--list-backup) export CONF_BACKUP_LIST=1;;
-		-f) export CONF_IMAGE="$2"; shift;;
-		-F|--force) export FORCE=1;;
-		-T|--test) export TEST=1;;
-		-h|--help) export HELP=1; break;;
-		-*)
-			echo "Invalid option: $1" >&2
-			exit 1
+	-i) export INTERACTIVE=1 ;;
+	-v) export VERBOSE="$((VERBOSE + 1))" ;;
+	-q) export VERBOSE="$((VERBOSE - 1))" ;;
+	-n) export SAVE_CONFIG=0 ;;
+	-c) export SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/etc ;;
+	-o) export SAVE_OVERLAY=1 SAVE_OVERLAY_PATH=/ ;;
+	-p) export SAVE_PARTITIONS=0 ;;
+	-k) export SAVE_INSTALLED_PKGS=1 ;;
+	-u) export SKIP_UNCHANGED=1 ;;
+	-b | --create-backup)
+		export CONF_BACKUP="$2" NEED_IMAGE=1
+		shift
 		;;
-		*) break;;
+	-r | --restore-backup)
+		export CONF_RESTORE="$2" NEED_IMAGE=1
+		shift
+		;;
+	-l | --list-backup) export CONF_BACKUP_LIST=1 ;;
+	-f)
+		export CONF_IMAGE="$2"
+		shift
+		;;
+	-F | --force) export FORCE=1 ;;
+	-T | --test) export TEST=1 ;;
+	-h | --help)
+		export HELP=1
+		break
+		;;
+	-*)
+		echo "Invalid option: $1" >&2
+		exit 1
+		;;
+	*) break ;;
 	esac
-	shift;
+	shift
 done
 
 export CONFFILES=/tmp/sysupgrade.conffiles
@@ -61,7 +73,7 @@ export INSTALLED_PACKAGES=${ETCBACKUP_DIR}/installed_packages.txt
 IMAGE="$1"
 
 [ -z "$IMAGE" -a -z "$NEED_IMAGE" -a $CONF_BACKUP_LIST -eq 0 -o $HELP -gt 0 ] && {
-	cat <<EOF
+	cat << EOF
 Usage: $0 [<upgrade-option>...] <image file or URL>
        $0 [-q] [-i] [-c] [-u] [-o] [-k] <backup-command> <file>
 
@@ -102,7 +114,7 @@ EOF
 }
 
 [ -n "$IMAGE" -a -n "$NEED_IMAGE" ] && {
-	cat <<-EOF
+	cat <<- EOF
 		-b|--create-backup and -r|--restore-backup do not perform a firmware upgrade.
 		Do not specify both -b|-r and a firmware image.
 	EOF
@@ -111,7 +123,6 @@ EOF
 
 # prevent messages from clobbering the tarball when using stdout
 [ "$CONF_BACKUP" = "-" ] && export VERBOSE=0
-
 
 list_conffiles() {
 	awk '
@@ -135,15 +146,17 @@ list_static_conffiles() {
 	local filter=$1
 
 	find $(sed -ne '/^[[:space:]]*$/d; /^#/d; p' \
-		/etc/sysupgrade.conf /lib/upgrade/keep.d/* 2>/dev/null) \
-		\( -type f -o -type l \) $filter 2>/dev/null
+		/etc/sysupgrade.conf /lib/upgrade/keep.d/* 2> /dev/null) \
+		\( -type f -o -type l \) $filter 2> /dev/null
 }
 
 add_conffiles() {
 	local file="$1"
 
-	( list_static_conffiles "$find_filter"; list_changed_conffiles ) |
-		sort -u > "$file"
+	(
+		list_static_conffiles "$find_filter"
+		list_changed_conffiles
+	) | sort -u > "$file"
 	return 0
 }
 
@@ -175,21 +188,23 @@ add_overlayfiles() {
 			find /usr/lib/opkg/info -type f -name "*.control" -exec sed \
 				-ne '/^Alternatives/{s/^Alternatives: //;s/, /\n/g;p}' {} \; |
 				cut -f2 -d:
-		} |  grep -v -x -F -f $conffiles |
-		     grep -v -x -F -f $keepfiles | sort -u > "$packagesfiles"
+		} | grep -v -x -F -f $conffiles |
+			grep -v -x -F -f $keepfiles | sort -u > "$packagesfiles"
 		rm -f "$keepfiles" "$conffiles"
 	fi
 
 	# busybox grep bug when file is empty
 	[ -s "$packagesfiles" ] || echo > $packagesfiles
 
-	( cd /overlay/upper/; find .$SAVE_OVERLAY_PATH \( -type f -o -type l \) $find_filter | sed \
-		-e 's,^\.,,' \
-		-e '\,^/etc/board.json$,d' \
-		-e '\,/[^/]*-opkg$,d' \
-		-e '\,^/etc/urandom.seed$,d' \
-		-e "\,^$INSTALLED_PACKAGES$,d" \
-		-e '\,^/usr/lib/opkg/.*,d' \
+	(
+		cd /overlay/upper/
+		find .$SAVE_OVERLAY_PATH \( -type f -o -type l \) $find_filter | sed \
+			-e 's,^\.,,' \
+			-e '\,^/etc/board.json$,d' \
+			-e '\,/[^/]*-opkg$,d' \
+			-e '\,^/etc/urandom.seed$,d' \
+			-e "\,^$INSTALLED_PACKAGES$,d" \
+			-e '\,^/usr/lib/opkg/.*,d'
 	) | grep -v -x -F -f $packagesfiles > "$file"
 
 	rm -f "$packagesfiles"
@@ -238,9 +253,9 @@ do_save_conffiles() {
 		mkdir -p "$RAMFS/upper" "$RAMFS/work"
 		mount -t overlay overlay -o lowerdir=$ETCBACKUP_DIR,upperdir=$RAMFS/upper,workdir=$RAMFS/work $ETCBACKUP_DIR &&
 			UMOUNT_ETCBACKUP_DIR=1 || {
-				echo "Cannot mount '$ETCBACKUP_DIR' as tmpfs to avoid touching disk while saving the list of installed packages." >&2
-				ask_bool 0 "Abort" && exit
-			}
+			echo "Cannot mount '$ETCBACKUP_DIR' as tmpfs to avoid touching disk while saving the list of installed packages." >&2
+			ask_bool 0 "Abort" && exit
+		}
 
 		# Format: pkg-name<TAB>{rom,overlay,unkown}
 		# rom is used for pkgs in /rom, even if updated later
@@ -253,7 +268,7 @@ do_save_conffiles() {
 
 	v "Saving config files..."
 	[ "$VERBOSE" -gt 1 ] && TAR_V="v" || TAR_V=""
-	tar c${TAR_V}zf "$conf_tar" -T "$CONFFILES" 2>/dev/null
+	tar c${TAR_V}zf "$conf_tar" -T "$CONFFILES" 2> /dev/null
 	if [ "$?" -ne 0 ]; then
 		echo "Failed to create the configuration backup."
 		rm -f "$conf_tar"
@@ -292,32 +307,32 @@ if [ -n "$CONF_RESTORE" ]; then
 	exit $?
 fi
 
-type platform_check_image >/dev/null 2>/dev/null || {
+type platform_check_image > /dev/null 2> /dev/null || {
 	echo "Firmware upgrade is not implemented for this platform." >&2
 	exit 1
 }
 
 case "$IMAGE" in
-	http://*|\
+http://* | \
 	https://*)
-		wget -O/tmp/sysupgrade.img "$IMAGE" || exit 1
-		IMAGE=/tmp/sysupgrade.img
-		;;
+	wget -O/tmp/sysupgrade.img "$IMAGE" || exit 1
+	IMAGE=/tmp/sysupgrade.img
+	;;
 esac
 
 IMAGE="$(readlink -f "$IMAGE")"
 
 case "$IMAGE" in
-	'')
-		echo "Image file not found." >&2
-		exit 1
-		;;
-	/tmp/*)	;;
-	*)
-		v "Image not in /tmp, copying..."
-		cp -f "$IMAGE" /tmp/sysupgrade.img
-		IMAGE=/tmp/sysupgrade.img
-		;;
+'')
+	echo "Image file not found." >&2
+	exit 1
+	;;
+/tmp/*) ;;
+*)
+	v "Image not in /tmp, copying..."
+	cp -f "$IMAGE" /tmp/sysupgrade.img
+	IMAGE=/tmp/sysupgrade.img
+	;;
 esac
 
 json_load "$(/usr/libexec/validate_firmware_image "$IMAGE")" || {
@@ -336,11 +351,11 @@ json_get_var valid "valid"
 
 if [ -n "$CONF_IMAGE" ]; then
 	case "$(get_magic_word $CONF_IMAGE cat)" in
-		# .gz files
-		1f8b) ;;
-		*)
-			echo "Invalid config file. Please use only .tar.gz files" >&2
-			exit 1
+	# .gz files
+	1f8b) ;;
+	*)
+		echo "Invalid config file. Please use only .tar.gz files" >&2
+		exit 1
 		;;
 	esac
 	get_image "$CONF_IMAGE" "cat" > "$CONF_TAR"
@@ -363,7 +378,7 @@ v "Commencing upgrade. Closing all shell sessions."
 COMMAND='/lib/upgrade/do_stage2'
 
 if [ -n "$FAILSAFE" ]; then
-	printf '%s\x00%s\x00%s' "$RAM_ROOT" "$IMAGE" "$COMMAND" >/tmp/sysupgrade
+	printf '%s\x00%s\x00%s' "$RAM_ROOT" "$IMAGE" "$COMMAND" > /tmp/sysupgrade
 	lock -u /tmp/.failsafe
 else
 	json_init

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -5,7 +5,7 @@
 . /usr/share/libubox/jshn.sh
 
 usage() {
-	cat <<EOF
+	cat << EOF
 Usage: $0 [config|up|down|reconf|reload|status]
 enables (default), disables or configures devices not yet configured.
 EOF
@@ -21,7 +21,7 @@ ubus_wifi_cmd() {
 	ubus call network.wireless "$1" "$(json_dump)"
 }
 
-find_net_config() {(
+find_net_config() { (
 	local vif="$1"
 	local cfg
 	local ifname
@@ -38,10 +38,9 @@ find_net_config() {(
 	}
 	[ -z "$cfg" ] && return 0
 	echo "$cfg"
-)}
+); }
 
-
-bridge_interface() {(
+bridge_interface() { (
 	local cfg="$1"
 	[ -z "$cfg" ] && return 0
 
@@ -54,15 +53,14 @@ bridge_interface() {(
 		prepare_interface_bridge "$cfg"
 		return $?
 	done
-)}
+); }
 
 prepare_key_wep() {
 	local key="$1"
 	local hex=1
 
 	echo -n "$key" | grep -qE "[^a-fA-F0-9]" && hex=0
-	[ "${#key}" -eq 10 -a $hex -eq 1 ] || \
-	[ "${#key}" -eq 26 -a $hex -eq 1 ] || {
+	[ "${#key}" -eq 10 -a $hex -eq 1 ] || [ "${#key}" -eq 26 -a $hex -eq 1 ] || {
 		[ "${key:0:2}" = "s:" ] && key="${key#s:}"
 		key="$(echo -n "$key" | hexdump -ve '1/1 "%02x" ""')"
 	}
@@ -77,30 +75,30 @@ wifi_fixup_hwmode() {
 	config_get channel "$device" channel
 	config_get hwmode "$device" hwmode
 	case "$hwmode" in
-		11bg) hwmode=bg;;
-		11a) hwmode=a;;
-		11ad) hwmode=ad;;
-		11b) hwmode=b;;
-		11g) hwmode=g;;
-		11n*)
-			hwmode_11n="${hwmode##11n}"
-			case "$hwmode_11n" in
-				a|g) ;;
-				default) hwmode_11n="$default"
-			esac
-			config_set "$device" hwmode_11n "$hwmode_11n"
+	11bg) hwmode=bg ;;
+	11a) hwmode=a ;;
+	11ad) hwmode=ad ;;
+	11b) hwmode=b ;;
+	11g) hwmode=g ;;
+	11n*)
+		hwmode_11n="${hwmode##11n}"
+		case "$hwmode_11n" in
+		a | g) ;;
+		default) hwmode_11n="$default" ;;
+		esac
+		config_set "$device" hwmode_11n "$hwmode_11n"
 		;;
-		*)
-			hwmode=
-			if [ "${channel:-0}" -gt 0 ]; then
-				if [ "${channel:-0}" -gt 14 ]; then
-					hwmode=a
-				else
-					hwmode=g
-				fi
+	*)
+		hwmode=
+		if [ "${channel:-0}" -gt 0 ]; then
+			if [ "${channel:-0}" -gt 14 ]; then
+				hwmode=a
 			else
-				hwmode="$default"
+				hwmode=g
 			fi
+		else
+			hwmode="$default"
+		fi
 		;;
 	esac
 	config_set "$device" hwmode "$hwmode"
@@ -114,7 +112,7 @@ _wifi_updown() {
 			set disable
 		}
 		config_get iftype "$device" type
-		if eval "type ${1}_$iftype" 2>/dev/null >/dev/null; then
+		if eval "type ${1}_$iftype" 2> /dev/null > /dev/null; then
 			eval "scan_$iftype '$device'"
 			eval "${1}_$iftype '$device'" || echo "$device($iftype): ${1} failed"
 		elif [ ! -f /lib/netifd/wireless/$iftype.sh ]; then
@@ -151,8 +149,8 @@ wifi_reload() {
 }
 
 wifi_detect_notice() {
-	>&2 echo "WARNING: Wifi detect is deprecated. Use wifi config instead"
-	>&2 echo "For more information, see commit 5f8f8a366136a07df661e31decce2458357c167a"
+	echo >&2 "WARNING: Wifi detect is deprecated. Use wifi config instead"
+	echo >&2 "For more information, see commit 5f8f8a366136a07df661e31decce2458357c167a"
 	exit 1
 }
 
@@ -160,7 +158,7 @@ wifi_config() {
 	[ ! -f /etc/config/wireless ] && touch /etc/config/wireless
 
 	for driver in $DRIVERS; do (
-		if eval "type detect_$driver" 2>/dev/null >/dev/null; then
+		if eval "type detect_$driver" 2> /dev/null > /dev/null; then
 			eval "detect_$driver" || echo "$driver: Detect failed" >&2
 		else
 			echo "$driver: Hardware detection not supported" >&2
@@ -168,12 +166,12 @@ wifi_config() {
 	); done
 }
 
-start_net() {(
+start_net() { (
 	local iface="$1"
 	local config="$2"
 	local vifmac="$3"
 
-	[ -f "/var/run/$iface.pid" ] && kill "$(cat /var/run/${iface}.pid)" 2>/dev/null
+	[ -f "/var/run/$iface.pid" ] && kill < "/var/run/${iface}.pid" 2> /dev/null
 	[ -z "$config" ] || {
 		include /lib/network
 		scan_interfaces
@@ -181,7 +179,7 @@ start_net() {(
 			setup_interface "$iface" "$config" "" "$vifmac"
 		done
 	}
-)}
+); }
 
 set_wifi_up() {
 	local cfg="$1"
@@ -195,7 +193,7 @@ set_wifi_down() {
 	local vifs vif vifstr
 
 	[ -f "/var/run/wifi-${cfg}.pid" ] &&
-		kill "$(cat "/var/run/wifi-${cfg}.pid")" 2>/dev/null
+		kill "$(cat "/var/run/wifi-${cfg}.pid")" 2> /dev/null
 	uci_revert_state wireless "$cfg"
 	config_get vifs "$cfg" vifs
 	for vif in $vifs; do
@@ -212,21 +210,21 @@ scan_wifi() {
 
 		# section start
 		case "$type" in
-			wifi-device)
-				append DEVICES "$section"
-				config_set "$section" vifs ""
-				config_set "$section" ht_capab ""
+		wifi-device)
+			append DEVICES "$section"
+			config_set "$section" vifs ""
+			config_set "$section" ht_capab ""
 			;;
 		esac
 
 		# section end
 		config_get TYPE "$CONFIG_SECTION" TYPE
 		case "$TYPE" in
-			wifi-iface)
-				config_get device "$CONFIG_SECTION" device
-				config_get vifs "$device" vifs
-				append vifs "$CONFIG_SECTION"
-				config_set "$device" vifs "$vifs"
+		wifi-iface)
+			config_get device "$CONFIG_SECTION" device
+			config_get vifs "$device" vifs
+			append vifs "$CONFIG_SECTION"
+			config_set "$device" vifs "$vifs"
 			;;
 		esac
 	}
@@ -239,14 +237,23 @@ include /lib/wifi
 scan_wifi
 
 case "$1" in
-	down) wifi_updown "disable" "$2";;
-	detect) wifi_detect_notice ;;
-	config) wifi_config ;;
-	status) ubus_wifi_cmd "status" "$2";;
-	reload) wifi_reload "$2";;
-	reload_legacy) wifi_reload_legacy "$2";;
-	--help|help) usage;;
-	reconf) ubus call network reload; wifi_updown "reconf" "$2";;
-	''|up) ubus call network reload; wifi_updown "enable" "$2";;
-	*) usage; exit 1;;
+down) wifi_updown "disable" "$2" ;;
+detect) wifi_detect_notice ;;
+config) wifi_config ;;
+status) ubus_wifi_cmd "status" "$2" ;;
+reload) wifi_reload "$2" ;;
+reload_legacy) wifi_reload_legacy "$2" ;;
+--help | help) usage ;;
+reconf)
+	ubus call network reload
+	wifi_updown "reconf" "$2"
+	;;
+'' | up)
+	ubus call network reload
+	wifi_updown "enable" "$2"
+	;;
+*)
+	usage
+	exit 1
+	;;
 esac

--- a/package/base-files/files/usr/libexec/validate_firmware_image
+++ b/package/base-files/files/usr/libexec/validate_firmware_image
@@ -49,18 +49,18 @@ FWTOOL_DEVICE_MATCH=$?
 
 json_set_namespace validate_firmware_image old_ns
 json_init
-	json_add_object "tests"
-		json_add_boolean fwtool_signature "$(err_to_bool $FWTOOL_SIGNATURE)"
-		json_add_boolean fwtool_device_match "$(err_to_bool $FWTOOL_DEVICE_MATCH)"
+json_add_object "tests"
+json_add_boolean fwtool_signature "$(err_to_bool $FWTOOL_SIGNATURE)"
+json_add_boolean fwtool_device_match "$(err_to_bool $FWTOOL_DEVICE_MATCH)"
 
-		# Call platform_check_image() here so it can add its test
-		# results and still mark image properly.
-		json_set_namespace $old_ns
-		platform_check_image "$1" >&2 || notify_firmware_invalid
-		json_set_namespace validate_firmware_image old_ns
-	json_close_object
-	json_add_boolean valid "$VALID"
-	json_add_boolean forceable "$FORCEABLE"
-	json_add_boolean allow_backup "$ALLOW_BACKUP"
+# Call platform_check_image() here so it can add its test
+# results and still mark image properly.
+json_set_namespace $old_ns
+platform_check_image "$1" >&2 || notify_firmware_invalid
+json_set_namespace validate_firmware_image old_ns
+json_close_object
+json_add_boolean valid "$VALID"
+json_add_boolean forceable "$FORCEABLE"
+json_add_boolean allow_backup "$ALLOW_BACKUP"
 json_dump -i
 json_set_namespace $old_ns


### PR DESCRIPTION
This patch lints all bash files installed via the base-files package.
Linting is a baseline for pretty code and shouldn't steal time away from
reviewers.

The tool `shfmt`[1] is used with options to fit the current style as good
as possible, however fixes up areas where it's not.

    shfmt -w -sr -s <filename>

Once existing, this command should be added to a CI.

To improve readability of JSON/jshn.sh functions every case of
`json_select ..` should be followed by a comment describing the new
level, e.g. `json_select .. # root`.

[1]: https://github.com/mvdan/sh

Suggested-by: Mariana Moreira <m.camargomoreira@gmail.com>
Signed-off-by: Paul Spooren <mail@aparcar.org>