### PR TITLE
ath79: improve support for GL.iNet GL-XE300

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
@@ -143,12 +143,12 @@
 
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &eth1 {
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
 };
 
 &wmac {

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -14,6 +14,10 @@ glinet,gl-ar300m-nand|\
 glinet,gl-ar300m-nor)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	;;
+glinet,gl-xe300)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x10"
+	;;
 netgear,r6100)
 	ucidef_set_led_netdev "wan-green" "WAN (green)" "green:wan" "eth1"
 	;;

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -25,6 +25,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:2" "3:lan:1" "1:wan"
 		;;
+	glinet,gl-xe300)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "4:lan"
+		;;
 	netgear,r6100)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
- fix eth0 eth1 sharing same mac so it conforms to the behavior stated
  in the original commit and the way it is in vendor firmware :
  WAN is label, LAN is label +1 and WLAN is label +2
- add default leds config
- add default network config

Signed-off-by: Pascal Coudurier <coudu@wanadoo.fr>