### PR TITLE
ramips: add support for Mercusys MR70X

### DIFF
--- a/target/linux/ramips/dts/mt7621_mercusys_mr70x.dts
+++ b/target/linux/ramips/dts/mt7621_mercusys_mr70x.dts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mercusys,mr70x", "mediatek,mt7621-soc";
+	model = "Mercusys MR70X";
+
+	aliases {
+		led-boot = &led_orange;
+		led-failsafe = &led_orange;
+		led-running = &led_green;
+		led-upgrade = &led_green;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_green: dome_green {
+			label = "green:dome";
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_orange: dome_orange {
+			label = "orange:dome";
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x40000 0xf60000>;
+			};
+
+			factory: partition@fa0000 {
+				label = "factory";
+				reg = <0xfa0000 0x60000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x50000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1120,6 +1120,18 @@ define Device/mediatek_mt7621-eval-board
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
 
+define Device/mercusys_mr70x
+  $(Device/dsa-migration)
+  $(Device/tplink-safeloader)
+  KERNEL := $(KERNEL_DTB) | uImage lzma
+  IMAGE_SIZE := 15744k
+  DEVICE_VENDOR := Mercusys
+  DEVICE_MODEL := MR70X
+  DEVICE_PACKAGES := kmod-mt7915e
+  TPLINK_BOARD_ID := MR70X
+endef
+TARGET_DEVICES += mercusys_mr70x
+
 define Device/MikroTik
   $(Device/dsa-migration)
   DEVICE_VENDOR := MikroTik

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -26,6 +26,7 @@ ramips_setup_interfaces()
 	ampedwireless,ally-r1900k|\
 	gehua,ghl-r-001|\
 	hiwifi,hc5962|\
+	mercusys,mr70x|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\
 	xiaomi,mi-router-cr6606|\
@@ -183,6 +184,11 @@ ramips_setup_macs()
 	linksys,ea8100-v2)
 		lan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		wan_mac=$lan_mac
+		label_mac=$lan_mac
+		;;
+	mercusys,mr70x)
+		lan_mac=$(mtd_get_mac_binary factory 0x8)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$lan_mac
 		;;
 	mikrotik,routerboard-750gr3|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -81,6 +81,11 @@ case "$board" in
 			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 0x100000)" > /sys${DEVPATH}/macaddress
 		fi
 		;;
+	mercusys,mr70x)
+		hw_mac_addr="$(mtd_get_mac_binary factory 0x8)"
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr -1 > /sys${DEVPATH}/macaddress
+		;;
 	raisecom,msg1500-x-00)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_ascii Config protest_lan_mac)" \


### PR DESCRIPTION
Add support for Mercusys MR70X.

Hardware:
- SoC: MediaTek MT7621AT (880MHz, Duel-Core)
- RAM: DDR3 128MB
- Flash: Winbond W25Q128JV (SPI-NOR 16MB)
- WiFi: MediaTek MT7915D (2.4GHz, 5GHz, DBDC)
- Ethernet: MediaTek MT7530 (WAN x1, LAN x3, SoC)
- UART: [GND, RX, TX, 3.3V] (115200 8N1, J1)

Installation:
1. Flash factory image. This can be done using stock web ui
2. Connect to OpenWrt with an SSH connection to 192.168.1.1
3. Perform sysupgrade with sysupgrade image

Revert to stock firmware:
- Flash stock firmware via OEM Web UI Recovery mode

Web UI Recovery method:
1. Unplug the router
2. Plug in and hold reset button 5~10 secs
3. Set your computer IP address manually to 192.168.1.x / 255.255.255.0
4. Flash image with web browser to 192.168.1.1
