### PR TITLE
base-files: wifi: call scan_wifi after network reload

### DIFF
--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -133,9 +133,9 @@ wifi_updown() {
 		cmd=up
 	}
 	[ reconf = "$1" ] && {
+		ubus call network reload
 		scan_wifi
 		cmd=reconf
-		ubus call network reload
 	}
 	ubus_wifi_cmd "$cmd" "$2"
 	_wifi_updown "$@"

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -128,9 +128,9 @@ wifi_updown() {
 	[ enable = "$1" ] && {
 		_wifi_updown disable "$2"
 		ubus_wifi_cmd "$cmd" "$2"
+		ubus call network reload
 		scan_wifi
 		cmd=up
-		ubus call network reload
 	}
 	[ reconf = "$1" ] && {
 		scan_wifi


### PR DESCRIPTION
    Commits e8b542960921 and b82cc8071366 included an unintended change and
    we now call scan_wifi before a network reload.

    Restore the original behavior and call scan_wifi only after a network reload.

    Fixes: b82cc8071366 ("base-files: wifi: swap the order of some ubus calls")
    Fixes: e8b542960921 ("base-files: wifi: tidy up the reconf code")
    Signed-off-by: Bob Cantor <bobc@confidesk.com>