### PR TITLE
mt76: add patch that fixes ibss and meshpoint

### DIFF
--- a/package/kernel/mt76/patches/001-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
+++ b/package/kernel/mt76/patches/001-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
@@ -180,11 +180,9 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  net/ethernet/eth.c                                 | 11 ++--
  85 files changed, 218 insertions(+), 364 deletions(-)
 
-diff --git a/drivers/net/wireless/mediatek/mt76/eeprom.c b/drivers/net/wireless/mediatek/mt76/eeprom.c
-index 665b54c5c8ae5..6d895738222ad 100644
 --- a/eeprom.c
 +++ b/eeprom.c
-@@ -91,15 +91,9 @@ void
+@@ -91,15 +91,9 @@ mt76_eeprom_override(struct mt76_phy *ph
  {
  	struct mt76_dev *dev = phy->dev;
  
@@ -201,6 +199,3 @@ index 665b54c5c8ae5..6d895738222ad 100644
  
  	if (!is_valid_ether_addr(phy->macaddr)) {
  		eth_random_addr(phy->macaddr);
--- 
-cgit 1.2.3-1.el7
-

--- a/package/kernel/mt76/patches/100-mt76-mt7615-mt7622-fix-ibss-and-meshpoint.patch
+++ b/package/kernel/mt76/patches/100-mt76-mt7615-mt7622-fix-ibss-and-meshpoint.patch
@@ -1,0 +1,57 @@
+From b3be16e335289b5a5dfa23a3e1f5ee86bd581ac6 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Thu, 7 Oct 2021 22:20:33 +0200
+Subject: [PATCH] mt76: mt7615: mt7622: fix ibss and meshpoint
+
+commit 7f4b7920318b ("mt76: mt7615: add ibss support") introduced IBSS
+and commit f4ec7fdf7f83 ("mt76: mt7615: enable support for mesh")
+meshpoint support.
+
+Both used in the "get_omac_idx"-function:
+
+	if (~mask & BIT(HW_BSSID_0))
+		return HW_BSSID_0;
+
+With commit d8d59f66d136 ("mt76: mt7615: support 16 interfaces") the
+ibss and meshpoint mode should "prefer hw bssid slot 1-3". However,
+with that change the ibss or meshpoint mode will not send any beacon on
+the mt7622 wifi anymore. Devices were still able to exchange data but
+only if a bssid already existed. Two mt7622 devices will never be able
+to communicate.
+
+This commits reverts the preferation of slot 1-3 for ibss and
+meshpoint. Only NL80211_IFTYPE_STATION will still prefer slot 1-3.
+
+Tested on Banana Pi R64.
+
+Fixes: d8d59f66d136 ("mt76: mt7615: support 16 interfaces").
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ mt7615/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mt7615/main.c b/mt7615/main.c
+index dada43d6d879..51260a669d16 100644
+--- a/mt7615/main.c
++++ b/mt7615/main.c
+@@ -135,8 +135,6 @@ static int get_omac_idx(enum nl80211_iftype type, u64 mask)
+ 	int i;
+ 
+ 	switch (type) {
+-	case NL80211_IFTYPE_MESH_POINT:
+-	case NL80211_IFTYPE_ADHOC:
+ 	case NL80211_IFTYPE_STATION:
+ 		/* prefer hw bssid slot 1-3 */
+ 		i = get_free_idx(mask, HW_BSSID_1, HW_BSSID_3);
+@@ -160,6 +158,8 @@ static int get_omac_idx(enum nl80211_iftype type, u64 mask)
+ 			return HW_BSSID_0;
+ 
+ 		break;
++	case NL80211_IFTYPE_ADHOC:
++	case NL80211_IFTYPE_MESH_POINT:
+ 	case NL80211_IFTYPE_MONITOR:
+ 	case NL80211_IFTYPE_AP:
+ 		/* ap uses hw bssid 0 and ext bssid */
+-- 
+2.33.0
+

--- a/package/kernel/mt76/patches/100-mt76-mt7615-mt7622-fix-ibss-and-meshpoint.patch
+++ b/package/kernel/mt76/patches/100-mt76-mt7615-mt7622-fix-ibss-and-meshpoint.patch
@@ -30,11 +30,9 @@ Signed-off-by: Nick Hainke <vincent@systemli.org>
  mt7615/main.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/mt7615/main.c b/mt7615/main.c
-index dada43d6d879..51260a669d16 100644
 --- a/mt7615/main.c
 +++ b/mt7615/main.c
-@@ -135,8 +135,6 @@ static int get_omac_idx(enum nl80211_iftype type, u64 mask)
+@@ -135,8 +135,6 @@ static int get_omac_idx(enum nl80211_ift
  	int i;
  
  	switch (type) {
@@ -43,7 +41,7 @@ index dada43d6d879..51260a669d16 100644
  	case NL80211_IFTYPE_STATION:
  		/* prefer hw bssid slot 1-3 */
  		i = get_free_idx(mask, HW_BSSID_1, HW_BSSID_3);
-@@ -160,6 +158,8 @@ static int get_omac_idx(enum nl80211_iftype type, u64 mask)
+@@ -160,6 +158,8 @@ static int get_omac_idx(enum nl80211_ift
  			return HW_BSSID_0;
  
  		break;
@@ -52,6 +50,3 @@ index dada43d6d879..51260a669d16 100644
  	case NL80211_IFTYPE_MONITOR:
  	case NL80211_IFTYPE_AP:
  		/* ap uses hw bssid 0 and ext bssid */
--- 
-2.33.0
-


### PR DESCRIPTION
mt7622 is not able to open an ibss or meshpoint network. The devices will not send any beacons. However, if another device is opening a mesh network, the devices will be able to exchange data. Only two mt7622 devices will never be able to communicate since they just do not send any beacons out and so none of the devices will see the other one.

Fixes:
- https://github.com/openwrt/mt76/issues/590
- https://forum.banana-pi.org/t/bpi-r64-mesh-802-11s-on-internal-wifi-card-mt7622av