### PR TITLE
generic: fix jffs2 compilation with GCC_PLUGIN_RANDSTRUCT enabled

### DIFF
--- a/target/linux/generic/pending-5.10/530-jffs2_make_lzma_available.patch
+++ b/target/linux/generic/pending-5.10/530-jffs2_make_lzma_available.patch
@@ -351,7 +351,7 @@ Signed-off-by: Alexandros C. Couloumbis <alex@ozo.com>
 +		LZMA_FREE(address);
 +}
 +
-+static ISzAlloc lzma_alloc = {p_lzma_malloc, p_lzma_free};
++static ISzAlloc lzma_alloc = { .Alloc = p_lzma_malloc, .Free = p_lzma_free };
 +
 +#endif
 --- /dev/null

--- a/target/linux/generic/pending-5.4/530-jffs2_make_lzma_available.patch
+++ b/target/linux/generic/pending-5.4/530-jffs2_make_lzma_available.patch
@@ -351,7 +351,7 @@ Signed-off-by: Alexandros C. Couloumbis <alex@ozo.com>
 +		LZMA_FREE(address);
 +}
 +
-+static ISzAlloc lzma_alloc = {p_lzma_malloc, p_lzma_free};
++static ISzAlloc lzma_alloc = { .Alloc = p_lzma_malloc, .Free = p_lzma_free };
 +
 +#endif
 --- /dev/null


### PR DESCRIPTION
Designated initializers are required when using the randstruct GCC
plugin, otherwise an error like the following is seen:

./include/linux/lzma.h:60:31: error: positional initialization of field in 'struct' declared with 'designated_init' attribute [-Werror=designated-init]

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>

Build tested: 21.02 x86-64 gcc-10, 21.02 mpc85xx gcc-10, master ath79 gcc-8 (kernel 5.4 and 5.10)
Build and runtime tested: 21.02 ath79 gcc-10
