### PR TITLE
kernel/modules: support ESP_OFFLOAD

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -263,7 +263,7 @@ define KernelPackage/ipsec4
 	CONFIG_INET_XFRM_MODE_TRANSPORT \
 	CONFIG_INET_XFRM_MODE_TUNNEL \
 	CONFIG_INET_XFRM_TUNNEL \
-	CONFIG_INET_ESP_OFFLOAD=n
+	CONFIG_INET_ESP_OFFLOAD
   FILES:=$(foreach mod,$(IPSEC4-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoLoad,32,$(notdir $(IPSEC4-m)))
 endef
@@ -303,7 +303,7 @@ define KernelPackage/ipsec6
 	CONFIG_INET6_XFRM_MODE_TRANSPORT \
 	CONFIG_INET6_XFRM_MODE_TUNNEL \
 	CONFIG_INET6_XFRM_TUNNEL \
-	CONFIG_INET6_ESP_OFFLOAD=n
+	CONFIG_INET6_ESP_OFFLOAD
   FILES:=$(foreach mod,$(IPSEC6-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoLoad,32,$(notdir $(IPSEC6-m)))
 endef


### PR DESCRIPTION
ESP offload allows GRO which can increase performance. It is also needed by XFRM_OFFLOAD for NICs which support ESP hardware acceleration.

@hauke Was there a strong reason you removed it in https://github.com/CodeFetch/openwrt/commit/b0d7fcdc4951aea64f93600776d8a5a535a2e9cc? From how I understand the autoload statement it will not be automatically loaded. Is that correct?