### PR TITLE
ipq40xx: MR33: Fix `orange: power` LED is missing

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -606,7 +606,7 @@ define Device/meraki_mr33
 	SOC := qcom-ipq4029
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct
+	DEVICE_PACKAGES := -swconfig ath10k-firmware-qca9887-ct kmod-leds-gpio
 endef
 TARGET_DEVICES += meraki_mr33
 


### PR DESCRIPTION
Install kmod-leds-gpio by default to fix this problem

Signed-off-by: Tan Zien <nabsdh9@gmail.com>

Run test: ipq40xx, MR33, kernel version 5.10.x