### PR TITLE
ltq-vdsl-app: add error vector counters to the ubus metrics

### DIFF
--- a/package/network/config/ltq-vdsl-app/Makefile
+++ b/package/network/config/ltq-vdsl-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-app
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=9
+PKG_RELEASE:=$(AUTORELEASE)
 PKG_BASE_NAME:=dsl_cpe_control
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@OPENWRT

--- a/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-app/src/src/dsl_cpe_ubus.c
@@ -477,32 +477,28 @@ static void g997_xtu_system_enabling(int fd, standard_t *standard) {
 		m_str("standard", str);
 }
 
-static vector_t get_vector_status() {
+static void get_vector_status(int fd, vector_t *status) {
+	*status = VECTOR_UNKNOWN;
+
 #ifdef INCLUDE_DSL_CPE_API_VRX
-	int fd = open(DSL_CPE_DSL_LOW_DEV "/0", O_RDWR, 0644);
 	if (fd < 0)
-		return VECTOR_UNKNOWN;
+		return;
 
-	IOCTL_MEI_dsmStatus_t out;
-	memset(&out, 0, sizeof(IOCTL_MEI_dsmStatus_t));
-	int ret = ioctl(fd, FIO_MEI_DSM_STATUS_GET, &out);
-	close(fd);
-
-	if (ret)
-		return VECTOR_UNKNOWN;
+	IOCTL(IOCTL_MEI_dsmStatus_t, FIO_MEI_DSM_STATUS_GET);
 
 	switch (out.eVectorStatus) {
 	case e_MEI_VECTOR_STAT_OFF:
-		return VECTOR_OFF;
+		*status = VECTOR_OFF;
+		break;
 	case e_MEI_VECTOR_STAT_ON_DS:
-		return VECTOR_ON_DS;
+		*status = VECTOR_ON_DS;
+		break;
 	case e_MEI_VECTOR_STAT_ON_DS_US:
-		return VECTOR_ON_DS_US;
+		*status = VECTOR_ON_DS_US;
+		break;
 	default:
-		return VECTOR_UNKNOWN;
+		break;
 	};
-#else
-	return VECTOR_UNKNOWN;
 #endif
 }
 
@@ -720,7 +716,7 @@ static int metrics(struct ubus_context *ctx, struct ubus_object *obj,
 		   struct ubus_request_data *req, const char *method,
 		   struct blob_attr *msg)
 {
-	int fd;
+	int fd, fd_mei;
 	void *c, *c2;
 	standard_t standard = STD_UNKNOWN;
 	profile_t profile = PROFILE_UNKNOWN;
@@ -733,6 +729,12 @@ static int metrics(struct ubus_context *ctx, struct ubus_object *obj,
 #endif
 	if (fd < 0)
 		return UBUS_STATUS_UNKNOWN_ERROR;
+
+#ifdef INCLUDE_DSL_CPE_API_VRX
+	fd_mei = open(DSL_CPE_DSL_LOW_DEV "/0", O_RDWR, 0644);
+#else
+	fd_mei = -1;
+#endif
 
 	blob_buf_init(&b, 0);
 
@@ -749,7 +751,7 @@ static int metrics(struct ubus_context *ctx, struct ubus_object *obj,
 
 	if (standard == STD_G_993_2) {
 		band_plan_status(fd, &profile);
-		vector = get_vector_status();
+		get_vector_status(fd_mei, &vector);
 	}
 
 	describe_mode(standard, profile, vector);
@@ -803,6 +805,8 @@ static int metrics(struct ubus_context *ctx, struct ubus_object *obj,
 
 	ubus_send_reply(ctx, req, b.head);
 
+	if (fd_mei >= 0)
+		close(fd_mei);
 	close(fd);
 
 	return 0;


### PR DESCRIPTION
These are useful stats to debug vector related line deteriorations, see [0].

Example output:
```
    "erb": {
	    "sent": 169925,
    	    "discarded": 0
    }
```

[0] https://forum.openwrt.org/t/vectoring-on-lantiq-vrx200-vr9-missing-callback-for-sending-error-samples/104046
