### PR TITLE
ath79: patch Asus RP-AC66 clean up and add sysupgrade image

### DIFF
--- a/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
+++ b/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_orange;
 		led-running = &led_power;
 		led-upgrade = &led_orange;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -534,10 +534,6 @@ ath79_setup_macs()
 		lan_mac=$(macaddr_setbit $base_mac 29)
 		[ $lan_mac = $base_mac ] && lan_mac=$(macaddr_unsetbit $base_mac 29)
 		;;
-	asus,rp-ac66)
-		lan_mac=$(mtd_get_mac_binary art 0x1002)
-		label_mac=$lan_mac
-		;;
 	avm,fritz1750e|\
 	avm,fritz450e|\
 	avm,fritzdvbc)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -17,10 +17,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x0) 2)
 		;;
-	avm,fritz1750e|\
-	avm,fritzdvbc)
-		caldata_extract "urlader" 0x198a 0x844
-		;;
 	asus,rp-ac66|\
 	comfast,cf-wr650ac-v1|\
 	comfast,cf-wr650ac-v2|\
@@ -49,6 +45,10 @@ case "$FIRMWARE" in
 	ubnt,unifiac-pro|\
 	yuncore,a770)
 		caldata_extract "art" 0x5000 0x844
+		;;
+	avm,fritz1750e|\
+	avm,fritzdvbc)
+		caldata_extract "urlader" 0x198a 0x844
 		;;
 	devolo,dvl1200e|\
 	devolo,dvl1200i|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -334,6 +334,7 @@ define Device/asus_rp-ac66
   SOC := qca9563
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RP-AC66
+  IMAGE_SIZE := 15488k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs


### PR DESCRIPTION
label-mac-device to dts, clean up 02_network, reorder device in 11-ath10k-caldata and provide sysupgrade.bin 

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
