### PR TITLE
ipq806x:TP-Link C2600: fix MAC address fetching for eth ports

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-ad7200-c2600.dtsi
@@ -82,152 +82,158 @@
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 
-			partition@0 {
-				label = "SBL1";
-				reg = <0x0 0x20000>;
-				read-only;
-			};
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 
-			partition@20000 {
-				label = "MIBIB";
-				reg = <0x20000 0x20000>;
-				read-only;
-			};
+				partition@0 {
+					label = "SBL1";
+					reg = <0x0 0x20000>;
+					read-only;
+				};
 
-			partition@40000 {
-				label = "SBL2";
-				reg = <0x40000 0x20000>;
-				read-only;
-			};
+				partition@20000 {
+					label = "MIBIB";
+					reg = <0x20000 0x20000>;
+					read-only;
+				};
 
-			partition@60000 {
-				label = "SBL3";
-				reg = <0x60000 0x30000>;
-				read-only;
-			};
+				partition@40000 {
+					label = "SBL2";
+					reg = <0x40000 0x20000>;
+					read-only;
+				};
 
-			partition@90000 {
-				label = "DDRCONFIG";
-				reg = <0x90000 0x10000>;
-				read-only;
-			};
+				partition@60000 {
+					label = "SBL3";
+					reg = <0x60000 0x30000>;
+					read-only;
+				};
 
-			partition@a0000 {
-				label = "SSD";
-				reg = <0xa0000 0x10000>;
-				read-only;
-			};
+				partition@90000 {
+					label = "DDRCONFIG";
+					reg = <0x90000 0x10000>;
+					read-only;
+				};
 
-			partition@b0000 {
-				label = "TZ";
-				reg = <0xb0000 0x30000>;
-				read-only;
-			};
+				partition@a0000 {
+					label = "SSD";
+					reg = <0xa0000 0x10000>;
+					read-only;
+				};
 
-			partition@e0000 {
-				label = "RPM";
-				reg = <0xe0000 0x20000>;
-				read-only;
-			};
+				partition@b0000 {
+					label = "TZ";
+					reg = <0xb0000 0x30000>;
+					read-only;
+				};
 
-			partition@100000 {
-				label = "fs-uboot";
-				reg = <0x100000 0x70000>;
-				read-only;
-			};
+				partition@e0000 {
+					label = "RPM";
+					reg = <0xe0000 0x20000>;
+					read-only;
+				};
 
-			partition@170000 {
-				label = "uboot-env";
-				reg = <0x170000 0x40000>;
-				read-only;
-			};
+				partition@100000 {
+					label = "fs-uboot";
+					reg = <0x100000 0x70000>;
+					read-only;
+				};
 
-			partition@1b0000 {
-				label = "radio";
-				reg = <0x1b0000 0x40000>;
-				read-only;
-			};
+				partition@170000 {
+					label = "uboot-env";
+					reg = <0x170000 0x40000>;
+					read-only;
+				};
 
-			partition@1f0000 {
-				label = "os-image";
-				reg = <0x1f0000 0x400000>;
-			};
+				partition@1b0000 {
+					label = "radio";
+					reg = <0x1b0000 0x40000>;
+					read-only;
+				};
 
-			partition@5f0000 {
-				label = "rootfs";
-				reg = <0x5f0000 0x1900000>;
-			};
+				partition@1f0000 {
+					label = "os-image";
+					reg = <0x1f0000 0x400000>;
+				};
 
-			defaultmac: partition@1ef0000 {
-				label = "default-mac";
-				reg = <0x1ef0000 0x00200>;
-				read-only;
-			};
+				partition@5f0000 {
+					label = "rootfs";
+					reg = <0x5f0000 0x1900000>;
+				};
 
-			partition@1ef0200 {
-				label = "pin";
-				reg = <0x1ef0200 0x00200>;
-				read-only;
-			};
+				defaultmac: partition@1ef0000 {
+					label = "default-mac";
+					reg = <0x1ef0000 0x00200>;
+					read-only;
+				};
 
-			partition@1ef0400 {
-				label = "product-info";
-				reg = <0x1ef0400 0x0fc00>;
-				read-only;
-			};
+				partition@1ef0200 {
+					label = "pin";
+					reg = <0x1ef0200 0x00200>;
+					read-only;
+				};
 
-			partition@1f00000 {
-				label = "partition-table";
-				reg = <0x1f00000 0x10000>;
-				read-only;
-			};
+				partition@1ef0400 {
+					label = "product-info";
+					reg = <0x1ef0400 0x0fc00>;
+					read-only;
+				};
 
-			partition@1f10000 {
-				label = "soft-version";
-				reg = <0x1f10000 0x10000>;
-				read-only;
-			};
+				partition@1f00000 {
+					label = "partition-table";
+					reg = <0x1f00000 0x10000>;
+					read-only;
+				};
 
-			partition@1f20000 {
-				label = "support-list";
-				reg = <0x1f20000 0x10000>;
-				read-only;
-			};
+				partition@1f10000 {
+					label = "soft-version";
+					reg = <0x1f10000 0x10000>;
+					read-only;
+				};
 
-			partition@1f30000 {
-				label = "profile";
-				reg = <0x1f30000 0x10000>;
-				read-only;
-			};
+				partition@1f20000 {
+					label = "support-list";
+					reg = <0x1f20000 0x10000>;
+					read-only;
+				};
 
-			partition@1f40000 {
-				label = "default-config";
-				reg = <0x1f40000 0x10000>;
-				read-only;
-			};
+				partition@1f30000 {
+					label = "profile";
+					reg = <0x1f30000 0x10000>;
+					read-only;
+				};
 
-			partition@1f50000 {
-				label = "user-config";
-				reg = <0x1f50000 0x40000>;
-				read-only;
-			};
+				partition@1f40000 {
+					label = "default-config";
+					reg = <0x1f40000 0x10000>;
+					read-only;
+				};
 
-			partition@1f90000 {
-				label = "qos-db";
-				reg = <0x1f90000 0x40000>;
-				read-only;
-			};
+				partition@1f50000 {
+					label = "user-config";
+					reg = <0x1f50000 0x40000>;
+					read-only;
+				};
 
-			partition@1fd0000 {
-				label = "usb-config";
-				reg = <0x1fd0000 0x10000>;
-				read-only;
-			};
+				partition@1f90000 {
+					label = "qos-db";
+					reg = <0x1f90000 0x40000>;
+					read-only;
+				};
 
-			partition@1fe0000 {
-				label = "log";
-				reg = <0x1fe0000 0x20000>;
-				read-only;
+				partition@1fd0000 {
+					label = "usb-config";
+					reg = <0x1fd0000 0x10000>;
+					read-only;
+				};
+
+				partition@1fe0000 {
+					label = "log";
+					reg = <0x1fe0000 0x20000>;
+					read-only;
+				};
 			};
 		};
 	};


### PR DESCRIPTION
The partitions that have compatible property set are skipped by mtd if
they are not contained inside partitions property and this breaks
fetching MAC address from "default-mac" partition.

Fix this by defining all the partitions inside partitions property with
compatible = "fixed-partitions" as nvmem requires the standard
partitions scheme to work correctly.

Fixes: FS#3945

Signed-off-by: Filip Matijević <filip.matijevic.pz@gmail.com>
Reviewed-by: Ansuel Smith <ansuelsmth@gmail.com>
