### PR TITLE
x86: enable kmod-tg3 on 64-bit by default

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -2,7 +2,8 @@ define Device/generic
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := x86/64
   DEVICE_PACKAGES += kmod-amazon-ena kmod-bnx2 kmod-e1000e kmod-e1000 \
-	kmod-forcedeth kmod-igb kmod-ixgbe kmod-amd-xgbe kmod-r8169 kmod-fs-vfat
+	kmod-forcedeth kmod-igb kmod-ixgbe kmod-amd-xgbe kmod-r8169 \
+	kmod-fs-vfat kmod-tg3
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -1,9 +1,10 @@
 define Device/generic
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := x86/64
-  DEVICE_PACKAGES += kmod-amazon-ena kmod-bnx2 kmod-e1000e kmod-e1000 \
-	kmod-forcedeth kmod-igb kmod-ixgbe kmod-amd-xgbe kmod-r8169 \
-	kmod-fs-vfat kmod-tg3
+  DEVICE_PACKAGES += \
+  	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-e1000e kmod-e1000 \
+	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-ixgbe  kmod-r8169 \
+	kmod-tg3
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
Gigabit ethernet adapters using BCM5719/5720 chipset
are common on servers and as easy/cheap to get as
Intel based ones.
Usually found in 2-port and 4-port cards.

Also some devices recently added to x86_64 target
like the Meraki MX100 use this chipset for 8 of
their 12 integrated ports.

Signed-off-by: Alberto Bursi <alberto.bursi@outlook.it>

This is basically a followup of https://github.com/openwrt/openwrt/commit/9c4f903999d8303eba5e1972c6afe5ae7e2a9d39 where I added  kmod-bnx2 for older gen Broadcomm gbit eth chipsets