### PR TITLE
mvebu: Backport pci-aardvark patches fixing MSI support

### DIFF
--- a/target/linux/mvebu/patches-5.4/035-PCI-pci-bridge-emul-Add-description-for-class_revisi.patch
+++ b/target/linux/mvebu/patches-5.4/035-PCI-pci-bridge-emul-Add-description-for-class_revisi.patch
@@ -1,0 +1,47 @@
+From ac952eed0e5db283fb23f4bafb7bfccb4db1e581 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 2 Dec 2020 18:16:01 +0100
+Subject: [PATCH 35/55] PCI: pci-bridge-emul: Add description for
+ class_revision field
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The current assignment to the class_revision member
+
+  class_revision |= cpu_to_le32(PCI_CLASS_BRIDGE_PCI << 16);
+
+can make the reader think that class is at high 16 bits of the member and
+revision at low 16 bits.
+
+In reality, class is at high 24 bits, but the class for PCI Bridge Normal
+Decode is PCI_CLASS_BRIDGE_PCI << 8.
+
+Change the assignment and add a comment to make this clearer.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/pci-bridge-emul.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pci/pci-bridge-emul.c b/drivers/pci/pci-bridge-emul.c
+index 3026346ccb18..4412707c76ba 100644
+--- a/drivers/pci/pci-bridge-emul.c
++++ b/drivers/pci/pci-bridge-emul.c
+@@ -275,7 +275,11 @@ int pci_bridge_emul_init(struct pci_bridge_emul *bridge,
+ {
+ 	BUILD_BUG_ON(sizeof(bridge->conf) != PCI_BRIDGE_CONF_END);
+ 
+-	bridge->conf.class_revision |= cpu_to_le32(PCI_CLASS_BRIDGE_PCI << 16);
++	/*
++	 * class_revision: Class is high 24 bits and revision is low 8 bit of this member,
++	 * while class for PCI Bridge Normal Decode has the 24-bit value: PCI_CLASS_BRIDGE_PCI << 8
++	 */
++	bridge->conf.class_revision |= cpu_to_le32((PCI_CLASS_BRIDGE_PCI << 8) << 8);
+ 	bridge->conf.header_type = PCI_HEADER_TYPE_BRIDGE;
+ 	bridge->conf.cache_line_size = 0x10;
+ 	bridge->conf.status = cpu_to_le16(PCI_STATUS_CAP_LIST);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/036-PCI-pci-bridge-emul-Add-definitions-for-missing-capa.patch
+++ b/target/linux/mvebu/patches-5.4/036-PCI-pci-bridge-emul-Add-definitions-for-missing-capa.patch
@@ -1,0 +1,84 @@
+From b65d35b55439cc2405ea97939d5f7306fc39eb03 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 24 Nov 2021 16:59:41 +0100
+Subject: [PATCH 36/55] PCI: pci-bridge-emul: Add definitions for missing
+ capabilities registers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+pci-bridge-emul driver already allocates buffer for capabilities up to the
+PCI_EXP_SLTSTA2 register, but does not define bit access behavior for these
+registers. Add these missing definitions.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+[ Added .rsvd member for stable ]
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/pci-bridge-emul.c | 49 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 49 insertions(+)
+
+diff --git a/drivers/pci/pci-bridge-emul.c b/drivers/pci/pci-bridge-emul.c
+index 4412707c76ba..fa3d403990a2 100644
+--- a/drivers/pci/pci-bridge-emul.c
++++ b/drivers/pci/pci-bridge-emul.c
+@@ -261,6 +261,55 @@ struct pci_bridge_reg_behavior pcie_cap_regs_behavior[PCI_CAP_PCIE_SIZEOF / 4] =
+ 		.w1c = PCI_EXP_RTSTA_PME,
+ 		.rsvd = GENMASK(31, 18),
+ 	},
++
++	[PCI_EXP_DEVCAP2 / 4] = {
++		/*
++		 * Device capabilities 2 register has reserved bits [30:27].
++		 * Also bits [26:24] are reserved for non-upstream ports.
++		 */
++		.ro = BIT(31) | GENMASK(23, 0),
++		.rsvd = GENMASK(30, 24),
++	},
++
++	[PCI_EXP_DEVCTL2 / 4] = {
++		/*
++		 * Device control 2 register is RW. Bit 11 is reserved for
++		 * non-upstream ports.
++		 *
++		 * Device status 2 register is reserved.
++		 */
++		.rw = GENMASK(15, 12) | GENMASK(10, 0),
++		.rsvd = BIT(11) | (GENMASK(15, 0) << 16),
++	},
++
++	[PCI_EXP_LNKCAP2 / 4] = {
++		/* Link capabilities 2 register has reserved bits [30:25] and 0. */
++		.ro = BIT(31) | GENMASK(24, 1),
++		.rsvd = GENMASK(30, 25) | BIT(0),
++	},
++
++	[PCI_EXP_LNKCTL2 / 4] = {
++		/*
++		 * Link control 2 register is RW.
++		 *
++		 * Link status 2 register has bits 5, 15 W1C;
++		 * bits 10, 11 reserved and others are RO.
++		 */
++		.rw = GENMASK(15, 0),
++		.w1c = (BIT(15) | BIT(5)) << 16,
++		.ro = (GENMASK(14, 12) | GENMASK(9, 6) | GENMASK(4, 0)) << 16,
++		.rsvd = GENMASK(11, 10) << 16,
++	},
++
++	[PCI_EXP_SLTCAP2 / 4] = {
++		/* Slot capabilities 2 register is reserved. */
++		.rsvd = GENMASK(31, 0),
++	},
++
++	[PCI_EXP_SLTCTL2 / 4] = {
++		/* Both Slot control 2 and Slot status 2 registers are reserved. */
++		.rsvd = GENMASK(31, 0),
++	},
+ };
+ 
+ /*
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/037-PCI-aardvark-Add-support-for-DEVCAP2-DEVCTL2-LNKCAP2.patch
+++ b/target/linux/mvebu/patches-5.4/037-PCI-aardvark-Add-support-for-DEVCAP2-DEVCTL2-LNKCAP2.patch
@@ -1,0 +1,64 @@
+From 9b3827308e4ffc480dcc6b969383f2ec37129220 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 2 Dec 2020 18:29:29 +0100
+Subject: [PATCH 37/55] PCI: aardvark: Add support for DEVCAP2, DEVCTL2,
+ LNKCAP2 and LNKCTL2 registers on emulated bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PCI aardvark hardware supports access to DEVCAP2, DEVCTL2, LNKCAP2 and
+LNKCTL2 configuration registers of PCIe core via PCIE_CORE_PCIEXP_CAP.
+Export them via emulated software root bridge.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index a96f85fb9f98..69ed432a7278 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -875,8 +875,13 @@ advk_pci_bridge_emul_pcie_conf_read(struct pci_bridge_emul *bridge,
+ 	case PCI_CAP_LIST_ID:
+ 	case PCI_EXP_DEVCAP:
+ 	case PCI_EXP_DEVCTL:
++	case PCI_EXP_DEVCAP2:
++	case PCI_EXP_DEVCTL2:
++	case PCI_EXP_LNKCAP2:
++	case PCI_EXP_LNKCTL2:
+ 		*value = advk_readl(pcie, PCIE_CORE_PCIEXP_CAP + reg);
+ 		return PCI_BRIDGE_EMUL_HANDLED;
++
+ 	default:
+ 		return PCI_BRIDGE_EMUL_NOT_HANDLED;
+ 	}
+@@ -890,10 +895,6 @@ advk_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 	struct advk_pcie *pcie = bridge->data;
+ 
+ 	switch (reg) {
+-	case PCI_EXP_DEVCTL:
+-		advk_writel(pcie, new, PCIE_CORE_PCIEXP_CAP + reg);
+-		break;
+-
+ 	case PCI_EXP_LNKCTL:
+ 		advk_writel(pcie, new, PCIE_CORE_PCIEXP_CAP + reg);
+ 		if (new & PCI_EXP_LNKCTL_RL)
+@@ -915,6 +916,12 @@ advk_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 		advk_writel(pcie, new, PCIE_ISR0_REG);
+ 		break;
+ 
++	case PCI_EXP_DEVCTL:
++	case PCI_EXP_DEVCTL2:
++	case PCI_EXP_LNKCTL2:
++		advk_writel(pcie, new, PCIE_CORE_PCIEXP_CAP + reg);
++		break;
++
+ 	default:
+ 		break;
+ 	}
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/038-PCI-aardvark-Clear-all-MSIs-at-setup.patch
+++ b/target/linux/mvebu/patches-5.4/038-PCI-aardvark-Clear-all-MSIs-at-setup.patch
@@ -1,0 +1,62 @@
+From 290cb4c80bd482f2aaf29bc52602ad402bd4b61f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sun, 28 Mar 2021 14:34:49 +0200
+Subject: [PATCH 38/55] PCI: aardvark: Clear all MSIs at setup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We already clear all the other interrupts (ISR0, ISR1, HOST_CTRL_INT).
+
+Define a new macro PCIE_MSI_ALL_MASK and do the same clearing for MSIs,
+to ensure that we don't start receiving spurious interrupts.
+
+Use this new mask in advk_pcie_handle_msi();
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 69ed432a7278..6fd0e248f85a 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -111,6 +111,7 @@
+ #define PCIE_MSI_ADDR_HIGH_REG			(CONTROL_BASE_ADDR + 0x54)
+ #define PCIE_MSI_STATUS_REG			(CONTROL_BASE_ADDR + 0x58)
+ #define PCIE_MSI_MASK_REG			(CONTROL_BASE_ADDR + 0x5C)
++#define     PCIE_MSI_ALL_MASK			GENMASK(31, 0)
+ #define PCIE_MSI_PAYLOAD_REG			(CONTROL_BASE_ADDR + 0x9C)
+ #define     PCIE_MSI_DATA_MASK			GENMASK(15, 0)
+ 
+@@ -570,6 +571,7 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	advk_writel(pcie, reg, PCIE_CORE_CTRL2_REG);
+ 
+ 	/* Clear all interrupts */
++	advk_writel(pcie, PCIE_MSI_ALL_MASK, PCIE_MSI_STATUS_REG);
+ 	advk_writel(pcie, PCIE_ISR0_ALL_MASK, PCIE_ISR0_REG);
+ 	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_REG);
+ 	advk_writel(pcie, PCIE_IRQ_ALL_MASK, HOST_CTRL_INT_STATUS_REG);
+@@ -582,7 +584,7 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_MASK_REG);
+ 
+ 	/* Unmask all MSIs */
+-	advk_writel(pcie, 0, PCIE_MSI_MASK_REG);
++	advk_writel(pcie, ~(u32)PCIE_MSI_ALL_MASK, PCIE_MSI_MASK_REG);
+ 
+ 	/* Enable summary interrupt for GIC SPI source */
+ 	reg = PCIE_IRQ_ALL_MASK & (~PCIE_IRQ_ENABLE_INTS_MASK);
+@@ -1390,7 +1392,7 @@ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ 
+ 	msi_mask = advk_readl(pcie, PCIE_MSI_MASK_REG);
+ 	msi_val = advk_readl(pcie, PCIE_MSI_STATUS_REG);
+-	msi_status = msi_val & ~msi_mask;
++	msi_status = msi_val & ((~msi_mask) & PCIE_MSI_ALL_MASK);
+ 
+ 	for (msi_idx = 0; msi_idx < MSI_IRQ_NUM; msi_idx++) {
+ 		if (!(BIT(msi_idx) & msi_status))
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/039-PCI-aardvark-Rewrite-IRQ-code-to-chained-IRQ-handler.patch
+++ b/target/linux/mvebu/patches-5.4/039-PCI-aardvark-Rewrite-IRQ-code-to-chained-IRQ-handler.patch
@@ -1,0 +1,119 @@
+From a533dbcbfd3df0d7a1ffffb5794eac990b2122fc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sat, 27 Mar 2021 14:44:11 +0100
+Subject: [PATCH 39/55] PCI: aardvark: Rewrite IRQ code to chained IRQ handler
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Rewrite the code to use irq_set_chained_handler_and_data() handler with
+chained_irq_enter() and chained_irq_exit() processing instead of using
+devm_request_irq().
+
+advk_pcie_irq_handler() reads IRQ status bits and calls other functions
+based on which bits are set. These functions then read its own IRQ status
+bits and calls other aardvark functions based on these bits. Finally
+generic_handle_irq() with translated linux IRQ numbers are called.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 42 +++++++++++++++------------
+ 1 file changed, 23 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 6fd0e248f85a..c4bd953f7967 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -277,6 +277,7 @@ struct advk_pcie {
+ 		u32 actions;
+ 	} wins[OB_WIN_COUNT];
+ 	u8 wins_count;
++	int irq;
+ 	struct irq_domain *irq_domain;
+ 	struct irq_chip irq_chip;
+ 	raw_spinlock_t irq_lock;
+@@ -1442,21 +1443,26 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 	}
+ }
+ 
+-static irqreturn_t advk_pcie_irq_handler(int irq, void *arg)
++static void advk_pcie_irq_handler(struct irq_desc *desc)
+ {
+-	struct advk_pcie *pcie = arg;
+-	u32 status;
++	struct advk_pcie *pcie = irq_desc_get_handler_data(desc);
++	struct irq_chip *chip = irq_desc_get_chip(desc);
++	u32 val, mask, status;
+ 
+-	status = advk_readl(pcie, HOST_CTRL_INT_STATUS_REG);
+-	if (!(status & PCIE_IRQ_CORE_INT))
+-		return IRQ_NONE;
++	chained_irq_enter(chip, desc);
+ 
+-	advk_pcie_handle_int(pcie);
++	val = advk_readl(pcie, HOST_CTRL_INT_STATUS_REG);
++	mask = advk_readl(pcie, HOST_CTRL_INT_MASK_REG);
++	status = val & ((~mask) & PCIE_IRQ_ALL_MASK);
+ 
+-	/* Clear interrupt */
+-	advk_writel(pcie, PCIE_IRQ_CORE_INT, HOST_CTRL_INT_STATUS_REG);
++	if (status & PCIE_IRQ_CORE_INT) {
++		advk_pcie_handle_int(pcie);
+ 
+-	return IRQ_HANDLED;
++		/* Clear interrupt */
++		advk_writel(pcie, PCIE_IRQ_CORE_INT, HOST_CTRL_INT_STATUS_REG);
++	}
++
++	chained_irq_exit(chip, desc);
+ }
+ 
+ static int advk_pcie_parse_request_of_pci_ranges(struct advk_pcie *pcie)
+@@ -1576,7 +1582,7 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 	struct resource *res;
+ 	struct pci_host_bridge *bridge;
+ 	struct resource_entry *entry;
+-	int ret, irq;
++	int ret;
+ 
+ 	bridge = devm_pci_alloc_host_bridge(dev, sizeof(struct advk_pcie));
+ 	if (!bridge)
+@@ -1590,14 +1596,9 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 	if (IS_ERR(pcie->base))
+ 		return PTR_ERR(pcie->base);
+ 
+-	irq = platform_get_irq(pdev, 0);
+-	ret = devm_request_irq(dev, irq, advk_pcie_irq_handler,
+-			       IRQF_SHARED | IRQF_NO_THREAD, "advk-pcie",
+-			       pcie);
+-	if (ret) {
+-		dev_err(dev, "Failed to register interrupt\n");
+-		return ret;
+-	}
++	pcie->irq = platform_get_irq(pdev, 0);
++	if (pcie->irq < 0)
++		return pcie->irq;
+ 
+ 	ret = advk_pcie_parse_request_of_pci_ranges(pcie);
+ 	if (ret) {
+@@ -1726,6 +1727,8 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 		return ret;
+ 	}
+ 
++	irq_set_chained_handler_and_data(pcie->irq, advk_pcie_irq_handler, pcie);
++
+ 	list_splice_init(&pcie->resources, &bridge->windows);
+ 	bridge->dev.parent = dev;
+ 	bridge->sysdata = pcie;
+@@ -1736,6 +1739,7 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 
+ 	ret = pci_host_probe(bridge);
+ 	if (ret < 0) {
++		irq_set_chained_handler_and_data(pcie->irq, NULL, NULL);
+ 		advk_pcie_remove_msi_irq_domain(pcie);
+ 		advk_pcie_remove_irq_domain(pcie);
+ 		return ret;
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/040-PCI-aardvark-Fix-support-for-MSI-interrupts.patch
+++ b/target/linux/mvebu/patches-5.4/040-PCI-aardvark-Fix-support-for-MSI-interrupts.patch
@@ -1,0 +1,98 @@
+From aa3e075a0c2dbf5503e6f1a1d396dca308a60c0b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 12 Feb 2021 16:24:07 +0100
+Subject: [PATCH 40/55] PCI: aardvark: Fix support for MSI interrupts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Aardvark hardware supports Multi-MSI and MSI_FLAG_MULTI_PCI_MSI is already
+set for the MSI chip. But when allocating MSI interrupt numbers for
+Multi-MSI, the numbers need to be properly aligned, otherwise endpoint
+devices send MSI interrupt with incorrect numbers.
+
+Fix this issue by using function bitmap_find_free_region() instead of
+bitmap_find_next_zero_area().
+
+To ensure that aligned MSI interrupt numbers are used by endpoint devices,
+we cannot use Linux virtual irq numbers (as they are random and not
+properly aligned). Instead we need to use the aligned hwirq numbers.
+
+This change fixes receiving MSI interrupts on Armada 3720 boards and
+allows using NVMe disks which use Multi-MSI feature with 3 interrupts.
+
+Without this NVMe disks freeze booting as linux nvme-core.c is waiting
+60s for an interrupt.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 23 ++++++++++++-----------
+ 1 file changed, 12 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index c4bd953f7967..5bd7f1543325 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1185,7 +1185,7 @@ static void advk_msi_irq_compose_msi_msg(struct irq_data *data,
+ 
+ 	msg->address_lo = lower_32_bits(msi_msg);
+ 	msg->address_hi = upper_32_bits(msi_msg);
+-	msg->data = data->irq;
++	msg->data = data->hwirq;
+ }
+ 
+ static int advk_msi_set_affinity(struct irq_data *irq_data,
+@@ -1202,15 +1202,11 @@ static int advk_msi_irq_domain_alloc(struct irq_domain *domain,
+ 	int hwirq, i;
+ 
+ 	mutex_lock(&pcie->msi_used_lock);
+-	hwirq = bitmap_find_next_zero_area(pcie->msi_used, MSI_IRQ_NUM,
+-					   0, nr_irqs, 0);
+-	if (hwirq >= MSI_IRQ_NUM) {
+-		mutex_unlock(&pcie->msi_used_lock);
+-		return -ENOSPC;
+-	}
+-
+-	bitmap_set(pcie->msi_used, hwirq, nr_irqs);
++	hwirq = bitmap_find_free_region(pcie->msi_used, MSI_IRQ_NUM,
++					order_base_2(nr_irqs));
+ 	mutex_unlock(&pcie->msi_used_lock);
++	if (hwirq < 0)
++		return -ENOSPC;
+ 
+ 	for (i = 0; i < nr_irqs; i++)
+ 		irq_domain_set_info(domain, virq + i, hwirq + i,
+@@ -1228,7 +1224,7 @@ static void advk_msi_irq_domain_free(struct irq_domain *domain,
+ 	struct advk_pcie *pcie = domain->host_data;
+ 
+ 	mutex_lock(&pcie->msi_used_lock);
+-	bitmap_clear(pcie->msi_used, d->hwirq, nr_irqs);
++	bitmap_release_region(pcie->msi_used, d->hwirq, order_base_2(nr_irqs));
+ 	mutex_unlock(&pcie->msi_used_lock);
+ }
+ 
+@@ -1390,6 +1386,7 @@ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ {
+ 	u32 msi_val, msi_mask, msi_status, msi_idx;
+ 	u16 msi_data;
++	int virq;
+ 
+ 	msi_mask = advk_readl(pcie, PCIE_MSI_MASK_REG);
+ 	msi_val = advk_readl(pcie, PCIE_MSI_STATUS_REG);
+@@ -1405,7 +1402,11 @@ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ 		 */
+ 		advk_writel(pcie, BIT(msi_idx), PCIE_MSI_STATUS_REG);
+ 		msi_data = advk_readl(pcie, PCIE_MSI_PAYLOAD_REG) & PCIE_MSI_DATA_MASK;
+-		generic_handle_irq(msi_data);
++		virq = irq_find_mapping(pcie->msi_inner_domain, msi_data);
++		if (virq)
++			generic_handle_irq(virq);
++		else
++			dev_err_ratelimited(&pcie->pdev->dev, "unexpected MSI 0x%04hx\n", msi_data);
+ 	}
+ 
+ 	advk_writel(pcie, PCIE_ISR0_MSI_INT_PENDING,
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/041-PCI-aardvark-Fix-reading-MSI-interrupt-number.patch
+++ b/target/linux/mvebu/patches-5.4/041-PCI-aardvark-Fix-reading-MSI-interrupt-number.patch
@@ -1,0 +1,63 @@
+From 36bbe878e1afb9d883358465376529e5665f6bbe Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 2 Jul 2021 16:39:47 +0200
+Subject: [PATCH 41/55] PCI: aardvark: Fix reading MSI interrupt number
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In advk_pcie_handle_msi() the authors expect that when bit i in the W1C
+register PCIE_MSI_STATUS_REG is cleared, the PCIE_MSI_PAYLOAD_REG is
+updated to contain the MSI number corresponding to index i.
+
+Experiments show that this is not so, and instead PCIE_MSI_PAYLOAD_REG
+always contains the number of the last received MSI, overall.
+
+Do not read PCIE_MSI_PAYLOAD_REG register for determining MSI interrupt
+number. Since Aardvark already forbids more than 32 interrupts and uses
+own allocated hwirq numbers, the msi_idx already corresponds to the
+received MSI number.
+
+Fixes: 8c39d710363c ("PCI: aardvark: Add Aardvark PCI host controller driver")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 5bd7f1543325..9f4b5f5777e2 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1385,7 +1385,6 @@ static void advk_pcie_remove_irq_domain(struct advk_pcie *pcie)
+ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ {
+ 	u32 msi_val, msi_mask, msi_status, msi_idx;
+-	u16 msi_data;
+ 	int virq;
+ 
+ 	msi_mask = advk_readl(pcie, PCIE_MSI_MASK_REG);
+@@ -1396,17 +1395,13 @@ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ 		if (!(BIT(msi_idx) & msi_status))
+ 			continue;
+ 
+-		/*
+-		 * msi_idx contains bits [4:0] of the msi_data and msi_data
+-		 * contains 16bit MSI interrupt number
+-		 */
+ 		advk_writel(pcie, BIT(msi_idx), PCIE_MSI_STATUS_REG);
+-		msi_data = advk_readl(pcie, PCIE_MSI_PAYLOAD_REG) & PCIE_MSI_DATA_MASK;
+-		virq = irq_find_mapping(pcie->msi_inner_domain, msi_data);
++
++		virq = irq_find_mapping(pcie->msi_inner_domain, msi_idx);
+ 		if (virq)
+ 			generic_handle_irq(virq);
+ 		else
+-			dev_err_ratelimited(&pcie->pdev->dev, "unexpected MSI 0x%04hx\n", msi_data);
++			dev_err_ratelimited(&pcie->pdev->dev, "unexpected MSI 0x%02x\n", msi_idx);
+ 	}
+ 
+ 	advk_writel(pcie, PCIE_ISR0_MSI_INT_PENDING,
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/042-PCI-aardvark-Refactor-unmasking-summary-MSI-interrup.patch
+++ b/target/linux/mvebu/patches-5.4/042-PCI-aardvark-Refactor-unmasking-summary-MSI-interrup.patch
@@ -1,0 +1,49 @@
+From 0b74153f2803c4ebb5bda150840241130d9e1655 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sun, 28 Mar 2021 14:34:49 +0200
+Subject: [PATCH 42/55] PCI: aardvark: Refactor unmasking summary MSI interrupt
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Refactor the masking of ISR0/1 Sources and unmasking of summary MSI interrupt
+so that it corresponds to the comments:
+- first mask all ISR0/1
+- then unmask all MSIs
+- then unmask summary MSI interrupt
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 9f4b5f5777e2..33f56aae5cee 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -578,15 +578,17 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	advk_writel(pcie, PCIE_IRQ_ALL_MASK, HOST_CTRL_INT_STATUS_REG);
+ 
+ 	/* Disable All ISR0/1 Sources */
+-	reg = PCIE_ISR0_ALL_MASK;
+-	reg &= ~PCIE_ISR0_MSI_INT_PENDING;
+-	advk_writel(pcie, reg, PCIE_ISR0_MASK_REG);
+-
++	advk_writel(pcie, PCIE_ISR0_ALL_MASK, PCIE_ISR0_MASK_REG);
+ 	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_MASK_REG);
+ 
+ 	/* Unmask all MSIs */
+ 	advk_writel(pcie, ~(u32)PCIE_MSI_ALL_MASK, PCIE_MSI_MASK_REG);
+ 
++	/* Unmask summary MSI interrupt */
++	reg = advk_readl(pcie, PCIE_ISR0_MASK_REG);
++	reg &= ~PCIE_ISR0_MSI_INT_PENDING;
++	advk_writel(pcie, reg, PCIE_ISR0_MASK_REG);
++
+ 	/* Enable summary interrupt for GIC SPI source */
+ 	reg = PCIE_IRQ_ALL_MASK & (~PCIE_IRQ_ENABLE_INTS_MASK);
+ 	advk_writel(pcie, reg, HOST_CTRL_INT_MASK_REG);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/043-PCI-aardvark-Add-support-for-masking-MSI-interrupts.patch
+++ b/target/linux/mvebu/patches-5.4/043-PCI-aardvark-Add-support-for-masking-MSI-interrupts.patch
@@ -1,0 +1,119 @@
+From 5ad4ef19f74e75ce3703f28d519b146fe8047aec Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 2 Jul 2021 16:44:10 +0200
+Subject: [PATCH 43/55] PCI: aardvark: Add support for masking MSI interrupts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We should not unmask MSIs at setup, but only when kernel asks for them
+to be unmasked.
+
+At setup, mask all MSIs, and implement IRQ chip callbacks for masking
+and unmasking particular MSIs.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 52 ++++++++++++++++++++++++---
+ 1 file changed, 48 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 33f56aae5cee..85850f2d6676 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -285,6 +285,7 @@ struct advk_pcie {
+ 	struct irq_domain *msi_inner_domain;
+ 	struct irq_chip msi_bottom_irq_chip;
+ 	struct irq_chip msi_irq_chip;
++	raw_spinlock_t msi_irq_lock;
+ 	struct msi_domain_info msi_domain_info;
+ 	DECLARE_BITMAP(msi_used, MSI_IRQ_NUM);
+ 	struct mutex msi_used_lock;
+@@ -577,12 +578,10 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_REG);
+ 	advk_writel(pcie, PCIE_IRQ_ALL_MASK, HOST_CTRL_INT_STATUS_REG);
+ 
+-	/* Disable All ISR0/1 Sources */
++	/* Disable All ISR0/1 and MSI Sources */
+ 	advk_writel(pcie, PCIE_ISR0_ALL_MASK, PCIE_ISR0_MASK_REG);
+ 	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_MASK_REG);
+-
+-	/* Unmask all MSIs */
+-	advk_writel(pcie, ~(u32)PCIE_MSI_ALL_MASK, PCIE_MSI_MASK_REG);
++	advk_writel(pcie, PCIE_MSI_ALL_MASK, PCIE_MSI_MASK_REG);
+ 
+ 	/* Unmask summary MSI interrupt */
+ 	reg = advk_readl(pcie, PCIE_ISR0_MASK_REG);
+@@ -1196,6 +1195,46 @@ static int advk_msi_set_affinity(struct irq_data *irq_data,
+ 	return -EINVAL;
+ }
+ 
++static void advk_msi_irq_mask(struct irq_data *d)
++{
++	struct advk_pcie *pcie = d->domain->host_data;
++	irq_hw_number_t hwirq = irqd_to_hwirq(d);
++	unsigned long flags;
++	u32 mask;
++
++	raw_spin_lock_irqsave(&pcie->msi_irq_lock, flags);
++	mask = advk_readl(pcie, PCIE_MSI_MASK_REG);
++	mask |= BIT(hwirq);
++	advk_writel(pcie, mask, PCIE_MSI_MASK_REG);
++	raw_spin_unlock_irqrestore(&pcie->msi_irq_lock, flags);
++}
++
++static void advk_msi_irq_unmask(struct irq_data *d)
++{
++	struct advk_pcie *pcie = d->domain->host_data;
++	irq_hw_number_t hwirq = irqd_to_hwirq(d);
++	unsigned long flags;
++	u32 mask;
++
++	raw_spin_lock_irqsave(&pcie->msi_irq_lock, flags);
++	mask = advk_readl(pcie, PCIE_MSI_MASK_REG);
++	mask &= ~BIT(hwirq);
++	advk_writel(pcie, mask, PCIE_MSI_MASK_REG);
++	raw_spin_unlock_irqrestore(&pcie->msi_irq_lock, flags);
++}
++
++static void advk_msi_top_irq_mask(struct irq_data *d)
++{
++	pci_msi_mask_irq(d);
++	irq_chip_mask_parent(d);
++}
++
++static void advk_msi_top_irq_unmask(struct irq_data *d)
++{
++	pci_msi_unmask_irq(d);
++	irq_chip_unmask_parent(d);
++}
++
+ static int advk_msi_irq_domain_alloc(struct irq_domain *domain,
+ 				     unsigned int virq,
+ 				     unsigned int nr_irqs, void *args)
+@@ -1290,6 +1329,7 @@ static int advk_pcie_init_msi_irq_domain(struct advk_pcie *pcie)
+ 	struct msi_domain_info *msi_di;
+ 	phys_addr_t msi_msg_phys;
+ 
++	raw_spin_lock_init(&pcie->msi_irq_lock);
+ 	mutex_init(&pcie->msi_used_lock);
+ 
+ 	bottom_ic = &pcie->msi_bottom_irq_chip;
+@@ -1297,9 +1337,13 @@ static int advk_pcie_init_msi_irq_domain(struct advk_pcie *pcie)
+ 	bottom_ic->name = "MSI";
+ 	bottom_ic->irq_compose_msi_msg = advk_msi_irq_compose_msi_msg;
+ 	bottom_ic->irq_set_affinity = advk_msi_set_affinity;
++	bottom_ic->irq_mask = advk_msi_irq_mask;
++	bottom_ic->irq_unmask = advk_msi_irq_unmask;
+ 
+ 	msi_ic = &pcie->msi_irq_chip;
+ 	msi_ic->name = "advk-MSI";
++	msi_ic->irq_mask = advk_msi_top_irq_mask;
++	msi_ic->irq_unmask = advk_msi_top_irq_unmask;
+ 
+ 	msi_di = &pcie->msi_domain_info;
+ 	msi_di->flags = MSI_FLAG_USE_DEF_DOM_OPS | MSI_FLAG_USE_DEF_CHIP_OPS |
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/044-PCI-aardvark-Fix-setting-MSI-address.patch
+++ b/target/linux/mvebu/patches-5.4/044-PCI-aardvark-Fix-setting-MSI-address.patch
@@ -1,0 +1,99 @@
+From 702bb39243e6b816e4eb5b4f67de7e459b4e743c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 26 Mar 2021 17:35:44 +0100
+Subject: [PATCH 44/55] PCI: aardvark: Fix setting MSI address
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+MSI address for receiving MSI interrupts needs to be correctly set before
+enabling processing of MSI interrupts.
+
+Move code for setting PCIE_MSI_ADDR_LOW_REG and PCIE_MSI_ADDR_HIGH_REG
+from advk_pcie_init_msi_irq_domain() to advk_pcie_setup_hw(), before
+enabling PCIE_CORE_CTRL2_MSI_ENABLE.
+
+After this we can remove the now unused member msi_msg, which was used
+only for MSI doorbell address. MSI address can be any address which cannot
+be used to DMA to. So change it to the address of the main struct advk_pcie.
+
+Fixes: 8c39d710363c ("PCI: aardvark: Add Aardvark PCI host controller driver")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Acked-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+Cc: stable@vger.kernel.org # f21a8b1b6837 ("PCI: aardvark: Move to MSI handling using generic MSI support")
+---
+ drivers/pci/controller/pci-aardvark.c | 21 +++++++++------------
+ 1 file changed, 9 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 85850f2d6676..f2f63760b232 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -289,7 +289,6 @@ struct advk_pcie {
+ 	struct msi_domain_info msi_domain_info;
+ 	DECLARE_BITMAP(msi_used, MSI_IRQ_NUM);
+ 	struct mutex msi_used_lock;
+-	u16 msi_msg;
+ 	int root_bus_nr;
+ 	int link_gen;
+ 	struct pci_bridge_emul bridge;
+@@ -485,6 +484,7 @@ static void advk_pcie_disable_ob_win(struct advk_pcie *pcie, u8 win_num)
+ 
+ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ {
++	phys_addr_t msi_addr;
+ 	u32 reg;
+ 	int i;
+ 
+@@ -567,6 +567,11 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	reg |= LANE_COUNT_1;
+ 	advk_writel(pcie, reg, PCIE_CORE_CTRL0_REG);
+ 
++	/* Set MSI address */
++	msi_addr = virt_to_phys(pcie);
++	advk_writel(pcie, lower_32_bits(msi_addr), PCIE_MSI_ADDR_LOW_REG);
++	advk_writel(pcie, upper_32_bits(msi_addr), PCIE_MSI_ADDR_HIGH_REG);
++
+ 	/* Enable MSI */
+ 	reg = advk_readl(pcie, PCIE_CORE_CTRL2_REG);
+ 	reg |= PCIE_CORE_CTRL2_MSI_ENABLE;
+@@ -1182,10 +1187,10 @@ static void advk_msi_irq_compose_msi_msg(struct irq_data *data,
+ 					 struct msi_msg *msg)
+ {
+ 	struct advk_pcie *pcie = irq_data_get_irq_chip_data(data);
+-	phys_addr_t msi_msg = virt_to_phys(&pcie->msi_msg);
++	phys_addr_t msi_addr = virt_to_phys(pcie);
+ 
+-	msg->address_lo = lower_32_bits(msi_msg);
+-	msg->address_hi = upper_32_bits(msi_msg);
++	msg->address_lo = lower_32_bits(msi_addr);
++	msg->address_hi = upper_32_bits(msi_addr);
+ 	msg->data = data->hwirq;
+ }
+ 
+@@ -1327,7 +1332,6 @@ static int advk_pcie_init_msi_irq_domain(struct advk_pcie *pcie)
+ 	struct device_node *node = dev->of_node;
+ 	struct irq_chip *bottom_ic, *msi_ic;
+ 	struct msi_domain_info *msi_di;
+-	phys_addr_t msi_msg_phys;
+ 
+ 	raw_spin_lock_init(&pcie->msi_irq_lock);
+ 	mutex_init(&pcie->msi_used_lock);
+@@ -1350,13 +1354,6 @@ static int advk_pcie_init_msi_irq_domain(struct advk_pcie *pcie)
+ 		MSI_FLAG_MULTI_PCI_MSI;
+ 	msi_di->chip = msi_ic;
+ 
+-	msi_msg_phys = virt_to_phys(&pcie->msi_msg);
+-
+-	advk_writel(pcie, lower_32_bits(msi_msg_phys),
+-		    PCIE_MSI_ADDR_LOW_REG);
+-	advk_writel(pcie, upper_32_bits(msi_msg_phys),
+-		    PCIE_MSI_ADDR_HIGH_REG);
+-
+ 	pcie->msi_inner_domain =
+ 		irq_domain_add_linear(NULL, MSI_IRQ_NUM,
+ 				      &advk_msi_domain_ops, pcie);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/045-PCI-aardvark-Enable-MSI-X-support.patch
+++ b/target/linux/mvebu/patches-5.4/045-PCI-aardvark-Enable-MSI-X-support.patch
@@ -1,0 +1,43 @@
+From 0e75cb288a42e6b200affbd679bf924866466a38 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 2 Apr 2021 14:05:24 +0200
+Subject: [PATCH 45/55] PCI: aardvark: Enable MSI-X support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+According to PCI 3.0 specification, sending both MSI and MSI-X interrupts
+is done by DWORD memory write operation to doorbell message address. The
+write operation for MSI has zero upper 16 bits and the MSI interrupt number
+in the lower 16 bits, while the write operation for MSI-X contains a 32-bit
+value from MSI-X table.
+
+Since the driver only uses interrupt numbers from range 0..31, the upper
+16 bits of the DWORD memory write operation to doorbell message address
+are zero even for MSI-X interrupts. Thus we can enable MSI-X interrupts.
+
+Testing proves that kernel can correctly receive MSI-X interrupts from PCIe
+cards which supports both MSI and MSI-X interrupts.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index f2f63760b232..93ce68b405a8 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1351,7 +1351,7 @@ static int advk_pcie_init_msi_irq_domain(struct advk_pcie *pcie)
+ 
+ 	msi_di = &pcie->msi_domain_info;
+ 	msi_di->flags = MSI_FLAG_USE_DEF_DOM_OPS | MSI_FLAG_USE_DEF_CHIP_OPS |
+-		MSI_FLAG_MULTI_PCI_MSI;
++			MSI_FLAG_MULTI_PCI_MSI | MSI_FLAG_PCI_MSIX;
+ 	msi_di->chip = msi_ic;
+ 
+ 	pcie->msi_inner_domain =
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/046-PCI-aardvark-Add-support-for-ERR-interrupt-on-emulat.patch
+++ b/target/linux/mvebu/patches-5.4/046-PCI-aardvark-Add-support-for-ERR-interrupt-on-emulat.patch
@@ -1,0 +1,107 @@
+From 76f7a3f3b171f9d61b98de67a399906506011fe0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 12 Feb 2021 20:32:55 +0100
+Subject: [PATCH 46/55] PCI: aardvark: Add support for ERR interrupt on
+ emulated bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+ERR interrupt is triggered when corresponding bit is unmasked in both ISR0
+and PCI_EXP_DEVCTL registers. Unmasking ERR bits in PCI_EXP_DEVCTL register
+is not enough. This means that currently the ERR interrupt is never
+triggered.
+
+Unmask ERR bits in ISR0 register at driver probe time. ERR interrupt is not
+triggered until ERR bits are unmasked also in PCI_EXP_DEVCTL register,
+which is done by AER driver. So it is safe to unconditionally unmask all
+ERR bits in aardvark probe.
+
+Aardvark HW sets PCI_ERR_ROOT_AER_IRQ to zero and when corresponding bits
+in ISR0 and PCI_EXP_DEVCTL are enabled, the HW triggers a generic interrupt
+on GIC. Chain this interrupt to PCIe interrupt 0 with
+generic_handle_domain_irq() to allow processing of ERR interrupts.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 38 ++++++++++++++++++++++++++-
+ 1 file changed, 37 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 93ce68b405a8..4a70439d7ad5 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -98,6 +98,10 @@
+ #define PCIE_MSG_PM_PME_MASK			BIT(7)
+ #define PCIE_ISR0_MASK_REG			(CONTROL_BASE_ADDR + 0x44)
+ #define     PCIE_ISR0_MSI_INT_PENDING		BIT(24)
++#define     PCIE_ISR0_CORR_ERR			BIT(11)
++#define     PCIE_ISR0_NFAT_ERR			BIT(12)
++#define     PCIE_ISR0_FAT_ERR			BIT(13)
++#define     PCIE_ISR0_ERR_MASK			GENMASK(13, 11)
+ #define     PCIE_ISR0_INTX_ASSERT(val)		BIT(16 + (val))
+ #define     PCIE_ISR0_INTX_DEASSERT(val)	BIT(20 + (val))
+ #define     PCIE_ISR0_ALL_MASK			GENMASK(31, 0)
+@@ -785,11 +789,15 @@ advk_pci_bridge_emul_base_conf_read(struct pci_bridge_emul *bridge,
+ 	case PCI_INTERRUPT_LINE: {
+ 		/*
+ 		 * From the whole 32bit register we support reading from HW only
+-		 * one bit: PCI_BRIDGE_CTL_BUS_RESET.
++		 * two bits: PCI_BRIDGE_CTL_BUS_RESET and PCI_BRIDGE_CTL_SERR.
+ 		 * Other bits are retrieved only from emulated config buffer.
+ 		 */
+ 		__le32 *cfgspace = (__le32 *)&bridge->conf;
+ 		u32 val = le32_to_cpu(cfgspace[PCI_INTERRUPT_LINE / 4]);
++		if (advk_readl(pcie, PCIE_ISR0_MASK_REG) & PCIE_ISR0_ERR_MASK)
++			val &= ~(PCI_BRIDGE_CTL_SERR << 16);
++		else
++			val |= PCI_BRIDGE_CTL_SERR << 16;
+ 		if (advk_readl(pcie, PCIE_CORE_CTRL1_REG) & HOT_RESET_GEN)
+ 			val |= PCI_BRIDGE_CTL_BUS_RESET << 16;
+ 		else
+@@ -815,6 +823,19 @@ advk_pci_bridge_emul_base_conf_write(struct pci_bridge_emul *bridge,
+ 		break;
+ 
+ 	case PCI_INTERRUPT_LINE:
++		/*
++		 * According to Figure 6-3: Pseudo Logic Diagram for Error
++		 * Message Controls in PCIe base specification, SERR# Enable bit
++		 * in Bridge Control register enable receiving of ERR_* messages
++		 */
++		if (mask & (PCI_BRIDGE_CTL_SERR << 16)) {
++			u32 val = advk_readl(pcie, PCIE_ISR0_MASK_REG);
++			if (new & (PCI_BRIDGE_CTL_SERR << 16))
++				val &= ~PCIE_ISR0_ERR_MASK;
++			else
++				val |= PCIE_ISR0_ERR_MASK;
++			advk_writel(pcie, val, PCIE_ISR0_MASK_REG);
++		}
+ 		if (mask & (PCI_BRIDGE_CTL_BUS_RESET << 16)) {
+ 			u32 val = advk_readl(pcie, PCIE_CORE_CTRL1_REG);
+ 			if (new & (PCI_BRIDGE_CTL_BUS_RESET << 16))
+@@ -1465,6 +1486,21 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
+ 	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
+ 
++	/* Process ERR interrupt */
++	if (isr0_status & PCIE_ISR0_ERR_MASK) {
++		advk_writel(pcie, PCIE_ISR0_ERR_MASK, PCIE_ISR0_REG);
++
++		/*
++		 * Aardvark HW returns zero for PCI_ERR_ROOT_AER_IRQ, so use
++		 * PCIe interrupt 0
++		 */
++		virq = irq_find_mapping(pcie->irq_domain, 0);
++		if (virq)
++			generic_handle_irq(virq);
++		else
++			dev_err_ratelimited(&pcie->pdev->dev, "unhandled ERR IRQ\n");
++	}
++
+ 	/* Process MSI interrupts */
+ 	if (isr0_status & PCIE_ISR0_MSI_INT_PENDING)
+ 		advk_pcie_handle_msi(pcie);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/047-PCI-aardvark-Fix-reading-PCI_EXP_RTSTA_PME-bit-on-em.patch
+++ b/target/linux/mvebu/patches-5.4/047-PCI-aardvark-Fix-reading-PCI_EXP_RTSTA_PME-bit-on-em.patch
@@ -1,0 +1,49 @@
+From 7071dea9c531d69f594b7cf1714422eda87f0943 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 8 Dec 2021 05:57:54 +0100
+Subject: [PATCH 47/55] PCI: aardvark: Fix reading PCI_EXP_RTSTA_PME bit on
+ emulated bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The emulated bridge returns incorrect value for PCI_EXP_RTSTA register
+during readout in advk_pci_bridge_emul_pcie_conf_read() function: the
+correct bit is BIT(16), but we are setting BIT(23), because the code
+does
+  *value = (isr0 & PCIE_MSG_PM_PME_MASK) << 16
+where
+  PCIE_MSG_PM_PME_MASK
+is
+  BIT(7).
+
+The code should probably have been something like
+  *value = (!!(isr0 & PCIE_MSG_PM_PME_MASK)) << 16,
+but we are better of using an if() and using the proper macro for this
+bit.
+
+Fixes: 8a3ebd8de328 ("PCI: aardvark: Implement emulated root PCI bridge config space")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 4a70439d7ad5..b849edf5d8b6 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -874,7 +874,9 @@ advk_pci_bridge_emul_pcie_conf_read(struct pci_bridge_emul *bridge,
+ 	case PCI_EXP_RTSTA: {
+ 		u32 isr0 = advk_readl(pcie, PCIE_ISR0_REG);
+ 		u32 msglog = advk_readl(pcie, PCIE_MSG_LOG_REG);
+-		*value = (isr0 & PCIE_MSG_PM_PME_MASK) << 16 | (msglog >> 16);
++		*value = msglog >> 16;
++		if (isr0 & PCIE_MSG_PM_PME_MASK)
++			*value |= PCI_EXP_RTSTA_PME;
+ 		return PCI_BRIDGE_EMUL_HANDLED;
+ 	}
+ 
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/048-PCI-aardvark-Optimize-writing-PCI_EXP_RTCTL_PMEIE-an.patch
+++ b/target/linux/mvebu/patches-5.4/048-PCI-aardvark-Optimize-writing-PCI_EXP_RTCTL_PMEIE-an.patch
@@ -1,0 +1,57 @@
+From c7638940ea3d1e646662eab9ff403b14e885faa2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 8 Dec 2021 06:03:50 +0100
+Subject: [PATCH 48/55] PCI: aardvark: Optimize writing PCI_EXP_RTCTL_PMEIE and
+ PCI_EXP_RTSTA_PME on emulated bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To optimize advk_pci_bridge_emul_pcie_conf_write() code, touch
+PCIE_ISR0_REG and PCIE_ISR0_MASK_REG registers only when it is really
+needed, when processing PCI_EXP_RTCTL_PMEIE and PCI_EXP_RTSTA_PME bits.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 20 +++++++++++---------
+ 1 file changed, 11 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index b849edf5d8b6..de21f3b1f958 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -933,19 +933,21 @@ advk_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 			advk_pcie_wait_for_retrain(pcie);
+ 		break;
+ 
+-	case PCI_EXP_RTCTL: {
++	case PCI_EXP_RTCTL:
+ 		/* Only mask/unmask PME interrupt */
+-		u32 val = advk_readl(pcie, PCIE_ISR0_MASK_REG) &
+-			~PCIE_MSG_PM_PME_MASK;
+-		if ((new & PCI_EXP_RTCTL_PMEIE) == 0)
+-			val |= PCIE_MSG_PM_PME_MASK;
+-		advk_writel(pcie, val, PCIE_ISR0_MASK_REG);
++		if (mask & PCI_EXP_RTCTL_PMEIE) {
++			u32 val = advk_readl(pcie, PCIE_ISR0_MASK_REG);
++			if (new & PCI_EXP_RTCTL_PMEIE)
++				val &= ~PCIE_MSG_PM_PME_MASK;
++			else
++				val |= PCIE_MSG_PM_PME_MASK;
++			advk_writel(pcie, val, PCIE_ISR0_MASK_REG);
++		}
+ 		break;
+-	}
+ 
+ 	case PCI_EXP_RTSTA:
+-		new = (new & PCI_EXP_RTSTA_PME) >> 9;
+-		advk_writel(pcie, new, PCIE_ISR0_REG);
++		if (new & PCI_EXP_RTSTA_PME)
++			advk_writel(pcie, PCIE_MSG_PM_PME_MASK, PCIE_ISR0_REG);
+ 		break;
+ 
+ 	case PCI_EXP_DEVCTL:
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/049-PCI-aardvark-Add-support-for-PME-interrupts.patch
+++ b/target/linux/mvebu/patches-5.4/049-PCI-aardvark-Add-support-for-PME-interrupts.patch
@@ -1,0 +1,54 @@
+From 6cca65db6228c7b317bc7f8470132a9d42a3864d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Wed, 8 Dec 2021 06:07:44 +0100
+Subject: [PATCH 49/55] PCI: aardvark: Add support for PME interrupts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently enabling PCI_EXP_RTSTA_PME bit in PCI_EXP_RTCTL register does
+nothing. This is because PCIe PME driver expects to receive PCIe interrupt
+defined in PCI_EXP_FLAGS_IRQ register, but aardvark hardware does not
+trigger PCIe INTx/MSI interrupt for PME event, rather it triggers custom
+aardvark interrupt which this driver is not processing yet.
+
+Fix this issue by handling PME interrupt in advk_pcie_handle_int() and
+chaining it to PCIe interrupt 0 with generic_handle_domain_irq() (since
+aardvark sets PCI_EXP_FLAGS_IRQ to zero). With this change PCIe PME driver
+finally starts receiving PME interrupt.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index de21f3b1f958..243faab52f6c 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1490,6 +1490,21 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
+ 	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
+ 
++	/* Process PME interrupt */
++	if (isr0_status & PCIE_MSG_PM_PME_MASK) {
++		/*
++		 * Do not clear PME interrupt bit in ISR0, it is cleared by IRQ
++		 * receiver by writing to the PCI_EXP_RTSTA register of emulated
++		 * root bridge. Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ,
++		 * so use PCIe interrupt 0.
++		 */
++		virq = irq_find_mapping(pcie->irq_domain, 0);
++		if (virq)
++			generic_handle_irq(virq);
++		else
++			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
++	}
++
+ 	/* Process ERR interrupt */
+ 	if (isr0_status & PCIE_ISR0_ERR_MASK) {
+ 		advk_writel(pcie, PCIE_ISR0_ERR_MASK, PCIE_ISR0_REG);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/050-PCI-aardvark-Fix-support-for-PME-requester-on-emulat.patch
+++ b/target/linux/mvebu/patches-5.4/050-PCI-aardvark-Fix-support-for-PME-requester-on-emulat.patch
@@ -1,0 +1,181 @@
+From eb5daf7d03c26b8342a0b6107faa524744fd6874 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Fri, 19 Feb 2021 14:22:22 +0100
+Subject: [PATCH 50/55] PCI: aardvark: Fix support for PME requester on
+ emulated bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enable aardvark PME interrupt unconditionally by unmasking it and read PME
+requester ID to emulated bridge config space immediately after receiving
+interrupt.
+
+PME requester ID is stored in the PCIE_MSG_LOG_REG register, which contains
+the last inbound message. So when new inbound message is received by HW
+(including non-PM), the content in PCIE_MSG_LOG_REG register is replaced by
+a new value.
+
+PCIe specification mandates that subsequent PMEs are kept pending until the
+PME Status Register bit is cleared by software by writing a 1b.
+
+Support for masking/unmasking PME interrupt on emulated bridge via
+PCI_EXP_RTCTL_PMEIE bit is now implemented only in emulated bridge config
+space, to ensure that we do not miss any aardvark PME interrupt.
+
+Reading of PCI_EXP_RTCAP and PCI_EXP_RTSTA registers is simplified as final
+value is now always stored into emulated bridge config space by the
+interrupt handler, so there is no need to implement support for these
+registers in read_pcie callback.
+
+Clearing of W1C bit PCI_EXP_RTSTA_PME is now also simplified as it is done
+by pci-bridge-emul.c code for emulated bridge config space. So there is no
+need to implement support for clearing this bit in write_pcie callback.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 97 +++++++++++++++------------
+ 1 file changed, 53 insertions(+), 44 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 243faab52f6c..4e1d08dc751a 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -597,6 +597,11 @@ static void advk_pcie_setup_hw(struct advk_pcie *pcie)
+ 	reg &= ~PCIE_ISR0_MSI_INT_PENDING;
+ 	advk_writel(pcie, reg, PCIE_ISR0_MASK_REG);
+ 
++	/* Unmask PME interrupt for processing of PME requester */
++	reg = advk_readl(pcie, PCIE_ISR0_MASK_REG);
++	reg &= ~PCIE_MSG_PM_PME_MASK;
++	advk_writel(pcie, reg, PCIE_ISR0_MASK_REG);
++
+ 	/* Enable summary interrupt for GIC SPI source */
+ 	reg = PCIE_IRQ_ALL_MASK & (~PCIE_IRQ_ENABLE_INTS_MASK);
+ 	advk_writel(pcie, reg, HOST_CTRL_INT_MASK_REG);
+@@ -863,22 +868,11 @@ advk_pci_bridge_emul_pcie_conf_read(struct pci_bridge_emul *bridge,
+ 		*value = PCI_EXP_SLTSTA_PDS << 16;
+ 		return PCI_BRIDGE_EMUL_HANDLED;
+ 
+-	case PCI_EXP_RTCTL: {
+-		u32 val = advk_readl(pcie, PCIE_ISR0_MASK_REG);
+-		*value = (val & PCIE_MSG_PM_PME_MASK) ? 0 : PCI_EXP_RTCTL_PMEIE;
+-		*value |= le16_to_cpu(bridge->pcie_conf.rootctl) & PCI_EXP_RTCTL_CRSSVE;
+-		*value |= PCI_EXP_RTCAP_CRSVIS << 16;
+-		return PCI_BRIDGE_EMUL_HANDLED;
+-	}
+-
+-	case PCI_EXP_RTSTA: {
+-		u32 isr0 = advk_readl(pcie, PCIE_ISR0_REG);
+-		u32 msglog = advk_readl(pcie, PCIE_MSG_LOG_REG);
+-		*value = msglog >> 16;
+-		if (isr0 & PCIE_MSG_PM_PME_MASK)
+-			*value |= PCI_EXP_RTSTA_PME;
+-		return PCI_BRIDGE_EMUL_HANDLED;
+-	}
++	/*
++	 * PCI_EXP_RTCTL and PCI_EXP_RTSTA are also supported, but do not need
++	 * to be handled here, because their values are stored in emulated
++	 * config space buffer, and we read them from there when needed.
++	 */
+ 
+ 	case PCI_EXP_LNKCAP: {
+ 		u32 val = advk_readl(pcie, PCIE_CORE_PCIEXP_CAP + reg);
+@@ -933,22 +927,19 @@ advk_pci_bridge_emul_pcie_conf_write(struct pci_bridge_emul *bridge,
+ 			advk_pcie_wait_for_retrain(pcie);
+ 		break;
+ 
+-	case PCI_EXP_RTCTL:
+-		/* Only mask/unmask PME interrupt */
+-		if (mask & PCI_EXP_RTCTL_PMEIE) {
+-			u32 val = advk_readl(pcie, PCIE_ISR0_MASK_REG);
+-			if (new & PCI_EXP_RTCTL_PMEIE)
+-				val &= ~PCIE_MSG_PM_PME_MASK;
+-			else
+-				val |= PCIE_MSG_PM_PME_MASK;
+-			advk_writel(pcie, val, PCIE_ISR0_MASK_REG);
+-		}
++	case PCI_EXP_RTCTL: {
++		u16 rootctl = le16_to_cpu(bridge->pcie_conf.rootctl);
++		/* Only emulation of PMEIE and CRSSVE bits is provided */
++		rootctl &= PCI_EXP_RTCTL_PMEIE | PCI_EXP_RTCTL_CRSSVE;
++		bridge->pcie_conf.rootctl = cpu_to_le16(rootctl);
+ 		break;
++	}
+ 
+-	case PCI_EXP_RTSTA:
+-		if (new & PCI_EXP_RTSTA_PME)
+-			advk_writel(pcie, PCIE_MSG_PM_PME_MASK, PCIE_ISR0_REG);
+-		break;
++	/*
++	 * PCI_EXP_RTSTA is also supported, but does not need to be handled
++	 * here, because its value is stored in emulated config space buffer,
++	 * and we write it there when needed.
++	 */
+ 
+ 	case PCI_EXP_DEVCTL:
+ 	case PCI_EXP_DEVCTL2:
+@@ -1450,6 +1441,35 @@ static void advk_pcie_remove_irq_domain(struct advk_pcie *pcie)
+ 	irq_domain_remove(pcie->irq_domain);
+ }
+ 
++static void advk_pcie_handle_pme(struct advk_pcie *pcie)
++{
++	u32 requester = advk_readl(pcie, PCIE_MSG_LOG_REG) >> 16;
++	int virq;
++
++	advk_writel(pcie, PCIE_MSG_PM_PME_MASK, PCIE_ISR0_REG);
++
++	/*
++	 * PCIE_MSG_LOG_REG contains the last inbound message, so store
++	 * the requester ID only when PME was not asserted yet.
++	 * Also do not trigger PME interrupt when PME is still asserted.
++	 */
++	if (!(le32_to_cpu(pcie->bridge.pcie_conf.rootsta) & PCI_EXP_RTSTA_PME)) {
++		pcie->bridge.pcie_conf.rootsta = cpu_to_le32(requester | PCI_EXP_RTSTA_PME);
++
++		/*
++		 * Trigger PME interrupt only if PMEIE bit in Root Control is set.
++		 * Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ, so use PCIe interrupt 0.
++		 */
++		if (le16_to_cpu(pcie->bridge.pcie_conf.rootctl) & PCI_EXP_RTCTL_PMEIE) {
++			virq = irq_find_mapping(pcie->irq_domain, 0);
++			if (virq)
++				generic_handle_irq(virq);
++			else
++				dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
++		}
++	}
++}
++
+ static void advk_pcie_handle_msi(struct advk_pcie *pcie)
+ {
+ 	u32 msi_val, msi_mask, msi_status, msi_idx;
+@@ -1490,20 +1510,9 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 	isr1_mask = advk_readl(pcie, PCIE_ISR1_MASK_REG);
+ 	isr1_status = isr1_val & ((~isr1_mask) & PCIE_ISR1_ALL_MASK);
+ 
+-	/* Process PME interrupt */
+-	if (isr0_status & PCIE_MSG_PM_PME_MASK) {
+-		/*
+-		 * Do not clear PME interrupt bit in ISR0, it is cleared by IRQ
+-		 * receiver by writing to the PCI_EXP_RTSTA register of emulated
+-		 * root bridge. Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ,
+-		 * so use PCIe interrupt 0.
+-		 */
+-		virq = irq_find_mapping(pcie->irq_domain, 0);
+-		if (virq)
+-			generic_handle_irq(virq);
+-		else
+-			dev_err_ratelimited(&pcie->pdev->dev, "unhandled PME IRQ\n");
+-	}
++	/* Process PME interrupt as the first one to do not miss PME requester id */
++	if (isr0_status & PCIE_MSG_PM_PME_MASK)
++		advk_pcie_handle_pme(pcie);
+ 
+ 	/* Process ERR interrupt */
+ 	if (isr0_status & PCIE_ISR0_ERR_MASK) {
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/051-PCI-aardvark-Use-separate-INTA-interrupt-for-emulate.patch
+++ b/target/linux/mvebu/patches-5.4/051-PCI-aardvark-Use-separate-INTA-interrupt-for-emulate.patch
@@ -1,0 +1,160 @@
+From 53a78de7e7cefad412f343b9d9f3d828cb237faf Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 1 Apr 2021 20:12:48 +0200
+Subject: [PATCH 51/55] PCI: aardvark: Use separate INTA interrupt for emulated
+ root bridge
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Emulated root bridge currently provides only one Legacy INTA interrupt
+which is used for reporting PCIe PME and ERR events and handled by kernel
+PCIe PME and AER drivers.
+
+Aardvark HW reports these PME and ERR events separately, so there is no
+need to mix real INTA interrupt and emulated INTA interrupt for PCIe PME
+and AER drivers.
+
+Register a new advk-EMU irq chip and a new irq domain for emulated root
+bridge and use this new separate irq domain for providing INTA interrupt
+from emulated root bridge for PME and ERR events.
+
+The real INTA interrupt from real devices is now separate.
+
+A custom map_irq callback function on PCI host bridge structure is used to
+allocate IRQ mapping for emulated root bridge from new irq domain. Original
+callback of_irq_parse_and_map_pci() is used for all other devices as before.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 66 +++++++++++++++++++++++++--
+ 1 file changed, 63 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 4e1d08dc751a..b1bc07ed898d 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -282,6 +282,8 @@ struct advk_pcie {
+ 	} wins[OB_WIN_COUNT];
+ 	u8 wins_count;
+ 	int irq;
++	struct irq_domain *emul_irq_domain;
++	struct irq_chip emul_irq_chip;
+ 	struct irq_domain *irq_domain;
+ 	struct irq_chip irq_chip;
+ 	raw_spinlock_t irq_lock;
+@@ -1441,6 +1443,40 @@ static void advk_pcie_remove_irq_domain(struct advk_pcie *pcie)
+ 	irq_domain_remove(pcie->irq_domain);
+ }
+ 
++static int advk_pcie_emul_irq_map(struct irq_domain *h,
++				  unsigned int virq, irq_hw_number_t hwirq)
++{
++	struct advk_pcie *pcie = h->host_data;
++
++	irq_set_chip_and_handler(virq, &pcie->emul_irq_chip, handle_simple_irq);
++	irq_set_chip_data(virq, pcie);
++
++	return 0;
++}
++
++static const struct irq_domain_ops advk_pcie_emul_irq_domain_ops = {
++	.map = advk_pcie_emul_irq_map,
++	.xlate = irq_domain_xlate_onecell,
++};
++
++static int advk_pcie_init_emul_irq_domain(struct advk_pcie *pcie)
++{
++	pcie->emul_irq_chip.name = "advk-EMU";
++	pcie->emul_irq_domain = irq_domain_add_linear(NULL, 1,
++				&advk_pcie_emul_irq_domain_ops, pcie);
++	if (!pcie->emul_irq_domain) {
++		dev_err(&pcie->pdev->dev, "Failed to add emul IRQ domain\n");
++		return -ENOMEM;
++	}
++
++	return 0;
++}
++
++static void advk_pcie_remove_emul_irq_domain(struct advk_pcie *pcie)
++{
++	irq_domain_remove(pcie->emul_irq_domain);
++}
++
+ static void advk_pcie_handle_pme(struct advk_pcie *pcie)
+ {
+ 	u32 requester = advk_readl(pcie, PCIE_MSG_LOG_REG) >> 16;
+@@ -1461,7 +1497,7 @@ static void advk_pcie_handle_pme(struct advk_pcie *pcie)
+ 		 * Aardvark HW returns zero for PCI_EXP_FLAGS_IRQ, so use PCIe interrupt 0.
+ 		 */
+ 		if (le16_to_cpu(pcie->bridge.pcie_conf.rootctl) & PCI_EXP_RTCTL_PMEIE) {
+-			virq = irq_find_mapping(pcie->irq_domain, 0);
++			virq = irq_find_mapping(pcie->emul_irq_domain, 0);
+ 			if (virq)
+ 				generic_handle_irq(virq);
+ 			else
+@@ -1522,7 +1558,7 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 		 * Aardvark HW returns zero for PCI_ERR_ROOT_AER_IRQ, so use
+ 		 * PCIe interrupt 0
+ 		 */
+-		virq = irq_find_mapping(pcie->irq_domain, 0);
++		virq = irq_find_mapping(pcie->emul_irq_domain, 0);
+ 		if (virq)
+ 			generic_handle_irq(virq);
+ 		else
+@@ -1568,6 +1604,21 @@ static void advk_pcie_irq_handler(struct irq_desc *desc)
+ 	chained_irq_exit(chip, desc);
+ }
+ 
++static int advk_pcie_map_irq(const struct pci_dev *dev, u8 slot, u8 pin)
++{
++	struct advk_pcie *pcie = dev->bus->sysdata;
++
++	/*
++	 * Emulated root bridge has its own emulated irq chip and irq domain.
++	 * Argument pin is the INTx pin (1=INTA, 2=INTB, 3=INTC, 4=INTD) and
++	 * hwirq for irq_create_mapping() is indexed from zero.
++	 */
++	if (dev->bus->number == pcie->root_bus_nr)
++		return irq_create_mapping(pcie->emul_irq_domain, pin - 1);
++	else
++		return of_irq_parse_and_map_pci(dev, slot, pin);
++}
++
+ static int advk_pcie_parse_request_of_pci_ranges(struct advk_pcie *pcie)
+ {
+ 	int err, res_valid = 0;
+@@ -1830,6 +1881,14 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 		return ret;
+ 	}
+ 
++	ret = advk_pcie_init_emul_irq_domain(pcie);
++	if (ret) {
++		dev_err(dev, "Failed to initialize irq\n");
++		advk_pcie_remove_msi_irq_domain(pcie);
++		advk_pcie_remove_irq_domain(pcie);
++		return ret;
++	}
++
+ 	irq_set_chained_handler_and_data(pcie->irq, advk_pcie_irq_handler, pcie);
+ 
+ 	list_splice_init(&pcie->resources, &bridge->windows);
+@@ -1837,12 +1896,13 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 	bridge->sysdata = pcie;
+ 	bridge->busnr = 0;
+ 	bridge->ops = &advk_pcie_ops;
+-	bridge->map_irq = of_irq_parse_and_map_pci;
++	bridge->map_irq = advk_pcie_map_irq;
+ 	bridge->swizzle_irq = pci_common_swizzle;
+ 
+ 	ret = pci_host_probe(bridge);
+ 	if (ret < 0) {
+ 		irq_set_chained_handler_and_data(pcie->irq, NULL, NULL);
++		advk_pcie_remove_emul_irq_domain(pcie);
+ 		advk_pcie_remove_msi_irq_domain(pcie);
+ 		advk_pcie_remove_irq_domain(pcie);
+ 		return ret;
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/052-PCI-aardvark-Check-return-value-of-generic_handle_ir.patch
+++ b/target/linux/mvebu/patches-5.4/052-PCI-aardvark-Check-return-value-of-generic_handle_ir.patch
@@ -1,0 +1,36 @@
+From da82d9f11ac75aa6ff4358bc97c237f787a59be0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 18 Mar 2021 17:04:32 +0100
+Subject: [PATCH 52/55] PCI: aardvark: Check return value of
+ generic_handle_irq() when processing INTx IRQ
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is possible that we receive spurious INTx interrupt. Check for the
+return value of generic_handle_irq() when processing INTx IRQ.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index b1bc07ed898d..5dd8afee31be 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1578,7 +1578,9 @@ static void advk_pcie_handle_int(struct advk_pcie *pcie)
+ 			    PCIE_ISR1_REG);
+ 
+ 		virq = irq_find_mapping(pcie->irq_domain, i);
+-		generic_handle_irq(virq);
++		if (generic_handle_irq(virq) == -EINVAL)
++			dev_err_ratelimited(&pcie->pdev->dev, "unexpected INT%c IRQ\n",
++					    (char)i + 'A');
+ 	}
+ }
+ 
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/053-PCI-aardvark-Remove-irq_mask_ack-callback-for-INTx-i.patch
+++ b/target/linux/mvebu/patches-5.4/053-PCI-aardvark-Remove-irq_mask_ack-callback-for-INTx-i.patch
@@ -1,0 +1,34 @@
+From dbbad46fa24a90cfb41a950abb4fdc7be40556ac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 1 Apr 2021 14:24:12 +0200
+Subject: [PATCH 53/55] PCI: aardvark: Remove irq_mask_ack callback for INTx
+ interrupts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Callback for irq_mask_ack is the same as for irq_mask. As there is no
+special handling for irq_ack, there is no need to define irq_mask_ack too.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Acked-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 5dd8afee31be..f973a108c454 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1421,7 +1421,6 @@ static int advk_pcie_init_irq_domain(struct advk_pcie *pcie)
+ 	}
+ 
+ 	irq_chip->irq_mask = advk_pcie_irq_mask;
+-	irq_chip->irq_mask_ack = advk_pcie_irq_mask;
+ 	irq_chip->irq_unmask = advk_pcie_irq_unmask;
+ 
+ 	pcie->irq_domain =
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/054-PCI-aardvark-Don-t-mask-irq-when-mapping.patch
+++ b/target/linux/mvebu/patches-5.4/054-PCI-aardvark-Don-t-mask-irq-when-mapping.patch
@@ -1,0 +1,32 @@
+From a44e47991829a47f189e338e5064d7f379b0eb6a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Thu, 1 Apr 2021 14:30:06 +0200
+Subject: [PATCH 54/55] PCI: aardvark: Don't mask irq when mapping
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+By default, all Legacy INTx interrupts are masked, so there is no need to
+mask this interrupt during irq_map callback.
+
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index f973a108c454..1200434eb88c 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1330,7 +1330,6 @@ static int advk_pcie_irq_map(struct irq_domain *h,
+ {
+ 	struct advk_pcie *pcie = h->host_data;
+ 
+-	advk_pcie_irq_mask(irq_get_irq_data(virq));
+ 	irq_set_status_flags(virq, IRQ_LEVEL);
+ 	irq_set_chip_and_handler(virq, &pcie->irq_chip,
+ 				 handle_level_irq);
+-- 
+2.34.1
+

--- a/target/linux/mvebu/patches-5.4/055-PCI-aardvark-Fix-checking-for-MEM-resource-type.patch
+++ b/target/linux/mvebu/patches-5.4/055-PCI-aardvark-Fix-checking-for-MEM-resource-type.patch
@@ -1,0 +1,45 @@
+From cb3382d1970c9a7f18484ff6b375783717f5ce64 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pali=20Roh=C3=A1r?= <pali@kernel.org>
+Date: Sat, 6 Nov 2021 15:17:47 +0100
+Subject: [PATCH 55/55] PCI: aardvark: Fix checking for MEM resource type
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+IORESOURCE_MEM_64 is not type but type flag. Remove incorrect check for
+type IORESOURCE_MEM_64.
+
+Fixes: 64f160e19e92 ("PCI: aardvark: Configure PCIe resources from 'ranges' DT property")
+Signed-off-by: Pali Rohár <pali@kernel.org>
+Signed-off-by: Marek Behún <kabel@kernel.org>
+---
+ drivers/pci/controller/pci-aardvark.c | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/pci/controller/pci-aardvark.c b/drivers/pci/controller/pci-aardvark.c
+index 1200434eb88c..a6c842d75fe9 100644
+--- a/drivers/pci/controller/pci-aardvark.c
++++ b/drivers/pci/controller/pci-aardvark.c
+@@ -1772,8 +1772,7 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 		 * only PIO for issuing configuration transfers which does
+ 		 * not use PCIe window configuration.
+ 		 */
+-		if (type != IORESOURCE_MEM && type != IORESOURCE_MEM_64 &&
+-		    type != IORESOURCE_IO)
++		if (type != IORESOURCE_MEM && type != IORESOURCE_IO)
+ 			continue;
+ 
+ 		/*
+@@ -1781,8 +1780,7 @@ static int advk_pcie_probe(struct platform_device *pdev)
+ 		 * configuration is set to transparent memory access so it
+ 		 * does not need window configuration.
+ 		 */
+-		if ((type == IORESOURCE_MEM || type == IORESOURCE_MEM_64) &&
+-		    entry->offset == 0)
++		if (type == IORESOURCE_MEM && entry->offset == 0)
+ 			continue;
+ 
+ 		/*
+-- 
+2.34.1
+


### PR DESCRIPTION
Backport pci-aardvark patches fixing MSI and adding MSI-X support.

This makes it possible for drivers to use MSI interrupts, which means
that it also enables supporting NVMe drives.

Most of these patches come from
  https://lore.kernel.org/linux-pci/20211208061851.31867-1-kabel@kernel.org/
some from
  https://lore.kernel.org/linux-pci/20211203195244.11ca183f@thinkpad/
(with fixes that are commented there already).

They are not yet merged in upstream kernel, but are waiting for review.

_Patch for openwrt master branch is a WIP_