### PR TITLE
build,wpa-cli: fix for wpa-cli package not being built

### DIFF
--- a/include/package-bin.mk
+++ b/include/package-bin.mk
@@ -4,7 +4,7 @@
 
 ifeq ($(DUMP),)
   define BuildTarget/bin
-    TARGET_VARIANT=$(if $(ALL_VARIANTS),$(if $(VARIANT),$(VARIANT),$(firstword $(ALL_VARIANTS))))
+    TARGET_VARIANT=$(if $(ALL_VARIANTS),$(if $(VARIANT),$(filter-out *,$(VARIANT)),$(firstword $(ALL_VARIANTS))))
     ifeq ($(if $(TARGET_VARIANT),$(BUILD_VARIANT)),$(TARGET_VARIANT))
     ifdef Package/$(1)/install
       ifneq ($(CONFIG_PACKAGE_$(1))$(DEVELOPER),)

--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -105,7 +105,7 @@ ifeq ($(DUMP),)
     IDIR_$(1):=$(PKG_BUILD_DIR)/ipkg-$(PKGARCH)/$(1)
     KEEP_$(1):=$(strip $(call Package/$(1)/conffiles))
 
-    TARGET_VARIANT:=$$(if $(ALL_VARIANTS),$$(if $$(VARIANT),$$(VARIANT),$(firstword $(ALL_VARIANTS))))
+    TARGET_VARIANT:=$$(if $(ALL_VARIANTS),$$(if $$(VARIANT),$$(filter-out *,$$(VARIANT)),$(firstword $(ALL_VARIANTS))))
     ifeq ($(BUILD_VARIANT),$$(if $$(TARGET_VARIANT),$$(TARGET_VARIANT),$(BUILD_VARIANT)))
     do_install=
     ifdef Package/$(1)/install

--- a/include/subdir.mk
+++ b/include/subdir.mk
@@ -69,7 +69,7 @@ define subdir
         $(if $(call diralias,$(bd)),$(call warn_eval,$(1)/$(bd),l,T,$(1)/$(call diralias,$(bd))/$(btype)/$(target): $(1)/$(bd)/$(btype)/$(target)))
       )
       $(call warn_eval,$(1)/$(bd),t,T,$(1)/$(bd)/$(target): $(if $(NO_DEPS)$(QUILT),,$($(1)/$(bd)/$(target)) $(call $(1)//$(target),$(1)/$(bd))))
-        $(foreach variant,$(if $(BUILD_VARIANT),$(BUILD_VARIANT),$(if $(strip $($(1)/$(bd)/variants)),$($(1)/$(bd)/variants),$(if $($(1)/$(bd)/default-variant),$($(1)/$(bd)/default-variant),__default))),
+        $(foreach variant,$(filter-out *,$(if $(BUILD_VARIANT),$(BUILD_VARIANT),$(if $(strip $($(1)/$(bd)/variants)),$($(1)/$(bd)/variants),$(if $($(1)/$(bd)/default-variant),$($(1)/$(bd)/default-variant),__default)))),
 			$(if $(BUILD_LOG),@mkdir -p $(BUILD_LOG_DIR)/$(1)/$(bd)/$(filter-out __default,$(variant)))
 			$(if $($(1)/autoremove),$(call rebuild_check,$(1)/$(bd),$(target),,$(filter-out __default,$(variant)),$($(1)/$(bd)/variants)))
 			$(call log_make,$(1)/$(bd),$(target),,$(filter-out __default,$(variant)),$($(1)/$(bd)/variants)) \

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -426,6 +426,7 @@ define Package/hostapd-utils
   TITLE:=IEEE 802.1x Authenticator (utils)
   URL:=http://hostap.epitest.fi/
   DEPENDS:=@$(subst $(space),||,$(foreach pkg,$(HOSTAPD_PROVIDERS),PACKAGE_$(pkg)))
+  VARIANT:=*
 endef
 
 define Package/hostapd-utils/description
@@ -439,6 +440,7 @@ define Package/wpa-cli
   SUBMENU:=WirelessAPD
   DEPENDS:=@$(subst $(space),||,$(foreach pkg,$(SUPPLICANT_PROVIDERS),PACKAGE_$(pkg)))
   TITLE:=WPA Supplicant command line control utility
+  VARIANT:=*
 endef
 
 define Package/eapol-test/Default


### PR DESCRIPTION
[It was brought to my attention](https://github.com/openwrt/openwrt/commit/67f9245ee57eaf47093275670b227c7911f485d4#commitcomment-59339612) that the wpa-cli package was not getting built after #4728.

19aae94 made it so that all packages without a defined `VARIANT` built in the same Makefile as packages with a defined `VARIANT` get built only with the first `VARIANT` in the list of menuconfig-selected package variants.  If all variants are selected, the first one defined is used.

Hostapd only builds wpa-cli if the variant has supplicant support (variants that are not hostapd*):
https://github.com/openwrt/openwrt/blob/67f9245ee57eaf47093275670b227c7911f485d4/package/network/services/hostapd/Makefile#L652-L653

The first variant that gets built with CONFIG_ALL is hostapd-full-internal, so wpa-cli will not have its install section:
```
Makefile:710: WARNING: skipping wpa-cli -- package has no install section
```
If we just changed the order of the packages, then we would hit a problem with hostapd-utils, which not built for supplicant-only packages.

To circumvent this, the fist commit restores the original behavior of building a package for every defined variant if they have 
```
VARIANT:=*
````
The second commit then changes wpa-cli and hostapd-utils packages to have `VARIANT:=*`.

I've done a quick search through the packages to spot any other package that uses that logic, but found none that defined packages without a defined `VARIANT` that had sections guarded by `BUILD_VARIANT` conditionals.