### PR TITLE
umbim/wwan: DHCP and static configuration coexistence, bugfixes.

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -217,18 +217,19 @@ _proto_mbim_setup() {
 			json_close_array
 
 			json_add_string gateway $(_proto_mbim_get_field ipv4gateway "$mbimconfig")
-
-			[ "$peerdns" = 0 ] || {
-				json_add_array dns
-				for server in $(_proto_mbim_get_field ipv4dnsserver "$mbimconfig"); do
-					json_add_string "" "$server"
-				done
-				json_close_array
-			}
 		elif [ "$dhcp" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCP on $ifname"
 			json_add_string proto "dhcp"
 		fi
+
+		[ "$peerdns" = 0 ] || {
+			json_add_array dns
+			for server in $(_proto_mbim_get_field ipv4dnsserver "$mbimconfig"); do
+				json_add_string "" "$server"
+			done
+			json_close_array
+		}
+
 		proto_add_dynamic_defaults
 		[ -n "$zone" ] && json_add_string zone "$zone"
 		[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
@@ -258,18 +259,20 @@ _proto_mbim_setup() {
 
 			json_add_string ip6gw $(_proto_mbim_get_field ipv6gateway "$mbimconfig")
 
-			[ "$peerdns" = 0 ] || {
-				json_add_array dns
-				for server in $(_proto_mbim_get_field ipv6dnsserver "$mbimconfig"); do
-					json_add_string "" "$server"
-				done
-				json_close_array
-			}
 		elif [ "$dhcpv6" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCPv6 on $ifname"
 			json_add_string proto "dhcpv6"
 			json_add_string extendprefix 1
 		fi
+
+		[ "$peerdns" = 0 ] || {
+			json_add_array dns
+			for server in $(_proto_mbim_get_field ipv6dnsserver "$mbimconfig"); do
+				json_add_string "" "$server"
+			done
+			json_close_array
+		}
+
 		proto_add_dynamic_defaults
 		[ -n "$zone" ] && json_add_string zone "$zone"
 		[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -187,7 +187,7 @@ _proto_mbim_setup() {
 			json_close_array
 			json_add_string gateway "$ipv4gateway"
 			json_add_array dns
-			json_add_string "" "$ipv4dnsserver"
+			[ "$peerdns" = 0 ] || json_add_string "" "$ipv4dnsserver"
 			json_close_array
 			proto_add_dynamic_defaults
 			json_close_object
@@ -204,7 +204,7 @@ _proto_mbim_setup() {
 			json_close_array
 			json_add_string ip6gw "$ipv6gateway"
 			json_add_array dns
-			json_add_string "" "$ipv6dnsserver"
+			[ "$peerdns" = 0 ] || json_add_string "" "$ipv6dnsserver"
 			json_close_array
 			proto_add_dynamic_defaults
 			json_close_object

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -179,8 +179,11 @@ _proto_mbim_setup() {
 	proto_init_update "$ifname" 1
 	proto_send_update "$interface"
 
+	[ -z "$dhcp" ] && dhcp=1
+	[ -z "$dhcpv6" ] && dhcpv6=1
+
 	[ "$iptype" != "ipv6" ] && {
-		if [ -z "$dhcp" -o "$dhcp" = 0 ]; then
+		if [ -n "$ipv4address" ]; then
 			json_init
 			json_add_string name "${interface}_4"
 			json_add_string ifname "@$interface"
@@ -196,7 +199,7 @@ _proto_mbim_setup() {
 			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
-		else
+		elif [ "$dhcp" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCP on $ifname"
 			json_init
 			json_add_string name "${interface}_4"
@@ -210,7 +213,7 @@ _proto_mbim_setup() {
 	}
 
 	[ "$iptype" != "ipv4" ] && {
-		if [ -z "$dhcpv6" -o "$dhcpv6" = 0 ]; then
+		if [ -n "$ipv6address" ]; then
 			json_init
 			json_add_string name "${interface}_6"
 			json_add_string ifname "@$interface"
@@ -226,7 +229,7 @@ _proto_mbim_setup() {
 			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
-		else
+		elif [ "$dhcpv6" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCPv6 on $ifname"
 			json_init
 			json_add_string name "${interface}_6"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -152,10 +152,13 @@ _proto_mbim_setup() {
 	[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] || pdptype="ipv4v6"
 
 	echo "mbim[$$]" "Connect to network"
-	while ! umbim $DBG -n -t $tid -d $device connect "$pdptype:$apn" "$auth" "$username" "$password"; do
+	umbim $DBG -n -t $tid -d $device connect "$pdptype:$apn" "$auth" "$username" "$password" || {
+		echo "mbim[$$]" "Failed to connect bearer"
 		tid=$((tid + 1))
-		sleep 1;
-	done
+		umbim $DBG -t $tid -d "$device" disconnect
+		proto_notify_error "$interface" CONNECT_FAILED
+		return 1
+	}
 	tid=$((tid + 1))
 
 	echo "mbim[$$]" "Connected"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -258,6 +258,12 @@ _proto_mbim_setup() {
 			done
 			json_close_array
 
+			json_add_array ip6prefix
+			for address in $ipv6address; do
+				json_add_string "" "$address"
+			done
+			json_close_array
+
 			json_add_string ip6gw $(_proto_mbim_get_field ipv6gateway "$mbimconfig")
 
 			[ "$peerdns" = 0 ] || {

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -203,11 +203,11 @@ _proto_mbim_setup() {
 	[ -z "$dhcpv6" ] && dhcpv6=1
 
 	[ "$iptype" != "ipv6" ] && {
+		json_init
+		json_add_string name "${interface}_4"
+		json_add_string ifname "@$interface"
 		ipv4address=$(_proto_mbim_get_field ipv4address "$mbimconfig")
 		if [ -n "$ipv4address" ]; then
-			json_init
-			json_add_string name "${interface}_4"
-			json_add_string ifname "@$interface"
 			json_add_string proto "static"
 
 			json_add_array ipaddr
@@ -225,32 +225,23 @@ _proto_mbim_setup() {
 				done
 				json_close_array
 			}
-
-			proto_add_dynamic_defaults
-			[ -n "$zone" ] && json_add_string zone "$zone"
-			[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
-			json_close_object
-			ubus call network add_dynamic "$(json_dump)"
 		elif [ "$dhcp" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCP on $ifname"
-			json_init
-			json_add_string name "${interface}_4"
-			json_add_string ifname "@$interface"
 			json_add_string proto "dhcp"
-			proto_add_dynamic_defaults
-			[ -n "$zone" ] && json_add_string zone "$zone"
-			[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
-			json_close_object
-			ubus call network add_dynamic "$(json_dump)"
 		fi
+		proto_add_dynamic_defaults
+		[ -n "$zone" ] && json_add_string zone "$zone"
+		[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
 	}
 
 	[ "$iptype" != "ipv4" ] && {
+		json_init
+		json_add_string name "${interface}_6"
+		json_add_string ifname "@$interface"
 		ipv6address=$(_proto_mbim_get_field ipv6address "$mbimconfig")
 		if [ -n "$ipv6address" ]; then
-			json_init
-			json_add_string name "${interface}_6"
-			json_add_string ifname "@$interface"
 			json_add_string proto "static"
 
 			json_add_array ip6addr
@@ -274,25 +265,16 @@ _proto_mbim_setup() {
 				done
 				json_close_array
 			}
-
-			proto_add_dynamic_defaults
-			[ -n "$zone" ] && json_add_string zone "$zone"
-			[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
-			json_close_object
-			ubus call network add_dynamic "$(json_dump)"
 		elif [ "$dhcpv6" != 0 ]; then
 			echo "mbim[$$]" "Starting DHCPv6 on $ifname"
-			json_init
-			json_add_string name "${interface}_6"
-			json_add_string ifname "@$interface"
 			json_add_string proto "dhcpv6"
 			json_add_string extendprefix 1
-			proto_add_dynamic_defaults
-			[ -n "$zone" ] && json_add_string zone "$zone"
-			[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
-			json_close_object
-			ubus call network add_dynamic "$(json_dump)"
 		fi
+		proto_add_dynamic_defaults
+		[ -n "$zone" ] && json_add_string zone "$zone"
+		[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
 	}
 
 	[ -z "$mtu" ] && {

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -19,6 +19,7 @@ proto_mbim_init_config() {
 	proto_config_add_string auth
 	proto_config_add_string username
 	proto_config_add_string password
+	[ -e /proc/sys/net/ipv6 ] && proto_config_add_string ipv6
 	proto_config_add_boolean dhcp
 	proto_config_add_boolean dhcpv6
 	proto_config_add_string pdptype
@@ -32,6 +33,8 @@ _proto_mbim_setup() {
 
 	local device apn pincode delay allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
 	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
+
+	[ ! -e /proc/sys/net/ipv6 ] && ipv6=0 || json_get_var ipv6 ipv6
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -150,6 +153,7 @@ _proto_mbim_setup() {
 	tid=$((tid + 1))
 
 	pdptype=$(echo "$pdptype" | awk '{print tolower($0)}')
+	[ "$ipv6" = 0 ] && pdptype="ipv4"
 
 	local req_pdptype="" # Pass "default" PDP type to umbim if unconfigured
 	[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && req_pdptype="$pdptype:"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -20,6 +20,7 @@ proto_mbim_init_config() {
 	proto_config_add_string username
 	proto_config_add_string password
 	proto_config_add_boolean dhcp
+	proto_config_add_boolean dhcpv6
 	proto_config_add_string pdptype
 	proto_config_add_defaults
 }
@@ -29,8 +30,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner dhcp pdptype $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp pdptype $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -209,7 +210,7 @@ _proto_mbim_setup() {
 	}
 
 	[ "$iptype" != "ipv4" ] && {
-		if [ -z "$dhcp" -o "$dhcp" = 0 ]; then
+		if [ -z "$dhcpv6" -o "$dhcpv6" = 0 ]; then
 			json_init
 			json_add_string name "${interface}_6"
 			json_add_string ifname "@$interface"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -20,6 +20,7 @@ proto_mbim_init_config() {
 	proto_config_add_string username
 	proto_config_add_string password
 	proto_config_add_boolean dhcp
+	proto_config_add_string pdptype
 	proto_config_add_defaults
 }
 
@@ -28,8 +29,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner dhcp $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner dhcp pdptype $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp pdptype $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -147,8 +148,11 @@ _proto_mbim_setup() {
 	}
 	tid=$((tid + 1))
 
+	pdptype=$(echo "$pdptype" | awk '{print tolower($0)}')
+	[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] || pdptype="ipv4v6"
+
 	echo "mbim[$$]" "Connect to network"
-	while ! umbim $DBG -n -t $tid -d $device connect "$apn" "$auth" "$username" "$password"; do
+	while ! umbim $DBG -n -t $tid -d $device connect "$pdptype:$apn" "$auth" "$username" "$password"; do
 		tid=$((tid + 1))
 		sleep 1;
 	done
@@ -164,56 +168,64 @@ _proto_mbim_setup() {
 		proto_init_update "$ifname" 1
 		proto_send_update "$interface"
 
-		json_init
-		json_add_string name "${interface}_4"
-		json_add_string ifname "@$interface"
-		json_add_string proto "static"
-		json_add_array ipaddr
-		json_add_string "" "$ipv4address"
-		json_close_array
-		json_add_string gateway "$ipv4gateway"
-		json_add_array dns
-		json_add_string "" "$ipv4dnsserver"
-		json_close_array
-		proto_add_dynamic_defaults
-		json_close_object
-		ubus call network add_dynamic "$(json_dump)"
+		[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv4v6" ] && {
+			json_init
+			json_add_string name "${interface}_4"
+			json_add_string ifname "@$interface"
+			json_add_string proto "static"
+			json_add_array ipaddr
+			json_add_string "" "$ipv4address"
+			json_close_array
+			json_add_string gateway "$ipv4gateway"
+			json_add_array dns
+			json_add_string "" "$ipv4dnsserver"
+			json_close_array
+			proto_add_dynamic_defaults
+			json_close_object
+			ubus call network add_dynamic "$(json_dump)"
+		}
 
-		json_init
-		json_add_string name "${interface}_6"
-		json_add_string ifname "@$interface"
-		json_add_string proto "static"
-		json_add_array ip6addr
-		json_add_string "" "$ipv6address"
-		json_close_array
-		json_add_string ip6gw "$ipv6gateway"
-		json_add_array dns
-		json_add_string "" "$ipv6dnsserver"
-		json_close_array
-		proto_add_dynamic_defaults
-		json_close_object
-		ubus call network add_dynamic "$(json_dump)"
+		[ "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && {
+			json_init
+			json_add_string name "${interface}_6"
+			json_add_string ifname "@$interface"
+			json_add_string proto "static"
+			json_add_array ip6addr
+			json_add_string "" "$ipv6address"
+			json_close_array
+			json_add_string ip6gw "$ipv6gateway"
+			json_add_array dns
+			json_add_string "" "$ipv6dnsserver"
+			json_close_array
+			proto_add_dynamic_defaults
+			json_close_object
+			ubus call network add_dynamic "$(json_dump)"
+		}
 	else
 		echo "mbim[$$]" "Starting DHCP on $ifname"
 		proto_init_update "$ifname" 1
 		proto_send_update "$interface"
 
-		json_init
-		json_add_string name "${interface}_4"
-		json_add_string ifname "@$interface"
-		json_add_string proto "dhcp"
-		proto_add_dynamic_defaults
-		json_close_object
-		ubus call network add_dynamic "$(json_dump)"
+		[ "$pdptype" = "ipv4" -o "$pdptype" = "ipv4v6" ] && {
+			json_init
+			json_add_string name "${interface}_4"
+			json_add_string ifname "@$interface"
+			json_add_string proto "dhcp"
+			proto_add_dynamic_defaults
+			json_close_object
+			ubus call network add_dynamic "$(json_dump)"
+		}
 
-		json_init
-		json_add_string name "${interface}_6"
-		json_add_string ifname "@$interface"
-		json_add_string proto "dhcpv6"
-		json_add_string extendprefix 1
-		proto_add_dynamic_defaults
-		json_close_object
-		ubus call network add_dynamic "$(json_dump)"
+		[ "$pdptype" = "ipv6" -o "$pdptype" = "ipv4v6" ] && {
+			json_init
+			json_add_string name "${interface}_6"
+			json_add_string ifname "@$interface"
+			json_add_string proto "dhcpv6"
+			json_add_string extendprefix 1
+			proto_add_dynamic_defaults
+			json_close_object
+			ubus call network add_dynamic "$(json_dump)"
+		}
 	fi
 
 	uci_set_state network $interface tid "$tid"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -179,7 +179,9 @@ _proto_mbim_setup() {
 	local zone="$(fw3 -q network "$interface" 2>/dev/null)"
 
 	echo "mbim[$$]" "Setting up $ifname"
-	eval $(umbim $DBG -n -t $tid -d $device config | sed 's/: /=/g')
+	local mbimconfig="$(umbim $DBG -n -t $tid -d $device config)"
+	echo "$mbimconfig"
+	eval $(echo "$mbimconfig" | sed 's/: /=/g')
 	tid=$((tid + 1))
 
 	proto_init_update "$ifname" 1

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -169,6 +169,8 @@ _proto_mbim_setup() {
 
 	echo "mbim[$$]" "Connected"
 
+	local zone="$(fw3 -q network "$interface" 2>/dev/null)"
+
 	if [ -z "$dhcp" -o "$dhcp" = 0 ]; then
 		echo "mbim[$$]" "Setting up $ifname"
 		eval $(umbim $DBG -n -t $tid -d $device config | sed 's/: /=/g')
@@ -190,6 +192,7 @@ _proto_mbim_setup() {
 			[ "$peerdns" = 0 ] || json_add_string "" "$ipv4dnsserver"
 			json_close_array
 			proto_add_dynamic_defaults
+			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		}
@@ -207,6 +210,7 @@ _proto_mbim_setup() {
 			[ "$peerdns" = 0 ] || json_add_string "" "$ipv6dnsserver"
 			json_close_array
 			proto_add_dynamic_defaults
+			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		}
@@ -221,6 +225,7 @@ _proto_mbim_setup() {
 			json_add_string ifname "@$interface"
 			json_add_string proto "dhcp"
 			proto_add_dynamic_defaults
+			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		}
@@ -232,6 +237,7 @@ _proto_mbim_setup() {
 			json_add_string proto "dhcpv6"
 			json_add_string extendprefix 1
 			proto_add_dynamic_defaults
+			[ -n "$zone" ] && json_add_string zone "$zone"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		}

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -169,7 +169,7 @@ _proto_mbim_setup() {
 
 	echo "mbim[$$]" "Connected"
 
-	if [ "$dhcp" = 0 ]; then
+	if [ -z "$dhcp" -o "$dhcp" = 0 ]; then
 		echo "mbim[$$]" "Setting up $ifname"
 		eval $(umbim $DBG -n -t $tid -d $device config | sed 's/: /=/g')
 		tid=$((tid + 1))

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -23,6 +23,7 @@ proto_mbim_init_config() {
 	proto_config_add_boolean dhcp
 	proto_config_add_boolean dhcpv6
 	proto_config_add_string pdptype
+	proto_config_add_int mtu
 	proto_config_add_defaults
 }
 
@@ -44,9 +45,9 @@ _proto_mbim_setup() {
 	local ret
 
 	local device apn pincode delay auth username password allow_roaming allow_partner
-	local dhcp dhcpv6 pdptype ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	local dhcp dhcpv6 pdptype ip4table ip6table mtu $PROTO_DEFAULT_OPTIONS
 	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner
-	json_get_vars dhcp dhcpv6 pdptype ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	json_get_vars dhcp dhcpv6 pdptype ip4table ip6table mtu $PROTO_DEFAULT_OPTIONS
 
 	[ ! -e /proc/sys/net/ipv6 ] && ipv6=0 || json_get_var ipv6 ipv6
 
@@ -292,6 +293,19 @@ _proto_mbim_setup() {
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		fi
+	}
+
+	[ -z "$mtu" ] && {
+		local ipv4mtu=$(_proto_mbim_get_field ipv4mtu "$mbimconfig")
+		ipv4mtu="${ipv4mtu:-0}"
+		local ipv6mtu=$(_proto_mbim_get_field ipv6mtu "$mbimconfig")
+		ipv6mtu="${ipv6mtu:-0}"
+
+		mtu=$((ipv6mtu > ipv4mtu ? ipv6mtu : ipv4mtu))
+	}
+	[ -n "$mtu" -a "$mtu" != 0 ] && {
+		echo Setting MTU of $ifname to $mtu
+		/sbin/ip link set dev $ifname mtu $mtu
 	}
 
 	uci_set_state network $interface tid "$tid"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -203,18 +203,29 @@ _proto_mbim_setup() {
 	[ -z "$dhcpv6" ] && dhcpv6=1
 
 	[ "$iptype" != "ipv6" ] && {
+		ipv4address=$(_proto_mbim_get_field ipv4address "$mbimconfig")
 		if [ -n "$ipv4address" ]; then
 			json_init
 			json_add_string name "${interface}_4"
 			json_add_string ifname "@$interface"
 			json_add_string proto "static"
+
 			json_add_array ipaddr
-			json_add_string "" "$ipv4address"
+			for address in $ipv4address; do
+				json_add_string "" "$address"
+			done
 			json_close_array
-			json_add_string gateway "$ipv4gateway"
-			json_add_array dns
-			[ "$peerdns" = 0 ] || json_add_string "" "$ipv4dnsserver"
-			json_close_array
+
+			json_add_string gateway $(_proto_mbim_get_field ipv4gateway "$mbimconfig")
+
+			[ "$peerdns" = 0 ] || {
+				json_add_array dns
+				for server in $(_proto_mbim_get_field ipv4dnsserver "$mbimconfig"); do
+					json_add_string "" "$server"
+				done
+				json_close_array
+			}
+
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
 			[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
@@ -235,18 +246,29 @@ _proto_mbim_setup() {
 	}
 
 	[ "$iptype" != "ipv4" ] && {
+		ipv6address=$(_proto_mbim_get_field ipv6address "$mbimconfig")
 		if [ -n "$ipv6address" ]; then
 			json_init
 			json_add_string name "${interface}_6"
 			json_add_string ifname "@$interface"
 			json_add_string proto "static"
+
 			json_add_array ip6addr
-			json_add_string "" "$ipv6address"
+			for address in $ipv6address; do
+				json_add_string "" "$address"
+			done
 			json_close_array
-			json_add_string ip6gw "$ipv6gateway"
-			json_add_array dns
-			[ "$peerdns" = 0 ] || json_add_string "" "$ipv6dnsserver"
-			json_close_array
+
+			json_add_string ip6gw $(_proto_mbim_get_field ipv6gateway "$mbimconfig")
+
+			[ "$peerdns" = 0 ] || {
+				json_add_array dns
+				for server in $(_proto_mbim_get_field ipv6dnsserver "$mbimconfig"); do
+					json_add_string "" "$server"
+				done
+				json_close_array
+			}
+
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
 			[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -19,6 +19,7 @@ proto_mbim_init_config() {
 	proto_config_add_string auth
 	proto_config_add_string username
 	proto_config_add_string password
+	proto_config_add_boolean dhcp
 	proto_config_add_defaults
 }
 
@@ -27,8 +28,8 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay allow_roaming allow_partner dhcp $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp $PROTO_DEFAULT_OPTIONS
 
 	[ -n "$ctl_device" ] && device=$ctl_device
 
@@ -153,28 +154,69 @@ _proto_mbim_setup() {
 	done
 	tid=$((tid + 1))
 
+	echo "mbim[$$]" "Connected"
+
+	if [ "$dhcp" = 0 ]; then
+		echo "mbim[$$]" "Setting up $ifname"
+		eval $(umbim $DBG -n -t $tid -d $device config | sed 's/: /=/g')
+		tid=$((tid + 1))
+
+		proto_init_update "$ifname" 1
+		proto_send_update "$interface"
+
+		json_init
+		json_add_string name "${interface}_4"
+		json_add_string ifname "@$interface"
+		json_add_string proto "static"
+		json_add_array ipaddr
+		json_add_string "" "$ipv4address"
+		json_close_array
+		json_add_string gateway "$ipv4gateway"
+		json_add_array dns
+		json_add_string "" "$ipv4dnsserver"
+		json_close_array
+		proto_add_dynamic_defaults
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
+
+		json_init
+		json_add_string name "${interface}_6"
+		json_add_string ifname "@$interface"
+		json_add_string proto "static"
+		json_add_array ip6addr
+		json_add_string "" "$ipv6address"
+		json_close_array
+		json_add_string ip6gw "$ipv6gateway"
+		json_add_array dns
+		json_add_string "" "$ipv6dnsserver"
+		json_close_array
+		proto_add_dynamic_defaults
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
+	else
+		echo "mbim[$$]" "Starting DHCP on $ifname"
+		proto_init_update "$ifname" 1
+		proto_send_update "$interface"
+
+		json_init
+		json_add_string name "${interface}_4"
+		json_add_string ifname "@$interface"
+		json_add_string proto "dhcp"
+		proto_add_dynamic_defaults
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
+
+		json_init
+		json_add_string name "${interface}_6"
+		json_add_string ifname "@$interface"
+		json_add_string proto "dhcpv6"
+		json_add_string extendprefix 1
+		proto_add_dynamic_defaults
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
+	fi
+
 	uci_set_state network $interface tid "$tid"
-
-	echo "mbim[$$]" "Connected, starting DHCP"
-	proto_init_update "$ifname" 1
-	proto_send_update "$interface"
-
-	json_init
-	json_add_string name "${interface}_4"
-	json_add_string ifname "@$interface"
-	json_add_string proto "dhcp"
-	proto_add_dynamic_defaults
-	json_close_object
-	ubus call network add_dynamic "$(json_dump)"
-
-	json_init
-	json_add_string name "${interface}_6"
-	json_add_string ifname "@$interface"
-	json_add_string proto "dhcpv6"
-	json_add_string extendprefix 1
-	proto_add_dynamic_defaults
-	json_close_object
-	ubus call network add_dynamic "$(json_dump)"
 }
 
 proto_mbim_setup() {

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -26,6 +26,18 @@ proto_mbim_init_config() {
 	proto_config_add_defaults
 }
 
+_proto_mbim_get_field() {
+        local field="$1"
+        shift
+        local mbimconfig="$@"
+        echo "$mbimconfig" | while read -r line; do
+                variable=${line%%:*}
+                [ "$variable" = "$field" ] || continue;
+                value=${line##* }
+                echo -n "$value "
+        done
+}
+
 _proto_mbim_setup() {
 	local interface="$1"
 	local tid=2

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -193,7 +193,6 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Setting up $ifname"
 	local mbimconfig="$(umbim $DBG -n -t $tid -d $device config)"
 	echo "$mbimconfig"
-	eval $(echo "$mbimconfig" | sed 's/: /=/g')
 	tid=$((tid + 1))
 
 	proto_init_update "$ifname" 1

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -31,8 +31,10 @@ _proto_mbim_setup() {
 	local tid=2
 	local ret
 
-	local device apn pincode delay allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
-	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner dhcp dhcpv6 pdptype $PROTO_DEFAULT_OPTIONS
+	local device apn pincode delay auth username password allow_roaming allow_partner
+	local dhcp dhcpv6 pdptype ip4table ip6table $PROTO_DEFAULT_OPTIONS
+	json_get_vars device apn pincode delay auth username password allow_roaming allow_partner
+	json_get_vars dhcp dhcpv6 pdptype ip4table ip6table $PROTO_DEFAULT_OPTIONS
 
 	[ ! -e /proc/sys/net/ipv6 ] && ipv6=0 || json_get_var ipv6 ipv6
 
@@ -201,6 +203,7 @@ _proto_mbim_setup() {
 			json_close_array
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
+			[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		elif [ "$dhcp" != 0 ]; then
@@ -211,6 +214,7 @@ _proto_mbim_setup() {
 			json_add_string proto "dhcp"
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
+			[ -n "$ip4table" ] && json_add_string ip4table "$ip4table"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		fi
@@ -231,6 +235,7 @@ _proto_mbim_setup() {
 			json_close_array
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
+			[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		elif [ "$dhcpv6" != 0 ]; then
@@ -242,6 +247,7 @@ _proto_mbim_setup() {
 			json_add_string extendprefix 1
 			proto_add_dynamic_defaults
 			[ -n "$zone" ] && json_add_string zone "$zone"
+			[ -n "$ip6table" ] && json_add_string ip6table "$ip6table"
 			json_close_object
 			ubus call network add_dynamic "$(json_dump)"
 		fi


### PR DESCRIPTION
This bulilds on top of #2759 - it is included verbatim, and includes fixes inspired by #3680.

Main improvement is optional fallback to DHCP address configuration if static configuration from MBIM is not available, separately for IPv6 and IPv4, which is in line with MBIM specification 1.0. If IPv4-only or IPv6-only PDP type is selected, only sub-interface of the selected type is created.

Missing standard options from other protocols are included as well. With those fixes, MBIM finally works reasonably well with those fixes.

Run tested on TP-Link Archer C7v2 plus Sierra EM7455 (DW5811e MBIM flavour) 