### PR TITLE
tools/cpio: fix compilation with clang

### DIFF
--- a/tools/cpio/patches/001-duplicate-program-name.patch
+++ b/tools/cpio/patches/001-duplicate-program-name.patch
@@ -4,8 +4,6 @@ https://git.savannah.gnu.org/cgit/cpio.git/commit/?id=641d3f489cf6238bb916368d4b
 
 * src/global.c: Remove superfluous declaration of program_name
 
-diff --git a/src/global.c b/src/global.c
-index fb3abe9..acf92bc 100644
 --- a/src/global.c
 +++ b/src/global.c
 @@ -184,9 +184,6 @@ unsigned int warn_option = 0;

--- a/tools/cpio/patches/010-clang.patch
+++ b/tools/cpio/patches/010-clang.patch
@@ -1,0 +1,11 @@
+--- a/gnu/xalloc-oversized.h
++++ b/gnu/xalloc-oversized.h
+@@ -52,7 +52,7 @@ typedef size_t __xalloc_count_type;
+ #elif ((5 <= __GNUC__ \
+         || (__has_builtin (__builtin_mul_overflow) \
+             && __has_builtin (__builtin_constant_p))) \
+-       && !__STRICT_ANSI__)
++       && !__STRICT_ANSI__) && !defined(__clang__)
+ # define xalloc_oversized(n, s) \
+    (__builtin_constant_p (n) && __builtin_constant_p (s) \
+     ? __xalloc_oversized (n, s) \


### PR DESCRIPTION
A define dealing with builtin type is wrong. A gnulib update fixes
this, but that requires a new cpio version.

Refresh other patch.

Signed-off-by: Rosen Penev <rosenp@gmail.com>