### PR TITLE
[21.02] kernel: backport workaround for Realtek RTL8672 and RTL9601C chips

### DIFF
--- a/target/linux/generic/backport-5.4/852-v5.10-0001-net-sfp-VSOL-V2801F-CarlitoxxPro-CPGOS03-0490-v2.0-w.patch
+++ b/target/linux/generic/backport-5.4/852-v5.10-0001-net-sfp-VSOL-V2801F-CarlitoxxPro-CPGOS03-0490-v2.0-w.patch
@@ -1,0 +1,144 @@
+From 0d035bed2a4a6c4878518749348be61bf082d12a Mon Sep 17 00:00:00 2001
+From: Russell King <rmk+kernel@armlinux.org.uk>
+Date: Wed, 9 Dec 2020 11:22:49 +0000
+Subject: [PATCH] net: sfp: VSOL V2801F / CarlitoxxPro CPGOS03-0490 v2.0
+ workaround
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add a workaround for the detection of VSOL V2801F / CarlitoxxPro
+CPGOS03-0490 v2.0 GPON module which CarlitoxxPro states needs single
+byte I2C reads to the EEPROM.
+
+Pali Rohár reports that he also has a CarlitoxxPro-based V2801F module,
+which reports a manufacturer of "OEM". This manufacturer can't be
+matched as it appears in many different modules, so also match the part
+number too.
+
+Reported-by: Thomas Schreiber <tschreibe@gmail.com>
+Reported-by: Pali Rohár <pali@kernel.org>
+Tested-by: Pali Rohár <pali@kernel.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/sfp.c | 63 +++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 58 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -191,6 +191,7 @@ struct sfp {
+ 	struct sfp_bus *sfp_bus;
+ 	struct phy_device *mod_phy;
+ 	const struct sff_data *type;
++	size_t i2c_block_size;
+ 	u32 max_power_mW;
+ 
+ 	unsigned int (*get_state)(struct sfp *);
+@@ -305,10 +306,19 @@ static int sfp_i2c_read(struct sfp *sfp,
+ 			size_t len)
+ {
+ 	struct i2c_msg msgs[2];
+-	u8 bus_addr = a2 ? 0x51 : 0x50;
++	size_t block_size;
+ 	size_t this_len;
++	u8 bus_addr;
+ 	int ret;
+ 
++	if (a2) {
++		block_size = 16;
++		bus_addr = 0x51;
++	} else {
++		block_size = sfp->i2c_block_size;
++		bus_addr = 0x50;
++	}
++
+ 	msgs[0].addr = bus_addr;
+ 	msgs[0].flags = 0;
+ 	msgs[0].len = 1;
+@@ -320,8 +330,8 @@ static int sfp_i2c_read(struct sfp *sfp,
+ 
+ 	while (len) {
+ 		this_len = len;
+-		if (this_len > 16)
+-			this_len = 16;
++		if (this_len > block_size)
++			this_len = block_size;
+ 
+ 		msgs[1].len = this_len;
+ 
+@@ -1569,6 +1579,28 @@ static int sfp_sm_mod_hpower(struct sfp
+ 	return 0;
+ }
+ 
++/* Some modules (Nokia 3FE46541AA) lock up if byte 0x51 is read as a
++ * single read. Switch back to reading 16 byte blocks unless we have
++ * a CarlitoxxPro module (rebranded VSOL V2801F). Even more annoyingly,
++ * some VSOL V2801F have the vendor name changed to OEM.
++ */
++static int sfp_quirk_i2c_block_size(const struct sfp_eeprom_base *base)
++{
++	if (!memcmp(base->vendor_name, "VSOL            ", 16))
++		return 1;
++	if (!memcmp(base->vendor_name, "OEM             ", 16) &&
++	    !memcmp(base->vendor_pn,   "V2801F          ", 16))
++		return 1;
++
++	/* Some modules can't cope with long reads */
++	return 16;
++}
++
++static void sfp_quirks_base(struct sfp *sfp, const struct sfp_eeprom_base *base)
++{
++	sfp->i2c_block_size = sfp_quirk_i2c_block_size(base);
++}
++
+ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ {
+ 	/* SFP module inserted - read I2C data */
+@@ -1577,14 +1609,20 @@ static int sfp_sm_mod_probe(struct sfp *
+ 	u8 check;
+ 	int ret;
+ 
+-	ret = sfp_read(sfp, false, 0, &id, sizeof(id));
++	/* Some modules (CarlitoxxPro CPGOS03-0490) do not support multibyte
++	 * reads from the EEPROM, so start by reading the base identifying
++	 * information one byte at a time.
++	 */
++	sfp->i2c_block_size = 1;
++
++	ret = sfp_read(sfp, false, 0, &id.base, sizeof(id.base));
+ 	if (ret < 0) {
+ 		if (report)
+ 			dev_err(sfp->dev, "failed to read EEPROM: %d\n", ret);
+ 		return -EAGAIN;
+ 	}
+ 
+-	if (ret != sizeof(id)) {
++	if (ret != sizeof(id.base)) {
+ 		dev_err(sfp->dev, "EEPROM short read: %d\n", ret);
+ 		return -EAGAIN;
+ 	}
+@@ -1612,6 +1650,21 @@ static int sfp_sm_mod_probe(struct sfp *
+ 		}
+ 	}
+ 
++	/* Apply any early module-specific quirks */
++	sfp_quirks_base(sfp, &id.base);
++
++	ret = sfp_read(sfp, false, SFP_CC_BASE + 1, &id.ext, sizeof(id.ext));
++	if (ret < 0) {
++		if (report)
++			dev_err(sfp->dev, "failed to read EEPROM: %d\n", ret);
++		return -EAGAIN;
++	}
++
++	if (ret != sizeof(id.ext)) {
++		dev_err(sfp->dev, "EEPROM short read: %d\n", ret);
++		return -EAGAIN;
++	}
++
+ 	check = sfp_check(&id.ext, sizeof(id.ext) - 1);
+ 	if (check != id.ext.cc_ext) {
+ 		if (cotsworks) {

--- a/target/linux/generic/backport-5.4/852-v5.10-0002-net-sfp-add-workaround-for-Realtek-RTL8672-and-RTL96.patch
+++ b/target/linux/generic/backport-5.4/852-v5.10-0002-net-sfp-add-workaround-for-Realtek-RTL8672-and-RTL96.patch
@@ -1,0 +1,211 @@
+From 426c6cbc409cbda9ab1a9dbf15d3c2ef947eb8c1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Mon, 25 Jan 2021 16:02:27 +0100
+Subject: [PATCH] net: sfp: add workaround for Realtek RTL8672 and RTL9601C
+ chips
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The workaround for VSOL V2801F brand based GPON SFP modules added in commit
+0d035bed2a4a ("net: sfp: VSOL V2801F / CarlitoxxPro CPGOS03-0490 v2.0
+workaround") works only for IDs added explicitly to the list. Since there
+are rebranded modules where OEM vendors put different strings into the
+vendor name field, we cannot base workaround on IDs only.
+
+Moreover the issue which the above mentioned commit tried to work around is
+generic not only to VSOL based modules, but rather to all GPON modules
+based on Realtek RTL8672 and RTL9601C chips.
+
+These include at least the following GPON modules:
+* V-SOL V2801F
+* C-Data FD511GX-RM0
+* OPTON GP801R
+* BAUDCOM BD-1234-SFM
+* CPGOS03-0490 v2.0
+* Ubiquiti U-Fiber Instant
+* EXOT EGS1
+
+These Realtek chips have broken EEPROM emulator which for N-byte read
+operation returns just the first byte of EEPROM data, followed by N-1
+zeros.
+
+Introduce a new function, sfp_id_needs_byte_io(), which detects SFP modules
+with broken EEPROM emulator based on N-1 zeros and switch to 1 byte EEPROM
+reading operation.
+
+Function sfp_i2c_read() now always uses single byte reading when it is
+required and when function sfp_hwmon_probe() detects single byte access,
+it disables registration of hwmon device, because in this case we cannot
+reliably and atomically read 2 bytes as is required by the standard for
+retrieving values from diagnostic area.
+
+(These Realtek chips are broken in a way that violates SFP standards for
+diagnostic interface. Kernel in this case simply cannot do anything less
+of skipping registration of the hwmon interface.)
+
+This patch fixes reading of EEPROM content from SFP modules based on
+Realtek RTL8672 and RTL9601C chips. Diagnostic interface of EEPROM stays
+broken and cannot be fixed.
+
+Fixes: 0d035bed2a4a ("net: sfp: VSOL V2801F / CarlitoxxPro CPGOS03-0490 v2.0 workaround")
+Co-developed-by: Russell King <rmk+kernel@armlinux.org.uk>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 100 ++++++++++++++++++++++++++++--------------
+ 1 file changed, 67 insertions(+), 33 deletions(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -306,19 +306,11 @@ static int sfp_i2c_read(struct sfp *sfp,
+ 			size_t len)
+ {
+ 	struct i2c_msg msgs[2];
+-	size_t block_size;
++	u8 bus_addr = a2 ? 0x51 : 0x50;
++	size_t block_size = sfp->i2c_block_size;
+ 	size_t this_len;
+-	u8 bus_addr;
+ 	int ret;
+ 
+-	if (a2) {
+-		block_size = 16;
+-		bus_addr = 0x51;
+-	} else {
+-		block_size = sfp->i2c_block_size;
+-		bus_addr = 0x50;
+-	}
+-
+ 	msgs[0].addr = bus_addr;
+ 	msgs[0].flags = 0;
+ 	msgs[0].len = 1;
+@@ -1245,6 +1237,20 @@ static void sfp_hwmon_probe(struct work_
+ 	struct sfp *sfp = container_of(work, struct sfp, hwmon_probe.work);
+ 	int err, i;
+ 
++	/* hwmon interface needs to access 16bit registers in atomic way to
++	 * guarantee coherency of the diagnostic monitoring data. If it is not
++	 * possible to guarantee coherency because EEPROM is broken in such way
++	 * that does not support atomic 16bit read operation then we have to
++	 * skip registration of hwmon device.
++	 */
++	if (sfp->i2c_block_size < 2) {
++		dev_info(sfp->dev,
++			 "skipping hwmon device registration due to broken EEPROM\n");
++		dev_info(sfp->dev,
++			 "diagnostic EEPROM area cannot be read atomically to guarantee data coherency\n");
++		return;
++	}
++
+ 	err = sfp_read(sfp, true, 0, &sfp->diag, sizeof(sfp->diag));
+ 	if (err < 0) {
+ 		if (sfp->hwmon_tries--) {
+@@ -1579,26 +1585,30 @@ static int sfp_sm_mod_hpower(struct sfp
+ 	return 0;
+ }
+ 
+-/* Some modules (Nokia 3FE46541AA) lock up if byte 0x51 is read as a
+- * single read. Switch back to reading 16 byte blocks unless we have
+- * a CarlitoxxPro module (rebranded VSOL V2801F). Even more annoyingly,
+- * some VSOL V2801F have the vendor name changed to OEM.
++/* GPON modules based on Realtek RTL8672 and RTL9601C chips (e.g. V-SOL
++ * V2801F, CarlitoxxPro CPGOS03-0490, Ubiquiti U-Fiber Instant, ...) do
++ * not support multibyte reads from the EEPROM. Each multi-byte read
++ * operation returns just one byte of EEPROM followed by zeros. There is
++ * no way to identify which modules are using Realtek RTL8672 and RTL9601C
++ * chips. Moreover every OEM of V-SOL V2801F module puts its own vendor
++ * name and vendor id into EEPROM, so there is even no way to detect if
++ * module is V-SOL V2801F. Therefore check for those zeros in the read
++ * data and then based on check switch to reading EEPROM to one byte
++ * at a time.
+  */
+-static int sfp_quirk_i2c_block_size(const struct sfp_eeprom_base *base)
++static bool sfp_id_needs_byte_io(struct sfp *sfp, void *buf, size_t len)
+ {
+-	if (!memcmp(base->vendor_name, "VSOL            ", 16))
+-		return 1;
+-	if (!memcmp(base->vendor_name, "OEM             ", 16) &&
+-	    !memcmp(base->vendor_pn,   "V2801F          ", 16))
+-		return 1;
++	size_t i, block_size = sfp->i2c_block_size;
+ 
+-	/* Some modules can't cope with long reads */
+-	return 16;
+-}
++	/* Already using byte IO */
++	if (block_size == 1)
++		return false;
+ 
+-static void sfp_quirks_base(struct sfp *sfp, const struct sfp_eeprom_base *base)
+-{
+-	sfp->i2c_block_size = sfp_quirk_i2c_block_size(base);
++	for (i = 1; i < len; i += block_size) {
++		if (memchr_inv(buf + i, '\0', min(block_size - 1, len - i)))
++			return false;
++	}
++	return true;
+ }
+ 
+ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+@@ -1609,11 +1619,11 @@ static int sfp_sm_mod_probe(struct sfp *
+ 	u8 check;
+ 	int ret;
+ 
+-	/* Some modules (CarlitoxxPro CPGOS03-0490) do not support multibyte
+-	 * reads from the EEPROM, so start by reading the base identifying
+-	 * information one byte at a time.
++	/* Some SFP modules and also some Linux I2C drivers do not like reads
++	 * longer than 16 bytes, so read the EEPROM in chunks of 16 bytes at
++	 * a time.
+ 	 */
+-	sfp->i2c_block_size = 1;
++	sfp->i2c_block_size = 16;
+ 
+ 	ret = sfp_read(sfp, false, 0, &id.base, sizeof(id.base));
+ 	if (ret < 0) {
+@@ -1627,6 +1637,33 @@ static int sfp_sm_mod_probe(struct sfp *
+ 		return -EAGAIN;
+ 	}
+ 
++	/* Some SFP modules (e.g. Nokia 3FE46541AA) lock up if read from
++	 * address 0x51 is just one byte at a time. Also SFF-8472 requires
++	 * that EEPROM supports atomic 16bit read operation for diagnostic
++	 * fields, so do not switch to one byte reading at a time unless it
++	 * is really required and we have no other option.
++	 */
++	if (sfp_id_needs_byte_io(sfp, &id.base, sizeof(id.base))) {
++		dev_info(sfp->dev,
++			 "Detected broken RTL8672/RTL9601C emulated EEPROM\n");
++		dev_info(sfp->dev,
++			 "Switching to reading EEPROM to one byte at a time\n");
++		sfp->i2c_block_size = 1;
++
++		ret = sfp_read(sfp, false, 0, &id.base, sizeof(id.base));
++		if (ret < 0) {
++			if (report)
++				dev_err(sfp->dev, "failed to read EEPROM: %d\n",
++					ret);
++			return -EAGAIN;
++		}
++
++		if (ret != sizeof(id.base)) {
++			dev_err(sfp->dev, "EEPROM short read: %d\n", ret);
++			return -EAGAIN;
++		}
++	}
++
+ 	/* Cotsworks do not seem to update the checksums when they
+ 	 * do the final programming with the final module part number,
+ 	 * serial number and date code.
+@@ -1650,9 +1687,6 @@ static int sfp_sm_mod_probe(struct sfp *
+ 		}
+ 	}
+ 
+-	/* Apply any early module-specific quirks */
+-	sfp_quirks_base(sfp, &id.base);
+-
+ 	ret = sfp_read(sfp, false, SFP_CC_BASE + 1, &id.ext, sizeof(id.ext));
+ 	if (ret < 0) {
+ 		if (report)

--- a/target/linux/generic/pending-5.4/739-net-avoid-tx-fault-with-Nokia-GPON-module.patch
+++ b/target/linux/generic/pending-5.4/739-net-avoid-tx-fault-with-Nokia-GPON-module.patch
@@ -39,7 +39,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  /* SFP module presence detection is poor: the three MOD DEF signals are
   * the same length on the PCB, which means it's possible for MOD DEF 0 to
-@@ -218,6 +228,7 @@ struct sfp {
+@@ -219,6 +229,7 @@ struct sfp {
  
  	struct sfp_eeprom_id id;
  	unsigned int module_power_mW;
@@ -47,7 +47,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  #if IS_ENABLED(CONFIG_HWMON)
  	struct sfp_diag diag;
-@@ -1655,6 +1666,12 @@ static int sfp_sm_mod_probe(struct sfp *
+@@ -1742,6 +1753,12 @@ static int sfp_sm_mod_probe(struct sfp *
  	if (ret < 0)
  		return ret;
  
@@ -60,7 +60,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	return 0;
  }
  
-@@ -1860,11 +1877,12 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1947,11 +1964,12 @@ static void sfp_sm_main(struct sfp *sfp,
  			break;
  
  		if (sfp->state & SFP_F_TX_FAULT) {
@@ -77,7 +77,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  			if (timeout > T_WAIT)
  				timeout -= T_WAIT;
  			else
-@@ -1881,8 +1899,8 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1968,8 +1986,8 @@ static void sfp_sm_main(struct sfp *sfp,
  
  	case SFP_S_INIT:
  		if (event == SFP_E_TIMEOUT && sfp->state & SFP_F_TX_FAULT) {
@@ -88,7 +88,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  			 */
  			sfp_sm_fault(sfp, SFP_S_INIT_TX_FAULT,
  				     sfp->sm_retries == 5);
-@@ -1901,7 +1919,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1988,7 +2006,7 @@ static void sfp_sm_main(struct sfp *sfp,
  	case SFP_S_INIT_TX_FAULT:
  		if (event == SFP_E_TIMEOUT) {
  			sfp_module_tx_fault_reset(sfp);
@@ -97,7 +97,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		}
  		break;
  
-@@ -1925,7 +1943,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2012,7 +2030,7 @@ static void sfp_sm_main(struct sfp *sfp,
  	case SFP_S_TX_FAULT:
  		if (event == SFP_E_TIMEOUT) {
  			sfp_module_tx_fault_reset(sfp);

--- a/target/linux/generic/pending-5.4/740-net-sfp-remove-incomplete-100BASE-FX-and-100BASE-LX-.patch
+++ b/target/linux/generic/pending-5.4/740-net-sfp-remove-incomplete-100BASE-FX-and-100BASE-LX-.patch
@@ -30,7 +30,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	if (phylink_test(link_modes, 1000baseX_Full))
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1489,18 +1489,7 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -1505,18 +1505,7 @@ static void sfp_sm_fault(struct sfp *sfp
  
  static void sfp_sm_probe_for_phy(struct sfp *sfp)
  {

--- a/target/linux/generic/pending-5.4/742-net-sfp-add-more-extended-compliance-codes.patch
+++ b/target/linux/generic/pending-5.4/742-net-sfp-add-more-extended-compliance-codes.patch
@@ -132,7 +132,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	if (phylink_test(link_modes, 2500baseX_Full))
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -242,7 +242,7 @@ struct sfp {
+@@ -243,7 +243,7 @@ struct sfp {
  
  static bool sff_module_supported(const struct sfp_eeprom_id *id)
  {
@@ -141,7 +141,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	       id->base.phys_ext_id == SFP_PHYS_EXT_ID_SFP;
  }
  
-@@ -253,7 +253,7 @@ static const struct sff_data sff_data =
+@@ -254,7 +254,7 @@ static const struct sff_data sff_data =
  
  static bool sfp_module_supported(const struct sfp_eeprom_id *id)
  {

--- a/target/linux/generic/pending-5.4/743-net-sfp-add-module-start-stop-upstream-notifications.patch
+++ b/target/linux/generic/pending-5.4/743-net-sfp-add-module-start-stop-upstream-notifications.patch
@@ -78,7 +78,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	[SFP_S_WAIT] = "wait",
  	[SFP_S_INIT] = "init",
  	[SFP_S_INIT_TX_FAULT] = "init_tx_fault",
-@@ -1831,6 +1833,8 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1918,6 +1920,8 @@ static void sfp_sm_main(struct sfp *sfp,
  		if (sfp->sm_state == SFP_S_LINK_UP &&
  		    sfp->sm_dev_state == SFP_DEV_UP)
  			sfp_sm_link_down(sfp);
@@ -87,7 +87,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		if (sfp->mod_phy)
  			sfp_sm_phy_detach(sfp);
  		sfp_module_tx_disable(sfp);
-@@ -1898,6 +1902,10 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1985,6 +1989,10 @@ static void sfp_sm_main(struct sfp *sfp,
  			 * clear.  Probe for the PHY and check the LOS state.
  			 */
  			sfp_sm_probe_for_phy(sfp);

--- a/target/linux/generic/pending-5.4/744-net-sfp-move-phy_start-phy_stop-to-phylink.patch
+++ b/target/linux/generic/pending-5.4/744-net-sfp-move-phy_start-phy_stop-to-phylink.patch
@@ -54,7 +54,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	.connect_phy = phylink_sfp_connect_phy,
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1396,7 +1396,6 @@ static void sfp_sm_mod_next(struct sfp *
+@@ -1412,7 +1412,6 @@ static void sfp_sm_mod_next(struct sfp *
  
  static void sfp_sm_phy_detach(struct sfp *sfp)
  {
@@ -62,7 +62,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	sfp_remove_phy(sfp->sfp_bus);
  	phy_device_remove(sfp->mod_phy);
  	phy_device_free(sfp->mod_phy);
-@@ -1427,7 +1426,6 @@ static void sfp_sm_probe_phy(struct sfp
+@@ -1443,7 +1442,6 @@ static void sfp_sm_probe_phy(struct sfp
  	}
  
  	sfp->mod_phy = phy;

--- a/target/linux/generic/pending-5.4/753-net-sfp-add-support-for-Clause-45-PHYs.patch
+++ b/target/linux/generic/pending-5.4/753-net-sfp-add-support-for-Clause-45-PHYs.patch
@@ -14,7 +14,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1402,12 +1402,12 @@ static void sfp_sm_phy_detach(struct sfp
+@@ -1418,12 +1418,12 @@ static void sfp_sm_phy_detach(struct sfp
  	sfp->mod_phy = NULL;
  }
  
@@ -29,7 +29,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	if (phy == ERR_PTR(-ENODEV)) {
  		dev_info(sfp->dev, "no PHY detected\n");
  		return;
-@@ -1417,6 +1417,13 @@ static void sfp_sm_probe_phy(struct sfp
+@@ -1433,6 +1433,13 @@ static void sfp_sm_probe_phy(struct sfp
  		return;
  	}
  
@@ -43,7 +43,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	err = sfp_add_phy(sfp->sfp_bus, phy);
  	if (err) {
  		phy_device_remove(phy);
-@@ -1487,10 +1494,32 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -1503,10 +1510,32 @@ static void sfp_sm_fault(struct sfp *sfp
  	}
  }
  
@@ -78,7 +78,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  }
  
  static int sfp_module_parse_power(struct sfp *sfp)
-@@ -1550,6 +1579,13 @@ static int sfp_sm_mod_hpower(struct sfp
+@@ -1566,6 +1595,13 @@ static int sfp_sm_mod_hpower(struct sfp
  		return -EAGAIN;
  	}
  

--- a/target/linux/generic/pending-5.4/754-net-sfp-fix-unbind.patch
+++ b/target/linux/generic/pending-5.4/754-net-sfp-fix-unbind.patch
@@ -15,7 +15,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -2344,6 +2344,10 @@ static int sfp_remove(struct platform_de
+@@ -2431,6 +2431,10 @@ static int sfp_remove(struct platform_de
  
  	sfp_unregister_socket(sfp->sfp_bus);
  

--- a/target/linux/generic/pending-5.4/755-net-sfp-fix-hwmon.patch
+++ b/target/linux/generic/pending-5.4/755-net-sfp-fix-hwmon.patch
@@ -15,7 +15,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1796,6 +1796,10 @@ static void sfp_sm_module(struct sfp *sf
+@@ -1883,6 +1883,10 @@ static void sfp_sm_module(struct sfp *sf
  			break;
  		}
  
@@ -26,7 +26,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		sfp_sm_mod_next(sfp, SFP_MOD_WAITDEV, 0);
  		/* fall through */
  	case SFP_MOD_WAITDEV:
-@@ -1845,15 +1849,6 @@ static void sfp_sm_module(struct sfp *sf
+@@ -1932,15 +1936,6 @@ static void sfp_sm_module(struct sfp *sf
  	case SFP_MOD_ERROR:
  		break;
  	}

--- a/target/linux/generic/pending-5.4/756-net-sfp-use-a-definition-for-the-fault-recovery-atte.patch
+++ b/target/linux/generic/pending-5.4/756-net-sfp-use-a-definition-for-the-fault-recovery-atte.patch
@@ -26,7 +26,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  /* SFP module presence detection is poor: the three MOD DEF signals are
   * the same length on the PCB, which means it's possible for MOD DEF 0 to
   * connect before the I2C bus on MOD DEF 1/2.
-@@ -1885,7 +1893,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1972,7 +1980,7 @@ static void sfp_sm_main(struct sfp *sfp,
  		sfp_module_tx_enable(sfp);
  
  		/* Initialise the fault clearance retries */
@@ -35,7 +35,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  		/* We need to check the TX_FAULT state, which is not defined
  		 * while TX_DISABLE is asserted. The earliest we want to do
-@@ -1925,7 +1933,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2012,7 +2020,7 @@ static void sfp_sm_main(struct sfp *sfp,
  			 * or t_start_up, so assume there is a fault.
  			 */
  			sfp_sm_fault(sfp, SFP_S_INIT_TX_FAULT,
@@ -44,7 +44,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		} else if (event == SFP_E_TIMEOUT || event == SFP_E_TX_CLEAR) {
  	init_done:	/* TX_FAULT deasserted or we timed out with TX_FAULT
  			 * clear.  Probe for the PHY and check the LOS state.
-@@ -1938,7 +1946,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2025,7 +2033,7 @@ static void sfp_sm_main(struct sfp *sfp,
  			sfp_sm_link_check_los(sfp);
  
  			/* Reset the fault retry count */

--- a/target/linux/generic/pending-5.4/757-net-sfp-rename-sm_retries.patch
+++ b/target/linux/generic/pending-5.4/757-net-sfp-rename-sm_retries.patch
@@ -13,7 +13,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -234,7 +234,7 @@ struct sfp {
+@@ -235,7 +235,7 @@ struct sfp {
  	unsigned char sm_mod_tries;
  	unsigned char sm_dev_state;
  	unsigned short sm_state;
@@ -22,7 +22,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  	struct sfp_eeprom_id id;
  	unsigned int module_power_mW;
-@@ -1490,7 +1490,7 @@ static bool sfp_los_event_inactive(struc
+@@ -1506,7 +1506,7 @@ static bool sfp_los_event_inactive(struc
  
  static void sfp_sm_fault(struct sfp *sfp, unsigned int next_state, bool warn)
  {
@@ -31,7 +31,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		dev_err(sfp->dev,
  			"module persistently indicates fault, disabling\n");
  		sfp_sm_next(sfp, SFP_S_TX_DISABLE, 0);
-@@ -1893,7 +1893,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -1980,7 +1980,7 @@ static void sfp_sm_main(struct sfp *sfp,
  		sfp_module_tx_enable(sfp);
  
  		/* Initialise the fault clearance retries */
@@ -40,7 +40,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  		/* We need to check the TX_FAULT state, which is not defined
  		 * while TX_DISABLE is asserted. The earliest we want to do
-@@ -1933,7 +1933,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2020,7 +2020,7 @@ static void sfp_sm_main(struct sfp *sfp,
  			 * or t_start_up, so assume there is a fault.
  			 */
  			sfp_sm_fault(sfp, SFP_S_INIT_TX_FAULT,
@@ -49,7 +49,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  		} else if (event == SFP_E_TIMEOUT || event == SFP_E_TX_CLEAR) {
  	init_done:	/* TX_FAULT deasserted or we timed out with TX_FAULT
  			 * clear.  Probe for the PHY and check the LOS state.
-@@ -1946,7 +1946,7 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2033,7 +2033,7 @@ static void sfp_sm_main(struct sfp *sfp,
  			sfp_sm_link_check_los(sfp);
  
  			/* Reset the fault retry count */

--- a/target/linux/generic/pending-5.4/758-net-sfp-error-handling-for-phy-probe.patch
+++ b/target/linux/generic/pending-5.4/758-net-sfp-error-handling-for-phy-probe.patch
@@ -10,7 +10,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -1410,7 +1410,7 @@ static void sfp_sm_phy_detach(struct sfp
+@@ -1426,7 +1426,7 @@ static void sfp_sm_phy_detach(struct sfp
  	sfp->mod_phy = NULL;
  }
  
@@ -19,7 +19,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  {
  	struct phy_device *phy;
  	int err;
-@@ -1418,18 +1418,18 @@ static void sfp_sm_probe_phy(struct sfp
+@@ -1434,18 +1434,18 @@ static void sfp_sm_probe_phy(struct sfp
  	phy = get_phy_device(sfp->i2c_mii, SFP_PHY_ADDR, is_c45);
  	if (phy == ERR_PTR(-ENODEV)) {
  		dev_info(sfp->dev, "no PHY detected\n");
@@ -41,7 +41,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	}
  
  	err = sfp_add_phy(sfp->sfp_bus, phy);
-@@ -1437,10 +1437,12 @@ static void sfp_sm_probe_phy(struct sfp
+@@ -1453,10 +1453,12 @@ static void sfp_sm_probe_phy(struct sfp
  		phy_device_remove(phy);
  		phy_device_free(phy);
  		dev_err(sfp->dev, "sfp_add_phy failed: %d\n", err);
@@ -55,7 +55,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  }
  
  static void sfp_sm_link_up(struct sfp *sfp)
-@@ -1513,21 +1515,24 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -1529,21 +1531,24 @@ static void sfp_sm_fault(struct sfp *sfp
   * Clause 45 copper SFP+ modules (10G) appear to switch their interface
   * mode according to the negotiated line speed.
   */
@@ -83,7 +83,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  }
  
  static int sfp_module_parse_power(struct sfp *sfp)
-@@ -1938,7 +1943,10 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2025,7 +2030,10 @@ static void sfp_sm_main(struct sfp *sfp,
  	init_done:	/* TX_FAULT deasserted or we timed out with TX_FAULT
  			 * clear.  Probe for the PHY and check the LOS state.
  			 */

--- a/target/linux/generic/pending-5.4/759-net-sfp-re-attempt-probing-for-phy.patch
+++ b/target/linux/generic/pending-5.4/759-net-sfp-re-attempt-probing-for-phy.patch
@@ -48,7 +48,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  /* SFP module presence detection is poor: the three MOD DEF signals are
   * the same length on the PCB, which means it's possible for MOD DEF 0 to
   * connect before the I2C bus on MOD DEF 1/2.
-@@ -235,6 +243,7 @@ struct sfp {
+@@ -236,6 +244,7 @@ struct sfp {
  	unsigned char sm_dev_state;
  	unsigned short sm_state;
  	unsigned char sm_fault_retries;
@@ -56,7 +56,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  	struct sfp_eeprom_id id;
  	unsigned int module_power_mW;
-@@ -1416,10 +1425,8 @@ static int sfp_sm_probe_phy(struct sfp *
+@@ -1432,10 +1441,8 @@ static int sfp_sm_probe_phy(struct sfp *
  	int err;
  
  	phy = get_phy_device(sfp->i2c_mii, SFP_PHY_ADDR, is_c45);
@@ -69,7 +69,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  	if (IS_ERR(phy)) {
  		dev_err(sfp->dev, "mdiobus scan returned %ld\n", PTR_ERR(phy));
  		return PTR_ERR(phy);
-@@ -1867,6 +1874,7 @@ static void sfp_sm_module(struct sfp *sf
+@@ -1954,6 +1961,7 @@ static void sfp_sm_module(struct sfp *sf
  static void sfp_sm_main(struct sfp *sfp, unsigned int event)
  {
  	unsigned long timeout;
@@ -77,7 +77,7 @@ Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
  
  	/* Some events are global */
  	if (sfp->sm_state != SFP_S_DOWN &&
-@@ -1940,22 +1948,39 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2027,22 +2035,39 @@ static void sfp_sm_main(struct sfp *sfp,
  			sfp_sm_fault(sfp, SFP_S_INIT_TX_FAULT,
  				     sfp->sm_fault_retries == N_FAULT_INIT);
  		} else if (event == SFP_E_TIMEOUT || event == SFP_E_TX_CLEAR) {


### PR DESCRIPTION
Recently into OpenWrt 21.02, there was added SFP support for Turris Omnia (https://github.com/openwrt/openwrt/commit/24e564d327943a32181db4568fff43cc18d93b13 and https://github.com/openwrt/openwrt/commit/5e2a2b086cee9a7ba9f765dbf62a62f456b6713a), I'd like to expand list of SFP modules, which can be connected to the Turris Omnia and used in OpenWrt as they are working in Turris OS, which is based on top of each OpenWrt versions.

This commit, which I cherry-picked from https://github.com/openwrt/openwrt/pull/4388 was merged to master branch (https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=f032601ed7d70fe1f468219b68750230b6ea1906), but since then mvebu target has been switched to kernel 5.10, so it would be nice to have it even in the stable release.

Commit message follow:

Adds support for GPON SFP modules based on the Realtek RTL8672 and
RTL9601C chips, including but not limited to:
* V-SOL V2801F
* C-Data FD511GX-RM0
* OPTON GP801R
* BAUDCOM BD-1234-SFM
* CPGOS03-0490 v2.0
* Ubiquiti U-Fiber Instant
* EXOT EGS1

This allows me to drop following patch in Turris OS: https://gitlab.nic.cz/turris/os/build/-/blob/27f27e365344c8f3d80e4d2db35e52f2465c7d40/patches/openwrt/wip/0013-kernel-backport-workaround-for-Realtek-RTL8672.patch

Soon, I will send patches to support GPON SFP modules.