### PR TITLE
dnsmasq: add procd_jail for serversfile

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -972,7 +972,18 @@ dnsmasq_start()
 	config_list_foreach "$cfg" "addnhosts" append_addnhosts
 	config_list_foreach "$cfg" "bogusnxdomain" append_bogusnxdomain
 	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.leases"
-	append_parm "$cfg" "serversfile" "--servers-file"
+	local serversfile
+	config_get serversfile "$cfg" "serversfile"
+	if [ -n "$serversfile" ]; then
+		xappend "--servers-file=$serversfile"
+		local serversfile_dir="$(dirname "$serversfile")"
+		if [ "$serversfile_dir" = "/tmp" ]; then
+			log_once "Please move serversfile to a directory other than /tmp if the file is going to be replaced"
+			append EXTRA_MOUNT "$serversfile"
+		else
+			append EXTRA_MOUNT "$serversfile_dir"
+		fi
+	fi
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
 	append_parm "$cfg" "local_ttl" "--local-ttl"


### PR DESCRIPTION
If `serversfile` is outside of usual dnsmasq location make sure its
directory is added to `procd_add_jail_mount`.

Signed-off-by: Stan Grishin <stangri@melmac.ca>
