### PR TITLE
kernel: bump 5.10 to 5.10.78

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .156
-LINUX_VERSION-5.10 = .77
+LINUX_VERSION-5.10 = .78
 
 LINUX_KERNEL_HASH-5.4.156 = 06fe73e4623fcf1b3c0d0e1983d8286a2ff5b8fffbcb2163f4c01696a1c377fe
-LINUX_KERNEL_HASH-5.10.77 = d3b64edfc1dd7212e62ed733aeeb73d64ffd6d9658d322d44cddf1b41d5b8fc3
+LINUX_KERNEL_HASH-5.10.78 = be806c98e222ea581530727a8e83b0b96fcd678afd12944eb530e58776a6050f
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm27xx/patches-5.10/950-0138-usb-add-plumbing-for-updating-interrupt-endpoint-int.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0138-usb-add-plumbing-for-updating-interrupt-endpoint-int.patch
@@ -81,7 +81,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  extern int usb_driver_set_configuration(struct usb_device *udev, int config);
 --- a/include/linux/usb/hcd.h
 +++ b/include/linux/usb/hcd.h
-@@ -384,6 +384,11 @@ struct hc_driver {
+@@ -382,6 +382,11 @@ struct hc_driver {
  		 * or bandwidth constraints.
  		 */
  	void	(*reset_bandwidth)(struct usb_hcd *, struct usb_device *);
@@ -93,7 +93,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  		/* Returns the hardware-chosen device address */
  	int	(*address_device)(struct usb_hcd *, struct usb_device *udev);
  		/* prepares the hardware to send commands to the device */
-@@ -445,6 +450,8 @@ extern void usb_hcd_unmap_urb_setup_for_
+@@ -443,6 +448,8 @@ extern void usb_hcd_unmap_urb_setup_for_
  extern void usb_hcd_unmap_urb_for_dma(struct usb_hcd *, struct urb *);
  extern void usb_hcd_flush_endpoint(struct usb_device *udev,
  		struct usb_host_endpoint *ep);

--- a/target/linux/bcm27xx/patches-5.10/950-0139-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0139-xhci-implement-xhci_fixup_endpoint-for-interval-adju.patch
@@ -15,7 +15,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
 
 --- a/drivers/usb/host/xhci.c
 +++ b/drivers/usb/host/xhci.c
-@@ -1468,6 +1468,103 @@ command_cleanup:
+@@ -1467,6 +1467,103 @@ command_cleanup:
  }
  
  /*
@@ -119,7 +119,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
   * non-error returns are a promise to giveback() the urb later
   * we drop ownership so next owner (or urb unlink) can get it
   */
-@@ -5367,6 +5464,7 @@ static const struct hc_driver xhci_hc_dr
+@@ -5366,6 +5463,7 @@ static const struct hc_driver xhci_hc_dr
  	.endpoint_reset =	xhci_endpoint_reset,
  	.check_bandwidth =	xhci_check_bandwidth,
  	.reset_bandwidth =	xhci_reset_bandwidth,

--- a/target/linux/bcm4908/patches-5.10/075-v5.13-0005-net-dsa-bcm_sf2-fix-BCM4908-RGMII-reg-s.patch
+++ b/target/linux/bcm4908/patches-5.10/075-v5.13-0005-net-dsa-bcm_sf2-fix-BCM4908-RGMII-reg-s.patch
@@ -33,7 +33,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		break;
  	default:
  		switch (port) {
-@@ -1223,9 +1228,7 @@ static const u16 bcm_sf2_4908_reg_offset
+@@ -1227,9 +1232,7 @@ static const u16 bcm_sf2_4908_reg_offset
  	[REG_PHY_REVISION]	= 0x14,
  	[REG_SPHY_CNTRL]	= 0x24,
  	[REG_CROSSBAR]		= 0xc8,

--- a/target/linux/bcm4908/patches-5.10/700-net-dsa-bcm_sf2-enable-GPHY-for-switch-probing.patch
+++ b/target/linux/bcm4908/patches-5.10/700-net-dsa-bcm_sf2-enable-GPHY-for-switch-probing.patch
@@ -29,7 +29,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 
 --- a/drivers/net/dsa/bcm_sf2.c
 +++ b/drivers/net/dsa/bcm_sf2.c
-@@ -1484,10 +1484,14 @@ static int bcm_sf2_sw_probe(struct platf
+@@ -1488,10 +1488,14 @@ static int bcm_sf2_sw_probe(struct platf
  	rev = reg_readl(priv, REG_PHY_REVISION);
  	priv->hw_params.gphy_rev = rev & PHY_REVISION_MASK;
  

--- a/target/linux/bcm4908/patches-5.10/701-net-dsa-bcm_sf2-keep-GPHY-enabled-on-the-BCM4908.patch
+++ b/target/linux/bcm4908/patches-5.10/701-net-dsa-bcm_sf2-keep-GPHY-enabled-on-the-BCM4908.patch
@@ -15,7 +15,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 
 --- a/drivers/net/dsa/bcm_sf2.c
 +++ b/drivers/net/dsa/bcm_sf2.c
-@@ -1498,6 +1498,12 @@ static int bcm_sf2_sw_probe(struct platf
+@@ -1502,6 +1502,12 @@ static int bcm_sf2_sw_probe(struct platf
  		 priv->hw_params.core_rev >> 8, priv->hw_params.core_rev & 0xff,
  		 priv->irq0, priv->irq1);
  

--- a/target/linux/generic/backport-5.10/782-net-next-1-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
+++ b/target/linux/generic/backport-5.10/782-net-next-1-of-net-pass-the-dst-buffer-to-of_get_mac_address.patch
@@ -933,7 +933,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	}
 --- a/drivers/net/ethernet/microchip/lan743x_main.c
 +++ b/drivers/net/ethernet/microchip/lan743x_main.c
-@@ -2835,7 +2835,6 @@ static int lan743x_pcidev_probe(struct p
+@@ -2837,7 +2837,6 @@ static int lan743x_pcidev_probe(struct p
  {
  	struct lan743x_adapter *adapter = NULL;
  	struct net_device *netdev = NULL;
@@ -941,7 +941,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  	int ret = -ENODEV;
  
  	netdev = devm_alloc_etherdev(&pdev->dev,
-@@ -2852,9 +2851,7 @@ static int lan743x_pcidev_probe(struct p
+@@ -2854,9 +2853,7 @@ static int lan743x_pcidev_probe(struct p
  			      NETIF_MSG_IFDOWN | NETIF_MSG_TX_QUEUED;
  	netdev->max_mtu = LAN743X_MAX_FRAME_SIZE;
  

--- a/target/linux/generic/pending-5.10/811-pci_disable_usb_common_quirks.patch
+++ b/target/linux/generic/pending-5.10/811-pci_disable_usb_common_quirks.patch
@@ -98,7 +98,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #endif  /*  __LINUX_USB_PCI_QUIRKS_H  */
 --- a/include/linux/usb/hcd.h
 +++ b/include/linux/usb/hcd.h
-@@ -486,7 +486,14 @@ extern int usb_hcd_pci_probe(struct pci_
+@@ -484,7 +484,14 @@ extern int usb_hcd_pci_probe(struct pci_
  extern void usb_hcd_pci_remove(struct pci_dev *dev);
  extern void usb_hcd_pci_shutdown(struct pci_dev *dev);
  


### PR DESCRIPTION
All patches automatically rebased.

Build system: x86_64
Build-tested: bcm2711/RPi4B
Run-tested: bcm2711/RPi4B

Signed-off-by: John Audia <graysky@archlinux.us>