### PR TITLE
ath79: Add support for TP-Link EC230-G1

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_ec230-g1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_ec230-g1.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "tplink,ec230-g1", "qca,qca9563";
+	model = "TP-Link EC230-G1";
+
+	aliases {
+		label-mac-device = &eth0;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan2g {
+			label = "green:wlan2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			label = "green:wlan5g";
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_fail {
+			label = "amber:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "WPS button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0xfa0000>;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x010000>;
+				read-only;
+			};
+
+			partition@fd0000 {
+				label = "romfile";
+				reg = <0xfd0000 0x010000>;
+				read-only;
+			};
+
+			rom: partition@fe0000 {
+				label = "rom";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&pcie {
+	status = "okay";
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+
+	mtd-mac-address = <&rom 0xf100>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&rom 0xf100>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -305,7 +305,8 @@ tplink,tl-wr1043n-v5)
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x02"
 	;;
 tplink,archer-c6-v2|\
-tplink,archer-c6-v2-us)
+tplink,archer-c6-v2-us|\
+tplink,ec230-g1)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3c"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -324,7 +324,8 @@ ath79_setup_interfaces()
 	tplink,tl-wdr3600-v1|\
 	tplink,tl-wdr4300-v1|\
 	tplink,tl-wdr4300-v1-il|\
-	tplink,tl-wdr4310-v1)
+	tplink,tl-wdr4310-v1|\
+	tplink,ec230-g1)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -257,6 +257,12 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) 1)
 		;;
+	tplink,ec230-g1)
+		caldata_extract "art" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary rom 0xf100) -1)
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	xiaomi,aiot-ac2350)
 		caldata_extract "art" 0x5000 0x2f20
 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -437,6 +437,18 @@ define Device/tplink_eap245-v3
 endef
 TARGET_DEVICES += tplink_eap245-v3
 
+define Device/tplink_ec230-g1
+  $(Device/tplink-v2)
+  SOC := qca9563
+  IMAGE_SIZE := 16000k
+  DEVICE_MODEL := EC230-G1
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  TPLINK_HWID := 0x4E8C8701
+  TPLINK_HWREV := 0x00060034
+  TPLINK_FLASHLAYOUT := 16Mqca
+endef
+TARGET_DEVICES += tplink_ec230-g1
+
 define Device/tplink_re350k-v1
   $(Device/tplink-safeloader)
   SOC := qca9558


### PR DESCRIPTION
Introduction: This device is sold to and distributed by ISPs (TIME in Malaysia). Hardware-wise, it is identical to Archer C6 (EU) but with 16MB flash. However software-wise it is very different (partition table, label MAC location, bootloader).

Specification:
- CPU: Qualcomm Atheros QCA9563-AL3A
- RAM: Zentel A3R1GE40JBF-8E (128MB)
- Flash: GigaDevice GD25Q127CSIG (16MB)
- 5GHz PHY: Qualcomm Atheros QCA9886
- Ethernet PHY: Qualcomm Atheros QCA8337N-AL3C (5 port 1000BASE-T + SGMII + ?)

Note: Some original firmware doesn't have the ability to update through the wizard (web interface or RESET button on boot), thus I cannot confirm flashing it that way for now, until somebody can tag along here.
For now, you'll need to use UART and tftp to install new firmware.

Prerequisite:
- Prepare USB TTL adapter, 3 jumper wire (test pad would be about size of wire diameter) and a kind, sentient being, also known as person.
- Set up TFTP server to serve the sysupgrade image. Refer OpenWrt wiki [generic.flashing.tftp](https://openwrt.org/docs/guide-user/installation/generic.flashing.tftp) to set it up.

Installation:
- Disassemble the casing. Two screw on the bottom then pry the top casing with brute force.
- Pry off metal shielding to expose the CPU circuitry.
- Connect network cable between PC and device.
- With help of other people, have them hold jumper wire over the tiny UART test pad. UART Tx would be near the small antenna labeled TP_UART_IN, and UART Rx would be near CPU labeled TP_UART_OUT.
- Open serial terminal of your liking and power on the device.
- Interrupt boot process when you see `Hit any key to stop autoboot:`
- On prompt `ath>`, enter following command, replacing <> where necessary:
```
	tftpboot 0x80020000 <your openwrt sysupgrade.bin>
	erase 0x9f020000 +0x<hex of size of sysupgrade.bin>
	cp.b 0x80020000 0x9f020000 0x<hex of size of sysupgrade.bin>
	bootm 0x9f020000
```
- Done. Let it boot.

Signed-off-by: Izuan Nazrin <zerro.tur@gmail.com>