### PR TITLE
mt7621:Added PanguBox-M1 evaluation board support.

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -430,6 +430,16 @@ define Device/d-team_pbr-m1
 endef
 TARGET_DEVICES += d-team_pbr-m1
 
+define Device/pgb-m1
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DTS := PGB-M1
+  IMAGE_SIZE := 32768k
+  DEVICE_TITLE := PanguBox PGB-M1
+  DEVICE_PACKAGES := kmod-usb3 kmod-usb-ledtrig-usbport kmod-i2c-mt762x kmod-rtc-pcf8563 kmod-nvme nvme-cli
+endef
+TARGET_DEVICES += pgb-m1
+
 define Device/edimax_ra21s
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Added PanguBox-M1 evaluation board support in target/linux/ramips/image/mt7621.mk.