### PR TITLE
ath79: add support for TP-Link RE455 v1

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_re455-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re455-v1.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9563_tplink_re450.dtsi"
+
+/ {
+	compatible = "tplink,re455-v1", "qca,qca9563";
+	model = "TP-Link RE455 v1";
+};
+
+&partitions {
+	partition@0 {
+		label = "u-boot";
+		reg = <0x000000 0x020000>;
+		read-only;
+	};
+
+	info: partition@20000 {
+		label = "info";
+		reg = <0x020000 0x002000>;
+		read-only;
+	};
+
+	partition@22000 {
+		label = "partition-table";
+		reg = <0x022000 0x002000>;
+		read-only;
+	};
+
+	partition@24000 {
+		label = "info2";
+		reg = <0x024000 0x00a000>;
+		read-only;
+	};
+
+	partition@2e000 {
+		label = "config";
+		reg = <0x02e000 0x022000>;
+		read-only;
+	};
+
+	partition@50000 {
+		compatible = "tplink,firmware";
+		label = "firmware";
+		reg = <0x050000 0x7a0000>;
+	};
+
+	art: partition@7f0000 {
+		label = "art";
+		reg = <0x7f0000 0x010000>;
+		read-only;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -352,7 +352,8 @@ tplink,tl-wr902ac-v1)
 tplink,re355-v1|\
 tplink,re450-v1|\
 tplink,re450-v2|\
-tplink,re450-v3)
+tplink,re450-v3|\
+tplink,re455-v1)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan_data" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN Link" "green:lan_link" "eth0" "link"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -70,6 +70,7 @@ ath79_setup_interfaces()
 	tplink,re450-v1|\
 	tplink,re450-v2|\
 	tplink,re450-v3|\
+	tplink,re455-v1|\
 	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-ac|\
 	ubnt,bullet-m-ar7240|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -141,7 +141,8 @@ case "$FIRMWARE" in
 		;;
 	tplink,eap245-v1|\
 	tplink,re450-v2|\
-	tplink,re450-v3)
+	tplink,re450-v3|\
+	tplink,re455-v1)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) 1)
 		;;

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -486,6 +486,18 @@ define Device/tplink_re450-v3
 endef
 TARGET_DEVICES += tplink_re450-v3
 
+define Device/tplink_re455-v1
+  $(Device/tplink-safeloader)
+  SOC := qca9563
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE455
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  TPLINK_BOARD_ID := RE455-V1
+  LOADER_TYPE := elf
+endef
+TARGET_DEVICES += tplink_re455-v1
+
 define Device/tplink_tl-mr6400-v1
   $(Device/tplink-8mlzma)
   SOC := qca9531

--- a/tools/firmware-utils/src/tplink-safeloader.c
+++ b/tools/firmware-utils/src/tplink-safeloader.c
@@ -2400,6 +2400,46 @@ static struct device_info boards[] = {
 		.last_sysupgrade_partition = "file-system"
 	},
 
+	/** Firmware layout for the RE455 v1 */
+	{
+		.id     = "RE455-V1",
+		.vendor = "",
+		.support_list =
+			"SupportList:\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:00000000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:55530000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:45550000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:4A500000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:43410000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:41550000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:41530000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:4B520000}\r\n"
+			"{product_name:RE455,product_ver:1.0.0,special_id:42520000}\r\n",
+		.part_trail = 0x00,
+		.soft_ver = NULL,
+
+		/* We're using a dynamic kernel/rootfs split here */
+		.partitions = {
+			{"fs-uboot", 0x00000, 0x20000},
+			{"default-mac", 0x20000, 0x00020},
+			{"pin", 0x20020, 0x00020},
+			{"product-info", 0x21000, 0x01000},
+			{"partition-table", 0x22000, 0x02000},
+			{"soft-version", 0x24000, 0x01000},
+			{"support-list", 0x25000, 0x01000},
+			{"profile", 0x26000, 0x08000},
+			{"user-config", 0x2e000, 0x10000},
+			{"default-config", 0x3e000, 0x10000},
+			{"config-info", 0x4e000, 0x00400},
+			{"firmware", 0x50000, 0x7a0000},
+			{"radio", 0x7f0000, 0x10000},
+			{NULL, 0, 0}
+		},
+
+		.first_sysupgrade_partition = "os-image",
+		.last_sysupgrade_partition = "file-system"
+	},
+
 	/** Firmware layout for the RE500 */
 	{
 		.id     = "RE500-V1",


### PR DESCRIPTION
TP-Link RE455 v1 is a dual band router/range-extender based on
Qualcomm/Atheros QCA9563 + QCA9880.

This device is nearly identical to RE450 v3

Specification:

- 775 MHz CPU
- 64 MB of RAM (DDR2)
- 8 MB of FLASH (SPI NOR)
- 3T3R 2.4 GHz
- 3T3R 5 GHz
- 1x 10/100/1000 Mbps Ethernet (AR8033 PHY)
- 7x LED, 4x button
- UART header on PCB[1]

Flash instruction:
Apply factory image in OEM firmware web-gui.

[1] Didn't work, probably need to short unpopulated resistor R64 and R69 as RE450v3

Signed-off-by: Roberto Valentini <valantin89@gmail.com>
