### PR TITLE
umdns: add missing syscall to seccomp filter

### DIFF
--- a/package/network/services/umdns/files/umdns.json
+++ b/package/network/services/umdns/files/umdns.json
@@ -6,6 +6,7 @@
 				"bind",
 				"brk",
 				"clock_gettime",
+				"clock_gettime64",
 				"close",
 				"connect",
 				"epoll_create",


### PR DESCRIPTION
The 'clock_gettime64', syscall is missing.
Found with 'utrace /usr/sbin/umdns' on an R7800.