### PR TITLE
base-files: wifi: fixup commits e8b5429609 and b82cc80713

### DIFF
--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -128,14 +128,14 @@ wifi_updown() {
 	[ enable = "$1" ] && {
 		_wifi_updown disable "$2"
 		ubus_wifi_cmd "$cmd" "$2"
+		ubus call network reload
 		scan_wifi
 		cmd=up
-		ubus call network reload
 	}
 	[ reconf = "$1" ] && {
+		ubus call network reload
 		scan_wifi
 		cmd=reconf
-		ubus call network reload
 	}
 	ubus_wifi_cmd "$cmd" "$2"
 	_wifi_updown "$@"


### PR DESCRIPTION
It is probably preferable to call scan_wifi after reloading the network.
So revert the ordering of these two calls to that prior to
commits e8b5429609 and b82cc80713, ie change,
   scan_wifi
   ubus call network reload
to,
   ubus call network reload
   scan_wifi

Signed-off-by: Bob Cantor <86426832+bobc26@users.noreply.github.com>