### PR TITLE
scripts: package-metadata add pkgindexjson call

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -619,6 +619,22 @@ END_JSON
 	print "[$json]";
 }
 
+sub gen_package_index_json() {
+	my $json;
+	parse_package_metadata($ARGV[0]) or exit 1;
+	foreach my $name (sort {uc($a) cmp uc($b)} keys %package) {
+		my $pkg = $package{$name};
+		$json = <<"END_JSON";
+${json}
+"$name": "$pkg->{version}",
+END_JSON
+	}
+
+	$json =~ s/[\n\r]//g;
+	$json =~ s/\,$//;
+	print "{$json}";
+}
+
 sub parse_command() {
 	GetOptions("ignore=s", \@ignore);
 	my $cmd = shift @ARGV;
@@ -629,6 +645,7 @@ sub parse_command() {
 		/^source$/ and return gen_package_source();
 		/^pkgaux$/ and return gen_package_auxiliary();
 		/^pkgmanifestjson$/ and return gen_package_manifest_json();
+		/^pkgindexjson$/ and return gen_package_index_json();
 		/^license$/ and return gen_package_license(0);
 		/^licensefull$/ and return gen_package_license(1);
 		/^usergroup$/ and return gen_usergroup_list();
@@ -642,6 +659,7 @@ Available Commands:
 	$0 source [file] 			Package source file information
 	$0 pkgaux [file]			Package auxiliary variables in makefile format
 	$0 pkgmanifestjson [file]		Package manifests in JSON format
+	$0 pkgindexjson [file]			Package name and version in JSON format
 	$0 license [file] 			Package license information
 	$0 licensefull [file] 			Package license information (full list)
 	$0 usergroup [file]			Package usergroup allocation list


### PR DESCRIPTION
The new `pkgindexjson` call prints all package names and versions of a
feed in JSON format. This function can be used to print an overview of
packages and versions used for downstream tooling.

The script is entirely based on Petrs work on dependency visualisation.

Signed-off-by: Paul Spooren <mail@aparcar.org>