### PR TITLE
ipq806x: ecw5410: multiple fixes

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -29,8 +29,6 @@ tplink,vr2600v)
 	;;
 edgecore,ecw5410)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
-	ucidef_set_interface_macaddr "lan" "$(mtd_get_mac_binary "0:art" 0x6)"
-	ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary "0:art" 0x0)"
 	;;
 linksys,ea7500-v1)
 	hw_mac_addr=$(mtd_get_mac_ascii devinfo hw_mac_addr)

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -12,8 +12,7 @@ case "$FIRMWARE" in
 	askey,rt4230w-rev6)
 		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
-	asrock,g10 |\
-	edgecore,ecw5410)
+	asrock,g10)
 		caldata_extract "0:art" 0x1000 0x2f20
 		;;
 	buffalo,wxr-2533dhp |\
@@ -56,6 +55,9 @@ case "$FIRMWARE" in
 	nec,wg2600hp3 |\
 	tplink,vr2600v)
 		caldata_extract "ART" 0x5000 0x2f20
+		;;
+	edgecore,ecw5410)
+		caldata_extract "0:art" 0x1000 0x2f20
 		;;
 	linksys,ea7500-v1 |\
 	linksys,ea8500)

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
@@ -34,7 +34,6 @@
 
 	aliases {
 		serial1 = &gsbi1_serial;
-		mdio-gpio0 = &mdio0;
 		ethernet0 = &gmac3;
 		ethernet1 = &gmac2;
 
@@ -293,26 +292,18 @@
 	};
 };
 
-&soc {
-	mdio1: mdio {
-		compatible = "virtual,mdio-gpio";
-		#address-cells = <1>;
-		#size-cells = <0>;
+&mdio0 {
+	status = "okay";
 
-		status = "okay";
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
 
-		pinctrl-0 = <&mdio0_pins>;
-		pinctrl-names = "default";
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
 
-		gpios = <&qcom_pinmux 1 GPIO_ACTIVE_HIGH &qcom_pinmux 0 GPIO_ACTIVE_HIGH>;
-
-		phy0: ethernet-phy@0 {
-			reg = <0>;
-		};
-
-		phy1: ethernet-phy@1 {
-			reg = <1>;
-		};
+	phy1: ethernet-phy@1 {
+		reg = <1>;
 	};
 };
 
@@ -330,7 +321,7 @@
 	status = "okay";
 
 	qcom,id = <3>;
-	mdiobus = <&mdio1>;
+	mdiobus = <&mdio0>;
 
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8068-ecw5410.dts
@@ -34,8 +34,8 @@
 
 	aliases {
 		serial1 = &gsbi1_serial;
-		ethernet0 = &gmac3;
-		ethernet1 = &gmac2;
+		ethernet0 = &gmac2;
+		ethernet1 = &gmac3;
 
 		led-boot = &led_power_green;
 		led-failsafe = &led_power_red;


### PR DESCRIPTION
This PR introduces multiple fixes to the ECW5410 support.

GPIO bit-banging an MDIO interface is dropped as there is no reason for that since the SoC has an MDIO controller and there is a driver for it.

PCI1 QCA9984 radio was unable to load the BDF as it couldn't detect the BMI ID due to no pre-cal data being provided to the driver.

And lastly, overriding the MAC-s via userspace helper is dropped as there is no reason to do so.
All that was needed is to correct the ethernet aliases to the proper order so that MAC-s matched the stock FW.

Signed-off-by: Robert Marko <robert.marko@sartura.hr>