### PR TITLE
umdns: fix start script when 'seccomp' is not installed

### DIFF
--- a/package/network/services/umdns/files/umdns.init
+++ b/package/network/services/umdns/files/umdns.init
@@ -33,7 +33,7 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PROG"
-	[ -f /etc/seccomp/umdns.json ] && procd_set_param seccomp /etc/seccomp/umdns.json
+	[ -f /etc/seccomp/umdns.json -a -f /sbin/seccomp ] && procd_set_param seccomp /etc/seccomp/umdns.json
 	procd_set_param respawn
 	procd_open_trigger
 	procd_add_config_trigger "config.change" "umdns" /etc/init.d/umdns reload


### PR DESCRIPTION
The umdns service can actually operate with and without seccomp enabled.
However, now when seccomp is not installed, the service script cannot start 
the umdns service because the seccomp binary is missing.

In this case the System Log prints out a bunch of lines similar to:
```daemon.err dawn[2194]: Failed to look up test object for umdns```

This patch fixes the problem by checking both the presence of the 
configuration file and the binary file of the seccomp package.

Signed-off-by: Lars The mail@lars18th.net
