### PR TITLE
ramips: Add support command fw_setsys for Xiaomi routers

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -38,10 +38,7 @@ buffalo,wsr-1166dhp|\
 buffalo,wsr-600dhp|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
-xiaomi,mi-router-3g-v2|\
-xiaomi,mi-router-4a-gigabit|\
 xiaomi,mi-router-4c|\
-xiaomi,miwifi-3c|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626|\
 zte,mf283plus)
@@ -63,13 +60,22 @@ linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 linksys,ea8100-v1|\
 linksys,ea8100-v2|\
-mts,wg430223|\
+mts,wg430223)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	;;
+xiaomi,mi-router-3g-v2|\
+xiaomi,mi-router-4a-gigabit|\
+xiaomi,miwifi-3c)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x4000" "0x10000"
+	;;
 xiaomi,mi-router-3g|\
 xiaomi,mi-router-3-pro|\
 xiaomi,mi-router-4|\
 xiaomi,mi-router-ac2100|\
 xiaomi,redmi-router-ac2100)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x4000" "0x20000"
 	;;
 zyxel,nr7101)
 	idx="$(find_mtd_index Config)"


### PR DESCRIPTION
The system parameters are contained in the `Bdata` partition.
To use the `fw_setsys` command, you need to create a file `fw_sys.config`. This file is created after calling the functions `ubootenv_add_uci_sys_config` and `ubootenv_add_app_config`.
