### PR TITLE
binutils: fix compiling with arch based distros

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -9,14 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
 PKG_VERSION:=2.37
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_VERSION:=$(PKG_VERSION)
 PKG_HASH:=820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c
 
-PKG_FIXUP:=autoreconf
+PKG_FIXUP:=patch-libtool
 PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof binutils ld libiberty gold intl
 PKG_REMOVE_FILES:=libtool.m4
 PKG_INSTALL:=1


### PR DESCRIPTION
    binutils: fix compiling with arch-based distros
    
    Arch Linux users have encountered problems with packages that have a dependency on binutils. This error happens when libtool is doing:
      libtool: relink: ...
    So change PKG_FIXUP to "patch-libtool".
    
    Fixes error in the form of:
      libtool: install: error: relink `libctf.la' with the above command
               before installing it
    
    Upstream Bug:
    https://sourceware.org/bugzilla/show_bug.cgi?id=28545
    
    OpenWrt Bug:
    https://bugs.openwrt.org/index.php?do=details&task_id=4149
