### PR TITLE
toolchaini/gcc: fix libstdc++ dual abi model

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -115,7 +115,7 @@ GCC_CONFIGURE:= \
 		--disable-decimal-float \
 		--with-diagnostics-color=auto-if-env \
 		--enable-__cxa_atexit \
-		--disable-libstdcxx-dual-abi \
+		--enable-libstdcxx-dual-abi \
 		--with-default-libstdcxx-abi=new
 ifneq ($(CONFIG_mips)$(CONFIG_mipsel),)
   GCC_CONFIGURE += --with-mips-plt


### PR DESCRIPTION
Hello to all.

Parameter "with-default-libstdcxx-abi=new" must be set for parameter "enable-libstdcxx-dual-abi" to work.

Info:
[dual abi](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html)

Signed-off-by: Ivan Maslov <avenger_msoft@mail.ru>