### PR TITLE
treewide: improve spelling

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -107,7 +107,7 @@ menu "Global build settings"
 		default n
 		help
 		  This makes file checksums part of package metadata. It increases size
-		  but provides you with pkg_check command to check for flash coruptions.
+		  but provides you with pkg_check command to check for flash corruptions.
 
 	config INCLUDE_CONFIG
 		bool "Include build configuration in firmware" if DEVEL

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1112,7 +1112,7 @@ config KERNEL_SQUASHFS_XATTR
 	bool "Squashfs XATTR support"
 
 #
-# compile optimiziation setting
+# compile optimization setting
 #
 choice
 	prompt "Compiler optimization level"

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -4697,7 +4697,7 @@ sub process {
 ## 		    $line !~ /^.\s*$Type\s+$Ident(?:\s*=[^,{]*)?\s*,\s*$Type\s*$Ident.*/) {
 ##
 ## 			# Remove any bracketed sections to ensure we do not
-## 			# falsly report the parameters of functions.
+## 			# falsely report the parameters of functions.
 ## 			my $ln = $line;
 ## 			while ($ln =~ s/\([^\(\)]*\)//g) {
 ## 			}

--- a/scripts/deptest.sh
+++ b/scripts/deptest.sh
@@ -122,7 +122,7 @@ test_package() # $1=pkgname
 	fi
 }
 
-# parse commandline options
+# parse command-line options
 packages=
 lean_test=0
 force=0

--- a/scripts/dl_cleanup.py
+++ b/scripts/dl_cleanup.py
@@ -14,7 +14,7 @@ import os
 import re
 import getopt
 
-# Commandline options
+# Command-line options
 opt_dryrun = False
 
 

--- a/scripts/dl_github_archive.py
+++ b/scripts/dl_github_archive.py
@@ -207,7 +207,7 @@ class GitHubCommitTsCache(object):
 
 
 class DownloadGitHubTarball(object):
-    """Download and repack archive tarabll from GitHub.
+    """Download and repack archive tarball from GitHub.
 
     Compared with the method of packing after cloning the whole repo, this
     method is more friendly to users with fragile internet connection.
@@ -220,7 +220,7 @@ class DownloadGitHubTarball(object):
 
      - GitHub archives do not contain source codes for submodules.
 
-     - GitHub archives seem to respect .gitattributes and ignore pathes with
+     - GitHub archives seem to respect .gitattributes and ignore paths with
        export-ignore attributes.
 
     For the first two issues, the method will fail loudly to allow fallback to

--- a/scripts/ext-toolchain.sh
+++ b/scripts/ext-toolchain.sh
@@ -569,7 +569,7 @@ while [ -n "$1" ]; do
 			echo -e "  Most commands also take a --cflags parameter which " >&2
 			echo -e "  is used to specify C flags to be passed to the "     >&2
 			echo -e "  cross compiler when performing tests."               >&2
-			echo -e "  This paremter may be repeated multiple times."       >&2
+			echo -e "  This parameter may be repeated multiple times."      >&2
 			exit 1
 		;;
 

--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -7,7 +7,7 @@ from sys import argv
 import json
 
 if len(argv) != 2:
-    print("JSON info files script requires ouput file as argument")
+    print("JSON info files script requires output file as argument")
     exit(1)
 
 output_path = Path(argv[1])

--- a/scripts/linksys-image.sh
+++ b/scripts/linksys-image.sh
@@ -11,11 +11,11 @@
 # This is appended to the factory image and is tested by the Linksys Upgrader - as observed in civic.
 # The footer is 256 bytes. The format is:
 #  .LINKSYS.        This is detected by the Linksys upgrader before continuing with upgrade. (9 bytes)
-#  <VERSION>        The version number of upgrade. Not checked so use arbitary value (8 bytes)
+#  <VERSION>        The version number of upgrade. Not checked so use arbitrary value (8 bytes)
 #  <TYPE>           Model of target device, padded (0x20) to (15 bytes)
 #  <CRC>      	    CRC checksum of the image to flash (8 byte)
 #  <padding>	    Padding (0x20) (7 bytes)
-#  <signature>	    Signature of signer. Not checked so use Arbitary value (16 bytes)
+#  <signature>	    Signature of signer. Not checked so use Arbitrary value (16 bytes)
 #  <padding>        Padding (0x00) (192 bytes)
 #  0x0A		    (1 byte)
 

--- a/scripts/pad_image
+++ b/scripts/pad_image
@@ -2,7 +2,7 @@
 
 function usage {
   echo "Usage: prepare_image image_type kernel_image rootfs_image header_size"
-  echo "Padd root and kernel image to the correct size and append the jffs2 start marker as needed"
+  echo "Pad root and kernel image to the correct size and append the jffs2 start marker as needed"
   exit 1
 }
 

--- a/scripts/sign_images.sh
+++ b/scripts/sign_images.sh
@@ -3,12 +3,12 @@
 # directory where search for images
 TOP_DIR="${TOP_DIR:-./bin/targets}"
 # key to sign images
-BUILD_KEY="${BUILD_KEY:-key-build}" # TODO unifiy naming?
+BUILD_KEY="${BUILD_KEY:-key-build}" # TODO unify naming?
 # remove other signatures (added e.g.  by buildbot)
 REMOVE_OTER_SIGNATURES="${REMOVE_OTER_SIGNATURES:-1}"
 
 # find all sysupgrade images in TOP_DIR
-# factory images don't need signatures as non OpenWrt system doen't check them anyway
+# factory images don't need signatures as non OpenWrt system doesn't check them anyway
 for image in $(find $TOP_DIR -type f -name "*-sysupgrade.bin"); do
 	# check if image actually support metadata
 	if fwtool -i /dev/null "$image"; then

--- a/scripts/size_compare.sh
+++ b/scripts/size_compare.sh
@@ -7,9 +7,9 @@
 ###
 ### The script compares locally compiled package with the package indexes
 ### available upstream. This way the storage impact of optimizations or
-### feature modifiactions is easy to see.
+### feature modifications is easy to see.
 ###
-### If no environmental variables are set the scritp reads the current
+### If no environmental variables are set the script reads the current
 ### .config file. The evaluated env variables are the following:
 ###
 ###   TARGET SUBTARGET ARCH PACKAGES BIN_DIR BASE_URL CHECK_INSTALLED

--- a/scripts/slugimage.pl
+++ b/scripts/slugimage.pl
@@ -772,7 +772,7 @@ sub writeOutFirmware {
 				 $_->{'name'}, $filename);
 	    }
 
-	    # If the next parition is before the end of the current image, then rewind.
+	    # If the next partition is before the end of the current image, then rewind.
 	    elsif ($_->{'offset'} < $end_point) {
 		$debug and printf("Rewound %s before <%s> in \"%s\"\n",
 				  (($end_point - $_->{'offset'}) >= $block_size ?
@@ -971,7 +971,7 @@ if (!GetOptions("d|debug"       => \$debug,
     print "  [-b|--redboot]   <file>		Input/Output RedBoot filename\n";
     print "  [-s|--sysconf]   <file>		Input/Output SysConf filename\n";
     print "  [-L|--loader]    <file>		Second stage boot loader filename\n";
-    print "  [-k|--kernel]    <file>		Input/Ouptut Kernel filename\n";
+    print "  [-k|--kernel]    <file>		Input/Output Kernel filename\n";
     print "  [-r|--ramdisk]   <file>		Input/Output Ramdisk filename(s)\n";
     print "  [-f|--fisdir]    <file>		Input/Output FIS directory filename\n";
     print "  [-m|--microcode] <file>		Input/Output Microcode filename\n";


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/openwrt/commit/6649eed9cde3a205c8452d4d9fb7a6ed4584da91#commitcomment-57080390

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/openwrt/commit/ecc7c9cc898e0e4534faf3957deb3684c05e5992

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

---

I expect to squash the commits in this PR once people consider their content (and I'll write a proper commit message at that time).

The reason I don't squash commits eagerly is that often it turns out that certain word families need to be dropped, and it's much easier to do so when they're independent commits.

