### PR TITLE
qosify: move package to Base System

### DIFF
--- a/package/network/config/qosify/Makefile
+++ b/package/network/config/qosify/Makefile
@@ -27,8 +27,8 @@ include $(INCLUDE_DIR)/bpf.mk
 include $(INCLUDE_DIR)/nls.mk
 
 define Package/qosify
-  SECTION:=net
-  CATEGORY:=Network
+  SECTION:=utils
+  CATEGORY:=Base system
   TITLE:=A simple QoS solution based eBPF + CAKE
   DEPENDS:=+libbpf +libubox +libubus +kmod-sched-cake +kmod-sched-bpf +kmod-ifb +tc-full $(BPF_DEPENDS)
 endef


### PR DESCRIPTION

Since sqm-scripts and qos-scripts packages are in the same category as qosify, the firsts being in the Base System category, I find it understandable to move the latter to Base System instead of network section.

Signed-off-by: Rodrigo B. de Sousa Martins <rodrigo.sousa.577@gmail.com>
