### PR TITLE
realtek: add ZyXEL GS1900-24HPv2 support

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -14,7 +14,8 @@ d-link,dgs-1210-10p|\
 zyxel,gs1900-8|\
 zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2|\
-zyxel,gs1900-10hp)
+zyxel,gs1900-10hp|\
+zyxel,gs1900-24hp-v2)
 	idx="$(find_mtd_index u-boot-env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x400" "0x10000"

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -61,6 +61,9 @@ zyxel,gs1900-8hp-v1|\
 zyxel,gs1900-8hp-v2)
 	ucidef_set_poe 70 "$lan_list"
 	;;
+zyxel,gs1900-24hp-v2)
+	ucidef_set_poe 170 "$lan_list"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v2.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v2.dts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_zyxel_gs1900.dtsi"
+
+/ {
+	compatible = "zyxel,gs1900-24hp-v2", "realtek,rtl838x-soc";
+	model = "ZyXEL GS1900-24HP v2 Switch";
+
+	/* i2c of the left SFP cage: port 25 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 25 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of the right SFP cage: port 26 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&mdio {
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+
+	INTERNAL_PHY(24)
+	INTERNAL_PHY(26)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+
+		port@24 {
+			reg = <24>;
+			label = "lan25";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan26";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
+	};
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -153,4 +153,13 @@ define Device/zyxel_gs1900-8hp-v2
 endef
 TARGET_DEVICES += zyxel_gs1900-8hp-v2
 
+define Device/zyxel_gs1900-24hp-v2
+  $(Device/zyxel_gs1900)
+  SOC := rtl8382
+  DEVICE_MODEL := GS1900-24HP
+  DEVICE_VARIANT := v2
+  ZYXEL_VERS := ABTP
+endef
+TARGET_DEVICES += zyxel_gs1900-24hp-v2
+
 $(eval $(call BuildImage))


### PR DESCRIPTION
This patch adds support for the RTL8382 based GS1900-24HPv2 from ZyXEL.

Signed-off-by: Soma Zambelly <zambelly.soma@gmail.com>