### PR TITLE
hostapd: refresh patchset

### DIFF
--- a/package/network/services/hostapd/patches/380-disable_ctrl_iface_mib.patch
+++ b/package/network/services/hostapd/patches/380-disable_ctrl_iface_mib.patch
@@ -12,7 +12,7 @@
  else
 --- a/hostapd/ctrl_iface.c
 +++ b/hostapd/ctrl_iface.c
-@@ -3569,6 +3569,7 @@ static int hostapd_ctrl_iface_receive_pr
+@@ -3570,6 +3570,7 @@ static int hostapd_ctrl_iface_receive_pr
  						      reply_size);
  	} else if (os_strcmp(buf, "STATUS-DRIVER") == 0) {
  		reply_len = hostapd_drv_status(hapd, reply, reply_size);
@@ -20,7 +20,7 @@
  	} else if (os_strcmp(buf, "MIB") == 0) {
  		reply_len = ieee802_11_get_mib(hapd, reply, reply_size);
  		if (reply_len >= 0) {
-@@ -3610,6 +3611,7 @@ static int hostapd_ctrl_iface_receive_pr
+@@ -3611,6 +3612,7 @@ static int hostapd_ctrl_iface_receive_pr
  	} else if (os_strncmp(buf, "STA-NEXT ", 9) == 0) {
  		reply_len = hostapd_ctrl_iface_sta_next(hapd, buf + 9, reply,
  							reply_size);

--- a/package/network/services/hostapd/patches/600-ubus_support.patch
+++ b/package/network/services/hostapd/patches/600-ubus_support.patch
@@ -31,7 +31,7 @@
  };
  
  enum hostapd_chan_status {
-@@ -154,6 +155,7 @@ struct hostapd_data {
+@@ -169,6 +170,7 @@ struct hostapd_data {
  	struct hostapd_iface *iface;
  	struct hostapd_config *iconf;
  	struct hostapd_bss_config *conf;
@@ -39,7 +39,7 @@
  	int interface_added; /* virtual interface added for this BSS */
  	unsigned int started:1;
  	unsigned int disabled:1;
-@@ -610,6 +612,7 @@ hostapd_alloc_bss_data(struct hostapd_if
+@@ -628,6 +630,7 @@ hostapd_alloc_bss_data(struct hostapd_if
  		       struct hostapd_bss_config *bss);
  int hostapd_setup_interface(struct hostapd_iface *iface);
  int hostapd_setup_interface_complete(struct hostapd_iface *iface, int err);
@@ -515,7 +515,7 @@
  
 --- a/src/ap/wnm_ap.c
 +++ b/src/ap/wnm_ap.c
-@@ -441,7 +441,8 @@ static void ieee802_11_rx_bss_trans_mgmt
+@@ -442,7 +442,8 @@ static void ieee802_11_rx_bss_trans_mgmt
  	wpa_hexdump(MSG_DEBUG, "WNM: BSS Transition Candidate List Entries",
  		    pos, end - pos);
  
@@ -525,7 +525,7 @@
  }
  
  
-@@ -463,7 +464,7 @@ static void ieee802_11_rx_bss_trans_mgmt
+@@ -464,7 +465,7 @@ static void ieee802_11_rx_bss_trans_mgmt
  					      size_t len)
  {
  	u8 dialog_token, status_code, bss_termination_delay;
@@ -534,7 +534,7 @@
  	int enabled = hapd->conf->bss_transition;
  	struct sta_info *sta;
  
-@@ -510,6 +511,7 @@ static void ieee802_11_rx_bss_trans_mgmt
+@@ -511,6 +512,7 @@ static void ieee802_11_rx_bss_trans_mgmt
  			wpa_printf(MSG_DEBUG, "WNM: not enough room for Target BSSID field");
  			return;
  		}
@@ -542,7 +542,7 @@
  		sta->agreed_to_steer = 1;
  		eloop_cancel_timeout(ap_sta_reset_steer_flag_timer, hapd, sta);
  		eloop_register_timeout(2, 0, ap_sta_reset_steer_flag_timer,
-@@ -529,6 +531,10 @@ static void ieee802_11_rx_bss_trans_mgmt
+@@ -530,6 +532,10 @@ static void ieee802_11_rx_bss_trans_mgmt
  			MAC2STR(addr), status_code, bss_termination_delay);
  	}
  

--- a/package/network/services/hostapd/patches/700-wifi-reload.patch
+++ b/package/network/services/hostapd/patches/700-wifi-reload.patch
@@ -156,7 +156,7 @@
  	struct hostapd_config * (*config_read_cb)(const char *config_fname);
  	int (*ctrl_iface_init)(struct hostapd_data *hapd);
  	void (*ctrl_iface_deinit)(struct hostapd_data *hapd);
-@@ -156,6 +156,7 @@ struct hostapd_data {
+@@ -171,6 +171,7 @@ struct hostapd_data {
  	struct hostapd_config *iconf;
  	struct hostapd_bss_config *conf;
  	struct hostapd_ubus_bss ubus;
@@ -164,7 +164,7 @@
  	int interface_added; /* virtual interface added for this BSS */
  	unsigned int started:1;
  	unsigned int disabled:1;
-@@ -604,7 +605,7 @@ struct hostapd_iface {
+@@ -622,7 +623,7 @@ struct hostapd_iface {
  int hostapd_for_each_interface(struct hapd_interfaces *interfaces,
  			       int (*cb)(struct hostapd_iface *iface,
  					 void *ctx), void *ctx);

--- a/package/network/services/hostapd/patches/720-iface_max_num_sta.patch
+++ b/package/network/services/hostapd/patches/720-iface_max_num_sta.patch
@@ -17,7 +17,7 @@
  	} else if (os_strcmp(buf, "extended_key_id") == 0) {
 --- a/src/ap/hostapd.h
 +++ b/src/ap/hostapd.h
-@@ -648,6 +648,7 @@ void hostapd_cleanup_cs_params(struct ho
+@@ -666,6 +666,7 @@ void hostapd_cleanup_cs_params(struct ho
  void hostapd_periodic_iface(struct hostapd_iface *iface);
  int hostapd_owe_trans_get_info(struct hostapd_data *hapd);
  void hostapd_ocv_check_csa_sa_query(void *eloop_ctx, void *timeout_ctx);


### PR DESCRIPTION
Recently the hostapd has undergone many changes. The patches were not refreshed.
Refreshed with
    make package/hostapd/{clean,refresh}

Refreshed:
    - 380-disable_ctrl_iface_mib.patch
    - 600-ubus_support.patch
    - 700-wifi-reload.patch
    - 720-iface_max_num_sta.patch
