### PR TITLE
fritz-tools: fix returning wrong values due to strncmp usage

### DIFF
--- a/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
+++ b/package/utils/fritz-tools/src/fritz_tffs_nand_read.c
@@ -340,7 +340,7 @@ static int show_matching_key_value(struct tffs_key_name_table *key_names)
 	for (uint32_t i = 0; i < key_names->size; i++) {
 		name = key_names->entries[i].val;
 
-		if (strncmp(name, name_filter, strlen(name)) == 0) {
+		if (strcmp(name, name_filter) == 0) {
 			if (find_entry(key_names->entries[i].id, &tmp)) {
 				print_entry_value(&tmp);
 				printf("\n");

--- a/package/utils/fritz-tools/src/fritz_tffs_read.c
+++ b/package/utils/fritz-tools/src/fritz_tffs_read.c
@@ -204,7 +204,7 @@ static int show_matching_key_value(uint8_t *buffer,
 	for (i = 0; i < key_names->size; i++) {
 		name = key_names->entries[i].val;
 
-		if (strncmp(name, name_filter, strlen(name)) == 0) {
+		if (strcmp(name, name_filter) == 0) {
 			id = to_entry_header_id(*key_names->entries[i].id);
 
 			if (find_entry(buffer, id, &tmp)) {


### PR DESCRIPTION
When having two keys that start with the same characters and the second
key just has one character more nand_tffs_read and tffs_read return the
wrong value for the longer key. This is due to the usage of strncmp in
combination with the length of the shorter key which is usually first
in the list before the longer key and when strncmp matches, the search
is stopped. The problem only occurs when the length of the two keys
is different, not if just the last character is different.
The fix is to use strcmp and as such it will only return the value if
the key (name) and the key to look for (namefilter) have the same value
and length.
A sample case returning wrong values is when keys macwlan and macwlan2
are defined and querying macwlan2 returns the value for macwlan.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>