### PR TITLE
ipq806x: revert SDC clock changes for NBG6817 MMC

### DIFF
--- a/target/linux/ipq806x/patches-5.10/097-1-ipq806x-gcc-add-missing-clk-flag.patch
+++ b/target/linux/ipq806x/patches-5.10/097-1-ipq806x-gcc-add-missing-clk-flag.patch
@@ -69,22 +69,6 @@ Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
  		},
  	},
  };
-@@ -1293,6 +1295,7 @@ static struct clk_rcg sdc1_src = {
- 			.parent_names = gcc_pxo_pll8,
- 			.num_parents = 2,
- 			.ops = &clk_rcg_ops,
-+			.flags = CLK_SET_RATE_GATE,
- 		},
- 	}
- };
-@@ -1341,6 +1344,7 @@ static struct clk_rcg sdc3_src = {
- 			.parent_names = gcc_pxo_pll8,
- 			.num_parents = 2,
- 			.ops = &clk_rcg_ops,
-+			.flags = CLK_SET_RATE_GATE,
- 		},
- 	}
- };
 @@ -1424,6 +1428,7 @@ static struct clk_rcg tsif_ref_src = {
  			.parent_names = gcc_pxo_pll8,
  			.num_parents = 2,


### PR DESCRIPTION
## In brief
* Remove `CLK_SET_RATE_GATE` for the SD MMC interfaces `sdc1_src` and `sdc3_src`
  * Fixes ZyXEL NBG6817 boot failures with newer Kingston MMC
  * Fixes regression from [`0470159` ipq806x: switch to kernel 5.10](https://github.com/openwrt/openwrt/commit/0470159552641c2b11ccc1b0fcfcb4ea08f2c6ab )
  * Context [for clock gating in this presentation](https://elinux.org/images/b/b8/Elc2013_Clement.pdf )

### Review request
@Ansuel Whenever you have the time, would you look over this?

I also encourage anyone with an NBG6817 to try this, whether your device currently works on snapshots (make sure it still works) or if it fails to boot after the v5.10 switch (check if it's fixed).

## Test case
### Check if you're affected

1.  Log in via SSH/etc on a working NBG6817
2.  Run this command

```
cd /sys/block/mmcblk0/device/ && tail -v cid date name manfid fwrev hwrev oemid rev
```
3.  Compare the `name` with the table below

`name`   | Status
---------|-------
`S10004` | 🏁 Unaffected
`M62704` | ✅ Fixed
Other    | ❓ Unknown

### Steps
1.  Prepare [for TFTP recovery](https://openwrt.org/toh/zyxel/nbg6817#oem_installation_using_the_tftp_method ) if you don't have [hardware serial console access](https://openwrt.org/toh/zyxel/nbg6817#serial )
2.  Compile and flash to the [ZyXEL NBG6817](https://openwrt.org/toh/zyxel/nbg6817 )
3.  Check if the device boots

### Before
*Hardware serial console as the device won't finish booting:*

```
[    2.746605] mmc0: error -110 whilst initialising MMC card
[…trimmed other messages…]
[    2.877832] Waiting for root device /dev/mmcblk0p5...
```

### After

Router boots successfully.

## Setup for capturing logs

**NOTE:** You almost certainly need [hardware serial console access to capture the logs](https://openwrt.org/toh/zyxel/nbg6817#serial )!  This requires opening your router, soldering, and a UART adapter cable.

### Enable [Dynamic Debugging for the Linux kernel](https://www.kernel.org/doc/html/latest/admin-guide/dynamic-debug-howto.html )

1.  Run `make menuconfig`
2.  Select `Global build settings --->`
3.  Select `Kernel build options --->`
4.  Enable `Compile the kernel with dynamic printk` via spacebar
5.  Save and exit (arrow key to `Exit` until prompted to save, then save)

Alternatively, set `CONFIG_KERNEL_DYNAMIC_DEBUG=y` in your `.config`.

### Turn on dynamic debugging at boot

Modify [`bootargs` in `target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts`](https://github.com/openwrt/openwrt/blob/a424dfd66bd881fc117ede8b737a0f8dd2c6dd37/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-nbg6817.dts#L25 ) to add…

```
bootargs = "[…existing bootargs…] dyndbg=\"file drivers/mmc/* +p\" dynamic_debug.verbose=1 loglevel=8";
```

For example:
```diff
 	chosen {
-		bootargs = "rootfstype=squashfs,ext4 rootwait noinitrd fstools_ignore_partname=1";
+		bootargs = "rootfstype=squashfs,ext4 rootwait noinitrd fstools_ignore_partname=1 dyndbg=\"file drivers/mmc/* +p\" dynamic_debug.verbose=1 loglevel=8";
 		append-rootblock = "root=/dev/mmcblk0p";
 	};
```

### Compile OpenWRT, flash

1.  Compile build
2.  Flash via `sysupgrade` in LuCI or command line
3.  **Be prepared to recover - see next step**

### Reboot to working alternative partition via serial console

*Sorry, I don't (yet) know how to do this without serial console access.  But if you don't have serial console access, you can't get the necessary kernel logs anyways.  [Use TFTP recovery instead.](https://openwrt.org/toh/zyxel/nbg6817#debricking)*

1.  [Connect to hardware serial console](https://openwrt.org/toh/zyxel/nbg6817#serial )
2.  Interrupt boot at `Hit any key to stop autoboot:`
3.  Run `ATSE NBG6817`
4.  Copy the result (e.g. `001976FE4B04`)
     * Changes with **every boot** - can't reuse this
5.  On your local system, run `./zyxel-uboot-password-tool.sh <copied value here>`
     * Example: `./zyxel-uboot-password-tool.sh 001976FE4B04`
6.  Run the command provided by the password tool
     * Example: `ATEN 1,910F129B`
     * Changes with **every boot** - can't reuse this
7.  Run `ATGU`
     * You now have full u-boot shell until next boot - unlocking is not remembered
8.  Run **either** `run boot_mmc` (*for booting partition set `FF`*) **or** `run boot_mmc_1` (*for booting partition set `01`*)
     * These commands are **not** affected by the dual-boot partition flags

**NOTE:** This will **not** set the dual-boot partition flag.  You'll need to fix that manually.

To simplify toggling the dual-boot partition flag, [use the `nbg6817-dualboot` script](https://github.com/pkgadd/nbg6817/blob/master/nbg6817-dualboot ).  Copy this to `<openwrt_source_directory>/files/usr/sbin/nbg6817-dualboot` before compiling.

[`zyxel-uboot-password-tool.sh` and instructions from commit](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=459c8c9ef816156107e297964d088ddee2b4eef5 ):
```
#!/bin/bash
# Determine ZyXEL uboot password to unlock full access
# Must be run for EVERY boot
#
# See https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=459c8c9ef816156107e297964d088ddee2b4eef5

ror32() {
  echo $(( ($1 >> $2) | (($1 << (32 - $2) & (2**32-1)) ) ))
}

v="0x$1"
a="0x${v:2:6}"
b=$(( $a + 0x10F0A563))
c=$(( 0x${v:12:14} & 7 ))
p=$(( $(ror32 $b $c) ^ $a ))
printf "ATEN 1,%X\n" $p
```

## Kernel serial console logs with dynamic debugging

### Before
```
[…trimmed…]
[    3.171343] mmci-pl18x 12400000.sdcc: designer ID = 0x51
[    3.171397] mmci-pl18x 12400000.sdcc: revision = 0x0
[    3.175811] mmci-pl18x 12400000.sdcc: clocking block at 96000000 Hz
[    3.181134] mmci-pl18x 12400000.sdcc: No vqmmc regulator found
[    3.186788] mmci-pl18x 12400000.sdcc: mmc0: PL180 manf 51 rev0 at 0x12400000 irq 41,0 (pio)
[    3.192902] mmci-pl18x 12400000.sdcc: DMA channels RX dma1chan1, TX dma1chan2
[    3.215609] mmc0: clock 0Hz busmode 2 powermode 1 cs 0 Vdd 21 width 1 timing 0
[    3.227532] mmci-pl18x 12400000.sdcc: Initial signal voltage of 3.3v
[    3.247518] mmc0: clock 52000000Hz busmode 2 powermode 2 cs 0 Vdd 21 width 1 timing 0
[…trimmed…]
[    3.997725] mmc0: req done (CMD2): -110: 00000000 00000000 00000000 00000000
[    4.003631] mmci-pl18x 12400000.sdcc: irq0 (data+cmd) 00000000
[    4.003659] mmc0: error -110 whilst initialising MMC card
[    4.016481] mmc0: clock 0Hz busmode 2 powermode 0 cs 0 Vdd 0 width 1 timing 0
```

*Notice how the initial clock is 52 MHz, which is incorrect - MMC requires negotiation to enable higher speeds.*

### After
```
[…trimmed…]
[    3.168996] mmci-pl18x 12400000.sdcc: designer ID = 0x51
[    3.169051] mmci-pl18x 12400000.sdcc: revision = 0x0
[    3.173492] mmci-pl18x 12400000.sdcc: clocking block at 96000000 Hz
[    3.178808] mmci-pl18x 12400000.sdcc: No vqmmc regulator found
[    3.184702] mmci-pl18x 12400000.sdcc: mmc0: PL180 manf 51 rev0 at 0x12400000 irq 41,0 (pio)
[    3.190573] mmci-pl18x 12400000.sdcc: DMA channels RX dma1chan1, TX dma1chan2
[    3.217873] mmc0: clock 0Hz busmode 2 powermode 1 cs 0 Vdd 21 width 1 timing 0
[    3.229250] mmci-pl18x 12400000.sdcc: Initial signal voltage of 3.3v
[    3.249111] mmc0: clock 400000Hz busmode 2 powermode 2 cs 0 Vdd 21 width 1 timing 0
[…trimmed…]
[    4.392652] mmci-pl18x 12400000.sdcc: irq0 (data+cmd) 00000000
[    4.392785] mmc0: clock 52000000Hz busmode 2 powermode 2 cs 0 Vdd 21 width 1 timing 1
[    4.406554] mmc0: starting CMD6 arg 03b70201 flags 0000049d
[…trimmed…]
```

*Now, the MMC properly initializes and later switches to high speed.*

## Thanks
* Ansuel for maintaining/help with the IPQ806x platform, kernel code
* `slh` for additional debugging and suggestions
* `dwfreed` for confirming newer MMC details, clock frequency
* `robimarko` for device driver debug printing help, clock debugging
* Drake for testing and confirmation with their own newer NBG6817

...and anyone else I missed!

---

*This hopefully unblocks my efforts [to fix the IPQ806x CPU reset/crash](https://github.com/digitalcircuit/openwrt-ipq806x-qa-cpu-reset#readme ).  Feel free to look at that ongoing investigation if you have spare time.*