### PR TITLE
kernel: backport mdio_find_bus from 5.10.x

### DIFF
--- a/target/linux/generic/backport-5.4/771-mdio-bus-add-generic-find-bus.patch
+++ b/target/linux/generic/backport-5.4/771-mdio-bus-add-generic-find-bus.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/net/phy/mdio_bus.c b/drivers/net/phy/mdio_bus.c
+index 229e480179ff..46dfb112fd04 100644
+--- a/drivers/net/phy/mdio_bus.c
++++ b/drivers/net/phy/mdio_bus.c
+@@ -260,6 +260,23 @@ static struct class mdio_bus_class = {
+ 	.dev_release	= mdiobus_release,
+ };
+ 
++/**
++ * mdio_find_bus - Given the name of a mdiobus, find the mii_bus.
++ * @mdio_bus_np: Pointer to the mii_bus.
++ *
++ * Returns a reference to the mii_bus, or NULL if none found.  The
++ * embedded struct device will have its reference count incremented,
++ * and this must be put_deviced'ed once the bus is finished with.
++ */
++struct mii_bus *mdio_find_bus(const char *mdio_name)
++{
++	struct device *d;
++
++	d = class_find_device_by_name(&mdio_bus_class, mdio_name);
++	return d ? to_mii_bus(d) : NULL;
++}
++EXPORT_SYMBOL(mdio_find_bus);
++
+ #if IS_ENABLED(CONFIG_OF_MDIO)
+ /**
+  * of_mdio_find_bus - Given an mii_bus node, find the mii_bus.
+diff --git a/include/linux/phy.h b/include/linux/phy.h
+index dd4a91f1feaa..5700dd4dbb6f 100644
+--- a/include/linux/phy.h
++++ b/include/linux/phy.h
+@@ -273,6 +273,7 @@ static inline struct mii_bus *devm_mdiobus_alloc(struct device *dev)
+ 	return devm_mdiobus_alloc_size(dev, 0);
+ }
+ 
++struct mii_bus *mdio_find_bus(const char *mdio_name);
+ void devm_mdiobus_free(struct device *dev, struct mii_bus *bus);
+ struct phy_device *mdiobus_scan(struct mii_bus *bus, int addr);
+ 


### PR DESCRIPTION
kernel: backport mdio_find_bus from 5.10.x

mdio-tools (https://github.com/wkz/mdio-tools) requires the use of
mdio_find_bus, which is not present in 5.4.x.

This patch backports the required change from 5.10.x to 5.4.x

The original patch submission for this can be found at
https://patchwork.ozlabs.org/project/netdev/patch
/20200201074625.8698-2-jeremy.linton@arm.com/ :

--

It appears most ethernet drivers follow one of two main strategies
for mdio bus/phy management. A monolithic model where the net driver
itself creates, probes and uses the phy, and one where an external
mdio/phy driver instantiates the mdio bus/phy and the net driver
only attaches to a known phy. Usually in this latter model the phys
are discovered via DT relationships or simply phy name/address
hardcoding.

This is a shame because modern well behaved mdio buses are self
describing and can be probed. The mdio layer itself is fully capable
of this, yet there isn't a clean way for a standalone net driver
to attach and enumerate the discovered devices. This is because
outside of of_mdio_find_bus() there isn't a straightforward way
to acquire the mii_bus pointer.

So, lets add a mdio_find_bus which can return the mii_bus based
only on its name.

--

Signed-off-by: Damien Mascord <tusker@tusker.org>