### PR TITLE
hostapd: add measurement report value for beacon reports

### DIFF
--- a/package/network/services/hostapd/src/src/ap/ubus.c
+++ b/package/network/services/hostapd/src/src/ap/ubus.c
@@ -2019,6 +2019,7 @@ void hostapd_ubus_notify_beacon_report(
 	blobmsg_add_macaddr(&b, "bssid", rep->bssid);
 	blobmsg_add_u16(&b, "antenna-id", rep->antenna_id);
 	blobmsg_add_u16(&b, "parent-tsf", rep->parent_tsf);
+	blobmsg_add_u16(&b, "rep-mode", rep_mode);
 
 	ubus_notify(ctx, &hapd->ubus.obj, "beacon-report", b.head, -1);
 }


### PR DESCRIPTION
Add the measurement report value to the beacon reports send via ubus. It
is possible to derive from the measurement report if a station refused to
do a beacon report and why. It is important to know why a station refuses
to do a beacon-report. In particular, we should not request a beacon
report from a station again that refused a beacon-report before.

The rejection reasons can be found by looking at the bits defined by:
- MEASUREMENT_REPORT_MODE_ACCEPT
- MEASUREMENT_REPORT_MODE_REJECT_LATE
- MEASUREMENT_REPORT_MODE_REJECT_INCAPABLE
- MEASUREMENT_REPORT_MODE_REJECT_REFUSED