### PR TITLE
readline: disable shared library for host

### DIFF
--- a/package/libs/readline/Makefile
+++ b/package/libs/readline/Makefile
@@ -45,6 +45,7 @@ define Package/libreadline/description
 	history expansion on previous commands.
 endef
 
+HOST_CONFIGURE_ARGS += --disable-shared --with-pic
 CONFIGURE_ARGS += --with-curses --disable-install-examples
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Allows to avoid rpath hacks with at least softethervpn.

--with-pic is needed as it's not default with static libraries, only
shared ones.

Signed-off-by: Rosen Penev <rosenp@gmail.com>