### PR TITLE
[21.02] tcpdump: libpcap: Remove http://www.us.tcpdump.org mirror

### DIFF
--- a/package/libs/libpcap/Makefile
+++ b/package/libs/libpcap/Makefile
@@ -12,8 +12,7 @@ PKG_VERSION:=1.9.1
 PKG_RELEASE:=3.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \
-        http://www.tcpdump.org/release/
+PKG_SOURCE_URL:=http://www.tcpdump.org/release/
 PKG_HASH:=635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>

--- a/package/network/utils/tcpdump/Makefile
+++ b/package/network/utils/tcpdump/Makefile
@@ -12,8 +12,7 @@ PKG_VERSION:=4.9.3
 PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=http://www.us.tcpdump.org/release/ \
-	http://www.tcpdump.org/release/
+PKG_SOURCE_URL:=http://www.tcpdump.org/release/
 PKG_HASH:=2cd47cb3d460b6ff75f4a9940f594317ad456cfbf2bd2c8e5151e16559db6410
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>


### PR DESCRIPTION
The http://www.us.tcpdump.org mirror will go offline soon, only use the
normal download URL.

Reported-by: Denis Ovsienko <denis@ovsienko.info>
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit 18bdfc803bef00fad03f90b73b6e65c3c79cb397)
Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>
[rebased for OpenWrt 21.02 branch]