### PR TITLE
ramips: add WPS button for newifi d1

### DIFF
--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -47,6 +47,12 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
 	};
 
 	gpio_export {
@@ -159,7 +165,7 @@
 
 &state_default {
 	gpio {
-		groups = "jtag", "uart2";
+		groups = "jtag", "uart2", "wdt";
 		function = "gpio";
 	};
 };


### PR DESCRIPTION
This device has a WPS button under WiFi antenna cover, add it to dts.

Signed-off-by: David Yang <mmyangfl@gmail.com>