### PR TITLE
gettext-full: fix compilation under macOS

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -58,22 +58,18 @@ CONFIGURE_ARGS += \
 	--without-emacs
 
 HOST_CONFIGURE_ARGS += \
-	--disable-shared \
-	--enable-static \
+	--enable-shared \
+	--disable-static \
 	--disable-libasprintf \
 	--disable-rpath \
 	--disable-java \
 	--disable-openmp \
 	--without-emacs \
-	--without-libxml2-prefix
+	--with-included-libxml \
+	--with-pic
 
 HOST_CONFIGURE_VARS += \
-	EMACS="no" \
-	am_cv_lib_iconv=no \
-	am_cv_func_iconv=no \
-	ac_cv_header_iconv_h=no \
-
-HOST_CFLAGS += $(HOST_FPIC)
+	EMACS="no"
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/libintl-full/include

--- a/package/libs/libiconv-full/Makefile
+++ b/package/libs/libiconv-full/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE:=libiconv-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/libiconv
 PKG_HASH:=e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04
 PKG_BUILD_DIR:=$(BUILD_DIR)/libiconv-$(PKG_VERSION)
+HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/libiconv-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=LGPL-2.1-or-later
@@ -25,6 +26,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/libiconv-full/Default
   URL:=https://www.gnu.org/software/libiconv/
@@ -61,6 +63,10 @@ CONFIGURE_ARGS += \
 	--disable-rpath \
 	--enable-relocatable
 
+HOST_CONFIGURE_ARGS += \
+	--disable-shared \
+	--with-pic
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/libiconv-full/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/iconv.h $(1)/usr/lib/libiconv-full/include/
@@ -88,3 +94,4 @@ endef
 $(eval $(call BuildPackage,libcharset))
 $(eval $(call BuildPackage,libiconv-full))
 $(eval $(call BuildPackage,iconv))
+$(eval $(call HostBuild))

--- a/package/libs/libiconv/Makefile
+++ b/package/libs/libiconv/Makefile
@@ -19,7 +19,6 @@ PKG_LICENSE_FILES:=LICENSE
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include $(INCLUDE_DIR)/package.mk
-include $(INCLUDE_DIR)/host-build.mk
 
 define Package/libiconv
   SECTION:=libs
@@ -51,29 +50,4 @@ define Package/libiconv/install
 	touch $(1)/tmp/.libiconv-placeholder
 endef
 
-define Host/Prepare
-	mkdir -p $(HOST_BUILD_DIR)
-endef
-
-define Host/Configure
-
-endef
-
-define Host/Compile
-	$(HOSTCC) -c src/iconv.c -o $(HOST_BUILD_DIR)/iconv.o -Isrc/include -fPIC
-	ar rcs $(HOST_BUILD_DIR)/libiconv.a $(HOST_BUILD_DIR)/iconv.o
-endef
-
-define Host/Install
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/lib
-	$(INSTALL_DATA) $(HOST_BUILD_DIR)/libiconv.a $(STAGING_DIR_HOSTPKG)/lib/
-
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/include
-	$(INSTALL_DATA) ./src/include/iconv.h $(STAGING_DIR_HOSTPKG)/include/
-
-	$(INSTALL_DIR) $(STAGING_DIR_HOSTPKG)/share/aclocal
-	$(INSTALL_DATA) ./src/m4/* $(STAGING_DIR_HOSTPKG)/share/aclocal/
-endef
-
-$(eval $(call HostBuild))
 $(eval $(call BuildPackage,libiconv))


### PR DESCRIPTION
static linking under macOS doesn't work correctly for some reason.
Switch to shared linking for the host build.

Also start using libiconv/host for the host build. shared linking
seems to fail without libiconv.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @httpstorm Try testing with gmake package/rpcsvc-proto/host
