### PR TITLE
kernel: enhance multicast routing support

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -986,6 +986,19 @@ config KERNEL_IP_MROUTE
 	  Multicast routing requires a multicast routing daemon in
 	  addition to kernel support.
 
+if KERNEL_IP_MROUTE
+
+	config KERNEL_IP_MROUTE_MULTIPLE_TABLES
+		def_bool y
+
+	config KERNEL_IP_PIMSM_V1
+		def_bool y
+
+	config KERNEL_IP_PIMSM_V2
+		def_bool y
+
+endif
+
 #
 # IPv6 configuration
 #
@@ -1008,8 +1021,15 @@ if KERNEL_IPV6
 		  Multicast routing requires a multicast routing daemon in
 		  addition to kernel support.
 
-	config KERNEL_IPV6_PIMSM_V2
-		def_bool n
+	if KERNEL_IPV6_MROUTE
+
+		config KERNEL_IPV6_MROUTE_MULTIPLE_TABLES
+			def_bool y
+
+		config KERNEL_IPV6_PIMSM_V2
+			def_bool y
+
+	endif
 
 	config KERNEL_IPV6_SEG6_LWTUNNEL
 		bool "Enable support for lightweight tunnels"


### PR DESCRIPTION
cc: @mwarning

Certain utilities, such as smcroute [1], require additional multicast
routing options to be enabled, otherwise they will not function
correctly. Enable these relevant dependancies when IPv4 and/or IPv6
multicast routing are enabled.

[1] https://github.com/troglobit/smcroute/blob/master/README.md#linux-requirements

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>