### PR TITLE
ramips: add support for Telewell TW-4G (LTE) router

### DIFF
--- a/target/linux/ramips/dts/mt7620a_telewell_tw-4g-lte.dts
+++ b/target/linux/ramips/dts/mt7620a_telewell_tw-4g-lte.dts
@@ -1,0 +1,169 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "telewell,tw-4g-lte", "ralink,mt7620a-soc";
+	model = "Telewell TW-4G (LTE)";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "green:status";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usbpower {
+			gpio-export,name = "usbpower";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "amit,jimage";
+				label = "firmware";
+				reg = <0x10000 0xfe0000>;
+			};
+
+			config: partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		phy-mode = "rgmii";
+		mediatek,fixed-link = <1000 1 1 1>;
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+			qca,ar8327-initvals = <
+				0x04 0x87300000 /* PORT0 PAD MODE CTRL */
+				0x0c 0x00000000 /* PORT6 PAD MODE CTRL */
+				0x7c 0x0000007e /* PORT0_STATUS */
+				0x94 0x00000000 /* PORT6_STATUS */
+			>;
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <8>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&config 0xe08c>;
+		nvmem-cells = <&macaddr_config_e080>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uartf", "i2c";
+		function = "gpio";
+	};
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_e080: macaddr@e080 {
+		reg = <0xe080 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1015,6 +1015,19 @@ define Device/sitecom_wlr-4100-v1-002
 endef
 TARGET_DEVICES += sitecom_wlr-4100-v1-002
 
+define Device/telewell_tw-4g-lte
+  $(Device/amit_jboot)
+  SOC := mt7620a
+  IMAGE_SIZE := 16256k
+  DEVICE_VENDOR := Telewell
+  DEVICE_MODEL := TW-4G (LTE)
+  DLINK_ROM_ID := TLW6E3804001
+  DLINK_FAMILY_MEMBER := 0x6E38
+  DLINK_FIRMWARE_SIZE := 0xFE0000
+  DEVICE_PACKAGES += kmod-mt76x0e
+endef
+TARGET_DEVICES += telewell_tw-4g-lte
+
 define Device/tplink_archer-c20i
   $(Device/tplink-v2)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -211,6 +211,13 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:3" "1:lan:2" "2:lan:1" "3:wan" "6@eth0"
 		;;
+	telewell,tw-4g-lte)
+		ucidef_add_switch "switch0" \
+			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "0@eth0"
+		ucidef_add_switch "switch1" \
+			"5:lan" "6@eth0"
+		ucidef_add_switch_attr "switch1" "enable" "false"
+		;;
 	tplink,archer-c20i|\
 	tplink,archer-c20-v1|\
 	tplink,archer-c50-v1)
@@ -306,7 +313,8 @@ ramips_setup_macs()
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
 	dlink,dwr-960|\
-	lava,lr-25g001)
+	lava,lr-25g001|\
+	telewell,tw-4g-lte)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -29,7 +29,8 @@ case "$FIRMWARE" in
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
 	dlink,dwr-960|\
-	lava,lr-25g001)
+	lava,lr-25g001|\
+	telewell,tw-4g-lte)
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000


### PR DESCRIPTION
- 2.4GHz wifi working ok
- 5GHz wifi shows up but power is very weak
- WPA3 security will put this hardware on it's knees, better to use WPA2
- This device is clone of Lava lr25g001 router
