### PR TITLE
mediatek: mt7623: import patch to fix msi warning

### DIFF
--- a/target/linux/generic/backport-5.10/820-v5.13-make-pci_host_common_probe-declare-its-reliance-on-msi-domains.patch
+++ b/target/linux/generic/backport-5.10/820-v5.13-make-pci_host_common_probe-declare-its-reliance-on-msi-domains.patch
@@ -1,0 +1,34 @@
+From 9ec37efb87832b578d7972fc80b04d94f5d2bbe3 Mon Sep 17 00:00:00 2001
+From: Marc Zyngier <maz@kernel.org>
+Date: Tue, 30 Mar 2021 16:11:42 +0100
+Subject: PCI/MSI: Make pci_host_common_probe() declare its reliance on MSI
+ domains
+
+The generic PCI host driver relies on MSI domains for MSIs to
+be provided to its end-points. Make this dependency explicit.
+
+This cures the warnings occuring on arm/arm64 VMs when booted
+with PCI virtio devices and no MSI controller (no GICv3 ITS,
+for example).
+
+It is likely that other drivers will need to express the same
+dependency.
+
+Link: https://lore.kernel.org/r/20210330151145.997953-12-maz@kernel.org
+Signed-off-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Bjorn Helgaas <bhelgaas@google.com>
+---
+ drivers/pci/controller/pci-host-common.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/pci/controller/pci-host-common.c
++++ b/drivers/pci/controller/pci-host-common.c
+@@ -77,6 +77,7 @@ int pci_host_common_probe(struct platfor
+ 
+ 	bridge->sysdata = cfg;
+ 	bridge->ops = (struct pci_ops *)&ops->pci_ops;
++	bridge->msi_domain = true;
+ 
+ 	platform_set_drvdata(pdev, bridge);
+ 

--- a/target/linux/generic/backport-5.10/821-v5.13-let-pci-host-bridges-declar-their-reliance-on-msi-domains.patch
+++ b/target/linux/generic/backport-5.10/821-v5.13-let-pci-host-bridges-declar-their-reliance-on-msi-domains.patch
@@ -1,0 +1,44 @@
+From 94e89b145371b68fa0ea294855adebcd03e0522e Mon Sep 17 00:00:00 2001
+From: Marc Zyngier <maz@kernel.org>
+Date: Tue, 30 Mar 2021 16:11:41 +0100
+Subject: PCI/MSI: Let PCI host bridges declare their reliance on MSI domains
+
+There is a whole class of host bridges that cannot know whether
+MSIs will be provided or not, as they rely on other blocks
+to provide the MSI functionnality, using MSI domains.  This is
+the case for example on systems that use the ARM GIC architecture.
+
+Introduce a new attribute ('msi_domain') indicating that implicit
+dependency, and use this property to set the NO_MSI flag when
+no MSI domain is found at probe time.
+
+Link: https://lore.kernel.org/r/20210330151145.997953-11-maz@kernel.org
+Signed-off-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Bjorn Helgaas <bhelgaas@google.com>
+---
+ drivers/pci/probe.c | 2 ++
+ include/linux/pci.h | 1 +
+ 2 files changed, 3 insertions(+)
+
+--- a/drivers/pci/probe.c
++++ b/drivers/pci/probe.c
+@@ -925,6 +925,8 @@ static int pci_register_host_bridge(stru
+ 	device_enable_async_suspend(bus->bridge);
+ 	pci_set_bus_of_node(bus);
+ 	pci_set_bus_msi_domain(bus);
++	if (bridge->msi_domain && !dev_get_msi_domain(&bus->dev))
++		bus->bus_flags |= PCI_BUS_FLAGS_NO_MSI;
+ 
+ 	if (!parent)
+ 		set_dev_node(bus->bridge, pcibus_to_node(bus));
+--- a/include/linux/pci.h
++++ b/include/linux/pci.h
+@@ -545,6 +545,7 @@ struct pci_host_bridge {
+ 	unsigned int	native_dpc:1;		/* OS may use PCIe DPC */
+ 	unsigned int	preserve_config:1;	/* Preserve FW resource setup */
+ 	unsigned int	size_windows:1;		/* Enable root bus sizing */
++	unsigned int	msi_domain:1;		/* Bridge wants MSI domain */
+ 
+ 	/* Resource alignment requirements */
+ 	resource_size_t (*align_resource)(struct pci_dev *dev,

--- a/target/linux/generic/backport-5.10/822-v5.13-advertise-lack-of-built-in-msi-handling.patch
+++ b/target/linux/generic/backport-5.10/822-v5.13-advertise-lack-of-built-in-msi-handling.patch
@@ -1,0 +1,59 @@
+From 645e9c38383d7fcde2784ee537fa18ec9bed54d9 Mon Sep 17 00:00:00 2001
+From: Thomas Gleixner <tglx@linutronix.de>
+Date: Tue, 30 Mar 2021 16:11:43 +0100
+Subject: PCI: mediatek: Advertise lack of built-in MSI handling
+
+Some Mediatek host bridges cannot handle MSIs, which is sad.
+This also results in an ugly warning at device probe time,
+as the core PCI code wasn't told that MSIs were not available.
+
+Advertise this fact to the rest of the core PCI code by
+using the 'msi_domain' attribute, which still opens the possibility
+for another block to provide the MSI functionnality.
+
+[maz: commit message, switched over to msi_domain attribute]
+
+Link: https://lore.kernel.org/r/20210330151145.997953-13-maz@kernel.org
+Reported-by: Frank Wunderlich <frank-w@public-files.de>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
+Acked-by: Bjorn Helgaas <bhelgaas@google.com>
+---
+ drivers/pci/controller/pcie-mediatek.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/pci/controller/pcie-mediatek.c
++++ b/drivers/pci/controller/pcie-mediatek.c
+@@ -143,6 +143,7 @@ struct mtk_pcie_port;
+  * struct mtk_pcie_soc - differentiate between host generations
+  * @need_fix_class_id: whether this host's class ID needed to be fixed or not
+  * @need_fix_device_id: whether this host's device ID needed to be fixed or not
++ * @no_msi: Bridge has no MSI support, and relies on an external block
+  * @device_id: device ID which this host need to be fixed
+  * @ops: pointer to configuration access functions
+  * @startup: pointer to controller setting functions
+@@ -151,6 +152,7 @@ struct mtk_pcie_port;
+ struct mtk_pcie_soc {
+ 	bool need_fix_class_id;
+ 	bool need_fix_device_id;
++	bool no_msi;
+ 	unsigned int device_id;
+ 	struct pci_ops *ops;
+ 	int (*startup)(struct mtk_pcie_port *port);
+@@ -1087,6 +1089,7 @@ static int mtk_pcie_probe(struct platfor
+ 
+ 	host->ops = pcie->soc->ops;
+ 	host->sysdata = pcie;
++	host->msi_domain = pcie->soc->no_msi;
+ 
+ 	err = pci_host_probe(host);
+ 	if (err)
+@@ -1176,6 +1179,7 @@ static const struct dev_pm_ops mtk_pcie_
+ };
+ 
+ static const struct mtk_pcie_soc mtk_pcie_soc_v1 = {
++	.no_msi = true,
+ 	.ops = &mtk_pcie_ops,
+ 	.startup = mtk_pcie_startup_port,
+ };

--- a/target/linux/mediatek/patches-5.10/000-spi-fix-fifo.patch
+++ b/target/linux/mediatek/patches-5.10/000-spi-fix-fifo.patch
@@ -18,11 +18,9 @@ Signed-off-by: Mark Brown <broonie@kernel.org>
  drivers/spi/spi-mt65xx.c | 16 +++++++++++++---
  1 file changed, 13 insertions(+), 3 deletions(-)
 
-diff --git a/drivers/spi/spi-mt65xx.c b/drivers/spi/spi-mt65xx.c
-index 976f73b9e2998..8d5fa7f1e5069 100644
 --- a/drivers/spi/spi-mt65xx.c
 +++ b/drivers/spi/spi-mt65xx.c
-@@ -427,13 +427,23 @@ static int mtk_spi_fifo_transfer(struct spi_master *master,
+@@ -434,13 +434,23 @@ static int mtk_spi_fifo_transfer(struct
  	mtk_spi_setup_packet(master);
  
  	cnt = xfer->len / 4;
@@ -49,6 +47,3 @@ index 976f73b9e2998..8d5fa7f1e5069 100644
  	}
  
  	mtk_spi_enable_transfer(master);
--- 
-cgit 1.2.3-1.el7
-

--- a/target/linux/mediatek/patches-5.10/330-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-5.10/330-mtk-bmt-support.patch
@@ -815,7 +815,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1139,6 +1140,8 @@ static int spinand_probe(struct spi_mem
+@@ -1140,6 +1141,8 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -824,7 +824,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1164,6 +1167,7 @@ static int spinand_remove(struct spi_mem
+@@ -1165,6 +1168,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-5.10/510-net-mediatek-add-flow-offload-for-mt7623.patch
+++ b/target/linux/mediatek/patches-5.10/510-net-mediatek-add-flow-offload-for-mt7623.patch
@@ -14,7 +14,7 @@ Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -3272,6 +3272,7 @@ static const struct mtk_soc_data mt7623_
+@@ -3274,6 +3274,7 @@ static const struct mtk_soc_data mt7623_
  	.hw_features = MTK_HW_FEATURES,
  	.required_clks = MT7623_CLKS_BITMAP,
  	.required_pctl = true,

--- a/target/linux/mediatek/patches-5.10/601-PCI-mediatek-Use-regmap-to-get-shared-pcie-cfg-base.patch
+++ b/target/linux/mediatek/patches-5.10/601-PCI-mediatek-Use-regmap-to-get-shared-pcie-cfg-base.patch
@@ -150,7 +150,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
  #include <linux/reset.h>
  
  #include "../pci.h"
-@@ -205,6 +207,7 @@ struct mtk_pcie_port {
+@@ -207,6 +209,7 @@ struct mtk_pcie_port {
   * struct mtk_pcie - PCIe host information
   * @dev: pointer to PCIe device
   * @base: IO mapped register base
@@ -158,7 +158,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
   * @free_ck: free-run reference clock
   * @mem: non-prefetchable memory resource
   * @ports: pointer to PCIe port information
-@@ -213,6 +216,7 @@ struct mtk_pcie_port {
+@@ -215,6 +218,7 @@ struct mtk_pcie_port {
  struct mtk_pcie {
  	struct device *dev;
  	void __iomem *base;
@@ -166,7 +166,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
  	struct clk *free_ck;
  
  	struct list_head ports;
-@@ -648,7 +652,7 @@ static int mtk_pcie_setup_irq(struct mtk
+@@ -650,7 +654,7 @@ static int mtk_pcie_setup_irq(struct mtk
  		return err;
  	}
  
@@ -175,7 +175,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
  	if (port->irq < 0)
  		return port->irq;
  
-@@ -674,12 +678,11 @@ static int mtk_pcie_startup_port_v2(stru
+@@ -676,12 +680,11 @@ static int mtk_pcie_startup_port_v2(stru
  	if (!mem)
  		return -EINVAL;
  
@@ -193,7 +193,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
  	}
  
  	/* Assert all reset signals */
-@@ -983,6 +986,7 @@ static int mtk_pcie_subsys_powerup(struc
+@@ -985,6 +988,7 @@ static int mtk_pcie_subsys_powerup(struc
  	struct device *dev = pcie->dev;
  	struct platform_device *pdev = to_platform_device(dev);
  	struct resource *regs;
@@ -201,7 +201,7 @@ Signed-off-by: chuanjia.liu <Chuanjia.Liu@mediatek.com>
  	int err;
  
  	/* get shared registers, which are optional */
-@@ -995,6 +999,13 @@ static int mtk_pcie_subsys_powerup(struc
+@@ -997,6 +1001,13 @@ static int mtk_pcie_subsys_powerup(struc
  		}
  	}
  

--- a/target/linux/mediatek/patches-5.10/610-pcie-mediatek-fix-clearing-interrupt-status.patch
+++ b/target/linux/mediatek/patches-5.10/610-pcie-mediatek-fix-clearing-interrupt-status.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/pci/controller/pcie-mediatek.c
 +++ b/drivers/pci/controller/pcie-mediatek.c
-@@ -613,10 +613,10 @@ static void mtk_pcie_intr_handler(struct
+@@ -615,10 +615,10 @@ static void mtk_pcie_intr_handler(struct
  	if (status & INTX_MASK) {
  		for_each_set_bit_from(bit, &status, PCI_NUM_INTX + INTX_SHIFT) {
  			/* Clear the INTx */

--- a/target/linux/mediatek/patches-5.10/700-net-ethernet-mtk_eth_soc-add-support-for-coherent-DM.patch
+++ b/target/linux/mediatek/patches-5.10/700-net-ethernet-mtk_eth_soc-add-support-for-coherent-DM.patch
@@ -51,7 +51,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SOC_MT7628)) {
  		ret = device_reset(eth->dev);
  		if (ret) {
-@@ -3074,6 +3082,16 @@ static int mtk_probe(struct platform_dev
+@@ -3076,6 +3084,16 @@ static int mtk_probe(struct platform_dev
  		}
  	}
  

--- a/target/linux/mediatek/patches-5.10/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
+++ b/target/linux/mediatek/patches-5.10/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
@@ -78,7 +78,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  struct mtk_pcie_port;
  
  /**
-@@ -1040,6 +1046,27 @@ static int mtk_pcie_setup(struct mtk_pci
+@@ -1042,6 +1048,27 @@ static int mtk_pcie_setup(struct mtk_pci
  	struct mtk_pcie_port *port, *tmp;
  	int err;
  


### PR DESCRIPTION
The Mediatek host bridge cannot handle Message Signaled Interrupts (MSIs). The core PCI code is not aware that MSI is not available. This results in warnings of the form:

```
WARNING: CPU: 2 PID: 112 at include/linux/msi.h:219 pci_msi_setup_msi_irqs.constprop.8+0x64/0x6c
Modules linked in: ahci(+) libahci libata sd_mod scsi_mod gpio_button_hotplug
CPU: 2 PID: 112 Comm: kmodloader Not tainted 5.10.52 #0
Hardware name: Mediatek Cortex-A7 (Device Tree)
```

Use the 'no_msi' attribute to signal missing MSI support to the core PCI.
