### PR TITLE
kernel: bump 5.10 to 5.10.64

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .143
-LINUX_VERSION-5.10 = .63
+LINUX_VERSION-5.10 = .64
 
 LINUX_KERNEL_HASH-5.4.143 = 0953650b05a5f806d76c5691583e94e141f4f691bc0ba75a60b643740f021d24
-LINUX_KERNEL_HASH-5.10.63 = 19a15e838885a0081de5f9874e608fc3f3b1d9e69f2cc5cfa883b8b5499bcb2e
+LINUX_KERNEL_HASH-5.10.64 = 3eb84bd24a2de2b4749314e34597c02401c5d6831b055ed5224adb405c35e30a
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/apm821xx/patches-5.10/802-usb-xhci-force-msi-renesas-xhci.patch
+++ b/target/linux/apm821xx/patches-5.10/802-usb-xhci-force-msi-renesas-xhci.patch
@@ -43,7 +43,7 @@ produce a noisy warning.
  		hcd->msi_enabled = 1;
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1888,6 +1888,7 @@ struct xhci_hcd {
+@@ -1891,6 +1891,7 @@ struct xhci_hcd {
  	struct xhci_hub		usb2_rhub;
  	struct xhci_hub		usb3_rhub;
  	/* support xHCI 1.0 spec USB2 hardware LPM */

--- a/target/linux/bcm27xx/patches-5.10/950-0145-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0145-xhci-add-quirk-for-host-controllers-that-don-t-updat.patch
@@ -80,7 +80,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  	/*
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1881,6 +1881,7 @@ struct xhci_hcd {
+@@ -1884,6 +1884,7 @@ struct xhci_hcd {
  #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
  #define XHCI_SG_TRB_CACHE_SIZE_QUIRK	BIT_ULL(39)
  #define XHCI_NO_SOFT_RETRY	BIT_ULL(40)

--- a/target/linux/bcm27xx/patches-5.10/950-0154-xhci-Use-more-event-ring-segment-table-entries.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0154-xhci-Use-more-event-ring-segment-table-entries.patch
@@ -47,7 +47,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  			val);
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1650,8 +1650,8 @@ struct urb_priv {
+@@ -1653,8 +1653,8 @@ struct urb_priv {
   * Each segment table entry is 4*32bits long.  1K seems like an ok size:
   * (1K bytes * 8bytes/bit) / (4*32 bits) = 64 segment entries in the table,
   * meaning 64 ring segments.

--- a/target/linux/bcm27xx/patches-5.10/950-0355-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0355-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
@@ -51,7 +51,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1882,6 +1882,7 @@ struct xhci_hcd {
+@@ -1885,6 +1885,7 @@ struct xhci_hcd {
  #define XHCI_SG_TRB_CACHE_SIZE_QUIRK	BIT_ULL(39)
  #define XHCI_NO_SOFT_RETRY	BIT_ULL(40)
  #define XHCI_EP_CTX_BROKEN_DCS	BIT_ULL(41)

--- a/target/linux/bcm27xx/patches-5.10/950-0733-usb-xhci-workaround-for-bogus-SET_DEQ_PENDING-endpoi.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0733-usb-xhci-workaround-for-bogus-SET_DEQ_PENDING-endpoi.patch
@@ -26,7 +26,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
 --- a/drivers/usb/host/xhci-ring.c
 +++ b/drivers/usb/host/xhci-ring.c
-@@ -4255,9 +4255,9 @@ void xhci_queue_new_dequeue_state(struct
+@@ -4256,9 +4256,9 @@ void xhci_queue_new_dequeue_state(struct
  	}
  	ep = &xhci->devs[slot_id]->eps[ep_index];
  	if ((ep->ep_state & SET_DEQ_PENDING)) {

--- a/target/linux/bcm53xx/patches-5.10/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
+++ b/target/linux/bcm53xx/patches-5.10/180-usb-xhci-add-support-for-performing-fake-doorbell.patch
@@ -127,7 +127,7 @@ it on BCM4708 family.
  /*
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1881,6 +1881,7 @@ struct xhci_hcd {
+@@ -1884,6 +1884,7 @@ struct xhci_hcd {
  #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
  #define XHCI_SG_TRB_CACHE_SIZE_QUIRK	BIT_ULL(39)
  #define XHCI_NO_SOFT_RETRY	BIT_ULL(40)

--- a/target/linux/generic/backport-5.10/610-v5.13-02-netfilter-Fix-fall-through-warnings-for-Clang.patch
+++ b/target/linux/generic/backport-5.10/610-v5.13-02-netfilter-Fix-fall-through-warnings-for-Clang.patch
@@ -24,7 +24,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  	case CT_DCCP_INVALID:
 --- a/net/netfilter/nf_tables_api.c
 +++ b/net/netfilter/nf_tables_api.c
-@@ -8369,6 +8369,7 @@ static int nf_tables_check_loops(const s
+@@ -8394,6 +8394,7 @@ static int nf_tables_check_loops(const s
  							data->verdict.chain);
  				if (err < 0)
  					return err;

--- a/target/linux/generic/backport-5.10/610-v5.13-10-netfilter-nftables-update-table-flags-from-the-commi.patch
+++ b/target/linux/generic/backport-5.10/610-v5.13-10-netfilter-nftables-update-table-flags-from-the-commi.patch
@@ -70,7 +70,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  	nft_trans_table_update(trans) = true;
  	list_add_tail(&trans->list, &ctx->net->nft.commit_list);
  	return 0;
-@@ -7878,11 +7882,10 @@ static int nf_tables_commit(struct net *
+@@ -7903,11 +7907,10 @@ static int nf_tables_commit(struct net *
  		switch (trans->msg_type) {
  		case NFT_MSG_NEWTABLE:
  			if (nft_trans_table_update(trans)) {
@@ -86,7 +86,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  			} else {
  				nft_clear(net, trans->ctx.table);
  			}
-@@ -8095,11 +8098,9 @@ static int __nf_tables_abort(struct net
+@@ -8120,11 +8123,9 @@ static int __nf_tables_abort(struct net
  		switch (trans->msg_type) {
  		case NFT_MSG_NEWTABLE:
  			if (nft_trans_table_update(trans)) {

--- a/target/linux/generic/backport-5.10/782-net-next-1-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
+++ b/target/linux/generic/backport-5.10/782-net-next-1-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
@@ -1586,7 +1586,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	if (!is_valid_ether_addr(ndev->dev_addr))
  		eth_hw_addr_random(ndev);
  	temac_do_set_mac_address(ndev);
-@@ -1372,7 +1372,7 @@ static int temac_probe(struct platform_d
+@@ -1370,7 +1370,7 @@ static int temac_probe(struct platform_d
  	struct device_node *temac_np = dev_of_node(&pdev->dev), *dma_np;
  	struct temac_local *lp;
  	struct net_device *ndev;
@@ -1595,7 +1595,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	__be32 *p;
  	bool little_endian;
  	int rc = 0;
-@@ -1563,8 +1563,8 @@ static int temac_probe(struct platform_d
+@@ -1561,8 +1561,8 @@ static int temac_probe(struct platform_d
  
  	if (temac_np) {
  		/* Retrieve the MAC address */

--- a/target/linux/generic/hack-5.10/410-block-fit-partition-parser.patch
+++ b/target/linux/generic/hack-5.10/410-block-fit-partition-parser.patch
@@ -1,6 +1,6 @@
 --- a/block/blk.h
 +++ b/block/blk.h
-@@ -357,6 +357,7 @@ char *disk_name(struct gendisk *hd, int
+@@ -353,6 +353,7 @@ char *disk_name(struct gendisk *hd, int
  #define ADDPART_FLAG_NONE	0
  #define ADDPART_FLAG_RAID	1
  #define ADDPART_FLAG_WHOLEDISK	2


### PR DESCRIPTION
All patches automatically rebased.

Build system: x86_64
Build-tested: bcm2711/RPi4B, ipq806x/R7800
Run-tested: bcm2711/RPi4B, ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>