### PR TITLE
umdns: add missing syscall to seccomp filter

### DIFF
--- a/package/network/services/umdns/files/umdns.json
+++ b/package/network/services/umdns/files/umdns.json
@@ -21,6 +21,7 @@
 				"fstat",
 				"getsockname",
 				"ioctl",
+				"madvise",
 				"mmap",
 				"mmap2",
 				"munmap",


### PR DESCRIPTION
The 'madvise', syscall is missing.
Found with 'utrace /usr/sbin/umdns' on an R7800 and RT3200.
