### PR TITLE
kernel: bpf-headers: fix build error when testing kernel is used

### DIFF
--- a/package/kernel/bpf-headers/Makefile
+++ b/package/kernel/bpf-headers/Makefile
@@ -14,6 +14,9 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=linux
 PKG_PATCHVER:=5.10
+# Manually include kernel version and hash from kernel details file
+include $(INCLUDE_DIR)/kernel-$(PKG_PATCHVER)
+
 PKG_VERSION:=$(PKG_PATCHVER)$(strip $(LINUX_VERSION-$(PKG_PATCHVER)))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=$(LINUX_SITE)


### PR DESCRIPTION
Now that we have separate files for each kernel version,
only the version/hash for the target kernel are available.
This cause a missing hash error (and wrong kernel version) for
bpf-headers when a testing kernel version is used for the current target.

Fix this error by manually including the kernel version/hash file for the
specific kernel version requested.

@aparcar I posted this on mailing list but nobody checked it. Posting it here so we can track this in a better way

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
