### PR TITLE
kernel: add kmod-video-gspca-sq930x

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -855,6 +855,19 @@ endef
 
 $(eval $(call KernelPackage,video-gspca-sq905c))
 
+define KernelPackage/video-gspca-sq930x
+  TITLE:=sq930x webcam support
+  KCONFIG:=CONFIG_USB_GSPCA_SQ930X
+  FILES:=$(LINUX_DIR)/drivers/media/$(V4L2_USB_DIR)/gspca/gspca_sq930x.ko
+  AUTOLOAD:=$(call AutoProbe,gspca_sq930x)
+  $(call AddDepends/camera-gspca)
+endef
+
+define KernelPackage/video-gspca-sq930x/description
+ The SQ Technologies SQ930X based USB Camera Driver (sq930x) kernel module
+endef
+
+$(eval $(call KernelPackage,video-gspca-sq930x))
 
 define KernelPackage/video-gspca-stk014
   TITLE:=stk014 webcam support


### PR DESCRIPTION
This module adds support for USB WebCams, which uses SQ930X chip [1].

[1] https://cateee.net/lkddb/web-lkddb/USB_GSPCA_SQ930X.html