### PR TITLE
fstools: ensure filesystems are mounted before log service starts

### DIFF
--- a/package/system/fstools/files/fstab.init
+++ b/package/system/fstools/files/fstab.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # (C) 2013 openwrt.org
 
-START=40
+START=12
 
 boot() {
 	/sbin/block mount


### PR DESCRIPTION
Currently, the fstab service starts after the log service which breaks the
ability to write a persistent log file to a filesystem mounted by the fstab
service. Thus, change the start order of the fstab service so it starts right
before the log service.

Fixes: b131853 ("ubox: update to latest git revision")
Signed-off-by: Timo Sigurdsson <public_timo.s@silentcreek.de>