### PR TITLE
ramips: fix dtc warnings for telco-electronics_x1

### DIFF
--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -166,25 +166,25 @@
 
 &pcie {
 	status = "okay";
+};
 
-	pcie0 {
-		wifi@0,0 {
-			compatible = "pci14c3,7603";
-			reg = <0x0000 0 0 0 0>;
-			mediatek,mtd-eeprom = <&factory 0x0000>;
-			ieee80211-freq-limit = <2400000 2500000>;
-		};
+&pcie0 {
+	wifi@0,0 {
+		compatible = "pci14c3,7603";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
 	};
+};
 
-	pcie1 {
-		wifi@0,0 {
-			compatible = "pci14c3,7662";
-			reg = <0x0000 0 0 0 0>;
-			mediatek,mtd-eeprom = <&factory 0x8000>;
-			ieee80211-freq-limit = <5000000 6000000>;
-			led {
-				led-sources = <2>;
-			};
+&pcie1 {
+	wifi@0,0 {
+		compatible = "pci14c3,7662";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		led {
+			led-sources = <2>;
 		};
 	};
 };


### PR DESCRIPTION
In all other dts files, the entire block is not edited like this.
They're edited separately.

Signed-off-by: Rosen Penev <rosenp@gmail.com>