### PR TITLE
linux-firmware: add firmware for intel ax200 and cypress-nvram: fix firmware is not exist for raspberry pi compute 4 

### DIFF
--- a/package/firmware/cypress-nvram/Makefile
+++ b/package/firmware/cypress-nvram/Makefile
@@ -100,6 +100,9 @@ define Package/cypress-nvram-43455-sdio-rpi-4b/install
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
+		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt
 endef
 
 $(eval $(call BuildPackage,cypress-nvram-43455-sdio-rpi-4b))

--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -7,6 +7,13 @@ define Package/ibt-firmware/install
 endef
 $(eval $(call BuildPackage,ibt-firmware))
 
+Package/iwlwifi-firmware-ax200 = $(call Package/firmware-default,Intel AX200 firmware)
+define Package/iwlwifi-firmware-ax200/install
+	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-cc-a0-62.ucode $(1)/lib/firmware
+endef
+$(eval $(call BuildPackage,iwlwifi-firmware-ax200))
+
 Package/iwl3945-firmware = $(call Package/firmware-default,Intel IWL3945 firmware)
 define Package/iwl3945-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware


### PR DESCRIPTION
To solving raspberry pi cm4 can not found firmware problem,  I add file "brcmfmac43455-sdio.raspberrypi,4-compute-module.txt" to "/lib/firmware/brcm".

And then add firmware to "/lib/firmware" for support intel ax200 PCIe wireless network card.

Thank you.