### PR TITLE
ramips: fix mt76x8 network script alphabetic sort

### DIFF
--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -97,6 +97,13 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "0:wan" "6@eth0"
 		;;
+	joowin,jw-wr758ac-v1|\
+	joowin,jw-wr758ac-v2|\
+	tplink,tl-wr902ac-v3|\
+	wavlink,wl-wn576a2)
+		ucidef_add_switch "switch0" \
+			"4:lan" "6@eth0"
+		;;
 	jotale,js76x8-8m|\
 	jotale,js76x8-16m|\
 	jotale,js76x8-32m)
@@ -128,13 +135,6 @@ ramips_setup_interfaces()
 	tplink,tl-mr6400-v5)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
-		;;
-	joowin,jw-wr758ac-v1|\
-	joowin,jw-wr758ac-v2|\
-	tplink,tl-wr902ac-v3|\
-	wavlink,wl-wn576a2)
-		ucidef_add_switch "switch0" \
-			"4:lan" "6@eth0"
 		;;
 	vocore,vocore2|\
 	vocore,vocore2-lite)


### PR DESCRIPTION
When support for Joowin WR758AC V1 and V2 was added in 766733e17226221a310a30c91927a79f07a456e5, the corresponding block with the case condition on the network initialization script for mt76x8 devices was left alphabetically unsorted. 

Fix this by moving that block to the correct place.