### PR TITLE
kernel: bump 5.10 to 5.10.60

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .140
-LINUX_VERSION-5.10 = .59
+LINUX_VERSION-5.10 = .60
 
 LINUX_KERNEL_HASH-5.4.140 = 2c657a2df4f2e805ac50aeb39ecf5d1e4cb1501e7fcf15eafd14486b587f7e43
-LINUX_KERNEL_HASH-5.10.59 = 333cadc15f23e2060bb9701dbd9c23cfb196c528cded797329a0c369c2b6ea80
+LINUX_KERNEL_HASH-5.10.60 = 696ff7753f6c7c5123dbcb0a22d693cb358c760c61a76649531b6a207155f78d
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/backport-5.10/780-net-dsa-mt7530-setup-core-clock-even-in-TRGMII-mode.patch
+++ b/target/linux/generic/backport-5.10/780-net-dsa-mt7530-setup-core-clock-even-in-TRGMII-mode.patch
@@ -21,7 +21,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -435,34 +435,32 @@ mt7530_pad_clk_setup(struct dsa_switch *
+@@ -436,34 +436,32 @@ mt7530_pad_clk_setup(struct dsa_switch *
  			     TD_DM_DRVP(8) | TD_DM_DRVN(8));
  
  	/* Setup core clock for MT7530 */

--- a/target/linux/generic/backport-5.10/781-v5.13-net-dsa-mt7530-Add-support-for-EEE-features.patch
+++ b/target/linux/generic/backport-5.10/781-v5.13-net-dsa-mt7530-Add-support-for-EEE-features.patch
@@ -17,7 +17,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/dsa/mt7530.c
 +++ b/drivers/net/dsa/mt7530.c
-@@ -2269,6 +2269,17 @@ static void mt753x_phylink_mac_link_up(s
+@@ -2270,6 +2270,17 @@ static void mt753x_phylink_mac_link_up(s
  			mcr |= PMCR_RX_FC_EN;
  	}
  
@@ -35,7 +35,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	mt7530_set(priv, MT7530_PMCR_P(port), mcr);
  }
  
-@@ -2499,6 +2510,36 @@ mt753x_phy_write(struct dsa_switch *ds,
+@@ -2500,6 +2511,36 @@ mt753x_phy_write(struct dsa_switch *ds,
  	return priv->info->phy_write(ds, port, regnum, val);
  }
  
@@ -72,7 +72,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  static const struct dsa_switch_ops mt7530_switch_ops = {
  	.get_tag_protocol	= mtk_get_tag_protocol,
  	.setup			= mt753x_setup,
-@@ -2527,6 +2568,8 @@ static const struct dsa_switch_ops mt753
+@@ -2528,6 +2569,8 @@ static const struct dsa_switch_ops mt753
  	.phylink_mac_an_restart	= mt753x_phylink_mac_an_restart,
  	.phylink_mac_link_down	= mt753x_phylink_mac_link_down,
  	.phylink_mac_link_up	= mt753x_phylink_mac_link_up,

--- a/target/linux/generic/hack-5.10/221-module_exports.patch
+++ b/target/linux/generic/hack-5.10/221-module_exports.patch
@@ -56,7 +56,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}								\
  									\
  	/* __*init sections */						\
-@@ -1018,6 +1028,8 @@
+@@ -1019,6 +1029,8 @@
  
  #define COMMON_DISCARDS							\
  	SANITIZER_DISCARDS						\

--- a/target/linux/x86/patches-5.10/012-pcengines-apu2-detect-apuv4-board.patch
+++ b/target/linux/x86/patches-5.10/012-pcengines-apu2-detect-apuv4-board.patch
@@ -14,7 +14,7 @@ Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
 
 --- a/drivers/platform/x86/pcengines-apuv2.c
 +++ b/drivers/platform/x86/pcengines-apuv2.c
-@@ -213,6 +213,33 @@ static const struct dmi_system_id apu_gp
+@@ -215,6 +215,33 @@ static const struct dmi_system_id apu_gp
  		},
  		.driver_data = (void *)&board_apu2,
  	},


### PR DESCRIPTION
No deleted or manually refreshed patches.

Run-tested:
ath79/generic (TL-WDR3600)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>