### PR TITLE
treewide: use uniform vendor for british telecom

### DIFF
--- a/target/linux/bcm63xx/image/bcm63xx.mk
+++ b/target/linux/bcm63xx/image/bcm63xx.mk
@@ -346,7 +346,7 @@ TARGET_DEVICES += brcm_bcm963269bhr
 ### BT ###
 define Device/bt_home-hub-2-a
   $(Device/bcm63xx-legacy)
-  DEVICE_VENDOR := BT
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Home Hub 2.0
   DEVICE_VARIANT := A
   CFE_BOARD_ID := HOMEHUB2A
@@ -358,7 +358,7 @@ TARGET_DEVICES += bt_home-hub-2-a
 
 define Device/bt_voyager-2110
   $(Device/bcm63xx-legacy)
-  DEVICE_VENDOR := BT
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Voyager 2110
   CFE_BOARD_ID := V2110
   CHIP_ID := 6348
@@ -370,7 +370,7 @@ TARGET_DEVICES += bt_voyager-2110
 
 define Device/bt_voyager-2500v-bb
   $(Device/bcm63xx-legacy)
-  DEVICE_VENDOR := BT
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Voyager 2500V
   CFE_BOARD_ID := V2500V_BB
   CHIP_ID := 6348

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -31,7 +31,7 @@ TARGET_DEVICES += avm_fritz7320
 
 define Device/bt_homehub-v3a
   $(Device/NAND)
-  DEVICE_VENDOR := British Telecom
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Home Hub 3
   DEVICE_VARIANT := Type A
   BOARD_NAME := BTHOMEHUBV3A

--- a/target/linux/lantiq/image/danube.mk
+++ b/target/linux/lantiq/image/danube.mk
@@ -183,7 +183,7 @@ TARGET_DEVICES += audiocodes_mp-252
 
 define Device/bt_homehub-v2b
   $(Device/NAND)
-  DEVICE_VENDOR := British Telecom
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Home Hub 2
   DEVICE_VARIANT := Type B
   BOARD_NAME := BTHOMEHUBV2B

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -204,7 +204,7 @@ TARGET_DEVICES += avm_fritz7430
 define Device/bt_homehub-v5a
   $(Device/dsa-migration)
   $(Device/NAND)
-  DEVICE_VENDOR := British Telecom
+  DEVICE_VENDOR := British Telecom (BT)
   DEVICE_MODEL := Home Hub 5
   DEVICE_VARIANT := Type A
   BOARD_NAME := BTHOMEHUBV5A


### PR DESCRIPTION
British Telecom is mostly known as BT.

Signed-off-by: Moritz Warning <moritzwarning@web.de>
