### PR TITLE
ramips: add support for Sony WG-C10/NWC1

### DIFF
--- a/target/linux/ramips/base-files/etc/uci-defaults/03_wireless
+++ b/target/linux/ramips/base-files/etc/uci-defaults/03_wireless
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+sony,wg-c10)
+	uci set wireless.radio0.disabled=0
+	;;
+esac
+
+uci commit wireless
+
+exit 0

--- a/target/linux/ramips/dts/rt5350_sony_wg-c10.dts
+++ b/target/linux/ramips/dts/rt5350_sony_wg-c10.dts
@@ -1,0 +1,104 @@
+#include "rt5350.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "sony,wg-c10", "ralink,rt5350-soc";
+	model = "Sony WG C10";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8 root=/dev/mtdblock5";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			label = "red:wlan";
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@1 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@2 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@3 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@4 {
+				label = "nvram";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@5 {
+				label = "nvram_backup";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	status = "disabled";
+};
+
+&esw {
+	status = "disabled";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -973,6 +973,18 @@ define Device/skyline_sl-r7205
 endef
 TARGET_DEVICES += skyline_sl-r7205
 
+define Device/sony_wg-c10
+  SOC := rt5350
+  IMAGE_SIZE := 7744k
+  DEVICE_VENDOR := Sony
+  DEVICE_MODEL := WG-C10
+  SUPPORTED_DEVICES += wg-c10
+  DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2 kmod-usb-storage kmod-fs-ext4 \
+	kmod-fs-vfat block-mount rssileds
+  DEFAULT := n
+endef
+TARGET_DEVICES += sony_wg-c10
+
 define Device/sparklan_wcr-150gn
   SOC := rt3050
   BLOCKSIZE := 64k

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
@@ -86,6 +86,11 @@ intenso,memory2move)
 omnima,miniembplug)
 	ucidef_set_led_netdev "wifi_led" "wifi" "red:wlan" "wlan0"
 	;;
+sony,wg-c10)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:wlan" "wlan0" "1" "40" "0" "6"
+	ucidef_set_led_wlan "wifi" "wifi" "rt2800soc-phy0::radio" "phy0tx"
+	;;
 vocore,vocore-8m|\
 vocore,vocore-16m)
 	ucidef_set_led_netdev "eth" "ETH" "orange:eth" "eth0"


### PR DESCRIPTION
A pocket mobile wireless NAS for SD memory cards from Sony.
Similar to Intenso Memory 2 Move but without build it HDD and Ethernet port.

Specification:
- SoC: RT5350
- RAM: 32MB
- Flash: 8MB (SPI)
- WiFi: 2.4G integrated
- USB: 1 x USB 2.0
- LEDS: two Red/Green led, one of it is GPIO controlled

Installation:
  Firmware upload and recovery can be done only via UART using u-boot
  console and binary upload via kermit protocol, which is typical for for
  Ralink SoC family, and well described for other devices [1]. Basically flash
  procedure has two steps, load & boot openwrt initramfs image using
  loadb and bootm u-boot commands, when openwrt is up and running normal
  system upgrade can be done via ssh console.

Knows issues:
  Please note, in order to get access to UART pins device needs to be
  disassembled and fully charged beforehand, since on board pmic disable main
  SoC when charging cable is connected. This can be workarounded by using
  micro-USB cable, without D+ D- lines (power only cable). However USB Host
  port won't be powered in any case if micro-USB cable is attached, this also
  can be fixed by using USB Hub with external power supply.
  Since this device doesn't have an Ethernet port OpenWRT WiFi is enabled on
  first boot [2], since this is the only way to recover missconfigured
  device or get access after "Factory Reset" without disassembling it.

[1] https://www.realmtech.net/2016-04/openwrt-on-a-belkin-wemo-hard-way
[2] https://openwrt.org/docs/guide-user/installation/flashing_openwrt_with_wifi_enabled_on_first_boot

Signed-off-by: Dmitry Ivanov <mail@skazzka.com>