### PR TITLE
base-files: fix /tmp/TZ when zoneinfo not installed

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -24,7 +24,11 @@ system_config() {
 	rm -f /tmp/TZ
 	if [ -n "$zonename" ]; then
 		local zname=$(echo "$zonename" | tr ' ' _)
-		[ -f "/usr/share/zoneinfo/$zname" ] && ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime
+		if [ -f "/usr/share/zoneinfo/$zname" ]; then
+			ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime
+		else
+			echo "$timezone" > /tmp/TZ
+		fi
 	else
 		echo "$timezone" > /tmp/TZ
 	fi


### PR DESCRIPTION
An extra block is needed to set /tmp/TZ when zoneinfo is not installed.
Otherwise, wrong time.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Should fix https://github.com/openwrt/openwrt/commit/8af62ede189aa504135db05474d34c9f8a1ed35d