### PR TITLE
[RFC] feeds: enable video feed again

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -2,7 +2,7 @@ src-git packages https://git.openwrt.org/feed/packages.git
 src-git luci https://git.openwrt.org/project/luci.git
 src-git routing https://git.openwrt.org/feed/routing.git
 src-git telephony https://git.openwrt.org/feed/telephony.git
-#src-git video https://github.com/openwrt/video.git
+src-git video https://git.openwrt.org/feed/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git
 #src-link custom /usr/src/openwrt/custom-feed


### PR DESCRIPTION
The video feed recently received support for Wayland and many devices
supporting OpenWrt could be used for e.g. Kiosk deployments, showing the
content of a website or similar.

Enabling the feed again allows user to easily test these packages.

Signed-off-by: Paul Spooren <mail@aparcar.org>