### PR TITLE
[21.02] cypress-nvram: fix firmware is not exist for raspberry pi compute 4

### DIFF
--- a/package/firmware/cypress-nvram/Makefile
+++ b/package/firmware/cypress-nvram/Makefile
@@ -100,6 +100,9 @@ define Package/cypress-nvram-43455-sdio-rpi-4b/install
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-model-b.txt
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/brcmfmac43455-sdio.raspberrypi,4-model-b.txt \
+		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt
 endef
 
 $(eval $(call BuildPackage,cypress-nvram-43455-sdio-rpi-4b))


### PR DESCRIPTION
I spotted it on device [Mini Router from Seeedstudio](https://www.seeedstudio.com/Dual-GbE-Carrier-Board-with-4GB-RAM-32GB-eMMC-RPi-CM4-Case-p-5029.html), where I flashed OpenWrt 21.02.1 and in logs, I can see:

```
Sun Oct 24 09:01:50 2021 kern.info kernel: [    6.691216] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43455-sdio for chip BCM4345/6
Sun Oct 24 09:01:50 2021 kern.warn kernel: [    6.708398] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt failed with error -2
Sun Oct 24 09:01:50 2021 kern.warn kernel: [    6.720689] brcmfmac mmc1:0001:1: Falling back to sysfs fallback for: brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt
Sun Oct 24 09:01:50 2021 kern.warn kernel: [    6.736237] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.txt failed with error -2
Sun Oct 24 09:01:50 2021 kern.warn kernel: [    6.745993] brcmfmac mmc1:0001:1: Falling back to sysfs fallback for: brcm/brcmfmac43455-sdio.txt
```

Cherry-picked from PR https://github.com/openwrt/openwrt/pull/4689 and improved the commit message to have it more clear.