### PR TITLE
mediatek: mt7623: import patch to fix spi

### DIFF
--- a/target/linux/mediatek/patches-5.10/000-spi-fix-fifo.patch
+++ b/target/linux/mediatek/patches-5.10/000-spi-fix-fifo.patch
@@ -1,0 +1,54 @@
+From 3a70dd2d050331ee4cf5ad9d5c0a32d83ead9a43 Mon Sep 17 00:00:00 2001
+From: Peter Hess <peter.hess@ph-home.de>
+Date: Tue, 6 Jul 2021 14:16:09 +0200
+Subject: spi: mediatek: fix fifo rx mode
+
+In FIFO mode were two problems:
+- RX mode was never handled and
+- in this case the tx_buf pointer was NULL and caused an exception
+
+fix this by handling RX mode in mtk_spi_fifo_transfer
+
+Fixes: a568231f4632 ("spi: mediatek: Add spi bus for Mediatek MT8173")
+Signed-off-by: Peter Hess <peter.hess@ph-home.de>
+Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
+Link: https://lore.kernel.org/r/20210706121609.680534-1-linux@fw-web.de
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-mt65xx.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/spi/spi-mt65xx.c b/drivers/spi/spi-mt65xx.c
+index 976f73b9e2998..8d5fa7f1e5069 100644
+--- a/drivers/spi/spi-mt65xx.c
++++ b/drivers/spi/spi-mt65xx.c
+@@ -427,13 +427,23 @@ static int mtk_spi_fifo_transfer(struct spi_master *master,
+ 	mtk_spi_setup_packet(master);
+ 
+ 	cnt = xfer->len / 4;
+-	iowrite32_rep(mdata->base + SPI_TX_DATA_REG, xfer->tx_buf, cnt);
++	if (xfer->tx_buf)
++		iowrite32_rep(mdata->base + SPI_TX_DATA_REG, xfer->tx_buf, cnt);
++
++	if (xfer->rx_buf)
++		ioread32_rep(mdata->base + SPI_RX_DATA_REG, xfer->rx_buf, cnt);
+ 
+ 	remainder = xfer->len % 4;
+ 	if (remainder > 0) {
+ 		reg_val = 0;
+-		memcpy(&reg_val, xfer->tx_buf + (cnt * 4), remainder);
+-		writel(reg_val, mdata->base + SPI_TX_DATA_REG);
++		if (xfer->tx_buf) {
++			memcpy(&reg_val, xfer->tx_buf + (cnt * 4), remainder);
++			writel(reg_val, mdata->base + SPI_TX_DATA_REG);
++		}
++		if (xfer->rx_buf) {
++			reg_val = readl(mdata->base + SPI_RX_DATA_REG);
++			memcpy(xfer->rx_buf + (cnt * 4), &reg_val, remainder);
++		}
+ 	}
+ 
+ 	mtk_spi_enable_transfer(master);
+-- 
+cgit 1.2.3-1.el7
+


### PR DESCRIPTION
The patch fixes the fifo rx mode for the mt7623. It is already accepted upstream for Linux Kernel 5.15.

To test the spi we can change the dts file to
```
&spi0 {
	pinctrl-names = "default";
	pinctrl-0 = <&spi0_pins_a>;
	status = "okay";
	spidev: spidev@0 {
		compatible = "linux,spidev";
		spi-max-frequency = <1000000>;
		reg = <0>;
	};
};
```
Afterwards we should see a spidev device under /dev/.
To test it we can further use spidev-test.

**I was only able to compile test, since my BPI-R2 is not available. Maybe some other person can also run-test?** @dangowrt 