### PR TITLE
ramips: fix tl-mr3020-v3 switch topology to configure vlans via luci

### DIFF
--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -25,7 +25,6 @@ ramips_setup_interfaces()
 	tplink,re200-v4|\
 	tplink,re220-v2|\
 	tplink,re305-v1|\
-	tplink,tl-mr3020-v3|\
 	tplink,tl-wr802n-v4|\
 	tplink,tl-wa801nd-v5|\
 	widora,neo-16m|\
@@ -33,6 +32,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "false"
 		ucidef_set_interface_lan "eth0"
+		;;
+	tplink,tl-mr3020-v3)
+		ucidef_add_switch "switch0" \
+			"0:lan" "6@eth0"
 		;;
 	asus,rt-n10p-v3|\
 	asus,rt-n11p-b1|\


### PR DESCRIPTION
Currently it is not possible to configure VLANs via LUCI on
tplink tl-mr3020-v3. This patch fixes switch topology for the
LUCI interface.

This PR is a copy of merged PR https://github.com/openwrt/openwrt/pull/4797 but it is a backport to 21.02 branch

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>