### PR TITLE
[21.02] buildsystem: add CONFIG_SECCOMP

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -386,4 +386,16 @@ menu "Global build settings"
 
 	endchoice
 
+	config SECCOMP
+		bool "Enable SECCOMP"
+		select KERNEL_SECCOMP
+		select PACKAGE_procd-seccomp
+		depends on (aarch64 || arm || armeb || mips || mipsel || i386 || powerpc || x86_64)
+		depends on !TARGET_uml
+		default y
+		help
+		  This option enables seccomp kernel features to safely
+		  execute untrusted bytecode and selects the seccomp-variants
+		  of procd
+
 endmenu

--- a/include/target.mk
+++ b/include/target.mk
@@ -33,6 +33,16 @@ else
 DEFAULT_PACKAGES+=busybox procd
 endif
 
+# include ujail on systems with enough storage
+ifeq ($(CONFIG_SMALL_FLASH),)
+DEFAULT_PACKAGES+=procd-ujail
+endif
+
+# include seccomp ld-preload hooks if kernel supports it
+ifneq ($(CONFIG_SECCOMP),)
+DEFAULT_PACKAGES+=procd-seccomp
+endif
+
 # For the basic set
 DEFAULT_PACKAGES.basic:=
 # For nas targets

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -82,8 +82,7 @@ endef
 define Package/procd-seccomp
   SECTION:=base
   CATEGORY:=Base system
-  DEPENDS:=@(arm||armeb||mips||mipsel||i386||powerpc||x86_64) @!TARGET_uml \
-	  @KERNEL_SECCOMP +libubox +libblobmsg-json
+  DEPENDS:=@SECCOMP +libubox +libblobmsg-json
   TITLE:=OpenWrt process seccomp helper + utrace
 endef
 


### PR DESCRIPTION
Until now, this feature was switched on via the kernel configuration
option KERNEL_SECCOMP.

The follwing change a7f794cd2aa104fdbd4c6e38f9b76373bf9b96e1 now requires that
the package procd-seccomp must also enabled for buildinmg.

However, this is not the case we have no dependency and the imagebuilder
cannot build the image, because of the implicit package selection.

This change adds a new configuration option CONFIG_SECCOMP.
The new option  has the same behaviour as the configuration
option CONFIG_SELINUX.

If the CONFIG_SECCOMP is selected then the package procd-seccomp and
KERNEL_SECCOMP is enabled for this build.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>
Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit b118efa0d25f5b60226a9d316eb838dd6be22f78)
Signed-off-by: Nick Hainke <vincent@systemli.org>

