### PR TITLE
meson and zstd update

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -98,7 +98,7 @@ define Host/Configure/Meson
 		--native-file $(HOST_BUILD_DIR)/openwrt-native.txt \
 		$(MESON_HOST_ARGS) \
 		$(MESON_HOST_BUILD_DIR) \
-		$(HOST_BUILD_DIR), \
+		$(MESON_HOST_BUILD_DIR)/.., \
 		$(MESON_HOST_VARS))
 endef
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -74,7 +74,7 @@ $(curdir)/sdcc/compile := $(curdir)/bison/compile
 $(curdir)/squashfs/compile := $(curdir)/lzma-old/compile
 $(curdir)/squashfskit4/compile := $(curdir)/xz/compile $(curdir)/zlib/compile
 $(curdir)/zlib/compile := $(curdir)/cmake/compile
-$(curdir)/zstd/compile := $(curdir)/cmake/compile
+$(curdir)/zstd/compile := $(curdir)/meson/compile
 
 ifneq ($(HOST_OS),Linux)
   $(curdir)/squashfskit4/compile += $(curdir)/coreutils/compile

--- a/tools/zstd/Makefile
+++ b/tools/zstd/Makefile
@@ -1,25 +1,35 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zstd
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.5.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/facebook/zstd/releases/download/v$(PKG_VERSION)
-PKG_HASH:=5194fbfa781fcf45b98c5e849651aa7b3b0a008c6b72d4a0db760f3002291e94
+PKG_HASH:=7c42d56fac126929a6a85dbc73ff1db2411d04f104fae9bdea51305663a83fd0
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 PKG_CPE_ID:=cpe:/a:facebook:zstandard
 
-CMAKE_SOURCE_SUBDIR:=build/cmake
-
 include $(INCLUDE_DIR)/host-build.mk
-include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/meson.mk
 
-CMAKE_HOST_OPTIONS += \
-	-DBUILD_TESTING=OFF \
-	-DCMAKE_C_COMPILER_LAUNCHER="" \
-	-DCMAKE_C_COMPILER=$(HOSTCC_NOCACHE) \
-	-DZSTD_LEGACY_SUPPORT=OFF
+MESON_HOST_BUILD_DIR:=$(HOST_BUILD_DIR)/build/meson/openwrt-build
+
+HOSTCC:= $(HOSTCC_NOCACHE)
+HOST_LDFLAGS += -Wl,-rpath,$(STAGING_DIR_HOST)/lib
+
+MESON_HOST_ARGS += \
+	-Dlegacy_level=7 \
+	-Ddebug_level=0 \
+	-Dbacktrace=false \
+	-Dstatic_runtime=false \
+	-Dbin_programs=true \
+	-Dbin_tests=false \
+	-Dbin_contrib=false \
+	-Dmulti_thread=enabled \
+	-Dzlib=disabled \
+	-Dlzma=disabled \
+	-Dlz4=disabled
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
The first commit is a bugfix for host meson packages with a non default build directory. Needed by the next.

The second is a zstd update and conversion to build with meson.