### PR TITLE
build: fix ldconfig symlink on macos

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -198,4 +198,4 @@ prereq: $(STAGING_DIR_HOST)/bin/mkhash
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \
-	$(LN) /bin/true $(STAGING_DIR_HOST)/bin/ldconfig))
+	$(LN) $(if $(findstring Darwin,$(HOST_OS)),/usr/bin/true,/bin/true) $(STAGING_DIR_HOST)/bin/ldconfig))


### PR DESCRIPTION
/bin/true does not exist on macos, but macos has /usr/bin/true.
This patch uses /usr/bin/true if HOST_OS is Darwin (macos)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>