### PR TITLE
layerscape: fix config restore for FRWY-LS1046A

### DIFF
--- a/target/linux/layerscape/base-files/lib/preinit/79_move_config
+++ b/target/linux/layerscape/base-files/lib/preinit/79_move_config
@@ -11,6 +11,7 @@ move_config() {
 	fsl,ls1021a-iot-sdboot | \
 	fsl,ls1021a-twr-sdboot | \
 	fsl,ls1043a-rdb-sdboot | \
+	fsl,ls1046a-frwy-sdboot | \
 	fsl,ls1046a-rdb-sdboot | \
 	fsl,ls1088a-rdb-sdboot)
 		if [ -b $BOOTPART ]; then


### PR DESCRIPTION
commit 2c2d77bd3bd4 ("layerscape: add FRWY-LS1046A board support")
missed to add an entry to the 79_move_config preinit script.

Therefore, the config transfer on sysupgrade wass broken for this device.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>
