### PR TITLE
lantiq: xrx200: enable use of baby jumbo frames

### DIFF
--- a/target/linux/lantiq/patches-5.10/0702-net-lantiq-add-support-for-jumbo-frames.patch
+++ b/target/linux/lantiq/patches-5.10/0702-net-lantiq-add-support-for-jumbo-frames.patch
@@ -1,0 +1,150 @@
+From 023626670c1611f14a1eb863d75717e927d84dad Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sat, 2 Oct 2021 17:58:54 +0100
+Subject: [PATCH 1/2] net: lantiq: add support for jumbo frames
+
+Add support for jumbo frames. Full support for jumbo frames requires
+changes in the DSA switch driver (lantiq_gswip.c).
+
+Tested on BT Hone Hub 5A.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 64 +++++++++++++++++++++++++---
+ 1 file changed, 57 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/ethernet/lantiq_xrx200.c b/drivers/net/ethernet/lantiq_xrx200.c
+index b624459e0164..bc17c14bf0ba 100644
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -14,13 +14,15 @@
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ 
++#include <linux/if_vlan.h>
++
+ #include <linux/of_net.h>
+ #include <linux/of_platform.h>
+ 
+ #include <xway_dma.h>
+ 
+ /* DMA */
+-#define XRX200_DMA_DATA_LEN	0x600
++#define XRX200_DMA_DATA_LEN	(SZ_64K - 1)
+ #define XRX200_DMA_RX		0
+ #define XRX200_DMA_TX		1
+ 
+@@ -106,7 +108,8 @@ static void xrx200_flush_dma(struct xrx200_chan *ch)
+ 			break;
+ 
+ 		desc->ctl = LTQ_DMA_OWN | LTQ_DMA_RX_OFFSET(NET_IP_ALIGN) |
+-			    XRX200_DMA_DATA_LEN;
++			    (ch->priv->net_dev->mtu + VLAN_ETH_HLEN +
++			     ETH_FCS_LEN);
+ 		ch->dma.desc++;
+ 		ch->dma.desc %= LTQ_DESC_NUM;
+ 	}
+@@ -154,19 +157,20 @@ static int xrx200_close(struct net_device *net_dev)
+ 
+ static int xrx200_alloc_skb(struct xrx200_chan *ch)
+ {
++	int len = ch->priv->net_dev->mtu + VLAN_ETH_HLEN + ETH_FCS_LEN;
+ 	struct sk_buff *skb = ch->skb[ch->dma.desc];
+ 	dma_addr_t mapping;
+ 	int ret = 0;
+ 
+ 	ch->skb[ch->dma.desc] = netdev_alloc_skb_ip_align(ch->priv->net_dev,
+-							  XRX200_DMA_DATA_LEN);
++							  len);
+ 	if (!ch->skb[ch->dma.desc]) {
+ 		ret = -ENOMEM;
+ 		goto skip;
+ 	}
+ 
+ 	mapping = dma_map_single(ch->priv->dev, ch->skb[ch->dma.desc]->data,
+-				 XRX200_DMA_DATA_LEN, DMA_FROM_DEVICE);
++				 len, DMA_FROM_DEVICE);
+ 	if (unlikely(dma_mapping_error(ch->priv->dev, mapping))) {
+ 		dev_kfree_skb_any(ch->skb[ch->dma.desc]);
+ 		ch->skb[ch->dma.desc] = skb;
+@@ -179,8 +183,7 @@ static int xrx200_alloc_skb(struct xrx200_chan *ch)
+ 	wmb();
+ skip:
+ 	ch->dma.desc_base[ch->dma.desc].ctl =
+-		LTQ_DMA_OWN | LTQ_DMA_RX_OFFSET(NET_IP_ALIGN) |
+-		XRX200_DMA_DATA_LEN;
++		LTQ_DMA_OWN | LTQ_DMA_RX_OFFSET(NET_IP_ALIGN) | len;
+ 
+ 	return ret;
+ }
+@@ -340,10 +343,57 @@ static netdev_tx_t xrx200_start_xmit(struct sk_buff *skb,
+ 	return NETDEV_TX_OK;
+ }
+ 
++static int
++xrx200_change_mtu(struct net_device *net_dev, int new_mtu)
++{
++	struct xrx200_priv *priv = netdev_priv(net_dev);
++	struct xrx200_chan *ch_rx = &priv->chan_rx;
++	int old_mtu = net_dev->mtu;
++	bool running = false;
++	struct sk_buff *skb;
++	int curr_desc;
++	int ret = 0;
++
++	net_dev->mtu = new_mtu;
++
++	if (new_mtu <= old_mtu)
++		return ret;
++
++	running = netif_running(net_dev);
++	if (running) {
++		napi_disable(&ch_rx->napi);
++		ltq_dma_close(&ch_rx->dma);
++	}
++
++	xrx200_poll_rx(&ch_rx->napi, LTQ_DESC_NUM);
++	curr_desc = ch_rx->dma.desc;
++
++	for (ch_rx->dma.desc = 0; ch_rx->dma.desc < LTQ_DESC_NUM;
++	     ch_rx->dma.desc++) {
++		skb = ch_rx->skb[ch_rx->dma.desc];
++		ret = xrx200_alloc_skb(ch_rx);
++		if (ret) {
++			net_dev->mtu = old_mtu;
++			break;
++		}
++		dev_kfree_skb_any(skb);
++	}
++
++	ch_rx->dma.desc = curr_desc;
++	if (running) {
++		napi_enable(&ch_rx->napi);
++		ltq_dma_open(&ch_rx->dma);
++		ltq_dma_enable_irq(&ch_rx->dma);
++	}
++
++	return ret;
++}
++
+ static const struct net_device_ops xrx200_netdev_ops = {
+ 	.ndo_open		= xrx200_open,
+ 	.ndo_stop		= xrx200_close,
+ 	.ndo_start_xmit		= xrx200_start_xmit,
++	.ndo_change_mtu		= xrx200_change_mtu,
+ 	.ndo_set_mac_address	= eth_mac_addr,
+ 	.ndo_validate_addr	= eth_validate_addr,
+ };
+@@ -454,7 +504,7 @@ static int xrx200_probe(struct platform_device *pdev)
+ 	net_dev->netdev_ops = &xrx200_netdev_ops;
+ 	SET_NETDEV_DEV(net_dev, dev);
+ 	net_dev->min_mtu = ETH_ZLEN;
+-	net_dev->max_mtu = XRX200_DMA_DATA_LEN;
++	net_dev->max_mtu = XRX200_DMA_DATA_LEN - VLAN_ETH_HLEN - ETH_FCS_LEN;
+ 
+ 	/* load the memory ranges */
+ 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+-- 
+2.29.3
+

--- a/target/linux/lantiq/patches-5.10/0703-net-lantiq-enable-jumbo-frames-on-GSWIP.patch
+++ b/target/linux/lantiq/patches-5.10/0703-net-lantiq-enable-jumbo-frames-on-GSWIP.patch
@@ -1,0 +1,106 @@
+From 24a43ae2ac0ea06c474b1c80dc75651294d49321 Mon Sep 17 00:00:00 2001
+From: Thomas Nixon <tom@tomn.co.uk>
+Date: Sat, 2 Oct 2021 00:48:05 +0100
+Subject: [PATCH 2/2] net: lantiq: enable jumbo frames on GSWIP
+
+This enables non-standard MTUs on a per-port basis, with the overall
+frame size set based on the CPU port.
+
+When the MTU is not changed, this should have no effect.
+
+Long packets crash the switch with MTUs of greater than 2526, so the
+maximum is limited for now.
+
+Signed-off-by: Thomas Nixon <tom@tomn.co.uk>
+---
+ drivers/net/dsa/lantiq_gswip.c | 46 +++++++++++++++++++++++++++++++---
+ 1 file changed, 42 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/dsa/lantiq_gswip.c b/drivers/net/dsa/lantiq_gswip.c
+index 95e634cbc4b6..2dd16e13a2a7 100644
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -238,6 +238,11 @@
+ 
+ #define XRX200_GPHY_FW_ALIGN	(16 * 1024)
+ 
++/* maximum packet size supported by the switch; in theory this should be 9600,
++ * but long packets currently cause lock-ups with an MTU of over 2526
++ */
++#define GSWIP_MAX_PACKET_LENGTH	2556
++
+ struct gswip_hw_info {
+ 	int max_ports;
+ 	int cpu_port;
+@@ -851,10 +856,6 @@ static int gswip_setup(struct dsa_switch *ds)
+ 	gswip_switch_mask(priv, 0, GSWIP_PCE_PCTRL_0_INGRESS,
+ 			  GSWIP_PCE_PCTRL_0p(cpu_port));
+ 
+-	gswip_switch_mask(priv, 0, GSWIP_MAC_CTRL_2_MLEN,
+-			  GSWIP_MAC_CTRL_2p(cpu_port));
+-	gswip_switch_w(priv, VLAN_ETH_FRAME_LEN + 8 + ETH_FCS_LEN,
+-		       GSWIP_MAC_FLEN);
+ 	gswip_switch_mask(priv, 0, GSWIP_BM_QUEUE_GCTRL_GL_MOD,
+ 			  GSWIP_BM_QUEUE_GCTRL);
+ 
+@@ -871,6 +872,8 @@ static int gswip_setup(struct dsa_switch *ds)
+ 		return err;
+ 	}
+ 
++	ds->mtu_enforcement_ingress = true;
++
+ 	gswip_port_enable(ds, cpu_port, NULL);
+ 	return 0;
+ }
+@@ -1433,6 +1436,39 @@ static int gswip_port_fdb_dump(struct dsa_switch *ds, int port,
+ 	return 0;
+ }
+ 
++static int gswip_port_max_mtu(struct dsa_switch *ds, int port)
++{
++	/* includes 8 bytes for special header */
++	return GSWIP_MAX_PACKET_LENGTH - VLAN_ETH_HLEN - ETH_FCS_LEN;
++}
++
++static int gswip_port_change_mtu(struct dsa_switch *ds, int port, int new_mtu)
++{
++	struct gswip_priv *priv = ds->priv;
++	int cpu_port = priv->hw_info->cpu_port;
++
++	/* cpu port always has maximum mtu of user ports, so use it to set
++	 * switch frame size, including 8 byte special header
++	 */
++	if (port == cpu_port) {
++		new_mtu += 8;
++		gswip_switch_w(priv, VLAN_ETH_HLEN + new_mtu + ETH_FCS_LEN,
++			       GSWIP_MAC_FLEN);
++	}
++
++	/* enable MLEN for ports with non-standard MTUs, including the special
++	 * header on the CPU port added above
++	 */
++	if (new_mtu != ETH_DATA_LEN)
++		gswip_switch_mask(priv, 0, GSWIP_MAC_CTRL_2_MLEN,
++				  GSWIP_MAC_CTRL_2p(port));
++	else
++		gswip_switch_mask(priv, GSWIP_MAC_CTRL_2_MLEN, 0,
++				  GSWIP_MAC_CTRL_2p(port));
++
++	return 0;
++}
++
+ static void gswip_phylink_validate(struct dsa_switch *ds, int port,
+ 				   unsigned long *supported,
+ 				   struct phylink_link_state *state)
+@@ -1776,6 +1812,8 @@ static const struct dsa_switch_ops gswip_switch_ops = {
+ 	.port_fdb_add		= gswip_port_fdb_add,
+ 	.port_fdb_del		= gswip_port_fdb_del,
+ 	.port_fdb_dump		= gswip_port_fdb_dump,
++	.port_change_mtu	= gswip_port_change_mtu,
++	.port_max_mtu		= gswip_port_max_mtu,
+ 	.phylink_validate	= gswip_phylink_validate,
+ 	.phylink_mac_config	= gswip_phylink_mac_config,
+ 	.phylink_mac_link_down	= gswip_phylink_mac_link_down,
+-- 
+2.29.3
+

--- a/target/linux/lantiq/patches-5.4/0702-net-lantiq-enable-baby-jumbo-frames-on-xrx200.patch
+++ b/target/linux/lantiq/patches-5.4/0702-net-lantiq-enable-baby-jumbo-frames-on-xrx200.patch
@@ -1,0 +1,61 @@
+From 3e5779db34e2397ec0fd336a993fd907f28c0da8 Mon Sep 17 00:00:00 2001
+From: Thomas Nixon <tom@tomn.co.uk>
+Date: Sat, 3 Jul 2021 15:57:03 +0100
+Subject: [PATCH] net: lantiq: enable baby jumbo frames on xrx200
+
+xrx200 MTU is reduced so that the maximum mtu setting works correctly.
+
+The maximum packet size accepted by the switch is increased to match the
+maximum mtu.
+
+Signed-off-by: Thomas Nixon <tom@tomn.co.uk>
+---
+ drivers/net/dsa/lantiq_gswip.c       | 9 ++++++---
+ drivers/net/ethernet/lantiq_xrx200.c | 4 +++-
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/dsa/lantiq_gswip.c b/drivers/net/dsa/lantiq_gswip.c
+index 3225de0f655f..e02ea6f61824 100644
+--- a/drivers/net/dsa/lantiq_gswip.c
++++ b/drivers/net/dsa/lantiq_gswip.c
+@@ -835,9 +835,12 @@ static int gswip_setup(struct dsa_switch *ds)
+ 	gswip_switch_mask(priv, 0, GSWIP_PCE_PCTRL_0_INGRESS,
+ 			  GSWIP_PCE_PCTRL_0p(cpu_port));
+ 
+-	gswip_switch_mask(priv, 0, GSWIP_MAC_CTRL_2_MLEN,
+-			  GSWIP_MAC_CTRL_2p(cpu_port));
+-	gswip_switch_w(priv, VLAN_ETH_FRAME_LEN + 8 + ETH_FCS_LEN,
++	/* enable baby jumbo frames on all ports */
++	for (i = 0; i < priv->hw_info->max_ports; i++)
++		gswip_switch_mask(priv, 0, GSWIP_MAC_CTRL_2_MLEN,
++				  GSWIP_MAC_CTRL_2p(i));
++	/* 8 bytes for special tag, 8 for baby jumbo */
++	gswip_switch_w(priv, VLAN_ETH_FRAME_LEN + 8 + 8 + ETH_FCS_LEN,
+ 		       GSWIP_MAC_FLEN);
+ 	gswip_switch_mask(priv, 0, GSWIP_BM_QUEUE_GCTRL_GL_MOD,
+ 			  GSWIP_BM_QUEUE_GCTRL);
+diff --git a/drivers/net/ethernet/lantiq_xrx200.c b/drivers/net/ethernet/lantiq_xrx200.c
+index 95e7caabff95..69b6cbd36375 100644
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -14,6 +14,8 @@
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ 
++#include <linux/if_vlan.h>
++
+ #include <linux/of_net.h>
+ #include <linux/of_platform.h>
+ 
+@@ -453,7 +455,7 @@ static int xrx200_probe(struct platform_device *pdev)
+ 	net_dev->netdev_ops = &xrx200_netdev_ops;
+ 	SET_NETDEV_DEV(net_dev, dev);
+ 	net_dev->min_mtu = ETH_ZLEN;
+-	net_dev->max_mtu = XRX200_DMA_DATA_LEN;
++	net_dev->max_mtu = XRX200_DMA_DATA_LEN - VLAN_ETH_HLEN - NET_IP_ALIGN;
+ 
+ 	/* load the memory ranges */
+ 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+-- 
+2.29.3
+


### PR DESCRIPTION
xrx200 MTU is reduced so that the maximum mtu setting works correctly.

The maximum packet size accepted by the switch is increased to match the maximum mtu.

The motivation is to allow an ethernet MTU of 1508, which can carry a PPPoE session with an MTU of 1500 as per rfc4638. Currently if you use a lantiq device as an ADSL/VDSL modem only, you have to live with a MTU of 1492, which is less than ideal.

I'd like to send this upstream; haven't done that yet though.

EDIT: the following discussion is now out of date, see [this thread](https://github.com/openwrt/openwrt/pull/4353#discussion_r668331201).

This slightly changes the switch configuration, so could affect performance -- I'll run some tests on this in the next few days. So far I've tested both patches on a netgear DM200 and a homehub v5a with maximum-MTU pings (`ping -s 1480`) and regular network traffic.

The thing I'm not 100% sure about with this is that the switch ports are all set to work with a 1508-byte mtu, because (AFAIK) there's only one setting for this, and a per-port enable. The DSA slave device doesn't reject packets over the configured MTU limit, so you can have an interface with a configured MTU of 1500 which passes 1508-byte packets fine.

I think this should be ok -- in other cases this seems unavoidable given how VLAN tags are handled -- but it's not totally clear to me.