### PR TITLE
tools/meson: update to 0.60.0

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -64,6 +64,7 @@ define Meson/CreateNativeFile
 		-e "s|@CC@|$(foreach BIN,$(HOSTCC),'$(BIN)',)|" \
 		-e "s|@CXX@|$(foreach BIN,$(HOSTCXX),'$(BIN)',)|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
+		-e "s|@CMAKE@|$(STAGING_DIR_HOST)/bin/cmake|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(HOST_CFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(HOST_CXXFLAGS) $(HOST_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@LDFLAGS@|$(foreach FLAG,$(HOST_LDFLAGS),'$(FLAG)',)|" \
@@ -80,6 +81,7 @@ define Meson/CreateCrossFile
 		-e "s|@STRIP@|$(TARGET_CROSS)strip|" \
 		-e "s|@NM@|$(TARGET_NM)|" \
 		-e "s|@PKGCONFIG@|$(PKG_CONFIG)|" \
+		-e "s|@CMAKE@|$(STAGING_DIR_HOST)/bin/cmake|" \
 		-e "s|@CFLAGS@|$(foreach FLAG,$(TARGET_CFLAGS) $(EXTRA_CFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@CXXFLAGS@|$(foreach FLAG,$(TARGET_CXXFLAGS) $(EXTRA_CXXFLAGS) $(TARGET_CPPFLAGS) $(EXTRA_CPPFLAGS),'$(FLAG)',)|" \
 		-e "s|@LDFLAGS@|$(foreach FLAG,$(TARGET_LDFLAGS) $(EXTRA_LDFLAGS),'$(FLAG)',)|" \

--- a/tools/meson/Makefile
+++ b/tools/meson/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=meson
-PKG_VERSION:=0.59.2
+PKG_VERSION:=0.60.0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/mesonbuild/meson/releases/download/$(PKG_VERSION)
-PKG_HASH:=13dee549a7ba758b7e33ce7719f28d1d337a98d10d378a4779ccc996f5a2fc49
+PKG_HASH:=080d68b685e9a0d9c9bb475457e097b49e1d1a6f750abc971428a8d2e1b12d47
 
 PKG_MAINTAINER:=Andre Heider <a.heider@gmail.com>
 PKG_LICENSE:=Apache-2.0

--- a/tools/meson/files/openwrt-cross.txt.in
+++ b/tools/meson/files/openwrt-cross.txt.in
@@ -5,6 +5,7 @@ ar = '@AR@'
 strip = '@STRIP@'
 nm = '@NM@'
 pkgconfig = '@PKGCONFIG@'
+cmake = '@CMAKE@'
 
 [built-in options]
 c_args = [@CFLAGS@]

--- a/tools/meson/files/openwrt-native.txt.in
+++ b/tools/meson/files/openwrt-native.txt.in
@@ -2,6 +2,7 @@
 c = [@CC@]
 cpp = [@CXX@]
 pkgconfig = '@PKGCONFIG@'
+cmake = '@CMAKE@'
 
 [built-in options]
 c_args = [@CFLAGS@]


### PR DESCRIPTION
Add cmake support to meson. Otherwise only pkgconfig can be used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @dhewg 