### PR TITLE
iucode-tool: fix host-compile on macos and non-x86 linux

### DIFF
--- a/package/libs/argp-standalone/Makefile
+++ b/package/libs/argp-standalone/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=argp-standalone
 PKG_VERSION:=1.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.lysator.liu.se/~nisse/misc/
@@ -20,6 +20,7 @@ PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE:=Makefile.am
 
 include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/host-build.mk
 
 define Package/argp-standalone
   SECTION:=libs
@@ -45,4 +46,14 @@ define Build/InstallDev
 		$(1)/usr/lib/
 endef
 
+define Host/Install
+	$(INSTALL_DIR) $(1)/include
+	$(CP)   $(HOST_BUILD_DIR)/argp.h \
+		$(1)/include/
+	$(INSTALL_DIR) $(1)/lib
+	$(CP)   $(HOST_BUILD_DIR)/libargp.a \
+		$(1)/lib/
+endef
+
 $(eval $(call BuildPackage,argp-standalone))
+$(eval $(call HostBuild))

--- a/package/system/iucode-tool/Makefile
+++ b/package/system/iucode-tool/Makefile
@@ -9,13 +9,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iucode-tool
 PKG_VERSION:=2.3.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=iucode-tool_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://gitlab.com/iucode-tool/releases/raw/latest
 PKG_HASH:=12b88efa4d0d95af08db05a50b3dcb217c0eb2bfc67b483779e33d498ddb2f95
 
 PKG_BUILD_DEPENDS:=USE_UCLIBC:argp-standalone USE_MUSL:argp-standalone
+HOST_BUILD_DEPENDS:=HOST_OS_MACOS:argp-standalone/host
 
 PKG_MAINTAINER:=Zoltan HERPAI <wigyori@uid0.hu>
 PKG_LICENSE:=GPL-2.0
@@ -40,6 +41,18 @@ define Package/iucode-tool/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/iucode_tool $(1)/usr/bin/
 endef
+
+# List of build hosts with working cpuid.h
+IUT_NATIVE_HOST_OS_ARCH := \
+	linux/x86_64 linux/amd64 linux/i386 linux/i686
+
+IUT_HOST_OS_ARCH := $(call tolower,$(HOST_OS))/$(HOST_ARCH)
+
+# Use cpuid.h compat header if build host does not have working cpuid.h
+ifeq ($(filter $(IUT_HOST_OS_ARCH),$(IUT_NATIVE_HOST_OS_ARCH)),)
+HOST_CFLAGS += \
+	-I$(HOST_BUILD_DIR)/cpuid-compat
+endif
 
 define Host/Install
 	$(INSTALL_BIN) $(HOST_BUILD_DIR)/iucode_tool $(STAGING_DIR_HOST)/bin/iucode_tool

--- a/package/system/iucode-tool/patches/200_add-cpuid-compatibility-header-to-build-on-non-x86.patch
+++ b/package/system/iucode-tool/patches/200_add-cpuid-compatibility-header-to-build-on-non-x86.patch
@@ -1,0 +1,31 @@
+From a21e75da32c0016f1575ea29775565934a67660d Mon Sep 17 00:00:00 2001
+From: "Sergey V. Lobanov" <sergey@lobanov.in>
+Date: Sat, 5 Feb 2022 13:10:23 +0300
+Subject: [PATCH] Add cpuid compatibility header to build on non-x86 hosts
+
+Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>
+---
+ cpuid-compat/cpuid.h | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 cpuid-compat/cpuid.h
+
+--- /dev/null
++++ b/cpuid-compat/cpuid.h
+@@ -0,0 +1,17 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ *  cpuid compatibility header to build iucode-tool on non-x86 hosts
++ *
++ *  Copyright (C) 2022       Sergey V. Lobanov <sergey@lobanov.in>
++ */
++
++#ifdef __APPLE__
++# include <limits.h>
++#endif
++
++static __inline int __get_cpuid (unsigned int leaf,
++              unsigned int *eax, unsigned int *ebx,
++              unsigned int *ecx, unsigned int *edx)
++{
++    return 0;
++}


### PR DESCRIPTION
This PR has two commits:
1. add argp-standalone/host required to build iucode-tool on macos
2. cpuid.h fix for iucode-tool on non-x86 linux and macos build hosts

Detailed description is provided in the commits.