### PR TITLE
[RFT] qca8k: add support for multiple additional experimental feature

### DIFF
--- a/target/linux/generic/pending-5.10/850-01-net-dsa-qca8k-add-support-for-port-fast-aging.patch
+++ b/target/linux/generic/pending-5.10/850-01-net-dsa-qca8k-add-support-for-port-fast-aging.patch
@@ -1,0 +1,59 @@
+From 6b8d1fab6a529f758d89153dc35cb63e783575cf Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sat, 9 Oct 2021 02:54:27 +0200
+Subject: [PATCH 1/7] net: dsa: qca8k: add support for port fast aging
+
+The switch doesn't support fast aging but it does support the flush of
+the ARL table for a specific port. Add this function to simulate
+fast aging and proprely support stp state set.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 11 +++++++++++
+ drivers/net/dsa/qca8k.h |  1 +
+ 2 files changed, 12 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index aae0cfcd0ce8..ddbf1ff9489e 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1650,6 +1650,16 @@ qca8k_port_bridge_leave(struct dsa_switch *ds, int port, struct net_device *br)
+ 		  QCA8K_PORT_LOOKUP_MEMBER, BIT(QCA8K_CPU_PORT));
+ }
+ 
++static void
++qca8k_port_fast_age(struct dsa_switch *ds, int port)
++{
++	struct qca8k_priv *priv = ds->priv;
++
++	mutex_lock(&priv->reg_mutex);
++	qca8k_fdb_access(priv, QCA8K_FDB_FLUSH_PORT, port);
++	mutex_unlock(&priv->reg_mutex);
++}
++
+ static int
+ qca8k_port_enable(struct dsa_switch *ds, int port,
+ 		  struct phy_device *phy)
+@@ -1859,6 +1869,7 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.port_stp_state_set	= qca8k_port_stp_state_set,
+ 	.port_bridge_join	= qca8k_port_bridge_join,
+ 	.port_bridge_leave	= qca8k_port_bridge_leave,
++	.port_fast_age		= qca8k_port_fast_age,
+ 	.port_fdb_add		= qca8k_port_fdb_add,
+ 	.port_fdb_del		= qca8k_port_fdb_del,
+ 	.port_fdb_dump		= qca8k_port_fdb_dump,
+diff --git a/drivers/net/dsa/qca8k.h b/drivers/net/dsa/qca8k.h
+index 2d0c41e8cb75..c5a265962e64 100644
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -243,6 +243,7 @@ enum qca8k_fdb_cmd {
+ 	QCA8K_FDB_FLUSH	= 1,
+ 	QCA8K_FDB_LOAD = 2,
+ 	QCA8K_FDB_PURGE = 3,
++	QCA8K_FDB_FLUSH_PORT = 5,
+ 	QCA8K_FDB_NEXT = 6,
+ 	QCA8K_FDB_SEARCH = 7,
+ };
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-02-net-dsa-qca8k-add-support-for-mirror-mode.patch
+++ b/target/linux/generic/pending-5.10/850-02-net-dsa-qca8k-add-support-for-mirror-mode.patch
@@ -1,0 +1,171 @@
+From 05982640d472bde56bb2f91d5013b32b23b0934a Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Sat, 9 Oct 2021 02:57:16 +0200
+Subject: [PATCH 2/7] net: dsa: qca8k: add support for mirror mode
+
+The switch support mirror mode. Only one port can set as mirror port and
+every other port can set to both ingress and egress mode. The mirror
+port is disabled and reverted to normal operation once every port is
+removed from sending packet to the mirror mode.
+Also modify the fdb logit to send packet to both destination and mirror
+port by default to support mirror mode.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 98 ++++++++++++++++++++++++++++++++++++++++-
+ drivers/net/dsa/qca8k.h |  4 ++
+ 2 files changed, 101 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index ddbf1ff9489e..e98b35668673 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -9,6 +9,7 @@
+ #include <linux/module.h>
+ #include <linux/phy.h>
+ #include <linux/netdevice.h>
++#include <linux/bitfield.h>
+ #include <net/dsa.h>
+ #include <linux/of_net.h>
+ #include <linux/of_mdio.h>
+@@ -1765,6 +1766,99 @@ qca8k_port_fdb_dump(struct dsa_switch *ds, int port,
+ 	return 0;
+ }
+ 
++static int
++qca8k_port_mirror_add(struct dsa_switch *ds, int port,
++		      struct dsa_mall_mirror_tc_entry *mirror,
++		      bool ingress)
++{
++	struct qca8k_priv *priv = ds->priv;
++	int monitor_port, ret;
++	u32 reg, val;
++
++	/* Check for existent entry */
++	if ((ingress ? priv->mirror_rx : priv->mirror_tx) & BIT(port))
++		return -EEXIST;
++
++	ret = qca8k_read(priv, QCA8K_REG_GLOBAL_FW_CTRL0, &val);
++	if (ret)
++		return ret;
++
++	/* QCA83xx can have only one port set to mirror mode.
++	 * Check that the correct port is requested and return error otherwise.
++	 * When no mirror port is set, the values is set to 0xF
++	 */
++	monitor_port = FIELD_GET(QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM, val);
++	if (monitor_port != 0xF && monitor_port != mirror->to_local_port)
++		return -EEXIST;
++
++	/* Set the monitor port */
++	val = FIELD_PREP(QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM,
++			 mirror->to_local_port);
++	ret = qca8k_rmw(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
++			QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM, val);
++	if (ret)
++		return ret;
++
++	if (ingress) {
++		reg = QCA8K_PORT_LOOKUP_CTRL(port);
++		val = QCA8K_PORT_LOOKUP_ING_MIRROR_EN;
++	} else {
++		reg = QCA8K_REG_PORT_HOL_CTRL1(port);
++		val = QCA8K_PORT_HOL_CTRL1_EG_MIRROR_EN;
++	}
++
++	ret = qca8k_rmw(priv, reg, val, val);
++	if (ret)
++		return ret;
++
++	/* Track mirror port for tx and rx to decide when the
++	 * mirror port has to be disabled.
++	 */
++	if (ingress)
++		priv->mirror_rx |= BIT(port);
++	else
++		priv->mirror_tx |= BIT(port);
++
++	return 0;
++}
++
++static void
++qca8k_port_mirror_del(struct dsa_switch *ds, int port,
++		      struct dsa_mall_mirror_tc_entry *mirror)
++{
++	struct qca8k_priv *priv = ds->priv;
++	u32 reg, val;
++	int ret;
++
++	if (mirror->ingress) {
++		reg = QCA8K_PORT_LOOKUP_CTRL(port);
++		val = QCA8K_PORT_LOOKUP_ING_MIRROR_EN;
++	} else {
++		reg = QCA8K_REG_PORT_HOL_CTRL1(port);
++		val = QCA8K_PORT_HOL_CTRL1_EG_MIRROR_EN;
++	}
++
++	ret = qca8k_reg_clear(priv, reg, val);
++	if (ret)
++		goto err;
++
++	if (mirror->ingress)
++		priv->mirror_rx &= ~BIT(port);
++	else
++		priv->mirror_tx &= ~BIT(port);
++
++	/* No port set to send packet to mirror port. Disable mirror port */
++	if (!priv->mirror_rx && !priv->mirror_tx) {
++		val = FIELD_PREP(QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM, 0xF);
++		ret = qca8k_rmw(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
++				QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM, val);
++		if (ret)
++			goto err;
++	}
++err:
++	dev_err(priv->dev, "Failed to del mirror port from %d", port);
++}
++
+ static int
+ qca8k_port_vlan_filtering(struct dsa_switch *ds, int port, bool vlan_filtering,
+ 			  struct netlink_ext_ack *extack)
+@@ -1873,6 +1967,8 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.port_fdb_add		= qca8k_port_fdb_add,
+ 	.port_fdb_del		= qca8k_port_fdb_del,
+ 	.port_fdb_dump		= qca8k_port_fdb_dump,
++	.port_mirror_add	= qca8k_port_mirror_add,
++	.port_mirror_del	= qca8k_port_mirror_del,
+ 	.port_vlan_filtering	= qca8k_port_vlan_filtering,
+ 	.port_vlan_add		= qca8k_port_vlan_add,
+ 	.port_vlan_del		= qca8k_port_vlan_del,
+diff --git a/drivers/net/dsa/qca8k.h b/drivers/net/dsa/qca8k.h
+index c5a265962e64..9f02995ce538 100644
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -162,6 +162,7 @@
+ #define   QCA8K_VTU_FUNC1_FULL				BIT(4)
+ #define QCA8K_REG_GLOBAL_FW_CTRL0			0x620
+ #define   QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN		BIT(10)
++#define   QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM		GENMASK(7, 4)
+ #define QCA8K_REG_GLOBAL_FW_CTRL1			0x624
+ #define   QCA8K_GLOBAL_FW_CTRL1_IGMP_DP_S		24
+ #define   QCA8K_GLOBAL_FW_CTRL1_BC_DP_S			16
+@@ -182,6 +183,7 @@
+ #define   QCA8K_PORT_LOOKUP_STATE_FORWARD		(4 << 16)
+ #define   QCA8K_PORT_LOOKUP_STATE			GENMASK(18, 16)
+ #define   QCA8K_PORT_LOOKUP_LEARN			BIT(20)
++#define   QCA8K_PORT_LOOKUP_ING_MIRROR_EN		BIT(25)
+ 
+ #define QCA8K_REG_GLOBAL_FC_THRESH			0x800
+ #define   QCA8K_GLOBAL_FC_GOL_XON_THRES(x)		((x) << 16)
+@@ -269,6 +271,8 @@ struct qca8k_match_data {
+ struct qca8k_priv {
+ 	u8 switch_id;
+ 	u8 switch_revision;
++	u8 mirror_rx;
++	u8 mirror_tx;
+ 	bool legacy_phy_port_mapping;
+ 	struct regmap *regmap;
+ 	struct mii_bus *bus;
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-03-net-dsa-qca8k-add-set_ageing_time-support.patch
+++ b/target/linux/generic/pending-5.10/850-03-net-dsa-qca8k-add-set_ageing_time-support.patch
@@ -1,0 +1,67 @@
+From 8e94440aaaf9887c88284b1ac1a170bb6c5424ab Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 18 Oct 2021 00:30:45 +0200
+Subject: [PATCH 3/7] net: dsa: qca8k: add set_ageing_time support
+
+qca8k support setting ageing time in set of 7s. Add support for it and
+return error with value greater than the max value accepted of 7645m.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 18 ++++++++++++++++++
+ drivers/net/dsa/qca8k.h |  3 +++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index e98b35668673..f3b2fc85e546 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1661,6 +1661,23 @@ qca8k_port_fast_age(struct dsa_switch *ds, int port)
+ 	mutex_unlock(&priv->reg_mutex);
+ }
+ 
++static int
++qca8k_set_ageing_time(struct dsa_switch *ds, unsigned int msecs)
++{
++	struct qca8k_priv *priv = ds->priv;
++	unsigned int secs = msecs / 1000;
++	u32 val;
++
++	/* AGE_TIME reg is set in 7s step */
++	val = secs / 7;
++
++	if (val > FIELD_MAX(QCA8K_ATU_AGE_TIME_MASK))
++		return -ERANGE;
++
++	return qca8k_rmw(priv, QCA8K_REG_ATU_CTRL, QCA8K_ATU_AGE_TIME_MASK,
++			 QCA8K_ATU_AGE_TIME(val));
++}
++
+ static int
+ qca8k_port_enable(struct dsa_switch *ds, int port,
+ 		  struct phy_device *phy)
+@@ -1954,6 +1971,7 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.get_strings		= qca8k_get_strings,
+ 	.get_ethtool_stats	= qca8k_get_ethtool_stats,
+ 	.get_sset_count		= qca8k_get_sset_count,
++	.set_ageing_time	= qca8k_set_ageing_time,
+ 	.get_mac_eee		= qca8k_get_mac_eee,
+ 	.set_mac_eee		= qca8k_set_mac_eee,
+ 	.port_enable		= qca8k_port_enable,
+diff --git a/drivers/net/dsa/qca8k.h b/drivers/net/dsa/qca8k.h
+index 9f02995ce538..cd5076c1f046 100644
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -160,6 +160,9 @@
+ #define   QCA8K_VTU_FUNC1_BUSY				BIT(31)
+ #define   QCA8K_VTU_FUNC1_VID_S				16
+ #define   QCA8K_VTU_FUNC1_FULL				BIT(4)
++#define QCA8K_REG_ATU_CTRL				0x618
++#define   QCA8K_ATU_AGE_TIME_MASK			GENMASK(15, 0)
++#define   QCA8K_ATU_AGE_TIME(x)				FIELD_PREP(QCA8K_ATU_AGE_TIME_MASK, (x))
+ #define QCA8K_REG_GLOBAL_FW_CTRL0			0x620
+ #define   QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN		BIT(10)
+ #define   QCA8K_GLOBAL_FW_CTRL0_MIRROR_PORT_NUM		GENMASK(7, 4)
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-04-net-dsa-qca8k-add-min-max-ageing-time.patch
+++ b/target/linux/generic/pending-5.10/850-04-net-dsa-qca8k-add-min-max-ageing-time.patch
@@ -1,0 +1,30 @@
+From 8088602442b8df3554334a4bda3ca414315a6ab9 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 18 Oct 2021 02:41:42 +0200
+Subject: [PATCH 4/7] net: dsa: qca8k: add min/max ageing time
+
+Add min and max ageing value for qca8k switch.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index f3b2fc85e546..05b12f26f45e 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1174,6 +1174,10 @@ qca8k_setup(struct dsa_switch *ds)
+ 	/* We don't have interrupts for link changes, so we need to poll */
+ 	ds->pcs_poll = true;
+ 
++	/* Set min a max ageing value supported */
++	ds->ageing_time_min = 7000;
++	ds->ageing_time_max = 458745000;
++
+ 	return 0;
+ }
+ 
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-05-net-dsa-qca8k-add-support-for-mdb_add-del.patch
+++ b/target/linux/generic/pending-5.10/850-05-net-dsa-qca8k-add-support-for-mdb_add-del.patch
@@ -1,0 +1,111 @@
+From c26e09569669195e92fcc117e288576d6493bd27 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 18 Oct 2021 00:37:05 +0200
+Subject: [PATCH 5/7] net: dsa: qca8k: add support for mdb_add/del
+
+Add support for mdb add/dell function. The ARL table is used to insert
+the rule. A new search function is introduced to search the rule and add
+additional port to it. If every port is removed from the rule, it's
+removed. It's set STATIC in the ARL table (aka it doesn't age) to not be
+flushed by fast age function.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 67 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 67 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index 05b12f26f45e..d8a40d466c8c 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -446,6 +446,23 @@ qca8k_fdb_flush(struct qca8k_priv *priv)
+ 	mutex_unlock(&priv->reg_mutex);
+ }
+ 
++static int
++qca8k_fdb_search(struct qca8k_priv *priv, struct qca8k_fdb *fdb, const u8 *mac, u16 vid)
++{
++	int ret;
++
++	mutex_lock(&priv->reg_mutex);
++	qca8k_fdb_write(priv, vid, 0, mac, 0);
++	ret = qca8k_fdb_access(priv, QCA8K_FDB_SEARCH, -1);
++	if (ret < 0)
++		goto exit;
++
++	ret = qca8k_fdb_read(priv, fdb);
++exit:
++	mutex_unlock(&priv->reg_mutex);
++	return ret;
++}
++
+ static int
+ qca8k_vlan_access(struct qca8k_priv *priv, enum qca8k_vlan_cmd cmd, u16 vid)
+ {
+@@ -1787,6 +1804,54 @@ qca8k_port_fdb_dump(struct dsa_switch *ds, int port,
+ 	return 0;
+ }
+ 
++static int
++qca8k_port_mdb_add(struct dsa_switch *ds, int port,
++		    const struct switchdev_obj_port_mdb *mdb)
++{
++	struct qca8k_priv *priv = ds->priv;
++	struct qca8k_fdb fdb = { 0 };
++	const u8 *addr = mdb->addr;
++	u8 port_mask = BIT(port);
++	u16 vid = mdb->vid;
++	int ret;
++
++	/* Check if entry already exist */
++	ret = qca8k_fdb_search(priv, &fdb, addr, vid);
++	if (ret < 0)
++		return ret;
++
++	/* Add port to fdb portmask */
++	fdb.port_mask |= port_mask;
++
++	return qca8k_port_fdb_insert(priv, addr, fdb.port_mask, vid);
++}
++
++static int
++qca8k_port_mdb_del(struct dsa_switch *ds, int port,
++		    const struct switchdev_obj_port_mdb *mdb)
++{
++	struct qca8k_priv *priv = ds->priv;
++	struct qca8k_fdb fdb = { 0 };
++	const u8 *addr = mdb->addr;
++	u8 port_mask = BIT(port);
++	u16 vid = mdb->vid;
++	int ret;
++
++	/* Check if entry already exist */
++	ret = qca8k_fdb_search(priv, &fdb, addr, vid);
++	if (ret < 0)
++		return ret;
++
++	/* Only port in the rule is this port. Remove rule */
++	if (fdb.port_mask == port_mask)
++		return qca8k_fdb_del(priv, addr, port_mask, vid);
++
++	/* Remove port from port mask */
++	fdb.port_mask &= ~port_mask;
++
++	return qca8k_port_fdb_insert(priv, addr, fdb.port_mask, vid);
++}
++
+ static int
+ qca8k_port_mirror_add(struct dsa_switch *ds, int port,
+ 		      struct dsa_mall_mirror_tc_entry *mirror,
+@@ -1989,6 +2054,8 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.port_fdb_add		= qca8k_port_fdb_add,
+ 	.port_fdb_del		= qca8k_port_fdb_del,
+ 	.port_fdb_dump		= qca8k_port_fdb_dump,
++	.port_mdb_add		= qca8k_port_mdb_add,
++	.port_mdb_del		= qca8k_port_mdb_del,
+ 	.port_mirror_add	= qca8k_port_mirror_add,
+ 	.port_mirror_del	= qca8k_port_mirror_del,
+ 	.port_vlan_filtering	= qca8k_port_vlan_filtering,
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-06-net-dsa-qca8k-add-LAG-support.patch
+++ b/target/linux/generic/pending-5.10/850-06-net-dsa-qca8k-add-LAG-support.patch
@@ -1,0 +1,205 @@
+From be7bec6ea00cc43a3c41213e13b2d6ef76e28fbf Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 18 Oct 2021 02:30:23 +0200
+Subject: [PATCH 6/7] net: dsa: qca8k: add LAG support
+
+Add LAG support to this switch. In Documentation this is described as
+trunk mode. A max of 4 LAGs are supported and each can support up to 4
+port. The only tx mode supported is Hash mode and no reference is
+present for active backup or any other mode in Documentation.
+When no port are present in the trunk, the trunk is disabled in the
+switch.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 114 ++++++++++++++++++++++++++++++++++++++++
+ drivers/net/dsa/qca8k.h |  24 +++++++++
+ 2 files changed, 138 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index d8a40d466c8c..2491905dafe8 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1195,6 +1195,9 @@ qca8k_setup(struct dsa_switch *ds)
+ 	ds->ageing_time_min = 7000;
+ 	ds->ageing_time_max = 458745000;
+ 
++	/* Set max number of LAGs supported */
++	ds->num_lag_ids = QCA8K_NUM_LAGS;
++
+ 	return 0;
+ }
+ 
+@@ -2034,6 +2037,118 @@ qca8k_get_tag_protocol(struct dsa_switch *ds, int port,
+ 	return DSA_TAG_PROTO_QCA;
+ }
+ 
++static bool
++qca8k_lag_can_offload(struct dsa_switch *ds,
++		      struct net_device *lag,
++		      struct netdev_lag_upper_info *info)
++{
++	struct dsa_port *dp;
++	int id, members = 0;
++
++	id = dsa_lag_id(ds->dst, lag);
++	if (id < 0 || id >= ds->num_lag_ids)
++		return false;
++
++	dsa_lag_foreach_port(dp, ds->dst, lag)
++		/* Includes the port joining the LAG */
++		members++;
++
++	if (members > QCA8K_NUM_PORTS_FOR_LAG)
++		return false;
++
++	if (info->tx_type != NETDEV_LAG_TX_TYPE_HASH)
++		return false;
++
++	return true;
++}
++
++static int
++qca8k_lag_refresh_portmap(struct dsa_switch *ds, int port,
++			  struct net_device *lag, bool delete)
++{
++	struct qca8k_priv *priv = ds->priv;
++	int ret, id, i;
++	u32 val;
++
++	id = dsa_lag_id(ds->dst, lag);
++
++	/* Read current port member */
++	ret = qca8k_read(priv, QCA8K_REG_GOL_TRUNK_CTRL0, &val);
++	if (ret)
++		return ret;
++
++	/* Shift val to the correct trunk */
++	val >>= QCA8K_REG_GOL_TRUNK_SHIFT(id);
++	val &= QCA8K_REG_GOL_TRUNK_MEMBER_MASK;
++	if (delete)
++		val &= ~BIT(port);
++	else
++		val |= BIT(port);
++
++	/* Update port member. With empty portmap disable trunk */
++	ret = qca8k_rmw(priv, QCA8K_REG_GOL_TRUNK_CTRL0,
++			QCA8K_REG_GOL_TRUNK_MEMBER(id) |
++			QCA8K_REG_GOL_TRUNK_EN(id),
++			!val << QCA8K_REG_GOL_TRUNK_SHIFT(id) |
++			val << QCA8K_REG_GOL_TRUNK_SHIFT(id));
++
++	/* Search empty member if adding or port on deleting */
++	for (i = 0; i < 4; i++) {
++		ret = qca8k_read(priv, QCA8K_REG_GOL_TRUNK_CTRL(id), &val);
++		if (ret)
++			return ret;
++
++		val >>= QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(id, i);
++		val &= QCA8K_REG_GOL_TRUNK_ID_MEM_ID_MASK;
++
++		if (delete) {
++			/* If port flagged to be disabled assume this member is
++			 * empty
++			 */
++			if (val != QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN_MASK)
++				continue;
++
++			val &= QCA8K_REG_GOL_TRUNK_ID_MEM_ID_PORT_MASK;
++			if (val != port)
++				continue;
++		} else {
++			/* If port flagged to be enabled assume this member is
++			 * already set
++			 */
++			if (val == QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN_MASK)
++				continue;
++		}
++
++		/* We find the member to remove */
++		break;
++	}
++
++	/* Set port in the correct port mask or disable port if in delate mode */
++	return qca8k_rmw(priv, QCA8K_REG_GOL_TRUNK_CTRL(id),
++			 QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN(id, i) |
++			 QCA8K_REG_GOL_TRUNK_ID_MEM_ID_PORT(id, i),
++			 !delete << QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(id, i) |
++			 port << QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(id, i));
++}
++
++static int
++qca8k_port_lag_join(struct dsa_switch *ds, int port,
++		    struct net_device *lag,
++		    struct netdev_lag_upper_info *info)
++{
++	if (!qca8k_lag_can_offload(ds, lag, info))
++		return -EOPNOTSUPP;
++
++	return qca8k_lag_refresh_portmap(ds, port, lag, false);
++}
++
++static int
++qca8k_port_lag_leave(struct dsa_switch *ds, int port,
++		     struct net_device *lag)
++{
++	return qca8k_lag_refresh_portmap(ds, port, lag, true);
++}
++
+ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.get_tag_protocol	= qca8k_get_tag_protocol,
+ 	.setup			= qca8k_setup,
+@@ -2067,6 +2179,8 @@ static const struct dsa_switch_ops qca8k_switch_ops = {
+ 	.phylink_mac_link_down	= qca8k_phylink_mac_link_down,
+ 	.phylink_mac_link_up	= qca8k_phylink_mac_link_up,
+ 	.get_phy_flags		= qca8k_get_phy_flags,
++	.port_lag_join		= qca8k_port_lag_join,
++	.port_lag_leave		= qca8k_port_lag_leave,
+ };
+ 
+ static int qca8k_read_switch_id(struct qca8k_priv *priv)
+diff --git a/drivers/net/dsa/qca8k.h b/drivers/net/dsa/qca8k.h
+index cd5076c1f046..85d7073d2026 100644
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -14,6 +14,8 @@
+ 
+ #define QCA8K_NUM_PORTS					7
+ #define QCA8K_MAX_MTU					9000
++#define QCA8K_NUM_LAGS					4
++#define QCA8K_NUM_PORTS_FOR_LAG				4
+ 
+ #define PHY_ID_QCA8327					0x004dd034
+ #define QCA8K_ID_QCA8327				0x12
+@@ -188,6 +190,28 @@
+ #define   QCA8K_PORT_LOOKUP_LEARN			BIT(20)
+ #define   QCA8K_PORT_LOOKUP_ING_MIRROR_EN		BIT(25)
+ 
++#define QCA8K_REG_GOL_TRUNK_CTRL0			0x700
++/* 4 max trunk first
++ * first 6 bit for member bitmap
++ * 7th bit is to enable trunk port
++ */
++#define QCA8K_REG_GOL_TRUNK_SHIFT(_i)			((_i) * 8)
++#define QCA8K_REG_GOL_TRUNK_EN_MASK			BIT(7)
++#define QCA8K_REG_GOL_TRUNK_EN(_i)			(QCA8K_REG_GOL_TRUNK_EN_MASK << QCA8K_REG_GOL_TRUNK_SHIFT(_i))
++#define QCA8K_REG_GOL_TRUNK_MEMBER_MASK			GENMASK(6, 0)
++#define QCA8K_REG_GOL_TRUNK_MEMBER(_i)			(QCA8K_REG_GOL_TRUNK_MEMBER_MASK << QCA8K_REG_GOL_TRUNK_SHIFT(_i))
++/* 0x704 for TRUNK 0-1 --- 0x708 for TRUNK 2-3 */
++#define QCA8K_REG_GOL_TRUNK_CTRL(_i)			(0x704 + (((_i) / 2) * 4))
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_MASK		GENMASK(3, 0)
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN_MASK		BIT(3)
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_PORT_MASK		GENMASK(2, 0)
++#define QCA8K_REG_GOL_TRUNK_ID_SHIFT(_i)		(((_i) / 2) * 16)
++#define QCA8K_REG_GOL_MEM_ID_SHIFT(_i)			((_i) * 4)
++/* Complex shift: FIRST shift for port THEN shift for trunk */
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(_i,_j)	(QCA8K_REG_GOL_MEM_ID_SHIFT(_j) + QCA8K_REG_GOL_TRUNK_ID_SHIFT(_i))
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN(_i,_j)		(QCA8K_REG_GOL_TRUNK_ID_MEM_ID_EN_MASK << QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(_i,_j))
++#define QCA8K_REG_GOL_TRUNK_ID_MEM_ID_PORT(_i,_j)	(QCA8K_REG_GOL_TRUNK_ID_MEM_ID_PORT_MASK << QCA8K_REG_GOL_TRUNK_ID_MEM_ID_SHIFT(_i,_j))
++
+ #define QCA8K_REG_GLOBAL_FC_THRESH			0x800
+ #define   QCA8K_GLOBAL_FC_GOL_XON_THRES(x)		((x) << 16)
+ #define   QCA8K_GLOBAL_FC_GOL_XON_THRES_S		GENMASK(24, 16)
+-- 
+2.32.0
+

--- a/target/linux/generic/pending-5.10/850-07-net-dsa-qca8k-enable-mtu_enforcement_ingress.patch
+++ b/target/linux/generic/pending-5.10/850-07-net-dsa-qca8k-enable-mtu_enforcement_ingress.patch
@@ -1,0 +1,31 @@
+From fbd00a0c47c071812bee168fbdb60a447fe752a7 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Mon, 18 Oct 2021 02:47:14 +0200
+Subject: [PATCH 7/7] net: dsa: qca8k: enable mtu_enforcement_ingress
+
+qca8k have a global MTU. Inform DSA of this as the change MTU port
+function checks the max MTU across all port and sets the max value
+anyway as this switch doesn't support per port MTU.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/net/dsa/qca8k.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/net/dsa/qca8k.c b/drivers/net/dsa/qca8k.c
+index 2491905dafe8..943843c468d1 100644
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1198,6 +1198,9 @@ qca8k_setup(struct dsa_switch *ds)
+ 	/* Set max number of LAGs supported */
+ 	ds->num_lag_ids = QCA8K_NUM_LAGS;
+ 
++	/* Global MTU. Inform dsa that per port MTU is not supported */
++	ds->mtu_enforcement_ingress = true;
++
+ 	return 0;
+ }
+ 
+-- 
+2.32.0
+


### PR DESCRIPTION
ALERT
--
It seems kernel 5.10 lacks any support for lag. This was later added to kernel 5.13+ so RIP. We will have to wait for 5.16.
I'm keeping the patch here just to track all the difference and version for anyone that wants to test these new feature.

The main idea is to **resurrect bloogic** patch and add all these missing feature and **the golden patch of hnat feature** :D 

THIS IS ONLY COMPILE TESTED.
--
I would REALLY appreciate anyone that can put some time testing fast aging and the mirror mode feature. They were present in the original driver and it can be useful for someone. Fast aging should be included to better handle bridge registration and change.

**Also this depends on the qca8k backport pr to correctly work. #4528**

Feature to implement:
---

- [x] aging setting
- [x] fast age
- [x] mirror port
- [x] multicast db (TO BE REWORKED... currently doesn't remove rule)
- [x] lag
- [x] alert DSA for global mtu
- [ ] hnat 

3 main feature here are actually NOT TESTED and also NO IDEA IF THEY WORK.

- Mirror port should be work but again NOT TESTED. But the implementation is not that strange.
- MDB function. From Documentation we should use ARL table but no idea if it does actually work.
- lag support is a big LOL. In Documentation it's defined as Trunk. The implementation looks to be correct but who know if it does actually work. i don't have a device to test it so i need to wait some good guy to test it.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>