### PR TITLE
ath79: add support for jjPlus JWAP230

### DIFF
--- a/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
+++ b/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "jjPlus JWAP230";
+	compatible = "jjplus,jwap230", "qca,qca9550";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_art_lan: macaddr@0 {
+					reg = <0x0 0x6>;
+				};
+
+				macaddr_art_wan: macaddr@6 {
+					reg = <0x6 0x6>;
+				};
+
+				calibration_art_wlan: calibration@1000 {
+					reg = <0x1000 0x440>;
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	switch {
+		compatible = "qca,ar8327";
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x58 0xffb7ffb7 /* LED_CTRL2 */
+			0x5c 0x03ffff00 /* LED_CTRL3 */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			0x0c 0x00080080 /* PORT6 PAD MODE CTRL */
+			0x94 0x0000007e /* PORT6_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_wan>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0xae000000 0x80000101 0x80001313>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+
+	gmac_config: gmac-config {
+		device = <&gmac>;
+
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <0>;
+		txd-delay = <0>;
+		rgmii-enabled = <1>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_lan>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0x03000101 0x00000101 0x00001313>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&calibration_art_wlan>;
+	nvmem-cell-names = "calibration";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -306,6 +306,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
+	jjplus,jwap230)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "5:wan:1" "1:lan:2" "6@eth1"
+		;;
 	joyit,jt-or750i)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1407,6 +1407,14 @@ define Device/jjplus_ja76pf2
 endef
 TARGET_DEVICES += jjplus_ja76pf2
 
+define Device/jjplus_jwap230
+  SOC := qca9558
+  DEVICE_VENDOR := jjPlus
+  DEVICE_MODEL := JWAP230
+  IMAGE_SIZE := 16000k
+endef
+TARGET_DEVICES += jjplus_jwap230
+
 define Device/joyit_jt-or750i
   SOC := qca9531
   DEVICE_VENDOR := Joy-IT


### PR DESCRIPTION
ath79: add support for jjPlus JWAP230


The jjPlus JWAP230 is an access point board built around the QCA9558,
with built-in 2.4GHz 3x3 N WiFi (28dBm). It can be expanded with 2
mini-PCIe boards, and has an USB2 root port.

Specifications:
- SOC: Qualcomm Atheros QCA9558
- CPU: 720MHz
- H/W switch: QCA8327 rev 2
- Flash: 16 MiB SPI NOR (en25qh128)
- RAM: 128 MiB DDR2
- WLAN: AR9550 built-in SoC bgn 3T3R (ath9k)
- PCI: 2x mini-PCIe (optional 5V)
- USB2:
  - 1x Type A root port
  - 1x combined mini-PCIe
- Ethernet:
  - 2x 10/100/1000 (1x PoE 802.3af (36-57 V))

Notes:
 The device used to be supported in the ar71xx target.

Flash instructions:
- install from u-boot with tftp (requires serial access)
  > setenv ipaddr a.b.c.d
  > setenv serverip e.f.g.h
  > tftp 0x80060000 \
      openwrt-ath79-generic-jjplus_jwap230-squashfs-sysupgrade.bin
  > erase 0x9f050000 +${filesize}
  > cp.b $fileaddr 0x9f050000 $filesize
  > setenv bootcmd bootm 0x9f050000
  > saveenv

Signed-off-by: Olivier Valentin <valentio@free.fr>