### PR TITLE
Build: prereq more python 3.10 fixes

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -159,7 +159,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.5, \
 	python3.7 -V 2>&1 | grep 'Python 3', \
 	python3.6 -V 2>&1 | grep 'Python 3', \
 	python3.5 -V 2>&1 | grep 'Python 3', \
-	python3 -V 2>&1 | grep -E 'Python 3\.[5-9]\.?'))
+	python3 -V 2>&1 | grep -E 'Python 3\.([5-9]|10)\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.5, \
 	python3.10 -V 2>&1 | grep 'Python 3', \
@@ -168,7 +168,7 @@ $(eval $(call SetupHostCommand,python3,Please install Python >= 3.5, \
 	python3.7 -V 2>&1 | grep 'Python 3', \
 	python3.6 -V 2>&1 | grep 'Python 3', \
 	python3.5 -V 2>&1 | grep 'Python 3', \
-	python3 -V 2>&1 | grep -E 'Python 3\.[5-9]\.?'))
+	python3 -V 2>&1 | grep -E 'Python 3\.([5-9]|10)\.?'))
 
 $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \


### PR DESCRIPTION
"[5-9]" won't catch python3 minor version 10 so we need "or" matching

