### PR TITLE
trelay: trelay relayed interface promiscuous mode

### DIFF
--- a/package/kernel/trelay/files/trelay.init
+++ b/package/kernel/trelay/files/trelay.init
@@ -14,6 +14,7 @@ check_relay() {
 	[ -d "/sys/class/net/${dev1}" -a -d "/sys/class/net/${dev2}" ] || return
 
 	ip link set dev "$dev1" up
+	ip link set dev "$dev1" promisc on
 	ip link set dev "$dev2" up
 	echo "${dev1}-${dev2},${dev1},${dev2}" > /sys/kernel/debug/trelay/add
 }


### PR DESCRIPTION
trelay only works when relayed interface is in promiscuous mode. 

Implementing fix referenced in report FS#3598 by Dawid Wróbe

Signed-off-by: Mario Medina medina.mario45@gmail.com