### PR TITLE
ramips: add support for ZyXEL Keenetic Giga III

### DIFF
--- a/target/linux/ramips/dts/mt7621_zyxel_keenetic-giga-iii.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_keenetic-giga-iii.dts
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "zyxel,keenetic-giga-iii", "mediatek,mt7621-soc";
+	model = "ZyXEL Keenetic Giga III";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		fn1 {
+			label = "fn1";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		fn2 {
+			label = "fn2";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+			default-state = "keep";
+		};
+
+		fn {
+			label = "green:fn";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb2 {
+			label = "green:usb2";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb3 {
+			label = "green:usb3";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power_usb2 {
+			gpio-export,name = "power_usb2";
+			gpio-export,output = <1>;
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+		
+		power_usb3 {
+			gpio-export,name = "power_usb3";
+			gpio-export,output = <1>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x7500000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";          // RF-EEPROM
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		/* U-Boot expects to find kernel image at 0x180000 */
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x3e40000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubiconcat0";
+				reg = <0x400000 0x3a40000>;
+			};
+		};
+
+		partition@3fc0000 { // ADDR = (0x8000000 - 0x80000) / 2 = 0x3fc0000
+			label = "u-state";
+			reg = <0x3fc0000 0x80000>;
+		};
+
+		partition@4040000 {
+			label = "u-config-res";
+			reg = <0x4040000 0x80000>;
+			read-only;
+		};
+
+		partition@40c0000 {
+			label = "factory-res";     // RF-EEPROM_res
+			reg = <0x40c0000 0x80000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@4140000 {
+			label = "ubiconcat1";        // Firmware_2
+			reg = <0x4140000 0x3ac0000>;
+		};
+
+		/* U-Boot used latest 32 BLOCK for factory bbt table */
+		partition@7c00000 { // 128MiB - 32*128KiB = 0x7c00000
+			label = "mtk-nand-bbt";
+			reg = <0x7c00000 0x400000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	reset-gpios = <&gpio 19 GPIO_ACTIVE_LOW>,
+	              <&gpio 8 GPIO_ACTIVE_LOW>;
+};
+
+&pcie0 { // MT7612EN wifi5g
+	mt76@0,0 {  
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 { // MT7602EN wifi2g
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	ethphy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart3", "uart2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 { /* LAN and WiFi2 mac (wan - 1) */
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_28: macaddr@28 { /* WAN mac (LABEL) */
+		reg = <0x28 0x6>;
+	};
+
+	macaddr_factory_8004: macaddr@8004 { /* WiFi5 mac (wan + 1) */
+		reg = <0x8004 0x6>;
+	};
+};

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -174,6 +174,25 @@ define Build/zyimage
 	$(STAGING_DIR_HOST)/bin/zyimage $(1) $@
 endef
 
+define Build/zyimage-with-distver
+	$(eval hwid=$(word 1,$(1)))
+	$(eval repo_ver=$$(shell cut -d '-' -f 1 <<< "$$(VERSION_NUMBER)"))
+	$(eval repo_date=$$(shell date --utc -d @$$(SOURCE_DATE_EPOCH) +%y%m%d))
+	$(eval full_ver=$(DEVICE_VENDOR) $(DEVICE_MODEL) $(VERSION_DIST) $(repo_ver) $(repo_date))
+	$(STAGING_DIR_HOST)/bin/zyimage -d $(hwid) -v '$(full_ver)' $@
+endef
+
+define Build/uImage-with-distver
+	$(eval comp_type=$(word 1,$(1)))
+	$(eval prefix=$(word 2,$(1)))
+	$(eval args=$(wordlist 3,$(words $(1)),$(1)))
+	$(eval repo_ver=$$(shell cut -d '-' -f 1 <<< "$$(VERSION_NUMBER)"))
+	$(eval repo_date=$$(shell date --utc -d @$$(SOURCE_DATE_EPOCH) +%y%m%d))
+	$(eval full_ver=$(VERSION_DIST) $(repo_ver) $(repo_date))
+	$(eval img_name=$(prefix) $(full_ver))
+	$(call Build/uImage, $(comp_type) -n '$(img_name)' $(args))
+endef
+
 define Device/Default
   PROFILES = Default
   KERNEL := $(KERNEL_DTB) | uImage lzma

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2274,6 +2274,24 @@ define Device/zio_freezio
 endef
 TARGET_DEVICES += zio_freezio
 
+define Device/zyxel_keenetic-giga-iii
+  $(Device/dsa-migration)
+  KERNEL_SIZE := 4096k  # kernel partition size
+  IMAGE_SIZE := 51000k
+  BLOCKSIZE := 128k     # NAND erase size
+  PAGESIZE := 2048      # NAND page size
+  UBINIZE_OPTS := -E 5  # EOD marks to "hide" factory sig at EOF
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := Keenetic Giga III
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb3 kmod-usb-ledtrig-usbport
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage-with-distver none KN-GIGA3
+  IMAGES := sysupgrade.tar factory.bin
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+		check-size | pad-to $$(BLOCKSIZE) | zyimage-with-distver 0x2880
+endef
+TARGET_DEVICES += zyxel_keenetic-giga-iii
+
 define Device/zyxel_lte3301-plus
   $(Device/dsa-migration)
   BLOCKSIZE := 128k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -169,6 +169,11 @@ zbtlink,zbt-wg1608-16m)
 	ucidef_set_led_netdev "lan4" "LAN4" "green:lan-4" "lan4"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
+zyxel,keenetic-giga-iii)
+	ucidef_set_led_netdev "internet" "Internet" "green:internet" "wan"
+	ucidef_set_led_netdev "wifi2g" "WiFi 2.4G" "green:wifi2g" "wlan1"
+	ucidef_set_led_netdev "wifi5g" "WiFi 5G" "green:wifi5g" "wlan0"
+	;;
 zyxel,lte3301-plus)
 	ucidef_set_led_netdev "internet" "internet" "white:internet" "wwan0"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -25,6 +25,17 @@ boot() {
 	samknows,whitebox-v8)
 		fw_setenv bootcount 0
 		;;
+	zyxel,keenetic-giga-iii)
+		local data
+		local part=$(find_mtd_part "u-state")
+		if [ -n "$part" ]; then
+			data=$(hexdump -v -s 6 -n 2 -e '2/1 "%02x"' $part 2>/dev/null)
+			if [ "$data" != "0000" ]; then
+				logger -p notice -t init.d "Reset U-State boot_fails counter and set boot_backup=0."
+				printf '\x00\x00' | dd of="$part" bs=1 seek=6 count=2 conv=notrunc 2>/dev/null
+			fi
+		fi
+		;;
 	zyxel,lte3301-plus)
 		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 1
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -120,6 +120,21 @@ platform_do_upgrade() {
 	ubnt,edgerouter-x-sfp)
 		platform_upgrade_ubnt_erx "$1"
 		;;
+	zyxel,keenetic-giga-iii)
+		local magic=$( nand_get_magic_long "$1" 0 )
+		echo "Firmware image $1 contain magic $magic"
+		if [ "$magic" == "27051956" ]; then
+			echo "Forced upgrade firmware partition..." 
+			mtd -f write $1 firmware
+			echo "uImage-firmware write successful! Reboot..."
+			sync
+			umount -a
+			reboot -f
+			exit 1
+		fi
+		CI_KERNPART="kernel"
+		nand_do_upgrade "$1"
+		;;
 	zyxel,lte3301-plus|\
 	zyxel,nr7101)
 		fw_setenv CheckBypass 0


### PR DESCRIPTION
**ZyXEL Keenetic Giga III** is a 2.4/5 GHz band 11ac router, based on MT7621ST.

Specification:
-------------
* SoC: MediaTek MT7621ST (1C/2T)
* RAM: 256 MB DDR3
* Flash: 128 MB NAND S34ML01G200TFI00
* Ethernet: 5x 10/100/1000 Mbps
* WIFI: 5 GHz   MT7612EN nac
* WIFI: 2.4 GHz MT7602EN bgn
* USB: 1x 2.0, 1x 3.0
* BTN: Power, Reset, WPS, FN1, FN2
* LEDS: Power(Green),Fn(Green),Wan(Green),WiFi2(Green),WiFi5(Green),USB1(Green),USB2(Green)
* UART: present as five pads without through-holes on the PCB.
Pads are located above 2.4G LED and under board logotype (GND/empty/RX/TX/Vcc).
UART uses 3.3V and settings: 57600-8-N-1

MAC addresses as verified by stock firmware:
----------------------------------------------

| Interface   |       MAC         | Factory | Format |
|-------------|-------------------|---------|--------|
| WiFi (2.4g) | xx:xx:xx:xx:xx:20 | 0x4     | binary |
| LAN         | xx:xx:xx:xx:xx:20 | 0x4     | binary |
| WAN (label) | xx:xx:xx:xx:xx:21 | 0x28    | binary |
| WiFi (5g)   | xx:xx:xx:xx:xx:22 | 0x8004  | binary |

Installation via U-Boot:
------------------------
* Download the latest OpenWrt firmware factory-image and rename it to kgiga3_recovery.bin
* Set up a Tftp server on a PC (e.g. Tftpd32) and place the firmware image to the root directory of the server.
* Power off the router and use a twisted pair cable to connect the PC to any of the router's LAN ports.
* Configure the network adapter of the PC to use IP address 192.168.1.2 and subnet mask 255.255.255.0.
* Power up the router while holding the reset button pressed.
* Wait approximately for 5 seconds and then release the reset button.
* The router should download the firmware via TFTP and complete flashing in a few minutes.
* Connect with SSH to 192.168.1.1 and set a root password or browse to http://192.168.1.1 if LuCI is installed.

Installation via Keenetic-OS GUI:
------------------------------------------------
* Set the IP address 192.168.1.1 for the connected device (in the KeeneticOS settings and in the network connection properties).
* Open the page "http://192.168.1.1/a" in the browser, enter the command "more proc:/dual_image/boot_active" (without quotes) in the "Command" field and click the "Send request" button.
* A response will appear in the browser, from which you need to select only the value of the "message" parameter.
* If the value of the "message" parameter is not equal to 2, then you need to force flash any official firmware and go to the first step of the instruction.
* To install OpenWRT, go to the "General Settings" page and in the "System Files" section, click on "firmware".
* Then click the "Replace File" button.
* In the window that appears, specify the location of the file "openwrt-ramips-mt7621-zyxel_keenetic-giga-iii-squashfs-factory.bin".
* The installation of OpenWRT on the device will begin.
* After installing the firmware, the device will reboot itself and start OpenWRT (takes about 60...90 seconds).

Revert to the stock firmware via OpenWrt GUI:
------------------------------------------------
* Upload the stock image using "Flash Firmware" interface.
* Select "Force update" and continuing upgrade.
