### PR TITLE
ramips: add support for I-O DATA WN-DX2033GR

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-dx2033gr", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-DX2033GR";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "idmkey";
+		reg = <0x6b00000 0x0100000>;
+		read-only;
+	};
+
+	partition@6c00000 {
+		label = "Backup";
+		reg = <0x6c00000 0x1380000>;
+		read-only;
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		ieee80211-freq-limit = <2400000 2483000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 5710000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -708,6 +708,15 @@ define Device/iodata_wn-dx1200gr
 endef
 TARGET_DEVICES += iodata_wn-dx1200gr
 
+define Device/iodata_wn-dx2033gr
+  $(Device/iodata_nand)
+  DEVICE_MODEL := WN-DX2033GR
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	uImage lzma -M 0x434f4d42 -n '3.10(XID.0)b30' | iodata-mstc-header
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware
+endef
+TARGET_DEVICES += iodata_wn-dx2033gr
+
 define Device/iodata_wn-gx300gr
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -84,7 +84,8 @@ platform_do_upgrade() {
 		;;
 	iodata,wn-ax1167gr2|\
 	iodata,wn-ax2033gr|\
-	iodata,wn-dx1167r)
+	iodata,wn-dx1167r|\
+	iodata,wn-dx2033gr)
 		iodata_mstc_upgrade_prepare "0xfe75"
 		nand_do_upgrade "$1"
 		;;


### PR DESCRIPTION
I-O DATA WN-DX2033GR is a 2.4/5 GHz band 11ac (Wi-Fi 5) router, based on
MT7621A.

Specification:

- SoC		: MediaTek MT7621A
- RAM		: DDR3 128 MiB
- Flash		: Raw NAND 128 MiB (Macronix MX30LF1G18AC-TI)
- WLAN		: 2.4/5 GHz
  - 2.4 GHz	: 2T2R, MediaTek MT7603E
  - 5 GHz	: 4T4R, MediaTek MT7615
- Ethernet	: 5x 10/100/1000 Mbps
  - Switch	: MediaTek MT7530 (SoC)
- LEDs/Keys	: 2x/3x (2x buttons, 1x slide-switch)
- UART		: through-hole on PCB
  - J5: 3.3V, TX, RX, NC, GND from triangle mark
  - 57600n8
- Power		: 12 VDC, 1 A

Flash instruction using initramfs image:

1. Boot WN-DX2033GR normally
2. Access to "http://192.168.0.1/" and open firmware update page
   ("ファームウェア")
3. Select the OpenWrt initramfs image and click update ("更新") button
   to perform firmware update
4. On the initramfs image, download the sysupgrade.bin image to the
   device and perform sysupgrade with it
5. Wait ~120 seconds to complete flashing

Notes:

- The hardware of WN-DX2033GR and WN-AX2033GR are almost the same, and
  it is certified under the same radio-wave related regulations in Japan

- The last 0x80000 (512 KiB) in NAND flash is not used on stock firmware

- stock firmware requires "customized uImage header" (called as "combo
  image") by MSTC (MitraStar Technology Corp.), but U-Boot doesn't

  - uImage magic ( 0x0 - 0x3 ) : 0x434F4D42 ("COMB")
  - header crc32 ( 0x4 - 0x7 ) : with "data length" and "data crc32"
  - image name   (0x20 - 0x37) : model ID and firmware versions
  - data length  (0x38 - 0x3b) : kernel + rootfs
  - data crc32   (0x3c - 0x3f) : kernel + rootfs

- There are 2x important flags in the flash:

  - bootnum   : select os partition for booting (persist, 0x4)

    - 0x01: firmware
    - 0x02: firmware_2

  - debugflag : allow interrupt kernel loader, it's named as "Z-LOADER"
    (Factory, 0xFE75)

    - 0x00: disable debug
    - 0x01: enable debug

MAC addresses:

LAN     : 50:41:B9:xx:xx:90 (Factory, 0xE000 (hex) / Ubootenv, ethaddr (text))
WAN     : 50:41:B9:xx:xx:92 (Factory, 0xE006 (hex))
2.4 GHz : 50:41:B9:xx:xx:90 (Factory, 0x4    (hex))
5 GHz   : 50:41:B9:xx:xx:91 (Factory, 0x8004 (hex))

Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>