### PR TITLE
wolfssl: fix validating new Let's Encrypt certificates

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -64,6 +64,7 @@ TARGET_LDFLAGS += -flto
 
 # --enable-stunnel needed for OpenSSL API compatibility bits
 CONFIGURE_ARGS += \
+	--enable-reproducible-build \
 	--enable-lighty \
 	--enable-opensslall \
 	--enable-opensslextra \

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -59,7 +59,13 @@ define Package/libwolfssl/config
 	source "$(SOURCE)/Config.in"
 endef
 
-TARGET_CFLAGS += $(FPIC) -DFP_MAX_BITS=8192 -fomit-frame-pointer -flto
+TARGET_CFLAGS += \
+	$(FPIC) \
+	-fomit-frame-pointer \
+	-flto \
+	-DFP_MAX_BITS=8192 \
+	-DWOLFSSL_ALT_CERT_CHAINS
+
 TARGET_LDFLAGS += -flto
 
 # --enable-stunnel needed for OpenSSL API compatibility bits

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
 PKG_VERSION:=4.8.1-stable
-PKG_RELEASE:=1
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
@@ -97,7 +97,7 @@ endif
 
 ifeq ($(CONFIG_WOLFSSL_HAS_WPAS),y)
 CONFIGURE_ARGS += \
-	--enable-wpas --enable-sha512 --enable-fortress --enable-fastmath
+	--enable-wpas --enable-fortress --enable-fastmath
 endif
 
 define Build/InstallDev


### PR DESCRIPTION
Build with WOLFSSL_ALT_CERT_CHAINS:
```
Alternate certification chains, as oppossed to requiring full chain validataion.
Certificate validation behavior is relaxed, similar to openssl and
browsers. Only the peer certificate must validate to a trusted
certificate. Without this, all certificates sent by a peer must be
used in the trust chain or the connection will be rejected.
```
This fixes e.g. uclient-fetch and curl connecting to servers using a Let's Encrypt certificate which are cross-signed by the now expired DST Root CA X3, see [0].

This is the recommended solution from upstream [1].

The overall binary size increases by ~4.3kb.

Draft as:
* ~~it's not yet clear what exactly the implications of WOLFSSL_ALT_CERT_CHAINS are~~
* ~~does the change now require ca-bundle for the library itself (curl already has a dependency on it)~~

[0] https://github.com/openwrt/packages/issues/16674
[1] https://github.com/wolfSSL/wolfssl/issues/4443#issuecomment-934926793