### PR TITLE
build: avoid spurious rebuilds

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -59,6 +59,21 @@ define dl_tar_pack
 		$$$${TAR_TIMESTAMP:+--mtime="$$$$TAR_TIMESTAMP"} -c $(2) | $(call dl_pack,$(1))
 endef
 
+gen_sha256sum = $(shell $(MKHASH) sha256 $(DL_DIR)/$(1))
+
+# Used in Build/CoreTargets and HostBuild/Core as an integrity check for
+# downloaded files.  It will add a FORCE rule if the sha256 hash does not
+# match, so that the download can be more thoroughly handled by download.pl.
+define check_download_integrity
+  expected_hash:=$(strip $(if $(filter-out x,$(HASH)),$(HASH),$(MIRROR_HASH)))
+  $$(if $$(and $(FILE),$$(wildcard $(DL_DIR)/$(FILE)), \
+	       $$(filter undefined,$$(flavor DownloadChecked/$(FILE)))), \
+    $$(eval DownloadChecked/$(FILE):=1) \
+    $$(if $$(filter-out $$(call gen_sha256sum,$(FILE)),$$(expected_hash)), \
+      $(DL_DIR)/$(FILE): FORCE) \
+  )
+endef
+
 ifdef CHECK
 check_escape=$(subst ','\'',$(1))
 #')
@@ -73,8 +88,6 @@ ifndef FIXUP
 else
   check_warn = $(if $(filter-out undefined,$(origin F_$(1))),$(filter ,$(shell $(call F_$(1),$(2),$(3),$(4)) >&2)),$(check_warn_nofix))
 endif
-
-gen_sha256sum = $(shell $(MKHASH) sha256 $(DL_DIR)/$(1))
 
 ifdef FIXUP
 F_hash_deprecated = $(SCRIPT_DIR)/fixup-makefile.pl $(CURDIR)/Makefile fix-hash $(3) $(call gen_sha256sum,$(1)) $(2)

--- a/include/host-build.mk
+++ b/include/host-build.mk
@@ -180,7 +180,7 @@ ifndef DUMP
     clean-build: host-clean-build
   endif
 
-  $(DL_DIR)/$(FILE): FORCE
+  $(call check_download_integrity)
 
   $(_host_target)host-prepare: $(HOST_STAMP_PREPARED)
   $(_host_target)host-configure: $(HOST_STAMP_CONFIGURED)

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -128,6 +128,10 @@ endef
 define Kernel/CompileModules/Default
 	rm -f $(LINUX_DIR)/vmlinux $(LINUX_DIR)/System.map
 	+$(KERNEL_MAKE) $(if $(KERNELNAME),$(KERNELNAME),all) modules
+	# If .config did not change, use the previous timestamp to avoid package rebuilds
+	cmp -s $(LINUX_DIR)/.config $(LINUX_DIR)/.config.modules.save && \
+		mv $(LINUX_DIR)/.config.modules.save $(LINUX_DIR)/.config; \
+	$(CP) $(LINUX_DIR)/.config $(LINUX_DIR)/.config.modules.save
 endef
 
 OBJCOPY_STRIP = -R .reginfo -R .notes -R .note -R .comment -R .mdebug -R .note.gnu.build-id

--- a/include/package-bin.mk
+++ b/include/package-bin.mk
@@ -4,7 +4,8 @@
 
 ifeq ($(DUMP),)
   define BuildTarget/bin
-    ifeq ($(if $(VARIANT),$(BUILD_VARIANT)),$(VARIANT))
+    TARGET_VARIANT=$(if $(ALL_VARIANTS),$(if $(VARIANT),$(VARIANT),$(firstword $(ALL_VARIANTS))))
+    ifeq ($(if $(TARGET_VARIANT),$(BUILD_VARIANT)),$(TARGET_VARIANT))
     ifdef Package/$(1)/install
       ifneq ($(CONFIG_PACKAGE_$(1))$(DEVELOPER),)
         $(_pkg_target)compile: $(PKG_BUILD_DIR)/.pkgdir/$(1).installed

--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -105,7 +105,8 @@ ifeq ($(DUMP),)
     IDIR_$(1):=$(PKG_BUILD_DIR)/ipkg-$(PKGARCH)/$(1)
     KEEP_$(1):=$(strip $(call Package/$(1)/conffiles))
 
-    ifeq ($(BUILD_VARIANT),$$(if $$(VARIANT),$$(VARIANT),$(BUILD_VARIANT)))
+    TARGET_VARIANT:=$$(if $(ALL_VARIANTS),$$(if $$(VARIANT),$$(VARIANT),$(firstword $(ALL_VARIANTS))))
+    ifeq ($(BUILD_VARIANT),$$(if $$(TARGET_VARIANT),$$(TARGET_VARIANT),$(BUILD_VARIANT)))
     do_install=
     ifdef Package/$(1)/install
       do_install=yes

--- a/include/package.mk
+++ b/include/package.mk
@@ -183,7 +183,7 @@ define Build/CoreTargets
   $(call Build/Autoclean)
   $(call DefaultTargets)
 
-  $(DL_DIR)/$(FILE): FORCE
+  $(call check_download_integrity)
 
   download:
 	$(foreach hook,$(Hooks/Download),

--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -29,12 +29,14 @@ diralias=$(if $(findstring $(1),$(call lastdir,$(1))),,$(call lastdir,$(1)))
 subdir_make_opts = \
 	-r -C $(1) \
 		BUILD_SUBDIR="$(1)" \
-		BUILD_VARIANT="$(4)"
+		BUILD_VARIANT="$(4)" \
+		ALL_VARIANTS="$(5)"
 
 # 1: subdir
 # 2: target
 # 3: build type
 # 4: build variant
+# 5: all variants
 log_make = \
 	 $(if $(call debug,$(1),v),,@)+ \
 	 $(if $(BUILD_LOG), \
@@ -62,15 +64,15 @@ define subdir
     $(foreach target,$(SUBTARGETS) $($(1)/subtargets),
       $(foreach btype,$(buildtypes-$(bd)),
         $(call warn_eval,$(1)/$(bd),t,T,$(1)/$(bd)/$(btype)/$(target): $(if $(NO_DEPS)$(QUILT),,$($(1)/$(bd)/$(btype)/$(target)) $(call $(1)//$(btype)/$(target),$(1)/$(bd)/$(btype))))
-		  $(call log_make,$(1)/$(bd),$(target),$(btype),$(filter-out __default,$(variant))) \
+		  $(call log_make,$(1)/$(bd),$(target),$(btype),$(filter-out __default,$(variant)),$($(1)/$(bd)/variants)) \
 			|| $(call ERROR,$(2),   ERROR: $(1)/$(bd) [$(btype)] failed to build.,$(findstring $(bd),$($(1)/builddirs-ignore-$(btype)-$(target))))
         $(if $(call diralias,$(bd)),$(call warn_eval,$(1)/$(bd),l,T,$(1)/$(call diralias,$(bd))/$(btype)/$(target): $(1)/$(bd)/$(btype)/$(target)))
       )
       $(call warn_eval,$(1)/$(bd),t,T,$(1)/$(bd)/$(target): $(if $(NO_DEPS)$(QUILT),,$($(1)/$(bd)/$(target)) $(call $(1)//$(target),$(1)/$(bd))))
         $(foreach variant,$(if $(BUILD_VARIANT),$(BUILD_VARIANT),$(if $(strip $($(1)/$(bd)/variants)),$($(1)/$(bd)/variants),$(if $($(1)/$(bd)/default-variant),$($(1)/$(bd)/default-variant),__default))),
 			$(if $(BUILD_LOG),@mkdir -p $(BUILD_LOG_DIR)/$(1)/$(bd)/$(filter-out __default,$(variant)))
-			$(if $($(1)/autoremove),$(call rebuild_check,$(1)/$(bd),$(target),,$(filter-out __default,$(variant))))
-			$(call log_make,$(1)/$(bd),$(target),,$(filter-out __default,$(variant))) \
+			$(if $($(1)/autoremove),$(call rebuild_check,$(1)/$(bd),$(target),,$(filter-out __default,$(variant)),$($(1)/$(bd)/variants)))
+			$(call log_make,$(1)/$(bd),$(target),,$(filter-out __default,$(variant)),$($(1)/$(bd)/variants)) \
 				|| $(call ERROR,$(1),   ERROR: $(1)/$(bd) failed to build$(if $(filter-out __default,$(variant)), (build variant: $(variant))).,$(findstring $(bd),$($(1)/builddirs-ignore-$(target)))) 
         )
       $(if $(PREREQ_ONLY)$(DUMP_TARGET_DB),,

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -677,6 +677,9 @@ ifeq ($(BUILD_VARIANT),supplicant-full-wolfssl)
   endef
 endif
 
+# Build hostapd-common before its dependents, to avoid
+# spurious rebuilds when building multiple variants.
+$(eval $(call BuildPackage,hostapd-common))
 $(eval $(call BuildPackage,hostapd))
 $(eval $(call BuildPackage,hostapd-basic))
 $(eval $(call BuildPackage,hostapd-basic-openssl))
@@ -703,7 +706,6 @@ $(eval $(call BuildPackage,wpa-supplicant-openssl))
 $(eval $(call BuildPackage,wpa-supplicant-wolfssl))
 $(eval $(call BuildPackage,wpa-cli))
 $(eval $(call BuildPackage,hostapd-utils))
-$(eval $(call BuildPackage,hostapd-common))
 $(eval $(call BuildPackage,eapol-test))
 $(eval $(call BuildPackage,eapol-test-openssl))
 $(eval $(call BuildPackage,eapol-test-wolfssl))

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -232,9 +232,11 @@ endef
 
 $(eval $(call BuildPackage,ip-tiny))
 $(eval $(call BuildPackage,ip-full))
+# build tc-mod-iptables before its dependents, to avoid
+# spurious rebuilds when building multiple variants.
+$(eval $(call BuildPackage,tc-mod-iptables))
 $(eval $(call BuildPackage,tc-tiny))
 $(eval $(call BuildPackage,tc-full))
-$(eval $(call BuildPackage,tc-mod-iptables))
 $(eval $(call BuildPackage,genl))
 $(eval $(call BuildPackage,ip-bridge))
 $(eval $(call BuildPackage,ss))

--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=f2fs-tools
 PKG_VERSION:=1.14.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/linux/kernel/git/jaegeuk/f2fs-tools.git/snapshot/
@@ -85,6 +85,7 @@ define Package/libf2fs
   DEPENDS:=+libuuid
   ABI_VERSION:=6
   CONFLICTS:=libf2fs-selinux
+  VARIANT:=default
 endef
 
 define Package/libf2fs-selinux
@@ -93,6 +94,7 @@ define Package/libf2fs-selinux
   TITLE:=Library for Flash-Friendly File System (F2FS) tools with SELinux support
   DEPENDS:=+libuuid +libselinux
   ABI_VERSION:=6
+  VARIANT:=selinux
 endef
 
 CONFIGURE_ARGS += \


### PR DESCRIPTION
I'm really annoyed by spurious rebuilds.  From time to time I run compile with `CONFIG_ALL`, especially after a gcc, musl or other toolchain upgrade.  I hit a trivial bug (new compiler warning turned into error, missing include); then I have to run `make` again, and most all packages get rebuild once again.  Something that already takes forever, starts all over again.

The first culprit I found was that we are forcing every package to be downloaded again every time, without checking its integrity first.
ab2fe94 takes care of that by verifying the expected hash before forcing a new download.  [I've sent the patch to the mailing list](https://patchwork.ozlabs.org/project/openwrt/patch/20210820123412.8632-1-cotequeiroz@gmail.com/), but it did not catch anyone's attention there.

Then, there's the kernel `.config` timestamp, used to decide wether or not to rebuild kernel-module packages.
e462010 saves the `.config` file to `.config.modules.save`, and compares it the current `.config`.  If they match, then `.config.modules.save` is moved into `.config` to keep its timestamp.  That keeps many kernel-dependent packages from getting unnecessarily rebuilt.

Package Makefiles with multiple `VARIANTS` defined also cause trouble, especially when they define packages without a `VARIANT`.  The latter end up getting built--and trumped--for every defined variant, causing rebuilds of dependent packages as well.  
c95311e takes care of that by building packages with empty VARIANT only with first variant that's selected for building.

Finally, there were individual packages that needed minor adjustments.  
* `hostapd` needs the `hostapd-common` being the first package to be built, as every other package in that `Makefile` depends on it.
* `iproute2` has a similar issue as `hostapd`, and needs `tc-mod-iptables` to be built before `tc-tiny` and `tc-full`.
* `f2fstools` had two different libf2fs flavours, but they did not specify a `VARIANT`, so they were always compiled with identical settings, which ended up being equal to the last VARIANT built: 
```
f778197a78068c34fe7230aa5ebc1352a5ae5a1f4c9a9b8e88223599a2ba007e  default/usr/lib/libf2fs.so.8.0.0
f778197a78068c34fe7230aa5ebc1352a5ae5a1f4c9a9b8e88223599a2ba007e  selinux/usr/lib/libf2fs.so.8.0.0
```

Ping @nbd168 as maintainer of f2fstools and hostapd.