### PR TITLE
[PATCH] bcm63xx: t-com w303v typ B: detect wifi chip & fix default failsafe mode [21.02.0]

### DIFF
--- a/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
+++ b/target/linux/bcm63xx/dts/bcm6358-t-com-speedport-w-303v.dts
@@ -26,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&pinctrl 11 0>;
+			gpios = <&pinctrl 11 1>;
 			linux,code = <KEY_RESTART>;
 			debounce-interval = <60>;
 		};

--- a/target/linux/bcm63xx/patches-5.10/516-board-bcm6358.patch
+++ b/target/linux/bcm63xx/patches-5.10/516-board-bcm6358.patch
@@ -97,7 +97,7 @@
  static struct board_info __initdata board_DWVS0 = {
  	.name = "DWV-S0",
  	.expected_cpu_id = 0x6358,
-@@ -1624,6 +1707,238 @@ static struct board_info __initdata boar
+@@ -1624,6 +1707,245 @@ static struct board_info __initdata boar
  		.force_duplex_full = 1,
  	},
  };
@@ -332,11 +332,18 @@
 +		.has_phy = 1,
 +		.use_internal_phy = 1,
 +	},
++
++	.use_fallback_sprom 		= 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM4322,
++		.pci_bus 		= 0,
++ 		.pci_dev 		= 1,
++	},
 +};
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
  /*
-@@ -1694,7 +2009,20 @@ static const struct board_info __initcon
+@@ -1694,7 +2016,20 @@ static const struct board_info __initcon
  	&board_96358vw,
  	&board_96358vw2,
  	&board_AGPFS0,
@@ -357,7 +364,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  };
  
-@@ -1771,11 +2099,24 @@ static struct of_device_id const bcm963x
+@@ -1771,11 +2106,24 @@ static struct of_device_id const bcm963x
  	{ .compatible = "alcatel,rg100a", .data = &board_96358vw2, },
  	{ .compatible = "brcm,bcm96358vw", .data = &board_96358vw, },
  	{ .compatible = "brcm,bcm96358vw2", .data = &board_96358vw2, },

--- a/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
+++ b/target/linux/bcm63xx/patches-5.4/516-board-bcm6358.patch
@@ -97,7 +97,7 @@
  static struct board_info __initdata board_DWVS0 = {
  	.name				= "DWV-S0",
  	.expected_cpu_id		= 0x6358,
-@@ -1638,6 +1721,238 @@ static struct board_info __initdata boar
+@@ -1638,6 +1721,245 @@ static struct board_info __initdata boar
  	.has_ohci0			= 1,
  	.has_ehci0			= 1,
  };
@@ -332,11 +332,18 @@
 +		.has_phy = 1,
 +		.use_internal_phy = 1,
 +	},
++
++	.use_fallback_sprom 		= 1,
++	.fallback_sprom = {
++		.type = SPROM_BCM4322,
++		.pci_bus 		= 0,
++ 		.pci_dev 		= 1,
++	},
 +};
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  
  /*
-@@ -1708,7 +2023,20 @@ static const struct board_info __initcon
+@@ -1708,7 +2030,20 @@ static const struct board_info __initcon
  	&board_96358vw,
  	&board_96358vw2,
  	&board_AGPFS0,
@@ -357,7 +364,7 @@
  #endif /* CONFIG_BCM63XX_CPU_6358 */
  };
  
-@@ -1785,11 +2113,24 @@ static struct of_device_id const bcm963x
+@@ -1785,11 +2120,24 @@ static struct of_device_id const bcm963x
  	{ .compatible = "alcatel,rg100a", .data = &board_96358vw2, },
  	{ .compatible = "brcm,bcm96358vw", .data = &board_96358vw, },
  	{ .compatible = "brcm,bcm96358vw2", .data = &board_96358vw2, },


### PR DESCRIPTION
sprom fallback need to intialize the wlan pci wifi-bridge correctly.
and reset button corrected - no regular boot without pressing the reset key fixed
- broken wifi->fixed 
- default boot into failsafe->fixed

i compiled and tested only with the kernel 5.4 version **and it is working now (wifi+boot)**, 
kernel 5.10 should be similar, but is untested.
i also made a wiki at https://github.com/hontz1/openwrt_readme_t-com-w303v-B#readme
