### PR TITLE
ramips: use soft LED lighting by default for phicomm k2x devices

### DIFF
--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -5,10 +5,10 @@
 
 / {
 	aliases {
-		led-boot = &led_blue;
-		led-failsafe = &led_blue;
-		led-running = &led_blue;
-		led-upgrade = &led_blue;
+		led-boot = &led_red;
+		led-failsafe = &led_red;
+		led-running = &led_yellow;
+		led-upgrade = &led_red;
 	};
 
 	keys {
@@ -24,18 +24,17 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_blue: blue {
+		blue {
 			label = "blue:status";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-			default-state = "on";
 		};
 
-		yellow {
+		led_yellow: yellow {
 			label = "yellow:status";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 		};
 
-		red {
+		led_red: red {
 			label = "red:status";
 			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		};

--- a/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
+++ b/target/linux/ramips/dts/mt7621_phicomm_k2p.dts
@@ -8,26 +8,26 @@
 	model = "Phicomm K2P";
 
 	aliases {
-		led-boot = &led_blue;
-		led-failsafe = &led_blue;
-		led-running = &led_blue;
-		led-upgrade = &led_blue;
+		led-boot = &led_red;
+		led-failsafe = &led_red;
+		led-running = &led_yellow;
+		led-upgrade = &led_red;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		stat_r {
+		led_red: red {
 			label = "red:status";
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 
-		stat_y {
+		led_yellow: yellow {
 			label = "yellow:status";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		led_blue: stat_b {
+		blue {
 			label = "blue:status";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
For Phicomm K2x devices, the brightness of the blue LED is very high, which can
nearly illuminate the whole room, that's too bad. Yellow LED has the softest
brightness so choose it as running status LED and use red LED to show system
status, just like Phicomm K2T.

Signed-off-by: Shiji Yang <yangshiji66@qq.com>


