### PR TITLE
ralink: add support for Linksys EA6350 v4

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -52,6 +52,7 @@ ravpower,rp-wd03)
 jcg,q20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+linksys,ea6350-v4|\
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2|\

--- a/target/linux/ramips/dts/mt7621_linksys_ea6350-v4.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_ea6350-v4.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_linksys_ea7xxx.dtsi"
+
+/ {
+	compatible = "linksys,ea6350-v4", "mediatek,mt7621-soc";
+	model = "Linksys EA6350 v4";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -895,6 +895,15 @@ define Device/linksys_ea7xxx
 	append-ubi | check-size | linksys-image type=$$$$(LINKSYS_HWNAME)
 endef
 
+define Device/linksys_ea6350-v4
+	$(Device/linksys_ea7xxx)
+	DEVICE_MODEL := EA6350
+	DEVICE_VARIANT := v4
+	LINKSYS_HWNAME := EA6350
+	DEVICE_PACKAGES += kmod-mt7603 kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += linksys_ea6350-v4
+
 define Device/linksys_ea7300-v1
   $(Device/linksys_ea7xxx)
   DEVICE_MODEL := EA7300

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -55,6 +55,7 @@ gnubee,gb-pc2)
 linksys,e5600)
 	ucidef_set_led_netdev "wan" "wan link" "blue:wan" "wan" "link"
 	;;
+linksys,ea6350-v4|\
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\
 linksys,ea7500-v2|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -144,6 +144,7 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	linksys,e5600|\
+	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -30,6 +30,7 @@ case "$board" in
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
 	linksys,e5600|\
+	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -9,6 +9,7 @@ boot() {
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
 	linksys,e5600|\
+	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -61,6 +61,7 @@ platform_do_upgrade() {
 	iptime,a3004t|\
 	jcg,q20|\
 	linksys,e5600|\
+	linksys,ea6350-v4|\
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\
 	linksys,ea7500-v2|\


### PR DESCRIPTION
Specifications:
- SoC: MT7621DAT (880MHz, 2 Cores)
- RAM: 128 MB
- Flash: 128 MB NAND
- Ethernet: 5x 1GiE MT7530
- WiFi: MT7603/MT7613
- USB: 1x USB 3.0

This is another MT7621 device, very similar to other Linksys EA7300
series devices.

Installation:

Upload the generated factory.bin image via the stock web firmware
updater.

Reverting to factory firmware:

Like other EA7300 devices, this device has an A/B router configuration
to prevent bricking.  Hard-resetting this device three (3) times will
put the device in failsafe (default) mode.  At this point, flash the
OEM image to itself and reboot.  This puts the router back into the 'B'
image and allows for a firmware upgrade.

Troubleshooting:

If the firmware will not boot, first restore the factory as described
above.  This will then allow the factory.bin update to be applied
properly.

Signed-off-by: Nick McKinney <nick@ndmckinney.net>