### PR TITLE
 mac80211: always call wireless_set_data  (FS#3784)

### DIFF
--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -1021,10 +1021,8 @@ drv_mac80211_setup() {
 		return 1
 	}
 
-	[ -z "$(uci -q -P /var/state show wireless._${phy})" ] && {
-		uci -q -P /var/state set wireless._${phy}=phy
-		wireless_set_data phy="$phy"
-	}
+	wireless_set_data phy="$phy"
+	[ -z "$(uci -q -P /var/state show wireless._${phy})" ] && uci -q -P /var/state set wireless._${phy}=phy
 
 	OLDAPLIST=$(uci -q -P /var/state get wireless._${phy}.aplist)
 	OLDSPLIST=$(uci -q -P /var/state get wireless._${phy}.splist)

--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -1189,6 +1189,10 @@ drv_mac80211_teardown() {
 	json_select data
 	json_get_vars phy
 	json_select ..
+	[ -n "$phy" ] || {
+		echo "Bug: PHY is undefined for device '$1'"
+		return 1
+	}
 
 	mac80211_interface_cleanup "$phy"
 	uci -q -P /var/state revert wireless._${phy}


### PR DESCRIPTION
When wifi is turned off, drv_mac80211_teardown sometimes fails (silently)
because the device to be torn down is not defined.  

This situation arises if drv_mac80211_setup was called twice when
wifi was turned on.

This commit ensures that the device to be torn down is always defined
in drv_mac80211_teardown.

Steps to reproduce:

1) Use /sbin/wifi to turn on wifi.
   uci set wireless.@wifi-iface[0].disabled=0
   uci set wireless.@wifi-device[0].disabled=0
   uci commit
   wifi

2) Use /sbin/wifi to turn off wifi.
   uci set wireless.@wifi-device[0].disabled=1
   uci commit
   wifi

3) Observe that wifi is still up.

branches affected: trunk, 21.02