### PR TITLE
ath79: expand rootfs for DIR-825-B1 with unused space

### DIFF
--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -109,6 +109,23 @@
 			};
 		};
 	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
 };
 
 &usb1 {
@@ -186,9 +203,8 @@
 				read-only;
 			};
 
-			partition@50000 {
-				compatible = "denx,uimage";
-				label = "firmware";
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
 				reg = <0x050000 0x610000>;
 			};
 
@@ -198,10 +214,9 @@
 				read-only;
 			};
 
-			partition@670000 {
-				label = "unknown";
+			fwconcat1: partition@670000 {
+				label = "fwconcat1";
 				reg = <0x670000 0x190000>;
-				read-only;
 			};
 		};
 	};


### PR DESCRIPTION
ath79: expand rootfs for DIR-825-B1 with unused space

Expand currently unused flash space to roofs for DIR-825-B1 by using the same
flash space as the old ar71xx big image without moving the caldata.

With some testing this partition is use in the OEM firmware
but if changed is regenerated which allows reverting to OEM firmware.

Signed-off-by: Alan Luck <luckyhome2008@gmail.com>