### PR TITLE
x86/base-files: add/improve support for Sophos SG/XG products

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -17,8 +17,15 @@ pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 roqos-roqos-core-rc10)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
-sophos-sg-105|sophos-xg-105)
+sophos-sg-105r1|sophos-xg-105r1| \
+sophos-sg-105r2|sophos-xg-105r2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
+	;;
+sophos-sg-135r1|sophos-xg-135r1| \
+sophos-sg-135Wr1|sophos-xg-135Wr1| \
+sophos-sg-135r2|sophos-xg-135r2| \
+sophos-sg-135Wr2|sophos-xg-135Wr2)
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "eth1"
 	;;
 traverse-technologies-geos)
 	ucidef_set_interface_lan "eth0 eth1"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -23,9 +23,11 @@ do_sysinfo_x86() {
 			break
 			;;
 		"Sophos:SG"|"Sophos:XG")
-			case "$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)" in
-			105*)
-				product="${product}-105"
+			local product_version
+			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
+			case "$product_version" in
+			105*|135*)
+				product="${product}-${product_version}"
 				break
 				;;
 			esac


### PR DESCRIPTION
This furthers work here: https://github.com/openwrt/openwrt/pull/4024 and https://github.com/openwrt/openwrt/pull/4056 and includes:

* Better product ID for Sophos SG/XG-105 models
* Add support for Sophos SG/XG-135 r1, r2 with/without wireless

@aparcar @hauke -- can this be also cherry-picked for 21.02? Should I create a separate PR?

Signed-off-by: Stan Grishin <stangri@melmac.ca>
