### PR TITLE
ramips: add support for Cudy X6

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_x6.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_x6.dts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "cudy,x6", "mediatek,mt7621-soc";
+	model = "CUDY X6";
+
+	aliases {
+		led-boot = &led_internet_blue;
+		led-failsafe = &led_internet_blue;
+		led-running = &led_internet_blue;
+		led-upgrade = &led_internet_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet_blue: internet_blue {
+			label = "blue:internet";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_red {
+			label = "red:internet";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1f80000>;
+			};
+
+			partition@1fd0000 {
+				label = "debug";
+				reg = <0x1fd0000 0x10000>;
+				read-only;
+			};
+
+			partition@1fe0000 {
+				label = "backup";
+				reg = <0x1fe0000 0x10000>;
+				read-only;
+			};
+
+			bdinfo: partition@1ff0000 {
+				label = "bdinfo";
+				reg = <0x1ff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_bdinfo_de00>;
+ 			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "jtag";
+		function = "gpio";
+	};
+};
+
+&bdinfo {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_bdinfo_de00: macaddr@de00 {
+		reg = <0xde00 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -281,6 +281,16 @@ define Device/cudy_wr2100
 endef
 TARGET_DEVICES += cudy_wr2100
 
+define Device/cudy_x6
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 32256k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := X6
+  UIMAGE_NAME := R13
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += cudy_x6
+
 define Device/dlink_dir-8xx-a1
   $(Device/dsa-migration)
   IMAGE_SIZE := 16000k


### PR DESCRIPTION
Specifications:
 - SoC: MediaTek MT7621
 - RAM: 256 MB
 - Flash: 32 MB
 - WiFi: MediaTek MT7915E
 - Switch: 1 WAN, 4 LAN (Gigabit)
 - Ports: 1 USB 3.0
 - Buttons: Reset, WPS
 - LEDs: Power, System, Wan, Lan 1-4, WiFi 2.4G, WiFi 5G, WPS, USB
 - Power: DC 12V 1A tip positive

Installation:

Download and flash the manufacturer's built OpenWRT image available at
http://www.cudytech.com/openwrt_software_download
Install the new OpenWRT image via luci (System -> Backup/Flash firmware)
Be sure to NOT keep settings. The force upgrade may need to be checked
due to differences in router naming conventions.

Recovery:
 - Loads only signed manufacture firmware due to bootloader RSA verification
 - serve tftp-recovery image as /recovery.bin on 192.168.1.88/24
 - connect to any lan ethernet port
 - power on the device while holding the reset button
 - wait at least 8 seconds before releasing reset button for image to
   download

Signed-off-by: Alessio Prescenzo <alessioprescenzo@gmail.com>

