### PR TITLE
kernel: lzma-openwrt magic change for x86_64

### DIFF
--- a/target/linux/generic/hack-5.10/230-openwrt_lzma_options.patch
+++ b/target/linux/generic/hack-5.10/230-openwrt_lzma_options.patch
@@ -13,11 +13,12 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
 
 --- a/lib/decompress.c
 +++ b/lib/decompress.c
-@@ -53,6 +53,7 @@ static const struct compress_format comp
+@@ -53,6 +53,8 @@ static const struct compress_format comp
  	{ {0x1f, 0x9e}, "gzip", gunzip },
  	{ {0x42, 0x5a}, "bzip2", bunzip2 },
  	{ {0x5d, 0x00}, "lzma", unlzma },
 +	{ {0x6d, 0x00}, "lzma-openwrt", unlzma },
++	{ {0x62, 0x00}, "lzma-openwrt", unlzma },
  	{ {0xfd, 0x37}, "xz", unxz },
  	{ {0x89, 0x4c}, "lzo", unlzo },
  	{ {0x02, 0x21}, "lz4", unlz4 },


### PR DESCRIPTION
with CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA=y option, the
initramfs-kernel magic is 0x62 0x00 on x86_64 build
