### PR TITLE
ramips: WSR-2533DHPL: Allow Kernel2 region to be written

### DIFF
--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhpl.dts
@@ -145,7 +145,6 @@
 			partition@810000 {
 				label = "Kernel2";
 				reg = <0x810000 0x7c0000>;
-				read-only;
 			};
 
 			partition@fd0000 {


### PR DESCRIPTION
This isn't necessary for OpenWrt to function, so remove the read-only
flag.

Signed-off-by: Kazuki Hashimoto <kazukih@tuta.io>