### PR TITLE
6rd: delete tunnel on interface teardown

### DIFF
--- a/package/network/ipv6/6rd/Makefile
+++ b/package/network/ipv6/6rd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=6rd
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/ipv6/6rd/files/6rd.sh
+++ b/package/network/ipv6/6rd/files/6rd.sh
@@ -82,6 +82,8 @@ proto_6rd_setup() {
 
 proto_6rd_teardown() {
 	local cfg="$1"
+	local link="6rd-$cfg"
+	ip link del $link
 }
 
 proto_6rd_init_config() {


### PR DESCRIPTION
Delete tunnel on 6rd interface teardown.
Should solve problem related to tunnel stuck on restart loop
with "Unknown Command" on tunnel restart due to wan connection drop.

This patch is similar to the one written by Ansuel on Aug 2, 2021
but the 6rd teardown produces the same symptoms when the network
service is restarted.
