### PR TITLE
ramips: add support for TP-Link Archer C50 v6

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_8m-split-uboot.dtsi"
+
+/ {
+	compatible = "tplink,archer-c50-v6", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer C50 v6";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2 {
+			label = "green:wlan2g";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5 {
+			label = "green:wlan5g";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			label = "green:lan";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			label = "green:wan";
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_orange {
+			label = "orange:wan";
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "green:wps";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an",
+				   "p3led_an", "p4led_an", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&radio 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&macaddr_rom_f100>;
+		nvmem-cell-names = "mac-address";
+		mac-address-increment = <(-1)>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -488,6 +488,21 @@ define Device/tplink_archer-c50-v4
 endef
 TARGET_DEVICES += tplink_archer-c50-v4
 
+define Device/tplink_archer-c50-v6
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 7616k
+  DEVICE_MODEL := Archer C50
+  DEVICE_VARIANT := v6
+  TPLINK_FLASHLAYOUT := 8MSUmtk
+  TPLINK_HWID := 0x001D589B
+  TPLINK_HWREV := 0x93
+  TPLINK_HWREVADD := 0x2
+  DEVICE_PACKAGES := kmod-mt7663-firmware-ap kmod-mt7603 kmod-mt7615e
+  IMAGES := sysupgrade.bin
+  SUPPORTED_DEVICES += tplink,c50-v6
+endef
+TARGET_DEVICES += tplink_archer-c50-v6
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -67,7 +67,8 @@ tplink,tl-wr850n-v2)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
 tplink,archer-c50-v3|\
-tplink,archer-c50-v4)
+tplink,archer-c50-v4|\
+tplink,archer-c50-v6)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan2g" "phy0tpt"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ ramips_setup_interfaces()
 	tplink,archer-c20-v5|\
 	tplink,archer-c50-v3|\
 	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6|\
 	tplink,tl-mr3420-v5|\
 	tplink,tl-wr840n-v4|\
 	tplink,tl-wr840n-v5|\
@@ -253,7 +254,8 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0xf100)" 1)
 		;;
 	tplink,archer-c20-v5|\
-	tplink,archer-c50-v4)
+	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
 		;;
 	wavlink,wl-wn570ha1|\

--- a/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt76x8/base-files/lib/upgrade/platform.sh
@@ -29,7 +29,8 @@ platform_do_upgrade() {
 		default_do_upgrade "$1"
 		;;
 	tplink,archer-c20-v5|\
-	tplink,archer-c50-v4)
+	tplink,archer-c50-v4|\
+	tplink,archer-c50-v6)
 		MTD_ARGS="-t romfile"
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
mt7628an board, with a mt7613 5g chip. Not entirely sure about
the HWIDs in mt76x8.mk. Also, it is a split uboot image, so will
require different firmware for flashing in OEM GUI. Not sure about
the config of that either. Rest is verbatim copied from c50 v4.
Currently using a v4 image in the device with 7615 and 7663 packages
built using imagebuilder, and 2.4g, 5g, LEDs, ethernet working just fine.
