### PR TITLE
build: store source_date_epoch as integer

### DIFF
--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -44,7 +44,7 @@ image_info = {
     "target": "{}/{}".format(getenv("TARGET"), getenv("SUBTARGET")),
     "version_code": getenv("VERSION_CODE"),
     "version_number": getenv("VERSION_NUMBER"),
-    "source_date_epoch": getenv("SOURCE_DATE_EPOCH"),
+    "source_date_epoch": int(getenv("SOURCE_DATE_EPOCH")),
     "profiles": {
         device_id: {
             "image_prefix": getenv("DEVICE_IMG_PREFIX"),


### PR DESCRIPTION
The value is retreived from a env variable which defaults to be read as
a string. However the SOURCE_DATE_EPOCH is a unix timestamp aka integer.

Fix this to allow downstream tools to parse the value directly.

Signed-off-by: Paul Spooren <mail@aparcar.org>