### PR TITLE
strace: remove code coverage makefile var

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=strace
 PKG_VERSION:=5.10
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://strace.io/files/$(PKG_VERSION)

--- a/package/devel/strace/patches/010-m4.patch
+++ b/package/devel/strace/patches/010-m4.patch
@@ -1,0 +1,10 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -408,7 +408,6 @@ strace_LDADD += $(libiberty_LIBS)
+ endif
+ endif
+ 
+-@CODE_COVERAGE_RULES@
+ CODE_COVERAGE_BRANCH_COVERAGE = 1
+ CODE_COVERAGE_GENHTML_OPTIONS = $(CODE_COVERAGE_GENHTML_OPTIONS_DEFAULT) \
+ 	--prefix $(shell cd $(abs_top_srcdir)/.. && pwd || echo .)


### PR DESCRIPTION
It relies on a custom ax_code_coverage.m4 file included with strace.
Unfortunately, this conflicts with the one included with
autoconf-macros. Instead of creating a huge patch to fix it, just remove
the variable as code coverage is not used here.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @stintel 