### PR TITLE
WIP, hostapd: Support EAP-SIM auth

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -153,6 +153,7 @@ define Package/hostapd
 $(call Package/hostapd/Default,$(1))
   TITLE+= (built-in full)
   VARIANT:=full-internal
+  DEPENDS+=+libpcsclite
 endef
 
 define Package/hostapd/description
@@ -164,7 +165,7 @@ define Package/hostapd-openssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
 endef
 
 Package/hostapd-openssl/description = $(Package/hostapd/description)
@@ -173,7 +174,7 @@ define Package/hostapd-wolfssl
 $(call Package/hostapd/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
 endef
 
 Package/hostapd-wolfssl/description = $(Package/hostapd/description)
@@ -239,6 +240,7 @@ define Package/wpad
 $(call Package/wpad/Default,$(1))
   TITLE+= (built-in full)
   VARIANT:=wpad-full-internal
+  DEPENDS+=+libpcsclite
 endef
 
 define Package/wpad/description
@@ -250,7 +252,7 @@ define Package/wpad-openssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=wpad-full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
 endef
 
 Package/wpad-openssl/description = $(Package/wpad/description)
@@ -259,7 +261,7 @@ define Package/wpad-wolfssl
 $(call Package/wpad/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=wpad-full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
 endef
 
 Package/wpad-wolfssl/description = $(Package/wpad/description)
@@ -319,7 +321,7 @@ endef
 define Package/wpad-mesh-openssl
 $(call Package/wpad-mesh,$(1))
   TITLE+= (OpenSSL, 11s, SAE)
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
   VARIANT:=wpad-mesh-openssl
 endef
 
@@ -328,7 +330,7 @@ Package/wpad-mesh-openssl/description = $(Package/wpad-mesh/description)
 define Package/wpad-mesh-wolfssl
 $(call Package/wpad-mesh,$(1))
   TITLE+= (wolfSSL, 11s, SAE)
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
   VARIANT:=wpad-mesh-wolfssl
 endef
 
@@ -352,20 +354,21 @@ define Package/wpa-supplicant
 $(call Package/wpa-supplicant/Default,$(1))
   TITLE+= (built-in full)
   VARIANT:=supplicant-full-internal
+  DEPENDS+=+libpcsclite
 endef
 
 define Package/wpa-supplicant-openssl
 $(call Package/wpa-supplicant/Default,$(1))
   TITLE+= (OpenSSL full)
   VARIANT:=supplicant-full-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
 endef
 
 define Package/wpa-supplicant-wolfssl
 $(call Package/wpa-supplicant/Default,$(1))
   TITLE+= (wolfSSL full)
   VARIANT:=supplicant-full-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
 endef
 
 define Package/wpa-supplicant/config
@@ -389,14 +392,14 @@ define Package/wpa-supplicant-mesh-openssl
 $(call Package/wpa-supplicant-mesh/Default,$(1))
   TITLE+= (OpenSSL, 11s, SAE)
   VARIANT:=supplicant-mesh-openssl
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
 endef
 
 define Package/wpa-supplicant-mesh-wolfssl
 $(call Package/wpa-supplicant-mesh/Default,$(1))
   TITLE+= (wolfSSL, 11s, SAE)
   VARIANT:=supplicant-mesh-wolfssl
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
 endef
 
 define Package/wpa-supplicant-basic
@@ -453,6 +456,7 @@ define Package/eapol-test
   $(call Package/eapol-test/Default,$(1))
   TITLE+= (built-in full)
   VARIANT:=supplicant-full-internal
+  DEPENDS+=+libpcsclite
 endef
 
 define Package/eapol-test-openssl
@@ -460,7 +464,7 @@ define Package/eapol-test-openssl
   TITLE+= (OpenSSL full)
   VARIANT:=supplicant-full-openssl
   CONFLICTS:=$(filter-out eapol-test-openssl ,$(EAPOL_TEST_PROVIDERS))
-  DEPENDS+=+libopenssl
+  DEPENDS+=+libopenssl +libpcsclite
   PROVIDES:=eapol-test
 endef
 
@@ -469,7 +473,7 @@ define Package/eapol-test-wolfssl
   TITLE+= (wolfSSL full)
   VARIANT:=supplicant-full-wolfssl
   CONFLICTS:=$(filter-out eapol-test-openssl ,$(filter-out eapol-test-wolfssl ,$(EAPOL_TEST_PROVIDERS)))
-  DEPENDS+=+libwolfssl
+  DEPENDS+=+libwolfssl +libpcsclite
   PROVIDES:=eapol-test
 endef
 
@@ -504,6 +508,11 @@ TARGET_CPPFLAGS := \
 
 TARGET_CFLAGS += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -flto=jobserver -fuse-linker-plugin -lubox -lubus
+
+ifeq ($(CONFIG_VARIANT),full)
+  TARGET_LDFLAGS += -lpcsclite
+  TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/PCSC
+endif
 
 ifdef CONFIG_PACKAGE_kmod-cfg80211
   TARGET_LDFLAGS += -lm -lnl-tiny

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -128,7 +128,7 @@ CONFIG_EAP_GTC=y
 CONFIG_EAP_OTP=y
 
 # EAP-SIM (enable CONFIG_PCSC, if EAP-SIM is used)
-#CONFIG_EAP_SIM=y
+CONFIG_EAP_SIM=y
 
 # Enable SIM simulator (Milenage) for EAP-SIM
 #CONFIG_SIM_SIMULATOR=y
@@ -146,7 +146,7 @@ CONFIG_EAP_OTP=y
 CONFIG_EAP_LEAP=y
 
 # EAP-AKA (enable CONFIG_PCSC, if EAP-AKA is used)
-#CONFIG_EAP_AKA=y
+CONFIG_EAP_AKA=y
 
 # EAP-AKA' (enable CONFIG_PCSC, if EAP-AKA' is used).
 # This requires CONFIG_EAP_AKA to be enabled, too.
@@ -195,7 +195,7 @@ CONFIG_SMARTCARD=y
 
 # PC/SC interface for smartcards (USIM, GSM SIM)
 # Enable this if EAP-SIM or EAP-AKA is included
-#CONFIG_PCSC=y
+CONFIG_PCSC=y
 
 # Support HT overrides (disable HT/HT40, mask MCS rates, etc.)
 CONFIG_HT_OVERRIDES=y


### PR DESCRIPTION
Support EAP-SIM authentication, to fix FS#3926 (https://bugs.openwrt.org/index.php?do=details&task_id=3926)

More info about the topic:
- https://forum.openwrt.org/t/bug-wpa-supplicant-eap-sim-aka-support-compile-error/46771
- https://forum.turris.cz/t/802-1x-eap-sim-support/13610


Based on @micmac1 patch :)