### PR TITLE
ipq40xx: MR33: Fix LP5562 LED driver probe

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4029-mr33.dts
@@ -16,6 +16,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
 
 / {
 	model = "Meraki MR33 Access Point";
@@ -166,30 +167,40 @@
 		reg = <0x30>;
 		clock-mode = /bits/8 <2>;
 		enable-gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
 		/* RGB led */
-		status_red: chan0 {
+		status_red: chan@0 {
 			chan-name = "red:status";
 			led-cur = /bits/ 8 <0x20>;
 			max-cur = /bits/ 8 <0x60>;
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
 		};
 
-		status_green: chan1 {
+		status_green: chan@1 {
 			chan-name = "green:status";
 			led-cur = /bits/ 8 <0x20>;
 			max-cur = /bits/ 8 <0x60>;
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
 		};
 
-		chan2 {
+		chan@2 {
 			chan-name = "blue:status";
 			led-cur = /bits/ 8 <0x20>;
 			max-cur = /bits/ 8 <0x60>;
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
 		};
 
-		chan3 {
+		chan@3 {
 			chan-name = "white:status";
 			led-cur = /bits/ 8 <0x20>;
 			max-cur = /bits/ 8 <0x60>;
+			reg = <3>;
+			color = <LED_COLOR_ID_WHITE>;
 		};
 	};
 };


### PR DESCRIPTION
Refer to:
https://github.com/torvalds/linux/commit/b86d3d21cd4c9bc18cbcf3b668565cf1e31023d5
https://github.com/torvalds/linux/commit/9b663b34c94a78f39fa2c7a8271b1f828b546e16

Signed-off-by: Tan Zien <nabsdh9@gmail.com>

Run test: ipq40xx, MR33, kernel version 5.10.x