### PR TITLE
kernel: 5.10: backport mac06 explicit disable patch

### DIFF
--- a/target/linux/generic/backport-5.10/750-v5.16-net-dsa-qca8k-make-sure-pad0-mac06-exchange-is-disabled.patch
+++ b/target/linux/generic/backport-5.10/750-v5.16-net-dsa-qca8k-make-sure-pad0-mac06-exchange-is-disabled.patch
@@ -1,0 +1,47 @@
+From 5f15d392dcb4aa250a63d6f2c5adfc26c0aedc78 Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 2 Nov 2021 19:30:41 +0100
+Subject: net: dsa: qca8k: make sure PAD0 MAC06 exchange is disabled
+
+Some device set MAC06 exchange in the bootloader. This cause some
+problem as we don't support this strange mode and we just set the port6
+as the primary CPU port. With MAC06 exchange, PAD0 reg configure port6
+instead of port0. Add an extra check and explicitly disable MAC06 exchange
+to correctly configure the port PAD config.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+Fixes: 3fcf734aa482 ("net: dsa: qca8k: add support for cpu port 6")
+Reviewed-by: Vladimir Oltean <olteanv@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/dsa/qca8k.c | 8 ++++++++
+ drivers/net/dsa/qca8k.h | 1 +
+ 2 files changed, 9 insertions(+)
+
+--- a/drivers/net/dsa/qca8k.c
++++ b/drivers/net/dsa/qca8k.c
+@@ -1109,6 +1109,14 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
++	/* Make sure MAC06 is disabled */
++	ret = qca8k_reg_clear(priv, QCA8K_REG_PORT0_PAD_CTRL,
++			      QCA8K_PORT0_PAD_MAC06_EXCHANGE_EN);
++	if (ret) {
++		dev_err(priv->dev, "failed disabling MAC06 exchange");
++		return ret;
++	}
++
+ 	/* Enable CPU Port */
+ 	ret = qca8k_reg_set(priv, QCA8K_REG_GLOBAL_FW_CTRL0,
+ 			    QCA8K_GLOBAL_FW_CTRL0_CPU_PORT_EN);
+--- a/drivers/net/dsa/qca8k.h
++++ b/drivers/net/dsa/qca8k.h
+@@ -34,6 +34,7 @@
+ #define   QCA8K_MASK_CTRL_DEVICE_ID_MASK		GENMASK(15, 8)
+ #define   QCA8K_MASK_CTRL_DEVICE_ID(x)			((x) >> 8)
+ #define QCA8K_REG_PORT0_PAD_CTRL			0x004
++#define   QCA8K_PORT0_PAD_MAC06_EXCHANGE_EN		BIT(31)
+ #define   QCA8K_PORT0_PAD_SGMII_RXCLK_FALLING_EDGE	BIT(19)
+ #define   QCA8K_PORT0_PAD_SGMII_TXCLK_FALLING_EDGE	BIT(18)
+ #define QCA8K_REG_PORT5_PAD_CTRL			0x008


### PR DESCRIPTION
This commit adds Ansuel Smith's explicit mac06 disable.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>