### PR TITLE
config: pack toolchain per default on buildbots

### DIFF
--- a/target/toolchain/Config.in
+++ b/target/toolchain/Config.in
@@ -1,6 +1,7 @@
 config MAKE_TOOLCHAIN
 	bool "Package the OpenWrt-based Toolchain"
 	depends on !EXTERNAL_TOOLCHAIN
+	default BUILDBOT
 	help
 	  Package the created toolchain as a tarball under the bin/ directory as
 	  OpenWrt-Toolchain-$(BOARD)-for-$(ARCH)$(ARCH_SUFFIX)-gcc-$(GCCV)$(DIR_SUFFIX).


### PR DESCRIPTION
The toolchain can be used for accelerated CI builds. This commit enabled
the packing of it by default on buildbots.

Signed-off-by: Paul Spooren <mail@aparcar.org>