### PR TITLE
generic: fix mac-address-increment patch

### DIFF
--- a/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.10/682-of_net-add-mac-address-increment-support.patch
@@ -1,7 +1,7 @@
-From 639dba857aa554f2a78572adc4cf3c32de9ec2e2 Mon Sep 17 00:00:00 2001
+From 844c273286f328acf0dab5fbd5d864366b4904dc Mon Sep 17 00:00:00 2001
 From: Ansuel Smith <ansuelsmth@gmail.com>
 Date: Tue, 30 Mar 2021 18:21:14 +0200
-Subject: [PATCH 2/2] of_net: add mac-address-increment support
+Subject: [PATCH] of_net: add mac-address-increment support
 
 Lots of embedded devices use the mac-address of other interface
 extracted from nvmem cells and increments it by one or two. Add two
@@ -15,12 +15,12 @@ early has to be increased.
 
 Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 ---
- drivers/of/of_net.c | 59 ++++++++++++++++++++++++++++++++++-----------
- 1 file changed, 45 insertions(+), 14 deletions(-)
+ drivers/of/of_net.c | 43 +++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 39 insertions(+), 4 deletions(-)
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -115,27 +115,52 @@ static int of_get_mac_addr_nvmem(struct
+@@ -119,28 +119,63 @@ static int of_get_mac_addr_nvmem(struct device_node *np, u8 *addr)
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.
   *
@@ -28,15 +28,17 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 + * using:
 + * - mac-address-increment-byte to decide what byte to increase
 + *   (if not defined is increased the last byte)
-+ * - mac-address-increment to decide how much to increase. The value will
-+ *   not overflow to other bytes if the increment is over 255.
-+ *   (example 00:01:02:03:04:ff + 1 == 00:01:02:03:04:00)
++ * - mac-address-increment to decide how much to increase. The value WILL
++ *   overflow to other bytes if the increment is over 255 or the total
++ *   increment will exceed 255 of the current byte.
++ *   (example 00:01:02:03:04:ff + 1 == 00:01:02:03:05:00)
++ *   (example 00:01:02:03:04:fe + 5 == 00:01:02:03:05:03)
 + *
   * Return: 0 on success and errno in case of error.
  */
  int of_get_mac_address(struct device_node *np, u8 *addr)
  {
-+	u32 inc_idx, mac_inc;
++	u32 inc_idx, mac_inc, mac_val;
  	int ret;
  
 +	/* Check first if the increment byte is present and valid.
@@ -64,16 +66,24 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  	if (!ret)
 -		return 0;
 +		goto found;
-+
+ 
+-	return of_get_mac_addr_nvmem(np, addr);
 +	ret = of_get_mac_addr_nvmem(np, addr);
 +	if (ret)
 +		return ret;
 +
 +found:
-+	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
-+		addr[inc_idx] += mac_inc;
- 
--	return of_get_mac_addr_nvmem(np, addr);
++	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc)) {
++		/* Convert to a contiguous value */
++		mac_val = (addr[3] << 16) + (addr[4] << 8) + addr[5];
++		mac_val += mac_inc << 8 * (5-inc_idx);
++
++		/* Apply the incremented value handling overflow case */
++		addr[3] = (mac_val >> 16) & 0xff;
++		addr[4] = (mac_val >> 8) & 0xff;
++		addr[5] = (mac_val >> 0) & 0xff;
++	}
++
 +	return ret;
  }
  EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.10/683-of_net-add-mac-address-to-of-tree.patch
@@ -29,8 +29,8 @@
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
 @@ -161,6 +182,7 @@ found:
- 	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
- 		addr[inc_idx] += mac_inc;
+ 		addr[5] = (mac_val >> 0) & 0xff;
+ 	}
  
 +	of_add_mac_address(np, addr);
  	return ret;

--- a/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
+++ b/target/linux/generic/pending-5.4/682-of_net-add-mac-address-increment-support.patch
@@ -1,7 +1,7 @@
-From 639dba857aa554f2a78572adc4cf3c32de9ec2e2 Mon Sep 17 00:00:00 2001
+From 844c273286f328acf0dab5fbd5d864366b4904dc Mon Sep 17 00:00:00 2001
 From: Ansuel Smith <ansuelsmth@gmail.com>
 Date: Tue, 30 Mar 2021 18:21:14 +0200
-Subject: [PATCH 2/2] of_net: add mac-address-increment support
+Subject: [PATCH] of_net: add mac-address-increment support
 
 Lots of embedded devices use the mac-address of other interface
 extracted from nvmem cells and increments it by one or two. Add two
@@ -15,12 +15,12 @@ early has to be increased.
 
 Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 ---
- drivers/of/of_net.c | 59 ++++++++++++++++++++++++++++++++++-----------
- 1 file changed, 45 insertions(+), 14 deletions(-)
+ drivers/of/of_net.c | 43 +++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 39 insertions(+), 4 deletions(-)
 
 --- a/drivers/of/of_net.c
 +++ b/drivers/of/of_net.c
-@@ -109,27 +109,52 @@ static int of_get_mac_addr_nvmem(struct
+@@ -119,28 +119,63 @@ static int of_get_mac_addr_nvmem(struct device_node *np, u8 *addr)
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.
   *
@@ -28,15 +28,17 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
 + * using:
 + * - mac-address-increment-byte to decide what byte to increase
 + *   (if not defined is increased the last byte)
-+ * - mac-address-increment to decide how much to increase. The value will
-+ *   not overflow to other bytes if the increment is over 255.
-+ *   (example 00:01:02:03:04:ff + 1 == 00:01:02:03:04:00)
++ * - mac-address-increment to decide how much to increase. The value WILL
++ *   overflow to other bytes if the increment is over 255 or the total
++ *   increment will exceed 255 of the current byte.
++ *   (example 00:01:02:03:04:ff + 1 == 00:01:02:03:05:00)
++ *   (example 00:01:02:03:04:fe + 5 == 00:01:02:03:05:03)
 + *
   * Return: 0 on success and errno in case of error.
  */
  int of_get_mac_address(struct device_node *np, u8 *addr)
  {
-+	u32 inc_idx, mac_inc;
++	u32 inc_idx, mac_inc, mac_val;
  	int ret;
  
 +	/* Check first if the increment byte is present and valid.
@@ -64,16 +66,24 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  	if (!ret)
 -		return 0;
 +		goto found;
-+
+ 
+-	return of_get_mac_addr_nvmem(np, addr);
 +	ret = of_get_mac_addr_nvmem(np, addr);
 +	if (ret)
 +		return ret;
 +
 +found:
-+	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
-+		addr[inc_idx] += mac_inc;
- 
--	return of_get_mac_addr_nvmem(np, addr);
++	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc)) {
++		/* Convert to a contiguous value */
++		mac_val = (addr[3] << 16) + (addr[4] << 8) + addr[5];
++		mac_val += mac_inc << 8 * (5-inc_idx);
++
++		/* Apply the incremented value handling overflow case */
++		addr[3] = (mac_val >> 16) & 0xff;
++		addr[4] = (mac_val >> 8) & 0xff;
++		addr[5] = (mac_val >> 0) & 0xff;
++	}
++
 +	return ret;
  }
  EXPORT_SYMBOL(of_get_mac_address);

--- a/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
+++ b/target/linux/generic/pending-5.4/683-of_net-add-mac-address-to-of-tree.patch
@@ -29,8 +29,8 @@
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
 @@ -155,6 +176,7 @@ found:
- 	if (!of_property_read_u32(np, "mac-address-increment", &mac_inc))
- 		addr[inc_idx] += mac_inc;
+ 		addr[5] = (mac_val >> 0) & 0xff;
+ 	}
  
 +	of_add_mac_address(np, addr);
  	return ret;


### PR DESCRIPTION
Fix mac address increment patch. Permit to overflow to the next
byte and correctly calculate the incremented mac.

Reported-by: Chen Minqiang <ptpt52@gmail.com>
Fixes: d284e6ef0f06 ("treewide: convert mtd-mac-address-increment* to generic implementation")
Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

In theory should be a slimmer version of #4740
@ptpt52 can you test this variant?