### PR TITLE
QCA6390 (ath11k_pci) support

### DIFF
--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -1,0 +1,17 @@
+Package/ath11k-board-qca6390 = $(call Package/firmware-default,ath10k qca6390 board firmware)
+define Package/ath11k-board-qca6390/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/qca6390/hw2.0
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/ath11k/qca6390/hw2.0/board-2.bin \
+		$(1)/lib/firmware/ath11k/qca6390/hw2.0/
+endef
+$(eval $(call BuildPackage,ath11k-board-qca6390))
+Package/ath11k-firmware-qca6390 = $(call Package/firmware-default,ath11k qca6390 firmware,+ath11k-board-qca6390)
+define Package/ath11k-firmware-qca6390/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/qca6390/hw2.0
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/ath11k/qca6390/hw2.0/amss.bin \
+		$(PKG_BUILD_DIR)/ath11k/qca6390/hw2.0/m3.bin \
+		$(1)/lib/firmware/ath11k/qca6390/hw2.0
+endef
+$(eval $(call BuildPackage,ath11k-firmware-qca6390))

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1256,3 +1256,19 @@ define KernelPackage/f71808e-wdt/description
 endef
 
 $(eval $(call KernelPackage,f71808e-wdt))
+
+
+define KernelPackage/qmi-helpers
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Qualcomm QMI Helpers
+  KCONFIG:=CONFIG_QCOM_QMI_HELPERS
+  FILES:=$(LINUX_DIR)/drivers/soc/qcom/qmi_helpers.ko
+  AUTOLOAD:=$(call AutoProbe,qcom-helpers,1)
+endef
+
+define KernelPackage/qmi-helpers/description
+  Kernel module for the Qualcomm QMI helpers support found on some Qualcomm
+  SoCs.
+endef
+
+$(eval $(call KernelPackage,qmi-helpers))

--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -1,6 +1,6 @@
 PKG_DRIVERS += \
 	ath ath5k ath6kl ath6kl-sdio ath6kl-usb ath9k ath9k-common ath9k-htc ath10k ath10k-smallbuffers \
-	carl9170 owl-loader ar5523 wil6210
+	ath11k carl9170 owl-loader ar5523 wil6210
 
 PKG_CONFIG_DEPENDS += \
 	CONFIG_PACKAGE_ATH_DEBUG \
@@ -19,6 +19,7 @@ ifdef CONFIG_PACKAGE_MAC80211_DEBUGFS
 	ATH9K_DEBUGFS \
 	ATH9K_HTC_DEBUGFS \
 	ATH10K_DEBUGFS \
+	ATH11K_DEBUGFS \
 	CARL9170_DEBUGFS \
 	ATH5K_DEBUG \
 	ATH6KL_DEBUG \
@@ -27,6 +28,7 @@ endif
 
 ifdef CONFIG_PACKAGE_MAC80211_TRACING
   config-y += \
+	ATH11K_TRACING \
 	ATH10K_TRACING \
 	ATH6KL_TRACING \
 	ATH_TRACEPOINTS \
@@ -35,9 +37,9 @@ ifdef CONFIG_PACKAGE_MAC80211_TRACING
 endif
 
 config-$(call config_package,ath) += ATH_CARDS ATH_COMMON
-config-$(CONFIG_PACKAGE_ATH_DEBUG) += ATH_DEBUG ATH10K_DEBUG ATH9K_STATION_STATISTICS
+config-$(CONFIG_PACKAGE_ATH_DEBUG) += ATH_DEBUG ATH11K_DEBUG ATH10K_DEBUG ATH9K_STATION_STATISTICS
 config-$(CONFIG_PACKAGE_ATH_DFS) += ATH9K_DFS_CERTIFIED ATH10K_DFS_CERTIFIED
-config-$(CONFIG_PACKAGE_ATH_SPECTRAL) += ATH9K_COMMON_SPECTRAL ATH10K_SPECTRAL
+config-$(CONFIG_PACKAGE_ATH_SPECTRAL) += ATH9K_COMMON_SPECTRAL ATH10K_SPECTRAL ATH11K_SPECTRAL
 config-$(CONFIG_PACKAGE_ATH_DYNACK) += ATH9K_DYNACK
 config-$(call config_package,ath9k) += ATH9K
 config-$(call config_package,ath9k-common) += ATH9K_COMMON
@@ -56,6 +58,7 @@ config-$(CONFIG_ATH10K_THERMAL) += ATH10K_THERMAL
 config-$(call config_package,ath9k-htc) += ATH9K_HTC
 config-$(call config_package,ath10k) += ATH10K ATH10K_PCI
 config-$(call config_package,ath10k-smallbuffers) += ATH10K ATH10K_PCI ATH10K_SMALLBUFFERS
+config-$(call config_package,ath11k) += ATH11K ATH11K_PCI
 
 config-$(call config_package,ath5k) += ATH5K
 ifdef CONFIG_TARGET_ath25
@@ -287,6 +290,24 @@ define KernelPackage/ath10k-smallbuffers
   $(call KernelPackage/ath10k)
   TITLE+= (small buffers for low-RAM devices)
   VARIANT:=smallbuffers
+endef
+
+define KernelPackage/ath11k
+  $(call KernelPackage/mac80211/Default)
+  TITLE:=Atheros 802.11ax wireless cards support
+  URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath11k
+  DEPENDS+= @PCI_SUPPORT +kmod-ath +@DRIVER_11N_SUPPORT +@DRIVER_11AC_SUPPORT \
+	+@DRIVER_11AX_SUPPORT +kmod-crypto-michael-mic +kmod-qmi-helpers
+  FILES:= \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k_pci.ko
+  AUTOLOAD:=$(call AutoProbe,ath11k_pci)
+endef
+
+define KernelPackage/ath11k/description
+This module adds support for wireless adapters based on
+Atheros IEEE 802.11ax family of chipsets. For now only
+PCI is supported.
 endef
 
 define KernelPackage/carl9170

--- a/target/linux/generic/hack-5.10/262-qcom-qmi-helpers-unhide.patch
+++ b/target/linux/generic/hack-5.10/262-qcom-qmi-helpers-unhide.patch
@@ -1,0 +1,15 @@
+This makes it possible to select QCOM_QMI_HELPERS directly. We 
+need this to be able to compile this into the kernel and make use of it 
+from backports.
+
+--- a/drivers/soc/qcom/Kconfig
++++ b/drivers/soc/qcom/Kconfig
+@@ -92,7 +92,7 @@
+ 	select QCOM_QMI_HELPERS
+ 
+ config QCOM_QMI_HELPERS
+-	tristate
++	tristate "Qualcomm QMI Helper"
+ 	depends on NET
+ 
+ config QCOM_RMTFS_MEM


### PR DESCRIPTION
Tested on generic x86_64 machine with FN-Link QCAi6390 M.2 module.