### PR TITLE
hostapd: compile with OCV and provide configuration method

### DIFF
--- a/package/network/services/hostapd/files/hostapd-basic.config
+++ b/package/network/services/hostapd/files/hostapd-basic.config
@@ -54,7 +54,7 @@ CONFIG_RSN_PREAUTH=y
 #CONFIG_IEEE80211W=y
 
 # Support Operating Channel Validation
-#CONFIG_OCV=y
+CONFIG_OCV=y
 
 # Integrated EAP server
 #CONFIG_EAP=y

--- a/package/network/services/hostapd/files/hostapd-full.config
+++ b/package/network/services/hostapd/files/hostapd-full.config
@@ -54,7 +54,7 @@ CONFIG_RSN_PREAUTH=y
 #CONFIG_IEEE80211W=y
 
 # Support Operating Channel Validation
-#CONFIG_OCV=y
+CONFIG_OCV=y
 
 # Integrated EAP server
 CONFIG_EAP=y

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -1272,7 +1272,7 @@ wpa_supplicant_add_network() {
 	json_get_vars \
 		ssid bssid key \
 		basic_rate mcast_rate \
-		ieee80211w ieee80211r fils \
+		ieee80211w ieee80211r fils ocv \
 		multi_ap \
 		default_disabled
 
@@ -1323,6 +1323,8 @@ wpa_supplicant_add_network() {
 		[ "$multi_ap" = 1 ] && append network_data "multi_ap_backhaul_sta=1" "$N$T"
 		[ "$default_disabled" = 1 ] && append network_data "disabled=1" "$N$T"
 	}
+
+	[ -n "$ocv" ] && append network_data "ocv=$ocv" "$N$T"
 
 	case "$auth_type" in
 		none) ;;

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -372,6 +372,8 @@ hostapd_common_add_bss_config() {
 
 	config_add_boolean fils
 	config_add_string fils_dhcp
+
+	config_add_int ocv
 }
 
 hostapd_set_vlan_file() {
@@ -544,7 +546,7 @@ hostapd_set_bss_options() {
 		airtime_bss_weight airtime_bss_limit airtime_sta_weight \
 		multicast_to_unicast proxy_arp per_sta_vif \
 		eap_server eap_user_file ca_cert server_cert private_key private_key_passwd server_id \
-		vendor_elements fils
+		vendor_elements fils ocv
 
 	set_default fils 0
 	set_default isolate 0
@@ -616,6 +618,8 @@ hostapd_set_bss_options() {
 			append bss_conf "radius_acct_interim_interval=$acct_interval" "$N"
 		json_for_each_item append_radius_acct_req_attr radius_acct_req_attr
 	}
+
+	[ -n "$ocv" ] && append bss_conf "ocv=$ocv" "$N"
 
 	case "$auth_type" in
 		sae|owe|eap192|eap-eap192)

--- a/package/network/services/hostapd/files/wpa_supplicant-basic.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-basic.config
@@ -315,7 +315,7 @@ CONFIG_NO_LINUX_PACKET_SOCKET_WAR=y
 #CONFIG_IEEE80211W=y
 
 # Support Operating Channel Validation
-#CONFIG_OCV=y
+CONFIG_OCV=y
 
 # Select TLS implementation
 # openssl = OpenSSL (default)

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -315,7 +315,7 @@ CONFIG_NO_LINUX_PACKET_SOCKET_WAR=y
 #CONFIG_IEEE80211W=y
 
 # Support Operating Channel Validation
-#CONFIG_OCV=y
+CONFIG_OCV=y
 
 # Select TLS implementation
 # openssl = OpenSSL (default)

--- a/package/network/services/hostapd/src/src/utils/build_features.h
+++ b/package/network/services/hostapd/src/src/utils/build_features.h
@@ -55,6 +55,10 @@ static inline int has_feature(const char *feat)
 	if (!strcmp(feat, "fils"))
 		return 1;
 #endif
+#ifdef CONFIG_OCV
+	if (!strcmp(feat, "ocv"))
+		return 1;
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
Operating Channel Validation (OCV) is a relatively recent security feature that prevents person-in-the-middle multi-channel attacks, and it's described in detail in the following paper: https://papers.mathyvanhoef.com/wisec2018.pdf

This pull request enables the compilation of OCV for -basic and -full variants of hostapd, wpa_supplicant, and wpad. A configuration method through the wireless config file is provided, and a method to check whether the installed hostaps/wpa_supplicant/wpad version has OCV support is also provided (for future luci integration).

**I have only tested whether this works with hostapd, not with wpa_supplicant.**

Compiling with OCV support results in a small size increase (sizes calculated prior to [update to v2.10](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=adb8c09a83d3f8e1d9e9fcbb8189b415ac0f6e86)):

**Size of wpad-basic-openssl:**
Without OCV: 731509 bytes
With OCV: 739701 bytes
Difference: 8192 bytes (1.12% relative increase)

**Size of wpad-basic-wolfssl:**
Without OCV: 727413 bytes
With OCV: 735605 bytes
Difference: 8192 bytes (1.13% relative increase)