### PR TITLE
ramips: fix tplink re200v3 led assignments for Power and Wifi (red)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re200-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200-v3.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7628an_tplink_re200.dtsi"
+#include "mt7628an_tplink_re200v3.dtsi"
 
 / {
 	compatible = "tplink,re200-v3", "mediatek,mt7628an-soc";

--- a/target/linux/ramips/dts/mt7628an_tplink_re200v3.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200v3.dtsi
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		label-mac-device = &ethernet;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_red {
+			label = "red:wifi";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g_green {
+			label = "green:wifi2g";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g_green {
+			label = "green:wifi5g";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0x7a0000>;
+			};
+
+			config: partition@7c0000 {
+				label = "config";
+				reg = <0x7c0000 0x30000>;
+				read-only;
+			};
+
+			radio: partition@7f0000 {
+				label = "radio";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "p4led_an", "p3led_an", "p2led_an", "p1led_an",
+				"p0led_an", "wled_an", "i2c", "wdt", "refclk";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config_2008>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&radio 0x0>;
+
+	nvmem-cells = <&macaddr_config_2008>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&macaddr_config_2008>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <2>;
+	};
+};
+
+&config {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_config_2008: macaddr@2008 {
+		reg = <0x2008 0x6>;
+	};
+};


### PR DESCRIPTION
Power Led was not assigned correctly with mt7628an_tplink_re200.dtsi for V3 and V4. Same for Wifi (red)

Signed-off-by: Richard Fröhning <misanthropos@gmx.de>
