### PR TITLE
sunxi: add rtc-sun6i package

### DIFF
--- a/target/linux/sunxi/modules.mk
+++ b/target/linux/sunxi/modules.mk
@@ -2,6 +2,24 @@
 #
 # Copyright (C) 2013-2016 OpenWrt.org
 
+define KernelPackage/rtc-sun6i
+    SUBMENU:=$(OTHER_MENU)
+    TITLE:=Sunxi SoC sun6i RTC support
+    DEPENDS:=@TARGET_sunxi
+    $(call AddDepends/rtc)
+    KCONFIG:= \
+	CONFIG_RTC_DRV_SUN6I \
+	CONFIG_RTC_CLASS=y
+    FILES:=$(LINUX_DIR)/drivers/rtc/rtc-sun6i.ko
+    AUTOLOAD:=$(call AutoLoad,50,rtc-sun6i)
+endef
+
+define KernelPackage/rtc-sun6i/description
+ Support for the RTC found in some Allwinner SoCs like the A31 or the A64
+endef
+
+$(eval $(call KernelPackage,rtc-sun6i))
+
 define KernelPackage/rtc-sunxi
     SUBMENU:=$(OTHER_MENU)
     TITLE:=Sunxi SoC built-in RTC support


### PR DESCRIPTION
From linux source code , rtc-sunxi package is only for a10,a20. 
```
	{ .compatible = "allwinner,sun4i-a10-rtc", .data = &data_year_param[0] },
	{ .compatible = "allwinner,sun7i-a20-rtc", .data = &data_year_param[1] },
	{ ... },
```
but rtc-sun6i can support more cpu.
```
	{ .compatible = "allwinner,sun6i-a31-rtc" },
	{ .compatible = "allwinner,sun8i-a23-rtc" },
	{ .compatible = "allwinner,sun8i-h3-rtc" },
	{ .compatible = "allwinner,sun8i-r40-rtc" },
	{ .compatible = "allwinner,sun8i-v3-rtc" },
	{ .compatible = "allwinner,sun50i-h5-rtc" },
	{ .compatible = "allwinner,sun50i-h6-rtc" },
	{ ... },
```

EDIT: This module maybe can help to provide clock to detect sdio wifi on board , and USB 3.0 on H6 depend on this.
```
[    2.948430] sun6i-rtc 1f00000.rtc: registered as rtc0
[    2.953565] sun6i-rtc 1f00000.rtc: setting system clock to 1970-01-01T00:01:42 UTC (102)
[    2.961823] sun6i-rtc 1f00000.rtc: RTC enabled
[ ... ]
[    4.328497] sunxi-mmc 1c10000.mmc: allocated mmc-pwrseq
[    4.591300] mmc1: new high speed SDIO card at address 0001  
```