### PR TITLE
mtd-utils - corrects NAND_SUPPORT dependency

### DIFF
--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -33,7 +33,6 @@ define Package/mtd-utils/Default
   SECTION:=utils
   CATEGORY:=Utilities
   URL:=http://www.linux-mtd.infradead.org/
-  DEPENDS:=@NAND_SUPPORT
 endef
 
 define Package/ubi-utils
@@ -48,6 +47,7 @@ endef
 define Package/nand-utils
  $(call Package/mtd-utils/Default)
   TITLE:=Utilities for nand flash erase/read/write/test
+  DEPENDS:=@NAND_SUPPORT
 endef
 
 define Package/nand-utils/description


### PR DESCRIPTION
At present the entire mtd-utils package depends on NAND_SUPPORT.
However, there are valid uses for mtd-utils for NOR devices amongst others.
This patch moves the NAND_SUPPORT dependency to the nand-utils 
sub-package itself.