### PR TITLE
ath79: switch ZyXEL NBG6716 kernel partition size to 6MiB

### DIFF
--- a/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
@@ -147,12 +147,12 @@
 
 		partition@500000 {
 			label = "kernel";
-			reg = <0x500000 0x400000>;
+			reg = <0x500000 0x600000>;
 		};
 
-		partition@900000 {
+		partition@b00000 {
 			label = "ubi";
-			reg = <0x900000 0x7700000>;
+			reg = <0xb00000 0x7500000>;
 		};
 	};
 };

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/05_fix-compat-version
@@ -2,7 +2,8 @@
 
 case "$(board_name)" in
 	meraki,mr12|\
-	meraki,mr16)
+	meraki,mr16|\
+	zyxel,nbg6716)
 		uci set system.@system[0].compat_version="2.0"
 		uci commit system
 		;;

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -1,13 +1,12 @@
 # attention: only zlib compression is allowed for the boot fs
 define Build/zyxel-buildkerneljffs
-	rm -rf  $(KDIR_TMP)/zyxelnbg6716
-	mkdir -p $(KDIR_TMP)/zyxelnbg6716/image/boot
-	cp $@ $(KDIR_TMP)/zyxelnbg6716/image/boot/vmlinux.lzma.uImage
+	mkdir -p $@.tmp/boot
+	cp $@ $@.tmp/boot/vmlinux.lzma.uImage
 	$(STAGING_DIR_HOST)/bin/mkfs.jffs2 \
 		--big-endian --squash-uids -v -e 128KiB -q -f -n -x lzma -x rtime \
 		-o $@ \
-		-d $(KDIR_TMP)/zyxelnbg6716/image
-	rm -rf $(KDIR_TMP)/zyxelnbg6716
+		-d $@.tmp
+	rm -rf $@.tmp
 endef
 
 define Build/zyxel-factory

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -232,6 +232,16 @@ TARGET_DEVICES += netgear_wndr4500-v3
 
 define Device/zyxel_nbg6716
   SOC := qca9558
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Kernel partition has been resized to 6M. \
+	A sysupgrade will brick your device. \
+	Please install a fresh factory image via bootloader. \
+	Alternatively, you can flash sysupgrade-6M-Kernel.bin with \
+	zcat sysupgrade-6M-Kernel.bin | mtd -r -e /dev/mtd3 write - /dev/mtd3 .\
+	This may thow an error, because it is a 256M image. There are \
+	devices out there with this flash size. \
+	You have to ignore it and reboot. \
+	Notice that you will always loose configuration.
   DEVICE_VENDOR := ZyXEL
   DEVICE_MODEL := NBG6716
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
@@ -239,19 +249,18 @@ define Device/zyxel_nbg6716
   RAS_BOARD := NBG6716
   RAS_ROOTFS_SIZE := 29696k
   RAS_VERSION := "OpenWrt Linux-$(LINUX_VERSION)"
-  KERNEL_SIZE := 4096k
+  KERNEL_SIZE := 6144k
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL := kernel-bin | append-dtb | uImage none | zyxel-buildkerneljffs | \
-	check-size 4096k
-  IMAGES := sysupgrade.tar sysupgrade-4M-Kernel.bin factory.bin
+	check-size 6144k
+  IMAGES := sysupgrade.tar sysupgrade-6M-Kernel.bin factory.bin
   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | \
 	sysupgrade-tar rootfs=$$$$@ | append-metadata
-  IMAGE/sysupgrade-4M-Kernel.bin/squashfs := append-kernel | \
+  IMAGE/sysupgrade-6M-Kernel.bin/squashfs := append-kernel | \
 	pad-to $$$$(KERNEL_SIZE) | append-ubi | pad-to 263192576 | gzip
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	zyxel-factory
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-ubi | zyxel-factory
   UBINIZE_OPTS := -E 5
-  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_nbg6716

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -254,6 +254,8 @@ define Device/zyxel_nbg6716
   PAGESIZE := 2048
   KERNEL := kernel-bin | append-dtb | uImage none | zyxel-buildkerneljffs | \
 	check-size 6144k
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none | \
+	zyxel-buildkerneljffs | zyxel-factory
   IMAGES := sysupgrade.tar sysupgrade-6M-Kernel.bin factory.bin
   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | \
 	sysupgrade-tar rootfs=$$$$@ | append-metadata


### PR DESCRIPTION
ath79: switch ZyXEL NBG6716 kernel partition size to 6MiB

For kernel 5.10 support, we need to resize the kernel image to 6MiB.
Because the bootloader has problems with big compressed kernels,
the kernel is only compressed by jffs2, and that is inefficient.

But devices need a fresh reinstall because of resulting ubi partition
changes. Therefore a sysupgrade will brick your device.

Please install a fresh factory image via bootloader.
Alternatively, you can flash sysupgrade-6M-Kernel.bin with
zcat sysupgrade-6M-Kernel.bin | mtd -r -e /dev/mtd 3 write - /dev/mtd3

This may thow an error, because it is a 256M image. There are
devices out there with this flash size. You need to ignore it and force
a reboot.

Notice that you will always loose configuration.

This enables the device by default again. It has been deactivated in commit
5d8ea6d34f9f23d4dfff4ffcac8c9599d842c3a8

Signed-off-by: André Valentin <avalentin@marcant.net>