### PR TITLE
[RFC/RFT] build: switch to firewall4 by default

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -54,10 +54,9 @@ DEFAULT_PACKAGES.nas:=\
 # For router targets
 DEFAULT_PACKAGES.router:=\
 	dnsmasq \
-	firewall \
-	ip6tables \
-	iptables \
-	kmod-ipt-offload \
+	firewall4 \
+	nftables \
+	kmod-nft-offload \
 	odhcp6c \
 	odhcpd-ipv6only \
 	ppp \

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -60,7 +60,7 @@ define Package/iptables/config
 
   config IPTABLES_NFTABLES
 	bool "Enable Nftables support"
-	default n
+	default y
 	help
 		This enable nftables support in iptables.
 endef
@@ -108,7 +108,7 @@ endef
 define Package/iptables-nft
 $(call Package/iptables/Default)
   TITLE:=IP firewall administration tool nft
-  DEPENDS:=iptables @IPTABLES_NFTABLES +libxtables-nft
+  DEPENDS:=+iptables @IPTABLES_NFTABLES +libxtables-nft
 endef
 
 define Package/iptables-nft/description


### PR DESCRIPTION
The next OpenWrt release might use `firewall4`, let's test it?

This commit replaces firewall aka firewall3 with its nftables based
successor firewall4.

Heads up for packages.git: https://github.com/openwrt/packages/issues/16818
Heads up for routing.git: https://github.com/openwrt/routing/issues/731
Heads up for luci.git: https://github.com/openwrt/luci/issues/5409

**Issues**:

- [x] option zone in /etc/config/network is ignored by firewall4
- [x] flow offloading doesn't work if no interfaces are configured
- [x] rules with option _name are skipped
- [x] defaults section is ignored if it contains any unsupported option
- [x] ipsets of type ipv{4,6}_addr claim CIDR is invalid
- [x] ipsets don't support timeout

Working on those [here](https://git.openwrt.org/?p=project/firewall4.git;a=log;h=refs/heads/staging/stintel/dev)