### PR TITLE
ramips: add support for Wavlink WL-WN535K1

### DIFF
--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,wl-wn535k1", "ralink,mt7620a-soc";
+	model = "Wavlink WL-WN535K1";
+
+	aliases {
+		label-mac-device = &wifi0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		touchlink {
+			label = "touchlink";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+				
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x730000>;
+			};
+
+			partition@780000 {
+				label = "vendor";
+				reg = <0x780000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "llllw";
+
+	port@4 {
+		status = "okay";
+		phy-handle = <&phy4>;
+		phy-mode = "rgmii";
+	};
+
+	port@5 {
+		status = "okay";
+		phy-handle = <&phy5>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			phy-mode = "rgmii";
+		};
+
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,port4-gmac;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	gpio {
+		groups = "ephy", "i2c", "uartf";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1151,6 +1151,18 @@ define Device/wavlink_wl-wn530hg4
 endef
 TARGET_DEVICES += wavlink_wl-wn530hg4
 
+define Device/wavlink_wl-wn535k1
+  SOC := mt7620a
+  IMAGE_SIZE := 7360k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN535K1
+  DEVICE_ALT0_VENDOR := Talius
+  DEVICE_ALT0_MODEL := TAL-WMESH1
+  KERNEL_INITRAMFS_SUFFIX := -WN535K1$$(KERNEL_SUFFIX)
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-phy-realtek
+endef
+TARGET_DEVICES += wavlink_wl-wn535k1
+
 define Device/wavlink_wl-wn579x3
   SOC := mt7620a
   IMAGE_SIZE := 7744k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -199,6 +199,11 @@ tplink,archer-mr200)
 tplink,re200-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+wavlink,wl-wn535k1)
+	ucidef_set_led_switch "lan1" "lan2" "green:lan1" "switch0" "0x04"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x20"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 wavlink,wl-wn579x3)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x20"
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x10"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -218,6 +218,10 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
 		ucidef_set_interface_wan "usb0"
 		;;
+	wavlink,wl-wn535k1)
+		ucidef_add_switch "switch0" \
+			"2:lan" "5:lan" "4:wan" "6@eth0"
+		;;
 	wavlink,wl-wn579x3)
 		ucidef_add_switch "switch0" \
 			"5:lan" "4:wan" "6@eth0"
@@ -365,6 +369,10 @@ ramips_setup_macs()
 	tplink,archer-c50-v1|\
 	tplink,archer-mr200)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
+		;;
+	wavlink,wl-wn535k1)
+		wan_mac=$(mtd_get_mac_binary factory 0x2e)
+		label_mac=$(mtd_get_mac_binary factory 0x8004)
 		;;
 	zbtlink,zbt-we1026-5g-16m)
 		label_mac=$(mtd_get_mac_binary factory 0x4)


### PR DESCRIPTION
ramips: add support for Wavlink WL-WN535K1

The Wavlink WL-WN535K1 is a "mesh" router with 2 gigabit ethernet ports
and one fast ethernet port. Mine is branded as Talius WMESH1.
It can be found in kits of 2 or 3 (WL-WN535K2 or WL-WN535K3). 
The motherboard is labelled as WS-WN535G3-B-V1.2 so this image could
work also for WL-WN535G3R and WS-WN535G3R but it's untested.

```
Hardware
--------
SoC:   Mediatek MT7620A
RAM:   64MB
FLASH: 8MB NOR (GigaDevice GD25Q64CS)
ETH:   
  - 2x 10/100/1000 Mbps Ethernet (RTL8211F)
  - 1x 10/100 Mbps Ethernet (integrated in SOC)
WIFI:
  - 2.4GHz: 1x (integrated in SOC) (2x2:2)
  - 5GHz:   1x MT7612E (2x2:2)
  - 4 internal antennas
BTN:
  - 1x Reset button
  - 1x Touchlink button (set to WPS)
  - 1x ON/OFF switch
LEDS:
  - 1x Red led (status)
  - 1x Blue led (status)
  - 3x Green leds (ethernet port status/act)
UART:
  - 57600-8-N-1
``` 

Everything works correctly.

Currently there is no firmware update available. Because of this, in
order to restore the OEM firmware, you must firstly dump the OEM
firmware from your router before you flash the OpenWrt image.

Backup the OEM Firmware
-----------------------
The following steps are to be intended for users having little to none
experience in linux. Obviously there are many ways to backup the OEM
firmware, but probably this is the easiest way for this router.
Procedure tested on WN535K1_V1510_200916 firmware version.

1) Go to http://192.168.10.1/webcmd.shtml

2) Type the following line in the "Command" input box and then press enter:
	mkdir /etc_ro/lighttpd/www/dev; dd if=/dev/mtd0ro of=/etc_ro/lighttpd/www/dev/mtd0ro

3) After few seconds in the textarea should appear this output:
		16384+0 records in
	16384+0 records out
	
   If your output doesn't match mine, stop reading and ask for
   help in the forum.

4) Open in another tab http://192.168.10.1/dev/mtd0ro to download the
   content of the whole NOR. If this file weight 0 byte, stop reading
   and ask for help in the forum.

5) Come back to the http://192.168.10.1/webcmd.shtml webpage and type:
	rm /etc_ro/lighttpd/www/dev/mtd0ro;for i in 1 2 3 4 5; do dd if=/dev/mtd${i}ro of=/etc_ro/lighttpd/www/dev/mtd${i}ro; done

6) After few seconds, in the textarea should appear this output:
		384+0 records in
	384+0 records out
	128+0 records in
	128+0 records out
	128+0 records in
	128+0 records out
	14720+0 records in
	14720+0 records out
	1024+0 records in
	1024+0 records out
	
   If your output doesn't match mine, stop reading and ask for
   help in the forum.

7) Open the following links to download the partitions of the OEM FW:
	http://192.168.10.1/dev/mtd1ro
	http://192.168.10.1/dev/mtd2ro
	http://192.168.10.1/dev/mtd3ro
	http://192.168.10.1/dev/mtd4ro
	http://192.168.10.1/dev/mtd5ro

   If one (or more) of these files weight 0 byte, stop reading and ask
   for help in the forum.

8) Store these downloaded files in a safe place.

9) Reboot your router to remove any temporary file from your router.

Installation
------------
Flash the initramfs image in the OEM firmware interface 
(http://192.168.10.1/update_mesh.shtml).
When openwrt boots, flash the sysupgrade image otherwise you won't be
able to keep configuration between reboots.

Restore OEM Firmware
--------------------
Flash the "mtd4ro" file you previously backed-up directly from LUCI.
Warning: Remember to not keep settings!
Warning2: Remember to force the flash.

Notes
-----
1) Router mac addresses:
   LAN		XX:XX:XX:XX:XX:E2 (factory @ 0x28)
   WAN		XX:XX:XX:XX:XX:E3 (factory @ 0x2e)
   WIFI 2G	XX:XX:XX:XX:XX:E4 (factory @ 0x04)
   WIFI 5G	XX:XX:XX:XX:XX:E5 (factory @ 0x8004)
   
   LABEL	XX:XX:XX:XX:XX:E5

2) The OEM firmware upgrade page accepts only files containing the
   string "WN535K1" in the filename.

3) Additional notes 1,2,3 in the WS-WN583A6 commit are still valid
(https://github.com/openwrt/openwrt/commit/92780d80ab6f5f03fac2407c06eb267dd83914a1)

Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>