### PR TITLE
dnsmasq: fix ipset with multi domain

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -791,25 +791,23 @@ dhcp_relay_add() {
 
 dnsmasq_ipset_add() {
 	local cfg="$1"
-	local ipsets domains
+	local ipsets
 
 	add_ipset() {
 		ipsets="${ipsets:+$ipsets,}$1"
 	}
 
 	add_domain() {
-		# leading '/' is expected
-		domains="$domains/$1"
+		xappend "--ipset=/$1/$ipsets"
 	}
 
 	config_list_foreach "$cfg" "name" add_ipset
-	config_list_foreach "$cfg" "domain" add_domain
 
-	if [ -z "$ipsets" ] || [ -z "$domains" ]; then
+	if [ -z "$ipsets" ]; then
 		return 0
 	fi
 
-	xappend "--ipset=$domains/$ipsets"
+	config_list_foreach "$cfg" "domain" add_domain
 }
 
 dnsmasq_start()


### PR DESCRIPTION
Adding a lot of domains to a single ipset option crashes dnsmasq.
E.g. the issue is relevant for IP sets with DoH domains:
https://github.com/dibdot/DoH-IP-blocklists/blob/master/doh-domains.txt
Split ipset config lines by domain to avoid dnsmasq crashing.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>