### PR TITLE
ramips: add support for Linksys EA8100 v2

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -54,6 +54,7 @@ linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 linksys,ea8100-v1|\
+linksys,ea8100-v2|\
 xiaomi,mi-router-3g|\
 xiaomi,mi-router-3-pro|\
 xiaomi,mi-router-4|\

--- a/target/linux/ramips/dts/mt7621_linksys_ea8100-v2.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea8100-v2.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_linksys_ea7xxx.dtsi"
+
+/ {
+	compatible = "linksys,ea8100-v2", "mediatek,mt7621-soc";
+	model = "Linksys EA8100 v2";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -862,6 +862,14 @@ define Device/linksys_ea8100-v1
 endef
 TARGET_DEVICES += linksys_ea8100-v1
 
+define Device/linksys_ea8100-v2
+  $(Device/linksys_ea7xxx)
+  DEVICE_MODEL := EA8100
+  DEVICE_VARIANT := v2
+  LINKSYS_HWNAME := EA8100v2
+endef
+TARGET_DEVICES += linksys_ea8100-v2
+
 define Device/linksys_re6500
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -52,7 +52,8 @@ linksys,e5600)
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2|\
-linksys,ea8100-v1)
+linksys,ea8100-v1|\
+linksys,ea8100-v2)
 	ucidef_set_led_netdev "lan1" "lan1 link" "green:lan1" "lan1" "link"
 	ucidef_set_led_netdev "lan2" "lan2 link" "green:lan2" "lan2" "link"
 	ucidef_set_led_netdev "lan3" "lan3 link" "green:lan3" "lan3" "link"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -143,7 +143,8 @@ ramips_setup_macs()
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
-	linksys,ea8100-v1)
+	linksys,ea8100-v1|\
+	linksys,ea8100-v2)
 		lan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		wan_mac=$lan_mac
 		label_mac=$lan_mac

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -22,7 +22,8 @@ case "$board" in
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
-	linksys,ea8100-v1)
+	linksys,ea8100-v1|\
+	linksys,ea8100-v2)
 		hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -12,7 +12,8 @@ boot() {
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
-	linksys,ea8100-v1)
+	linksys,ea8100-v1|\
+	linksys,ea8100-v2)
 		mtd resetbc s_env || true
 		;;
 	samknows,whitebox-v8)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -63,6 +63,7 @@ platform_do_upgrade() {
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\
 	linksys,ea8100-v1|\
+	linksys,ea8100-v2|\
 	netgear,r6220|\
 	netgear,r6260|\
 	netgear,r6350|\


### PR DESCRIPTION
Could this be backported to 21.02 as well? Just like the v1, this should be a clean cherry-pick.

cc: @wizetek