### PR TITLE
build: do not require git/rsync for ImageBuilder

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -53,6 +53,12 @@ $(eval $(call TestHostCommand,ncurses, \
 	Please install ncurses. (Missing libncurses.so or ncurses.h), \
 	echo 'int main(int argc, char **argv) { initscr(); return 0; }' | \
 		gcc -include ncurses.h -x c -o $(TMP_DIR)/a.out - -lncurses))
+
+$(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
+	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))
+
+$(eval $(call SetupHostCommand,rsync,Please install 'rsync', \
+	rsync --version </dev/null))
 endif # IB
 
 ifeq ($(HOST_OS),Linux)
@@ -174,14 +180,8 @@ $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \
 	$(STAGING_DIR_HOST)/bin/python3 -c 'import distutils'))
 
-$(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.7.12.2, \
-	git --exec-path | xargs -I % -- grep -q -- --recursive %/git-submodule))
-
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))
-
-$(eval $(call SetupHostCommand,rsync,Please install 'rsync', \
-	rsync --version </dev/null))
 
 $(eval $(call SetupHostCommand,which,Please install 'which', \
 	which which | grep which))


### PR DESCRIPTION
The ImageBuilder does not need git or rsync since it only glues files
together, packages are downloaded via wget and not rsync.

Signed-off-by: Paul Spooren <mail@aparcar.org>