### PR TITLE
ramips: add support for ipTIME T5004

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_t5004.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_t5004.dts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,t5004", "mediatek,mt7621-soc";
+	model = "ipTIME T5004";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			label = "blue:cpu";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0xc0000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7e40000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7a40000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -804,6 +804,21 @@ define Device/iptime_a8004t
 endef
 TARGET_DEVICES += iptime_a8004t
 
+define Device/iptime_t5004
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 129280k
+  UBINIZE_OPTS := -E 5
+  UIMAGE_NAME := t5004
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := T5004
+  DEVICE_PACKAGES := -wpad-basic-wolfssl
+endef
+TARGET_DEVICES += iptime_t5004
+
 define Device/jcg_jhr-ac876m
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -135,6 +135,10 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
 		;;
+	iptime,t5004)
+		lan_mac=$(mtd_get_mac_ascii config ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
 	jcg,y2|\
 	wavlink,wl-wn531a6|\
 	winstars,ws-wn583a6|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -59,6 +59,7 @@ platform_do_upgrade() {
 	dlink,dir-853-a3|\
 	hiwifi,hc5962|\
 	iptime,a3004t|\
+	iptime,t5004|\
 	jcg,q20|\
 	linksys,e5600|\
 	linksys,ea7300-v1|\


### PR DESCRIPTION
ipTIME T5004 is a five-port Gigabit Ethernet router, based on MediaTek MT7621A.

Specifications:
* SoC: MT7621AT
* RAM: DDR3 128MB
* Flash: NAND 128MB
* Ethernet: 5x 1Gbps
  * Switch: SoC internal
* UART: J4 (57600 8N1)
  * pinout: [3V3] (TXD) (RXD) (GND)

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Write stock image to firmware partition.
    `# mtd write stock.bin firmware`