### PR TITLE
[PoC] wireguard-tools: switch to netifd extdev

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -39,7 +39,8 @@ define Package/wireguard-tools
   DEPENDS:= \
 	  +@BUSYBOX_CONFIG_IP \
 	  +@BUSYBOX_CONFIG_FEATURE_IP_LINK \
-	  +kmod-wireguard
+	  +kmod-wireguard \
+	  +rpcd
 endef
 
 define Package/wireguard-tools/description
@@ -58,8 +59,10 @@ define Package/wireguard-tools/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/wg $(1)/usr/bin/
 	$(INSTALL_BIN) ./files/wireguard_watchdog $(1)/usr/bin/
-	$(INSTALL_DIR) $(1)/lib/netifd/proto/
-	$(INSTALL_BIN) ./files/wireguard.sh $(1)/lib/netifd/proto/
+	$(INSTALL_DIR) $(1)/usr/libexec/rpcd/
+	$(INSTALL_BIN) ./files/wireguard.rpcd $(1)/usr/libexec/rpcd/
+	$(INSTALL_DIR) $(1)/lib/netifd/extdev-config/
+	$(INSTALL_BIN) ./files/wireguard.extdev $(1)/lib/netifd/extdev-config/
 endef
 
 $(eval $(call BuildPackage,wireguard-tools))

--- a/package/network/utils/wireguard-tools/files/wireguard.extdev
+++ b/package/network/utils/wireguard-tools/files/wireguard.extdev
@@ -1,0 +1,2 @@
+{ "name" : "wireguard", "ubus_name" : "wireguard", "bridge" : "0", "config" : [ ["name", 3], ["private_key", 3], [ "listen_port", 5], [ "mtu", 5 ] ] }
+

--- a/package/network/utils/wireguard-tools/files/wireguard.rpcd
+++ b/package/network/utils/wireguard-tools/files/wireguard.rpcd
@@ -1,0 +1,160 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+. /usr/share/libubox/jshn.sh
+
+proto_wireguard_setup_peer() {
+	local peer_config="$1"
+
+	local disabled
+	local public_key
+	local preshared_key
+	local allowed_ips
+	local route_allowed_ips
+	local endpoint_host
+	local endpoint_port
+	local persistent_keepalive
+
+	config_get device "${peer_config}" "device" "wg0"
+
+	if [ "$device" != "$name" ]; then
+		return 0
+	fi
+
+	config_get_bool disabled "${peer_config}" "disabled" 0
+	config_get public_key "${peer_config}" "public_key"
+	config_get preshared_key "${peer_config}" "preshared_key"
+	config_get allowed_ips "${peer_config}" "allowed_ips"
+	config_get_bool route_allowed_ips "${peer_config}" "route_allowed_ips" 0
+	config_get endpoint_host "${peer_config}" "endpoint_host"
+	config_get endpoint_port "${peer_config}" "endpoint_port"
+	config_get persistent_keepalive "${peer_config}" "persistent_keepalive"
+
+	if [ "${disabled}" -eq 1 ]; then
+		# skip disabled peers
+		return 0
+	fi
+
+	if [ -z "$public_key" ]; then
+		echo "Skipping peer config $peer_config because public key is not defined."
+		return 0
+	fi
+
+	echo "[Peer]" >> "${wg_cfg}"
+	echo "PublicKey=${public_key}" >> "${wg_cfg}"
+	if [ "${preshared_key}" ]; then
+		echo "PresharedKey=${preshared_key}" >> "${wg_cfg}"
+	fi
+	for allowed_ip in $allowed_ips; do
+		echo "AllowedIPs=${allowed_ip}" >> "${wg_cfg}"
+	done
+	if [ "${endpoint_host}" ]; then
+		case "${endpoint_host}" in
+			*:*)
+				endpoint="[${endpoint_host}]"
+				;;
+			*)
+				endpoint="${endpoint_host}"
+				;;
+		esac
+		if [ "${endpoint_port}" ]; then
+			endpoint="${endpoint}:${endpoint_port}"
+		else
+			endpoint="${endpoint}:51820"
+		fi
+		echo "Endpoint=${endpoint}" >> "${wg_cfg}"
+	fi
+	if [ "${persistent_keepalive}" ]; then
+		echo "PersistentKeepalive=${persistent_keepalive}" >> "${wg_cfg}"
+	fi
+
+	if [ ${route_allowed_ips} -ne 0 ]; then
+		for allowed_ip in ${allowed_ips}; do
+			case "${allowed_ip}" in
+				*:*/*)
+					proto_add_ipv6_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+					;;
+				*.*/*)
+					proto_add_ipv4_route "${allowed_ip%%/*}" "${allowed_ip##*/}"
+					;;
+				*:*)
+					proto_add_ipv6_route "${allowed_ip%%/*}" "128"
+					;;
+				*.*)
+					proto_add_ipv4_route "${allowed_ip%%/*}" "32"
+					;;
+			esac
+		done
+	fi
+}
+
+create() {
+	local name private_key listen_port addresses mtu fwmark ip6prefix nohostroute tunlink
+	read input;
+	json_load "$input"
+
+	json_get_var name name "wg0"
+	json_get_var private_key private_key 
+	json_get_var listen_port listen_port "51820"
+	json_get_var addresses addresses
+	json_get_var mtu mtu
+	json_get_var fwmark fwmark
+	json_get_var ip6prefix ip6prefix
+	json_get_var nohostroute nohostroute
+	json_get_var tunlink tunlink
+
+	local wg_dir="/tmp/wireguard"
+	local wg_cfg="${wg_dir}/${name}"
+
+	ip link add dev "$name" type wireguard || true
+
+	if [ "${mtu}" ]; then
+		ip link set mtu "${mtu}" dev "${name}"
+	fi
+
+	umask 077
+	mkdir -p "${wg_dir}"
+	echo "[Interface]" > "${wg_cfg}"
+	echo "PrivateKey=${private_key}" >> "${wg_cfg}"
+	if [ "${listen_port}" ]; then
+		echo "ListenPort=${listen_port}" >> "${wg_cfg}"
+	fi
+	if [ "${fwmark}" ]; then
+		echo "FwMark=${fwmark}" >> "${wg_cfg}"
+	fi
+	config_load network
+	config_foreach proto_wireguard_setup_peer "wireguard-peer"
+
+	# apply configuration file
+	wg setconf "$name" "$wg_cfg"
+	WG_RETURN="$?"
+
+	rm -f "${wg_cfg}"
+
+	if [ ${WG_RETURN} -ne 0 ]; then
+		sleep 5
+		proto_setup_failed "${name}"
+		exit 1
+	fi
+}
+
+main () {
+	case "$1" in
+		list)
+			json_init
+			json_add_object "create"
+			json_add_string "name" "wg0"
+			json_add_integer "listen_port" 55180
+			json_add_string "private_key" 
+			json_add_integer "mtu"
+			json_close_object
+			json_dump
+			;;
+		call)
+			create
+			;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
I wanted to use Wireguard on a VM to tunnel multiple devices. Whenever changing/adding peers, a network restart would be required to apply the changes. This is a flaw of the scripts configuring Wireguard based on UCI settings: The `netifd` daemon doesn't update Wireguard on a *network reload*. Restarting however means that all connections are briefly interrupted, not ideal for larger setups.

While I first looked into extending `netifd` to handle reloads for *proto scripts*, @dangowrt mentioned the newly introduced `extdev` capabilities of `netifd`. Essentially daemons or `rpcd` scripts can be registered and handle *device* management. This would allow a cleaner UCI configuration and most interesting, reloading of the configuration without interrupting existing connections.

The documentation on `extdev` is sparse and the implementation within netifd *incomplete* (i.e. no multi-line JSON support, enums are passed as numbers), however [ovsd](https://gitlab.hhi.fraunhofer.de/wn-ina/ovsd) can be used as an inspiration.

Code is mostly copied from the current `proto/wireguard.sh` script.

**This is a proof of concept**

Below is an example for the "new" configuration style which is more in line with how devices/interfaces are currently defined.

```
config device                                                                                                                                
        option type 'wireguard'                                                                                                                    
        option name 'wg0'                                                                                                                          
        option private_key 'xxx'                                                                          
        option listen_port '55180'                                                                                                                 
                                                                                                                                             
config interface 'wg0'                                                                                                                       
        option device 'wg0'                                                                                                                        
        option proto 'static'                                                                                                                      
        list ipaddr '10.0.0.2/24'
        list ipaddr '10.10.0.2/24'                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                          
config wireguard-peer                                                                                                                        
        option device 'wg0'                                                                                                                  
        list allowed_ips '0.0.0.0/0'                                                                                                         
        list allowed_ips '::/0'                                                                                                              
        option endpoint_host '123.123.123.123'                                                                                                 
        option persistent_keepalive '25'                                                                                                     
        option public_key 'xxx'                                                                     
        option description 'tunnel-server'                                                                                                        
        option route_allowed_ips '1'  
```

@zx2c4 please have a look and feel free to rip this into pieces