### PR TITLE
mediatek mt7622: fix 300mhz typo in dts

### DIFF
--- a/target/linux/mediatek/patches-5.10/721-dts-mt7622-mediatek-fix-300mhz.patch
+++ b/target/linux/mediatek/patches-5.10/721-dts-mt7622-mediatek-fix-300mhz.patch
@@ -1,0 +1,27 @@
+From: Jip de Beer <gpk6x3591g0l@opayq.com>
+Date: Sun, 9 Jan 2022 13:14:04 +0100
+Subject: [PATCH] mediatek mt7622: fix 300mhz typo in dts
+
+The lowest frequency should be 300MHz, since that is the label
+assigned to the OPP in the mt7622.dtsi device tree, while there is one
+missing zero in the actual value.
+
+To be clear, the lowest frequency should be 300MHz instead of 30MHz.
+
+As mentioned @dangowrt on the OpenWrt forum there is no benefit in
+leaving 30MHz as the lowest frequency.
+
+Signed-off-by: Jip de Beer <gpk6x3591g0l@opayq.com>
+Signed-off-by: Fritz D. Ansel <fdansel@yandex.ru>
+---
+--- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
+@@ -24,7 +24,7 @@
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 		opp-300000000 {
+-			opp-hz = /bits/ 64 <30000000>;
++			opp-hz = /bits/ 64 <300000000>;
+ 			opp-microvolt = <950000>;
+ 		};
+ 


### PR DESCRIPTION
Since https://github.com/openwrt/openwrt/pull/4440 has been closed, this is another attempt to merge just the fix by @selanf for the 300mhz typo in dts. As mentioned by @dangowrt on the [OpenWRT forum](https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/1229) there is no benefit in leaving 30mhz as the lowest frequency.

