### PR TITLE
base-files: adapt to ntpd changes

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -315,6 +315,7 @@ generate_static_system() {
 		add_list system.ntp.server='1.openwrt.pool.ntp.org'
 		add_list system.ntp.server='2.openwrt.pool.ntp.org'
 		add_list system.ntp.server='3.openwrt.pool.ntp.org'
+		set system.ntp.enable_gpsd='0'
 	EOF
 
 	if json_is_a system object; then


### PR DESCRIPTION
Time synchronization can also be done via gpsd. Until now you have to
patch the init.d-file.

With ("ntpd: add option for enabling gpsd) it is enough to set:
    option enable_gpsd '1'

Depends on: https://github.com/openwrt/packages/pull/17644