### PR TITLE
ath79: Fix mac addresses for devices using mtdparts (variant 1)

### DIFF
--- a/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
+++ b/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
@@ -130,33 +130,17 @@
 &eth0 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x6>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &wmac {
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
+++ b/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
@@ -142,31 +142,15 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x6>;
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &wmac {
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -96,8 +96,7 @@
 
 	pll-data = <0x02000000 0x00000101 0x00001313>;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
@@ -114,8 +113,7 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <1>;
 };
 
@@ -126,18 +124,7 @@
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		qca,no-eeprom;
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		mtd-mac-address = <&art 0x0>;
 		mac-address-increment = <8>;
-	};
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
@@ -145,33 +145,17 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x6>;
 };
 
 &eth1 {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &wmac {
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
+++ b/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
@@ -132,8 +132,7 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &eth1 {
@@ -142,29 +141,13 @@
 	 */
 	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
 
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x6>;
 };
 
 &wmac {
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <2>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
+++ b/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
@@ -114,8 +114,7 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 };
 
 &eth1 {
@@ -124,8 +123,7 @@
 	 */
 	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <1>;
 };
 
@@ -133,17 +131,6 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <2>;
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
@@ -140,8 +140,7 @@
 
 	pll-data = <0x82000101 0x80000101 0x80001313>;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy1>;
@@ -161,8 +160,7 @@
 
 	pll-data = <0x03000101 0x80000101 0x80001313>;
 
-	nvmem-cells = <&macaddr_art_6>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x6>;
 
 	qca955x-sgmii-fixup;
 
@@ -173,25 +171,10 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <2>;
 };
 
 &pcie0 {
 	status = "okay";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
-
-	macaddr_art_6: macaddr@6 {
-		reg = <0x6 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
@@ -141,8 +141,7 @@
 
 	pll-data = <0x82000000 0x80000101 0x80001313>;
 
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy5>;
@@ -157,21 +156,10 @@
 	status = "okay";
 
 	mtd-cal-data = <&art 0x1000>;
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&art 0x0>;
 	mac-address-increment = <1>;
 };
 
 &pcie0 {
 	status = "okay";
-};
-
-&art {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_art_0: macaddr@0 {
-		reg = <0x0 0x6>;
-	};
 };

--- a/target/linux/ath79/dts/qca9558_openmesh_mr900-v1.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr900-v1.dts
@@ -19,8 +19,7 @@
 	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		mtd-mac-address = <&art 0x0>;
 		mac-address-increment = <16>;
 	};
 };

--- a/target/linux/ath79/dts/qca9558_openmesh_mr900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr900-v2.dts
@@ -19,8 +19,7 @@
 	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0>;
-		nvmem-cell-names = "mac-address";
+		mtd-mac-address = <&art 0x0>;
 		mac-address-increment = <16>;
 	};
 };

--- a/target/linux/generic/pending-5.10/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
+++ b/target/linux/generic/pending-5.10/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
@@ -1,0 +1,102 @@
+From 6f8e5369ae054ec6c9265581d5a7e39738a5cd84 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 30 Mar 2021 13:16:38 +0200
+Subject: [PATCH 1/2] NET: add mtd-mac-address support to of_get_mac_address()
+
+Many embedded devices have information such as mac addresses stored inside mtd
+devices. This patch allows us to add a property inside a node describing a
+network interface. The new property points at a mtd partition with an offset
+where the mac address can be found.
+
+Signed-off-by: John Crispin <blogic@openwrt.org>
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/of/of_net.c | 75 ++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 74 insertions(+), 1 deletion(-)
+
+--- a/drivers/of/of_net.c
++++ b/drivers/of/of_net.c
+@@ -12,6 +12,7 @@
+ #include <linux/export.h>
+ #include <linux/device.h>
+ #include <linux/nvmem-consumer.h>
++#include <linux/mtd/mtd.h>
+ 
+ /**
+  * of_get_phy_mode - Get phy mode for given device_node
+@@ -95,6 +96,52 @@ static int of_get_mac_addr_nvmem(struct
+ 	return 0;
+ }
+ 
++static int of_get_mac_address_mtd(struct device_node *np, u8 *addr)
++{
++#ifdef CONFIG_MTD
++	struct platform_device *pdev = of_find_device_by_node(np);
++	struct device_node *mtd_np = NULL;
++	size_t retlen;
++	int size, ret;
++	struct mtd_info *mtd;
++	const char *part;
++	const __be32 *list;
++	phandle phandle;
++	u8 mac[ETH_ALEN];
++
++	list = of_get_property(np, "mtd-mac-address", &size);
++	if (!list || (size != (2 * sizeof(*list))))
++		return -ENODEV;
++
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
++		return -ENODEV;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return -ENODEV;
++
++	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
++	put_mtd_device(mtd);
++
++	if (!is_valid_ether_addr(mac))
++		return -EINVAL;
++
++	memcpy(addr, mac, ETH_ALEN);
++
++	return 0;
++#endif
++	return -EINVAL;
++}
++
++
+ /**
+  * Search the device tree for the best MAC address to use.  'mac-address' is
+  * checked first, because that is supposed to contain to "most recent" MAC
+@@ -115,6 +162,10 @@ static int of_get_mac_addr_nvmem(struct
+  * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
+  * but is all zeros.
+  *
++ *
++ * If a mtd-mac-address property exists, try to fetch the MAC address from the
++ * specified mtd device.
++ *
+  * Return: 0 on success and errno in case of error.
+ */
+ int of_get_mac_address(struct device_node *np, u8 *addr)
+@@ -136,6 +187,10 @@ int of_get_mac_address(struct device_nod
+ 	if (!ret)
+ 		return 0;
+ 
++	ret = of_get_mac_address_mtd(np, addr);
++	if (!ret)
++		return 0;
++
+ 	return of_get_mac_addr_nvmem(np, addr);
+ }
+ EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
@@ -20,9 +20,9 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -115,27 +115,52 @@ static int of_get_mac_addr_nvmem(struct
-  * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
-  * but is all zeros.
+@@ -166,31 +166,56 @@ static int of_get_mac_address_mtd(struct
+  * If a mtd-mac-address property exists, try to fetch the MAC address from the
+  * specified mtd device.
   *
 + * DT can tell the system to increment the mac-address after is extracted by
 + * using:
@@ -61,6 +61,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		goto found;
  
  	ret = of_get_mac_addr(np, "address", addr);
+ 	if (!ret)
+-		return 0;
++		goto found;
+ 
+ 	ret = of_get_mac_address_mtd(np, addr);
  	if (!ret)
 -		return 0;
 +		goto found;

--- a/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
@@ -1,7 +1,7 @@
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -95,6 +95,27 @@ static int of_get_mac_addr_nvmem(struct
- 	return 0;
+@@ -141,6 +141,26 @@ static int of_get_mac_address_mtd(struct
+ 	return -EINVAL;
  }
  
 +static int of_add_mac_address(struct device_node *np, u8* addr)
@@ -24,11 +24,10 @@
 +	kfree(prop);
 +	return -ENOMEM;
 +}
-+
+ 
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
-  * checked first, because that is supposed to contain to "most recent" MAC
-@@ -161,6 +182,7 @@ found:
+@@ -216,6 +236,7 @@ found:
  	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
  		addr[inc_idx] += mac_inc;
  

--- a/target/linux/generic/pending-5.4/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
+++ b/target/linux/generic/pending-5.4/681-NET-add-mtd-mac-address-support-to-of_get_mac_addres.patch
@@ -1,0 +1,102 @@
+From 6f8e5369ae054ec6c9265581d5a7e39738a5cd84 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 30 Mar 2021 13:16:38 +0200
+Subject: [PATCH 1/2] NET: add mtd-mac-address support to of_get_mac_address()
+
+Many embedded devices have information such as mac addresses stored inside mtd
+devices. This patch allows us to add a property inside a node describing a
+network interface. The new property points at a mtd partition with an offset
+where the mac address can be found.
+
+Signed-off-by: John Crispin <blogic@openwrt.org>
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ drivers/of/of_net.c | 75 ++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 74 insertions(+), 1 deletion(-)
+
+--- a/drivers/of/of_net.c
++++ b/drivers/of/of_net.c
+@@ -12,6 +12,7 @@
+ #include <linux/export.h>
+ #include <linux/device.h>
+ #include <linux/nvmem-consumer.h>
++#include <linux/mtd/mtd.h>
+ 
+ /**
+  * of_get_phy_mode - Get phy mode for given device_node
+@@ -89,6 +90,52 @@ static int of_get_mac_addr_nvmem(struct
+ 	return 0;
+ }
+ 
++static int of_get_mac_address_mtd(struct device_node *np, u8 *addr)
++{
++#ifdef CONFIG_MTD
++	struct platform_device *pdev = of_find_device_by_node(np);
++	struct device_node *mtd_np = NULL;
++	size_t retlen;
++	int size, ret;
++	struct mtd_info *mtd;
++	const char *part;
++	const __be32 *list;
++	phandle phandle;
++	u8 mac[ETH_ALEN];
++
++	list = of_get_property(np, "mtd-mac-address", &size);
++	if (!list || (size != (2 * sizeof(*list))))
++		return -ENODEV;
++
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
++		return -ENODEV;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return -ENODEV;
++
++	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
++	put_mtd_device(mtd);
++
++	if (!is_valid_ether_addr(mac))
++		return -EINVAL;
++
++	memcpy(addr, mac, ETH_ALEN);
++
++	return 0;
++#endif
++	return -EINVAL;
++}
++
++
+ /**
+  * Search the device tree for the best MAC address to use.  'mac-address' is
+  * checked first, because that is supposed to contain to "most recent" MAC
+@@ -109,6 +156,10 @@ static int of_get_mac_addr_nvmem(struct
+  * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
+  * but is all zeros.
+  *
++ *
++ * If a mtd-mac-address property exists, try to fetch the MAC address from the
++ * specified mtd device.
++ *
+  * Return: 0 on success and errno in case of error.
+ */
+ int of_get_mac_address(struct device_node *np, u8 *addr)
+@@ -130,6 +181,10 @@ int of_get_mac_address(struct device_nod
+ 	if (!ret)
+ 		return 0;
+ 
++	ret = of_get_mac_address_mtd(np, addr);
++	if (!ret)
++		return 0;
++
+ 	return of_get_mac_addr_nvmem(np, addr);
+ }
+ EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
@@ -20,9 +20,9 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -109,27 +109,52 @@ static int of_get_mac_addr_nvmem(struct
-  * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
-  * but is all zeros.
+@@ -160,31 +160,56 @@ static int of_get_mac_address_mtd(struct
+  * If a mtd-mac-address property exists, try to fetch the MAC address from the
+  * specified mtd device.
   *
 + * DT can tell the system to increment the mac-address after is extracted by
 + * using:
@@ -61,6 +61,11 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		goto found;
  
  	ret = of_get_mac_addr(np, "address", addr);
+ 	if (!ret)
+-		return 0;
++		goto found;
+ 
+ 	ret = of_get_mac_address_mtd(np, addr);
  	if (!ret)
 -		return 0;
 +		goto found;

--- a/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
@@ -1,7 +1,7 @@
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -89,6 +89,27 @@ static int of_get_mac_addr_nvmem(struct
- 	return 0;
+@@ -135,6 +135,26 @@ static int of_get_mac_address_mtd(struct
+ 	return -EINVAL;
  }
  
 +static int of_add_mac_address(struct device_node *np, u8* addr)
@@ -24,11 +24,10 @@
 +	kfree(prop);
 +	return -ENOMEM;
 +}
-+
+ 
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
-  * checked first, because that is supposed to contain to "most recent" MAC
-@@ -155,6 +176,7 @@ found:
+@@ -210,6 +230,7 @@ found:
  	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
  		addr[inc_idx] += mac_inc;
  


### PR DESCRIPTION
**This is the variant which returns to the old mtd-mac-address hack for some devices which are known to be affected. There is a potential second variant https://github.com/openwrt/openwrt/pull/4731 which avoids changes to the DTS by introducing an of-compat hack in the mtdparts cmdline parser. I have tested this other PR sucessfully together with the pending OpenMesh devices in https://github.com/ecsv/openwrt/compare/base...ecsv:openmesh-nvmem-mtdparts**

This reverts commit 5ae2e786395c ("kernel: drop support for mtd-mac-address") and partially commit abc17bf306ac ("ath79: convert mtd-mac-address to nvmem implementation"). The nvmem-cell based mac-address code doesn't support nvmem-cell definitions which try to reference partitions which are not defined using the devicetree but by the bootloader using Linux kernel's cmdline parameter mtdparts.

Devices which used mtdparts print following messages when booting up:

    libphy: Fixed MDIO Bus: probed
    ag71xx 19000000.eth: invalid MAC address, using random address
    libphy: ag71xx_mdio: probed
    ag71xx 19000000.eth: connected to PHY at mdio.0:01 [uid=004dd072, driver=Atheros 8035 ethernet]
    eth0: Atheros AG71xx at 0xb9000000, irq 4, mode: rgmii-id
    ag71xx 1a000000.eth: invalid MAC address, using random address
    ag71xx 1a000000.eth: connected to PHY at mdio.0:02 [uid=004dd074, driver=Atheros 8031 ethernet]

These devices must therefore be able to use the old mtd-mac-address based lookup until there is actually support for generic mtd based devices in the nvmem(-cell) kernel code. I have also asked the kernel maintainers if it is maybe already supported and I've just missed it: https://lists.openwrt.org/pipermail/openwrt-devel/2021-October/036687.html