### PR TITLE
zram-swap: fix zram getting low priority than other swaps

### DIFF
--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -143,16 +143,16 @@ start()
 	}
 
 	local zram_size="$( zram_getsize )"
-	local zram_priority="$( uci -q get system.@system[0].zram_priority )"
-	zram_priority=${zram_priority:+-p $zram_priority}
+    local zram_priority=$(awk 'BEGIN {p=0}; NR>1 {if ($5 >= p) {p=$5 + 1}}; END {print p}' /proc/swaps)
 
 	logger -s -t zram_start -p daemon.debug "activating '$zram_dev' for swapping ($zram_size MegaBytes)"
 
 	zram_reset "$zram_dev" "enforcing defaults"
 	zram_comp_algo "$zram_dev"
 	echo $(( $zram_size * 1024 * 1024 )) >"/sys/block/$( basename "$zram_dev" )/disksize"
+  
 	busybox mkswap "$zram_dev"
-	busybox swapon -d $zram_priority "$zram_dev"
+	busybox swapon -d -p $zram_priority "$zram_dev"
 }
 
 stop()


### PR DESCRIPTION
This fix should allow zram to get priority higher than other currently attached swaps

**Before Fix:**
```
root@OpenWrt:~# cat /proc/swaps
Filename                                Type            Size    Used    Priority
/dev/sda2                               partition       158716  444     -2
/dev/zram0                              partition       13308   0       -3
```

**After Fix:**
```
root@OpenWrt:~# cat /proc/swaps
Filename                                Type            Size    Used    Priority
/dev/sda2                               partition       158716  0       -2
/dev/zram0                              partition       13308   512     0
```

Signed-off-by: Fawaz Ahmed <fawazahmed0@hotmail.com>


