### PR TITLE
[21.02] kirkwood: increase kernel partition of Linksyses

### DIFF
--- a/target/linux/kirkwood/files-5.4/arch/arm/boot/dts/kirkwood-ea3500.dts
+++ b/target/linux/kirkwood/files-5.4/arch/arm/boot/dts/kirkwood-ea3500.dts
@@ -165,7 +165,7 @@
 
 		partition@200000 {
 			label = "kernel1";
-			reg = <0x200000 0x290000>;
+			reg = <0x200000 0x1400000>;
 		};
 
 		partition@490000 {
@@ -175,7 +175,7 @@
 
 		partition@1600000 {
 			label = "kernel2";
-			reg = <0x1600000 0x290000>;
+			reg = <0x1600000 0x1400000>;
 		};
 
 		partition@1890000 {

--- a/target/linux/kirkwood/patches-5.4/105-linksys-viper-dts.patch
+++ b/target/linux/kirkwood/patches-5.4/105-linksys-viper-dts.patch
@@ -28,8 +28,9 @@
  
  		partition@200000 {
 -			label = "kernel";
+-			reg = <0x200000 0x2A0000>;
 +			label = "kernel1";
- 			reg = <0x200000 0x2A0000>;
++			reg = <0x200000 0x1A00000>;
  		};
  
  		partition@4a0000 {
@@ -40,8 +41,9 @@
  
  		partition@1c00000 {
 -			label = "alt_kernel";
+-			reg = <0x1C00000 0x2A0000>;
 +			label = "kernel2";
- 			reg = <0x1C00000 0x2A0000>;
++			reg = <0x1C00000 0x1A00000>;
  		};
  
  		partition@1ea0000 {


### PR DESCRIPTION
At this moment kernel partition in Linksyses EA3500/E4200/EA4500 is
ended before start of rootfs partition. It was introduced in 9808b9ae02
and it broke easy revert to stock. Sysupgrade, when OFW is used, write
whole stock image to kernel partition. Most likeley image will be bigger
than small kernel partition and it make stock system invalid.

This patch change size of kernel partitions and now it overlaps rootfs.
Revert to stock will be possible again.

Fixes: 9808b9ae02 ("kirkwood: switch to kernel 4.9")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>