### PR TITLE
Fix okli loader

### DIFF
--- a/target/linux/ath79/image/lzma-loader/src/Makefile
+++ b/target/linux/ath79/image/lzma-loader/src/Makefile
@@ -31,7 +31,7 @@ OBJDUMP		:= $(CROSS_COMPILE)objdump
 BIN_FLAGS	:= -O binary -R .reginfo -R .note -R .comment -R .mdebug \
 		   -R .MIPS.abiflags -S
 
-CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -Os \
+CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -O2 \
 		  -fno-strict-aliasing -fno-common -fomit-frame-pointer -G 0 \
 		  -mno-abicalls -fno-pic -ffunction-sections -pipe -mlong-calls \
 		  -fno-common -ffreestanding -fhonour-copts -nostartfiles \

--- a/target/linux/ramips/image/lzma-loader/src/Makefile
+++ b/target/linux/ramips/image/lzma-loader/src/Makefile
@@ -36,7 +36,7 @@ include $(PLATFORM).mk
 BIN_FLAGS	:= -O binary -R .reginfo -R .note -R .comment -R .mdebug \
 		   -R .MIPS.abiflags -S
 
-CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -Os \
+CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -O2 \
 		  -fno-strict-aliasing -fno-common -fomit-frame-pointer -G 0 \
 		  -mno-abicalls -fno-pic -ffunction-sections -pipe -mlong-calls \
 		  -fno-common -ffreestanding -fhonour-copts -nostartfiles \


### PR DESCRIPTION
    gcc 11 build with -Os generate broken okli-loader
    notice that no issue with gcc 10
    here disable -Os option as a workaround

