### PR TITLE
bcm47xx: switch to Kernel 5.10

### DIFF
--- a/target/linux/bcm47xx/Makefile
+++ b/target/linux/bcm47xx/Makefile
@@ -10,8 +10,7 @@ BOARDNAME:=Broadcom BCM47xx/53xx (MIPS)
 FEATURES:=squashfs usb
 SUBTARGETS:=generic mips74k legacy
 
-KERNEL_PATCHVER:=5.4
-KERNEL_TESTING_PATCHVER:=5.10
+KERNEL_PATCHVER:=5.10
 
 define Target/Description
 	Build firmware images for Broadcom based BCM47xx/53xx routers with MIPS CPU, *not* ARM.


### PR DESCRIPTION
Support for 5.10 was just added via d88f3b8a427acd1aef7ec3fc4c8e47c7a665d7d0 but I want to keep track of testing. Please comment here your results so we have this merged before the next release.

Signed-off-by: Paul Spooren <mail@aparcar.org>