### PR TITLE
ath79: add support for TP-Link TL-WR941HP v1

### DIFF
--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
-/dts-v1/;
+
+#include "qca956x.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
-
-#include "qca956x.dtsi"
 
 / {
 	compatible = "tplink,tl-wr941hp-v1", "qca,tp9343";
@@ -21,10 +20,10 @@
 	leds {
 		compatible = "gpio-leds";
 
-        ranext {
-            label = "blue:ranext";
-            gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
-        };
+		re {
+			label = "blue:re";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
 
 		wifi {
 			label = "blue:wifi";
@@ -34,17 +33,17 @@
 
 		led_power: power {
 			label = "blue:power";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;      
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
-		wan_data {
-			label = "blue:wan_data";
+		wan_blue {
+			label = "blue:wan";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		wan_link {
-			label = "red:wan_link";
+		wan_red {
+			label = "red:wan";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
@@ -62,7 +61,7 @@
 	keys {
 		compatible = "gpio-keys";
 
-		ranext {
+		re {
 			label = "range extender button";
 			linux,code = <BTN_0>;
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
@@ -76,7 +75,7 @@
 			debounce-interval = <60>;
 		};
 
-    	reset {
+		reset {
 			label = "reset button";
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
@@ -90,10 +89,6 @@
 			debounce-interval = <60>;
 		};
 	};
-};
-
-&uart {
-	status = "okay";
 };
 
 &spi {
@@ -121,15 +116,9 @@
 				reg = <0x020000 0x730000>;
 			};
 
-			info: partition@750000 {
-				label = "info";
-				reg = <0x750000 0x010000>;
-				read-only;
-			};
-
-			partition@760000 {
-				label = "tplink";
-				reg = <0x760000 0x090000>;
+			config: partition@750000 {
+				label = "config";
+				reg = <0x750000 0x0a0000>;
 				read-only;
 			};
 
@@ -142,53 +131,24 @@
 	};
 };
 
-&mdio1 {
-	status = "okay";
-	resets = <&rst 23>;
-	reset-names = "mdio";
-	builtin-switch;
-
-	builtin_switch: switch0@1f {
-		compatible = "qca,ar8229";
-		reg = <0x1f>;
-		resets = <&rst 8>;
-		reset-names = "switch";
-		phy-mode = "gmii";
-		//remove this line is important
-		//qca,phy4-mii-enable;
-		qca,mib-poll-interval = <500>;
-
-		mdio-bus {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			phy0: ethernet-phy@0 {
-				reg = <0>;
-				phy-mode = "mii";
-			};
-
-		};
-	};
-};
-
 &eth0 {
 	status = "okay";
 
-	phy-handle = <&phy0>;
-
-	mtd-mac-address = <&info 0x8>;
+	phy-handle = <&swphy0>;
+		
+	mtd-mac-address = <&config 0x8>;
 	mtd-mac-address-increment = <1>;
 };
 
 &eth1 {
 	status = "okay";
-	mtd-mac-address = <&info 0x8>;
-	mtd-mac-address-increment = <2>;
+	
+	mtd-mac-address = <&config 0x8>;
 };
 
 &wmac {
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	mtd-mac-address = <&info 0x8>;
+	mtd-mac-address = <&config 0x8>;
 };

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "qca956x.dtsi"
+
+/ {
+	compatible = "tplink,tl-wr941hp-v1", "qca,tp9343";
+	model = "TP-Link TL-WR941HP v1";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+        ranext {
+            label = "blue:ranext";
+            gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+        };
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;      
+			default-state = "on";
+		};
+
+		wan_data {
+			label = "blue:wan_data";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_link {
+			label = "red:wan_link";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "blue:lan";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		ranext {
+			label = "range extender button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wifi {
+			label = "wifi button";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+    	reset {
+			label = "reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps button";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&uart {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x730000>;
+			};
+
+			info: partition@750000 {
+				label = "info";
+				reg = <0x750000 0x010000>;
+				read-only;
+			};
+
+			partition@760000 {
+				label = "tplink";
+				reg = <0x760000 0x090000>;
+				read-only;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio1 {
+	status = "okay";
+	resets = <&rst 23>;
+	reset-names = "mdio";
+	builtin-switch;
+
+	builtin_switch: switch0@1f {
+		compatible = "qca,ar8229";
+		reg = <0x1f>;
+		resets = <&rst 8>;
+		reset-names = "switch";
+		phy-mode = "gmii";
+		//remove this line is important
+		//qca,phy4-mii-enable;
+		qca,mib-poll-interval = <500>;
+
+		mdio-bus {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			phy0: ethernet-phy@0 {
+				reg = <0>;
+				phy-mode = "mii";
+			};
+
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&phy0>;
+
+	mtd-mac-address = <&info 0x8>;
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+	mtd-mac-address = <&info 0x8>;
+	mtd-mac-address-increment = <2>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&info 0x8>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -345,11 +345,6 @@ tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"
 	;;
-tplink,tl-wr941hp-v1)
-	ucidef_set_led_netdev "wan_data" "WAN Data" "blue:wan_data" "eth1"    "tx rx"
-	ucidef_set_led_netdev "wan_link" "WAN Link" "red:wan_link"  "eth1"    "link"
-	ucidef_set_led_switch "lan"      "LAN"      "blue:lan"      "switch0" "0x1e"
-	;;
 tplink,re355-v1|\
 tplink,re450-v1|\
 tplink,re450-v2|\
@@ -374,6 +369,10 @@ tplink,tl-wr842n-v2)
 	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x08"
 	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x10"
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x02"
+	;;
+tplink,tl-wr941hp-v1)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1" "link tx rx"
+	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x1e"
 	;;
 trendnet,tew-823dru)
 	ucidef_set_led_netdev "wan" "WAN" "green:planet" "eth0"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -345,6 +345,11 @@ tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"
 	;;
+tplink,tl-wr941hp-v1)
+	ucidef_set_led_netdev "wan_data" "WAN Data" "blue:wan_data" "eth1"    "tx rx"
+	ucidef_set_led_netdev "wan_link" "WAN Link" "red:wan_link"  "eth1"    "link"
+	ucidef_set_led_switch "lan"      "LAN"      "blue:lan"      "switch0" "0x1e"
+	;;
 tplink,re355-v1|\
 tplink,re450-v1|\
 tplink,re450-v2|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -201,6 +201,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
+    tplink,tl-wr941hp-v1)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	zyxel,nbg6616)

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -201,11 +201,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
 		;;
-    tplink,tl-wr941hp-v1)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1"
-		;;
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	zyxel,nbg6616)
@@ -402,7 +397,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "5:lan:4"
 		;;
-	tplink,tl-wr842n-v2)
+	tplink,tl-wr842n-v2)\
+	tplink,tl-wr941hp-v1)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:1" "3:lan:2" "4:lan:3"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -798,6 +798,17 @@ define Device/tplink_tl-wr902ac-v1
 endef
 TARGET_DEVICES += tplink_tl-wr902ac-v1
 
+define Device/tplink_tl-wr941hp-v1
+  $(Device/tplink-safeloader)
+  SOC := tp9343
+  DEVICE_MODEL := TL-WR941HP
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := TL-WR941HP-V1
+  IMAGE_SIZE := 7360k
+  SUPPORTED_DEVICES += tplink,tl-wr941hp-v1
+endef
+TARGET_DEVICES += tplink_tl-wr941hp-v1
+
 define Device/tplink_wbs210-v1
   $(Device/tplink-safeloader-okli)
   SOC := ar9344

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -805,7 +805,6 @@ define Device/tplink_tl-wr941hp-v1
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := TL-WR941HP-V1
   IMAGE_SIZE := 7360k
-  SUPPORTED_DEVICES += tplink,tl-wr941hp-v1
 endef
 TARGET_DEVICES += tplink_tl-wr941hp-v1
 

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1940,10 +1940,6 @@ static struct device_info boards[] = {
 		.part_trail = 0x00,
 		.soft_ver = NULL,
 
-		/**
-		   384KB were moved from file-system to os-image
-		   in comparison to the stock image
-		*/
 		.partitions = {
 			{"fs-uboot", 0x00000, 0x20000},
 			{"firmware", 0x20000, 0x730000},

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -1930,6 +1930,41 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system",
 	},
 
+    /** Firmware layout for the TL-WR941HP v1 */
+	{
+		.id     = "TL-WR941HP-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\n"
+			"{product_name:TL-WR941HP,product_ver:1.0.0,special_id:00000000}\n",
+		.part_trail = 0x00,
+		.soft_ver = NULL,
+
+		/**
+		   384KB were moved from file-system to os-image
+		   in comparison to the stock image
+		*/
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"firmware", 0x20000, 0x730000},
+			{"default-mac", 0x750000, 0x00200},
+			{"pin", 0x750200, 0x00200},
+			{"product-info", 0x750400, 0x0fc00},
+			{"soft-version", 0x760000, 0x0b000},
+			{"support-list", 0x76b000, 0x04000},
+			{"profile", 0x770000, 0x04000},
+			{"default-config", 0x774000, 0x0b000},
+			{"user-config", 0x780000, 0x40000},
+			{"partition-table", 0x7c0000, 0x10000},
+			{"log", 0x7d0000, 0x20000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system",
+	},
+
 	/** Firmware layout for the TL-WR942N V1 */
 	{
 		.id     = "TLWR942NV1",


### PR DESCRIPTION
Specifications:
    SOC:        Qualcomm Atheros TP9343 (750 MHz)
    Flash:      8 Mb (GigaDevice GD25Q64CSIG)
    RAM:        64 Mb (Zentel A3R12E40DBF-8E)
    Serial:     yes, 4-pin header
    Wlan:       Qualcomm Atheros TP9343, antenna: MIM0 3x3:3 RP-SMA
                3 x 2.4GHz power amp module Skyworks (SiGe) SE2576L
    Ethernet:   Qualcomm Atheros TP9343
    Lan speed:  100M ports: 4
    Lan speed:  100M ports: 1

Label MAC addresses based on vendor firmware:
LAN *:ee label
WAN *:ef label +1
WLAN *:ee label
The label MAC address found in "config" partition at 0x8

Forum page:    
    https://forum.openwrt.org/t/adding-device-support-tp-link-wr941hp/

Flash instruction:
    Upload the generated factory firmware on web interface.

Images here: https://listado.mercadolibre.com.ar/wr941hp

Signed-off-by: Diogenes Rengo <rengocbx250@gmail.com>