### PR TITLE
libjson-c: don't build shared host libraries

### DIFF
--- a/package/libs/libjson-c/Makefile
+++ b/package/libs/libjson-c/Makefile
@@ -27,9 +27,7 @@ include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_HOST_OPTIONS += \
-	-DCMAKE_SKIP_RPATH=FALSE \
-	-DCMAKE_MACOSX_RPATH=1 \
-	-DCMAKE_INSTALL_RPATH="${STAGING_DIR_HOST}/lib"
+	-DBUILD_SHARED_LIBS=FALSE
 
 define Package/libjson-c
   SECTION:=libs


### PR DESCRIPTION
Avoids having to deal with various rpath hacks.

Signed-off-by: Rosen Penev <rosenp@gmail.com>