### PR TITLE
tools/meson: fix usage with SDK

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -56,7 +56,7 @@ MESON_CPU:="$(CPU_TYPE)$(if $(CPU_SUBTYPE),+$(CPU_SUBTYPE))"
 endif
 
 define Meson
-	$(2) $(STAGING_DIR_HOST)/bin/meson $(1)
+	$(2) $(STAGING_DIR_HOST)/bin/$(PYTHON) $(STAGING_DIR_HOST)/bin/meson $(1)
 endef
 
 define Meson/CreateNativeFile

--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -21,7 +21,7 @@ endef
 
 define Host/Install
 	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin
-	$(HOST_BUILD_DIR)/packaging/create_zipapp.py $(HOST_BUILD_DIR) --interpreter $(STAGING_DIR_HOST)/bin/$(PYTHON) --outfile $(STAGING_DIR_HOST)/bin/meson
+	$(HOST_BUILD_DIR)/packaging/create_zipapp.py $(HOST_BUILD_DIR) --outfile $(STAGING_DIR_HOST)/bin/meson
 	$(INSTALL_DIR) $(STAGING_DIR_HOST)/lib/meson
 	$(INSTALL_CONF) files/openwrt-cross.txt.in $(STAGING_DIR_HOST)/lib/meson/
 	$(INSTALL_CONF) files/openwrt-native.txt.in $(STAGING_DIR_HOST)/lib/meson/


### PR DESCRIPTION
The python path cannot be embedded in the meson binary as it changes
with the SDK.

Signed-off-by: Rosen Penev <rosenp@gmail.com>