### PR TITLE
ath79: add support for TP-Link TL-WR841HP v2

### DIFF
--- a/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "TP-Link TL-WR841HP v2";
+	compatible = "tplink,tl-wr841hp-v2", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &wmac;
+	};
+	
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+		
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x020000 0x7d0000>;
+			};
+
+			art: partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gpio {
+	gpio_ext_lna0 {
+		gpio-hog;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:ext:lna0";
+	};
+
+	gpio_ext_lna1 {
+		gpio-hog;
+		gpios = <19 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "tp-link:ext:lna1";
+	};
+};
+
+&wmac {
+	status = "okay";
+	
+	mtd-cal-data = <&art 0x1000>;
+	
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth0 {
+	status = "okay";
+	
+	phy-handle = <&swphy0>;
+
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cell-names = "mac-address";
+	
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+	};
+};
+
+&uboot {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_uboot_1fc00: macaddr@1fc00 {
+		reg = <0x1fc00 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -372,6 +372,7 @@ tplink,tl-wpa8630p-v2.0-eu|\
 tplink,tl-wpa8630p-v2.1-eu)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3c"
 	;;
+tplink,tl-wr841hp-v2|\
 tplink,tl-wr842n-v2)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x04"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -410,6 +410,7 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1" "5:lan:4"
 		;;
+	tplink,tl-wr841hp-v2|\
 	tplink,tl-wr842n-v2|\
 	tplink,tl-wr941hp-v1)
 		ucidef_set_interface_wan "eth1"

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -754,6 +754,15 @@ define Device/tplink_tl-wr810n-v2
 endef
 TARGET_DEVICES += tplink_tl-wr810n-v2
 
+define Device/tplink_tl-wr841hp-v2
+  $(Device/tplink-8mlzma)
+  SOC := ar9344
+  DEVICE_MODEL := TL-WR841HP
+  DEVICE_VARIANT := v2
+  TPLINK_HWID := 0x08411002
+endef
+TARGET_DEVICES += tplink_tl-wr841hp-v2
+
 define Device/tplink_tl-wr841hp-v3
   $(Device/tplink-8mlzma)
   SOC := qca9533


### PR DESCRIPTION
This is a patch for **TP-Link TL-WR841HP v2**

**Specifications:**
- AR9344 SoC, 8 MB nor flash, 64 MB DDR2 RAM
- 2x2 9dBi antenna, wifi 2.4Ghz 300Mbps
- 4x Ethernet LAN 10/100, 1x Ethernet WAN 10/100
- 1x WAN, 4x LAN, Wifi, PWR, WPS, SYSTEM Leds
- Reset/WPS button
- Serial UART at J4 onboard: 3.3v GND RX TX, 1152008N1

**MAC addresses as verified by OEM firmware:**

Vendor-----OpenWrt---Address
LAN--------eth0--------label
WAN-------eth1--------label (+1)
WLAN------phy0-------label

The label MAC address was found in u-boot 0x1fc00.

**Installation:**
To install openwrt,
 - set the device's SSID to each of the following lines,
   making sure to include the backticks.
 - set the ssid and click save between each line.
```
`echo "httpd -k"> /tmp/s`
`echo "sleep 10">> /tmp/s`
`echo "httpd -r&">> /tmp/s`
`echo "sleep 10">> /tmp/s`
`echo "httpd -k">> /tmp/s`
`echo "sleep 10">> /tmp/s`
`echo "httpd -f">> /tmp/s`
`sh /tmp/s`
```
- Now, wait 60 sec.
- After the reboot sequence, the router may have fallen back to
  its default IP address with the default credentials (admin:admin).
- Log in to the web interface and go the the firmware upload page.
  Select "openwrt-ath79-generic-tplink_tl-wr841hp-v2-squashfs-factory.bin"
  and you're done : the system now accepts the openwrt.

**Forum support topic:**
https://forum.openwrt.org/t/support-for-tplink-tl-wr841hp-v2/69445/

Signed-off-by: Saiful Islam <si87868@gmail.com>