### PR TITLE
build: fix syntax issue in scan.mk

### DIFF
--- a/include/scan.mk
+++ b/include/scan.mk
@@ -88,7 +88,7 @@ $(TMP_DIR)/info/.files-$(SCAN_TARGET).mk: $(FILELIST)
 			gsub(/\//, "_", info); \
 			dir=$$0; \
 			pkg=""; \
-			if($$NF in override) \
+			if ($$NF in override) \
 				pkg=override[$$NF]; \
 			print "$$(eval $$(call PackageDir," info "," dir "," pkg "))"; \
 		} ' < $<; \


### PR DESCRIPTION
Syntax issue 
```diff
- if($$NF in override) \
+ if ($$NF in override) \
```