### PR TITLE
ramips: add support for Sitecom WLR-4100 v1 002

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -17,7 +17,8 @@ alfa-network,awusfree1|\
 alfa-network,quad-e4g|\
 alfa-network,r36m-e4g|\
 alfa-network,tube-e4g|\
-engenius,esr600h)
+engenius,esr600h|\
+sitecom,wlr-4100-v1-002)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"
 	;;
 allnet,all0256n-4m|\

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "sitecom,wlr-4100-v1-002", "ralink,mt7620a-soc";
+	model = "Sitecom WLR-4100 v1 002";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "amber:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wps {
+			label = "white:wps";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb-power {
+			gpio-export,name = "usb-power";
+			gpio-export,output = <1>;
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			config: partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "backup";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "storage";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+	mtd-mac-address = <&factory 0x4>;
+
+	port@5 {
+		status = "okay";
+
+		phy-mode = "rgmii";
+		mediatek,fixed-link = <1000 1 1 1>;
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+
+			qca,ar8327-initvals = <
+				0x04 0x06200000  /* PORT0 PAD MODE CTRL */
+				0x08 0x01000000  /* PORT5 PAD MODE CTRL  RX delay EN all ports 0, 5, 6 */
+				0x7c 0x0000007e  /* PORT0_STATUS */
+				0x94 0x00000000  /* PORT6_STATUS */
+			>;
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <8>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "i2c", "wled", "spi refclk";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1001,6 +1001,20 @@ define Device/sercomm_na930
 endef
 TARGET_DEVICES += sercomm_na930
 
+define Device/sitecom_wlr-4100-v1-002
+  SOC := mt7620a
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7744k
+  IMAGES += factory.dlf
+  IMAGE/factory.dlf := $$(sysupgrade_bin) | check-size | \
+	senao-header -r 0x0222 -p 0x104A -t 2
+  DEVICE_VENDOR := Sitecom
+  DEVICE_MODEL := WLR-4100
+  DEVICE_VARIANT := v1002
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci uboot-envtools
+endef
+TARGET_DEVICES += sitecom_wlr-4100-v1-002
+
 define Device/tplink_archer-c20i
   $(Device/tplink-v2)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -137,7 +137,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
-	engenius,esr600)
+	engenius,esr600|\
+	sitecom,wlr-4100-v1-002)
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "0@eth0"
 		ucidef_add_switch "switch1" \
@@ -317,7 +318,8 @@ ramips_setup_macs()
 	edimax,br-6478ac-v2)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 2)
 		;;
-	engenius,esr600)
+	engenius,esr600|\
+	sitecom,wlr-4100-v1-002)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		;;


### PR DESCRIPTION
Sitecom WLR-4100 v1 002 (marked as X4 N300) is a wireless router

**Specification:**
SoC: MT7620A
RAM: 64 MB DDR2
Flash: MX25L6405D SPI NOR 8 MB
WIFI: 2.4 GHz integrated
Ethernet: 5x 10/100/1000 Mbps QCA8337
USB: 1x 2.0
LEDS: 2x GPIO controlled, 5x switch
Buttons: 1x GPIO controlled
UART: row of 4 unpopulated holes near USB port, starting count from white triangle on PCB:
1. VCC 3.3V
2. GND
3. TX
4. RX

- baud: 115200, parity: none, flow control: none

**Installation**
1. Connect to one of LAN (yellow) ethernet ports,
2. Open router configuration interface,
3. Go to Toolbox > Firmware,
4. Browse for OpenWrt factory image with dlf extension and hit Apply,
5. Wait few minutes, after the Power LED will stop blinking, the router is ready for configuration.

**Known issues**
    Some USB 2.0 devices work at full speed mode 1.1 only

**Additional information**
    OEM firmware shell password is: SitecomSenao
    useful for creating backup of original firmware.
    There is also another revision of this device (v1 001), based on RT3352 SoC

Signed-off-by: Andrea Poletti <polex73@yahoo.it>
