### PR TITLE
imagebuilder: add USE_CONFIG_PACKAGES

### DIFF
--- a/scripts/config2packages.sh
+++ b/scripts/config2packages.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+config_file="$1"
+device="$2"
+
+is_yes () {
+	grep -qe "^$1=y\$" "$config_file"
+}
+
+if [ "$#" -lt 1 ]; then
+	echo "ERROR: config is not given. $0 .config [DEVICE]" 1>&2
+	exit 1
+fi
+
+if is_yes CONFIG_TARGET_PER_DEVICE_ROOTFS; then
+	board="$(grep -e '^CONFIG_TARGET_BOARD=' "$config_file" | cut -d '=' -f 2 | tr -d '"')"
+	subtarget="$(grep -e '^CONFIG_TARGET_SUBTARGET=' "$config_file" | cut -d '=' -f 2 | tr -d '"')"
+
+	if [ -z "$device" ]; then
+		echo "ERROR: CONFIG_TARGET_PER_DEVICE_ROOTFS=y, but device is unset. $0 $1 DEVICE" 1>&2
+		exit 1
+	elif ! grep -qe "^CONFIG_TARGET_DEVICE_PACKAGES_${board}_${subtarget}_DEVICE_${device}=" "$config_file"; then
+		echo "ERROR: CONFIG_TARGET_DEVICE_PACKAGES_${board}_${subtarget}_DEVICE_${device} not found for device \"$device\"." 1>&2
+		exit 1
+	fi
+fi
+
+# Per device packages
+if is_yes CONFIG_TARGET_PER_DEVICE_ROOTFS; then
+	grep -e "^CONFIG_TARGET_DEVICE_PACKAGES_${board}_${subtarget}_DEVICE_${device}=" "$config_file" | \
+		cut -d '=' -f 2 | tr -d '"' | tr -s '\n' ' '
+fi
+
+# some CONFIG_PACKAGE_* symbols appear, which are not a package, therefore
+# strip everything that begins with uppercase characters.
+grep -e '^CONFIG_PACKAGE_[[:lower:]].*=y' "$config_file" | \
+	cut -d '_' -f 3- | cut -d '=' -f 1 | \
+	tr -s '\n' ' '
+
+
+# Disable default packages (if necessary)
+default_packages="$(
+	grep -e '^CONFIG_DEFAULT_[[:lower:]].*=y$' "$config_file" | \
+		sed 's/^CONFIG_DEFAULT_\(.*\)=y$/\1/'
+)"
+
+for default_package in $default_packages; do
+	if ! is_yes "CONFIG_PACKAGE_${default_package}"; then
+		echo "-${default_package}"
+	fi
+done | tr -s '\n' ' '

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -42,6 +42,7 @@ Building images:
 
 	make image PROFILE="<profilename>" # override the default target profile
 	make image PACKAGES="<pkg1> [<pkg2> [<pkg3> ...]]" # include extra packages
+	make image USE_CONFIG_PACKAGES=1 # include packages configured in .config
 	make image FILES="<path>" # include extra files from <path>
 	make image BIN_DIR="<path>" # alternative output directory for the images
 	make image EXTRA_IMAGE_NAME="<string>" # Add this to the output image filename (sanitized)
@@ -107,7 +108,7 @@ _call_info: FORCE
 	echo 'Available Profiles:'
 	echo; $(PROFILE_LIST)
 
-BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
+BUILD_PACKAGES:=$(USER_PACKAGES) $(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel) $(if $(USE_CONFIG_PACKAGES),$(shell ./scripts/config2packages.sh $(TOPDIR)/.config $(patsubst DEVICE_%,%,$(USER_PROFILE)))) $(BUILD_PACKAGES)
 # "-pkgname" in the package list means remove "pkgname" from the package list
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 PACKAGES:=


### PR DESCRIPTION
The aim of this commit is to allow passing the package selection
from the host build system to the imagebuilder. While normally the
package selection for imagebuilder images is completely happening
within the imagebuilder (and not in the host build system), in
some situations it can be useful to pass the package selection
from the host build system to the imagebuilder. For example, if
you want to make the image builder available to users only to
add some additional files your firmware, but do not want users
to have to deal with package selection.

As the .config file is already passed from the host build system
to the imagebuilder, the necessary information was actually already
available in the imagebuilder even before this commit. However it was
not used. The imagebuilder ignored the configured packages in
.config completely and only respected the default packages and
packages explicitly specified with PACKAGES=... in the imagebuilder.

After this commit, the user of the imagebuilder can optionally
specify make USE_CONFIG_PACKAGES=1 ..., to change this behaviour.
In that case, the .config is parsed by the imagebuilder and the
configured packages from there are used to build images. This way,
an image with package selection identical to the normal openwrt
build (that built the imagebuilder) is built.

If USE_CONFIG_PACKAGES is not specified for the make command within
the imagebuilder, this commit does not change any behaviour.

Signed-off-by: Leonardo Mörlein <me@irrelefant.net>

--

CC: @aparcar 
