### PR TITLE
generic: fix mediatek and dsa not detecting mac-addr from nvmem

### DIFF
--- a/target/linux/generic/hack-5.10/780-drivers-net-mediatek-register-of_platform-for-every-.patch
+++ b/target/linux/generic/hack-5.10/780-drivers-net-mediatek-register-of_platform-for-every-.patch
@@ -1,0 +1,32 @@
+From c94b2cfd25c282e2974accc1b07da98ae7139b47 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 23 Jul 2021 12:14:33 +0200
+Subject: [PATCH 1/2] drivers: net: mediatek: register of_platform for every
+ port
+
+Currently the nvmem framework require the devicenode to be registred on
+the of_platform or of_get_mac_address fail to get the macaddress if
+defined using an nvmem cell. Fix this by registrering these special node
+so they can be found by of_find_device_by_node.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/ethernet/mediatek/mtk_eth_soc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/net/ethernet/mediatek/mtk_eth_soc.c b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+index ed4eacef17ce..666803817540 100644
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -3015,6 +3015,8 @@ static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
+ 	eth->netdev[id]->dev.of_node = np;
+ 
+ 	eth->netdev[id]->max_mtu = MTK_MAX_RX_LENGTH - MTK_RX_ETH_HLEN;
++	
++	of_platform_device_create(np, NULL, NULL);
+ 
+ 	return 0;
+ 
+-- 
+2.31.1
+

--- a/target/linux/generic/hack-5.10/781-dsa-register-every-port-with-of_platform.patch
+++ b/target/linux/generic/hack-5.10/781-dsa-register-every-port-with-of_platform.patch
@@ -1,0 +1,40 @@
+From 8bab551f44204fc5d43977063cd704112c17c750 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 23 Jul 2021 12:17:27 +0200
+Subject: [PATCH 2/2] dsa: register every port with of_platform
+
+The declaration of a different mac-addr using the nvmem framework is
+currently broken. The dsa code use the generic of_get_mac_address where
+the nvmem function require the device node to be registred in the
+of_platform to be found by of_find_device_by_node. Register every port
+in the of_platform so they can corrently found and a custom mac-addr can
+correctly be declared using a nvmem-cell declared in the dts.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ net/dsa/dsa2.c | 2 +
+ 1 file changed, 2 insertion(+)
+
+diff --git a/net/dsa/dsa2.c b/net/dsa/dsa2.c
+index b71e87909f0e..55bbc1a769ca 100644
+--- a/net/dsa/dsa2.c
++++ b/net/dsa/dsa2.c
+@@ -14,6 +14,7 @@
+ #include <linux/rtnetlink.h>
+ #include <linux/of.h>
+ #include <linux/of_net.h>
++#include <linux/of_platform.h>
+ #include <net/devlink.h>
+ 
+ #include "dsa_priv.h"
+@@ -392,6 +392,7 @@ static int dsa_port_setup(struct dsa_port *dp)
+ 
+ 		break;
+ 	case DSA_PORT_TYPE_USER:
++		of_platform_device_create(dp->dn, NULL, NULL);
+ 		dp->mac = of_get_mac_address(dp->dn);
+ 		err = dsa_slave_create(dp);
+ 		if (err)
+-- 
+2.31.1
+

--- a/target/linux/generic/hack-5.4/780-drivers-net-mediatek-register-of_platform-for-every-.patch
+++ b/target/linux/generic/hack-5.4/780-drivers-net-mediatek-register-of_platform-for-every-.patch
@@ -1,0 +1,32 @@
+From c94b2cfd25c282e2974accc1b07da98ae7139b47 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 23 Jul 2021 12:14:33 +0200
+Subject: [PATCH 1/2] drivers: net: mediatek: register of_platform for every
+ port
+
+Currently the nvmem framework require the devicenode to be registred on
+the of_platform or of_get_mac_address fail to get the macaddress if
+defined using an nvmem cell. Fix this by registrering these special node
+so they can be found by of_find_device_by_node.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/ethernet/mediatek/mtk_eth_soc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/net/ethernet/mediatek/mtk_eth_soc.c b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+index ed4eacef17ce..666803817540 100644
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -3015,6 +3015,8 @@ static int mtk_add_mac(struct mtk_eth *eth, struct device_node *np)
+ 	eth->netdev[id]->dev.of_node = np;
+ 
+ 	eth->netdev[id]->max_mtu = MTK_MAX_RX_LENGTH - MTK_RX_ETH_HLEN;
++	
++	of_platform_device_create(np, NULL, NULL);
+ 
+ 	return 0;
+ 
+-- 
+2.31.1
+

--- a/target/linux/generic/hack-5.4/781-dsa-register-every-port-with-of_platform.patch
+++ b/target/linux/generic/hack-5.4/781-dsa-register-every-port-with-of_platform.patch
@@ -1,0 +1,40 @@
+From 8bab551f44204fc5d43977063cd704112c17c750 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 23 Jul 2021 12:17:27 +0200
+Subject: [PATCH 2/2] dsa: register every port with of_platform
+
+The declaration of a different mac-addr using the nvmem framework is
+currently broken. The dsa code use the generic of_get_mac_address where
+the nvmem function require the device node to be registred in the
+of_platform to be found by of_find_device_by_node. Register every port
+in the of_platform so they can corrently found and a custom mac-addr can
+correctly be declared using a nvmem-cell declared in the dts.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ net/dsa/dsa2.c | 2 +
+ 1 file changed, 2 insertion(+)
+
+diff --git a/net/dsa/dsa2.c b/net/dsa/dsa2.c
+index b71e87909f0e..55bbc1a769ca 100644
+--- a/net/dsa/dsa2.c
++++ b/net/dsa/dsa2.c
+@@ -14,6 +14,7 @@
+ #include <linux/rtnetlink.h>
+ #include <linux/of.h>
+ #include <linux/of_net.h>
++#include <linux/of_platform.h>
+ #include <net/devlink.h>
+ 
+ #include "dsa_priv.h"
+@@ -392,6 +392,7 @@ static int dsa_port_setup(struct dsa_port *dp)
+ 			break;
+ 		devlink_port_registered = true;
+ 
++		of_platform_device_create(dp->dn, NULL, NULL);
+ 		dp->mac = of_get_mac_address(dp->dn);
+ 		err = dsa_slave_create(dp);
+ 		if (err)
+-- 
+2.31.1
+


### PR DESCRIPTION
Nvmem require the device node to be registered with the of_platform.
Register the device node so that nvmem can correctly find the dev and
correctly load the mac-addr stored in the nvmem cell declared in the dts.

This should be a quick fix for the mac-addr breakage for ramips and mediatek.
I will send an RFC patch upstream to check if we can find a better solution for this.
I put in hack as they will probably dropped later for (ideally) an upstream solution.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>