### PR TITLE
[WIP] spidev_test: remove the nonshared flag

### DIFF
--- a/package/utils/spidev_test/Makefile
+++ b/package/utils/spidev_test/Makefile
@@ -10,7 +10,6 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=spidev-test
 PKG_RELEASE:=$(LINUX_VERSION)
-PKG_FLAGS:=nonshared
 PKG_BUILD_DIR:=$(LINUX_DIR)/tools/spi-$(TARGET_DIR_NAME)
 PKG_BUILD_PARALLEL:=1
 
@@ -19,7 +18,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/spidev-test
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=+kmod-spi-dev @!IN_SDK
+  DEPENDS:=+kmod-spi-dev
   TITLE:=SPI testing utility
   VERSION:=$(LINUX_VERSION)-$(PKG_RELEASE)
   URL:=http://www.kernel.org


### PR DESCRIPTION
Spidev-test is built as a nonshared package by the phase1 image buildbot
and is available under target/packages/. However, spidev-test is also
picked up by the phase2 builders but they fail with:
  cp: cannot stat '...
    /tools/spi/*': No such file or directory

There is no reason that spidev-test is marked as nonshared. No target
ships it as a default package nor depends an other nonshared package on
it. Remove the nonshared and @!IN_SDK flag to fix the compilation of the
phase 2 builders and remove error buildlogs.

Fixes: https://github.com/PolynomialDivision/openwrt/commit/bdaaf66e28bd45837e420ac2300df108091ec97a ("utils/spidev_test: build package directly from Linux")