### PR TITLE
base-files: upgrade: fix efi partitions size calculation.

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -245,7 +245,7 @@ get_partitions() { # <device> <filename>
 				local type="$1"
 				local lba="$(( $(hex_le32_to_cpu $4) * 0x100000000 + $(hex_le32_to_cpu $3) ))"
 				local end="$(( $(hex_le32_to_cpu $6) * 0x100000000 + $(hex_le32_to_cpu $5) ))"
-				local num="$(( $end - $lba ))"
+				local num="$(( $end - $lba + 1 ))"
 
 				[ "$type" = "00000000000000000000000000000000" ] && continue
 


### PR DESCRIPTION
There is an off by one error in the calculation of efi partition sizes, we are missing the last sector of each partition,
compared with the output of gparted.

Initially submitted as part of #2951