### PR TITLE
ath79: Add support for COMFAST CF-E320N v2

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-e320n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e320n-v2.dts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "comfast,cf-e320n-v2", "qca,qca9531";
+	model = "COMFAST CF-E320N v2";
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_rssihigh;
+		led-failsafe = &led_rssihigh;
+		led-upgrade = &led_rssihigh;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &led_rssilow_pin &led_rssimediumhigh_pin &led_rssihigh_pin>;
+
+		wan {
+			label = "red:wan";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssilow {
+			label = "red:rssilow";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssimediumlow {
+			label = "red:rssimediumlow";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssimediumhigh {
+			label = "green:rssimediumhigh";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_rssihigh: rssihigh {
+			label = "green:rssihigh";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pinmux {
+	led_rssilow_pin: pinmux_rssilow_pin {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+
+	led_rssimediumhigh_pin: pinmux_rssimediumhigh_pin {
+		pinctrl-single,bits = <0xc 0x0 0x00ff0000>;
+	};
+
+	led_rssihigh_pin: pinmux_rssihigh_pin {
+		pinctrl-single,bits = <0x10 0x0 0x000000ff>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x010000>;
+				read-only;
+			};
+
+			art: partition@10000 {
+				label = "art";
+				reg = <0x010000 0x010000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x020000 0x7c0000>;
+			};
+
+			partition@7e0000 {
+				label = "configs";
+				reg = <0x7e0000 0x010000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "nvram";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_art_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_art_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -180,6 +180,15 @@ comfast,cf-e314n-v2)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+comfast,cf-e320n-v2)
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
+	ucidef_set_led_switch "wan" "WAN" "red:wan" "switch0" "0x02"
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan0" "1" "100"
+	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "red:rssimediumlow" "wlan0" "26" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
+	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
+	;;
 comfast,cf-e375ac)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x04"
 	ucidef_set_led_switch "wan" "WAN" "red:wan" "switch0" "0x02"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -239,6 +239,7 @@ ath79_setup_interfaces()
 	comfast,cf-e110n-v2|\
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\
+	comfast,cf-e320n-v2|\
 	compex,wpj531-16m|\
 	openmesh,a40|\
 	openmesh,a60|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -806,6 +806,16 @@ define Device/comfast_cf-e314n-v2
 endef
 TARGET_DEVICES += comfast_cf-e314n-v2
 
+define Device/comfast_cf-e320n-v2
+  SOC := qca9531
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-E320N
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := rssileds
+  IMAGE_SIZE := 7936k
+endef
+TARGET_DEVICES += comfast_cf-e320n-v2
+
 define Device/comfast_cf-e375ac
   SOC := qca9563
   DEVICE_VENDOR := COMFAST


### PR DESCRIPTION
COMFAST CF-E320N v2 is a Ceiling AP with PoE support, based on
Qualcomm/Atheros QCA9531.

Short specification:

    2x 10/100 Mbps Ethernet, with 24v PoE support
    64 MB of RAM (DDR2)
    16 MB of FLASH (SPI)
    2T2R 2.4 GHz, 802.11b/g/n
    Built-in 2x 3 dBi antennas
    Output power (max): 110 mW (19 dBm)

Flash instruction:

Original firmware is based on OpenWrt.
Use sysupgrade image directly in vendor GUI.

Based on: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commitdiff;h=31952dbd1c40a2cd015ef435bd64fa9b2bb87eec
