### PR TITLE
6in4: delete tunnel on interface teardown

### DIFF
--- a/package/network/ipv6/6in4/Makefile
+++ b/package/network/ipv6/6in4/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=6in4
-PKG_RELEASE:=26
+PKG_RELEASE:=27
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -138,6 +138,8 @@ proto_6in4_setup() {
 
 proto_6in4_teardown() {
 	local cfg="$1"
+	local link="6in4-$cfg"
+	ip link del $link
 }
 
 proto_6in4_init_config() {


### PR DESCRIPTION
Delete tunnel on 6in4 interface teardown.
Should solve problem related to tunnel stuck on restart loop
with "Unknown Command" on tunnel restart due to wan connection drop.
Fixes: FS#3690

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>