### PR TITLE
kernel: add kmod-vrf

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1043,6 +1043,17 @@ if KERNEL_IPV6
 endif
 
 #
+# Miscellaneous network configuration
+#
+
+config KERNEL_NET_L3_MASTER_DEV
+	bool "L3 Master device support"
+	default n
+	help
+	  This module provides glue between core networking code and device
+	  drivers to support L3 master devices like VRF.
+
+#
 # NFS related symbols
 #
 config KERNEL_IP_PNP

--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -564,6 +564,23 @@ endef
 $(eval $(call KernelPackage,veth))
 
 
+define KernelPackage/vrf
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Virtual Routing and Forwarding (Lite)
+  DEPENDS:=@KERNEL_NET_L3_MASTER_DEV
+  KCONFIG:=CONFIG_NET_VRF
+  FILES:=$(LINUX_DIR)/drivers/net/vrf.ko
+  AUTOLOAD:=$(call AutoLoad,30,vrf)
+endef
+
+define KernelPackage/vrf/description
+ This option enables the support for mapping interfaces into VRF's. The
+ support enables VRF devices.
+endef
+
+$(eval $(call KernelPackage,vrf))
+
+
 define KernelPackage/slhc
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   HIDDEN:=1


### PR DESCRIPTION
Add option to compile kmod-vrf, support for Virtual Routing and
Forwarding (Lite).

This module depends on NET_L3_MASTER_DEV, which is a boolean kernel
option, so we need to create a configuration option also for this, and
make kmod-vrf depend on it.

Signed-off-by: Marek Behún <kabel@kernel.org>