### PR TITLE
hostapd: fix segfault when deinit mesh ifaces

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -1498,6 +1498,11 @@ void hostapd_ubus_free_bss(struct hostapd_data *hapd)
 	struct ubus_object *obj = &hapd->ubus.obj;
 	char *name = (char *) obj->name;
 
+#ifdef CONFIG_MESH
+	if (hapd->conf->mesh & MESH_ENABLED)
+		return;
+#endif
+
 	if (!ctx)
 		return;
 


### PR DESCRIPTION
In hostapd_ubus_add_bss(), ubus objects are not registered for mesh
interfaces. This provokes a segfault when accessing the ubus object in
mesh deinit.

This commit adds the same condition to hostapd_ubus_free_bss() for
discarding those mesh interfaces.

Signed-off-by: Jesus Fernandez Manzano <jesus.manzano@galgus.net>
