### PR TITLE
base-files: chmod 1777 /var/lock

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -21,9 +21,10 @@ boot() {
 	[ -f /proc/mounts ] || /sbin/mount_root
 	[ -f /proc/jffs2_bbc ] && echo "S" > /proc/jffs2_bbc
 
-	mkdir -p /var/run
-	mkdir -p /var/log
 	mkdir -p /var/lock
+	chmod 1777 /var/lock
+	mkdir -p /var/log
+	mkdir -p /var/run
 	mkdir -p /var/state
 	mkdir -p /var/tmp
 	mkdir -p /tmp/.uci


### PR DESCRIPTION
Per FHS 3.0, /var/lock is the location for lock files [1]
however its current permissions (755) are toor estrictive for use by
unprivileged processes.
Debian and Ubuntu set them to 1777, and now so do we.

[1] https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#varlockLockFiles

Signed-off-by: Deomid "rojer" Ryabkov <rojer@rojer.me>