### PR TITLE
add support for Dual-Q H721

### DIFF
--- a/target/linux/ramips/dts/mt7621_dual-q_h721.dts
+++ b/target/linux/ramips/dts/mt7621_dual-q_h721.dts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dual-q,h721", "mediatek,mt7621-soc";
+	model = "Dual-Q H721";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb-30-power {
+			gpio-export,name = "usb-30-power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		usb-20-power {
+			gpio-export,name = "usb-20-power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		usb1 {
+			label = "green:usb1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		sig1 {
+			label = "green:sig1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		usb2 {
+			label = "green:usb2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "green:sig2";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		tf {
+			label = "green:tf";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi1 {
+			label = "green:wifi1";
+			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2 {
+			label = "green:wifi2";
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status: status {
+			label = "green:status";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1487,6 +1487,16 @@ define Device/unielec_u7621-06-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
 
+define Device/dual-q_h721
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Dual-Q
+  DEVICE_MODEL := H721
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-basic-wolfssl
+endef
+TARGET_DEVICES += dual-q_h721
+
 define Device/wavlink_wl-wn531a6
   $(Device/dsa-migration)
   DEVICE_VENDOR := Wavlink


### PR DESCRIPTION
Dual-Q H721 is a router platform board, it is the smaller model of the U7621-06.

The device has the following specifications:

MT7621AT (880 MHz)
256 of RAM (DDR3)
16 MB of FLASH (MX25l12805d SPI)
5x 1 Gbps Ethernet (MT7621 built-in switch)
1x M.2 (NGFF) 3.7V 3A  max for 5G M.2 Modem work at USB3.0 mode
1x Minipcie 3.7V  3A max for LTE Modem work at USB2.0 Mode 
2x Minipcie for WIFI card
4x Lan+1x  Wan 10/100M/1000M RJ45 port 
14x LEDs (1x GPIO-controlled)
1x reset button
1x UART header (4-pins)
1x DC jack for main power (5~27 V)
The following has been tested and is working:

Ethernet switch
miniPCIe slots (tested with Wi-Fi cards and LTE modem cards)
miniSIM slot (works with normal size simcard)
sysupgrade
reset button
Installation:

This board has no locked down bootloader. The seller can be asked to install openwrt, so upgrades are standard
sysupgrade method.

Recovery:

This board contains a Chinese, closed-source bootloader called Breed
(Boot and Recovery Environment for Embedded Devices). Breed supports web
recovery and to enter it, you keep the reset button pressed for around
5 seconds during boot. Your machine will be assigned an IP through DHCP
and the router will use IP address 192.168.1.1. The recovery website is
in Chinese, but is easy to use. Click on the second item in the list to
access the recovery page, then the second item on the next page is where
you select the firmware. In order to start the recovery, you click the
button at the bottom.