### PR TITLE
bcm4908: fix calculation of new cferam index

### DIFF
--- a/target/linux/bcm4908/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm4908/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 
-RAMFS_COPY_BIN="bcm4908img"
+RAMFS_COPY_BIN="bcm4908img expr"
 
 PART_NAME=firmware
 
@@ -129,7 +129,7 @@ platform_calc_new_cferam() {
 	umount $dir
 	rm -fr $dir
 
-	idx=$(((idx + inc) % 1000))
+	idx=$(($(expr $idx + $inc) % 1000))
 
 	echo $(printf "cferam.%03d" $idx)
 }


### PR DESCRIPTION
The arithmetic expansion fails when idx becomes a two digit number.
Fix this by relying on expr command.
```
root@OpenWrt:/# echo $(((028 + 0) % 1000))
/bin/ash: arithmetic syntax error
root@OpenWrt:/# echo $(($(busybox expr 028 + 0) % 1000))
28
```