### PR TITLE
ipq40xx: use zImage for GL.iNet GL-B1300, GL-S1300 to shrink below 4096k

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -495,7 +495,7 @@ endef
 TARGET_DEVICES += glinet_gl-ap1300
 
 define Device/glinet_gl-b1300
-	$(call Device/FitImage)
+	$(call Device/FitzImage)
 	DEVICE_VENDOR := GL.iNet
 	DEVICE_MODEL := GL-B1300
 	BOARD_NAME := gl-b1300
@@ -507,7 +507,7 @@ endef
 TARGET_DEVICES += glinet_gl-b1300
 
 define Device/glinet_gl-s1300
-	$(call Device/FitImage)
+	$(call Device/FitzImage)
 	DEVICE_VENDOR := GL.iNet
 	DEVICE_MODEL := GL-S1300
 	SOC := qcom-ipq4029


### PR DESCRIPTION
This is the oneliner for GL-B1300 and GL-S1300 to survive the k5.10 switch (#4620).

I don't have GL-S1300, but I think this fix helps that device too: they use the same [U-Boot binary](https://github.com/gl-inet/uboot-ipq40xx).