### PR TITLE
mediatek: limit scaling_min_freq to 437500 kHz

### DIFF
--- a/target/linux/mediatek/mt7622/base-files/etc/init.d/cpufreq
+++ b/target/linux/mediatek/mt7622/base-files/etc/init.d/cpufreq
@@ -1,0 +1,11 @@
+#!/bin/sh /etc/rc.common
+
+START=15
+
+boot() {
+  case $(board_name) in
+    linksys,e8450*)
+    echo 437500 > /sys/devices/system/cpu/cpufreq/policy0/scaling_min_freq || true
+    ;;
+  esac
+}


### PR DESCRIPTION
Due to the bug described here[1], limit the scaling_min_freq to 437500 kHz to avoid the low voltage conditon that causes a hang on rebooting RT3200/E8450.

1. https://forum.openwrt.org/t/belkin-rt3200-linksys-e8450-wifi-ax-discussion/94302/1490

Build-tested: mt7622/RT3200
Run-tested: mt7622/RT3200

Signed-off-by: John Audia <graysky@archlinux.us>