### PR TITLE
ath79: mikrotik: enable USB module on RouterBoard wAPR-2nD

### DIFF
--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-wapr-2nd.dts
@@ -68,3 +68,11 @@
 &pcie0 {
 	status = "okay";
 };
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -68,7 +68,7 @@ define Device/mikrotik_routerboard-wapr-2nd
   $(Device/mikrotik_nor)
   SOC := qca9533
   DEVICE_MODEL := RouterBOARD wAPR-2nD (wAP R)
-  DEVICE_PACKAGES += rssileds
+  DEVICE_PACKAGES += kmod-usb2 rssileds
   IMAGE_SIZE := 16256k
 endef
 TARGET_DEVICES += mikrotik_routerboard-wapr-2nd


### PR DESCRIPTION
The MikroTik RouterBOARD wAPR-2nD (wAP R) router features a miniPCI-e
slot with USB lines connected, which are used by some USB cards with
miniPCI-e form factor, like the R11e-LR8. Enabling USB support is
required for such cards to work.

Tested on a MikroTik wAP LR8 kit (RB wAPR-2nD + R11e-LR8).

Related: https://github.com/openwrt/openwrt/pull/4706
cc: @aparcar 