### PR TITLE
hostapd: fix mesh in HE mode with 20 MHz bw

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -1165,7 +1165,7 @@ wpa_supplicant_set_fixed_freq() {
 	append network_data "frequency=$freq" "$N$T"
 	case "$htmode" in
 		NOHT) append network_data "disable_ht=1" "$N$T";;
-		HT20|VHT20) append network_data "disable_ht40=1" "$N$T";;
+		HE20|HT20|VHT20) append network_data "disable_ht40=1" "$N$T";;
 		HT40*|VHT40*|VHT80*|VHT160*) append network_data "ht40=1" "$N$T";;
 	esac
 	case "$htmode" in


### PR DESCRIPTION
When using htmode 'HE20' with a radio in mesh mode, wpa-supplicant will
default to 40 MHz bw if disable_ht40 is not set. This commit fixes this
behaviour.

Signed-off-by: Jesús Fernández Manzano <jesus.manzano@galgus.net>