### PR TITLE
mediatek: mt7622: add support for ipTIME AX8004M

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-envtools/files/mediatek_mt7622
@@ -16,6 +16,10 @@ linksys,e8450-ubi)
 	ubootenv_add_uci_config "/dev/ubi0_0" "0x0" "0x1f000" "0x1f000" "1"
 	ubootenv_add_uci_config "/dev/ubi0_1" "0x0" "0x1f000" "0x1f000" "1"
 	;;
+iptime,ax8004m|\
+iptime,ax8004m-ubi)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"
+	;;
 bananapi,bpi-r64)
 	. /lib/upgrade/common.sh
 	export_bootdevice

--- a/target/linux/mediatek/dts/mt7622-iptime-ax8004m-ubi.dts
+++ b/target/linux/mediatek/dts/mt7622-iptime-ax8004m-ubi.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR MIT)
+
+/dts-v1/;
+#include "mt7622-iptime-ax8004m.dtsi"
+
+/ {
+	model = "ipTIME AX8004M (UBI)";
+	compatible = "iptime,ax8004m-ubi", "mediatek,mt7622";
+};
+
+&snand {
+	partitions {
+		partition@200000 {
+			label = "firmware1";
+			reg = <0x0200000 0x2000000>;
+			read-only;
+		};
+
+		partition@2200000 {
+			label = "kernel";
+			reg = <0x2200000 0x0400000>;
+		};
+
+		partition@2600000 {
+			label = "ubi";
+			reg = <0x2600000 0x4C00000>;
+		};
+	};
+};
+

--- a/target/linux/mediatek/dts/mt7622-iptime-ax8004m.dts
+++ b/target/linux/mediatek/dts/mt7622-iptime-ax8004m.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR MIT)
+
+/dts-v1/;
+#include "mt7622-iptime-ax8004m.dtsi"
+
+/ {
+	model = "ipTIME AX8004M";
+};
+
+&snand {
+	partitions {
+		partition@200000 {
+			label = "firmware1";
+			compatible = "denx,fit";
+			openwrt,cmdline-match = "boot_from=firmware1";
+			reg = <0x0200000 0x2000000>;
+		};
+
+		partition@2200000 {
+			label = "firmware2";
+			compatible = "denx,fit";
+			openwrt,cmdline-match = "boot_from=firmware2";
+			reg = <0x2200000 0x2000000>;
+		};
+
+		partition@2600000 {
+			label = "data";
+			reg = <0x4200000 0x3000000>;
+		};
+	};
+};
+

--- a/target/linux/mediatek/dts/mt7622-iptime-ax8004m.dtsi
+++ b/target/linux/mediatek/dts/mt7622-iptime-ax8004m.dtsi
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+
+/ {
+	compatible = "iptime,ax8004m", "mediatek,mt7622";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n1 swiotlb=512";
+	};
+
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		factory {
+			label = "factory";
+			linux,code = <BTN_0>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			label = "orange:cpu";
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "orange:wlan2g";
+			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "orange:wlan5g";
+			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&btif {
+	// This device doesn't have an antenna, but it actually works.
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch@0 {
+			compatible = "mediatek,mt7531";
+			reg = <0>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				wan: port@4 {
+					reg = <4>;
+					label = "wan";
+					mtd-mac-address = <&factory 0x0004>;
+					mtd-mac-address-increment = <1>;
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "okay";
+};
+
+&pio {
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+				 "pcie0_1_waken",
+				 "pcie0_1_clkreq";
+		};
+	};
+
+	pcie1_pins: pcie1-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie1_pad_perst",
+				 "pcie1_0_waken",
+				 "pcie1_0_clkreq";
+		};
+	};
+
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+
+	pwm7_pins: pwm1-2-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm_ch7_2";
+		};
+	};
+
+	wled_pins: wled-pins {
+		mux {
+			function = "led";
+			groups = "wled";
+		};
+	};
+
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+	};
+
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx" ;
+		};
+	};
+
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm7_pins>;
+	status = "okay";
+};
+
+&pwrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+
+	status = "okay";
+};
+
+&slot0 {
+	wmac1: mt7915@0,0 {
+		reg = <0x0 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		mediatek,mtd-eeprom = <&factory 0x05000>;
+	};
+};
+
+&snand {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+
+	mediatek,bmt-v2;
+	mediatek,bmt-table-size = <0x1000>;
+	mediatek,quad-spi;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Preloader";
+			reg = <0x0000000 0x0080000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "ATF";
+			reg = <0x0080000 0x0040000>;
+			read-only;
+		};
+
+		partition@c0000 {
+			label = "Bootloader";
+			reg = <0x00c0000 0x0080000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "Config";
+			reg = <0x0140000 0x0080000>;
+		};
+
+		factory: partition@1c0000 {
+			label = "Factory";
+			reg = <0x01c0000 0x0040000>;
+			read-only;
+		};
+	};
+
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&u3phy {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};
+
+&wmac {
+	mediatek,mtd-eeprom = <&factory 0x0000>;
+	status = "okay";
+};
+
+&wan {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <3>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@0 {
+		reg = <0x4 0x6>;
+	};
+};
+

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -176,6 +176,40 @@ define Device/linksys_e8450-ubi
 endef
 TARGET_DEVICES += linksys_e8450-ubi
 
+define Device/iptime_ax8004m
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX8004M
+  DEVICE_DTS := mt7622-iptime-ax8004m
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3
+  KERNEL_LOADADDR := 0x41000000
+  IMAGE_SIZE := 32768k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to 128k | append-rootfs | \
+                pad-rootfs | check-size $$$$(IMAGE_SIZE) | iptime-crc32 ax8004m
+endef
+TARGET_DEVICES += iptime_ax8004m
+
+define Device/iptime_ax8004m-ubi
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX8004M
+  DEVICE_VARIANT := UBI
+  DEVICE_DTS := mt7622-iptime-ax8004m-ubi
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-usb3
+  UBINIZE_OPTS := -E 5
+  KERNEL_LOADADDR := 0x41000000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 4194304
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+                iptime-crc32 ax8004m
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += iptime_ax8004m-ubi
+
+
 define Device/mediatek_mt7622-rfb1
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MTK7622 rfb1 AP

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -9,6 +9,8 @@ mediatek_setup_interfaces()
 
 	case $board in
 	bananapi,bpi-r64|\
+	iptime,ax8004m|\
+	iptime,ax8004m-ubi|\
 	linksys,e8450|\
 	linksys,e8450-ubi|\
 	mediatek,mt7622-rfb1|\

--- a/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/mt7622/base-files/etc/init.d/bootcount
@@ -4,6 +4,16 @@ START=99
 
 boot() {
 	case $(board_name) in
+	iptime,ax8004m)
+		if grep -q boot_from=firmware2 /proc/cmdline; then
+			fw_setenv boot_from firmware2
+		else
+			fw_setenv boot_from firmware1
+		fi
+		;;
+	iptime,ax8004m-ubi)
+		fw_setenv boot_from firmware2
+		;;
 	linksys,e8450)
 		mtd erase senv || true
 		;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -34,6 +34,14 @@ platform_do_upgrade() {
 			nand_do_upgrade "$1"
 		fi
 		;;
+	iptime,ax8004m)
+		if grep -q boot_from=firmware2 /proc/cmdline; then
+			PART_NAME=firmware2
+		else
+			PART_NAME=firmware1
+		fi
+		default_do_upgrade "$1"
+		;;
 	linksys,e8450-ubi)
 		CI_KERNPART="fit"
 		nand_do_upgrade "$1"
@@ -46,6 +54,7 @@ platform_do_upgrade() {
 		fi
 		default_do_upgrade "$1"
 		;;
+	iptime,ax8004m-ubi|\
 	mediatek,mt7622-rfb1-ubi|\
 	totolink,a8000ru)
 		nand_do_upgrade "$1"
@@ -68,6 +77,7 @@ platform_check_image() {
 	buffalo,wsr-2533dhp2)
 		buffalo_check_image "$board" "$magic" "$1" || return 1
 		;;
+	iptime,ax8004m-ubi|\
 	mediatek,mt7622-rfb1-ubi|\
 	totolink,a8000ru)
 		nand_do_platform_check "$board" "$1"


### PR DESCRIPTION
ipTIME AX8004M is an 802.11ax (Wi-Fi 6) router, based on MediaTek
MT7622.

Specifications:
* SoC: MediaTek MT7622A
* RAM: 512 MiB
* Flash: SPI-NAND MX35LF1GE4AB 128 MiB
* Wi-Fi:
  * MediaTek MT7622A (SoC): 2.4Ghz
  * MediaTek MT7915E: 5Ghz
* Ethernet: 5x 1GbE
  * Switch: MediaTek MT7531
* USB: 1x 3.0
* UART: J4 (115200 baud)
  * Pinout: [3V3] (TXD) (RXD) (GND)

MAC Addresses:
* LAN    : 52:86:94:xx:xx:47 (none)
* WAN    : 52:86:94:xx:xx:45 (none)
* 2.4 GHz: 52:86:94:xx:xx:44 (Factory, 0x0004 (hex))
* 5 GHz  : 52:86:94:xx:xx:46 (Factory, 0x5004 (hex))

Notes:
* This device has a dual-boot partition scheme, this firmware supports two
  variants, the jffs2 variant works regardless of which boot partition is
  flashed, but each boot partition size is 32MiB, the ubi variant is
  provides 76MiB space by combining second boot partition and user data
  partition, but it works only second boot partition.

Installation:
* Upload factory image through the stock web interface.
* In case the ubi variant, it will fail to boot if it is flashed to
  the first boot partition. If the stock web interface still served after
  rebooting, flash the stock firmware once and try again.

Revert to stock firmware:
* via Recovery mode:
  1. Press reset button, power up the device, wait >10s for CPU LED
   to stop blinking.
  2. Upload stock image through the recovery web page at 192.168.0.1.
* via U-boot:
  1. Check the current boot partition `cat /proc/cmdline`.
  2. Switch to the other side of boot partition
   `fw_setenv boot_from firmware1` or `fw_setenv boot_from firmware2`.
  3. `reboot`.