### PR TITLE
ramips: add support for D-Link DAP-1325-A1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
+++ b/target/linux/ramips/dts/mt7628an_dlink_dap-1325-a1.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dap-1325-a1", "mediatek,mt7628an-soc";
+	model = "D-Link DAP-1325 A1";
+	
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-high {
+			label = "green:wifi-high";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-mid {
+			label = "green:wifi-mid";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "green:wifi-low";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+		
+		
+		wifi-verylow {
+			label = "red:wifi-verylow";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "refclk","gpio","wled_an","i2s","uart1","wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&wmac {
+	status = "okay";
+	mtd-mac-address = <&factory 0x28>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -100,6 +100,13 @@ define Device/d-team_pbr-d1
 endef
 TARGET_DEVICES += d-team_pbr-d1
 
+define Device/dlink_dap-1325-a1
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1325 A1
+endef
+TARGET_DEVICES += dlink_dap-1325-a1
+
 define Device/duzun_dm06
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := DuZun

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -24,6 +24,13 @@ cudy,wr1000)
 	ucidef_set_led_switch "lan1" "lan1" "blue:lan1" "switch0" "0x08"
 	ucidef_set_led_switch "lan2" "lan2" "blue:lan2" "switch0" "0x04"
 	;;
+dlink,dap-1325-a1)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "wifi-verylow" "wifi-verylow" "red:wifi-verylow" "wlan0" "1" "24"
+	ucidef_set_led_rssi "wifi-low" "wifi-low" "green:wifi-low" "wlan0" "25" "100"
+	ucidef_set_led_rssi "wifi-med" "wifi-med" "green:wifi-mid" "wlan0" "50" "100"
+	ucidef_set_led_rssi "wifi-high" "wifi-high" "green:wifi-high" "wlan0" "75" "100"
+	;;
 elecom,wrc-1167fs)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x8"
 	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x10"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ ramips_setup_interfaces()
 	case $board in
 	alfa-network,awusfree1|\
 	d-team,pbr-d1|\
+	dlink,dap-1325-a1|\
 	glinet,microuter-n300|\
 	glinet,vixmini|\
 	hak5,wifi-pineapple-mk7|\


### PR DESCRIPTION
This patch adds support for D-Link DAP-1325-A1 (Range Extender Wi-Fi N300)
	
### Specifications:

- SoC: 580Mhz MT7628NN
- RAM: 64MB, DDR2 SDRAM
- Storage: 8MB, SPI
- Ethernet: 1x 10/100 LAN port
- WIFI: 2.4 GHz 802.11bgn
- LED: Status (2x to provide 3 colors), Wi-Fi Signal Strength (4x)
- Buttons: Reset, WPS
- UART: Serial console (57600, 8n1)
Row of 4 holes near LAN port, starting from square hole:
3.3V, TX,RX,GND
- FCC ID: fccid.io/KA2AP1325A1/

### Installation:

### Failsafe UI
Firmware can be uploaded with Failsafe UI web page:
- turn device off
- press and hold reset button
- turn device on
- keep holding reset until red wifi strength led turns on (ab. 10sec)
- connect to device through LAN port
PC must be configured with static ip (192.168.0.x)
- connect to 192.168.0.50
- select image to be flashed and upload.
Device will reboot after successful update

### Serial port/TFTP server

- Connect through serial connectors on PCB (e.g. with teraterm)
- Set up a TFTP server, and connect through LAN with static IP
- Put image file in the root of the server
- Boot the device and select '2' at U-Boot startup
- Set device IP, server IP and image file name
- Start upload and flash

Signed-off-by: Giovanni Cascione ing.cascione@gmail.com