### PR TITLE
ipq806x: ASRock g10: fix bogus read errors

### DIFF
--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-g10.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-g10.dts
@@ -186,6 +186,9 @@
 		nand-bus-width = <8>;
 		nand-ecc-step-size = <512>;
 
+		nand-is-boot-medium;
+		qcom,boot_pages_size = <0x1200000>;
+
 		partitions {
 			compatible = "qcom,smem-part";
 		};


### PR DESCRIPTION
Properly declare that the g10 is booting from NAND and define its
correct (larger than on other devices-) boot_pages_size, to prevent
the kernel from constantly falling over missing OOB error correction
for the bootloader.

This patch prevents a constant slew of (bogus) read errors reported
by the kernel and keeping the CPU busy and fixes:

```
blk_update_request: I/O error, dev mtdblock0, sector 0 op 0x0:(READ) flags 0x80700 phys_seg 4 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 3 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 16 op 0x0:(READ) flags 0x80700 phys_seg 2 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 24 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 0 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 0
Buffer I/O error on dev mtdblock0, logical block 0, async page read
blk_update_request: I/O error, dev mtdblock0, sector 32 op 0x0:(READ) flags 0x80700 phys_seg 8 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 40 op 0x0:(READ) flags 0x80700 phys_seg 7 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 48 op 0x0:(READ) flags 0x80700 phys_seg 6 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 56 op 0x0:(READ) flags 0x80700 phys_seg 5 prio class 0
blk_update_request: I/O error, dev mtdblock0, sector 64 op 0x0:(READ) flags 0x80700 phys_seg 4 prio class 0
Buffer I/O error on dev mtdblock0, logical block 1, async page read
Buffer I/O error on dev mtdblock1, logical block 0, async page read
Buffer I/O error on dev mtdblock1, logical block 1, async page read
Buffer I/O error on dev mtdblock2, logical block 0, async page read
Buffer I/O error on dev mtdblock2, logical block 1, async page read
Buffer I/O error on dev mtdblock3, logical block 0, async page read
Buffer I/O error on dev mtdblock3, logical block 0, async page read
Buffer I/O error on dev mtdblock4, logical block 0, async page read
Buffer I/O error on dev mtdblock4, logical block 1, async page read
```

Suggested-by: Ansuel Smith <ansuelsmth@gmail.com>
Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>