### PR TITLE
mt7621: add support for PanguBox PGB-M1 reference board

### DIFF
--- a/target/linux/ramips/dts/mt7621_pangubox_pgb-m1.dts
+++ b/target/linux/ramips/dts/mt7621_pangubox_pgb-m1.dts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible =  "PanguBox,PGB-M1","mediatek,mt7621-soc";
+	model = "PanguBox PGB-M1";
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_green;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_power_green: sys {
+			label = "blue:sys";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <32000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+
+            partition@50 {
+                label = "fullflash";
+                reg = <0x0 0x0>;
+            };
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1715,3 +1715,13 @@ define Device/zyxel_wap6805
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_wap6805
+
+define Device/pangubox_pgb-m1
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DTS := PGB-M1
+  IMAGE_SIZE := 32768k
+  DEVICE_TITLE := PanguBox PGB-M1
+  DEVICE_PACKAGES := kmod-usb3 kmod-usb-ledtrig-usbport kmod-i2c-mt762x kmod-rtc-pcf8563 kmod-nvme nvme-cli kmod-mt7915e
+endef
+TARGET_DEVICES += pangubox_pgb-m1


### PR DESCRIPTION
PanguBox PGB-M1 reference board

Specifications:

CPU:    MediaTek MT7621AT@880MHz
DRAM:   512Mb DDR3
Flash:  32Mb SPI-NOR
WAN:    1x
LAN:    4x
WLAN:   MT7905DAN(MAC) + MT7975DN(RF)
USB:    1x 3.0
Button: 1x reset
LEDs:   a lot
4G module:Sierra Wireless AirPrime EM7355
Slot：1x sim card slot

Base configuration:
    1.Run the following command to open the OpenWrt Graphical configuration interface.
        make menuconfig
    2.Selecting a Hardware Platform
        Location:
            ->Target System(MediaTek Ralink MIPS)
            ->Subtarget(MT7621 based boards)
            ->Target Profile(PanguBox PGB-M1)
    3.Selecting LuCI package
        (1)LuCI interface with Uhttpd as Webserver
        Location:
            ->LuCI
                -> 1.Collections
                <*> luci
           Location:
        (2)Select the language for the LuCI Web display
            ->LuCI
                ->2.Modules
                ->Translations
                <*>English(en)
                <*>Chinese Simplified(zh_Hans)
                ......

Build the project：

    Run the following command in the project root directory.
    make V=99

Obtaining firmware:
    The firmware is stored in the following directory.
    ${HOME}/openwrt/bin/targets/ramips/mt7621

Installation:

    1. Upgrade the firmware using tftp(PGB-M1 is provided by default)
    Note:
        The development board must be in the same network segment as the PC.
    (1)Use a network cable to connect the LAN interface of the development
        board to the PC network port.
    (2)Set the IP address of the development board to a static IP address.
        For example: 192.168.1.1
    (3)Set the IP address of the TFTP server IP address.
        For example: 192.168.1.100
    (4)Reboot the board.
    (5)Press key 2 on your keyboard to start burning the firmware.
    (6)Input device IP (192.168.1.1) ==:<device ip>
    (7)Input server IP (192.168.1.100) ==:<server ip>
    (8)Input Linux Kernel filename () ==:<kernel image>
    Example:
        ......
        [After the development board is powered on, please press no. 2 to select the burning mode of the firmware.]
        ......
        2: Load Firmware then write to Flash via TFTP
         Warning!! Erase Linux in Flash then burn new one. Are you sure? (Y/N)
         Please Input new ones /or Ctrl-C to discard
         Input device IP (192.168.1.1) ==:192.168.1.1
         Input server IP (192.168.1.100) ==:192.168.1.100
         Input Linux Kernel filename () ==:openwrt-ramips-mt7621-pangubox_pgb-m1-squashfs-sysupgrade.bin

         NetLoop,call eth_halt !
         NetLoop,call eth_init !
         Ralink GMAC initializing
         TFTP from server 192.168.1.100; our IP address is 192.168.1.1
         Filename 'openwrt-ramips-mt7621-pangubox_pgb-m1-squashfs-sysupgrade.bin'.

         TIMEOUT_COUNT=10,Load address: 0x80100000
         Loading: Got ARP REQUEST, return our IP
         Got ARP REQUEST, return our IP
         ......

    2. Use Web Browser Upgrade the Firmware

    (1)Use a network cable to connect the LAN interface of the development
        board to the PC network port.
    (2)Set the IP address of the computer to a static IP address.
        For example, 192.168.1.100.
    (3)Restart the development board and press the reset button for about 5 seconds.
    (4)In this case, the following interface is displayed in logs
       printed by the serial port.
    Example:
        ______________________________________________________
        |                                                    |
        |            HTTPD Recovery Module v3.0              |
        |                                                    |
        | Note:Please Use Web Browser Upgrade the Firmware ! |
        |                                                    |
        |          Copyright 2020 PandoraBox Team            |
        |____________________________________________________|

        [kernel]uOS Version: v2.0
        [kernel]PWM-LED Thread started!!
        [kernel]Task Thread started!!
        [TCP/IP]ETH0 MAC:00:20:76:00:00:1E

        [TCP/IP]Max ReceiveBuffer:1492!
        [TCP/IP]IP:192.168.1.1
        [TCP/IP]Netmask:255.255.255.0
        [TCP/IP]Default Router:0.0.0.0
        [DHCPD]Server IP:192.168.1.1
        [DHCPD]IP Pool:192.168.1.100-192.168.1.150

        Ralink GMAC initializing
        [kernel]Enter uOS core task!
        waiting ......
    (5)In the browser, access the following IP address
        192.168.1.1
        Then, follow the instructions on the upgrade page.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
