### PR TITLE
[WIP] ath79: add support for Ruckus ZF7363 board

### DIFF
--- a/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
+++ b/target/linux/ath79/dts/ar7161_ruckus_zf7363.dts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar7100.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "ruckus,zf7363", "qca,ar7161";
+	model = "Ruckus ZF7363";
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		// DIR (Zone Director) LED - Indicates Zone director connection status
+		dir {
+			label = "green:dir";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan2g_green {
+			label = "green:wlan2g";
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan2g_orange {
+			label = "orange:wlan2g";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g_orange {
+			label = "orange:wlan5g";
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		/* TODO: gpio 10 freezes system
+		// Hard Reset?
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+		*/
+
+		// OPT
+		opt {
+			label = "opt";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/* TODO
+	rtl8363s { // RTL8363S Switch
+		compatible = "realtek,rtl8363s";
+		gpio-sda = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		gpio-sck = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		realtek,initvals = <0x06 0x0108>;
+
+		mdio-bus {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			status = "okay";
+
+			phy-mask = <0x10>;
+
+			phy1: ethernet-phy@1 {
+				reg = <1>;
+				phy-mode = "rgmii";
+			};
+		};
+	};
+	*/
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			// 0x000000000000-0x000000040000 : "u-boot"
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x40000>;
+				read-only;
+			};
+
+			// 0x000000040000-0x000000740000 : "rcks_wlan.main"
+			partition@40000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				openwrt,offset = <0xA0>;
+				openwrt,partition-magic = <0x52434B53>;
+				reg = <0x40000 0x700000>;
+				read-only;
+			};
+
+			// 0x000000740000-0x000000860000 : "rcks_wlan.bkup"
+			partition@740000 {
+				label = "firmware-backup";
+				reg = <0x740000 0x120000>;
+				read-only;
+			};
+
+			// 0x000000860000-0x000000e40000 : "v54_$rootfs$_2"
+			partition@860000 {
+				label = "reserved-space";
+				reg = <0x860000 0x5e0000>;
+				read-only;
+			};
+
+			// 0x000000e40000-0x000000f80000 : "datafs"
+			partition@e40000 {
+				label = "config-data";
+				reg = <0xe40000 0x140000>;
+				read-only;
+			};
+
+			// 0x000000f80000-0x000000fc0000 : "u-boot-env"
+			partition@f80000 {
+				label = "u-boot-env";
+				reg = <0xf80000 0x40000>;
+				read-only;
+			};
+
+			// 0x000000fc0000-0x000001000000 : "Board Data"
+			art: partition@fc0000 {
+				label = "art";
+				reg = <0xfc0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&art {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	// WiFi 2.4G
+	macaddr_art_60: macaddr@60 {
+		reg = <0x60 0x6>;
+	};
+
+	// eth2/eth0 (Stock/OpenWrt)
+	macaddr_art_66: macaddr@66 {
+		reg = <0x66 0x6>;
+	};
+
+	// eth1/eth1 (Stock/OpenWrt)
+	macaddr_art_6c: macaddr@6c {
+		reg = <0x6c 0x6>;
+	};
+
+	// WiFi 5G
+	macaddr_art_76: macaddr@76 {
+		reg = <0x76 0x6>;
+	};
+
+	// eth0/eth2 (Stock/OpenWrt)
+	macaddr_art_8058: macaddr@8058 {
+		reg = <0x8058 0x6>;
+	};
+
+	// label_mac
+	macaddr_art_807e: macaddr@807e {
+		reg = <0x807e 0x6>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath9k0: wifi@0,11 { // 2.4 GHz
+		compatible = "pci168c,0029";
+		nvmem-cells = <&macaddr_art_60>;
+		nvmem-cell-names = "mac-address";
+		reg = <0x8800 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+
+	ath9k1: wifi@0,12 { // 5 GHz
+		compatible = "pci168c,0029";
+		nvmem-cells = <&macaddr_art_76>;
+		nvmem-cell-names = "mac-address";
+		reg = <0x9000 0 0 0 0>;
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	/*
+	  | reg: label | Stock | OpenWrt |    Comment         |
+	  | ---------- | ----- | ------- | ------------------ |
+	  | 0: wan     | eth2  | eth0    | working, PoE in    |
+	  | ?: opt     | eth0  | eth2    | not working        |
+	  | 2: lan     | eth1  | eth1    | working on 100Mbps |
+	*/
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_66>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_6c>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii";
+	phy-handle = <&phy2>;
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -403,6 +403,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:wan"
 		;;
+	ruckus,zf7363)
+		ucidef_set_interface_wan "eth0"
+		ucidef_set_interface_lan "eth1"
+		;;
 	teltonika,rut955|\
 	teltonika,rut955-h7v3c0)
 		ucidef_set_interface_wan "eth1"
@@ -676,6 +680,9 @@ ath79_setup_macs()
 	rosinson,wr818)
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
+	ruckus,zf7363)
+		label_mac=$(mtd_get_mac_binary art 0x807e)
 		;;
 	sitecom,wlr-7100|\
 	sitecom,wlr-8100)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -154,6 +154,9 @@ case "$FIRMWARE" in
 	meraki,mr16)
 		caldata_extract "art" 0x11000 0xeb8
 		;;
+	ruckus,zf7363)
+		caldata_extract "art" 0x41000 0x440
+		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;
@@ -171,6 +174,9 @@ case "$FIRMWARE" in
 		;;
 	meraki,mr16)
 		caldata_extract "art" 0x15000 0xeb8
+		;;
+	ruckus,zf7363)
+		caldata_extract "art" 0x45000 0x440
 		;;
 	*)
 		caldata_die "board $board is not supported yet"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2195,6 +2195,18 @@ define Device/rosinson_wr818
 endef
 TARGET_DEVICES += rosinson_wr818
 
+define Device/ruckus_zf7363
+  SOC := ar7161
+  DEVICE_VENDOR := Ruckus
+  DEVICE_MODEL := ZF7363
+  IMAGE_SIZE := 7168k
+  BLOCKSIZE := 256k
+  #TODO: add ruckus_fw_header (ath79: add support for Ruckus R500 #4241)
+  KERNEL := kernel-bin | append-dtb | lzma-no-dict | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+endef
+TARGET_DEVICES += ruckus_zf7363
+
 define Device/samsung_wam250
   SOC := ar9344
   DEVICE_VENDOR := Samsung


### PR DESCRIPTION
Specifications:
```
SoC:     AR7161 (680 MHz)
DRAM:    64 Mb DDR2
Flash:   16 Mb SPI-NOR
Switch:  1x 10/100 Mbps via RTL8363s switch?, (not working)
         1x 10/100 Mbps via RGMII, (working)
         1x 10/100/1000 Mbps (802.af PoE-in) via RGMII (working)
WLAN:    AR9280 (2x2 11an / 11n) WLAN
USB:     1x 2.0, not populated
UART:    standard QCA UART header
JTAG:    no?
Button:  1x Hard Reset, 1x OPT
LEDs:    5x labeled (PWR,OPT,DIR,2.4G,5G) + lot more
Power:   12 VDC / 1.25 A
Misc:    ...
```

MAC addresses as verified by OEM firmware:
```
use   address   source
label *:90      art 0x807e
WAN   *:93      art 0x66
LAN1  *:94      art 0x6c
LAN2  *:95      art 0x8058
2g    *:98      art 0x60
5g    *:9c      art 0x76
```

Installation:
```
  * Requires TFTP server at 192.168.199.1, w/ initramfs & sysupgrade .bins
  * Open shell case and connect a USB to TTL cable to upper serial headers
  * Power on the router; connect to U-boot over 115200-baud connection
  * Interrupt U-boot process to boot Openwrt by running:
       tftpboot 81000000 <filename-of-initramfs-kernel>.bin;
       bootm 0x81000000;
  * Copy sysupgrade image to /tmp on ZF7363
  * TODO: sysupgrade /tmp/<filename-of-sysupgrade>.bin
```
Signed-off-by: Joachim Ernst <mail-openwrt@0x4A6F.dev>
Signed-off-by: Nick Hahn <nick.hahn@posteo.de>