### PR TITLE
dnsmasq: use '--local' for 'Local server'

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -907,7 +907,7 @@ dnsmasq_start()
 	append_parm "$cfg" "minport" "--min-port"
 	append_parm "$cfg" "maxport" "--max-port"
 	append_parm "$cfg" "domain" "--domain"
-	append_parm "$cfg" "local" "--server"
+	append_parm "$cfg" "local" "--local"
 	config_list_foreach "$cfg" "listen_address" append_listenaddress
 	config_list_foreach "$cfg" "server" append_server
 	config_list_foreach "$cfg" "rev_server" append_rev_server


### PR DESCRIPTION
in fact --server and --local are the same - but if there are 2 different input fields in luci the corresponding parameter should be used, for easier debugging etc

