### PR TITLE
treewide: drop use of which

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(if $(findstring $(space),$(TOPDIR)),$(error ERROR: The path to the OpenWrt dir
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell which -a pkg-config | grep -E '\/usr' | head -n 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '\/usr' | head -n 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)

--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -10,7 +10,7 @@ ifneq ($(CONFIG_USE_LLVM_HOST),)
   else
     BPF_PATH:=$(PATH)
   endif
-  CLANG:=$(firstword $(shell PATH='$(BPF_PATH)' which clang clang-13 clang-12 clang-11))
+  CLANG:=$(firstword $(shell PATH='$(BPF_PATH)' command -v clang clang-13 clang-12 clang-11))
   LLVM_VER:=$(subst clang,,$(notdir $(CLANG)))
 endif
 ifneq ($(CONFIG_USE_LLVM_PREBUILT),)

--- a/include/cmake.mk
+++ b/include/cmake.mk
@@ -24,7 +24,7 @@ MAKE_PATH = $(firstword $(CMAKE_BINARY_SUBDIR) .)
 ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
   cmake_tool=$(TOOLCHAIN_DIR)/bin/$(1)
 else
-  cmake_tool=$(shell which $(1))
+  cmake_tool=$(shell command -v $(1))
 endif
 
 ifeq ($(CONFIG_CCACHE),)

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -49,7 +49,7 @@ endef
 
 define RequireCommand
   define Require/$(1)
-    which $(1)
+    command -v $(1)
   endef
 
   $$(eval $$(call Require,$(1),$(2)))
@@ -103,7 +103,7 @@ define SetupHostCommand
 	           $(call QuoteHostCommand,$(11)) $(call QuoteHostCommand,$(12)); do \
 		if [ -n "$$$$$$$$cmd" ]; then \
 			bin="$$$$$$$$(PATH="$(subst $(space),:,$(filter-out $(STAGING_DIR_HOST)/%,$(subst :,$(space),$(PATH))))" \
-				which "$$$$$$$${cmd%% *}")"; \
+				command -v "$$$$$$$${cmd%% *}")"; \
 			if [ -x "$$$$$$$$bin" ] && eval "$$$$$$$$cmd" >/dev/null 2>/dev/null; then \
 				mkdir -p "$(STAGING_DIR_HOST)/bin"; \
 				ln -sf "$$$$$$$$bin" "$(STAGING_DIR_HOST)/bin/$(strip $(1))"; \

--- a/scripts/command_all.sh
+++ b/scripts/command_all.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Reduced version of which -a using command utility
+
+case $PATH in
+	(*[!:]:) PATH="$PATH:" ;;
+esac
+
+for ELEMENT in $(echo $PATH | tr ":" "\n"); do
+        PATH=$ELEMENT command -v "$@"
+done

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -54,10 +54,8 @@ sub localmirrors {
 
 sub which($) {
 	my $prog = shift;
-	my $res = `which $prog`;
+	my $res = `command -v $prog`;
 	$res or return undef;
-	$res =~ /^no / and return undef;
-	$res =~ /not found/ and return undef;
 	return $res;
 }
 

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -14,7 +14,7 @@ chdir $ENV{TOPDIR};
 $ENV{GIT_CONFIG_PARAMETERS}="'core.autocrlf=false'";
 $ENV{GREP_OPTIONS}="";
 
-my $mk=`which gmake 2>/dev/null`;	# select the right 'make' program
+my $mk=`command -v gmake 2>/dev/null`;	# select the right 'make' program
 chomp($mk);		# trim trailing newline
 $mk or $mk = "make";	# default to 'make'
 

--- a/scripts/ubinize-image.sh
+++ b/scripts/ubinize-image.sh
@@ -131,7 +131,7 @@ if [ ! -r "$rootfs" -o ! -r "$kernel" -a ! "$outfile" ]; then
 	exit 1
 fi
 
-ubinize="$( which ubinize )"
+ubinize="$( command -v ubinize )"
 if [ ! -x "$ubinize" ]; then
 	echo "ubinize tool not found or not usable"
 	exit 1

--- a/target/sdk/files/Makefile
+++ b/target/sdk/files/Makefile
@@ -14,7 +14,7 @@ export TOPDIR LC_ALL LANG SDK
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell which -a pkg-config | grep -E '\/usr' | head -n 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -E '\/usr' | head -n 1)
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)
 
 ifneq ($(OPENWRT_BUILD),1)


### PR DESCRIPTION
Ubuntu started to flag which as deprecated and it
seems which is not really standard and may vary
across Distro.
Drop the use of which and use the standard 'command -v'
for this simple task.
Which is still present in the prereq if some package/script
still use which.
A utility script called command_all.sh is implemented that
will just mimic the output of which -a.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>