### PR TITLE
kernel: mac-address-increment on last 3 bytes

### DIFF
--- a/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
@@ -16,11 +16,11 @@ early has to be increased.
 Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 ---
  drivers/of/of_net.c | 59 ++++++++++++++++++++++++++++++++++-----------
- 1 file changed, 45 insertions(+), 14 deletions(-)
+ 1 file changed, 58 insertions(+), 14 deletions(-)
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -115,27 +115,52 @@ static int of_get_mac_addr_nvmem(struct
+@@ -115,27 +115,65 @@ static int of_get_mac_addr_nvmem(struct
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.
   *
@@ -70,8 +70,21 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		return ret;
 +
 +found:
-+	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
-+		addr[inc_idx] += mac_inc;
++	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc)) {
++		unsigned int val;
++		if (inc_idx == 3) {
++			addr[inc_idx] += mac_inc;
++		} else if (inc_idx == 4) {
++			val = (addr[3] << 8) + addr[4] + mac_inc;
++			addr[3] = (val >> 8) & 0xff;
++			addr[4] = (val >> 0) & 0xff;
++		} else if (inc_idx == 5) {
++			val = (addr[3] << 16) + (addr[4] << 8) + addr[5] + mac_inc;
++			addr[3] = (val >> 16) & 0xff;
++			addr[4] = (val >> 8) & 0xff;
++			addr[5] = (val >> 0) & 0xff;
++		}
++	}
  
 -	return of_get_mac_addr_nvmem(np, addr);
 +	return ret;

--- a/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
@@ -28,9 +28,9 @@
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -161,6 +182,7 @@ found:
- 	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
- 		addr[inc_idx] += mac_inc;
+@@ -174,6 +195,7 @@ found:
+ 		}
+ 	}
  
 +	of_add_mac_address(np, addr);
  	return ret;

--- a/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
@@ -16,11 +16,11 @@ early has to be increased.
 Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 ---
  drivers/of/of_net.c | 59 ++++++++++++++++++++++++++++++++++-----------
- 1 file changed, 45 insertions(+), 14 deletions(-)
+ 1 file changed, 58 insertions(+), 14 deletions(-)
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -109,27 +109,52 @@ static int of_get_mac_addr_nvmem(struct
+@@ -109,27 +109,65 @@ static int of_get_mac_addr_nvmem(struct
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.
   *
@@ -70,8 +70,21 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 +		return ret;
 +
 +found:
-+	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
-+		addr[inc_idx] += mac_inc;
++	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc)) {
++		unsigned int val;
++		if (inc_idx == 3) {
++			addr[inc_idx] += mac_inc;
++		} else if (inc_idx == 4) {
++			val = (addr[3] << 8) + addr[4] + mac_inc;
++			addr[3] = (val >> 8) & 0xff;
++			addr[4] = (val >> 0) & 0xff;
++		} else if (inc_idx == 5) {
++			val = (addr[3] << 16) + (addr[4] << 8) + addr[5] + mac_inc;
++			addr[3] = (val >> 16) & 0xff;
++			addr[4] = (val >> 8) & 0xff;
++			addr[5] = (val >> 0) & 0xff;
++		}
++	}
  
 -	return of_get_mac_addr_nvmem(np, addr);
 +	return ret;

--- a/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
@@ -28,9 +28,9 @@
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -155,6 +176,7 @@ found:
- 	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
- 		addr[inc_idx] += mac_inc;
+@@ -168,6 +189,7 @@ found:
+ 		}
+ 	}
  
 +	of_add_mac_address(np, addr);
  	return ret;


### PR DESCRIPTION
This align to helper function macaddr_add in base-files
Also refresh patches

macaddr_add() in `/lib/functions/system.sh`
https://github.com/openwrt/openwrt/blob/605192f46c1576fe8abb3df6041d21c3f20e664a/package/base-files/files/lib/functions/system.sh#L147-L155