### PR TITLE
USB ethernet gadget support for Raspberry PI Zero W

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -147,6 +147,7 @@ define KernelPackage/usb-gadget-ehci-debug
 	CONFIG_USB_G_DBGP_PRINTK=n
   DEPENDS:=+kmod-usb-gadget +kmod-usb-lib-composite +kmod-usb-gadget-serial
   FILES:=$(LINUX_DIR)/drivers/usb/gadget/legacy/g_dbgp.ko
+  AUTOLOAD:=$(call AutoLoad,52,g_dbgp)
   $(call AddDepends/usb)
 endef
 
@@ -169,7 +170,7 @@ define KernelPackage/usb-gadget-eth
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_ecm_subset.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_rndis.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_ether.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_ecm)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_ecm g_ether)
   $(call AddDepends/usb)
 endef
 
@@ -207,7 +208,7 @@ define KernelPackage/usb-gadget-serial
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_obex.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_serial.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_serial.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_acm)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_acm g_serial)
   $(call AddDepends/usb)
 endef
 
@@ -224,7 +225,7 @@ define KernelPackage/usb-gadget-mass-storage
   FILES:= \
 	$(LINUX_DIR)/drivers/usb/gadget/function/usb_f_mass_storage.ko \
 	$(LINUX_DIR)/drivers/usb/gadget/legacy/g_mass_storage.ko
-  AUTOLOAD:=$(call AutoLoad,52,usb_f_mass_storage)
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_mass_storage g_mass_storage)
   $(call AddDepends/usb)
 endef
 

--- a/target/linux/bcm27xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm27xx/base-files/etc/board.d/02_network
@@ -24,7 +24,7 @@ raspberrypi,4-model-b)
 	;;
 
 raspberrypi,model-zero-w)
-	ucidef_set_interface_lan "wlan0"
+	ucidef_set_interface_lan "usb0"
 	;;
 esac
 

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -77,7 +77,8 @@ define Device/rpi
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	cypress-nvram-43430-sdio-rpi-zero-w \
-	kmod-brcmfmac wpad-basic-wolfssl
+	kmod-brcmfmac wpad-basic-wolfssl \
+	kmod-usb-dwc2 kmod-usb-net-rndis kmod-usb-gadget-cdc-composite
 endef
 ifeq ($(SUBTARGET),bcm2708)
   TARGET_DEVICES += rpi

--- a/target/linux/bcm27xx/image/distroconfig.txt
+++ b/target/linux/bcm27xx/image/distroconfig.txt
@@ -8,6 +8,7 @@
 # See https://www.raspberrypi.org/documentation/configuration/uart.md
 [pi0w]
 dtoverlay=disable-bt
+dtoverlay=dwc2
 [pi3]
 dtoverlay=disable-bt
 [pi4]


### PR DESCRIPTION
This PR enables the users of Raspberry PI Zero W devices to use the device without any external UART connected. This was needed before, because the device doesn't have any other network connectivity, and WLAN won't come up without setting country codes in Raspbian before using this device with OpenWRT.