### PR TITLE
scripts/env: fix git conf defaultBranch not "master"

### DIFF
--- a/scripts/env
+++ b/scripts/env
@@ -61,7 +61,7 @@ env_init() {
 	mkdir -p "$ENVDIR" || error "Failed to create the environment directory"
 	cd "$ENVDIR" || error "Failed to switch to the environment directory"
 	[ -d .git ] || { 
-		git init &&
+		git init -b master &&
 		touch .config &&
 		mkdir files &&
 		git add . && 


### PR DESCRIPTION
Since version 2.28, git has a config option init.defaultBranch to set the name
of the first branch created with git init. The env script expects this name to
be "master". This commit sets the initial branch name to "master"
instead of using the git configured one.

Signed-off-by: Arne Zachlod <arne@nerdkeller.org>
