### PR TITLE
dnsmasq: workaround for procd-ujail RO/RW conflicts, add log-facility

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -205,6 +205,18 @@ ismounted() {
 	return 1
 }
 
+isparentdir() {
+	local dirname1="$1"
+	local dirname2="$2"
+	case "${dirname1}/" in
+		"$dirname2"*)
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
 append_addnhosts() {
 	ismounted "$1" || append EXTRA_MOUNT "$1"
 	xappend "--addn-hosts=$1"
@@ -1162,10 +1174,26 @@ dnsmasq_start()
 		[ -n "$instance_netdev" ] && procd_set_param netdev $instance_netdev
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
-	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
-	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
-	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
+	for procd_ro in \
+		$CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS \
+		$EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE \
+		$dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript \
+		/etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers ; do
+			if [ -d "$procd_ro" ] ; then
+				for procd_rw in \
+					/var/run/dnsmasq/ \
+					$leasefile \
+					$logfacility ; do
+						isparentdir "$procd_rw" "$procd_ro" && \
+							log_once "$procd_ro contains resource requiring RW mounting and therefore cannot be RO ujail mounted. RW access to $procd_ro enabled." && \
+							procd_add_jail_mount_rw $procd_ro && \
+							continue 2
+					done
+					procd_add_jail_mount $procd_ro
+			else
+				procd_add_jail_mount $procd_ro
+			fi
+	done
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 	case "$logfacility" in */*)
 		[ ! -e "$logfacility" ] && touch "$logfacility"


### PR DESCRIPTION
Add the log-facility file to the procd jail mount with rw access.
linked luci PR: [#5611](https://github.com/openwrt/luci/pull/5611)
Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>