### PR TITLE
x86: add/improve support for Sophos SG/XG products

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -18,9 +18,19 @@ roqos-roqos-core-rc10)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
 sophos-sg-105r1|sophos-xg-105r1| \
-sophos-sg-105r2|sophos-xg-105r2)
+sophos-sg-105Wr1|sophos-xg-105Wr1| \
+sophos-sg-105r2|sophos-xg-105r2| \
+sophos-sg-105Wr2|sophos-xg-105Wr2| \
+sophos-sg-115r1|sophos-xg-115r1| \
+sophos-sg-115Wr1|sophos-xg-115Wr1| \
+sophos-sg-115r2|sophos-xg-115r2| \
+sophos-sg-115Wr2|sophos-xg-115Wr2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
 	;;
+sophos-sg-125r1|sophos-xg-125r1| \
+sophos-sg-125Wr1|sophos-xg-125Wr1| \
+sophos-sg-125r2|sophos-xg-125r2| \
+sophos-sg-125Wr2|sophos-xg-125Wr2| \
 sophos-sg-135r1|sophos-xg-135r1| \
 sophos-sg-135Wr1|sophos-xg-135Wr1| \
 sophos-sg-135r2|sophos-xg-135r2| \

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -26,7 +26,7 @@ do_sysinfo_x86() {
 			local product_version
 			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
 			case "$product_version" in
-			105*|135*)
+			105*|115*|125*|135*)
 				product="${product}-${product_version}"
 				break
 				;;


### PR DESCRIPTION
* Add support for Sophos SG/XG-115 r1, r2 with/without wireless
* Add support for Sophos SG/XG-125 r1, r2 with/without wireless
* Add wireless support for SG/XG-105

Signed-off-by: Raylynn Knight <rayknight@me.com>

