### PR TITLE
toolchain/binutils: v2.37 Close the file descriptor if there is no archive fd

### DIFF
--- a/toolchain/binutils/patches/2.37/600-Close_the_file_descriptor.patch
+++ b/toolchain/binutils/patches/2.37/600-Close_the_file_descriptor.patch
@@ -1,0 +1,19 @@
+diff --git a/bfd/plugin.c b/bfd/plugin.c
+index 6cfa2b66470..3bab8febe88 100644
+--- a/bfd/plugin.c
++++ b/bfd/plugin.c
+@@ -291,6 +291,14 @@ bfd_plugin_close_file_descriptor (bfd *abfd, int fd)
+ 	     && !bfd_is_thin_archive (abfd->my_archive))
+ 	abfd = abfd->my_archive;
+ 
++      /* Close the file descriptor if there is no archive plugin file
++	 descriptor.  */
++      if (abfd->archive_plugin_fd == -1)
++	{
++	  close (fd);
++	  return;
++	}
++
+       abfd->archive_plugin_fd_open_count--;
+       /* Dup the archive plugin file descriptor for later use, which
+ 	 will be closed by _bfd_archive_close_and_cleanup.  */


### PR DESCRIPTION
This fixes the following build error:
/home/build/openwrt/staging_dir/toolchain-aarch64_cortex-a53_gcc-11.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/11.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: /home/build/openwrt/build_dir/target-aarch64_cortex-a53_musl/node-v14.18.2/out/Release/obj.target/tools/v8_gypfiles/libv8_base_without_compiler.a: error adding symbols: malformed archive
collect2: error: ld returned 1 exit status

It's a bad error handling related to -EMFILE (too many open files). nodejs is probably just very close to open file limit.

https://sourceware.org/bugzilla/show_bug.cgi?id=28138
https://github.com/nodejs/node/issues/39452

https://github.com/openwrt/packages/issues/17496
https://github.com/openwrt/packages/issues/16729
https://github.com/openwrt/packages/issues/17164

Signed-off-by: Hirokazu MORIKAWA <morikw2@gmail.com>
