### PR TITLE
musl: fix mmap pass wrong offset to kernel

### DIFF
--- a/toolchain/musl/patches/910-mmap-force-unsigned-long-offset-fix.patch
+++ b/toolchain/musl/patches/910-mmap-force-unsigned-long-offset-fix.patch
@@ -1,0 +1,20 @@
+--- a/src/mman/mmap.c
++++ b/src/mman/mmap.c
+@@ -14,7 +14,7 @@ weak_alias(dummy, __vm_wait);
+ void *__mmap(void *start, size_t len, int prot, int flags, int fd, off_t off)
+ {
+ 	long ret;
+-	if (off & OFF_MASK) {
++	if ((unsigned long)off & OFF_MASK) {
+ 		errno = EINVAL;
+ 		return MAP_FAILED;
+ 	}
+@@ -26,7 +26,7 @@ void *__mmap(void *start, size_t len, in
+ 		__vm_wait();
+ 	}
+ #ifdef SYS_mmap2
+-	ret = __syscall(SYS_mmap2, start, len, prot, flags, fd, off/UNIT);
++	ret = __syscall(SYS_mmap2, start, len, prot, flags, fd, (unsigned long)off/UNIT);
+ #else
+ 	ret = __syscall(SYS_mmap, start, len, prot, flags, fd, off);
+ #endif


### PR DESCRIPTION
for example off_t x=0x8d9eb000, the x/4096 result is 0xfff8d9eb, but on the kernel side
0x8d9eb is expected
as sys_mmap2 defined
```
asmlinkage long sys_mmap2(unsigned long addr, unsigned long len,
                        unsigned long prot, unsigned long flags,
                        unsigned long fd, unsigned long pgoff);
```
where pgoff is type of unsigned long

expecting to pass pgoff=0x8d9eb to sys_mmap2()
but actually `off/UNIT` pass pgoff=0xfff8d9eb to to sys_mmap2()

this happens on arm_cortex-a15/arm_cortex-a7 (or more) with gcc

for an test code:
```
 #include <stdio.h>
 #include <sys/types.h>

int main(void)
{
	long aaa = 0x8d9eb000;
	unsigned long x, y;

	x = aaa/4096;
	y = (unsigned long)aaa/4096;

	printf("%lx\n", aaa/4096);
	printf("%lx\n", (unsigned long)aaa/4096);
	printf("%lx %lx\n", x, y);

	return 0;
}
OUTPUT (arm):
fff8d9eb
8d9eb
fff8d9eb 8d9eb
```