### PR TITLE
elfutils: update to 0.182

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
-PKG_VERSION:=0.180
-PKG_RELEASE:=2
+PKG_VERSION:=0.182
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION)
-PKG_HASH:=b827b6e35c59d188ba97d7cf148fa8dc6f5c68eb6c5981888dfdbb758c0b569d
+PKG_HASH:=ecc406914edf335f0b7fc084ebe6c460c4d6d5175bfdd6688c1c78d9146b8858
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
 PKG_LICENSE:=GPL-3.0-or-later
@@ -63,7 +63,9 @@ endif
 CONFIGURE_ARGS += \
 	--program-prefix=eu- \
 	--disable-debuginfod \
-	--without-lzma
+	--disable-libdebuginfod \
+	--without-lzma \
+	--without-zstd
 
 TARGET_CFLAGS += -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral
 

--- a/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
+++ b/package/libs/elfutils/patches/0001-ppc_initreg.c-Incliude-asm-ptrace.h-for-pt_regs-defi.patch
@@ -17,8 +17,6 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
  backends/ppc_initreg.c | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/backends/ppc_initreg.c b/backends/ppc_initreg.c
-index 0e0d359..e5cca7e 100644
 --- a/backends/ppc_initreg.c
 +++ b/backends/ppc_initreg.c
 @@ -33,6 +33,7 @@
@@ -29,6 +27,3 @@ index 0e0d359..e5cca7e 100644
  # include <sys/user.h>
  #endif
  
--- 
-2.23.0
-

--- a/package/libs/elfutils/patches/003-libintl-compatibility.patch
+++ b/package/libs/elfutils/patches/003-libintl-compatibility.patch
@@ -11,7 +11,7 @@
  Requires.private: zlib
 --- a/configure.ac
 +++ b/configure.ac
-@@ -586,6 +586,9 @@ AC_CONFIG_FILES([config/libelf.pc config
+@@ -590,6 +590,9 @@ AC_CONFIG_FILES([config/libelf.pc config
  AC_SUBST(USE_NLS, yes)
  AM_PO_SUBDIRS
  
@@ -47,7 +47,7 @@
  #define _(Str) dgettext ("elfutils", Str)
 --- a/libdwfl/libdwflP.h
 +++ b/libdwfl/libdwflP.h
-@@ -44,6 +44,9 @@
+@@ -47,6 +47,9 @@
  
  typedef struct Dwfl_Process Dwfl_Process;
  

--- a/package/libs/elfutils/patches/005-build_only_libs.patch
+++ b/package/libs/elfutils/patches/005-build_only_libs.patch
@@ -4,8 +4,8 @@
  pkginclude_HEADERS = version.h
  
  SUBDIRS = config m4 lib libelf libcpu backends libebl libdwelf libdwfl libdw \
--	  libasm src po doc tests
+-	  libasm debuginfod src po doc tests
 +	  libasm
  
- if DEBUGINFOD
- SUBDIRS += debuginfod
+ EXTRA_DIST = elfutils.spec GPG-KEY NOTES CONTRIBUTING \
+ 	     COPYING COPYING-GPLV2 COPYING-LGPLV3

--- a/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
+++ b/package/libs/elfutils/patches/006-Fix-build-on-aarch64-musl.patch
@@ -22,8 +22,6 @@ Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
  backends/arm_initreg.c     | 2 +-
  2 files changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/backends/aarch64_initreg.c b/backends/aarch64_initreg.c
-index daf6f37..6445276 100644
 --- a/backends/aarch64_initreg.c
 +++ b/backends/aarch64_initreg.c
 @@ -33,7 +33,7 @@
@@ -35,7 +33,7 @@ index daf6f37..6445276 100644
  # include <sys/user.h>
  # include <sys/ptrace.h>
  /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */
-@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t tid __attribute__ ((unused)),
+@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t
  
    Dwarf_Word dwarf_fregs[32];
    for (int r = 0; r < 32; r++)
@@ -44,8 +42,6 @@ index daf6f37..6445276 100644
  
    if (! setfunc (64, 32, dwarf_fregs, arg))
      return false;
-diff --git a/backends/arm_initreg.c b/backends/arm_initreg.c
-index efcabaf..062bb9e 100644
 --- a/backends/arm_initreg.c
 +++ b/backends/arm_initreg.c
 @@ -38,7 +38,7 @@

--- a/package/libs/elfutils/patches/110-no-cdefs.patch
+++ b/package/libs/elfutils/patches/110-no-cdefs.patch
@@ -24,28 +24,3 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  
  #include <system.h>
  
---- a/libelf/elf.h
-+++ b/libelf/elf.h
-@@ -19,9 +19,9 @@
- #ifndef _ELF_H
- #define	_ELF_H 1
- 
--#include <features.h>
--
--__BEGIN_DECLS
-+#ifdef __cplusplus
-+extern "C" {
-+#endif
- 
- /* Standard ELF types.  */
- 
-@@ -4103,6 +4103,8 @@ enum
- #define R_ARC_TLS_LE_S9		0x4a
- #define R_ARC_TLS_LE_32		0x4b
- 
--__END_DECLS
-+#ifdef __cplusplus
-+}
-+#endif
- 
- #endif	/* elf.h */


### PR DESCRIPTION
Add --disable-libdebuginfod with remove libcurl dependency.

Remove totally unused host elfutils.

Refreshed and rebased patches.

Also happens to fix compilation with GCC11.

Newer versions of elfutils seem to have some kind of dependency on
obstack.

Signed-off-by: Rosen Penev <rosenp@gmail.com>