### PR TITLE
bcm27xx: Support Raspberry Pi Zero 2 W

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -92,17 +92,22 @@ define Device/rpi-2
   DEVICE_ALT1_VENDOR := Raspberry Pi
   DEVICE_ALT1_MODEL := 4B/400/4CM
   DEVICE_ALT1_VARIANT := (32bit)
+  DEVICE_ALT2_VENDOR := Raspberry Pi
+  DEVICE_ALT2_MODEL := Zero 2 W
+  DEVICE_ALT2_VARIANT :=(32bit)
   DEVICE_DTS := \
 	bcm2709-rpi-2-b bcm2710-rpi-2-b \
 	bcm2710-rpi-3-b bcm2710-rpi-3-b-plus \
 	bcm2711-rpi-4-b bcm2711-rpi-400 \
-	bcm2710-rpi-cm3 bcm2711-rpi-cm4
+	bcm2710-rpi-cm3 bcm2711-rpi-cm4 \
+	bcm2710-rpi-zero-2 bcm2710-rpi-zero-2-w
   SUPPORTED_DEVICES := \
 	rpi-2-b rpi-3-b rpi-3-b-plus rpi-cm \
 	raspberrypi,2-model-b raspberrypi,2-model-b-rev2 \
 	raspberrypi,3-model-b raspberrypi,3-model-b-plus \
 	raspberrypi,3-compute-module raspberrypi,compute-module-3 \
-	raspberrypi,400 raspberrypi,4-compute-module raspberrypi,4-model-b
+	raspberrypi,400 raspberrypi,4-compute-module raspberrypi,4-model-b \
+	raspberrypi,model-zero-2-w
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	cypress-nvram-43430-sdio-rpi-3b \
@@ -122,16 +127,20 @@ define Device/rpi-3
   DEVICE_ALT0_VENDOR := Raspberry Pi
   DEVICE_ALT0_MODEL := 2B-1.2
   DEVICE_ALT0_VARIANT := (64bit)
+  DEVICE_ALT1_VENDOR := Raspberry Pi
+  DEVICE_ALT1_MODEL := Zero 2 W
+  DEVICE_ALT1_VARIANT := (64bit)
   KERNEL_IMG := kernel8.img
   DEVICE_DTS := \
 	broadcom/bcm2710-rpi-2-b \
 	broadcom/bcm2710-rpi-3-b broadcom/bcm2710-rpi-3-b-plus \
-	broadcom/bcm2710-rpi-cm3
+	broadcom/bcm2710-rpi-cm3 broadcom/bcm2710-rpi-zero-2-w
   SUPPORTED_DEVICES := \
 	rpi-3-b rpi-3-b-plus \
 	raspberrypi,2-model-b-rev2 \
 	raspberrypi,3-model-b raspberrypi,3-model-b-plus \
-	raspberrypi,3-compute-module raspberrypi,compute-module-3
+	raspberrypi,3-compute-module raspberrypi,compute-module-3 \
+	raspberrypi,model-zero-2-w
   DEVICE_PACKAGES := \
 	cypress-firmware-43430-sdio \
 	cypress-nvram-43430-sdio-rpi-3b \

--- a/target/linux/bcm27xx/image/distroconfig.txt
+++ b/target/linux/bcm27xx/image/distroconfig.txt
@@ -8,6 +8,8 @@
 # See https://www.raspberrypi.org/documentation/configuration/uart.md
 [pi0w]
 dtoverlay=disable-bt
+[pi02]
+dtoverlay=disable-bt
 [pi3]
 dtoverlay=disable-bt
 [pi4]

--- a/target/linux/bcm27xx/patches-5.10/950-0739-raspberryi-pi-zero-2-w-dts.patch
+++ b/target/linux/bcm27xx/patches-5.10/950-0739-raspberryi-pi-zero-2-w-dts.patch
@@ -1,0 +1,242 @@
+Index: linux-5.10.78/arch/arm/boot/dts/Makefile
+===================================================================
+--- linux-5.10.78.orig/arch/arm/boot/dts/Makefile
++++ linux-5.10.78/arch/arm/boot/dts/Makefile
+@@ -110,7 +110,9 @@ dtb-$(CONFIG_ARCH_BCM2835) += \
+ 	bcm2837-rpi-3-b-plus.dtb \
+ 	bcm2837-rpi-cm3-io3.dtb \
+ 	bcm2835-rpi-zero.dtb \
+-	bcm2835-rpi-zero-w.dtb
++	bcm2835-rpi-zero-w.dtb \
++	bcm2710-rpi-zero-2.dtb \
++	bcm2710-rpi-zero-2-w.dtb
+ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4708-asus-rt-ac56u.dtb \
+ 	bcm4708-asus-rt-ac68u.dtb \
+Index: linux-5.10.78/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
+===================================================================
+--- /dev/null
++++ linux-5.10.78/arch/arm/boot/dts/bcm2710-rpi-zero-2-w.dts
+@@ -0,0 +1,198 @@
++/dts-v1/;
++
++#include "bcm2710.dtsi"
++#include "bcm2709-rpi.dtsi"
++#include "bcm283x-rpi-csi1-2lane.dtsi"
++#include "bcm283x-rpi-i2c0mux_0_44.dtsi"
++#include "bcm2708-rpi-bt.dtsi"
++#include "bcm283x-rpi-cam1-regulator.dtsi"
++
++/ {
++	compatible = "raspberrypi,model-zero-2-w", "brcm,bcm2837";
++	model = "Raspberry Pi Zero 2 W";
++
++	chosen {
++		bootargs = "coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_compat_alsa=0 snd_bcm2835.enable_hdmi=1";
++	};
++
++	aliases {
++		serial0 = &uart1;
++		serial1 = &uart0;
++		mmc1 = &mmcnr;
++	};
++};
++
++&gpio {
++	spi0_pins: spi0_pins {
++		brcm,pins = <9 10 11>;
++		brcm,function = <4>; /* alt0 */
++	};
++
++	spi0_cs_pins: spi0_cs_pins {
++		brcm,pins = <8 7>;
++		brcm,function = <1>; /* output */
++	};
++
++	i2c0_pins: i2c0 {
++		brcm,pins = <0 1>;
++		brcm,function = <4>;
++	};
++
++	i2c1_pins: i2c1 {
++		brcm,pins = <2 3>;
++		brcm,function = <4>;
++	};
++
++	i2s_pins: i2s {
++		brcm,pins = <18 19 20 21>;
++		brcm,function = <4>; /* alt0 */
++	};
++
++	sdio_pins: sdio_pins {
++		brcm,pins =     <34 35 36 37 38 39>;
++		brcm,function = <7>; // alt3 = SD1
++		brcm,pull =     <0 2 2 2 2 2>;
++	};
++
++	bt_pins: bt_pins {
++		brcm,pins = <43>;
++		brcm,function = <4>; /* alt0:GPCLK2 */
++		brcm,pull = <0>;
++	};
++
++	uart0_pins: uart0_pins {
++		brcm,pins = <30 31 32 33>;
++		brcm,function = <7>; /* alt3=UART0 */
++		brcm,pull = <2 0 0 2>; /* up none none up */
++	};
++
++	uart1_pins: uart1_pins {
++		brcm,pins;
++		brcm,function;
++		brcm,pull;
++	};
++
++	audio_pins: audio_pins {
++		brcm,pins = <>;
++		brcm,function = <>;
++	};
++};
++
++&mmcnr {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio_pins>;
++	bus-width = <4>;
++	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++
++		firmwares {
++			fw_43436p {
++				chipid = <43430>;
++				revmask = <4>;
++				fw_base = "brcm/brcmfmac43436-sdio";
++			};
++			fw_43436s {
++				chipid = <43430>;
++				revmask = <2>;
++				fw_base = "brcm/brcmfmac43436s-sdio";
++			};
++		};
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pins &bt_pins>;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>;
++	status = "okay";
++};
++
++&spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins &spi0_cs_pins>;
++	cs-gpios = <&gpio 8 1>, <&gpio 7 1>;
++
++	spidev0: spidev@0{
++		compatible = "spidev";
++		reg = <0>;	/* CE0 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <125000000>;
++	};
++
++	spidev1: spidev@1{
++		compatible = "spidev";
++		reg = <1>;	/* CE1 */
++		#address-cells = <1>;
++		#size-cells = <0>;
++		spi-max-frequency = <125000000>;
++	};
++};
++
++&i2c0if {
++	clock-frequency = <100000>;
++};
++
++&i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c1_pins>;
++	clock-frequency = <100000>;
++};
++
++&i2c2 {
++	clock-frequency = <100000>;
++};
++
++&i2s {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s_pins>;
++};
++
++&leds {
++	act_led: led-act {
++		label = "led0";
++		linux,default-trigger = "actpwr";
++		gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&hdmi {
++	hpd-gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
++};
++
++&audio {
++	pinctrl-names = "default";
++	pinctrl-0 = <&audio_pins>;
++	brcm,disable-headphones = <1>;
++};
++
++&bt {
++	shutdown-gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
++};
++
++&minibt {
++	shutdown-gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
++};
++
++&cam1_reg {
++	gpio = <&gpio 40 GPIO_ACTIVE_HIGH>;
++};
++
++/ {
++	__overrides__ {
++		act_led_gpio = <&act_led>,"gpios:4";
++		act_led_activelow = <&act_led>,"gpios:8";
++		act_led_trigger = <&act_led>,"linux,default-trigger";
++	};
++};
++
+Index: linux-5.10.78/arch/arm/boot/dts/bcm2710-rpi-zero-2.dts
+===================================================================
+--- /dev/null
++++ linux-5.10.78/arch/arm/boot/dts/bcm2710-rpi-zero-2.dts
+@@ -0,0 +1 @@
++#include "bcm2710-rpi-zero-2-w.dts"
+Index: linux-5.10.78/arch/arm64/boot/dts/broadcom/Makefile
+===================================================================
+--- linux-5.10.78.orig/arch/arm64/boot/dts/broadcom/Makefile
++++ linux-5.10.78/arch/arm64/boot/dts/broadcom/Makefile
+@@ -10,6 +10,7 @@ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rp
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-400.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-cm3.dtb
+ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-cm4.dtb
++dtb-$(CONFIG_ARCH_BCM2835) += bcm2710-rpi-zero-2.dtb
+ 
+ subdir-y	+= northstar2
+ subdir-y	+= stingray
+Index: linux-5.10.78/arch/arm64/boot/dts/broadcom/bcm2710-rpi-zero-2.dts
+===================================================================
+--- /dev/null
++++ linux-5.10.78/arch/arm64/boot/dts/broadcom/bcm2710-rpi-zero-2.dts
+@@ -0,0 +1 @@
++#include "../../../../arm/boot/dts/bcm2710-rpi-zero-2.dts"


### PR DESCRIPTION
Raspberry Pi Zero 2 W uses the same SoC as the already supported
Raspberry Pi 3, for which support in OpenWRT already existed.

As with the Raspberry Pi 3, Bluetooth was disabled in order to have
serial access at boot time.

Specification:
- 4x 1GHz Cortex A53
- 512 MB RAM
- SD Card
- 2.4 GHz WLAN

Signed-off-by: Arne Zachlod <arne@nerdkeller.org>