### PR TITLE
CI: add formal checks

### DIFF
--- a/.github/workflows/ci_helpers.sh
+++ b/.github/workflows/ci_helpers.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+color_out() {
+	printf "\e[0;$1m%s\e[0;0m\n" "$2"
+}
+
+success() {
+	color_out 32 "$1"
+}
+
+info() {
+	color_out 36 "$1"
+}
+
+err() {
+	color_out 31 "$1"
+}
+
+warn() {
+	color_out 33 "$1"
+}
+
+err_die() {
+	err "$1"
+	exit 1
+}

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -1,0 +1,70 @@
+name: Test Formalities
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Test Formalities
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Determine branch name
+        run: |
+          BRANCH="${GITHUB_BASE_REF#refs/heads/}"
+          echo "Building for $BRANCH"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Test formalities
+        run: |
+          source .github/workflows/ci_helpers.sh
+
+          RET=0
+          for commit in $(git rev-list HEAD ^origin/$BRANCH); do
+            info "=== Checking commit '$commit'"
+            if git show --format='%P' -s $commit | grep -qF ' '; then
+              err "Pull request should not include merge commits"
+              RET=1
+            fi
+
+            author="$(git show -s --format=%aN $commit)"
+            if echo $author | grep -q '\S\+\s\+\S\+'; then
+              success "Author name ($author) seems ok"
+            else
+              err "Author name ($author) need to be your real name 'firstname lastname'"
+              RET=1
+            fi
+
+            subject="$(git show -s --format=%s $commit)"
+            if echo "$subject" | grep -q -e '^[0-9A-Za-z,+/_-]\+: ' -e '^Revert '; then
+              success "Commit subject line seems ok ($subject)"
+            else
+              err "Commit subject line MUST start with '<area>: ' ($subject)"
+              RET=1
+            fi
+
+            body="$(git show -s --format=%b $commit)"
+            sob="$(git show -s --format='Signed-off-by: %aN <%aE>' $commit)"
+            if echo "$body" | grep -qF "$sob"; then
+              success "Signed-off-by match author"
+            else
+              err "Signed-off-by is missing or doesn't match author (should be '$sob')"
+              RET=1
+            fi
+
+            if echo "$body" | grep -v "Signed-off-by:"; then
+              success "A commit message exists"
+            else
+              err "Missing commit message. Please describe your changes"
+              RET=1
+            fi
+          done
+
+          exit $RET


### PR DESCRIPTION
The formal checks verify the following things:
-  Commits does not contain any merge commits
- Signed by a real name
- Commit titles starts with an `<area>:`
- Author name matches signed of name

Signed-off-by: Paul Spooren <mail@aparcar.org>