### PR TITLE
kernel: add missing IR_IMON_RAW config symbol

### DIFF
--- a/target/linux/generic/config-5.10
+++ b/target/linux/generic/config-5.10
@@ -2766,6 +2766,7 @@ CONFIG_IP_VS_MH_TAB_INDEX=10
 # CONFIG_IR_IGUANA is not set
 # CONFIG_IR_IMG is not set
 # CONFIG_IR_IMON is not set
+# CONFIG_IR_IMON_RAW is not set
 # CONFIG_IR_JVC_DECODER is not set
 # CONFIG_IR_LIRC_CODEC is not set
 # CONFIG_IR_MCEUSB is not set


### PR DESCRIPTION
The kernel option: https://cateee.net/lkddb/web-lkddb/IR_IMON_RAW.html

Fixes:
    SoundGraph iMON Receiver (early raw IR models) (IR_IMON_RAW) [N/m/?] (NEW)