### PR TITLE
ath79: merge D-Link DAP-2695 with dtsi

### DIFF
--- a/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
@@ -56,7 +56,7 @@
 		#size-cells = <1>;
 		compatible = "mx25l12805d";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
@@ -160,5 +160,5 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	mtd-cal-data = <&art 0x1000>;
 };

--- a/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dap-2695-a1.dts
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qca955x.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "qca955x_dlink_dap-2xxx.dtsi"
 
 / {
 	compatible = "dlink,dap-2695-a1", "qca,qca9558";
@@ -48,69 +45,29 @@
 	};
 };
 
-&spi {
-	status = "okay";
+&partitions {
+	partition@70000 {
+		label = "firmware";
+		reg = <0x070000 0xf00000>;
+		compatible = "wrg";
+	};
 
-	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "mx25l12805d";
-		reg = <0>;
-		spi-max-frequency = <50000000>;
+	partition@f70000 {
+		label = "captival";
+		reg = <0xf70000 0x070000>;
+		read-only;
+	};
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+	partition@fe0000 {
+		label = "certificate";
+		reg = <0xfe0000 0x010000>;
+		read-only;
+	};
 
-			partition@0 {
-				label = "u-boot";
-				reg = <0x000000 0x040000>;
-				read-only;
-			};
-
-			partition@40000 {
-				label = "bdcfg";
-				reg = <0x040000 0x010000>;
-				read-only;
-			};
-
-			partition@50000 {
-				label = "rgdb";
-				reg = <0x050000 0x010000>;
-				read-only;
-			};
-
-			partition@60000 {
-				label = "langpack";
-				reg = <0x060000 0x010000>;
-				read-only;
-			};
-
-			partition@70000 {
-				compatible = "wrg";
-				label = "firmware";
-				reg = <0x070000 0xf00000>;
-			};
-
-			partition@f70000 {
-				label = "captival";
-				reg = <0xf70000 0x070000>;
-				read-only;
-			};
-
-			partition@fe0000 {
-				label = "certificate";
-				reg = <0xfe0000 0x010000>;
-				read-only;
-			};
-
-			art: partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
+	art: partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
 	};
 };
 
@@ -155,10 +112,4 @@
 
 &pcie0 {
 	status = "okay";
-};
-
-&wmac {
-	status = "okay";
-
-	mtd-cal-data = <&art 0x1000>;
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -18,10 +18,6 @@ case "$FIRMWARE" in
 	avm,fritzdvbc)
 		caldata_extract_reverse "urlader" 0x1541 0x440
 		;;
-	dlink,dap-2695-a1)
-		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii bdcfg "wlanmac")
-		;;
 	dlink,dir-505|\
 	dlink,dir-825-c1|\
 	dlink,dir-835-a1)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -28,6 +28,7 @@ case "$board" in
 		;;
 	dlink,dap-2660-a1|\
 	dlink,dap-2680-a1|\
+	dlink,dap-2695-a1|\
 	dlink,dap-3662-a1)
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -842,7 +842,7 @@ define Device/dlink_dap-2695-a1
   SOC := qca9558
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
   DEVICE_VENDOR := D-Link
-  DEVICE_MODEL := DAP-2965
+  DEVICE_MODEL := DAP-2695
   DEVICE_VARIANT := A1
   IMAGES := factory.img sysupgrade.bin
   IMAGE_SIZE := 15360k

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -839,20 +839,13 @@ endef
 TARGET_DEVICES += dlink_dap-2680-a1
 
 define Device/dlink_dap-2695-a1
+  $(Device/dlink_dap-2xxx)
   SOC := qca9558
-  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DAP-2695
   DEVICE_VARIANT := A1
-  IMAGES := factory.img sysupgrade.bin
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
   IMAGE_SIZE := 15360k
-  IMAGE/default := append-kernel | pad-offset 65536 160
-  IMAGE/factory.img := $$(IMAGE/default) | append-rootfs | wrgg-pad-rootfs | \
-	mkwrggimg | check-size
-  IMAGE/sysupgrade.bin := $$(IMAGE/default) | mkwrggimg | append-rootfs | \
-	wrgg-pad-rootfs | check-size | append-metadata
-  KERNEL := kernel-bin | append-dtb | relocate-kernel | lzma
-  KERNEL_INITRAMFS := $$(KERNEL) | mkwrggimg
   DAP_SIGNATURE := wapac02_dkbs_dap2695
   SUPPORTED_DEVICES += dap-2695-a1
 endef


### PR DESCRIPTION
Further devices from the series have been added in the meantime,
introducing `qca955x_dlink_dap-2xxx.dtsi`.

Thus, merge support for DAP-2695 with the existing dtsi.
SPI frequency will be increased to 50 MHz.

This implies factory images can now be flashed via the regular
OEM Web UI, as well as the bootloader recovery.

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>