### PR TITLE
ramips: add support for ipTIME A3002MESH

### DIFF
--- a/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3002mesh.dts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,a3002mesh", "mediatek,mt7621-soc";
+	model = "ipTIME A3002MESH";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			label = "amber:cpu";
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <0>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_uboot_1fc40: macaddr@1fc40 {
+					reg = <0x1fc40 0x6>;
+				};
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_1fc40>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <(2)>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_uboot_1fc40>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -765,6 +765,16 @@ define Device/iodata_wnpr2600g
 endef
 TARGET_DEVICES += iodata_wnpr2600g
 
+define Device/iptime_a3002mesh
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a3002me
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A3002MESH
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware
+endef
+TARGET_DEVICES += iptime_a3002mesh
+
 define Device/iptime_a3004ns-dual
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ ramips_setup_interfaces()
 		;;
 	asiarf,ap7621-nv1|\
 	glinet,gl-mt1300|\
+	iptime,a3002mesh|\
 	jcg,q20|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -25,6 +25,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1 > /sys${DEVPATH}/macaddress
 		;;
+	iptime,a3002mesh|\
 	iptime,a3004t)
 		hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"
 		[ "$PHYNBR" = "0" ] && \


### PR DESCRIPTION
Add support for ipTIME A3002MESH.

Hardware:
- SoC: MediaTek MT7621AT (880MHz, Duel-Core)
- RAM: DDR3 128MB
- Flash: XMC XM25QH128AHIG (SPI-NOR 16MB)
- WiFi: MediaTek MT7615D (2.4GHz, 5GHz, DBDC)
- Ethernet: MediaTek MT7530 (WAN x1, LAN x2, SoC)
- UART: [GND, RX, TX, 3.3V] (57600 8N1, J4)

MAC addresses:
| interface |        MAC        |     source     | comment
|-----------|-------------------|----------------|----------
|       LAN | 70:XX:XX:5X:XX:X3 |                |
|       WAN | 70:XX:XX:5X:XX:X1 | u-boot 0x1fc40 |
|   WLAN 2G | 72:XX:XX:4X:XX:X0 |                |
|   WLAN 5G | 70:XX:XX:5X:XX:X0 | factory 0x4    |
|           | 70:XX:XX:5X:XX:X0 | u-boot 0x1fc20 | unknown
|           | 70:XX:XX:5X:XX:X2 | factory 0x8004 | unknown

- WLAN 2G MAC address is not the same as stock firmware since OpenWrt uses LAN MAC address with local bit sets.

Installation:
1. Flash initramfs image. This can be done using stock web ui or TFTP
2. Connect to OpenWrt with an SSH connection to 192.168.1.1
3. Perform sysupgrade with sysupgrade image

Revert to stock firmware:
- Flash stock firmware via OEM TFTP Recovery mode
- Perform sysupgrade with stock image

TFTP Recovery method:
1. Unplug the router
2. Hold the reset button and plug in
3. Release when the power LED stops flashing and go off
4. Set your computer IP address manually to 192.168.0.x / 255.255.255.0
5. Flash image with TFTP client to 192.168.0.1
