### PR TITLE
uboot-envtools: mvebu: update uci defaults for Turris Omnia

### DIFF
--- a/package/boot/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-envtools/files/mvebu
@@ -17,7 +17,10 @@ buffalo,ls421de)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000"
 	;;
 cznic,turris-omnia)
-	if grep -q 'U-Boot 2015.10-rc2' /dev/mtd0; then
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+		ubootenv_add_uci_config "/dev/mtd${idx}" "0x0" "0x10000" "0x10000"
+	elif grep -q 'U-Boot 2015.10-rc2' /dev/mtd0; then
 		ubootenv_add_uci_config "/dev/mtd0" "0xc0000" "0x10000" "0x40000"
 	else
 		ubootenv_add_uci_config "/dev/mtd0" "0xf0000" "0x10000" "0x10000"


### PR DESCRIPTION
From version 2021.09 U-Boot will fixup Turris Omnia's DTB before
booting, separating U-Boot's environment into separate MTD partition
"u-boot-env" [1].

Check if "u-boot-env" MTD partition exists and set the uci defaults
accordingly.

[1] https://lists.denx.de/pipermail/u-boot/2021-July/455017.html

Signed-off-by: Marek Behún <marek.behun@nic.cz>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
