### PR TITLE
treewide: unify capitalization of NETGEAR

### DIFF
--- a/target/linux/bcm4908/image/Makefile
+++ b/target/linux/bcm4908/image/Makefile
@@ -87,7 +87,7 @@ endef
 TARGET_DEVICES += asus_gt-ac5300
 
 define Device/netgear_r8000p
-  DEVICE_VENDOR := Netgear
+  DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := R8000P
   DEVICE_DTS := broadcom/bcm4908/bcm4906-netgear-r8000p
   IMAGES := bin

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbr50.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbr50.dts
@@ -3,7 +3,7 @@
 #include "qcom-ipq4019-orbi.dtsi"
 
 / {
-	model = "NETGEAR RBR50";
+	model = "Netgear RBR50";
 	compatible = "netgear,rbr50";
 
 	chosen {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbs50.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-rbs50.dts
@@ -3,7 +3,7 @@
 #include "qcom-ipq4019-orbi.dtsi"
 
 / {
-	model = "NETGEAR RBS50";
+	model = "Netgear RBS50";
 	compatible = "netgear,rbs50";
 
 	chosen {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-srr60.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-srr60.dts
@@ -3,7 +3,7 @@
 #include "qcom-ipq4019-orbi.dtsi"
 
 / {
-	model = "NETGEAR SRR60";
+	model = "Netgear SRR60";
 	compatible = "netgear,srr60";
 
 	chosen {

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-srs60.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4019-srs60.dts
@@ -3,7 +3,7 @@
 #include "qcom-ipq4019-orbi.dtsi"
 
 / {
-	model = "NETGEAR SRS60";
+	model = "Netgear SRS60";
 	compatible = "netgear,srs60";
 
 	chosen {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -784,7 +784,7 @@ TARGET_DEVICES += netgear_srs60
 define Device/netgear_wac510
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
-	DEVICE_VENDOR := Netgear
+	DEVICE_VENDOR := NETGEAR
 	DEVICE_MODEL := WAC510
 	SOC := qcom-ipq4018
 	DEVICE_DTS_CONFIG := config@5


### PR DESCRIPTION
A quick grep shows "NETGEAR" with all uppercase is mostly used for
DEVICE_VENDOR, and "Netgear" with initial caps is mostly used for
model strings. Convert the few remaining exceptions to unify usages.

I wonder if this is really meaningful change, though.