### PR TITLE
sunix: fix typo in kmod-ata-core

### DIFF
--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -22,7 +22,7 @@ TARGET_DEVICES += linksprite_a10-pcduino
 define Device/marsboard_a10-marsboard
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
-  DEVICE_PACKAGES:=mod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi \
+  DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi \
 	sound-soc-sunxi
   SOC := sun4i
 endef


### PR DESCRIPTION
There was a missing `k` in the package name.
s/mod-ata-core/kmod-ata-core

Signed-off-by: Paul Spooren <mail@aparcar.org>