### PR TITLE
[21.02] Add kernel modules: kmod-leds-uleds and kmod-ledtrig-pattern

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -84,6 +84,22 @@ endef
 $(eval $(call KernelPackage,ledtrig-oneshot))
 
 
+define KernelPackage/ledtrig-pattern
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED Pattern Trigger
+  KCONFIG:=CONFIG_LEDS_TRIGGER_PATTERN
+  FILES:=$(LED_TRIGGER_DIR)/ledtrig-pattern.ko
+  AUTOLOAD:=$(call AutoLoad,50,ledtrig-pattern)
+endef
+
+define KernelPackage/ledtrig-pattern/description
+ This allows LEDs to be controlled by a software or hardware pattern
+ which is a series of tuples, of brightness and duration (ms).
+endef
+
+$(eval $(call KernelPackage,ledtrig-pattern))
+
+
 define KernelPackage/leds-pca963x
   SUBMENU:=$(LEDS_MENU)
   TITLE:=PCA963x LED support

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -114,3 +114,17 @@ define KernelPackage/leds-pwm/description
 endef
 
 $(eval $(call KernelPackage,leds-pwm))
+
+define KernelPackage/leds-uleds
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=Userspace LEDs
+  KCONFIG:=CONFIG_LEDS_USER
+  FILES:=$(LINUX_DIR)/drivers/leds/uleds.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-uleds,1)
+endef
+
+define KernelPackage/leds-uleds/description
+ This option enables support for userspace LEDs.
+endef
+
+$(eval $(call KernelPackage,leds-uleds))

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -120,7 +120,7 @@ define KernelPackage/leds-uleds
   TITLE:=Userspace LEDs
   KCONFIG:=CONFIG_LEDS_USER
   FILES:=$(LINUX_DIR)/drivers/leds/uleds.ko
-  AUTOLOAD:=$(call AutoLoad,60,leds-uleds,1)
+  AUTOLOAD:=$(call AutoLoad,60,uleds,1)
 endef
 
 define KernelPackage/leds-uleds/description


### PR DESCRIPTION
Recently into OpenWrt 21.02, there was cherry-picked commit to support multicolor & RGB LEDs for 5.4 kernel (https://github.com/openwrt/openwrt/commit/739e359241a3855bf8f7b6b99978495ad52d1004). It would be nice to have more improvements related to LEDs. In Turris OS, we have all these three commits [[1+2]](https://gitlab.nic.cz/turris/os/build/-/blob/329ea7f142ca963b90f0de1434ebdde8851cef1c/patches/openwrt/backport/0001-kernel-add-kmod-leds-uleds.patch) [[3]](https://gitlab.nic.cz/turris/os/build/-/blob/329ea7f142ca963b90f0de1434ebdde8851cef1c/patches/openwrt/backport/0002-kernel-add-kmod-ledtrig-pattern.patch) , which are cherry-picked from the master branch. It would be nice to see them accepted in OpenWrt 21.02. 

For almost all targets these two kernel options are not set.
- ``CONFIG_LEDS_TRIGGER_PATTERN=y``: apm821xx 
- ``CONFIG_LEDS_USER is not set``: for all targets

So it should not change almost anything.

Compile tested with defaults (not set) and with both set kernel option:
- [Seeed's mini router](https://www.seeedstudio.com/Dual-GbE-Carrier-Board-with-4GB-RAM-32GB-eMMC-RPi-CM4-Case-p-5029.html) (RPI4 CM, bcm2711)
- [Turris Omnia](https://www.turris.com/en/omnia/overview/) (mvebu/cortex-a9)
