### PR TITLE
kernel: fix warning about unused try_to_force_load

### DIFF
--- a/target/linux/generic/hack-5.10/204-module_strip.patch
+++ b/target/linux/generic/hack-5.10/204-module_strip.patch
@@ -104,7 +104,23 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config MODULES_TREE_LOOKUP
 --- a/kernel/module.c
 +++ b/kernel/module.c
-@@ -3247,9 +3247,11 @@ static int setup_load_info(struct load_i
+@@ -1285,6 +1285,7 @@ static struct module_attribute *modinfo_
+ 
+ static const char vermagic[] = VERMAGIC_STRING;
+ 
++#if defined(CONFIG_MODVERSIONS) || !defined(CONFIG_MODULE_STRIPPED)
+ static int try_to_force_load(struct module *mod, const char *reason)
+ {
+ #ifdef CONFIG_MODULE_FORCE_LOAD
+@@ -1296,6 +1297,7 @@ static int try_to_force_load(struct modu
+ 	return -ENOEXEC;
+ #endif
+ }
++#endif
+ 
+ #ifdef CONFIG_MODVERSIONS
+ 
+@@ -3247,9 +3249,11 @@ static int setup_load_info(struct load_i
  
  static int check_modinfo(struct module *mod, struct load_info *info, int flags)
  {
@@ -117,7 +133,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	if (flags & MODULE_INIT_IGNORE_VERMAGIC)
  		modmagic = NULL;
  
-@@ -3270,6 +3272,7 @@ static int check_modinfo(struct module *
+@@ -3270,6 +3274,7 @@ static int check_modinfo(struct module *
  				mod->name);
  		add_taint_module(mod, TAINT_OOT_MODULE, LOCKDEP_STILL_OK);
  	}

--- a/target/linux/generic/hack-5.4/204-module_strip.patch
+++ b/target/linux/generic/hack-5.4/204-module_strip.patch
@@ -112,6 +112,22 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config MODULES_TREE_LOOKUP
 --- a/kernel/module.c
 +++ b/kernel/module.c
+@@ -1285,6 +1285,7 @@ static struct module_attribute *modinfo_
+ 
+ static const char vermagic[] = VERMAGIC_STRING;
+ 
++#if defined(CONFIG_MODVERSIONS) || !defined(CONFIG_MODULE_STRIPPED)
+ static int try_to_force_load(struct module *mod, const char *reason)
+ {
+ #ifdef CONFIG_MODULE_FORCE_LOAD
+@@ -1296,6 +1297,7 @@ static int try_to_force_load(struct modu
+ 	return -ENOEXEC;
+ #endif
+ }
++#endif
+ 
+ #ifdef CONFIG_MODVERSIONS
+ 
 @@ -3256,9 +3256,11 @@ static int setup_load_info(struct load_i
  
  static int check_modinfo(struct module *mod, struct load_info *info, int flags)


### PR DESCRIPTION
There is a longlasting warn about unused defined try_to_force_load.
Fix this by including this function only when actually used.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>