### PR TITLE
sunxi: remove kmod-rtc-sunxi for unsupported devices

### DIFF
--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -22,7 +22,7 @@ TARGET_DEVICES += cubietech_cubietruck
 define Device/friendlyarm_nanopi-m1-plus
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-leds-gpio kmod-brcmfmac \
+  DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
 	cypress-firmware-43430-sdio wpad-basic-wolfssl
   SOC := sun8i-h3
 endef
@@ -38,7 +38,7 @@ TARGET_DEVICES += friendlyarm_nanopi-neo
 define Device/friendlyarm_nanopi-neo-air
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
-  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-leds-gpio kmod-brcmfmac \
+  DEVICE_PACKAGES := kmod-leds-gpio kmod-brcmfmac \
 	cypress-firmware-43430-sdio wpad-basic-wolfssl
   SOC := sun8i-h3
 endef
@@ -47,7 +47,7 @@ TARGET_DEVICES += friendlyarm_nanopi-neo-air
 define Device/friendlyarm_nanopi-r1
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1
-  DEVICE_PACKAGES := kmod-rtc-sunxi kmod-usb-net-rtl8152 kmod-leds-gpio \
+  DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-leds-gpio \
 	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-wolfssl
   SOC := sun8i-h3
 endef
@@ -84,7 +84,7 @@ TARGET_DEVICES += lemaker_bananapi
 define Device/sinovoip_bananapi-m2-berry
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
 	cypress-firmware-43430-sdio wpad-basic-wolfssl
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
   SOC := sun8i-v40
@@ -94,7 +94,7 @@ TARGET_DEVICES += sinovoip_bananapi-m2-berry
 define Device/sinovoip_bananapi-m2-ultra
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
+  DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
 	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
   SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
   SOC := sun8i-r40
@@ -129,7 +129,7 @@ TARGET_DEVICES += linksprite_pcduino3-nano
 define Device/mele_m9
   DEVICE_VENDOR := Mele
   DEVICE_MODEL := M9
-  DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
+  DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtl8192cu
   SOC := sun6i-a31
 endef
 TARGET_DEVICES += mele_m9
@@ -170,7 +170,7 @@ TARGET_DEVICES += olimex_a20-olinuxino-micro
 define Device/sinovoip_bananapi-m2-plus
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-leds-gpio kmod-brcmfmac \
+  DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
 	brcmfmac-firmware-43430a0-sdio wpad-basic-wolfssl
   SOC := sun8i-h3
 endef
@@ -187,7 +187,7 @@ TARGET_DEVICES += xunlong_orangepi-one
 define Device/xunlong_orangepi-pc
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
+  DEVICE_PACKAGES:=kmod-gpio-button-hotplug
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-pc
@@ -195,7 +195,7 @@ TARGET_DEVICES += xunlong_orangepi-pc
 define Device/xunlong_orangepi-pc-plus
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-gpio-button-hotplug
+  DEVICE_PACKAGES:=kmod-gpio-button-hotplug
   SOC := sun8i-h3
 endef
 TARGET_DEVICES += xunlong_orangepi-pc-plus
@@ -211,7 +211,7 @@ TARGET_DEVICES += xunlong_orangepi-plus
 define Device/xunlong_orangepi-r1
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi R1
-  DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-usb-net-rtl8152
+  DEVICE_PACKAGES:=kmod-usb-net-rtl8152
   SOC := sun8i-h2-plus
 endef
 TARGET_DEVICES += xunlong_orangepi-r1


### PR DESCRIPTION
From driver source:

	{ .compatible = "allwinner,sun4i-a10-rtc", .data =
	&data_year_param[0] },
	{ .compatible = "allwinner,sun7i-a20-rtc", .data =
	&data_year_param[1] },

The rtc-sunxi module only supports allwinner a10 and a20 SoCs,
other SoCs in the cortexa7 and cortexa53 subtarget using the
CONFIG_RTC_DRV_SUN6I driver which is compiled into the kernel
binary, so remove this package for these unsupported devices.