### PR TITLE
imagebuilder: show architecture in `make info` output

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -102,6 +102,7 @@ staging_dir/host/.prereq-build: include/prereq-build.mk
 
 _call_info: FORCE
 	echo 'Current Target: "$(TARGETID)"'
+	echo 'Current Architecture: "$(ARCH)"'
 	echo 'Current Revision: "$(REVISION)"'
 	echo 'Default Packages: $(DEFAULT_PACKAGES)'
 	echo 'Available Profiles:'


### PR DESCRIPTION
Using `make info` show the current target, revision, default packages
and available profiles. This commits adds the used architecture.

Signed-off-by: Paul Spooren <mail@aparcar.org>