### PR TITLE
fix totolink x5000r wrong wi-fi 5GHZ mac address

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -39,4 +39,9 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	totolink,x5000r)
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x8004)" \
+				> /sys${DEVPATH}/macaddress
+		;;
 esac


### PR DESCRIPTION
totolink x5000r wi-fi 5GHZ MAC addresses map:

factory 0x8004 : wlan5g MAC addresses