### PR TITLE
imx6: switch to Kernel 5.10

### DIFF
--- a/target/linux/imx6/Makefile
+++ b/target/linux/imx6/Makefile
@@ -11,8 +11,7 @@ FEATURES:=audio display fpu gpio pcie rtc usb usbgadget squashfs targz nand ubif
 CPU_TYPE:=cortex-a9
 CPU_SUBTYPE:=neon
 
-KERNEL_PATCHVER:=5.4
-KERNEL_TESTING_PATCHVER:=5.10
+KERNEL_PATCHVER:=5.10
 
 include $(INCLUDE_DIR)/target.mk
 


### PR DESCRIPTION
CI build with artifacts: https://github.com/aparcar/openwrt/actions/runs/1289784479

Signed-off-by: Paul Spooren <mail@aparcar.org>