### PR TITLE
kernel: add kmod-net-lan78xx

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1201,6 +1201,23 @@ endef
 $(eval $(call KernelPackage,usb-net-kaweth))
 
 
+define KernelPackage/usb-net-lan78xx
+  TITLE:=USB-To-Ethernet Microchip LAN78XX convertors
+  DEPENDS:=+kmod-libphy
+  KCONFIG:=CONFIG_USB_LAN78XX
+  FILES:=$(LINUX_DIR)/drivers/$(USBNET_DIR)/lan78xx.ko
+  AUTOLOAD:=$(call AutoProbe,lan78xx)
+  $(call AddDepends/usb-net)
+endef
+
+define KernelPackage/usb-net-lan78xx/description
+ Kernel module for Microchip LAN78XX based USB 2 & USB 3
+ 10/100/1000 Ethernet adapters.
+endef
+
+$(eval $(call KernelPackage,usb-net-lan78xx))
+
+
 define KernelPackage/usb-net-pegasus
   TITLE:=Kernel module for USB-to-Ethernet Pegasus convertors
   KCONFIG:=CONFIG_USB_PEGASUS


### PR DESCRIPTION
Add kernel module for Microchip LAN78XX based USB 2 & USB 3 10/100/1000 Ethernet adapters. [1]

For example, this kernel module is required for Raspberry Pi 3 B+ [2] and as well for Seeed Studio's Mini Router based on RPI CM4 [3]

- Compile and run tested for Seeed Studio's Mini Router based on RPI CM4, OpenWrt 21.02.1 [3], which uses: **Microchip's LAN7800**

**Before this commit:**
System log from LuCI:
```
Sun Oct 24 09:01:50 2021 kern.info kernel: [    0.530293] usb 2-3: Product: LAN7800
```

lsusb
```
root@OpenWrt:/tmp# lsusb -t
/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/4p, 5000M
    |__ Port 3: Dev 2, If 0, Class=, Driver=, 5000M
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/1p, 480M
    |__ Port 1: Dev 2, If 0, Class=, Driver=hub/4p, 480M
root@OpenWrt:/tmp# lsusb
Bus 001 Device 002: ID 2109:3431  USB2.0 Hub
Bus 001 Device 001: ID 1d6b:0002 Linux 5.4.154 xhci-hcd xHCI Host Controller
Bus 002 Device 002: ID 0424:7800 Microchip LAN7800
Bus 002 Device 001: ID 1d6b:0003 Linux 5.4.154 xhci-hcd xHCI Host Controller
```

**After this commit:**

System log:
```
[  140.482984] libphy: lan78xx-mdiobus: probed
[  140.487190] lan78xx 2-3:1.0 (unnamed net_device) (uninitialized): int urb period 64
[  140.497711] usbcore: registered new interface driver lan78xx
```

lsusb
```
root@OpenWrt:~# lsusb -t
/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/4p, 5000M
    |__ Port 3: Dev 2, If 0, Class=, Driver=lan78xx, 5000M
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/1p, 480M
    |__ Port 1: Dev 2, If 0, Class=, Driver=hub/4p, 480M
root@OpenWrt:~# lsusb
Bus 001 Device 002: ID 2109:3431  USB2.0 Hub
Bus 001 Device 001: ID 1d6b:0002 Linux 5.4.154 xhci-hcd xHCI Host Controller
Bus 002 Device 002: ID 0424:7800 Microchip LAN7800
Bus 002 Device 001: ID 1d6b:0003 Linux 5.4.154 xhci-hcd xHCI Host Controller
```

- Compile tested for Turris Omnia, mvebu, cortexa9, OpenWrt master
Package contents verified

This pull request tries to help a little bit with https://github.com/openwrt/openwrt/pull/4191, which is not merged for almost a year and it is required for [Seeed Studio's Mini Router based on RPI CM4](https://www.seeedstudio.com/Dual-GbE-Carrier-Board-with-4GB-RAM-32GB-eMMC-RPi-CM4-Case-p-5029.html), which has two Ethernet ports, but only one is working due to missing ``lan78xx`` driver, which this PR adds to OpenWrt as kernel package module. Then, it is necessary to figure out how to have it installed by default in the ``factory`` and ``sysupgrade`` images.

Nitpick: A few modules in `make menuconfig` →  ``Kernel modules`` → ``USB Support`` have longer ``TITLE``, thus it is not shown there. That's why my change does not begin TITLE with ``Kernel modules for`` or ``Support for``.

CC: @Noltari 

[1] https://cateee.net/lkddb/web-lkddb/USB_LAN78XX.html
[2] https://www.raspberrypi.com/products/raspberry-pi-3-model-b-plus/
[3] https://www.seeedstudio.com/Dual-GbE-Carrier-Board-with-4GB-RAM-32GB-eMMC-RPi-CM4-Case-p-5029.html
