### PR TITLE
ramips: improve miwifi-mini dts

### DIFF
--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -60,7 +60,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
+		spi-max-frequency = <70000000>;
+		m25p,fast-read;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -71,12 +71,12 @@
 			partition@0 {
 				label = "u-boot";
 				reg = <0x0 0x30000>;
+				read-only;
 			};
 
 			partition@30000 {
 				label = "u-boot-env";
 				reg = <0x30000 0x10000>;
-				read-only;
 			};
 
 			factory: partition@40000 {

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -37,6 +37,21 @@
 			label = "red:status";
 			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
 	};
 
 	keys {
@@ -119,9 +134,6 @@
 };
 
 &ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
-
 	mtd-mac-address = <&factory 0x28>;
 
 	mediatek,portmap = "llllw";
@@ -147,7 +159,7 @@
 
 &state_default {
 	gpio {
-		groups = "i2c", "rgmii1";
+		groups = "ephy", "i2c", "rgmii1";
 		function = "gpio";
 	};
 };

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -198,6 +198,11 @@ wavlink,wl-wn579x3)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x20"
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"
 	;;
+xiaomi,miwifi-mini)
+	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x01"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 zbtlink,zbt-ape522ii)
 	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "green:wlan2g4" "wlan1"
 	ucidef_set_led_netdev "sys1" "wlan1" "green:sys1" "wlan1" "tx rx"


### PR DESCRIPTION
1. increase flash freq for miwifi-mini from 10MHz to 70MHz
2. lock u-boot partition and unlock u-boot-env
3. enable ephy leds

tested on miwifi-mini