### PR TITLE
hostapd: Radius based VLANs on AP with PSK

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -740,6 +740,25 @@ hostapd_set_bss_options() {
 		;;
 	esac
 
+	case "$auth_type" in
+		none|owe|psk|sae|psk-sae|wep)
+			json_get_vars \
+			auth_server auth_port auth_secret \
+			ownip radius_client_addr
+
+			[ -n "$auth_server" ] &&  {
+				set_default auth_port 1812
+
+				append bss_conf "auth_server_addr=$auth_server" "$N"
+				append bss_conf "auth_server_port=$auth_port" "$N"
+				[ -n "$auth_secret" ] && append bss_conf "auth_server_shared_secret=$auth_secret" "$N"
+				[ -n "$ownip" ] && append bss_conf "own_ip_addr=$ownip" "$N"
+				[ -n "$radius_client_addr" ] && append bss_conf "radius_client_addr=$radius_client_addr" "$N"
+				append bss_conf "macaddr_acl=2" "$N"
+			}
+		;;
+	esac
+
 	local auth_algs=$((($auth_mode_shared << 1) | $auth_mode_open))
 	append bss_conf "auth_algs=${auth_algs:-1}" "$N"
 	append bss_conf "wpa=$wpa" "$N"


### PR DESCRIPTION
This patch allows the user to set `auth_server` and related settings on
non WPA2 Enterprise AP modes in `/etc/config/wireless`, too, so the
Radius Attributes for Dynamic VLAN Assignment can be fetched from Radius.

Without this patch, `auth_server` and other needed options are only
written to `hostapd-phy<n>.conf` when `option encryption wpa2` is set.

`hostapd` however supports "Station MAC address -based authentication" for
non WPA Enterprise Modes, too.

A classic approch is to use `accept_mac_file` which contains MAC addr
and VLAN-ID pairs. But, using `accept_mac_file` does not support
VLAN assignment for unknown stations.

This is a sample `freeradius3` config, where a known station
("7e:a6:a7:2a:93:d2") is assigned to VLAN `65` and unknown stations are
assigned to VLAN `67`.

```
"7ea6a72a93d2" Cleartext-Password := "7ea6a72a93d2"
        Tunnel-Type = "VLAN",
        Tunnel-Medium-Type = "IEEE-802",
        Tunnel-Private-Group-Id = 65

DEFAULT Cleartext-Password := "%{User-Name}"
        Tunnel-Type = "VLAN",
        Tunnel-Medium-Type = "IEEE-802",
        Tunnel-Private-Group-Id = 67
```

Other option is to configure known stations via `accept_mac_file` and
using only Radius for unknown stations.

I tested this patch only with `wpa_key_mgmt=WPA-PSK`, and assumed that
it should work with other Encryption/Access Mode, too.
