### PR TITLE
arm-trusted-firmware-mvebu: cherry-pick post release mox-boot-builder fixes

### DIFF
--- a/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/103-wtmi-Do-a-proper-UART-reset-with-clock-change-as-des.patch
+++ b/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/103-wtmi-Do-a-proper-UART-reset-with-clock-change-as-des.patch
@@ -1,0 +1,117 @@
+From 18ccb83a06b61346057265933aee0f7c47242da0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Tue, 13 Jul 2021 17:12:16 +0200
+Subject: [PATCH] wtmi: Do a proper UART reset with clock change as described
+ in spec
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ wtmi/uart.c | 44 +++++++++++++++++++++++++++++++++++++++-----
+ wtmi/uart.h |  2 ++
+ 2 files changed, 41 insertions(+), 5 deletions(-)
+
+diff --git a/wtmi/uart.c b/wtmi/uart.c
+index 75864b5..001edde 100644
+--- a/wtmi/uart.c
++++ b/wtmi/uart.c
+@@ -40,6 +40,8 @@
+ #include "stdio.h"
+ #include "debug.h"
+ 
++#define UART_CLK	0xc0012010
++
+ const struct uart_info uart1_info = {
+ 	.rx	= 0xc0012000,
+ 	.tx	= 0xc0012004,
+@@ -48,6 +50,8 @@ const struct uart_info uart1_info = {
+ 	.rx_ready_bit = BIT(4),
+ 	.baud	= 0xc0012010,
+ 	.possr	= 0xc0012014,
++	.dis	= 0xc0013804,
++	.dis_bit = 31,
+ };
+ 
+ const struct uart_info uart2_info = {
+@@ -58,6 +62,8 @@ const struct uart_info uart2_info = {
+ 	.rx_ready_bit = BIT(14),
+ 	.baud	= 0xc0012210,
+ 	.possr	= 0xc0012214,
++	.dis	= 0xc0013804,
++	.dis_bit = 29,
+ };
+ 
+ int uart_putc(int _c, void *p);
+@@ -76,21 +82,49 @@ void uart_reset(const struct uart_info *info, unsigned int baudrate)
+ {
+ 	u32 parent_rate = get_ref_clk() * 1000000;
+ 
++	/* disable UART */
++	setbitsl(info->dis, BIT(info->dis_bit), BIT(info->dis_bit));
++
++	/* enable loopback */
++	writel(BIT(12), info->ctrl);
++
++	/* reset FIFOs */
++	setbitsl(info->ctrl, BIT(14) | BIT(15), BIT(14) | BIT(15));
++
++	/* wait one or more frame periods (frame period is 87us at 115200 Bd) */
++	udelay(200);
++
++	/* wait until TX empty */
++	while (!(readl(info->status) & BIT(6)))
++		udelay(20);
++
++	/* gate UART clocks */
++	setbitsl(UART_CLK, BIT(20) | BIT(21), BIT(20) | BIT(21));
++
++	/* set parent clock to XTAL and clear TBG configs */
++	setbitsl(UART_CLK, 0, BIT(19) | 0x3fc00);
++
++	/* ungate UART clocks */
++	setbitsl(UART_CLK, 0, BIT(20) | BIT(21));
++
+ 	/* set baudrate */
+-	writel(div_round_closest_u32(parent_rate, baudrate * 16), info->baud);
++	setbitsl(info->baud, div_round_closest_u32(parent_rate, baudrate * 16),
++		 0x3ff);
+ 
+ 	/* set Programmable Oversampling Stack to 0, UART defaults to 16X scheme */
+ 	writel(0, info->possr);
+ 
+-	/* reset FIFOs */
+-	writel(BIT(14) | BIT(15), info->ctrl);
++	/* diable loopback */
++	setbitsl(info->ctrl, 0, BIT(12));
+ 
+-	udelay(1);
++	/* clear reset */
++	setbitsl(info->ctrl, 0, BIT(14) | BIT(15));
+ 
+ 	/* No Parity, 1 Stop */
+ 	writel(0, info->ctrl);
+ 
+-	udelay(100);
++	/* enable UART */
++	setbitsl(info->dis, 0, BIT(info->dis_bit));
+ 
+ 	/* uart2 pinctrl enable */
+ 	if (info == &uart2_info)
+diff --git a/wtmi/uart.h b/wtmi/uart.h
+index 587a5f2..c0e26fb 100644
+--- a/wtmi/uart.h
++++ b/wtmi/uart.h
+@@ -45,6 +45,8 @@ struct uart_info {
+ 	u32 rx_ready_bit;
+ 	u32 baud;
+ 	u32 possr;
++	u32 dis;
++	u32 dis_bit;
+ };
+ 
+ extern const struct uart_info uart1_info, uart2_info;
+-- 
+2.33.0
+

--- a/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/104-Makefile-fix-awk-printf.patch
+++ b/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/104-Makefile-fix-awk-printf.patch
@@ -1,0 +1,31 @@
+From f8f0ca4274a7903be01e7ea82ed26f73fa664f1f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Fri, 16 Jul 2021 18:17:28 +0200
+Subject: [PATCH] Makefile: fix awk printf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Awk's printf %c prints multibyte character when LC_ALL=UTF-8.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 2cbd1a0..a8b077d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -67,7 +67,7 @@ arm-trusted-firmware/build/a3700/release/boot-image.bin: u-boot/u-boot.bin FORCE
+ 
+ a53-firmware.bin: arm-trusted-firmware/build/a3700/release/boot-image.bin
+ 	cp -a $< $@
+-	od -v -tu8 -An -j 131184 -N 8 $@ | awk '{ for (i = 0; i < 64; i += 8) printf "%c", and(rshift(1310720-$$1, i), 255) }' | dd of=$@ bs=1 seek=131192 count=8 conv=notrunc 2>/dev/null
++	od -v -tu8 -An -j 131184 -N 8 $@ | LC_ALL=C awk '{ for (i = 0; i < 64; i += 8) printf "%c", and(rshift(1310720-$$1, i), 255) }' | dd of=$@ bs=1 seek=131192 count=8 conv=notrunc 2>/dev/null
+ 
+ u-boot/u-boot.bin: FORCE
+ 	$(MAKE) -C u-boot CROSS_COMPILE=$(CROSS_COMPILE) turris_mox_defconfig
+-- 
+2.33.0
+

--- a/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/105-Makefile-fix-wrong-size-computation-of-bl3-image.patch
+++ b/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/105-Makefile-fix-wrong-size-computation-of-bl3-image.patch
@@ -1,0 +1,29 @@
+From f9f794b5aa289f787359d6dce42fe57aa52f97ea Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Fri, 16 Jul 2021 18:18:21 +0200
+Subject: [PATCH] Makefile: fix wrong size computation of bl3 image
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index a8b077d..0597425 100644
+--- a/Makefile
++++ b/Makefile
+@@ -67,7 +67,7 @@ arm-trusted-firmware/build/a3700/release/boot-image.bin: u-boot/u-boot.bin FORCE
+ 
+ a53-firmware.bin: arm-trusted-firmware/build/a3700/release/boot-image.bin
+ 	cp -a $< $@
+-	od -v -tu8 -An -j 131184 -N 8 $@ | LC_ALL=C awk '{ for (i = 0; i < 64; i += 8) printf "%c", and(rshift(1310720-$$1, i), 255) }' | dd of=$@ bs=1 seek=131192 count=8 conv=notrunc 2>/dev/null
++	od -v -tu8 -An -j 131184 -N 8 $@ | LC_ALL=C awk '{ for (i = 0; i < 64; i += 8) printf "%c", and(rshift(1310720-131072-$$1, i), 255) }' | dd of=$@ bs=1 seek=131192 count=8 conv=notrunc 2>/dev/null
+ 
+ u-boot/u-boot.bin: FORCE
+ 	$(MAKE) -C u-boot CROSS_COMPILE=$(CROSS_COMPILE) turris_mox_defconfig
+-- 
+2.33.0
+

--- a/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/106-wtmi-Count-RAM-size-from-both-CS0-and-CS1.patch
+++ b/package/boot/arm-trusted-firmware-mvebu/patches-mox-boot-builder/106-wtmi-Count-RAM-size-from-both-CS0-and-CS1.patch
@@ -1,0 +1,66 @@
+From e8c94a5b064a71e4754af680d147c7301a494e63 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <marek.behun@nic.cz>
+Date: Thu, 22 Jul 2021 16:47:23 +0200
+Subject: [PATCH] wtmi: Count RAM size from both CS0 and CS1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+For devices using both chip selects (some variants of EspressoBIN, for
+example) the current code returns wrong RAM size, which causes failure
+in probing the turris-mox-rwtm driver in Linux. Fix this.
+
+Signed-off-by: Marek Behún <marek.behun@nic.cz>
+---
+ wtmi/main.c | 28 ++++++++++++++++++++++------
+ 1 file changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/wtmi/main.c b/wtmi/main.c
+index aa65a21..7e6ed1a 100644
+--- a/wtmi/main.c
++++ b/wtmi/main.c
+@@ -15,19 +15,35 @@
+ #include "debug.h"
+ 
+ #ifndef DEPLOY
++static int cs_reg_to_ram_size(u32 addr)
++{
++	u32 reg = readl(addr);
++
++	if (!(reg & 0x1))
++		return 0;
++
++	reg = (reg >> 16) & 0x1f;
++	if (reg >= 7)
++		return 1 << (reg - 4);
++	else
++		return (1 << reg) * 384;
++}
++
+ static int get_ram_size(void)
+ {
+ 	static int ram_size;
+-	u32 reg;
+ 
+ 	if (ram_size)
+ 		return ram_size;
+ 
+-	reg = (readl(0xc0000200) >> 16) & 0x1f;
+-	if (reg >= 7 && reg <= 16)
+-		ram_size = 1 << (reg - 4);
+-	else
+-		ram_size = 512;
++	ram_size = cs_reg_to_ram_size(0xc0000200) +
++		   cs_reg_to_ram_size(0xc0000208);
++
++	if (!ram_size) {
++		printf("No DDR chip configured!\n");
++		while (1)
++			wait_for_irq();
++	}
+ 
+ 	return ram_size;
+ }
+-- 
+2.33.0
+


### PR DESCRIPTION
This fixes probing the turris-mox-rwtm driver in Linux for devices using both chip selects.

8c94a5 wtmi: Count RAM size from both CS0 and CS1
f9f794b Makefile: fix wrong size computation of bl3 image
f8f0ca4 Makefile: fix awk printf
18ccb83 wtmi: Do a proper UART reset with clock change as described in spec

Signed-off-by: Andre Heider <a.heider@gmail.com>