### PR TITLE
ramips: w2914ns-v2: consolidate leds nodes into dtsi

### DIFF
--- a/target/linux/ramips/dts/mt7621_wevo_11acnas.dts
+++ b/target/linux/ramips/dts/mt7621_wevo_11acnas.dts
@@ -3,15 +3,4 @@
 / {
 	compatible = "wevo,11acnas", "mediatek,mt7621-soc";
 	model = "WeVO 11AC NAS Router";
-
-	leds {
-		compatible = "gpio-leds";
-
-		usb {
-			label = "green:usb";
-			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
-			linux,default-trigger = "usbport";
-		};
-	};
 };

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dts
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dts
@@ -3,15 +3,4 @@
 / {
 	compatible = "wevo,w2914ns-v2", "mediatek,mt7621-soc";
 	model = "WeVO W2914NS v2";
-
-	leds {
-		compatible = "gpio-leds";
-
-		usb {
-			label = "green:usb";
-			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
-			linux,default-trigger = "usbport";
-		};
-	};
 };

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -8,6 +8,17 @@
 		label-mac-device = &wan;
 	};
 
+	leds {
+		compatible = "gpio-leds";
+
+		usb {
+			label = "green:usb";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ramips/dts/mt7621_zio_freezio.dts
+++ b/target/linux/ramips/dts/mt7621_zio_freezio.dts
@@ -5,15 +5,4 @@
 / {
 	compatible = "zio,freezio", "mediatek,mt7621-soc";
 	model = "ZIO FREEZIO";
-
-	leds {
-		compatible = "gpio-leds";
-
-		usb {
-			label = "green:usb";
-			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
-			trigger-sources = <&xhci_ehci_port1>;
-			linux,default-trigger = "usbport";
-		};
-	};
 };


### PR DESCRIPTION
w2914ns-v2, 11acnas, and freezio use almost same board and thus share a
common dtsi file. Now that LED labels do not contain "devicename" since
commit c846dd91f0a6 ("ramips: remove model name from LED labels"), let's
move the leds nodes to dtsi and remove them from dts.

Note that freezio has only one USB 3.0 port and adding &ehci_port2 trigger
does not incur any visible changes.