### PR TITLE
ath10k: backport fix for module load regression with iram-recovery

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/081-ath10k-fix-module-load-regression-with-iram-recovery-feature.patch
+++ b/package/kernel/mac80211/patches/ath10k/081-ath10k-fix-module-load-regression-with-iram-recovery-feature.patch
@@ -1,0 +1,130 @@
+From 6f8c8bf4c7c9be1c42088689fd4370e06b46608a Mon Sep 17 00:00:00 2001
+From: Abinaya Kalaiselvan <akalaise@codeaurora.org>
+Date: Wed, 20 Oct 2021 11:59:07 +0300
+Subject: ath10k: fix module load regression with iram-recovery feature
+
+Commit 9af7c32ceca8 ("ath10k: add target IRAM recovery feature support")
+introduced a new firmware feature flag ATH10K_FW_FEATURE_IRAM_RECOVERY. But
+this caused ath10k_pci module load to fail if ATH10K_FW_CRASH_DUMP_RAM_DATA bit
+was not enabled in the ath10k coredump_mask module parameter:
+
+[ 2209.328190] ath10k_pci 0000:02:00.0: qca9984/qca9994 hw1.0 target 0x01000000 chip_id 0x00000000 sub 168c:cafe
+[ 2209.434414] ath10k_pci 0000:02:00.0: kconfig debug 1 debugfs 1 tracing 1 dfs 1 testmode 1
+[ 2209.547191] ath10k_pci 0000:02:00.0: firmware ver 10.4-3.9.0.2-00099 api 5 features no-p2p,mfp,peer-flow-ctrl,btcoex-param,allows-mesh-bcast,no-ps,peer-fixed-rate,iram-recovery crc32 cbade90a
+[ 2210.896485] ath10k_pci 0000:02:00.0: board_file api 1 bmi_id 0:1 crc32 a040efc2
+[ 2213.603339] ath10k_pci 0000:02:00.0: failed to copy target iram contents: -12
+[ 2213.839027] ath10k_pci 0000:02:00.0: could not init core (-12)
+[ 2213.933910] ath10k_pci 0000:02:00.0: could not probe fw (-12)
+
+And by default coredump_mask does not have ATH10K_FW_CRASH_DUMP_RAM_DATA
+enabled so anyone using a firmware with iram-recovery feature would fail. To my
+knowledge only QCA9984 firmwares starting from release 10.4-3.9.0.2-00099
+enabled the feature.
+
+The reason for regression was that ath10k_core_copy_target_iram() used
+ath10k_coredump_get_mem_layout() to get the memory layout, but when
+ATH10K_FW_CRASH_DUMP_RAM_DATA was disabled it would get just NULL and bail out
+with an error.
+
+While looking at all this I noticed another bug: if CONFIG_DEV_COREDUMP is
+disabled but the firmware has iram-recovery enabled the module load fails with
+similar error messages. I fixed that by returning 0 from
+ath10k_core_copy_target_iram() when _ath10k_coredump_get_mem_layout() returns
+NULL.
+
+Tested-on: QCA9984 hw2.0 PCI 10.4-3.9.0.2-00139
+
+Fixes: 9af7c32ceca8 ("ath10k: add target IRAM recovery feature support")
+Signed-off-by: Abinaya Kalaiselvan <akalaise@codeaurora.org>
+Signed-off-by: Jouni Malinen <jouni@codeaurora.org>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+Link: https://lore.kernel.org/r/20211020075054.23061-1-kvalo@codeaurora.org
+---
+ drivers/net/wireless/ath/ath10k/core.c     | 11 +++++++++--
+ drivers/net/wireless/ath/ath10k/coredump.c | 11 ++++++++---
+ drivers/net/wireless/ath/ath10k/coredump.h |  7 +++++++
+ 3 files changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/wireless/ath/ath10k/core.c b/drivers/net/wireless/ath/ath10k/core.c
+index 112e04bb0e57b..5935e0973d146 100644
+--- a/drivers/net/wireless/ath/ath10k/core.c
++++ b/drivers/net/wireless/ath/ath10k/core.c
+@@ -2690,9 +2690,16 @@ static int ath10k_core_copy_target_iram(struct ath10k *ar)
+ 	int i, ret;
+ 	u32 len, remaining_len;
+ 
+-	hw_mem = ath10k_coredump_get_mem_layout(ar);
++	/* copy target iram feature must work also when
++	 * ATH10K_FW_CRASH_DUMP_RAM_DATA is disabled, so
++	 * _ath10k_coredump_get_mem_layout() to accomplist that
++	 */
++	hw_mem = _ath10k_coredump_get_mem_layout(ar);
+ 	if (!hw_mem)
+-		return -ENOMEM;
++		/* if CONFIG_DEV_COREDUMP is disabled we get NULL, then
++		 * just silently disable the feature by doing nothing
++		 */
++		return 0;
+ 
+ 	for (i = 0; i < hw_mem->region_table.size; i++) {
+ 		tmp = &hw_mem->region_table.regions[i];
+diff --git a/drivers/net/wireless/ath/ath10k/coredump.c b/drivers/net/wireless/ath/ath10k/coredump.c
+index 7eb72290a925c..55e7e11d06d94 100644
+--- a/drivers/net/wireless/ath/ath10k/coredump.c
++++ b/drivers/net/wireless/ath/ath10k/coredump.c
+@@ -1447,11 +1447,17 @@ static u32 ath10k_coredump_get_ramdump_size(struct ath10k *ar)
+ 
+ const struct ath10k_hw_mem_layout *ath10k_coredump_get_mem_layout(struct ath10k *ar)
+ {
+-	int i;
+-
+ 	if (!test_bit(ATH10K_FW_CRASH_DUMP_RAM_DATA, &ath10k_coredump_mask))
+ 		return NULL;
+ 
++	return _ath10k_coredump_get_mem_layout(ar);
++}
++EXPORT_SYMBOL(ath10k_coredump_get_mem_layout);
++
++const struct ath10k_hw_mem_layout *_ath10k_coredump_get_mem_layout(struct ath10k *ar)
++{
++	int i;
++
+ 	if (WARN_ON(ar->target_version == 0))
+ 		return NULL;
+ 
+@@ -1464,7 +1470,6 @@ const struct ath10k_hw_mem_layout *ath10k_coredump_get_mem_layout(struct ath10k
+ 
+ 	return NULL;
+ }
+-EXPORT_SYMBOL(ath10k_coredump_get_mem_layout);
+ 
+ struct ath10k_fw_crash_data *ath10k_coredump_new(struct ath10k *ar)
+ {
+diff --git a/drivers/net/wireless/ath/ath10k/coredump.h b/drivers/net/wireless/ath/ath10k/coredump.h
+index 42404e246e0e9..240d705150888 100644
+--- a/drivers/net/wireless/ath/ath10k/coredump.h
++++ b/drivers/net/wireless/ath/ath10k/coredump.h
+@@ -176,6 +176,7 @@ int ath10k_coredump_register(struct ath10k *ar);
+ void ath10k_coredump_unregister(struct ath10k *ar);
+ void ath10k_coredump_destroy(struct ath10k *ar);
+ 
++const struct ath10k_hw_mem_layout *_ath10k_coredump_get_mem_layout(struct ath10k *ar);
+ const struct ath10k_hw_mem_layout *ath10k_coredump_get_mem_layout(struct ath10k *ar);
+ 
+ #else /* CONFIG_DEV_COREDUMP */
+@@ -214,6 +215,12 @@ ath10k_coredump_get_mem_layout(struct ath10k *ar)
+ 	return NULL;
+ }
+ 
++static inline const struct ath10k_hw_mem_layout *
++_ath10k_coredump_get_mem_layout(struct ath10k *ar)
++{
++	return NULL;
++}
++
+ #endif /* CONFIG_DEV_COREDUMP */
+ 
+ #endif /* _COREDUMP_H_ */
+-- 
+cgit 1.2.3-1.el7
+

--- a/package/kernel/mac80211/patches/ath10k/921-ath10k_init_devices_synchronously.patch
+++ b/package/kernel/mac80211/patches/ath10k/921-ath10k_init_devices_synchronously.patch
@@ -14,7 +14,7 @@ Signed-off-by: Sven Eckelmann <sven@open-mesh.com>
 
 --- a/drivers/net/wireless/ath/ath10k/core.c
 +++ b/drivers/net/wireless/ath/ath10k/core.c
-@@ -3345,6 +3345,16 @@ int ath10k_core_register(struct ath10k *
+@@ -3352,6 +3352,16 @@ int ath10k_core_register(struct ath10k *
  
  	queue_work(ar->workqueue, &ar->register_work);
  

--- a/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
+++ b/package/kernel/mac80211/patches/ath10k/974-ath10k_add-LED-and-GPIO-controlling-support-for-various-chipsets.patch
@@ -172,7 +172,7 @@ v13:
  		.patch_load_addr = QCA9888_HW_2_0_PATCH_LOAD_ADDR,
  		.uart_pin = 7,
  		.cc_wraparound_type = ATH10K_HW_CC_WRAP_SHIFTED_EACH,
-@@ -3060,6 +3066,10 @@ int ath10k_core_start(struct ath10k *ar,
+@@ -3067,6 +3073,10 @@ int ath10k_core_start(struct ath10k *ar,
  		goto err_hif_stop;
  	}
  
@@ -183,7 +183,7 @@ v13:
  	return 0;
  
  err_hif_stop:
-@@ -3318,9 +3328,18 @@ static void ath10k_core_register_work(st
+@@ -3325,9 +3335,18 @@ static void ath10k_core_register_work(st
  		goto err_spectral_destroy;
  	}
  
@@ -202,7 +202,7 @@ v13:
  err_spectral_destroy:
  	ath10k_spectral_destroy(ar);
  err_debug_destroy:
-@@ -3366,6 +3385,8 @@ void ath10k_core_unregister(struct ath10
+@@ -3373,6 +3392,8 @@ void ath10k_core_unregister(struct ath10
  	if (!test_bit(ATH10K_FLAG_CORE_REGISTERED, &ar->dev_flags))
  		return;
  

--- a/package/kernel/mac80211/patches/ath10k/984-ath10k-Try-to-get-mac-address-from-dts.patch
+++ b/package/kernel/mac80211/patches/ath10k/984-ath10k-Try-to-get-mac-address-from-dts.patch
@@ -26,7 +26,7 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  #include <linux/property.h>
  #include <linux/dmi.h>
  #include <linux/ctype.h>
-@@ -3236,6 +3237,8 @@ static int ath10k_core_probe_fw(struct a
+@@ -3243,6 +3244,8 @@ static int ath10k_core_probe_fw(struct a
  
  	device_get_mac_address(ar->dev, ar->mac_addr, sizeof(ar->mac_addr));
  


### PR DESCRIPTION
Backport upstream fix for module load regression caused by IRAM recovery.
Without this patch devices using mainline ath10k driver could lost wireless
function because ath10k module failed to load.

Signed-off-by: Zhijun You <hujy652@gmail.com>

@adschm I am not sure if this is the correct numbering
