### PR TITLE
ramips: add support for HUMAX E10 

### DIFF
--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "humax,e10", "mediatek,mt7621-soc";
+	model = "HUMAX E10";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &wan;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio-usb-power {
+			gpio-export,name = "power:usb";
+			gpio-export,output = <1>;
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		pairing {
+			label = "green:pairing";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps-reset {
+			label = "wps_reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x30000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,offset = <FW_EDIMAX_OFFSET>;
+				openwrt,partition-magic = <FW_MAGIC_EDIMAX>;
+				label = "firmware";
+				reg = <0x70000 0xf90000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_10007>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_1000d>;
+			nvmem-cell-names = "mac-address";
+		};
+	
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_10007: macaddr@10007 {
+		reg = <0x10007 0x6>;
+	};
+
+	macaddr_factory_1000d: macaddr@1000d {
+		reg = <0x1000d 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -637,6 +637,25 @@ define Device/hiwifi_hc5962
 endef
 TARGET_DEVICES += hiwifi_hc5962
 
+define Device/humax_e10
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15936k
+  DEVICE_VENDOR := HUMAX
+  DEVICE_MODEL := E10
+  DEVICE_ALT0_VENDOR := HUMAX
+  DEVICE_ALT0_MODEL := QUANTUM E10
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	edimax-header -s CSYS -m EA03 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+	check-size | append-metadata
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
+	edimax-header -s CSYS -m EA03 -f 0x70000 -S 0x01100000 | \
+	check-size | zip upg -P f013c26cf0a320fb71d03356dcb6bb63
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+endef
+TARGET_DEVICES += humax_e10
+
 define Device/iodata_wn-ax1167gr
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -30,6 +30,7 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	asiarf,ap7621-001|\
+	humax,e10|\
 	winstars,ws-wn583a6)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;


### PR DESCRIPTION
HUMAX E10 (also known as HUMAX QUANTUM E10) is a 2.4/5GHz band AC router,
based on MediaTek MT7621A.

Specifications:
- SoC: MT7621A
- RAM: DDR3 128MB
- Flash: SPI NOR 16MB (MXIC MX25L12805D)
- WiFi:
  - 2.4GHz: MT7615
  - 5GHz: MT7615
- Ethernet: 2x 10/100/1000Mbps
  - Switch: SoC internal
- USB: 1x USB 2.0 Type-A
- UART: J1 (57600 8N1)
  - pinout: [3V3] (RXD) (GND) (TXD)

Installation via web interface:
- Flash **factory** image through the stock web interface.

Recovery procedure:
1. Connect ethernet cable between Router **LAN** port and PC Ethernet port.
2. Set your computer to a static IP **192.168.1.1**
3. Turn the device off and wait a few seconds. Hold the WPS button on front
   of device and insert power.
4. Send a firmware image to **192.168.1.6** using TFTP.
   You can use any TFTP client. (tftp, curl, Tftpd64...)
- It can accept both images which is
  HUMAX stock firmware dump (0x70000-0x1000000) image
  and OpenWRT **sysupgrade** image.

Signed-off-by: Kyoungkyu Park <choryu.park@choryu.space>