### PR TITLE
x86: added support to generate VHDX images

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -272,6 +272,12 @@ menu "Target Images"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		select PACKAGE_kmod-e1000
 
+	config VHDX_IMAGES
+		bool "Build Hyper-V image files (VHDX)"
+		depends on TARGET_x86
+		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
+		select PACKAGE_kmod-e1000
+
 	config TARGET_IMAGES_GZIP
 		bool "GZip images"
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_x86 || TARGET_armvirt || TARGET_malta

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -374,7 +374,7 @@ define Build/patch-cmdline
 endef
 
 # Convert a raw image into a $1 type image.
-# E.g. | qemu-image vdi
+# E.g. | qemu-image vdi <optional extra arguments to qemu-img binary>
 define Build/qemu-image
 	if command -v qemu-img; then \
 		qemu-img convert -f raw -O $1 $@ $@.new; \

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=i386
 BOARD:=x86
 BOARDNAME:=x86
-FEATURES:=squashfs ext4 vdi vmdk pcmcia targz fpu boot-part rootfs-part
+FEATURES:=squashfs ext4 vdi vmdk vhdx pcmcia targz fpu boot-part rootfs-part
 SUBTARGETS:=generic legacy geode 64
 
 KERNEL_PATCHVER:=5.10

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -109,6 +109,7 @@ define Device/Default
   IMAGE/combined.img.gz := grub-config pc | combined | grub-install | gzip | append-metadata
   IMAGE/combined.vdi := grub-config pc | combined | grub-install | qemu-image vdi
   IMAGE/combined.vmdk := grub-config pc | combined | grub-install | qemu-image vmdk
+  IMAGE/combined.vhdx := grub-config pc | combined | grub-install | qemu-image vhdx -o subformat=dynamic
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
   ARTIFACT/image-efi.iso := grub-config iso | iso efi
@@ -116,6 +117,7 @@ define Device/Default
   IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
   IMAGE/combined-efi.vdi := grub-config efi | combined efi | grub-install efi | qemu-image vdi
   IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
+  IMAGE/combined-efi.vhdx := grub-config efi | combined efi | grub-install efi | qemu-image vhdx -o subformat=dynamic
   ifeq ($(CONFIG_TARGET_IMAGES_GZIP),y)
     IMAGES-y := rootfs.img.gz
     IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.img.gz
@@ -139,6 +141,10 @@ define Device/Default
   ifeq ($(CONFIG_VMDK_IMAGES),y)
     IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vmdk
     IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vmdk
+  endif
+  ifeq ($(CONFIG_VHDX_IMAGES),y)
+    IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vhdx
+    IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vhdx
   endif
   IMAGES := $$(IMAGES-y)
   ARTIFACTS := $$(ARTIFACTS-y)


### PR DESCRIPTION
Added support to generate dynamic-sized VHDX images for Hyper-V. Compile-tested on x86 and run-tested on Windows 10 21H2 (Hyper-V).