### PR TITLE
libnftnl: update to 1.2.0

### DIFF
--- a/package/libs/libnftnl/Makefile
+++ b/package/libs/libnftnl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnftnl
-PKG_VERSION:=1.1.8
-PKG_RELEASE:=1
+PKG_VERSION:=1.2.0
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://netfilter.org/projects/$(PKG_NAME)/files
-PKG_HASH:=04a3fa5b08b736268f7e65836b9f05d9d5f438181467bee3c76c3c4a4f3ab711
+PKG_HASH:=90b01fddfe9be8c3245c3ba5ff5a4424a8df708828f92b2b361976b658c074f5
 
 PKG_MAINTAINER:=Steven Barth <steven@midlink.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Switch to AUTORELEASE to avoid manual increments.

Signed-off-by: Rosen Penev <rosenp@gmail.com>