### PR TITLE
procd: extract service command from /etc/shint to /sbin

### DIFF
--- a/package/base-files/files/etc/rc.common
+++ b/package/base-files/files/etc/rc.common
@@ -126,6 +126,7 @@ extra_command "enabled" "Check if service is started on boot"
 	extra_command "running" "Check if service is running"
 	extra_command "status" "Service status"
 	extra_command "trace" "Start with syscall trace"
+	extra_command "info" "Dump procd service info"
 
 	. $IPKG_INSTROOT/lib/functions/procd.sh
 	basescript=$(readlink "$initscript")
@@ -147,6 +148,13 @@ extra_command "enabled" "Check if service is started on boot"
 	trace() {
 		TRACE_SYSCALLS=1
 		start "$@"
+	}
+
+	info() {
+		json_init
+		json_add_string name "$(basename ${basescript:-$initscript})"
+		json_add_boolean verbose "1"
+		_procd_ubus_call list
 	}
 
 	stop() {

--- a/package/base-files/files/etc/shinit
+++ b/package/base-files/files/etc/shinit
@@ -8,26 +8,5 @@ alias ll='ls -alF --color=auto'
 [ -x /usr/bin/arp -o -x /sbin/arp ] || arp() { cat /proc/net/arp; }
 [ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
 
-service() {
-	if [ -f "/etc/init.d/$1" ]; then
-		/etc/init.d/$@
-	else
-		echo "Usage: service <service> [command]"
-		if [ -n "$1" ]; then
-			echo "Service "'"'"$1"'"'" not found, the following services are available:"
-		else
-			echo "The following services are available:"
-		fi
-		for F in /etc/init.d/* ; do
-			printf "%-30s\t%10s\t%10s\n"  "$F" \
-			$( $($F enabled) && echo "enabled" || echo "disabled" ) \
-			$( [ "$(ubus call service list "{ 'verbose': true, 'name': '$(basename $F)' }" \
-			| jsonfilter -q -e "@['$(basename $F)'].instances[*].running" | uniq)" = "true" ] \
-			&& echo "running" || echo "stopped" )
-		done;
-		return 1
-	fi
-}
-
 [ -n "$KSH_VERSION" -o \! -s "$HOME/.shinit" ] || . "$HOME/.shinit"
 [ -z "$KSH_VERSION" -o \! -s "$HOME/.mkshrc" ] || . "$HOME/.mkshrc"

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -137,6 +137,7 @@ define Package/procd/install
 	$(INSTALL_BIN) ./files/reload_config $(1)/sbin/
 	$(INSTALL_CONF) ./files/hotplug*.json $(1)/etc/
 	$(INSTALL_DATA) ./files/procd.sh $(1)/lib/functions/
+	$(INSTALL_BIN) ./files/service $(1)/sbin/service
 endef
 
 Package/procd-selinux/install = $(Package/procd/install)

--- a/package/system/procd/files/service
+++ b/package/system/procd/files/service
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+main() {
+	local service="$1"
+	local cmd="$2"
+
+	local boot status
+
+	if [ -f "/etc/init.d/${service}" ]; then
+		/etc/init.d/"${service}" "${cmd}"
+		exit "$?"
+	fi
+
+	if [ -n "$service" ]; then
+		echo "Service \"$1\" not found:"
+		exit 1
+	fi
+
+	echo "Usage: $(basename "$0") <service> [command]"
+	for service in /etc/init.d/* ; do
+		boot="$($service enabled && echo "enabled" || echo "disabled" )"
+		status="$( [ "$(ubus call service list "{ 'verbose': true, 'name': '$(basename "$service")' }" \
+			| jsonfilter -q -e "@['$(basename "$service")'].instances[*].running" | uniq)" = "true" ] \
+			&& echo "running" || echo "stopped" )"
+
+		printf "%-30s\\t%10s\\t%10s\\n"  "$service" "$boot" "$status"
+	done
+}
+
+main "$@"


### PR DESCRIPTION
Using the service command as a shell alias function has certain disadvantages.
1. if you don't look it up explicitly, you don't know the command, because it is not offered in a tab compilation.
2. The `shinit` file is maintained in the base files. But the command belongs to procd, because it uses its ubus backend. Therefore, in my view, it also belongs to `procd`.

The second commit adds a simplified call for the following ubus command.
`ubus call service list "{ 'verbose': true, 'name': '<service-name>' }"`

It has always bothered me that I had to enter the whole thing if I wanted to have the extended information from the `procd` for this service.