### PR TITLE
kirkwood: add support for Endian 4i Edge 200...

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -30,6 +30,9 @@ seagate,goflexnet|\
 zyxel,nsa310s)
 	ucidef_set_interface_lan "eth0" "dhcp"
 	;;
+endian,4i-edge-200)
+	ucidef_set_interface_lan "port1 port2 port3 port4 eth1"
+	;;
 linksys,e4200-v2|\
 linksys,ea3500|\
 linksys,ea4500)

--- a/target/linux/kirkwood/base-files/lib/preinit/07_set_iface_mac
+++ b/target/linux/kirkwood/base-files/lib/preinit/07_set_iface_mac
@@ -19,6 +19,14 @@ preinit_set_mac_address() {
 		ip link set dev dmz address $(macaddr_add $mac 8) 2>/dev/null
 		ip link set dev dsl address $(macaddr_add $mac 9) 2>/dev/null
 		;;
+	endian,4i-edge-200)
+		mac=$(cat /sys/class/net/eth0/address)
+
+		ip link set dev port1 address $mac 2>/dev/null
+		ip link set dev port2 address $(macaddr_add $mac 1) 2>/dev/null
+		ip link set dev port3 address $(macaddr_add $mac 2) 2>/dev/null
+		ip link set dev port4 address $(macaddr_add $mac 3) 2>/dev/null
+		;;
 	esac
 }
 

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-4i-edge-200.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-4i-edge-200.dts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Endian 4i Edge 200 Board Description
+ * Note: Endian UTM Mini is hardware clone of Endian Edge 200
+ * Copyright 2021 Pawel Dembicki <paweldembicki@gmail.com>
+ */
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6281.dtsi"
+
+/ {
+	model = "Endian 4i Edge 200";
+	compatible = "endian,4i-edge-200", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x20000000>;
+	};
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_orange;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_orange;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+		stdout-path = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&pmx_led49 &pmx_led35 &pmx_led34>;
+		pinctrl-names = "default";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_orange: status_orange {
+			label = "orange:status";
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		sdcard {
+			label = "orange:sdcard";
+			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc0";
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&eth0port {
+	speed = <1000>;
+	duplex = <1>;
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&eth1port {
+	phy-handle = <&ethphyb>;
+};
+
+&mdio {
+	status = "okay";
+
+	ethphyb: ethernet-phy@b {
+		reg = <0x0b>;
+
+		marvell,reg-init =
+			/* link-activity, bi-color mode 4 */
+			<3 0x10 0xfff0 0xf>; /* Reg 3,16 <- 0xzzzf */
+	};
+
+	switch0: switch@11 {
+		compatible = "marvell,mv88e6085";
+		reg = <0x11>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "port1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "port2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "port3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "port4";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "cpu";
+				phy-mode = "rgmii-id";
+				ethernet = <&eth0port>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+	pinctrl-0 = <&pmx_nand>;
+	pinctrl-names = "default";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x00000000 0x000a0000>;
+		read-only;
+	};
+
+	partition@a0000 {
+		label = "u-boot-env";
+		reg = <0x000a0000 0x00060000>;
+		read-only;
+	};
+
+	partition@100000 {
+		label = "kernel";
+		reg = <0x00100000 0x00400000>;
+	};
+
+	partition@500000 {
+		label = "ubi";
+		reg = <0x00500000 0x1fb00000>;
+	};
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl-0 = <&pmx_sysrst>;
+	pinctrl-names = "default";
+
+	pmx_sysrst: pmx-sysrst {
+		marvell,pins = "mpp6";
+		marvell,function = "sysrst";
+	};
+
+	pmx_sdio_cd: pmx-sdio-cd {
+		marvell,pins = "mpp28";
+		marvell,function = "gpio";
+	};
+
+	pmx_led34: pmx_led34 {
+		marvell,pins = "mpp34";
+		marvell,function = "gpio";
+	};
+
+	pmx_led35: pmx_led35 {
+		marvell,pins = "mpp35";
+		marvell,function = "gpio";
+	};
+
+	pmx_led49: pmx_led49 {
+		marvell,pins = "mpp49";
+		marvell,function = "gpio";
+	};
+};
+
+&rtc {
+	status = "okay";
+};
+
+&sata_phy0 {
+	status = "disabled";
+};
+
+&sata_phy1 {
+	status = "disabled";
+};
+
+&sdio {
+	pinctrl-0 = <&pmx_sdio_cd>;
+	pinctrl-names = "default";
+	status = "okay";
+	cd-gpios = <&gpio0 28 9>;
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -140,6 +140,17 @@ define Device/ctera_c200-v1
 endef
 TARGET_DEVICES += ctera_c200-v1
 
+define Device/endian_4i-edge-200
+  DEVICE_VENDOR := Endian
+  DEVICE_MODEL := 4i Edge 200
+  DEVICE_ALT0_VENDOR := Endian
+  DEVICE_ALT0_MODEL := UTM Mini Firewall
+  DEVICE_PACKAGES := kmod-ath9k kmod-mvsdio wpad-basic-wolfssl
+  KERNEL_SIZE := 4096k
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += endian_4i-edge-200
+
 define Device/globalscale_sheevaplug
   DEVICE_VENDOR := Globalscale
   DEVICE_MODEL := Sheevaplug


### PR DESCRIPTION
...and his clone Endian UTM Mini.

Hardware:
  - SoC: Marvell 88F6281-A1 ARMv5TE Processor 1.2GHz
  - Ram: 512MB (4x Nanya NT5TU128M8GE-AC)
  - NAND Flash: 512MB (Micron 29F4G08AAC)
  - Lan 1-4: 4x GBE (Marvell 88E6171R-TFJ2)
  - Lan 5: 1x GBE (Marvell 88E1116R-NNC1)
  - Storage: MicroSD Slot
  - WLAN: MiniPCIe Slot present, and fitted with SparkLan WPEA-110N/E
          (Atheros AR9280 chipset) (ONLY Endian UTM Mini WLAN)
  - USB: 1x USB 2.0 port
  - Console: RJ-45 port
  - LEDs: 3x GPIO controlled

Known issues:
  - LAN5 configured as WAN
  - WLAN led (Endian UTM Mini) is drived by MPCIE card

Installation by TFTP + serial:
  - Setup TFTP server and copy initramfs image
  - Connect serial console
  - Stop booting in u-boot
  - Do:
	setenv bootargs 'console=ttyS0,115200n8 earlyprintk'
	saveenv
	setenv serverip 192.168.1.1
	setenv ipaddr 192.168.1.2
	tftpboot 0x1200000 openwrt-kirkwood-endian_4i-edge-200-initramfs-uImage
	bootm 0x1200000
  - copy sysupgrade image via ssh.
  - run sysupgrade

Installation by USB + serial:
  - Copy initramfs image to fat32 usb drive
  - Connect pendrive to USB 2.0 front socket
  - Connect serial console
  - Stop booting in u-boot
  - Do:
	setenv bootargs 'console=ttyS0,115200n8 earlyprintk'
        saveenv
	usb reset
	fatload usb 0:1 0x1200000 openwrt-kirkwood-endian_4i-edge-200-initramfs-uImage
	bootm 0x1200000
  - copy sysupgrade image via ssh.
  - run sysupgrade

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
