### PR TITLE
odhcpd: set skip dhcp check by default

### DIFF
--- a/package/network/services/odhcpd/files/odhcpd.defaults
+++ b/package/network/services/odhcpd/files/odhcpd.defaults
@@ -44,6 +44,7 @@ set dhcp.odhcpd.leasetrigger=/usr/sbin/odhcpd-update
 set dhcp.odhcpd.loglevel=4
 set dhcp.lan.dhcpv4=$V4MODE
 set dhcp.lan.dhcpv6=$V6MODE
+set dhcp.lan.force='1'
 set dhcp.lan.ra=$V6MODE
 set dhcp.lan.ra_slaac=1
 add_list dhcp.lan.ra_flags=managed-config


### PR DESCRIPTION
Some brands of routers (Example: TP-LINK)
they do not distinguish between LAN or WAN by default.
That means they will respond to DHCPC requests on any port.
When openwrt is used as a gateway to these routers.
If openwrt do a DHCP check on LAN,
that will no longer respond to DHCPC requests from the back end.
This causes the back routes to not find the WAN correctly.
The default setting of dhcp.lan.force will avoid this problem.

I think this is a necessary change in order to ensure that it works out of the box.