### PR TITLE
ramips: Add broken-flash-reset for HLK-7621A EvB

### DIFF
--- a/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
+++ b/target/linux/ramips/dts/mt7621_hilink_hlk-7621a-evb.dts
@@ -27,6 +27,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <44000000>;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
This is needed because the HLK-7621 EvB has 32MB of flash, so it will have to use 4B addressing and the `broken-flash-reset` hack has to be used to be able to reboot.