### PR TITLE
wolfssl: enable ECC Curve 25519 by default

### DIFF
--- a/package/libs/wolfssl/Config.in
+++ b/package/libs/wolfssl/Config.in
@@ -49,7 +49,7 @@ config WOLFSSL_HAS_WPAS
 
 config WOLFSSL_HAS_ECC25519
 	bool "Include ECC Curve 25519 support"
-	default n
+	default y
 
 config WOLFSSL_HAS_OPENVPN
 	bool "Include OpenVPN support"


### PR DESCRIPTION
Maintainer: @cotequeiroz 

* fixes https://github.com/openwrt/packages/issues/16652
see: https://github.com/openwrt/packages/issues/16674#issuecomment-934983898

Would it be OK to backport it to 21.02.0?

Signed-off-by: Stan Grishin <stangri@melmac.net>
