### PR TITLE
mac80211: fixed missing cfg80211 dependency on kmod-rfkill

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -97,7 +97,7 @@ PKG_CONFIG_DEPENDS += \
 define KernelPackage/cfg80211
   $(call KernelPackage/mac80211/Default)
   TITLE:=cfg80211 - wireless configuration API
-  DEPENDS+= +iw +iwinfo +wireless-regdb
+  DEPENDS+= +iw +iwinfo +wireless-regdb +USE_RFKILL:kmod-rfkill
   ABI_VERSION:=$(PKG_VERSION)-$(PKG_RELEASE)
   FILES:= \
 	$(PKG_BUILD_DIR)/compat/compat.ko \


### PR DESCRIPTION
_Updated_

When compiling with `CONFIG_USE_RFKILL=y`, the build fails and mentions that dependency on `kmod-rfkill` is missing, which is [correct](https://linux-wireless.vger.kernel.narkive.com/m8JY9Iks/cfg80211-depends-on-rfkill-or-not). Add this dependency to the `Makefile`.

Depend on `+USE_RFKILL` and not `PACKAGE_kmod-rfkill`, because it forces selection of `kmod-rfkill` package. Other 
combinations in `DEPENDS` like `USE_RFKILL:kmod-rfkill`, `PACKAGE_kmod-rfkill:kmod-rfkill` and `+PACKAGE_kmod-rfkill:kmod-rfkill` do not force selection of `kmod-rfkill` package.

The `kmod-rfkill` package itself depends on `USE_RFKILL`, so with `+USE_RFKILL` in `kmod-cfg80211` package it is not possible to select wrong combination of packages.