### PR TITLE
automake: always use correct path for aclocal.real

### DIFF
--- a/tools/automake/files/aclocal
+++ b/tools/automake/files/aclocal
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-aclocal.real $ACLOCAL_INCLUDE $@
+${STAGING_DIR_HOST}/bin/aclocal.real $ACLOCAL_INCLUDE $@


### PR DESCRIPTION
Before this commit, it was assumed that aclocal.real is in the PATH. While
this was fine for the normal build workflow, this led to some issues if

    make TOPDIR="$(pwd)" -C "$pkgdir" compile

was called manually. The command failed with:

    /home/.../openwrt/staging_dir/host/bin/aclocal: line 2: aclocal.real: command not found
    autoreconf: /home/.../openwrt/staging_dir/host/bin/aclocal failed with exit status: 127

After the commit, the package is built sucessfully.

Signed-off-by: Leonardo Mörlein <me@irrelefant.net>
