### PR TITLE
base-files: service_running does not work for instances check as expected

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -105,9 +105,9 @@ service_data() {
 }
 
 service_running() {
-	local service="${1:-$(basename $initscript)}"
-	local instance="${2:-*}"
-	procd_running "$service" "$instance" "$@"
+	local instance="${1:-*}"
+
+	procd_running "$(basename $initscript)" "$instance"
 }
 
 ${INIT_TRACE:+set -x}


### PR DESCRIPTION
The function `service_running` does not work for instances check as expected:

The following command checks if a instance of a service is running.
/etc/init.d/\<service\> running \<instance\>

 In the variable `$@`, which is passed to the function
`service_running`, the first argument is always the `instance` which
should be checked. Because all other variables where removed from `$@`
with `shift`.

Before this change the first argument of `$@` was set to the `$service`
Variable. So the function does not work as expected. The `$service`
variable was always the instance which should be checked. This is not
what we want.

