### PR TITLE
image/build: fix Build/eva-image and Device/AVM

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -208,7 +208,7 @@ define Build/elx-header
 endef
 
 define Build/eva-image
-	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
+	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_ENTRY) $@ $@.new
 	mv $@.new $@
 endef
 

--- a/target/linux/lantiq/image/Makefile
+++ b/target/linux/lantiq/image/Makefile
@@ -99,7 +99,9 @@ endef
 
 define Device/AVM
   DEVICE_VENDOR := AVM
-  KERNEL := kernel-bin | append-dtb | lzma | eva-image
+  KERNEL_LOADADDR:=$(shell awk '/[AT] _text/ { print "0x"$$1; }' < $(LINUX_DIR)/System.map)
+  KERNEL_ENTRY:=$(shell awk '/T kernel_entry/ { print "0x"$$1; }' < $(LINUX_DIR)/System.map)
+  KERNEL := kernel-bin | append-dtb | lzma | eva-image | pad-to 256
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-avm-fakeroot | \
 	append-rootfs | pad-rootfs | check-size | append-metadata


### PR DESCRIPTION
The variable KERNEL_ENTRY is defined in the lantiq image Makefile, but
not used in Build/eva-image.
This patch changes the second occurance of KERNEL_LOADADDR to
KERNEL_ENTRY.
The AVM kernel images are padded to 256 bytes, which is added to the
kernel build instruction in Device/AVM.
The AVM kernel images use the addresses from System.map and pass them
to lzma2eva firmware utility. The System.map address entry named _text
is used for KERNEL_LOADADDR and the System.map address entry named
kernel_entry (without the _ in front) is used for KERNEL_ENTRY.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>