### PR TITLE
[21.02] ustream-ssl: variants conflict with each other

### DIFF
--- a/package/libs/ustream-ssl/Makefile
+++ b/package/libs/ustream-ssl/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ustream-ssl
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ustream-ssl.git
@@ -37,6 +37,7 @@ define Package/libustream-wolfssl
   $(Package/libustream/default)
   TITLE += (wolfssl)
   DEPENDS += +PACKAGE_libustream-wolfssl:libwolfssl
+  CONFLICTS := libustream-openssl
   VARIANT:=wolfssl
 endef
 
@@ -44,6 +45,7 @@ define Package/libustream-mbedtls
   $(Package/libustream/default)
   TITLE += (mbedtls)
   DEPENDS += +libmbedtls
+  CONFLICTS := libustream-openssl libustream-wolfssl
   VARIANT:=mbedtls
   DEFAULT_VARIANT:=1
 endef


### PR DESCRIPTION
Backported PR: https://github.com/openwrt/openwrt/pull/4296

Commit message:

```
This adds conflicts between variants of libustream pacakge.
They provide the same file and thus it should not be possible to install
them side by side.
```

My test case on target bcm2711 running OpenWrt 21.02.1:
```
root@OpenWrt:~# opkg list-installed | grep libustream
libustream-wolfssl20201210 - 2020-12-10-68d09243-1
root@OpenWrt:~# opkg install libustream-mbedtls
Installing libustream-mbedtls20201210 (2020-12-10-68d09243-1) to root...
Downloading https://downloads.openwrt.org/releases/21.02.1/packages/aarch64_cortex-a72/base/libustream-mbedtls20201210_2020-12-10-68d09243-1_aarch64_cortex-a72.ipk
Installing libmbedtls12 (2.16.11-1) to root...
Downloading https://downloads.openwrt.org/releases/21.02.1/packages/aarch64_cortex-a72/base/libmbedtls12_2.16.11-1_aarch64_cortex-a72.ipk
Configuring libmbedtls12.
Collected errors:
 * check_data_file_clashes: Package libustream-mbedtls20201210 wants to install file /lib/libustream-ssl.so
	But that file is already provided by package  * libustream-wolfssl20201210
 * opkg_install_cmd: Cannot install package libustream-mbedtls.
root@OpenWrt:~# opkg install libustream-openssl
Installing libustream-openssl20201210 (2020-12-10-68d09243-1) to root...
Downloading https://downloads.openwrt.org/releases/21.02.1/packages/aarch64_cortex-a72/base/libustream-openssl20201210_2020-12-10-68d09243-1_aarch64_cortex-a72.ipk
Installing libopenssl1.1 (1.1.1m-1) to root...
Downloading https://downloads.openwrt.org/releases/21.02.1/packages/aarch64_cortex-a72/base/libopenssl1.1_1.1.1m-1_aarch64_cortex-a72.ipk
Configuring libopenssl1.1.
Collected errors:
 * check_data_file_clashes: Package libustream-openssl20201210 wants to install file /lib/libustream-ssl.so
	But that file is already provided by package  * libustream-wolfssl20201210
 * opkg_install_cmd: Cannot install package libustream-openssl.
root@OpenWrt:~# opkg install libustream-openssl --force-overwrite
Installing libustream-openssl20201210 (2020-12-10-68d09243-1) to root...
Downloading https://downloads.openwrt.org/releases/21.02.1/packages/aarch64_cortex-a72/base/libustream-openssl20201210_2020-12-10-68d09243-1_aarch64_cortex-a72.ipk
Configuring libustream-openssl20201210.
```

Conclusion:
- It was possible to install ``libustream-openssl`` and ``libustream-wolfssl`` side by side by using ``--force-overwrite``
```
root@OpenWrt:~# opkg list-installed | grep libustream
libustream-openssl20201210 - 2020-12-10-68d09243-1
libustream-wolfssl20201210 - 2020-12-10-68d09243-1
```

It happens also on OpenWrt 19.07. Should I send pull request?

I tested the fix on Turris Omnia running on OpenWrt master:
```
root@turris:/# opkg list-installed | grep libustream
libustream-openssl - 2020-12-10-68d09243-2
root@turris:/# opkg install libustream-mbedtls
Installing libustream-mbedtls (2020-12-10-68d09243-2) to root...
Collected errors:
 * check_conflicts_for: The following packages conflict with libustream-mbedtls:
 * check_conflicts_for: 	libustream-openssl * 
 * opkg_install_cmd: Cannot install package libustream-mbedtls.
root@turris:/# opkg install libustream-mbedtls --force-overwrite
 * check_conflicts_for: The following packages conflict with libustream-wolfssl:
 * check_conflicts_for: 	libustream-openssl * 
 * opkg_install_cmd: Cannot install package libustream-wolfssl.
root@turris:/# opkg install libustream-wolfssl --force-overwrite
Installing libustream-wolfssl (2020-12-10-68d09243-2) to root...
Collected errors:
 * check_conflicts_for: The following packages conflict with libustream-wolfssl:
 * check_conflicts_for: 	libustream-openssl * 
 * opkg_install_cmd: Cannot install package libustream-wolfssl.
Installing libustream-mbedtls (2020-12-10-68d09243-2) to root...
Collected errors:
 * check_conflicts_for: The following packages conflict with libustream-mbedtls:
 * check_conflicts_for: 	libustream-openssl * 
 * opkg_install_cmd: Cannot install package libustream-mbedtls.
```