### PR TITLE
ath79: add ALT vars for MikroTik wAP board

### DIFF
--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -68,6 +68,10 @@ define Device/mikrotik_routerboard-wapr-2nd
   $(Device/mikrotik_nor)
   SOC := qca9533
   DEVICE_MODEL := RouterBOARD wAPR-2nD (wAP R)
+  DEVICE_ALT0_VENDOR := MikroTik
+  DEVICE_ALT0_MODEL := RouterBOARD wAP LR8/LR9 kit
+  DEVICE_ALT1_VENDOR := MikroTik
+  DEVICE_ALT1_MODEL := RouterBOARD wAP 4G/4G US/LTE kit
   DEVICE_PACKAGES += rssileds
   IMAGE_SIZE := 16256k
 endef


### PR DESCRIPTION
Both LR8 and LR9 boards are based on the wAPR-2nD board with an attached
R11e-LR8 (LR9) LoRa module. Add the ALT vars to make this more obvious.

Signed-off-by: Paul Spooren <mail@aparcar.org>

CC: @rogerpueyo 