### PR TITLE
tools/m4: fix compilation with clang

### DIFF
--- a/tools/m4/patches/020-clang.patch
+++ b/tools/m4/patches/020-clang.patch
@@ -1,0 +1,11 @@
+--- a/lib/xalloc-oversized.h
++++ b/lib/xalloc-oversized.h
+@@ -52,7 +52,7 @@ typedef size_t __xalloc_count_type;
+ #elif ((5 <= __GNUC__ \
+         || (__has_builtin (__builtin_mul_overflow) \
+             && __has_builtin (__builtin_constant_p))) \
+-       && !__STRICT_ANSI__)
++       && !__STRICT_ANSI__) && !defined(__clang__)
+ # define xalloc_oversized(n, s) \
+    (__builtin_constant_p (n) && __builtin_constant_p (s) \
+     ? __xalloc_oversized (n, s) \


### PR DESCRIPTION
A define dealing with builtin types is wrong. A gnulib update fixes
this, but that requires a new m4 version.

Signed-off-by: Rosen Penev <rosenp@gmail.com>