### PR TITLE
ramips: add support for HUMAX E2

### DIFF
--- a/target/linux/ramips/dts/mt7620a_humax_e2.dts
+++ b/target/linux/ramips/dts/mt7620a_humax_e2.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "humax,e2", "ralink,mt7620a-soc";
+	model = "HUMAX E2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		pairing {
+			label = "green:pairing";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			label = "green:wlan";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x30000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_10007: macaddr@10007 {
+					reg = <0x10007 0x6>;
+				};
+			};
+
+			partition@70000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,offset = <FW_EDIMAX_OFFSET>;
+				openwrt,partition-magic = <FW_MAGIC_EDIMAX>;
+				label = "firmware";
+				reg = <0x70000 0x790000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_10007>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii1";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -526,6 +526,20 @@ define Device/hnet_c108
 endef
 TARGET_DEVICES += hnet_c108
 
+define Device/humax_e2
+  SOC := mt7620a
+  IMAGE_SIZE := 7744k
+  DEVICE_VENDOR := HUMAX
+  DEVICE_MODEL := E2
+  DEVICE_ALT0_VENDOR := HUMAX
+  DEVICE_ALT0_MODEL := QUANTUM E2
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	edimax-header -s CSYS -m RN75 -f 0x70000 -S 0x01100000 | pad-rootfs | \
+	check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt76x0e
+endef
+TARGET_DEVICES += humax_e2
+
 define Device/sunvalley_filehub_common
   SOC := mt7620n
   IMAGE_SIZE := 6144k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -125,6 +125,9 @@ hnet,c108)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	ucidef_set_led_netdev "modem" "modem" "green:modem" "wwan0"
 	;;
+humax,e2)
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
+	;;
 iodata,wn-ac1167gr|\
 iodata,wn-ac733gr3)
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0radio"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -100,7 +100,8 @@ ramips_setup_interfaces()
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "4:wan:5" "6@eth0"
 		;;
 	comfast,cf-wr800n|\
-	hnet,c108)
+	hnet,c108|\
+	humax,e2)
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;


### PR DESCRIPTION
HUMAX E2 (also known as HUMAX QUANTUM E2) is a 2.4/5GHz band AC router,
based on MediaTek MT7620A.

Specifications:
- SoC: MT7620A
- RAM: DDR2 64MB
- Flash: SPI NOR 8MB (MXIC MX25L6405D)
- WiFi:
  - 2.4GHz: SoC internal
  - 5GHz: MT7610E
- Ethernet: 1x 10/100Mbps
  - Switch: SoC internal
- UART: J2 (57600 8N1)
  - pinout: [3V3] (RXD) (GND) (TXD)

Installation and Recovery via TFTP:
1. Connect ethernet cable between Router port and PC Ethernet port.
2. Set your computer to a static IP **192.168.1.1**
3. Turn the device off and wait a few seconds. Hold the WPS button on front
   of device and insert power.
4. Send a firmware image to **192.168.1.6** using TFTP.
   You can use any TFTP client. (tftp, curl, Tftpd64...)
5. Wait until Power LED stop flashing. **DO NOT TURN OFF DEVICE!**
   The device will be automatically rebooted.

Signed-off-by: Kyoungkyu Park <choryu.park@choryu.space>