### PR TITLE
libpcap: add rpcapd as package

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -43,6 +43,19 @@ define Package/libpcap/config
 	source "$(SOURCE)/Config.in"
 endef
 
+define Package/rpcapd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Capture daemon to be controlled by a remote libpcap application
+  URL:=http://www.tcpdump.org/
+  DEPENDS+= +libpcap
+endef
+
+ifdef CONFIG_PACKAGE_rpcapd
+	CMAKE_OPTIONS += \
+		-DENABLE_REMOTE=ON
+endif
+
 CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
 	-DBUILD_WITH_LIBNL=OFF \
@@ -81,4 +94,10 @@ define Package/libpcap/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcap.so.* $(1)/usr/lib/
 endef
 
+define Package/rpcapd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/rpcapd $(1)/usr/sbin/
+endef
+
 $(eval $(call BuildPackage,libpcap))
+$(eval $(call BuildPackage,rpcapd))

--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpcap
 PKG_VERSION:=1.10.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \


### PR DESCRIPTION
This enables building of rpcapd and adds it as a package.

It is a daemon that allows remote packet capturing from another machine.
E.g. Wireshark can talk to it using the Remote Capture Protocol (RPCAP).
https://www.tcpdump.org/manpages/rpcapd.8.html

Compile and run tested: OpenWrt SNAPSHOT r17190-2801fe6132 on x86/64

Signed-off-by: Stephan Schmidtmer <hurz@gmx.org>