### PR TITLE
sunxi: update nanopi neo air that use brcmfmac43430a0

### DIFF
--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -39,7 +39,7 @@ define Device/friendlyarm_nanopi-neo-air
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
   DEVICE_PACKAGES := kmod-rtc-sunxi kmod-leds-gpio kmod-brcmfmac \
-	cypress-firmware-43430-sdio wpad-basic-wolfssl
+	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air


### PR DESCRIPTION
Hi,

This PR update wifi firmware used for nanopi neo air, with cypress-firmware-43430-sdio there is no wifi detected, as brcmfmac-firmware-43430a0-sdio allow to acces to wifi.

Best Regards,
Michel. 
