### PR TITLE
ath79: add support for GL.iNet GL-XE300

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "glinet,gl-xe300", "qca,qca9531";
+	model = "GL.iNet GL-XE300";
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_lte_power {
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			gpio-export,name = "lte_power";
+			gpio-export,output = <1>;
+		};
+
+		gpio_sd_detect {
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			gpio-export,name = "sd_detect";
+			gpio-export,output = <0>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			label = "green:lan";
+		};
+
+		wan {
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			label = "green:wan";
+		};
+
+		wlan {
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			label = "green:wlan";
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lte {
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			label = "green:lte";
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "kernel";
+				reg = <0x60000 0x400000>;
+			};
+
+			partition@460000 {
+				label = "nor_reserved";
+				reg = <0x460000 0xba0000>;
+			};
+		};
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x8000000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	mtd-mac-address-increment = <1>;
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -150,6 +150,22 @@ define Device/glinet_gl-e750
 endef
 TARGET_DEVICES += glinet_gl-e750
 
+define Device/glinet_gl-xe300
+  SOC := qca9531
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-XE300
+  DEVICE_PACKAGES := kmod-usb2 block-mount kmod-usb-serial-ch341
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 131072k
+  PAGESIZE := 2048
+  VID_HDR_OFFSET := 2048
+  BLOCKSIZE := 128k
+  IMAGES += factory.img
+  IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_gl-xe300
+
 # fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + 0xff)
 define Device/netgear_ath79_nand
   DEVICE_VENDOR := NETGEAR


### PR DESCRIPTION
The GL.iNet GL-XE300 is a 4G LTE Wireless router, based on QCA9531 SoC.

Specifications:

 - SoC: QCA9531 (650MHz)
 - RAM: DDR2 128M
 - Flash: SPI NOR 16M + SPI NAND 128M
 - WiFi: 2.4GHz with 2 antennas
 - Ethernet:
   - 1x LAN (10/100M)
   - 1x WAN (10/100M)
 - LTE:
 - USB: 1x USB 2.0 port
 - UART:
   - 3.3V, TX, RX, GND / 115200 8N1

MAC addresses as verified by OEM firmware:
    
 |use|address|source|
 |-----|-----------|---------|
 |LAN|*:c5|art 0x0 (label)|
 |WAN|*:c6|label + 1|
 |WLAN|*:c7|art 0x1002|

Installation via U-Boot rescue:

 i. Hold power button for 6 seconds
 ii. Go to http://192.168.1.1
 iii. Select the OpenWrt factory image and start upgrade
 iiii. Wait for the router to flash new firmware and reboot

Revert to stock firmware:

 i. Download the stock firmware from GL.Inet website
 ii. Use the same method explained above to flash the stock firmware

Signed-off-by: Victorien Molle <victorien.molle@wifirst.fr>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
