### PR TITLE
gpio-cdev: add nu801 userspace driver

### DIFF
--- a/package/system/gpio-cdev/nu801/Makefile
+++ b/package/system/gpio-cdev/nu801/Makefile
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nu801
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/chunkeey/nu801.git
+PKG_SOURCE_VERSION:=794a588fce3150129bb2e5bb37590c7daceb8927
+
+PKG_MAINTAINER:=Christian Lamparter <chunkeey@gmail.com>
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/nu801
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Userspace GPIO Drivers
+  DEPENDS:=@!LINUX_5_4 +kmod-leds-uleds
+  KCONFIG:= \
+    CONFIG_GPIO_CDEV=y
+  TITLE:=NU801 LED Driver
+endef
+
+define Package/nu801/description
+This package contains a userspace driver to power the NUMEN Tech. NU801 LED Driver.
+endef
+
+define Package/nu801/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/nu801 $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/nu801.init $(1)/etc/init.d/nu801
+
+endef
+
+$(eval $(call BuildPackage,nu801))

--- a/package/system/gpio-cdev/nu801/files/nu801.init
+++ b/package/system/gpio-cdev/nu801/files/nu801.init
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+START=15
+STOP=94
+USE_PROCD=1
+
+start_service() {
+	. /lib/functions.sh
+
+	procd_open_instance
+	procd_set_param command /usr/sbin/nu801 "$(board_name)"
+	procd_set_param respawn 5 1 5
+	procd_close_instance
+}


### PR DESCRIPTION
This adds a userspace interpretation of the nu801 driver used by Meraki
hardware. Previously this was a driver that was added per target, but as
multiple targets now have this driver, we should move to something that
can be shared by all targets since no driver exists upstream.

Co-developed-by: Christian Lamparter <chunkeey@gmail.com>
Signed-off-by: Chris Blake <chrisrblake93@gmail.com>
Signed-off-by: Christian Lamparter <chunkeey@gmail.com>

This is a followup to the previous RFC PR that was at https://github.com/openwrt/openwrt/pull/4284. Now that 5.10 is the 
default kernel for x86, I am working on pre-reqs for getting Meraki
MX100 support merged into OpenWRT.

CC @chunkeey 