### PR TITLE
ipip: add 'nohostroute' option

### DIFF
--- a/package/network/config/ipip/Makefile
+++ b/package/network/config/ipip/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ipip
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk

--- a/package/network/config/ipip/files/ipip.sh
+++ b/package/network/config/ipip/files/ipip.sh
@@ -12,7 +12,7 @@ proto_ipip_setup() {
 	local remoteip
 
 	local df ipaddr peeraddr tunlink ttl tos zone mtu
-	json_get_vars df ipaddr peeraddr tunlink ttl tos zone mtu
+	json_get_vars df ipaddr peeraddr tunlink ttl tos zone mtu nohostroute
 
 	[ -z "$peeraddr" ] && {
 		proto_notify_error "$cfg" "MISSING_PEER_ADDRESS"
@@ -32,7 +32,9 @@ proto_ipip_setup() {
 		break
 	done
 
-	( proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink" )
+	if [ "${nohostroute}" != "1" ]; then
+		( proto_add_host_dependency "$cfg" "$peeraddr" "$tunlink" )
+	fi
 
 	[ -z "$ipaddr" ] && {
 		local wanif="$tunlink"
@@ -84,6 +86,7 @@ proto_ipip_init_config() {
 	proto_config_add_string "ipaddr"
 	proto_config_add_string "peeraddr"
 	proto_config_add_boolean "df"
+	proto_config_add_boolean "nohostroute"
 }
 
 [ -n "$INCLUDE_ONLY" ] || {


### PR DESCRIPTION
Add the nohostroute option as available for gre and wg tunnels to
allow the user to prevent explicit creation of a route to the peer
address.

tested successfully on ipq806x device

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>