### PR TITLE
mt7621: add support for PanguBox IP04349 reference board

### DIFF
--- a/target/linux/ramips/dts/mt7621_pangubox_ip04349.dts
+++ b/target/linux/ramips/dts/mt7621_pangubox_ip04349.dts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "pangubox,ip04349", "mediatek,mt7621-soc";
+	model = "PanguBox IP04349";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "blue:sys";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -429,6 +429,15 @@ define Device/d-team_pbr-m1
 endef
 TARGET_DEVICES += d-team_pbr-m1
 
+define Device/pangubox_ip04349
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := PanguBox
+  DEVICE_MODEL := IP04349
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
+endef
+TARGET_DEVICES += pangubox_ip04349
+
 define Device/edimax_ra21s
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
PanguBox IP04349 reference board.

Specifications:

Chip configuration  :MT7621A + MT7615N * 2
Product type        :Wireless Router
Wireless parameters :Dual-Band(2.4G+5G).2.4G(4T4R),5G(4T4R)
Flash type          :SPI(8pin)
Flash size          :16M Byte
RAM type            :DDR3
RAM size            :256M Byte
Power               :12V/2A
Wired Port          :1WAN+4LAN
USB Port            :1 * 3.0 USB Port

Base configuration:
    1.Run the following command to open the OpenWrt Graphical configuration interface.
        make menuconfig
    2.Selecting a Hardware Platform
        Location:
            ->Target System(MediaTek Ralink MIPS)
            ->Subtarget(MT7621 based boards)
            ->Target Profile(PanguBox IP04349)
    3.Selecting LuCI package
        (1)LuCI interface with Uhttpd as Webserver
        Location:
            ->LuCI
                -> 1.Collections
                <*> luci
           Location:
        (2)Select the language for the LuCI Web display
            ->LuCI
                ->2.Modules
                ->Translations
                <*>English(en)
                <*>Chinese Simplified(zh_Hans)
                ......

Build the project：

    Run the following command in the project root directory.
    make V=99

Obtaining firmware:
    The firmware is stored in the following directory.
    ${HOME}/openwrt/bin/targets/ramips/mt7621

Installation:

    1. Upgrade the firmware using tftp(IP04349 is provided by default)
    Note:
        The development board must be in the same network segment as the PC.
    (1)Use a network cable to connect the LAN interface of the development
        board to the PC network port.
    (2)Set the IP address of the development board to a static IP address.
        For example: 192.168.1.1
    (3)Set the IP address of the TFTP server IP address.
        For example: 192.168.1.100
    (4)Reboot the board.
    (5)Press key 2 on your keyboard to start burning the firmware.
    (6)Input device IP (192.168.1.1) ==:<device ip>
    (7)Input server IP (192.168.1.100) ==:<server ip>
    (8)Input Linux Kernel filename () ==:<kernel image>
    Example:
        ......
        [After the development board is powered on, please press no. 2 to select the burning mode of the firmware.]
        ......
		Please choose the operation: 
		   1: Load system code to SDRAM via TFTP. 
		   2: Load system code then write to Flash via TFTP. 
		   3: Boot system code via Flash (default).
		   4: Entr boot command line interface.
		   6: Load Flash code then burn to Flash via TFTP. 
		   7: Load Boot Loader code then write to Flash via Serial. 
		   9: Load Boot Loader code then write to Flash via TFTP. 
		default: 3

		You choosed 2

		2: System Load Linux Kernel then write to Flash via TFTP. 
		 Warning!! Erase Linux in Flash then burn new one. Are you sure?(Y/N)Y
		 Please Input new ones /or Ctrl-C to discard
				Input device IP (192.168.1.1) ==:192.168.1.1
				Input server IP (192.168.1.2) ==:192.168.1.100
				Input Linux Kernel filename () ==:openwrt-ramips-mt7621-pangubox_ip04349-squashfs-sysupgrade.bin
		Trying Eth0 (10/100-M)

		 Waitting for RX_DMA_BUSY status Start... done


		 ETH_STATE_ACTIVE!! 
		TFTP from server 192.168.1.100; our IP address is 192.168.1.1
		Filename 'openwrt-ramips-mt7621-pangubox_ip04349-squashfs-sysupgrade.bin'.

		 TIMEOUT_COUNT=10,Load address: 0x84000000
		Loading: Got ARP REPLY, set server/gtwy eth addr (3c:97:0e:6f:90:f3)
		Got it
				 #################################################################
				 #################################################################
				 #################################################################
				 #################################################################
				 #################################################################
				 #################################################################
				 ......
				 #############################################
		done
		Bytes transferred = 15205442 (e80442 hex)
		LoadAddr=84000000 NetBootFileXferSize= 00e80442
		upfile len = 0xe80442
		orig web erase+write
		raspi_erase: offs:50000 len:e80000
		#Waiting for the system to start.
        ......

    2.Restore factory setting
	If you want to restore factory Settings, press the reset button on the development board.

Other information:

	If you would like more information, please visit the website below to get help.
	http://docs.pangubox.com

Signed-off-by: Fang Huan <2673483151@qq.com>