### PR TITLE
nanopi-r2s: support booting from UHS TF card

### DIFF
--- a/package/boot/uboot-rockchip/patches/103-nanopi-r2s-support-UHS-card.patch
+++ b/package/boot/uboot-rockchip/patches/103-nanopi-r2s-support-UHS-card.patch
@@ -1,0 +1,43 @@
+diff --git a/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi b/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+index 9e2ced1..d546974 100644
+--- a/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+@@ -33,6 +33,10 @@
+ 	u-boot,dm-spl;
+ };
+ 
++&vcc_io_sdio {
++	u-boot,dm-spl;
++};
++
+ &gmac2io {
+ 	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
+ 	snps,reset-active-low;
+diff --git a/arch/arm/dts/rk3328-nanopi-r2s.dts b/arch/arm/dts/rk3328-nanopi-r2s.dts
+index 5445c5c..452e476 100644
+--- a/arch/arm/dts/rk3328-nanopi-r2s.dts
++++ b/arch/arm/dts/rk3328-nanopi-r2s.dts
+@@ -323,7 +323,7 @@
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+-	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>;
++	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>, <&sdmmc0m1_gpio>;
+ 	pinctrl-names = "default";
+ 	sd-uhs-sdr12;
+ 	sd-uhs-sdr25;
+diff --git a/configs/nanopi-r2s-rk3328_defconfig b/configs/nanopi-r2s-rk3328_defconfig
+index 2f67439..43fd536 100644
+--- a/configs/nanopi-r2s-rk3328_defconfig
++++ b/configs/nanopi-r2s-rk3328_defconfig
+@@ -57,6 +57,10 @@ CONFIG_FASTBOOT_BUF_ADDR=0x800800
+ CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_IO_VOLTAGE=y
++CONFIG_SPL_MMC_IO_VOLTAGE=y
++CONFIG_MMC_UHS_SUPPORT=y
++CONFIG_SPL_MMC_UHS_SUPPORT=y
+ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+ CONFIG_SF_DEFAULT_SPEED=20000000


### PR DESCRIPTION
When flash latest firmware on sandisk TF card, could not boot normally.

U-Boot SPL 2021.04 (Jul 02 2021 - 19:50:12 +0000)
Trying to boot from MMC1
mmc_load_image_raw_sector: mmc block read error
SPL: failed to boot from all boot devices

I made pathces to suport ultra high speed card on nanopi-r2s by enable
MMC_IO_VOLTAGE and MMC_UHS_SUPPORT.

Signed-off-by: Jason416 <jason416@foxmail.com>