### PR TITLE
umbim: minimal set of bugfixes

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -65,6 +65,8 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Reading capabilities"
 	umbim $DBG -n -d $device caps || {
 		echo "mbim[$$]" "Failed to read modem caps"
+		tid=$((tid + 1))
+		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" PIN_FAILED
 		return 1
 	}
@@ -74,6 +76,8 @@ _proto_mbim_setup() {
 		echo "mbim[$$]" "Sending pin"
 		umbim $DBG -n -t $tid -d $device unlock "$pincode" || {
 			echo "mbim[$$]" "Unable to verify PIN"
+			tid=$((tid + 1))
+			umbim $DBG -t $tid -d "$device" disconnect
 			proto_notify_error "$interface" PIN_FAILED
 			proto_block_restart "$interface"
 			return 1
@@ -84,6 +88,8 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Checking pin"
 	umbim $DBG -n -t $tid -d $device pinstate || {
 		echo "mbim[$$]" "PIN required"
+		tid=$((tid + 1))
+		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" PIN_FAILED
 		proto_block_restart "$interface"
 		return 1
@@ -93,6 +99,8 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Checking subscriber"
 	umbim $DBG -n -t $tid -d $device subscriber || {
 		echo "mbim[$$]" "Subscriber init failed"
+		tid=$((tid + 1))
+		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" NO_SUBSCRIBER
 		return 1
 	}
@@ -101,6 +109,8 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Register with network"
 	umbim $DBG -n -t $tid -d $device registration || {
 		echo "mbim[$$]" "Subscriber registration failed"
+		tid=$((tid + 1))
+		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" NO_REGISTRATION
 		return 1
 	}
@@ -109,6 +119,8 @@ _proto_mbim_setup() {
 	echo "mbim[$$]" "Attach to network"
 	umbim $DBG -n -t $tid -d $device attach || {
 		echo "mbim[$$]" "Failed to attach to network"
+		tid=$((tid + 1))
+		umbim $DBG -t $tid -d "$device" disconnect
 		proto_notify_error "$interface" ATTACH_FAILED
 		return 1
 	}
@@ -169,7 +181,7 @@ proto_mbim_teardown() {
 
 	echo "mbim[$$]" "Stopping network"
 	[ -n "$tid" ] && {
-		umbim $DBG -t$tid -d "$device" disconnect
+		umbim $DBG -t $tid -d "$device" disconnect
 		uci_revert_state network $interface tid
 	}
 

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -86,7 +86,8 @@ _proto_mbim_setup() {
 	tid=$((tid + 1))
 
 	echo "mbim[$$]" "Checking pin"
-	umbim $DBG -n -t $tid -d $device pinstate || {
+	umbim $DBG -n -t $tid -d $device pinstate
+	[ $? -eq 2 ] && {
 		echo "mbim[$$]" "PIN required"
 		tid=$((tid + 1))
 		umbim $DBG -t $tid -d "$device" disconnect

--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -154,6 +154,7 @@ _proto_mbim_setup() {
 	json_add_string proto "dhcpv6"
 	json_add_string extendprefix 1
 	proto_add_dynamic_defaults
+	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
 }
 


### PR DESCRIPTION
This is minimal set of fixes extracted from #4405, required to make MBIM support operationonal. Currently only in DHCP mode:
- Ensure that disconnect is executed in error cases, so subsequent reconnect attempts won't fail due to transaction ID mismatch,
- Check for PIN1 state explicitly, so connection would not fail due to PIN2 being locked, which is not required for network registration.
- Ensure JSON stream fed to netifd for creating dynamic sub-interface is valid by adding missing json_close_object call.

These are all changes from @sch-m. No code changes from #4405, only updated commit descriptions. This does not supersede #4405, which I plan to refactor once this is merged.

For IPv4, tested only to creating DHCP sub-interface, as EM7455 does not support DHCP configuration for IPv4 by default. 

Compile tested: ath79/generic subtarget
Run tested: TP-Link Archer C7v2 plus Sierra EM7455 (DW5811e MBIM flavour)