### PR TITLE
ramips: fix reboot for remaining 32 MB boards

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dts
@@ -7,6 +7,10 @@
 	model = "Youku YK-L1";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_youku_yk-l1.dtsi
@@ -56,7 +56,7 @@
 &spi0 {
 	status = "okay";
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-h-32m.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-h-32m.dts
@@ -8,6 +8,10 @@
 	model = "Zbtlink ZBT-WE1026-H (32M)";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026.dtsi
@@ -30,7 +30,7 @@
 &spi0 {
 	status = "okay";
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-32m.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-32m.dts
@@ -5,6 +5,10 @@
 	model = "Zbtlink ZBT-WE826 (32M)";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-e.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-e.dts
@@ -33,6 +33,10 @@
 	};
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
@@ -52,7 +52,7 @@
 &spi0 {
 	status = "okay";
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
@@ -69,6 +69,7 @@
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		m25p,fast-read;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
+++ b/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
@@ -47,6 +47,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526-32m.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526-32m.dts
@@ -5,6 +5,10 @@
 	model = "Zbtlink ZBT-WG3526 (32M)";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -49,7 +49,7 @@
 &spi0 {
 	status = "okay";
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -81,6 +81,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7688a.dts
@@ -61,6 +61,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7628an_jotale_js76x8-32m.dts
+++ b/target/linux/ramips/dts/mt7628an_jotale_js76x8-32m.dts
@@ -7,6 +7,10 @@
 	model = "Jotale JS76x8 (32M)";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
+++ b/target/linux/ramips/dts/mt7628an_jotale_js76x8.dtsi
@@ -58,7 +58,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2.dtsi
@@ -95,7 +95,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_onion_omega2p.dts
+++ b/target/linux/ramips/dts/mt7628an_onion_omega2p.dts
@@ -5,6 +5,10 @@
 	model = "Onion Omega2+";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7628an_widora_neo-32m.dts
+++ b/target/linux/ramips/dts/mt7628an_widora_neo-32m.dts
@@ -5,6 +5,10 @@
 	model = "Widora-NEO (32M)";
 };
 
+&flash0 {
+	broken-flash-reset;
+};
+
 &firmware {
 	reg = <0x50000 0x1fb0000>;
 };

--- a/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
+++ b/target/linux/ramips/dts/mt7628an_widora_neo.dtsi
@@ -52,7 +52,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_pins>, <&spi_cs1_pins>;
 
-	flash@0 {
+	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
+++ b/target/linux/ramips/dts/mt7628an_wiznet_wizfi630s.dts
@@ -97,6 +97,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_wrtnode_wrtnode2.dtsi
@@ -28,6 +28,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -86,6 +86,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
The following devices have a Winbond W25Q256FV flash chip,
which does not have the RESET pin enabled by default,
and otherwise would require setting a bit in a status register.

Before moving to Linux 5.4, we had the patch:
0053-mtd-spi-nor-add-w25q256-3b-mode-switch.patch
which kept specific flash chips with explicit 3-byte and 4-byte address modes
to stay in 3-byte address mode while idle (after an erase or write)
by using a custom flag SPI_NOR_4B_READ_OP that was part of the patch.

this was obsoleted by the patch:
481-mtd-spi-nor-rework-broken-flash-reset-support.patch
which uses the newer upstream flag SNOR_F_BROKEN_RESET
for devices with a flash chip that cannot be hardware reset with RESET pin
and therefore must be left in 3-byte address mode when idle.

The new patch requires that the DTS of affected devices
have the property "broken-flash-reset", which was not yet added for most of them.

This commit adds the property for remaining affected devices in ramips target,
specifically because of the flash chip model.

However, it is possible that there are other devices
where the flash chip uses an explicit 4-byte address mode
and the RESET pin is not connected to the SOC on the board,
and those DTS would also need this property.

Ref: 22d982ea0033 ("ramips: add support for switching between 3-byte and 4-byte addressing")
Ref: dfa521f12953 ("generic: spi-nor: rework broken-flash-reset")
Signed-off-by: Michael Pratt <mcpratt@pm.me>