### PR TITLE
[21.02] ccache: update to 4.2.1

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.1
+PKG_VERSION:=4.2.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=5fdc804056632d722a1182e15386696f0ea6c59cb4ab4d65a54f0b269ae86f99
+PKG_HASH:=9d6ba1cdefdc690401f404b747d81a9a1802b17af4235815866b7620d980477e
 
 HOST_BUILD_PARALLEL:=1
 

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache.cpp
 +++ b/src/ccache.cpp
-@@ -1654,6 +1654,7 @@ calculate_result_name(Context& ctx,
+@@ -1756,6 +1756,7 @@ calculate_result_name(Context& ctx,
                               "CPLUS_INCLUDE_PATH",
                               "OBJC_INCLUDE_PATH",
                               "OBJCPLUS_INCLUDE_PATH", // clang


### PR DESCRIPTION
Update ccache to 4.2.1 - cherry-picked from ``master`` branch.

While compiling on Gentoo, the ccache can not be compiled due to this
error:

/openwrt/build_dir/host/ccache-4.1/unittest/../src/third_party/doctest.h:4084:47: error: size of array 'altStackMem' is not an integral constant-expression
 4084 |         static char             altStackMem[4 * SIGSTKSZ];
      |                                               ^

This was fixed in ccache version 4.2.1 [1] by upgrading doctest [2].

[1] https://github.com/ccache/ccache/issues/825
[2] https://github.com/doctest/doctest/issues/473