### PR TITLE
ath79: use Qualcomm ath10k for QCA9887 devices

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1133,7 +1133,7 @@ define Device/engenius_ews511ap
   SOC := qca9531
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EWS511AP
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887
   IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += engenius_ews511ap
@@ -1218,7 +1218,7 @@ define Device/glinet_gl-ar750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-AR750
-  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k ath10k-firmware-qca9887
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar750
 endef
@@ -1247,7 +1247,7 @@ define Device/glinet_gl-x750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-X750
-  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-usb2 kmod-ath10k ath10k-firmware-qca9887
   IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += glinet_gl-x750
@@ -1467,7 +1467,7 @@ define Device/nec_wg800hp
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | \
 	xor-image -p 6A57190601121E4C004C1E1201061957 -x | nec-fw LASER_ATERM
-  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct-full-htt
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887
 endef
 TARGET_DEVICES += nec_wg800hp
 
@@ -2051,7 +2051,7 @@ define Device/qxwlan_e600gac-v2
   SOC := qca9531
   DEVICE_VENDOR := Qxwlan
   DEVICE_MODEL := E600GAC
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887
   SUPPORTED_DEVICES += e600gac-v2
 endef
 
@@ -2320,7 +2320,7 @@ define Device/yuncore_a770
   SOC := qca9531
   DEVICE_VENDOR := YunCore
   DEVICE_MODEL := A770
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887
   IMAGE_SIZE := 16000k
   IMAGES += tftp.bin
   IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -111,7 +111,7 @@ define Device/glinet_gl-ar750s-common
   SOC := qca9563
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-AR750S
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2 \
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887 kmod-usb2 \
 	kmod-usb-storage block-mount
   IMAGE_SIZE := 16000k
 endef
@@ -137,7 +137,7 @@ define Device/glinet_gl-e750
   SOC := qca9531
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-E750
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887 kmod-usb2
   SUPPORTED_DEVICES += gl-e750
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 131072k


### PR DESCRIPTION
Issues were observed with the Candelatech version of the QCA9887 driver.
It was said that this will not be fixed and it may be better to use the
official driver instead (which works stable):
https://github.com/greearb/ath10k-ct/issues/180#issuecomment-840677362

Note: A remaining user of the qca9887-ct driver is the Meraki MR33 which is
not being handled by this commit as it is an (probably unaffected) IPQ40xx-based device.