### PR TITLE
[21.02] ath79: add support for Xiaomi AIoT Router AC2350

### DIFF
--- a/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
+++ b/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Xiaomi AIoT AC2350";
+	compatible = "xiaomi,aiot-ac2350", "qca,qca9563";
+
+	aliases {
+		label-mac-device = &eth0;
+
+		led-boot = &led_system_orange;
+		led-failsafe = &led_system_orange;
+		led-running = &led_system_blue;
+		led-upgrade = &led_system_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_blue: system_blue {
+			label = "blue:system";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system_orange: system_orange {
+			label = "orange:system";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "blue:wan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		wps {
+			gpio-export,name = "wps";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb-reset {
+			gpio-export,name = "usb-reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Nvram";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "Bdata";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "crash";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			art: partition@60000 {
+				label = "art";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "cfg_bak";
+				reg = <0x70000 0x20000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "overlay";
+				reg = <0x90000 0x170000>;
+				read-only;
+			};
+
+			partition@200000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x200000 0xe00000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x1>;
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x00000080 /* PORT0 PAD MODE CTRL */
+			0x08 0x01000000 /* PORT5 PAD MODE CTRL */
+			0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+			0x10 0x602613a0 /* POWER_ON_STRAP */
+			0x50 0xcf35cf35 /* LED_CTRL0 */
+			0x54 0xca35ca35 /* LED_CTRL1 */
+			0x58 0xc935c935 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x000000fe /* PORT0_STATUS */
+			0x94 0x000010c2 /* PORT6_STATUS */
+			0xe0 0xc74164de /* SGMII_CTRL */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+
+	mtd-mac-address = <&art 0x0>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+};
+
+&pcie {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -407,6 +407,9 @@ wd,mynet-wifi-rangeextender)
 	ucidef_set_led_rssi "rssimedium" "RSSIMED" "blue:rssi-med" "wlan0" "33" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIMAX" "blue:rssi-max" "wlan0" "66" "100"
 	;;
+xiaomi,aiot-ac2350)
+	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
+	;;
 yuncore,a770)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -310,7 +310,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan"
 		;;
-	nec,wg800hp)
+	nec,wg800hp|\
+	xiaomi,aiot-ac2350)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:lan" "4:lan" "1:wan"
 		;;
@@ -662,6 +663,9 @@ ath79_setup_macs()
 		;;
 	wd,mynet-wifi-rangeextender)
 		lan_mac=$(nvram get et0macaddr)
+		;;
+	xiaomi,aiot-ac2350)
+		lan_mac=$(mtd_get_mac_binary art 0x1002)
 		;;
 	zyxel,nbg6616)
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -243,6 +243,11 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary info 0x8) +1)
 		;;
+	xiaomi,aiot-ac2350)
+		caldata_extract "art" 0x5000 0x2f20
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9984/hw1.0/board.bin
+		;;
 	yuncore,a782|\
 	yuncore,xd4200)
 		caldata_extract "art" 0x5000 0x2f20

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2203,6 +2203,15 @@ define Device/winchannel_wb2000
 endef
 TARGET_DEVICES += winchannel_wb2000
 
+define Device/xiaomi_aiot-ac2350
+  SOC := qca9563
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := AIoT AC2350
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9984-ct
+  IMAGE_SIZE := 14336k
+endef
+TARGET_DEVICES += xiaomi_aiot-ac2350
+
 define Device/xiaomi_mi-router-4q
   SOC := qca9561
   DEVICE_VENDOR := Xiaomi


### PR DESCRIPTION
This pull request aims to add support for the Xiaomi AIoT Router AC2350 in the openwrt-21.02 branch. The commit has been directly cherry-picked from the master branch with no needed changes. Quite a few people have asked for a stable 21.02 image for this device. This is my first time contributing to openwrt, I hope I've done everything correctly. 

Signed-off-by: Marios Koutsoukis <marios.k239@gmail.com>