### PR TITLE
at91: drop /etc/config/firewall

### DIFF
--- a/target/linux/at91/base-files/etc/config/firewall
+++ b/target/linux/at91/base-files/etc/config/firewall
@@ -1,6 +1,0 @@
-config defaults
-	option syn_flood	1
-	option input		ACCEPT
-	option output		ACCEPT 
-	option forward		REJECT
-


### PR DESCRIPTION
The file can't be part of base files or the base-files and firewall
packages collide. Two packages must not provide the same config files
without having a defined CONFLICT since it would result in an
undeterministic config state depending on what package is installed
last.

Signed-off-by: Paul Spooren <mail@aparcar.org>