### PR TITLE
ramips: mt7621: use trgmii for switch

### DIFF
--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -534,7 +534,7 @@
 						reg = <6>;
 						label = "cpu";
 						ethernet = <&gmac0>;
-						phy-mode = "rgmii";
+						phy-mode = "trgmii";
 
 						fixed-link {
 							speed = <1000>;


### PR DESCRIPTION
trgmii support came in kernel 5.3. Bumps CPU port speed to 1200Mbit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>