### PR TITLE
pcre: bring back C++ bindings

### DIFF
--- a/package/libs/pcre/Makefile
+++ b/package/libs/pcre/Makefile
@@ -24,6 +24,7 @@ PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
 PKG_CONFIG_DEPENDS:=\
+	CONFIG_PACKAGE_libpcrecpp \
 	CONFIG_PCRE_JIT_ENABLED
 
 include $(INCLUDE_DIR)/package.mk
@@ -54,12 +55,18 @@ define Package/libpcre32
   TITLE:=A Perl Compatible Regular Expression library (32bit support)
 endef
 
+define Package/libpcrecpp
+  $(call Package/libpcre/default)
+  TITLE:=C++ wrapper for Perl Compatible Regular Expression library
+  DEPENDS:=+libpcre +libstdcpp
+endef
+
 HOST_CONFIGURE_ARGS += \
 	--enable-utf8 \
 	--enable-unicode-properties \
 	--enable-pcre16 \
 	--with-match-limit-recursion=16000 \
-	--disable-cpp
+	--enable-cpp
 
 TARGET_CFLAGS += $(FPIC)
 
@@ -70,7 +77,7 @@ CONFIGURE_ARGS += \
 	--enable-pcre32 \
 	$(if $(CONFIG_PCRE_JIT_ENABLED),--enable-jit,--disable-jit) \
 	--with-match-limit-recursion=16000 \
-	-disable-cpp
+	--$(if $(CONFIG_PACKAGE_libpcrecpp),en,dis)able-cpp
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)"
@@ -109,7 +116,13 @@ define Package/libpcre32/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcre32.so* $(1)/usr/lib/
 endef
 
+define Package/libpcrecpp/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libpcrecpp.so.* $(1)/usr/lib/
+endef
+
 $(eval $(call BuildPackage,libpcre))
 $(eval $(call BuildPackage,libpcre16))
 $(eval $(call BuildPackage,libpcre32))
+$(eval $(call BuildPackage,libpcrecpp))
 $(eval $(call HostBuild))


### PR DESCRIPTION
It seems some people use them privately.

Reported-by: Jan Kardell <jan.kardell@telliq.com>
Signed-off-by: Rosen Penev <rosenp@gmail.com>