### PR TITLE
[21.02] ipq40xx: ar40xx: reset port status register

### DIFF
--- a/target/linux/ipq40xx/files/drivers/net/phy/ar40xx.c
+++ b/target/linux/ipq40xx/files/drivers/net/phy/ar40xx.c
@@ -1198,8 +1198,7 @@ ar40xx_init_port(struct ar40xx_priv *priv, int port)
 {
 	u32 t;
 
-	ar40xx_rmw(priv, AR40XX_REG_PORT_STATUS(port),
-			AR40XX_PORT_AUTO_LINK_EN, 0);
+	ar40xx_write(priv, AR40XX_REG_PORT_STATUS(port), 0);
 
 	ar40xx_write(priv, AR40XX_REG_PORT_HEADER(port), 0);
 


### PR DESCRIPTION
This resolves incosnsitencies of the configured RX / TX flow control
modes between different boards or bootloaders.
