### PR TITLE
ipq40xx: add support for FRITZ!Box 7520

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -269,6 +269,8 @@ define Device/avm_fritzbox-7530
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := AVM
 	DEVICE_MODEL := FRITZ!Box 7530
+	DEVICE_ALT0_VENDOR := AVM
+	DEVICE_ALT0_MODEL := FRITZ!Box 7520
 	SOC := qcom-ipq4019
 	DEVICE_PACKAGES := fritz-caldata fritz-tffs-nand
 endef


### PR DESCRIPTION
The hardware and install procedure is identical to the 7530, see

95b0c07a "ipq40xx: add support for FritzBox 7530"

Just use the 7520 specific filenames instead.

Signed-off-by: Andre Heider <a.heider@gmail.com>