### PR TITLE
mac80211: Add possibility to identify card by id

### DIFF
--- a/package/kernel/mac80211/Makefile
+++ b/package/kernel/mac80211/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=mac80211
 
 PKG_VERSION:=5.15.8-1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/projects/backports/stable/v5.15.8/
 PKG_HASH:=9f71b659c034f19d156532ec780fcb606cee3c4ccc42e2f8ef18dd3e9f1b6820
 

--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
@@ -24,7 +24,7 @@ OLDUMLIST=
 drv_mac80211_init_device_config() {
 	hostapd_common_add_device_config
 
-	config_add_string path phy 'macaddr:macaddr'
+	config_add_string path phy card 'macaddr:macaddr'
 	config_add_string tx_burst
 	config_add_string distance
 	config_add_int beacon_int chanbw frag rts
@@ -570,6 +570,11 @@ find_phy() {
 			grep -i -q "$macaddr" "/sys/class/ieee80211/${phy}/macaddress" && return 0
 		done
 	}
+	[ -n "$card" ] && {
+		for phy in $(ls /sys/class/ieee80211 2>/dev/null); do
+			[ "$card" = "$(cat "/sys/class/ieee80211/${phy}/device/vendor"):$(cat "/sys/class/ieee80211/${phy}/device/device")" ] && return 0
+		done
+	}
 	return 1
 }
 
@@ -1024,7 +1029,7 @@ drv_mac80211_cleanup() {
 drv_mac80211_setup() {
 	json_select config
 	json_get_vars \
-		phy macaddr path \
+		phy macaddr card path \
 		country chanbw distance \
 		txpower antenna_gain \
 		rxantenna txantenna \

--- a/package/kernel/mac80211/files/lib/wifi/mac80211.sh
+++ b/package/kernel/mac80211/files/lib/wifi/mac80211.sh
@@ -24,6 +24,17 @@ lookup_phy() {
 			return
 		done
 	}
+
+	local card="$(config_get "$device" card)"
+	[ -n "$card" ] && {
+		for _phy in /sys/class/ieee80211/*; do
+			[ -e "$_phy" ] || continue
+
+			[ "$card" = "$(cat ${_phy}/device/vendor):$(cat ${_phy}/device/device)" ] || continue
+			phy="${_phy##*/}"
+			return
+		done
+	}
 	phy=
 	return
 }
@@ -42,6 +53,11 @@ find_mac80211_phy() {
 	config_get macaddr "$device" macaddr
 	[ -z "$macaddr" ] && {
 		config_set "$device" macaddr "$(cat /sys/class/ieee80211/${phy}/macaddress)"
+	}
+
+	config_get card "$device" card
+	[ -z "$card" ] && {
+		config_set "$device" card "$(cat /sys/class/ieee80211/${phy}/device/vendor):$(cat /sys/class/ieee80211/${phy}/device/device)"
 	}
 
 	return 0


### PR DESCRIPTION
Sometimes it is easier to set configuration by WiFi card used regardless
of slot or mac address. Especially when deploying same image across
multiple routers with slightly different configuration. Therefore this
commit introduces an option to use in radio configuration option card
with expected value of vendor_id:device_id.

Signed-off-by: Michal Hrusecky <michal.hrusecky@turris.com>