### PR TITLE
[RFC] introduce dynamic wireless defaults

### DIFF
--- a/package/base-files/files/bin/board_detect
+++ b/package/base-files/files/bin/board_detect
@@ -4,11 +4,14 @@ CFG=$1
 
 [ -n "$CFG" ] || CFG=/etc/board.json
 
-[ -d "/etc/board.d/" -a ! -s "$CFG" ] && {
-	for a in $(ls /etc/board.d/*); do
-		[ -s $a ] || continue;
-		$(. $a)
-	done
-}
+(
+	flock 9 || return 1
+	[ -d "/etc/board.d/" -a ! -s "$CFG" ] && {
+		for a in $(ls /etc/board.d/*); do
+			[ -s $a ] || continue;
+			$(. $a)
+		done
+	}
+) 9>/tmp/lock/board_detect.lock
 
 [ -s "$CFG" ] || return 1

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -626,6 +626,70 @@ ucidef_set_hostname() {
 	json_select ..
 }
 
+ucidef_set_wireless() {
+	local ssid="$1"
+	local encryption="$2"
+	local key="$3"
+
+	json_select_object wireless
+		json_add_string ssid "$ssid"
+		[ -n "$encryption" ] && json_add_string encryption "$encryption"
+		[ -n "$key" ] && json_add_string key "$key"
+	json_select ..
+}
+
+ucidef_enable_wireless() {
+	local bands="$1"
+	local enable_2ghz
+	local enable_5ghz
+	local enable_6ghz
+	local enable_60ghz
+
+	case "$bands" in
+		*2*|*b*)
+			enable_2ghz=1
+			;;
+		all)
+			enable_2ghz=1
+			enable_5ghz=1
+			enable_6ghz=1
+			enable_60ghz=1
+			;;
+	esac
+
+	case "${bands//a[dy]/}" in
+		*5*|*a*)
+			enable_5ghz=1
+			;;
+	esac
+
+	case "${bands/60/}" in
+		*6*|*ax*)
+			enable_6ghz=1
+			;;
+	esac
+
+	case "$bands" in
+		*60*|*ad*|*ay*)
+			enable_60ghz=1
+			;;
+	esac
+
+	json_select_object wireless
+	[ "$enable_2ghz" = "1" ] && json_add_boolean enable_2ghz 1
+	[ "$enable_5ghz" = "1" ] && json_add_boolean enable_5ghz 1
+	[ "$enable_6ghz" = "1" ] && json_add_boolean enable_6ghz 1
+	[ "$enable_60ghz" = "1" ] && json_add_boolean enable_60ghz 1
+	json_select ..
+}
+
+ucidef_set_country() {
+	local country="$1"
+	json_select_object wireless
+		json_add_string country "$country"
+	json_select ..
+}
+
 ucidef_set_ntpserver() {
 	local server
 

--- a/package/base-files/files/sbin/wifi
+++ b/package/base-files/files/sbin/wifi
@@ -168,6 +168,7 @@ wifi_config() {
 			echo "$driver: Hardware detection not supported" >&2
 		fi
 	); done
+	wifi_updown "reconf"
 }
 
 start_net() {(

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -748,10 +748,22 @@ ath79_setup_macs()
 	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
+ath79_setup_wireless()
+{
+	local board="$1"
+
+	case "$board" in
+	tplink,tl-wdr4300-v1-il)
+		ucidef_set_country "IL"
+		;;
+	esac
+}
+
 board_config_update
 board=$(board_name)
 ath79_setup_interfaces $board
 ath79_setup_macs $board
+ath79_setup_wireless $board
 board_config_flush
 
 exit 0


### PR DESCRIPTION
This PR tries to improve the basic idea of https://github.com/openwrt/openwrt/pull/4349 but integrate it into the existing `uci-defaults` pattern.

New uci-default functions:
 - `ucidef_set_wireless ssid [encryption [key]]`
 - `ucidef_set_country cc`
 - `ucidef_enable_wireless {2, 5, all}`

They are supposed to be used in /etc/board.d/* scripts to define board-specific defaults for wireless.
Example use-cases:
 - better wireless defaults which are dynamically generated (e.g. based on NVRAM) and may correspond to what is printed on labels
 - wireless-only devices which need enabled wifi on first boot
 - need for model-specific default wireless country code

This implementation suffers from the shortcoming of having the sleep-poll for `/etc/board.json` in case the hotplug event to add the wireless radio arrives before `board_detect` is being called. As there is no locking I'd consider it dangerous to just call `board_detect` from the hotplug handler as well, so sleeping and checking if the file has been created was the best thing I could come up with in shell. @aparcar @jow- @mrkiko @ynezz Ideas are welcome!