### PR TITLE
[19.07] kirkwood: increase kernel partition of Linksyses

### DIFF
--- a/target/linux/kirkwood/patches-4.14/104-ea3500.patch
+++ b/target/linux/kirkwood/patches-4.14/104-ea3500.patch
@@ -177,7 +177,7 @@
 +
 +		partition@200000 {
 +			label = "kernel1";
-+			reg = <0x200000 0x290000>;
++			reg = <0x200000 0x1400000>;
 +		};
 +
 +		partition@490000 {
@@ -187,7 +187,7 @@
 +
 +		partition@1600000 {
 +			label = "kernel2";
-+			reg = <0x1600000 0x290000>;
++			reg = <0x1600000 0x1400000>;
 +		};
 +
 +		partition@1890000 {

--- a/target/linux/kirkwood/patches-4.14/105-ea4500.patch
+++ b/target/linux/kirkwood/patches-4.14/105-ea4500.patch
@@ -26,8 +26,9 @@
  
  		partition@200000 {
 -			label = "kernel";
+-			reg = <0x200000 0x2A0000>;
 +			label = "kernel1";
- 			reg = <0x200000 0x2A0000>;
++			reg = <0x200000 0x1A00000>;
  		};
  
  		partition@4A0000 {
@@ -38,8 +39,9 @@
  
  		partition@1C00000 {
 -			label = "alt_kernel";
+-			reg = <0x1C00000 0x2A0000>;
 +			label = "kernel2";
- 			reg = <0x1C00000 0x2A0000>;
++			reg = <0x1C00000 0x1A00000>;
  		};
  
  		partition@1EA0000 {


### PR DESCRIPTION
At this moment kernel partition in Linksyses EA3500/E4200/EA4500 is
ended before start of rootfs partition. It was introduced in 9808b9ae02
and it broke easy revert to stock. Sysupgrade, when OFW is used, write
whole stock image to kernel partition. Most likeley image will be bigger
than small kernel partition and it make stock system invalid.

This patch change size of kernel partitions and now it overlaps rootfs.
Revert to stock will be possible again.

Fixes: 9808b9ae02 ("kirkwood: switch to kernel 4.9")

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
