### PR TITLE
kernel: 5.10: dsa: qca8k: backport stability improvements

### DIFF
--- a/target/linux/generic/backport-5.10/785-v5.14-01-net-dsa-qca8k-change-simple-print-to-dev-variant.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-01-net-dsa-qca8k-change-simple-print-to-dev-variant.patch
@@ -1,0 +1,35 @@
+From 5d9e068402dcf7354cc8ee66c2152845306d2ccb Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:51 +0200
+Subject: [PATCH] net: dsa: qca8k: change simple print to dev variant
+
+Change pr_err and pr_warn to dev variant.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -701,7 +701,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 
+ 	/* Make sure that port 0 is the cpu port */
+ 	if (!dsa_is_cpu_port(ds, 0)) {
+-		pr_err("port 0 is not the CPU port\n");
++		dev_err(priv->dev, "port 0 is not the CPU port");
+ 		return -EINVAL;
+ 	}
+ 
+@@ -711,7 +711,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 	priv->regmap = devm_regmap_init(ds->dev, NULL, priv,
+ 					&qca8k_regmap_config);
+ 	if (IS_ERR(priv->regmap))
+-		pr_warn("regmap initialization failed");
++		dev_warn(priv->dev, "regmap initialization failed");
+ 
+ 	ret = qca8k_setup_mdio_bus(priv);
+ 	if (ret)

--- a/target/linux/generic/backport-5.10/785-v5.14-02-net-dsa-qca8k-use-iopoll-macro-for-qca8k_busy_wait.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-02-net-dsa-qca8k-use-iopoll-macro-for-qca8k_busy_wait.patch
@@ -1,0 +1,61 @@
+From 2ad255f2faaffb3af786031fba2e7955454b558a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:52 +0200
+Subject: [PATCH] net: dsa: qca8k: use iopoll macro for qca8k_busy_wait
+
+Use iopoll macro instead of while loop.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 23 +++++++++++------------
+ drivers/net/dsa/qca8k.h |  2 ++
+ 2 files changed, 13 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -262,21 +262,20 @@ static struct regmap_config qca8k_regmap
+ static int
+ qca8k_busy_wait(struct qca8k_priv *priv, u32 reg, u32 mask)
+ {
+-	unsigned long timeout;
++	u32 val;
++	int ret;
+ 
+-	timeout = jiffies + msecs_to_jiffies(20);
++	ret = read_poll_timeout(qca8k_read, val, !(val & mask),
++				0, QCA8K_BUSY_WAIT_TIMEOUT * USEC_PER_MSEC, false,
++				priv, reg);
+ 
+-	/* loop until the busy flag has cleared */
+-	do {
+-		u32 val = qca8k_read(priv, reg);
+-		int busy = val & mask;
++	/* Check if qca8k_read has failed for a different reason
++	 * before returning -ETIMEDOUT
++	 */
++	if (ret < 0 && val < 0)
++		return val;
+ 
+-		if (!busy)
+-			break;
+-		cond_resched();
+-	} while (!time_after_eq(jiffies, timeout));
+-
+-	return time_after_eq(jiffies, timeout);
++	return ret;
+ }
+ 
+ static void
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -18,6 +18,8 @@
+ #define PHY_ID_QCA8337					0x004dd036
+ #define QCA8K_ID_QCA8337				0x13
+ 
++#define QCA8K_BUSY_WAIT_TIMEOUT				20
++
+ #define QCA8K_NUM_FDB_RECORDS				2048
+ 
+ #define QCA8K_CPU_PORT					0

--- a/target/linux/generic/backport-5.10/785-v5.14-03-net-dsa-qca8k-improve-qca8k-read-write-rmw-bus-acces.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-03-net-dsa-qca8k-improve-qca8k-read-write-rmw-bus-acces.patch
@@ -1,0 +1,86 @@
+From 504bf65931824eda83494e5b5d75686e27ace03e Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:53 +0200
+Subject: [PATCH] net: dsa: qca8k: improve qca8k read/write/rmw bus access
+
+Put bus in local variable to improve faster access to the mdio bus.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 29 ++++++++++++++++-------------
+ 1 file changed, 16 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -142,17 +142,18 @@ qca8k_set_page(struct mii_bus *bus, u16
+ static u32
+ qca8k_read(struct qca8k_priv *priv, u32 reg)
+ {
++	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 val;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+-	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(priv->bus, page);
+-	val = qca8k_mii_read32(priv->bus, 0x10 | r2, r1);
++	qca8k_set_page(bus, page);
++	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
+ 
+-	mutex_unlock(&priv->bus->mdio_lock);
++	mutex_unlock(&bus->mdio_lock);
+ 
+ 	return val;
+ }
+@@ -160,35 +161,37 @@ qca8k_read(struct qca8k_priv *priv, u32
+ static void
+ qca8k_write(struct qca8k_priv *priv, u32 reg, u32 val)
+ {
++	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+-	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(priv->bus, page);
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
++	qca8k_set_page(bus, page);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, val);
+ 
+-	mutex_unlock(&priv->bus->mdio_lock);
++	mutex_unlock(&bus->mdio_lock);
+ }
+ 
+ static u32
+ qca8k_rmw(struct qca8k_priv *priv, u32 reg, u32 mask, u32 val)
+ {
++	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 ret;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+-	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(priv->bus, page);
+-	ret = qca8k_mii_read32(priv->bus, 0x10 | r2, r1);
++	qca8k_set_page(bus, page);
++	ret = qca8k_mii_read32(bus, 0x10 | r2, r1);
+ 	ret &= ~mask;
+ 	ret |= val;
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, ret);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, ret);
+ 
+-	mutex_unlock(&priv->bus->mdio_lock);
++	mutex_unlock(&bus->mdio_lock);
+ 
+ 	return ret;
+ }

--- a/target/linux/generic/backport-5.10/785-v5.14-04-net-dsa-qca8k-handle-qca8k_set_page-errors.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-04-net-dsa-qca8k-handle-qca8k_set_page-errors.patch
@@ -1,0 +1,101 @@
+From ba5707ec58cfb6853dff41c2aae72deb6a03d389 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:54 +0200
+Subject: [PATCH] net: dsa: qca8k: handle qca8k_set_page errors
+
+With a remote possibility, the set_page function can fail. Since this is
+a critical part of the write/read qca8k regs, propagate the error and
+terminate any read/write operation.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 33 ++++++++++++++++++++++++++-------
+ 1 file changed, 26 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -127,16 +127,23 @@ qca8k_mii_write32(struct mii_bus *bus, i
+ 				    "failed to write qca8k 32bit register\n");
+ }
+ 
+-static void
++static int
+ qca8k_set_page(struct mii_bus *bus, u16 page)
+ {
++	int ret;
++
+ 	if (page == qca8k_current_page)
+-		return;
++		return 0;
+ 
+-	if (bus->write(bus, 0x18, 0, page) < 0)
++	ret = bus->write(bus, 0x18, 0, page);
++	if (ret < 0) {
+ 		dev_err_ratelimited(&bus->dev,
+ 				    "failed to set qca8k page\n");
++		return ret;
++	}
++
+ 	qca8k_current_page = page;
++	return 0;
+ }
+ 
+ static u32
+@@ -150,11 +157,14 @@ qca8k_read(struct qca8k_priv *priv, u32
+ 
+ 	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(bus, page);
++	val = qca8k_set_page(bus, page);
++	if (val < 0)
++		goto exit;
++
+ 	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
+ 
++exit:
+ 	mutex_unlock(&bus->mdio_lock);
+-
+ 	return val;
+ }
+ 
+@@ -163,14 +173,19 @@ qca8k_write(struct qca8k_priv *priv, u32
+ {
+ 	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
++	int ret;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+ 	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(bus, page);
++	ret = qca8k_set_page(bus, page);
++	if (ret < 0)
++		goto exit;
++
+ 	qca8k_mii_write32(bus, 0x10 | r2, r1, val);
+ 
++exit:
+ 	mutex_unlock(&bus->mdio_lock);
+ }
+ 
+@@ -185,12 +200,16 @@ qca8k_rmw(struct qca8k_priv *priv, u32 r
+ 
+ 	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	qca8k_set_page(bus, page);
++	ret = qca8k_set_page(bus, page);
++	if (ret < 0)
++		goto exit;
++
+ 	ret = qca8k_mii_read32(bus, 0x10 | r2, r1);
+ 	ret &= ~mask;
+ 	ret |= val;
+ 	qca8k_mii_write32(bus, 0x10 | r2, r1, ret);
+ 
++exit:
+ 	mutex_unlock(&bus->mdio_lock);
+ 
+ 	return ret;

--- a/target/linux/generic/backport-5.10/785-v5.14-05-net-dsa-qca8k-handle-error-with-qca8k_read-operation.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-05-net-dsa-qca8k-handle-error-with-qca8k_read-operation.patch
@@ -1,0 +1,207 @@
+From 028f5f8ef44fcf87a456772cbb9f0d90a0a22884 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:55 +0200
+Subject: [PATCH] net: dsa: qca8k: handle error with qca8k_read operation
+
+qca8k_read can fail. Rework any user to handle error values and
+correctly return.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 73 ++++++++++++++++++++++++++++++++---------
+ 1 file changed, 58 insertions(+), 15 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -231,8 +231,13 @@ static int
+ qca8k_regmap_read(void *ctx, uint32_t reg, uint32_t *val)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ctx;
++	int ret;
++
++	ret = qca8k_read(priv, reg);
++	if (ret < 0)
++		return ret;
+ 
+-	*val = qca8k_read(priv, reg);
++	*val = ret;
+ 
+ 	return 0;
+ }
+@@ -300,15 +305,20 @@ qca8k_busy_wait(struct qca8k_priv *priv,
+ 	return ret;
+ }
+ 
+-static void
++static int
+ qca8k_fdb_read(struct qca8k_priv *priv, struct qca8k_fdb *fdb)
+ {
+-	u32 reg[4];
++	u32 reg[4], val;
+ 	int i;
+ 
+ 	/* load the ARL table into an array */
+-	for (i = 0; i < 4; i++)
+-		reg[i] = qca8k_read(priv, QCA8K_REG_ATU_DATA0 + (i * 4));
++	for (i = 0; i < 4; i++) {
++		val = qca8k_read(priv, QCA8K_REG_ATU_DATA0 + (i * 4));
++		if (val < 0)
++			return val;
++
++		reg[i] = val;
++	}
+ 
+ 	/* vid - 83:72 */
+ 	fdb->vid = (reg[2] >> QCA8K_ATU_VID_S) & QCA8K_ATU_VID_M;
+@@ -323,6 +333,8 @@ qca8k_fdb_read(struct qca8k_priv *priv,
+ 	fdb->mac[3] = (reg[0] >> QCA8K_ATU_ADDR3_S) & 0xff;
+ 	fdb->mac[4] = (reg[0] >> QCA8K_ATU_ADDR4_S) & 0xff;
+ 	fdb->mac[5] = reg[0] & 0xff;
++
++	return 0;
+ }
+ 
+ static void
+@@ -374,6 +386,8 @@ qca8k_fdb_access(struct qca8k_priv *priv
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_FDB_LOAD) {
+ 		reg = qca8k_read(priv, QCA8K_REG_ATU_FUNC);
++		if (reg < 0)
++			return reg;
+ 		if (reg & QCA8K_ATU_FUNC_FULL)
+ 			return -1;
+ 	}
+@@ -388,10 +402,10 @@ qca8k_fdb_next(struct qca8k_priv *priv,
+ 
+ 	qca8k_fdb_write(priv, fdb->vid, fdb->port_mask, fdb->mac, fdb->aging);
+ 	ret = qca8k_fdb_access(priv, QCA8K_FDB_NEXT, port);
+-	if (ret >= 0)
+-		qca8k_fdb_read(priv, fdb);
++	if (ret < 0)
++		return ret;
+ 
+-	return ret;
++	return qca8k_fdb_read(priv, fdb);
+ }
+ 
+ static int
+@@ -449,6 +463,8 @@ qca8k_vlan_access(struct qca8k_priv *pri
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_VLAN_LOAD) {
+ 		reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC1);
++		if (reg < 0)
++			return reg;
+ 		if (reg & QCA8K_VTU_FUNC1_FULL)
+ 			return -ENOMEM;
+ 	}
+@@ -475,6 +491,8 @@ qca8k_vlan_add(struct qca8k_priv *priv,
+ 		goto out;
+ 
+ 	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
++	if (reg < 0)
++		return reg;
+ 	reg |= QCA8K_VTU_FUNC0_VALID | QCA8K_VTU_FUNC0_IVL_EN;
+ 	reg &= ~(QCA8K_VTU_FUNC0_EG_MODE_MASK << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	if (untagged)
+@@ -506,6 +524,8 @@ qca8k_vlan_del(struct qca8k_priv *priv,
+ 		goto out;
+ 
+ 	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
++	if (reg < 0)
++		return reg;
+ 	reg &= ~(3 << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	reg |= QCA8K_VTU_FUNC0_EG_MODE_NOT <<
+ 			QCA8K_VTU_FUNC0_EG_MODE_S(port);
+@@ -621,8 +641,11 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 			    QCA8K_MDIO_MASTER_BUSY))
+ 		return -ETIMEDOUT;
+ 
+-	val = (qca8k_read(priv, QCA8K_MDIO_MASTER_CTRL) &
+-		QCA8K_MDIO_MASTER_DATA_MASK);
++	val = qca8k_read(priv, QCA8K_MDIO_MASTER_CTRL);
++	if (val < 0)
++		return val;
++
++	val &= QCA8K_MDIO_MASTER_DATA_MASK;
+ 
+ 	return val;
+ }
+@@ -978,6 +1001,8 @@ qca8k_phylink_mac_link_state(struct dsa_
+ 	u32 reg;
+ 
+ 	reg = qca8k_read(priv, QCA8K_REG_PORT_STATUS(port));
++	if (reg < 0)
++		return reg;
+ 
+ 	state->link = !!(reg & QCA8K_PORT_STATUS_LINK_UP);
+ 	state->an_complete = state->link;
+@@ -1078,18 +1103,26 @@ qca8k_get_ethtool_stats(struct dsa_switc
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	const struct qca8k_mib_desc *mib;
+-	u32 reg, i;
++	u32 reg, i, val;
+ 	u64 hi;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(ar8327_mib); i++) {
+ 		mib = &ar8327_mib[i];
+ 		reg = QCA8K_PORT_MIB_COUNTER(port) + mib->offset;
+ 
+-		data[i] = qca8k_read(priv, reg);
++		val = qca8k_read(priv, reg);
++		if (val < 0)
++			continue;
++
+ 		if (mib->size == 2) {
+ 			hi = qca8k_read(priv, reg + 4);
+-			data[i] |= hi << 32;
++			if (hi < 0)
++				continue;
+ 		}
++
++		data[i] = val;
++		if (mib->size == 2)
++			data[i] |= hi << 32;
+ 	}
+ }
+ 
+@@ -1107,18 +1140,25 @@ qca8k_set_mac_eee(struct dsa_switch *ds,
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	u32 lpi_en = QCA8K_REG_EEE_CTRL_LPI_EN(port);
++	int ret = 0;
+ 	u32 reg;
+ 
+ 	mutex_lock(&priv->reg_mutex);
+ 	reg = qca8k_read(priv, QCA8K_REG_EEE_CTRL);
++	if (reg < 0) {
++		ret = reg;
++		goto exit;
++	}
++
+ 	if (eee->eee_enabled)
+ 		reg |= lpi_en;
+ 	else
+ 		reg &= ~lpi_en;
+ 	qca8k_write(priv, QCA8K_REG_EEE_CTRL, reg);
+-	mutex_unlock(&priv->reg_mutex);
+ 
+-	return 0;
++exit:
++	mutex_unlock(&priv->reg_mutex);
++	return ret;
+ }
+ 
+ static int
+@@ -1456,6 +1496,9 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 
+ 	/* read the switches ID register */
+ 	id = qca8k_read(priv, QCA8K_REG_MASK_CTRL);
++	if (id < 0)
++		return id;
++
+ 	id >>= QCA8K_MASK_CTRL_ID_S;
+ 	id &= QCA8K_MASK_CTRL_ID_M;
+ 	if (id != QCA8K_ID_QCA8337)

--- a/target/linux/generic/backport-5.10/785-v5.14-06-net-dsa-qca8k-handle-error-with-qca8k_write-operatio.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-06-net-dsa-qca8k-handle-error-with-qca8k_write-operatio.patch
@@ -1,0 +1,263 @@
+From d7805757c75c76e9518fc1023a29f0c4eed5b581 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:56 +0200
+Subject: [PATCH] net: dsa: qca8k: handle error with qca8k_write operation
+
+qca8k_write can fail. Rework any user to handle error values and
+correctly return.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 102 ++++++++++++++++++++++++++--------------
+ 1 file changed, 67 insertions(+), 35 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -168,7 +168,7 @@ exit:
+ 	return val;
+ }
+ 
+-static void
++static int
+ qca8k_write(struct qca8k_priv *priv, u32 reg, u32 val)
+ {
+ 	struct mii_bus *bus = priv->bus;
+@@ -187,6 +187,7 @@ qca8k_write(struct qca8k_priv *priv, u32
+ 
+ exit:
+ 	mutex_unlock(&bus->mdio_lock);
++	return ret;
+ }
+ 
+ static u32
+@@ -247,9 +248,7 @@ qca8k_regmap_write(void *ctx, uint32_t r
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ctx;
+ 
+-	qca8k_write(priv, reg, val);
+-
+-	return 0;
++	return qca8k_write(priv, reg, val);
+ }
+ 
+ static const struct regmap_range qca8k_readable_ranges[] = {
+@@ -367,6 +366,7 @@ static int
+ qca8k_fdb_access(struct qca8k_priv *priv, enum qca8k_fdb_cmd cmd, int port)
+ {
+ 	u32 reg;
++	int ret;
+ 
+ 	/* Set the command and FDB index */
+ 	reg = QCA8K_ATU_FUNC_BUSY;
+@@ -377,7 +377,9 @@ qca8k_fdb_access(struct qca8k_priv *priv
+ 	}
+ 
+ 	/* Write the function register triggering the table access */
+-	qca8k_write(priv, QCA8K_REG_ATU_FUNC, reg);
++	ret = qca8k_write(priv, QCA8K_REG_ATU_FUNC, reg);
++	if (ret)
++		return ret;
+ 
+ 	/* wait for completion */
+ 	if (qca8k_busy_wait(priv, QCA8K_REG_ATU_FUNC, QCA8K_ATU_FUNC_BUSY))
+@@ -447,6 +449,7 @@ static int
+ qca8k_vlan_access(struct qca8k_priv *priv, enum qca8k_vlan_cmd cmd, u16 vid)
+ {
+ 	u32 reg;
++	int ret;
+ 
+ 	/* Set the command and VLAN index */
+ 	reg = QCA8K_VTU_FUNC1_BUSY;
+@@ -454,7 +457,9 @@ qca8k_vlan_access(struct qca8k_priv *pri
+ 	reg |= vid << QCA8K_VTU_FUNC1_VID_S;
+ 
+ 	/* Write the function register triggering the table access */
+-	qca8k_write(priv, QCA8K_REG_VTU_FUNC1, reg);
++	ret = qca8k_write(priv, QCA8K_REG_VTU_FUNC1, reg);
++	if (ret)
++		return ret;
+ 
+ 	/* wait for completion */
+ 	if (qca8k_busy_wait(priv, QCA8K_REG_VTU_FUNC1, QCA8K_VTU_FUNC1_BUSY))
+@@ -502,7 +507,9 @@ qca8k_vlan_add(struct qca8k_priv *priv,
+ 		reg |= QCA8K_VTU_FUNC0_EG_MODE_TAG <<
+ 				QCA8K_VTU_FUNC0_EG_MODE_S(port);
+ 
+-	qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
++	ret = qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
++	if (ret)
++		return ret;
+ 	ret = qca8k_vlan_access(priv, QCA8K_VLAN_LOAD, vid);
+ 
+ out:
+@@ -545,7 +552,9 @@ qca8k_vlan_del(struct qca8k_priv *priv,
+ 	if (del) {
+ 		ret = qca8k_vlan_access(priv, QCA8K_VLAN_PURGE, vid);
+ 	} else {
+-		qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
++		ret = qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
++		if (ret)
++			return ret;
+ 		ret = qca8k_vlan_access(priv, QCA8K_VLAN_LOAD, vid);
+ 	}
+ 
+@@ -555,15 +564,20 @@ out:
+ 	return ret;
+ }
+ 
+-static void
++static int
+ qca8k_mib_init(struct qca8k_priv *priv)
+ {
++	int ret;
++
+ 	mutex_lock(&priv->reg_mutex);
+ 	qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_FLUSH | QCA8K_MIB_BUSY);
+ 	qca8k_busy_wait(priv, QCA8K_REG_MIB, QCA8K_MIB_BUSY);
+ 	qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_CPU_KEEP);
+-	qca8k_write(priv, QCA8K_REG_MODULE_EN, QCA8K_MODULE_EN_MIB);
++
++	ret = qca8k_write(priv, QCA8K_REG_MODULE_EN, QCA8K_MODULE_EN_MIB);
++
+ 	mutex_unlock(&priv->reg_mutex);
++	return ret;
+ }
+ 
+ static void
+@@ -600,6 +614,7 @@ static int
+ qca8k_mdio_write(struct qca8k_priv *priv, int port, u32 regnum, u16 data)
+ {
+ 	u32 phy, val;
++	int ret;
+ 
+ 	if (regnum >= QCA8K_MDIO_MASTER_MAX_REG)
+ 		return -EINVAL;
+@@ -613,7 +628,9 @@ qca8k_mdio_write(struct qca8k_priv *priv
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum) |
+ 	      QCA8K_MDIO_MASTER_DATA(data);
+ 
+-	qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
++	ret = qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
++	if (ret)
++		return ret;
+ 
+ 	return qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+ 		QCA8K_MDIO_MASTER_BUSY);
+@@ -623,6 +640,7 @@ static int
+ qca8k_mdio_read(struct qca8k_priv *priv, int port, u32 regnum)
+ {
+ 	u32 phy, val;
++	int ret;
+ 
+ 	if (regnum >= QCA8K_MDIO_MASTER_MAX_REG)
+ 		return -EINVAL;
+@@ -635,7 +653,9 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 	      QCA8K_MDIO_MASTER_READ | QCA8K_MDIO_MASTER_PHY_ADDR(phy) |
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum);
+ 
+-	qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
++	ret = qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
++	if (ret)
++		return ret;
+ 
+ 	if (qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+ 			    QCA8K_MDIO_MASTER_BUSY))
+@@ -766,12 +786,18 @@ qca8k_setup(struct dsa_switch *ds)
+ 		      QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
+ 
+ 	/* Enable MIB counters */
+-	qca8k_mib_init(priv);
++	ret = qca8k_mib_init(priv);
++	if (ret)
++		dev_warn(priv->dev, "mib init failed");
+ 
+ 	/* Enable QCA header mode on the cpu port */
+-	qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(QCA8K_CPU_PORT),
+-		    QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_TX_S |
+-		    QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_RX_S);
++	ret = qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(QCA8K_CPU_PORT),
++			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_TX_S |
++			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_RX_S);
++	if (ret) {
++		dev_err(priv->dev, "failed enabling QCA header mode");
++		return ret;
++	}
+ 
+ 	/* Disable forwarding by default on all ports */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+@@ -783,11 +809,13 @@ qca8k_setup(struct dsa_switch *ds)
+ 		qca8k_port_set_status(priv, i, 0);
+ 
+ 	/* Forward all unknown frames to CPU port for Linux processing */
+-	qca8k_write(priv, QCA8K_REG_GLOBAL_FW_CTRL1,
+-		    BIT(0) << QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S |
+-		    BIT(0) << QCA8K_GLOBAL_FW_CTRL1_BC_DP_S |
+-		    BIT(0) << QCA8K_GLOBAL_FW_CTRL1_MC_DP_S |
+-		    BIT(0) << QCA8K_GLOBAL_FW_CTRL1_UC_DP_S);
++	ret = qca8k_write(priv, QCA8K_REG_GLOBAL_FW_CTRL1,
++			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S |
++			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_BC_DP_S |
++			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_MC_DP_S |
++			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_UC_DP_S);
++	if (ret)
++		return ret;
+ 
+ 	/* Setup connection between CPU port & user ports */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
+@@ -815,16 +843,20 @@ qca8k_setup(struct dsa_switch *ds)
+ 			qca8k_rmw(priv, QCA8K_EGRESS_VLAN(i),
+ 				  0xfff << shift,
+ 				  QCA8K_PORT_VID_DEF << shift);
+-			qca8k_write(priv, QCA8K_REG_PORT_VLAN_CTRL0(i),
+-				    QCA8K_PORT_VLAN_CVID(QCA8K_PORT_VID_DEF) |
+-				    QCA8K_PORT_VLAN_SVID(QCA8K_PORT_VID_DEF));
++			ret = qca8k_write(priv, QCA8K_REG_PORT_VLAN_CTRL0(i),
++					  QCA8K_PORT_VLAN_CVID(QCA8K_PORT_VID_DEF) |
++					  QCA8K_PORT_VLAN_SVID(QCA8K_PORT_VID_DEF));
++			if (ret)
++				return ret;
+ 		}
+ 	}
+ 
+ 	/* Setup our port MTUs to match power on defaults */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+ 		priv->port_mtu[i] = ETH_FRAME_LEN + ETH_FCS_LEN;
+-	qca8k_write(priv, QCA8K_MAX_FRAME_SIZE, ETH_FRAME_LEN + ETH_FCS_LEN);
++	ret = qca8k_write(priv, QCA8K_MAX_FRAME_SIZE, ETH_FRAME_LEN + ETH_FCS_LEN);
++	if (ret)
++		dev_warn(priv->dev, "failed setting MTU settings");
+ 
+ 	/* Flush the FDB table */
+ 	qca8k_fdb_flush(priv);
+@@ -1140,8 +1172,8 @@ qca8k_set_mac_eee(struct dsa_switch *ds,
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	u32 lpi_en = QCA8K_REG_EEE_CTRL_LPI_EN(port);
+-	int ret = 0;
+ 	u32 reg;
++	int ret;
+ 
+ 	mutex_lock(&priv->reg_mutex);
+ 	reg = qca8k_read(priv, QCA8K_REG_EEE_CTRL);
+@@ -1154,7 +1186,7 @@ qca8k_set_mac_eee(struct dsa_switch *ds,
+ 		reg |= lpi_en;
+ 	else
+ 		reg &= ~lpi_en;
+-	qca8k_write(priv, QCA8K_REG_EEE_CTRL, reg);
++	ret = qca8k_write(priv, QCA8K_REG_EEE_CTRL, reg);
+ 
+ exit:
+ 	mutex_unlock(&priv->reg_mutex);
+@@ -1284,9 +1316,7 @@ qca8k_port_change_mtu(struct dsa_switch
+ 			mtu = priv->port_mtu[i];
+ 
+ 	/* Include L2 header / FCS length */
+-	qca8k_write(priv, QCA8K_MAX_FRAME_SIZE, mtu + ETH_HLEN + ETH_FCS_LEN);
+-
+-	return 0;
++	return qca8k_write(priv, QCA8K_MAX_FRAME_SIZE, mtu + ETH_HLEN + ETH_FCS_LEN);
+ }
+ 
+ static int

--- a/target/linux/generic/backport-5.10/785-v5.14-07-net-dsa-qca8k-handle-error-with-qca8k_rmw-operation.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-07-net-dsa-qca8k-handle-error-with-qca8k_rmw-operation.patch
@@ -1,0 +1,226 @@
+From aaf421425cbdec4eb6fd75a29e65c2867b0b7bbd Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:57 +0200
+Subject: [PATCH] net: dsa: qca8k: handle error with qca8k_rmw operation
+
+qca8k_rmw can fail. Rework any user to handle error values and
+correctly return. Change qca8k_rmw to return the error code or 0 instead
+of the reg value. The reg returned by qca8k_rmw wasn't used anywhere,
+so this doesn't cause any functional change.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 133 +++++++++++++++++++++++++---------------
+ 1 file changed, 83 insertions(+), 50 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -190,12 +190,13 @@ exit:
+ 	return ret;
+ }
+ 
+-static u32
+-qca8k_rmw(struct qca8k_priv *priv, u32 reg, u32 mask, u32 val)
++static int
++qca8k_rmw(struct qca8k_priv *priv, u32 reg, u32 mask, u32 write_val)
+ {
+ 	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+-	u32 ret;
++	u32 val;
++	int ret;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+@@ -205,10 +206,15 @@ qca8k_rmw(struct qca8k_priv *priv, u32 r
+ 	if (ret < 0)
+ 		goto exit;
+ 
+-	ret = qca8k_mii_read32(bus, 0x10 | r2, r1);
+-	ret &= ~mask;
+-	ret |= val;
+-	qca8k_mii_write32(bus, 0x10 | r2, r1, ret);
++	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
++	if (val < 0) {
++		ret = val;
++		goto exit;
++	}
++
++	val &= ~mask;
++	val |= write_val;
++	qca8k_mii_write32(bus, 0x10 | r2, r1, val);
+ 
+ exit:
+ 	mutex_unlock(&bus->mdio_lock);
+@@ -216,16 +222,16 @@ exit:
+ 	return ret;
+ }
+ 
+-static void
++static int
+ qca8k_reg_set(struct qca8k_priv *priv, u32 reg, u32 val)
+ {
+-	qca8k_rmw(priv, reg, 0, val);
++	return qca8k_rmw(priv, reg, 0, val);
+ }
+ 
+-static void
++static int
+ qca8k_reg_clear(struct qca8k_priv *priv, u32 reg, u32 val)
+ {
+-	qca8k_rmw(priv, reg, val, 0);
++	return qca8k_rmw(priv, reg, val, 0);
+ }
+ 
+ static int
+@@ -570,12 +576,19 @@ qca8k_mib_init(struct qca8k_priv *priv)
+ 	int ret;
+ 
+ 	mutex_lock(&priv->reg_mutex);
+-	qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_FLUSH | QCA8K_MIB_BUSY);
++	ret = qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_FLUSH | QCA8K_MIB_BUSY);
++	if (ret)
++		goto exit;
++
+ 	qca8k_busy_wait(priv, QCA8K_REG_MIB, QCA8K_MIB_BUSY);
+-	qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_CPU_KEEP);
++
++	ret = qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_CPU_KEEP);
++	if (ret)
++		goto exit;
+ 
+ 	ret = qca8k_write(priv, QCA8K_REG_MODULE_EN, QCA8K_MODULE_EN_MIB);
+ 
++exit:
+ 	mutex_unlock(&priv->reg_mutex);
+ 	return ret;
+ }
+@@ -747,9 +760,8 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ 		 * a dt-overlay and driver reload changed the configuration
+ 		 */
+ 
+-		qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
+-				QCA8K_MDIO_MASTER_EN);
+-		return 0;
++		return qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
++				       QCA8K_MDIO_MASTER_EN);
+ 	}
+ 
+ 	priv->ops.phy_read = qca8k_phy_read;
+@@ -782,8 +794,12 @@ qca8k_setup(struct dsa_switch *ds)
+ 		return ret;
+ 
+ 	/* Enable CPU Port */
+-	qca8k_reg_set(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
+-		      QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
++	ret = qca8k_reg_set(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
++			    QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
++	if (ret) {
++		dev_err(priv->dev, "failed enabling CPU port");
++		return ret;
++	}
+ 
+ 	/* Enable MIB counters */
+ 	ret = qca8k_mib_init(priv);
+@@ -800,9 +816,12 @@ qca8k_setup(struct dsa_switch *ds)
+ 	}
+ 
+ 	/* Disable forwarding by default on all ports */
+-	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+-		qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+-			  QCA8K_PORT_LOOKUP_MEMBER, 0);
++	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++		ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
++				QCA8K_PORT_LOOKUP_MEMBER, 0);
++		if (ret)
++			return ret;
++	}
+ 
+ 	/* Disable MAC by default on all ports */
+ 	for (i = 1; i < QCA8K_NUM_PORTS; i++)
+@@ -821,28 +840,37 @@ qca8k_setup(struct dsa_switch *ds)
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
+ 		/* CPU port gets connected to all user ports of the switch */
+ 		if (dsa_is_cpu_port(ds, i)) {
+-			qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(QCA8K_CPU_PORT),
+-				  QCA8K_PORT_LOOKUP_MEMBER, dsa_user_ports(ds));
++			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(QCA8K_CPU_PORT),
++					QCA8K_PORT_LOOKUP_MEMBER, dsa_user_ports(ds));
++			if (ret)
++				return ret;
+ 		}
+ 
+ 		/* Individual user ports get connected to CPU port only */
+ 		if (dsa_is_user_port(ds, i)) {
+ 			int shift = 16 * (i % 2);
+ 
+-			qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+-				  QCA8K_PORT_LOOKUP_MEMBER,
+-				  BIT(QCA8K_CPU_PORT));
++			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
++					QCA8K_PORT_LOOKUP_MEMBER,
++					BIT(QCA8K_CPU_PORT));
++			if (ret)
++				return ret;
+ 
+ 			/* Enable ARP Auto-learning by default */
+-			qca8k_reg_set(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+-				      QCA8K_PORT_LOOKUP_LEARN);
++			ret = qca8k_reg_set(priv, QCA8K_PORT_LOOKUP_CTRL(i),
++					    QCA8K_PORT_LOOKUP_LEARN);
++			if (ret)
++				return ret;
+ 
+ 			/* For port based vlans to work we need to set the
+ 			 * default egress vid
+ 			 */
+-			qca8k_rmw(priv, QCA8K_EGRESS_VLAN(i),
+-				  0xfff << shift,
+-				  QCA8K_PORT_VID_DEF << shift);
++			ret = qca8k_rmw(priv, QCA8K_EGRESS_VLAN(i),
++					0xfff << shift,
++					QCA8K_PORT_VID_DEF << shift);
++			if (ret)
++				return ret;
++
+ 			ret = qca8k_write(priv, QCA8K_REG_PORT_VLAN_CTRL0(i),
+ 					  QCA8K_PORT_VLAN_CVID(QCA8K_PORT_VID_DEF) |
+ 					  QCA8K_PORT_VLAN_SVID(QCA8K_PORT_VID_DEF));
+@@ -1234,7 +1262,7 @@ qca8k_port_bridge_join(struct dsa_switch
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	int port_mask = BIT(QCA8K_CPU_PORT);
+-	int i;
++	int i, ret;
+ 
+ 	for (i = 1; i < QCA8K_NUM_PORTS; i++) {
+ 		if (dsa_to_port(ds, i)->bridge_dev != br)
+@@ -1242,17 +1270,20 @@ qca8k_port_bridge_join(struct dsa_switch
+ 		/* Add this port to the portvlan mask of the other ports
+ 		 * in the bridge
+ 		 */
+-		qca8k_reg_set(priv,
+-			      QCA8K_PORT_LOOKUP_CTRL(i),
+-			      BIT(port));
++		ret = qca8k_reg_set(priv,
++				    QCA8K_PORT_LOOKUP_CTRL(i),
++				    BIT(port));
++		if (ret)
++			return ret;
+ 		if (i != port)
+ 			port_mask |= BIT(i);
+ 	}
++
+ 	/* Add all other ports to this ports portvlan mask */
+-	qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(port),
+-		  QCA8K_PORT_LOOKUP_MEMBER, port_mask);
++	ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(port),
++			QCA8K_PORT_LOOKUP_MEMBER, port_mask);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static void

--- a/target/linux/generic/backport-5.10/785-v5.14-08-net-dsa-qca8k-handle-error-from-qca8k_busy_wait.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-08-net-dsa-qca8k-handle-error-from-qca8k_busy_wait.patch
@@ -1,0 +1,66 @@
+From b7c818d194927bdc60ed15db55bb8654496a36b7 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:58 +0200
+Subject: [PATCH] net: dsa: qca8k: handle error from qca8k_busy_wait
+
+Propagate errors from qca8k_busy_wait instead of hardcoding return
+value.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -388,8 +388,9 @@ qca8k_fdb_access(struct qca8k_priv *priv
+ 		return ret;
+ 
+ 	/* wait for completion */
+-	if (qca8k_busy_wait(priv, QCA8K_REG_ATU_FUNC, QCA8K_ATU_FUNC_BUSY))
+-		return -1;
++	ret = qca8k_busy_wait(priv, QCA8K_REG_ATU_FUNC, QCA8K_ATU_FUNC_BUSY);
++	if (ret)
++		return ret;
+ 
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_FDB_LOAD) {
+@@ -468,8 +469,9 @@ qca8k_vlan_access(struct qca8k_priv *pri
+ 		return ret;
+ 
+ 	/* wait for completion */
+-	if (qca8k_busy_wait(priv, QCA8K_REG_VTU_FUNC1, QCA8K_VTU_FUNC1_BUSY))
+-		return -ETIMEDOUT;
++	ret = qca8k_busy_wait(priv, QCA8K_REG_VTU_FUNC1, QCA8K_VTU_FUNC1_BUSY);
++	if (ret)
++		return ret;
+ 
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_VLAN_LOAD) {
+@@ -580,7 +582,9 @@ qca8k_mib_init(struct qca8k_priv *priv)
+ 	if (ret)
+ 		goto exit;
+ 
+-	qca8k_busy_wait(priv, QCA8K_REG_MIB, QCA8K_MIB_BUSY);
++	ret = qca8k_busy_wait(priv, QCA8K_REG_MIB, QCA8K_MIB_BUSY);
++	if (ret)
++		goto exit;
+ 
+ 	ret = qca8k_reg_set(priv, QCA8K_REG_MIB, QCA8K_MIB_CPU_KEEP);
+ 	if (ret)
+@@ -670,9 +674,10 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 	if (ret)
+ 		return ret;
+ 
+-	if (qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+-			    QCA8K_MDIO_MASTER_BUSY))
+-		return -ETIMEDOUT;
++	ret = qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++			      QCA8K_MDIO_MASTER_BUSY);
++	if (ret)
++		return ret;
+ 
+ 	val = qca8k_read(priv, QCA8K_MDIO_MASTER_CTRL);
+ 	if (val < 0)

--- a/target/linux/generic/backport-5.10/785-v5.14-09-net-dsa-qca8k-add-support-for-qca8327-switch.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-09-net-dsa-qca8k-add-support-for-qca8327-switch.patch
@@ -1,0 +1,96 @@
+From 6e82a457e06252b59102486767539cc9c2aba60b Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 22:59:59 +0200
+Subject: [PATCH] net: dsa: qca8k: add support for qca8327 switch
+
+qca8327 switch is a low tier version of the more recent qca8337.
+It does share the same regs used by the qca8k driver and can be
+supported with minimal change.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 23 ++++++++++++++++++++---
+ drivers/net/dsa/qca8k.h |  6 ++++++
+ 2 files changed, 26 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1533,6 +1533,7 @@ static const struct dsa_switch_ops qca8k
+ static int
+ qca8k_sw_probe(struct mdio_device *mdiodev)
+ {
++	const struct qca8k_match_data *data;
+ 	struct qca8k_priv *priv;
+ 	u32 id;
+ 
+@@ -1560,6 +1561,11 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 		gpiod_set_value_cansleep(priv->reset_gpio, 0);
+ 	}
+ 
++	/* get the switches ID from the compatible */
++	data = of_device_get_match_data(&mdiodev->dev);
++	if (!data)
++		return -ENODEV;
++
+ 	/* read the switches ID register */
+ 	id = qca8k_read(priv, QCA8K_REG_MASK_CTRL);
+ 	if (id < 0)
+@@ -1567,8 +1573,10 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 
+ 	id >>= QCA8K_MASK_CTRL_ID_S;
+ 	id &= QCA8K_MASK_CTRL_ID_M;
+-	if (id != QCA8K_ID_QCA8337)
++	if (id != data->id) {
++		dev_err(&mdiodev->dev, "Switch id detected %x but expected %x", id, data->id);
+ 		return -ENODEV;
++	}
+ 
+ 	priv->ds = devm_kzalloc(&mdiodev->dev, sizeof(*priv->ds), GFP_KERNEL);
+ 	if (!priv->ds)
+@@ -1634,9 +1642,18 @@ static int qca8k_resume(struct device *d
+ static SIMPLE_DEV_PM_OPS(qca8k_pm_ops,
+ 			 qca8k_suspend, qca8k_resume);
+ 
++static const struct qca8k_match_data qca832x = {
++	.id = QCA8K_ID_QCA8327,
++};
++
++static const struct qca8k_match_data qca833x = {
++	.id = QCA8K_ID_QCA8337,
++};
++
+ static const struct of_device_id qca8k_of_match[] = {
+-	{ .compatible = "qca,qca8334" },
+-	{ .compatible = "qca,qca8337" },
++	{ .compatible = "qca,qca8327", .data = &qca832x },
++	{ .compatible = "qca,qca8334", .data = &qca833x },
++	{ .compatible = "qca,qca8337", .data = &qca833x },
+ 	{ /* sentinel */ },
+ };
+ 
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -15,6 +15,8 @@
+ #define QCA8K_NUM_PORTS					7
+ #define QCA8K_MAX_MTU					9000
+ 
++#define PHY_ID_QCA8327					0x004dd034
++#define QCA8K_ID_QCA8327				0x12
+ #define PHY_ID_QCA8337					0x004dd036
+ #define QCA8K_ID_QCA8337				0x13
+ 
+@@ -213,6 +215,10 @@ struct ar8xxx_port_status {
+ 	int enabled;
+ };
+ 
++struct qca8k_match_data {
++	u8 id;
++};
++
+ struct qca8k_priv {
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;

--- a/target/linux/generic/backport-5.10/785-v5.14-10-devicetree-net-dsa-qca8k-Document-new-compatible-qca.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-10-devicetree-net-dsa-qca8k-Document-new-compatible-qca.patch
@@ -1,0 +1,26 @@
+From 227a9ffc1bc77037339530607fe129af3824620e Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:00 +0200
+Subject: [PATCH] devicetree: net: dsa: qca8k: Document new compatible qca8327
+
+Add support for qca8327 in the compatible list.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Acked-by: Rob Herring <robh@kernel.org>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -3,6 +3,7 @@
+ Required properties:
+ 
+ - compatible: should be one of:
++    "qca,qca8327"
+     "qca,qca8334"
+     "qca,qca8337"
+ 

--- a/target/linux/generic/backport-5.10/785-v5.14-11-net-dsa-qca8k-add-priority-tweak-to-qca8337-switch.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-11-net-dsa-qca8k-add-priority-tweak-to-qca8337-switch.patch
@@ -1,0 +1,130 @@
+From 83a3ceb39b2495171aabe9446271b94c678354f3 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:01 +0200
+Subject: [PATCH] net: dsa: qca8k: add priority tweak to qca8337 switch
+
+The port 5 of the qca8337 have some problem in flood condition. The
+original legacy driver had some specific buffer and priority settings
+for the different port suggested by the QCA switch team. Add this
+missing settings to improve switch stability under load condition.
+The packet priority tweak is only needed for the qca8337 switch and
+other qca8k switch are not affected.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 47 +++++++++++++++++++++++++++++++++++++++++
+ drivers/net/dsa/qca8k.h | 25 ++++++++++++++++++++++
+ 2 files changed, 72 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -779,6 +779,7 @@ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	int ret, i;
++	u32 mask;
+ 
+ 	/* Make sure that port 0 is the cpu port */
+ 	if (!dsa_is_cpu_port(ds, 0)) {
+@@ -884,6 +885,51 @@ qca8k_setup(struct dsa_switch *ds)
+ 		}
+ 	}
+ 
++	/* The port 5 of the qca8337 have some problem in flood condition. The
++	 * original legacy driver had some specific buffer and priority settings
++	 * for the different port suggested by the QCA switch team. Add this
++	 * missing settings to improve switch stability under load condition.
++	 * This problem is limited to qca8337 and other qca8k switch are not affected.
++	 */
++	if (priv->switch_id == QCA8K_ID_QCA8337) {
++		for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++			switch (i) {
++			/* The 2 CPU port and port 5 requires some different
++			 * priority than any other ports.
++			 */
++			case 0:
++			case 5:
++			case 6:
++				mask = QCA8K_PORT_HOL_CTRL0_EG_PRI0(0x3) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI1(0x4) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI2(0x4) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI3(0x4) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI4(0x6) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI5(0x8) |
++					QCA8K_PORT_HOL_CTRL0_EG_PORT(0x1e);
++				break;
++			default:
++				mask = QCA8K_PORT_HOL_CTRL0_EG_PRI0(0x3) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI1(0x4) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI2(0x6) |
++					QCA8K_PORT_HOL_CTRL0_EG_PRI3(0x8) |
++					QCA8K_PORT_HOL_CTRL0_EG_PORT(0x19);
++			}
++			qca8k_write(priv, QCA8K_REG_PORT_HOL_CTRL0(i), mask);
++
++			mask = QCA8K_PORT_HOL_CTRL1_ING(0x6) |
++			QCA8K_PORT_HOL_CTRL1_EG_PRI_BUF_EN |
++			QCA8K_PORT_HOL_CTRL1_EG_PORT_BUF_EN |
++			QCA8K_PORT_HOL_CTRL1_WRED_EN;
++			qca8k_rmw(priv, QCA8K_REG_PORT_HOL_CTRL1(i),
++				  QCA8K_PORT_HOL_CTRL1_ING_BUF |
++				  QCA8K_PORT_HOL_CTRL1_EG_PRI_BUF_EN |
++				  QCA8K_PORT_HOL_CTRL1_EG_PORT_BUF_EN |
++				  QCA8K_PORT_HOL_CTRL1_WRED_EN,
++				  mask);
++		}
++	}
++
+ 	/* Setup our port MTUs to match power on defaults */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+ 		priv->port_mtu[i] = ETH_FRAME_LEN + ETH_FCS_LEN;
+@@ -1578,6 +1624,7 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 		return -ENODEV;
+ 	}
+ 
++	priv->switch_id = id;
+ 	priv->ds = devm_kzalloc(&mdiodev->dev, sizeof(*priv->ds), GFP_KERNEL);
+ 	if (!priv->ds)
+ 		return -ENOMEM;
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -168,6 +168,30 @@
+ #define   QCA8K_PORT_LOOKUP_STATE			GENMASK(18, 16)
+ #define   QCA8K_PORT_LOOKUP_LEARN			BIT(20)
+ 
++#define QCA8K_REG_PORT_HOL_CTRL0(_i)			(0x970 + (_i) * 0x8)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI0_BUF		GENMASK(3, 0)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI0(x)		((x) << 0)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI1_BUF		GENMASK(7, 4)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI1(x)		((x) << 4)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI2_BUF		GENMASK(11, 8)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI2(x)		((x) << 8)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI3_BUF		GENMASK(15, 12)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI3(x)		((x) << 12)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI4_BUF		GENMASK(19, 16)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI4(x)		((x) << 16)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI5_BUF		GENMASK(23, 20)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PRI5(x)		((x) << 20)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PORT_BUF		GENMASK(29, 24)
++#define   QCA8K_PORT_HOL_CTRL0_EG_PORT(x)		((x) << 24)
++
++#define QCA8K_REG_PORT_HOL_CTRL1(_i)			(0x974 + (_i) * 0x8)
++#define   QCA8K_PORT_HOL_CTRL1_ING_BUF			GENMASK(3, 0)
++#define   QCA8K_PORT_HOL_CTRL1_ING(x)			((x) << 0)
++#define   QCA8K_PORT_HOL_CTRL1_EG_PRI_BUF_EN		BIT(6)
++#define   QCA8K_PORT_HOL_CTRL1_EG_PORT_BUF_EN		BIT(7)
++#define   QCA8K_PORT_HOL_CTRL1_WRED_EN			BIT(8)
++#define   QCA8K_PORT_HOL_CTRL1_EG_MIRROR_EN		BIT(16)
++
+ /* Pkt edit registers */
+ #define QCA8K_EGRESS_VLAN(x)				(0x0c70 + (4 * (x / 2)))
+ 
+@@ -220,6 +244,7 @@ struct qca8k_match_data {
+ };
+ 
+ struct qca8k_priv {
++	u8 switch_id;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+ 	struct ar8xxx_port_status port_sts[QCA8K_NUM_PORTS];

--- a/target/linux/generic/backport-5.10/785-v5.14-12-net-dsa-qca8k-limit-port5-delay-to-qca8337.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-12-net-dsa-qca8k-limit-port5-delay-to-qca8337.patch
@@ -1,0 +1,31 @@
+From 5bf9ff3b9fb5ecb67a1a3517b26db3a00f2a2f11 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:02 +0200
+Subject: [PATCH] net: dsa: qca8k: limit port5 delay to qca8337
+
+Limit port5 rx delay to qca8337. This is taken from the legacy QSDK code
+that limits the rx delay on port5 to only this particular switch version,
+on other switch only the tx and rx delay for port0 are needed.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1003,8 +1003,10 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 			    QCA8K_PORT_PAD_RGMII_EN |
+ 			    QCA8K_PORT_PAD_RGMII_TX_DELAY(QCA8K_MAX_DELAY) |
+ 			    QCA8K_PORT_PAD_RGMII_RX_DELAY(QCA8K_MAX_DELAY));
+-		qca8k_write(priv, QCA8K_REG_PORT5_PAD_CTRL,
+-			    QCA8K_PORT_PAD_RGMII_RX_DELAY_EN);
++		/* QCA8337 requires to set rgmii rx delay */
++		if (priv->switch_id == QCA8K_ID_QCA8337)
++			qca8k_write(priv, QCA8K_REG_PORT5_PAD_CTRL,
++				    QCA8K_PORT_PAD_RGMII_RX_DELAY_EN);
+ 		break;
+ 	case PHY_INTERFACE_MODE_SGMII:
+ 	case PHY_INTERFACE_MODE_1000BASEX:

--- a/target/linux/generic/backport-5.10/785-v5.14-13-net-dsa-qca8k-add-GLOBAL_FC-settings-needed-for-qca8.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-13-net-dsa-qca8k-add-GLOBAL_FC-settings-needed-for-qca8.patch
@@ -1,0 +1,48 @@
+From 0fc57e4b5e39461fc0a54aae0afe4241363a7267 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:03 +0200
+Subject: [PATCH] net: dsa: qca8k: add GLOBAL_FC settings needed for qca8327
+
+Switch qca8327 needs special settings for the GLOBAL_FC_THRES regs.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 10 ++++++++++
+ drivers/net/dsa/qca8k.h |  6 ++++++
+ 2 files changed, 16 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -930,6 +930,16 @@ qca8k_setup(struct dsa_switch *ds)
+ 		}
+ 	}
+ 
++	/* Special GLOBAL_FC_THRESH value are needed for ar8327 switch */
++	if (priv->switch_id == QCA8K_ID_QCA8327) {
++		mask = QCA8K_GLOBAL_FC_GOL_XON_THRES(288) |
++		       QCA8K_GLOBAL_FC_GOL_XOFF_THRES(496);
++		qca8k_rmw(priv, QCA8K_REG_GLOBAL_FC_THRESH,
++			  QCA8K_GLOBAL_FC_GOL_XON_THRES_S |
++			  QCA8K_GLOBAL_FC_GOL_XOFF_THRES_S,
++			  mask);
++	}
++
+ 	/* Setup our port MTUs to match power on defaults */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+ 		priv->port_mtu[i] = ETH_FRAME_LEN + ETH_FCS_LEN;
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -168,6 +168,12 @@
+ #define   QCA8K_PORT_LOOKUP_STATE			GENMASK(18, 16)
+ #define   QCA8K_PORT_LOOKUP_LEARN			BIT(20)
+ 
++#define QCA8K_REG_GLOBAL_FC_THRESH			0x800
++#define   QCA8K_GLOBAL_FC_GOL_XON_THRES(x)		((x) << 16)
++#define   QCA8K_GLOBAL_FC_GOL_XON_THRES_S		GENMASK(24, 16)
++#define   QCA8K_GLOBAL_FC_GOL_XOFF_THRES(x)		((x) << 0)
++#define   QCA8K_GLOBAL_FC_GOL_XOFF_THRES_S		GENMASK(8, 0)
++
+ #define QCA8K_REG_PORT_HOL_CTRL0(_i)			(0x970 + (_i) * 0x8)
+ #define   QCA8K_PORT_HOL_CTRL0_EG_PRI0_BUF		GENMASK(3, 0)
+ #define   QCA8K_PORT_HOL_CTRL0_EG_PRI0(x)		((x) << 0)

--- a/target/linux/generic/backport-5.10/785-v5.14-14-net-dsa-qca8k-add-support-for-switch-rev.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-14-net-dsa-qca8k-add-support-for-switch-rev.patch
@@ -1,0 +1,114 @@
+From 95ffeaf18b3bb90eeef52cbf7d79ccc9d0345ff5 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:04 +0200
+Subject: [PATCH] net: dsa: qca8k: add support for switch rev
+
+qca8k internal phy driver require some special debug value to be set
+based on the switch revision. Rework the switch id read function to
+also read the chip revision.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 53 ++++++++++++++++++++++++++---------------
+ drivers/net/dsa/qca8k.h |  7 ++++--
+ 2 files changed, 39 insertions(+), 21 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1588,12 +1588,40 @@ static const struct dsa_switch_ops qca8k
+ 	.phylink_mac_link_up	= qca8k_phylink_mac_link_up,
+ };
+ 
++static int qca8k_read_switch_id(struct qca8k_priv *priv)
++{
++	const struct qca8k_match_data *data;
++	u32 val;
++	u8 id;
++
++	/* get the switches ID from the compatible */
++	data = of_device_get_match_data(priv->dev);
++	if (!data)
++		return -ENODEV;
++
++	val = qca8k_read(priv, QCA8K_REG_MASK_CTRL);
++	if (val < 0)
++		return -ENODEV;
++
++	id = QCA8K_MASK_CTRL_DEVICE_ID(val & QCA8K_MASK_CTRL_DEVICE_ID_MASK);
++	if (id != data->id) {
++		dev_err(priv->dev, "Switch id detected %x but expected %x", id, data->id);
++		return -ENODEV;
++	}
++
++	priv->switch_id = id;
++
++	/* Save revision to communicate to the internal PHY driver */
++	priv->switch_revision = (val & QCA8K_MASK_CTRL_REV_ID_MASK);
++
++	return 0;
++}
++
+ static int
+ qca8k_sw_probe(struct mdio_device *mdiodev)
+ {
+-	const struct qca8k_match_data *data;
+ 	struct qca8k_priv *priv;
+-	u32 id;
++	int ret;
+ 
+ 	/* allocate the private data struct so that we can probe the switches
+ 	 * ID register
+@@ -1619,24 +1647,11 @@ qca8k_sw_probe(struct mdio_device *mdiod
+ 		gpiod_set_value_cansleep(priv->reset_gpio, 0);
+ 	}
+ 
+-	/* get the switches ID from the compatible */
+-	data = of_device_get_match_data(&mdiodev->dev);
+-	if (!data)
+-		return -ENODEV;
++	/* Check the detected switch id */
++	ret = qca8k_read_switch_id(priv);
++	if (ret)
++		return ret;
+ 
+-	/* read the switches ID register */
+-	id = qca8k_read(priv, QCA8K_REG_MASK_CTRL);
+-	if (id < 0)
+-		return id;
+-
+-	id >>= QCA8K_MASK_CTRL_ID_S;
+-	id &= QCA8K_MASK_CTRL_ID_M;
+-	if (id != data->id) {
+-		dev_err(&mdiodev->dev, "Switch id detected %x but expected %x", id, data->id);
+-		return -ENODEV;
+-	}
+-
+-	priv->switch_id = id;
+ 	priv->ds = devm_kzalloc(&mdiodev->dev, sizeof(*priv->ds), GFP_KERNEL);
+ 	if (!priv->ds)
+ 		return -ENOMEM;
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -30,8 +30,10 @@
+ 
+ /* Global control registers */
+ #define QCA8K_REG_MASK_CTRL				0x000
+-#define   QCA8K_MASK_CTRL_ID_M				0xff
+-#define   QCA8K_MASK_CTRL_ID_S				8
++#define   QCA8K_MASK_CTRL_REV_ID_MASK			GENMASK(7, 0)
++#define   QCA8K_MASK_CTRL_REV_ID(x)			((x) >> 0)
++#define   QCA8K_MASK_CTRL_DEVICE_ID_MASK		GENMASK(15, 8)
++#define   QCA8K_MASK_CTRL_DEVICE_ID(x)			((x) >> 8)
+ #define QCA8K_REG_PORT0_PAD_CTRL			0x004
+ #define QCA8K_REG_PORT5_PAD_CTRL			0x008
+ #define QCA8K_REG_PORT6_PAD_CTRL			0x00c
+@@ -251,6 +253,7 @@ struct qca8k_match_data {
+ 
+ struct qca8k_priv {
+ 	u8 switch_id;
++	u8 switch_revision;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+ 	struct ar8xxx_port_status port_sts[QCA8K_NUM_PORTS];

--- a/target/linux/generic/backport-5.10/785-v5.14-15-net-dsa-qca8k-add-ethernet-ports-fallback-to-setup_m.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-15-net-dsa-qca8k-add-ethernet-ports-fallback-to-setup_m.patch
@@ -1,0 +1,28 @@
+From 1ee0591a1093c2448642c33433483e9260275f7b Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:05 +0200
+Subject: [PATCH] net: dsa: qca8k: add ethernet-ports fallback to
+ setup_mdio_bus
+
+Dsa now also supports ethernet-ports. Add this new binding as a fallback
+if the ports node can't be found.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -719,6 +719,9 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ 
+ 	ports = of_get_child_by_name(priv->dev->of_node, "ports");
+ 	if (!ports)
++		ports = of_get_child_by_name(priv->dev->of_node, "ethernet-ports");
++
++	if (!ports)
+ 		return -EINVAL;
+ 
+ 	for_each_available_child_of_node(ports, port) {

--- a/target/linux/generic/backport-5.10/785-v5.14-16-net-dsa-qca8k-make-rgmii-delay-configurable.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-16-net-dsa-qca8k-make-rgmii-delay-configurable.patch
@@ -1,0 +1,188 @@
+From e4b9977cee1583da38a6e9118078bb728aaccf7b Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:06 +0200
+Subject: [PATCH] net: dsa: qca8k: make rgmii delay configurable
+
+The legacy qsdk code used a different delay instead of the max value.
+Qsdk use 1 ns for rx and 2 ns for tx. Make these values configurable
+using the standard rx/tx-internal-delay-ps ethernet binding and apply
+qsdk values by default. The connected gmac doesn't add any delay so no
+additional delay is added to tx/rx.
+On this switch the delay is actually in ns so value should be in the
+1000 order. Any value converted from ps to ns by dividing it by 1000
+as the switch max value for delay is 3ns.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 82 ++++++++++++++++++++++++++++++++++++++++-
+ drivers/net/dsa/qca8k.h | 11 +++---
+ 2 files changed, 86 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -778,6 +778,68 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ }
+ 
+ static int
++qca8k_setup_of_rgmii_delay(struct qca8k_priv *priv)
++{
++	struct device_node *port_dn;
++	phy_interface_t mode;
++	struct dsa_port *dp;
++	u32 val;
++
++	/* CPU port is already checked */
++	dp = dsa_to_port(priv->ds, 0);
++
++	port_dn = dp->dn;
++
++	/* Check if port 0 is set to the correct type */
++	of_get_phy_mode(port_dn, &mode);
++	if (mode != PHY_INTERFACE_MODE_RGMII_ID &&
++	    mode != PHY_INTERFACE_MODE_RGMII_RXID &&
++	    mode != PHY_INTERFACE_MODE_RGMII_TXID) {
++		return 0;
++	}
++
++	switch (mode) {
++	case PHY_INTERFACE_MODE_RGMII_ID:
++	case PHY_INTERFACE_MODE_RGMII_RXID:
++		if (of_property_read_u32(port_dn, "rx-internal-delay-ps", &val))
++			val = 2;
++		else
++			/* Switch regs accept value in ns, convert ps to ns */
++			val = val / 1000;
++
++		if (val > QCA8K_MAX_DELAY) {
++			dev_err(priv->dev, "rgmii rx delay is limited to a max value of 3ns, setting to the max value");
++			val = 3;
++		}
++
++		priv->rgmii_rx_delay = val;
++		/* Stop here if we need to check only for rx delay */
++		if (mode != PHY_INTERFACE_MODE_RGMII_ID)
++			break;
++
++		fallthrough;
++	case PHY_INTERFACE_MODE_RGMII_TXID:
++		if (of_property_read_u32(port_dn, "tx-internal-delay-ps", &val))
++			val = 1;
++		else
++			/* Switch regs accept value in ns, convert ps to ns */
++			val = val / 1000;
++
++		if (val > QCA8K_MAX_DELAY) {
++			dev_err(priv->dev, "rgmii tx delay is limited to a max value of 3ns, setting to the max value");
++			val = 3;
++		}
++
++		priv->rgmii_tx_delay = val;
++		break;
++	default:
++		return 0;
++	}
++
++	return 0;
++}
++
++static int
+ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+@@ -802,6 +864,10 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
++	ret = qca8k_setup_of_rgmii_delay(priv);
++	if (ret)
++		return ret;
++
+ 	/* Enable CPU Port */
+ 	ret = qca8k_reg_set(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
+ 			    QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
+@@ -970,6 +1036,8 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 	case 0: /* 1st CPU port */
+ 		if (state->interface != PHY_INTERFACE_MODE_RGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII_ID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_TXID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_RXID &&
+ 		    state->interface != PHY_INTERFACE_MODE_SGMII)
+ 			return;
+ 
+@@ -985,6 +1053,8 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 	case 6: /* 2nd CPU port / external PHY */
+ 		if (state->interface != PHY_INTERFACE_MODE_RGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII_ID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_TXID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_RXID &&
+ 		    state->interface != PHY_INTERFACE_MODE_SGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_1000BASEX)
+ 			return;
+@@ -1008,14 +1078,18 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		qca8k_write(priv, reg, QCA8K_PORT_PAD_RGMII_EN);
+ 		break;
+ 	case PHY_INTERFACE_MODE_RGMII_ID:
++	case PHY_INTERFACE_MODE_RGMII_TXID:
++	case PHY_INTERFACE_MODE_RGMII_RXID:
+ 		/* RGMII_ID needs internal delay. This is enabled through
+ 		 * PORT5_PAD_CTRL for all ports, rather than individual port
+ 		 * registers
+ 		 */
+ 		qca8k_write(priv, reg,
+ 			    QCA8K_PORT_PAD_RGMII_EN |
+-			    QCA8K_PORT_PAD_RGMII_TX_DELAY(QCA8K_MAX_DELAY) |
+-			    QCA8K_PORT_PAD_RGMII_RX_DELAY(QCA8K_MAX_DELAY));
++			    QCA8K_PORT_PAD_RGMII_TX_DELAY(priv->rgmii_tx_delay) |
++			    QCA8K_PORT_PAD_RGMII_RX_DELAY(priv->rgmii_rx_delay) |
++			    QCA8K_PORT_PAD_RGMII_TX_DELAY_EN |
++			    QCA8K_PORT_PAD_RGMII_RX_DELAY_EN);
+ 		/* QCA8337 requires to set rgmii rx delay */
+ 		if (priv->switch_id == QCA8K_ID_QCA8337)
+ 			qca8k_write(priv, QCA8K_REG_PORT5_PAD_CTRL,
+@@ -1073,6 +1147,8 @@ qca8k_phylink_validate(struct dsa_switch
+ 		if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII_ID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_TXID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_RXID &&
+ 		    state->interface != PHY_INTERFACE_MODE_SGMII)
+ 			goto unsupported;
+ 		break;
+@@ -1090,6 +1166,8 @@ qca8k_phylink_validate(struct dsa_switch
+ 		if (state->interface != PHY_INTERFACE_MODE_NA &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_RGMII_ID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_TXID &&
++		    state->interface != PHY_INTERFACE_MODE_RGMII_RXID &&
+ 		    state->interface != PHY_INTERFACE_MODE_SGMII &&
+ 		    state->interface != PHY_INTERFACE_MODE_1000BASEX)
+ 			goto unsupported;
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -38,12 +38,11 @@
+ #define QCA8K_REG_PORT5_PAD_CTRL			0x008
+ #define QCA8K_REG_PORT6_PAD_CTRL			0x00c
+ #define   QCA8K_PORT_PAD_RGMII_EN			BIT(26)
+-#define   QCA8K_PORT_PAD_RGMII_TX_DELAY(x)		\
+-						((0x8 + (x & 0x3)) << 22)
+-#define   QCA8K_PORT_PAD_RGMII_RX_DELAY(x)		\
+-						((0x10 + (x & 0x3)) << 20)
+-#define   QCA8K_MAX_DELAY				3
++#define   QCA8K_PORT_PAD_RGMII_TX_DELAY(x)		((x) << 22)
++#define   QCA8K_PORT_PAD_RGMII_RX_DELAY(x)		((x) << 20)
++#define	  QCA8K_PORT_PAD_RGMII_TX_DELAY_EN		BIT(25)
+ #define   QCA8K_PORT_PAD_RGMII_RX_DELAY_EN		BIT(24)
++#define   QCA8K_MAX_DELAY				3
+ #define   QCA8K_PORT_PAD_SGMII_EN			BIT(7)
+ #define QCA8K_REG_PWS					0x010
+ #define   QCA8K_PWS_SERDES_AEN_DIS			BIT(7)
+@@ -254,6 +253,8 @@ struct qca8k_match_data {
+ struct qca8k_priv {
+ 	u8 switch_id;
+ 	u8 switch_revision;
++	u8 rgmii_tx_delay;
++	u8 rgmii_rx_delay;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+ 	struct ar8xxx_port_status port_sts[QCA8K_NUM_PORTS];

--- a/target/linux/generic/backport-5.10/785-v5.14-17-net-dsa-qca8k-clear-MASTER_EN-after-phy-read-write.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-17-net-dsa-qca8k-clear-MASTER_EN-after-phy-read-write.patch
@@ -1,0 +1,50 @@
+From 63c33bbfeb6842a956a0eb12901e28eb335bdb18 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:07 +0200
+Subject: [PATCH] net: dsa: qca8k: clear MASTER_EN after phy read/write
+
+Clear MDIO_MASTER_EN bit from MDIO_MASTER_CTRL after read/write
+operation. The MDIO_MASTER_EN bit is not reset after read/write
+operation and the next operation can be wrongly interpreted by the
+switch as a mdio operation. This cause a production of wrong/garbage
+data from the switch and underfined bheavior. (random port drop,
+unplugged port flagged with link up, wrong port speed)
+Also on driver remove the MASTER_CTRL can be left set and cause the
+malfunction of any next driver using the mdio device.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -649,8 +649,14 @@ qca8k_mdio_write(struct qca8k_priv *priv
+ 	if (ret)
+ 		return ret;
+ 
+-	return qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+-		QCA8K_MDIO_MASTER_BUSY);
++	ret = qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++			      QCA8K_MDIO_MASTER_BUSY);
++
++	/* even if the busy_wait timeouts try to clear the MASTER_EN */
++	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
++			QCA8K_MDIO_MASTER_EN);
++
++	return ret;
+ }
+ 
+ static int
+@@ -685,6 +691,10 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 
+ 	val &= QCA8K_MDIO_MASTER_DATA_MASK;
+ 
++	/* even if the busy_wait timeouts try to clear the MASTER_EN */
++	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
++			QCA8K_MDIO_MASTER_EN);
++
+ 	return val;
+ }
+ 

--- a/target/linux/generic/backport-5.10/785-v5.14-18-net-dsa-qca8k-dsa-qca8k-protect-MASTER-busy_wait-wit.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-18-net-dsa-qca8k-dsa-qca8k-protect-MASTER-busy_wait-wit.patch
@@ -1,0 +1,128 @@
+From 60df02b6ea4581d72eb7a3ab7204504a54059b72 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:08 +0200
+Subject: [PATCH] net: dsa: qca8k: dsa: qca8k: protect MASTER busy_wait with
+ mdio mutex
+
+MDIO_MASTER operation have a dedicated busy wait that is not protected
+by the mdio mutex. This can cause situation where the MASTER operation
+is done and a normal operation is executed between the MASTER read/write
+and the MASTER busy_wait. Rework the qca8k_mdio_read/write function to
+address this issue by binding the lock for the whole MASTER operation
+and not only the mdio read/write common operation.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 68 +++++++++++++++++++++++++++++++++--------
+ 1 file changed, 55 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -628,8 +628,31 @@ qca8k_port_to_phy(int port)
+ }
+ 
+ static int
++qca8k_mdio_busy_wait(struct qca8k_priv *priv, u32 reg, u32 mask)
++{
++	u16 r1, r2, page;
++	u32 val;
++	int ret;
++
++	qca8k_split_addr(reg, &r1, &r2, &page);
++
++	ret = read_poll_timeout(qca8k_mii_read32, val, !(val & mask), 0,
++				QCA8K_BUSY_WAIT_TIMEOUT * USEC_PER_MSEC, false,
++				priv->bus, 0x10 | r2, r1);
++
++	/* Check if qca8k_read has failed for a different reason
++	 * before returnting -ETIMEDOUT
++	 */
++	if (ret < 0 && val < 0)
++		return val;
++
++	return ret;
++}
++
++static int
+ qca8k_mdio_write(struct qca8k_priv *priv, int port, u32 regnum, u16 data)
+ {
++	u16 r1, r2, page;
+ 	u32 phy, val;
+ 	int ret;
+ 
+@@ -645,12 +668,21 @@ qca8k_mdio_write(struct qca8k_priv *priv
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum) |
+ 	      QCA8K_MDIO_MASTER_DATA(data);
+ 
+-	ret = qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
++	qca8k_split_addr(QCA8K_MDIO_MASTER_CTRL, &r1, &r2, &page);
++
++	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++
++	ret = qca8k_set_page(priv->bus, page);
+ 	if (ret)
+-		return ret;
++		goto exit;
++
++	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
+ 
+-	ret = qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+-			      QCA8K_MDIO_MASTER_BUSY);
++	ret = qca8k_mdio_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++				   QCA8K_MDIO_MASTER_BUSY);
++
++exit:
++	mutex_unlock(&priv->bus->mdio_lock);
+ 
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+ 	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
+@@ -662,6 +694,7 @@ qca8k_mdio_write(struct qca8k_priv *priv
+ static int
+ qca8k_mdio_read(struct qca8k_priv *priv, int port, u32 regnum)
+ {
++	u16 r1, r2, page;
+ 	u32 phy, val;
+ 	int ret;
+ 
+@@ -676,21 +709,30 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 	      QCA8K_MDIO_MASTER_READ | QCA8K_MDIO_MASTER_PHY_ADDR(phy) |
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum);
+ 
+-	ret = qca8k_write(priv, QCA8K_MDIO_MASTER_CTRL, val);
+-	if (ret)
+-		return ret;
++	qca8k_split_addr(QCA8K_MDIO_MASTER_CTRL, &r1, &r2, &page);
++
++	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	ret = qca8k_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
+-			      QCA8K_MDIO_MASTER_BUSY);
++	ret = qca8k_set_page(priv->bus, page);
+ 	if (ret)
+-		return ret;
++		goto exit;
+ 
+-	val = qca8k_read(priv, QCA8K_MDIO_MASTER_CTRL);
+-	if (val < 0)
+-		return val;
++	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
++
++	ret = qca8k_mdio_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++				   QCA8K_MDIO_MASTER_BUSY);
++	if (ret)
++		goto exit;
+ 
++	val = qca8k_mii_read32(priv->bus, 0x10 | r2, r1);
+ 	val &= QCA8K_MDIO_MASTER_DATA_MASK;
+ 
++exit:
++	mutex_unlock(&priv->bus->mdio_lock);
++
++	if (val >= 0)
++		val &= QCA8K_MDIO_MASTER_DATA_MASK;
++
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+ 	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
+ 			QCA8K_MDIO_MASTER_EN);

--- a/target/linux/generic/backport-5.10/785-v5.14-19-net-dsa-qca8k-enlarge-mdio-delay-and-timeout.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-19-net-dsa-qca8k-enlarge-mdio-delay-and-timeout.patch
@@ -1,0 +1,39 @@
+From 617960d72e93de0f3fa52407e2d39e8c43e73b0a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:09 +0200
+Subject: [PATCH] net: dsa: qca8k: enlarge mdio delay and timeout
+
+The witch require some extra delay after setting page or the next
+read/write can use still use the old page. Add a delay after the
+set_page function to address this as it's done in QSDK legacy driver.
+Some timeouts were notice with VLAN and phy function, enlarge the
+mdio busy wait timeout to fix these problems.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 1 +
+ drivers/net/dsa/qca8k.h | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -143,6 +143,7 @@ qca8k_set_page(struct mii_bus *bus, u16
+ 	}
+ 
+ 	qca8k_current_page = page;
++	usleep_range(1000, 2000);
+ 	return 0;
+ }
+ 
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -20,7 +20,7 @@
+ #define PHY_ID_QCA8337					0x004dd036
+ #define QCA8K_ID_QCA8337				0x13
+ 
+-#define QCA8K_BUSY_WAIT_TIMEOUT				20
++#define QCA8K_BUSY_WAIT_TIMEOUT				2000
+ 
+ #define QCA8K_NUM_FDB_RECORDS				2048
+ 

--- a/target/linux/generic/backport-5.10/785-v5.14-20-net-dsa-qca8k-add-support-for-internal-phy-and-inter.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-20-net-dsa-qca8k-add-support-for-internal-phy-and-inter.patch
@@ -1,0 +1,267 @@
+From 759bafb8a3226326ca357613bc90acf738f80c32 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:10 +0200
+Subject: [PATCH] net: dsa: qca8k: add support for internal phy and internal
+ mdio
+
+Add support to setup_mdio_bus for internal phy declaration. Introduce a
+flag to use the legacy port phy mapping by default and use the direct
+mapping if a mdio node is detected in the switch node. Register a
+dedicated mdio internal mdio bus to address the different mapping
+between port and phy if the mdio node is detected.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 112 +++++++++++++++++++++++++++++-----------
+ drivers/net/dsa/qca8k.h |   1 +
+ 2 files changed, 83 insertions(+), 30 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -11,6 +11,7 @@
+ #include <linux/netdevice.h>
+ #include <net/dsa.h>
+ #include <linux/of_net.h>
++#include <linux/of_mdio.h>
+ #include <linux/of_platform.h>
+ #include <linux/if_bridge.h>
+ #include <linux/mdio.h>
+@@ -629,7 +630,7 @@ qca8k_port_to_phy(int port)
+ }
+ 
+ static int
+-qca8k_mdio_busy_wait(struct qca8k_priv *priv, u32 reg, u32 mask)
++qca8k_mdio_busy_wait(struct mii_bus *bus, u32 reg, u32 mask)
+ {
+ 	u16 r1, r2, page;
+ 	u32 val;
+@@ -639,7 +640,7 @@ qca8k_mdio_busy_wait(struct qca8k_priv *
+ 
+ 	ret = read_poll_timeout(qca8k_mii_read32, val, !(val & mask), 0,
+ 				QCA8K_BUSY_WAIT_TIMEOUT * USEC_PER_MSEC, false,
+-				priv->bus, 0x10 | r2, r1);
++				bus, 0x10 | r2, r1);
+ 
+ 	/* Check if qca8k_read has failed for a different reason
+ 	 * before returnting -ETIMEDOUT
+@@ -651,19 +652,16 @@ qca8k_mdio_busy_wait(struct qca8k_priv *
+ }
+ 
+ static int
+-qca8k_mdio_write(struct qca8k_priv *priv, int port, u32 regnum, u16 data)
++qca8k_mdio_write(struct mii_bus *salve_bus, int phy, int regnum, u16 data)
+ {
++	struct qca8k_priv *priv = salve_bus->priv;
+ 	u16 r1, r2, page;
+-	u32 phy, val;
++	u32 val;
+ 	int ret;
+ 
+ 	if (regnum >= QCA8K_MDIO_MASTER_MAX_REG)
+ 		return -EINVAL;
+ 
+-	/* callee is responsible for not passing bad ports,
+-	 * but we still would like to make spills impossible.
+-	 */
+-	phy = qca8k_port_to_phy(port) % PHY_MAX_ADDR;
+ 	val = QCA8K_MDIO_MASTER_BUSY | QCA8K_MDIO_MASTER_EN |
+ 	      QCA8K_MDIO_MASTER_WRITE | QCA8K_MDIO_MASTER_PHY_ADDR(phy) |
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum) |
+@@ -679,33 +677,29 @@ qca8k_mdio_write(struct qca8k_priv *priv
+ 
+ 	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
+ 
+-	ret = qca8k_mdio_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++	ret = qca8k_mdio_busy_wait(priv->bus, QCA8K_MDIO_MASTER_CTRL,
+ 				   QCA8K_MDIO_MASTER_BUSY);
+ 
+ exit:
+-	mutex_unlock(&priv->bus->mdio_lock);
+-
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+-	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
+-			QCA8K_MDIO_MASTER_EN);
++	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, 0);
++
++	mutex_unlock(&priv->bus->mdio_lock);
+ 
+ 	return ret;
+ }
+ 
+ static int
+-qca8k_mdio_read(struct qca8k_priv *priv, int port, u32 regnum)
++qca8k_mdio_read(struct mii_bus *salve_bus, int phy, int regnum)
+ {
++	struct qca8k_priv *priv = salve_bus->priv;
+ 	u16 r1, r2, page;
+-	u32 phy, val;
++	u32 val;
+ 	int ret;
+ 
+ 	if (regnum >= QCA8K_MDIO_MASTER_MAX_REG)
+ 		return -EINVAL;
+ 
+-	/* callee is responsible for not passing bad ports,
+-	 * but we still would like to make spills impossible.
+-	 */
+-	phy = qca8k_port_to_phy(port) % PHY_MAX_ADDR;
+ 	val = QCA8K_MDIO_MASTER_BUSY | QCA8K_MDIO_MASTER_EN |
+ 	      QCA8K_MDIO_MASTER_READ | QCA8K_MDIO_MASTER_PHY_ADDR(phy) |
+ 	      QCA8K_MDIO_MASTER_REG_ADDR(regnum);
+@@ -720,24 +714,22 @@ qca8k_mdio_read(struct qca8k_priv *priv,
+ 
+ 	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
+ 
+-	ret = qca8k_mdio_busy_wait(priv, QCA8K_MDIO_MASTER_CTRL,
++	ret = qca8k_mdio_busy_wait(priv->bus, QCA8K_MDIO_MASTER_CTRL,
+ 				   QCA8K_MDIO_MASTER_BUSY);
+ 	if (ret)
+ 		goto exit;
+ 
+ 	val = qca8k_mii_read32(priv->bus, 0x10 | r2, r1);
+-	val &= QCA8K_MDIO_MASTER_DATA_MASK;
+ 
+ exit:
++	/* even if the busy_wait timeouts try to clear the MASTER_EN */
++	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, 0);
++
+ 	mutex_unlock(&priv->bus->mdio_lock);
+ 
+ 	if (val >= 0)
+ 		val &= QCA8K_MDIO_MASTER_DATA_MASK;
+ 
+-	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+-	qca8k_reg_clear(priv, QCA8K_MDIO_MASTER_CTRL,
+-			QCA8K_MDIO_MASTER_EN);
+-
+ 	return val;
+ }
+ 
+@@ -746,7 +738,14 @@ qca8k_phy_write(struct dsa_switch *ds, i
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+ 
+-	return qca8k_mdio_write(priv, port, regnum, data);
++	/* Check if the legacy mapping should be used and the
++	 * port is not correctly mapped to the right PHY in the
++	 * devicetree
++	 */
++	if (priv->legacy_phy_port_mapping)
++		port = qca8k_port_to_phy(port) % PHY_MAX_ADDR;
++
++	return qca8k_mdio_write(priv->bus, port, regnum, data);
+ }
+ 
+ static int
+@@ -755,7 +754,14 @@ qca8k_phy_read(struct dsa_switch *ds, in
+ 	struct qca8k_priv *priv = ds->priv;
+ 	int ret;
+ 
+-	ret = qca8k_mdio_read(priv, port, regnum);
++	/* Check if the legacy mapping should be used and the
++	 * port is not correctly mapped to the right PHY in the
++	 * devicetree
++	 */
++	if (priv->legacy_phy_port_mapping)
++		port = qca8k_port_to_phy(port) % PHY_MAX_ADDR;
++
++	ret = qca8k_mdio_read(priv->bus, port, regnum);
+ 
+ 	if (ret < 0)
+ 		return 0xffff;
+@@ -764,10 +770,37 @@ qca8k_phy_read(struct dsa_switch *ds, in
+ }
+ 
+ static int
++qca8k_mdio_register(struct qca8k_priv *priv, struct device_node *mdio)
++{
++	struct dsa_switch *ds = priv->ds;
++	struct mii_bus *bus;
++
++	bus = devm_mdiobus_alloc(ds->dev);
++
++	if (!bus)
++		return -ENOMEM;
++
++	bus->priv = (void *)priv;
++	bus->name = "qca8k slave mii";
++	bus->read = qca8k_mdio_read;
++	bus->write = qca8k_mdio_write;
++	snprintf(bus->id, MII_BUS_ID_SIZE, "qca8k-%d",
++		 ds->index);
++
++	bus->parent = ds->dev;
++	bus->phy_mask = ~ds->phys_mii_mask;
++
++	ds->slave_mii_bus = bus;
++
++	return devm_of_mdiobus_register(priv->dev, bus, mdio);
++}
++
++static int
+ qca8k_setup_mdio_bus(struct qca8k_priv *priv)
+ {
+ 	u32 internal_mdio_mask = 0, external_mdio_mask = 0, reg;
+-	struct device_node *ports, *port;
++	struct device_node *ports, *port, *mdio;
++	phy_interface_t mode;
+ 	int err;
+ 
+ 	ports = of_get_child_by_name(priv->dev->of_node, "ports");
+@@ -788,7 +821,10 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ 		if (!dsa_is_user_port(priv->ds, reg))
+ 			continue;
+ 
+-		if (of_property_read_bool(port, "phy-handle"))
++		of_get_phy_mode(port, &mode);
++
++		if (of_property_read_bool(port, "phy-handle") &&
++		    mode != PHY_INTERFACE_MODE_INTERNAL)
+ 			external_mdio_mask |= BIT(reg);
+ 		else
+ 			internal_mdio_mask |= BIT(reg);
+@@ -825,8 +861,23 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ 				       QCA8K_MDIO_MASTER_EN);
+ 	}
+ 
++	/* Check if the devicetree declare the port:phy mapping */
++	mdio = of_get_child_by_name(priv->dev->of_node, "mdio");
++	if (of_device_is_available(mdio)) {
++		err = qca8k_mdio_register(priv, mdio);
++		if (err)
++			of_node_put(mdio);
++
++		return err;
++	}
++
++	/* If a mapping can't be found the legacy mapping is used,
++	 * using the qca8k_port_to_phy function
++	 */
++	priv->legacy_phy_port_mapping = true;
+ 	priv->ops.phy_read = qca8k_phy_read;
+ 	priv->ops.phy_write = qca8k_phy_write;
++
+ 	return 0;
+ }
+ 
+@@ -1212,7 +1263,8 @@ qca8k_phylink_validate(struct dsa_switch
+ 	case 5:
+ 		/* Internal PHY */
+ 		if (state->interface != PHY_INTERFACE_MODE_NA &&
+-		    state->interface != PHY_INTERFACE_MODE_GMII)
++		    state->interface != PHY_INTERFACE_MODE_GMII &&
++		    state->interface != PHY_INTERFACE_MODE_INTERNAL)
+ 			goto unsupported;
+ 		break;
+ 	case 6: /* 2nd CPU port / external PHY */
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -255,6 +255,7 @@ struct qca8k_priv {
+ 	u8 switch_revision;
+ 	u8 rgmii_tx_delay;
+ 	u8 rgmii_rx_delay;
++	bool legacy_phy_port_mapping;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+ 	struct ar8xxx_port_status port_sts[QCA8K_NUM_PORTS];

--- a/target/linux/generic/backport-5.10/785-v5.14-21-devicetree-bindings-dsa-qca8k-Document-internal-mdio.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-21-devicetree-bindings-dsa-qca8k-Document-internal-mdio.patch
@@ -1,0 +1,93 @@
+From 0c994a28e7518f098c84a3049cb2915780db873a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:11 +0200
+Subject: [PATCH] devicetree: bindings: dsa: qca8k: Document internal mdio
+ definition
+
+Document new way of declare mapping of internal PHY to port.
+The new implementation directly declare the PHY connected to the port
+by adding a node in the switch node. The driver detect this and register
+an internal mdiobus using the mapping defined in the mdio node.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Rob Herring <robh@kernel.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ .../devicetree/bindings/net/dsa/qca8k.txt     | 39 +++++++++++++++++++
+ 1 file changed, 39 insertions(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -21,6 +21,10 @@ described in dsa/dsa.txt. If the QCA8K s
+ mdio-bus each subnode describing a port needs to have a valid phandle
+ referencing the internal PHY it is connected to. This is because there's no
+ N:N mapping of port and PHY id.
++To declare the internal mdio-bus configuration, declare a mdio node in the
++switch node and declare the phandle for the port referencing the internal
++PHY is connected to. In this config a internal mdio-bus is registered and
++the mdio MASTER is used as communication.
+ 
+ Don't use mixed external and internal mdio-bus configurations, as this is
+ not supported by the hardware.
+@@ -150,26 +154,61 @@ for the internal master mdio-bus configu
+ 				port@1 {
+ 					reg = <1>;
+ 					label = "lan1";
++					phy-mode = "internal";
++					phy-handle = <&phy_port1>;
+ 				};
+ 
+ 				port@2 {
+ 					reg = <2>;
+ 					label = "lan2";
++					phy-mode = "internal";
++					phy-handle = <&phy_port2>;
+ 				};
+ 
+ 				port@3 {
+ 					reg = <3>;
+ 					label = "lan3";
++					phy-mode = "internal";
++					phy-handle = <&phy_port3>;
+ 				};
+ 
+ 				port@4 {
+ 					reg = <4>;
+ 					label = "lan4";
++					phy-mode = "internal";
++					phy-handle = <&phy_port4>;
+ 				};
+ 
+ 				port@5 {
+ 					reg = <5>;
+ 					label = "wan";
++					phy-mode = "internal";
++					phy-handle = <&phy_port5>;
++				};
++			};
++
++			mdio {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				phy_port1: phy@0 {
++					reg = <0>;
++				};
++
++				phy_port2: phy@1 {
++					reg = <1>;
++				};
++
++				phy_port3: phy@2 {
++					reg = <2>;
++				};
++
++				phy_port4: phy@3 {
++					reg = <3>;
++				};
++
++				phy_port5: phy@4 {
++					reg = <4>;
+ 				};
+ 			};
+ 		};

--- a/target/linux/generic/backport-5.10/785-v5.14-22-net-dsa-qca8k-improve-internal-mdio-read-write-bus-a.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-22-net-dsa-qca8k-improve-internal-mdio-read-write-bus-a.patch
@@ -1,0 +1,95 @@
+From b7ebac354d54f1657bb89b7a7ca149db50203e6a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:12 +0200
+Subject: [PATCH] net: dsa: qca8k: improve internal mdio read/write bus access
+
+Improve the internal mdio read/write bus access by caching the value
+without accessing it for every read/write.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 28 +++++++++++++++-------------
+ 1 file changed, 15 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -655,6 +655,7 @@ static int
+ qca8k_mdio_write(struct mii_bus *salve_bus, int phy, int regnum, u16 data)
+ {
+ 	struct qca8k_priv *priv = salve_bus->priv;
++	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 val;
+ 	int ret;
+@@ -669,22 +670,22 @@ qca8k_mdio_write(struct mii_bus *salve_b
+ 
+ 	qca8k_split_addr(QCA8K_MDIO_MASTER_CTRL, &r1, &r2, &page);
+ 
+-	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	ret = qca8k_set_page(priv->bus, page);
++	ret = qca8k_set_page(bus, page);
+ 	if (ret)
+ 		goto exit;
+ 
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, val);
+ 
+-	ret = qca8k_mdio_busy_wait(priv->bus, QCA8K_MDIO_MASTER_CTRL,
++	ret = qca8k_mdio_busy_wait(bus, QCA8K_MDIO_MASTER_CTRL,
+ 				   QCA8K_MDIO_MASTER_BUSY);
+ 
+ exit:
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, 0);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, 0);
+ 
+-	mutex_unlock(&priv->bus->mdio_lock);
++	mutex_unlock(&bus->mdio_lock);
+ 
+ 	return ret;
+ }
+@@ -693,6 +694,7 @@ static int
+ qca8k_mdio_read(struct mii_bus *salve_bus, int phy, int regnum)
+ {
+ 	struct qca8k_priv *priv = salve_bus->priv;
++	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 val;
+ 	int ret;
+@@ -706,26 +708,26 @@ qca8k_mdio_read(struct mii_bus *salve_bu
+ 
+ 	qca8k_split_addr(QCA8K_MDIO_MASTER_CTRL, &r1, &r2, &page);
+ 
+-	mutex_lock_nested(&priv->bus->mdio_lock, MDIO_MUTEX_NESTED);
++	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	ret = qca8k_set_page(priv->bus, page);
++	ret = qca8k_set_page(bus, page);
+ 	if (ret)
+ 		goto exit;
+ 
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, val);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, val);
+ 
+-	ret = qca8k_mdio_busy_wait(priv->bus, QCA8K_MDIO_MASTER_CTRL,
++	ret = qca8k_mdio_busy_wait(bus, QCA8K_MDIO_MASTER_CTRL,
+ 				   QCA8K_MDIO_MASTER_BUSY);
+ 	if (ret)
+ 		goto exit;
+ 
+-	val = qca8k_mii_read32(priv->bus, 0x10 | r2, r1);
++	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
+ 
+ exit:
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+-	qca8k_mii_write32(priv->bus, 0x10 | r2, r1, 0);
++	qca8k_mii_write32(bus, 0x10 | r2, r1, 0);
+ 
+-	mutex_unlock(&priv->bus->mdio_lock);
++	mutex_unlock(&bus->mdio_lock);
+ 
+ 	if (val >= 0)
+ 		val &= QCA8K_MDIO_MASTER_DATA_MASK;

--- a/target/linux/generic/backport-5.10/785-v5.14-23-net-dsa-qca8k-pass-switch_revision-info-to-phy-dev_f.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-23-net-dsa-qca8k-pass-switch_revision-info-to-phy-dev_f.patch
@@ -1,0 +1,48 @@
+From a46aec02bc06ac2c33f326339e4ef88c735dc30d Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:13 +0200
+Subject: [PATCH] net: dsa: qca8k: pass switch_revision info to phy dev_flags
+
+Define get_phy_flags to pass switch_Revision needed to tweak the
+internal PHY with debug values based on the revision.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1740,6 +1740,22 @@ qca8k_port_vlan_del(struct dsa_switch *d
+ 	return ret;
+ }
+ 
++static u32 qca8k_get_phy_flags(struct dsa_switch *ds, int port)
++{
++	struct qca8k_priv *priv = ds->priv;
++
++	/* Communicate to the phy internal driver the switch revision.
++	 * Based on the switch revision different values needs to be
++	 * set to the dbg and mmd reg on the phy.
++	 * The first 2 bit are used to communicate the switch revision
++	 * to the phy driver.
++	 */
++	if (port > 0 && port < 6)
++		return priv->switch_revision;
++
++	return 0;
++}
++
+ static enum dsa_tag_protocol
+ qca8k_get_tag_protocol(struct dsa_switch *ds, int port,
+ 		       enum dsa_tag_protocol mp)
+@@ -1774,6 +1790,7 @@ static const struct dsa_switch_ops qca8k
+ 	.phylink_mac_config	= qca8k_phylink_mac_config,
+ 	.phylink_mac_link_down	= qca8k_phylink_mac_link_down,
+ 	.phylink_mac_link_up	= qca8k_phylink_mac_link_up,
++	.get_phy_flags		= qca8k_get_phy_flags,
+ };
+ 
+ static int qca8k_read_switch_id(struct qca8k_priv *priv)

--- a/target/linux/generic/backport-5.10/785-v5.14-25-net-phy-add-support-for-qca8k-switch-internal-PHY-in.patch
+++ b/target/linux/generic/backport-5.10/785-v5.14-25-net-phy-add-support-for-qca8k-switch-internal-PHY-in.patch
@@ -1,0 +1,229 @@
+From 272833b9b3b3969be7a91839121d86662c8c4253 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Fri, 14 May 2021 23:00:15 +0200
+Subject: [PATCH] net: phy: add support for qca8k switch internal PHY in at803x
+
+Since the at803x share the same regs, it's assumed they are based on the
+same implementation. Make it part of the at803x PHY driver to skip
+having redudant code.
+Add initial support for qca8k internal PHYs. The internal PHYs requires
+special mmd and debug values to be set based on the switch revision
+passwd using the dev_flags. Supports output of idle, receive and eee_wake
+errors stats.
+Some debug values sets can't be translated as the documentation lacks any
+reference about them.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/Kconfig  |   5 +-
+ drivers/net/phy/at803x.c | 132 ++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 134 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -235,10 +235,11 @@ config NXP_TJA11XX_PHY
+ 	  Currently supports the NXP TJA1100 and TJA1101 PHY.
+ 
+ config AT803X_PHY
+-	tristate "Qualcomm Atheros AR803X PHYs"
++	tristate "Qualcomm Atheros AR803X PHYs and QCA833x PHYs"
+ 	depends on REGULATOR
+ 	help
+-	  Currently supports the AR8030, AR8031, AR8033 and AR8035 model
++	  Currently supports the AR8030, AR8031, AR8033, AR8035 and internal
++	  QCA8337(Internal qca8k PHY) model
+ 
+ config QSEMI_PHY
+ 	tristate "Quality Semiconductor PHYs"
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -92,10 +92,16 @@
+ #define AT803X_DEBUG_REG_5			0x05
+ #define AT803X_DEBUG_TX_CLK_DLY_EN		BIT(8)
+ 
++#define AT803X_DEBUG_REG_3C			0x3C
++
++#define AT803X_DEBUG_REG_3D			0x3D
++
+ #define AT803X_DEBUG_REG_1F			0x1F
+ #define AT803X_DEBUG_PLL_ON			BIT(2)
+ #define AT803X_DEBUG_RGMII_1V8			BIT(3)
+ 
++#define MDIO_AZ_DEBUG				0x800D
++
+ /* AT803x supports either the XTAL input pad, an internal PLL or the
+  * DSP as clock reference for the clock output pad. The XTAL reference
+  * is only used for 25 MHz output, all other frequencies need the PLL.
+@@ -142,10 +148,34 @@
+ #define AT803X_PAGE_FIBER		0
+ #define AT803X_PAGE_COPPER		1
+ 
++#define QCA8327_PHY_ID				0x004dd034
++#define QCA8337_PHY_ID				0x004dd036
++#define QCA8K_PHY_ID_MASK			0xffffffff
++
++#define QCA8K_DEVFLAGS_REVISION_MASK		GENMASK(2, 0)
++
+ MODULE_DESCRIPTION("Qualcomm Atheros AR803x PHY driver");
+ MODULE_AUTHOR("Matus Ujhelyi");
+ MODULE_LICENSE("GPL");
+ 
++enum stat_access_type {
++	PHY,
++	MMD
++};
++
++struct at803x_hw_stat {
++	const char *string;
++	u8 reg;
++	u32 mask;
++	enum stat_access_type access_type;
++};
++
++static struct at803x_hw_stat at803x_hw_stats[] = {
++	{ "phy_idle_errors", 0xa, GENMASK(7, 0), PHY},
++	{ "phy_receive_errors", 0x15, GENMASK(15, 0), PHY},
++	{ "eee_wake_errors", 0x16, GENMASK(15, 0), MMD},
++};
++
+ struct at803x_priv {
+ 	int flags;
+ #define AT803X_KEEP_PLL_ENABLED	BIT(0)	/* don't turn off internal PLL */
+@@ -154,6 +184,7 @@ struct at803x_priv {
+ 	struct regulator_dev *vddio_rdev;
+ 	struct regulator_dev *vddh_rdev;
+ 	struct regulator *vddio;
++	u64 stats[ARRAY_SIZE(at803x_hw_stats)];
+ };
+ 
+ struct at803x_context {
+@@ -165,6 +196,17 @@ struct at803x_context {
+ 	u16 led_control;
+ };
+ 
++static int at803x_debug_reg_write(struct phy_device *phydev, u16 reg, u16 data)
++{
++	int ret;
++
++	ret = phy_write(phydev, AT803X_DEBUG_ADDR, reg);
++	if (ret < 0)
++		return ret;
++
++	return phy_write(phydev, AT803X_DEBUG_DATA, data);
++}
++
+ static int at803x_debug_reg_read(struct phy_device *phydev, u16 reg)
+ {
+ 	int ret;
+@@ -327,6 +369,53 @@ static void at803x_get_wol(struct phy_de
+ 		wol->wolopts |= WAKE_MAGIC;
+ }
+ 
++static int at803x_get_sset_count(struct phy_device *phydev)
++{
++	return ARRAY_SIZE(at803x_hw_stats);
++}
++
++static void at803x_get_strings(struct phy_device *phydev, u8 *data)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(at803x_hw_stats); i++) {
++		strscpy(data + i * ETH_GSTRING_LEN,
++			at803x_hw_stats[i].string, ETH_GSTRING_LEN);
++	}
++}
++
++static u64 at803x_get_stat(struct phy_device *phydev, int i)
++{
++	struct at803x_hw_stat stat = at803x_hw_stats[i];
++	struct at803x_priv *priv = phydev->priv;
++	int val;
++	u64 ret;
++
++	if (stat.access_type == MMD)
++		val = phy_read_mmd(phydev, MDIO_MMD_PCS, stat.reg);
++	else
++		val = phy_read(phydev, stat.reg);
++
++	if (val < 0) {
++		ret = U64_MAX;
++	} else {
++		val = val & stat.mask;
++		priv->stats[i] += val;
++		ret = priv->stats[i];
++	}
++
++	return ret;
++}
++
++static void at803x_get_stats(struct phy_device *phydev,
++			     struct ethtool_stats *stats, u64 *data)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(at803x_hw_stats); i++)
++		data[i] = at803x_get_stat(phydev, i);
++}
++
+ static int at803x_suspend(struct phy_device *phydev)
+ {
+ 	int value;
+@@ -1102,6 +1191,34 @@ static int at803x_cable_test_start(struc
+ 	return 0;
+ }
+ 
++static int qca83xx_config_init(struct phy_device *phydev)
++{
++	u8 switch_revision;
++
++	switch_revision = phydev->dev_flags & QCA8K_DEVFLAGS_REVISION_MASK;
++
++	switch (switch_revision) {
++	case 1:
++		/* For 100M waveform */
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_0, 0x02ea);
++		/* Turn on Gigabit clock */
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3D, 0x68a0);
++		break;
++
++	case 2:
++		phy_write_mmd(phydev, MDIO_MMD_AN, MDIO_AN_EEE_ADV, 0x0);
++		fallthrough;
++	case 4:
++		phy_write_mmd(phydev, MDIO_MMD_PCS, MDIO_AZ_DEBUG, 0x803f);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3D, 0x6860);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_5, 0x2c46);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3C, 0x6000);
++		break;
++	}
++
++	return 0;
++}
++
+ static struct phy_driver at803x_driver[] = {
+ {
+ 	/* Qualcomm Atheros AR8035 */
+@@ -1198,7 +1315,20 @@ static struct phy_driver at803x_driver[]
+ 	.read_status		= at803x_read_status,
+ 	.soft_reset		= genphy_soft_reset,
+ 	.config_aneg		= at803x_config_aneg,
+-} };
++}, {
++	/* QCA8337 */
++	.phy_id = QCA8337_PHY_ID,
++	.phy_id_mask = QCA8K_PHY_ID_MASK,
++	.name = "QCA PHY 8337",
++	/* PHY_GBIT_FEATURES */
++	.probe = at803x_probe,
++	.flags = PHY_IS_INTERNAL,
++	.config_init = qca83xx_config_init,
++	.soft_reset = genphy_soft_reset,
++	.get_sset_count = at803x_get_sset_count,
++	.get_strings = at803x_get_strings,
++	.get_stats = at803x_get_stats,
++}, };
+ 
+ module_phy_driver(at803x_driver);
+ 

--- a/target/linux/generic/backport-5.10/786-v5.14-net-dsa-qca8k-fix-missing-unlock-on-error-in-qca8k-vlan.patch
+++ b/target/linux/generic/backport-5.10/786-v5.14-net-dsa-qca8k-fix-missing-unlock-on-error-in-qca8k-vlan.patch
@@ -1,0 +1,64 @@
+From 0d56e5c191b197e1d30a0a4c92628836dafced0f Mon Sep 17 00:00:00 2001
+From: Wei Yongjun <weiyongjun1@huawei.com>
+Date: Tue, 18 May 2021 11:24:13 +0000
+Subject: [PATCH] net: dsa: qca8k: fix missing unlock on error in
+ qca8k_vlan_(add|del)
+
+Add the missing unlock before return from function qca8k_vlan_add()
+and qca8k_vlan_del() in the error handling case.
+
+Fixes: 028f5f8ef44f ("net: dsa: qca8k: handle error with qca8k_read operation")
+Reported-by: Hulk Robot <hulkci@huawei.com>
+Signed-off-by: Wei Yongjun <weiyongjun1@huawei.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -506,8 +506,10 @@ qca8k_vlan_add(struct qca8k_priv *priv,
+ 		goto out;
+ 
+ 	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
+-	if (reg < 0)
+-		return reg;
++	if (reg < 0) {
++		ret = reg;
++		goto out;
++	}
+ 	reg |= QCA8K_VTU_FUNC0_VALID | QCA8K_VTU_FUNC0_IVL_EN;
+ 	reg &= ~(QCA8K_VTU_FUNC0_EG_MODE_MASK << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	if (untagged)
+@@ -519,7 +521,7 @@ qca8k_vlan_add(struct qca8k_priv *priv,
+ 
+ 	ret = qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
+ 	if (ret)
+-		return ret;
++		goto out;
+ 	ret = qca8k_vlan_access(priv, QCA8K_VLAN_LOAD, vid);
+ 
+ out:
+@@ -541,8 +543,10 @@ qca8k_vlan_del(struct qca8k_priv *priv,
+ 		goto out;
+ 
+ 	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
+-	if (reg < 0)
+-		return reg;
++	if (reg < 0) {
++		ret = reg;
++		goto out;
++	}
+ 	reg &= ~(3 << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	reg |= QCA8K_VTU_FUNC0_EG_MODE_NOT <<
+ 			QCA8K_VTU_FUNC0_EG_MODE_S(port);
+@@ -564,7 +568,7 @@ qca8k_vlan_del(struct qca8k_priv *priv,
+ 	} else {
+ 		ret = qca8k_write(priv, QCA8K_REG_VTU_FUNC0, reg);
+ 		if (ret)
+-			return ret;
++			goto out;
+ 		ret = qca8k_vlan_access(priv, QCA8K_VLAN_LOAD, vid);
+ 	}
+ 

--- a/target/linux/generic/backport-5.10/787-v5.14-01-net-dsa-qca8k-check-return-value-of-read-functions-c.patch
+++ b/target/linux/generic/backport-5.10/787-v5.14-01-net-dsa-qca8k-check-return-value-of-read-functions-c.patch
@@ -1,0 +1,348 @@
+From 7c9896e37807862e276064dd9331860f5d27affc Mon Sep 17 00:00:00 2001
+From: Yang Yingliang <yangyingliang@huawei.com>
+Date: Sat, 29 May 2021 11:04:38 +0800
+Subject: [PATCH] net: dsa: qca8k: check return value of read functions
+ correctly
+
+Current return type of qca8k_mii_read32() and qca8k_read() are
+unsigned, it can't be negative, so the return value check is
+unuseful. For check the return value correctly, change return
+type of the read functions and add a output parameter to store
+the read value.
+
+Signed-off-by: Yang Yingliang <yangyingliang@huawei.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/qca8k.c | 130 +++++++++++++++++++---------------------
+ 1 file changed, 60 insertions(+), 70 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -89,26 +89,26 @@ qca8k_split_addr(u32 regaddr, u16 *r1, u
+ 	*page = regaddr & 0x3ff;
+ }
+ 
+-static u32
+-qca8k_mii_read32(struct mii_bus *bus, int phy_id, u32 regnum)
++static int
++qca8k_mii_read32(struct mii_bus *bus, int phy_id, u32 regnum, u32 *val)
+ {
+-	u32 val;
+ 	int ret;
+ 
+ 	ret = bus->read(bus, phy_id, regnum);
+ 	if (ret >= 0) {
+-		val = ret;
++		*val = ret;
+ 		ret = bus->read(bus, phy_id, regnum + 1);
+-		val |= ret << 16;
++		*val |= ret << 16;
+ 	}
+ 
+ 	if (ret < 0) {
+ 		dev_err_ratelimited(&bus->dev,
+ 				    "failed to read qca8k 32bit register\n");
++		*val = 0;
+ 		return ret;
+ 	}
+ 
+-	return val;
++	return 0;
+ }
+ 
+ static void
+@@ -148,26 +148,26 @@ qca8k_set_page(struct mii_bus *bus, u16
+ 	return 0;
+ }
+ 
+-static u32
+-qca8k_read(struct qca8k_priv *priv, u32 reg)
++static int
++qca8k_read(struct qca8k_priv *priv, u32 reg, u32 *val)
+ {
+ 	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+-	u32 val;
++	int ret;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+ 	mutex_lock_nested(&bus->mdio_lock, MDIO_MUTEX_NESTED);
+ 
+-	val = qca8k_set_page(bus, page);
+-	if (val < 0)
++	ret = qca8k_set_page(bus, page);
++	if (ret < 0)
+ 		goto exit;
+ 
+-	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
++	ret = qca8k_mii_read32(bus, 0x10 | r2, r1, val);
+ 
+ exit:
+ 	mutex_unlock(&bus->mdio_lock);
+-	return val;
++	return ret;
+ }
+ 
+ static int
+@@ -208,11 +208,9 @@ qca8k_rmw(struct qca8k_priv *priv, u32 r
+ 	if (ret < 0)
+ 		goto exit;
+ 
+-	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
+-	if (val < 0) {
+-		ret = val;
++	ret = qca8k_mii_read32(bus, 0x10 | r2, r1, &val);
++	if (ret < 0)
+ 		goto exit;
+-	}
+ 
+ 	val &= ~mask;
+ 	val |= write_val;
+@@ -240,15 +238,8 @@ static int
+ qca8k_regmap_read(void *ctx, uint32_t reg, uint32_t *val)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ctx;
+-	int ret;
+-
+-	ret = qca8k_read(priv, reg);
+-	if (ret < 0)
+-		return ret;
+-
+-	*val = ret;
+ 
+-	return 0;
++	return qca8k_read(priv, reg, val);
+ }
+ 
+ static int
+@@ -296,18 +287,18 @@ static struct regmap_config qca8k_regmap
+ static int
+ qca8k_busy_wait(struct qca8k_priv *priv, u32 reg, u32 mask)
+ {
++	int ret, ret1;
+ 	u32 val;
+-	int ret;
+ 
+-	ret = read_poll_timeout(qca8k_read, val, !(val & mask),
++	ret = read_poll_timeout(qca8k_read, ret1, !(val & mask),
+ 				0, QCA8K_BUSY_WAIT_TIMEOUT * USEC_PER_MSEC, false,
+-				priv, reg);
++				priv, reg, &val);
+ 
+ 	/* Check if qca8k_read has failed for a different reason
+ 	 * before returning -ETIMEDOUT
+ 	 */
+-	if (ret < 0 && val < 0)
+-		return val;
++	if (ret < 0 && ret1 < 0)
++		return ret1;
+ 
+ 	return ret;
+ }
+@@ -316,13 +307,13 @@ static int
+ qca8k_fdb_read(struct qca8k_priv *priv, struct qca8k_fdb *fdb)
+ {
+ 	u32 reg[4], val;
+-	int i;
++	int i, ret;
+ 
+ 	/* load the ARL table into an array */
+ 	for (i = 0; i < 4; i++) {
+-		val = qca8k_read(priv, QCA8K_REG_ATU_DATA0 + (i * 4));
+-		if (val < 0)
+-			return val;
++		ret = qca8k_read(priv, QCA8K_REG_ATU_DATA0 + (i * 4), &val);
++		if (ret < 0)
++			return ret;
+ 
+ 		reg[i] = val;
+ 	}
+@@ -396,9 +387,9 @@ qca8k_fdb_access(struct qca8k_priv *priv
+ 
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_FDB_LOAD) {
+-		reg = qca8k_read(priv, QCA8K_REG_ATU_FUNC);
+-		if (reg < 0)
+-			return reg;
++		ret = qca8k_read(priv, QCA8K_REG_ATU_FUNC, &reg);
++		if (ret < 0)
++			return ret;
+ 		if (reg & QCA8K_ATU_FUNC_FULL)
+ 			return -1;
+ 	}
+@@ -477,9 +468,9 @@ qca8k_vlan_access(struct qca8k_priv *pri
+ 
+ 	/* Check for table full violation when adding an entry */
+ 	if (cmd == QCA8K_VLAN_LOAD) {
+-		reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC1);
+-		if (reg < 0)
+-			return reg;
++		ret = qca8k_read(priv, QCA8K_REG_VTU_FUNC1, &reg);
++		if (ret < 0)
++			return ret;
+ 		if (reg & QCA8K_VTU_FUNC1_FULL)
+ 			return -ENOMEM;
+ 	}
+@@ -505,11 +496,9 @@ qca8k_vlan_add(struct qca8k_priv *priv,
+ 	if (ret < 0)
+ 		goto out;
+ 
+-	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
+-	if (reg < 0) {
+-		ret = reg;
++	ret = qca8k_read(priv, QCA8K_REG_VTU_FUNC0, &reg);
++	if (ret < 0)
+ 		goto out;
+-	}
+ 	reg |= QCA8K_VTU_FUNC0_VALID | QCA8K_VTU_FUNC0_IVL_EN;
+ 	reg &= ~(QCA8K_VTU_FUNC0_EG_MODE_MASK << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	if (untagged)
+@@ -542,11 +531,9 @@ qca8k_vlan_del(struct qca8k_priv *priv,
+ 	if (ret < 0)
+ 		goto out;
+ 
+-	reg = qca8k_read(priv, QCA8K_REG_VTU_FUNC0);
+-	if (reg < 0) {
+-		ret = reg;
++	ret = qca8k_read(priv, QCA8K_REG_VTU_FUNC0, &reg);
++	if (ret < 0)
+ 		goto out;
+-	}
+ 	reg &= ~(3 << QCA8K_VTU_FUNC0_EG_MODE_S(port));
+ 	reg |= QCA8K_VTU_FUNC0_EG_MODE_NOT <<
+ 			QCA8K_VTU_FUNC0_EG_MODE_S(port);
+@@ -638,19 +625,19 @@ qca8k_mdio_busy_wait(struct mii_bus *bus
+ {
+ 	u16 r1, r2, page;
+ 	u32 val;
+-	int ret;
++	int ret, ret1;
+ 
+ 	qca8k_split_addr(reg, &r1, &r2, &page);
+ 
+-	ret = read_poll_timeout(qca8k_mii_read32, val, !(val & mask), 0,
++	ret = read_poll_timeout(qca8k_mii_read32, ret1, !(val & mask), 0,
+ 				QCA8K_BUSY_WAIT_TIMEOUT * USEC_PER_MSEC, false,
+-				bus, 0x10 | r2, r1);
++				bus, 0x10 | r2, r1, &val);
+ 
+ 	/* Check if qca8k_read has failed for a different reason
+ 	 * before returnting -ETIMEDOUT
+ 	 */
+-	if (ret < 0 && val < 0)
+-		return val;
++	if (ret < 0 && ret1 < 0)
++		return ret1;
+ 
+ 	return ret;
+ }
+@@ -725,7 +712,7 @@ qca8k_mdio_read(struct mii_bus *salve_bu
+ 	if (ret)
+ 		goto exit;
+ 
+-	val = qca8k_mii_read32(bus, 0x10 | r2, r1);
++	ret = qca8k_mii_read32(bus, 0x10 | r2, r1, &val);
+ 
+ exit:
+ 	/* even if the busy_wait timeouts try to clear the MASTER_EN */
+@@ -733,10 +720,10 @@ exit:
+ 
+ 	mutex_unlock(&bus->mdio_lock);
+ 
+-	if (val >= 0)
+-		val &= QCA8K_MDIO_MASTER_DATA_MASK;
++	if (ret >= 0)
++		ret = val & QCA8K_MDIO_MASTER_DATA_MASK;
+ 
+-	return val;
++	return ret;
+ }
+ 
+ static int
+@@ -1211,7 +1198,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		qca8k_write(priv, reg, QCA8K_PORT_PAD_SGMII_EN);
+ 
+ 		/* Enable/disable SerDes auto-negotiation as necessary */
+-		val = qca8k_read(priv, QCA8K_REG_PWS);
++		qca8k_read(priv, QCA8K_REG_PWS, &val);
+ 		if (phylink_autoneg_inband(mode))
+ 			val &= ~QCA8K_PWS_SERDES_AEN_DIS;
+ 		else
+@@ -1219,7 +1206,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		qca8k_write(priv, QCA8K_REG_PWS, val);
+ 
+ 		/* Configure the SGMII parameters */
+-		val = qca8k_read(priv, QCA8K_REG_SGMII_CTRL);
++		qca8k_read(priv, QCA8K_REG_SGMII_CTRL, &val);
+ 
+ 		val |= QCA8K_SGMII_EN_PLL | QCA8K_SGMII_EN_RX |
+ 			QCA8K_SGMII_EN_TX | QCA8K_SGMII_EN_SD;
+@@ -1314,10 +1301,11 @@ qca8k_phylink_mac_link_state(struct dsa_
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u32 reg;
++	int ret;
+ 
+-	reg = qca8k_read(priv, QCA8K_REG_PORT_STATUS(port));
+-	if (reg < 0)
+-		return reg;
++	ret = qca8k_read(priv, QCA8K_REG_PORT_STATUS(port), &reg);
++	if (ret < 0)
++		return ret;
+ 
+ 	state->link = !!(reg & QCA8K_PORT_STATUS_LINK_UP);
+ 	state->an_complete = state->link;
+@@ -1419,19 +1407,20 @@ qca8k_get_ethtool_stats(struct dsa_switc
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	const struct qca8k_mib_desc *mib;
+ 	u32 reg, i, val;
+-	u64 hi;
++	u64 hi = 0;
++	int ret;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(ar8327_mib); i++) {
+ 		mib = &ar8327_mib[i];
+ 		reg = QCA8K_PORT_MIB_COUNTER(port) + mib->offset;
+ 
+-		val = qca8k_read(priv, reg);
+-		if (val < 0)
++		ret = qca8k_read(priv, reg, &val);
++		if (ret < 0)
+ 			continue;
+ 
+ 		if (mib->size == 2) {
+-			hi = qca8k_read(priv, reg + 4);
+-			if (hi < 0)
++			ret = qca8k_read(priv, reg + 4, (u32 *)&hi);
++			if (ret < 0)
+ 				continue;
+ 		}
+ 
+@@ -1459,7 +1448,7 @@ qca8k_set_mac_eee(struct dsa_switch *ds,
+ 	int ret;
+ 
+ 	mutex_lock(&priv->reg_mutex);
+-	reg = qca8k_read(priv, QCA8K_REG_EEE_CTRL);
++	ret = qca8k_read(priv, QCA8K_REG_EEE_CTRL, &reg);
+ 	if (reg < 0) {
+ 		ret = reg;
+ 		goto exit;
+@@ -1802,14 +1791,15 @@ static int qca8k_read_switch_id(struct q
+ 	const struct qca8k_match_data *data;
+ 	u32 val;
+ 	u8 id;
++	int ret;
+ 
+ 	/* get the switches ID from the compatible */
+ 	data = of_device_get_match_data(priv->dev);
+ 	if (!data)
+ 		return -ENODEV;
+ 
+-	val = qca8k_read(priv, QCA8K_REG_MASK_CTRL);
+-	if (val < 0)
++	ret = qca8k_read(priv, QCA8K_REG_MASK_CTRL, &val);
++	if (ret < 0)
+ 		return -ENODEV;
+ 
+ 	id = QCA8K_MASK_CTRL_DEVICE_ID(val & QCA8K_MASK_CTRL_DEVICE_ID_MASK);

--- a/target/linux/generic/backport-5.10/787-v5.14-02-net-dsa-qca8k-add-missing-check-return-value-in-qca8.patch
+++ b/target/linux/generic/backport-5.10/787-v5.14-02-net-dsa-qca8k-add-missing-check-return-value-in-qca8.patch
@@ -1,0 +1,47 @@
+From 9fe99de01440d9ede74d447ac76e9c445d8daae9 Mon Sep 17 00:00:00 2001
+From: Yang Yingliang <yangyingliang@huawei.com>
+Date: Sat, 29 May 2021 11:04:39 +0800
+Subject: [PATCH] net: dsa: qca8k: add missing check return value in
+ qca8k_phylink_mac_config()
+
+Now we can check qca8k_read() return value correctly, so if
+it fails, we need return directly.
+
+Signed-off-by: Yang Yingliang <yangyingliang@huawei.com>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/dsa/qca8k.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1128,6 +1128,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u32 reg, val;
++	int ret;
+ 
+ 	switch (port) {
+ 	case 0: /* 1st CPU port */
+@@ -1198,7 +1199,9 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		qca8k_write(priv, reg, QCA8K_PORT_PAD_SGMII_EN);
+ 
+ 		/* Enable/disable SerDes auto-negotiation as necessary */
+-		qca8k_read(priv, QCA8K_REG_PWS, &val);
++		ret = qca8k_read(priv, QCA8K_REG_PWS, &val);
++		if (ret)
++			return;
+ 		if (phylink_autoneg_inband(mode))
+ 			val &= ~QCA8K_PWS_SERDES_AEN_DIS;
+ 		else
+@@ -1206,7 +1209,9 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		qca8k_write(priv, QCA8K_REG_PWS, val);
+ 
+ 		/* Configure the SGMII parameters */
+-		qca8k_read(priv, QCA8K_REG_SGMII_CTRL, &val);
++		ret = qca8k_read(priv, QCA8K_REG_SGMII_CTRL, &val);
++		if (ret)
++			return;
+ 
+ 		val |= QCA8K_SGMII_EN_PLL | QCA8K_SGMII_EN_RX |
+ 			QCA8K_SGMII_EN_TX | QCA8K_SGMII_EN_SD;

--- a/target/linux/generic/backport-5.10/788-v5.14-01-net-dsa-qca8k-fix-an-endian-bug-in-qca8k-get-ethtool.patch
+++ b/target/linux/generic/backport-5.10/788-v5.14-01-net-dsa-qca8k-fix-an-endian-bug-in-qca8k-get-ethtool.patch
@@ -1,0 +1,47 @@
+aFrom aa3d020b22cb844ab7bdbb9e5d861a64666e2b74 Mon Sep 17 00:00:00 2001
+From: Dan Carpenter <dan.carpenter@oracle.com>
+Date: Wed, 9 Jun 2021 12:52:12 +0300
+Subject: [PATCH] net: dsa: qca8k: fix an endian bug in
+ qca8k_get_ethtool_stats()
+
+The "hi" variable is a u64 but the qca8k_read() writes to the top 32
+bits of it.  That will work on little endian systems but it's a bit
+subtle.  It's cleaner to make declare "hi" as a u32.  We will still need
+to cast it when we shift it later on in the function but that's fine.
+
+Fixes: 7c9896e37807 ("net: dsa: qca8k: check return value of read functions correctly")
+Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1412,7 +1412,7 @@ qca8k_get_ethtool_stats(struct dsa_switc
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+ 	const struct qca8k_mib_desc *mib;
+ 	u32 reg, i, val;
+-	u64 hi = 0;
++	u32 hi = 0;
+ 	int ret;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(ar8327_mib); i++) {
+@@ -1424,14 +1424,14 @@ qca8k_get_ethtool_stats(struct dsa_switc
+ 			continue;
+ 
+ 		if (mib->size == 2) {
+-			ret = qca8k_read(priv, reg + 4, (u32 *)&hi);
++			ret = qca8k_read(priv, reg + 4, &hi);
+ 			if (ret < 0)
+ 				continue;
+ 		}
+ 
+ 		data[i] = val;
+ 		if (mib->size == 2)
+-			data[i] |= hi << 32;
++			data[i] |= (u64)hi << 32;
+ 	}
+ }
+ 

--- a/target/linux/generic/backport-5.10/788-v5.14-02-net-dsa-qca8k-check-the-correct-variable-in-qca8k-se.patch
+++ b/target/linux/generic/backport-5.10/788-v5.14-02-net-dsa-qca8k-check-the-correct-variable-in-qca8k-se.patch
@@ -1,0 +1,31 @@
+From 3d0167f2a627528032821cdeb78b4eab0510460f Mon Sep 17 00:00:00 2001
+From: Dan Carpenter <dan.carpenter@oracle.com>
+Date: Wed, 9 Jun 2021 12:53:03 +0300
+Subject: [PATCH] net: dsa: qca8k: check the correct variable in
+ qca8k_set_mac_eee()
+
+This code check "reg" but "ret" was intended so the error handling will
+never trigger.
+
+Fixes: 7c9896e37807 ("net: dsa: qca8k: check return value of read functions correctly")
+Signed-off-by: Dan Carpenter <dan.carpenter@oracle.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1454,10 +1454,8 @@ qca8k_set_mac_eee(struct dsa_switch *ds,
+ 
+ 	mutex_lock(&priv->reg_mutex);
+ 	ret = qca8k_read(priv, QCA8K_REG_EEE_CTRL, &reg);
+-	if (reg < 0) {
+-		ret = reg;
++	if (ret < 0)
+ 		goto exit;
+-	}
+ 
+ 	if (eee->eee_enabled)
+ 		reg |= lpi_en;

--- a/target/linux/generic/backport-5.10/789-v5.15-net-dsa-qca8k-fix-kernel-panic-with-legacy-mdio-mapping.patch
+++ b/target/linux/generic/backport-5.10/789-v5.15-net-dsa-qca8k-fix-kernel-panic-with-legacy-mdio-mapping.patch
@@ -1,0 +1,80 @@
+From ce062a0adbfe933b1932235fdfd874c4c91d1bb0 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sat, 11 Sep 2021 17:50:09 +0200
+Subject: net: dsa: qca8k: fix kernel panic with legacy mdio mapping
+
+When the mdio legacy mapping is used the mii_bus priv registered by DSA
+refer to the dsa switch struct instead of the qca8k_priv struct and
+causes a kernel panic. Create dedicated function when the internal
+dedicated mdio driver is used to properly handle the 2 different
+implementation.
+
+Fixes: 759bafb8a322 ("net: dsa: qca8k: add support for internal phy and internal mdio")
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 30 ++++++++++++++++++++++--------
+ 1 file changed, 22 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -643,10 +643,8 @@ qca8k_mdio_busy_wait(struct mii_bus *bus
+ }
+ 
+ static int
+-qca8k_mdio_write(struct mii_bus *salve_bus, int phy, int regnum, u16 data)
++qca8k_mdio_write(struct mii_bus *bus, int phy, int regnum, u16 data)
+ {
+-	struct qca8k_priv *priv = salve_bus->priv;
+-	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 val;
+ 	int ret;
+@@ -682,10 +680,8 @@ exit:
+ }
+ 
+ static int
+-qca8k_mdio_read(struct mii_bus *salve_bus, int phy, int regnum)
++qca8k_mdio_read(struct mii_bus *bus, int phy, int regnum)
+ {
+-	struct qca8k_priv *priv = salve_bus->priv;
+-	struct mii_bus *bus = priv->bus;
+ 	u16 r1, r2, page;
+ 	u32 val;
+ 	int ret;
+@@ -727,6 +723,24 @@ exit:
+ }
+ 
+ static int
++qca8k_internal_mdio_write(struct mii_bus *slave_bus, int phy, int regnum, u16 data)
++{
++	struct qca8k_priv *priv = slave_bus->priv;
++	struct mii_bus *bus = priv->bus;
++
++	return qca8k_mdio_write(bus, phy, regnum, data);
++}
++
++static int
++qca8k_internal_mdio_read(struct mii_bus *slave_bus, int phy, int regnum)
++{
++	struct qca8k_priv *priv = slave_bus->priv;
++	struct mii_bus *bus = priv->bus;
++
++	return qca8k_mdio_read(bus, phy, regnum);
++}
++
++static int
+ qca8k_phy_write(struct dsa_switch *ds, int port, int regnum, u16 data)
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+@@ -775,8 +789,8 @@ qca8k_mdio_register(struct qca8k_priv *p
+ 
+ 	bus->priv = (void *)priv;
+ 	bus->name = "qca8k slave mii";
+-	bus->read = qca8k_mdio_read;
+-	bus->write = qca8k_mdio_write;
++	bus->read = qca8k_internal_mdio_read;
++	bus->write = qca8k_internal_mdio_write;
+ 	snprintf(bus->id, MII_BUS_ID_SIZE, "qca8k-%d",
+ 		 ds->index);
+ 

--- a/target/linux/generic/backport-5.10/792-v5.16-net-phy-at803x-add-support-for-qca-8327-internal-phy.patch
+++ b/target/linux/generic/backport-5.10/792-v5.16-net-phy-at803x-add-support-for-qca-8327-internal-phy.patch
@@ -1,0 +1,48 @@
+From 0ccf8511182436183c031e8a2f740ae91a02c625 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 14 Sep 2021 14:33:45 +0200
+Subject: net: phy: at803x: add support for qca 8327 internal phy
+
+Add support for qca8327 internal phy needed for correct init of the
+switch port. It does use the same qca8337 function and reg just with a
+different id.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Tested-by: Rosen Penev <rosenp@gmail.com>
+Tested-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -1328,6 +1328,19 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count = at803x_get_sset_count,
+ 	.get_strings = at803x_get_strings,
+ 	.get_stats = at803x_get_stats,
++}, {
++	/* QCA8327 */
++	.phy_id = QCA8327_PHY_ID,
++	.phy_id_mask = QCA8K_PHY_ID_MASK,
++	.name = "QCA PHY 8327",
++	/* PHY_GBIT_FEATURES */
++	.probe = at803x_probe,
++	.flags = PHY_IS_INTERNAL,
++	.config_init = qca83xx_config_init,
++	.soft_reset = genphy_soft_reset,
++	.get_sset_count = at803x_get_sset_count,
++	.get_strings = at803x_get_strings,
++	.get_stats = at803x_get_stats,
+ }, };
+ 
+ module_phy_driver(at803x_driver);
+@@ -1338,6 +1351,8 @@ static struct mdio_device_id __maybe_unu
+ 	{ PHY_ID_MATCH_EXACT(ATH8032_PHY_ID) },
+ 	{ PHY_ID_MATCH_EXACT(ATH8035_PHY_ID) },
+ 	{ PHY_ID_MATCH_EXACT(ATH9331_PHY_ID) },
++	{ PHY_ID_MATCH_EXACT(QCA8337_PHY_ID) },
++	{ PHY_ID_MATCH_EXACT(QCA8327_PHY_ID) },
+ 	{ }
+ };
+ 

--- a/target/linux/generic/backport-5.10/795-v5.16-01-net-phy-at803x-add-support-for-qca-8327-A-variant.patch
+++ b/target/linux/generic/backport-5.10/795-v5.16-01-net-phy-at803x-add-support-for-qca-8327-A-variant.patch
@@ -1,0 +1,65 @@
+From b4df02b562f4aa14ff6811f30e1b4d2159585c59 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 19 Sep 2021 18:28:15 +0200
+Subject: net: phy: at803x: add support for qca 8327 A variant internal phy
+
+For qca8327 internal phy there are 2 different switch variant with 2
+different phy id. Add this missing variant so the internal phy can be
+correctly identified and fixed.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -148,7 +148,8 @@
+ #define AT803X_PAGE_FIBER		0
+ #define AT803X_PAGE_COPPER		1
+ 
+-#define QCA8327_PHY_ID				0x004dd034
++#define QCA8327_A_PHY_ID			0x004dd033
++#define QCA8327_B_PHY_ID			0x004dd034
+ #define QCA8337_PHY_ID				0x004dd036
+ #define QCA8K_PHY_ID_MASK			0xffffffff
+ 
+@@ -1329,10 +1330,23 @@ static struct phy_driver at803x_driver[]
+ 	.get_strings = at803x_get_strings,
+ 	.get_stats = at803x_get_stats,
+ }, {
+-	/* QCA8327 */
+-	.phy_id = QCA8327_PHY_ID,
++	/* QCA8327-A from switch QCA8327-AL1A */
++	.phy_id = QCA8327_A_PHY_ID,
+ 	.phy_id_mask = QCA8K_PHY_ID_MASK,
+-	.name = "QCA PHY 8327",
++	.name = "QCA PHY 8327-A",
++	/* PHY_GBIT_FEATURES */
++	.probe = at803x_probe,
++	.flags = PHY_IS_INTERNAL,
++	.config_init = qca83xx_config_init,
++	.soft_reset = genphy_soft_reset,
++	.get_sset_count = at803x_get_sset_count,
++	.get_strings = at803x_get_strings,
++	.get_stats = at803x_get_stats,
++}, {
++	/* QCA8327-B from switch QCA8327-BL1A */
++	.phy_id = QCA8327_B_PHY_ID,
++	.phy_id_mask = QCA8K_PHY_ID_MASK,
++	.name = "QCA PHY 8327-B",
+ 	/* PHY_GBIT_FEATURES */
+ 	.probe = at803x_probe,
+ 	.flags = PHY_IS_INTERNAL,
+@@ -1352,7 +1366,8 @@ static struct mdio_device_id __maybe_unu
+ 	{ PHY_ID_MATCH_EXACT(ATH8035_PHY_ID) },
+ 	{ PHY_ID_MATCH_EXACT(ATH9331_PHY_ID) },
+ 	{ PHY_ID_MATCH_EXACT(QCA8337_PHY_ID) },
+-	{ PHY_ID_MATCH_EXACT(QCA8327_PHY_ID) },
++	{ PHY_ID_MATCH_EXACT(QCA8327_A_PHY_ID) },
++	{ PHY_ID_MATCH_EXACT(QCA8327_B_PHY_ID) },
+ 	{ }
+ };
+ 

--- a/target/linux/generic/backport-5.10/795-v5.16-02-net-phy-at803x-add-resume-suspend-function-to-qca83x.patch
+++ b/target/linux/generic/backport-5.10/795-v5.16-02-net-phy-at803x-add-resume-suspend-function-to-qca83x.patch
@@ -1,0 +1,45 @@
+From 15b9df4ece17d084f14eb0ca1cf05f2ad497e425 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 19 Sep 2021 18:28:16 +0200
+Subject: net: phy: at803x: add resume/suspend function to qca83xx phy
+
+Add resume/suspend function to qca83xx internal phy.
+We can't use the at803x generic function as the documentation lacks of
+any support for WoL regs.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -1329,6 +1329,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count = at803x_get_sset_count,
+ 	.get_strings = at803x_get_strings,
+ 	.get_stats = at803x_get_stats,
++	.suspend		= genphy_suspend,
++	.resume			= genphy_resume,
+ }, {
+ 	/* QCA8327-A from switch QCA8327-AL1A */
+ 	.phy_id = QCA8327_A_PHY_ID,
+@@ -1342,6 +1344,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count = at803x_get_sset_count,
+ 	.get_strings = at803x_get_strings,
+ 	.get_stats = at803x_get_stats,
++	.suspend		= genphy_suspend,
++	.resume			= genphy_resume,
+ }, {
+ 	/* QCA8327-B from switch QCA8327-BL1A */
+ 	.phy_id = QCA8327_B_PHY_ID,
+@@ -1355,6 +1359,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count = at803x_get_sset_count,
+ 	.get_strings = at803x_get_strings,
+ 	.get_stats = at803x_get_stats,
++	.suspend		= genphy_suspend,
++	.resume			= genphy_resume,
+ }, };
+ 
+ module_phy_driver(at803x_driver);

--- a/target/linux/generic/backport-5.10/795-v5.16-03-net-phy-at803x-fix-spacing-and-improve-name-for-83xx.patch
+++ b/target/linux/generic/backport-5.10/795-v5.16-03-net-phy-at803x-fix-spacing-and-improve-name-for-83xx.patch
@@ -1,0 +1,95 @@
+From d44fd8604a4ab92119adb35f05fd87612af722b5 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 19 Sep 2021 18:28:17 +0200
+Subject: net: phy: at803x: fix spacing and improve name for 83xx phy
+
+Fix spacing and improve name for 83xx phy following other phy in the
+same driver.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 60 ++++++++++++++++++++++++------------------------
+ 1 file changed, 30 insertions(+), 30 deletions(-)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -1318,47 +1318,47 @@ static struct phy_driver at803x_driver[]
+ 	.config_aneg		= at803x_config_aneg,
+ }, {
+ 	/* QCA8337 */
+-	.phy_id = QCA8337_PHY_ID,
+-	.phy_id_mask = QCA8K_PHY_ID_MASK,
+-	.name = "QCA PHY 8337",
++	.phy_id			= QCA8337_PHY_ID,
++	.phy_id_mask		= QCA8K_PHY_ID_MASK,
++	.name			= "Qualcomm Atheros 8337 internal PHY",
+ 	/* PHY_GBIT_FEATURES */
+-	.probe = at803x_probe,
+-	.flags = PHY_IS_INTERNAL,
+-	.config_init = qca83xx_config_init,
+-	.soft_reset = genphy_soft_reset,
+-	.get_sset_count = at803x_get_sset_count,
+-	.get_strings = at803x_get_strings,
+-	.get_stats = at803x_get_stats,
++	.probe			= at803x_probe,
++	.flags			= PHY_IS_INTERNAL,
++	.config_init		= qca83xx_config_init,
++	.soft_reset		= genphy_soft_reset,
++	.get_sset_count		= at803x_get_sset_count,
++	.get_strings		= at803x_get_strings,
++	.get_stats		= at803x_get_stats,
+ 	.suspend		= genphy_suspend,
+ 	.resume			= genphy_resume,
+ }, {
+ 	/* QCA8327-A from switch QCA8327-AL1A */
+-	.phy_id = QCA8327_A_PHY_ID,
+-	.phy_id_mask = QCA8K_PHY_ID_MASK,
+-	.name = "QCA PHY 8327-A",
++	.phy_id			= QCA8327_A_PHY_ID,
++	.phy_id_mask		= QCA8K_PHY_ID_MASK,
++	.name			= "Qualcomm Atheros 8327-A internal PHY",
+ 	/* PHY_GBIT_FEATURES */
+-	.probe = at803x_probe,
+-	.flags = PHY_IS_INTERNAL,
+-	.config_init = qca83xx_config_init,
+-	.soft_reset = genphy_soft_reset,
+-	.get_sset_count = at803x_get_sset_count,
+-	.get_strings = at803x_get_strings,
+-	.get_stats = at803x_get_stats,
++	.probe			= at803x_probe,
++	.flags			= PHY_IS_INTERNAL,
++	.config_init		= qca83xx_config_init,
++	.soft_reset		= genphy_soft_reset,
++	.get_sset_count		= at803x_get_sset_count,
++	.get_strings		= at803x_get_strings,
++	.get_stats		= at803x_get_stats,
+ 	.suspend		= genphy_suspend,
+ 	.resume			= genphy_resume,
+ }, {
+ 	/* QCA8327-B from switch QCA8327-BL1A */
+-	.phy_id = QCA8327_B_PHY_ID,
+-	.phy_id_mask = QCA8K_PHY_ID_MASK,
+-	.name = "QCA PHY 8327-B",
++	.phy_id			= QCA8327_B_PHY_ID,
++	.phy_id_mask		= QCA8K_PHY_ID_MASK,
++	.name			= "Qualcomm Atheros 8327-B internal PHY",
+ 	/* PHY_GBIT_FEATURES */
+-	.probe = at803x_probe,
+-	.flags = PHY_IS_INTERNAL,
+-	.config_init = qca83xx_config_init,
+-	.soft_reset = genphy_soft_reset,
+-	.get_sset_count = at803x_get_sset_count,
+-	.get_strings = at803x_get_strings,
+-	.get_stats = at803x_get_stats,
++	.probe			= at803x_probe,
++	.flags			= PHY_IS_INTERNAL,
++	.config_init		= qca83xx_config_init,
++	.soft_reset		= genphy_soft_reset,
++	.get_sset_count		= at803x_get_sset_count,
++	.get_strings		= at803x_get_strings,
++	.get_stats		= at803x_get_stats,
+ 	.suspend		= genphy_suspend,
+ 	.resume			= genphy_resume,
+ }, };

--- a/target/linux/generic/backport-5.10/796-v5.16-01-net-phy-at803x-fix-resume-for-QCA8327-phy.patch
+++ b/target/linux/generic/backport-5.10/796-v5.16-01-net-phy-at803x-fix-resume-for-QCA8327-phy.patch
@@ -1,0 +1,131 @@
+From ba3c01ee02ed0d821c9f241f179bbc9457542b8f Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 10 Oct 2021 00:46:15 +0200
+Subject: net: phy: at803x: fix resume for QCA8327 phy
+
+From Documentation phy resume triggers phy reset and restart
+auto-negotiation. Add a dedicated function to wait reset to finish as
+it was notice a regression where port sometime are not reliable after a
+suspend/resume session. The reset wait logic is copied from phy_poll_reset.
+Add dedicated suspend function to use genphy_suspend only with QCA8337
+phy and set only additional debug settings for QCA8327. With more test
+it was reported that QCA8327 doesn't proprely support this mode and
+using this cause the unreliability of the switch ports, especially the
+malfunction of the port0.
+
+Fixes: 15b9df4ece17 ("net: phy: at803x: add resume/suspend function to qca83xx phy")
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 69 +++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 63 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -92,9 +92,14 @@
+ #define AT803X_DEBUG_REG_5			0x05
+ #define AT803X_DEBUG_TX_CLK_DLY_EN		BIT(8)
+ 
++#define AT803X_DEBUG_REG_HIB_CTRL		0x0b
++#define   AT803X_DEBUG_HIB_CTRL_SEL_RST_80U	BIT(10)
++#define   AT803X_DEBUG_HIB_CTRL_EN_ANY_CHANGE	BIT(13)
++
+ #define AT803X_DEBUG_REG_3C			0x3C
+ 
+ #define AT803X_DEBUG_REG_3D			0x3D
++#define   AT803X_DEBUG_GATE_CLK_IN1000		BIT(6)
+ 
+ #define AT803X_DEBUG_REG_1F			0x1F
+ #define AT803X_DEBUG_PLL_ON			BIT(2)
+@@ -1220,6 +1225,58 @@ static int qca83xx_config_init(struct ph
+ 	return 0;
+ }
+ 
++static int qca83xx_resume(struct phy_device *phydev)
++{
++	int ret, val;
++
++	/* Skip reset if not suspended */
++	if (!phydev->suspended)
++		return 0;
++
++	/* Reinit the port, reset values set by suspend */
++	qca83xx_config_init(phydev);
++
++	/* Reset the port on port resume */
++	phy_set_bits(phydev, MII_BMCR, BMCR_RESET | BMCR_ANENABLE);
++
++	/* On resume from suspend the switch execute a reset and
++	 * restart auto-negotiation. Wait for reset to complete.
++	 */
++	ret = phy_read_poll_timeout(phydev, MII_BMCR, val, !(val & BMCR_RESET),
++				    50000, 600000, true);
++	if (ret)
++		return ret;
++
++	msleep(1);
++
++	return 0;
++}
++
++static int qca83xx_suspend(struct phy_device *phydev)
++{
++	u16 mask = 0;
++
++	/* Only QCA8337 support actual suspend.
++	 * QCA8327 cause port unreliability when phy suspend
++	 * is set.
++	 */
++	if (phydev->drv->phy_id == QCA8337_PHY_ID) {
++		genphy_suspend(phydev);
++	} else {
++		mask |= ~(BMCR_SPEED1000 | BMCR_FULLDPLX);
++		phy_modify(phydev, MII_BMCR, mask, 0);
++	}
++
++	at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_3D,
++			      AT803X_DEBUG_GATE_CLK_IN1000, 0);
++
++	at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_HIB_CTRL,
++			      AT803X_DEBUG_HIB_CTRL_EN_ANY_CHANGE |
++			      AT803X_DEBUG_HIB_CTRL_SEL_RST_80U, 0);
++
++	return 0;
++}
++
+ static struct phy_driver at803x_driver[] = {
+ {
+ 	/* Qualcomm Atheros AR8035 */
+@@ -1329,8 +1386,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count		= at803x_get_sset_count,
+ 	.get_strings		= at803x_get_strings,
+ 	.get_stats		= at803x_get_stats,
+-	.suspend		= genphy_suspend,
+-	.resume			= genphy_resume,
++	.suspend		= qca83xx_suspend,
++	.resume			= qca83xx_resume,
+ }, {
+ 	/* QCA8327-A from switch QCA8327-AL1A */
+ 	.phy_id			= QCA8327_A_PHY_ID,
+@@ -1344,8 +1401,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count		= at803x_get_sset_count,
+ 	.get_strings		= at803x_get_strings,
+ 	.get_stats		= at803x_get_stats,
+-	.suspend		= genphy_suspend,
+-	.resume			= genphy_resume,
++	.suspend		= qca83xx_suspend,
++	.resume			= qca83xx_resume,
+ }, {
+ 	/* QCA8327-B from switch QCA8327-BL1A */
+ 	.phy_id			= QCA8327_B_PHY_ID,
+@@ -1359,8 +1416,8 @@ static struct phy_driver at803x_driver[]
+ 	.get_sset_count		= at803x_get_sset_count,
+ 	.get_strings		= at803x_get_strings,
+ 	.get_stats		= at803x_get_stats,
+-	.suspend		= genphy_suspend,
+-	.resume			= genphy_resume,
++	.suspend		= qca83xx_suspend,
++	.resume			= qca83xx_resume,
+ }, };
+ 
+ module_phy_driver(at803x_driver);

--- a/target/linux/generic/backport-5.10/796-v5.16-02-net-phy-at803x-add-DAC-amplitude-fix-for-8327-phy.patch
+++ b/target/linux/generic/backport-5.10/796-v5.16-02-net-phy-at803x-add-DAC-amplitude-fix-for-8327-phy.patch
@@ -1,0 +1,91 @@
+From 1ca8311949aec5c9447645731ef1c6bc5bd71350 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 10 Oct 2021 00:46:16 +0200
+Subject: net: phy: at803x: add DAC amplitude fix for 8327 phy
+
+QCA8327 internal phy require DAC amplitude adjustement set to +6% with
+100m speed. Also add additional define to report a change of the same
+reg in QCA8337. (different scope it does set 1000m voltage)
+Add link_change_notify function to set the proper amplitude adjustement
+on PHY_RUNNING state and disable on any other state.
+
+Fixes: b4df02b562f4 ("net: phy: at803x: add support for qca 8327 A variant internal phy")
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -87,6 +87,8 @@
+ #define AT803X_PSSR_MR_AN_COMPLETE	0x0200
+ 
+ #define AT803X_DEBUG_REG_0			0x00
++#define QCA8327_DEBUG_MANU_CTRL_EN		BIT(2)
++#define QCA8337_DEBUG_MANU_CTRL_EN		GENMASK(3, 2)
+ #define AT803X_DEBUG_RX_CLK_DLY_EN		BIT(15)
+ 
+ #define AT803X_DEBUG_REG_5			0x05
+@@ -1222,9 +1224,37 @@ static int qca83xx_config_init(struct ph
+ 		break;
+ 	}
+ 
++	/* QCA8327 require DAC amplitude adjustment for 100m set to +6%.
++	 * Disable on init and enable only with 100m speed following
++	 * qca original source code.
++	 */
++	if (phydev->drv->phy_id == QCA8327_A_PHY_ID ||
++	    phydev->drv->phy_id == QCA8327_B_PHY_ID)
++		at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++				      QCA8327_DEBUG_MANU_CTRL_EN, 0);
++
+ 	return 0;
+ }
+ 
++static void qca83xx_link_change_notify(struct phy_device *phydev)
++{
++	/* QCA8337 doesn't require DAC Amplitude adjustement */
++	if (phydev->drv->phy_id == QCA8337_PHY_ID)
++		return;
++
++	/* Set DAC Amplitude adjustment to +6% for 100m on link running */
++	if (phydev->state == PHY_RUNNING) {
++		if (phydev->speed == SPEED_100)
++			at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++					      QCA8327_DEBUG_MANU_CTRL_EN,
++					      QCA8327_DEBUG_MANU_CTRL_EN);
++	} else {
++		/* Reset DAC Amplitude adjustment */
++		at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++				      QCA8327_DEBUG_MANU_CTRL_EN, 0);
++	}
++}
++
+ static int qca83xx_resume(struct phy_device *phydev)
+ {
+ 	int ret, val;
+@@ -1379,6 +1409,7 @@ static struct phy_driver at803x_driver[]
+ 	.phy_id_mask		= QCA8K_PHY_ID_MASK,
+ 	.name			= "Qualcomm Atheros 8337 internal PHY",
+ 	/* PHY_GBIT_FEATURES */
++	.link_change_notify	= qca83xx_link_change_notify,
+ 	.probe			= at803x_probe,
+ 	.flags			= PHY_IS_INTERNAL,
+ 	.config_init		= qca83xx_config_init,
+@@ -1394,6 +1425,7 @@ static struct phy_driver at803x_driver[]
+ 	.phy_id_mask		= QCA8K_PHY_ID_MASK,
+ 	.name			= "Qualcomm Atheros 8327-A internal PHY",
+ 	/* PHY_GBIT_FEATURES */
++	.link_change_notify	= qca83xx_link_change_notify,
+ 	.probe			= at803x_probe,
+ 	.flags			= PHY_IS_INTERNAL,
+ 	.config_init		= qca83xx_config_init,
+@@ -1409,6 +1441,7 @@ static struct phy_driver at803x_driver[]
+ 	.phy_id_mask		= QCA8K_PHY_ID_MASK,
+ 	.name			= "Qualcomm Atheros 8327-B internal PHY",
+ 	/* PHY_GBIT_FEATURES */
++	.link_change_notify	= qca83xx_link_change_notify,
+ 	.probe			= at803x_probe,
+ 	.flags			= PHY_IS_INTERNAL,
+ 	.config_init		= qca83xx_config_init,

--- a/target/linux/generic/backport-5.10/796-v5.16-03-net-phy-at803x-enable-prefer-master-for-83xx-interna.patch
+++ b/target/linux/generic/backport-5.10/796-v5.16-03-net-phy-at803x-enable-prefer-master-for-83xx-interna.patch
@@ -1,0 +1,27 @@
+From 9d1c29b4028557a496be9c5eb2b4b86063700636 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 10 Oct 2021 00:46:17 +0200
+Subject: net: phy: at803x: enable prefer master for 83xx internal phy
+
+From original QCA source code the port was set to prefer master as port
+type in 1000BASE-T mode. Apply the same settings also here.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -1233,6 +1233,9 @@ static int qca83xx_config_init(struct ph
+ 		at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
+ 				      QCA8327_DEBUG_MANU_CTRL_EN, 0);
+ 
++	/* Following original QCA sourcecode set port to prefer master */
++	phy_set_bits(phydev, MII_CTRL1000, CTL1000_PREFER_MASTER);
++
+ 	return 0;
+ }
+ 

--- a/target/linux/generic/backport-5.10/796-v5.16-04-net-phy-at803x-better-describe-debug-regs.patch
+++ b/target/linux/generic/backport-5.10/796-v5.16-04-net-phy-at803x-better-describe-debug-regs.patch
@@ -1,0 +1,127 @@
+From 67999555ff42e91de7654488d9a7735bd9e84555 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 10 Oct 2021 00:46:18 +0200
+Subject: net: phy: at803x: better describe debug regs
+
+Give a name to known debug regs from Documentation instead of using
+unknown hex values.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/at803x.c | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -86,12 +86,12 @@
+ #define AT803X_PSSR			0x11	/*PHY-Specific Status Register*/
+ #define AT803X_PSSR_MR_AN_COMPLETE	0x0200
+ 
+-#define AT803X_DEBUG_REG_0			0x00
++#define AT803X_DEBUG_ANALOG_TEST_CTRL		0x00
+ #define QCA8327_DEBUG_MANU_CTRL_EN		BIT(2)
+ #define QCA8337_DEBUG_MANU_CTRL_EN		GENMASK(3, 2)
+ #define AT803X_DEBUG_RX_CLK_DLY_EN		BIT(15)
+ 
+-#define AT803X_DEBUG_REG_5			0x05
++#define AT803X_DEBUG_SYSTEM_CTRL_MODE		0x05
+ #define AT803X_DEBUG_TX_CLK_DLY_EN		BIT(8)
+ 
+ #define AT803X_DEBUG_REG_HIB_CTRL		0x0b
+@@ -100,7 +100,7 @@
+ 
+ #define AT803X_DEBUG_REG_3C			0x3C
+ 
+-#define AT803X_DEBUG_REG_3D			0x3D
++#define AT803X_DEBUG_REG_GREEN			0x3D
+ #define   AT803X_DEBUG_GATE_CLK_IN1000		BIT(6)
+ 
+ #define AT803X_DEBUG_REG_1F			0x1F
+@@ -274,25 +274,25 @@ static int at803x_read_page(struct phy_d
+ 
+ static int at803x_enable_rx_delay(struct phy_device *phydev)
+ {
+-	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0, 0,
++	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL, 0,
+ 				     AT803X_DEBUG_RX_CLK_DLY_EN);
+ }
+ 
+ static int at803x_enable_tx_delay(struct phy_device *phydev)
+ {
+-	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_5, 0,
++	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE, 0,
+ 				     AT803X_DEBUG_TX_CLK_DLY_EN);
+ }
+ 
+ static int at803x_disable_rx_delay(struct phy_device *phydev)
+ {
+-	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL,
+ 				     AT803X_DEBUG_RX_CLK_DLY_EN, 0);
+ }
+ 
+ static int at803x_disable_tx_delay(struct phy_device *phydev)
+ {
+-	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_5,
++	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE,
+ 				     AT803X_DEBUG_TX_CLK_DLY_EN, 0);
+ }
+ 
+@@ -1208,9 +1208,9 @@ static int qca83xx_config_init(struct ph
+ 	switch (switch_revision) {
+ 	case 1:
+ 		/* For 100M waveform */
+-		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_0, 0x02ea);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL, 0x02ea);
+ 		/* Turn on Gigabit clock */
+-		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3D, 0x68a0);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_GREEN, 0x68a0);
+ 		break;
+ 
+ 	case 2:
+@@ -1218,8 +1218,8 @@ static int qca83xx_config_init(struct ph
+ 		fallthrough;
+ 	case 4:
+ 		phy_write_mmd(phydev, MDIO_MMD_PCS, MDIO_AZ_DEBUG, 0x803f);
+-		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3D, 0x6860);
+-		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_5, 0x2c46);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_GREEN, 0x6860);
++		at803x_debug_reg_write(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE, 0x2c46);
+ 		at803x_debug_reg_write(phydev, AT803X_DEBUG_REG_3C, 0x6000);
+ 		break;
+ 	}
+@@ -1230,7 +1230,7 @@ static int qca83xx_config_init(struct ph
+ 	 */
+ 	if (phydev->drv->phy_id == QCA8327_A_PHY_ID ||
+ 	    phydev->drv->phy_id == QCA8327_B_PHY_ID)
+-		at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++		at803x_debug_reg_mask(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL,
+ 				      QCA8327_DEBUG_MANU_CTRL_EN, 0);
+ 
+ 	/* Following original QCA sourcecode set port to prefer master */
+@@ -1248,12 +1248,12 @@ static void qca83xx_link_change_notify(s
+ 	/* Set DAC Amplitude adjustment to +6% for 100m on link running */
+ 	if (phydev->state == PHY_RUNNING) {
+ 		if (phydev->speed == SPEED_100)
+-			at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++			at803x_debug_reg_mask(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL,
+ 					      QCA8327_DEBUG_MANU_CTRL_EN,
+ 					      QCA8327_DEBUG_MANU_CTRL_EN);
+ 	} else {
+ 		/* Reset DAC Amplitude adjustment */
+-		at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_0,
++		at803x_debug_reg_mask(phydev, AT803X_DEBUG_ANALOG_TEST_CTRL,
+ 				      QCA8327_DEBUG_MANU_CTRL_EN, 0);
+ 	}
+ }
+@@ -1300,7 +1300,7 @@ static int qca83xx_suspend(struct phy_de
+ 		phy_modify(phydev, MII_BMCR, mask, 0);
+ 	}
+ 
+-	at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_3D,
++	at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_GREEN,
+ 			      AT803X_DEBUG_GATE_CLK_IN1000, 0);
+ 
+ 	at803x_debug_reg_mask(phydev, AT803X_DEBUG_REG_HIB_CTRL,

--- a/target/linux/generic/backport-5.10/797-v5.16-01-dsa-qca8k-add-mac-power-sel-support.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-01-dsa-qca8k-add-mac-power-sel-support.patch
@@ -1,0 +1,80 @@
+From d8b6f5bae6d3b648a67b6958cb98e4e97256d652 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:06 +0200
+Subject: dsa: qca8k: add mac_power_sel support
+
+Add missing mac power sel support needed for ipq8064/5 SoC that require
+1.8v for the internal regulator port instead of the default 1.5v.
+If other device needs this, consider adding a dedicated binding to
+support this.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 31 +++++++++++++++++++++++++++++++
+ drivers/net/dsa/qca8k.h |  5 +++++
+ 2 files changed, 36 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -951,6 +951,33 @@ qca8k_setup_of_rgmii_delay(struct qca8k_
+ }
+ 
+ static int
++qca8k_setup_mac_pwr_sel(struct qca8k_priv *priv)
++{
++	u32 mask = 0;
++	int ret = 0;
++
++	/* SoC specific settings for ipq8064.
++	 * If more device require this consider adding
++	 * a dedicated binding.
++	 */
++	if (of_machine_is_compatible("qcom,ipq8064"))
++		mask |= QCA8K_MAC_PWR_RGMII0_1_8V;
++
++	/* SoC specific settings for ipq8065 */
++	if (of_machine_is_compatible("qcom,ipq8065"))
++		mask |= QCA8K_MAC_PWR_RGMII1_1_8V;
++
++	if (mask) {
++		ret = qca8k_rmw(priv, QCA8K_REG_MAC_PWR_SEL,
++				QCA8K_MAC_PWR_RGMII0_1_8V |
++				QCA8K_MAC_PWR_RGMII1_1_8V,
++				mask);
++	}
++
++	return ret;
++}
++
++static int
+ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+@@ -979,6 +1006,10 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
++	ret = qca8k_setup_mac_pwr_sel(priv);
++	if (ret)
++		return ret;
++
+ 	/* Enable CPU Port */
+ 	ret = qca8k_reg_set(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
+ 			    QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -100,6 +100,11 @@
+ #define   QCA8K_SGMII_MODE_CTRL_PHY			(1 << 22)
+ #define   QCA8K_SGMII_MODE_CTRL_MAC			(2 << 22)
+ 
++/* MAC_PWR_SEL registers */
++#define QCA8K_REG_MAC_PWR_SEL				0x0e4
++#define   QCA8K_MAC_PWR_RGMII1_1_8V			BIT(18)
++#define   QCA8K_MAC_PWR_RGMII0_1_8V			BIT(19)
++
+ /* EEE control registers */
+ #define QCA8K_REG_EEE_CTRL				0x100
+ #define  QCA8K_REG_EEE_CTRL_LPI_EN(_i)			((_i + 1) * 2)

--- a/target/linux/generic/backport-5.10/797-v5.16-02-dt-bindings-net-dsa-qca8k-Add-SGMII-clock-phase-prop.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-02-dt-bindings-net-dsa-qca8k-Add-SGMII-clock-phase-prop.patch
@@ -1,0 +1,30 @@
+From fdbf35df9c091db9c46e57e9938e3f7a4f603a7c Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:07 +0200
+Subject: dt-bindings: net: dsa: qca8k: Add SGMII clock phase properties
+
+Add names and descriptions of additional PORT0_PAD_CTRL properties.
+qca,sgmii-(rx|tx)clk-falling-edge are for setting the respective clock
+phase to failling edge.
+
+Co-developed-by: Matthew Hagan <mnhagan88@gmail.com>
+Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -37,6 +37,10 @@ A CPU port node has the following option
+                           managed entity. See
+                           Documentation/devicetree/bindings/net/fixed-link.txt
+                           for details.
++- qca,sgmii-rxclk-falling-edge: Set the receive clock phase to falling edge.
++                                Mostly used in qca8327 with CPU port 0 set to
++                                sgmii.
++- qca,sgmii-txclk-falling-edge: Set the transmit clock phase to falling edge.
+ 
+ For QCA8K the 'fixed-link' sub-node supports only the following properties:
+ 

--- a/target/linux/generic/backport-5.10/797-v5.16-03-net-dsa-qca8k-add-support-for-sgmii-falling-edge.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-03-net-dsa-qca8k-add-support-for-sgmii-falling-edge.patch
@@ -1,0 +1,127 @@
+From 6c43809bf1bee76c434e365a26546a92a5fbec14 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:08 +0200
+Subject: net: dsa: qca8k: add support for sgmii falling edge
+
+Add support for this in the qca8k driver. Also add support for SGMII
+rx/tx clock falling edge. This is only present for pad0, pad5 and
+pad6 have these bit reserved from Documentation. Add a comment that this
+is hardcoded to PAD0 as qca8327/28/34/37 have an unique sgmii line and
+setting falling in port0 applies to both configuration with sgmii used
+for port0 or port6.
+
+Co-developed-by: Matthew Hagan <mnhagan88@gmail.com>
+Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 63 +++++++++++++++++++++++++++++++++++++++++++++++++
+ drivers/net/dsa/qca8k.h |  4 ++++
+ 2 files changed, 67 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -978,6 +978,42 @@ qca8k_setup_mac_pwr_sel(struct qca8k_pri
+ }
+ 
+ static int
++qca8k_parse_port_config(struct qca8k_priv *priv)
++{
++	struct device_node *port_dn;
++	phy_interface_t mode;
++	struct dsa_port *dp;
++	int port, ret;
++
++	/* We have 2 CPU port. Check them */
++	for (port = 0; port < QCA8K_NUM_PORTS; port++) {
++		/* Skip every other port */
++		if (port != 0 && port != 6)
++			continue;
++
++		dp = dsa_to_port(priv->ds, port);
++		port_dn = dp->dn;
++
++		if (!of_device_is_available(port_dn))
++			continue;
++
++		ret = of_get_phy_mode(port_dn, &mode);
++		if (ret)
++			continue;
++
++		if (mode == PHY_INTERFACE_MODE_SGMII) {
++			if (of_property_read_bool(port_dn, "qca,sgmii-txclk-falling-edge"))
++				priv->sgmii_tx_clk_falling_edge = true;
++
++			if (of_property_read_bool(port_dn, "qca,sgmii-rxclk-falling-edge"))
++				priv->sgmii_rx_clk_falling_edge = true;
++		}
++	}
++
++	return 0;
++}
++
++static int
+ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+@@ -990,6 +1026,11 @@ qca8k_setup(struct dsa_switch *ds)
+ 		return -EINVAL;
+ 	}
+ 
++	/* Parse CPU port config to be later used in phy_link mac_config */
++	ret = qca8k_parse_port_config(priv);
++	if (ret)
++		return ret;
++
+ 	mutex_init(&priv->reg_mutex);
+ 
+ 	/* Start by setting up the register mapping */
+@@ -1274,6 +1315,28 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		}
+ 
+ 		qca8k_write(priv, QCA8K_REG_SGMII_CTRL, val);
++
++		/* For qca8327/qca8328/qca8334/qca8338 sgmii is unique and
++		 * falling edge is set writing in the PORT0 PAD reg
++		 */
++		if (priv->switch_id == QCA8K_ID_QCA8327 ||
++		    priv->switch_id == QCA8K_ID_QCA8337)
++			reg = QCA8K_REG_PORT0_PAD_CTRL;
++
++		val = 0;
++
++		/* SGMII Clock phase configuration */
++		if (priv->sgmii_rx_clk_falling_edge)
++			val |= QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE;
++
++		if (priv->sgmii_tx_clk_falling_edge)
++			val |= QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE;
++
++		if (val)
++			ret = qca8k_rmw(priv, reg,
++					QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE |
++					QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE,
++					val);
+ 		break;
+ 	default:
+ 		dev_err(ds->dev, "xMII mode %s not supported for port %d\n",
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -35,6 +35,8 @@
+ #define   QCA8K_MASK_CTRL_DEVICE_ID_MASK		GENMASK(15, 8)
+ #define   QCA8K_MASK_CTRL_DEVICE_ID(x)			((x) >> 8)
+ #define QCA8K_REG_PORT0_PAD_CTRL			0x004
++#define   QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE	BIT(19)
++#define   QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE	BIT(18)
+ #define QCA8K_REG_PORT5_PAD_CTRL			0x008
+ #define QCA8K_REG_PORT6_PAD_CTRL			0x00c
+ #define   QCA8K_PORT_PAD_RGMII_EN			BIT(26)
+@@ -260,6 +262,8 @@ struct qca8k_priv {
+ 	u8 switch_revision;
+ 	u8 rgmii_tx_delay;
+ 	u8 rgmii_rx_delay;
++	bool sgmii_rx_clk_falling_edge;
++	bool sgmii_tx_clk_falling_edge;
+ 	bool legacy_phy_port_mapping;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;

--- a/target/linux/generic/backport-5.10/797-v5.16-04-dt-bindings-net-dsa-qca8k-Document-support-for-CPU-p.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-04-dt-bindings-net-dsa-qca8k-Document-support-for-CPU-p.patch
@@ -1,0 +1,29 @@
+From 731d613338ec6de482053ffa3f71be2325b0f8eb Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:09 +0200
+Subject: dt-bindings: net: dsa: qca8k: Document support for CPU port 6
+
+The switch now support CPU port to be set 6 instead of be hardcoded to
+0. Document support for it and describe logic selection.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -29,7 +29,11 @@ the mdio MASTER is used as communication
+ Don't use mixed external and internal mdio-bus configurations, as this is
+ not supported by the hardware.
+ 
+-The CPU port of this switch is always port 0.
++This switch support 2 CPU port. Normally and advised configuration is with
++CPU port set to port 0. It is also possible to set the CPU port to port 6
++if the device requires it. The driver will configure the switch to the defined
++port. With both CPU port declared the first CPU port is selected as primary
++and the secondary CPU ignored.
+ 
+ A CPU port node has the following optional node:
+ 

--- a/target/linux/generic/backport-5.10/797-v5.16-05-net-dsa-qca8k-add-support-for-cpu-port-6.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-05-net-dsa-qca8k-add-support-for-cpu-port-6.patch
@@ -1,0 +1,153 @@
+From 3fcf734aa482487df83cf8f18608438fcf59127f Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:10 +0200
+Subject: net: dsa: qca8k: add support for cpu port 6
+
+Currently CPU port is always hardcoded to port 0. This switch have 2 CPU
+ports. The original intention of this driver seems to be use the
+mac06_exchange bit to swap MAC0 with MAC6 in the strange configuration
+where device have connected only the CPU port 6. To skip the
+introduction of a new binding, rework the driver to address the
+secondary CPU port as primary and drop any reference of hardcoded port.
+With configuration of mac06 exchange, just skip the definition of port0
+and define the CPU port as a secondary. The driver will autoconfigure
+the switch to use that as the primary CPU port.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 51 ++++++++++++++++++++++++++++++++++---------------
+ drivers/net/dsa/qca8k.h |  2 --
+ 2 files changed, 36 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -977,6 +977,22 @@ qca8k_setup_mac_pwr_sel(struct qca8k_pri
+ 	return ret;
+ }
+ 
++static int qca8k_find_cpu_port(struct dsa_switch *ds)
++{
++	struct qca8k_priv *priv = ds->priv;
++
++	/* Find the connected cpu port. Valid port are 0 or 6 */
++	if (dsa_is_cpu_port(ds, 0))
++		return 0;
++
++	dev_dbg(priv->dev, "port 0 is not the CPU port. Checking port 6");
++
++	if (dsa_is_cpu_port(ds, 6))
++		return 6;
++
++	return -EINVAL;
++}
++
+ static int
+ qca8k_parse_port_config(struct qca8k_priv *priv)
+ {
+@@ -1017,13 +1033,13 @@ static int
+ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+-	int ret, i;
++	int cpu_port, ret, i;
+ 	u32 mask;
+ 
+-	/* Make sure that port 0 is the cpu port */
+-	if (!dsa_is_cpu_port(ds, 0)) {
+-		dev_err(priv->dev, "port 0 is not the CPU port");
+-		return -EINVAL;
++	cpu_port = qca8k_find_cpu_port(ds);
++	if (cpu_port < 0) {
++		dev_err(priv->dev, "No cpu port configured in both cpu port0 and port6");
++		return cpu_port;
+ 	}
+ 
+ 	/* Parse CPU port config to be later used in phy_link mac_config */
+@@ -1065,7 +1081,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 		dev_warn(priv->dev, "mib init failed");
+ 
+ 	/* Enable QCA header mode on the cpu port */
+-	ret = qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(QCA8K_CPU_PORT),
++	ret = qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(cpu_port),
+ 			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_TX_S |
+ 			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_RX_S);
+ 	if (ret) {
+@@ -1087,10 +1103,10 @@ qca8k_setup(struct dsa_switch *ds)
+ 
+ 	/* Forward all unknown frames to CPU port for Linux processing */
+ 	ret = qca8k_write(priv, QCA8K_REG_GLOBAL_FW_CTRL1,
+-			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S |
+-			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_BC_DP_S |
+-			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_MC_DP_S |
+-			  BIT(0) << QCA8K_GLOBAL_FW_CTRL1_UC_DP_S);
++			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S |
++			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_BC_DP_S |
++			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_MC_DP_S |
++			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_UC_DP_S);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -1098,7 +1114,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
+ 		/* CPU port gets connected to all user ports of the switch */
+ 		if (dsa_is_cpu_port(ds, i)) {
+-			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(QCA8K_CPU_PORT),
++			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(cpu_port),
+ 					QCA8K_PORT_LOOKUP_MEMBER, dsa_user_ports(ds));
+ 			if (ret)
+ 				return ret;
+@@ -1110,7 +1126,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 
+ 			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+ 					QCA8K_PORT_LOOKUP_MEMBER,
+-					BIT(QCA8K_CPU_PORT));
++					BIT(cpu_port));
+ 			if (ret)
+ 				return ret;
+ 
+@@ -1616,9 +1632,12 @@ static int
+ qca8k_port_bridge_join(struct dsa_switch *ds, int port, struct net_device *br)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+-	int port_mask = BIT(QCA8K_CPU_PORT);
++	int port_mask, cpu_port;
+ 	int i, ret;
+ 
++	cpu_port = dsa_to_port(ds, port)->cpu_dp->index;
++	port_mask = BIT(cpu_port);
++
+ 	for (i = 1; i < QCA8K_NUM_PORTS; i++) {
+ 		if (dsa_to_port(ds, i)->bridge_dev != br)
+ 			continue;
+@@ -1645,7 +1664,9 @@ static void
+ qca8k_port_bridge_leave(struct dsa_switch *ds, int port, struct net_device *br)
+ {
+ 	struct qca8k_priv *priv = (struct qca8k_priv *)ds->priv;
+-	int i;
++	int cpu_port, i;
++
++	cpu_port = dsa_to_port(ds, port)->cpu_dp->index;
+ 
+ 	for (i = 1; i < QCA8K_NUM_PORTS; i++) {
+ 		if (dsa_to_port(ds, i)->bridge_dev != br)
+@@ -1662,7 +1683,7 @@ qca8k_port_bridge_leave(struct dsa_switc
+ 	 * this port
+ 	 */
+ 	qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(port),
+-		  QCA8K_PORT_LOOKUP_MEMBER, BIT(QCA8K_CPU_PORT));
++		  QCA8K_PORT_LOOKUP_MEMBER, BIT(cpu_port));
+ }
+ 
+ static int
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -24,8 +24,6 @@
+ 
+ #define QCA8K_NUM_FDB_RECORDS				2048
+ 
+-#define QCA8K_CPU_PORT					0
+-
+ #define QCA8K_PORT_VID_DEF				1
+ 
+ /* Global control registers */

--- a/target/linux/generic/backport-5.10/797-v5.16-06-net-dsa-qca8k-rework-rgmii-delay-logic-and-scan-for-.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-06-net-dsa-qca8k-rework-rgmii-delay-logic-and-scan-for-.patch
@@ -1,0 +1,295 @@
+From 5654ec78dd7e64b1e04777b24007344329e6a63b Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:11 +0200
+Subject: net: dsa: qca8k: rework rgmii delay logic and scan for cpu port 6
+
+Future proof commit. This switch have 2 CPU ports and one valid
+configuration is first CPU port set to sgmii and second CPU port set to
+rgmii-id. The current implementation detects delay only for CPU port
+zero set to rgmii and doesn't count any delay set in a secondary CPU
+port. Drop the current delay scan function and move it to the sgmii
+parser function to generalize and implicitly add support for secondary
+CPU port set to rgmii-id. Introduce new logic where delay is enabled
+also with internal delay binding declared and rgmii set as PHY mode.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 165 ++++++++++++++++++++++++------------------------
+ drivers/net/dsa/qca8k.h |  10 ++-
+ 2 files changed, 89 insertions(+), 86 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -889,68 +889,6 @@ qca8k_setup_mdio_bus(struct qca8k_priv *
+ }
+ 
+ static int
+-qca8k_setup_of_rgmii_delay(struct qca8k_priv *priv)
+-{
+-	struct device_node *port_dn;
+-	phy_interface_t mode;
+-	struct dsa_port *dp;
+-	u32 val;
+-
+-	/* CPU port is already checked */
+-	dp = dsa_to_port(priv->ds, 0);
+-
+-	port_dn = dp->dn;
+-
+-	/* Check if port 0 is set to the correct type */
+-	of_get_phy_mode(port_dn, &mode);
+-	if (mode != PHY_INTERFACE_MODE_RGMII_ID &&
+-	    mode != PHY_INTERFACE_MODE_RGMII_RXID &&
+-	    mode != PHY_INTERFACE_MODE_RGMII_TXID) {
+-		return 0;
+-	}
+-
+-	switch (mode) {
+-	case PHY_INTERFACE_MODE_RGMII_ID:
+-	case PHY_INTERFACE_MODE_RGMII_RXID:
+-		if (of_property_read_u32(port_dn, "rx-internal-delay-ps", &val))
+-			val = 2;
+-		else
+-			/* Switch regs accept value in ns, convert ps to ns */
+-			val = val / 1000;
+-
+-		if (val > QCA8K_MAX_DELAY) {
+-			dev_err(priv->dev, "rgmii rx delay is limited to a max value of 3ns, setting to the max value");
+-			val = 3;
+-		}
+-
+-		priv->rgmii_rx_delay = val;
+-		/* Stop here if we need to check only for rx delay */
+-		if (mode != PHY_INTERFACE_MODE_RGMII_ID)
+-			break;
+-
+-		fallthrough;
+-	case PHY_INTERFACE_MODE_RGMII_TXID:
+-		if (of_property_read_u32(port_dn, "tx-internal-delay-ps", &val))
+-			val = 1;
+-		else
+-			/* Switch regs accept value in ns, convert ps to ns */
+-			val = val / 1000;
+-
+-		if (val > QCA8K_MAX_DELAY) {
+-			dev_err(priv->dev, "rgmii tx delay is limited to a max value of 3ns, setting to the max value");
+-			val = 3;
+-		}
+-
+-		priv->rgmii_tx_delay = val;
+-		break;
+-	default:
+-		return 0;
+-	}
+-
+-	return 0;
+-}
+-
+-static int
+ qca8k_setup_mac_pwr_sel(struct qca8k_priv *priv)
+ {
+ 	u32 mask = 0;
+@@ -996,19 +934,21 @@ static int qca8k_find_cpu_port(struct ds
+ static int
+ qca8k_parse_port_config(struct qca8k_priv *priv)
+ {
++	int port, cpu_port_index = 0, ret;
+ 	struct device_node *port_dn;
+ 	phy_interface_t mode;
+ 	struct dsa_port *dp;
+-	int port, ret;
++	u32 delay;
+ 
+ 	/* We have 2 CPU port. Check them */
+-	for (port = 0; port < QCA8K_NUM_PORTS; port++) {
++	for (port = 0; port < QCA8K_NUM_PORTS && cpu_port_index < QCA8K_NUM_CPU_PORTS; port++) {
+ 		/* Skip every other port */
+ 		if (port != 0 && port != 6)
+ 			continue;
+ 
+ 		dp = dsa_to_port(priv->ds, port);
+ 		port_dn = dp->dn;
++		cpu_port_index++;
+ 
+ 		if (!of_device_is_available(port_dn))
+ 			continue;
+@@ -1017,12 +957,54 @@ qca8k_parse_port_config(struct qca8k_pri
+ 		if (ret)
+ 			continue;
+ 
+-		if (mode == PHY_INTERFACE_MODE_SGMII) {
++		switch (mode) {
++		case PHY_INTERFACE_MODE_RGMII:
++		case PHY_INTERFACE_MODE_RGMII_ID:
++		case PHY_INTERFACE_MODE_RGMII_TXID:
++		case PHY_INTERFACE_MODE_RGMII_RXID:
++			delay = 0;
++
++			if (!of_property_read_u32(port_dn, "tx-internal-delay-ps", &delay))
++				/* Switch regs accept value in ns, convert ps to ns */
++				delay = delay / 1000;
++			else if (mode == PHY_INTERFACE_MODE_RGMII_ID ||
++				 mode == PHY_INTERFACE_MODE_RGMII_TXID)
++				delay = 1;
++
++			if (delay > QCA8K_MAX_DELAY) {
++				dev_err(priv->dev, "rgmii tx delay is limited to a max value of 3ns, setting to the max value");
++				delay = 3;
++			}
++
++			priv->rgmii_tx_delay[cpu_port_index] = delay;
++
++			delay = 0;
++
++			if (!of_property_read_u32(port_dn, "rx-internal-delay-ps", &delay))
++				/* Switch regs accept value in ns, convert ps to ns */
++				delay = delay / 1000;
++			else if (mode == PHY_INTERFACE_MODE_RGMII_ID ||
++				 mode == PHY_INTERFACE_MODE_RGMII_RXID)
++				delay = 2;
++
++			if (delay > QCA8K_MAX_DELAY) {
++				dev_err(priv->dev, "rgmii rx delay is limited to a max value of 3ns, setting to the max value");
++				delay = 3;
++			}
++
++			priv->rgmii_rx_delay[cpu_port_index] = delay;
++
++			break;
++		case PHY_INTERFACE_MODE_SGMII:
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-txclk-falling-edge"))
+ 				priv->sgmii_tx_clk_falling_edge = true;
+ 
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-rxclk-falling-edge"))
+ 				priv->sgmii_rx_clk_falling_edge = true;
++
++			break;
++		default:
++			continue;
+ 		}
+ 	}
+ 
+@@ -1059,10 +1041,6 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = qca8k_setup_of_rgmii_delay(priv);
+-	if (ret)
+-		return ret;
+-
+ 	ret = qca8k_setup_mac_pwr_sel(priv);
+ 	if (ret)
+ 		return ret;
+@@ -1229,8 +1207,8 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 			 const struct phylink_link_state *state)
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+-	u32 reg, val;
+-	int ret;
++	int cpu_port_index, ret;
++	u32 reg, val, delay;
+ 
+ 	switch (port) {
+ 	case 0: /* 1st CPU port */
+@@ -1242,6 +1220,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 			return;
+ 
+ 		reg = QCA8K_REG_PORT0_PAD_CTRL;
++		cpu_port_index = QCA8K_CPU_PORT0;
+ 		break;
+ 	case 1:
+ 	case 2:
+@@ -1260,6 +1239,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 			return;
+ 
+ 		reg = QCA8K_REG_PORT6_PAD_CTRL;
++		cpu_port_index = QCA8K_CPU_PORT6;
+ 		break;
+ 	default:
+ 		dev_err(ds->dev, "%s: unsupported port: %i\n", __func__, port);
+@@ -1274,23 +1254,40 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 
+ 	switch (state->interface) {
+ 	case PHY_INTERFACE_MODE_RGMII:
+-		/* RGMII mode means no delay so don't enable the delay */
+-		qca8k_write(priv, reg, QCA8K_PORT_PAD_RGMII_EN);
+-		break;
+ 	case PHY_INTERFACE_MODE_RGMII_ID:
+ 	case PHY_INTERFACE_MODE_RGMII_TXID:
+ 	case PHY_INTERFACE_MODE_RGMII_RXID:
+-		/* RGMII_ID needs internal delay. This is enabled through
+-		 * PORT5_PAD_CTRL for all ports, rather than individual port
+-		 * registers
++		val = QCA8K_PORT_PAD_RGMII_EN;
++
++		/* Delay can be declared in 3 different way.
++		 * Mode to rgmii and internal-delay standard binding defined
++		 * rgmii-id or rgmii-tx/rx phy mode set.
++		 * The parse logic set a delay different than 0 only when one
++		 * of the 3 different way is used. In all other case delay is
++		 * not enabled. With ID or TX/RXID delay is enabled and set
++		 * to the default and recommended value.
++		 */
++		if (priv->rgmii_tx_delay[cpu_port_index]) {
++			delay = priv->rgmii_tx_delay[cpu_port_index];
++
++			val |= QCA8K_PORT_PAD_RGMII_TX_DELAY(delay) |
++			       QCA8K_PORT_PAD_RGMII_TX_DELAY_EN;
++		}
++
++		if (priv->rgmii_rx_delay[cpu_port_index]) {
++			delay = priv->rgmii_rx_delay[cpu_port_index];
++
++			val |= QCA8K_PORT_PAD_RGMII_RX_DELAY(delay) |
++			       QCA8K_PORT_PAD_RGMII_RX_DELAY_EN;
++		}
++
++		/* Set RGMII delay based on the selected values */
++		qca8k_write(priv, reg, val);
++
++		/* QCA8337 requires to set rgmii rx delay for all ports.
++		 * This is enabled through PORT5_PAD_CTRL for all ports,
++		 * rather than individual port registers.
+ 		 */
+-		qca8k_write(priv, reg,
+-			    QCA8K_PORT_PAD_RGMII_EN |
+-			    QCA8K_PORT_PAD_RGMII_TX_DELAY(priv->rgmii_tx_delay) |
+-			    QCA8K_PORT_PAD_RGMII_RX_DELAY(priv->rgmii_rx_delay) |
+-			    QCA8K_PORT_PAD_RGMII_TX_DELAY_EN |
+-			    QCA8K_PORT_PAD_RGMII_RX_DELAY_EN);
+-		/* QCA8337 requires to set rgmii rx delay */
+ 		if (priv->switch_id == QCA8K_ID_QCA8337)
+ 			qca8k_write(priv, QCA8K_REG_PORT5_PAD_CTRL,
+ 				    QCA8K_PORT_PAD_RGMII_RX_DELAY_EN);
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -13,6 +13,7 @@
+ #include <linux/gpio.h>
+ 
+ #define QCA8K_NUM_PORTS					7
++#define QCA8K_NUM_CPU_PORTS				2
+ #define QCA8K_MAX_MTU					9000
+ 
+ #define PHY_ID_QCA8327					0x004dd034
+@@ -255,13 +256,18 @@ struct qca8k_match_data {
+ 	u8 id;
+ };
+ 
++enum {
++	QCA8K_CPU_PORT0,
++	QCA8K_CPU_PORT6,
++};
++
+ struct qca8k_priv {
+ 	u8 switch_id;
+ 	u8 switch_revision;
+-	u8 rgmii_tx_delay;
+-	u8 rgmii_rx_delay;
+ 	bool sgmii_rx_clk_falling_edge;
+ 	bool sgmii_tx_clk_falling_edge;
++	u8 rgmii_rx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
++	u8 rgmii_tx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
+ 	bool legacy_phy_port_mapping;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;

--- a/target/linux/generic/backport-5.10/797-v5.16-07-dt-bindings-net-dsa-qca8k-Document-qca-sgmii-enable-.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-07-dt-bindings-net-dsa-qca8k-Document-qca-sgmii-enable-.patch
@@ -1,0 +1,33 @@
+From 13ad5ccc093ff448b99ac7e138e91e78796adb48 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:12 +0200
+Subject: dt-bindings: net: dsa: qca8k: Document qca,sgmii-enable-pll
+
+Document qca,sgmii-enable-pll binding used in the CPU nodes to
+enable SGMII PLL on MAC config.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -45,6 +45,16 @@ A CPU port node has the following option
+                                 Mostly used in qca8327 with CPU port 0 set to
+                                 sgmii.
+ - qca,sgmii-txclk-falling-edge: Set the transmit clock phase to falling edge.
++- qca,sgmii-enable-pll  : For SGMII CPU port, explicitly enable PLL, TX and RX
++                          chain along with Signal Detection.
++                          This should NOT be enabled for qca8327. If enabled with
++                          qca8327 the sgmii port won't correctly init and an err
++                          is printed.
++                          This can be required for qca8337 switch with revision 2.
++                          A warning is displayed when used with revision greater
++                          2.
++                          With CPU port set to sgmii and qca8337 it is advised
++                          to set this unless a communication problem is observed.
+ 
+ For QCA8K the 'fixed-link' sub-node supports only the following properties:
+ 

--- a/target/linux/generic/backport-5.10/797-v5.16-08-net-dsa-qca8k-add-explicit-SGMII-PLL-enable.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-08-net-dsa-qca8k-add-explicit-SGMII-PLL-enable.patch
@@ -1,0 +1,65 @@
+From bbc4799e8bb6c397e3b3fec13de68e179f5db9ff Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:13 +0200
+Subject: net: dsa: qca8k: add explicit SGMII PLL enable
+
+Support enabling PLL on the SGMII CPU port. Some device require this
+special configuration or no traffic is transmitted and the switch
+doesn't work at all. A dedicated binding is added to the CPU node
+port to apply the correct reg on mac config.
+Fail to correctly configure sgmii with qca8327 switch and warn if pll is
+used on qca8337 with a revision greater than 1.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 19 +++++++++++++++++--
+ drivers/net/dsa/qca8k.h |  1 +
+ 2 files changed, 18 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1002,6 +1002,18 @@ qca8k_parse_port_config(struct qca8k_pri
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-rxclk-falling-edge"))
+ 				priv->sgmii_rx_clk_falling_edge = true;
+ 
++			if (of_property_read_bool(port_dn, "qca,sgmii-enable-pll")) {
++				priv->sgmii_enable_pll = true;
++
++				if (priv->switch_id == QCA8K_ID_QCA8327) {
++					dev_err(priv->dev, "SGMII PLL should NOT be enabled for qca8327. Aborting enabling");
++					priv->sgmii_enable_pll = false;
++				}
++
++				if (priv->switch_revision < 2)
++					dev_warn(priv->dev, "SGMII PLL should NOT be enabled for qca8337 with revision 2 or more.");
++			}
++
+ 			break;
+ 		default:
+ 			continue;
+@@ -1312,8 +1324,11 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		if (ret)
+ 			return;
+ 
+-		val |= QCA8K_SGMII_EN_PLL | QCA8K_SGMII_EN_RX |
+-			QCA8K_SGMII_EN_TX | QCA8K_SGMII_EN_SD;
++		val |= QCA8K_SGMII_EN_SD;
++
++		if (priv->sgmii_enable_pll)
++			val |= QCA8K_SGMII_EN_PLL | QCA8K_SGMII_EN_RX |
++			       QCA8K_SGMII_EN_TX;
+ 
+ 		if (dsa_is_cpu_port(ds, port)) {
+ 			/* CPU port, we're talking to the CPU MAC, be a PHY */
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -266,6 +266,7 @@ struct qca8k_priv {
+ 	u8 switch_revision;
+ 	bool sgmii_rx_clk_falling_edge;
+ 	bool sgmii_tx_clk_falling_edge;
++	bool sgmii_enable_pll;
+ 	u8 rgmii_rx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
+ 	u8 rgmii_tx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
+ 	bool legacy_phy_port_mapping;

--- a/target/linux/generic/backport-5.10/797-v5.16-09-dt-bindings-net-dsa-qca8k-Document-qca-led-open-drai.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-09-dt-bindings-net-dsa-qca8k-Document-qca-led-open-drai.patch
@@ -1,0 +1,37 @@
+From 924087c5c3d41553700b0eb83ca2a53b91643dca Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:14 +0200
+Subject: dt-bindings: net: dsa: qca8k: Document qca,led-open-drain binding
+
+Document new binding qca,ignore-power-on-sel used to ignore
+power on strapping and use sw regs instead.
+Document qca,led-open.drain to set led to open drain mode, the
+qca,ignore-power-on-sel is mandatory with this enabled or an error will
+be reported.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -13,6 +13,17 @@ Required properties:
+ Optional properties:
+ 
+ - reset-gpios: GPIO to be used to reset the whole device
++- qca,ignore-power-on-sel: Ignore power on pin strapping to configure led open
++                           drain or eeprom presence. This is needed for broken
++                           devices that have wrong configuration or when the oem
++                           decided to not use pin strapping and fallback to sw
++                           regs.
++- qca,led-open-drain: Set leds to open-drain mode. This requires the
++                      qca,ignore-power-on-sel to be set or the driver will fail
++                      to probe. This is needed if the oem doesn't use pin
++                      strapping to set this mode and prefers to set it using sw
++                      regs. The pin strapping related to led open drain mode is
++                      the pin B68 for QCA832x and B49 for QCA833x
+ 
+ Subnodes:
+ 

--- a/target/linux/generic/backport-5.10/797-v5.16-10-net-dsa-qca8k-add-support-for-pws-config-reg.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-10-net-dsa-qca8k-add-support-for-pws-config-reg.patch
@@ -1,0 +1,92 @@
+From 362bb238d8bf1470424214a8a5968d9c6cce68fa Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:15 +0200
+Subject: net: dsa: qca8k: add support for pws config reg
+
+Some qca8327 switch require to force the ignore of power on sel
+strapping. Some switch require to set the led open drain mode in regs
+instead of using strapping. While most of the device implements this
+using the correct way using pin strapping, there are still some broken
+device that require to be set using sw regs.
+Introduce a new binding and support these special configuration.
+As led open drain require to ignore pin strapping to work, the probe
+fails with EINVAL error with incorrect configuration.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 39 +++++++++++++++++++++++++++++++++++++++
+ drivers/net/dsa/qca8k.h |  6 ++++++
+ 2 files changed, 45 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -932,6 +932,41 @@ static int qca8k_find_cpu_port(struct ds
+ }
+ 
+ static int
++qca8k_setup_of_pws_reg(struct qca8k_priv *priv)
++{
++	struct device_node *node = priv->dev->of_node;
++	u32 val = 0;
++	int ret;
++
++	/* QCA8327 require to set to the correct mode.
++	 * His bigger brother QCA8328 have the 172 pin layout.
++	 * Should be applied by default but we set this just to make sure.
++	 */
++	if (priv->switch_id == QCA8K_ID_QCA8327) {
++		ret = qca8k_rmw(priv, QCA8K_REG_PWS, QCA8327_PWS_PACKAGE148_EN,
++				QCA8327_PWS_PACKAGE148_EN);
++		if (ret)
++			return ret;
++	}
++
++	if (of_property_read_bool(node, "qca,ignore-power-on-sel"))
++		val |= QCA8K_PWS_POWER_ON_SEL;
++
++	if (of_property_read_bool(node, "qca,led-open-drain")) {
++		if (!(val & QCA8K_PWS_POWER_ON_SEL)) {
++			dev_err(priv->dev, "qca,led-open-drain require qca,ignore-power-on-sel to be set.");
++			return -EINVAL;
++		}
++
++		val |= QCA8K_PWS_LED_OPEN_EN_CSR;
++	}
++
++	return qca8k_rmw(priv, QCA8K_REG_PWS,
++			QCA8K_PWS_LED_OPEN_EN_CSR | QCA8K_PWS_POWER_ON_SEL,
++			val);
++}
++
++static int
+ qca8k_parse_port_config(struct qca8k_priv *priv)
+ {
+ 	int port, cpu_port_index = 0, ret;
+@@ -1053,6 +1088,10 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
++	ret = qca8k_setup_of_pws_reg(priv);
++	if (ret)
++		return ret;
++
+ 	ret = qca8k_setup_mac_pwr_sel(priv);
+ 	if (ret)
+ 		return ret;
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -46,6 +46,12 @@
+ #define   QCA8K_MAX_DELAY				3
+ #define   QCA8K_PORT_PAD_SGMII_EN			BIT(7)
+ #define QCA8K_REG_PWS					0x010
++#define   QCA8K_PWS_POWER_ON_SEL			BIT(31)
++/* This reg is only valid for QCA832x and toggle the package
++ * type from 176 pin (by default) to 148 pin used on QCA8327
++ */
++#define   QCA8327_PWS_PACKAGE148_EN			BIT(30)
++#define   QCA8K_PWS_LED_OPEN_EN_CSR			BIT(24)
+ #define   QCA8K_PWS_SERDES_AEN_DIS			BIT(7)
+ #define QCA8K_REG_MODULE_EN				0x030
+ #define   QCA8K_MODULE_EN_MIB				BIT(0)

--- a/target/linux/generic/backport-5.10/797-v5.16-11-dt-bindings-net-dsa-qca8k-document-support-for-qca83.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-11-dt-bindings-net-dsa-qca8k-document-support-for-qca83.patch
@@ -1,0 +1,32 @@
+From ed7988d77fbfb79366b68f9e7fa60a6080da23d4 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:16 +0200
+Subject: dt-bindings: net: dsa: qca8k: document support for qca8328
+
+QCA8328 is the bigger brother of qca8327. Document the new compatible
+binding and add some information to understand the various switch
+compatible.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/dsa/qca8k.txt | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.txt
+@@ -3,9 +3,10 @@
+ Required properties:
+ 
+ - compatible: should be one of:
+-    "qca,qca8327"
+-    "qca,qca8334"
+-    "qca,qca8337"
++    "qca,qca8328": referenced as AR8328(N)-AK1(A/B) QFN 176 pin package
++    "qca,qca8327": referenced as AR8327(N)-AL1A DR-QFN 148 pin package
++    "qca,qca8334": referenced as QCA8334-AL3C QFN 88 pin package
++    "qca,qca8337": referenced as QCA8337N-AL3(B/C) DR-QFN 148 pin package
+ 
+ - #size-cells: must be 0
+ - #address-cells: must be 1

--- a/target/linux/generic/backport-5.10/797-v5.16-12-net-dsa-qca8k-add-support-for-QCA8328.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-12-net-dsa-qca8k-add-support-for-QCA8328.patch
@@ -1,0 +1,78 @@
+From f477d1c8bdbef4f400718238e350f16f521d2a3e Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:17 +0200
+Subject: net: dsa: qca8k: add support for QCA8328
+
+QCA8328 switch is the bigger brother of the qca8327. Same regs different
+chip. Change the function to set the correct pin layout and introduce a
+new match_data to differentiate the 2 switch as they have the same ID
+and their internal PHY have the same ID.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 19 ++++++++++++++++---
+ drivers/net/dsa/qca8k.h |  1 +
+ 2 files changed, 17 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -935,6 +935,7 @@ static int
+ qca8k_setup_of_pws_reg(struct qca8k_priv *priv)
+ {
+ 	struct device_node *node = priv->dev->of_node;
++	const struct qca8k_match_data *data;
+ 	u32 val = 0;
+ 	int ret;
+ 
+@@ -943,8 +944,14 @@ qca8k_setup_of_pws_reg(struct qca8k_priv
+ 	 * Should be applied by default but we set this just to make sure.
+ 	 */
+ 	if (priv->switch_id == QCA8K_ID_QCA8327) {
++		data = of_device_get_match_data(priv->dev);
++
++		/* Set the correct package of 148 pin for QCA8327 */
++		if (data->reduced_package)
++			val |= QCA8327_PWS_PACKAGE148_EN;
++
+ 		ret = qca8k_rmw(priv, QCA8K_REG_PWS, QCA8327_PWS_PACKAGE148_EN,
+-				QCA8327_PWS_PACKAGE148_EN);
++				val);
+ 		if (ret)
+ 			return ret;
+ 	}
+@@ -2098,7 +2105,12 @@ static int qca8k_resume(struct device *d
+ static SIMPLE_DEV_PM_OPS(qca8k_pm_ops,
+ 			 qca8k_suspend, qca8k_resume);
+ 
+-static const struct qca8k_match_data qca832x = {
++static const struct qca8k_match_data qca8327 = {
++	.id = QCA8K_ID_QCA8327,
++	.reduced_package = true,
++};
++
++static const struct qca8k_match_data qca8328 = {
+ 	.id = QCA8K_ID_QCA8327,
+ };
+ 
+@@ -2107,7 +2119,8 @@ static const struct qca8k_match_data qca
+ };
+ 
+ static const struct of_device_id qca8k_of_match[] = {
+-	{ .compatible = "qca,qca8327", .data = &qca832x },
++	{ .compatible = "qca,qca8327", .data = &qca8327 },
++	{ .compatible = "qca,qca8328", .data = &qca8328 },
+ 	{ .compatible = "qca,qca8334", .data = &qca833x },
+ 	{ .compatible = "qca,qca8337", .data = &qca833x },
+ 	{ /* sentinel */ },
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -260,6 +260,7 @@ struct ar8xxx_port_status {
+ 
+ struct qca8k_match_data {
+ 	u8 id;
++	bool reduced_package;
+ };
+ 
+ enum {

--- a/target/linux/generic/backport-5.10/797-v5.16-13-net-dsa-qca8k-set-internal-delay-also-for-sgmii.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-13-net-dsa-qca8k-set-internal-delay-also-for-sgmii.patch
@@ -1,0 +1,159 @@
+From cef08115846e581f80ff99abf7bf218da1840616 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:18 +0200
+Subject: net: dsa: qca8k: set internal delay also for sgmii
+
+QCA original code report port instability and sa that SGMII also require
+to set internal delay. Generalize the rgmii delay function and apply the
+advised value if they are not defined in DT.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 88 +++++++++++++++++++++++++++++++++----------------
+ drivers/net/dsa/qca8k.h |  2 ++
+ 2 files changed, 62 insertions(+), 28 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1004,6 +1004,7 @@ qca8k_parse_port_config(struct qca8k_pri
+ 		case PHY_INTERFACE_MODE_RGMII_ID:
+ 		case PHY_INTERFACE_MODE_RGMII_TXID:
+ 		case PHY_INTERFACE_MODE_RGMII_RXID:
++		case PHY_INTERFACE_MODE_SGMII:
+ 			delay = 0;
+ 
+ 			if (!of_property_read_u32(port_dn, "tx-internal-delay-ps", &delay))
+@@ -1036,8 +1037,13 @@ qca8k_parse_port_config(struct qca8k_pri
+ 
+ 			priv->rgmii_rx_delay[cpu_port_index] = delay;
+ 
+-			break;
+-		case PHY_INTERFACE_MODE_SGMII:
++			/* Skip sgmii parsing for rgmii* mode */
++			if (mode == PHY_INTERFACE_MODE_RGMII ||
++			    mode == PHY_INTERFACE_MODE_RGMII_ID ||
++			    mode == PHY_INTERFACE_MODE_RGMII_TXID ||
++			    mode == PHY_INTERFACE_MODE_RGMII_RXID)
++				break;
++
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-txclk-falling-edge"))
+ 				priv->sgmii_tx_clk_falling_edge = true;
+ 
+@@ -1261,12 +1267,53 @@ qca8k_setup(struct dsa_switch *ds)
+ }
+ 
+ static void
++qca8k_mac_config_setup_internal_delay(struct qca8k_priv *priv, int cpu_port_index,
++				      u32 reg)
++{
++	u32 delay, val = 0;
++	int ret;
++
++	/* Delay can be declared in 3 different way.
++	 * Mode to rgmii and internal-delay standard binding defined
++	 * rgmii-id or rgmii-tx/rx phy mode set.
++	 * The parse logic set a delay different than 0 only when one
++	 * of the 3 different way is used. In all other case delay is
++	 * not enabled. With ID or TX/RXID delay is enabled and set
++	 * to the default and recommended value.
++	 */
++	if (priv->rgmii_tx_delay[cpu_port_index]) {
++		delay = priv->rgmii_tx_delay[cpu_port_index];
++
++		val |= QCA8K_PORT_PAD_RGMII_TX_DELAY(delay) |
++			QCA8K_PORT_PAD_RGMII_TX_DELAY_EN;
++	}
++
++	if (priv->rgmii_rx_delay[cpu_port_index]) {
++		delay = priv->rgmii_rx_delay[cpu_port_index];
++
++		val |= QCA8K_PORT_PAD_RGMII_RX_DELAY(delay) |
++			QCA8K_PORT_PAD_RGMII_RX_DELAY_EN;
++	}
++
++	/* Set RGMII delay based on the selected values */
++	ret = qca8k_rmw(priv, reg,
++			QCA8K_PORT_PAD_RGMII_TX_DELAY_MASK |
++			QCA8K_PORT_PAD_RGMII_RX_DELAY_MASK |
++			QCA8K_PORT_PAD_RGMII_TX_DELAY_EN |
++			QCA8K_PORT_PAD_RGMII_RX_DELAY_EN,
++			val);
++	if (ret)
++		dev_err(priv->dev, "Failed to set internal delay for CPU port%d",
++			cpu_port_index == QCA8K_CPU_PORT0 ? 0 : 6);
++}
++
++static void
+ qca8k_phylink_mac_config(struct dsa_switch *ds, int port, unsigned int mode,
+ 			 const struct phylink_link_state *state)
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+ 	int cpu_port_index, ret;
+-	u32 reg, val, delay;
++	u32 reg, val;
+ 
+ 	switch (port) {
+ 	case 0: /* 1st CPU port */
+@@ -1315,32 +1362,10 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 	case PHY_INTERFACE_MODE_RGMII_ID:
+ 	case PHY_INTERFACE_MODE_RGMII_TXID:
+ 	case PHY_INTERFACE_MODE_RGMII_RXID:
+-		val = QCA8K_PORT_PAD_RGMII_EN;
+-
+-		/* Delay can be declared in 3 different way.
+-		 * Mode to rgmii and internal-delay standard binding defined
+-		 * rgmii-id or rgmii-tx/rx phy mode set.
+-		 * The parse logic set a delay different than 0 only when one
+-		 * of the 3 different way is used. In all other case delay is
+-		 * not enabled. With ID or TX/RXID delay is enabled and set
+-		 * to the default and recommended value.
+-		 */
+-		if (priv->rgmii_tx_delay[cpu_port_index]) {
+-			delay = priv->rgmii_tx_delay[cpu_port_index];
+-
+-			val |= QCA8K_PORT_PAD_RGMII_TX_DELAY(delay) |
+-			       QCA8K_PORT_PAD_RGMII_TX_DELAY_EN;
+-		}
+-
+-		if (priv->rgmii_rx_delay[cpu_port_index]) {
+-			delay = priv->rgmii_rx_delay[cpu_port_index];
+-
+-			val |= QCA8K_PORT_PAD_RGMII_RX_DELAY(delay) |
+-			       QCA8K_PORT_PAD_RGMII_RX_DELAY_EN;
+-		}
++		qca8k_write(priv, reg, QCA8K_PORT_PAD_RGMII_EN);
+ 
+-		/* Set RGMII delay based on the selected values */
+-		qca8k_write(priv, reg, val);
++		/* Configure rgmii delay */
++		qca8k_mac_config_setup_internal_delay(priv, cpu_port_index, reg);
+ 
+ 		/* QCA8337 requires to set rgmii rx delay for all ports.
+ 		 * This is enabled through PORT5_PAD_CTRL for all ports,
+@@ -1411,6 +1436,13 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 					QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE |
+ 					QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE,
+ 					val);
++
++		/* From original code is reported port instability as SGMII also
++		 * require delay set. Apply advised values here or take them from DT.
++		 */
++		if (state->interface == PHY_INTERFACE_MODE_SGMII)
++			qca8k_mac_config_setup_internal_delay(priv, cpu_port_index, reg);
++
+ 		break;
+ 	default:
+ 		dev_err(ds->dev, "xMII mode %s not supported for port %d\n",
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -39,7 +39,9 @@
+ #define QCA8K_REG_PORT5_PAD_CTRL			0x008
+ #define QCA8K_REG_PORT6_PAD_CTRL			0x00c
+ #define   QCA8K_PORT_PAD_RGMII_EN			BIT(26)
++#define   QCA8K_PORT_PAD_RGMII_TX_DELAY_MASK		GENMASK(23, 22)
+ #define   QCA8K_PORT_PAD_RGMII_TX_DELAY(x)		((x) << 22)
++#define   QCA8K_PORT_PAD_RGMII_RX_DELAY_MASK		GENMASK(21, 20)
+ #define   QCA8K_PORT_PAD_RGMII_RX_DELAY(x)		((x) << 20)
+ #define	  QCA8K_PORT_PAD_RGMII_TX_DELAY_EN		BIT(25)
+ #define   QCA8K_PORT_PAD_RGMII_RX_DELAY_EN		BIT(24)

--- a/target/linux/generic/backport-5.10/797-v5.16-14-net-dsa-qca8k-move-port-config-to-dedicated-struct.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-14-net-dsa-qca8k-move-port-config-to-dedicated-struct.patch
@@ -1,0 +1,124 @@
+From fd0bb28c547f7c8affb1691128cece38f5b626a1 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:19 +0200
+Subject: net: dsa: qca8k: move port config to dedicated struct
+
+Move ports related config to dedicated struct to keep things organized.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Reviewed-by: Florian Fainelli <f.fainelli@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 26 +++++++++++++-------------
+ drivers/net/dsa/qca8k.h | 10 +++++++---
+ 2 files changed, 20 insertions(+), 16 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1019,7 +1019,7 @@ qca8k_parse_port_config(struct qca8k_pri
+ 				delay = 3;
+ 			}
+ 
+-			priv->rgmii_tx_delay[cpu_port_index] = delay;
++			priv->ports_config.rgmii_tx_delay[cpu_port_index] = delay;
+ 
+ 			delay = 0;
+ 
+@@ -1035,7 +1035,7 @@ qca8k_parse_port_config(struct qca8k_pri
+ 				delay = 3;
+ 			}
+ 
+-			priv->rgmii_rx_delay[cpu_port_index] = delay;
++			priv->ports_config.rgmii_rx_delay[cpu_port_index] = delay;
+ 
+ 			/* Skip sgmii parsing for rgmii* mode */
+ 			if (mode == PHY_INTERFACE_MODE_RGMII ||
+@@ -1045,17 +1045,17 @@ qca8k_parse_port_config(struct qca8k_pri
+ 				break;
+ 
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-txclk-falling-edge"))
+-				priv->sgmii_tx_clk_falling_edge = true;
++				priv->ports_config.sgmii_tx_clk_falling_edge = true;
+ 
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-rxclk-falling-edge"))
+-				priv->sgmii_rx_clk_falling_edge = true;
++				priv->ports_config.sgmii_rx_clk_falling_edge = true;
+ 
+ 			if (of_property_read_bool(port_dn, "qca,sgmii-enable-pll")) {
+-				priv->sgmii_enable_pll = true;
++				priv->ports_config.sgmii_enable_pll = true;
+ 
+ 				if (priv->switch_id == QCA8K_ID_QCA8327) {
+ 					dev_err(priv->dev, "SGMII PLL should NOT be enabled for qca8327. Aborting enabling");
+-					priv->sgmii_enable_pll = false;
++					priv->ports_config.sgmii_enable_pll = false;
+ 				}
+ 
+ 				if (priv->switch_revision < 2)
+@@ -1281,15 +1281,15 @@ qca8k_mac_config_setup_internal_delay(st
+ 	 * not enabled. With ID or TX/RXID delay is enabled and set
+ 	 * to the default and recommended value.
+ 	 */
+-	if (priv->rgmii_tx_delay[cpu_port_index]) {
+-		delay = priv->rgmii_tx_delay[cpu_port_index];
++	if (priv->ports_config.rgmii_tx_delay[cpu_port_index]) {
++		delay = priv->ports_config.rgmii_tx_delay[cpu_port_index];
+ 
+ 		val |= QCA8K_PORT_PAD_RGMII_TX_DELAY(delay) |
+ 			QCA8K_PORT_PAD_RGMII_TX_DELAY_EN;
+ 	}
+ 
+-	if (priv->rgmii_rx_delay[cpu_port_index]) {
+-		delay = priv->rgmii_rx_delay[cpu_port_index];
++	if (priv->ports_config.rgmii_rx_delay[cpu_port_index]) {
++		delay = priv->ports_config.rgmii_rx_delay[cpu_port_index];
+ 
+ 		val |= QCA8K_PORT_PAD_RGMII_RX_DELAY(delay) |
+ 			QCA8K_PORT_PAD_RGMII_RX_DELAY_EN;
+@@ -1397,7 +1397,7 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 
+ 		val |= QCA8K_SGMII_EN_SD;
+ 
+-		if (priv->sgmii_enable_pll)
++		if (priv->ports_config.sgmii_enable_pll)
+ 			val |= QCA8K_SGMII_EN_PLL | QCA8K_SGMII_EN_RX |
+ 			       QCA8K_SGMII_EN_TX;
+ 
+@@ -1425,10 +1425,10 @@ qca8k_phylink_mac_config(struct dsa_swit
+ 		val = 0;
+ 
+ 		/* SGMII Clock phase configuration */
+-		if (priv->sgmii_rx_clk_falling_edge)
++		if (priv->ports_config.sgmii_rx_clk_falling_edge)
+ 			val |= QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE;
+ 
+-		if (priv->sgmii_tx_clk_falling_edge)
++		if (priv->ports_config.sgmii_tx_clk_falling_edge)
+ 			val |= QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE;
+ 
+ 		if (val)
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -270,15 +270,19 @@ enum {
+ 	QCA8K_CPU_PORT6,
+ };
+ 
+-struct qca8k_priv {
+-	u8 switch_id;
+-	u8 switch_revision;
++struct qca8k_ports_config {
+ 	bool sgmii_rx_clk_falling_edge;
+ 	bool sgmii_tx_clk_falling_edge;
+ 	bool sgmii_enable_pll;
+ 	u8 rgmii_rx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
+ 	u8 rgmii_tx_delay[QCA8K_NUM_CPU_PORTS]; /* 0: CPU port0, 1: CPU port6 */
++};
++
++struct qca8k_priv {
++	u8 switch_id;
++	u8 switch_revision;
+ 	bool legacy_phy_port_mapping;
++	struct qca8k_ports_config ports_config;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+ 	struct ar8xxx_port_status port_sts[QCA8K_NUM_PORTS];

--- a/target/linux/generic/backport-5.10/797-v5.16-15-dt-bindings-net-ipq8064-mdio-fix-warning-with-new-qc.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-15-dt-bindings-net-ipq8064-mdio-fix-warning-with-new-qc.patch
@@ -1,0 +1,26 @@
+From e52073a8e3086046a098b8a7cbeb282ff0cdb424 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:20 +0200
+Subject: dt-bindings: net: ipq8064-mdio: fix warning with new qca8k switch
+
+Fix warning now that we have qca8k switch Documentation using yaml.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ Documentation/devicetree/bindings/net/qcom,ipq8064-mdio.yaml | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/Documentation/devicetree/bindings/net/qcom,ipq8064-mdio.yaml
++++ b/Documentation/devicetree/bindings/net/qcom,ipq8064-mdio.yaml
+@@ -51,6 +51,9 @@ examples:
+         switch@10 {
+             compatible = "qca,qca8337";
+             reg = <0x10>;
+-            /* ... */
++
++            ports {
++              /* ... */
++            };
+         };
+     };

--- a/target/linux/generic/backport-5.10/797-v5.16-16-dt-bindings-net-dsa-qca8k-convert-to-YAML-schema.patch
+++ b/target/linux/generic/backport-5.10/797-v5.16-16-dt-bindings-net-dsa-qca8k-convert-to-YAML-schema.patch
@@ -1,0 +1,631 @@
+From d291fbb8245d5ba04979fed85575860a5cea7196 Mon Sep 17 00:00:00 2001
+From: Matthew Hagan <mnhagan88@gmail.com>
+Date: Thu, 14 Oct 2021 00:39:21 +0200
+Subject: dt-bindings: net: dsa: qca8k: convert to YAML schema
+
+Convert the qca8k bindings to YAML format.
+
+Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>
+Co-developed-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ .../devicetree/bindings/net/dsa/qca8k.txt          | 245 --------------
+ .../devicetree/bindings/net/dsa/qca8k.yaml         | 362 +++++++++++++++++++++
+ 2 files changed, 362 insertions(+), 245 deletions(-)
+ delete mode 100644 Documentation/devicetree/bindings/net/dsa/qca8k.txt
+ create mode 100644 Documentation/devicetree/bindings/net/dsa/qca8k.yaml
+
+--- a/Documentation/devicetree/bindings/net/dsa/qca8k.txt
++++ /dev/null
+@@ -1,245 +0,0 @@
+-* Qualcomm Atheros QCA8xxx switch family
+-
+-Required properties:
+-
+-- compatible: should be one of:
+-    "qca,qca8328": referenced as AR8328(N)-AK1(A/B) QFN 176 pin package
+-    "qca,qca8327": referenced as AR8327(N)-AL1A DR-QFN 148 pin package
+-    "qca,qca8334": referenced as QCA8334-AL3C QFN 88 pin package
+-    "qca,qca8337": referenced as QCA8337N-AL3(B/C) DR-QFN 148 pin package
+-
+-- #size-cells: must be 0
+-- #address-cells: must be 1
+-
+-Optional properties:
+-
+-- reset-gpios: GPIO to be used to reset the whole device
+-- qca,ignore-power-on-sel: Ignore power on pin strapping to configure led open
+-                           drain or eeprom presence. This is needed for broken
+-                           devices that have wrong configuration or when the oem
+-                           decided to not use pin strapping and fallback to sw
+-                           regs.
+-- qca,led-open-drain: Set leds to open-drain mode. This requires the
+-                      qca,ignore-power-on-sel to be set or the driver will fail
+-                      to probe. This is needed if the oem doesn't use pin
+-                      strapping to set this mode and prefers to set it using sw
+-                      regs. The pin strapping related to led open drain mode is
+-                      the pin B68 for QCA832x and B49 for QCA833x
+-
+-Subnodes:
+-
+-The integrated switch subnode should be specified according to the binding
+-described in dsa/dsa.txt. If the QCA8K switch is connect to a SoC's external
+-mdio-bus each subnode describing a port needs to have a valid phandle
+-referencing the internal PHY it is connected to. This is because there's no
+-N:N mapping of port and PHY id.
+-To declare the internal mdio-bus configuration, declare a mdio node in the
+-switch node and declare the phandle for the port referencing the internal
+-PHY is connected to. In this config a internal mdio-bus is registered and
+-the mdio MASTER is used as communication.
+-
+-Don't use mixed external and internal mdio-bus configurations, as this is
+-not supported by the hardware.
+-
+-This switch support 2 CPU port. Normally and advised configuration is with
+-CPU port set to port 0. It is also possible to set the CPU port to port 6
+-if the device requires it. The driver will configure the switch to the defined
+-port. With both CPU port declared the first CPU port is selected as primary
+-and the secondary CPU ignored.
+-
+-A CPU port node has the following optional node:
+-
+-- fixed-link            : Fixed-link subnode describing a link to a non-MDIO
+-                          managed entity. See
+-                          Documentation/devicetree/bindings/net/fixed-link.txt
+-                          for details.
+-- qca,sgmii-rxclk-falling-edge: Set the receive clock phase to falling edge.
+-                                Mostly used in qca8327 with CPU port 0 set to
+-                                sgmii.
+-- qca,sgmii-txclk-falling-edge: Set the transmit clock phase to falling edge.
+-- qca,sgmii-enable-pll  : For SGMII CPU port, explicitly enable PLL, TX and RX
+-                          chain along with Signal Detection.
+-                          This should NOT be enabled for qca8327. If enabled with
+-                          qca8327 the sgmii port won't correctly init and an err
+-                          is printed.
+-                          This can be required for qca8337 switch with revision 2.
+-                          A warning is displayed when used with revision greater
+-                          2.
+-                          With CPU port set to sgmii and qca8337 it is advised
+-                          to set this unless a communication problem is observed.
+-
+-For QCA8K the 'fixed-link' sub-node supports only the following properties:
+-
+-- 'speed' (integer, mandatory), to indicate the link speed. Accepted
+-  values are 10, 100 and 1000
+-- 'full-duplex' (boolean, optional), to indicate that full duplex is
+-  used. When absent, half duplex is assumed.
+-
+-Examples:
+-
+-for the external mdio-bus configuration:
+-
+-	&mdio0 {
+-		phy_port1: phy@0 {
+-			reg = <0>;
+-		};
+-
+-		phy_port2: phy@1 {
+-			reg = <1>;
+-		};
+-
+-		phy_port3: phy@2 {
+-			reg = <2>;
+-		};
+-
+-		phy_port4: phy@3 {
+-			reg = <3>;
+-		};
+-
+-		phy_port5: phy@4 {
+-			reg = <4>;
+-		};
+-
+-		switch@10 {
+-			compatible = "qca,qca8337";
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			reset-gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+-			reg = <0x10>;
+-
+-			ports {
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-				port@0 {
+-					reg = <0>;
+-					label = "cpu";
+-					ethernet = <&gmac1>;
+-					phy-mode = "rgmii";
+-					fixed-link {
+-						speed = 1000;
+-						full-duplex;
+-					};
+-				};
+-
+-				port@1 {
+-					reg = <1>;
+-					label = "lan1";
+-					phy-handle = <&phy_port1>;
+-				};
+-
+-				port@2 {
+-					reg = <2>;
+-					label = "lan2";
+-					phy-handle = <&phy_port2>;
+-				};
+-
+-				port@3 {
+-					reg = <3>;
+-					label = "lan3";
+-					phy-handle = <&phy_port3>;
+-				};
+-
+-				port@4 {
+-					reg = <4>;
+-					label = "lan4";
+-					phy-handle = <&phy_port4>;
+-				};
+-
+-				port@5 {
+-					reg = <5>;
+-					label = "wan";
+-					phy-handle = <&phy_port5>;
+-				};
+-			};
+-		};
+-	};
+-
+-for the internal master mdio-bus configuration:
+-
+-	&mdio0 {
+-		switch@10 {
+-			compatible = "qca,qca8337";
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			reset-gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+-			reg = <0x10>;
+-
+-			ports {
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-
+-				port@0 {
+-					reg = <0>;
+-					label = "cpu";
+-					ethernet = <&gmac1>;
+-					phy-mode = "rgmii";
+-					fixed-link {
+-						speed = 1000;
+-						full-duplex;
+-					};
+-				};
+-
+-				port@1 {
+-					reg = <1>;
+-					label = "lan1";
+-					phy-mode = "internal";
+-					phy-handle = <&phy_port1>;
+-				};
+-
+-				port@2 {
+-					reg = <2>;
+-					label = "lan2";
+-					phy-mode = "internal";
+-					phy-handle = <&phy_port2>;
+-				};
+-
+-				port@3 {
+-					reg = <3>;
+-					label = "lan3";
+-					phy-mode = "internal";
+-					phy-handle = <&phy_port3>;
+-				};
+-
+-				port@4 {
+-					reg = <4>;
+-					label = "lan4";
+-					phy-mode = "internal";
+-					phy-handle = <&phy_port4>;
+-				};
+-
+-				port@5 {
+-					reg = <5>;
+-					label = "wan";
+-					phy-mode = "internal";
+-					phy-handle = <&phy_port5>;
+-				};
+-			};
+-
+-			mdio {
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-
+-				phy_port1: phy@0 {
+-					reg = <0>;
+-				};
+-
+-				phy_port2: phy@1 {
+-					reg = <1>;
+-				};
+-
+-				phy_port3: phy@2 {
+-					reg = <2>;
+-				};
+-
+-				phy_port4: phy@3 {
+-					reg = <3>;
+-				};
+-
+-				phy_port5: phy@4 {
+-					reg = <4>;
+-				};
+-			};
+-		};
+-	};
+--- /dev/null
++++ b/Documentation/devicetree/bindings/net/dsa/qca8k.yaml
+@@ -0,0 +1,362 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/net/dsa/qca8k.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Qualcomm Atheros QCA83xx switch family
++
++maintainers:
++  - John Crispin <john@phrozen.org>
++
++description:
++  If the QCA8K switch is connect to an SoC's external mdio-bus, each subnode
++  describing a port needs to have a valid phandle referencing the internal PHY
++  it is connected to. This is because there is no N:N mapping of port and PHY
++  ID. To declare the internal mdio-bus configuration, declare an MDIO node in
++  the switch node and declare the phandle for the port, referencing the internal
++  PHY it is connected to. In this config, an internal mdio-bus is registered and
++  the MDIO master is used for communication. Mixed external and internal
++  mdio-bus configurations are not supported by the hardware.
++
++properties:
++  compatible:
++    oneOf:
++      - enum:
++          - qca,qca8327
++          - qca,qca8328
++          - qca,qca8334
++          - qca,qca8337
++    description: |
++      qca,qca8328: referenced as AR8328(N)-AK1(A/B) QFN 176 pin package
++      qca,qca8327: referenced as AR8327(N)-AL1A DR-QFN 148 pin package
++      qca,qca8334: referenced as QCA8334-AL3C QFN 88 pin package
++      qca,qca8337: referenced as QCA8337N-AL3(B/C) DR-QFN 148 pin package
++
++  reg:
++    maxItems: 1
++
++  reset-gpios:
++    description:
++      GPIO to be used to reset the whole device
++    maxItems: 1
++
++  qca,ignore-power-on-sel:
++    $ref: /schemas/types.yaml#/definitions/flag
++    description:
++      Ignore power-on pin strapping to configure LED open-drain or EEPROM
++      presence. This is needed for devices with incorrect configuration or when
++      the OEM has decided not to use pin strapping and falls back to SW regs.
++
++  qca,led-open-drain:
++    $ref: /schemas/types.yaml#/definitions/flag
++    description:
++      Set LEDs to open-drain mode. This requires the qca,ignore-power-on-sel to
++      be set, otherwise the driver will fail at probe. This is required if the
++      OEM does not use pin strapping to set this mode and prefers to set it
++      using SW regs. The pin strappings related to LED open-drain mode are
++      B68 on the QCA832x and B49 on the QCA833x.
++
++  mdio:
++    type: object
++    description: Qca8k switch have an internal mdio to access switch port.
++                 If this is not present, the legacy mapping is used and the
++                 internal mdio access is used.
++                 With the legacy mapping the reg corresponding to the internal
++                 mdio is the switch reg with an offset of -1.
++
++    properties:
++      '#address-cells':
++        const: 1
++      '#size-cells':
++        const: 0
++
++    patternProperties:
++      "^(ethernet-)?phy@[0-4]$":
++        type: object
++
++        allOf:
++          - $ref: "http://devicetree.org/schemas/net/mdio.yaml#"
++
++        properties:
++          reg:
++            maxItems: 1
++
++        required:
++          - reg
++
++patternProperties:
++  "^(ethernet-)?ports$":
++    type: object
++    properties:
++      '#address-cells':
++        const: 1
++      '#size-cells':
++        const: 0
++
++    patternProperties:
++      "^(ethernet-)?port@[0-6]$":
++        type: object
++        description: Ethernet switch ports
++
++        properties:
++          reg:
++            description: Port number
++
++          label:
++            description:
++              Describes the label associated with this port, which will become
++              the netdev name
++            $ref: /schemas/types.yaml#/definitions/string
++
++          link:
++            description:
++              Should be a list of phandles to other switch's DSA port. This
++              port is used as the outgoing port towards the phandle ports. The
++              full routing information must be given, not just the one hop
++              routes to neighbouring switches
++            $ref: /schemas/types.yaml#/definitions/phandle-array
++
++          ethernet:
++            description:
++              Should be a phandle to a valid Ethernet device node.  This host
++              device is what the switch port is connected to
++            $ref: /schemas/types.yaml#/definitions/phandle
++
++          phy-handle: true
++
++          phy-mode: true
++
++          fixed-link: true
++
++          mac-address: true
++
++          sfp: true
++
++          qca,sgmii-rxclk-falling-edge:
++            $ref: /schemas/types.yaml#/definitions/flag
++            description:
++              Set the receive clock phase to falling edge. Mostly commonly used on
++              the QCA8327 with CPU port 0 set to SGMII.
++
++          qca,sgmii-txclk-falling-edge:
++            $ref: /schemas/types.yaml#/definitions/flag
++            description:
++              Set the transmit clock phase to falling edge.
++
++          qca,sgmii-enable-pll:
++            $ref: /schemas/types.yaml#/definitions/flag
++            description:
++              For SGMII CPU port, explicitly enable PLL, TX and RX chain along with
++              Signal Detection. On the QCA8327 this should not be enabled, otherwise
++              the SGMII port will not initialize. When used on the QCA8337, revision 3
++              or greater, a warning will be displayed. When the CPU port is set to
++              SGMII on the QCA8337, it is advised to set this unless a communication
++              issue is observed.
++
++        required:
++          - reg
++
++        additionalProperties: false
++
++oneOf:
++  - required:
++      - ports
++  - required:
++      - ethernet-ports
++
++required:
++  - compatible
++  - reg
++
++additionalProperties: true
++
++examples:
++  - |
++    #include <dt-bindings/gpio/gpio.h>
++
++    mdio {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        external_phy_port1: ethernet-phy@0 {
++            reg = <0>;
++        };
++
++        external_phy_port2: ethernet-phy@1 {
++            reg = <1>;
++        };
++
++        external_phy_port3: ethernet-phy@2 {
++            reg = <2>;
++        };
++
++        external_phy_port4: ethernet-phy@3 {
++            reg = <3>;
++        };
++
++        external_phy_port5: ethernet-phy@4 {
++            reg = <4>;
++        };
++
++        switch@10 {
++            compatible = "qca,qca8337";
++            #address-cells = <1>;
++            #size-cells = <0>;
++            reset-gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
++            reg = <0x10>;
++
++            ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    label = "cpu";
++                    ethernet = <&gmac1>;
++                    phy-mode = "rgmii";
++
++                    fixed-link {
++                        speed = <1000>;
++                        full-duplex;
++                    };
++                };
++
++                port@1 {
++                    reg = <1>;
++                    label = "lan1";
++                    phy-handle = <&external_phy_port1>;
++                };
++
++                port@2 {
++                    reg = <2>;
++                    label = "lan2";
++                    phy-handle = <&external_phy_port2>;
++                };
++
++                port@3 {
++                    reg = <3>;
++                    label = "lan3";
++                    phy-handle = <&external_phy_port3>;
++                };
++
++                port@4 {
++                    reg = <4>;
++                    label = "lan4";
++                    phy-handle = <&external_phy_port4>;
++                };
++
++                port@5 {
++                    reg = <5>;
++                    label = "wan";
++                    phy-handle = <&external_phy_port5>;
++                };
++            };
++        };
++    };
++  - |
++    #include <dt-bindings/gpio/gpio.h>
++
++    mdio {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        switch@10 {
++            compatible = "qca,qca8337";
++            #address-cells = <1>;
++            #size-cells = <0>;
++            reset-gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
++            reg = <0x10>;
++
++            ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    label = "cpu";
++                    ethernet = <&gmac1>;
++                    phy-mode = "rgmii";
++
++                    fixed-link {
++                        speed = <1000>;
++                        full-duplex;
++                    };
++                };
++
++                port@1 {
++                    reg = <1>;
++                    label = "lan1";
++                    phy-mode = "internal";
++                    phy-handle = <&internal_phy_port1>;
++                };
++
++                port@2 {
++                    reg = <2>;
++                    label = "lan2";
++                    phy-mode = "internal";
++                    phy-handle = <&internal_phy_port2>;
++                };
++
++                port@3 {
++                    reg = <3>;
++                    label = "lan3";
++                    phy-mode = "internal";
++                    phy-handle = <&internal_phy_port3>;
++                };
++
++                port@4 {
++                    reg = <4>;
++                    label = "lan4";
++                    phy-mode = "internal";
++                    phy-handle = <&internal_phy_port4>;
++                };
++
++                port@5 {
++                    reg = <5>;
++                    label = "wan";
++                    phy-mode = "internal";
++                    phy-handle = <&internal_phy_port5>;
++                };
++
++                port@6 {
++                    reg = <0>;
++                    label = "cpu";
++                    ethernet = <&gmac1>;
++                    phy-mode = "sgmii";
++
++                    qca,sgmii-rxclk-falling-edge;
++
++                    fixed-link {
++                        speed = <1000>;
++                        full-duplex;
++                    };
++                };
++            };
++
++            mdio {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                internal_phy_port1: ethernet-phy@0 {
++                    reg = <0>;
++                };
++
++                internal_phy_port2: ethernet-phy@1 {
++                    reg = <1>;
++                };
++
++                internal_phy_port3: ethernet-phy@2 {
++                    reg = <2>;
++                };
++
++                internal_phy_port4: ethernet-phy@3 {
++                    reg = <3>;
++                };
++
++                internal_phy_port5: ethernet-phy@4 {
++                    reg = <4>;
++                };
++            };
++        };
++    };

--- a/target/linux/generic/backport-5.10/798-v5.16-net-dsa-qca8k-fix-delay-applied-to-wrong-cpu-in-parse-p.patch
+++ b/target/linux/generic/backport-5.10/798-v5.16-net-dsa-qca8k-fix-delay-applied-to-wrong-cpu-in-parse-p.patch
@@ -1,0 +1,28 @@
+From 06dd34a628ae5b6a839b757e746de165d6789ca8 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sun, 17 Oct 2021 16:56:46 +0200
+Subject: net: dsa: qca8k: fix delay applied to wrong cpu in parse_port_config
+
+Fix delay settings applied to wrong cpu in parse_port_config. The delay
+values is set to the wrong index as the cpu_port_index is incremented
+too early. Start the cpu_port_index to -1 so the correct value is
+applied to address also the case with invalid phy mode and not available
+port.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -976,7 +976,7 @@ qca8k_setup_of_pws_reg(struct qca8k_priv
+ static int
+ qca8k_parse_port_config(struct qca8k_priv *priv)
+ {
+-	int port, cpu_port_index = 0, ret;
++	int port, cpu_port_index = -1, ret;
+ 	struct device_node *port_dn;
+ 	phy_interface_t mode;
+ 	struct dsa_port *dp;

--- a/target/linux/generic/backport-5.10/799-v5.16-net-dsa-qca8k-tidy-for-loop-in-setup-and-add-cpu-port-c.patch
+++ b/target/linux/generic/backport-5.10/799-v5.16-net-dsa-qca8k-tidy-for-loop-in-setup-and-add-cpu-port-c.patch
@@ -1,0 +1,151 @@
+From 040e926f5813a5f4cc18dbff7c942d1e52f368f2 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 19 Oct 2021 02:08:50 +0200
+Subject: net: dsa: qca8k: tidy for loop in setup and add cpu port check
+
+Tidy and organize qca8k setup function from multiple for loop.
+Change for loop in bridge leave/join to scan all port and skip cpu port.
+No functional change intended.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 74 +++++++++++++++++++++++++++++--------------------
+ 1 file changed, 44 insertions(+), 30 deletions(-)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1122,28 +1122,34 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		dev_warn(priv->dev, "mib init failed");
+ 
+-	/* Enable QCA header mode on the cpu port */
+-	ret = qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(cpu_port),
+-			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_TX_S |
+-			  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_RX_S);
+-	if (ret) {
+-		dev_err(priv->dev, "failed enabling QCA header mode");
+-		return ret;
+-	}
+-
+-	/* Disable forwarding by default on all ports */
++	/* Initial setup of all ports */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++		/* Disable forwarding by default on all ports */
+ 		ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+ 				QCA8K_PORT_LOOKUP_MEMBER, 0);
+ 		if (ret)
+ 			return ret;
+-	}
+ 
+-	/* Disable MAC by default on all ports */
+-	for (i = 1; i < QCA8K_NUM_PORTS; i++)
+-		qca8k_port_set_status(priv, i, 0);
++		/* Enable QCA header mode on all cpu ports */
++		if (dsa_is_cpu_port(ds, i)) {
++			ret = qca8k_write(priv, QCA8K_REG_PORT_HDR_CTRL(i),
++					  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_TX_S |
++					  QCA8K_PORT_HDR_CTRL_ALL << QCA8K_PORT_HDR_CTRL_RX_S);
++			if (ret) {
++				dev_err(priv->dev, "failed enabling QCA header mode");
++				return ret;
++			}
++		}
++
++		/* Disable MAC by default on all user ports */
++		if (dsa_is_user_port(ds, i))
++			qca8k_port_set_status(priv, i, 0);
++	}
+ 
+-	/* Forward all unknown frames to CPU port for Linux processing */
++	/* Forward all unknown frames to CPU port for Linux processing
++	 * Notice that in multi-cpu config only one port should be set
++	 * for igmp, unknown, multicast and broadcast packet
++	 */
+ 	ret = qca8k_write(priv, QCA8K_REG_GLOBAL_FW_CTRL1,
+ 			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S |
+ 			  BIT(cpu_port) << QCA8K_GLOBAL_FW_CTRL1_BC_DP_S |
+@@ -1152,11 +1158,13 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
+-	/* Setup connection between CPU port & user ports */
++	/* Setup connection between CPU port & user ports
++	 * Configure specific switch configuration for ports
++	 */
+ 	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
+ 		/* CPU port gets connected to all user ports of the switch */
+ 		if (dsa_is_cpu_port(ds, i)) {
+-			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(cpu_port),
++			ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(i),
+ 					QCA8K_PORT_LOOKUP_MEMBER, dsa_user_ports(ds));
+ 			if (ret)
+ 				return ret;
+@@ -1193,16 +1201,14 @@ qca8k_setup(struct dsa_switch *ds)
+ 			if (ret)
+ 				return ret;
+ 		}
+-	}
+ 
+-	/* The port 5 of the qca8337 have some problem in flood condition. The
+-	 * original legacy driver had some specific buffer and priority settings
+-	 * for the different port suggested by the QCA switch team. Add this
+-	 * missing settings to improve switch stability under load condition.
+-	 * This problem is limited to qca8337 and other qca8k switch are not affected.
+-	 */
+-	if (priv->switch_id == QCA8K_ID_QCA8337) {
+-		for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++		/* The port 5 of the qca8337 have some problem in flood condition. The
++		 * original legacy driver had some specific buffer and priority settings
++		 * for the different port suggested by the QCA switch team. Add this
++		 * missing settings to improve switch stability under load condition.
++		 * This problem is limited to qca8337 and other qca8k switch are not affected.
++		 */
++		if (priv->switch_id == QCA8K_ID_QCA8337) {
+ 			switch (i) {
+ 			/* The 2 CPU port and port 5 requires some different
+ 			 * priority than any other ports.
+@@ -1238,6 +1244,12 @@ qca8k_setup(struct dsa_switch *ds)
+ 				  QCA8K_PORT_HOL_CTRL1_WRED_EN,
+ 				  mask);
+ 		}
++
++		/* Set initial MTU for every port.
++		 * We have only have a general MTU setting. So track
++		 * every port and set the max across all port.
++		 */
++		priv->port_mtu[i] = ETH_FRAME_LEN + ETH_FCS_LEN;
+ 	}
+ 
+ 	/* Special GLOBAL_FC_THRESH value are needed for ar8327 switch */
+@@ -1251,8 +1263,6 @@ qca8k_setup(struct dsa_switch *ds)
+ 	}
+ 
+ 	/* Setup our port MTUs to match power on defaults */
+-	for (i = 0; i < QCA8K_NUM_PORTS; i++)
+-		priv->port_mtu[i] = ETH_FRAME_LEN + ETH_FCS_LEN;
+ 	ret = qca8k_write(priv, QCA8K_MAX_FRAME_SIZE, ETH_FRAME_LEN + ETH_FCS_LEN);
+ 	if (ret)
+ 		dev_warn(priv->dev, "failed setting MTU settings");
+@@ -1728,7 +1738,9 @@ qca8k_port_bridge_join(struct dsa_switch
+ 	cpu_port = dsa_to_port(ds, port)->cpu_dp->index;
+ 	port_mask = BIT(cpu_port);
+ 
+-	for (i = 1; i < QCA8K_NUM_PORTS; i++) {
++	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++		if (dsa_is_cpu_port(ds, i))
++			continue;
+ 		if (dsa_to_port(ds, i)->bridge_dev != br)
+ 			continue;
+ 		/* Add this port to the portvlan mask of the other ports
+@@ -1758,7 +1770,9 @@ qca8k_port_bridge_leave(struct dsa_switc
+ 
+ 	cpu_port = dsa_to_port(ds, port)->cpu_dp->index;
+ 
+-	for (i = 1; i < QCA8K_NUM_PORTS; i++) {
++	for (i = 0; i < QCA8K_NUM_PORTS; i++) {
++		if (dsa_is_cpu_port(ds, i))
++			continue;
+ 		if (dsa_to_port(ds, i)->bridge_dev != br)
+ 			continue;
+ 		/* Remove this port to the portvlan mask of the other ports

--- a/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
+++ b/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
@@ -20,7 +20,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
-@@ -935,6 +935,34 @@ static int at803x_set_tunable(struct phy
+@@ -1024,6 +1024,34 @@ static int at803x_set_tunable(struct phy
  	}
  }
  
@@ -55,7 +55,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  static int at803x_cable_test_result_trans(u16 status)
  {
  	switch (FIELD_GET(AT803X_CDT_STATUS_STAT_MASK, status)) {
-@@ -1156,7 +1184,7 @@ static struct phy_driver at803x_driver[]
+@@ -1273,7 +1301,7 @@ static struct phy_driver at803x_driver[]
  	.resume			= at803x_resume,
  	.read_page		= at803x_read_page,
  	.write_page		= at803x_write_page,

--- a/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
+++ b/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
@@ -20,7 +20,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
-@@ -1024,6 +1024,34 @@ static int at803x_set_tunable(struct phy
+@@ -1025,6 +1025,34 @@ static int at803x_set_tunable(struct phy
  	}
  }
  
@@ -55,7 +55,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  static int at803x_cable_test_result_trans(u16 status)
  {
  	switch (FIELD_GET(AT803X_CDT_STATUS_STAT_MASK, status)) {
-@@ -1273,7 +1301,7 @@ static struct phy_driver at803x_driver[]
+@@ -1274,7 +1302,7 @@ static struct phy_driver at803x_driver[]
  	.resume			= at803x_resume,
  	.read_page		= at803x_read_page,
  	.write_page		= at803x_write_page,

--- a/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
+++ b/target/linux/generic/pending-5.10/730-net-phy-at803x-fix-feature-detection.patch
@@ -20,7 +20,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
-@@ -1025,6 +1025,34 @@ static int at803x_set_tunable(struct phy
+@@ -1032,6 +1032,34 @@ static int at803x_set_tunable(struct phy
  	}
  }
  
@@ -55,7 +55,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  static int at803x_cable_test_result_trans(u16 status)
  {
  	switch (FIELD_GET(AT803X_CDT_STATUS_STAT_MASK, status)) {
-@@ -1274,7 +1302,7 @@ static struct phy_driver at803x_driver[]
+@@ -1364,7 +1392,7 @@ static struct phy_driver at803x_driver[]
  	.resume			= at803x_resume,
  	.read_page		= at803x_read_page,
  	.write_page		= at803x_write_page,


### PR DESCRIPTION
This is a backport of Ansuel Smith's "Multiple improvement to qca8k stability"
series. The QCA8337 switch is available on multiple platforms including
ipq806x, ath79 and bcm53xx.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>