### PR TITLE
ramips: add support for Beeline SmartBox Flash

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -52,6 +52,7 @@ ravpower,rp-wd03)
 jcg,q20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+beeline,smartbox-flash|\
 linksys,ea6350-v4|\
 linksys,ea7300-v1|\
 linksys,ea7300-v2|\

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-flash.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-flash.dts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "beeline,smartbox-flash", "mediatek,mt7621-soc";
+	model = "Beeline SmartBox Flash";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "blue:wan";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-2 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x5240000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot-env";
+			reg = <0x100000 0x100000>;
+		};
+
+		factory: partition@200000 {
+			label = "Factory";
+			reg = <0x200000 0x100000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_fff0: macaddr@fff0 {
+				reg = <0xfff0 0x6>;
+			};
+		};
+
+		partition@300000 {
+			label = "firmware";
+			reg = <0x300000 0x2000000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x440000>;
+			};
+
+			ubiconcat0: partition@400000 {
+				label = "ubiconcat0";
+				reg = <0x440000 0x1bc0000>;
+			};
+		};
+
+		partition@2300000 {
+			label = "Firmware2";
+			reg = <0x2300000 0x2000000>;
+			read-only;
+		};
+
+		partition@4300000 {
+			label = "glbcfg";
+			reg = <0x4300000 0x200000>;
+			read-only;
+		};
+
+		partition@4500000 {
+			label = "board_data";
+			reg = <0x4500000 0x100000>;
+			read-only;
+		};
+
+		partition@4600000 {
+			label = "glbcfg2";
+			reg = <0x4600000 0x200000>;
+			read-only;
+		};
+
+		partition@4800000 {
+			label = "board_data2";
+			reg = <0x4800000 0x100000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@4900000 {
+			label = "ubiconcat1";
+			reg = <0x4900000 0x3680000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -11,6 +11,9 @@ asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN link" "blue:wan" "wan"
 	;;
+beeline,smartbox-flash)
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
+	;;
 cudy,wr2100)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -38,6 +38,7 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	asiarf,ap7621-nv1|\
+	beeline,smartbox-flash|\
 	glinet,gl-mt1300|\
 	iptime,a3002mesh|\
 	jcg,q20|\
@@ -114,6 +115,11 @@ ramips_setup_macs()
 	asus,rt-ac85p)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env et1macaddr)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
+		;;
+	beeline,smartbox-flash)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env eth2macaddr)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env eth3macaddr)
+		label_mac=$lan_mac
 		;;
 	buffalo,wsr-1166dhp)
 		local index="$(find_mtd_index "board_data")"

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,12 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	beeline,smartbox-flash)
+		hw_mac_addr_ra0="$(mtd_get_mac_ascii u-boot-env ra0macaddr)"
+		hw_mac_addr_rax0="$(mtd_get_mac_ascii u-boot-env rax0macaddr)"
+		[ "$PHYNBR" = "0" ] && echo -n $hw_mac_addr_ra0 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n $hw_mac_addr_rax0 > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,7 @@ platform_do_upgrade() {
 	ampedwireless,ally-r1900k|\
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
+	beeline,smartbox-flash|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\


### PR DESCRIPTION
Beeline SmartBox Flash
--------------------------
Beeline SmartBox Flash is a wireless AC1300 (WiFi 5) router manufactured by Arcadyan company and distributed by Beeline ISP.

Device specification
--------------------
SoC Type: MediaTek MT7621AT
RAM: 256 MiB, Winbond W632GU6NB
Flash: 128 MiB (NAND), Winbond W29N01HVSINF
Wireless 2.4 GHz (MT7615DN): b/g/n, 2x2
Wireless 5 GHz (MT7615DN): a/n/ac, 2x2
Ethernet: 3xGbE (WAN, LAN1, LAN2)
USB ports: 1xUSB3.0
Button: 1 (Reset / WPS)
LEDs: 1 RGB LED
Power: 12 VDC, 1.5 A
Connector type: Barrel
Bootloader: U-Boot (Ralink UBoot Version: 5.0.0.2)
OEM: Arcadyan WE42022

Installation
------------
1. Place *kernel.bin and *rootfs.bin on any web server (192.168.1.2 in this example)
2. Connect to the router using telnet shell (no password required)
3. Save MAC adresses to U-Boot environment:
```
   uboot_env --set --name eth2macaddr --value $(ifconfig | grep eth2 | \
	awk '{print $5}')
   uboot_env --set --name eth3macaddr --value $(ifconfig | grep eth3 | \
	awk '{print $5}')
   uboot_env --set --name ra0macaddr --value $(ifconfig | grep ra0 | \
	awk '{print $5}')
   uboot_env --set --name rax0macaddr --value $(ifconfig | grep rax0 | \
	awk '{print $5}')
```
4. Ensure that MACs were saved correctly:
```
   uboot_env --get --name eth2macaddr
   uboot_env --get --name eth3macaddr
   uboot_env --get --name ra0macaddr
   uboot_env --get --name rax0macaddr
```
5. Download and write the OpenWrt images on flash:
```
cd /tmp
wget http://192.168.1.2/factory.trx
mtd_write erase /dev/mtd4
mtd_write write factory.trx /dev/mtd4
```
6. Set 1st boot partition and reboot:
```
   uboot_env --set --name bootpartition --value 0
   reboot
```

Back to Stock
-------------
1. Run in the OpenWrt shell:
```
   fw_setenv bootpartition 1
   reboot
```
2. Upgrade the stock firmware with any version to overwrite the OpenWrt in Slot 1.

MAC addresses
-------------
```
+-----------+-------------------+----------------+
| Interface | MAC               | Source         |
+-----------+-------------------+----------------+
| label     | 30:xx:xx:51:xx:09 | No MACs was    |
| LAN       | 30:xx:xx:51:xx:09 | found on Flash |
| WAN       | 30:xx:xx:51:xx:06 | [1]            |
| WLAN_2g   | 30:xx:xx:51:xx:07 |                |
| WLAN_5g   | 32:xx:xx:41:xx:07 |                |
+-----------+-------------------+----------------+
```
[1]:
a. Label hasn't been found neither in factory nor in other places.
b. MAC addresses are stored in encrypted partition "glbcfg". Encryption key hasn't known yet. To ensure the correct MACs in OpenWrt, a hack with saving of the MACs to u-boot-env during the installation was applied.
c. Default Ralink ethernet MAC address (00:0C:43:28:80:36) was found in "Factory" 0xfff0. It's the same for all Smartbox Flash devices. OEM firmware also uses this MAC when initialazes ethernet driver. In OpenWrt we use it only as internal GMAC (eth0), all other MACs are unique. Therefore, there is no any barriers to the operation of several Smartbox Flash devices even within the same broadcast domain.

Stock firmware image format
---------------------------
```
+--------------+---------------+----------------------------------------+
| Offset       | 1.0.15        | Description                            |
+==============+===============+========================================+
| 0x0          | 5d 43 6f 74   | TRX magic "]Cot"                       |
+--------------+---------------+----------------------------------------+
| 0x4          | 00 70 ff 00   | Length (reverse)                       |
+--------------+---------------+----------------------------------------+
|              |               | htonl(~crc) from 0xc ("flag_version")  |
| 0x8          | 72 b3 93 16   | to "Length"                            |
+--------------+---------------+----------------------------------------+
| 0xc          | 00 00 01 00   | Flags                                  |
+--------------+---------------+----------------------------------------+
|              |               | Offset (reverse) of Kernel partition   |
| 0x10         | 1c 00 00 00   | from the start of the header           |
+--------------+---------------+----------------------------------------+
|              |               | Offset (reverse) of RootFS partition   |
| 0x14         | 00 00 42 00   | from the start of the header           |
+--------------+---------------+----------------------------------------+
| 0x18         | 00 00 00 00   | Zeroes                                 |
+--------------+---------------+----------------------------------------+
| 0x1c         | 27 05 19 56 … | Kernel data + zero padding             |
+--------------+---------------+----------------------------------------+
|              |               | RootFS data (starting with "hsqs") +   |
| 0x420000     | 68 73 71 73 … | zero padding to "Length"               |
+--------------+---------------+----------------------------------------+
|              |               | Some signature data (format is         |
|              |               | unknown). Necessary for the fw         |
| "Lenght"     | 00 00 00 00 … | update via oem fw web interface.       |
+--------------+---------------+----------------------------------------+
| "Lenght" +   |               | TRX magic "HDR0". U-Boot is            |
| 0x10c        | 48 44 52 30   | checking it at every boot.             |
+--------------+---------------+----------------------------------------+
|              |               | 1.00:                                  |
|              |               |   Zero padding to ("Lenght" + 0x23000) |
|              |               | 1.0.12:                                |
|              |               |   Zero padding to ("Lenght" + 0x2a000) |
| "Lenght" +   |               | 1.0.13, 1.0.15, 1.0.16:                |
| 0x110        | 00 00 00 00   |   Zero padding to ("Lenght" + 0x10000) |
+--------------+---------------+----------------------------------------+
```

Topic on OpenWrt forum
----------------------------
[Add support for Beeline SmartBox Flash](https://forum.openwrt.org/t/add-support-for-beeline-smartbox-flash/110059)

Other devices from the series
--------------------------------
Beeline Smart Box TURBO+ - https://github.com/openwrt/openwrt/pull/4108
Beeline SmartBox GIGA - https://github.com/openwrt/openwrt/pull/4195
Beeline SmartBox Pro - https://github.com/openwrt/openwrt/pull/4770