### PR TITLE
ath79: add unused flash room to rootfs for the DIR-825-B1 backport PR#4603

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -111,6 +111,23 @@
 			};
 		};
 	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
 };
 
 &usb1 {
@@ -188,9 +205,8 @@
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
 				reg = <0x050000 0x610000>;
 			};
 
@@ -200,10 +216,9 @@
 				read-only;
 			};
 
-			partition@670000 {
-				label = "unknown";
+			fwconcat1: partition@670000 {
+				label = "fwconcat1";
 				reg = <0x670000 0x190000>;
-				read-only;
 			};
 		};
 	};


### PR DESCRIPTION
ath79: add unused flash room to rootfs for the DIR-825-B1

Signed-off-by: Alan Luck <luckyhome2008@gmail.com>