### PR TITLE
grub2: x86: efi boot add search module for better find boot partition on multiple disk

### DIFF
--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -120,28 +120,28 @@ define Package/grub2/install
 		-O i386-pc \
 		-c $(PKG_BUILD_DIR)/grub-early.cfg \
 		-o $(STAGING_DIR_IMAGE)/grub2/gpt-core.img \
-		at_keyboard biosdisk boot chain configfile fat linux ls part_gpt reboot serial vga
+		at_keyboard biosdisk boot chain configfile fat linux ls part_gpt reboot search serial vga
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \
 		-O i386-pc \
 		-c ./files/grub-early.cfg \
 		-o $(STAGING_DIR_IMAGE)/grub2/generic-core.img \
-		at_keyboard biosdisk boot chain configfile ext2 linux ls part_msdos reboot serial vga
+		at_keyboard biosdisk boot chain configfile ext2 linux ls part_msdos reboot search serial vga
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \
 		-O i386-pc \
 		-c ./files/grub-early.cfg \
 		-o $(STAGING_DIR_IMAGE)/grub2/eltorito.img \
-		at_keyboard biosdisk boot chain configfile iso9660 linux ls part_msdos reboot serial test vga
+		at_keyboard biosdisk boot chain configfile iso9660 linux ls part_msdos reboot search serial test vga
 	$(STAGING_DIR_HOST)/bin/grub-mkimage \
 		-d $(PKG_BUILD_DIR)/grub-core \
 		-p /boot/grub \
 		-O i386-pc \
 		-c ./files/grub-early.cfg \
 		-o $(STAGING_DIR_IMAGE)/grub2/legacy-core.img \
-		biosdisk boot chain configfile ext2 linux ls part_msdos reboot serial vga
+		biosdisk boot chain configfile ext2 linux ls part_msdos reboot search serial vga
 endef
 
 define Package/grub2-efi/install

--- a/target/linux/x86/image/grub-efi.cfg
+++ b/target/linux/x86/image/grub-efi.cfg
@@ -3,7 +3,7 @@
 
 set default="0"
 set timeout="@TIMEOUT@"
-set root='(hd0,gpt1)'
+search -l kernel -s root
 
 menuentry "@TITLE@" {
 	linux /boot/vmlinuz @GPT_ROOTPART@ @CMDLINE@ noinitrd


### PR DESCRIPTION
Previous `set root='(hd0,gpt1)'` on multiple disk may find a wrong disk.
Using grub search function and previous boot partition label to better find boot disk.
Label name "kernel" from scripts/gen_image_generic.sh.