### PR TITLE
toolchain: switch packaged toolchain to tar.xz

### DIFF
--- a/target/toolchain/Makefile
+++ b/target/toolchain/Makefile
@@ -26,7 +26,7 @@ all: compile
 
 TOOLCHAIN_PREFIX:=$(TOOLCHAIN_BUILD_DIR)/toolchain-$(ARCH)$(ARCH_SUFFIX)_gcc-$(GCCV)$(DIR_SUFFIX)
 
-$(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2: clean
+$(BIN_DIR)/$(TOOLCHAIN_NAME).tar.xz: clean
 	mkdir -p $(TOOLCHAIN_BUILD_DIR)
 	$(TAR) -cf - -C $(TOPDIR)/staging_dir/  \
 	       $(foreach exclude,$(EXCLUDE_DIRS),--exclude="$(exclude)") \
@@ -62,13 +62,14 @@ $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2: clean
 	find $(TOOLCHAIN_BUILD_DIR) -name CVS | $(XARGS) rm -rf
 	mkdir -p $(BIN_DIR)
 	(cd $(BUILD_DIR); \
-		tar cfj $@ $(TOOLCHAIN_NAME); \
+		tar -I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' -cf $@ $(TOOLCHAIN_NAME) \
+		--mtime="$(shell date --date=@$(SOURCE_DATE_EPOCH))"; \
 	)
 
 download:
 prepare:
-compile: $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2
+compile: $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.xz
 install: compile
 
 clean:
-	rm -rf $(TOOLCHAIN_BUILD_DIR) $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.bz2
+	rm -rf $(TOOLCHAIN_BUILD_DIR) $(BIN_DIR)/$(TOOLCHAIN_NAME).tar.xz


### PR DESCRIPTION
Currently the tar.bz2 while ImageBuilder and SDK switched to tar.xz.
Unify it for faster compression since it will make use of
multi-threading.

Signed-off-by: Paul Spooren <mail@aparcar.org>