### PR TITLE
[21.02] base-files: chmod 1777 /var/lock

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -21,9 +21,10 @@ boot() {
 	[ -f /proc/mounts ] || /sbin/mount_root
 	[ -f /proc/jffs2_bbc ] && echo "S" > /proc/jffs2_bbc
 
-	mkdir -p /var/run
-	mkdir -p /var/log
 	mkdir -p /var/lock
+	chmod 1777 /var/lock
+	mkdir -p /var/log
+	mkdir -p /var/run
 	mkdir -p /var/state
 	mkdir -p /var/tmp
 	mkdir -p /tmp/.uci


### PR DESCRIPTION
Hi all

Would it be possible to backport this commit to 21.02? This way we can sort out permission issues with USB dongles, like the ones used with asterisk-chan-dongle in the telephony repo.

Thanks for your consideration!

Kind regards,
Seb