### PR TITLE
Fix The LED order of wndr4500v3 devices to match case label numbers

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -33,10 +33,13 @@ ath79_setup_interfaces()
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\
 	netgear,wndr4300sw|\
-	netgear,wndr4300-v2|\
-	netgear,wndr4500-v3)
+	netgear,wndr4300-v2)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan"
+		;;
+	netgear,wndr4500-v3)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
 		;;
 	netgear,wndr4300tn)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
The LED and LAN port numbering on the case are reversed relative to the wndr4300v2.  I created this patch to so that the ordering in OpenWRT will be consistent with that.