### PR TITLE
kernel: upgrade to latest stable 5.4.138

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -6,9 +6,9 @@ ifdef CONFIG_TESTING_KERNEL
   KERNEL_PATCHVER:=$(KERNEL_TESTING_PATCHVER)
 endif
 
-LINUX_VERSION-5.4 = .137
+LINUX_VERSION-5.4 = .138
 
-LINUX_KERNEL_HASH-5.4.137 = f09e5e366ce5d8bde887cda229ef17138fd1653706a702221f934f99aaa31f7c
+LINUX_KERNEL_HASH-5.4.138 = a43957727a54e5e1035d7372a1e64203ae8e3060c52a3816916157967f9a8657
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))


### PR DESCRIPTION
adds a bugfix for ath10k on mvebu and other improvements, see https://lwn.net/Articles/865196/