### PR TITLE
ramips: add support for ipTIME A3004T

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004t.dts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "iptime,a3004t", "mediatek,mt7621-soc";
+	model = "ipTIME A3004T";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			label = "orange:cpu";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "orange:wlan2g";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "orange:wlan5g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x20000>;
+			read-only;
+		};
+
+		factory: partition@a0000 {
+			label = "factory";
+			reg = <0xa0000 0x20000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_4: macaddr@4 {
+				reg = <0x4 0x6>;
+			};
+
+			macaddr_factory_8004: macaddr@8004 {
+				reg = <0x8004 0x6>;
+			};
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7e40000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7a40000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(3)>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <(1)>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -766,6 +766,23 @@ define Device/iptime_a3004ns-dual
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
+define Device/iptime_a3004t
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  FILESYSTEMS := squashfs
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 129280k
+  UIMAGE_NAME := a3004t
+  UBINIZE_OPTS := -E 5
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A3004T
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+endef
+TARGET_DEVICES += iptime_a3004t
+
 define Device/iptime_a6ns-m
   $(Device/dsa-migration)
   IMAGE_SIZE := 16128k

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -58,6 +58,7 @@ platform_do_upgrade() {
 	dlink,dir-2660-a1|\
 	dlink,dir-853-a3|\
 	hiwifi,hc5962|\
+	iptime,a3004t|\
 	jcg,q20|\
 	linksys,e5600|\
 	linksys,ea7300-v1|\


### PR DESCRIPTION
ramips: add support for ipTIME A3004T

ipTIME A3004T is a 2.4/5GHz band router, based on Mediatek MT7621.

Specifications:
 - SoC: MT7621 (880MHz)
 - RAM: DDR3 256M
 - Flash: NAND 128MB  (Macronix NAND 128MiB 3,3V 8-bit)
 - WiFi:
   - 2.4GHz: MT7615E
   - 5GHz : MT7615E
 - Ethernet:
   - 4x LAN
   - 1x WAN
 - USB: 1 * USB3.0 port
 - UART:
   - 3.3V, TX, RX, GND / 57600 8N1

Installation via web interface:
 1. Flash initramfs image using OEM's Recovery mode
 2. Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
 - Flash stock firmware via OEM's Recovery mode

How to use OEM's Recovery mode:
 1. Power up with holding down the reset key until CPU LED stop blinking.
 2. Set fixed ip with `192.168.0.2` with subnet mask `255.255.255.0`
 3. Flash image via tftp to `192.168.0.1`

Additional Notes:
 This router shares one MT7915E chip for both 2.4Ghz/5Ghz.
 radio0 will not working on 5Ghz as it's not connected to the antenna.

Signed-off-by: WonJung Kim <git@won-jung.kim>