### PR TITLE
sunxi: enable rtc-sun6i driver

### DIFF
--- a/target/linux/sunxi/modules.mk
+++ b/target/linux/sunxi/modules.mk
@@ -20,6 +20,24 @@ endef
 
 $(eval $(call KernelPackage,rtc-sunxi))
 
+define KernelPackage/rtc-sun6i
+    SUBMENU:=$(OTHER_MENU)
+    TITLE:=Sun6i SoC built-in RTC support
+    DEPENDS:=@TARGET_sunxi
+    $(call AddDepends/rtc)
+    KCONFIG:= \
+	CONFIG_RTC_DRV_SUN6I \
+	CONFIG_RTC_CLASS=y
+    FILES:=$(LINUX_DIR)/drivers/rtc/rtc-sun6i.ko
+    AUTOLOAD:=$(call AutoLoad,50,rtc-sun6i)
+endef
+
+define KernelPackage/rtc-sun6i/description
+ Support for the AllWinner sun6i SoC's onboard RTC
+endef
+
+$(eval $(call KernelPackage,rtc-sun6i))
+
 define KernelPackage/sunxi-ir
     SUBMENU:=$(OTHER_MENU)
     TITLE:=Sunxi SoC built-in IR support (A20)


### PR DESCRIPTION
old PR: #4483  can't reopen PR after force push

AP6212 wifi need wifi_pwrseq, but from OrangePi Lite 2 dts :
```
wifi_pwrseq: wifi_pwrseq {
	compatible = "mmc-pwrseq-simple";
	clocks = <&rtc 1>;
	clock-names = "ext_clock";
	reset-gpios = <&r_pio 1 3 GPIO_ACTIVE_LOW>; /* PM3 */
	post-power-on-delay-ms = <200>;
};
```

this pwrseq need rtc clock, or kernel won't find this device.
but now rtc-sunxi.c onlysupport A10/A20.
Orangepi Lite 2 use H6 ,from rtc-sun6i.c show compatible is
```
	{ .compatible = "allwinner,sun6i-a31-rtc" },
	{ .compatible = "allwinner,sun8i-a23-rtc" },
	{ .compatible = "allwinner,sun8i-h3-rtc" },
	{ .compatible = "allwinner,sun8i-r40-rtc" },
	{ .compatible = "allwinner,sun8i-v3-rtc" },
	{ .compatible = "allwinner,sun50i-h5-rtc" },
	{ .compatible = "allwinner,sun50i-h6-rtc" },
```
So it need this to let kernel find this mmc wifi device.
