### PR TITLE
 base-files: /sbin/wifi:  swap the order of some ubus calls

### DIFF
--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -128,6 +128,7 @@ wifi_updown() {
 	[ enable = "$1" ] && {
 		_wifi_updown disable "$2"
 		ubus_wifi_cmd "$cmd" "$2"
+		ubus call network reload
 		scan_wifi
 		cmd=up
 	}
@@ -247,6 +248,6 @@ case "$1" in
 	reload_legacy) wifi_reload_legacy "$2";;
 	--help|help) usage;;
 	reconf) ubus call network reload; wifi_updown "reconf" "$2";;
-	''|up) ubus call network reload; wifi_updown "enable" "$2";;
+	''|up) wifi_updown "enable" "$2";;
 	*) usage; exit 1;;
 esac

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -133,6 +133,7 @@ wifi_updown() {
 		cmd=up
 	}
 	[ reconf = "$1" ] && {
+		ubus call network reload
 		scan_wifi
 		cmd=reconf
 	}
@@ -247,7 +248,7 @@ case "$1" in
 	reload) wifi_reload "$2";;
 	reload_legacy) wifi_reload_legacy "$2";;
 	--help|help) usage;;
-	reconf) ubus call network reload; wifi_updown "reconf" "$2";;
+	reconf) wifi_updown "reconf" "$2";;
 	''|up) wifi_updown "enable" "$2";;
 	*) usage; exit 1;;
 esac


### PR DESCRIPTION
"/sbin/wifi up" makes three ubus calls:
1. ubus call network reload
2. ubus call network.wireless down
3. ubus call network.wireless up

The first and third ubus calls call drv_mac80211_setup,
while the second ubus call triggers wireless_device_setup_cancel,
so the call sequence becomes,

1. drv_mac80211_setup
2. wireless_device_setup_cancel
3. drv_mac80211_setup

This commit swaps the order of the first two ubus calls,
1. ubus call network.wireless down
2. ubus call network reload
3. ubus call network.wireless up

Consequently drv_mac80211_setup is only called once,
and two related bugs (#FS3784 and #FS3902) are no longer triggered by /sbin/wifi.

branches affected: trunk, 21.02
