### PR TITLE
dnsmasq: mount serversfile into jail

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -972,7 +972,11 @@ dnsmasq_start()
 	config_list_foreach "$cfg" "addnhosts" append_addnhosts
 	config_list_foreach "$cfg" "bogusnxdomain" append_bogusnxdomain
 	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.leases"
-	append_parm "$cfg" "serversfile" "--servers-file"
+	config_get serversfile "$cfg" serversfile ""
+	if [ -n "$serversfile" ]; then
+		xappend "--servers-file=$serversfile"
+		append EXTRA_MOUNT "$serversfile"
+	fi
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
 	append_parm "$cfg" "local_ttl" "--local-ttl"


### PR DESCRIPTION
This is required for the file to be read when used with ujail.