### PR TITLE
kernel: btrfs: enable ACL

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -70,7 +70,6 @@ define KernelPackage/fs-btrfs
   DEPENDS:=+kmod-lib-crc32c +kmod-lib-lzo +kmod-lib-zlib-inflate +kmod-lib-zlib-deflate +kmod-lib-raid6 +kmod-lib-xor +kmod-lib-zstd
   KCONFIG:=\
 	CONFIG_BTRFS_FS \
-	CONFIG_BTRFS_FS_POSIX_ACL=n \
 	CONFIG_BTRFS_FS_CHECK_INTEGRITY=n
   FILES:=\
 	$(LINUX_DIR)/fs/btrfs/btrfs.ko


### PR DESCRIPTION
By default CONFIG_BTRFS_FS_POSIX_ACL is disabled, it should be enabled
only when you enable CONFIG_FS_POSIX_ACL.

Right now, when you enable CONFIG_FS_POSIX_ACL it will enable
CONFIG_BTRFS_FS_POSIX_ACL, but it will be disabled once you install
kmod-btrfs. This should prevent it.

Btrfs has enabled by default ACL for mount option.

More details:
https://cateee.net/lkddb/web-lkddb/BTRFS_FS_POSIX_ACL.html
https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs(5)