### PR TITLE
ramips: add support for Joowin WR758AC V1 and V2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_joowin_jw-wr758ac.dtsi"
+
+/ {
+	compatible = "joowin,jw-wr758ac-v1", "mediatek,mt7628an-soc";
+	model = "Joowin WR758AC V1";
+};

--- a/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v2.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_joowin_jw-wr758ac.dtsi"
+
+/ {
+	compatible = "joowin,jw-wr758ac-v2", "mediatek,mt7628an-soc";
+	model = "Joowin WR758AC V2";
+};

--- a/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac.dtsi
+++ b/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac.dtsi
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "joowin,jw-wr758ac", "mediatek,mt7628an-soc";
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi-high {
+			label = "blue:wifi-high";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-med {
+			label = "blue:wifi-med";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "blue:wifi-low";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portdisable = <0x2f>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -220,6 +220,26 @@ define Device/iptime_a604m
 endef
 TARGET_DEVICES += iptime_a604m
 
+define Device/joowin_jw-wr758ac
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Joowin
+  DEVICE_MODEL := WR758AC
+endef
+
+define Device/joowin_jw-wr758ac-v1
+  $(Device/joowin_jw-wr758ac)
+  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_VARIANT := V1
+endef
+TARGET_DEVICES += joowin_jw-wr758ac-v1
+
+define Device/joowin_jw-wr758ac-v2
+  $(Device/joowin_jw-wr758ac)
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  DEVICE_VARIANT := V2
+endef
+TARGET_DEVICES += joowin_jw-wr758ac-v2
+
 define Device/jotale_js76x8
   DEVICE_VENDOR := Jotale
   DEVICE_MODEL := JS76x8

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -129,6 +129,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;
+	joowin,jw-wr758ac-v1|\
+	joowin,jw-wr758ac-v2|\
 	tplink,tl-wr902ac-v3|\
 	wavlink,wl-wn576a2)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
Signed-off-by: Rodrigo Araujo <araujo.rm@gmail.com>

This patch adds support for Joowin (aka Comfast) WR758AC V1 and V2 devices.

Both are MT7628AN based, but V1 has a MT7662 as its 5GHz chip, while V2 has a MT7663 as its 5GHz chip. Some units are apparently mislabelled as V1, so if when you boot OpenWRT you don't see the 5GHz WiFi chip in LuCI, try the other image.

To install, setup a TFTP server on a machine with IP address 192.168.1.10 connected to the device's ethernet port and rename the squashfs-sysupgrade.bin to firmware_auto.bin. Turn off the device using the physical switch, wait a few seconds and turn it on again. The device should pull the firmware_auto.bin from the TFTP server, when it does disconnect the cable or stop the TFTP server, and the device should boot up with OpenWRT installed and available on the usual 192.168.1.1 address after a while.

If anything is not OK with the patch please let me know so I can fix it.

Thanks and best regards.