### PR TITLE
gettext-full: disable parallel compilation

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -24,8 +24,8 @@ PKG_CPE_ID:=cpe:/a:gnu:gettext
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host
-PKG_BUILD_PARALLEL:=1
-HOST_BUILD_PARALLEL:=1
+PKG_BUILD_PARALLEL:=0
+HOST_BUILD_PARALLEL:=0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
Fails fairly reliably with make -j 12 on a Ryzen 3600.

Signed-off-by: Rosen Penev <rosenp@gmail.com>