### PR TITLE
[21.02] ath79: Add support for OpenMesh OM5P-AC v2

### DIFF
--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -7,26 +7,34 @@
 
 / {
 	compatible = "openmesh,om5p-ac-v2", "qca,qca9558";
-	model = "OpenMesh OM5P-AC V2";
+	model = "OpenMesh OM5P-AC v2";
 
-	extosc: ref {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-output-names = "ref";
-		clock-frequency = <40000000>;
+	chosen {
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		serial0 = &uart;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &eth0;
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		power {
-			label = "blue:power";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		};
-
 		wifi_green {
 			label = "green:wifi";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
 		};
 
 		wifi_yellow {
@@ -50,6 +58,32 @@
 		};
 	};
 
+	i2c {
+		compatible = "i2c-gpio";
+		gpios = <&gpio 19 GPIO_ACTIVE_HIGH /* sda */
+			 &gpio 18 GPIO_ACTIVE_HIGH /* scl */
+			>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c-gpio,scl-open-drain;
+		i2c-gpio,sda-open-drain;
+
+		tmp423a@4e {
+			compatible = "ti,tmp423";
+			reg = <0x4e>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+
 	gpio-export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
@@ -69,20 +103,16 @@
 
 &pinmux {
 	pinmux_pa_dcdc_pins {
-		pinctrl-single,bits = <0x0 0xff00 0x0>;
+		pinctrl-single,bits = <0x0 0x0 0xff0000>;
 	};
 
 	pinmux_pa_high_pins {
-		pinctrl-single,bits = <0x10 0xff 0x0>;
+		pinctrl-single,bits = <0x10 0x0 0xff>;
 	};
 };
 
 &pcie0 {
 	status = "okay";
-};
-
-&pll {
-	clocks = <&extosc>;
 };
 
 &spi {
@@ -93,6 +123,7 @@
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
+		/* partitions are passed via bootloader */
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -104,19 +135,29 @@
 				read-only;
 			};
 
-			partition@1 {
+			partition@40000 {
 				label = "u-boot-env";
 				reg = <0x040000 0x010000>;
 			};
 
-			partition@2 {
-				compatible = "denx,uimage";
-				label = "firmware";
+			partition@50000 {
+				label = "custom";
+				reg = <0x050000 0x060000>;
+				read-only;
+			};
+
+			partition@b0000 {
+				label = "inactive";
+				reg = <0x0b0000 0x7a0000>;
+			};
+
+			partition@850000 {
+				label = "inactive2";
 				reg = <0x850000 0x7a0000>;
 			};
 
-			partition@3 {
-				label = "art";
+			art: partition@ff0000 {
+				label = "ART";
 				reg = <0xff0000 0x010000>;
 				read-only;
 			};
@@ -127,18 +168,25 @@
 &mdio0 {
 	status = "okay";
 
+	phy-mask = <0x10>;
+
 	phy4: ethernet-phy@4 {
 		reg = <4>;
-		phy-mode = "rgmii-id";
+		eee-broken-100tx;
+		eee-broken-1000t;
 	};
 };
 
 &mdio1 {
 	status = "okay";
 
+	phy-mask = <0x2>;
+
 	phy1: ethernet-phy@1 {
 		reg = <1>;
-		phy-mode = "sgmii";
+		eee-broken-100tx;
+		eee-broken-1000t;
+		at803x-override-sgmii-link-check;
 	};
 };
 
@@ -147,7 +195,19 @@
 
 	pll-data = <0x82000101 0x80000101 0x80001313>;
 
+	mtd-mac-address = <&art 0x0>;
+
+	phy-mode = "rgmii-id";
 	phy-handle = <&phy4>;
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+		rxd-delay = <2>;
+		rxdv-delay = <2>;
+		txd-delay = <0>;
+		txen-delay = <0>;
+	};
 };
 
 &eth1 {
@@ -155,5 +215,17 @@
 
 	pll-data = <0x03000101 0x80000101 0x80001313>;
 
+	mtd-mac-address = <&art 0x6>;
+
+	qca955x-sgmii-fixup;
+
 	phy-handle = <&phy1>;
+};
+
+&wmac {
+	status = "okay";
+
+	mtd-cal-data = <&art 0x1000>;
+	mtd-mac-address = <&art 0x0>;
+	mac-address-increment = <2>;
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -100,12 +100,9 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(mtd_get_mac_binary art 0xc)
 		;;
 	openmesh,mr1750-v1|\
-	openmesh,mr1750-v2)
-		caldata_extract "ART" 0x5000 0x844
-		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
-		;;
+	openmesh,mr1750-v2|\
 	openmesh,om5p-ac-v2)
-		caldata_extract "art" 0x5000 0x844
+		caldata_extract "ART" 0x5000 0x844
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
 		;;
 	qihoo,c301)

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -78,7 +78,8 @@ platform_do_upgrade() {
 	openmesh,om2p-hs-v3|\
 	openmesh,om2p-hs-v4|\
 	openmesh,om2p-lc|\
-	openmesh,om5p)
+	openmesh,om5p|\
+	openmesh,om5p-ac-v2)
 		PART_NAME="inactive"
 		platform_do_upgrade_openmesh "$1"
 		;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1781,12 +1781,12 @@ endef
 TARGET_DEVICES += openmesh_om5p
 
 define Device/openmesh_om5p-ac-v2
+  $(Device/openmesh_common_64k)
   SOC := qca9558
-  DEVICE_VENDOR := OpenMesh
   DEVICE_MODEL := OM5P-AC
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct om-watchdog
-  IMAGE_SIZE := 7808k
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  OPENMESH_CE_TYPE := OM5PAC
   SUPPORTED_DEVICES += om5p-acv2
 endef
 TARGET_DEVICES += openmesh_om5p-ac-v2


### PR DESCRIPTION
Justification for backport: I am aware that [device support is usually not backported anymore](https://openwrt.org/docs/guide-developer/device-support-policies#device_support_backports). But OpenWrt-21.02 is already shipping (stub) images for the OM5P-AC v2 which are not working as expected. This was also reported by @michaelbilcot in https://github.com/openwrt/openwrt/pull/3720#issuecomment-941148225

So one thing which can be done is to remove the OM5P-AC v2 support completely from OpenWrt 21.02 or the actual support could be added. The latter was chosen in this PR. Adjustments made for this backport are:

* fixed conflicts with (not existing hardware entries) in 11-ath10k-caldata + upgrade/platform.sh
* switched back from nvmem-cells to mtd-mac-address to select the mac addresses via the device tree

These differences can also be checked via

    git range-diff 7e484b902d269d8fd22afeccb765ccc2cd8efa19..1699c1dc7f26b332f868d338457abfbe716d6ba0 cd5ba0cfbbdbefa28ea7734b3a163fa58d509184..7530c80b0bb621f2389bff16d191b572e3ebcf13

----

Device specifications:
======================

* Qualcomm/Atheros QCA9558 ver 1 rev 0
* 720/600/200 MHz (CPU/DDR/AHB)
* 128 MB of RAM
* 16 MB of SPI NOR flash
  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
* 2T2R 2.4 GHz Wi-Fi (11n)
* 2T2R 5 GHz Wi-Fi (11ac)
* 4x GPIO-LEDs (3x wifi, 1x power)
* 1x GPIO-button (reset)
* external h/w watchdog (enabled by default))
* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
* TI tmp423 (package kmod-hwmon-tmp421) for temperature monitoring
* 2x ethernet
  - eth0
    + AR8035 ethernet PHY (RGMII)
    + 10/100/1000 Mbps Ethernet
    + 802.3af POE
    + used as LAN interface
  - eth1
    + AR8031 ethernet PHY (RGMII)
    + 10/100/1000 Mbps Ethernet
    + 18-24V passive POE (mode B)
    + used as WAN interface
* 12-24V 1A DC
* internal antennas

This device support is based on the partially working stub from commit 53c474abbdfe ("ath79: add new OF only target for QCA MIPS silicon").

Flashing instructions:
======================

Various methods can be used to install the actual image on the flash. Two easy ones are:

ap51-flash
----------

The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be used to transfer the image to the u-boot when the device boots up.

initramfs from TFTP
-------------------

The serial console must be used to access the u-boot shell during bootup. It can then be used to first boot up the initramfs image from a TFTP server (here with the IP 192.168.1.21):

     setenv serverip 192.168.1.21
     setenv ipaddr 192.168.1.1
     tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr

The actual sysupgrade image can then be transferred (on the LAN port) to the device via

    scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/

On the device, the sysupgrade must then be started using

    sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
