### PR TITLE
kernel: add nft tproxy support

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -352,6 +352,8 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NFT_QUEUE,CONFIG_NFT_QUEUE, $(P_XT)nft_queu
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NFT_COMPAT,CONFIG_NFT_COMPAT, $(P_XT)nft_compat),))
 
+$(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_TPROXY, $(P_XT)nft_tproxy),))
+
 # userland only
 IPT_BUILTIN += $(NF_IPT-y) $(NF_IPT-m)
 IPT_BUILTIN += $(IPT_CORE-y) $(IPT_CORE-m)

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -63,8 +63,8 @@ $(eval $(if $(NF_KMOD),,$(call nf_add,IPT_CORE,CONFIG_NETFILTER_XT_MARK, $(P_XT)
 # conntrack
 
 # kernel only
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_DEFRAG,CONFIG_NF_DEFRAG_IPV4, $(P_V4)nf_defrag_ipv4),))
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNTRACK,CONFIG_NF_CONNTRACK, $(P_XT)nf_conntrack),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNTRACK,CONFIG_NF_DEFRAG_IPV4, $(P_V4)nf_defrag_ipv4),))
 
 $(eval $(call nf_add,IPT_CONNTRACK,CONFIG_NETFILTER_XT_MATCH_STATE, $(P_XT)xt_state))
 $(eval $(call nf_add,IPT_CONNTRACK,CONFIG_NETFILTER_XT_TARGET_CT, $(P_XT)xt_CT))
@@ -152,7 +152,7 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NF_REJECT6,CONFIG_NF_REJECT_IPV6, $(P_V6)nf
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT6,CONFIG_IP6_NF_IPTABLES, $(P_V6)ip6_tables),))
 
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNTRACK,CONFIG_NF_DEFRAG_IPV6, $(P_V6)nf_defrag_ipv6),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_DEFRAG,CONFIG_NF_DEFRAG_IPV6, $(P_V6)nf_defrag_ipv6),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_FILTER, $(P_V6)ip6table_filter),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_MANGLE, $(P_V6)ip6table_mangle),))
@@ -240,14 +240,14 @@ $(eval $(call nf_add,IPT_NFQUEUE,CONFIG_NETFILTER_XT_TARGET_NFQUEUE, $(P_XT)xt_N
 $(eval $(call nf_add,IPT_DEBUG,CONFIG_NETFILTER_XT_TARGET_TRACE, $(P_XT)xt_TRACE))
 
 # tproxy
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_SOCKET,CONFIG_NF_SOCKET_IPV4, $(P_V4)nf_socket_ipv4),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_SOCKET6,CONFIG_NF_SOCKET_IPV6, $(P_V6)nf_socket_ipv6),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV4, $(P_V4)nf_tproxy_ipv4),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV6, $(P_V6)nf_tproxy_ipv6),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_SOCKET_IPV4, $(P_V4)nf_socket_ipv4),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_SOCKET_IPV6, $(P_V6)nf_socket_ipv6),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY6,CONFIG_NF_TPROXY_IPV6, $(P_V6)nf_tproxy_ipv6),))
 
+$(eval $(if $(NF_KMOD),$(call nf_add,NFT_SOCKET,CONFIG_NFT_SOCKET, $(P_XT)nft_socket),))
 $(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_TPROXY, $(P_XT)nft_tproxy),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_SOCKET, $(P_XT)nft_socket),))
 
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_MATCH_SOCKET, $(P_XT)xt_socket))
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_TARGET_TPROXY, $(P_XT)xt_TPROXY))

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -243,12 +243,13 @@ $(eval $(call nf_add,IPT_DEBUG,CONFIG_NETFILTER_XT_TARGET_TRACE, $(P_XT)xt_TRACE
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV4, $(P_V4)nf_tproxy_ipv4),))
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV6, $(P_V6)nf_tproxy_ipv6),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_SOCKET_IPV4, $(P_V4)nf_socket_ipv4),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_SOCKET_IPV6, $(P_V6)nf_socket_ipv6),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_TPROXY, $(P_XT)nft_tproxy),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_SOCKET, $(P_XT)nft_socket),))
 
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_MATCH_SOCKET, $(P_XT)xt_socket))
-$(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_SOCKET_IPV4, $(P_V4)nf_socket_ipv4))
-$(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_SOCKET_IPV6, $(P_V6)nf_socket_ipv6))
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_TARGET_TPROXY, $(P_XT)xt_TPROXY))
 
 # led

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -152,7 +152,7 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NF_REJECT6,CONFIG_NF_REJECT_IPV6, $(P_V6)nf
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT6,CONFIG_IP6_NF_IPTABLES, $(P_V6)ip6_tables),))
 
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_DEFRAG,CONFIG_NF_DEFRAG_IPV6, $(P_V6)nf_defrag_ipv6),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_DEFRAG6,CONFIG_NF_DEFRAG_IPV6, $(P_V6)nf_defrag_ipv6),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_FILTER, $(P_V6)ip6table_filter),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_IPV6,CONFIG_IP6_NF_MANGLE, $(P_V6)ip6table_mangle),))

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -241,12 +241,15 @@ $(eval $(call nf_add,IPT_DEBUG,CONFIG_NETFILTER_XT_TARGET_TRACE, $(P_XT)xt_TRACE
 
 # tproxy
 
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV4, $(P_V4)nf_tproxy_ipv4),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_TPROXY,CONFIG_NF_TPROXY_IPV6, $(P_V6)nf_tproxy_ipv6),))
+
+$(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_TPROXY, $(P_XT)nft_tproxy),))
+
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_MATCH_SOCKET, $(P_XT)xt_socket))
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_SOCKET_IPV4, $(P_V4)nf_socket_ipv4))
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_SOCKET_IPV6, $(P_V6)nf_socket_ipv6))
 $(eval $(call nf_add,IPT_TPROXY,CONFIG_NETFILTER_XT_TARGET_TPROXY, $(P_XT)xt_TPROXY))
-$(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_TPROXY_IPV4, $(P_V4)nf_tproxy_ipv4))
-$(eval $(call nf_add,IPT_TPROXY,CONFIG_NF_TPROXY_IPV6, $(P_V6)nf_tproxy_ipv6))
 
 # led
 $(eval $(call nf_add,IPT_LED,CONFIG_NETFILTER_XT_TARGET_LED, $(P_XT)xt_LED))
@@ -351,8 +354,6 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NFT_FIB,CONFIG_NFT_FIB_IPV6, $(P_V6)nft_fib
 $(eval $(if $(NF_KMOD),$(call nf_add,NFT_QUEUE,CONFIG_NFT_QUEUE, $(P_XT)nft_queue),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NFT_COMPAT,CONFIG_NFT_COMPAT, $(P_XT)nft_compat),))
-
-$(eval $(if $(NF_KMOD),$(call nf_add,NFT_TPROXY,CONFIG_NFT_TPROXY, $(P_XT)nft_tproxy),))
 
 # userland only
 IPT_BUILTIN += $(NF_IPT-y) $(NF_IPT-m)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -118,7 +118,7 @@ define KernelPackage/nf-conntrack
         CONFIG_NF_CONNTRACK_MARK=y \
         CONFIG_NF_CONNTRACK_ZONES=y \
 	$(KCONFIG_NF_CONNTRACK)
-  DEPENDS:=+kmod-nf-defrag
+  DEPENDS:=+kmod-nf-defrag +IPV6:kmod-nf-defrag6
   FILES:=$(foreach mod,$(NF_CONNTRACK-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_CONNTRACK-m)))
 endef
@@ -1257,7 +1257,7 @@ $(eval $(call KernelPackage,nft-compat))
 define KernelPackage/nft-socket
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables socket support
-  DEPENDS:=+kmod-nft-core +kmod-nf-socket +kmod-nf-socket6
+  DEPENDS:=+kmod-nft-core +kmod-nf-socket +IPV6:kmod-nf-socket6
   FILES:=$(foreach mod,$(NFT_SOCKET-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_SOCKET-m)))
   KCONFIG:=$(KCONFIG_NFT_SOCKET)
@@ -1268,7 +1268,7 @@ $(eval $(call KernelPackage,nft-socket))
 define KernelPackage/nft-tproxy
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables tproxy support
-  DEPENDS:=+kmod-nft-core +kmod-nf-defrag +kmod-nf-defrag6 +kmod-nf-tproxy +kmod-nf-tproxy6
+  DEPENDS:=+kmod-nft-core +kmod-nf-defrag +kmod-nf-tproxy +IPV6:kmod-nf-defrag6 +IPV6:kmod-nf-tproxy6
   FILES:=$(foreach mod,$(NFT_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_TPROXY-m)))
   KCONFIG:=$(KCONFIG_NFT_TPROXY)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1190,3 +1190,14 @@ define KernelPackage/nft-compat
 endef
 
 $(eval $(call KernelPackage,nft-compat))
+
+define KernelPackage/nft-tproxy
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter nf_tables tproxy support
+  DEPENDS:=+kmod-nft-core kmod-ipt-tproxy
+  FILES:=$(foreach mod,$(NFT_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_TPROXY-m)))
+  KCONFIG:=$(KCONFIG_NFT_TPROXY)
+endef
+
+$(eval $(call KernelPackage,nft-tproxy))

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -87,6 +87,27 @@ endef
 
 $(eval $(call KernelPackage,ipt-core))
 
+define KernelPackage/nf-defrag
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter DEFRAG
+  KCONFIG:=$(KCONFIG_NF_DEFRAG)
+  FILES:=$(foreach mod,$(NF_DEFRAG-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_DEFRAG-m)))
+endef
+
+$(eval $(call KernelPackage,nf-defrag))
+
+
+define KernelPackage/nf-defrag6
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter IPV6-DEFRAG
+  KCONFIG:=$(KCONFIG_NF_DEFRAG6)
+  DEPENDS:=@IPV6 +kmod-nf-defrag
+  FILES:=$(foreach mod,$(NF_DEFRAG6-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_DEFRAG6-m)))
+endef
+
+$(eval $(call KernelPackage,nf-defrag6))
 
 define KernelPackage/nf-conntrack
   SUBMENU:=$(NF_MENU)
@@ -97,6 +118,7 @@ define KernelPackage/nf-conntrack
         CONFIG_NF_CONNTRACK_MARK=y \
         CONFIG_NF_CONNTRACK_ZONES=y \
 	$(KCONFIG_NF_CONNTRACK)
+  DEPENDS:=+kmod-nf-defrag
   FILES:=$(foreach mod,$(NF_CONNTRACK-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_CONNTRACK-m)))
 endef
@@ -113,7 +135,7 @@ define KernelPackage/nf-conntrack6
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter IPv6 connection tracking
   KCONFIG:=$(KCONFIG_NF_CONNTRACK6)
-  DEPENDS:=@IPV6 +kmod-nf-conntrack
+  DEPENDS:=@IPV6 +kmod-nf-conntrack +kmod-nf-defrag6
   FILES:=$(foreach mod,$(NF_CONNTRACK6-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_CONNTRACK6-m)))
 endef
@@ -161,16 +183,47 @@ endef
 
 $(eval $(call KernelPackage,nf-flow))
 
+define KernelPackage/nf-socket
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter SOCKET support
+  KCONFIG:=$(KCONFIG_NF_SOCKET)
+  FILES:=$(foreach mod,$(NF_SOCKET-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_SOCKET-m)))
+endef
+
+$(eval $(call KernelPackage,nf-socket))
+
+define KernelPackage/nf-socket6
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter IPV6-SOCKET support
+  KCONFIG:=$(KCONFIG_NF_SOCKET6)
+  DEPENDS:=@IPV6 +kmod-nf-socket
+  FILES:=$(foreach mod,$(NF_SOCKET6-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_SOCKET6-m)))
+endef
+
+$(eval $(call KernelPackage,nf-socket6))
+
 define KernelPackage/nf-tproxy
   SUBMENU:=$(NF_MENU)
-  TITLE:=Netfilter tproxy support
+  TITLE:=Netfilter TPROXY support
   KCONFIG:=$(KCONFIG_NF_TPROXY)
-  DEPENDS:=+kmod-nf-conntrack
   FILES:=$(foreach mod,$(NF_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_TPROXY-m)))
 endef
 
 $(eval $(call KernelPackage,nf-tproxy))
+
+define KernelPackage/nf-tproxy6
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter IPV6-TPROXY support
+  KCONFIG:=$(KCONFIG_NF_TPROXY6)
+  DEPENDS:=@IPV6 +kmod-nf-tproxy
+  FILES:=$(foreach mod,$(NF_TPROXY6-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_TPROXY6-m)))
+endef
+
+$(eval $(call KernelPackage,nf-tproxy6))
 
 define AddDepends/ipt
   SUBMENU:=$(NF_MENU)
@@ -1201,10 +1254,21 @@ endef
 
 $(eval $(call KernelPackage,nft-compat))
 
+define KernelPackage/nft-socket
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter nf_tables socket support
+  DEPENDS:=+kmod-nft-core +kmod-nf-socket +kmod-nf-socket6
+  FILES:=$(foreach mod,$(NFT_SOCKET-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_SOCKET-m)))
+  KCONFIG:=$(KCONFIG_NFT_SOCKET)
+endef
+
+$(eval $(call KernelPackage,nft-socket))
+
 define KernelPackage/nft-tproxy
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables tproxy support
-  DEPENDS:=+kmod-nft-core +kmod-nf-tproxy
+  DEPENDS:=+kmod-nft-core +kmod-nf-defrag +kmod-nf-defrag6 +kmod-nf-tproxy +kmod-nf-tproxy6
   FILES:=$(foreach mod,$(NFT_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_TPROXY-m)))
   KCONFIG:=$(KCONFIG_NFT_TPROXY)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -161,6 +161,16 @@ endef
 
 $(eval $(call KernelPackage,nf-flow))
 
+define KernelPackage/nf-tproxy
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter tproxy support
+  KCONFIG:=$(KCONFIG_NF_TPROXY)
+  DEPENDS:=+kmod-nf-conntrack
+  FILES:=$(foreach mod,$(NF_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_TPROXY-m)))
+endef
+
+$(eval $(call KernelPackage,nf-tproxy))
 
 define AddDepends/ipt
   SUBMENU:=$(NF_MENU)
@@ -647,7 +657,7 @@ $(eval $(call KernelPackage,ipt-led))
 
 define KernelPackage/ipt-tproxy
   TITLE:=Transparent proxying support
-  DEPENDS+=+kmod-ipt-conntrack +IPV6:kmod-nf-conntrack6 +IPV6:kmod-ip6tables
+  DEPENDS+=+kmod-ipt-conntrack +kmod-nf-tproxy +IPV6:kmod-nf-conntrack6 +IPV6:kmod-ip6tables
   KCONFIG:=$(KCONFIG_IPT_TPROXY)
   FILES:=$(foreach mod,$(IPT_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(IPT_TPROXY-m)))
@@ -1194,7 +1204,7 @@ $(eval $(call KernelPackage,nft-compat))
 define KernelPackage/nft-tproxy
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables tproxy support
-  DEPENDS:=+kmod-nft-core kmod-ipt-tproxy
+  DEPENDS:=+kmod-nft-core +kmod-nf-tproxy
   FILES:=$(foreach mod,$(NFT_TPROXY-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_TPROXY-m)))
   KCONFIG:=$(KCONFIG_NFT_TPROXY)


### PR DESCRIPTION
Added kmod-nft-tproxy package to enable nft to support tproxy.