### PR TITLE
README: add clang-12+ dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ the [Build System Setup](https://openwrt.org/docs/guide-developer/build-system/i
 documentation.
 
 ```
-binutils bzip2 diff find flex gawk gcc-6+ getopt grep install libc-dev libz-dev
-make4.1+ perl python3.6+ rsync subversion unzip which
+binutils bzip2 clang-12+ diff find flex gawk gcc-6+ getopt grep install libc-dev
+libz-dev make4.1+ perl python3.6+ rsync subversion unzip which
 ```
 
 ### Quickstart


### PR DESCRIPTION
package/kernel/bpf-headers requires clang 12+ so add it to README
It is required after commit 0ac0840088d538981a0df573bf58899e3ee9dbf7

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>