### PR TITLE
x86: fix support for Sophos SG/XG wireless products

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -18,23 +18,23 @@ roqos-roqos-core-rc10)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	;;
 sophos-sg-105r1|sophos-xg-105r1| \
-sophos-sg-105Wr1|sophos-xg-105Wr1| \
+sophos-sg-105wr1|sophos-xg-105wr1| \
 sophos-sg-105r2|sophos-xg-105r2| \
-sophos-sg-105Wr2|sophos-xg-105Wr2| \
+sophos-sg-105wr2|sophos-xg-105wr2| \
 sophos-sg-115r1|sophos-xg-115r1| \
-sophos-sg-115Wr1|sophos-xg-115Wr1| \
+sophos-sg-115wr1|sophos-xg-115wr1| \
 sophos-sg-115r2|sophos-xg-115r2| \
-sophos-sg-115Wr2|sophos-xg-115Wr2)
+sophos-sg-115wr2|sophos-xg-115wr2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3" "eth1"
 	;;
 sophos-sg-125r1|sophos-xg-125r1| \
-sophos-sg-125Wr1|sophos-xg-125Wr1| \
+sophos-sg-125wr1|sophos-xg-125wr1| \
 sophos-sg-125r2|sophos-xg-125r2| \
-sophos-sg-125Wr2|sophos-xg-125Wr2| \
+sophos-sg-125wr2|sophos-xg-125wr2| \
 sophos-sg-135r1|sophos-xg-135r1| \
-sophos-sg-135Wr1|sophos-xg-135Wr1| \
+sophos-sg-135wr1|sophos-xg-135wr1| \
 sophos-sg-135r2|sophos-xg-135r2| \
-sophos-sg-135Wr2|sophos-xg-135Wr2)
+sophos-sg-135wr2|sophos-xg-135wr2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "eth1"
 	;;
 traverse-technologies-geos)


### PR DESCRIPTION
Correct typo that caused network interfaces for Sophos 
SG/XG wireless devices to not be configured properly.

Tested on Sophos SG 135wr2, Sophos XG 125wr2
and Sophos SG 105wr1

Signed-off-by: Raylynn Knight <rayknight@me.com>