### PR TITLE
kernel: modules: make ar8216/8327 modularizable

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -417,6 +417,22 @@ endef
 $(eval $(call KernelPackage,switch-rtl8367b))
 
 
+define KernelPackage/switch-ar8xxx
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Atheros AR8216/8327 switch support
+  DEPENDS:=+kmod-swconfig
+  KCONFIG:=CONFIG_AR8216_PHY
+  FILES:=$(LINUX_DIR)/drivers/net/phy/ar8xxx.ko
+  AUTOLOAD:=$(call AutoLoad,43,ar8xxx,1)
+endef
+
+define KernelPackage/switch-ar8xxx/description
+ Atheros AR8216/8327 switch support
+endef
+
+$(eval $(call KernelPackage,switch-ar8xxx))
+
+
 define KernelPackage/natsemi
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=National Semiconductor DP8381x series

--- a/target/linux/generic/hack-5.10/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-5.10/700-swconfig_switch_drivers.patch
@@ -36,7 +36,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	  Support for FC is very limited.
 +
 +config AR8216_PHY
-+	tristate "Driver for Atheros AR8216 switches"
++	tristate "Driver for Atheros AR8216/8327 switches"
 +	select SWCONFIG
 +	select ETHERNET_PACKET_MANGLE
 +
@@ -95,13 +95,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config AMD_PHY
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
-@@ -24,6 +24,19 @@ libphy-$(CONFIG_LED_TRIGGER_PHY)	+= phy_
+@@ -24,6 +24,21 @@ libphy-$(CONFIG_LED_TRIGGER_PHY)	+= phy_
  obj-$(CONFIG_PHYLINK)		+= phylink.o
  obj-$(CONFIG_PHYLIB)		+= libphy.o
  
 +obj-$(CONFIG_SWCONFIG)		+= swconfig.o
 +obj-$(CONFIG_ADM6996_PHY)	+= adm6996.o
-+obj-$(CONFIG_AR8216_PHY)	+= ar8216.o ar8327.o
++obj-$(CONFIG_AR8216_PHY)	+= ar8xxx.o
++ar8xxx-y			+= ar8216.o
++ar8xxx-y			+= ar8327.o
 +obj-$(CONFIG_SWCONFIG_B53)	+= b53/
 +obj-$(CONFIG_IP17XX_PHY)	+= ip17xx.o
 +obj-$(CONFIG_PSB6970_PHY)	+= psb6970.o

--- a/target/linux/generic/hack-5.15/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-5.15/700-swconfig_switch_drivers.patch
@@ -36,8 +36,9 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	  Support for FC is very limited.
 +
 +config AR8216_PHY
-+	tristate "Driver for Atheros AR8216 switches"
++	tristate "Driver for Atheros AR8216/8327 switches"
 +	select SWCONFIG
++	select ETHERNET_PACKET_MANGLE
 +
 +config AR8216_PHY_LEDS
 +	bool "Atheros AR8216 switch LED support"
@@ -52,7 +53,6 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +config PSB6970_PHY
 +	tristate "Lantiq XWAY Tantos (PSB6970) Ethernet switch"
 +	select SWCONFIG
-+	select ETHERNET_PACKET_MANGLE
 +
 +config RTL8306_PHY
 +	tristate "Driver for Realtek RTL8306S switches"
@@ -95,13 +95,15 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  config AMD_PHY
 --- a/drivers/net/phy/Makefile
 +++ b/drivers/net/phy/Makefile
-@@ -24,6 +24,19 @@ libphy-$(CONFIG_LED_TRIGGER_PHY)	+= phy_
+@@ -24,6 +24,21 @@ libphy-$(CONFIG_LED_TRIGGER_PHY)	+= phy_
  obj-$(CONFIG_PHYLINK)		+= phylink.o
  obj-$(CONFIG_PHYLIB)		+= libphy.o
  
 +obj-$(CONFIG_SWCONFIG)		+= swconfig.o
 +obj-$(CONFIG_ADM6996_PHY)	+= adm6996.o
-+obj-$(CONFIG_AR8216_PHY)	+= ar8216.o ar8327.o
++obj-$(CONFIG_AR8216_PHY)	+= ar8xxx.o
++ar8xxx-y			+= ar8216.o
++ar8xxx-y			+= ar8327.o
 +obj-$(CONFIG_SWCONFIG_B53)	+= b53/
 +obj-$(CONFIG_IP17XX_PHY)	+= ip17xx.o
 +obj-$(CONFIG_PSB6970_PHY)	+= psb6970.o


### PR DESCRIPTION
This is required to permit an easier transition for the ath79 target to DSA.
Current swconfig driver and swconfig in general is not compatible with DSA due to how it does work.
Currently the driver scan every mdio and try to find one that match hid phy id. Problem is that this can't be stopped in every way possible as no compatible is used. At best it will cause massive delay (the timeout is 10 second for each mdio and we have at least 4) and at worst swconfig gets loaded before DSA and nothing work.

Considering how large ath79 is, it seems impossible to covert every device to DSA. We already used a script to convert most of them but many are untested/doesn't work that well. To at least start the DSA conversion, fix the ar8216 driver to correctly build as a module so that device can optionally include the swconfig module.

The idea is to compile DSA driver by default and include the swconfig module for the required devices. Optionally we can consider creating also modules for the DSA part.  This should permit the existence of both swconfig and DSA driver on one target without tweaking the swconfig driver to correctly include a compatible and probe only with the presence of that.

https://github.com/openwrt/openwrt/pull/4622 @neheb can you take a look at this and test if all works correctly?

Make ar8216/8327 swconfig driver modularizable and add
entry to the netdevices.mk kernel modules file.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>