### PR TITLE
iptables: enable nftable support by default

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
 PKG_VERSION:=1.8.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
@@ -60,7 +60,7 @@ define Package/iptables/config
 
   config IPTABLES_NFTABLES
 	bool "Enable Nftables support"
-	default n
+	default y
 	help
 		This enable nftables support in iptables.
 endef


### PR DESCRIPTION
OpenWrt plans to move over to firewall4 which uses nftables under the
hood. To allow a smooth migration the package `iptables-nft` offer a
transparent wrapper to apply iptables rules to nftables.

Without the config option for nftables the package isn't installed and
therefore can't be tested. This commit enabled it and therefore provides
the wrapper.

The size of the iptables package increases from 25436 to 26500 Bytes.

Signed-off-by: Paul Spooren <mail@aparcar.org>

CC: @stintel @jow- 