### PR TITLE
linux-firmware: add 2G and 5G precal binaries for QCA99X0

### DIFF
--- a/package/firmware/linux-firmware/qca_ath10k.mk
+++ b/package/firmware/linux-firmware/qca_ath10k.mk
@@ -9,6 +9,22 @@ define Download/qca99x0-board
 endef
 $(eval $(call Download,qca99x0-board))
 
+define Download/qca99x0-board-5g
+  URL:=https://github.com/kvalo/ath10k-firmware/raw/master/QCA99X0/hw2.0/
+  URL_FILE:=boardData_AR900B_CUS239_5G_v2_001.bin
+  FILE:=boardData_AR900B_CUS239_5G_v2_001.bin
+  HASH:=3bf7561ee373b369025dcd366d276d038a97d3397ccae41ce841d98a58b30aff
+endef
+$(eval $(call Download,qca99x0-board-5g))
+
+define Download/qca99x0-board-2g
+  URL:=https://github.com/kvalo/ath10k-firmware/raw/master/QCA99X0/hw2.0/
+  URL_FILE:=boardData_AR900B_CUS260_2G_v2_002.bin
+  FILE:=boardData_AR900B_CUS260_2G_v2_002.bin
+  HASH:=fd91ddf93a271633c28fb1831a1dc5e829c345fbf2aa8980e816585cf9b9e9ed
+endef
+$(eval $(call Download,qca99x0-board-2g))
+
 Package/ath10k-board-qca4019 = $(call Package/firmware-default,ath10k qca4019 board firmware)
 define Package/ath10k-board-qca4019/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA4019/hw1.0
@@ -123,6 +139,26 @@ define Package/ath10k-board-qca99x0/install
 		$(PKG_BUILD_DIR)/ath10k/QCA99X0/hw2.0/board.bin \
 		$(1)/lib/firmware/ath10k/QCA99X0/hw2.0/board.bin
 endef
+$(eval $(call BuildPackage,ath10k-board-qca99x0))
+
+Package/ath10k-board-qca99x0-2g = $(call Package/firmware-default,ath10k qca99x0 board 2g precal firmware)
+define Package/ath10k-board-qca99x0-2g/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA99X0/hw2.0
+	$(INSTALL_DATA) \
+		$(DL_DIR)/boardData_AR900B_CUS260_2G_v2_002.bin \
+		$(1)/lib/firmware/ath10k/QCA99X0/hw2.0/board-2g-precal.bin
+endef
+$(eval $(call BuildPackage,ath10k-board-qca99x0-2g))
+
+Package/ath10k-board-qca99x0-5g = $(call Package/firmware-default,ath10k qca99x0 board 5g precal firmware)
+define Package/ath10k-board-qca99x0-5g/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA99X0/hw2.0
+	$(INSTALL_DATA) \
+		$(DL_DIR)/boardData_AR900B_CUS239_5G_v2_001.bin \
+		$(1)/lib/firmware/ath10k/QCA99X0/hw2.0/board-5g-precal.bin
+endef
+$(eval $(call BuildPackage,ath10k-board-qca99x0-5g))
+
 $(eval $(call BuildPackage,ath10k-board-qca99x0))
 Package/ath10k-firmware-qca99x0 = $(call Package/firmware-default,ath10k qca99x0 firmware,+ath10k-board-qca99x0)
 define Package/ath10k-firmware-qca99x0/install


### PR DESCRIPTION
Some devices (such as Extreme Networks WS-AP3959i-ROW) do not contain precal binaries in ART, and the precal in the cards eeprom causes firmware load errors.

These firmware files were previously in linux-firmware, so these are adding them back and renaming to be cleaner.

Signed-off-by: Damien Mascord <tusker@tusker.org>
