### PR TITLE
ramips: add support for ELECOM WRC-2533GS2

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gs.dts
@@ -38,3 +38,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gst2.dts
@@ -38,3 +38,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1750gsv.dts
@@ -38,3 +38,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-1900gst.dts
@@ -38,3 +38,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gs2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gs2.dts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-gs-2pci.dtsi"
+
+/ {
+	compatible = "elecom,wrc-2533gs2", "mediatek,mt7621-soc";
+	model = "ELECOM WRC-2533GS2";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0xb00000>;
+	};
+
+	partition@b50000 {
+		label = "tm_pattern";
+		reg = <0xb50000 0x380000>;
+		read-only;
+	};
+
+	partition@ed0000 {
+		label = "tm_key";
+		reg = <0xed0000 0x80000>;
+		read-only;
+	};
+
+	partition@f50000 {
+		label = "nvram";
+		reg = <0xf50000 0x30000>;
+		read-only;
+	};
+
+	partition@f80000 {
+		label = "user_data";
+		reg = <0xf80000 0x80000>;
+		read-only;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_fffa>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_fff4: macaddr@fff4 {
+		reg = <0xfff4 0x6>;
+	};
+
+	macaddr_factory_fffa: macaddr@fffa {
+		reg = <0xfffa 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst.dts
@@ -36,3 +36,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-2533gst2.dts
@@ -38,3 +38,27 @@
 		read-only;
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_e000: macaddr@e000 {
+		reg = <0xe000 0x6>;
+	};
+
+	macaddr_factory_e006: macaddr@e006 {
+		reg = <0xe006 0x6>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
+++ b/target/linux/ramips/dts/mt7621_elecom_wrc-gs-2pci.dtsi
@@ -2,16 +2,6 @@
 
 #include "mt7621_elecom_wrc-gs.dtsi"
 
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
-};
-
-&wan {
-	nvmem-cells = <&macaddr_factory_e006>;
-	nvmem-cell-names = "mac-address";
-};
-
 &state_default {
 	gpio {
 		groups = "uart3", "jtag", "wdt", "sdhci";
@@ -44,19 +34,5 @@
 			led-sources = <0>;
 			led-active-low;
 		};
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_e000: macaddr@e000 {
-		reg = <0xe000 0x6>;
-	};
-
-	macaddr_factory_e006: macaddr@e006 {
-		reg = <0xe006 0x6>;
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -549,6 +549,14 @@ define Device/elecom_wrc-2533ghbk-i
 endef
 TARGET_DEVICES += elecom_wrc-2533ghbk-i
 
+define Device/elecom_wrc-2533gs2
+  $(Device/elecom_wrc-gs)
+  IMAGE_SIZE := 11264k
+  DEVICE_MODEL := WRC-2533GS2
+  ELECOM_HWNAME := WRC-2533GS2
+endef
+TARGET_DEVICES += elecom_wrc-2533gs2
+
 define Device/elecom_wrc-2533gst
   $(Device/elecom_wrc-gs)
   IMAGE_SIZE := 11264k


### PR DESCRIPTION
- move MAC address related configurations to device dts from dtsi of WRC-GS/GST devices with 2x PCIe
- add support for ELECOM WRC-2533GS2