### PR TITLE
libpcap: update to 1.10.1

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpcap
-PKG_VERSION:=1.10.0
-PKG_RELEASE:=1
+PKG_VERSION:=1.10.1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \
         http://www.tcpdump.org/release/
-PKG_HASH:=8d12b42623eeefee872f123bd0dc85d535b00df4d42e865f993c40f7bfc92b1e
+PKG_HASH:=ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-3-Clause

--- a/package/libs/libpcap/patches/100-no-openssl.patch
+++ b/package/libs/libpcap/patches/100-no-openssl.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -1006,7 +1006,6 @@ endif()
+@@ -1042,7 +1042,6 @@ endif()
  #
  # OpenSSL/libressl.
  #

--- a/package/libs/libpcap/patches/102-skip-manpages.patch
+++ b/package/libs/libpcap/patches/102-skip-manpages.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] skip manpages
 
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -2701,57 +2701,6 @@ if(NOT MSVC)
+@@ -2732,57 +2732,6 @@ if(NOT MSVC)
      if(MINGW)
          find_program(LINK_EXECUTABLE ln)
      endif(MINGW)


### PR DESCRIPTION
Switch to AUTORELEASE to avoid manual increments.

Refreshed patches.

Signed-off-by: Rosen Penev <rosenp@gmail.com>