### PR TITLE
[21.02] libpcap: add rpcapd as package

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libpcap
 PKG_VERSION:=1.9.1
-PKG_RELEASE:=3
+PKG_RELEASE:=3.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \
@@ -44,6 +44,19 @@ endef
 define Package/libpcap/config
 	source "$(SOURCE)/Config.in"
 endef
+
+define Package/rpcapd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Capture daemon to be controlled by a remote libpcap application
+  URL:=http://www.tcpdump.org/
+  DEPENDS+= +libpcap
+endef
+
+ifdef CONFIG_PACKAGE_rpcapd
+	CMAKE_OPTIONS += \
+		-DENABLE_REMOTE=ON
+endif
 
 CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
@@ -84,4 +97,10 @@ define Package/libpcap/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcap.so.* $(1)/usr/lib/
 endef
 
+define Package/rpcapd/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/rpcapd $(1)/usr/bin/
+endef
+
 $(eval $(call BuildPackage,libpcap))
+$(eval $(call BuildPackage,rpcapd))


### PR DESCRIPTION
This enables building of rpcapd and adds it as a package.

It is a daemon that allows remote packet capturing from another machine.
E.g. Wireshark can talk to it using the Remote Capture Protocol (RPCAP).
https://www.tcpdump.org/manpages/rpcapd.8.html

Compile and run tested:
OpenWrt 21.02.0-rc4 r16256-2d5ee43dc6 on x86/64 and mvebu/cortexa9

Signed-off-by: Stephan Schmidtmer <hurz@gmx.org>
(cherry picked from commit 891c8676a1602d31adf3ab9f913664ae0d3b4029)