### PR TITLE
x86: improve sysinfo handling of dummy values

### DIFF
--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -12,12 +12,24 @@ do_sysinfo_x86() {
 
 	for file in sys_vendor board_vendor; do
 		vendor="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
+		case "$vendor" in
+		empty | \
+		System\ manufacturer | \
+		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+			continue
+			;;
+		esac
 		[ -n "$vendor" ] && break
 	done
 
 	for file in product_name board_name; do
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
+		?*:empty | \
+		?*:System\ Product\ Name | \
+		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+			continue
+			;;
 		"PC Engines:APU")
 			product="apu1"
 			break


### PR DESCRIPTION
Fall back to using board_vendor and board_name, if known dummy values
are used for sys_vendor and product_name.

Examples:
```
	To be filled by O.E.M.:To be filled by O.E.M.
-->	INTEL Corporation:ChiefRiver
```
```
	System manufacturer:System Product Name
-->	ASUSTeK COMPUTER INC.:P8H77-M PRO
```
```
	To Be Filled By O.E.M.:To Be Filled By O.E.M.
-->	ASRock:Q1900DC-ITX
```
Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>