### PR TITLE
mediatek: add support for Ruijie RG-EW3200GX PRO

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -35,6 +35,9 @@ bananapi,bpi-r64)
 buffalo,wsr-2533dhp2)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x20000"
 	;;
+ruijie,rg-ew3200gx-pro)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x20000" "0x20000"
+	;;
 ubnt,unifi-6-lr-ubootmod)
 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x4000" "0x10000"
 	;;

--- a/target/linux/generic/pending-5.10/485-mtd-spi-nor-add-xmc-xm25qh128c.patch
+++ b/target/linux/generic/pending-5.10/485-mtd-spi-nor-add-xmc-xm25qh128c.patch
@@ -1,0 +1,11 @@
+--- a/drivers/mtd/spi-nor/xmc.c
++++ b/drivers/mtd/spi-nor/xmc.c
+@@ -14,6 +14,8 @@ static const struct flash_info xmc_parts
+ 			    SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ 	{ "XM25QH128A", INFO(0x207018, 0, 64 * 1024, 256,
+ 			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++	{ "XM25QH128C", INFO(0x204018, 0, 64 * 1024, 256,
++			     SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
+ };
+ 
+ const struct spi_nor_manufacturer spi_nor_xmc = {

--- a/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
+++ b/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+
+/ {
+	model = "Ruijie RG-EW3200GX PRO";
+	compatible = "ruijie,rg-ew3200gx-pro", "mediatek,mt7622";
+
+	aliases {
+		ethernet0 = &gmac0;
+		label-mac-device = &gmac0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n1";
+		bootargs = "console=ttyS0,115200n1 swiotlb=512";
+	};
+
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		mesh_green {
+			label = "green:mesh";
+			gpios = <&pio 79 GPIO_ACTIVE_LOW>;
+		};
+
+		mesh_red {
+			label = "red:mesh";
+			gpios = <&pio 82 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system: system_blue {
+			label = "blue:system";
+			gpios = <&pio 81 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-connection-type = "2500base-x";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@0 {
+			compatible = "mediatek,mt7531";
+			reg = <0>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				wan: port@4 {
+					reg = <4>;
+					label = "wan";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+};
+
+&slot0 {
+	mt7915@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x5000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pio {
+	epa_elna_pins: epa-elna-pins {
+		mux {
+			function = "antsel";
+			groups = "antsel0", "antsel1", "antsel2", "antsel3",
+				"antsel4", "antsel5", "antsel6", "antsel7",
+				"antsel8", "antsel9", "antsel12", "antsel13",
+				"antsel14", "antsel15", "antsel16", "antsel17";
+		};
+	};
+
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_0_waken",
+				 "pcie0_0_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	spi_nor_pins: spi-nor-pins {
+		mux {
+			function = "flash";
+			groups = "spi_nor";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx";
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwrap {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+};
+
+&nor_flash {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_nor_pins>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "ATF";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "u-boot";
+				reg = <0x60000 0x50000>;
+				read-only;
+			};
+
+			partition@B0000 {
+				label = "u-boot-env";
+				reg = <0xb0000 0x20000>;
+			};
+
+			factory: partition@D0000 {
+				label = "Factory";
+				reg = <0xd0000 0x80000>;
+				read-only;
+			};
+
+			partition@150000 {
+				label = "product_info";
+				reg = <0x150000 0x10000>;
+				read-only;
+			};
+
+			partition@160000 {
+				label = "kdump";
+				reg = <0x160000 0x10000>;
+				read-only;
+			};
+
+			partition@170000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x170000 0xe90000>;
+			};
+		};
+	};
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&uart0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+};
+
+&watchdog {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+};
+
+&wmac {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&epa_elna_pins>;
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -203,6 +203,15 @@ define Device/mediatek_mt7622-rfb1-ubi
 endef
 TARGET_DEVICES += mediatek_mt7622-rfb1-ubi
 
+define Device/ruijie_rg-ew3200gx-pro
+  DEVICE_VENDOR := Ruijie
+  DEVICE_MODEL := RG-EW3200GX PRO
+  DEVICE_DTS := mt7622-ruijie-rg-ew3200gx-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e
+endef
+TARGET_DEVICES += ruijie_rg-ew3200gx-pro
+
 define Device/totolink_a8000ru
   DEVICE_VENDOR := TOTOLINK
   DEVICE_MODEL := A8000RU

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -12,7 +12,8 @@ mediatek_setup_interfaces()
 	linksys,e8450|\
 	linksys,e8450-ubi|\
 	mediatek,mt7622-rfb1|\
-	mediatek,mt7622-rfb1-ubi)
+	mediatek,mt7622-rfb1-ubi|\
+	ruijie,rg-ew3200gx-pro)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
 		;;
 	buffalo,wsr-2533dhp2)
@@ -30,9 +31,24 @@ mediatek_setup_interfaces()
 	esac
 }
 
+mediatek_setup_macs()
+{
+	local board="$1"
+	local lan_mac=""
+
+	case $board in
+	ruijie,rg-ew3200gx-pro)
+		lan_mac=$(macaddr_add $(get_mac_label) 1)
+		;;
+	esac
+
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+}
+
 board_config_update
 board=$(board_name)
 mediatek_setup_interfaces $board
+mediatek_setup_macs $board
 board_config_flush
 
 exit 0

--- a/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -1,0 +1,17 @@
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	ruijie,rg-ew3200gx-pro)
+		[ "$PHYNBR" = "0" ] && macaddr_add $(get_mac_label) 3 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $(get_mac_label) 2 > /sys${DEVPATH}/macaddress
+		;;
+esac


### PR DESCRIPTION
X32 Pro is another product name for it in the Chinese market.

Specifications:
- SoC: MT7622B
- RAM: 256MB
- Flash: XMC XM25QH128C or Winbond WQ25Q128JVSQ 16MB SPI NOR
- Ethernet: 5x1GbE
- Switch: MT7531BE
- WiFi: 2.4G: MT7622 5G: MT7915AN+MT7975AN
- 3LEDs: System LED (blue) + Mesh LED (green) + Mesh LED (red)
- 2Keys: Mesh button + Reset button
- UART: Marked J19 on board. 3.3v, 115200n1
- Power: 12V 2.5A

MAC addresses as verified by OEM firmware:
use   address    source
WAN   *: F4       ethaddr@product_info
LAN    *: F5
5g       *: F6
2g       *: F7

Flash instruction:
1. Serve the initramfs.img using a TFTP server with address 10.10.10.3.
2. Interrupt the uboot startup process via UART.
3. Select "System Load Linux to SDRAM via TFTP" item.
4. (important) Back up firmware(mtd7) partitions with:
        dd if=/dev/mtd7 of=/tmp/firmware.bin
   and then download the firmware.bin image via SCP.
5. Flash the OpenWrt sysupgrade firmware.

Recovery stock firmware:
1. Transfer the firmware.bin image to the device.
2. Flash the image with:
        mtd write firmware.bin firmware

------------

The XMC XM25QH128C is a 16MB SPI NOR chip. Datasheet available at https://www.xmcwh.com/uploads/435/XM25QH128C.pdf

Signed-off-by: Langhua Ye <y1248289414@outlook.com>