### PR TITLE
ramips: add support for ASUS RT-AC1200GU

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -162,6 +162,8 @@ define Device/asus_rt-ac57u
   $(Device/dsa-migration)
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AC57U
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AC1200GU
   IMAGE_SIZE := 16064k
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
 	kmod-usb-ledtrig-usbport


### PR DESCRIPTION
Specifications:
SoC:    MediaTek MT7621AT
FLASH:  16  MiB (Spansion S25FL128SA)
RAM:    128 MiB (Winbond W631GG6KB-15)
WiFi1:  MediaTek MT7603EN
WiFi2:  MediaTek MT7612EN
USB:    Type-A USB 2.0 *1
BTN:    Reset *1, WPS *1
LED:    Power *1, LAN *4, WAN *1, WiFi *2, USB *1

MAC Address:
label   xxxx:a5:10	factory@0xe006
wan     xxxx:a5:10	factory@0xe006
lan     xxxx:a5:14	factory@0xe000
wlan2g  xxxx:a5:10	factory@0x4
wlan5g  xxxx:a5:14	factory@0x8004

Installation:
Open SSH in the Web-interface and upload firmware to /tmp directory
via SCP, then execute instruction and reboot:
/# mtd-write -i /tmp/*.bin -d linux
/# reboot

Additional information:
This commit based on 14e0e4f138e3 ramips:add support for ASUS RT-AC57U

RT-AC57U and RT-AC1200GU are the same model sold in different countries.
It can be confirmed from the official support page that the two models
use the same firmware:
https://www.asus.com/Networking-IoT-Servers/WiFi-Routers/ASUS-WiFi-Routers/RT-AC57U/HelpDesk_Download/
https://www.asus.com/Networking-IoT-Servers/WiFi-Routers/ASUS-WiFi-Routers/RT-AC1200GU/HelpDesk_Download/