### PR TITLE
mtd-utils: update to 2.1.4

### DIFF
--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mtd-utils
-PKG_VERSION:=2.1.2
+PKG_VERSION:=2.1.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=ftp://ftp.infradead.org/pub/mtd-utils/
-PKG_HASH:=8ad4c5f34716d40646aa28724a2f5616d325a6f119254f914e26976f1f76e9d6
+PKG_SOURCE_URL:=https://infraroot.at/pub/mtd/
+PKG_HASH:=2c6711d15d282c47cb3867b6857340597e26d332c238465134c602e5eef71b99
 
 PKG_INSTALL:=1
 PKG_FIXUP:=autoreconf

--- a/package/utils/mtd-utils/patches/130-lzma_jffs2.patch
+++ b/package/utils/mtd-utils/patches/130-lzma_jffs2.patch
@@ -1,6 +1,6 @@
 --- a/jffsX-utils/Makemodule.am
 +++ b/jffsX-utils/Makemodule.am
-@@ -4,11 +4,19 @@ mkfs_jffs2_SOURCES = \
+@@ -4,7 +4,10 @@ mkfs_jffs2_SOURCES = \
  	jffsX-utils/compr_zlib.c \
  	jffsX-utils/compr.h \
  	jffsX-utils/rbtree.c \
@@ -10,7 +10,12 @@
 +	jffsX-utils/lzma/LzmaEnc.c \
 +	jffsX-utils/lzma/LzmaDec.c \
  	jffsX-utils/compr.c \
- 	jffsX-utils/compr_rtime.c
+ 	jffsX-utils/compr_rtime.c \
+ 	jffsX-utils/compr.h \
+@@ -12,8 +15,13 @@ mkfs_jffs2_SOURCES = \
+ 	jffsX-utils/summary.h \
+ 	include/linux/jffs2.h \
+ 	include/mtd/jffs2-user.h
 +
 +if !WITHOUT_LZO
 +mkfs_jffs2_SOURCES += jffsX-utils/compr_lzo.c
@@ -20,7 +25,7 @@
 -mkfs_jffs2_CPPFLAGS = $(AM_CPPFLAGS) $(ZLIB_CFLAGS) $(LZO_CFLAGS)
 +mkfs_jffs2_CPPFLAGS = $(AM_CPPFLAGS) $(ZLIB_CFLAGS) $(LZO_CFLAGS) -I./include/linux/lzma
  
- jffs2reader_SOURCES = jffsX-utils/jffs2reader.c
+ jffs2reader_SOURCES = jffsX-utils/jffs2reader.c	include/mtd/jffs2-user.h
  jffs2reader_LDADD = libmtd.a $(ZLIB_LIBS) $(LZO_LIBS)
 --- a/jffsX-utils/compr.c
 +++ b/jffsX-utils/compr.c


### PR DESCRIPTION
Changes from 2.1.3 to 2.1.4:

Features:
      - ubiscan debugging and statistics utility

Fixes:
      - Some mtd-tests erroneously using sub-pages instead of the full page size
      - Buffer overrun in fectest
      - Missing jffs2 kernel header in the last release, leading to build
        failures on some systems.

Changes from 2.1.2 to 2.1.3:

Features:
       flashcp: Add new function that copy only different blocks
       flash_erase: Add flash erase chip
       Add flash_otp_erase
       Add an ubifs mount helper
       Add nandflipbits tool

Fixes:
       mkfs.ubifs: Fix runtime assertions when running without crypto
       mtd-utils: Use AC_SYS_LARGEFILE
       Fix test binary installation
       libmtd: avoid divide by zero
       ubihealthd: fix UBIFS build dependency
       mkfs.ubifs: remove OPENSSL_no_config()
       misc-utils: Add fectest to build system
       mkfs.ubifs: Fix build with SELinux
       Fix typos found by Debian's lintian tool
       Fix jffs2 build if zlib or lzo headers are not in default paths

Signed-off-by: Nick Hainke <vincent@systemli.org>
