### PR TITLE
add new kernel driver i2c-mux-pinctrl, pinctrl-based I2C multiplexer

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -185,6 +185,20 @@ endef
 
 $(eval $(call KernelPackage,i2c-mux-gpio))
 
+I2C_MUX_PINCTRL_MODULES:= \
+  CONFIG_I2C_MUX_PINCTRL:drivers/i2c/muxes/i2c-mux-pinctrl
+
+define KernelPackage/i2c-mux-pinctrl
+  $(call i2c_defaults,$(I2C_MUX_PINCTRL_MODULES),51)
+  TITLE:=pinctrl-based I2C multiplexer
+  DEPENDS:=+kmod-i2c-mux
+endef
+
+define KernelPackage/i2c-mux-pinctrl/description
+ Kernel modules for GENERIC_PINCTRL I2C bus mux/switching devices
+endef
+
+$(eval $(call KernelPackage,i2c-mux-pinctrl))
 
 I2C_MUX_PCA9541_MODULES:= \
   CONFIG_I2C_MUX_PCA9541:drivers/i2c/muxes/i2c-mux-pca9541


### PR DESCRIPTION
In kernel 5.4 there are new drivers, you need i2c-mux-pinctr for raspberry pi cm4 to enable the RTC on the IO board.

The sample for config.txt is:

dtoverlay=dwc2,dr_mode=host
dtparam=i2c_vc=on

If necessary, I can add all i2c drivers that are new there and test the compilation.

Signed-off-by: Jörg Schüler-Maroldt <joerg-linux@arcor.de>
