### PR TITLE
base-files: rfkill: fix HOSTAPD_START_FAILED error

### DIFF
--- a/package/base-files/files/etc/rc.button/rfkill
+++ b/package/base-files/files/etc/rc.button/rfkill
@@ -27,6 +27,6 @@ case "${TYPE}" in
 esac
 config_foreach wifi_rfkill_set wifi-device
 uci commit wireless
-wifi up
+wifi reload
 
 return 0


### PR DESCRIPTION
`wifi up` leads to strange errors at WNDR3800 and maybe other devices:

> hostapd: Configuration file: /var/run/hostapd-phy0.conf (phy wlan0)
> hostapd: Interface name wlan0 already in use
> netifd: radio0: Command failed: Invalid argument
> netifd: radio0: Device setup failed: HOSTAPD_START_FAILED
> netifd: radio0: WARNING: Variable 'data' does not exist or is not an array/object
> hostapd: Configuration file: /var/run/hostapd-phy1.conf (phy wlan1)
> hostapd: Interface name wlan1 already in use
> netifd: radio1: Command failed: Invalid argument
> netifd: radio1: Device setup failed: HOSTAPD_START_FAILED
> netifd: radio1: WARNING: Variable 'data' does not exist or is not an array/object

In this state it's not possible to enable/disable the wireless network using the rfkill button.

`wifi reload` seems like a good workaround and better action for the wifi command.