### PR TITLE
ath79: add support for ASUS RP-AC66

### DIFF
--- a/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
+++ b/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "ASUS RP-AC66";
+	compatible = "asus,rp-ac66", "qca,qca9563";
+
+	aliases {
+		led-boot = &led_orange;
+		led-failsafe = &led_orange;
+		led-running = &led_power;
+		led-upgrade = &led_orange;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_orange: wps {
+			label = "orange:wps";
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssilow-wlan0 {
+			label = "blue:rssilow-wlan0";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssimedium-wlan0 {
+			label = "red:rssimedium-wlan0";
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssihigh-wlan0 {
+			label = "green:rssihigh-wlan0";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssilow-wlan1 {
+			label = "blue:rssilow-wlan1";
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssimedium-wlan1 {
+			label = "red:rssimedium-wlan1";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssihigh-wlan1 {
+			label = "green:rssihigh-wlan1";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x10000>;
+				read-only;
+			};
+
+			art: partition@50000 {
+				label = "art";
+				reg = <0x050000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_art_1002: macaddr@1002 {
+					reg = <0x1002 0x6>;
+				};
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xf20000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0>;
+
+	phy0: ethernet-phy@3 {
+		reg = <0x3>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	nvmem-cells = <&macaddr_art_1002>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy0>;
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -48,6 +48,16 @@ alfa-network,r36a)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x10"
 	;;
+asus,rp-ac66)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "rssilow-wlan0" "RSSILOW" "blue:rssilow-wlan0" "wlan0" "1" "1"
+	ucidef_set_led_rssi "rssimedium-wlan0" "RSSIMEDIUM" "red:rssimedium-wlan0" "wlan0" "1" "79"
+	ucidef_set_led_rssi "rssihigh-wlan0" "RSSIHIGH" "green:rssihigh-wlan0" "wlan0" "70" "100"
+	ucidef_set_led_rssi "rssilow-wlan1" "RSSILOW" "blue:rssilow-wlan1" "wlan1" "1" "1"
+	ucidef_set_led_rssi "rssimedium-wlan1" "RSSIMEDIUM" "red:rssimedium-wlan1" "wlan1" "1" "79"
+	ucidef_set_led_rssi "rssihigh-wlan1" "RSSIHIGH" "green:rssihigh-wlan1" "wlan1" "70" "100"
+	;;
 avm,fritz1750e)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_rssimon "wlan1" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ath79_setup_interfaces()
 	alfa-network,pi-wifi4|\
 	arduino,yun|\
 	aruba,ap-105|\
+	asus,rp-ac66|\
 	avm,fritz1750e|\
 	avm,fritz300e|\
 	avm,fritzdvbc|\
@@ -532,6 +533,10 @@ ath79_setup_macs()
 		base_mac=$(mtd_get_mac_binary art 0x1002)
 		lan_mac=$(macaddr_setbit $base_mac 29)
 		[ $lan_mac = $base_mac ] && lan_mac=$(macaddr_unsetbit $base_mac 29)
+		;;
+	asus,rp-ac66)
+		lan_mac=$(mtd_get_mac_binary art 0x1002)
+		label_mac=$lan_mac
 		;;
 	avm,fritz1750e|\
 	avm,fritz450e|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,6 +12,9 @@ case "$FIRMWARE" in
 	8dev,lima)
 		caldata_extract "art" 0x1000 0x800
 		;;
+	asus,rp-ac66)
+		caldata_extract "art" 0x1000 0x440
+		;;
 	avm,fritz1750e|\
 	avm,fritz4020|\
 	avm,fritz450e|\

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -21,6 +21,7 @@ case "$FIRMWARE" in
 	avm,fritzdvbc)
 		caldata_extract "urlader" 0x198a 0x844
 		;;
+	asus,rp-ac66|\
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
 	devolo,dlan-pro-1200plus-ac|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -330,6 +330,18 @@ define Device/aruba_ap-105
 endef
 TARGET_DEVICES += aruba_ap-105
 
+define Device/asus_rp-ac66
+  SOC := qca9563
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RP-AC66
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct \
+	rssileds -swconfig
+endef
+TARGET_DEVICES += asus_rp-ac66
+
 define Device/atheros_db120
   $(Device/loader-okli-uimage)
   SOC := ar9344


### PR DESCRIPTION
Asus RP-AC66 Repeater

Hardware specifications:
Board: AP152
SoC: QCA9563
DRAM: 64MB DDR2
Flash: 25l128 16MB SPI-NOR
LAN/WAN: 1x1000M QCA8033
WiFi 5GHz: QCA9880
Clocks: CPU:775.000MHz, DDR:650.000MHz, AHB:258.333MHz, Ref:25.000MHz

MAC addresses as verified by OEM firmware:
use            address   source
Lan/Wan   *:24         art 0x1002 (label)
2G             *:24         art 0x1002
5G             *:26         art 0x5006

Installation:

Asus windows recovery tool:
 - install the Asus firmware restoration utility
 - unplug the router, hold the reset button while powering it on
 - release when the power LED flashes slowly
 - specify a static IP on your computer:
     IP address: 192.168.1.75
     Subnet mask 255.255.255.0
 - Start the Asus firmware restoration utility, specify the factory image
    and press upload
 - Do not power off the device after OpenWrt has booted until the LED flashing.

TFTP Recovery method:
 - set computer to a static ip, 192.168.1.75
 - connect computer to the LAN 1 port of the router
 - hold the reset button while powering on the router for a few seconds
 - send firmware image using a tftp client; i.e from linux:
 $ tftp
 tftp> binary
 tftp> connect 192.168.1.1
 tftp> put factory.bin
 tftp> quit

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
