### PR TITLE
wolfssl: fix compile when enable-devcrypto is set

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
 PKG_VERSION:=4.8.1-stable
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)

--- a/package/libs/wolfssl/patches/002-Update-macro-guard-on-SHA256-transform-call.patch
+++ b/package/libs/wolfssl/patches/002-Update-macro-guard-on-SHA256-transform-call.patch
@@ -1,0 +1,22 @@
+From f447e4c1fa4c932c0286fa0331966756e243db81 Mon Sep 17 00:00:00 2001
+From: JacobBarthelmeh <jacob@wolfssl.com>
+Date: Fri, 17 Sep 2021 15:06:13 -0700
+Subject: [PATCH] update macro guard on SHA256 transform call
+
+---
+ src/ssl.c   | 3 ++-
+ tests/api.c | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+--- a/src/ssl.c
++++ b/src/ssl.c
+@@ -17639,7 +17639,8 @@ size_t wolfSSL_get_client_random(const W
+     
+     #if defined(OPENSSL_EXTRA)
+     #if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || \
+-        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))
++        (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))) && \
++        !defined(WOLFSSL_DEVCRYPTO_HASH) && !defined(WOLFSSL_AFALG_HASH)
+     /* Apply SHA256 transformation to the data */
+     int wolfSSL_SHA256_Transform(WOLFSSL_SHA256_CTX* sha256, 
+                                                 const unsigned char* data)


### PR DESCRIPTION
fixing linking error when --enable-devcrypto=yes
fixes: 7d92bb050961 wolfssl: update to 4.8.1-stable
