### PR TITLE
kernel: 5.10: add patches to fix macronix flash

### DIFF
--- a/target/linux/ath79/patches-5.10/0052-mtd-spi-nor-use-4-bit-locking-for-MX25L12805D.patch
+++ b/target/linux/ath79/patches-5.10/0052-mtd-spi-nor-use-4-bit-locking-for-MX25L12805D.patch
@@ -21,7 +21,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/drivers/mtd/spi-nor/macronix.c
 +++ b/drivers/mtd/spi-nor/macronix.c
-@@ -50,7 +50,8 @@ static const struct flash_info macronix_
+@@ -51,7 +51,8 @@ static const struct flash_info macronix_
  	{ "mx25u4035",   INFO(0xc22533, 0, 64 * 1024,   8, SECT_4K) },
  	{ "mx25u8035",   INFO(0xc22534, 0, 64 * 1024,  16, SECT_4K) },
  	{ "mx25u6435f",  INFO(0xc22537, 0, 64 * 1024, 128, SECT_4K) },

--- a/target/linux/generic/pending-5.10/498-mtd-spi-nor-locking-support-for-MX25L6405D.patch
+++ b/target/linux/generic/pending-5.10/498-mtd-spi-nor-locking-support-for-MX25L6405D.patch
@@ -1,0 +1,34 @@
+From 8bf2ce6ea4ee840b70f55a27f80e1cd308051b13 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Mon, 27 Dec 2021 00:38:13 +0100
+Subject: [PATCH 1/2] mtd: spi-nor: locking support for MX25L6405D
+
+Macronix MX25L6405D supports locking with four block-protection bits.
+Currently, the driver only sets three bits.  If the bootloader does not
+sustain the flash chip in an unlocked state, the flash might be
+non-writeable. Add the corresponding flag to enable locking support with
+four bits in the status register.
+
+Tested on Nanostation M2 XM.
+
+Similar to commit 7ea40b54e83b ("mtd: spi-nor: enable locking support for
+MX25L12805D")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ drivers/mtd/spi-nor/macronix.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -42,7 +42,8 @@ static const struct flash_info macronix_
+ 	{ "mx25l1606e",  INFO(0xc22015, 0, 64 * 1024,  32, SECT_4K) },
+ 	{ "mx25l3205d",  INFO(0xc22016, 0, 64 * 1024,  64, SECT_4K) },
+ 	{ "mx25l3255e",  INFO(0xc29e16, 0, 64 * 1024,  64, SECT_4K) },
+-	{ "mx25l6405d",  INFO(0xc22017, 0, 64 * 1024, 128, SECT_4K) },
++	{ "mx25l6405d",  INFO(0xc22017, 0, 64 * 1024, 128, SECT_4K |
++			      SPI_NOR_HAS_LOCK | SPI_NOR_4BIT_BP) },
+ 	{ "mx25u2033e",  INFO(0xc22532, 0, 64 * 1024,   4, SECT_4K) },
+ 	{ "mx25u3235f",	 INFO(0xc22536, 0, 64 * 1024,  64,
+ 			      SECT_4K | SPI_NOR_DUAL_READ |

--- a/target/linux/generic/pending-5.10/499-mtd-spi-nor-disable-16-bit-sr-for-macronix.patch
+++ b/target/linux/generic/pending-5.10/499-mtd-spi-nor-disable-16-bit-sr-for-macronix.patch
@@ -1,0 +1,30 @@
+From 245224608b5368c10407da07557e546743d3c489 Mon Sep 17 00:00:00 2001
+From: Nick Hainke <vincent@systemli.org>
+Date: Mon, 27 Dec 2021 09:33:13 +0100
+Subject: [PATCH 2/2] mtd: spi-nor: disable 16-bit-sr for macronix
+
+Macronix flash chips seem to consist of only one status register.
+These chips will not work with the "16-bit Write Status (01h) Command".
+Disable SNOR_F_HAS_16BIT_SR for all Macronix chips.
+
+Tested with MX25L6405D.
+
+Fixes: 39d1e3340c73 ("mtd: spi-nor: Fix clearing of QE bit on
+lock()/unlock()")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+---
+ drivers/mtd/spi-nor/macronix.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/mtd/spi-nor/macronix.c
++++ b/drivers/mtd/spi-nor/macronix.c
+@@ -94,6 +94,7 @@ static void macronix_default_init(struct
+ {
+ 	nor->params->quad_enable = spi_nor_sr1_bit6_quad_enable;
+ 	nor->params->set_4byte_addr_mode = spi_nor_set_4byte_addr_mode;
++	nor->flags &= ~SNOR_F_HAS_16BIT_SR;
+ 	nor->flags |= SNOR_F_HAS_LOCK;
+ }
+ 


### PR DESCRIPTION
    kernel: 5.10: add patches to fix macronix flash
    
    mtd: spi-nor: locking support for MX25L6405D
    
    Macronix MX25L6405D supports locking with four block-protection bits.
    Currently, the driver only sets three bits.  If the bootloader does not
    sustain the flash chip in an unlocked state, the flash might be
    non-writeable. Add the corresponding flag to enable locking support with
    four bits in the status register.
    
    mtd: spi-nor: disable 16-bit-sr for macronix
    
    Macronix flash chips seem to consist of only one status register.
    These chips will not work with the "16-bit Write Status (01h) Command".
    Disable SNOR_F_HAS_16BIT_SR for all Macronix chips.
    
    Refreshed:
    - 0052-mtd-spi-nor-use-4-bit-locking-for-MX25L12805D.patch
