### PR TITLE
ath79: add support for Netgear R6100

### DIFF
--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "netgear,r6100", "qca,ar9344";
+	model = "Netgear R6100";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_power_amber;
+		led-failsafe = &led_power_amber;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_11>;
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_amber: power_amber {
+			label = "amber:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_wlan {
+			label = "blue:wlan";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_usb {
+			label = "blue:usb";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&hub_port>;
+			linux,default-trigger = "usbport";
+		};
+
+		wan_green {
+			label = "green:wan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "amber:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio {
+	usb_power {
+		gpio-hog;
+		gpios = <16 0>;
+		output-high;
+	};
+};
+
+&pinmux {
+	enable_gpio_11: pinmux_enable_gpio_11 {
+		pinctrl-single,bits = <0x8 0x0 0xff000000>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		caldata: partition@20000 {
+			label = "caldata";
+			reg = <0x20000 0x40000>;
+			read-only;
+		};
+
+		partition@60000 {
+			label = "caldata-backup";
+			reg = <0x60000 0x40000>;
+			read-only;
+		};
+
+		partition@a0000 {
+			label = "config";
+			reg = <0xa0000 0x80000>;
+		};
+
+		partition@120000 {
+			label = "pot";
+			reg = <0x120000 0x80000>;
+		};
+
+		partition@1a0000 {
+			label = "kernel";
+			reg = <0x1a0000 0x400000>;
+		};
+
+		partition@5a0000 {
+			label = "ubi";
+			reg = <0x5a0000 0x7560000>;
+		};
+
+		partition@7b00000 {
+			label = "language";
+			reg = <0x7b00000 0x200000>;
+		};
+
+		partition@7d00000 {
+			label = "traffic_meter";
+			reg = <0x7d00000 0x300000>;
+		};
+
+		firmware@1a0000 {
+			label = "firmware";
+			reg = <0x1a0000 0x1900000>;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	hub_port: port@1 {
+		reg = <1>;
+		#trigger-source-cells = <0>;
+	};
+};
+
+&builtin_switch {
+	/delete-property/qca,phy4-mii-enable;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_caldata_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_caldata_6>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&swphy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+
+	nvmem-cells = <&macaddr_caldata_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&macaddr_caldata_c>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&caldata {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_caldata_0: macaddr@0 {
+		reg = <0x0 0x6>;
+	};
+
+	macaddr_caldata_6: macaddr@6 {
+		reg = <0x6 0x6>;
+	};
+
+	macaddr_caldata_c: macaddr@c {
+		reg = <0xc 0x6>;
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -168,6 +168,17 @@ define Device/netgear_ath79_nand
   UBINIZE_OPTS := -E 5
 endef
 
+define Device/netgear_r6100
+  SOC := ar9344
+  DEVICE_MODEL := R6100
+  UIMAGE_MAGIC := 0x36303030
+  NETGEAR_BOARD_ID := R6100
+  NETGEAR_HW_ID := 29764434+0+128+128+2x2+2x2
+  $(Device/netgear_ath79_nand)
+  DEVICE_PACKAGES += kmod-ath9k kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += netgear_r6100
+
 define Device/netgear_wndr3700-v4
   SOC := ar9344
   DEVICE_MODEL := WNDR3700

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -10,6 +10,10 @@ glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	;;
+netgear,r6100)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_switch "wan-amber" "WAN (amber)" "amber:wan" "switch0" "0x1e"
+	;;
 netgear,wndr3700-v4|\
 netgear,wndr4300|\
 netgear,wndr4300sw|\

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -20,6 +20,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:2" "3:lan:1" "1:wan"
 		;;
+	netgear,r6100)
+		ucidef_set_interfaces_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+		;;
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,7 @@ case "$FIRMWARE" in
 	8dev,rambutan)
 		caldata_extract "caldata" 0x1000 0x800
 		;;
+	netgear,r6100|\
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -18,6 +18,9 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 1)
 		;;
+	netgear,r6100)
+		caldata_extract "caldata" 0x5000 0x844
+		;;
 	zyxel,nbg6716)
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 1)


### PR DESCRIPTION
Netgear R6100 AC1200 dual-band wifi router.

Specifications:

SoC:    QCA9344
DRAM:	128Mb DDR2
Flash:	128Mb NAND flash
Switch:	5x 10/100 via AR8229 switch integrated into SoC
WLAN:	AR9344 (SoC, 2.4G, 2x2) + QCA9882 (PCIe, 5G, 2x2)
USB:	1x 2.0
UART:	yes
LEDs:	4 + 2
Button:	3 (reset, WPS, wifi on/off)

Installation:

The factory image can be uploaded via the original web interface, which
is the easiest method to replace it. For subsequent upgrades, please use
the standard sysupgrade method.

Alternative installation / recovery:

The factory image can be uploaded with nmrpflash ("unofficial flash tool for
Netgear network devices") at boot-time. U-boot waits for a couple seconds
for a Netgear-compatible image as part of the boot process before loading
the kernel.

MAC addresses as verified by OEM firmware:
LAN	*:5D	caldata 0x0
WAN	*:5E	caldata 0x6
WLAN2G	*:5D	caldata 0x0
WLAN5G	*:5F	caldata 0x6 + 1

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>