### PR TITLE
kernel: bump 5.10 to 5.10.79

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .158
-LINUX_VERSION-5.10 = .78
+LINUX_VERSION-5.10 = .79
 
 LINUX_KERNEL_HASH-5.4.158 = 6e018fecdc8fc24553756e582d83b82d65b10a6b03ef36262a24911f839b8d59
-LINUX_KERNEL_HASH-5.10.78 = be806c98e222ea581530727a8e83b0b96fcd678afd12944eb530e58776a6050f
+LINUX_KERNEL_HASH-5.10.79 = e49955e16a2ee26d0b3ca1521912daba5ab8f7a6b2c9e5f538bb0ae7b837a8ad
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/bcm63xx/patches-5.10/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
+++ b/target/linux/bcm63xx/patches-5.10/206-USB-EHCI-allow-limiting-ports-for-ehci-platform.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jonas Gorski <jogo@openwrt.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -678,6 +678,10 @@ int ehci_setup(struct usb_hcd *hcd)
+@@ -687,6 +687,10 @@ int ehci_setup(struct usb_hcd *hcd)
  
  	/* cache this readonly data; minimize chip reads */
  	ehci->hcs_params = ehci_readl(ehci, &ehci->caps->hcs_params);

--- a/target/linux/generic/backport-5.10/810-v5.13-usb-ehci-add-spurious-flag-to-disable-overcurrent-ch.patch
+++ b/target/linux/generic/backport-5.10/810-v5.13-usb-ehci-add-spurious-flag-to-disable-overcurrent-ch.patch
@@ -26,7 +26,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 
 --- a/drivers/usb/host/ehci-hcd.c
 +++ b/drivers/usb/host/ehci-hcd.c
-@@ -651,7 +651,7 @@ static int ehci_run (struct usb_hcd *hcd
+@@ -660,7 +660,7 @@ static int ehci_run (struct usb_hcd *hcd
  		"USB %x.%x started, EHCI %x.%02x%s\n",
  		((ehci->sbrn & 0xf0)>>4), (ehci->sbrn & 0x0f),
  		temp >> 8, temp & 0xff,
@@ -57,7 +57,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  			/*
 --- a/drivers/usb/host/ehci-platform.c
 +++ b/drivers/usb/host/ehci-platform.c
-@@ -327,6 +327,8 @@ static int ehci_platform_probe(struct pl
+@@ -333,6 +333,8 @@ static int ehci_platform_probe(struct pl
  		hcd->has_tt = 1;
  	if (pdata->reset_on_resume)
  		priv->reset_on_resume = true;
@@ -68,10 +68,10 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  	if (ehci->big_endian_mmio) {
 --- a/drivers/usb/host/ehci.h
 +++ b/drivers/usb/host/ehci.h
-@@ -218,6 +218,7 @@ struct ehci_hcd {			/* one per controlle
- 	unsigned		frame_index_bug:1; /* MosChip (AKA NetMos) */
+@@ -219,6 +219,7 @@ struct ehci_hcd {			/* one per controlle
  	unsigned		need_oc_pp_cycle:1; /* MPC834X port power */
  	unsigned		imx28_write_fix:1; /* For Freescale i.MX28 */
+ 	unsigned		is_aspeed:1;
 +	unsigned		spurious_oc:1;
  
  	/* required for usb32 quirk */


### PR DESCRIPTION
Manually rebased:
generic/backport-5.10/810-v5.13-usb-ehci-add-spurious-flag-to-disable-overcurrent-ch.patch

Run-tested:
ramips/mt7621 (Redmi AC2100)

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>