### PR TITLE
imagebuilder: add hostpkgs to imagebuilder

### DIFF
--- a/scripts/bundle-libraries.sh
+++ b/scripts/bundle-libraries.sh
@@ -167,7 +167,7 @@ for BIN in "$@"; do
 
 	LDSO=""
 
-	[ -n "$LDD" ] && should_be_patched "$BIN" && {
+	[ -n "$LDD" ] && {
 		for token in $("$LDD" "$BIN" 2>/dev/null); do
 			case "$token" in */*.so*)
 				dest="$DIR/lib/${token##*/}"
@@ -190,7 +190,7 @@ for BIN in "$@"; do
 	}
 
 	# is a dynamically linked executable
-	if [ -n "$LDSO" ]; then
+	if [ -n "$LDSO" ] && should_be_patched "$BIN"; then
 		echo "Bundling ${BIN##*/}"
 
 		RUNDIR="$(readlink -f "$BIN")"; RUNDIR="${RUNDIR%/*}"

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -100,12 +100,27 @@ endif
 	  | $(XARGS) rm -rf
 	$(INSTALL_DIR) $(IB_IDIR)
 	-$(CP) $(STAGING_DIR_IMAGE)/* $(IB_IDIR)/
+	# install staging_dir/host/bin
 	$(INSTALL_DIR) $(PKG_BUILD_DIR)/staging_dir/host/bin
 	$(CP) $(STAGING_DIR_HOST)/bin/* $(PKG_BUILD_DIR)/staging_dir/host/bin/
 	(cd $(PKG_BUILD_DIR); find staging_dir/host/bin/ $(IB_LDIR)/scripts/dtc/ -type f | \
 		$(BUNDLER_COMMAND))
 	$(CP) $(TOPDIR)/staging_dir/host/lib/libfakeroot* $(PKG_BUILD_DIR)/staging_dir/host/lib
 	STRIP=$(STAGING_DIR_HOST)/bin/sstrip $(SCRIPT_DIR)/rstrip.sh $(PKG_BUILD_DIR)/staging_dir/host/bin/
+	# install staging_dir/hostpkg/bin
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/staging_dir/hostpkg/bin
+	$(CP) $(STAGING_DIR_HOSTPKG)/bin/* $(PKG_BUILD_DIR)/staging_dir/hostpkg/bin/
+	(cd $(PKG_BUILD_DIR); find staging_dir/hostpkg/bin/ $(IB_LDIR)/scripts/dtc/ -type f | \
+		$(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(PKG_BUILD_DIR)/staging_dir/hostpkg)
+	STRIP=sstrip $(SCRIPT_DIR)/rstrip.sh $(PKG_BUILD_DIR)/staging_dir/hostpkg/bin/
+	# install lua libs
+	if [ -d $(STAGING_DIR_HOSTPKG)/lib/lua ]; then \
+		$(INSTALL_DIR) $(PKG_BUILD_DIR)/staging_dir/hostpkg/lib/lua; \
+		$(CP) $(STAGING_DIR_HOSTPKG)/lib/lua $(PKG_BUILD_DIR)/staging_dir/hostpkg/lib/; \
+		(cd $(PKG_BUILD_DIR); find staging_dir/hostpkg/lib/lua/ -type f | \
+			$(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(PKG_BUILD_DIR)/staging_dir/hostpkg); \
+	fi
+	# bundle
 	(cd $(BUILD_DIR); \
 		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' -cf $@ $(IB_NAME) \
 		--mtime="$(shell date --date=@$(SOURCE_DATE_EPOCH))"; \


### PR DESCRIPTION
Before this commit, host packages were not installed into the
imagebuilder. This made it impossible to make use of hostpkgs in opkg
postinstall scripts in combination with the imagebuilder.

This commit changes this and ensures, that
- staging_dir/hostpkg/bin/* is installed to the imagebuilder.
- staging_dir/hostpkg/lib/lua is installed into the
  imagebuilder (if existing).
- Dependencies of lua libraries are installed into
  staging_dir/hostpkg/lib using bundle-libraries.sh.

After this commit, we are able to use hostpkgs (like lua) in opkg
postinstall scripts in combination with the imagebuilder, assuming
that those packages built as hostpkgs anyways.

With default OpenWrt configuration for x86-64, the unpacked
imagebuilder becomes this much larger:

    1.5M	staging_dir/hostpkg/bin
    3.6M	staging_dir/hostpkg/lib

Signed-off-by: Leonardo Mörlein <me@irrelefant.net>

(EDIT: Updated to new commit message.)

---

A test of (the newest version of) this PR is still compiling. I'll
inform you when this is finished. 

CC: @aparcar