### PR TITLE
lantiq: add wifi support for AVM FRITZ!Box 7430

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -23,9 +23,11 @@ case "$FIRMWARE" in
 			avm,fritz7360-v2)
 				caldata_extract "urlader" 0x985 0x1000
 				;;
-			avm,fritz7412|\
-			avm,fritz7430)
+			avm,fritz7412)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 4096 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
+				;;
+			avm,fritz7430)
+				/usr/bin/fritz_cal_extract -i 1 -s 0x1e800 -e 0x207 -l 4096 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader")
 				;;
 			bt,homehub-v5a)
 				caldata_extract_ubi "caldata" 0x1000 0x1000


### PR DESCRIPTION
Added the correct offset for the calibration data, according to
https://forum.openwrt.org/t/fritzbox-7430-and-wifi/86944