### PR TITLE
hostapd: Fix wpad crash when setting down meshpoint interface

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -1498,6 +1498,11 @@ void hostapd_ubus_free_bss(struct hostapd_data *hapd)
 	struct ubus_object *obj = &hapd->ubus.obj;
 	char *name = (char *) obj->name;
 
+#ifdef CONFIG_MESH
+	if (hapd->conf->mesh & MESH_ENABLED)
+		return;
+#endif
+
 	if (!ctx)
 		return;
 


### PR DESCRIPTION
wpa_supplicant_mesh_iface_deinit calls hostapd_interface_deinit when an interface is removed during an ifdown. And in this process, the hostapd_ubus_free_bss will be called to submit information about the removed bss to ubus using hostapd_send_shared_event. But the ubus object used for hostapd_send_shared_event will be uninitialized. The wpa-supplicant will subsequentially crash when something is doing ifups + ifdowns:

    while true; do
      ifdown mesh0
      sleep 10
      ifup mesh0
      sleep 10
    done

Stopping the ubus specific code whenever the hapd is for a meshpoint interface will avoid the access of the uninitialized ubus data.

The bug was original found in OpenWrt 21.02. The backtrace for the crash in OpenWrt 21.02 (ath79) is:

```
#0  0x77cc4bf3 in __ubus_notify_async (ctx=<optimized out>, type=<optimized out>, msg=<optimized out>, req=0x7fffa6a0, reply=false, obj=<optimized out>) at libubus-req.c:284
#1  0x77cc50ad in ubus_notify (ctx=0x5c3f50, obj=<optimized out>, type=<optimized out>, msg=<optimized out>, timeout=-1) at libubus-req.c:317
#2  0x00448f49 in hostapd_notify_ubus (obj=0x4c, bssname=0x5c2790 "mesh0", event=0x546da8 "remove") at ../src/ap/ubus.c:123
#3  0x00449087 in hostapd_send_shared_event (obj=0x4c, bssname=0x5c2790 "mesh0", event=0x546da8 "remove") at ../src/ap/ubus.c:156
#4  0x0044adf7 in hostapd_ubus_free_bss (hapd=0x5c1e30) at ../src/ap/ubus.c:1357
#5  0x00413543 in hostapd_free_hapd_data (hapd=0x5c1e30) at ../src/ap/hostapd.c:429
#6  0x0041370d in hostapd_cleanup (hapd=0x5c1e30) at ../src/ap/hostapd.c:532
#7  0x00415a05 in hostapd_bss_deinit (hapd=0x5c1e30) at ../src/ap/hostapd.c:2436
#8  0x00415a6b in hostapd_interface_deinit (iface=0x5b1600) at ../src/ap/hostapd.c:2463
#9  0x004f2b37 in wpa_supplicant_mesh_iface_deinit (wpa_s=0x77ff7010, ifmsh=0x5b1600, also_clear_hostapd=true) at mesh.c:73
#10 0x004f2a91 in wpa_supplicant_mesh_deinit (wpa_s=0x77ff7010, also_clear_hostapd=true) at mesh.c:33
#11 0x004f3c25 in wpa_supplicant_leave_mesh (wpa_s=0x77ff7010, need_deinit=true) at mesh.c:681
#12 0x004ca64b in wpa_supplicant_deauthenticate (wpa_s=0x77ff7010, reason_code=3) at wpa_supplicant.c:3999
#13 0x004ce7df in wpa_supplicant_deinit_iface (wpa_s=0x77ff7010, notify=1, terminate=0) at wpa_supplicant.c:6578
#14 0x004ceac7 in wpa_supplicant_remove_iface (global=0x77cf0590, wpa_s=0x77ff7010, terminate=0) at wpa_supplicant.c:6856
#15 0x004eca5f in wpas_config_remove (ctx=0x77cf0900, obj=0x77cf0648, req=0x7fffaa6c, method=0x5b1e30 "config_remove", msg=0x5b1e58) at ubus.c:312
#16 0x77cc42c7 in ubus_process_invoke (ctx=<optimized out>, hdr=<optimized out>, obj=0x77cf0648, attrbuf=<optimized out>, fd=-1) at /home/sven/projekte/siwu/om_build/tis/staging_dir/target-mips_24kc_musl/usr/include/libubox/blob.h:77
#17 0x77cc4523 in ubus_process_obj_msg (ctx=<optimized out>, buf=0x77cf0964, fd=<optimized out>) at libubus-obj.c:150
#18 0x77cc33cf in ubus_process_msg (ctx=0x77cf0900, buf=0x77cf0964, fd=<optimized out>) at libubus.c:106
#19 0x77cc3f9f in ubus_handle_data (u=0x77cf092c, events=<optimized out>) at libubus-io.c:318
#20 0x004ec4d3 in ubus_handle_event (ctx=0x77cf0900) at /home/sven/projekte/siwu/om_build/tis/staging_dir/target-mips_24kc_musl/usr/include/libubus.h:270
#21 0x004ec521 in ubus_receive (sock=9, eloop_ctx=0x77cf0900, sock_ctx=0x0) at ubus.c:36
#22 0x0043871d in eloop_sock_table_dispatch (events=0x5b1b70, nfds=1) at ../src/utils/eloop.c:625
#23 0x0043911f in eloop_run () at ../src/utils/eloop.c:1233
#24 0x004cef23 in wpa_supplicant_run (global=0x77cf0590) at wpa_supplicant.c:7132
#25 0x004c47e1 in wpa_supplicant_main (argc=5, argv=0x7fffad74) at main.c:404
#26 0x0040641f in main (argc=5, argv=0x7fffad74) at ./files/multicall.c:17
```

Cc: @T-X (you found a similar but in https://github.com/Telecominfraproject/wlan-ap/pull/272)