### PR TITLE
ath79: mikrotik: set 4k blocksize to fix SPI NOR sysupgrade

### DIFF
--- a/target/linux/ath79/image/common-mikrotik.mk
+++ b/target/linux/ath79/image/common-mikrotik.mk
@@ -7,6 +7,7 @@ endef
 
 define Device/mikrotik_nor
   $(Device/mikrotik)
+  BLOCKSIZE := 4k
   IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | \
 	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
 	check-size | append-metadata


### PR DESCRIPTION
This patch sets to 4k the blocksize of sysupgrade images for MikroTik devices with SPI NOR flash in the ath79 target. This way, the device configuration is kept over a sysupgrade process.

The MikroTik devices with an SPI NOR flash require using 4k sectors (CONFIG_MTD_SPI_NOR_USE_4K_SECTORS=y) in  order to write data to the small soft_config partition. This, due to current lack of driver support, prevents from using larger 64k sectors for the rest of partitions (which was possible in ar71xx and with earlier kernel versions).

Currently, sysupgrade images are generated with the default 64k blocksize. This causes settings not to be preserved over the sysupgrade process (after reboot, mount_root expects a 64k blocksize and, since 4k sectors are used, it is unable to recover the previous settings). Creating the images with a 4k blocksize allows keeping settings over the sysupgrade process.

Tested on a MikroTik RouterBoard wAPG-5HacT2HnD (wAP AC).

Fixes FS#3492.

Note: this patch only fixes keeping settings over a sysupgrade, it does not tackle the actual 4k/64k sectors problem (see https://github.com/openwrt/openwrt/pull/3271 for more details).