### PR TITLE
lantiq: replace patches with version accepted upstream

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -488,8 +488,6 @@
 			interrupt-names = "tx", "rx";
 			resets = <&reset0 21 16>, <&reset0 8 8>, <&reset0 3 3>;
 			reset-names = "switch", "ppe", "ppe_dsp";
-			lantiq,tx-burst-length = <8>;
-			lantiq,rx-burst-length = <8>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 

--- a/target/linux/lantiq/patches-5.10/0310-v5.16-MIPS-lantiq-dma-make-the-burst-length-configurable-b.patch
+++ b/target/linux/lantiq/patches-5.10/0310-v5.16-MIPS-lantiq-dma-make-the-burst-length-configurable-b.patch
@@ -1,12 +1,14 @@
-From 6615eeb39f7a110a196f20acbfb3a017da4d75d2 Mon Sep 17 00:00:00 2001
+From 49293bbc50cb7d44223eb49e0f7cb38e7dac2361 Mon Sep 17 00:00:00 2001
 From: Aleksander Jan Bajkowski <olek2@wp.pl>
-Date: Fri, 14 May 2021 21:25:08 +0200
-Subject: [PATCH 4/5] MIPS: lantiq: dma: make a burst length configurable in
- drivers
+Date: Tue, 14 Sep 2021 23:21:01 +0200
+Subject: [PATCH 4/5] MIPS: lantiq: dma: make the burst length configurable by
+ the drivers
 
-Make a burst length configurable in drivers.
+Make the burst length configurable by the drivers.
 
 Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Acked-by: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: David S. Miller <davem@davemloft.net>
 ---
  .../include/asm/mach-lantiq/xway/xway_dma.h   |  2 +-
  arch/mips/lantiq/xway/dma.c                   | 38 ++++++++++++++++---

--- a/target/linux/lantiq/patches-5.10/0710-v5.16-net-lantiq-configure-the-burst-length-in-ethernet-dr.patch
+++ b/target/linux/lantiq/patches-5.10/0710-v5.16-net-lantiq-configure-the-burst-length-in-ethernet-dr.patch
@@ -1,11 +1,12 @@
-From ec1a17a11aced3cd756e59d91ad6f50b7a2fabfb Mon Sep 17 00:00:00 2001
+From 14d4e308e0aa0b78dc7a059716861a4380de3535 Mon Sep 17 00:00:00 2001
 From: Aleksander Jan Bajkowski <olek2@wp.pl>
-Date: Sun, 16 May 2021 15:52:06 +0200
-Subject: [PATCH 5/5] net: lantiq: configure burst length for ethernet
+Date: Tue, 14 Sep 2021 23:21:02 +0200
+Subject: [PATCH 5/5] net: lantiq: configure the burst length in ethernet
+ drivers
 
-Configure the burst length for Ethernet. This improves Ethernet
-performance by 58%. According to the vendor BSP, 8W burst length
-is supported by ar9 and newer SoCs.
+Configure the burst length in Ethernet drivers. This improves
+Ethernet performance by 58%. According to the vendor BSP,
+8W burst length is supported by ar9 and newer SoCs.
 
 The NAT benchmark results on xRX200 (Down/Up):
 * 2W: 330 Mb/s
@@ -15,6 +16,7 @@ The NAT benchmark results on xRX200 (Down/Up):
 Tested on xRX200 and xRX330.
 
 Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: David S. Miller <davem@davemloft.net>
 ---
  drivers/net/ethernet/lantiq_etop.c   | 21 ++++++++++++++++++---
  drivers/net/ethernet/lantiq_xrx200.c | 21 ++++++++++++++++++---
@@ -37,7 +39,7 @@ Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
  	int err;
  
 -	ltq_dma_init_port(DMA_PORT_ETOP);
-+	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, priv->rx_burst_len);
++	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, rx_burst_len);
  
  	priv->txch.dma.nr = tx;
  	priv->txch.dma.dev = &priv->pdev->dev;
@@ -99,7 +101,7 @@ Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
  	int i;
  
 -	ltq_dma_init_port(DMA_PORT_ETOP);
-+	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, priv->rx_burst_len);
++	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, rx_burst_len);
  
  	ch_rx->dma.nr = XRX200_DMA_RX;
  	ch_rx->dma.dev = priv->dev;

--- a/target/linux/lantiq/patches-5.10/0711-v5.16-net-lantiq_xrx200-Hardcode-the-burst-length-value.patch
+++ b/target/linux/lantiq/patches-5.10/0711-v5.16-net-lantiq_xrx200-Hardcode-the-burst-length-value.patch
@@ -1,0 +1,73 @@
+From 7e553c44f09a8f536090904c6db5b8c9dbafa03b Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Tue, 26 Oct 2021 22:59:01 +0200
+Subject: [PATCH] net: lantiq_xrx200: Hardcode the burst length value
+
+All SoCs with this IP core support 8 burst length. Hauke
+suggested to hardcode this value and simplify the driver.
+
+Link: https://lkml.org/lkml/2021/9/14/1533
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 21 ++++-----------------
+ 1 file changed, 4 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -23,6 +23,7 @@
+ #define XRX200_DMA_DATA_LEN	0x600
+ #define XRX200_DMA_RX		0
+ #define XRX200_DMA_TX		1
++#define XRX200_DMA_BURST_LEN	8
+ 
+ /* cpu port mac */
+ #define PMAC_RX_IPG		0x0024
+@@ -71,9 +72,6 @@ struct xrx200_priv {
+ 	struct net_device *net_dev;
+ 	struct device *dev;
+ 
+-	int tx_burst_len;
+-	int rx_burst_len;
+-
+ 	__iomem void *pmac_reg;
+ };
+ 
+@@ -320,7 +318,7 @@ static netdev_tx_t xrx200_start_xmit(str
+ 		goto err_drop;
+ 
+ 	/* dma needs to start on a burst length value aligned address */
+-	byte_offset = mapping % (priv->tx_burst_len * 4);
++	byte_offset = mapping % (XRX200_DMA_BURST_LEN * 4);
+ 
+ 	desc->addr = mapping - byte_offset;
+ 	/* Make sure the address is written before we give it to HW */
+@@ -372,7 +370,8 @@ static int xrx200_dma_init(struct xrx200
+ 	int ret = 0;
+ 	int i;
+ 
+-	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, rx_burst_len);
++	ltq_dma_init_port(DMA_PORT_ETOP, XRX200_DMA_BURST_LEN,
++			  XRX200_DMA_BURST_LEN);
+ 
+ 	ch_rx->dma.nr = XRX200_DMA_RX;
+ 	ch_rx->dma.dev = priv->dev;
+@@ -490,18 +489,6 @@ static int xrx200_probe(struct platform_
+ 	if (err)
+ 		eth_hw_addr_random(net_dev);
+ 
+-	err = device_property_read_u32(dev, "lantiq,tx-burst-length", &priv->tx_burst_len);
+-	if (err < 0) {
+-		dev_err(dev, "unable to read tx-burst-length property\n");
+-		return err;
+-	}
+-
+-	err = device_property_read_u32(dev, "lantiq,rx-burst-length", &priv->rx_burst_len);
+-	if (err < 0) {
+-		dev_err(dev, "unable to read rx-burst-length property\n");
+-		return err;
+-	}
+-
+ 	/* bring up the dma engine and IP core */
+ 	err = xrx200_dma_init(priv);
+ 	if (err)

--- a/target/linux/lantiq/patches-5.10/0712-v5.16-net-ethernet-lantiq_etop-Fix-compilation-error.patch
+++ b/target/linux/lantiq/patches-5.10/0712-v5.16-net-ethernet-lantiq_etop-Fix-compilation-error.patch
@@ -1,0 +1,26 @@
+From 68eabc348148ae051631e8dab13c3b1a85c82896 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Tue, 9 Nov 2021 23:23:54 +0100
+Subject: [PATCH] net: ethernet: lantiq_etop: Fix compilation error
+
+This fixes the error detected when compiling the driver.
+
+Fixes: 14d4e308e0aa ("net: lantiq: configure the burst length in ethernet drivers")
+Reported-by: kernel test robot <lkp@intel.com>
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/lantiq_etop.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/lantiq_etop.c
++++ b/drivers/net/ethernet/lantiq_etop.c
+@@ -402,7 +402,7 @@ ltq_etop_dma_init(struct net_device *dev
+ 	int rx = priv->rx_irq - LTQ_DMA_ETOP;
+ 	int err;
+ 
+-	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, rx_burst_len);
++	ltq_dma_init_port(DMA_PORT_ETOP, priv->tx_burst_len, priv->rx_burst_len);
+ 
+ 	priv->txch.dma.nr = tx;
+ 	priv->txch.dma.dev = &priv->pdev->dev;


### PR DESCRIPTION
Replace recently added patches with version accepted upstream. It also avoids conflicts when backporting subsequent patches that add jumbo frame support (https://github.com/openwrt/openwrt/pull/4353). 

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
