### PR TITLE
kirkwood: add support for Ctera C200 V1 NAS

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -18,6 +18,7 @@ cisco,on100)
 	;;
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
+ctera,c200-v1|\
 globalscale,sheevaplug|\
 iom,iconnect-1.1|\
 iom,ix2-200|\

--- a/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
+++ b/target/linux/kirkwood/base-files/etc/init.d/hwmon_fancontrol
@@ -7,6 +7,13 @@ boot() {
 	# for more information, please read https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
 
 	case $(board_name) in
+	ctera,c200-v1)
+		path_to_hwmon='/sys/devices/platform/ocp@f1000000/f1011000.i2c/i2c-0/0-004c/hwmon/hwmon0'
+
+		# It should be related to hdd temerature instead lm63 temp
+		echo 1 > "$path_to_hwmon/pwm1_enable"
+		echo 128 > "$path_to_hwmon/pwm1"
+		;;
 	iom,ix2-200)
 		path_to_hwmon='/sys/class/hwmon/hwmon0'
 		echo 2 > "$path_to_hwmon/pwm1_enable" # fan is on pwm1

--- a/target/linux/kirkwood/base-files/lib/upgrade/platform.sh
+++ b/target/linux/kirkwood/base-files/lib/upgrade/platform.sh
@@ -1,4 +1,4 @@
-RAMFS_COPY_BIN='fw_printenv fw_setenv'
+RAMFS_COPY_BIN='fw_printenv fw_setenv strings'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 REQUIRE_IMAGE_METADATA=1
@@ -11,6 +11,17 @@ platform_do_upgrade() {
 	local board="$(board_name)"
 
 	case "$board" in
+	ctera,c200-v1)
+		part=$(find_mtd_part "active_bank")
+
+		if [ -n "$part" ]; then
+			CI_KERNPART="$(strings $part | grep bank)"
+			nand_do_upgrade "$1"
+		else
+			echo "active_bank partition missed!"
+			return 1
+		fi
+		;;
 	linksys,e4200-v2|\
 	linksys,ea3500|\
 	linksys,ea4500)

--- a/target/linux/kirkwood/base-files/sbin/ctera_c200-v1_back_to_factory
+++ b/target/linux/kirkwood/base-files/sbin/ctera_c200-v1_back_to_factory
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+case $(board_name) in
+ctera,c200-v1)
+	part=$(find_mtd_part "active_bank")
+
+	if [ -n "$part" ]; then
+		active_bank="$(strings $part | grep bank)"
+
+		if [ $active_bank = "bank1" ]; then
+			echo "bank2" > /tmp/change_bank
+		else
+			echo "bank1" > /tmp/change_bank
+		fi
+
+		mtd write /tmp/change_bank active_bank
+		reboot
+	else
+		echo "active_bank partition missed!"
+		return 1
+	fi
+	;;
+*)
+	echo "Unsupported hardware."
+	;;
+esac

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-c200-v1.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-c200-v1.dts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Ctera C200 V1 Board Description
+ * Copyright 2021 Pawel Dembicki <paweldembicki@gmail.com>
+ */
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6281.dtsi"
+
+/ {
+	model = "Ctera C200 V1";
+	compatible = "ctera,c200-v1", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		stdout-path = &uart0;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x20000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&pmx_buttons>;
+		pinctrl-names = "default";
+
+		power {
+			label = "Power Button";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio1 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		reset {
+			label = "Reset Button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+		};
+
+		usb1 {
+			label = "USB1 Button";
+			linux,code = <BTN_0>;
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2 {
+			label = "USB2 Button";
+			linux,code = <BTN_1>;
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-poweroff {
+		compatible = "gpio-poweroff";
+		pinctrl-0 = <&pmx_poweroff>;
+		pinctrl-names = "default";
+		gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&pmx_leds>;
+		pinctrl-names = "default";
+
+		led_status_green: status-green {
+			label = "green:status";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status-red {
+			label = "red:status";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+
+		cloud-blue {
+			label = "blue:cloud";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		disk1-green {
+			label = "green:disk1";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata1";
+		};
+
+		disk1-red {
+			label = "red:disk1";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		};
+
+		disk2-green {
+			label = "green:disk2";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata2";
+		};
+
+		disk2-red {
+			label = "red:disk2";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		disk-fail-green {
+			label = "green:disk-fail";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		disk-fail-red {
+			label = "red:disk-fail";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		usb1-green {
+			label = "green:usb1";
+			gpios = <&gpio1 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port2>;
+		};
+
+		usb1-red {
+			label = "red:usb1";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2-green {
+			label = "green:usb2";
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+			trigger-sources = <&hub_port1>;
+		};
+
+		usb2-red {
+			label = "red:usb2";
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+};
+
+&eth0port {
+	phy-handle = <&ethphy9>;
+};
+
+&i2c0 {
+	status = "okay";
+
+	rtc@30 {
+		compatible = "s35390a";
+		reg = <0x30>;
+	};
+
+	lm63@4c {
+		compatible = "national,lm63";
+		reg = <0x4c>;
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	ethphy9: ethernet-phy@9 {
+		reg = <9>;
+	};
+};
+
+&nand {
+	status = "okay";
+	chip-delay = <40>;
+
+	partition@0 {
+		label = "uboot";
+		reg = <0x0000000 0x200000>;
+	};
+
+	partition@200000 {
+		label = "certificate";
+		reg = <0x0200000 0x100000>;
+	};
+
+	partition@300000 {
+		label = "preset_cfg";
+		reg = <0x0300000 0x100000>;
+	};
+
+	partition@400000 {
+		label = "dev_params";
+		reg = <0x0400000 0x100000>;
+	};
+	partition@500000 {
+		label = "active_bank";
+		reg = <0x0500000 0x0100000>;
+	};
+
+	partition@600000 {
+		label = "magic";
+		reg = <0x0600000 0x0100000>;
+	};
+
+	partition@700000 {
+		label = "bank1";
+		reg = <0x0700000 0x2800000>;
+	};
+
+	partition@2f00000 {
+		label = "bank2";
+		reg = <0x2f00000 0x2800000>;
+	};
+
+	/* 0x5700000-0x5a00000 undefined in vendor firmware */
+
+	partition@5a00000 {
+		label = "reserved";
+		reg = <0x5a00000 0x2000000>;
+	};
+
+	partition@7a00000 {
+		label = "ubi";
+		reg = <0x7a00000 0x8600000>;
+	};
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pinctrl {
+	/* buzzer gpios are connected to two pins of buzzer
+	 * leave it as is due lack of proper driver
+	 */
+	pmx_buzzer: pmx-buzzer {
+		marvell,pins = "mpp12", "mpp13";
+		marvell,function = "gpio";
+	};
+
+	pmx_leds: pmx-leds {
+		marvell,pins = "mpp14", "mpp15", "mpp16", "mpp17", "mpp38",
+			       "mpp39", "mpp40", "mpp42", "mpp43", "mpp44",
+			       "mpp45", "mpp46", "mpp47";
+		marvell,function = "gpio";
+	};
+
+	pmx_buttons: pmx-buttons {
+		marvell,pins = "mpp28", "mpp29", "mpp48", "mpp49";
+		marvell,function = "gpio";
+	};
+
+	pmx_poweroff: pmx-poweroff {
+		marvell,pins = "mpp34";
+		marvell,function = "gpio";
+	};
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&sata {
+	status = "okay";
+	nr-ports = <2>;
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	port@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <1>;
+		#trigger-source-cells = <0>;
+
+		hub_port1: port@1 {
+			reg = <1>;
+			#trigger-source-cells = <0>;
+		};
+
+		hub_port2: port@2 {
+			reg = <2>;
+			#trigger-source-cells = <0>;
+		};
+	};
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -7,6 +7,63 @@ include $(INCLUDE_DIR)/image.mk
 
 KERNEL_LOADADDR:=0x8000
 
+# Some info about Ctera firmware:
+# 1. It's simple tar file (GNU standard), but it must have ".firm" suffix.
+# 2. It contains two images: kernel and romdisk. Both are required.
+# 3. Every image has header and trailer file.
+# 4. The struct of tar firmware is: header kernel trailer header romdisk trailer
+# 5. In header file are some strings used to describe image. It was decoded from
+#    factory image.
+# 6. Version format in header file is restricted by Original FW.
+# 7. Trailer file contains MD5 sum string of header and image file.
+# 8. Firmware file must have <=24MB size.
+
+define Build/ctera-firmware
+	mkdir -p $@.tmp
+
+	# Prepare header and trailer file for kernel
+	echo "# CTera firmware information file" > $@.tmp/header
+	echo "image_type=kernel" >> $@.tmp/header
+	echo "arch=Kirkwood" >> $@.tmp/header
+	echo "board=Any" >> $@.tmp/header
+	echo "version=3.1.22.30669" >> $@.tmp/header
+	echo "kernel_cmd=console=ttyS0,115200 earlyprintk" >> $@.tmp/header
+	echo "date=$$(date $(if $(SOURCE_DATE_EPOCH),-d@$(SOURCE_DATE_EPOCH)))" \
+		>> $@.tmp/header
+
+	cp $@ $@.tmp/kernel
+
+	echo "MD5=$$(cat $@.tmp/header $@.tmp/kernel | $(MKHASH) md5)" \
+		> $@.tmp/trailer
+
+	tar $(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-H gnu -C $@.tmp -cf $@.tar header kernel trailer
+
+	# Prepare header and trailer file for fake romdisk
+	echo "# CTera firmware information file" > $@.tmp/header
+	echo "image_type=romdisk" >> $@.tmp/header
+	echo "initrd=yes" >> $@.tmp/header
+	echo "arch=Kirkwood" >> $@.tmp/header
+	echo "board=Any" >> $@.tmp/header
+	echo "version=3.1.22.30669" >> $@.tmp/header
+	echo "date=$$(date $(if $(SOURCE_DATE_EPOCH),-d@$(SOURCE_DATE_EPOCH)))" \
+		>> $@.tmp/header
+
+	rm -f $@
+	touch $@
+	$(call Build/append-uImage-fakehdr, ramdisk)
+	cp $@ $@.tmp/romdisk
+
+	echo "MD5=$$(cat $@.tmp/header $@.tmp/romdisk | $(MKHASH) md5)" \
+		> $@.tmp/trailer
+
+	tar $(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-H gnu -C $@.tmp -rf $@.tar header romdisk trailer
+
+	mv $@.tar $@
+	rm -rf $@.tmp
+endef
+
 define Device/kernel-size-migration
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition design has changed compared to \
@@ -52,6 +109,19 @@ define Device/cisco_on100
   SUPPORTED_DEVICES += on100
 endef
 TARGET_DEVICES += cisco_on100
+
+define Device/ctera_c200-v1
+  DEVICE_VENDOR := Ctera
+  DEVICE_MODEL := C200
+  DEVICE_VARIANT := V1
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-gpio-button-hotplug \
+	kmod-hwmon-lm63 kmod-rtc-s35390a kmod-usb-ledtrig-usbport
+  KERNEL := kernel-bin | append-dtb | uImage none | ctera-firmware
+  KERNEL_IN_UBI :=
+  KERNEL_SUFFIX := -factory.firm
+  IMAGES := sysupgrade.bin
+endef
+TARGET_DEVICES += ctera_c200-v1
 
 define Device/cloudengines_pogoe02
   DEVICE_VENDOR := Cloud Engines


### PR DESCRIPTION
2-Bay NAS - maximum two 3.5" Harddisks

Hardware:
  - SoC: Marvell 88F6281-A1 ARMv5TE Processor 1.2GHz
  - Ram: 512MB (4x Nanya NT5TU128M8GE-AC)
  - NAND Flash: 256MB (Samsung 216 K9F2G08U0C)
  - Lan: 1x GBE (Marvell 88E1116R-NNC1)
  - Storage: 2x SATA HDD 3.5" Slot
  - USB: 2x USB 2.0 port
  - Console: Internal J3 connector (1: Vcc, 2: Rx, 3: Tx, 4: GND)
  - LEDs: 13x GPIO controlled
  - Buttons: 2x GPIO controlled

Known issues:
  - Buzzer is unused due lack of proper driver

Installation:
  - Apply factory initramfs image via stock web-gui.
  - Do sysupgrade to make installation complete.

Back to stock:
  - OpenWrt rootfs partition use unused space after stock firmware.
  - Full revert is possible.
  - Login via ssh and run: ctera_c200-v1_back_to_factory

Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
