### PR TITLE
ramips: add support for Asus RT-AC1200

### DIFF
--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2022 Ray Wang
+// Copyright (c) 2022 Ivan Pavlov
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "asus,rt-ac1200", "mediatek,mt7628an-soc";
+	model = "Asus RT-AC1200";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "blue:power";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+			trigger-sources = <&ohci_port1>, <&ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		led-all {
+			gpio-export,name = "led_all";
+			gpio-export,output = <0>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_28: macaddr@28 {
+					reg = <0x28 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "spi cs1", "refclk", "wled_an";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -38,6 +38,15 @@ define Device/alfa-network_awusfree1
 endef
 TARGET_DEVICES += alfa-network_awusfree1
 
+define Device/asus_rt-ac1200
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Asus
+  DEVICE_MODEL := RT-AC1200
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
+	kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += asus_rt-ac1200
+
 define Device/asus_rt-n10p-v3
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Asus

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -34,6 +34,29 @@ ramips_setup_interfaces()
 		ucidef_add_switch_attr "switch0" "enable" "false"
 		ucidef_set_interface_lan "eth0"
 		;;
+	asus,rt-ac1200|\
+	hilink,hlk-7628n|\
+	hilink,hlk-7688a|\
+	hiwifi,hc5861b|\
+	skylab,skw92a|\
+	tplink,archer-c20-v4|\
+	tplink,archer-c20-v5|\
+	tplink,archer-c50-v3|\
+	tplink,archer-c50-v4|\
+	tplink,tl-mr3420-v5|\
+	tplink,tl-wr840n-v4|\
+	tplink,tl-wr840n-v5|\
+	tplink,tl-wr841n-v13|\
+	tplink,tl-wr841n-v14|\
+	tplink,tl-wr842n-v5|\
+	tplink,tl-wr850n-v2|\
+	unielec,u7628-01-16m|\
+	wrtnode,wrtnode2p|\
+	wrtnode,wrtnode2r|\
+	zyxel,keenetic-extra-ii)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
+		;;
 	asus,rt-n10p-v3|\
 	asus,rt-n11p-b1|\
 	asus,rt-n12-vp-b1|\
@@ -68,28 +91,6 @@ ramips_setup_interfaces()
 	glinet,gl-mt300n-v2)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"
-		;;
-	hilink,hlk-7628n|\
-	hilink,hlk-7688a|\
-	hiwifi,hc5861b|\
-	skylab,skw92a|\
-	tplink,archer-c20-v4|\
-	tplink,archer-c20-v5|\
-	tplink,archer-c50-v3|\
-	tplink,archer-c50-v4|\
-	tplink,tl-mr3420-v5|\
-	tplink,tl-wr840n-v4|\
-	tplink,tl-wr840n-v5|\
-	tplink,tl-wr841n-v13|\
-	tplink,tl-wr841n-v14|\
-	tplink,tl-wr842n-v5|\
-	tplink,tl-wr850n-v2|\
-	unielec,u7628-01-16m|\
-	wrtnode,wrtnode2p|\
-	wrtnode,wrtnode2r|\
-	zyxel,keenetic-extra-ii)
-		ucidef_add_switch "switch0" \
-			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
 	hiwifi,hc5761a)
 		ucidef_add_switch "switch0" \
@@ -176,6 +177,11 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
+	asus,rt-ac1200|\
+	elecom,wrc-1167fs)
+		wan_mac=$(mtd_get_mac_binary factory 0x22)
+		label_mac=$wan_mac
+		;;
 	buffalo,wcr-1166ds)
 		local index="$(find_mtd_index "board_data")"
 		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
@@ -197,10 +203,6 @@ ramips_setup_macs()
 	wrtnode,wrtnode2r|\
 	zyxel,keenetic-extra-ii)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
-		;;
-	elecom,wrc-1167fs)
-		wan_mac=$(mtd_get_mac_binary factory 0x22)
-		label_mac=$wan_mac
 		;;
 	hiwifi,hc5661a|\
 	hiwifi,hc5761a|\


### PR DESCRIPTION
Asus RT-AC1200 is a 2.4/5GHz dual band AC router,
based on MediaTek MT7628AN.

Specification:
* SoC: MT7628AN
* RAM: DDR2 64 MiB
* Flash: 16 MiB NOR (W25Q128BV)
* Wi-Fi:
  * 2.4GHz: SoC Built-in
  * 5GHz: MT7612EN
* Ethernet: 5x 100Mbps
  * Switch: SoC built-in
* USB: 1x 2.0

Flash Layout:
 0x0000000-0x0030000 : "bootloader"
 0x0030000-0x0040000 : "nvram"
 0x0040000-0x0050000 : "factory"
 0x0050000-0x1000000 : "firmware"

MAC address:
 LAN: factory 0x28
 WAN: factory 0x22
 2.4G: factory 0x4
 5G: factory 0x8004

Installation via **recovery** mode:
1. Download the Asus recovery firmware (windows) tool from 
   http://dlcdnet.asus.com/pub/ASUS/LiveUpdate/Release/Wireless/Rescue.zip
2. Set your ethernet IP manually 192.168.1.5 / 255.255.255.0 with NO
   gateway.
3. Plug in your ethernet to LAN port 1 on the router.
4. Load up the recovery software with the firmware file, but don't press
   "Upload" yet.
5. Plug in the router to power WHILE HOLDING the reset button in. While
   CONTINUING to hold the button, select "Upload" Continue to hold the
   reset button in until it finishes and verifies!
6. If that doesn't work try pressing "Upload" first just before you do
   step 5. At some point while holding reset the rescue tool will finally
   detect and upload the firmware. That's when you can let go of the
   reset button.
7. The router will reboot and not much will happen. Wait a minute or 2.
8. Power off and on the router again. Voila. Set everything your Ethernet 
   IP back to DHCP (automatically) and you're good to go.

Revert to stock firmware:
1. Install stock image via recovery mode.

Tested-by: Ivan Pavlov <AuthorReflex@gmail.com>
Signed-off-by: Ray Wang <raywang777@foxmail.com>
