### PR TITLE
busybox: restore float sleep

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -757,6 +757,9 @@ config BUSYBOX_DEFAULT_SLEEP
 config BUSYBOX_DEFAULT_FEATURE_FANCY_SLEEP
 	bool
 	default y
+config BUSYBOX_DEFAULT_FEATURE_FLOAT_SLEEP
+	bool
+	default n
 config BUSYBOX_DEFAULT_SORT
 	bool
 	default y

--- a/package/utils/busybox/config/coreutils/Config.in
+++ b/package/utils/busybox/config/coreutils/Config.in
@@ -569,19 +569,23 @@ config BUSYBOX_CONFIG_SLEEP
 		sleep 2.3s 4.5h sleeps for 16202.3 seconds
 	Last one is "the most compatible" with coreutils sleep,
 	but it adds around 1k of code.
-
 config BUSYBOX_CONFIG_FEATURE_FANCY_SLEEP
 	bool "Enable multiple arguments and s/m/h/d suffixes"
 	default BUSYBOX_DEFAULT_FEATURE_FANCY_SLEEP
 	depends on BUSYBOX_CONFIG_SLEEP
 	help
 	Allow sleep to pause for specified minutes, hours, and days.
+config BUSYBOX_CONFIG_FEATURE_FLOAT_SLEEP
+	bool "Enable fractional arguments"
+	default BUSYBOX_DEFAULT_FEATURE_FLOAT_SLEEP
+	depends on BUSYBOX_CONFIG_FEATURE_FANCY_SLEEP
+	help
+	Allow for fractional numeric parameters.
 config BUSYBOX_CONFIG_SORT
 	bool "sort (7.7 kb)"
 	default BUSYBOX_DEFAULT_SORT
 	help
 	sort is used to sort lines of text in specified files.
-
 config BUSYBOX_CONFIG_FEATURE_SORT_BIG
 	bool "Full SuSv3 compliant sort (support -ktcbdfiogM)"
 	default BUSYBOX_DEFAULT_FEATURE_SORT_BIG


### PR DESCRIPTION
Support for float sleep was removed, probably unintentionally, by the
following two commits:

https://github.com/openwrt/openwrt/commit/9b9274342c47051e4f921d63f19cdf84aa0b8485
https://github.com/openwrt/openwrt/commit/eb6f5a58b904814f9a73281949f32f04c190d727

This patch adds the feature back.

Signed-off-by: John Marrett <johnf@zioncluster.ca>