### PR TITLE
imagebuilder: fix local packages/ folder

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -46,12 +46,16 @@ ifeq ($(CONFIG_IB_STANDALONE),)
 	$(VERSION_SED_SCRIPT) $(PKG_BUILD_DIR)/repositories.conf
 endif
 
-ifeq ($(CONFIG_BUILDBOT),)
 	$(INSTALL_DIR) $(PKG_BUILD_DIR)/packages
+	# create an empty package index so `opkg` doesn't report an error
+	touch $(PKG_BUILD_DIR)/packages/Packages
+	$(INSTALL_DATA) ./files/README.md $(PKG_BUILD_DIR)/packages/
+
 	echo ''                                                        >> $(PKG_BUILD_DIR)/repositories.conf
 	echo '## This is the local package repository, do not remove!' >> $(PKG_BUILD_DIR)/repositories.conf
 	echo 'src imagebuilder file:packages'                          >> $(PKG_BUILD_DIR)/repositories.conf
 
+ifeq ($(CONFIG_BUILDBOT),)
   ifeq ($(CONFIG_IB_STANDALONE),)
 	$(FIND) $(call FeedPackageDir,libc) -type f \
 		\( -name 'libc_*.ipk' -or -name 'kernel_*.ipk' -or -name 'kmod-*.ipk' \) \

--- a/target/imagebuilder/files/README.md
+++ b/target/imagebuilder/files/README.md
@@ -1,0 +1,11 @@
+# ./packages folder
+
+Add `.ipk` packages to this folder will allow the ImageBuilder to install them.
+
+For more complex setups consider adding a custom feed containing packages.
+
+    src custom file:///path/to/packages
+
+Whenever the ImageBuilder builds a firmware image this folder will be reloaded
+and a new package index created. In case signature checks are enabled the
+`./packages/Packages` index will be signed with a locally generated key pair.


### PR DESCRIPTION
This commit fixes commit "2999f810ff: build,IB: include kmods only in
local builds" which cause the local packages/ folder only to be added
for local builds but no longer for ImageBuilder created by the Buildbot.

The commits intention was to use remote kmods repositories rather than
storing them locally. Accidentally the entire handling of the local
`packages/` was removed.

Re-add the folder and include a README describing what it can be used
for.

Signed-off-by: Paul Spooren <mail@aparcar.org>