### PR TITLE
utils/mdadm: fix build on hosts without /run dir

### DIFF
--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -52,7 +52,7 @@ TARGET_CFLAGS += \
 
 TARGET_LDFLAGS += -Wl,--gc-sections
 
-MAKE_VARS += CHECK_RUN_DIR=0
+MAKE_FLAGS += CHECK_RUN_DIR=0
 
 define Build/Compile
 	$(call Build/Compile/Default,mdadm)


### PR DESCRIPTION
CHECK_RUN_DIR=0 must be a part of MAKE_FLAGS, not MAKE_VARS, otherwise
it is not possible to compile mdadm on host without /run dir.

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>

CC: @nbd168 