### PR TITLE
treewide: remove compatible = "mediatek,mt76"

### DIFF
--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -131,7 +131,6 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x5000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-960.dts
@@ -171,7 +171,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		mediatek,mtd-eeprom = <&config 0xe08e>;

--- a/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
+++ b/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
@@ -173,7 +173,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -179,7 +179,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&iNIC_rf 0x0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7620a_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7620a_iptime.dtsi
@@ -67,7 +67,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&uboot 0x1f800>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
+++ b/target/linux/ramips/dts/mt7620a_lb-link_bl-w1200.dts
@@ -150,7 +150,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;

--- a/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
+++ b/target/linux/ramips/dts/mt7620a_netis_wf2770.dts
@@ -153,7 +153,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_adslr_g7.dts
+++ b/target/linux/ramips/dts/mt7621_adslr_g7.dts
@@ -84,7 +84,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -93,7 +92,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_asus_rt-ac57u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ac57u.dts
@@ -106,7 +106,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 
@@ -119,7 +118,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 

--- a/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-n56u-b1.dts
@@ -125,7 +125,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 	};
@@ -133,7 +132,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 	};

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
@@ -204,7 +204,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -213,7 +212,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr2100.dts
@@ -88,7 +88,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -97,7 +96,6 @@
 
 &pcie1 {
 	wifi@1,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-a3.dts
@@ -154,7 +154,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		/* 5 GHz (phy1) does not take the address from calibration data,

--- a/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-853-r1.dts
@@ -92,7 +92,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		mediatek,mtd-eeprom = <&factory 0x0>;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-8xx.dtsi
@@ -66,7 +66,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -79,7 +78,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-xx60-a1.dtsi
@@ -125,7 +125,6 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -138,7 +137,6 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_edimax_re23s.dts
+++ b/target/linux/ramips/dts/mt7621_edimax_re23s.dts
@@ -120,7 +120,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -129,7 +128,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
+++ b/target/linux/ramips/dts/mt7621_edimax_rx21s.dtsi
@@ -101,7 +101,6 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -110,7 +109,6 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1167ghbk2-s.dts
@@ -167,7 +167,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		nvmem-cells = <&macaddr_factory_e000>;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk-i.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533ghbk-i.dts
@@ -178,7 +178,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -187,7 +186,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-1pci.dtsi
@@ -23,7 +23,6 @@
 
 &pcie0 {
 	wifi: wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
@@ -21,7 +21,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -35,7 +34,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
+++ b/target/linux/ramips/dts/mt7621_glinet_gl-mt1300.dts
@@ -108,7 +108,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
@@ -17,7 +17,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr.dts
@@ -17,7 +17,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		mediatek,mtd-eeprom = <&factory 0x0>;
@@ -27,7 +26,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		mediatek,mtd-eeprom = <&factory 0x8000>;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
@@ -23,7 +23,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1200gr.dts
@@ -168,7 +168,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		mediatek,mtd-eeprom = <&factory 0x0>;
@@ -178,7 +177,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		mediatek,mtd-eeprom = <&factory 0x8000>;

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx2033gr.dts
@@ -23,7 +23,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2483000>;
@@ -32,7 +31,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 5710000>;

--- a/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wnpr2600g.dts
@@ -166,7 +166,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -175,7 +174,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_iptime_a6ns-m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a6ns-m.dts
@@ -152,7 +152,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -161,7 +160,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a8004t.dts
@@ -136,7 +136,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -145,7 +144,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_jhr-ac876m.dts
@@ -104,7 +104,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -117,7 +116,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_jcg_q20.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q20.dts
@@ -137,7 +137,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -82,7 +82,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 	};

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -134,7 +134,6 @@
 
 &pcie0 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 	};
@@ -142,7 +141,6 @@
 
 &pcie1 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 	};

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -159,7 +159,6 @@
 
 &pcie0 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 	};
@@ -167,7 +166,6 @@
 
 &pcie1 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 	};

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
@@ -89,7 +89,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -98,7 +97,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
@@ -145,7 +145,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -154,7 +153,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -79,7 +79,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -88,7 +87,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -115,7 +115,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -124,7 +123,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_netis_wf2881.dts
+++ b/target/linux/ramips/dts/mt7621_netis_wf2881.dts
@@ -95,7 +95,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -109,7 +108,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -168,7 +168,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		nvmem-cells = <&macaddr_factory_e000>;
@@ -180,7 +179,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		nvmem-cells = <&macaddr_factory_e000>;

--- a/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_a7000r.dts
@@ -83,7 +83,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -92,7 +91,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
+++ b/target/linux/ramips/dts/mt7621_totolink_x5000r.dts
@@ -90,7 +90,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 	};

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -142,7 +142,6 @@
 
 &pcie0 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x0>;
 		nvmem-cells = <&macaddr_config_8>;
@@ -153,7 +152,6 @@
 
 &pcie1 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x8000>;
 		nvmem-cells = <&macaddr_config_8>;

--- a/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-x6-v3.dtsi
@@ -131,7 +131,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x0>;
 		nvmem-cells = <&macaddr_config_8>;
@@ -143,7 +142,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x8000>;
 		nvmem-cells = <&macaddr_config_8>;

--- a/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7621_tplink_rexx0-v1.dtsi
@@ -145,7 +145,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x0>;
 		nvmem-cells = <&macaddr_config_10008>;
@@ -157,7 +156,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&radio 0x8000>;
 		nvmem-cells = <&macaddr_config_10008>;

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -52,7 +52,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -61,7 +60,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn531a6.dts
@@ -121,7 +121,6 @@
 
 &pcie0 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -130,7 +129,6 @@
 
 &pcie1 {
 	mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
+++ b/target/linux/ramips/dts/mt7621_wevo_w2914ns-v2.dtsi
@@ -83,7 +83,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0>;
 
@@ -96,7 +95,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -104,7 +104,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 	};
@@ -112,7 +111,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 	};

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -159,7 +159,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -168,7 +167,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
+++ b/target/linux/ramips/dts/mt7621_xiaomi_router-ac2100.dtsi
@@ -8,7 +8,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -17,7 +16,6 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x0000>;
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr1000.dts
@@ -117,7 +117,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
+++ b/target/linux/ramips/dts/mt7628an_elecom_wrc-1167fs.dts
@@ -146,7 +146,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7628an_iptime.dtsi
+++ b/target/linux/ramips/dts/mt7628an_iptime.dtsi
@@ -95,7 +95,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
@@ -75,7 +75,6 @@
 
 &pcie0 {
 	wlan5g: mt76@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_mi-router-4a-100m.dts
@@ -27,7 +27,6 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,mtd-eeprom = <&factory 0x8000>;
 		ieee80211-freq-limit = <5000000 6000000>;


### PR DESCRIPTION
The mt76 driver does not use this or any other compatible string.

Signed-off-by: Rosen Penev <rosenp@gmail.com>
