### PR TITLE
kernel: add package kmod-iio-ads1015 and remove kmod-hwmon-ads1015

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -43,20 +43,6 @@ endef
 
 $(eval $(call KernelPackage,hwmon-ad7418))
 
-define KernelPackage/hwmon-ads1015
-  TITLE:=Texas Instruments ADS1015
-  KCONFIG:= CONFIG_SENSORS_ADS1015
-  FILES:= $(LINUX_DIR)/drivers/hwmon/ads1015.ko
-  AUTOLOAD:=$(call AutoLoad,60,ads1015)
-  $(call AddDepends/hwmon,+kmod-i2c-core)
-endef
-
-define KernelPackage/hwmon-ads1015/description
- Kernel module for Texas Instruments ADS1015 Analog-to-Digital converter
-endef
-
-$(eval $(call KernelPackage,hwmon-ads1015))
-
 define KernelPackage/hwmon-adt7410
   TITLE:=ADT7410 monitoring support
   KCONFIG:= \

--- a/package/kernel/linux/modules/iio.mk
+++ b/package/kernel/linux/modules/iio.mk
@@ -78,6 +78,21 @@ endef
 
 $(eval $(call KernelPackage,iio-ad799x))
 
+define KernelPackage/iio-ads1015
+  SUBMENU:=$(IIO_MENU)
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-regmap-i2c +kmod-industrialio-triggered-buffer
+  TITLE:=Texas Instruments ADS1015 ADC driver
+  KCONFIG:= CONFIG_TI_ADS1015
+  FILES:=$(LINUX_DIR)/drivers/iio/adc/ti-ads1015.ko
+  AUTOLOAD:=$(call AutoLoad,56,ti-ads1015)
+endef
+
+define KernelPackage/iio-ads1015/description
+ This driver adds support for Texas Instruments ADS1015 and ADS1115 ADCs.
+endef
+
+$(eval $(call KernelPackage,iio-ads1015))
+
 define KernelPackage/iio-hmc5843
   SUBMENU:=$(IIO_MENU)
   DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-regmap-i2c +kmod-industrialio-triggered-buffer


### PR DESCRIPTION
The hwmon driver for the ADC ADS1015 has been removed in Linux 5.4 in
favor of a driver in the iio system. For details see:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2c9d5b5e

This fixes: https://bugs.openwrt.org/index.php?do=details&task_id=4005

Run-tested: ramips/mt76x8 (Onion Omega 2+)

Signed-off-by: Christian Pointner <equinox@spreadspace.org>
