### PR TITLE
sunxi: add support for FriendlyARM NanoPi R1S-H5

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -184,6 +184,12 @@ define U-Boot/nanopi_r1
   BUILD_DEVICES:=friendlyarm_nanopi-r1
 endef
 
+define U-Boot/nanopi_r1s
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=U-Boot for NanoPi R1S (H5)
+  BUILD_DEVICES:=friendlyarm_nanopi-r1s
+endef
+
 define U-Boot/orangepi_r1
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi R1 (H2+)
@@ -332,6 +338,7 @@ UBOOT_TARGETS := \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
 	nanopi_r1 \
+        nanopi_r1s \
 	orangepi_zero \
 	orangepi_r1 \
 	orangepi_one \

--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -256,11 +256,11 @@ define U-Boot/nanopi_neo2
   UENV:=a64
 endef
 
-define U-Boot/nanopi_r1s
+define U-Boot/nanopi_r1s_h5
   BUILD_SUBTARGET:=cortexa53
   NAME:=U-Boot for NanoPi R1S (H5)
-  BUILD_DEVICES:=friendlyarm_nanopi-r1s
-  DEPENDS:=+PACKAGE_u-boot-nanopi_r1s:arm-trusted-firmware-sunxi
+  BUILD_DEVICES:=friendlyarm_nanopi-r1s-h5
+  DEPENDS:=+PACKAGE_u-boot-nanopi_r1s_h5:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
 
@@ -340,7 +340,7 @@ UBOOT_TARGETS := \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
 	nanopi_r1 \
-    nanopi_r1s \
+    nanopi_r1s_h5 \
 	orangepi_zero \
 	orangepi_r1 \
 	orangepi_one \

--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -184,12 +184,6 @@ define U-Boot/nanopi_r1
   BUILD_DEVICES:=friendlyarm_nanopi-r1
 endef
 
-define U-Boot/nanopi_r1s
-  BUILD_SUBTARGET:=cortexa53
-  NAME:=U-Boot for NanoPi R1S (H5)
-  BUILD_DEVICES:=friendlyarm_nanopi-r1s
-endef
-
 define U-Boot/orangepi_r1
   BUILD_SUBTARGET:=cortexa7
   NAME:=Orange Pi R1 (H2+)
@@ -259,6 +253,14 @@ define U-Boot/nanopi_neo2
   NAME:=NanoPi NEO2 (H5)
   BUILD_DEVICES:=friendlyarm_nanopi-neo2
   DEPENDS:=+PACKAGE_u-boot-nanopi_neo2:arm-trusted-firmware-sunxi
+  UENV:=a64
+endef
+
+define U-Boot/nanopi_r1s
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=U-Boot for NanoPi R1S (H5)
+  BUILD_DEVICES:=friendlyarm_nanopi-r1s
+  DEPENDS:=+PACKAGE_u-boot-nanopi_r1s:arm-trusted-firmware-sunxi
   UENV:=a64
 endef
 
@@ -338,7 +340,7 @@ UBOOT_TARGETS := \
 	nanopi_neo_plus2 \
 	nanopi_neo2 \
 	nanopi_r1 \
-        nanopi_r1s \
+    nanopi_r1s \
 	orangepi_zero \
 	orangepi_r1 \
 	orangepi_one \

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,20 +1,28 @@
 --- /dev/null
-+++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,120 @@
++++ b/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts
+@@ -0,0 +1,265 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+// Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++/*
++ * Copyright (C) 2021 Chukun Pan <amadeus@jmu.edu.cn>
++ *
++ * Based on sun50i-h5-nanopi-neo-plus2.dts, which is:
++ *   Copyright (C) 2017 Antony Antony <antony@phenome.org>
++ *   Copyright (C) 2016 ARM Ltd.
++ */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
-+	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi R1S H5";
++	compatible = "friendlyarm,nanopi-r1s-h5", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
++		ethernet1 = &rtl8189etv;
 +		serial0 = &uart0;
 +	};
 +
@@ -25,15 +33,30 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
++		led-0 {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		status {
-+			label = "nanopi:blue:status";
++		led-1 {
++			label = "nanopi:red:status";
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-2 {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r-gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +
@@ -63,6 +86,105 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
++
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0>, <1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	cpu_opp_table: cpu-opp-table {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <1000000 1000000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-648000000 {
++			opp-hz = /bits/ 64 <648000000>;
++			opp-microvolt = <1040000 1040000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <1080000 1080000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-912000000 {
++			opp-hz = /bits/ 64 <912000000>;
++			opp-microvolt = <1120000 1120000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-960000000 {
++			opp-hz = /bits/ 64 <960000000>;
++			opp-microvolt = <1160000 1160000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <1200000 1200000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1056000000 {
++			opp-hz = /bits/ 64 <1056000000>;
++			opp-microvolt = <1240000 1240000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1104000000 {
++			opp-hz = /bits/ 64 <1104000000>;
++			opp-microvolt = <1260000 1260000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>;
++			opp-microvolt = <1300000 1300000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
 +};
 +
 +&ehci1 {
@@ -78,7 +200,7 @@
 +	pinctrl-0 = <&emac_rgmii_pins>;
 +	phy-supply = <&reg_gmac_3v3>;
 +	phy-handle = <&ext_rgmii_phy>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
 +	status = "okay";
 +};
 +
@@ -89,11 +211,34 @@
 +	};
 +};
 +
++&i2c0 {
++	status = "okay";
++
++	eeprom@51 {
++		compatible = "microchip,24c02";
++		reg = <0x51>;
++		pagesize = <16>;
++	};
++};
++
 +&mmc0 {
 +	vmmc-supply = <&reg_vcc3v3>;
 +	bus-width = <4>;
 +	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
 +	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	rtl8189etv: sdio_wifi@1 {
++		reg = <1>;
++	};
 +};
 +
 +&ohci1 {
@@ -127,12 +272,12 @@
  	sun50i-h5-libretech-all-h5-cc.dtb \
  	sun50i-h5-nanopi-neo2.dtb \
  	sun50i-h5-nanopi-neo-plus2.dtb \
-+    sun50i-h5-nanopi-r1s.dtb \
++    sun50i-h5-nanopi-r1s-h5.dtb \
  	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \
 --- /dev/null
-+++ b/configs/nanopi_r1s_defconfig
++++ b/configs/nanopi_r1s_h5_defconfig
 @@ -0,0 +1,14 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
@@ -144,7 +289,7 @@
 +CONFIG_MACPWR="PD6"
 +CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
-+CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s"
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s-h5"
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_OHCI_HCD=y

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,20 +1,56 @@
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,163 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+// Copyright (C) 2017 Antony Antony <antony@phenome.org>
-+// Copyright (C) 2016 ARM Ltd.
+@@ -0,0 +1,188 @@
++/*
++ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/input/input.h>
-+#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi NEO Plus2";
-+	compatible = "friendlyarm,nanopi-neo-plus2", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi R1S";
++	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
@@ -26,17 +62,21 @@
 +	};
 +
 +	leds {
-+		compatible = "gpio-leds";
-+
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
-+		};
-+
++		/delete-node/ pwr;
 +		status {
 +			label = "nanopi:red:status";
-+			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		wan {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++
++		lan {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -57,36 +97,32 @@
 +		regulator-max-microvolt = <3300000>;
 +	};
 +
-+	vdd_cpux: gpio-regulator {
-+		compatible = "regulator-gpio";
-+		regulator-name = "vdd-cpux";
-+		regulator-type = "voltage";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1300000>;
-+		regulator-ramp-delay = <50>; /* 4ms */
-+		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
-+		gpios-states = <0x1>;
-+		states = <1100000 0>, <1300000 1>;
++	reg_usb0_vbus: usb0-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb0-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
++		status = "okay";
 +	};
 +
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
-+		post-power-on-delay-ms = <200>;
++		pinctrl-names = "default";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
 +	};
 +};
 +
-+&codec {
-+	allwinner,audio-routing =
-+		"Line Out", "LINEOUT",
-+		"MIC1", "Mic",
-+		"Mic",  "MBIAS";
++&ehci0 {
 +	status = "okay";
 +};
 +
-+&ehci0 {
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -110,38 +146,32 @@
 +	};
 +};
 +
-+&mmc0 {
-+	vmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <4>;
-+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
-+	status = "okay";
-+};
-+
 +&mmc1 {
-+	vmmc-supply = <&reg_vcc3v3>;
-+	vqmmc-supply = <&reg_vcc3v3>;
-+	mmc-pwrseq = <&wifi_pwrseq>;
-+	bus-width = <4>;
-+	non-removable;
-+	status = "okay";
++        vmmc-supply = <&reg_vcc3v3>;
++        vqmmc-supply = <&reg_vcc3v3>;
++        mmc-pwrseq = <&wifi_pwrseq>;
++        bus-width = <4>;
++        non-removable;
++        status = "okay";
 +
-+	brcmf: wifi@1 {
-+		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+	};
-+};
-+
-+&mmc2 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc2_8bit_pins>;
-+	vmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <8>;
-+	non-removable;
-+	cap-mmc-hw-reset;
-+	status = "okay";
++        brcmf: brcmf@1 {
++                reg = <1>;
++                compatible = "brcm,bcm4329-fmac";
++                interrupt-parent = <&pio>;
++                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
++                interrupt-names = "host-wake";
++        };
 +};
 +
 +&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
 +	status = "okay";
 +};
 +
@@ -156,12 +186,7 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&usbphy {
-+	/* USB Type-A ports' VBUS is always on */
++	dr_mode = "otg";
 +	status = "okay";
 +};
 --- a/arch/arm/dts/Makefile
@@ -170,20 +195,22 @@
  	sun50i-h5-libretech-all-h5-cc.dtb \
  	sun50i-h5-nanopi-neo2.dtb \
  	sun50i-h5-nanopi-neo-plus2.dtb \
-+        sun50i-h5-nanopi-r1s.dtb \
++    sun50i-h5-nanopi-r1s.dtb \
  	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \
 --- /dev/null
 +++ b/configs/nanopi_r1s_defconfig
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,14 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_SPL=y
 +CONFIG_MACH_SUN50I_H5=y
-+CONFIG_DRAM_CLK=672
++CONFIG_DRAM_CLK=408
 +CONFIG_DRAM_ZQ=3881977
 +# CONFIG_DRAM_ODT_EN is not set
++CONFIG_MACPWR="PD6"
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
 +CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s"
 +CONFIG_SUN8I_EMAC=y

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,57 +1,20 @@
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,244 @@
-+/*
-+ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
-+ * Copyright (C) 2017 Armbian
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
+@@ -0,0 +1,163 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (C) 2017 Antony Antony <antony@phenome.org>
++// Copyright (C) 2016 ARM Ltd.
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
-+	model = "FriendlyARM Nanopi R1S H5";
-+	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi NEO Plus2";
++	compatible = "friendlyarm,nanopi-neo-plus2", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
@@ -72,8 +35,8 @@
 +		};
 +
 +		status {
-+			label = "nanopi:blue:status";
-+			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			label = "nanopi:red:status";
++			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -94,33 +57,36 @@
 +		regulator-max-microvolt = <3300000>;
 +	};
 +
-+	reg_usb0_vbus: usb0-vbus {
-+		compatible = "regulator-fixed";
-+		regulator-name = "usb0-vbus";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
-+		status = "okay";
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0>, <1300000 1>;
 +	};
 +
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
-+		post-power-on-delay-ms = <50>;
++		post-power-on-delay-ms = <200>;
 +	};
++};
 +
++&codec {
++	allwinner,audio-routing =
++		"Line Out", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "MBIAS";
++	status = "okay";
 +};
 +
 +&ehci0 {
-+	status = "okay";
-+};
-+
-+&ehci1 {
-+	status = "okay";
-+};
-+
-+&ehci2 {
 +	status = "okay";
 +};
 +
@@ -137,7 +103,7 @@
 +	status = "okay";
 +};
 +
-+&mdio {
++&external_mdio {
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
@@ -152,22 +118,17 @@
 +};
 +
 +&mmc1 {
-+        vmmc-supply = <&reg_vcc3v3>;
-+        vqmmc-supply = <&reg_vcc3v3>;
-+        mmc-pwrseq = <&wifi_pwrseq>;
-+        bus-width = <4>;
-+        non-removable;
-+        status = "okay";
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
 +
-+        brcmf: brcmf@1 {
-+                reg = <1>;
-+                compatible = "brcm,bcm4329-fmac";
-+                interrupt-parent = <&pio>;
-+                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
-+                interrupt-names = "host-wake";
-+                pinctrl-names = "default";
-+                pinctrl-0 = <&wifi_wake>;
-+        };
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
 +};
 +
 +&mmc2 {
@@ -180,51 +141,11 @@
 +	status = "okay";
 +};
 +
-+&de {
-+	status = "okay";
-+};
-+
 +&ohci0 {
 +	status = "okay";
 +};
 +
-+&ohci1 {
-+	status = "okay";
-+};
-+
-+&ohci2 {
-+	status = "okay";
-+};
-+
 +&ohci3 {
-+	status = "okay";
-+};
-+
-+&hdmi {
-+	status = "okay";
-+};
-+
-+&mixer0 {
-+	status = "okay";
-+};
-+
-+&r_pio {
-+	wifi_wake: wifi_wake@0 {
-+		pins = "PL7";
-+		function = "gpio_out";
-+/*		bias-pull-up; */
-+	};
-+};
-+
-+
-+
-+
-+
-+&tcon0 {
-+	status = "okay";
-+};
-+
-+&r_i2c {
 +	status = "okay";
 +};
 +
@@ -235,14 +156,12 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "peripheral";
++	dr_mode = "host";
 +	status = "okay";
 +};
 +
 +&usbphy {
-+	/* USB Type-A port's VBUS is always on */
-+	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
-+	usb0_vbus-supply = <&reg_usb0_vbus>;
++	/* USB Type-A ports' VBUS is always on */
 +	status = "okay";
 +};
 --- a/arch/arm/dts/Makefile
@@ -251,7 +170,7 @@
  	sun50i-h5-libretech-all-h5-cc.dtb \
  	sun50i-h5-nanopi-neo2.dtb \
  	sun50i-h5-nanopi-neo-plus2.dtb \
-+    sun50i-h5-nanopi-r1s.dtb \
++        sun50i-h5-nanopi-r1s.dtb \
  	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -216,9 +216,9 @@
 +	};
 +};
 +
-+&hdmi_sound {
-+	status = "okay";
-+};
++
++
++
 +
 +&tcon0 {
 +	status = "okay";

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,8 +1,48 @@
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,120 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+// Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
+@@ -0,0 +1,244 @@
++/*
++ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ * Copyright (C) 2017 Armbian
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
@@ -10,7 +50,7 @@
 +#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
++	model = "FriendlyARM Nanopi R1S H5";
 +	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
 +
 +	aliases {
@@ -63,9 +103,24 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <50>;
++	};
++
 +};
 +
 +&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -82,7 +137,7 @@
 +	status = "okay";
 +};
 +
-+&external_mdio {
++&mdio {
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
@@ -96,11 +151,80 @@
 +	status = "okay";
 +};
 +
++&mmc1 {
++        vmmc-supply = <&reg_vcc3v3>;
++        vqmmc-supply = <&reg_vcc3v3>;
++        mmc-pwrseq = <&wifi_pwrseq>;
++        bus-width = <4>;
++        non-removable;
++        status = "okay";
++
++        brcmf: brcmf@1 {
++                reg = <1>;
++                compatible = "brcm,bcm4329-fmac";
++                interrupt-parent = <&pio>;
++                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
++                interrupt-names = "host-wake";
++                pinctrl-names = "default";
++                pinctrl-0 = <&wifi_wake>;
++        };
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&de {
++	status = "okay";
++};
++
 +&ohci0 {
 +	status = "okay";
 +};
 +
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
 +&ohci3 {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&mixer0 {
++	status = "okay";
++};
++
++&r_pio {
++	wifi_wake: wifi_wake@0 {
++		pins = "PL7";
++		function = "gpio_out";
++/*		bias-pull-up; */
++	};
++};
++
++&hdmi_sound {
++	status = "okay";
++};
++
++&tcon0 {
++	status = "okay";
++};
++
++&r_i2c {
 +	status = "okay";
 +};
 +
@@ -111,7 +235,7 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "otg";
++	dr_mode = "peripheral";
 +	status = "okay";
 +};
 +
@@ -127,7 +251,7 @@
  	sun50i-h5-libretech-all-h5-cc.dtb \
  	sun50i-h5-nanopi-neo2.dtb \
  	sun50i-h5-nanopi-neo-plus2.dtb \
-+        sun50i-h5-nanopi-r1s.dtb \
++    sun50i-h5-nanopi-r1s.dtb \
  	sun50i-h5-orangepi-zero-plus.dtb \
  	sun50i-h5-orangepi-pc2.dtb \
  	sun50i-h5-orangepi-prime.dtb \

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -65,11 +65,11 @@
 +	};
 +};
 +
-+&ehci0 {
++&ehci1 {
 +	status = "okay";
 +};
 +
-+&ehci3 {
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -96,11 +96,11 @@
 +	status = "okay";
 +};
 +
-+&ohci0 {
++&ohci1 {
 +	status = "okay";
 +};
 +
-+&ohci3 {
++&ohci2 {
 +	status = "okay";
 +};
 +
@@ -111,7 +111,7 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "otg";
++	dr_mode = "peripheral";
 +	status = "okay";
 +};
 +

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,0 +1,148 @@
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
+@@ -0,0 +1,120 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++
++/dts-v1/;
++#include "sun50i-h5.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "FriendlyARM NanoPi R1S";
++	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++
++	aliases {
++		ethernet0 = &emac;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++		status {
++			label = "nanopi:blue:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
++	reg_usb0_vbus: usb0-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb0-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
++		status = "okay";
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@7 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pa_pins>;
++	status = "okay";
++};
++
++&usb_otg {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbphy {
++	/* USB Type-A port's VBUS is always on */
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++	usb0_vbus-supply = <&reg_usb0_vbus>;
++	status = "okay";
++};
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -555,6 +555,7 @@ dtb-$(CONFIG_MACH_SUN50I_H5) += \
+ 	sun50i-h5-libretech-all-h5-cc.dtb \
+ 	sun50i-h5-nanopi-neo2.dtb \
+ 	sun50i-h5-nanopi-neo-plus2.dtb \
++        sun50i-h5-nanopi-r1s.dtb \
+ 	sun50i-h5-orangepi-zero-plus.dtb \
+ 	sun50i-h5-orangepi-pc2.dtb \
+ 	sun50i-h5-orangepi-prime.dtb \
+--- /dev/null
++++ b/configs/nanopi_r1s_defconfig
+@@ -0,0 +1,12 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_SPL=y
++CONFIG_MACH_SUN50I_H5=y
++CONFIG_DRAM_CLK=672
++CONFIG_DRAM_ZQ=3881977
++# CONFIG_DRAM_ODT_EN is not set
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-r1s"
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y

--- a/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/package/boot/uboot-sunxi/patches/253-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,47 +1,8 @@
 --- /dev/null
 +++ b/arch/arm/dts/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,188 @@
-+/*
-+ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
+@@ -0,0 +1,120 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
@@ -62,21 +23,17 @@
 +	};
 +
 +	leds {
-+		/delete-node/ pwr;
++		compatible = "gpio-leds";
++
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
 +		status {
-+			label = "nanopi:red:status";
++			label = "nanopi:blue:status";
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "heartbeat";
-+		};
-+
-+		wan {
-+			label = "nanopi:green:wan";
-+			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
-+		};
-+
-+		lan {
-+			label = "nanopi:green:lan";
-+			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -106,23 +63,9 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
-+
-+	wifi_pwrseq: wifi_pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
-+	};
 +};
 +
 +&ehci0 {
-+	status = "okay";
-+};
-+
-+&ehci1 {
-+	status = "okay";
-+};
-+
-+&ehci2 {
 +	status = "okay";
 +};
 +
@@ -146,32 +89,14 @@
 +	};
 +};
 +
-+&mmc1 {
-+        vmmc-supply = <&reg_vcc3v3>;
-+        vqmmc-supply = <&reg_vcc3v3>;
-+        mmc-pwrseq = <&wifi_pwrseq>;
-+        bus-width = <4>;
-+        non-removable;
-+        status = "okay";
-+
-+        brcmf: brcmf@1 {
-+                reg = <1>;
-+                compatible = "brcm,bcm4329-fmac";
-+                interrupt-parent = <&pio>;
-+                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
-+                interrupt-names = "host-wake";
-+        };
++&mmc0 {
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	status = "okay";
 +};
 +
 +&ohci0 {
-+	status = "okay";
-+};
-+
-+&ohci1 {
-+	status = "okay";
-+};
-+
-+&ohci2 {
 +	status = "okay";
 +};
 +
@@ -187,6 +112,13 @@
 +
 +&usb_otg {
 +	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbphy {
++	/* USB Type-A port's VBUS is always on */
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++	usb0_vbus-supply = <&reg_usb0_vbus>;
 +	status = "okay";
 +};
 --- a/arch/arm/dts/Makefile

--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -13,9 +13,9 @@ friendlyarm,nanopi-r1)
 	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
 	;;
 friendlyarm,nanopi-r1s)
-        ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
-        ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
-        ;;
+    ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
+    ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
+    ;;
 esac
 
 board_config_flush

--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -12,6 +12,10 @@ friendlyarm,nanopi-r1)
 	ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
 	;;
+friendlyarm,nanopi-r1s)
+        ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
+        ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
+        ;;
 esac
 
 board_config_flush

--- a/target/linux/sunxi/base-files/etc/board.d/01_leds
+++ b/target/linux/sunxi/base-files/etc/board.d/01_leds
@@ -12,9 +12,9 @@ friendlyarm,nanopi-r1)
 	ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
 	;;
-friendlyarm,nanopi-r1s)
-    ucidef_set_led_netdev "wan" "WAN" "nanopi:green:wan" "eth0"
-    ucidef_set_led_netdev "lan" "LAN" "nanopi:green:lan" "eth1"
+friendlyarm,nanopi-r1s-h5)
+    ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
+    ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1"
     ;;
 esac
 

--- a/target/linux/sunxi/base-files/etc/board.d/02_network
+++ b/target/linux/sunxi/base-files/etc/board.d/02_network
@@ -11,6 +11,9 @@ case $(board_name) in
 friendlyarm,nanopi-r1)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
+friendlyarm,nanopi-r1s-h5)
+	ucidef_set_interfaces_lan_wan "eth1" "eth0"
+	;;
 lamobo,lamobo-r1)
 	ucidef_add_switch "switch0" \
 		"4:lan:1" "0:lan:2" "1:lan:3" "2:lan:4" "3:wan" "8@eth0"

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -35,16 +35,14 @@ define Device/friendlyarm_nanopi-neo2
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
 
-define Device/friendlyarm_nanopi-r1s
+define Device/friendlyarm_nanopi-r1s-h5
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1S-H5
-  SUPPORTED_DEVICES:=nanopi-r1s
-  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb2 kmod-usb-net-rtl8152 \
-     kmod-brcmfmac kmod-leds-gpio kmod-ledtrig-heartbeat wpad-basic-wolfssl \
-     brcmfmac-firmware-43430-sdio
+  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb-net-rtl8152 \
+     kmod-leds-gpio kmod-ledtrig-heartbeat
   $(Device/sun50i-h5)
 endef
-TARGET_DEVICES += friendlyarm_nanopi-r1s
+TARGET_DEVICES += friendlyarm_nanopi-r1s-h5
 
 define Device/libretech_all-h3-cc-h5
   DEVICE_VENDOR := Libre Computer

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -35,6 +35,17 @@ define Device/friendlyarm_nanopi-neo2
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
 
+define Device/friendlyarm_nanopi-r1s
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R1S-H5
+  SUPPORTED_DEVICES:=nanopi-r1s
+  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb2 kmod-usb-net-rtl8152 \
+     kmod-brcmfmac kmod-leds-gpio kmod-ledtrig-heartbeat wpad-basic-wolfssl \
+     brcmfmac-firmware-43430-sdio
+  $(Device/sun50i-h5)
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r1s
+
 define Device/libretech_all-h3-cc-h5
   DEVICE_VENDOR := Libre Computer
   DEVICE_MODEL := ALL-H3-CC

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -24,10 +24,10 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,244 @@
+@@ -0,0 +1,201 @@
 +/*
-+ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
-+ * Copyright (C) 2017 Armbian
++ * Copyright (C) 2017 Antony Antony <antony@phenome.org>
++ * Copyright (C) 2016 ARM Ltd.
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual
@@ -72,9 +72,11 @@
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
-+	model = "FriendlyARM Nanopi R1S H5";
++	model = "FriendlyARM NanoPi R1S";
 +	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
 +
 +	aliases {
@@ -96,8 +98,8 @@
 +		};
 +
 +		status {
-+			label = "nanopi:blue:status";
-+			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			label = "nanopi:red:status";
++			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -118,33 +120,36 @@
 +		regulator-max-microvolt = <3300000>;
 +	};
 +
-+	reg_usb0_vbus: usb0-vbus {
-+		compatible = "regulator-fixed";
-+		regulator-name = "usb0-vbus";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
-+		status = "okay";
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0>, <1300000 1>;
 +	};
 +
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
-+		post-power-on-delay-ms = <50>;
++		post-power-on-delay-ms = <200>;
 +	};
++};
 +
++&codec {
++	allwinner,audio-routing =
++		"Line Out", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "MBIAS";
++	status = "okay";
 +};
 +
 +&ehci0 {
-+	status = "okay";
-+};
-+
-+&ehci1 {
-+	status = "okay";
-+};
-+
-+&ehci2 {
 +	status = "okay";
 +};
 +
@@ -161,7 +166,7 @@
 +	status = "okay";
 +};
 +
-+&mdio {
++&external_mdio {
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
@@ -176,22 +181,17 @@
 +};
 +
 +&mmc1 {
-+        vmmc-supply = <&reg_vcc3v3>;
-+        vqmmc-supply = <&reg_vcc3v3>;
-+        mmc-pwrseq = <&wifi_pwrseq>;
-+        bus-width = <4>;
-+        non-removable;
-+        status = "okay";
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
 +
-+        brcmf: brcmf@1 {
-+                reg = <1>;
-+                compatible = "brcm,bcm4329-fmac";
-+                interrupt-parent = <&pio>;
-+                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
-+                interrupt-names = "host-wake";
-+                pinctrl-names = "default";
-+                pinctrl-0 = <&wifi_wake>;
-+        };
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
 +};
 +
 +&mmc2 {
@@ -204,51 +204,11 @@
 +	status = "okay";
 +};
 +
-+&de {
-+	status = "okay";
-+};
-+
 +&ohci0 {
 +	status = "okay";
 +};
 +
-+&ohci1 {
-+	status = "okay";
-+};
-+
-+&ohci2 {
-+	status = "okay";
-+};
-+
 +&ohci3 {
-+	status = "okay";
-+};
-+
-+&hdmi {
-+	status = "okay";
-+};
-+
-+&mixer0 {
-+	status = "okay";
-+};
-+
-+&r_pio {
-+	wifi_wake: wifi_wake@0 {
-+		pins = "PL7";
-+		function = "irq";
-+		bias-pull-up;
-+	};
-+};
-+
-+
-+
-+
-+
-+&tcon0 {
-+	status = "okay";
-+};
-+
-+&r_i2c {
 +	status = "okay";
 +};
 +
@@ -259,13 +219,11 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "peripheral";
++	dr_mode = "host";
 +	status = "okay";
 +};
 +
 +&usbphy {
-+	/* USB Type-A port's VBUS is always on */
-+	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
-+	usb0_vbus-supply = <&reg_usb0_vbus>;
++	/* USB Type-A ports' VBUS is always on */
 +	status = "okay";
 +};

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -24,9 +24,10 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,159 @@
+@@ -0,0 +1,244 @@
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ * Copyright (C) 2017 Armbian
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual
@@ -73,7 +74,7 @@
 +#include <dt-bindings/gpio/gpio.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
++	model = "FriendlyARM Nanopi R1S H5";
 +	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
 +
 +	aliases {
@@ -126,9 +127,24 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <50>;
++	};
++
 +};
 +
 +&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -145,7 +161,7 @@
 +	status = "okay";
 +};
 +
-+&external_mdio {
++&mdio {
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
@@ -159,11 +175,80 @@
 +	status = "okay";
 +};
 +
++&mmc1 {
++        vmmc-supply = <&reg_vcc3v3>;
++        vqmmc-supply = <&reg_vcc3v3>;
++        mmc-pwrseq = <&wifi_pwrseq>;
++        bus-width = <4>;
++        non-removable;
++        status = "okay";
++
++        brcmf: brcmf@1 {
++                reg = <1>;
++                compatible = "brcm,bcm4329-fmac";
++                interrupt-parent = <&pio>;
++                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
++                interrupt-names = "host-wake";
++                pinctrl-names = "default";
++                pinctrl-0 = <&wifi_wake>;
++        };
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&de {
++	status = "okay";
++};
++
 +&ohci0 {
 +	status = "okay";
 +};
 +
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
 +&ohci3 {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&mixer0 {
++	status = "okay";
++};
++
++&r_pio {
++	wifi_wake: wifi_wake@0 {
++		pins = "PL7";
++		function = "irq";
++		bias-pull-up;
++	};
++};
++
++
++
++
++
++&tcon0 {
++	status = "okay";
++};
++
++&r_i2c {
 +	status = "okay";
 +};
 +
@@ -174,7 +259,7 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "otg";
++	dr_mode = "peripheral";
 +	status = "okay";
 +};
 +

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -24,7 +24,7 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,159 @@
+@@ -0,0 +1,192 @@
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 + *
@@ -126,13 +126,19 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
++	};
 +};
 +
-+&ehci0 {
++&ehci1 {
 +	status = "okay";
 +};
 +
-+&ehci3 {
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -159,11 +165,38 @@
 +	status = "okay";
 +};
 +
-+&ohci0 {
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	sdio_wifi: sdio_wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
 +	status = "okay";
 +};
 +
-+&ohci3 {
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
 +	status = "okay";
 +};
 +
@@ -174,7 +207,7 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "otg";
++	dr_mode = "peripheral";
 +	status = "okay";
 +};
 +

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -4,9 +4,9 @@
            - const: friendlyarm,nanopi-neo2
            - const: allwinner,sun50i-h5
  
-+      - description: FriendlyARM NanoPi R1S
++      - description: FriendlyARM NanoPi R1S H5
 +        items:
-+          - const: friendlyarm,nanopi-r1s
++          - const: friendlyarm,nanopi-r1s-h5
 +          - const: allwinner,sun50i-h5
 +
        - description: FriendlyARM NanoPi Neo Air
@@ -18,66 +18,36 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-emlid-neutis-n5-devboard.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
-+dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,192 @@
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s-h5.dts
+@@ -0,0 +1,269 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
-+ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ * Copyright (C) 2021 Chukun Pan <amadeus@jmu.edu.cn>
 + *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
++ * Based on sun50i-h5-nanopi-neo-plus2.dts, which is:
++ *   Copyright (C) 2017 Antony Antony <antony@phenome.org>
++ *   Copyright (C) 2016 ARM Ltd.
 + */
 +
 +/dts-v1/;
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi R1S";
-+	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++	model = "FriendlyARM NanoPi R1S H5";
++	compatible = "friendlyarm,nanopi-r1s-h5", "allwinner,sun50i-h5";
 +
 +	aliases {
 +		ethernet0 = &emac;
++		ethernet1 = &rtl8189etv;
 +		serial0 = &uart0;
 +	};
 +
@@ -88,15 +58,33 @@
 +	leds {
 +		compatible = "gpio-leds";
 +
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
++		led-0 {
++			function = LED_FUNCTION_LAN;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +
-+		status {
-+			label = "nanopi:blue:status";
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-2 {
++			function = LED_FUNCTION_WAN;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	r-gpio-keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +
@@ -127,11 +115,104 @@
 +		status = "okay";
 +	};
 +
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0>, <1300000 0x1>;
++	};
++
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <200>;
 +	};
++
++	cpu_opp_table: cpu-opp-table {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <1000000 1000000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-648000000 {
++			opp-hz = /bits/ 64 <648000000>;
++			opp-microvolt = <1040000 1040000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <1080000 1080000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-912000000 {
++			opp-hz = /bits/ 64 <912000000>;
++			opp-microvolt = <1120000 1120000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-960000000 {
++			opp-hz = /bits/ 64 <960000000>;
++			opp-microvolt = <1160000 1160000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <1200000 1200000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1056000000 {
++			opp-hz = /bits/ 64 <1056000000>;
++			opp-microvolt = <1240000 1240000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1104000000 {
++			opp-hz = /bits/ 64 <1104000000>;
++			opp-microvolt = <1260000 1260000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>;
++			opp-microvolt = <1300000 1300000 1310000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
 +};
 +
 +&ehci1 {
@@ -147,7 +228,7 @@
 +	pinctrl-0 = <&emac_rgmii_pins>;
 +	phy-supply = <&reg_gmac_3v3>;
 +	phy-handle = <&ext_rgmii_phy>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
 +	status = "okay";
 +};
 +
@@ -155,6 +236,16 @@
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
++	};
++};
++
++&i2c0 {
++	status = "okay";
++
++	eeprom@51 {
++		compatible = "microchip,24c02";
++		reg = <0x51>;
++		pagesize = <16>;
 +	};
 +};
 +
@@ -173,23 +264,9 @@
 +	non-removable;
 +	status = "okay";
 +
-+	sdio_wifi: sdio_wifi@1 {
++	rtl8189etv: sdio_wifi@1 {
 +		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+		interrupt-parent = <&pio>;
-+		interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>;
-+		interrupt-names = "host-wake";
 +	};
-+};
-+
-+&mmc2 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc2_8bit_pins>;
-+	vmmc-supply = <&reg_vcc3v3>;
-+	vqmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <8>;
-+	non-removable;
-+	status = "okay";
 +};
 +
 +&ohci1 {

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -24,7 +24,7 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,188 @@
+@@ -0,0 +1,159 @@
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 + *
@@ -86,21 +86,17 @@
 +	};
 +
 +	leds {
-+		/delete-node/ pwr;
++		compatible = "gpio-leds";
++
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
 +		status {
-+			label = "nanopi:red:status";
++			label = "nanopi:blue:status";
 +			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "heartbeat";
-+		};
-+
-+		wan {
-+			label = "nanopi:green:wan";
-+			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
-+		};
-+
-+		lan {
-+			label = "nanopi:green:lan";
-+			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -130,23 +126,9 @@
 +		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
 +		status = "okay";
 +	};
-+
-+	wifi_pwrseq: wifi_pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
-+	};
 +};
 +
 +&ehci0 {
-+	status = "okay";
-+};
-+
-+&ehci1 {
-+	status = "okay";
-+};
-+
-+&ehci2 {
 +	status = "okay";
 +};
 +
@@ -170,32 +152,14 @@
 +	};
 +};
 +
-+&mmc1 {
-+        vmmc-supply = <&reg_vcc3v3>;
-+        vqmmc-supply = <&reg_vcc3v3>;
-+        mmc-pwrseq = <&wifi_pwrseq>;
-+        bus-width = <4>;
-+        non-removable;
-+        status = "okay";
-+
-+        brcmf: brcmf@1 {
-+                reg = <1>;
-+                compatible = "brcm,bcm4329-fmac";
-+                interrupt-parent = <&pio>;
-+                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
-+                interrupt-names = "host-wake";
-+        };
++&mmc0 {
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	status = "okay";
 +};
 +
 +&ohci0 {
-+	status = "okay";
-+};
-+
-+&ohci1 {
-+	status = "okay";
-+};
-+
-+&ohci2 {
 +	status = "okay";
 +};
 +
@@ -211,5 +175,12 @@
 +
 +&usb_otg {
 +	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbphy {
++	/* USB Type-A port's VBUS is always on */
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++	usb0_vbus-supply = <&reg_usb0_vbus>;
 +	status = "okay";
 +};

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -24,10 +24,9 @@
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
-@@ -0,0 +1,201 @@
+@@ -0,0 +1,188 @@
 +/*
-+ * Copyright (C) 2017 Antony Antony <antony@phenome.org>
-+ * Copyright (C) 2016 ARM Ltd.
++ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual
@@ -72,8 +71,6 @@
 +#include "sun50i-h5.dtsi"
 +
 +#include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/input/input.h>
-+#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
 +	model = "FriendlyARM NanoPi R1S";
@@ -89,17 +86,21 @@
 +	};
 +
 +	leds {
-+		compatible = "gpio-leds";
-+
-+		pwr {
-+			label = "nanopi:green:pwr";
-+			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			default-state = "on";
-+		};
-+
++		/delete-node/ pwr;
 +		status {
 +			label = "nanopi:red:status";
-+			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		wan {
++			label = "nanopi:green:wan";
++			gpios = <&pio 6 11 GPIO_ACTIVE_HIGH>;
++		};
++
++		lan {
++			label = "nanopi:green:lan";
++			gpios = <&pio 0 9 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +
@@ -120,36 +121,32 @@
 +		regulator-max-microvolt = <3300000>;
 +	};
 +
-+	vdd_cpux: gpio-regulator {
-+		compatible = "regulator-gpio";
-+		regulator-name = "vdd-cpux";
-+		regulator-type = "voltage";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1300000>;
-+		regulator-ramp-delay = <50>; /* 4ms */
-+		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
-+		gpios-states = <0x1>;
-+		states = <1100000 0>, <1300000 1>;
++	reg_usb0_vbus: usb0-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb0-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
++		status = "okay";
 +	};
 +
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
-+		post-power-on-delay-ms = <200>;
++		pinctrl-names = "default";
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>;
 +	};
 +};
 +
-+&codec {
-+	allwinner,audio-routing =
-+		"Line Out", "LINEOUT",
-+		"MIC1", "Mic",
-+		"Mic",  "MBIAS";
++&ehci0 {
 +	status = "okay";
 +};
 +
-+&ehci0 {
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
 +	status = "okay";
 +};
 +
@@ -173,38 +170,32 @@
 +	};
 +};
 +
-+&mmc0 {
-+	vmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <4>;
-+	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
-+	status = "okay";
-+};
-+
 +&mmc1 {
-+	vmmc-supply = <&reg_vcc3v3>;
-+	vqmmc-supply = <&reg_vcc3v3>;
-+	mmc-pwrseq = <&wifi_pwrseq>;
-+	bus-width = <4>;
-+	non-removable;
-+	status = "okay";
++        vmmc-supply = <&reg_vcc3v3>;
++        vqmmc-supply = <&reg_vcc3v3>;
++        mmc-pwrseq = <&wifi_pwrseq>;
++        bus-width = <4>;
++        non-removable;
++        status = "okay";
 +
-+	brcmf: wifi@1 {
-+		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+	};
-+};
-+
-+&mmc2 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc2_8bit_pins>;
-+	vmmc-supply = <&reg_vcc3v3>;
-+	bus-width = <8>;
-+	non-removable;
-+	cap-mmc-hw-reset;
-+	status = "okay";
++        brcmf: brcmf@1 {
++                reg = <1>;
++                compatible = "brcm,bcm4329-fmac";
++                interrupt-parent = <&pio>;
++                interrupts = <6 10 IRQ_TYPE_LEVEL_LOW>; /* PG10 */
++                interrupt-names = "host-wake";
++        };
 +};
 +
 +&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
 +	status = "okay";
 +};
 +
@@ -219,11 +210,6 @@
 +};
 +
 +&usb_otg {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&usbphy {
-+	/* USB Type-A ports' VBUS is always on */
++	dr_mode = "otg";
 +	status = "okay";
 +};

--- a/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
+++ b/target/linux/sunxi/patches-5.4/302-sunxi-h5-add-support-for-nanopi-r1s.patch
@@ -1,0 +1,186 @@
+--- a/Documentation/devicetree/bindings/arm/sunxi.yaml
++++ b/Documentation/devicetree/bindings/arm/sunxi.yaml
+@@ -231,6 +231,11 @@ properties:
+           - const: friendlyarm,nanopi-neo2
+           - const: allwinner,sun50i-h5
+ 
++      - description: FriendlyARM NanoPi R1S
++        items:
++          - const: friendlyarm,nanopi-r1s
++          - const: allwinner,sun50i-h5
++
+       - description: FriendlyARM NanoPi Neo Air
+         items:
+           - const: friendlyarm,nanopi-neo-air
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -16,6 +16,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-ba
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-emlid-neutis-n5-devboard.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-prime.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-r1s.dts
+@@ -0,0 +1,159 @@
++/*
++ * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "sun50i-h5.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	model = "FriendlyARM NanoPi R1S";
++	compatible = "friendlyarm,nanopi-r1s", "allwinner,sun50i-h5";
++
++	aliases {
++		ethernet0 = &emac;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++		status {
++			label = "nanopi:blue:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	reg_gmac_3v3: gmac-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "gmac-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <100000>;
++		enable-active-high;
++		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
++	reg_usb0_vbus: usb0-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb0-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
++		status = "okay";
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&emac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&emac_rgmii_pins>;
++	phy-supply = <&reg_gmac_3v3>;
++	phy-handle = <&ext_rgmii_phy>;
++	phy-mode = "rgmii";
++	status = "okay";
++};
++
++&external_mdio {
++	ext_rgmii_phy: ethernet-phy@7 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <7>;
++	};
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pa_pins>;
++	status = "okay";
++};
++
++&usb_otg {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbphy {
++	/* USB Type-A port's VBUS is always on */
++	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
++	usb0_vbus-supply = <&reg_usb0_vbus>;
++	status = "okay";
++};


### PR DESCRIPTION
It has the following features:

- Allwinner H5, Quad-core Cortex-A53
- 512MB DDR3 RAM
- 10/100/1000M Ethernet x 2
- RTL8189ETV WiFi 802.11b/g/n
- USB 2.0 host port (A)
- MicroSD Slot
- Serial Debug Port
- 5V 2A DC power-supply

Signed-off-by: Marius Durbaca <mariusd84@gmail.com>
