### PR TITLE
Add bootstrap LTO to GCC

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -81,7 +81,7 @@ else
 endif
 
 GCC_CONFIGURE:= \
-	SHELL="$(BASH)" \
+	SHELL="$(BASH)" BUILD_CONFIG="bootstrap-lto" \
 	$(if $(shell gcc --version 2>&1 | grep -E "Apple.(LLVM|clang)"), \
 		CFLAGS="-O2 -fbracket-depth=512 -pipe" \
 		CXXFLAGS="-O2 -fbracket-depth=512 -pipe" \


### PR DESCRIPTION
We're using GCC in a quite instensive way during openwrt compilation,
performing LTO on the GCC binary itself will help speed up compilation process

Signed-off-by: jpsollie <janpieter.sollie@edpnet.be>