### PR TITLE
[21.02] ath79: Fix Archer C6/A6 v2 (US) WAN LED Color

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
@@ -43,12 +43,12 @@
 
 		wan {
 			label = "green:wan";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
 		};
 
 		wan_fail {
 			label = "amber:wan";
-			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		wps {


### PR DESCRIPTION
The amber and green wan led color was inverted in dts file, which ends up leaving the wan led amber when the connection is established, so, switch gpio led number (7 and 8) in qca9563_tplink_archer-c6-v2-us.dts.

Tip: the /etc/config/system file needs to be regenerated.

This PR fixes bug FS#2854.

Signed-off-by: Rodrigo B. de Sousa Martins <rodrigo.sousa.577@gmail.com>