### PR TITLE
ramips:  Add support for Dlink DIR-878 R1 version

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-r1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_dlink_dir-8xx-r1.dtsi"
+
+/ {
+	compatible = "dlink,dir-878-r1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-878 R1";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -375,6 +375,15 @@ define Device/dlink_dir-878-a1
 endef
 TARGET_DEVICES += dlink_dir-878-a1
 
+define Device/dlink_dir-878-r1
+  $(Device/dlink_dir-8xx-r1)
+  DEVICE_MODEL := DIR-878
+  DEVICE_VARIANT := R1
+  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  IMAGE/factory.bin := append-kernel | append-rootfs | check-size 
+endef
+
+TARGET_DEVICES += dlink_dir-878-r1
 define Device/dlink_dir-882-a1
   $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-882


### PR DESCRIPTION
This device has identical HW as DIR-878 A1, and has a flash map
As DIR-882 R1, which both are already supported.
Removed the DIR-882 R1 signature from the DIR-878 R1 as it did not help.
Method to upload the FW to 878 R1 will be updated in the device's wiki
page
Signed-off-by: lior-pugatch <buzz5800@gmail.com>