### PR TITLE
ramips: add support for ipTIME A3004NS-M

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,a3004ns-m", "mediatek,mt7621-soc";
+	model = "ipTIME A3004NS-M";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			label = "amber:cpu";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_uboot_1fc20: macaddr@1fc20 {
+					reg = <0x1fc20 0x6>;
+				};
+
+				macaddr_uboot_1fc40: macaddr@1fc40 {
+					reg = <0x1fc40 0x6>;
+				};
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_1fc20>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <3>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_uboot_1fc40>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -768,6 +768,16 @@ define Device/iptime_a3004ns-dual
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
+define Device/iptime_a3004ns-m
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a3004nm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A3004NS-M
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+endef
+TARGET_DEVICES += iptime_a3004ns-m
+
 define Device/iptime_a3004t
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -25,6 +25,12 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress
 		;;
+	iptime,a3004ns-m)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 3)" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		;;
 	iptime,ax2004m)
 		if [ "$PHYNBR" = "1" ]; then
 			base_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 3)


### PR DESCRIPTION
ipTIME A3004NS-M is an 802.11ac (Wi-Fi 5) router, based on MediaTek
MT7621A.

Specifications:
* SoC: MT7621A
* RAM: 256 MiB
* Flash: SPI NOR 16 MiB
* Wi-Fi:
  * MT7615D: 2.4/5 GHz (DBDC)
* Ethernet: 5x 1GbE
  * Switch: SoC built-in
* USB: 1x 3.0
* UART: J4 (57600 baud)
  * Pinout: [3V3] (TXD) (RXD) (GND)

MAC addresses:

| interface |        MAC        |     source     | comment
|-----------|-------------------|----------------|---------
|       LAN | 88:XX:XX:E9:XX:BF |                | [1]
|       WAN | 88:XX:XX:E9:XX:BD | u-boot 0x1fc40 |
|   WLAN 2G | 8A:XX:XX:C9:XX:BC |                |
|   WLAN 5G | 88:XX:XX:E9:XX:BC | factory 0x4    |
|           |                   |                |
|           | 88:XX:XX:E9:XX:BC | u-boot 0x1fc20 | [2]
|           | 88:XX:XX:E9:XX:BE | factory 0x8004 |

[1] Used in this patch as WLAN 2G MAC address with the local bit set
[2] LAN MAC address on older stock firmware (e.g. version 10.050)

Known issues:
* DBDC is not turned on automatically after boot.

Notes:
* phy0/phy1 should be set to wlan2g/wlan5g respectively.

Installation via web interface:
1.  Flash **initramfs** image through the stock web interface.
2.  Boot into OpenWrt and perform sysupgrade with sysupgrade image.

Revert to stock firmware:
1.  Perform sysupgrade with stock image.