### PR TITLE
build: recognize Python 3.10

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -157,6 +157,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 $(eval $(call CleanupPython2))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.6, \
+	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \
 	python3.8 -V 2>&1 | grep 'Python 3', \
 	python3.7 -V 2>&1 | grep 'Python 3', \
@@ -164,6 +165,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.6, \
 	python3 -V 2>&1 | grep -E 'Python 3\.[6-9]\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.6, \
+	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \
 	python3.8 -V 2>&1 | grep 'Python 3', \
 	python3.7 -V 2>&1 | grep 'Python 3', \


### PR DESCRIPTION
Fedora 35 contains Python 3.10 as default version. Make use of it.

Signed-off-by: Marcin Juszkiewicz <marcin@juszkiewicz.com.pl>