### PR TITLE
kernel-5.4: backport switchdev fix for bridge in bridge configurations

### DIFF
--- a/target/linux/generic/backport-5.4/790-v5.7-net-switchdev-do-not-propagate-bridge-updates-across.patch
+++ b/target/linux/generic/backport-5.4/790-v5.7-net-switchdev-do-not-propagate-bridge-updates-across.patch
@@ -1,0 +1,62 @@
+From 07c6f9805f12f1bb538ef165a092b300350384aa Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@armlinux.org.uk>
+Date: Wed, 26 Feb 2020 17:14:21 +0000
+Subject: [PATCH] net: switchdev: do not propagate bridge updates across
+ bridges
+
+When configuring a tree of independent bridges, propagating changes
+from the upper bridge across a bridge master to the lower bridge
+ports brings surprises.
+
+For example, a lower bridge may have vlan filtering enabled.  It
+may have a vlan interface attached to the bridge master, which may
+then be incorporated into another bridge.  As soon as the lower
+bridge vlan interface is attached to the upper bridge, the lower
+bridge has vlan filtering disabled.
+
+This occurs because switchdev recursively applies its changes to
+all lower devices no matter what.
+
+Reviewed-by: Ido Schimmel <idosch@mellanox.com>
+Tested-by: Ido Schimmel <idosch@mellanox.com>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/switchdev/switchdev.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/net/switchdev/switchdev.c b/net/switchdev/switchdev.c
+index 60630762a748b7..f25604d68337cf 100644
+--- a/net/switchdev/switchdev.c
++++ b/net/switchdev/switchdev.c
+@@ -475,6 +475,9 @@ static int __switchdev_handle_port_obj_add(struct net_device *dev,
+ 	 * necessary to go through this helper.
+ 	 */
+ 	netdev_for_each_lower_dev(dev, lower_dev, iter) {
++		if (netif_is_bridge_master(lower_dev))
++			continue;
++
+ 		err = __switchdev_handle_port_obj_add(lower_dev, port_obj_info,
+ 						      check_cb, add_cb);
+ 		if (err && err != -EOPNOTSUPP)
+@@ -526,6 +529,9 @@ static int __switchdev_handle_port_obj_del(struct net_device *dev,
+ 	 * necessary to go through this helper.
+ 	 */
+ 	netdev_for_each_lower_dev(dev, lower_dev, iter) {
++		if (netif_is_bridge_master(lower_dev))
++			continue;
++
+ 		err = __switchdev_handle_port_obj_del(lower_dev, port_obj_info,
+ 						      check_cb, del_cb);
+ 		if (err && err != -EOPNOTSUPP)
+@@ -576,6 +582,9 @@ static int __switchdev_handle_port_attr_set(struct net_device *dev,
+ 	 * necessary to go through this helper.
+ 	 */
+ 	netdev_for_each_lower_dev(dev, lower_dev, iter) {
++		if (netif_is_bridge_master(lower_dev))
++			continue;
++
+ 		err = __switchdev_handle_port_attr_set(lower_dev, port_attr_info,
+ 						       check_cb, set_cb);
+ 		if (err && err != -EOPNOTSUPP)


### PR DESCRIPTION
This patch fixes the forwarding behavior of bridge in bridge
configurations with DSA.

Without it, the configuration of the upper bridge might overwrite
settings of the lower bridge. For example, a vlan-aware bridge
with DSA interfaces in it might be offloaded to the DSA hardware. If the
bridge interface itself gets slave of a different bridge without vlan
filtering, the vlan filtering setting of the lower bridge is overwritten
by the upper bridge, which results in an incorrect hardware
configuration.

This was backported from kernel 5.7.

Ref: https://lore.kernel.org/netdev/20191222192235.GK25745@shell.armlinux.org.uk/
Fixes: FS#3996
Signed-off-by: Fabian Bläse <fabian@blaese.de>