### PR TITLE
lantiq: add support for AVM Fritzbox 3490, 5490 and 7490

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1739,6 +1739,7 @@ define KernelPackage/usb3
 	+TARGET_ramips_mt7621:kmod-usb-xhci-mtk \
 	+TARGET_mediatek:kmod-usb-xhci-mtk \
 	+TARGET_apm821xx_nand:kmod-usb-xhci-pci-renesas \
+	+TARGET_lantiq_xrx200:kmod-usb-xhci-pci-renesas \
 	+TARGET_mvebu_cortexa9:kmod-usb-xhci-pci-renesas
   KCONFIG:= \
 	CONFIG_USB_PCI=y \

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz3490.dtsi"
+
+/ {
+	compatible = "avm,fritz3490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz3490.dtsi"
+
+/ {
+	compatible = "avm,fritz3490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3490.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz3490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 3490";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_lan: lan {
+		label = "green:lan";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy0: ethernet-phy@0 {
+		reg = <0x00>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <0x01>;
+		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+	};
+
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+	};
+
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "lan3";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy0>;
+	};
+
+	port@1 {
+		reg = <1>;
+		label = "lan4";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy1>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz5490.dtsi"
+
+/ {
+	compatible = "avm,fritz5490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz5490.dtsi"
+
+/ {
+	compatible = "avm,fritz5490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz5490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 5490/5491";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_fiber: fiber {
+		label = "green:fiber";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy5: ethernet-phy@5 {
+		reg = <0x05>;
+	};
+
+	phy6: ethernet-phy@6 {
+		reg = <0x06>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy9: ethernet-phy@9 {
+		reg = <0x09>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "wan";
+		phy-mode = "rgmii";
+		phy-handle = <&phy6>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy5>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy9>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490-micron.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490-micron.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz7490.dtsi"
+
+/ {
+	compatible = "avm,fritz7490-micron", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490 (Micron NAND)";
+};
+
+&nand1 {
+	nand-ecc-engine = <&nand1>;
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritz7490.dtsi"
+
+/ {
+	compatible = "avm,fritz7490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7490.dtsi
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9_avm_fritzxx90.dtsi"
+
+/ {
+	compatible = "avm,fritz7490", "lantiq,xway", "lantiq,vr9";
+	model = "AVM FRITZ!Box 7490";
+};
+
+&aliases {
+	led-dsl = &led_info_green;
+	led-internet = &led_internet;
+	led-wifi = &led_wifi;
+};
+
+&leds {
+	led_internet: internet {
+		label = "green:internet";
+		gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+	};
+
+	led_fon: fon {
+		label = "green:fon";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+	};
+
+	led_wifi: wifi {
+		label = "green:wlan";
+		gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gswip_mdio {
+	phy0: ethernet-phy@0 {
+		reg = <0x00>;
+		reset-gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <0x01>;
+		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+	};
+
+	phy11: ethernet-phy@11 {
+		reg = <0x11>;
+	};
+
+	phy13: ethernet-phy@13 {
+		reg = <0x13>;
+	};
+};
+
+&gswip_ports {
+	port@0 {
+		reg = <0>;
+		label = "lan3";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy0>;
+	};
+
+	port@1 {
+		reg = <1>;
+		label = "lan4";
+		phy-mode = "rgmii-rxid";
+		phy-handle = <&phy1>;
+	};
+
+	port@2 {
+		reg = <2>;
+		label = "lan2";
+		phy-mode = "internal";
+		phy-handle = <&phy11>;
+	};
+
+	port@4 {
+		reg = <4>;
+		label = "lan1";
+		phy-mode = "internal";
+		phy-handle = <&phy13>;
+	};
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritzxx90.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritzxx90.dtsi
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "vr9.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/mips/lantiq_rcu_gphy.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyLTQ0,115200";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	aliases: aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_info_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_info_red;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		power {
+			label = "power";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_POWER>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&gpio 29 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_power_green: power_green {
+			label = "green:power";
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+
+		led_info_green: info_green {
+			label = "green:info";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led_info_red: info_red {
+			label = "red:info";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gphy0 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gphy1 {
+	lantiq,gphy-mode = <GPHY_MODE_GE>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&state_default>;
+	gpio-ranges = <&gpio 0 0 56>;
+
+	state_default: pinmux {
+		phy-rst {
+			lantiq,pins = "io32", "io44";
+			lantiq,pull = <0>;
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+
+		pcie-rst {
+			lantiq,pins = "io21";
+			lantiq,open-drain;
+			lantiq,output = <1>;
+		};
+	};
+
+	usb-vbus {
+		gpio-hog;
+		line-name = "usb-vbus";
+		gpios = <14 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	pcie-enable-dev {
+		gpio-hog;
+		line-name = "pcie-enable-dev";
+		gpios = <22 GPIO_ACTIVE_LOW>;
+		output-low;
+	};
+};
+
+&gswip {
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&spi {
+	status = "okay";
+
+	flash@4 {
+		compatible = "jedec,spi-nor";
+		reg = <4>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			urlader: partition@0 {
+				reg = <0x0 0x40000>;
+				label = "urlader";
+				read-only;
+			};
+
+			partition@40000 {
+				reg = <0x40000 0x60000>;
+				label = "tffs (1)";
+				read-only;
+			};
+
+			partition@a0000 {
+				reg = <0xa0000 0x60000>;
+				label = "tffs (2)";
+				read-only;
+			};
+		};
+	};
+};
+
+&localbus {
+	nand1: nand@1 {
+		compatible = "lantiq,nand-xway";
+		bank-width = <2>;
+		reg = <0x1 0x0 0x2000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x1fc00000>;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
+	lantiq,switch-pcie-endianess;
+};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -149,6 +149,30 @@ define Device/avm_fritz3390
 endef
 TARGET_DEVICES += avm_fritz3390
 
+define Device/avm_fritz3490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3490
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz3490
+
+define Device/avm_fritz3490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 3490
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz3490-micron
+
 define Device/avm_fritz5490
   $(Device/dsa-migration)
   $(Device/AVM)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -149,6 +149,42 @@ define Device/avm_fritz3390
 endef
 TARGET_DEVICES += avm_fritz3390
 
+define Device/avm_fritz5490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 5490
+  DEVICE_ALT0_VENDOR := AVM
+  DEVICE_ALT0_MODEL := FRITZ!Box 5491
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs \
+	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
+	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
+	-ltq-vdsl-vr9-app -kmod-owl-loader \
+	-dsl-vrx200-firmware-xdsl-a -dsl-vrx200-firmware-xdsl-b-patch
+endef
+TARGET_DEVICES += avm_fritz5490
+
+define Device/avm_fritz5490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 5490
+  DEVICE_ALT0_VENDOR := AVM
+  DEVICE_ALT0_MODEL := FRITZ!Box 5491
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs \
+	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
+	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
+	-ltq-vdsl-vr9-app -kmod-owl-loader \
+	-dsl-vrx200-firmware-xdsl-a -dsl-vrx200-firmware-xdsl-b-patch
+endef
+TARGET_DEVICES += avm_fritz5490-micron
+
 define Device/avm_fritz7360sl
   $(Device/dsa-migration)
   $(Device/AVM)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -208,6 +208,30 @@ define Device/avm_fritz7430
 endef
 TARGET_DEVICES += avm_fritz7430
 
+define Device/avm_fritz7490
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7490
+  DEVICE_VARIANT := Other NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz7490
+
+define Device/avm_fritz7490-micron
+  $(Device/dsa-migration)
+  $(Device/AVM)
+  $(Device/NAND)
+  DEVICE_MODEL := FRITZ!Box 7490
+  DEVICE_VARIANT := Micron NAND
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 49152k
+  DEVICE_PACKAGES := kmod-usb3 fritz-tffs -kmod-owl-loader
+endef
+TARGET_DEVICES += avm_fritz7490-micron
+
 define Device/bt_homehub-v5a
   $(Device/dsa-migration)
   $(Device/NAND)

--- a/target/linux/lantiq/patches-5.15/0001-MIPS-lantiq-add-pcie-driver.patch
+++ b/target/linux/lantiq/patches-5.15/0001-MIPS-lantiq-add-pcie-driver.patch
@@ -3913,6 +3913,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +#define IFX_RCU_AHB_BE_PCIE_M                    0x00000001  /* Configure AHB master port that connects to PCIe RC in big endian */
 +#define IFX_RCU_AHB_BE_PCIE_S                    0x00000010  /* Configure AHB slave port that connects to PCIe RC in little endian */
 +#define IFX_RCU_AHB_BE_XBAR_M                    0x00000002  /* Configure AHB master port that connects to XBAR in big endian */
++#define IFX_RCU_AHB_BE_XBAR_S                    0x00000008  /* Configure AHB slave port that connects to XBAR in big endian */
 +#define CONFIG_IFX_PCIE_PHY_36MHZ_MODE
 +
 +#define IFX_PMU1_MODULE_PCIE_PHY   (0)
@@ -4159,7 +4160,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +}
 +
 +#endif /* IFXMIPS_PCIE_VR9_H */
-+
 --- a/arch/mips/pci/pci-legacy.c
 +++ b/arch/mips/pci/pci-legacy.c
 @@ -305,3 +305,30 @@ char *__init pcibios_setup(char *str)

--- a/target/linux/lantiq/patches-5.15/0151-lantiq-ifxmips_pcie-use-of.patch
+++ b/target/linux/lantiq/patches-5.15/0151-lantiq-ifxmips_pcie-use-of.patch
@@ -39,7 +39,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  #include "ifxmips_pcie.h"
  #include "ifxmips_pcie_reg.h"
  
-@@ -40,6 +47,10 @@
+@@ -40,6 +47,11 @@
  static DEFINE_SPINLOCK(ifx_pcie_lock);
  
  u32 g_pcie_debug_flag = PCIE_MSG_ANY & (~PCIE_MSG_CFG);
@@ -47,10 +47,11 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
 +static struct phy *ltq_pcie_phy;
 +static struct reset_control *ltq_pcie_reset;
 +static struct regmap *ltq_rcu_regmap;
++static bool switch_pcie_endianess;
  
  static ifx_pcie_irq_t pcie_irqs[IFX_PCIE_CORE_NR] = {
      {
-@@ -82,6 +93,22 @@ void ifx_pcie_debug(const char *fmt, ...
+@@ -82,6 +94,22 @@ void ifx_pcie_debug(const char *fmt, ...
  	printk("%s", buf);
  }
  
@@ -73,7 +74,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  
  static inline int pcie_ltssm_enable(int pcie_port)
  {
-@@ -988,10 +1015,22 @@ int  ifx_pcie_bios_plat_dev_init(struct
+@@ -988,10 +1016,26 @@ int  ifx_pcie_bios_plat_dev_init(struct
  static int
  pcie_rc_initialize(int pcie_port)
  {
@@ -88,6 +89,10 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
 +#ifdef CONFIG_IFX_PCIE_HW_SWAP
 +	regmap_update_bits(ltq_rcu_regmap, 0x4c, IFX_RCU_AHB_BE_PCIE_S,
 +			   IFX_RCU_AHB_BE_PCIE_S);
++       if (switch_pcie_endianess) {
++	        regmap_update_bits(ltq_rcu_regmap, 0x4c, IFX_RCU_AHB_BE_XBAR_S,
++			           IFX_RCU_AHB_BE_XBAR_S);
++       }
 +#else
 +	regmap_update_bits(ltq_rcu_regmap, 0x4c, IFX_RCU_AHB_BE_PCIE_S,
 +			   0x0);
@@ -98,7 +103,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  
  	pcie_ep_gpio_rst_init(pcie_port);
  
-@@ -1000,26 +1039,21 @@ pcie_rc_initialize(int pcie_port)
+@@ -1000,26 +1044,21 @@ pcie_rc_initialize(int pcie_port)
  	* reset PCIe PHY will solve this issue 
  	*/
  	for (i = 0; i < IFX_PCIE_PHY_LOOP_CNT; i++) {
@@ -135,7 +140,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  
  		/* Enable PCIe PHY and Clock */
  		pcie_core_pmu_setup(pcie_port);
-@@ -1035,6 +1069,10 @@ pcie_rc_initialize(int pcie_port)
+@@ -1035,6 +1074,10 @@ pcie_rc_initialize(int pcie_port)
  		/* Once link is up, break out */
  		if (pcie_app_loigc_setup(pcie_port) == 0)
  			break;
@@ -146,7 +151,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  	}
  	if (i >= IFX_PCIE_PHY_LOOP_CNT) {
  		printk(KERN_ERR "%s link up failed!!!!!\n", __func__);
-@@ -1045,17 +1083,67 @@ pcie_rc_initialize(int pcie_port)
+@@ -1045,17 +1088,74 @@ pcie_rc_initialize(int pcie_port)
  	return 0;
  }
  
@@ -199,6 +204,13 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
 +        return PTR_ERR(ltq_pcie_reset);
 +    }
 +
++    if (of_property_read_bool(node, "lantiq,switch-pcie-endianess")) {
++        switch_pcie_endianess = true;
++        dev_info(&pdev->dev, "switch pcie endianess requested\n");
++    } else {
++        switch_pcie_endianess = false;
++    }
++
 +    ltq_rcu_regmap = syscon_regmap_lookup_by_phandle(node, "lantiq,rcu");
 +    if (IS_ERR(ltq_rcu_regmap))
 +        return PTR_ERR(ltq_rcu_regmap);
@@ -216,7 +228,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
      for (pcie_port = startup_port; pcie_port < IFX_PCIE_CORE_NR; pcie_port++){
  	if (pcie_rc_initialize(pcie_port) == 0) {
  	    IFX_PCIE_PRINT(PCIE_MSG_INIT, "%s: ifx_pcie_cfg_base 0x%p\n", 
-@@ -1067,6 +1155,7 @@ static int __init ifx_pcie_bios_init(voi
+@@ -1067,6 +1167,7 @@ static int __init ifx_pcie_bios_init(voi
                  return -ENOMEM;
              }
              ifx_pcie_controller[pcie_port].pcic.io_map_base = (unsigned long)io_map_base;
@@ -224,7 +236,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  
              register_pci_controller(&ifx_pcie_controller[pcie_port].pcic);
              /* XXX, clear error status */
-@@ -1083,6 +1172,30 @@ static int __init ifx_pcie_bios_init(voi
+@@ -1083,6 +1184,30 @@ static int __init ifx_pcie_bios_init(voi
  
      return 0;
  }
@@ -266,7 +278,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  #define IFX_REG_R32    ltq_r32
  #define IFX_REG_W32    ltq_w32
  #define CONFIG_IFX_PCIE_HW_SWAP
-@@ -53,21 +51,6 @@
+@@ -54,21 +52,6 @@
  #define OUT			((volatile u32*)(IFX_GPIO + 0x0070))
  
  
@@ -288,7 +300,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  static inline void pcie_ahb_pmu_setup(void) 
  {
  	/* Enable AHB bus master/slave */
-@@ -79,24 +62,6 @@ static inline void pcie_ahb_pmu_setup(vo
+@@ -80,24 +63,6 @@ static inline void pcie_ahb_pmu_setup(vo
      //AHBS_PMU_SETUP(IFX_PMU_ENABLE);
  }
  
@@ -313,7 +325,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  static inline void pcie_phy_pmu_enable(int pcie_port)
  {
  	struct clk *clk;
-@@ -115,17 +80,6 @@ static inline void pcie_phy_pmu_disable(
+@@ -116,17 +81,6 @@ static inline void pcie_phy_pmu_disable(
  //    PCIE_PHY_PMU_SETUP(IFX_PMU_DISABLE);
  }
  
@@ -331,7 +343,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  static inline void pcie_pdi_pmu_enable(int pcie_port)
  {
      /* Enable PDI to access PCIe PHY register */
-@@ -135,65 +89,6 @@ static inline void pcie_pdi_pmu_enable(i
+@@ -136,65 +90,6 @@ static inline void pcie_pdi_pmu_enable(i
      //PDI_PMU_SETUP(IFX_PMU_ENABLE);
  }
  

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -42,6 +42,8 @@ arcadyan,vgv7519-brn)
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
 avm,fritz3390|\
+avm,fritz3490|\
+avm,fritz3490-micron|\
 avm,fritz5490|\
 avm,fritz5490-micron|\
 avm,fritz7490|\

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -42,6 +42,8 @@ arcadyan,vgv7519-brn)
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
 avm,fritz3390|\
+avm,fritz5490|\
+avm,fritz5490-micron|\
 avm,fritz7490|\
 avm,fritz7490-micron)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/01_leds
@@ -41,7 +41,9 @@ arcadyan,vgv7519-brn)
 	;;
 avm,fritz3370-rev2-hynix|\
 avm,fritz3370-rev2-micron|\
-avm,fritz3390)
+avm,fritz3390|\
+avm,fritz7490|\
+avm,fritz7490-micron)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x17"
 	;;
 bt,homehub-v5a)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -18,6 +18,10 @@ lantiq_setup_interfaces()
 	arcadyan,arv7519rw22)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
+	avm,fritz5490|\
+	avm,fritz5490-micron)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	arcadyan,vgv7510kw22-brn|\
 	arcadyan,vgv7510kw22-nor|\
 	arcadyan,vgv7519-brn|\
@@ -118,6 +122,8 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
+	avm,fritz5490|\
+	avm,fritz5490-micron|\
 	avm,fritz7362sl|\
 	avm,fritz7490|\
 	avm,fritz7490-micron)

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -36,6 +36,8 @@ lantiq_setup_interfaces()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz7360sl|\
 	avm,fritz7360-v2|\
 	avm,fritz7362sl|\
@@ -70,6 +72,8 @@ lantiq_setup_dsl()
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
@@ -122,6 +126,8 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz5490|\
 	avm,fritz5490-micron|\
 	avm,fritz7362sl|\

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -36,6 +36,8 @@ lantiq_setup_interfaces()
 	avm,fritz7360-v2|\
 	avm,fritz7362sl|\
 	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron|\
 	buffalo,wbmr-300hpd|\
 	tplink,tdw8970|\
 	tplink,tdw8980|\
@@ -67,7 +69,9 @@ lantiq_setup_dsl()
 	avm,fritz7360sl|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
-	avm,fritz7430)
+	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron)
 		annex="b"
 		;;
 	esac
@@ -114,7 +118,9 @@ lantiq_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary urlader 0xa91)" 1)
 		;;
 	avm,fritz3390|\
-	avm,fritz7362sl)
+	avm,fritz7362sl|\
+	avm,fritz7490|\
+	avm,fritz7490-micron)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		wan_mac=$(fritz_tffs -n macdsl -i $(find_mtd_part "tffs (1)"))
 		;;

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -15,6 +15,8 @@ platform_do_upgrade() {
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	avm,fritz7430|\
+	avm,fritz7490|\
+	avm,fritz7490-micron|\
 	bt,homehub-v5a|\
 	zyxel,p-2812hnu-f1|\
 	zyxel,p-2812hnu-f3)

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,8 @@ platform_do_upgrade() {
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz3490|\
+	avm,fritz3490-micron|\
 	avm,fritz5490|\
 	avm,fritz5490-micron|\
 	avm,fritz7362sl|\

--- a/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,8 @@ platform_do_upgrade() {
 	avm,fritz3370-rev2-hynix|\
 	avm,fritz3370-rev2-micron|\
 	avm,fritz3390|\
+	avm,fritz5490|\
+	avm,fritz5490-micron|\
 	avm,fritz7362sl|\
 	avm,fritz7412|\
 	avm,fritz7430|\


### PR DESCRIPTION
This adds support for the Fritzbox 3490, 5490 and 7490 devices.
Those devices actually contain two SoCs, one Lantiq with a
5GHz WiFi and one QCA9558 with 2.4GHz and 5 GHz WiFi. Only the
Lantiq has access to the flash memory, the Atheros runs fully
from RAM and is booted by using a remoteproc kernel module.
The devices were manufactured with varying NAND chips which
requires Micron and non-Micron versions of the images.

Specifications:
 - SoC: Lantiq 500 MHz
 - RAM: 256 MB
 - Storage: 512 MB NAND, 8MB NOR
 - Wireless, separate SOC QCA9558 with 128MB RAM:
   · Qualcomm-QCA9558 w/ 3×3 MIMO for 2.4GHz 802.11b/g/n
   · Qualcomm-QCA9880 w/ 3×3 MIMO for 2.4/5GHz 802.11a/b/g/n/ac
   · AG71xx ethernet
 - Ethernet: Built-in AR 803x, 7 port 4 phy switch,
   4x 1000/100/10 port (5490 has additional qca8334 switch), Port 5 is
   fixed and connected to the Wireless SOC
 - Renesas µPD720202 USB3 PCIe, requires firmware binary on the device
 - VDSL2 modem

Unsupported:
 - DECT and ISDN telephony
 - 5490 two ethernet ports and fiber port not working

Installation:
Check which NAND the device has by using the following procedure with
stock firmware:
Go to to http://<fritzbox_ip>/support.lua, download the support data file
and search for string "NAND device" to get the manufacturer kernel output.
Use Micron image if Micron is displayed otherwise the non-Micron image.
Use the eva_ramboot.py script to boot the initramfs image. Follow the
procedure to interrupt booting by ftp into 192.168.178.1 within 5 seconds
after poweron.
Then transfer the sysupgrade image to the device and run sysupgrade to
flash it to the NAND.
For making USB work, an renesas xhci firmware file (e.g. v2026) is needed.
Needs to be placed in /lib/firmware.
For booting WASP, build the ATH79 target x7490 WASP image and copy it to
/lib/firmware. Konfiguration needs to be applied after boot. The WASP SoC
has no persistent storage.
WASP booting also requires the network boot firmware ath_tgt_fw1.fw which
is found when the AVM stock firmware is extracted.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>

This PR is also for testing the avm_wasp kernel module within the remote processor framework. Please report any issues or success using it. The avm_wasp module will be a kernel patch, which I hope will be accepted upstream.
I will also post some instructions on how to use it.
For building the x490 WASP target, a patch for firmware-utils is required, which has not yet been accepted.
