### PR TITLE
tools/ccache: add cmake dependency

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -87,7 +87,7 @@ endif
 ifneq ($(CONFIG_CCACHE)$(CONFIG_SDK),)
 $(foreach tool, $(filter-out xz zstd pkgconf patch ninja meson libressl cmake,$(tools-y)), $(eval $(curdir)/$(tool)/compile += $(curdir)/ccache/compile))
 tools-y += ccache
-$(curdir)/ccache/compile := $(curdir)/zstd/compile
+$(curdir)/ccache/compile := $(curdir)/cmake/compile $(curdir)/zstd/compile
 endif
 
 # in case there is no patch tool on the host we need to make patch tool a


### PR DESCRIPTION
Before the zstd meson change, ccache's cmake dependency was satisfied by
zstd. Now that it no longer is, it must be added.

Fixes: 8de901ccf7

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @hauke 