### PR TITLE
ramips: add missing label-mac-device for Xiaomi Mi Router 4A (100M)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4.dtsi
@@ -11,6 +11,7 @@
 		led-failsafe = &led_power_yellow;
 		led-running = &led_power_blue;
 		led-upgrade = &led_power_yellow;
+		label-mac-device = &ethernet;
 	};
 
 	chosen {


### PR DESCRIPTION
As both the Mi Router 4A (100M) and the Mi Router 4C use the same
label-mac-device, the alias can be moved to the shared dtsi.

Signed-off-by: Fabian Bläse <fabian@blaese.de>