### PR TITLE
ath79: Add Belkin F9K1119v1

### DIFF
--- a/target/linux/ath79/dts/qca9558_belkin_f9k1119-v1.dts
+++ b/target/linux/ath79/dts/qca9558_belkin_f9k1119-v1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_belkin_f9x-v2.dtsi"
+
+/ {
+	model = "Belkin F9K1119 v1 (AC 1600 DB)";
+	compatible = "belkin,f9k1119-v1", "qca,qca9558";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -139,6 +139,7 @@ ath79_setup_interfaces()
 		;;
 	belkin,f9j1108-v2|\
 	belkin,f9k1115-v2|\
+	belkin,f9k1119-v1|\
 	tplink,archer-c5-v1|\
 	tplink,archer-c7-v1|\
 	tplink,archer-c7-v2|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -450,6 +450,14 @@ define Device/belkin_f9k1115-v2
 endef
 TARGET_DEVICES += belkin_f9k1115-v2
 
+define Device/belkin_f9k1119-v1
+  $(Device/belkin_f9x-v1)
+  DEVICE_MODEL := F9K1119 v1 (AC1600 DB Wi-Fi)
+  EDIMAX_HEADER_MAGIC := eDiMaXsUpEr
+  EDIMAX_HEADER_MODEL := F9K1119V1
+endef
+TARGET_DEVICES += belkin_f9k1119-v1
+
 define Device/buffalo_bhr-4grv
   $(Device/buffalo_common)
   SOC := ar7242


### PR DESCRIPTION
ath79: add support for the Belkin F9K1119 v1 (AC1600 DB Wi-Fi)

This device is identical hardware to the F9K1115 v2 but uses
a different firmware magic and model number.

Specifications:

SoC: QCA9558
CPU: 720 MHz
Flash: 16 MiB NOR
RAM: 128 MiB
WiFi 2.4 GHz: QCA9558-AT4A 3x3 MIMO 802.11b/g/n
WiFi 5 GHz: QCA9880-2R4E 3x3 MIMO 802.11a/n/ac (mini-pcie)
Ethernet: 4x LAN and 1x WAN (all 1Gbit/s ports)
USB: 2 x USB 3.0

Flashing instructions:
The factory.bin should be flashed by the uboot HTTP upgrade page (which is by default listening on 192.168.2.1). Once the factory.bin has been written, sysupgrade.bin will work as usual.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

David Williams (thevolget@gmail.com)