### PR TITLE
ath79: add support for WD My Net N600

### DIFF
--- a/target/linux/ath79/dts/ar9344_wd_mynet-n600.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-n600.dts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_wd_mynet-nxxx.dtsi"
+
+/ {
+	model = "Western Digital My Net N600";
+	compatible = "wd,mynet-n600", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "blue:wireless";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "blue:internet";
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		wps {
+			label = "blue:wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio {
+	gpio_ext_lna0 {
+		gpio-hog;
+		gpios = <14 0>;
+		output-high;
+		line-name = "ext:lna0";
+	};
+
+	gpio_ext_lna1 {
+		gpio-hog;
+		gpios = <15 0>;
+		output-high;
+		line-name = "ext:lna1";
+	};
+};
+
+&pinmux {
+	pmx_led_switch: pinmux_led_switch {
+		pinctrl-single,bits =
+			<0x0 0x2c2b2a00 0xffffff00>, /* GPIO1-3 default to PHY2-4 */
+			<0x4 0x00000029 0x000000ff>; /* GPIO4 default to PHY1 */
+	};
+};
+
+&builtin_switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmx_led_switch>;
+};
+
+&usb {
+	status = "okay";
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy0>;
+
+	gmac-config {
+		device = <&gmac>;
+		switch-phy-swap = <1>;
+		switch-only-mode = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+};

--- a/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
@@ -1,17 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "ar9344.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "ar9344_wd_mynet-nxxx.dtsi"
 
 / {
 	model = "Western Digital My Net N750";
 	compatible = "wd,mynet-n750", "qca,ar9344";
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
-	};
 
 	aliases {
 		led-boot = &led_power;
@@ -59,75 +52,19 @@
 	};
 };
 
-&ref {
-	clock-frequency = <40000000>;
-};
-
 &gpio {
 	gpio_ext_lna0 {
 		gpio-hog;
 		gpios = <15 0>;
 		output-high;
-		line-name = "mynet-n750:ext:lna0";
+		line-name = "ext:lna0";
 	};
 
 	gpio_ext_lna1 {
 		gpio-hog;
 		gpios = <18 0>;
 		output-high;
-		line-name = "mynet-n750:ext:lna1";
-	};
-};
-
-&spi {
-	status = "okay";
-
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <25000000>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "bootloader";
-				reg = <0x000000 0x40000>;
-				read-only;
-			};
-
-			partition@40000 {
-				label = "bdcfg";
-				reg = <0x040000 0x10000>;
-				read-only;
-			};
-
-			partition@50000 {
-				label = "devdata";
-				reg = <0x050000 0x10000>;
-				read-only;
-			};
-
-			partition@60000 {
-				label = "devconf";
-				reg = <0x060000 0x10000>;
-				read-only;
-			};
-
-			partition@70000 {
-				compatible = "seama";
-				label = "firmware";
-				reg = <0x070000 0xf80000>;
-			};
-
-			art: partition@ff0000 {
-				label = "art";
-				reg = <0xff0000 0x010000>;
-				read-only;
-			};
-		};
+		line-name = "ext:lna1";
 	};
 };
 
@@ -152,26 +89,6 @@
 			#trigger-source-cells = <0>;
 		};
 	};
-};
-
-&usb_phy {
-	status = "okay";
-};
-
-&pcie {
-	status = "okay";
-
-	wifi@0,0 {
-		compatible = "pci168c,0033";
-		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
-	};
-};
-
-&wmac {
-	status = "okay";
-
-	qca,no-eeprom;
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar9344_wd_mynet-nxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-nxxx.dtsi
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "bdcfg";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "devdata";
+				reg = <0x050000 0x010000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "devconf";
+				reg = <0x060000 0x010000>;
+				read-only;
+			};
+
+			partition@70000 {
+				compatible = "seama";
+				label = "firmware";
+				reg = <0x070000 0xf80000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0033";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -129,7 +129,8 @@ ath79_setup_interfaces()
 	pcs,cr3000|\
 	tplink,archer-c58-v1|\
 	tplink,archer-c59-v1|\
-	tplink,archer-c59-v2)
+	tplink,archer-c59-v2|\
+	wd,mynet-n600)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
@@ -586,6 +587,7 @@ ath79_setup_macs()
 		;;
 	dlink,dir-859-a1|\
 	qihoo,c301|\
+	wd,mynet-n600|\
 	wd,mynet-n750)
 		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -30,6 +30,7 @@ case "$FIRMWARE" in
 	dlink,dir-859-a1|\
 	nec,wf1200cr|\
 	nec,wg1200cr|\
+	wd,mynet-n600|\
 	wd,mynet-n750)
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii devdata "wlan24mac")
@@ -126,6 +127,7 @@ case "$FIRMWARE" in
 	openmesh,mr600-v2)
 		caldata_extract "ART" 0x5000 0x440
 		;;
+	wd,mynet-n600|\
 	wd,mynet-n750)
 		caldata_extract "art" 0x5000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2319,6 +2319,18 @@ define Device/wallys_dr531
 endef
 TARGET_DEVICES += wallys_dr531
 
+define Device/wd_mynet-n600
+  $(Device/seama)
+  SOC := ar9344
+  DEVICE_VENDOR := Western Digital
+  DEVICE_MODEL := My Net N600
+  IMAGE_SIZE := 15872k
+  DEVICE_PACKAGES := kmod-usb2
+  SEAMA_SIGNATURE := wrgnd16_wd_db600
+  SUPPORTED_DEVICES += mynet-n600
+endef
+TARGET_DEVICES += wd_mynet-n600
+
 define Device/wd_mynet-n750
   $(Device/seama)
   SOC := ar9344


### PR DESCRIPTION
ath79: add support for WD My Net N600

SoC: AR9344
RAM: 128MB
Flash: 16MiB SPI NOR
5GHz WiFi: AR9382 PCIe 2x2:2 802.11n
2.4GHz WiFi: AR9344 (SoC) AHB 2x2:2 802.11n

5x Fast ethernet via SoC switch (green LEDs)
1x USB 2.0
4x front LEDs from SoC GPIO
1x front WPS button from SoC GPIO
1x bottom reset button from SoC GPIO

UART header JP1, 115200 no parity 1 stop
TX
GND
VCC
(N/P)
RX

Flash factory image via "emergency room" recovery:
- Configure your computer with a static IP 192.168.1.123/24
- Connect to LAN port on the N600 switch
- Hold reset putton
- Power on, holding reset until the power LED blinks slowly
- Visit http://192.168.1.1/ and upload OpenWrt factory image
- Wait at least 5 minutes for flashing, reboot and key generation
- Visit http://192.168.1.1/ (OpenWrt LuCI) and upload OpenWrt sysupgrade image

Signed-off-by: Ryan Mounce <ryan@mounce.com.au>