### PR TITLE
ramips: add support for Kroks KNdRt31R16 and KNdRt31R19 routers

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -37,6 +37,7 @@ beeline,smartbox-turbo)
 	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
+kroks,kndrt31r19|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
 xiaomi,mi-router-4c|\

--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -37,6 +37,7 @@ beeline,smartbox-turbo)
 	;;
 buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
+kroks,kndrt31r16|\
 kroks,kndrt31r19|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\

--- a/target/linux/ramips/dts/mt7628an_kroks.dtsi
+++ b/target/linux/ramips/dts/mt7628an_kroks.dtsi
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		serial1 = &uart1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: status {
+			label = "led:status";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "led:wifi";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+		m25p,fast-read;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio_reset {
+		groups = "wdt";
+		function = "gpio";
+	};
+
+	p0led_an {
+		groups = "p0led_an";
+		function = "p0led_an";
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0000>;
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
+++ b/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_kroks.dtsi"
+
+/ {
+	compatible = "kroks,kndrt31r16", "mediatek,mt7628an-soc";
+	model = "Kroks KNdRt31R16";
+
+	leds {
+		status {
+			label = "green:status";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb1power {
+			gpio-export,name = "usb1power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "wled_an";
+		function = "gpio";
+	};
+
+	p1led_an {
+		groups = "p1led_an";
+		function = "p1led_an";
+	};
+
+	p2led_an {
+		groups = "p2led_an";
+		function = "p2led_an";
+	};
+
+	p3led_an {
+		groups = "p3led_an";
+		function = "p3led_an";
+	};
+
+	p4led_an {
+		groups = "p4led_an";
+		function = "p4led_an";
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_kroks_kndrt31r19.dts
+++ b/target/linux/ramips/dts/mt7628an_kroks_kndrt31r19.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_kroks.dtsi"
+
+/ {
+	compatible = "kroks,kndrt31r19", "mediatek,mt7628an-soc";
+	model = "Kroks KNdRt31R19";
+
+	leds {
+		status {
+			label = "red:status";
+		};
+
+		wifi {
+			label = "yellow:wifi";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		modem1power {
+			gpio-export,name = "modem1power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		modem1sim1 {
+			gpio-export,name = "modem1sim1";
+			gpio-export,output = <1>;
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem1sim2 {
+			gpio-export,name = "modem1sim2";
+			gpio-export,output = <0>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem1rsim1 {
+			gpio-export,name = "modem1rsim1";
+			gpio-export,output = <0>;
+			gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem1rsim2 {
+			gpio-export,name = "modem1rsim2";
+			gpio-export,output = <0>;
+			gpios = <&gpio 40 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "p4led_an", "p3led_an", "wled_an";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -310,6 +310,17 @@ define Device/jotale_js76x8-32m
 endef
 TARGET_DEVICES += jotale_js76x8-32m
 
+define Device/kroks_kndrt31r19
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Kroks
+  DEVICE_MODEL := Rt-Pot mXw DS RSIM
+  DEVICE_ALT0_VENDOR := Kroks
+  DEVICE_ALT0_MODEL := KNdRt31R19
+  DEVICE_PACKAGES := kmod-usb2 uqmi
+  SUPPORTED_DEVICES += kndrt31r19
+endef
+TARGET_DEVICES += kroks_kndrt31r19
+
 define Device/mediatek_linkit-smart-7688
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := MediaTek

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -310,6 +310,17 @@ define Device/jotale_js76x8-32m
 endef
 TARGET_DEVICES += jotale_js76x8-32m
 
+define Device/kroks_kndrt31r16
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Kroks
+  DEVICE_MODEL := Rt-Cse5 UW DRSIM
+  DEVICE_ALT0_VENDOR := Kroks
+  DEVICE_ALT0_MODEL := KNdRt31R16
+  DEVICE_PACKAGES := kmod-usb2
+  SUPPORTED_DEVICES += kndrt31r16
+endef
+TARGET_DEVICES += kroks_kndrt31r16
+
 define Device/kroks_kndrt31r19
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Kroks

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ ramips_setup_interfaces()
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
 	hiwifi,hc5861b|\
+	kroks,kndrt31r16|\
 	skylab,skw92a|\
 	tplink,archer-c20-v4|\
 	tplink,archer-c20-v5|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -131,6 +131,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	kroks,kndrt31r19|\
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
Adding two Kroks devices:
- ramips: add support for KROKS Rt-Cse SIM Injector DS

    Aka Kroks Rt-Cse5 UW DRSIM (KNdRt31R16), ID 1958:
    https://kroks.ru/search/?text=1958
    See Kroks OpenWrt fork for support of other models:
    https://github.com/kroks-free/openwrt
    
    Device specs:
    - CPU: MediaTek MT7628AN
    - Flash: 16MB SPI NOR
    - RAM: 64MB
    - Bootloader: U-Boot
    - Ethernet: 5x 10/100 Mbps
    - 2.4 GHz: b/g/n SoC
    - USB: 1x
    - SIM-reader: 2x (driven by a dedicated chip with it's own firmware)
    - Buttons: reset
    - LEDs: 1x Power, 1x Wi-Fi, 12x others (SIM status, Internet, etc.)
    
    Flashing:
    - sysupgrade image via stock firmware WEB interface, IP: 192.168.1.254
    - U-Boot launches a WEB server if Reset button is held during power up,
      IP: 192.168.1.1
    
    MAC addresses as verified by OEM firmware:
    vendor   OpenWrt   source
    LAN      eth0      factory 0x4 (label)
    2g       wlan0     label
    
    Signed-off-by: Andrey Butirsky <butirsky@gmail.com>


- ramips: add support for Kroks Rt-Pot mXw DS RSIM router
    
    Aka "Kroks KNdRt31R19".
    Ported from v19.07.8 of OpenWrt fork:
    see https://github.com/kroks-free/openwrt
    for support of other models.
    
    Device specs:
    - CPU: MediaTek MT7628AN
    - Flash: 16MB SPI NOR
    - RAM: 64MB
    - Bootloader: U-Boot
    - Ethernet: 1x 10/100 Mbps
    - 2.4 GHz: b/g/n SoC
    - mPCIe: 1x (usually equipped with an LTE modem by vendor)
    - Buttons: reset
    - LEDs: 1x Modem, 1x Injector, 1x Wi-Fi, 1x Status
    
    Flashing:
    - sysupgrade image via stock firmware WEB interface.
    - U-Boot launches a WEB server if Reset button is held during power up.
    Server IP: 192.168.1.1
    
    SIM card switching:
    The device supports up to 4 SIM cards - 2 locally on board and 2 on
    remote SIM-injector.
    By default, 1-st local SIM is active.
    To switch to e.g. 1-st remote SIM:
    echo 0 > /sys/class/gpio/modem1power/value
    echo 0 > /sys/class/gpio/modem1sim1/value
    echo 1 > /sys/class/gpio/modem1rsim1/value
    echo 1 > /sys/class/gpio/modem1power/value
    
    MAC addresses as verified by OEM firmware:
    vendor   OpenWrt   source
    LAN      eth0      factory 0x4 (label)
    2g       wlan0     label
    
    Signed-off-by: Kroks <dev@kroks.ru>
    [butirsky@gmail.com: port to master; drop dts-v1]
    Signed-off-by: Andrey Butirsky <butirsky@gmail.com>