### PR TITLE
build: fix ldconfig executable error in python

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -198,5 +198,4 @@ prereq: $(STAGING_DIR_HOST)/bin/mkhash
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \
-	touch $(STAGING_DIR_HOST)/bin/ldconfig && \
-	chmod +x $(STAGING_DIR_HOST)/bin/ldconfig))
+	$(LN) /bin/true $(STAGING_DIR_HOST)/bin/ldconfig))


### PR DESCRIPTION
The empty executable is causing problems with meson builds, due to the
error: OSError: [Errno 8] Exec format error: 'ldconfig'

This patch changes the empty ldconfig stub to symlink to /bin/true to
work around this issue.

Signed-off-by: Damien Mascord <tusker@tusker.org>

---

Credits go to dhewg on IRC for the idea.

The following txt file shows the full build error

[ldconfig-full-error.txt](https://github.com/openwrt/openwrt/files/7452029/ldconfig-full-error.txt)