### PR TITLE
tools/llvm-bpf: make sure llvm-bpf.tar.gz is created

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -156,7 +156,13 @@ $(curdir)/ := .config prereq
 
 $(curdir)/install: $(curdir)/compile
 
+ifneq ($(and $(CONFIG_USE_LLVM_BUILD),$(CONFIG_SDK_LLVM_BPF)),)
+TOOLS_CHECK_STAMP_LOCATION:=
+else
+TOOLS_CHECK_STAMP_LOCATION:=$(STAGING_DIR_HOST)
+endif
+
 tools_enabled = $(foreach tool,$(sort $(tools-y) $(tools-)),$(if $(filter $(tool),$(tools-y)),y,n))
 $(eval $(call stampfile,$(curdir),tools,compile,,_$(subst $(space),,$(tools_enabled)),$(STAGING_DIR_HOST)))
-$(eval $(call stampfile,$(curdir),tools,check,$(TMP_DIR)/.build,,$(STAGING_DIR_HOST)))
+$(eval $(call stampfile,$(curdir),tools,check,$(TMP_DIR)/.build,,$(TOOLS_CHECK_STAMP_LOCATION)))
 $(eval $(call subdir,$(curdir)))

--- a/tools/llvm-bpf/Makefile
+++ b/tools/llvm-bpf/Makefile
@@ -41,21 +41,22 @@ CMAKE_HOST_OPTIONS += \
 	-DLLVM_TOOLCHAIN_TOOLS="llvm-objcopy;llvm-objdump;llvm-readelf;llvm-strip;llvm-ar;llvm-as;llvm-dis;llvm-link;llvm-nm;llvm-ranlib;llc;opt" \
 	-DCMAKE_SKIP_RPATH=OFF
 
-ifneq ($(CONFIG_SDK_LLVM_BPF),)
-  define Host/Install/Bin
+$(BIN_DIR)/llvm-bpf-$(PKG_VERSION).tar.xz: $(HOST_STAMP_INSTALLED)
 	echo "$(PKG_VERSION)" > $(CMAKE_HOST_INSTALL_PREFIX)/.llvm-version
 	STRIP_KMOD= PATCHELF= STRIP=strip $(SCRIPT_DIR)/rstrip.sh $(STAGING_DIR_HOST)/llvm-bpf
 	tar -C $(STAGING_DIR_HOST) \
 		-I '$(STAGING_DIR_HOST)/bin/xz -7e -T$(if $(filter 1,$(NPROC)),2,0)' \
-		-cf $(BIN_DIR)/llvm-bpf-$(PKG_VERSION).tar.xz llvm-bpf $(LLVM_BPF_PREFIX)
-  endef
+		-cf $@.tmp llvm-bpf $(LLVM_BPF_PREFIX)
+	mv $@.tmp $@
+
+ifneq ($(CONFIG_SDK_LLVM_BPF),)
+compile: $(BIN_DIR)/llvm-bpf-$(PKG_VERSION).tar.xz
 endif
 
 define Host/Install
 	rm -rf $(STAGING_DIR_HOST)/llvm-bpf*
 	$(Host/Install/Default)
 	ln -s $(LLVM_BPF_PREFIX) $(STAGING_DIR_HOST)/llvm-bpf
-	$(Host/Install/Bin)
 endef
 
 define Host/Uninstall


### PR DESCRIPTION
The llvm-bpf-$version.tar.xz might be absent. For example `make clean` executed, `CONFIG_TARGET` changed or even `CONFIG_SDK_LLVM_BPF` changed from `unset` to `y`. It's not needed to recompile llvm-bpt at this time.
