### PR TITLE
base-files: fix zoneinfo support

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -4,8 +4,7 @@
 START=10
 USE_PROCD=1
 
-validate_system_section()
-{
+validate_system_section() {
 	uci_load_validate system system "$1" "$2" \
 		'hostname:string:OpenWrt' \
 		'conloglevel:uinteger' \
@@ -22,9 +21,13 @@ system_config() {
 
 	echo "$hostname" > /proc/sys/kernel/hostname
 	[ -z "$conloglevel" -a -z "$buffersize" ] || dmesg ${conloglevel:+-n $conloglevel} ${buffersize:+-s $buffersize}
-	echo "$timezone" > /tmp/TZ
-	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/$zonename" ] && \
-		ln -sf "/usr/share/zoneinfo/$zonename" /tmp/localtime && rm -f /tmp/TZ
+	rm -f /tmp/TZ
+	if [ -n "$zonename" ]; then
+		local zname=$(echo "$zonename" | tr ' ' _)
+		[ -f "/usr/share/zoneinfo/$zname" ] && ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime
+	else
+		echo "$timezone" > /tmp/TZ
+	fi
 
 	# apply timezone to kernel
 	hwclock -u --systz
@@ -35,8 +38,7 @@ reload_service() {
 	config_foreach validate_system_section system system_config
 }
 
-service_triggers()
-{
+service_triggers() {
 	procd_add_reload_trigger "system"
 	procd_add_validation validate_system_section
 }


### PR DESCRIPTION
The system init script currently sets /tmp/localinfo when zoneinfo is
populated. However, zoneinfo has spaces in it whereas the actual files
have _ instead of spaces. This made the if condition never return true.

Example failure when removing the if condition:

/tmp/localtime -> /usr/share/zoneinfo/America/Los Angeles

This file does not exist. America/Los_Angeles does.

Signed-off-by: Rosen Penev <rosenp@gmail.com>