### PR TITLE
build: fix `which` detection on Fedora & MacOS

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -186,7 +186,9 @@ $(eval $(call SetupHostCommand,rsync,Please install 'rsync', \
 	rsync --version </dev/null))
 
 $(eval $(call SetupHostCommand,which,Please install 'which', \
-	which which | grep which))
+	/usr/bin/which which, \
+	/bin/which which, \
+	which which))
 
 $(STAGING_DIR_HOST)/bin/mkhash: $(SCRIPT_DIR)/mkhash.c
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Fix Fedora 34/35 issue where 'which' detection of 'which' wasn't working
because Fedora use alias and proc

Fixup of fca5ad55d2 prereq-build: fix `which` detection on Fedora

Reported-by: Jani Partanen <rtfm@iki.fi>
Suggest-by: Etienne Champetier <champetier.etienne@gmail.com>
Tested-by: Georgi Valkov <gvalkov@abv.bg>
Signed-off-by: Paul Spooren <mail@aparcar.org>