### PR TITLE
linksys_ea7xxx: make u_env rw to allow clearing bootcount

### DIFF
--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -90,7 +90,6 @@
 		partition@80000 {
 			label = "u_env";
 			reg = <0x80000 0x40000>;
-			read-only;
 		};
 
 		factory: partition@c0000 {


### PR DESCRIPTION
Tested on Linksys EA7300v2

These devices have an A/B boot, where the bootloader keeps track of
unsuccessful boots of the current configured firmware (A or B) and if it
fails 3 times, falls over to the other firmware.  With u_env read-only
the bootcount is never reset to 0, which leads to:
- every reboot the configuration is wiped as a safety measure of the
  device to allow it to boot the firmware successfully
- after 3 boots the device returns to firmware B, which is the factory
  firmware (not useful)

This reboot to firmware problem was also reported on the forums, e.g. at https://forum.openwrt.org/t/can-not-install-openwrt-on-linksys-ea7300-v2/85421/9

Signed-off-by: Fabian Groffen <grobian@gentoo.org>