### PR TITLE
ath79: add support for Sophos AP100/AP55 family

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -113,6 +113,12 @@ plasmacloud,pa300e)
 qihoo,c301)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
 	;;
+sophos,ap55|\
+sophos,ap55c|\
+sophos,ap100|\
+sophos,ap100c)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	;;
 wallys,dr531)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0xf800" "0x10000"
 	;;

--- a/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
+++ b/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/*
+ * The hardware of this board family is most likely shared with other devices
+ * from other manufacturers. Edimax appear to be the actual OEM.
+ *
+ * Sophos use the same exact board for the AP55C/AP100C, and AP55/AP100.
+ * Yes, this means your AP55C is a 3x3 AP with a software lock, and your
+ * AP55 is an AP100 with one missing antenna pigtail.
+ *
+ * AP55 and AP55C boards have different physical layouts, but are logically
+ * almost identical. AP55/100 have an empty micro-USB OTG port footprint,
+ * which may be possible to retrofit with some work.
+ */
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			label = "green:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_usb_vbus: reg_usb_vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+		status = "disabled";
+	};
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			config: partition@60000 {
+				label = "config";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0xf90000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x10>;
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0xa0000101 0xa0001313>;
+
+	nvmem-cells = <&macaddr_config_201a>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac_config: gmac-config {
+		device = <&gmac>;
+
+		rgmii-enabled = <1>;
+
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <3>;
+		txd-delay = <3>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_201a: macaddr@201a {
+		reg = <0x201a 0x6>;
+	};
+};
+
+&usb0 {
+	vbus-supply = <&reg_usb_vbus>;
+
+	hub_port0: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};

--- a/target/linux/ath79/dts/qca9558_sophos_ap100.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap100.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_sophos_ap.dtsi"
+
+/ {
+	compatible = "sophos,ap100", "qca,qca9558";
+	model = "Sophos AP100";
+};
+
+&reg_usb_vbus {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "host";
+};

--- a/target/linux/ath79/dts/qca9558_sophos_ap100c.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap100c.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_sophos_ap.dtsi"
+
+/ {
+	compatible = "sophos,ap100c", "qca,qca9558";
+	model = "Sophos AP100C";
+};

--- a/target/linux/ath79/dts/qca9558_sophos_ap55.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap55.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_sophos_ap.dtsi"
+
+/ {
+	compatible = "sophos,ap55", "qca,qca9558";
+	model = "Sophos AP55";
+};
+
+&reg_usb_vbus {
+	status = "okay";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+	dr_mode = "host";
+};

--- a/target/linux/ath79/dts/qca9558_sophos_ap55c.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap55c.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_sophos_ap.dtsi"
+
+/ {
+	compatible = "sophos,ap55c", "qca,qca9558";
+	model = "Sophos AP55C";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -57,6 +57,10 @@ ath79_setup_interfaces()
 	pisen,wmb001n|\
 	pisen,wmm003n|\
 	siemens,ws-ap3610|\
+	sophos,ap55|\
+	sophos,ap55c|\
+	sophos,ap100|\
+	sophos,ap100c|\
 	tplink,cpe210-v2|\
 	tplink,cpe210-v3|\
 	tplink,cpe510-v2|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -30,6 +30,10 @@ case "$FIRMWARE" in
 	qxwlan,e1700ac-v2-16m|\
 	qxwlan,e600gac-v2-8m|\
 	qxwlan,e600gac-v2-16m|\
+	sophos,ap55|\
+	sophos,ap55c|\
+	sophos,ap100|\
+	sophos,ap100c|\
 	ubnt,aircube-ac|\
 	ubnt,bullet-ac|\
 	ubnt,unifiac-lite|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2240,6 +2240,42 @@ define Device/sitecom_wlr-8100
 endef
 TARGET_DEVICES += sitecom_wlr-8100
 
+define Device/sophos_ap55
+  SOC := qca9558
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := AP55
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += sophos_ap55
+
+define Device/sophos_ap55c
+  SOC := qca9558
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := AP55C
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += sophos_ap55c
+
+define Device/sophos_ap100
+  SOC := qca9558
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := AP100
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += sophos_ap100
+
+define Device/sophos_ap100c
+  SOC := qca9558
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := AP100C
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += sophos_ap100c
+
 define Device/telco_t1
   SOC := qca9531
   DEVICE_VENDOR := Telco


### PR DESCRIPTION
The Sophos AP100, AP100C, AP55, and AP55C are dual-band 802.11ac access
points based on the Qualcomm QCA9558 SoC. They share PCB designs with
several devices that already have partial or full support, most notably the
Devolo DVL1750i/e.

The AP100 and AP100C are hardware-identical to the AP55 and AP55C, however
the 55 models' ART does not contain calibration data for their third chain
despite it being present on the PCB.

Specifications common to all models:
 - Qualcomm QCA9558 SoC @ 720 MHz (MIPS 74Kc Big-endian processor)
 - 128 MB RAM
 - 16 MB SPI flash
 - 1x 10/100/1000 Mbps Ethernet port, 802.3af PoE-in
 - Green and Red status LEDs sharing a single external light-pipe
 - Reset button on PCB[1]
 - Piezo beeper on PCB[2]
 - Serial UART header on PCB
 - Alternate power supply via 5.5x2.1mm DC jack @ 12 VDC

Unique to AP100 and AP100C:
 - 3T3R 2.4GHz 802.11b/g/n via SoC WMAC
 - 3T3R 5.8GHz 802.11a/n/ac via QCA9880 (PCI Express)

AP55 and AP55C:
 - 2T2R 2.4GHz 802.11b/g/n via SoC WMAC
 - 2T2R 5.8GHz 802.11a/n/ac via QCA9880 (PCI Express)

AP100 and AP55:
 - External RJ45 serial console port[3]
 - USB 2.0 Type A port, untested, power controlled via GPIO 21 or 22 (TBC)

Flashing instructions:

This firmware can be flashed either via a compatible Sophos SG or XG
firewall appliance, which does not require disassembling the device, or via
the U-Boot console available on the internal UART header.

To flash via XG appliance:
 - Register on Sophos' website for a no-cost Home Use XG firewall license
 - Download and install the XG software on a compatible PC or virtual
   machine, complete initial appliance setup, and enable SSH console access
 - Connect the target AP device to the XG appliance's LAN interface
 - Approve the AP from the XG Web UI and wait until it shows as Active
   (this can take 3-5 minutes)
 - Connect to the XG appliance over SSH and access the Advanced Console
   (Menu option 5, then menu option 3)
 - Run `sudo awetool` and select the menu option to connect to an AP via
   SSH. When prompted to enable SSH on the target AP, select Yes.
 - Wait 2-3 minutes, then select the AP from the awetool menu again. This
   will connect you to a root shell on the target AP.
 - Copy the firmware to /tmp/openwrt.bin on the target AP via SCP/TFTP/etc
 - Run `mtd -r write /tmp/openwrt.bin astaro_image`
 - When complete, the access point will reboot to OpenWRT.

To flash via U-Boot serial console:
 - Configure a TFTP server on your PC, and set IP address 192.168.99.8 with
   netmask 255.255.255.0
 - Copy the firmware .bin to the TFTP server and rename to 'uImage_AP100C'
 - Open the target AP's enclosure and locate the 4-pin 3.3V UART header [4]
 - Connect the AP ethernet to your PC's ethernet port
 - Connect a terminal to the UART at 115200 8/N/1 as usual
 - Power on the AP and press a key to cancel autoboot when prompted
 - Run the following commands at the U-Boot console:
    - `tftpboot`
    - `cp.b $fileaddr 0x9f070000 $filesize`
    - `boot`
 - The access point will boot to OpenWRT.

MAC addresses as verified by OEM firmware:

use   address     source
LAN   label       config 0x201a (label)
2g    label + 1   art 0x1002    (also found at config 0x2004)
5g    label + 9   art 0x5006

Increments confirmed across three AP55C, two AP55, and one AP100C.

These changes have been tested to function on both current master and
21.02.0 without any obvious issues.

[1] Button is present but does not alter state of any GPIO on SoC
[2] Buzzer and driver circuitry is present on PCB but is not connected to
    any GPIO. Shorting an unpopulated resistor next to the driver circuitry
    should connect the buzzer to GPIO 4, but this is unconfirmed.
[3] As with the Devolo sister devices, this external RJ45 serial port does
    not function; it is disabled on the OEM firmware as well, and may not
    be electrically connected.
[4] On AP100/AP55 models the UART header is accessible after removing
    the device's top cover. On AP100C/AP55C models, the PCB must be removed
    for access; three screws secure it to the case.
    Pin 1 is marked on the silkscreen. Pins from 1-4 are 3.3V, GND, TX, RX

Signed-off-by: Andrew Powers-Holmes <andrew@omnom.net>
