### PR TITLE
scripts: dump-target-info print kernel versions

### DIFF
--- a/scripts/dump-target-info.pl
+++ b/scripts/dump-target-info.pl
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use Cwd;
 
-my (%targets, %architectures);
+my (%targets, %architectures, %kernels);
 
 $ENV{'TOPDIR'} = Cwd::getcwd();
 
@@ -13,7 +13,7 @@ sub parse_targetinfo {
 	my ($target_dir, $subtarget) = @_;
 
 	if (open M, "make -C '$target_dir' --no-print-directory DUMP=1 TARGET_BUILD=1 SUBTARGET='$subtarget' |") {
-		my ($target_name, $target_arch, @target_features);
+		my ($target_name, $target_arch, $target_kernel, $target_testing_kernel, @target_features);
 		while (defined(my $line = readline M)) {
 			chomp $line;
 
@@ -23,19 +23,32 @@ sub parse_targetinfo {
 			elsif ($line =~ /^Target-Arch-Packages: (.+)$/) {
 				$target_arch = $1;
 			}
+			elsif ($line =~ /^Linux-Version: (\d\.\d+)\.\d+$/) {
+				$target_kernel = $1;
+			}
+			elsif ($line =~ /^Linux-Testing-Version: (\d\.\d+)\.\d+$/) {
+				$target_testing_kernel = $1;
+			}
 			elsif ($line =~ /^Target-Features: (.+)$/) {
 				@target_features = split /\s+/, $1;
 			}
 			elsif ($line =~ /^@\@$/) {
-				if ($target_name && $target_arch &&
+				if ($target_name && $target_arch && $target_kernel &&
 				    !grep { $_ eq 'broken' or $_ eq 'source-only' } @target_features) {
 					$targets{$target_name} = $target_arch;
 					$architectures{$target_arch} ||= [];
 					push @{$architectures{$target_arch}}, $target_name;
+					$kernels{$target_name} ||= [];
+					push @{$kernels{$target_name}}, $target_kernel;
+					if ($target_testing_kernel) {
+						push @{$kernels{$target_name}}, $target_testing_kernel;
+					}
 				}
 
 				undef $target_name;
 				undef $target_arch;
+				undef $target_kernel;
+				undef $target_testing_kernel;
 				@target_features = ();
 			}
 		}
@@ -85,7 +98,14 @@ elsif (@ARGV == 1 && $ARGV[0] eq 'architectures') {
 		printf "%s %s\n", $target_arch, join ' ', @{$architectures{$target_arch}};
 	}
 }
+elsif (@ARGV == 1 && $ARGV[0] eq 'kernels') {
+	get_targetinfo();
+	foreach my $target_name (sort keys %targets) {
+		printf "%s %s\n", $target_name, join ' ', @{$kernels{$target_name}};
+	}
+}
 else {
 	print "Usage: $0 targets\n";
 	print "Usage: $0 architectures\n";
+	print "Usage: $0 kernels\n";
 }


### PR DESCRIPTION
This commits adds the ability to print Kernel versions of all
targets/subtargets. If a testing Kernel is set print that version as
well.

Example output:

    apm821xx/nand 5.10
    apm821xx/sata 5.10
    arc770/generic 5.4
    archs38/generic 5.4
    armvirt/32 5.10
    armvirt/64 5.10
    at91/sam9x 5.10
    at91/sama5 5.10
    ath25/generic 5.4
    ath79/generic 5.4 5.10
    ath79/mikrotik 5.4 5.10
    --- %< ---

This should help to get a quick update on the state of Kernels.

Signed-off-by: Paul Spooren <mail@aparcar.org>

@jow- since there are 100 ways to solve the same problem in Perl I'm sure you're aware of 99 ways to improve this. Please let me know.