### PR TITLE
ramips: add support for ipTIME Ext N3 on 19.07

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -269,6 +269,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;
+	iptime,extn3)
+		ucidef_add_switch "switch0" \
+			"2:lan:2" "3:lan:1" "0:wan" "6@eth0"
+		;;
 	dir-860l-b1|\
 	elecom,wrc-1167ghbk2-s|\
 	elecom,wrc-2533gst|\

--- a/target/linux/ramips/dts/IPTIME-EXTN3.dts
+++ b/target/linux/ramips/dts/IPTIME-EXTN3.dts
@@ -1,0 +1,138 @@
+/dts-v1/;
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iptime,extn3", "mediatek,mt7628an-soc";
+	model = "ipTIME EXTN3";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x4000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			label = "extn3:blue:cpu";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "extn3:blue:wlan";
+			gpios = <&gpio1 46 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <60>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 45 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio1 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&pinctrl {
+		state_default: pinctrl0 {
+		gpio {
+			ralink,group = "i2c", "uart1", "wdt";
+			ralink,function = "gpio";
+		};
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x32>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0x3c0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&uboot 0x1fc20>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&pcie {
+	status = "disabled";
+};
+
+&pcie0 {
+	status = "disabled";
+};
+
+&wmac {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -93,6 +93,15 @@ define Device/hiwifi_hc5861b
 endef
 TARGET_DEVICES += hiwifi_hc5861b
 
+define Device/iptime_extn3
+  DTS := IPTIME-EXTN3
+  IMAGE_SIZE := 3840k
+  UIMAGE_NAME := extn3
+  DEVICE_TITLE := ipTIME EXTN3
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += iptime_extn3
+
 define Device/LinkIt7688
   DTS := LINKIT7688
   IMAGE_SIZE := $(ralink_default_fw_size_32M)

--- a/target/linux/ramips/patches-4.14/305-spi-nor-add-for-xmc25qh32-and-xmc25qh32a.patch
+++ b/target/linux/ramips/patches-4.14/305-spi-nor-add-for-xmc25qh32-and-xmc25qh32a.patch
@@ -1,0 +1,11 @@
+--- a/drivers/mtd/spi-nor/spi-nor.c
++++ b/drivers/mtd/spi-nor/spi-nor.c
+@@ -1278,6 +1278,8 @@ static const struct flash_info spi_nor_ids[] = {
+ 	{ "3S1400AN", S3AN_INFO(0x1f2600, 512, 528) },
+ 
+ 	/* XMC (Wuhan Xinxin Semiconductor Manufacturing Corp.) */
++	{ "XM25QH32", INFO(0x204016, 0, 32 * 1024, 64, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "XM25QH32A", INFO(0x207016, 0, 32 * 1024, 64, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH64A", INFO(0x207017, 0, 64 * 1024, 128, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256, SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ },


### PR DESCRIPTION
Add ipTIME N3/N300 with it's 4MB SPI NOR ids.

ipTIME Ext N3 and Ext N300 have a same pins and specification.
But few difference on PSU circuit and antennas.
ipTIME N3 have two 2.5dBi antenna.
ipTIME N300 have two 4dBi antenna.

ipTIME Ext N3 and Ext N300 Specifications:
* SoC: MT7628AN
* RAM: DDR2 64MB
* Flash: NOR-SPI 32MB (XM25QH32)
* Ethernet: Only one 1Gbps
  * Switch: SoC internal
* WiFi:
  * 2.4Ghz: Soc internal

Caution on real usage:
 * ipTime extender have a only one ethernet port.
   So user need to disable firewall or enable WiFi AP as default, before compile.
 * This device is 4MB Flash device. Cannot use luci.
 * By limitation from 4MB Flash, this patch focused on 19.07.