### PR TITLE
rockchip: fix mmc core set initial signal voltage on reboot

### DIFF
--- a/target/linux/rockchip/patches-5.10/105-mmc-fix-mmc-core-initial-signal-voltage-on-reboot.patch
+++ b/target/linux/rockchip/patches-5.10/105-mmc-fix-mmc-core-initial-signal-voltage-on-reboot.patch
@@ -1,0 +1,35 @@
+From 0d329112c709d6cfedf0fffb19f0cc6b19043f6b Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Wed, 20 Feb 2019 07:38:34 +0000
+Subject: [PATCH] mmc: core: set initial signal voltage on power off
+
+Some boards have SD card connectors where the power rail cannot be switched
+off by the driver. If the card has not been power cycled, it may still be
+using 1.8V signaling after a warm re-boot. Bootroms expecting 3.3V signaling
+will fail to boot from a UHS card that continue to use 1.8V signaling.
+
+Set initial signal voltage in mmc_power_off() to allow re-boot to function.
+
+This fixes re-boot with UHS cards on Asus Tinker Board (Rockchip RK3288),
+same issue have been seen on some Rockchip RK3399 boards.
+
+I am sending this as a RFC because I have no insights into SD/MMC subsystem,
+this change fix a re-boot issue on my boards and does not break emmc/sdio.
+Is this an acceptable workaround? Any advice is appreciated.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/mmc/core/core.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mmc/core/core.c
++++ b/drivers/mmc/core/core.c
+@@ -1354,6 +1354,8 @@ void mmc_power_off(struct mmc_host *host
+ 
+ 	mmc_pwrseq_power_off(host);
+ 
++	mmc_set_initial_signal_voltage(host);
++
+ 	host->ios.clock = 0;
+ 	host->ios.vdd = 0;
+ 


### PR DESCRIPTION
Some boards have SD card connectors where the power rail cannot be switched
off by the driver. If the card has not been power cycled, it may still be
using 1.8V signaling after a warm re-boot. Bootroms expecting 3.3V signaling
will fail to boot from a UHS card that continue to use 1.8V signaling.

Set initial signal voltage in mmc_power_off() to allow re-boot to function.

This fixes re-boot with UHS cards on Rockchip RK3288, RK3399 boards.

original author Jonas Karlman jonas@kwiboo.se

https://patchwork.kernel.org/project/linux-mmc/patch/AM3PR03MB09664161A7FA2BD68B2800A7AC620@AM3PR03MB0966.eurprd03.prod.outlook.com/

Signed-off-by: xiaobo <peterwillcn@gmail.com>
