### PR TITLE
base-files: fix /tmp/TZ when zoneinfo not installed

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -21,13 +21,10 @@ system_config() {
 
 	echo "$hostname" > /proc/sys/kernel/hostname
 	[ -z "$conloglevel" -a -z "$buffersize" ] || dmesg ${conloglevel:+-n $conloglevel} ${buffersize:+-s $buffersize}
-	rm -f /tmp/TZ
-	if [ -n "$zonename" ]; then
-		local zname=$(echo "$zonename" | tr ' ' _)
-		[ -f "/usr/share/zoneinfo/$zname" ] && ln -sf "/usr/share/zoneinfo/$zname" /tmp/localtime
-	else
-		echo "$timezone" > /tmp/TZ
-	fi
+	echo "$timezone" > /tmp/TZ
+	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ] \
+		&& ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime \
+		&& rm -f /tmp/TZ
 
 	# apply timezone to kernel
 	hwclock -u --systz


### PR DESCRIPTION
The zoneinfo packages are not installed per default so neither
/tmp/localtime nor /tmp/TZ is generated.

This patch mostly reverts the previous fix and instead incooperates a
solution suggested by Jo.

Fixes "base-files: fix zoneinfo support " 8af62ed

Signed-off-by: Paul Spooren <mail@aparcar.org>