### PR TITLE
ath79: ASUS RP-AC66 use flash till the end

### DIFF
--- a/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
+++ b/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
@@ -125,7 +125,7 @@
 			partition@60000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x060000 0xf20000>;
+				reg = <0x060000 0xfa0000>;
 			};
 		};
 	};

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -334,7 +334,7 @@ define Device/asus_rp-ac66
   SOC := qca9563
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RP-AC66
-  IMAGE_SIZE := 15488k
+  IMAGE_SIZE := 16000k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs


### PR DESCRIPTION
This makes available the additional space,
which was occupied by OEM's jffs2 partition before:
"0x000000f80000-0x000001000000 : jffs2"

Reverting to the OEM firmware will also recover
this partition, i.e. it is not needed and can be
used by OpenWrt.

Signed-off-by: Tamas Balogh <tamasbalogh@hotmail.com>
