### PR TITLE
ramips: add missing address-cells

### DIFF
--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -77,6 +77,8 @@
 		gpio: gpio@600 {
 			#gpio-cells = <2>;
 			#interrupt-cells = <2>;
+			#address-cells = <2>;
+
 			compatible = "mediatek,mt7621-gpio";
 			gpio-controller;
 			interrupt-controller;
@@ -404,6 +406,8 @@
 	};
 
 	gic: interrupt-controller@1fbc0000 {
+		#address-cells = <2>;
+
 		compatible = "mti,gic";
 		reg = <0x1fbc0000 0x2000>;
 


### PR DESCRIPTION
Fixes dtc warning:

Missing #address-cells in interrupt provider

Signed-off-by: Rosen Penev <rosenp@gmail.com>