### PR TITLE
kernel: skip hpower setting for the module which has no revs

### DIFF
--- a/target/linux/generic/pending-5.4/771-net-sfp-skip-hpowr-if-no-revision.patch
+++ b/target/linux/generic/pending-5.4/771-net-sfp-skip-hpowr-if-no-revision.patch
@@ -1,0 +1,12 @@
+@@ -0,0 +1,11 @@
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -1590,6 +1590,8 @@ static int sfp_module_parse_power(struct
+
+ static int sfp_sm_mod_hpower(struct sfp *sfp, bool enable)
+ {
++	if (sfp->id.ext.sff8472_compliance == SFP_SFF8472_COMPLIANCE_NONE)
++		return 0;
+ 	u8 val;
+ 	int err;
+


### PR DESCRIPTION
Signed-off-by: S.Teruyama <teruyama@springboard-inc.jp>

This commit adds support for NTT-Small-OCU
which has the sfp module with no compliance information.