### PR TITLE
binutils: add gold linker support

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -48,6 +48,7 @@ HOST_CONFIGURE_ARGS = \
 	--target=$(REAL_GNU_TARGET_NAME) \
 	--with-sysroot=$(TOOLCHAIN_DIR) \
 	--enable-deterministic-archives \
+	--enable-gold \
 	--enable-plugins \
 	--disable-multilib \
 	--disable-werror \


### PR DESCRIPTION
I need binutils-gold for building Crowdsec for OpenWrt !

This is a requirement for CGO packaging of sqlite3 on ARM...

I already get it on OpenWrt host, for POC ;
https://discourse.crowdsec.net/t/usr-bin-ld-cannot-find-ldl/143

root@ultra:~/binutils-2.36# ldd.gold --version
```
GNU gold (GNU Binutils 2.36) 1.16
Copyright (C) 2021 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```
References :
http://llvm.org/docs/GoldPlugin.html
https://forum.openwrt.org/t/usr-bin-ld-cannot-find-ldl/90987/6
https://github.com/openwrt/packages/issues/16193