### PR TITLE
ramips: Add support for Sercomm S1500 clones

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -34,6 +34,12 @@ ampedwireless,ally-r1900k)
 beeline,smartbox-giga)
 	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
 	;;
+beeline,smartbox-pro|\
+wifire,s1500-nbn)
+	idx="$(find_mtd_index BootLoad-Env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x20000"
+	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-pro.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621_sercomm_s1500.dtsi"
+
+/ {
+	compatible = "beeline,smartbox-pro", "mediatek,mt7621-soc";
+	model = "Beeline SmartBox PRO";
+
+	aliases {
+		label-mac-device = &gmac0;
+	};
+
+	keys {
+		switch_bt { // "LOW<->HIGH" Switch Button
+			label = "ROUT<->REP Switch_bt";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3 \
+			&ubiconcat4 &ubiconcat5 &ubiconcat6>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 { // 215936 KiB = 210,875 MiB
+				label = "ubi";
+				reg = <0x0 0xd2e0000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0_all {
+			label = "ALL";
+			reg = <0x0 0xff80000>;
+			read-only;
+		};
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x100000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_1000: macaddr@1000 {
+				reg = <0x1000 0x6>;
+			};
+		};
+
+		partition@200001 {
+			label = "sys_data";
+			reg = <0x200000 0x1400000>;
+			read-only;
+		}; // Uboot saveenv 0x600000 0x20000
+
+		partition@1600000 {
+			label = "boot_flag";
+			reg = <0x1600000 0x100000>;
+		};
+
+		partition@1700000 {
+			label = "kernel"; // Kernel_1
+			reg = <0x1700000 0x400000>;
+		};
+
+		partition@1b00000 {
+			label = "Kernel_2";
+			reg = <0x1b00000 0x400000>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1f00000 {
+			label = "RootFS_1";
+			reg = <0x1f00000 0x1e00000>;
+		};
+
+		partition@3d00000 {
+			label = "RootFS_2";
+			reg = <0x3d00000 0x1e00000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@5b00000 {
+			label = "JVM/OSGI1";
+			reg = <0x5b00000 0x3200000>;
+		};
+
+		ubiconcat2: partition@8d00000 {
+			label = "JVM/OSGI2";
+			reg = <0x8d00000 0x3200000>;
+		};
+
+		ubiconcat3: partition@bf00000 {
+			label = "OSGI data";
+			reg = <0xbf00000 0x3c00000>;
+		};
+
+		ubiconcat4: partition@fb00000 {
+			label = "Ftool";
+			reg = <0xfb00000 0x100000>;
+		};
+
+		/*
+		 * 4 MiB for Reserved Bad Block
+		 * 0x10000000-0xfc00000=0x400000
+		 */
+
+		partition@800000 {
+			label = "BootLoad-Env";
+			reg = <0x800000 0x20000>;
+		};
+
+		/*
+		 * U-Boot Sercomm saves the environment at 0x800000,
+		 * destroying the sys_data partition. To do this, this section has
+		 * been split to bypass the uboot env area.
+		 */
+
+		ubiconcat5: partition@200000 {
+			label = "sysdata01";
+			reg = <0x200000 0x600000>;
+		};
+
+		ubiconcat6: partition@820000 {
+			label = "sysdata02";
+			reg = <0x820000 0xde0000>;
+		};
+	};
+};
+
+&wan {
+	mac-address-increment = <1>;
+};
+
+&wlan_5g {
+	mac-address-increment = <2>;
+};

--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_wps;
+		led-failsafe = &led_wps;
+	};
+
+	/*
+	 * bootargs (/proc/cmdline) forced by u-boot Sercomm command:
+	 * Slot Sercomm0
+	 * console=ttyS1,57600 ubi.mtd=7 root=ubi0:rootfs rw rootfstype=ubifs
+	 * Slot Sercomm1
+	 * console=ttyS1,57600 ubi.mtd=8 root=ubi0:rootfs rw rootfstype=ubifs
+	 * need a patch to lookup the block number of the root device in this bootarg
+	 * chosen {
+	 *	find-rootblock = "ubi.mtd=";
+	 * };
+	 */
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "WPS Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: wps {
+			label = "blue:wps";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: status {
+			label = "white:status";
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "white:wlan2g";
+			color = <LED_COLOR_ID_WHITE>;
+			// function = LED_FUNCTION_WLAN0;
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "white:wlan5g";
+			color = <LED_COLOR_ID_WHITE>;
+			// function = LED_FUNCTION_WLAN1;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_speed {
+			label = "amber:wan";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_link_act {
+			label = "green:wan";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1_speed {
+			label = "amber:lan1";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1_link_act {
+			label = "green:lan1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2_speed {
+			label = "amber:lan2";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2_link_act {
+			label = "green:lan2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3_speed {
+			label = "amber:lan3";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3_link_act {
+			label = "green:lan3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4_speed {
+			label = "amber:lan4";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4_link_act {
+			label = "green:lan4";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_1000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 { // mt7612en
+	wlan_5g: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+
+		nvmem-cells = <&macaddr_factory_1000>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pcie1 { // mt7602en
+	wlan_2g: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+
+		nvmem-cells = <&macaddr_factory_1000>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "uart3", "jtag", "uart2", "i2c", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		wan: port@4 {
+			status = "okay";
+			label = "wan";
+
+			nvmem-cells = <&macaddr_factory_1000>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
+++ b/target/linux/ramips/dts/mt7621_wifire_s1500-nbn.dts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621_sercomm_s1500.dtsi"
+
+/ {
+	compatible = "wifire,s1500-nbn", "mediatek,mt7621-soc";
+	model = "WiFire S1500.NBN";
+
+	aliases {
+		label-mac-device = &wan;
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 { // 72192 KiB = 70,5 MiB
+				label = "ubi";
+				reg = <0x0 0x4680000>;
+			};
+		};
+	};
+};
+
+&led_wps {
+	label = "white:wps";
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0_all {
+			label = "ALL";
+			reg = <0x0 0x7f80000>;
+			read-only;
+		};
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory"; // RF-EEPROM
+			reg = <0x100000 0x100000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_1000: macaddr@1000 {
+				reg = <0x1000 0x6>;
+			};
+		};
+
+		ubiconcat1: partition@200000 {
+			label = "sys_data";
+			reg = <0x200000 0x1400000>;
+		};
+
+		partition@1600000 {
+			label = "boot_flag";
+			reg = <0x1600000 0x100000>;
+		};
+
+		partition@1700000 {
+			label = "kernel"; // Kernel_1
+			reg = <0x1700000 0x400000>;
+		};
+
+		partition@1b00000 {
+			label = "Kernel_2";
+			reg = <0x1b00000 0x400000>;
+			read-only;
+		};
+
+		ubiconcat0: partition@1f00000 {
+			label = "RootFS_1";
+			reg = <0x1f00000 0x2e00000>;
+		};
+
+		partition@4d00000 {
+			label = "RootFS_2";
+			reg = <0x4d00000 0x2e00000>;
+			read-only;
+		};
+
+		ubiconcat2: partition@7b00000 {
+			label = "Ftool";
+			reg = <0x7b00000 0x100000>;
+		};
+
+		ubiconcat3: partition@7c00000 {
+			label = "BCT";
+			reg = <0x7c00000 0x380000>;
+		};
+
+		/*
+		 * 512 KiB for Reserved Bad Block
+		 * 0x8000000-0x7f80000=0x80000
+		 */
+
+		partition@80000 { // U-boot Environment
+			label = "BootLoad-Env";
+			reg = <0x80000 0x20000>;
+		};
+	};
+};
+
+&wan {
+	mac-address-increment = <1>;
+};
+
+&wlan_2g {
+	mac-address-increment = <1>;
+};
+
+&wlan_5g {
+	mac-address-increment = <2>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -299,6 +299,19 @@ define Device/beeline_smartbox-giga
 endef
 TARGET_DEVICES += beeline_smartbox-giga
 
+define Device/beeline_smartbox-pro
+  $(Device/sercomm-s1500-common)
+  DEVICE_VENDOR := Beeline
+  DEVICE_MODEL := SmartBox PRO
+  SERCOMM_HWID := AWI
+  SERCOMM_HWVER := 10000
+  SERCOMM_SWVER := 2020
+  IMAGE/factory.img := append-ubi | sercomm-tag-factory-img-pro 0x1700100 0x1f00000 0x1b00100 0x3d00000
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := S1500 AWI
+endef
+TARGET_DEVICES += beeline_smartbox-pro
+
 define Device/buffalo_wsr-1166dhp
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)
@@ -1891,6 +1904,21 @@ define Device/wevo_w2914ns-v2
   SUPPORTED_DEVICES += w2914nsv2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
+
+define Device/wifire_s1500-nbn
+  $(Device/sercomm-s1500-common)
+  DEVICE_VENDOR := WiFire
+  DEVICE_MODEL := S1500.NBN
+  SERCOMM_HWVER := 10000
+  SERCOMM_0x10str := 0001
+  SERCOMM_SWVER := 2015
+  SERCOMM_HWID := BUC
+  IMAGE/factory.img := append-ubi | sercomm-tag-factory-type-AB-nbn | \
+    sercomm-crypto
+  DEVICE_ALT0_VENDOR := Sercomm
+  DEVICE_ALT0_MODEL := S1500 BUC
+endef
+TARGET_DEVICES += wifire_s1500-nbn
 
 define Device/winstars_ws-wn583a6
   $(Device/dsa-migration)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -27,6 +27,21 @@ beeline,smartbox-flash|\
 beeline,smartbox-giga)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
+beeline,smartbox-pro|\
+wifire,s1500-nbn)
+	ucidef_set_led_wlan "wlan2g" "Wi-Fi 2.4 GHz" "white:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "Wi-Fi 5 GHz" "white:wlan5g" "phy0tpt"
+	ucidef_set_led_netdev "wan_act" "WAN Link/Act" "green:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "lan1_act" "LAN1 Link/Act" "green:lan1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan2_act" "LAN2 Link/Act" "green:lan2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan3_act" "LAN3 Link/Act" "green:lan3" "lan3" "link tx rx"
+	ucidef_set_led_netdev "lan4_act" "LAN4 Link/Act" "green:lan4" "lan4" "link tx rx"
+	ucidef_set_led_wlan "wan_speed" "WAN 1Gb/s" "amber:wan" "mt7530-0:04:1Gbps"
+	ucidef_set_led_wlan "lan1_speed" "LAN1 1Gb/s" "amber:lan1" "mt7530-0:03:1Gbps"
+	ucidef_set_led_wlan "lan2_speed" "LAN2 1Gb/s" "amber:lan2" "mt7530-0:02:1Gbps"
+	ucidef_set_led_wlan "lan3_speed" "LAN3 1Gb/s" "amber:lan3" "mt7530-0:01:1Gbps"
+	ucidef_set_led_wlan "lan4_speed" "LAN4 1Gb/s" "amber:lan4" "mt7530-0:00:1Gbps"
+	;;
 cudy,wr2100)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -56,6 +56,7 @@ platform_do_upgrade() {
 	asus,rt-ax53u|\
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
+	beeline,smartbox-pro|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\
@@ -88,6 +89,7 @@ platform_do_upgrade() {
 	raisecom,msg1500-x-00|\
 	sercomm,na502|\
 	sercomm,na502s|\
+	wifire,s1500-nbn|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
This PR adds support for wireless routers:
OEM/ODM Serсomm S1500 AWI - [Beeline SmartBox PRO](https://openwrt.org/inbox/toh/beeline/smartbox_pro)
OEM/ODM Serсomm S1500 BUC - [WiFire S1500.NBN](https://openwrt.org/toh/wifire/s1500_nbn)

- [Specification](https://forum.openwrt.org/t/adding-support-for-sercomm-s1500-clones-beeline-smartbox-pro-wifire-s1500-nbn/110065#general-specification-2)
- [MAC addresses as verified by OEM firmware](https://forum.openwrt.org/t/adding-support-for-sercomm-s1500-clones-beeline-smartbox-pro-wifire-s1500-nbn/110065/15?u=maxs0nix)

### Installation
* Web UI Update
  1. Rename the firmware so that there are no dots in the name, except
  	for the dot in the ".img" file type. Example "openwrt-factory.img".
  2. Upload and update the firmware via the original web interface.

Remark: You might need make the 2rd step twice if your running firmware
is booted from the Slot 1 (Sercomm0 bootflag). The stock firmware
reverses the bootflag (Sercomm0 / Sercomm1) on each firmware update. 

#### Discussion forum topic:
* [Adding support for Sercomm S1500 clones (Beeline SmartBox Pro, WiFire S1500.NBN)](https://forum.openwrt.org/t/adding-support-for-sercomm-s1500-clones-beeline-smartbox-pro-wifire-s1500-nbn/110065)
##### Related devices (SerComm OEM/ODM):
* Sercomm S1500 - #4770 
  * [Beeline SmartBox PRO](https://wikidevi.wi-cat.ru/Beeline_SmartBox_Pro)
  * [WiFire S1500.NBN](https://wikidevi.wi-cat.ru/WiFire_S1500.NBN)
* Sercomm S2
  * [Beeline SmartBox GIGA](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-giga-on-stock-u-boot/99390) - :heavy_check_mark: #4195
* Sercomm S3
  * [Beeline SmartBox TURBO+](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-turbo/99635) - #4108
  * [Beeline SmartBox TURBO](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-turbo/99635/37) - :heavy_check_mark: #10118
  * [Etisalat Sercomm S3](https://forum.openwrt.org/t/add-support-for-sercomm-s3-on-stock-uboot/95970)
  * Rostelecom RT-SF-1
  * Rostelecom RT-FE-1