### PR TITLE
kernel: add kmod-lib-oid-registry

### DIFF
--- a/package/kernel/linux/modules/lib.mk
+++ b/package/kernel/linux/modules/lib.mk
@@ -272,3 +272,18 @@ define KernelPackage/asn1-decoder
 endef
 
 $(eval $(call KernelPackage,asn1-decoder))
+
+
+define KernelPackage/lib-oid-registry
+  SUBMENU:=$(LIB_MENU)
+  TITLE:=OID registry support
+  KCONFIG:=CONFIG_OID_REGISTRY
+  HIDDEN:=1
+  FILES:=$(LINUX_DIR)/lib/oid_registry.ko
+endef
+
+define KernelPackage/lib-oid-registry/description
+ Kernel module for OID registry support
+endef
+
+$(eval $(call KernelPackage,lib-oid-registry))


### PR DESCRIPTION
Needed for newer versions of ksmbd.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Fixes https://github.com/openwrt/packages/commit/e7afd1a9c74941102cfdfc96ba6761862ba295c8#commitcomment-54575291