### PR TITLE
toolchain/gcc: switch to version 11 by default

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_10
+	default GCC_USE_VERSION_11
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -2,12 +2,12 @@ config GCC_VERSION_8
 	default y if GCC_USE_VERSION_8
 	bool
 
-config GCC_VERSION_11
-	default y if GCC_USE_VERSION_11
+config GCC_VERSION_10
+	default y if GCC_USE_VERSION_10
 	bool
 
 config GCC_VERSION
 	string
 	default "8.4.0"		if GCC_VERSION_8
-	default "11.2.0"	if GCC_VERSION_11
-	default "10.3.0"
+	default "10.3.0"	if GCC_VERSION_10
+	default "11.2.0"


### PR DESCRIPTION
gcc10 seem to increase build size and gcc11 seem to fix that.

Signed-off-by: Paul Spooren <mail@aparcar.org>