### PR TITLE
bcm63xx: fix compilation with GCC11

### DIFF
--- a/target/linux/bcm63xx/patches-5.10/532-MIPS-BCM63XX-add-inventel-Livebox-support.patch
+++ b/target/linux/bcm63xx/patches-5.10/532-MIPS-BCM63XX-add-inventel-Livebox-support.patch
@@ -58,7 +58,7 @@ Subject: [PATCH] MIPS: BCM63XX: add inventel Livebox support
  #endif /* __BOARD_COMMON_H */
 --- /dev/null
 +++ b/arch/mips/bcm63xx/boards/board_livebox.c
-@@ -0,0 +1,153 @@
+@@ -0,0 +1,158 @@
 +/*
 + * This file is subject to the terms and conditions of the GNU General Public
 + * License. See the file "COPYING" in the main directory of this archive
@@ -130,12 +130,17 @@ Subject: [PATCH] MIPS: BCM63XX: add inventel Livebox support
 +/*
 + * register & return a new board mac address
 + */
-+static int livebox_get_mac_address(u8 *mac)
++static int livebox_get_mac_address(u8 mac[ETH_ALEN])
 +{
 +	u8 *p;
 +	int count;
++	void __iomem *volatile mmio;
 +
-+	memcpy(mac, (u8 *)0xBEBFF377, ETH_ALEN);
++	mmio = ioremap(0x1ebff377, 0x8);
++	if (!mmio)
++		return -EIO;
++	memcpy_fromio(mac, mmio, ETH_ALEN);
++	iounmap(mmio);
 +
 +	p = mac + ETH_ALEN - 1;
 +	count = mac_addr_used;

--- a/target/linux/bcm63xx/patches-5.4/532-MIPS-BCM63XX-add-inventel-Livebox-support.patch
+++ b/target/linux/bcm63xx/patches-5.4/532-MIPS-BCM63XX-add-inventel-Livebox-support.patch
@@ -58,7 +58,7 @@ Subject: [PATCH] MIPS: BCM63XX: add inventel Livebox support
  #endif /* __BOARD_COMMON_H */
 --- /dev/null
 +++ b/arch/mips/bcm63xx/boards/board_livebox.c
-@@ -0,0 +1,153 @@
+@@ -0,0 +1,158 @@
 +/*
 + * This file is subject to the terms and conditions of the GNU General Public
 + * License. See the file "COPYING" in the main directory of this archive
@@ -130,12 +130,17 @@ Subject: [PATCH] MIPS: BCM63XX: add inventel Livebox support
 +/*
 + * register & return a new board mac address
 + */
-+static int livebox_get_mac_address(u8 *mac)
++static int livebox_get_mac_address(u8 mac[ETH_ALEN])
 +{
 +	u8 *p;
 +	int count;
++	void __iomem *volatile mmio;
 +
-+	memcpy(mac, (u8 *)0xBEBFF377, ETH_ALEN);
++	mmio = ioremap(0x1ebff377, 0x8);
++	if (!mmio)
++		return -EIO;
++	memcpy_fromio(mac, mmio, ETH_ALEN);
++	iounmap(mmio);
 +
 +	p = mac + ETH_ALEN - 1;
 +	count = mac_addr_used;


### PR DESCRIPTION
While C allows array decay, GCC11 is more strict about it regarding
function parameters. Fix the type to match board_get_mac_address.

Fixes:

error: '__builtin_memcpy' reading 6 bytes from a region of size 0

Signed-off-by: Rosen Penev <rosenp@gmail.com>