### PR TITLE
scripts/mkits.sh: Fix the hash algorithm paramter

### DIFF
--- a/scripts/mkits.sh
+++ b/scripts/mkits.sh
@@ -46,7 +46,7 @@ LOADABLES=
 DTOVERLAY=
 DTADDR=
 
-while getopts ":A:a:c:C:D:d:e:f:i:k:n:o:O:v:r:S" OPTION
+while getopts ":A:a:c:C:D:d:e:f:i:k:n:o:O:v:r:H:" OPTION
 do
 	case $OPTION in
 		A ) ARCH=$OPTARG;;
@@ -63,7 +63,7 @@ do
 		o ) OUTPUT=$OPTARG;;
 		O ) DTOVERLAY="$DTOVERLAY ${OPTARG}";;
 		r ) ROOTFS=$OPTARG;;
-		S ) HASH=$OPTARG;;
+		H ) HASH=$OPTARG;;
 		v ) VERSION=$OPTARG;;
 		* ) echo "Invalid option passed to '$0' (options:$*)"
 		usage;;


### PR DESCRIPTION
The mkits.sh script help message states hash algorithm can be
specified using the -H command-line option, but it does not work
currently due to a bug in the script.

This patch fixes this problem by changing the option from -S to
-H and specify getopts parameter after it

Signed-off-by: Yonghyu Ban <yonghyu@empo.im>
