### PR TITLE
libcap: update to 2.51

### DIFF
--- a/package/libs/libcap/Makefile
+++ b/package/libs/libcap/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libcap
-PKG_VERSION:=2.48
-PKG_RELEASE:=1
+PKG_VERSION:=2.51
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/libs/security/linux-privs/libcap2
-PKG_HASH:=4de9590ee09a87c282d558737ffb5b6175ccbfd26d580add10df44d0f047f6c2
+PKG_HASH:=6609f3ab7aebcc8f9277f53a577c657d9f3056d1352ea623da7fd7c0f00890f9
 
 PKG_MAINTAINER:=Paul Wassi <p.wassi@gmx.at>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Switched to AUTORELEASE to avoid manual increments.

Signed-off-by: Rosen Penev <rosenp@gmail.com>