### PR TITLE
target/linux: add missing symbol

### DIFF
--- a/target/linux/generic/config-5.10
+++ b/target/linux/generic/config-5.10
@@ -1863,6 +1863,7 @@ CONFIG_FAT_DEFAULT_IOCHARSET="iso8859-1"
 # CONFIG_FB_DDC is not set
 # CONFIG_FB_FLEX is not set
 # CONFIG_FB_FOREIGN_ENDIAN is not set
+# CONFIG_FB_FSL_DIU is not set
 # CONFIG_FB_GEODE is not set
 # CONFIG_FB_GOLDFISH is not set
 # CONFIG_FB_HGA is not set


### PR DESCRIPTION
Found when building the qoriq target.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @stintel 