### PR TITLE
rampis: cleanup code formatting for ea6350-v4

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -913,11 +913,11 @@ define Device/linksys_ea7xxx
 endef
 
 define Device/linksys_ea6350-v4
-	$(Device/linksys_ea7xxx)
-	DEVICE_MODEL := EA6350
-	DEVICE_VARIANT := v4
-	LINKSYS_HWNAME := EA6350
-	DEVICE_PACKAGES += kmod-mt7603 kmod-mt7663-firmware-ap
+  $(Device/linksys_ea7xxx)
+  DEVICE_MODEL := EA6350
+  DEVICE_VARIANT := v4
+  LINKSYS_HWNAME := EA6350
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += linksys_ea6350-v4
 


### PR DESCRIPTION
Replace tabs with spaces in target/linux/ramips/image/mt7621.mk as
requested.

Signed-off-by: Nick McKinney <nick@ndmckinney.net>
