### PR TITLE
mac80211: add debug compile option for rtw88 devices

### DIFF
--- a/package/kernel/mac80211/realtek.mk
+++ b/package/kernel/mac80211/realtek.mk
@@ -27,6 +27,8 @@ config-y += STAGING
 
 config-$(call config_package,rtw88) += RTW88 RTW88_CORE RTW88_PCI
 config-y += RTW88_8822BE RTW88_8822CE RTW88_8723DE
+config-$(CONFIG_PACKAGE_RTW88_DEBUG) += RTW88_DEBUG
+config-$(CONFIG_PACKAGE_RTW88_DEBUGFS) += RTW88_DEBUGFS
 
 define KernelPackage/rtl818x/Default
   $(call KernelPackage/mac80211/Default)
@@ -173,6 +175,22 @@ define KernelPackage/rtl8xxxu/description
   author or reported to be working by third parties.
 
   Please report your results!
+endef
+
+define KernelPackage/rtw88/config
+	config PACKAGE_RTW88_DEBUG
+		bool "Realtek wireless debugging (rtw88)"
+		depends on PACKAGE_kmod-rtw88
+		help
+		  Enable debugging output for rtw88 devices
+
+	config PACKAGE_RTW88_DEBUGFS
+		bool "Enable rtw88 debugfS support"
+		select KERNEL_DEBUG_FS
+		depends on PACKAGE_kmod-rtw88
+		help
+		  Select this to see extensive information about
+		  the internal state of rtw88 in debugfs.
 endef
 
 define KernelPackage/rtw88


### PR DESCRIPTION
@nbd168 This commit adds the following package compile options.

CONFIG_PACKAGE_RTW88_DEBGUG:
Compile the driver with additional debug logging output

CONFIG_PACKAGE_RTW88_DEBGUGFS:
Add the possibility to map information about the driver rtw88 into
debugfs.
