### PR TITLE
dnsmasq: fix ismounted check

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -197,12 +197,12 @@ ismounted() {
 	for dirname in $EXTRA_MOUNT ; do
 		case "$filename" in
 			"${dirname}/"* | "${dirname}" )
-				return 1
+				return 0
 				;;
 		esac
 	done
 
-	return 0
+	return 1
 }
 
 append_addnhosts() {


### PR DESCRIPTION
Fix the return value, shell return codes should be 0 to indicate success (i.e. mount point found), 1 should be failure (i.e. mount point not-found).

Discovered when `dnsmasq` could not read custom file `/etc/hosts.home` added by `addnhosts` configuration option.

Fixes: ac4e8aa ("dnsmasq: fix more dnsmasq jail issues")