### PR TITLE
base-files: remove zcat from ramfs

### DIFF
--- a/package/base-files/files/lib/upgrade/stage2
+++ b/package/base-files/files/lib/upgrade/stage2
@@ -39,7 +39,7 @@ switch_to_ramfs() {
 	for binary in \
 		/bin/busybox /bin/ash /bin/sh /bin/mount /bin/umount	\
 		pivot_root mount_root reboot sync kill sleep		\
-		md5sum hexdump cat zcat dd tar				\
+		md5sum hexdump cat dd tar				\
 		ls basename find cp mv rm mkdir rmdir mknod touch chmod \
 		'[' printf wc grep awk sed cut				\
 		mtd partx losetup mkfs.ext4 nandwrite flash_erase	\


### PR DESCRIPTION
Now the executable zcat will not be called in ramfs. If we must use zcat in ramfs, we should use command busybox zcat instead of zcat, because the executable zcat cannot be correctly installed in ramfs after gzip is installed (https://github.com/openwrt/packages/issues/14925).

Signed-off-by: Chuck Fan <fanck0605@qq.com>
