### PR TITLE
lantiq: kernel: xway-nand: Move ECC engine setting to new DT binding

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_bt_homehub-v3a.dts
@@ -130,6 +130,8 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_bt_homehub-v2b.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_bt_homehub-v2b.dts
@@ -183,6 +183,8 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-hynix.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-hynix.dts
@@ -14,7 +14,7 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
-		nand-ecc-mode = "soft";
+		nand-use-soft-ecc-engine;
 		nand-ecc-strength = <3>;
 		nand-ecc-step-size = <256>;
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3370-rev2-micron.dts
@@ -6,7 +6,7 @@
 };
 
 &localbus {
-	flash@1 {
+	flash1: flash@1 {
 		compatible = "lantiq,nand-xway";
 		bank-width = <2>;
 		reg = <1 0x0 0x2000000>;
@@ -14,7 +14,7 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
-		nand-ecc-mode = "on-die";
+		nand-ecc-engine = <&flash1>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -231,7 +231,7 @@
 };
 
 &localbus {
-	flash@1 {
+	flash1: flash@1 {
 		compatible = "lantiq,nand-xway";
 		bank-width = <1>;
 		reg = <1 0x0 0x2000000>;
@@ -239,7 +239,7 @@
 		pinctrl-0 = <&nand_pins>;
 		pinctrl-names = "default";
 
-		nand-ecc-mode = "on-die";
+		nand-ecc-engine = <&flash1>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -46,7 +46,7 @@
 };
 
 &localbus {
-	flash@1 {
+	flash1: flash@1 {
 		compatible = "lantiq,nand-xway";
 		lantiq,cs1 = <1>;
 		bank-width = <1>;
@@ -55,7 +55,7 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
-		nand-ecc-mode = "on-die";
+		nand-ecc-engine = <&flash1>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
@@ -91,6 +91,8 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7430.dts
@@ -103,6 +103,8 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -216,6 +216,7 @@
 		nand-on-flash-bbt;
 		nand-ecc-strength = <3>;
 		nand-ecc-step-size = <256>;
+		nand-use-soft-ecc-engine;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nand.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920-nand.dts
@@ -19,6 +19,8 @@
 		pinctrl-0 = <&nand_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
@@ -30,6 +30,8 @@
 		pinctrl-0 = <&nand_pins>, <&nand_cs1_pins>;
 		pinctrl-names = "default";
 
+		nand-use-soft-ecc-engine;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f3.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f3.dts
@@ -51,6 +51,8 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
+		nand-use-soft-ecc-engine;
+
 		partition@0 {
 			label = "kernel";
 			reg = <0x0 0x200000>;

--- a/target/linux/lantiq/patches-5.4/0019-MTD-nand-support-new-dt-bindings.patch
+++ b/target/linux/lantiq/patches-5.4/0019-MTD-nand-support-new-dt-bindings.patch
@@ -1,0 +1,28 @@
+The nand-ecc-mode DT binding is depracated but the new bindings are
+not supported by kernel 5.4. Based on a fix in the kernel to not
+overwrite the DT ECC settings, the DT needs to be updated and moves
+to the new DT binding.
+Since the DT is shared between kernel 5.4 and 5.10, this patch is
+an interim solution to allow to use the new DT bindings in kernel 5.4.
+It should be removed when moving away from kernel 5.4.
+--- a/drivers/mtd/nand/raw/nand_base.c
++++ b/drivers/mtd/nand/raw/nand_base.c
+@@ -4851,10 +4851,17 @@
+ {
+ 	const char *pm;
+ 	int err, i;
++	struct device_node *eng_np;
+ 
+ 	err = of_property_read_string(np, "nand-ecc-mode", &pm);
+-	if (err < 0)
++	if (err < 0) {
++		if (of_property_read_bool(np, "nand-use-soft-ecc-engine"))
++			return NAND_ECC_SOFT;
++		eng_np = of_parse_phandle(np, "nand-ecc-engine", 0);
++		if (eng_np && (eng_np == np))
++			return NAND_ECC_ON_DIE;
+ 		return err;
++	}
+ 
+ 	for (i = 0; i < ARRAY_SIZE(nand_ecc_modes); i++)
+ 		if (!strcasecmp(pm, nand_ecc_modes[i]))


### PR DESCRIPTION
Hi,

this is prework to adding support for another device. I am working with the kernel maintainers, but its hard to come up with something without owning another lantiq device with NAND, e.g. the BT Homehub 5a.
I would be great, if someone owning e.g. a BT Homehub 5a could test if the device tree changes and removing the hardcoded setting in the linux kernel work for them. I will then send the kernel patches upstream.
I have searched the kernel sources, but I am not sure if the DT setting  nand-ecc-mode = "soft" is overwritten by some chip driver and like to make sure that this change does not break something.

Thanks.

When trying to add support for another device with Micron NAND chips,
it was discovered that the default setting in the kernel source does
not work with Micron Chips, since the device trees setting is
overwritten and hard coded by the kernel xway_nand driver.
This patch sets the ECC mode to soft in the device tree for the
devices that currently work fine with the hard coded setting and the
hardcoded setting is removed in the kernel driver.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>