### PR TITLE
ramips: correct vendor name for COMFAST/Joowin

### DIFF
--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_comfast_cf-wr758ac.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr758ac-v1", "mediatek,mt7628an-soc";
+	model = "COMFAST CF-WR758AC V1";
+};

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac-v2.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_comfast_cf-wr758ac.dtsi"
+
+/ {
+	compatible = "comfast,cf-wr758ac-v2", "mediatek,mt7628an-soc";
+	model = "COMFAST CF-WR758AC V2";
+};

--- a/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
+++ b/target/linux/ramips/dts/mt7628an_comfast_cf-wr758ac.dtsi
@@ -6,7 +6,7 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "joowin,jw-wr758ac", "mediatek,mt7628an-soc";
+	compatible = "comfast,cf-wr758ac", "mediatek,mt7628an-soc";
 
 	keys {
 		compatible = "gpio-keys";

--- a/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v1.dts
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
-
-#include "mt7628an_joowin_jw-wr758ac.dtsi"
-
-/ {
-	compatible = "joowin,jw-wr758ac-v1", "mediatek,mt7628an-soc";
-	model = "Joowin WR758AC V1";
-};

--- a/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_joowin_jw-wr758ac-v2.dts
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
-
-#include "mt7628an_joowin_jw-wr758ac.dtsi"
-
-/ {
-	compatible = "joowin,jw-wr758ac-v2", "mediatek,mt7628an-soc";
-	model = "Joowin WR758AC V2";
-};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -79,6 +79,32 @@ define Device/buffalo_wcr-1166ds
 endef
 TARGET_DEVICES += buffalo_wcr-1166ds
 
+define Device/comfast_cf-wr758ac
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-WR758AC
+  DEVICE_ALT0_VENDOR := Joowin
+  DEVICE_ALT0_MODEL := JW-WR758AC
+endef
+
+define Device/comfast_cf-wr758ac-v1
+  $(Device/comfast_cf-wr758ac)
+  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_VARIANT := V1
+  DEVICE_ALT0_VARIANT := V1
+  SUPPORTED_DEVICES += joowin,jw-wr758ac-v1
+endef
+TARGET_DEVICES += comfast_cf-wr758ac-v1
+
+define Device/comfast_cf-wr758ac-v2
+  $(Device/comfast_cf-wr758ac)
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  DEVICE_VARIANT := V2
+  DEVICE_ALT0_VARIANT := V2
+  SUPPORTED_DEVICES += joowin,jw-wr758ac-v2
+endef
+TARGET_DEVICES += comfast_cf-wr758ac-v2
+
 define Device/cudy_wr1000
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin
@@ -219,26 +245,6 @@ define Device/iptime_a604m
   DEVICE_PACKAGES := kmod-mt76x2
 endef
 TARGET_DEVICES += iptime_a604m
-
-define Device/joowin_jw-wr758ac
-  IMAGE_SIZE := 7872k
-  DEVICE_VENDOR := Joowin
-  DEVICE_MODEL := WR758AC
-endef
-
-define Device/joowin_jw-wr758ac-v1
-  $(Device/joowin_jw-wr758ac)
-  DEVICE_PACKAGES := kmod-mt76x2
-  DEVICE_VARIANT := V1
-endef
-TARGET_DEVICES += joowin_jw-wr758ac-v1
-
-define Device/joowin_jw-wr758ac-v2
-  $(Device/joowin_jw-wr758ac)
-  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
-  DEVICE_VARIANT := V2
-endef
-TARGET_DEVICES += joowin_jw-wr758ac-v2
 
 define Device/jotale_js76x8
   DEVICE_VENDOR := Jotale

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -53,6 +53,13 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
 		;;
+	comfast,cf-wr758ac-v1|\
+	comfast,cf-wr758ac-v2|\
+	tplink,tl-wr902ac-v3|\
+	wavlink,wl-wn576a2)
+		ucidef_add_switch "switch0" \
+			"4:lan" "6@eth0"
+		;;
 	cudy,wr1000)
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
@@ -128,13 +135,6 @@ ramips_setup_interfaces()
 	tplink,tl-mr6400-v5)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
-		;;
-	joowin,jw-wr758ac-v1|\
-	joowin,jw-wr758ac-v2|\
-	tplink,tl-wr902ac-v3|\
-	wavlink,wl-wn576a2)
-		ucidef_add_switch "switch0" \
-			"4:lan" "6@eth0"
 		;;
 	vocore,vocore2|\
 	vocore,vocore2-lite)


### PR DESCRIPTION
When Joowin WR758AC V1 and V2 devices were added, they should have been
added with the primary manufacturer name which is Comfast, since Joowin
is just an alternate vendor name on some coutries or stores.

Correct the vendor name on all files and set Joowin as ALT0 variants.

As a side effect, fix mt76x8 network script which was left incorrectly
unsorted on the case block conditions.

Fixes: 766733e172 ("ramips: add support for Joowin WR758AC V1 and V2")