### PR TITLE
ipq806x: fix min<>target opp volt mixup on ipq8065

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8062.dtsi
@@ -45,32 +45,35 @@
 	/delete-node/opp-1200000000;
 	/delete-node/opp-1400000000;
 
+	/*
+	 * Voltage thresholds are <target min max>
+	 */
 	opp-384000000 {
-		opp-microvolt-speed0-pvs0-v0 = <902500 950000 997500>;
-		opp-microvolt-speed0-pvs1-v0 = <855000 900000 945000>;
-		opp-microvolt-speed0-pvs2-v0 = <807500 850000 892500>;
-		opp-microvolt-speed0-pvs3-v0 = <760000 800000 840000>;
+		opp-microvolt-speed0-pvs0-v0 = <950000 902500 997500>;
+		opp-microvolt-speed0-pvs1-v0 = <900000 855000 945000>;
+		opp-microvolt-speed0-pvs2-v0 = <850000 807500 892500>;
+		opp-microvolt-speed0-pvs3-v0 = <800000 760000 840000>;
 	};
 
 	opp-600000000 {
-		opp-microvolt-speed0-pvs0-v0 = <950000 1000000 1050000>;
-		opp-microvolt-speed0-pvs1-v0 = <945000  950000  955000>;
-		opp-microvolt-speed0-pvs2-v0 = <895000  900000  905000>;
-		opp-microvolt-speed0-pvs3-v0 = <845000  850000  855000>;
+		opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
+		opp-microvolt-speed0-pvs1-v0 = <950000  945000  955000>;
+		opp-microvolt-speed0-pvs2-v0 = <900000  895000  905000>;
+		opp-microvolt-speed0-pvs3-v0 = <850000  845000  855000>;
 	};
 
 	opp-800000000 {
-		opp-microvolt-speed0-pvs0-v0 = <997500 1050000 1102500>;
-		opp-microvolt-speed0-pvs1-v0 = < 995000 1000000 1005000>;
-		opp-microvolt-speed0-pvs2-v0 = < 945000  950000  955000>;
-		opp-microvolt-speed0-pvs3-v0 = < 895000  900000  905000>;
+		opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
+		opp-microvolt-speed0-pvs1-v0 = <1000000 995000 1005000>;
+		opp-microvolt-speed0-pvs2-v0 = <950000  945000  955000>;
+		opp-microvolt-speed0-pvs3-v0 = <900000  895000  905000>;
 	};
 
 	opp-1000000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1045000 1100000 1155000>;
-		opp-microvolt-speed0-pvs1-v0 = <997500 1050000 1102500>;
-		opp-microvolt-speed0-pvs2-v0 = < 995000 1000000 1005000>;
-		opp-microvolt-speed0-pvs3-v0 = < 945000  950000  955000>;
+		opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
+		opp-microvolt-speed0-pvs1-v0 = <1050000  997500 1102500>;
+		opp-microvolt-speed0-pvs2-v0 = <1000000  995000 1005000>;
+		opp-microvolt-speed0-pvs3-v0 = <950000   945000  955000>;
 	};
 };
 

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065.dtsi
@@ -97,66 +97,69 @@
 
 	/delete-node/opp-1200000000;
 
+	/*
+	 * Voltage thresholds are <target min max>
+	 */
 	opp-384000000 {
-		opp-microvolt-speed0-pvs0-v0 = <926250 975000 1023750>;
-		opp-microvolt-speed0-pvs1-v0 = <902500 950000 997500>;
-		opp-microvolt-speed0-pvs2-v0 = <878750 925000 971250>;
-		opp-microvolt-speed0-pvs3-v0 = <855000 900000 945000>;
-		opp-microvolt-speed0-pvs4-v0 = <831250 875000 918750>;
-		opp-microvolt-speed0-pvs5-v0 = <783750 825000 866250>;
-		opp-microvolt-speed0-pvs6-v0 = <736250 775000 813750>;
+		opp-microvolt-speed0-pvs0-v0 = <975000 926250 1023750>;
+		opp-microvolt-speed0-pvs1-v0 = <950000 902500 997500>;
+		opp-microvolt-speed0-pvs2-v0 = <925000 878750 971250>;
+		opp-microvolt-speed0-pvs3-v0 = <900000 855000 945000>;
+		opp-microvolt-speed0-pvs4-v0 = <875000 831250 918750>;
+		opp-microvolt-speed0-pvs5-v0 = <825000 783750 866250>;
+		opp-microvolt-speed0-pvs6-v0 = <775000 736250 813750>;
 	};
 
 	opp-600000000 {
-		opp-microvolt-speed0-pvs0-v0 = <950000 1000000 1050000>;
-		opp-microvolt-speed0-pvs1-v0 = <926250 975000 1023750>;
-		opp-microvolt-speed0-pvs2-v0 = <902500 950000 997500>;
-		opp-microvolt-speed0-pvs3-v0 = <878750 925000 971250>;
-		opp-microvolt-speed0-pvs4-v0 = <855000 900000 945000>;
-		opp-microvolt-speed0-pvs5-v0 = <807500 850000 892500>;
-		opp-microvolt-speed0-pvs6-v0 = <760000 800000 840000>;
+		opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
+		opp-microvolt-speed0-pvs1-v0 = <975000 926250 1023750>;
+		opp-microvolt-speed0-pvs2-v0 = <950000 902500 997500>;
+		opp-microvolt-speed0-pvs3-v0 = <925000 878750 971250>;
+		opp-microvolt-speed0-pvs4-v0 = <900000 855000 945000>;
+		opp-microvolt-speed0-pvs5-v0 = <850000 807500 892500>;
+		opp-microvolt-speed0-pvs6-v0 = <800000 760000 840000>;
 	};
 
 	opp-800000000 {
-		opp-microvolt-speed0-pvs0-v0 = <997500 1050000 1102500>;
-		opp-microvolt-speed0-pvs1-v0 = <973750 1025000 1076250>;
-		opp-microvolt-speed0-pvs2-v0 = <950000 1000000 1050000>;
-		opp-microvolt-speed0-pvs3-v0 = <926250 975000 1023750>;
-		opp-microvolt-speed0-pvs4-v0 = <902500 950000 997500>;
-		opp-microvolt-speed0-pvs5-v0 = <855000 900000 945000>;
-		opp-microvolt-speed0-pvs6-v0 = <807500 850000 892500>;
+		opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
+		opp-microvolt-speed0-pvs1-v0 = <1025000 973750 1076250>;
+		opp-microvolt-speed0-pvs2-v0 = <1000000 950000 1050000>;
+		opp-microvolt-speed0-pvs3-v0 = <975000 926250 1023750>;
+		opp-microvolt-speed0-pvs4-v0 = <950000 902500 997500>;
+		opp-microvolt-speed0-pvs5-v0 = <900000 855000 945000>;
+		opp-microvolt-speed0-pvs6-v0 = <850000 807500 892500>;
 	};
 
 	opp-1000000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1045000 1100000 1155000>;
-		opp-microvolt-speed0-pvs1-v0 = <1021250 1075000 1128750>;
-		opp-microvolt-speed0-pvs2-v0 = <997500 1050000 1102500>;
-		opp-microvolt-speed0-pvs3-v0 = <973750 1025000 1076250>;
-		opp-microvolt-speed0-pvs4-v0 = <950000 1000000 1050000>;
-		opp-microvolt-speed0-pvs5-v0 = <902500 950000 997500>;
-		opp-microvolt-speed0-pvs6-v0 = <855000 900000 945000>;
+		opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
+		opp-microvolt-speed0-pvs1-v0 = <1075000 1021250 1128750>;
+		opp-microvolt-speed0-pvs2-v0 = <1050000 997500 1102500>;
+		opp-microvolt-speed0-pvs3-v0 = <1025000 973750 1076250>;
+		opp-microvolt-speed0-pvs4-v0 = <1000000 950000 1050000>;
+		opp-microvolt-speed0-pvs5-v0 = <950000 902500 997500>;
+		opp-microvolt-speed0-pvs6-v0 = <900000 855000 945000>;
 	};
 
 	opp-1400000000 {
-		opp-microvolt-speed0-pvs0-v0 = <1116250 1175000 1233750>;
-		opp-microvolt-speed0-pvs1-v0 = <1092500 1150000 1207500>;
-		opp-microvolt-speed0-pvs2-v0 = <1068750 1125000 1181250>;
-		opp-microvolt-speed0-pvs3-v0 = <1045000 1100000 1155000>;
-		opp-microvolt-speed0-pvs4-v0 = <1021250 1075000 1128750>;
-		opp-microvolt-speed0-pvs5-v0 = <973750 1025000 1076250>;
-		opp-microvolt-speed0-pvs6-v0 = <926250 975000 1023750>;
+		opp-microvolt-speed0-pvs0-v0 = <1175000 1116250 1233750>;
+		opp-microvolt-speed0-pvs1-v0 = <1150000 1092500 1207500>;
+		opp-microvolt-speed0-pvs2-v0 = <1125000 1068750 1181250>;
+		opp-microvolt-speed0-pvs3-v0 = <1100000 1045000 1155000>;
+		opp-microvolt-speed0-pvs4-v0 = <1075000 1021250 1128750>;
+		opp-microvolt-speed0-pvs5-v0 = <1025000 973750 1076250>;
+		opp-microvolt-speed0-pvs6-v0 = <975000 926250 1023750>;
 		opp-level = <1>;
 	};
 
 	opp-1725000000 {
 		opp-hz = /bits/ 64 <1725000000>;
-		opp-microvolt-speed0-pvs0-v0 = <1199375 1262500 1325625>;
-		opp-microvolt-speed0-pvs1-v0 = <1163750 1225000 1286250>;
-		opp-microvolt-speed0-pvs2-v0 = <1140000 1200000 1260000>;
-		opp-microvolt-speed0-pvs3-v0 = <1116250 1175000 1233750>;
-		opp-microvolt-speed0-pvs4-v0 = <1092500 1150000 1207500>;
-		opp-microvolt-speed0-pvs5-v0 = <1045000 1100000 1155000>;
-		opp-microvolt-speed0-pvs6-v0 = <997500 1050000 1102500>;
+		opp-microvolt-speed0-pvs0-v0 = <1262500 1199375 1325625>;
+		opp-microvolt-speed0-pvs1-v0 = <1225000 1163750 1286250>;
+		opp-microvolt-speed0-pvs2-v0 = <1200000 1140000 1260000>;
+		opp-microvolt-speed0-pvs3-v0 = <1175000 1116250 1233750>;
+		opp-microvolt-speed0-pvs4-v0 = <1150000 1092500 1207500>;
+		opp-microvolt-speed0-pvs5-v0 = <1100000 1045000 1155000>;
+		opp-microvolt-speed0-pvs6-v0 = <1050000 997500 1102500>;
 		opp-supported-hw = <0x1>;
 		clock-latency-ns = <100000>;
 		opp-level = <2>;

--- a/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.10/083-ipq8064-dtsi-additions.patch
@@ -26,7 +26,7 @@
  		};
  
  		cpu1: cpu@1 {
-@@ -38,14 +50,347 @@
+@@ -38,14 +50,350 @@
  			next-level-cache = <&L2>;
  			qcom,acc = <&acc1>;
  			qcom,saw = <&saw1>;
@@ -85,12 +85,15 @@
 +		compatible = "operating-points-v2-kryo-cpu";
 +		nvmem-cells = <&speedbin_efuse>;
 +
++		/*
++		 * Voltage thresholds are <target min max>
++		 */
 +		opp-384000000 {
 +			opp-hz = /bits/ 64 <384000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <950000 1000000 1050000>;
-+			opp-microvolt-speed0-pvs1-v0 = <878750 925000 971250>;
-+			opp-microvolt-speed0-pvs2-v0 = <831250 875000 918750>;
-+			opp-microvolt-speed0-pvs3-v0 = <760000 800000 840000>;
++			opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
++			opp-microvolt-speed0-pvs1-v0 = <925000 878750 971250>;
++			opp-microvolt-speed0-pvs2-v0 = <875000 831250 918750>;
++			opp-microvolt-speed0-pvs3-v0 = <800000 760000 840000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <0>;
@@ -98,10 +101,10 @@
 +
 +		opp-600000000 {
 +			opp-hz = /bits/ 64 <600000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <997500 1050000 1102500>;
-+			opp-microvolt-speed0-pvs1-v0 = <926250 975000 1023750>;
-+			opp-microvolt-speed0-pvs2-v0 = <878750 925000 971250>;
-+			opp-microvolt-speed0-pvs3-v0 = <807500 850000 892500>;
++			opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
++			opp-microvolt-speed0-pvs1-v0 = <975000 926250 1023750>;
++			opp-microvolt-speed0-pvs2-v0 = <925000 878750 971250>;
++			opp-microvolt-speed0-pvs3-v0 = <850000 807500 892500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -109,10 +112,10 @@
 +
 +		opp-800000000 {
 +			opp-hz = /bits/ 64 <800000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1045000 1100000 1155000>;
-+			opp-microvolt-speed0-pvs1-v0 = <973750 1025000 1076250>;
-+			opp-microvolt-speed0-pvs2-v0 = <945250 995000 1044750>;
-+			opp-microvolt-speed0-pvs3-v0 = <855000 900000 945000>;
++			opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
++			opp-microvolt-speed0-pvs1-v0 = <1025000 973750 1076250>;
++			opp-microvolt-speed0-pvs2-v0 = <995000 945250 1044750>;
++			opp-microvolt-speed0-pvs3-v0 = <900000 855000 945000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -120,10 +123,10 @@
 +
 +		opp-1000000000 {
 +			opp-hz = /bits/ 64 <1000000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1092500 1150000 1207500>;
-+			opp-microvolt-speed0-pvs1-v0 = <1021250 1075000 1128750>;
-+			opp-microvolt-speed0-pvs2-v0 = <973750 1025000 1076250>;
-+			opp-microvolt-speed0-pvs3-v0 = <902500 950000 997500>;
++			opp-microvolt-speed0-pvs0-v0 = <1150000 1092500 1207500>;
++			opp-microvolt-speed0-pvs1-v0 = <1075000 1021250 1128750>;
++			opp-microvolt-speed0-pvs2-v0 = <1025000 973750 1076250>;
++			opp-microvolt-speed0-pvs3-v0 = <950000 902500 997500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -131,10 +134,10 @@
 +
 +		opp-1200000000 {
 +			opp-hz = /bits/ 64 <1200000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1140000 1200000 1260000>;
-+			opp-microvolt-speed0-pvs1-v0 = <1068750 1125000 1181250>;
-+			opp-microvolt-speed0-pvs2-v0 = <1021250 1075000 1128750>;
-+			opp-microvolt-speed0-pvs3-v0 = <950000 1000000 1050000>;
++			opp-microvolt-speed0-pvs0-v0 = <1200000 1140000 1260000>;
++			opp-microvolt-speed0-pvs1-v0 = <1125000 1068750 1181250>;
++			opp-microvolt-speed0-pvs2-v0 = <1075000 1021250 1128750>;
++			opp-microvolt-speed0-pvs3-v0 = <1000000 950000 1050000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <2>;
@@ -142,10 +145,10 @@
 +
 +		opp-1400000000 {
 +			opp-hz = /bits/ 64 <1400000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1187500 1250000 1312500>;
-+			opp-microvolt-speed0-pvs1-v0 = <1116250 1175000 1233750>;
-+			opp-microvolt-speed0-pvs2-v0 = <1068750 1125000 1181250>;
-+			opp-microvolt-speed0-pvs3-v0 = <997500 1050000 1102500>;
++			opp-microvolt-speed0-pvs0-v0 = <1250000 1187500 1312500>;
++			opp-microvolt-speed0-pvs1-v0 = <1175000 1116250 1233750>;
++			opp-microvolt-speed0-pvs2-v0 = <1125000 1068750 1181250>;
++			opp-microvolt-speed0-pvs3-v0 = <1050000 997500 1102500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <2>;
@@ -377,7 +380,7 @@
  	memory {
  		device_type = "memory";
  		reg = <0x0 0x0>;
-@@ -93,6 +438,15 @@
+@@ -93,6 +441,15 @@
  		};
  	};
  
@@ -393,7 +396,7 @@
  	firmware {
  		scm {
  			compatible = "qcom,scm-ipq806x", "qcom,scm";
-@@ -120,6 +474,78 @@
+@@ -120,6 +477,78 @@
  			reg-names = "lpass-lpaif";
  		};
  
@@ -472,7 +475,7 @@
  		qcom_pinmux: pinmux@800000 {
  			compatible = "qcom,ipq8064-pinctrl";
  			reg = <0x800000 0x4000>;
-@@ -160,6 +586,15 @@
+@@ -160,6 +589,15 @@
  				};
  			};
  
@@ -488,7 +491,7 @@
  			spi_pins: spi_pins {
  				mux {
  					pins = "gpio18", "gpio19", "gpio21";
-@@ -169,6 +604,53 @@
+@@ -169,6 +607,53 @@
  				};
  			};
  
@@ -542,7 +545,7 @@
  			leds_pins: leds_pins {
  				mux {
  					pins = "gpio7", "gpio8", "gpio9",
-@@ -231,6 +713,17 @@
+@@ -231,6 +716,17 @@
  			clock-output-names = "acpu1_aux";
  		};
  
@@ -560,7 +563,7 @@
  		saw0: regulator@2089000 {
  			compatible = "qcom,saw2", "qcom,apq8064-saw2-v1.1-cpu", "syscon";
  			reg = <0x02089000 0x1000>, <0x02009000 0x1000>;
-@@ -243,6 +736,17 @@
+@@ -243,6 +739,17 @@
  			regulator;
  		};
  
@@ -578,7 +581,7 @@
  		gsbi2: gsbi@12480000 {
  			compatible = "qcom,gsbi-v1.0.0";
  			cell-index = <2>;
-@@ -478,6 +982,95 @@
+@@ -478,6 +985,95 @@
  			#reset-cells = <1>;
  		};
  
@@ -674,7 +677,7 @@
  		pcie0: pci@1b500000 {
  			compatible = "qcom,pcie-ipq8064";
  			reg = <0x1b500000 0x1000
-@@ -739,6 +1332,59 @@
+@@ -739,6 +1335,59 @@
  			status = "disabled";
  		};
  
@@ -734,7 +737,7 @@
  		vsdcc_fixed: vsdcc-regulator {
  			compatible = "regulator-fixed";
  			regulator-name = "SDCC Power";
-@@ -814,4 +1460,17 @@
+@@ -814,4 +1463,17 @@
  			};
  		};
  	};

--- a/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
+++ b/target/linux/ipq806x/patches-5.4/083-ipq8064-dtsi-additions.patch
@@ -26,7 +26,7 @@
  		};
  
  		cpu1: cpu@1 {
-@@ -38,11 +50,476 @@
+@@ -38,11 +50,479 @@
  			next-level-cache = <&L2>;
  			qcom,acc = <&acc1>;
  			qcom,saw = <&saw1>;
@@ -85,12 +85,15 @@
 +		compatible = "operating-points-v2-kryo-cpu";
 +		nvmem-cells = <&speedbin_efuse>;
 +
++		/*
++		 * Voltage thresholds are <target min max>
++		 */
 +		opp-384000000 {
 +			opp-hz = /bits/ 64 <384000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1000000>;
-+			opp-microvolt-speed0-pvs1-v0 = <925000>;
-+			opp-microvolt-speed0-pvs2-v0 = <875000>;
-+			opp-microvolt-speed0-pvs3-v0 = <800000>;
++			opp-microvolt-speed0-pvs0-v0 = <1000000 950000 1050000>;
++			opp-microvolt-speed0-pvs1-v0 = <925000 878750 971250>;
++			opp-microvolt-speed0-pvs2-v0 = <875000 831250 918750>;
++			opp-microvolt-speed0-pvs3-v0 = <800000 760000 840000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <0>;
@@ -98,10 +101,10 @@
 +
 +		opp-600000000 {
 +			opp-hz = /bits/ 64 <600000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1050000>;
-+			opp-microvolt-speed0-pvs1-v0 = <975000>;
-+			opp-microvolt-speed0-pvs2-v0 = <925000>;
-+			opp-microvolt-speed0-pvs3-v0 = <850000>;
++			opp-microvolt-speed0-pvs0-v0 = <1050000 997500 1102500>;
++			opp-microvolt-speed0-pvs1-v0 = <975000 926250 1023750>;
++			opp-microvolt-speed0-pvs2-v0 = <925000 878750 971250>;
++			opp-microvolt-speed0-pvs3-v0 = <850000 807500 892500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -109,10 +112,10 @@
 +
 +		opp-800000000 {
 +			opp-hz = /bits/ 64 <800000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1100000>;
-+			opp-microvolt-speed0-pvs1-v0 = <1025000>;
-+			opp-microvolt-speed0-pvs2-v0 = <995000>;
-+			opp-microvolt-speed0-pvs3-v0 = <900000>;
++			opp-microvolt-speed0-pvs0-v0 = <1100000 1045000 1155000>;
++			opp-microvolt-speed0-pvs1-v0 = <1025000 973750 1076250>;
++			opp-microvolt-speed0-pvs2-v0 = <995000 945250 1044750>;
++			opp-microvolt-speed0-pvs3-v0 = <900000 855000 945000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -120,10 +123,10 @@
 +
 +		opp-1000000000 {
 +			opp-hz = /bits/ 64 <1000000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1150000>;
-+			opp-microvolt-speed0-pvs1-v0 = <1075000>;
-+			opp-microvolt-speed0-pvs2-v0 = <1025000>;
-+			opp-microvolt-speed0-pvs3-v0 = <950000>;
++			opp-microvolt-speed0-pvs0-v0 = <1150000 1092500 1207500>;
++			opp-microvolt-speed0-pvs1-v0 = <1075000 1021250 1128750>;
++			opp-microvolt-speed0-pvs2-v0 = <1025000 973750 1076250>;
++			opp-microvolt-speed0-pvs3-v0 = <950000 902500 997500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <1>;
@@ -131,21 +134,21 @@
 +
 +		opp-1200000000 {
 +			opp-hz = /bits/ 64 <1200000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1200000>;
-+			opp-microvolt-speed0-pvs1-v0 = <1125000>;
-+			opp-microvolt-speed0-pvs2-v0 = <1075000>;
-+			opp-microvolt-speed0-pvs3-v0 = <1000000>;
++			opp-microvolt-speed0-pvs0-v0 = <1200000 1140000 1260000>;
++			opp-microvolt-speed0-pvs1-v0 = <1125000 1068750 1181250>;
++			opp-microvolt-speed0-pvs2-v0 = <1075000 1021250 1128750>;
++			opp-microvolt-speed0-pvs3-v0 = <1000000 950000 1050000>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
-+			opp-level = <1>;
++			opp-level = <2>;
 +		};
 +
 +		opp-1400000000 {
 +			opp-hz = /bits/ 64 <1400000000>;
-+			opp-microvolt-speed0-pvs0-v0 = <1250000>;
-+			opp-microvolt-speed0-pvs1-v0 = <1175000>;
-+			opp-microvolt-speed0-pvs2-v0 = <1125000>;
-+			opp-microvolt-speed0-pvs3-v0 = <1050000>;
++			opp-microvolt-speed0-pvs0-v0 = <1250000 1187500 1312500>;
++			opp-microvolt-speed0-pvs1-v0 = <1175000 1116250 1233750>;
++			opp-microvolt-speed0-pvs2-v0 = <1125000 1068750 1181250>;
++			opp-microvolt-speed0-pvs3-v0 = <1050000 997500 1102500>;
 +			opp-supported-hw = <0x1>;
 +			clock-latency-ns = <100000>;
 +			opp-level = <2>;
@@ -506,7 +509,7 @@
  		};
  	};
  
-@@ -93,6 +570,15 @@
+@@ -93,6 +573,15 @@
  		};
  	};
  
@@ -522,7 +525,7 @@
  	firmware {
  		scm {
  			compatible = "qcom,scm-ipq806x", "qcom,scm";
-@@ -120,6 +606,95 @@
+@@ -120,6 +609,95 @@
  			reg-names = "lpass-lpaif";
  		};
  
@@ -618,7 +621,7 @@
  		qcom_pinmux: pinmux@800000 {
  			compatible = "qcom,ipq8064-pinctrl";
  			reg = <0x800000 0x4000>;
-@@ -159,6 +734,15 @@
+@@ -159,6 +737,15 @@
  				};
  			};
  
@@ -634,7 +637,7 @@
  			spi_pins: spi_pins {
  				mux {
  					pins = "gpio18", "gpio19", "gpio21";
-@@ -168,6 +752,53 @@
+@@ -168,6 +755,53 @@
  				};
  			};
  
@@ -688,7 +691,7 @@
  			leds_pins: leds_pins {
  				mux {
  					pins = "gpio7", "gpio8", "gpio9",
-@@ -229,6 +860,17 @@
+@@ -229,6 +863,17 @@
  			clock-output-names = "acpu1_aux";
  		};
  
@@ -706,7 +709,7 @@
  		saw0: regulator@2089000 {
  			compatible = "qcom,saw2", "qcom,apq8064-saw2-v1.1-cpu", "syscon";
  			reg = <0x02089000 0x1000>, <0x02009000 0x1000>;
-@@ -241,6 +883,17 @@
+@@ -241,6 +886,17 @@
  			regulator;
  		};
  
@@ -724,7 +727,7 @@
  		gsbi2: gsbi@12480000 {
  			compatible = "qcom,gsbi-v1.0.0";
  			cell-index = <2>;
-@@ -436,6 +1089,15 @@
+@@ -436,6 +1092,15 @@
  			#power-domain-cells = <1>;
  		};
  
@@ -740,7 +743,7 @@
  		tcsr: syscon@1a400000 {
  			compatible = "qcom,tcsr-ipq8064", "syscon";
  			reg = <0x1a400000 0x100>;
-@@ -448,6 +1110,95 @@
+@@ -448,6 +1113,95 @@
  			#reset-cells = <1>;
  		};
  
@@ -836,7 +839,7 @@
  		pcie0: pci@1b500000 {
  			compatible = "qcom,pcie-ipq8064";
  			reg = <0x1b500000 0x1000
-@@ -601,6 +1352,167 @@
+@@ -601,6 +1355,167 @@
  			perst-gpio = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
  		};
  
@@ -1004,7 +1007,7 @@
  		vsdcc_fixed: vsdcc-regulator {
  			compatible = "regulator-fixed";
  			regulator-name = "SDCC Power";
-@@ -676,4 +1588,17 @@
+@@ -676,4 +1591,17 @@
  			};
  		};
  	};


### PR DESCRIPTION
## In brief
* Rearrange voltage triplets for `opp_table0` to match specs
   * See [Linux kernel documentation on Operating Performance Points](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/devicetree/bindings/opp/opp.txt?h=v5.4.142#n91)
   * `opp-microvolt` and `opp-microvolt-<name>` triplets are `<target min max>`, **NOT** `<min target max>`
   * Avoids CPU *always* at "minimum" voltage, ignoring actual intended target
   * Fixes regression from [`1e25423` ipq806x: refresh dtsi patches](https://github.com/openwrt/openwrt/commit/1e25423be8acb38e979cd5a38abb1ca4cac2837e) from [pull request #4192](https://github.com/openwrt/openwrt/pull/4192 )
   * *Does **not** fix SFTP USB HDD crash, but this should probably be addressed anyways*

### Review request
@Ansuel Whenever you have the time, would you look over this?  I tried to verify my changes, but it's possible I misunderstood or missed something.

## Test case
### Steps
1.  Compile and flash to an IPQ8065 device that does not override `opp_table0` from `qcom-ipq8065.dtsi`
     * Tested with [ZyXEL NBG6817](https://openwrt.org/toh/zyxel/nbg6817 )
2.  Check the CPU voltages for a known frequency
```
/usr/bin/tail -n +1 /sys/kernel/debug/opp/cpu0/opp\:1725000000/supply-0/u_volt_*
```
3.  Compare with the expected results in `qcom-ipq8065.dtsi`
     * With a PVS bin 2, `&opp_table0` → `opp-1725000000` → `opp-microvolt-speed0-pvs2-v0` shows expected values

### Before
*On an NBG6817 with a Qualcomm CPU of PVS bin 2*

```
/usr/bin/tail -n +1 /sys/kernel/debug/opp/cpu0/opp\:1725000000/supply-0/u_volt_*
==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_max <==
1260000

==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_min <==
1200000

==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_target <==
1140000
```
*Notice how `u_volt_target` is below `u_volt_min`, which doesn't make sense.  Separately, checking the regulator summary shows that the voltage actually gets set to below the minimum.*

### After
```
/usr/bin/tail -n +1 /sys/kernel/debug/opp/cpu0/opp\:1725000000/supply-0/u_volt_*
==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_max <==
1260000

==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_min <==
1140000

==> /sys/kernel/debug/opp/cpu0/opp:1725000000/supply-0/u_volt_target <==
1200000
```
*Notice how `u_volt_target` is above `u_volt_min` and still below `u_volt_max`, which makes more sense.  Also notice how the target voltage matches before [`1e25423` ipq806x: refresh dtsi patches](https://github.com/openwrt/openwrt/commit/1e25423be8acb38e979cd5a38abb1ca4cac2837e).*

### Additional notes
To check voltages and frequencies at run time, use…

```
/bin/cat /sys/kernel/debug/regulator/regulator_summary && /bin/cat /sys/kernel/debug/clk/clk_summary | grep "hfpll"
```

Also see the [Linux kernel documentation on Operating Performance Points](
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/Documentation/devicetree/bindings/opp/opp.txt?h=v5.4.142#n91)

---

*As to my ongoing diagnosing of the [Deja Dup SFTP upload to USB 3.0 HDD crash](https://lists.openwrt.org/pipermail/openwrt-devel/2021-August/036026.html ), this does **not** fix that issue, but [I am using this change as part of my backport tests](https://github.com/openwrt/openwrt/compare/openwrt-21.02...digitalcircuit:openwrt-21.02-cpufreq-dtsivolt-cache-fix-opp-order ).*