### PR TITLE
kbuild: add option to patch source tree DEVEL->EXTERNAL_KERNAL_TREE

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -77,6 +77,19 @@ menuconfig DEVEL
 	config EXTERNAL_KERNEL_TREE
 		string "Use external kernel tree" if DEVEL
 		default ""
+		help
+		  Enter an absolute full pathname to a local kernel source tree.
+		  If that is a checked-out working copy then the corresponding
+		  .git repository will not be touched.
+
+	config EXTERNAL_KERNEL_TREE_PATCH
+		bool "Patch external kernel tree" if DEVEL
+		depends on (EXTERNAL_KERNEL_TREE != "")
+		default y
+		help
+		  Set this true to apply OpenWrt patches to the unpatched
+		  external kernel tree.  If the external kernel tree is already
+		  patched then unset this option to prevent patching.
 
 	config KERNEL_GIT_CLONE_URI
 		string "Enter git repository to clone" if DEVEL

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -29,7 +29,6 @@ ifeq ($(strip $(CONFIG_EXTERNAL_KERNEL_TREE)),"")
     define Kernel/Prepare/Default
 	$(LINUX_CAT) $(DL_DIR)/$(LINUX_SOURCE) | $(TAR) -C $(KERNEL_BUILD_DIR) $(TAR_OPTIONS)
 	$(Kernel/Patch)
-	$(if $(QUILT),touch $(LINUX_DIR)/.quilt_used)
     endef
   else
     define Kernel/Prepare/Default
@@ -46,6 +45,9 @@ else
 	if [ -d $(LINUX_DIR)/user_headers ]; then \
 		rm -rf $(LINUX_DIR)/user_headers; \
 	fi
+    ifeq ($(CONFIG_EXTERNAL_KERNEL_TREE_PATCH),y)
+	$(Kernel/Patch)
+    endif
   endef
 endif
 

--- a/include/quilt.mk
+++ b/include/quilt.mk
@@ -103,6 +103,7 @@ define Kernel/Patch/Default
 	$(call PatchDir,$(LINUX_DIR),$(GENERIC_PATCH_DIR),generic/)
 	$(call PatchDir,$(LINUX_DIR),$(GENERIC_HACK_DIR),generic-hack/)
 	$(call PatchDir,$(LINUX_DIR),$(PATCH_DIR),platform/)
+	$(if $(QUILT),touch $(LINUX_DIR)/.quilt_used)
 endef
 
 define Quilt/RefreshDir


### PR DESCRIPTION
Hi people xD

my first contribution to OpenWrt. Hopefully useful =D ...

My goal is to make it possible to load custom `factory-roms` into the `rt2800` driver. I hope that my future work will be merged, but I can understand if it is too much out-of-the-art programming code.

---

Add DEVEL->EXTERNAL_KERNAL_TREE_PATCH option to KConf to make it possible to apply OpenWrt patches to external kernel source tree automatically.

Signed-off-by: Dirk Lehmann <develop@dj-l.de>
