### PR TITLE
sysntpd: set startlevel 25

### DIFF
--- a/package/utils/busybox/files/sysntpd
+++ b/package/utils/busybox/files/sysntpd
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2011 OpenWrt.org
 
-START=98
+START=25
 
 USE_PROCD=1
 PROG=/usr/sbin/ntpd


### PR DESCRIPTION
it should start shrt after network as
other things use it, like logging,
statistics, vnstat1/2
