### PR TITLE
[RFC]build: allow WiFi AP customization during build

### DIFF
--- a/include/version.mk
+++ b/include/version.mk
@@ -104,5 +104,9 @@ VERSION_SED_SCRIPT:=$(SED) 's,%U,$(call sed_escape,$(VERSION_REPO)),g' \
 	-e 's,%u,$(call sed_escape,$(VERSION_HOME_URL)),g' \
 	-e 's,%s,$(call sed_escape,$(VERSION_SUPPORT_URL)),g' \
 	-e 's,%P,$(call sed_escape,$(VERSION_PRODUCT)),g' \
-	-e 's,%h,$(call sed_escape,$(VERSION_HWREV)),g'
+	-e 's,%h,$(call sed_escape,$(VERSION_HWREV)),g' \
+	-e 's,%wD,$(call sed_escape,$(if $(WIFI_DISABLED),1,0)),g' \
+	-e 's,%wS,$(call sed_escape,$(WIFI_SSID)),g' \
+	-e 's,%wE,$(call sed_escape,$(WIFI_ENCRYPTION)),g' \
+	-e 's,%wK,$(call sed_escape,$(WIFI_KEY)),g'
 

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -158,6 +158,10 @@ define Package/base-files/install
 		$(1)/etc/device_info \
 		$(1)/usr/lib/os-release
 
+ifdef CONFIG_WIFIOPT
+	$(VERSION_SED_SCRIPT) $(1)/etc/openwrt_wifi_defaults
+endif
+
 	$(SED) "s#%PATH%#$(TARGET_INIT_PATH)#g" \
 		$(1)/sbin/hotplug-call \
 		$(1)/etc/preinit \

--- a/package/base-files/files/etc/openwrt_wifi_defaults
+++ b/package/base-files/files/etc/openwrt_wifi_defaults
@@ -1,0 +1,6 @@
+# file created during build time, do not edit
+# modify /etc/config/wireless to change WiFi!
+DISABLED='%wD'
+SSID='%wS'
+ENCRYPTION='%wE'
+KEY='%wK'

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -142,6 +142,55 @@ menuconfig INITOPT
 			previous versions of OpenWrt.  Removing this does nothing if
 			stderr is suppressed during preinit (which is the default).
 
+menuconfig WIFIOPT
+	bool "WiFi configuration options" if IMAGEOPT
+	default n
+	help
+		These options allow to override the WiFi settings embedded in
+		/etc/openwrt_wifi_default, which is used as a seed to setup the
+		default WiFI access points.
+
+if WIFIOPT
+
+	config WIFI_DISABLED
+		bool
+		prompt "Start WiFi disabled"
+		default y
+		help
+			Per default all WiFi access points are disabled. Change
+			this to enable WiFi interfaces after first boot.
+
+
+	config WIFI_SSID
+		string
+		prompt "WiFi SSID"
+		default "OpenWrt"
+		help
+			WiFi SSID used for automatically created access points.
+
+	config WIFI_ENCRYPTION
+		string
+		prompt "WiFi Encryption"
+		default "none"
+		help
+			WiFi encryption used for automatically created access points.
+
+			Supported modes:
+			none - No encryption
+			owe - OWE
+			sae - WPA3 Pers.
+			sae-mixed - WPA2/WPA3 Pers.
+			psk2 - WPA2 Pers.
+			psk - WPA Pers.
+
+	config WIFI_KEY
+		string
+		prompt "WiFi Key"
+		default ""
+		help
+			WiFi key used for automatically created access points.
+			Requires at least eight (8) characters.
+endif
 
 menuconfig VERSIONOPT
 	bool "Version configuration options" if IMAGEOPT

--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -136,6 +136,8 @@ get_band_defaults() {
 }
 
 detect_mac80211() {
+	[ -f /etc/openwrt_wifi_defaults ] && . /etc/openwrt_wifi_defaults
+
 	devidx=0
 	config_load wireless
 	while :; do
@@ -174,15 +176,16 @@ detect_mac80211() {
 			set wireless.radio${devidx}.channel=${channel}
 			set wireless.radio${devidx}.band=${mode_band}
 			set wireless.radio${devidx}.htmode=$htmode
-			set wireless.radio${devidx}.disabled=1
+			set wireless.radio${devidx}.disabled=${DISABLED:-1}
 
 			set wireless.default_radio${devidx}=wifi-iface
 			set wireless.default_radio${devidx}.device=radio${devidx}
 			set wireless.default_radio${devidx}.network=lan
 			set wireless.default_radio${devidx}.mode=ap
-			set wireless.default_radio${devidx}.ssid=OpenWrt
-			set wireless.default_radio${devidx}.encryption=none
+			set wireless.default_radio${devidx}.ssid="${SSID:-OpenWrt}"
+			set wireless.default_radio${devidx}.encryption="${ENCRYPTION:-none}"
 EOF
+		[ -n "$KEY" ] && uci set wireless.default_radio${devidx}.key="$KEY"
 		uci -q commit wireless
 
 		devidx=$(($devidx + 1))


### PR DESCRIPTION
This commit adds a sub-menu to the image options to modify the default
access point (AP) automatically created on first boot. The OpenWrt WiFi
AP is traditionally disabled for security reasons and does not require a
password (encryption "none").

The package base-files will generate a file called
`/etc/openwrt_wifi_defaults` which is read by the mac80211.sh script and
allows modification of the UCI options `disabled`, `ssid`, `encryption`
and `key`.

More sophisticated setups are not supported this is merely used to allow
modification of the default AP, just like `VERSIONOPT` is used to modify
the `/etc/openwrt_release` file.

Signed-off-by: Paul Spooren <mail@aparcar.org>