### PR TITLE
dropbear: allow to use with xinetd

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -106,14 +106,12 @@ CONFIGURE_ARGS += \
 # remove protocol idented software version number:
 # - LOCAL_IDENT
 # disable legacy/unsafe methods and unused functionality:
-# - INETD_MODE
 # - DROPBEAR_CLI_NETCAT
 # - DROPBEAR_DSS
 # - DO_MOTD
 DB_OPT_COMMON = \
 	DEFAULT_PATH|"$(TARGET_INIT_PATH)" \
 	!!LOCAL_IDENT|"SSH-2.0-dropbear" \
-	INETD_MODE|0 \
 	DROPBEAR_CLI_NETCAT|0 \
 	DROPBEAR_DSS|0 \
 	DO_MOTD|0 \


### PR DESCRIPTION
with xinetd allowed+blocked (ipv6) hosts could be set
what is not possible with stock dropbear package