### PR TITLE
ramips: Fix Lava lr-25g001 broken wifi leds

### DIFF
--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -41,11 +41,13 @@
 		wifi2g {
 			label = "green:wifi2g";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wifi5g {
 			label = "green:wifi5g";
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -143,10 +143,6 @@ kingston,mlwg2|\
 sanlinking,d240)
 	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	;;
-lava,lr-25g001)
-	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "green:wlan2g" "wlan1"
-	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "green:wlan5g" "wlan0"
-	;;
 lenovo,newifi-y1)
 	ucidef_set_led_netdev "wifi" "WIFI" "blue:wifi" "wlan1"
 	ucidef_set_led_netdev "wifi5g" "WIFI5G" "blue:wifi5g" "wlan0"


### PR DESCRIPTION
Led names for this device was different in 01_leds file and in device .dts
Switched to DT triggers, what works on Telewell TW-4 (LTE) clone device.
Someone need to test this if they works on Lava.

This should be backported also to 21.02

Signed-off-by: Jani Partanen <rtfm@iki.fi>
