### PR TITLE
bcm27xx: update distroconfig.txt for faster RPi4

### DIFF
--- a/target/linux/bcm27xx/image/distroconfig.txt
+++ b/target/linux/bcm27xx/image/distroconfig.txt
@@ -12,3 +12,5 @@ dtoverlay=disable-bt
 dtoverlay=disable-bt
 [pi4]
 dtoverlay=disable-bt
+# Run as fast as firmware / board allows
+arm_boost=1


### PR DESCRIPTION
Newer RPi 4 Rev 6 (8 GB models and recent 2 GB / 4 GB models) ship with the so-called C0 processor which can run turbo mode at 1.8 GHz max rather than 1.5 GHz gracefully.  Add 'arm_boost=1' to pi4 section of to enable.

Note that this setting has no effect on older chips; they continue with their 1.5 GHz max unless users overclock them.

Ref: https://www.raspberrypi.com/news/bullseye-bonus-1-8ghz-raspberry-pi-4

Signed-off-by: John Audia <graysky@archlinux.us>